### PR TITLE
fix(desktop): fit the main window to scaled displays

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -210,6 +210,41 @@ test.describe("Onboarding wizard", () => {
         }),
       ).toBeVisible();
 
+      const geometry = await app.electronApp.evaluate(
+        ({ BrowserWindow, screen }) => {
+          const mainWindow = BrowserWindow.getAllWindows()[0];
+          if (!mainWindow) {
+            throw new Error("Expected the onboarding BrowserWindow");
+          }
+          const bounds = mainWindow.getBounds();
+          return {
+            bounds,
+            workArea: screen.getDisplayMatching(bounds).workArea,
+          };
+        },
+      );
+      expect(geometry.bounds.x).toBeGreaterThanOrEqual(geometry.workArea.x);
+      expect(geometry.bounds.y).toBeGreaterThanOrEqual(geometry.workArea.y);
+      expect(geometry.bounds.x + geometry.bounds.width).toBeLessThanOrEqual(
+        geometry.workArea.x + geometry.workArea.width,
+      );
+      expect(geometry.bounds.y + geometry.bounds.height).toBeLessThanOrEqual(
+        geometry.workArea.y + geometry.workArea.height,
+      );
+
+      const wizard = await app.window.locator(".onboarding-wizard").boundingBox();
+      const viewport = await app.window.evaluate(() => ({
+        height: globalThis.innerHeight,
+        width: globalThis.innerWidth,
+      }));
+      expect(wizard).not.toBeNull();
+      expect(
+        Math.abs((wizard!.x + wizard!.width / 2) - viewport.width / 2),
+      ).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs((wizard!.y + wizard!.height / 2) - viewport.height / 2),
+      ).toBeLessThanOrEqual(1);
+
       const getStarted = app.window.getByRole("button", { name: /Get started/i });
       await expect(getStarted).toBeVisible();
       await getStarted.click();

--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -267,6 +267,24 @@ describe("createMainWindow", () => {
     expect(browserWindowState.setWindowOpenHandler).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the main window and its resize minimums inside the cursor display work area", async () => {
+    getDisplayNearestPointMock.mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1152, height: 696 },
+    });
+
+    const { createMainWindow } = await import("../window");
+    createMainWindow();
+
+    expect(browserWindowState.options).toMatchObject({
+      x: 0,
+      y: 0,
+      width: 1152,
+      height: 696,
+      minWidth: 960,
+      minHeight: 640,
+    });
+  });
+
   it("registers the main window for messaging push-event channels", async () => {
     const { createMainWindow } = await import("../window");
     const { debugListRegisteredWindows } = await import("../window-channels");

--- a/apps/desktop/src/main/__tests__/window-placement.test.ts
+++ b/apps/desktop/src/main/__tests__/window-placement.test.ts
@@ -113,4 +113,22 @@ describe("window placement", () => {
     });
     expect(electronMock.getDisplayNearestPoint).toHaveBeenCalledWith(cursor);
   });
+
+  it("fits oversized main-window bounds inside the cursor display work area", async () => {
+    const cursor = { x: 400, y: 200 };
+    electronMock.getCursorScreenPoint.mockReturnValue(cursor);
+    electronMock.getDisplayNearestPoint.mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1152, height: 696 },
+    });
+
+    const { boundsForCursorDisplay } = await import("../window-placement");
+
+    expect(boundsForCursorDisplay(1440, 960)).toEqual({
+      x: 0,
+      y: 0,
+      width: 1152,
+      height: 696,
+    });
+    expect(electronMock.getDisplayNearestPoint).toHaveBeenCalledWith(cursor);
+  });
 });

--- a/apps/desktop/src/main/window-placement.ts
+++ b/apps/desktop/src/main/window-placement.ts
@@ -9,6 +9,11 @@ type WindowPosition = {
   y: number;
 };
 
