### PR TITLE
feat(desktop): tighten 1.0 sidebar density and typography

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1081,8 +1081,12 @@ test("directory launchpad keeps new worktree as the sticky default after startin
     // Renamed in the chip-flow refactor: meta + PR + binding + reactions
     // chips all share a single `.thread-row__chips` flex-wrap container.
     const startedThreadChips = startedThreadRow.locator(".thread-row__chips");
-    await expect(startedThreadChips.getByText("worktree", { exact: true })).toBeVisible();
-    await expect(startedThreadChips.getByText("local", { exact: true })).toHaveCount(0);
+    await expect(
+      startedThreadChips.getByLabel(/^Copy path for worktree /),
+    ).toBeVisible();
+    await expect(
+      startedThreadChips.getByLabel(/^Copy local path for /),
+    ).toHaveCount(0);
 
     const contextRail = app.window.getByRole("complementary", {
       name: "Thread context",

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -220,6 +220,42 @@ test.describe("Onboarding wizard", () => {
         }),
       ).toBeVisible();
 
+      const missionControlRows = app.window.locator(
+        ".onboarding-wizard__mini-row--mc",
+      );
+      await expect(missionControlRows).toHaveCount(4);
+      for (const row of await missionControlRows.all()) {
+        const heading = row.locator(
+          ":scope > .onboarding-wizard__mini-heading",
+        );
+        const time = row.locator(":scope > .onboarding-wizard__mini-time");
+        const meta = row.locator(":scope > .onboarding-wizard__mini-meta");
+        await expect(heading).toHaveCount(1);
+        await expect(time).toHaveCount(1);
+        await expect(meta).toHaveCount(1);
+
+        const [rowBox, headingBox, timeBox, metaBox] = await Promise.all([
+          row.boundingBox(),
+          heading.boundingBox(),
+          time.boundingBox(),
+          meta.boundingBox(),
+        ]);
+        expect(rowBox).not.toBeNull();
+        expect(headingBox).not.toBeNull();
+        expect(timeBox).not.toBeNull();
+        expect(metaBox).not.toBeNull();
+        expect(
+          Math.abs(
+            headingBox!.y + headingBox!.height / 2
+            - (timeBox!.y + timeBox!.height / 2),
+          ),
+        ).toBeLessThan(2);
+        expect(metaBox!.y).toBeGreaterThan(headingBox!.y);
+        expect(metaBox!.y + metaBox!.height).toBeLessThanOrEqual(
+          rowBox!.y + rowBox!.height + 1,
+        );
+      }
+
       const back = app.window.getByRole("button", { name: /^← Back/i });
       await expect(back).toBeVisible();
       await back.click();

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -514,18 +514,24 @@ describe("DesktopSettingsService", () => {
       value: "mission-control",
       source: "default",
     });
+    expect(initialSettings.general.appearance.sidebarTextSize).toEqual({
+      value: "md",
+      source: "default",
+    });
     expect(readBootstrapAppearance(configPath)).toEqual({
       theme: "system",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
 
     // Write non-default values. The byte-preserving patch path should
-    // create `[general.appearance]` with both keys.
+    // create `[general.appearance]` with all three keys.
     await service.writeConfigPatch({
       general: {
         appearance: {
           theme: "light",
           density: "compact",
+          sidebarTextSize: "lg",
         },
       },
     });
@@ -534,6 +540,7 @@ describe("DesktopSettingsService", () => {
     expect(writtenFile).toContain("[general.appearance]");
     expect(writtenFile).toContain('theme = "light"');
     expect(writtenFile).toContain('density = "compact"');
+    expect(writtenFile).toContain('sidebar_text_size = "lg"');
 
     const afterWrite = await service.readSettings();
     expect(afterWrite.general.appearance.theme).toEqual({
@@ -544,18 +551,24 @@ describe("DesktopSettingsService", () => {
       value: "compact",
       source: "config",
     });
+    expect(afterWrite.general.appearance.sidebarTextSize).toEqual({
+      value: "lg",
+      source: "config",
+    });
     expect(readBootstrapAppearance(configPath)).toEqual({
       theme: "light",
       density: "compact",
+      sidebarTextSize: "lg",
     });
 
-    // Restore to defaults: the patch path should DELETE both keys
+    // Restore to defaults: the patch path should DELETE all three keys
     // (defaults aren't written to disk) so the file stays minimal.
     await service.writeConfigPatch({
       general: {
         appearance: {
           theme: "system",
           density: "mission-control",
+          sidebarTextSize: "md",
         },
       },
     });
@@ -563,13 +576,18 @@ describe("DesktopSettingsService", () => {
     const restoredFile = fs.readFileSync(configPath, "utf8");
     expect(restoredFile).not.toContain('theme = "');
     expect(restoredFile).not.toContain('density = "');
+    expect(restoredFile).not.toContain('sidebar_text_size = "');
 
     const afterRestore = await service.readSettings();
     expect(afterRestore.general.appearance.theme.source).toBe("default");
     expect(afterRestore.general.appearance.density.source).toBe("default");
+    expect(afterRestore.general.appearance.sidebarTextSize.source).toBe(
+      "default",
+    );
     expect(readBootstrapAppearance(configPath)).toEqual({
       theme: "system",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
   });
 
@@ -606,6 +624,7 @@ describe("DesktopSettingsService", () => {
     expect(onAppearanceChange).toHaveBeenLastCalledWith({
       theme: "light",
       density: "compact",
+      sidebarTextSize: "md",
     });
 
     // Patch that restores defaults still fires (the renderer needs to
@@ -625,6 +644,7 @@ describe("DesktopSettingsService", () => {
     expect(onAppearanceChange).toHaveBeenLastCalledWith({
       theme: "system",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
 
     // Patch with `general` but only developerMode (not appearance) must
@@ -647,6 +667,7 @@ describe("DesktopSettingsService", () => {
     expect(onAppearanceChange).toHaveBeenLastCalledWith({
       theme: "dark",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
   });
 

--- a/apps/desktop/src/main/settings/appearance-bootstrap.ts
+++ b/apps/desktop/src/main/settings/appearance-bootstrap.ts
@@ -3,7 +3,7 @@
  *
  * The async settings-snapshot read pulls in app-discovery, codex-discovery,
  * etc. and is much too heavy to run before window creation. We only need
- * theme + density to pass through `webPreferences.additionalArguments` so
+ * appearance preferences to pass through `webPreferences.additionalArguments` so
  * the preload can expose them to the inline bootstrap script in index.html
  * (which sets data-theme / data-density on `<html>` synchronously before
  * React mounts — avoids flash-of-wrong-theme).
@@ -16,10 +16,13 @@
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
 } from "@pwragent/shared";
 import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  isDesktopSidebarTextSize,
 } from "@pwragent/shared";
 import {
   readDesktopSettingsConfig,
@@ -29,6 +32,7 @@ import {
 export type BootstrapAppearance = {
   theme: DesktopAppearanceTheme;
   density: DesktopAppearanceDensity;
+  sidebarTextSize: DesktopSidebarTextSize;
 };
 
 export const BOOTSTRAP_APPEARANCE_ARG_PREFIX = "--pwragent-appearance=";
@@ -116,6 +120,9 @@ export function readBootstrapAppearance(
       density:
         config.general?.appearance?.density
         ?? DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+      sidebarTextSize:
+        config.general?.appearance?.sidebarTextSize
+        ?? DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
     };
   } catch {
     // Config missing / unreadable / malformed → fall back to defaults.
@@ -124,6 +131,7 @@ export function readBootstrapAppearance(
     return {
       theme: DESKTOP_APPEARANCE_THEME_DEFAULT,
       density: DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+      sidebarTextSize: DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
     };
   }
 }
@@ -151,7 +159,12 @@ export function parseBootstrapAppearanceArg(
           && (raw.density === "mission-control" || raw.density === "compact")
           ? (raw.density as DesktopAppearanceDensity)
           : DESKTOP_APPEARANCE_DENSITY_DEFAULT;
-      return { theme, density };
+      const sidebarTextSize =
+        raw && typeof raw.sidebarTextSize === "string"
+          && isDesktopSidebarTextSize(raw.sidebarTextSize)
+          ? raw.sidebarTextSize
+          : DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT;
+      return { theme, density, sidebarTextSize };
     } catch {
       return undefined;
     }

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -23,6 +23,7 @@ import type {
   DesktopProviderModelDefaults,
   DesktopProviderThreadModelMigration,
   DesktopSettingsConfigPatch,
+  DesktopSidebarTextSize,
   DesktopUpdateChannel,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
@@ -30,11 +31,13 @@ import type {
 import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
   DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELL_DEFAULT,
   DESKTOP_UPDATE_CHANNEL_DEFAULT,
   isDesktopAppearanceDensity,
   isDesktopAppearanceTheme,
+  isDesktopSidebarTextSize,
   isDesktopCodexProfileModel,
   isDesktopHotCpuProfileStartDelayMs,
   isDesktopHotCpuProfileTriggerMode,
@@ -92,6 +95,7 @@ export type DesktopSettingsConfig = {
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;
+      sidebarTextSize?: DesktopSidebarTextSize;
     };
     codexProfileModel?: DesktopCodexProfileModel;
     messagingAcknowledgment?: DesktopMessagingAcknowledgment | null;
@@ -744,6 +748,23 @@ export function desktopSettingsPatchToEdits(
     }
   }
 
+  if (patch.general?.appearance?.sidebarTextSize !== undefined) {
+    if (
+      patch.general.appearance.sidebarTextSize
+        === DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT
+    ) {
+      edits.push({
+        op: "delete",
+        path: ["general", "appearance", "sidebar_text_size"],
+      });
+    } else {
+      set(
+        ["general", "appearance", "sidebar_text_size"],
+        patch.general.appearance.sidebarTextSize,
+      );
+    }
+  }
+
   if (patch.general?.codexProfileModel !== undefined) {
     if (
       patch.general.codexProfileModel === DESKTOP_CODEX_PROFILE_MODEL_DEFAULT
@@ -1377,6 +1398,9 @@ function normalizeDesktopConfig(
       appearance: {
         theme: readAppearanceTheme(generalAppearance?.theme),
         density: readAppearanceDensity(generalAppearance?.density),
+        sidebarTextSize: readSidebarTextSize(
+          generalAppearance?.sidebar_text_size,
+        ),
       },
       codexProfileModel: readCodexProfileModel(general?.codex_profile_model),
       messagingAcknowledgment: readMessagingAcknowledgment(
@@ -1953,6 +1977,14 @@ function readAppearanceDensity(
   value: TomlScalar | undefined,
 ): DesktopAppearanceDensity | undefined {
   return typeof value === "string" && isDesktopAppearanceDensity(value)
+    ? value
+    : undefined;
+}
+
+function readSidebarTextSize(
+  value: TomlScalar | undefined,
+): DesktopSidebarTextSize | undefined {
+  return typeof value === "string" && isDesktopSidebarTextSize(value)
     ? value
     : undefined;
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1,6 +1,7 @@
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
@@ -33,6 +34,7 @@ import {
   DEFAULT_BACKGROUND_PR_POLLING,
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
   DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT,
@@ -212,12 +214,13 @@ type DesktopSettingsServiceOptions = {
    * touched `[general.appearance]`. The production wiring routes this
    * to `broadcastAppearanceChange` so secondary windows (changelog,
    * app-log, license, messaging activity) can re-apply
-   * `<html data-theme/data-density>` live. Tests can omit it (or
+   * `<html data-*>` appearance attributes live. Tests can omit it (or
    * provide a spy) without coupling the service to the window layer.
    */
   onAppearanceChange?: (appearance: {
     theme: DesktopAppearanceTheme;
     density: DesktopAppearanceDensity;
+    sidebarTextSize: DesktopSidebarTextSize;
   }) => void;
 };
 
@@ -584,6 +587,9 @@ export class DesktopSettingsService {
           ),
           density: this.resolveAppearanceDensity(
             config.general?.appearance?.density,
+          ),
+          sidebarTextSize: this.resolveSidebarTextSize(
+            config.general?.appearance?.sidebarTextSize,
           ),
         },
         codexProfileModel: this.resolveCodexProfileModel(
@@ -1193,12 +1199,15 @@ export class DesktopSettingsService {
     if (
       appearancePatch
       && (appearancePatch.theme !== undefined
-        || appearancePatch.density !== undefined)
+        || appearancePatch.density !== undefined
+        || appearancePatch.sidebarTextSize !== undefined)
     ) {
       const next = this.readConfig().config.general?.appearance;
       this.options.onAppearanceChange?.({
         theme: next?.theme ?? DESKTOP_APPEARANCE_THEME_DEFAULT,
         density: next?.density ?? DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+        sidebarTextSize:
+          next?.sidebarTextSize ?? DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
       });
     }
     // Any successful write notifies generic listeners so main-process services
@@ -1672,6 +1681,15 @@ export class DesktopSettingsService {
   ): DesktopSettingsValue<DesktopAppearanceDensity> {
     return {
       value: configValue ?? DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveSidebarTextSize(
+    configValue: DesktopSidebarTextSize | undefined,
+  ): DesktopSettingsValue<DesktopSidebarTextSize> {
+    return {
+      value: configValue ?? DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
       source: configValue === undefined ? "default" : "config",
     };
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -11,6 +11,7 @@ import type {
   ArchiveThreadResponse,
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
   EnsureDirectoryLaunchpadRequest,
@@ -245,6 +246,10 @@ import type {
   UpdateThreadExpectedBranchRequest,
   UpdateThreadExpectedBranchResponse,
   WriteDesktopSettingsConfigRequest,
+} from "@pwragent/shared";
+import {
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  isDesktopSidebarTextSize,
 } from "@pwragent/shared";
 import type { RendererErrorReport } from "../shared/renderer-error";
 import type { RendererDiagnosticLogRequest } from "../shared/renderer-diagnostic";
@@ -1447,6 +1452,7 @@ const desktopApi = Object.freeze({
     callback: (appearance: {
       theme: DesktopAppearanceTheme;
       density: DesktopAppearanceDensity;
+      sidebarTextSize: DesktopSidebarTextSize;
     }) => void,
   ): (() => void) => {
     const listener = (
@@ -1454,6 +1460,7 @@ const desktopApi = Object.freeze({
       payload: {
         theme: DesktopAppearanceTheme;
         density: DesktopAppearanceDensity;
+        sidebarTextSize: DesktopSidebarTextSize;
       },
     ) => callback(payload);
     ipcRenderer.on(APPEARANCE_CHANGED_EVENT_CHANNEL, listener);
@@ -1596,7 +1603,7 @@ const desktopApi = Object.freeze({
 // Decode the appearance hint passed from main via
 // `webPreferences.additionalArguments`. The inline bootstrap script in
 // index.html reads `window.__pwragentAppearance` synchronously, before
-// any React code runs, to set data-theme / data-density on `<html>` —
+// any React code runs, to set appearance data attributes on `<html>` —
 // this is what prevents flash-of-wrong-theme on launch. The TOML
 // (read by `readBootstrapAppearance` in main) is source of truth; the
 // renderer's writeSettingsConfig IPC keeps it in sync.
@@ -1604,6 +1611,7 @@ const APPEARANCE_ARG_PREFIX = "--pwragent-appearance=";
 function readBootstrapAppearance(): {
   theme: "system" | "dark" | "light";
   density: "mission-control" | "compact";
+  sidebarTextSize: DesktopSidebarTextSize;
 } {
   for (const arg of process.argv) {
     if (!arg.startsWith(APPEARANCE_ARG_PREFIX)) continue;
@@ -1617,12 +1625,21 @@ function readBootstrapAppearance(): {
         raw && (raw.density === "mission-control" || raw.density === "compact")
           ? raw.density
           : "mission-control";
-      return { theme, density };
+      const sidebarTextSize =
+        raw && typeof raw.sidebarTextSize === "string"
+          && isDesktopSidebarTextSize(raw.sidebarTextSize)
+          ? raw.sidebarTextSize
+          : DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT;
+      return { theme, density, sidebarTextSize };
     } catch {
       break;
     }
   }
-  return { theme: "system", density: "mission-control" };
+  return {
+    theme: "system",
+    density: "mission-control",
+    sidebarTextSize: DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  };
 }
 const bootstrapAppearance = readBootstrapAppearance();
 

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -9,7 +9,7 @@
     <title>PwrAgnt</title>
     <script>
       // Appearance bootstrap — runs BEFORE the React bundle loads so the
-      // first paint matches the persisted theme + density. Without this,
+      // first paint matches the persisted appearance. Without this,
       // a flash-of-wrong-theme appears on every launch (renders dark for
       // ~50-150ms, then snaps to light when React mounts the setting).
       //
@@ -58,6 +58,19 @@
           // when compact is selected.
           if (density === "compact") {
             document.documentElement.setAttribute("data-density", "compact");
+          }
+          // "md" is the default the bare :root carries. Unknown values are
+          // inert because no CSS notch selector matches them, so this inline
+          // script does not need a hand-copied enum that could become stale.
+          var sidebarTextSize = bridged.sidebarTextSize;
+          if (
+            typeof sidebarTextSize === "string"
+            && sidebarTextSize !== "md"
+          ) {
+            document.documentElement.setAttribute(
+              "data-sidebar-text",
+              sidebarTextSize
+            );
           }
         } catch (_) {
           // Bridge unavailable or shape wrong — fall back to dark + mission-

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -109,7 +109,7 @@ const LazyOnboardingWizard = lazy(async () => ({
 export function App() {
   const desktopApi = useDesktopApi();
   const settings = useDesktopSettings(desktopApi);
-  // Owns live theme + density state. Source of truth is per-profile
+  // Owns live appearance state. Source of truth is per-profile
   // config.toml; the snapshot pulls it in over IPC, the hook adopts it
   // when available, and setters write back via writeSettingsConfig.
   // The pre-React bootstrap script in index.html already set the initial
@@ -123,6 +123,8 @@ export function App() {
       ? {
         theme: settings.snapshot.general.appearance.theme.value,
         density: settings.snapshot.general.appearance.density.value,
+        sidebarTextSize:
+          settings.snapshot.general.appearance.sidebarTextSize.value,
       }
       : undefined,
     writeConfig: settings.writeConfig,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -476,6 +476,7 @@ describe("App", () => {
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },
+          sidebarTextSize: { value: "md", source: "default" },
         },
         codexProfileModel: { value: "shared", source: "default" },
         messagingAcknowledgment: { value: null, source: "default" },
@@ -719,6 +720,7 @@ describe("App", () => {
             appearance: {
               theme: { value: "system", source: "default" },
               density: { value: "mission-control", source: "default" },
+              sidebarTextSize: { value: "md", source: "default" },
             },
           },
           onboarding: {
@@ -1698,6 +1700,7 @@ describe("App", () => {
               appearance: {
                 theme: { value: "system", source: "default" },
                 density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
               },
             },
             onboarding: {

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -25,12 +25,7 @@ import {
   parseThreadIdentityKey,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
-import {
-  FolderIcon,
-  NewThreadIcon,
-  UnlinkedDotIcon,
-  WorkspaceIcon,
-} from "../../icons";
+import { NewThreadIcon, UnlinkedDotIcon, WorkspaceIcon } from "../../icons";
 import {
   didDragLeaveCurrentTarget,
   getDropIndicatorPosition,
@@ -110,6 +105,10 @@ type DirectoriesListProps = {
     emoji: string,
     present: boolean,
   ) => Promise<void>;
+  onSetThreadPin?: (
+    thread: NavigationThreadSummary,
+    pinned: boolean,
+  ) => Promise<void>;
   onUnbindMessagingBinding?: (
     thread: NavigationThreadSummary,
     binding: MessagingThreadBindingSummary,
@@ -162,6 +161,16 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
     launchpad.prompt.trim().length > 0 ||
     (launchpad.imageAttachments?.length ?? 0) > 0
   );
+}
+
+/**
+ * releases/1.0 has no Federation runtime. Keep the directory-launchpad
+ * layout independent from that runtime, but make the split-control capability
+ * explicit and deterministic instead of importing Federation state solely to
+ * discover that there are no eligible clients.
+ */
+function supportsFederationDirectoryLaunchTargets(): boolean {
+  return false;
 }
 
 /**
@@ -609,6 +618,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
+              onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
             );
@@ -699,6 +709,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             onPrefetchPullRequests={props.onPrefetchPullRequests}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
+            onSetThreadPin={props.onSetThreadPin}
             onUnbindMessagingBinding={props.onUnbindMessagingBinding}
           />
           {renderStaticSubthreads(thread)}
@@ -709,6 +720,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const dropIndicatorClass = isDirectoryDropTarget
       ? ` is-drop-target-${directoryDropIndicator!.position}`
       : "";
+    const federationLaunchTargetsAvailable =
+      supportsFederationDirectoryLaunchTargets();
 
     return (
       <section
@@ -818,7 +831,15 @@ export function DirectoriesList(props: DirectoriesListProps) {
         }
       >
         <div
-          className="directory-row__header"
+          className={`directory-row__header directory-row__header--with-launchpad${
+            federationLaunchTargetsAvailable
+              ? " directory-row__header--split"
+              : ""
+          }${
+            hasPendingLaunchpadState(directory)
+              ? " directory-row__header--has-draft"
+              : ""
+          }`}
           draggable={directoryDraggable}
           onDragStart={
             directoryDraggable
@@ -917,17 +938,19 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 aria-hidden="true"
                 className={`directory-row__chevron${expanded ? " is-open" : ""}`}
               />
-              <span aria-hidden="true" className="directory-row__icon">
-                {directory.kind === "workspace" ? (
-                  <WorkspaceIcon size={14} />
-                ) : directory.kind === "unlinked" ? (
-                  <UnlinkedDotIcon size={14} />
-                ) : (
-                  <FolderIcon size={14} />
-                )}
-              </span>
+              {directory.kind === "workspace" || directory.kind === "unlinked" ? (
+                <span aria-hidden="true" className="directory-row__icon">
+                  {directory.kind === "workspace" ? (
+                    <WorkspaceIcon size={14} />
+                  ) : (
+                    <UnlinkedDotIcon size={14} />
+                  )}
+                </span>
+              ) : null}
               <span className="directory-row__title-wrap">
-                <span className="thread-row__title">{directory.label}</span>
+                <span className="thread-row__title directory-row__title">
+                  {directory.label}
+                </span>
               </span>
             </span>
 
@@ -940,18 +963,20 @@ export function DirectoriesList(props: DirectoriesListProps) {
             </span>
           </button>
 
-          <button
-            aria-label={`Open new thread launchpad for ${directory.label}`}
-            className={`directory-row__launchpad-button${
-              hasPendingLaunchpadState(directory) ? " has-draft" : ""
-            }`}
-            type="button"
-            onClick={() => {
-              void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
-            }}
-          >
-            <NewThreadIcon size={16} />
-          </button>
+          <div className="directory-row__launchpad-cluster">
+            <button
+              aria-label={`Open new thread launchpad for ${directory.label}`}
+              className={`directory-row__launchpad-button${
+                hasPendingLaunchpadState(directory) ? " has-draft" : ""
+              }`}
+              type="button"
+              onClick={() => {
+                void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
+              }}
+            >
+              <NewThreadIcon size={16} />
+            </button>
+          </div>
         </div>
 
             {expanded ? (
@@ -1060,6 +1085,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
+                          onSetThreadPin={props.onSetThreadPin}
 	                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
 	                        />
                               {renderStaticSubthreads(thread)}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -59,6 +59,10 @@ type RecentsListProps = {
     emoji: string,
     present: boolean,
   ) => Promise<void>;
+  onSetThreadPin?: (
+    thread: NavigationThreadSummary,
+    pinned: boolean,
+  ) => Promise<void>;
   onUnbindMessagingBinding?: (
     thread: NavigationThreadSummary,
     binding: MessagingThreadBindingSummary,
@@ -222,6 +226,7 @@ export function RecentsList(props: RecentsListProps) {
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
+              onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           );
@@ -335,6 +340,7 @@ export function RecentsList(props: RecentsListProps) {
           onPrefetchPullRequests={props.onPrefetchPullRequests}
           onSelectThread={props.onSelectThread}
           onSetReaction={props.onSetReaction}
+          onSetThreadPin={props.onSetThreadPin}
           onUnbindMessagingBinding={props.onUnbindMessagingBinding}
         />
         {renderSubthreads(thread)}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -976,6 +976,7 @@ export function Sidebar(props: SidebarProps) {
               onOpenPullRequestContextMenu={openPullRequestContextMenu}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
+              onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : (
@@ -1000,6 +1001,7 @@ export function Sidebar(props: SidebarProps) {
                 onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
                 onSelectThread={props.onSelectThread}
                 onSetReaction={props.onSetThreadReaction}
+                onSetThreadPin={props.onSetThreadPin}
                 onUnbindMessagingBinding={props.onUnbindMessagingBinding}
               />
             )

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { isBranchDrifted } from "@pwragent/shared";
-import { BranchIcon, FolderIcon, PinIcon, TerminalIcon, WorktreeIcon } from "../../icons";
+import { BranchIcon, FolderIcon, TerminalIcon, WorktreeIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText } from "../../lib/copy-text";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -20,6 +20,8 @@ type ThreadMetaChipsProps = {
   queuedMessageState?: ThreadQueuedMessageState;
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
+  /** PR chips slot before the branch so actionable work packs first. */
+  prChips?: ReactNode;
   thread: NavigationThreadSummary;
 };
 
@@ -30,14 +32,9 @@ export function ThreadMetaChips({
   queuedMessageState,
   includeLinkedDirectories = false,
   linkedDirectoryMode = "label",
+  prChips,
   thread,
 }: ThreadMetaChipsProps) {
-  // Hover tooltip for the icon-only pin marker — sighted users get the
-  // "Pinned" label without the old text pill; screen readers get it from
-  // the marker's role="img" + aria-label. Uses the shared viewport
-  // tooltip (not a native `title`) so it escapes the sidebar's clipped
-  // scroll region, matching the copyable branch/path chips.
-  const pinTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const gitStateTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   // Sidebar rows are a clipped scroll region, so a native `title` gets
   // edge-clipped — the viewport tooltip is what the neighbouring chips use.
@@ -95,14 +92,20 @@ export function ThreadMetaChips({
                         : `Copy local path for ${directory.label}`
                     }
                     key={`${thread.id}:${directory.kind}:location-kind`}
-                    className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
+                    className="thread-row__chip thread-row__chip--location path-copy-target tooltip-target"
                     value={
                       directory.kind === "worktree"
                         ? directory.worktreePath ?? directory.path
                         : directory.path
                     }
                   >
-                    {directory.kind}
+                    <span aria-hidden="true" className="thread-row__chip-icon">
+                      {directory.kind === "worktree" ? (
+                        <WorktreeIcon size={12} />
+                      ) : (
+                        <FolderIcon size={12} />
+                      )}
+                    </span>
                   </CopyableThreadChip>
                 ),
               ]),
@@ -150,7 +153,7 @@ export function ThreadMetaChips({
       {queuedMessageState === "scheduled" ? (
         <span
           aria-label="A message is scheduled to send"
-          className="thread-row__chip thread-row__chip--scheduled"
+          className="thread-row__chip thread-row__chip--scheduled thread-row__chip--persistent"
           title="A message is scheduled to send"
         >
           Scheduled
@@ -158,7 +161,7 @@ export function ThreadMetaChips({
       ) : queuedMessageState === "queued" ? (
         <span
           aria-label="A message is queued to send"
-          className="thread-row__chip thread-row__chip--queued"
+          className="thread-row__chip thread-row__chip--queued thread-row__chip--persistent"
           title="A message is queued to send"
         >
           Queued
@@ -203,20 +206,7 @@ export function ThreadMetaChips({
 
       {linkedDirectoryChips}
 
-      {thread.pinnedRank && !thread.parentThreadId ? (
-        <span
-          aria-label="Pinned"
-          role="img"
-          className="thread-row__chip thread-row__chip--pin"
-          onMouseEnter={(event) => pinTooltip.show(event.currentTarget, "Pinned")}
-          onMouseLeave={pinTooltip.hide}
-        >
-          <span aria-hidden="true" className="thread-row__chip-icon">
-            <PinIcon size={12} />
-          </span>
-        </span>
-      ) : null}
-      {pinTooltip.tooltipNode}
+      {prChips}
 
       {branchChip ? (
         <CopyableThreadChip

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -12,7 +12,7 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
-import { SmileyIcon } from "../../icons";
+import { PinIcon, SmileyIcon } from "../../icons";
 import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
@@ -101,6 +101,10 @@ type ThreadRowProps = {
     emoji: string,
     present: boolean,
   ) => Promise<void>;
+  onSetThreadPin?: (
+    thread: NavigationThreadSummary,
+    pinned: boolean,
+  ) => Promise<void>;
   onOpenPullRequest?: (url: string) => void;
 };
 
@@ -115,6 +119,7 @@ export function ThreadRow(props: ThreadRowProps) {
   const addReactionRef = useRef<HTMLSpanElement>(null);
   const reactions = props.thread.reactions ?? [];
   const canReact = Boolean(props.onSetReaction);
+  const onSetThreadPin = props.onSetThreadPin;
   const bindings = props.thread.messagingBindings ?? [];
   // Pull straight from the navigation snapshot — main persists PR state
   // to the overlay store and surfaces it through the snapshot, so the
@@ -212,7 +217,11 @@ export function ThreadRow(props: ThreadRowProps) {
       ) : null}
       <button
         ref={rowButtonRef}
-        aria-label={props.thread.title}
+        aria-label={
+          props.thread.pinnedRank && !props.thread.parentThreadId
+            ? `${props.thread.title}, pinned`
+            : props.thread.title
+        }
         aria-pressed={selected}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
           selected ? " is-selected" : ""
@@ -247,18 +256,22 @@ export function ThreadRow(props: ThreadRowProps) {
           <span className="thread-row__heading">
             <ThreadRowStatus status={status} />
             <span className="thread-row__title">{props.thread.title}</span>
+            {props.thread.pinnedRank && !props.thread.parentThreadId ? (
+              <span aria-hidden="true" className="thread-row__heading-pin">
+                <PinIcon size={11} />
+              </span>
+            ) : null}
           </span>
           <span className="thread-row__time">
             {formatRelativeTime(props.thread.updatedAt)}
           </span>
         </span>
 
-        {/* Single ordered chip flow: meta (provider / location / pinned /
-            branch / drift) → messaging binding chips → PR chips →
-            reactions. Pinned rides with the meta chips so it never lands
-            alone on a wrapped row; PR chips + reactions stay last so the
-            fixed-width metadata packs first and single-chip orphan rows
-            are minimized. flex-wrap handles overflow naturally; the
+        {/* Single ordered chip flow: meta (provider / location → PR chips
+            → branch / drift / git state) → messaging binding chips →
+            reactions. PR chips pack before the longest metadata string;
+            pinned state rides the title line instead of spending a chip.
+            flex-wrap handles overflow naturally; the
             hover-only add-reaction affordance is positioned outside the
             flow so it cannot reserve a phantom wrapped row while hidden. */}
         <span
@@ -273,6 +286,30 @@ export function ThreadRow(props: ThreadRowProps) {
             queuedMessageState={props.queuedMessageThreadKeys?.[threadKey]}
             includeLinkedDirectories={props.includeLinkedDirectories}
             linkedDirectoryMode={props.linkedDirectoryMode}
+            prChips={prs.map((pr) => (
+              <PrChip
+                key={pr.url}
+                pr={pr}
+                showRepoPrefix={needsRepoPrefix(props.thread, pr, prs)}
+                onOpen={openPr}
+                onOpenContextMenu={
+                  props.onOpenPullRequestContextMenu
+                    ? (targetPr, position) =>
+                        props.onOpenPullRequestContextMenu!(
+                          props.thread,
+                          targetPr,
+                          position,
+                        )
+                    : undefined
+                }
+                onDetach={
+                  props.onDetachPullRequest
+                    ? (targetPr) =>
+                        props.onDetachPullRequest!(props.thread, targetPr)
+                    : undefined
+                }
+              />
+            ))}
             thread={props.thread}
           />
 
@@ -284,30 +321,6 @@ export function ThreadRow(props: ThreadRowProps) {
                 props.onUnbindMessagingBinding
                   ? (target) =>
                       void props.onUnbindMessagingBinding!(props.thread, target)
-                  : undefined
-              }
-            />
-          ))}
-
-          {prs.map((pr) => (
-            <PrChip
-              key={pr.url}
-              pr={pr}
-              showRepoPrefix={needsRepoPrefix(props.thread, pr, prs)}
-              onOpen={openPr}
-              onOpenContextMenu={
-                props.onOpenPullRequestContextMenu
-                  ? (targetPr, position) =>
-                      props.onOpenPullRequestContextMenu!(
-                        props.thread,
-                        targetPr,
-                        position,
-                      )
-                  : undefined
-              }
-              onDetach={
-                props.onDetachPullRequest
-                  ? (targetPr) => props.onDetachPullRequest!(props.thread, targetPr)
                   : undefined
               }
             />
@@ -325,6 +338,26 @@ export function ThreadRow(props: ThreadRowProps) {
       </button>
 
       <div className="thread-row__actions">
+        {onSetThreadPin && !props.thread.parentThreadId ? (
+          <button
+            aria-label={
+              props.thread.pinnedRank ? "Unpin thread" : "Pin thread"
+            }
+            aria-pressed={Boolean(props.thread.pinnedRank)}
+            className={`thread-row__pin-button${
+              props.thread.pinnedRank ? " is-pinned" : ""
+            }`}
+            title={props.thread.pinnedRank ? "Unpin thread" : "Pin thread"}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              void onSetThreadPin(props.thread, !props.thread.pinnedRank);
+            }}
+          >
+            <PinIcon size={12} aria-hidden="true" />
+          </button>
+        ) : null}
+
         {canReact ? (
           <AddReactionChip
             anchorRef={addReactionRef}
@@ -410,7 +443,7 @@ function ReactionChip(props: { emoji: string; onToggle: () => void }) {
       role="button"
       tabIndex={0}
       aria-label={`Remove reaction ${emoji} from thread`}
-      className="thread-row__chip thread-row__chip--reaction"
+      className="thread-row__chip thread-row__chip--reaction thread-row__chip--persistent"
       onClick={handleActivate}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1173,9 +1173,17 @@ describe("Sidebar", () => {
       name: /Local cleanup/i,
     });
 
-    expect(within(worktreeThreadButton).getByText("worktree")).toBeInTheDocument();
+    // Location-kind chips are icon-only; their accessible copy target keeps
+    // the local/worktree distinction available without spending row width.
+    expect(
+      within(worktreeThreadButton).getByLabelText("Copy path for worktree PwrAgent"),
+    ).toBeInTheDocument();
+    expect(within(worktreeThreadButton).queryByText("worktree")).not.toBeInTheDocument();
     expect(within(worktreeThreadButton).queryByText("PwrAgent")).not.toBeInTheDocument();
-    expect(within(localThreadButton).getByText("local")).toBeInTheDocument();
+    expect(
+      within(localThreadButton).getByLabelText("Copy local path for PwrAgent"),
+    ).toBeInTheDocument();
+    expect(within(localThreadButton).queryByText("local")).not.toBeInTheDocument();
   });
 
   it("opens the directory launchpad from the plus button", () => {
@@ -1200,11 +1208,19 @@ describe("Sidebar", () => {
       />
     );
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Open new thread launchpad for PwrAgent",
-      })
+    const launchpadButton = screen.getByRole("button", {
+      name: "Open new thread launchpad for PwrAgent",
+    });
+    const launchpadCluster = launchpadButton.closest(
+      ".directory-row__launchpad-cluster",
     );
+    expect(launchpadCluster).not.toBeNull();
+    expect(launchpadCluster?.querySelectorAll("button")).toHaveLength(1);
+    expect(launchpadButton.closest(".directory-row__header")).not.toHaveClass(
+      "directory-row__header--split",
+    );
+
+    fireEvent.click(launchpadButton);
 
     expect(onOpenLaunchpad).toHaveBeenCalledWith(directories[0], undefined);
   });
@@ -1706,8 +1722,8 @@ describe("Sidebar", () => {
     });
     expect(rows[0]).toHaveTextContent("Updated thread");
     expect(
-      within(rows[0]).getByRole("img", { name: "Pinned" }),
-    ).toBeInTheDocument();
+      rows[0]!.querySelector(".thread-row__heading-pin"),
+    ).not.toBeNull();
     expect(screen.getByRole("separator", { name: "Unpinned threads" })).toBeInTheDocument();
 
     const unpinnedRow = within(browseSection as HTMLElement).getByRole("button", {
@@ -1879,9 +1895,12 @@ describe("Sidebar", () => {
     });
     expect(rows[0]).toHaveTextContent("Updated thread");
     expect(
-      within(rows[0]).getByRole("img", { name: "Pinned" }),
-    ).toBeInTheDocument();
+      rows[0]!.querySelector(".thread-row__heading-pin"),
+    ).not.toBeNull();
     expect(rows[1]).toHaveTextContent("Cross-project cleanup");
+    expect(
+      rows[1]!.querySelector(".thread-row__heading-pin"),
+    ).toBeNull();
   });
 
   it("minimizes only unpinned directory threads and restores the sticky state", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -197,6 +197,55 @@ describe("ThreadRow chip flow", () => {
     expect(onUnbindMessagingBinding).not.toHaveBeenCalled();
   });
 
+  it("toggles the pin from the hover actions button without selecting the row", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    const { onSelectThread } = renderRow({
+      thread: {
+        ...baseThread,
+        pinnedRank: "1024",
+        reactions: [],
+      },
+      onSetThreadPin,
+    });
+
+    const pin = screen.getByRole("button", { name: "Unpin thread" });
+    expect(pin).toHaveClass("thread-row__pin-button");
+    expect(pin).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "Chip flow thread, pinned" }),
+    ).toBeInTheDocument();
+    expect(document.querySelector(".thread-row__heading-pin")).not.toBeNull();
+    expect(document.querySelector(".thread-row__chip--pin")).toBeNull();
+
+    fireEvent.click(pin);
+    expect(onSetThreadPin).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "thread-chips" }),
+      false,
+    );
+    expect(onSelectThread).not.toHaveBeenCalled();
+  });
+
+  it("pins an unpinned thread from the same actions button", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    renderRow({
+      thread: {
+        ...baseThread,
+        reactions: [],
+      },
+      onSetThreadPin,
+    });
+
+    const pin = screen.getByRole("button", { name: "Pin thread" });
+    expect(pin).toHaveAttribute("aria-pressed", "false");
+    expect(document.querySelector(".thread-row__heading-pin")).toBeNull();
+
+    fireEvent.click(pin);
+    expect(onSetThreadPin).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "thread-chips" }),
+      true,
+    );
+  });
+
   it("does not invoke onSelectThread when the add-reaction smiley is clicked", () => {
     const { container, onSelectThread } = renderRow();
     const addReaction = container.querySelector(
@@ -383,14 +432,17 @@ describe("ThreadRow chip flow", () => {
     // ThreadMetaChips internals.
     const indexOf = (selector: string): number =>
       chipNodes.findIndex((el) => el.matches(selector) || el.querySelector(selector) !== null);
-    const prIdx = indexOf(".thread-row__chip--pr, [data-pr-chip]");
+    const prIdx = indexOf(".pr-chip");
+    const branchIdx = indexOf(".thread-row__chip--mono");
     const bindingIdx = indexOf(".thread-row__chip--binding, .thread-row__chip-wrap");
     const reactionIdx = indexOf(".thread-row__chip--reaction");
-    // Each chip type that's present comes after the previous one. Messaging
-    // bindings sit before PR chips so fixed-width metadata packs first and
-    // the variable-count PR + reaction chips trail at the end.
-    if (bindingIdx >= 0 && prIdx >= 0) expect(bindingIdx).toBeLessThan(prIdx);
-    if (prIdx >= 0 && reactionIdx >= 0) expect(prIdx).toBeLessThan(reactionIdx);
+    // Actionable PRs pack before the long branch string; bindings and
+    // reactions continue to trail the shared metadata flow.
+    if (prIdx >= 0 && branchIdx >= 0) expect(prIdx).toBeLessThan(branchIdx);
+    if (branchIdx >= 0 && bindingIdx >= 0) expect(branchIdx).toBeLessThan(bindingIdx);
+    if (bindingIdx >= 0 && reactionIdx >= 0) {
+      expect(bindingIdx).toBeLessThan(reactionIdx);
+    }
   });
 
   it("shows the PR title and status in the shared hover card", () => {

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -44,6 +44,7 @@ import {
   FeishuIcon,
   LineIcon,
   MattermostIcon,
+  PinIcon,
   SlackIcon,
   TelegramIcon,
 } from "../../icons";
@@ -2858,14 +2859,14 @@ function ChoiceCard(props: {
    ---------------------------------------------------------------- */
 
 /* Mini ThreadRow chips — composed to mirror the live ThreadRow primitive:
-   - .mini-chip-pin renders the "Pinned" pill (accent-bordered, accent text)
+   - .mini-pin renders the in-title pin marker
    - .mini-chip-pr renders the "#123" PR pill (dot + number)
    - .mini-chip-meta renders the gray-fill chips (OpenAI / PwrAgnt / branch)
    Compact mode keeps Pin + PR + emoji; Mission Control adds the meta row. */
 function MiniPinChip() {
   return (
-    <span className="onboarding-wizard__mini-chip onboarding-wizard__mini-chip--pin">
-      Pinned
+    <span aria-hidden="true" className="onboarding-wizard__mini-pin">
+      <PinIcon size={9} />
     </span>
   );
 }
@@ -2953,32 +2954,32 @@ function DensityMissionControlPreview() {
     <div className="onboarding-wizard__mini">
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc is-active">
         <span className="onboarding-wizard__mini-title">PwrAgent - Release</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">2h</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>📁 PwrAgnt</MiniMetaChip>
           <MiniMetaChip>⌥ main</MiniMetaChip>
-          <MiniPinChip />
         </div>
       </div>
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
         <span className="onboarding-wizard__mini-title">PwrSnap - Release</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">May 7</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>📁 PwrSnap</MiniMetaChip>
           <MiniMetaChip>⌥ main</MiniMetaChip>
-          <MiniPinChip />
         </div>
       </div>
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
         <span className="onboarding-wizard__mini-title">Text Mode for Button Platforms</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">2d</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>⌥ PwrAgnt</MiniMetaChip>
           <MiniMetaChip>⌥ feat/messaging-text-mode</MiniMetaChip>
-          <MiniPinChip />
           <MiniPrChip num="352" status="ok" />
           <span className="onboarding-wizard__mini-emoji">👀</span>
         </div>
@@ -2986,12 +2987,12 @@ function DensityMissionControlPreview() {
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
         <span className="onboarding-wizard__mini-cookie" />
         <span className="onboarding-wizard__mini-title">Automation scheduling system</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">2d</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>⌥ PwrAgnt</MiniMetaChip>
           <MiniMetaChip>⌥ feat/automation</MiniMetaChip>
-          <MiniPinChip />
           <MiniPrChip num="376" status="ok" />
           <span className="onboarding-wizard__mini-emoji">🏃</span>
         </div>

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -2953,8 +2953,10 @@ function DensityMissionControlPreview() {
   return (
     <div className="onboarding-wizard__mini">
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc is-active">
-        <span className="onboarding-wizard__mini-title">PwrAgent - Release</span>
-        <MiniPinChip />
+        <span className="onboarding-wizard__mini-heading">
+          <span className="onboarding-wizard__mini-title">PwrAgent - Release</span>
+          <MiniPinChip />
+        </span>
         <span className="onboarding-wizard__mini-time">2h</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
@@ -2963,8 +2965,10 @@ function DensityMissionControlPreview() {
         </div>
       </div>
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
-        <span className="onboarding-wizard__mini-title">PwrSnap - Release</span>
-        <MiniPinChip />
+        <span className="onboarding-wizard__mini-heading">
+          <span className="onboarding-wizard__mini-title">PwrSnap - Release</span>
+          <MiniPinChip />
+        </span>
         <span className="onboarding-wizard__mini-time">May 7</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
@@ -2973,8 +2977,10 @@ function DensityMissionControlPreview() {
         </div>
       </div>
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
-        <span className="onboarding-wizard__mini-title">Text Mode for Button Platforms</span>
-        <MiniPinChip />
+        <span className="onboarding-wizard__mini-heading">
+          <span className="onboarding-wizard__mini-title">Text Mode for Button Platforms</span>
+          <MiniPinChip />
+        </span>
         <span className="onboarding-wizard__mini-time">2d</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
@@ -2985,9 +2991,11 @@ function DensityMissionControlPreview() {
         </div>
       </div>
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
-        <span className="onboarding-wizard__mini-cookie" />
-        <span className="onboarding-wizard__mini-title">Automation scheduling system</span>
-        <MiniPinChip />
+        <span className="onboarding-wizard__mini-heading">
+          <span className="onboarding-wizard__mini-cookie" />
+          <span className="onboarding-wizard__mini-title">Automation scheduling system</span>
+          <MiniPinChip />
+        </span>
         <span className="onboarding-wizard__mini-time">2d</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -17,6 +17,7 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import type {
   AppearanceController,
   DensityPreference,
+  SidebarTextSizePreference,
   ThemePreference,
 } from "../../lib/useAppearance";
 import {
@@ -49,7 +50,18 @@ const DENSITY_OPTIONS: Array<{
     meta: "Full thread chips",
     value: "mission-control",
   },
-  { label: "Compact", meta: "Chips hidden", value: "compact" },
+  { label: "Compact", meta: "Metadata chips hidden", value: "compact" },
+];
+
+const SIDEBAR_TEXT_SIZE_OPTIONS: Array<{
+  label: string;
+  value: SidebarTextSizePreference;
+}> = [
+  { label: "XS", value: "xs" },
+  { label: "S", value: "sm" },
+  { label: "M", value: "md" },
+  { label: "L", value: "lg" },
+  { label: "XL", value: "xl" },
 ];
 
 const PASTED_IMAGE_PATCH_OPTIONS: Array<{
@@ -457,13 +469,13 @@ export function GeneralSettings(props: {
               }
             />
             <SettingsField
-              label="Density"
-              sub="Compact hides the directory and PR chips in thread rows so more threads fit on screen. Reaction and pin markers stay visible."
+              label="Info density"
+              sub="Compact hides the provider, directory, and branch chips in thread rows so more threads fit on screen. PR chips, reactions, and pin markers stay visible."
               control={
                 <div
                   className="settings-segmented"
                   role="radiogroup"
-                  aria-label="Density"
+                  aria-label="Info density"
                 >
                   {DENSITY_OPTIONS.map((option) => (
                     <button
@@ -482,6 +494,40 @@ export function GeneralSettings(props: {
                       <span className="settings-segmented__meta">
                         {option.meta}
                       </span>
+                    </button>
+                  ))}
+                </div>
+              }
+            />
+            <SettingsField
+              label="Sidebar text size"
+              sub="Scales the thread and directory titles in the left sidebar. M is the tuned default; each notch moves the titles one pixel."
+              control={
+                <div
+                  className="settings-segmented"
+                  role="radiogroup"
+                  aria-label="Sidebar text size"
+                >
+                  {SIDEBAR_TEXT_SIZE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      aria-checked={
+                        appearance.sidebarTextSize === option.value
+                      }
+                      className={`settings-segmented__button${
+                        appearance.sidebarTextSize === option.value
+                          ? " is-active"
+                          : ""
+                      }`}
+                      role="radio"
+                      type="button"
+                      onClick={() => {
+                        props.appearanceController?.setSidebarTextSize(
+                          option.value,
+                        );
+                      }}
+                    >
+                      {option.label}
                     </button>
                   ))}
                 </div>

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -122,6 +122,7 @@ function createSnapshot(
       appearance: {
         theme: { value: "system", source: "default" },
         density: { value: "mission-control", source: "default" },
+        sidebarTextSize: { value: "md", source: "default" },
       },
       codexProfileModel: { value: "shared", source: "default" },
       messagingAcknowledgment: { value: null, source: "default" },

--- a/apps/desktop/src/renderer/src/lib/appearance.ts
+++ b/apps/desktop/src/renderer/src/lib/appearance.ts
@@ -5,13 +5,14 @@
  * block, owned by the main process. The desktop-settings-service
  * resolves it into `DesktopSettingsSnapshot.general.appearance`, the
  * renderer reads it through the existing settings IPC, and writes back
- * via `writeSettingsConfig({ general: { appearance: { theme, density } } })`.
+ * via `writeSettingsConfig({ general: { appearance: { theme, density,
+ * sidebarTextSize } } })`.
  *
  * The flash-of-wrong-theme path is:
  *   main `readBootstrapAppearance` (sync file read)
  *     → BrowserWindow `additionalArguments`
  *     → preload `contextBridge.exposeInMainWorld("__pwragentAppearance", …)`
- *     → inline `<script>` in index.html sets `<html data-theme/data-density>`
+ *     → inline `<script>` in index.html sets appearance data attributes
  *     → React mounts with attributes already in place.
  *
  * This file only owns the *runtime* helpers that the React hook uses to
@@ -22,24 +23,30 @@
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
 } from "@pwragent/shared";
 import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  isDesktopSidebarTextSize,
 } from "@pwragent/shared";
 
 export type ThemePreference = DesktopAppearanceTheme;
 export type DensityPreference = DesktopAppearanceDensity;
+export type SidebarTextSizePreference = DesktopSidebarTextSize;
 export type ResolvedTheme = "dark" | "light";
 
 export type AppearancePreference = {
   theme: ThemePreference;
   density: DensityPreference;
+  sidebarTextSize: SidebarTextSizePreference;
 };
 
 export const DEFAULT_APPEARANCE: AppearancePreference = {
   theme: DESKTOP_APPEARANCE_THEME_DEFAULT,
   density: DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+  sidebarTextSize: DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
 };
 
 /** Resolve `"system"` to either `"dark"` or `"light"` by querying the
@@ -64,6 +71,7 @@ export function resolveTheme(preference: ThemePreference): ResolvedTheme {
 export function applyAppearanceAttributes(
   resolvedTheme: ResolvedTheme,
   density: DensityPreference,
+  sidebarTextSize: SidebarTextSizePreference,
 ): void {
   if (typeof document === "undefined") return;
   const root = document.documentElement;
@@ -76,6 +84,11 @@ export function applyAppearanceAttributes(
     root.setAttribute("data-density", "compact");
   } else {
     root.removeAttribute("data-density");
+  }
+  if (sidebarTextSize !== DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT) {
+    root.setAttribute("data-sidebar-text", sidebarTextSize);
+  } else {
+    root.removeAttribute("data-sidebar-text");
   }
 }
 
@@ -94,6 +107,7 @@ export function readBridgedAppearance(): AppearancePreference {
   return {
     theme: normalizeTheme(bridged?.theme),
     density: normalizeDensity(bridged?.density),
+    sidebarTextSize: normalizeSidebarTextSize(bridged?.sidebarTextSize),
   };
 }
 
@@ -107,4 +121,10 @@ function normalizeDensity(value: unknown): DensityPreference {
   return value === "compact" || value === "mission-control"
     ? value
     : DEFAULT_APPEARANCE.density;
+}
+
+function normalizeSidebarTextSize(value: unknown): SidebarTextSizePreference {
+  return typeof value === "string" && isDesktopSidebarTextSize(value)
+    ? value
+    : DEFAULT_APPEARANCE.sidebarTextSize;
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -221,6 +221,7 @@ import type {
   DeleteDesktopPwrAgentProfileResponse,
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
   DesktopMessagingContactLookupRequest,
   DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
@@ -765,10 +766,10 @@ export type DesktopApi = {
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
   /**
    * Subscription for main → renderer appearance broadcasts. Fired
-   * whenever the user changes theme or density in Settings → the
+   * whenever the user changes appearance in Settings → the
    * write fans out to every open window so secondary surfaces
    * (changelog, app-log, license, messaging activity) can re-apply
-   * `<html data-theme/data-density>` live instead of staying stuck on
+   * `<html data-*>` appearance attributes live instead of staying stuck on
    * their bootstrap-time value. The renderer's `useAppearance` hook
    * subscribes for React state; `main.tsx` also subscribes for a bare
    * DOM update so aux windows without React-Appearance follow along.
@@ -777,6 +778,7 @@ export type DesktopApi = {
     callback: (appearance: {
       theme: DesktopAppearanceTheme;
       density: DesktopAppearanceDensity;
+      sidebarTextSize: DesktopSidebarTextSize;
     }) => void,
   ) => () => void;
   onCodexEnvironmentSetupProgress?: (

--- a/apps/desktop/src/renderer/src/lib/useAppearance.ts
+++ b/apps/desktop/src/renderer/src/lib/useAppearance.ts
@@ -9,6 +9,7 @@ import {
   type AppearancePreference,
   type DensityPreference,
   type ResolvedTheme,
+  type SidebarTextSizePreference,
   type ThemePreference,
 } from "./appearance";
 
@@ -21,6 +22,7 @@ export type AppearanceController = {
   appearance: AppearanceState;
   setTheme(theme: ThemePreference): void;
   setDensity(density: DensityPreference): void;
+  setSidebarTextSize(sidebarTextSize: SidebarTextSizePreference): void;
   setAppearance(preference: AppearancePreference): void;
 };
 
@@ -72,6 +74,7 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
       if (
         current.theme === snapshotPreference.theme
         && current.density === snapshotPreference.density
+        && current.sidebarTextSize === snapshotPreference.sidebarTextSize
       ) {
         return current;
       }
@@ -80,14 +83,22 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
         resolvedTheme: resolveTheme(snapshotPreference.theme),
       };
     });
-  }, [snapshotPreference?.theme, snapshotPreference?.density]);
+  }, [
+    snapshotPreference?.theme,
+    snapshotPreference?.density,
+    snapshotPreference?.sidebarTextSize,
+  ]);
 
   // Apply DOM attributes whenever the resolved appearance changes. No
   // localStorage cache to maintain — the source of truth is TOML, the
   // synchronous first-paint hint is the preload-bridged value.
   useEffect(() => {
-    applyAppearanceAttributes(appearance.resolvedTheme, appearance.density);
-  }, [appearance.resolvedTheme, appearance.density]);
+    applyAppearanceAttributes(
+      appearance.resolvedTheme,
+      appearance.density,
+      appearance.sidebarTextSize,
+    );
+  }, [appearance.resolvedTheme, appearance.density, appearance.sidebarTextSize]);
 
   // Subscribe to prefers-color-scheme changes so `theme: "system"` flips
   // live when the OS theme changes. Unsubscribe on unmount.
@@ -124,9 +135,13 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
   }, [writeConfig]);
 
   const persist = useCallback(
-    (theme: ThemePreference, density: DensityPreference) => {
+    (
+      theme: ThemePreference,
+      density: DensityPreference,
+      sidebarTextSize: SidebarTextSizePreference,
+    ) => {
       void writeConfigRef.current({
-        general: { appearance: { theme, density } },
+        general: { appearance: { theme, density, sidebarTextSize } },
       });
     },
     [],
@@ -136,7 +151,7 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
     (theme: ThemePreference) => {
       setAppearanceState((current) => {
         if (current.theme === theme) return current;
-        persist(theme, current.density);
+        persist(theme, current.density, current.sidebarTextSize);
         return {
           ...current,
           theme,
@@ -151,10 +166,24 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
     (density: DensityPreference) => {
       setAppearanceState((current) => {
         if (current.density === density) return current;
-        persist(current.theme, density);
+        persist(current.theme, density, current.sidebarTextSize);
         return {
           ...current,
           density,
+        };
+      });
+    },
+    [persist],
+  );
+
+  const setSidebarTextSize = useCallback(
+    (sidebarTextSize: SidebarTextSizePreference) => {
+      setAppearanceState((current) => {
+        if (current.sidebarTextSize === sidebarTextSize) return current;
+        persist(current.theme, current.density, sidebarTextSize);
+        return {
+          ...current,
+          sidebarTextSize,
         };
       });
     },
@@ -167,10 +196,15 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
         if (
           current.theme === preference.theme
           && current.density === preference.density
+          && current.sidebarTextSize === preference.sidebarTextSize
         ) {
           return current;
         }
-        persist(preference.theme, preference.density);
+        persist(
+          preference.theme,
+          preference.density,
+          preference.sidebarTextSize,
+        );
         return {
           ...preference,
           resolvedTheme: resolveTheme(preference.theme),
@@ -184,9 +218,15 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
     appearance,
     setTheme,
     setDensity,
+    setSidebarTextSize,
     setAppearance,
   };
 }
 
 export { DEFAULT_APPEARANCE };
-export type { ThemePreference, DensityPreference, ResolvedTheme };
+export type {
+  ThemePreference,
+  DensityPreference,
+  ResolvedTheme,
+  SidebarTextSizePreference,
+};

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
 } from "@pwragent/shared";
 import { App } from "./App";
 import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
@@ -19,7 +20,7 @@ const performancePruning = import.meta.env.DEV
 // Subscribe to main → renderer appearance broadcasts. Every window
 // (including secondary surfaces like changelog, app-log, license,
 // messaging activity) listens here so when the user changes theme or
-// density in Settings, the active <html data-theme/data-density>
+// appearance in Settings, the active <html data-*> attributes
 // attributes update everywhere instead of staying stuck on whatever
 // the window bootstrapped with at creation. The main window's
 // useAppearance hook also re-applies via its own React state path,
@@ -35,6 +36,7 @@ const desktopApi = (
         callback: (appearance: {
           theme: DesktopAppearanceTheme;
           density: DesktopAppearanceDensity;
+          sidebarTextSize: DesktopSidebarTextSize;
         }) => void,
       ) => () => void;
       onWindowFullscreen?: (
@@ -59,6 +61,7 @@ const unsubscribeAppearance = desktopApi?.onAppearanceChanged?.(
     applyAppearanceAttributes(
       resolveTheme(appearance.theme),
       appearance.density,
+      appearance.sidebarTextSize,
     );
   },
 );

--- a/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
@@ -8,8 +8,8 @@ import { describe, expect, it } from "vitest";
  * expand/collapse chevron must point RIGHT when collapsed (`rotate(-45deg)`)
  * and rotate 90deg to point DOWN when expanded (`rotate(45deg)`). The
  * direction lives entirely in CSS, so it can only be asserted here, not in
- * a render test. The sidebar thread-tree triangle is a deliberate FILLED
- * exception and is asserted separately.
+ * a render test. The sidebar tree is a deliberate FILLED-triangle family
+ * and is asserted separately.
  */
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
@@ -50,11 +50,6 @@ const INLINE_CHEVRONS: Array<{ name: string; collapsed: string; expanded: string
       '.transcript-work-phase-group__toggle[aria-expanded="true"] .transcript-work-phase-group__chevron',
   },
   {
-    name: "sidebar directory header",
-    collapsed: ".directory-row__chevron",
-    expanded: ".directory-row__chevron.is-open",
-  },
-  {
     name: "settings section header",
     collapsed: ".settings-panel--is-collapsed .settings-section__chevron::before",
     expanded: ".settings-section__chevron::before",
@@ -75,7 +70,6 @@ const INLINE_CHEVRONS: Array<{ name: string; collapsed: string; expanded: string
 const UNFILLED_BASE_RULES = [
   ".transcript-activity__chevron",
   ".transcript-work-phase-group__chevron",
-  ".directory-row__chevron",
   ".settings-section__chevron::before",
   ".live-work-rail__chevron",
 ];
@@ -114,11 +108,18 @@ describe("chevron disclosure direction contract", () => {
     expect(css).not.toContain("rotate(225deg)");
   });
 
-  it("keeps the sidebar thread-tree as a deliberate FILLED-triangle exception", () => {
-    // Intentionally NOT the unfilled -45/45 language: filled = navigation
-    // tree, unfilled = inline content disclosure. A solid triangle via
-    // border-left that swings 0 -> 90deg.
-    expect(ruleBody(".thread-row__subthread-toggle::before")).toContain("border-left");
-    expect(ruleBody(".thread-row__subthread-toggle.is-open::before")).toContain("rotate(90deg)");
+  it("keeps the sidebar as one deliberate FILLED-triangle family", () => {
+    for (const [base, open] of [
+      [".thread-row__subthread-toggle::before", ".thread-row__subthread-toggle.is-open::before"],
+      [".directory-row__chevron", ".directory-row__chevron.is-open"],
+      [
+        ".directory-row__thread-divider-chevron",
+        ".directory-row__thread-divider-chevron.is-open",
+      ],
+    ] as const) {
+      expect(ruleBody(base), `${base} filled caret`).toContain("border-left");
+      expect(ruleBody(base), `${base} filled caret`).not.toContain("border-right");
+      expect(ruleBody(open), `${open} swing`).toContain("rotate(90deg)");
+    }
   });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -18550,8 +18550,21 @@ a.transcript-message__messaging-origin:focus-visible {
   gap: 4px 8px;
   padding: 8px 8px 9px;
 }
+.onboarding-wizard__mini-row--mc .onboarding-wizard__mini-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 2px;
+  grid-column: 1;
+  grid-row: 1;
+}
+.onboarding-wizard__mini-row--mc .onboarding-wizard__mini-time {
+  grid-column: 2;
+  grid-row: 1;
+}
 .onboarding-wizard__mini-row--mc .onboarding-wizard__mini-meta {
   grid-column: 1 / -1;
+  grid-row: 2;
   display: flex;
   flex-wrap: wrap;
   gap: 4px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -190,6 +190,11 @@
      that defeat scanning. Themes / future surfaces can override
      this single token to retune both surfaces in lockstep. */
   --chat-column-max: 940px;
+
+  /* Sidebar title size — user-adjustable from Settings. Thread titles
+     read it directly; directory labels derive from it so hierarchy holds
+     at every notch. */
+  --sidebar-title-size: 13px;
 }
 
 /* ===========================================================================
@@ -350,72 +355,51 @@
    The default :root values target Mission Control behavior; the explicit
    data-density attribute selector only carries overrides.
    =========================================================================== */
-/* Suppress directory / PR / agent / binding chips in the list. Reaction
-   and pin markers stay visible — reactions because they're user-curated
-   signals, pin because the pin marker on its own is information-dense.
-   The "Scheduled"/"Queued" pending-send chips also stay visible: a pending
-   outbound message is a time-sensitive commitment the operator needs to
-   spot at a glance, so it survives the density strip like the pin marker.
+/* Suppress descriptive metadata chips in the list. Reactions and PR chips
+   stay visible because they are user-curated or actionable work product.
+   Time-sensitive chips mark themselves `--persistent` in TSX and survive
+   the density strip. Pinned state rides the title line instead of a chip.
 
    Scope the rule to `.thread-row__chips` so non-list surfaces that
    carry a `.thread-row__chip--*` variant (e.g. the questionnaire's mode
    chip in the transcript) don't get collapsed when compact density is
    on. The skill chip in the composer and the standalone SkillChip use
    `.chip` directly and aren't affected by this rule. */
-:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--pin):not(.thread-row__chip--scheduled):not(.thread-row__chip--queued) {
+:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--persistent) {
   display: none;
 }
 
 :root[data-density="compact"] .thread-row__chips {
-  /* Tighter inter-chip gap when only reactions + pin remain visible. */
+  /* Tighter inter-chip gap when only reactions + PRs remain visible. */
   gap: 4px;
 }
 
-/* Shrink the icon-only pin marker a touch in Compact so it tracks the
-   denser rows (the marker itself already replaced the old "Pinned"
-   pill — see `.thread-row__chip--pin`). */
-:root[data-density="compact"] .thread-row__chip--pin {
-  height: 18px;
-  min-width: 18px;
-  padding: 0 4px;
-}
-
-/* Tighten thread-row vertical real estate. The row keeps its column
-   layout (title row → chips row when chips remain), but every vertical
-   measurement shrinks. The hidden-chips selector zeroes the column gap
-   for rows where every chip is suppressed — :has() lets us detect
-   "container has at least one visible chip" without JS. */
+/* Both densities share the tuned 4px block padding. Compact differs only
+   in what it shows and keeps the slightly larger left title inset. */
 :root[data-density="compact"] .thread-row {
   gap: 4px;
-  padding: 6px 10px 6px 12px;
+  padding-left: 12px;
 }
 
-/* Pull the overflow + add-reaction buttons up by the same amount the row
-   shrank its top padding, so they keep aligning with the title line
-   instead of sinking toward the row's geometric center on short
-   single-line rows. .thread-row__actions is a SIBLING of .thread-row
-   under .thread-row-shell, so the override targets it directly. */
-:root[data-density="compact"] .thread-row__actions {
-  top: 3px;
-}
-
-/* Mirror the .thread-row__actions compact shift for the sub-thread toggle:
-   compact rows pad 6px (vs 8px), so the title line — and the toggle that
-   centers on it — moves up 2px (9px -> 7px). */
-:root[data-density="compact"] .thread-row__subthread-toggle {
-  top: 7px;
-}
-
-:root[data-density="compact"] .thread-row:not(:has(.thread-row__chip--reaction)):not(:has(.thread-row__chip--pin)) {
+:root[data-density="compact"] .thread-row:not(:has(.thread-row__chip--persistent)):not(:has(.pr-chip)) {
   gap: 0;
 }
 
-/* Pull the inter-row gap in tight so the list reads as a scannable
-   index, not a card stack. The section divider (.recents-pinned-divider)
-   keeps its own vertical breathing room. */
-:root[data-density="compact"] .sidebar-list,
-:root[data-density="compact"] .directory-groups {
-  gap: 2px;
+/* Sidebar title-size notches. "md" is carried by the bare :root token. */
+:root[data-sidebar-text="xs"] {
+  --sidebar-title-size: 11px;
+}
+
+:root[data-sidebar-text="sm"] {
+  --sidebar-title-size: 12px;
+}
+
+:root[data-sidebar-text="lg"] {
+  --sidebar-title-size: 14px;
+}
+
+:root[data-sidebar-text="xl"] {
+  --sidebar-title-size: 15px;
 }
 
 /* Thin, themed scrollbars on every scroll container — sidebar,
@@ -2941,6 +2925,11 @@ textarea,
   outline-offset: -2px;
 }
 
+/* Focused cards paint their ring above a neighbouring selected card. */
+.thread-row:focus {
+  z-index: 2;
+}
+
 .button--ghost {
   border-color: var(--border-subtle);
   background: transparent;
@@ -2984,11 +2973,9 @@ textarea,
 .directory-groups {
   display: flex;
   flex-direction: column;
-  /* Tightened from 8px in the Mission Control density pass. Rows are
-     borderless here, so the gap is pure separation — 4px reads as a
-     scannable index without the cards merging. Compact density drops
-     this further (see the density block). */
-  gap: 4px;
+  /* One tight rhythm in both densities; density controls information,
+     not the card's surrounding air. */
+  gap: 2px;
   padding: 12px 0 16px;
 }
 
@@ -3077,18 +3064,13 @@ textarea,
    subthread-list connector). Previously the whole card was padded 30px,
    which made parents look nested. */
 .thread-row-shell.has-subthreads .thread-row__heading {
-  padding-left: 20px;
+  padding-left: 14px;
 }
 
 .thread-row__subthread-toggle {
   position: absolute;
-  /* Center the toggle on the title's FIRST line, not the row's geometric
-     center — same anchoring as .thread-row__actions, whose 26px button is
-     topped at 5px so its midpoint lands on the ~18px title-line midpoint
-     (8px row padding-top + ~9px into the 15px/1.25 line box). The toggle is
-     18px tall, so top = 18 - 9 = 9. Compact density shifts this up 2px (see
-     the density-compact block) to track its 6px top padding. */
-  top: 9px;
+  /* Follow the user-adjustable title's first-line midpoint. */
+  top: round(calc(4px + (var(--sidebar-title-size) * 1.25 + 2px) / 2 - 9px), 1px);
   left: 8px;
   z-index: 4;
   display: grid;
@@ -3194,14 +3176,11 @@ textarea,
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   width: 100%;
-  /* Tightened from `12px 12px 12px 14px` in the Mission Control density
-     pass. With the lane's 8px inline padding this leaves ~18px of text
-     inset on each side; 8px block padding + the 4px row gap give ~20px
-     text-to-text between rows. (`.thread-row__actions` top is kept in
-     step with the block padding — see that rule.) */
-  padding: 8px 10px;
+  /* 4px block padding plus the 2px list gap yields a dense, stable
+     operator queue in both information-density modes. */
+  padding: 4px 10px;
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
@@ -3286,16 +3265,8 @@ textarea,
 
 .thread-row__actions {
   position: absolute;
-  /* Align the overflow button + add-reaction chip with the title line,
-     not the row's geometric center. The 26-px-tall button sits a few
-     pixels into the row's top padding so its vertical midpoint matches
-     the title's line midpoint. When the row is multi-line (chips
-     present) the title is still the FIRST line, so the same offset
-     keeps the button anchored to it. Offset tracks the row's top padding
-     (`top ≈ padding-top − 3`): Mission Control rows pad 8px → 5px here;
-     the Compact density variant overrides this `top` to 3px (see the
-     density-compact block at the top of the file) for its 6px padding. */
-  top: 5px;
+  /* Follow the user-adjustable title's first-line midpoint. */
+  top: round(calc(4px + (var(--sidebar-title-size) * 1.25 + 2px) / 2 - 13px), 1px);
   right: 9px;
   z-index: 3;
   display: flex;
@@ -3304,10 +3275,10 @@ textarea,
   pointer-events: none;
 }
 
+.thread-row__pin-button,
 .thread-row__overflow-button {
   position: static;
   display: grid;
-  width: 30px;
   height: 26px;
   place-items: center;
   padding: 0;
@@ -3315,8 +3286,6 @@ textarea,
   border-radius: 6px;
   background: var(--bg-panel-elevated);
   color: var(--text-secondary);
-  font-size: 15px;
-  font-weight: 700;
   line-height: 1;
   opacity: 0;
   pointer-events: none;
@@ -3327,6 +3296,13 @@ textarea,
     opacity 120ms ease;
 }
 
+.thread-row__overflow-button {
+  width: 30px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.thread-row-shell:has(.thread-row__pin-button:focus-visible) .thread-row__time,
 .thread-row-shell:hover .thread-row__time,
 .thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time,
 .thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row__time,
@@ -3334,12 +3310,16 @@ textarea,
   opacity: 0;
 }
 
+.thread-row-shell:hover .thread-row__pin-button,
+.thread-row__pin-button:focus-visible,
 .thread-row-shell:hover .thread-row__overflow-button,
 .thread-row__overflow-button:focus-visible {
   opacity: 1;
   pointer-events: auto;
 }
 
+.thread-row__pin-button:hover,
+.thread-row__pin-button:focus-visible,
 .thread-row__overflow-button:hover,
 .thread-row__overflow-button:focus-visible {
   border-color: var(--accent-border);
@@ -3571,8 +3551,15 @@ textarea,
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 8px;
+  gap: 2px;
   flex: 1 1 auto;
+}
+
+.thread-row__heading-pin {
+  display: inline-flex;
+  flex: 0 0 auto;
+  margin-left: 2px;
+  color: var(--accent-bright);
 }
 
 .thread-row__title,
@@ -3586,19 +3573,8 @@ textarea,
 
 .thread-row__title {
   padding-bottom: 2px;
-  /* Sidebar readability tune (issue #240 follow-up). The default
-     sidebar is 408px wide and resizes up to 560px in this app;
-     internal feedback noted that the previous 14/600 felt thin and
-     hard to read against the near-black panel at those widths. The
-     v2 design preview uses 13/600, but its sidebar is only 320px
-     wide — narrower than ours and built for a denser layout. We
-     err toward our wider canvas: 15/650 reads as a clear
-     scannable list-row title without going full Bold (700) which
-     would pull focus from the active thread's accent treatment.
-     Titles average 5-6 words so the extra px doesn't push them to
-     wrap. */
-  font-size: 15px;
-  font-weight: 650;
+  font-size: var(--sidebar-title-size);
+  font-weight: 600;
   line-height: 1.25;
 }
 
@@ -3630,12 +3606,13 @@ textarea,
   align-items: center;
   justify-content: center;
   flex: 0 0 16px;
+  transform: translateY(-1px);
 }
 
 .thread-row__status-cookie {
   display: block;
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border: 1px solid var(--accent-border);
   border-radius: 999px;
   background:
@@ -3695,6 +3672,23 @@ textarea,
   white-space: nowrap;
 }
 
+/* Sidebar chips run one step smaller than the shared pill primitive. */
+.thread-row__chips .thread-row__chip {
+  height: 20px;
+  gap: 5px;
+  font-size: 11px;
+}
+
+.thread-row__chips .pr-chip {
+  height: 20px;
+}
+
+.thread-row__chip--location {
+  min-width: 20px;
+  justify-content: center;
+  padding: 0 5px;
+}
+
 .thread-row__chip.thread-row__chip--reaction {
   min-width: 24px;
   justify-content: center;
@@ -3742,17 +3736,13 @@ textarea,
   font-weight: 600;
 }
 
-/* Pin marker — an icon-only orange pill. The pushpin glyph + the accent
-   tint carry the "pinned" signal without spending a word of row width;
-   the literal label lives in aria-label / title for assistive tech and
-   hover. Square-ish (min-width == height) so it reads as a marker, not a
-   text chip. */
-.thread-row__chip--pin {
-  min-width: 24px;
-  justify-content: center;
-  padding: 0 6px;
-  border: 1px solid var(--accent-border);
-  background: var(--accent-soft);
+/* Pin action sits beside the row's other hover-revealed controls. */
+.thread-row__pin-button {
+  width: 26px;
+}
+
+.thread-row__pin-button.is-pinned {
+  border-color: var(--accent-border);
   color: var(--accent-bright);
 }
 
@@ -4360,12 +4350,7 @@ textarea,
      section instead of only the sticky header. Plan 2026-05-09-002
      Unit K follow-up. */
   position: relative;
-  padding: 4px 0 0;
-  border-top: 1px solid var(--border-subtle);
-}
-
-.directory-row:first-child {
-  border-top: 0;
+  padding: 2px 0 0;
 }
 
 .directory-row__header {
@@ -4373,11 +4358,8 @@ textarea,
   position: sticky;
   top: 0;
   z-index: 5;
-  /* Gap between summary button and launchpad icon button. Tightened
-     from 8 → 4 — the icon button itself lost its border (no longer
-     reads as a separate "card" the way the framed 34px button did). */
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 4px;
+  /* The hover-revealed launchpad cluster overlays this single column. */
+  grid-template-columns: minmax(0, 1fr);
   align-items: center;
   background: var(--bg-sidebar);
 }
@@ -4470,12 +4452,7 @@ textarea,
      12 → 8 since the meta block now sits tighter against the
      scrollbar gutter. */
   gap: 8px;
-  /* Row height tightened 44 → 32. Was set to match the masthead's
-     44px button height, but rows are list entries and don't need
-     that same hit-target generosity. Combined with the row top
-     padding drop, each directory header now reads ~22px taller
-     than the comfortable touch target instead of 54px. */
-  min-height: 32px;
+  min-height: 24px;
   /* Lateral inset: 4px on the left sits before the disclosure chevron
      and folder icon; 10px on the right gives the meta block (attention
      count pill) breathing room from the selected-row border. */
@@ -4496,13 +4473,14 @@ textarea,
 }
 
 .directory-row__summary-main {
-  gap: 8px;
+  gap: 5px;
 }
 
 .directory-row__summary-meta {
   flex: 0 0 auto;
   gap: 10px;
   justify-content: flex-end;
+  transition: opacity 120ms ease;
 }
 
 .directory-row__icon {
@@ -4517,6 +4495,11 @@ textarea,
   min-width: 0;
 }
 
+.directory-row__title {
+  color: var(--text-secondary);
+  font-size: calc(var(--sidebar-title-size) - 1px);
+}
+
 .directory-row__attention {
   min-width: 24px;
   height: 24px;
@@ -4525,22 +4508,42 @@ textarea,
 }
 
 .directory-row__chevron {
-  /* Standard inline disclosure chevron (see .live-work-rail__chevron):
-     points right when collapsed, rotates 90deg to point down when
-     expanded. Sits at the left of the row, before the folder icon. */
+  /* Filled caret: one disclosure vocabulary across the sidebar tree. */
   display: inline-flex;
+  width: 0;
+  height: 0;
   flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-right: 1.75px solid var(--text-muted);
-  border-bottom: 1.75px solid var(--text-muted);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid var(--text-muted);
   opacity: 0.82;
   transition: transform 120ms ease;
-  transform: rotate(-45deg);
 }
 
 .directory-row__chevron.is-open {
-  transform: rotate(45deg);
+  transform: rotate(90deg);
+}
+
+/* Directory launchpad rides inside the summary's right edge and trades
+   places with the count block on hover. releases/1.0 never applies the
+   split modifier because its local Federation capability seam is false. */
+.directory-row__launchpad-cluster {
+  display: inline-flex;
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  z-index: 2;
+  align-items: center;
+  border-radius: 6px;
+  opacity: 0;
+  transform: translateY(-50%);
+  transition: opacity 120ms ease;
+}
+
+.directory-row__header:hover .directory-row__launchpad-cluster,
+.directory-row__launchpad-cluster:has(:focus-visible),
+.directory-row__header--has-draft .directory-row__launchpad-cluster {
+  opacity: 1;
 }
 
 .directory-row__launchpad-button {
@@ -4563,9 +4566,6 @@ textarea,
   color: var(--text-muted);
   font-size: 16px;
   line-height: 1;
-  /* The list wrapper carries `padding-right: 4px` so the icon
-     glyph already sits clear of the scrollbar gutter — no
-     additional margin needed here. */
 }
 
 .directory-row__launchpad-button:hover,
@@ -4583,11 +4583,38 @@ textarea,
   color: var(--accent-bright);
 }
 
+.directory-row__header--with-launchpad:hover .directory-row__summary-meta,
+.directory-row__header--with-launchpad:has(.directory-row__launchpad-cluster :focus-visible) .directory-row__summary-meta {
+  opacity: 0;
+}
+
+.directory-row__header--has-draft:not(:hover) .directory-row__summary-meta {
+  margin-right: 28px;
+}
+
+.directory-row__header--has-draft.directory-row__header--split:not(:hover) .directory-row__summary-meta {
+  margin-right: 44px;
+}
+
+@media (hover: none) {
+  .directory-row__header--with-launchpad .directory-row__launchpad-cluster {
+    opacity: 1;
+  }
+
+  .directory-row__header--with-launchpad .directory-row__summary-meta {
+    margin-right: 28px;
+  }
+
+  .directory-row__header--with-launchpad.directory-row__header--split .directory-row__summary-meta {
+    margin-right: 44px;
+  }
+}
+
 .directory-row__details {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px 0 14px 0;
+  padding: 8px 0 10px 0;
 }
 
 .directory-row__threads {
@@ -4639,17 +4666,17 @@ textarea,
 }
 
 .directory-row__thread-divider-chevron {
-  width: 6px;
-  height: 6px;
-  border-right: 1.5px solid currentColor;
-  border-bottom: 1.5px solid currentColor;
+  width: 0;
+  height: 0;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-left: 4px solid currentColor;
   opacity: 0.82;
   transition: transform 120ms ease;
-  transform: rotate(-45deg);
 }
 
 .directory-row__thread-divider-chevron.is-open {
-  transform: rotate(45deg);
+  transform: rotate(90deg);
 }
 
 .directory-row__threads .thread-row--compact {
@@ -18468,13 +18495,13 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* Real-app-mimic chips used in the preview cards. The visual contract
-   mirrors the live ThreadRow primitive — Pin chip uses --accent, PR
+   mirrors the live ThreadRow primitive — the pin is an in-title marker, PR
    chip uses a small status dot + #number, Meta chips are gray-on-near-
    black for OpenAI / directory / branch slots. */
-.onboarding-wizard__mini-chip--pin {
-  color: var(--accent);
-  border-color: var(--accent-border);
-  background: transparent;
+.onboarding-wizard__mini-pin {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--accent-bright);
 }
 .onboarding-wizard__mini-chip--pr {
   display: inline-flex;

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -79,7 +79,7 @@ Use a restrained desktop scale:
 
 - App title / page title: `40px / 700`
 - Section title: `24px / 650`
-- Thread row primary text: `14px / 600`
+- Thread row primary text: `13px / 600` (user-adjustable ±2px via Settings → General → Appearance → Sidebar text size; directory labels ride 1px below the thread title)
 - Body text: `14px / 400`
 - Secondary metadata: `12px / 500`
 - Labels / caps / tiny status: `11px / 600`

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -58,6 +58,7 @@ describe("desktop settings contracts", () => {
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },
+          sidebarTextSize: { value: "md", source: "default" },
         },
         codexProfileModel: { value: "shared", source: "default" },
         messagingAcknowledgment: { value: null, source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -47,6 +47,24 @@ export type DesktopAppearanceDensity =
 export const DESKTOP_APPEARANCE_DENSITY_DEFAULT: DesktopAppearanceDensity =
   "mission-control";
 
+/**
+ * Sidebar text-size notches. "md" is the default 13px thread-row title;
+ * each notch moves the title (and the directory label derived from it)
+ * by 1px in either direction. Deliberately a discrete scale rather than
+ * a free pixel value so every notch is a size the sidebar was designed
+ * and reviewed at.
+ */
+export const DESKTOP_SIDEBAR_TEXT_SIZES = [
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+] as const;
+export type DesktopSidebarTextSize =
+  (typeof DESKTOP_SIDEBAR_TEXT_SIZES)[number];
+export const DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT: DesktopSidebarTextSize = "md";
+
 export const DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELLS = [
   "auto",
   "pwsh",
@@ -298,6 +316,7 @@ export type DesktopIntegratedTerminalSettingsSnapshot = {
 export type DesktopAppearanceSnapshot = {
   theme: DesktopSettingsValue<DesktopAppearanceTheme>;
   density: DesktopSettingsValue<DesktopAppearanceDensity>;
+  sidebarTextSize: DesktopSettingsValue<DesktopSidebarTextSize>;
 };
 
 export type DesktopGeneralSettingsSnapshot = {
@@ -775,6 +794,7 @@ export type DesktopSettingsConfigPatch = {
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;
+      sidebarTextSize?: DesktopSidebarTextSize;
     };
     codexProfileModel?: DesktopCodexProfileModel;
     /** `null` clears the persisted acknowledgement. */
@@ -1365,6 +1385,14 @@ export function isDesktopAppearanceDensity(
 ): value is DesktopAppearanceDensity {
   return DESKTOP_APPEARANCE_DENSITIES.includes(
     value as DesktopAppearanceDensity,
+  );
+}
+
+export function isDesktopSidebarTextSize(
+  value: string,
+): value is DesktopSidebarTextSize {
+  return DESKTOP_SIDEBAR_TEXT_SIZES.includes(
+    value as DesktopSidebarTextSize,
   );
 }
 


### PR DESCRIPTION
## Summary

Backport the non-Federation sidebar density, typography, disclosure, chip-flow, pin-control, and Appearance Settings unit from #1570 to `releases/1.0`.

This was manually adapted instead of cherry-picked. PR #1570 was rebased over the Federation target stack (#1522 and #1562), and nearly every common UI file has also changed independently on `releases/1.0` through sidebar, PR-card, composer, and Settings backports. Cherry-picking would have imported 1.1-only behavior or overwritten release-specific work.

### Source provenance

- Source PR: https://github.com/pwrdrvr/PwrAgent/pull/1570
- Source squash SHA: `f25a48c2d00a83004f4248e83b242e03a69cc8b5`
- Source prerequisite squash SHAs inspected:
  - #1522: `0eb61ce3e863e02756e875cc4a45c77219959275`
  - #1562: `6143e0ce1016ae0ea342671a839d977c2194a873`

The source discussion, final merged diff, squash commit, before/after visual-regression screenshot, source test changes, CI results, and prerequisite stack were reviewed before adapting the release branch.

## Included

- Tightens thread/directory vertical rhythm, title hierarchy, chips, unread cookie, and filled sidebar disclosure carets.
- Removes redundant plain-directory folder icons and directory hairlines.
- Moves PR chips before branch metadata and makes local/worktree chips icon-only while retaining accessible copy labels.
- Moves pinned state into the title line and adds the source one-click hover pin/unpin action.
- Keeps directory launchpad `+` inside the header edge, swapping it with counts on hover/focus and preserving draft visibility.
- Fixes focused-row stacking so the focus ring paints above adjacent selected rows.
- Corrects “Info density” copy and adds Settings → General → Appearance → Sidebar text size (XS–XL).
- Updates the onboarding density preview, desktop style guide, and release-branch tests to match the live primitives.

## Federation adaptation for 1.0

`releases/1.0` has no Federation runtime. `DirectoriesList` therefore uses a small local capability seam:

```ts
function supportsFederationDirectoryLaunchTargets(): boolean {
  return false;
}
```

That deterministic false value keeps the reusable launchpad cluster/overlay layout, but never applies the split-control modifier. The rendered non-Federation case contains exactly one local `+` button and preserves the existing `onOpenLaunchpad(directory, backend)` interaction. A focused renderer test locks this behavior.

No Federation client data, service, contract, renderer state, IPC, target menu, remote-thread chip, or fake capability data is imported.

## Settings and config evolution

This adds one optional scalar under the existing table:

```toml
[general.appearance]
sidebar_text_size = "xs" # xs | sm | md | lg | xl
```

`md` is the default and is not written to disk. The key uses the existing byte-preserving TOML edit path, validates known values, falls back to `md`, participates in the no-flash bootstrap and all-window appearance broadcast, and is deleted again when restored to the default. This is an additive key rather than a backwards-incompatible table-shape change, so no read-fallback/lazy-conversion/dual-write migration is required; older 1.0 builds tolerate and preserve the unknown key.

## Migration audit

- No database or SQLite files changed.
- No SQL, schema, `user_version`, or migration statements appear in the diff.
- No state database migration is introduced or required.

## Deliberate omissions

- #1522/#1562 Federation targeting behavior, including its dropdown, target-selection helpers, contracts, state, services, IPC, and tests.
- The source `federation-remote-window` E2E adjustment and all remote-thread chip behavior.
- `AgentThreadChip` and `StarMapThreadCard` source edits; those surfaces are absent from `releases/1.0` and are 1.1-only.
- Automations, Star Map, Attention-lens, Federation, and other 1.1-only behavior and styles.
- The source visual-regression PNG and its main-only fixture/harness, which do not exist on `releases/1.0`. The source before/after image was inspected; release validation uses the applicable theme/chevron contracts and replay-backed directory-launchpad E2E instead.
- The source theme-contract pin-drop-boundary assertion, because that main-only boundary primitive is absent on the release branch. The applicable release token, color, and disclosure contracts remain covered.

## Validation

- `pnpm typecheck` — pass
- `pnpm lint:eslint` — pass (0 errors; 136 existing warnings)
- `pnpm lint:colors` — pass
- `pnpm lint:boundaries` — pass (1,123 modules / 3,451 dependencies)
- `pnpm lint:sql` — pass
- `pnpm lint:codex-storage` — pass
- Focused shared/settings/bootstrap/renderer/sidebar/theme suites — 11 files, 352 tests passed
- `pnpm --filter @pwragent/desktop test:e2e e2e/directory-launchpad-workspace.spec.ts` — production build pass; 14 replay-backed E2E tests passed
- `git diff --check` — pass

Theme/color contract coverage exercises the existing token vocabulary used by both light and dark themes; this backport introduces no new color literals or visually similar replacement tokens.
