### PR TITLE
test(desktop): stabilize Windows lifecycle stress tests

### DIFF
--- a/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
+++ b/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
@@ -8,6 +8,11 @@ import { test } from "@playwright/test";
 const STRESS_ARG = "--pwragent-vitest-stress";
 const PROCESS_SAMPLES_ARG = "--pwragent-vitest-process-samples";
 const TARGET_ARG_PREFIX = "--pwragent-vitest-target=";
+const TIMEOUT_ARG_PREFIX = "--pwragent-vitest-timeout-ms=";
+const PLAYWRIGHT_TIMEOUT_MS = 20 * 60 * 1_000;
+const DEFAULT_VITEST_TIMEOUT_MS = 19 * 60 * 1_000;
+const PROCESS_SNAPSHOT_TIMEOUT_MS = 10_000;
+const PROCESS_TREE_EXIT_TIMEOUT_MS = 15_000;
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(specDir, "../../..");
 
@@ -29,6 +34,7 @@ type CommandResult = {
 async function runCommand(
   command: string,
   args: string[],
+  timeoutMs?: number,
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -38,6 +44,22 @@ async function runCommand(
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      callback();
+    };
+    if (timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        finish(() => reject(new Error(
+          `${path.basename(command)} did not exit within ${timeoutMs}ms.`,
+        )));
+      }, timeoutMs);
+    }
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
@@ -46,9 +68,9 @@ async function runCommand(
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
     });
-    child.once("error", reject);
+    child.once("error", (error) => finish(() => reject(error)));
     child.once("close", (code, signal) => {
-      resolve({ code, signal, stderr, stdout });
+      finish(() => resolve({ code, signal, stderr, stdout }));
     });
   });
 }
