### PR TITLE
fix(desktop): stop HMR mounting a second React root over the first

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/renderer-entry.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/renderer-entry.test.tsx
@@ -15,8 +15,10 @@ vi.mock("../features/diagnostics/RendererErrorBoundary", () => ({
 vi.mock("../lib/dev-performance-pruning", () => ({
   installDevPerformancePruning: () => ({ prune: () => 0, stop: () => undefined }),
 }));
+// Returns its uninstall closure, like the real one — the entry keeps that
+// value now and hands it to the HMR dispose hook.
 vi.mock("../lib/renderer-error-reporting", () => ({
-  installGlobalRendererErrorHandlers: () => undefined,
+  installGlobalRendererErrorHandlers: () => () => undefined,
 }));
 
 describe("renderer entry point", () => {

--- a/apps/desktop/src/renderer/src/__tests__/renderer-entry.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/renderer-entry.test.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the `vi.mock` factories below (which vitest lifts above the
+// imports) can close over the same spies the assertions read.
+const { createRoot, render } = vi.hoisted(() => {
+  const render = vi.fn();
+  return { render, createRoot: vi.fn(() => ({ render })) };
+});
+
+vi.mock("react-dom/client", () => ({ default: { createRoot } }));
+vi.mock("../App", () => ({ App: () => null }));
+vi.mock("../features/diagnostics/RendererErrorBoundary", () => ({
+  RendererErrorBoundary: () => null,
+}));
+vi.mock("../lib/dev-performance-pruning", () => ({
+  installDevPerformancePruning: () => ({ prune: () => 0, stop: () => undefined }),
+}));
+vi.mock("../lib/renderer-error-reporting", () => ({
+  installGlobalRendererErrorHandlers: () => undefined,
+}));
+
+describe("renderer entry point", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    createRoot.mockClear();
+    render.mockClear();
+    vi.resetModules();
+  });
+
+  it("creates one React root and renders the shell into it", async () => {
+    await import("../main");
+
+    expect(createRoot).toHaveBeenCalledTimes(1);
+    expect(createRoot).toHaveBeenCalledWith(document.getElementById("root"));
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  // Vite's dev server makes every JSX module a self-accepting Fast Refresh
+  // boundary, `main.tsx` included. It can't actually refresh (its exports
+  // aren't components), so an HMR update re-executes the module body in the
+  // live page and only then invalidates. `vi.resetModules()` + re-import is
+  // that same re-execution: same document, same #root, fresh module.
+  //
+  // Before this was guarded, the second evaluation called `createRoot` again
+  // and left two roots reconciling one container — which is what produced the
+  // "You are calling ReactDOMClient.createRoot() on a container that has
+  // already been passed to createRoot() before" warning and the burst of
+  // `NotFoundError: Failed to execute 'removeChild' on 'Node'` reports in the
+  // main log on 2026-08-13.
+  it("reuses the existing root when the entry module is re-evaluated", async () => {
+    await import("../main");
+    vi.resetModules();
+    await import("../main");
+
+    expect(createRoot).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/renderer-root.ts
+++ b/apps/desktop/src/renderer/src/lib/renderer-root.ts
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+
+/**
+ * A mounted React root, narrowed to the one method the entry point uses.
+ * Structural rather than `ReactDOM.Root` so this module doesn't pull
+ * react-dom in just for a type.
+ */
+export type RendererRoot = {
+  render: (children: ReactNode) => void;
+};
+
+/**
+ * Where a container's root is parked between evaluations of the entry
+ * module.
+ *
+ * It has to live on the container, not in a module-level variable: Vite's
+ * dev server wraps every JSX module in a self-accepting Fast Refresh
+ * boundary, `main.tsx` included, and that module can't actually refresh
+ * (its exports aren't components). So an HMR update re-executes the whole
+ * module body in the live page and only then invalidates. A module-level
+ * cache is recreated along with the module and sees nothing. The container
+ * outlives every one of those re-evaluations, which makes it the only place
+ * the second evaluation can find the root the first one left behind.
+ *
+ * `Symbol.for` rather than `Symbol()` for the same reason — the module that
+ * declares it is itself re-evaluated, so the key must be looked up in the
+ * global registry instead of minted fresh.
+ */
+const ROOT_KEY: unique symbol = Symbol.for("pwragent.rendererRoot");
+
+type RootHost = Element & { [ROOT_KEY]?: RendererRoot };
+
+/**
+ * Render `children` into `container`, creating the React root only the
+ * first time the container is seen.
+ *
+ * Calling `createRoot` twice on one container leaves two roots reconciling
+ * the same DOM. Each owns nodes the other doesn't know about, so the loser
+ * throws `NotFoundError: Failed to execute 'removeChild' on 'Node'` when it
+ * tries to clean up. React's own
+ * "You are calling ReactDOMClient.createRoot() on a container that has
+ * already been passed to createRoot() before" warning is the mild half of
+ * that outcome.
+ *
+ * In a production build this runs exactly once and the lookup is a single
+ * miss; the guard exists for the dev HMR path, where it turns a dirty
+ * double-mount into a plain re-render.
+ */
+export function mountRendererRoot(
+  container: Element,
+  children: ReactNode,
+  createRoot: (container: Element) => RendererRoot,
+): RendererRoot {
+  const host = container as RootHost;
+  const root = host[ROOT_KEY] ?? createRoot(container);
+  host[ROOT_KEY] = root;
+  root.render(children);
+  return root;
+}

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -10,6 +10,7 @@ import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBound
 import { applyAppearanceAttributes, resolveTheme } from "./lib/appearance";
 import { installDevPerformancePruning } from "./lib/dev-performance-pruning";
 import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporting";
+import { mountRendererRoot } from "./lib/renderer-root";
 import "./styles/app.css";
 
 installGlobalRendererErrorHandlers();
@@ -186,12 +187,18 @@ function chooseRoot(): ReactElement {
 }
 
 desktopApi?.recordStartupProfileEvent?.("react-render:start");
-ReactDOM.createRoot(document.getElementById("root")!).render(
+// Mount through `mountRendererRoot` rather than calling `createRoot` here:
+// an HMR update re-executes this module in the live page (see that module's
+// notes), and a second `createRoot` on the same container leaves two roots
+// fighting over one DOM tree.
+mountRendererRoot(
+  document.getElementById("root")!,
   <React.StrictMode>
     <RendererErrorBoundary>
       <Suspense fallback={null}>{chooseRoot()}</Suspense>
     </RendererErrorBoundary>
   </React.StrictMode>,
+  (container) => ReactDOM.createRoot(container),
 );
 desktopApi?.recordStartupProfileEvent?.("react-render:scheduled");
 requestAnimationFrame(() => {

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -13,7 +13,7 @@ import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporti
 import { mountRendererRoot } from "./lib/renderer-root";
 import "./styles/app.css";
 
-installGlobalRendererErrorHandlers();
+const uninstallGlobalErrorHandlers = installGlobalRendererErrorHandlers();
 const performancePruning = import.meta.env.DEV
   ? installDevPerformancePruning()
   : undefined;
@@ -88,6 +88,13 @@ const unsubscribeFullscreen = desktopApi?.onWindowFullscreen?.(
 // `import.meta.hot` is undefined and the dispose registration is a
 // no-op — same listener, single lifetime.
 //
+// The global error handlers belong here for the same reason, and the cost
+// of leaving them out was visible: each re-evaluation added another
+// window `error` listener, so one uncaught error became one
+// `reportRendererError` round-trip per accumulated handler. A single pull
+// on 2026-08-13 walked one error up to nine duplicate reports in the main
+// log before the page reload reset the count.
+//
 // `import.meta.hot` is a Vite-injected dev-only property. We could pull
 // in `vite/client` triple-slash types globally, but that drags more
 // surface than we need; this single-site shape augmentation keeps the
@@ -99,6 +106,7 @@ const importMetaHot = (
 ).hot;
 if (importMetaHot) {
   importMetaHot.dispose(() => {
+    uninstallGlobalErrorHandlers();
     unsubscribeAppearance?.();
     unsubscribeFullscreen?.();
     performancePruning?.stop();


### PR DESCRIPTION
## What

`main.tsx` ended in a bare `ReactDOM.createRoot(document.getElementById("root")!)` at module scope. Vite's dev server wraps every JSX module in a self-accepting Fast Refresh boundary — `main.tsx` included — and that module can't actually refresh (`[vite] invalidate /src/main.tsx: Could not Fast Refresh ("true" export is incompatible)`). So an HMR update **re-executes the whole module body in the live page** and only then invalidates, and the second evaluation builds a second React root over the container the first one is still reconciling.

Two roots owning one DOM tree is not a warning-level problem. Each holds nodes the other doesn't know about, and the loser throws when it tries to clean up. One `git pull` on 2026-08-13 produced, in `profile-default.main.log`:

- 1 × `You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before`
- 10 × `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`

Those `removeChild` reports reach the main log through `reportRendererError` — the same error channel real renderer faults use.

## How

New `lib/renderer-root.ts` exposes `mountRendererRoot(container, children, createRoot)`, which parks the root on the **container** under a `Symbol.for` key. The container is what outlives module re-evaluation, so it is the only place a second evaluation can find the root the first one left behind — a module-level cache is recreated along with the module and sees nothing. A re-evaluation now re-renders instead of re-mounting. Production builds evaluate the entry once and take a single lookup miss.

## Testing

`__tests__/renderer-entry.test.tsx` drives the real entry module. `vi.resetModules()` + re-import is the same re-execution vite performs: same document, same `#root`, fresh module. The regression test asserts `createRoot` is called once and `render` twice; it fails on the pre-fix entry with `expected "vi.fn()" to be called 1 times, but got 2 times`.

Also verified in a live dev app (checkout-bound `dev` profile). With the fix, HMR re-executions of `main.tsx` log `hot updated` and nothing else. Reverting the file and repeating the identical edit reproduced the `createRoot` warning immediately — clean A/B in one log.

- `pnpm test --project desktop-renderer` — 2760 passed (176 files)
- `pnpm typecheck`, `pnpm lint:eslint` (changed files), `pnpm lint:boundaries` — clean

## Not in scope

This does not make `main.tsx` Fast-Refreshable. Vite still invalidates and reloads the page, which is the right outcome for an entry module — the fix is about what happens in the window before that reload.

Found while investigating a black bar below the composer in a long-running dev instance. That symptom is **not** explained by this: the renderer had run 14h42m with zero HMR updates and zero errors when it appeared. Still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)