+type WindowBounds = WindowPosition & {
+  width: number;
+  height: number;
+};
+
 export type WindowPlacementSource = {
   sourceBounds?: Rectangle | undefined;
   sourceWindow?: BrowserWindow | null | undefined;
@@ -44,6 +49,20 @@ export function placementForCursorDisplay(
     height,
     screen.getDisplayNearestPoint(screen.getCursorScreenPoint()),
   );
+}
+
+export function boundsForCursorDisplay(
+  width: number,
+  height: number,
+): WindowBounds {
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const fittedWidth = Math.min(width, display.workArea.width);
+  const fittedHeight = Math.min(height, display.workArea.height);
+  return {
+    ...centerWindowOnDisplay(fittedWidth, fittedHeight, display),
+    width: fittedWidth,
+    height: fittedHeight,
+  };
 }
 
 export function positionWindowForSourceDisplay(

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -55,7 +55,7 @@ import {
   navigationPreferencesAdditionalArguments,
   readBootstrapNavigationPreferences,
 } from "./navigation-browse-mode-bootstrap";
-import { placementForCursorDisplay } from "./window-placement";
+import { boundsForCursorDisplay } from "./window-placement";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
@@ -63,6 +63,8 @@ const isWindows = process.platform === "win32";
 const moduleDirectory = dirname(fileURLToPath(import.meta.url));
 const MAIN_WINDOW_WIDTH = 1440;
 const MAIN_WINDOW_HEIGHT = 960;
+const MAIN_WINDOW_MIN_WIDTH = 960;
+const MAIN_WINDOW_MIN_HEIGHT = 640;
 const mainLog = getMainLogger("pwragent:main");
 const heapLog = getMainLogger("pwragent:heap");
 const hotCpuLog = getMainLogger("pwragent:hot-cpu");
@@ -324,6 +326,10 @@ export function createMainWindow(options?: {
   const preloadPath = getPreloadPath();
   const appearance = readBootstrapAppearance();
   const navigationPreferences = readBootstrapNavigationPreferences();
+  const initialBounds = boundsForCursorDisplay(
+    MAIN_WINDOW_WIDTH,
+    MAIN_WINDOW_HEIGHT,
+  );
   const windowChrome = isMac
     ? {
         titleBarStyle: "hiddenInset" as const,
@@ -345,11 +351,9 @@ export function createMainWindow(options?: {
         }
       : {};
   const window = new BrowserWindow({
-    ...placementForCursorDisplay(MAIN_WINDOW_WIDTH, MAIN_WINDOW_HEIGHT),
-    width: MAIN_WINDOW_WIDTH,
-    height: MAIN_WINDOW_HEIGHT,
-    minWidth: 1200,
-    minHeight: 760,
+    ...initialBounds,
+    minWidth: Math.min(MAIN_WINDOW_MIN_WIDTH, initialBounds.width),
+    minHeight: Math.min(MAIN_WINDOW_MIN_HEIGHT, initialBounds.height),
     show: false,
     title: "PwrAgent",
     ...windowChrome,


### PR DESCRIPTION
## What changed

- clamp the initial main-window bounds to the cursor display's effective work area
- lower the normal resize floor from 1200×760 to 960×640, with an additional cap for smaller work areas
- add focused unit coverage for a 1152×696 DIP work area
- extend the onboarding E2E to assert that the native window stays on-screen and the wizard is centered in the renderer viewport

## Root cause

At 125% Windows display scaling, the 1440×900 VM exposes an effective Electron work area of roughly 1152×696 DIP. PwrAgent still requested a 1440×960 window with a 1200×760 minimum. Windows honored the minimum by extending the frameless window beyond the visible work area, which put the native minimize/maximize/close controls and the wizard's right edge off-screen.

The old config and missing Codex installation were incidental; window geometry is selected before either state is processed.

## Impact

The Windows caption controls remain visible and the first-run wizard is centered and fully reachable at scaled laptop/VM resolutions. Larger displays retain the existing 1440×960 startup size.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/app-bootstrap.test.ts apps/desktop/src/main/__tests__/window-placement.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- production desktop build
- focused local Electron onboarding E2E
- focused headed Windows VM onboarding E2E: 1 passed on `eb578086` (run `pwrlab-pwragent-e2e-20260813-115759-eb578086`)