@@ -67,7 +89,7 @@ async function captureRelevantProcesses(): Promise<ProcessSnapshotEntry[]> {
     "-NonInteractive",
     "-Command",
     powershell,
-  ]);
+  ], PROCESS_SNAPSHOT_TIMEOUT_MS);
   if (result.code !== 0) {
     throw new Error(
       `Process snapshot failed with exit ${result.code}: ${result.stderr.trim()}`,
@@ -97,6 +119,31 @@ function wait(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
+async function settleWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise.then((value) => ({ timedOut: false as const, value })),
+      new Promise<{ timedOut: true }>((resolve) => {
+        timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function terminateProcessTree(processId: number): Promise<CommandResult> {
+  return runCommand(
+    path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe"),
+    ["/PID", String(processId), "/T", "/F"],
+    PROCESS_TREE_EXIT_TIMEOUT_MS,
+  );
+}
+
 test.skip(
   process.platform !== "win32",
   "This diagnostic exercises the native Windows Vitest shutdown path.",
@@ -105,7 +152,7 @@ test.skip(
 test(
   "runs one complete Windows Vitest workspace iteration @windows-vitest-stress",
   async ({ browserName }, testInfo) => {
-    test.setTimeout(20 * 60 * 1_000);
+    test.setTimeout(PLAYWRIGHT_TIMEOUT_MS);
     test.skip(
       !testInfo.config.argv.includes(STRESS_ARG),
       `Pass ${STRESS_ARG} after Playwright's -- separator to run this diagnostic.`,
@@ -117,6 +164,21 @@ test(
     const vitestTarget = targetArgument?.slice(TARGET_ARG_PREFIX.length);
     if (vitestTarget && !/^[A-Za-z0-9_./-]+$/.test(vitestTarget)) {
       throw new Error(`Unsafe Vitest target: ${JSON.stringify(vitestTarget)}`);
+    }
+    const timeoutArgument = testInfo.config.argv.find((argument) =>
+      argument.startsWith(TIMEOUT_ARG_PREFIX),
+    );
+    const timeoutValue = timeoutArgument?.slice(TIMEOUT_ARG_PREFIX.length);
+    if (timeoutValue && !/^\d+$/.test(timeoutValue)) {
+      throw new Error(`Invalid Vitest timeout: ${JSON.stringify(timeoutValue)}`);
+    }
+    const vitestTimeoutMs = timeoutValue
+      ? Number(timeoutValue)
+      : DEFAULT_VITEST_TIMEOUT_MS;
+    if (vitestTimeoutMs < 1_000 || vitestTimeoutMs > DEFAULT_VITEST_TIMEOUT_MS) {
+      throw new Error(
+        `Vitest timeout must be between 1000 and ${DEFAULT_VITEST_TIMEOUT_MS}ms.`,
+      );
     }
 
     const iteration = testInfo.repeatEachIndex + 1;
@@ -132,6 +194,7 @@ test(
     log.write(`availableParallelism=${os.availableParallelism()}\n`);
     log.write(`totalMemoryBytes=${os.totalmem()}\n`);
     log.write(`vitestTarget=${vitestTarget ?? "(full workspace)"}\n`);
+    log.write(`vitestTimeoutMs=${vitestTimeoutMs}\n`);
     log.write(`processesBefore=${JSON.stringify(before)}\n`);
     log.write("\n===== pnpm test =====\n");
 
@@ -157,38 +220,120 @@ test(
     child.stderr.pipe(log, { end: false });
     let processSampling = captureProcessSamples;
     const processSampler = (async () => {
-      let previousSample = "";
-      while (processSampling) {
-        const sample = newlyRunningProcesses(
-          before,
-          await captureRelevantProcesses(),
-        );
-        const serialized = JSON.stringify(sample);
-        if (serialized !== previousSample) {
-          log.write(
-            `processSample=${JSON.stringify({
-              atMs: Date.now() - startedAt,
-              processes: sample,
-            })}\n`,
+      try {
+        let previousSample = "";
+        while (processSampling) {
+          const sample = newlyRunningProcesses(
+            before,
+            await captureRelevantProcesses(),
           );
-          previousSample = serialized;
+          const serialized = JSON.stringify(sample);
+          if (serialized !== previousSample) {
+            log.write(
+              `processSample=${JSON.stringify({
+                atMs: Date.now() - startedAt,
+                processes: sample,
+              })}\n`,
+            );
+            previousSample = serialized;
+          }
+          await wait(250);
         }
-        await wait(250);
+      } catch (error) {
+        log.write(
+          `processSamplingError=${JSON.stringify(error instanceof Error ? error.message : String(error))}\n`,
+        );
       }
     })();
-    const result = await new Promise<{
+    const childResult = new Promise<{
       code: number | null;
+      error?: Error;
       signal: NodeJS.Signals | null;
-    }>((resolve, reject) => {
-      child.once("error", reject);
+    }>((resolve) => {
+      child.once("error", (error) => resolve({ code: null, error, signal: null }));
       child.once("close", (code, signal) => resolve({ code, signal }));
     });
+    const deadlineResult = await settleWithin(childResult, vitestTimeoutMs);
+    const timedOut = deadlineResult.timedOut;
+    let processesAtTimeout: ProcessSnapshotEntry[] = [];
+    let result = deadlineResult.timedOut ? undefined : deadlineResult.value;
+    let childExitObserved = Boolean(result);
+    let residueClassified = true;
+    let timeoutProcessSnapshotClassified = true;
+    const captureForEvidence = async (label: string) => {
+      try {
+        return await captureRelevantProcesses();
+      } catch (error) {
+        residueClassified = false;
+        log.write(
+          `${label}Error=${JSON.stringify(error instanceof Error ? error.message : String(error))}\n`,
+        );
+        return [];
+      }
+    };
+    const captureOptionalTimeoutEvidence = async () => {
+      try {
+        return await captureRelevantProcesses();
+      } catch (error) {
+        timeoutProcessSnapshotClassified = false;
+        log.write(
+          `timeoutProcessSnapshotError=${JSON.stringify(error instanceof Error ? error.message : String(error))}\n`,
+        );
+        return [];
+      }
+    };
+    if (deadlineResult.timedOut) {
+      // Start the optional snapshot, but do not await it before cleanup.
+      // CIM enumeration can stall on the same degraded Windows host this
+      // diagnostic is meant to recover, while taskkill is the ownership
+      // boundary that must run promptly once Vitest exceeds its deadline.
+      const timeoutSnapshot = captureOptionalTimeoutEvidence();
+      if (child.pid) {
+        try {
+          const termination = await terminateProcessTree(child.pid);
+          log.write(
+            `processTreeTermination=${JSON.stringify({
+              code: termination.code,
+              signal: termination.signal,
+              stderr: termination.stderr.trim(),
+              stdout: termination.stdout.trim(),
+            })}\n`,
+          );
+          if (termination.code !== 0) child.kill("SIGKILL");
+        } catch (error) {
+          log.write(
+            `processTreeTerminationError=${JSON.stringify(error instanceof Error ? error.message : String(error))}\n`,
+          );
+          child.kill("SIGKILL");
+        }
+      }
+      processesAtTimeout = newlyRunningProcesses(
+        before,
+        await timeoutSnapshot,
+      );
+      log.write(
+        `vitestTimeout=${JSON.stringify({
+          atMs: Date.now() - startedAt,
+          processes: processesAtTimeout,
+          snapshotClassified: timeoutProcessSnapshotClassified,
+          timeoutMs: vitestTimeoutMs,
+        })}\n`,
+      );
+      const exitResult = await settleWithin(
+        childResult,
+        PROCESS_TREE_EXIT_TIMEOUT_MS,
+      );
+      if (!exitResult.timedOut) {
+        result = exitResult.value;
+        childExitObserved = true;
+      }
+    }
     processSampling = false;
     await processSampler;
 
-    const immediate = await captureRelevantProcesses();
+    const immediate = await captureForEvidence("immediateProcessSnapshot");
     await wait(2_000);
-    const settled = await captureRelevantProcesses();
+    const settled = await captureForEvidence("settledProcessSnapshot");
     const leakedImmediately = newlyRunningProcesses(before, immediate);
     const leakedAfterTwoSeconds = newlyRunningProcesses(before, settled);
     const durationMs = Date.now() - startedAt;
@@ -196,8 +341,15 @@ test(
     log.write("\n===== diagnostic summary =====\n");
     log.write(`finishedAt=${new Date().toISOString()}\n`);
     log.write(`durationMs=${durationMs}\n`);
-    log.write(`exitCode=${String(result.code)}\n`);
-    log.write(`signal=${String(result.signal)}\n`);
+    log.write(`timedOut=${String(timedOut)}\n`);
+    log.write(`timeoutMs=${timedOut ? String(vitestTimeoutMs) : "null"}\n`);
+    log.write(`processesAtTimeout=${JSON.stringify(processesAtTimeout)}\n`);
+    log.write(`timeoutProcessSnapshotClassified=${String(timeoutProcessSnapshotClassified)}\n`);
+    log.write(`childExitObserved=${String(childExitObserved)}\n`);
+    log.write(`exitCode=${String(result?.code ?? null)}\n`);
+    log.write(`signal=${String(result?.signal ?? null)}\n`);
+    log.write(`spawnError=${JSON.stringify(result?.error?.message ?? null)}\n`);
+    log.write(`processResidueClassified=${String(residueClassified)}\n`);
     log.write(`newProcessesImmediate=${JSON.stringify(leakedImmediately)}\n`);
     log.write(`newProcessesAfterTwoSeconds=${JSON.stringify(leakedAfterTwoSeconds)}\n`);
     await new Promise<void>((resolve, reject) => {
@@ -212,20 +364,32 @@ test(
     console.log(
       [
         `Windows Vitest stress iteration ${iteration}:`,
-        `exit=${String(result.code)}`,
+        `exit=${String(result?.code ?? null)}`,
+        `timedOut=${String(timedOut)}`,
         `durationMs=${durationMs}`,
         `persistentNewProcesses=${JSON.stringify(leakedAfterTwoSeconds)}`,
       ].join(" "),
     );
 
-    if (result.code !== 0) {
+    if (timedOut) {
       throw new Error(
-        `Windows Vitest stress iteration ${iteration} exited ${String(result.code)}.`,
+        `Windows Vitest stress iteration ${iteration} exceeded ${vitestTimeoutMs}ms; active processes before termination: ${JSON.stringify(processesAtTimeout)}`,
+      );
+    }
+    if (result?.error) throw result.error;
+    if (result?.code !== 0) {
+      throw new Error(
+        `Windows Vitest stress iteration ${iteration} exited ${String(result?.code)}.`,
       );
     }
     if (leakedAfterTwoSeconds.length > 0) {
       throw new Error(
         `Windows Vitest stress iteration ${iteration} left processes running: ${JSON.stringify(leakedAfterTwoSeconds)}`,
+      );
+    }
+    if (!residueClassified) {
+      throw new Error(
+        `Windows Vitest stress iteration ${iteration} could not classify process residue.`,
       );
     }
   },

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -226,13 +226,15 @@ describe("wrapCommandInWindowsJob", () => {
   });
 
   it("reports a PowerShell host-start timeout before wrapper code runs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-07T00:00:00.000Z"));
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
       env: { SystemRoot: "C:\\Windows" },
     });
     try {
-      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+      const startupTimeoutPromise = new Promise<WindowsJobStartupTimeout>(
         (resolve, reject) => {
           startWindowsJobReadyPoll({
             launch: wrapped,
@@ -244,6 +246,8 @@ describe("wrapCommandInWindowsJob", () => {
           });
         },
       );
+      await vi.runAllTimersAsync();
+      const startupTimeout = await startupTimeoutPromise;
       expect(startupTimeout).toMatchObject({
         stage: "powershell-start",
         timeoutMs: 40,
@@ -256,10 +260,13 @@ describe("wrapCommandInWindowsJob", () => {
       );
     } finally {
       wrapped.cleanup();
+      vi.useRealTimers();
     }
   });
 
   it("reports the last startup phase when progress stalls", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-07T00:00:00.000Z"));
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
@@ -270,7 +277,7 @@ describe("wrapCommandInWindowsJob", () => {
         wrapped.startupStatusFilePath,
         "12\tpowershell-started\t\n18\thelper-compile-started\t\n",
       );
-      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+      const startupTimeoutPromise = new Promise<WindowsJobStartupTimeout>(
         (resolve, reject) => {
           startWindowsJobReadyPoll({
             launch: wrapped,
@@ -282,6 +289,8 @@ describe("wrapCommandInWindowsJob", () => {
           });
         },
       );
+      await vi.runAllTimersAsync();
+      const startupTimeout = await startupTimeoutPromise;
       expect(startupTimeout).toMatchObject({
         stage: "progress-stall",
         timeoutMs: 40,
@@ -295,10 +304,13 @@ describe("wrapCommandInWindowsJob", () => {
       );
     } finally {
       wrapped.cleanup();
+      vi.useRealTimers();
     }
   });
 
   it("keeps progress extensions inside the overall readiness bound", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-07T00:00:00.000Z"));
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
@@ -309,7 +321,7 @@ describe("wrapCommandInWindowsJob", () => {
         wrapped.startupStatusFilePath,
         "12\tpowershell-started\t\n18\thelper-compile-started\t\n25\thelper-ready\t\n",
       );
-      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+      const startupTimeoutPromise = new Promise<WindowsJobStartupTimeout>(
         (resolve, reject) => {
           startWindowsJobReadyPoll({
             launch: wrapped,
@@ -321,6 +333,8 @@ describe("wrapCommandInWindowsJob", () => {
           });
         },
       );
+      await vi.runAllTimersAsync();
+      const startupTimeout = await startupTimeoutPromise;
       expect(startupTimeout).toMatchObject({
         stage: "overall-ready",
         timeoutMs: 40,
@@ -330,14 +344,15 @@ describe("wrapCommandInWindowsJob", () => {
       );
     } finally {
       wrapped.cleanup();
+      vi.useRealTimers();
     }
   });
 
   it.skipIf(process.platform !== "win32")(
-    "executes both native and Git Bash commands inside the Job",
+    "executes a native command inside the Job",
     async () => {
       const root = await mkdtemp(
-        path.join(os.tmpdir(), "pwragent-windows-job-test-"),
+        path.join(os.tmpdir(), "pwragent-windows-native-job-test-"),
       );
       try {
         const nativeResult = await runWrappedCommand({
@@ -354,12 +369,38 @@ describe("wrapCommandInWindowsJob", () => {
           stderr: "",
         });
         expect(nativeResult.stdout).toContain("job-native");
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    30_000,
+  );
 
+  it.skipIf(process.platform !== "win32")(
+    "executes Git inside the Job",
+    async () => {
+      const root = await mkdtemp(
+        path.join(os.tmpdir(), "pwragent-windows-git-job-test-"),
+      );
+      try {
         const gitResult = await runGitCommand(root, ["init", "-b", "main"], {
           ownProcessTree: true,
         });
         expect(gitResult.stderr).toBe("");
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    30_000,
+  );
 
+  it.skipIf(process.platform !== "win32")(
+    "executes Git Bash inside the Job",
+    async () => {
+      const root = await mkdtemp(
+        path.join(os.tmpdir(), "pwragent-windows-bash-job-test-"),
+      );
+      try {
         const bashResult = await runWrappedCommand({
           args: [
             "-lc",

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapScreen } from "../StarMapScreen";
+import { STAR_MAP_PAN_SPEED } from "../star-map-keyboard";
 
 /**
  * The map flies from the keyboard.
@@ -74,6 +75,43 @@ async function flushFrame() {
       requestAnimationFrame(() => resolve(undefined));
     });
   });
+}
+
+function controlAnimationFrames() {
+  let currentTime = 0;
+  let nextFrameId = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const request = vi
+    .spyOn(globalThis, "requestAnimationFrame")
+    .mockImplementation((callback) => {
+      const frameId = nextFrameId;
+      nextFrameId += 1;
+      callbacks.set(frameId, callback);
+      return frameId;
+    });
+  const cancel = vi
+    .spyOn(globalThis, "cancelAnimationFrame")
+    .mockImplementation((frameId) => {
+      callbacks.delete(frameId);
+    });
+
+  return {
+    flush: async (elapsedMs = 1000 / 60) => {
+      currentTime += elapsedMs;
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      if (pending.length !== 1) {
+        throw new Error(`Expected one animation frame, received ${pending.length}.`);
+      }
+      await act(async () => {
+        pending[0](currentTime);
+      });
+    },
+    restore: () => {
+      request.mockRestore();
+      cancel.mockRestore();
+    },
+  };
 }
 
 async function openMap(floating = false) {
@@ -191,24 +229,31 @@ describe("star map keyboard camera", () => {
     // repaint. Pressing 0 did nothing at all.
     await openMap();
     const opened = readTransform();
+    const frames = controlAnimationFrames();
 
-    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
-    await flushFrame();
-    await flushFrame();
-    expect(readTransform().x).toBeLessThan(opened.x);
+    try {
+      fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
+      await frames.flush();
+      await frames.flush();
+      expect(readTransform().x).toBeLessThan(opened.x);
 
-    fireEvent.keyDown(layer(), { key: "0", code: "Digit0" });
-    expect(readTransform()).toEqual(opened);
+      fireEvent.keyDown(layer(), { key: "0", code: "Digit0" });
+      expect(readTransform()).toEqual(opened);
 
-    // Still flying, so the NEXT frame continues from the reset position
-    // rather than teleporting back to where the flight had reached.
-    await flushFrame();
-    const afterReset = readTransform();
-    expect(afterReset.x).toBeLessThan(opened.x);
-    expect(afterReset.x).toBeGreaterThan(opened.x - 100);
+      // Still flying, so the NEXT frame continues from the reset position
+      // rather than teleporting back to where the flight had reached.
+      await frames.flush();
+      const afterReset = readTransform();
+      expect(afterReset.x).toBeCloseTo(
+        opened.x - STAR_MAP_PAN_SPEED / 60,
+        6,
+      );
 
-    fireEvent.keyUp(window, { key: "d", code: "KeyD" });
-    await flushFrame();
+      fireEvent.keyUp(window, { key: "d", code: "KeyD" });
+      await frames.flush();
+    } finally {
+      frames.restore();
+    }
   });
 
   it("composes a trackpad pinch with an in-flight keyboard pan", async () => {


### PR DESCRIPTION
## Summary

- make Windows Job startup timeout tests deterministic with fake clock control
- drive the star-map reset regression with controlled animation-frame timestamps
- split independent native, Git, and Git Bash ownership launches into separate 30-second tests
- make the Windows Vitest stress diagnostic terminate its owned process tree before the outer Playwright deadline and always persist timeout and residue evidence
- bound every PowerShell/CIM process snapshot and start optional timeout evidence without delaying process-tree termination
- add a bounded diagnostic timeout override so forced cleanup can be validated directly

## Root cause

The PR 1558 investigation did not reproduce its worktree EBUSY failures, but the full Windows stress run exposed deterministic test assumptions. One Job telemetry test used 40–200 ms real-time deadlines, so scheduler delay could make the overall deadline win. The star-map test assumed a frame shorter than the production 100 ms cap. A separate Windows integration test serialized three cold process launches inside one 30-second test even though one owned launch may legitimately consume nearly that budget. Finally, the outer Playwright timeout could kill a long Vitest iteration before its process-residue summary was written.

The timeout diagnostic initially awaited a CIM snapshot before terminating Vitest. The review fix bounds every snapshot at 10 seconds and invokes bounded `taskkill /T /F` before awaiting that optional evidence, so degraded process enumeration cannot defeat cleanup.

This PR changes test timing and diagnostic ownership only. It does not widen production or test timeouts, add retries, reduce workers, or serialize CI lanes.

## Rebase and lifecycle teardown

Rebased onto `origin/main` commit `93963d53` (`fix(tests): stop force-killing E2E apps that are shutting down correctly`). That change directly helps the Windows EBUSY lifecycle class by allowing normal Electron shutdown before its bounded Windows `taskkill /T /F` fallback and by waiting for profile processes to exit before deleting their home root.

A rebased Windows profile-backed app-quit run passed 5/5 with retries 0. No force-kill/taskkill fallback, teardown timeout, EBUSY/EPERM/ENOTEMPTY, cleanup error, or surviving-process warning was emitted. No Windows tweak to `93963d53` is included because the exercised path passed and there is no evidence-backed defect to change.

## Validation

Local, rebased head:

- focused Vitest: 41 passed, 4 platform skips
- `pnpm typecheck`
- `pnpm lint:eslint`: no errors; existing warnings only
- `pnpm lint:boundaries`: zero violations
- `git diff --check`

Windows, rebased head `96483726`, retries 0:

- forced 1-second diagnostic timeout: expected failure; `timedOut=true`, `childExitObserved=true`, `timeoutProcessSnapshotClassified=true`, `processResidueClassified=true`; `processTreeTermination` was logged before `vitestTimeout`; taskkill succeeded; no residue after two seconds
- Job-wrapper stress: 10/10 iterations passed; no persistent processes or Windows filesystem-lock warnings
- star-map stress: the test passed all 4 iterations in which Vitest started; one separate iteration failed before running any test with Vitest's 60-second `Timeout waiting for worker to respond`; no process residue
- profile-backed graceful app quit: 5/5 passed in 24.5 seconds; no force-kill, teardown, survivor, or filesystem-lock warnings

Earlier Windows validation on pre-rebase head `af153146`, retries 0:

- Job-wrapper stress: 20/20 passed
- star-map stress: 10/10 passed
- forced timeout: taskkill terminated the complete process tree and left no residue

Windows artifact run IDs for rebased head:

- `pwrlab-pwragent-e2e-20260813-085902-96483726` — forced timeout
- `pwrlab-pwragent-e2e-20260813-090656-96483726` — Job wrapper 10/10
- `pwrlab-pwragent-e2e-20260813-091525-96483726` — star map 4 starts passed, 1 Vitest worker-start failure
- `pwrlab-pwragent-e2e-20260813-093744-96483726` — profile-backed app quit 5/5

## Scope note

This does not claim to fix the original PR 1558 worktree EBUSY report. Both reported worktree tests passed throughout Windows repetition, and no evidence-backed process leak was found there. A separate onboarding graduation validation never reached teardown because its first wizard control did not appear on Windows, so it supplies no evidence for or against detached-profile cleanup.
