### PR TITLE
fix(desktop): defer Gemini onboarding login

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -31,9 +31,14 @@ type FakeProviderName = (typeof fakeProviderNames)[number];
 
 function fakeProviderScript(): string {
   return `#!${process.execPath}
+const fs = require("node:fs");
 const path = require("node:path");
 const name = path.basename(process.argv[1]).replace(/\\.(?:cmd|c?js)$/i, "");
 const args = process.argv.slice(2);
+const execLog = process.env.PWRAGENT_E2E_PROVIDER_EXEC_LOG;
+if (execLog) {
+  fs.appendFileSync(execLog, JSON.stringify({ name, args }) + "\\n");
+}
 
 if (args.includes("--version")) {
   console.log(name + " 999.0.0");
@@ -125,6 +130,7 @@ async function launchWizardWithFakeProviders(
   const homeRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), "pwragent-provider-discovery-e2e-"),
   );
+  const execLogPath = path.join(homeRoot, "provider-exec.jsonl");
   const customBin = path.join(homeRoot, ".bin");
   const commands =
     source === "path"
@@ -156,11 +162,12 @@ async function launchWizardWithFakeProviders(
       requiresReplayDriver: false,
       env: {
         PATH: discoveryPath,
+        PWRAGENT_E2E_PROVIDER_EXEC_LOG: execLogPath,
         PWRAGENT_CODEX_COMMAND: undefined,
         SHELL: process.platform === "darwin" ? "/bin/zsh" : "/bin/bash",
       },
     });
-    return { app, commands };
+    return { app, commands, execLogPath };
   } catch (error) {
     fs.rmSync(homeRoot, { recursive: true, force: true });
     throw error;
@@ -704,6 +711,37 @@ test.describe("Onboarding wizard", () => {
         ),
       ).toBeVisible();
       await expect(app.window.getByText(/xAI API key/i)).toHaveCount(0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("entering AI Providers does not launch Gemini before explicit login", async () => {
+    test.skip(process.platform === "win32", "Unix executable discovery only");
+    const { app, execLogPath } = await launchWizardWithFakeProviders("path");
+    try {
+      await app.window.getByRole("button", { name: /Get started/i }).click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await expect(
+        app.window.getByRole("tab", { name: /Gemini CLI Installed/i }),
+      ).toBeVisible({ timeout: 20_000 });
+
+      const executions = fs
+        .readFileSync(execLogPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as {
+          name: string;
+          args: string[];
+        });
+      expect(executions.some((execution) => execution.name === "gemini")).toBe(true);
+      expect(
+        executions.some(
+          (execution) =>
+            execution.name === "gemini" && execution.args.includes("--acp"),
+        ),
+      ).toBe(false);
     } finally {
       await app.close();
     }

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -418,6 +418,37 @@ describe("PwrAgent profiles", () => {
       expect(fs.readFileSync(configPath, "utf8")).toContain('theme = "dark"');
     });
 
+    it("backfills missing ACP defaults without overwriting existing choices", () => {
+      const { env, root } = createRoot();
+      const configPath = path.join(root, ".bootstrap", "config.toml");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        [
+          "[onboarding]",
+          "completed = false",
+          "",
+          "[acp_agents.gemini]",
+          "enabled = true",
+          "",
+          "[acp_agents.kimi]",
+          'cli_path = "/opt/kimi"',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      ensureBootstrapProfileDir({ env });
+
+      const contents = fs.readFileSync(configPath, "utf8");
+      expect(contents).toContain("[acp_agents.gemini]\nenabled = true");
+      expect(contents).toContain(
+        '[acp_agents.kimi]\ncli_path = "/opt/kimi"\nenabled = false',
+      );
+      expect(contents).toContain("[acp_agents.grok]\nenabled = false");
+      expect(contents).toContain("[acp_agents.qwen]\nenabled = false");
+    });
+
     it("cleanupBootstrapProfile removes the dir; subsequent existence check is false", () => {
       const { env, root } = createRoot();
       ensureBootstrapProfileDir({ env });

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -384,7 +384,7 @@ describe("PwrAgent profiles", () => {
       );
     });
 
-    it("ensureBootstrapProfileDir seeds an [onboarding] marker like a real profile", () => {
+    it("seeds onboarding with ACP providers disabled until the operator enables them", () => {
       const { env, root } = createRoot();
       const result = ensureBootstrapProfileDir({ env });
       expect(result.created).toBe(true);
@@ -397,6 +397,11 @@ describe("PwrAgent profiles", () => {
       // like a fresh real profile to the wizard's perspective.
       expect(contents).toContain("[onboarding]");
       expect(contents).toContain("completed = false");
+      expect(contents).toContain("[acp_agents.gemini]");
+      expect(contents).toContain("[acp_agents.grok]");
+      expect(contents).toContain("[acp_agents.kimi]");
+      expect(contents).toContain("[acp_agents.qwen]");
+      expect(contents.match(/enabled = false/g)).toHaveLength(4);
       expect(fs.existsSync(path.join(root, ".bootstrap", "state"))).toBe(true);
     });
 

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1156,11 +1156,61 @@ describe("settings ipc", () => {
       await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
       expect(probe).toHaveBeenCalledTimes(1);
 
+      localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([
+        {
+          backendId: "acp:gemini",
+          registryId: "gemini",
+          name: "Gemini CLI",
+          version: "0.43.0",
+          distributionKind: "local",
+          distributionSource: "gemini --acp --skip-trust",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-gemini-cli",
+          installedAt: 1234,
+          updatedAt: 1234,
+          launchDescriptor: {
+            backendId: "acp:gemini",
+            registryId: "gemini",
+            distributionKind: "local",
+            command: "gemini",
+            args: ["--acp", "--skip-trust"],
+            env: {},
+          },
+        },
+      ]);
+      const discoveredOnly = (await handlers
+        .get(ACP_AGENTS_LIST_CHANNEL)
+        ?.({}, { refresh: true, probeCapabilities: false })) as
+        | {
+            entries?: Array<{
+              registryId: string;
+              runtime?: unknown;
+              lastDiscoveredAt?: number;
+              version?: string;
+            }>;
+          }
+        | undefined;
+      expect(probe).toHaveBeenCalledTimes(1);
+      expect(
+        discoveredOnly?.entries?.find((entry) => entry.registryId === "gemini"),
+      ).toMatchObject({
+        version: "0.43.0",
+        runtime: undefined,
+        lastDiscoveredAt: undefined,
+      });
+
+      // A discovery-only version change invalidates the old runtime cache, so
+      // the next ordinary refresh must probe the upgraded CLI.
+      await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
+      expect(probe).toHaveBeenCalledTimes(2);
+
       // Forced refresh ("Discover new"): re-probe regardless of freshness.
       await handlers
         .get(ACP_AGENTS_LIST_CHANNEL)
         ?.({}, { refresh: true, force: true });
-      expect(probe).toHaveBeenCalledTimes(2);
+      expect(probe).toHaveBeenCalledTimes(3);
     } finally {
       disposeAppState();
     }
@@ -1168,7 +1218,7 @@ describe("settings ipc", () => {
     // discovery round-trips need headroom over the 5s default under CI load.
   }, 20_000);
 
-  it("coalesces concurrent forced ACP refreshes onto one probe pass", async () => {
+  it("coalesces matching forced and weaker regular ACP refreshes", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "pwragent-settings-ipc-"),
     );
@@ -1227,14 +1277,21 @@ describe("settings ipc", () => {
       const probe = acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities;
       const handler = handlers.get(ACP_AGENTS_LIST_CHANNEL);
 
-      // Two rapid "Discover new" clicks fire before the first pass resolves.
-      // Both are forced, so freshness can't gate the second — only the
-      // in-flight coalescing keeps them from launching the agent twice in
-      // parallel. The second must ride the first's forced pass: one probe.
-      await Promise.all([
-        handler?.({}, { refresh: true, force: true }),
-        handler?.({}, { refresh: true, force: true }),
-      ]);
+      let releaseProbe: (() => void) | undefined;
+      probe.mockImplementationOnce(
+        async () => await new Promise((resolve) => {
+          releaseProbe = () => resolve({});
+        }),
+      );
+
+      // A non-forced caller that arrives during a stronger forced pass must
+      // ride that pass instead of launching the same runtime in parallel.
+      const forced = handler?.({}, { refresh: true, force: true });
+      await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(1));
+      const forcedFollower = handler?.({}, { refresh: true, force: true });
+      const regular = handler?.({}, { refresh: true });
+      releaseProbe?.();
+      await Promise.all([forced, forcedFollower, regular]);
       expect(probe).toHaveBeenCalledTimes(1);
     } finally {
       disposeAppState();

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -857,9 +857,32 @@ describe("settings ipc", () => {
             entry.installed === false && entry.installStatus === "not-installed",
         ),
       ).toBe(true);
+      const discoveredOnly = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: true, probeCapabilities: false },
+      )) as { entries?: unknown[] } | undefined;
+      expect(discoveredOnly?.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            backendId: "acp:gemini",
+            installed: true,
+          }),
+        ]),
+      );
+      expect(
+        acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities,
+      ).not.toHaveBeenCalled();
+
+      const { applyDesktopSettingsPatch } = await import(
+        "../settings/desktop-config"
+      );
+      applyDesktopSettingsPatch(
+        path.join(tempRoot, ".bootstrap", "config.toml"),
+        { acpAgents: { gemini: { enabled: true } } },
+      );
       const refreshed = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
         {},
-        { refresh: true },
+        { refresh: true, force: true, registryIds: ["gemini"] },
       )) as { entries?: unknown[] } | undefined;
       expect(refreshed?.entries).toEqual(
         expect.arrayContaining([
@@ -892,6 +915,11 @@ describe("settings ipc", () => {
             "acp-discovery-workspace",
           ),
         }),
+      );
+      expect(
+        localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+      ).toHaveBeenLastCalledWith(
+        expect.objectContaining({ enabledRegistryIds: ["gemini"] }),
       );
       expect(
         fs.existsSync(path.join(tempRoot, "profiles", "default")),

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -152,8 +152,20 @@ async function refreshModelBackendsIfNeeded(params: {
 // from launching every agent twice in parallel. A forced caller that arrives
 // while only a non-forced pass is in flight still starts its own pass, so
 // "Discover new" is never a no-op.
-let inFlightAcpRefresh: Promise<ListAcpAgentSettingsResponse> | undefined;
-let inFlightAcpRefreshForced = false;
+const inFlightAcpRefreshes = new Map<
+  string,
+  Promise<ListAcpAgentSettingsResponse>
+>();
+
+function acpRefreshKey(request: ListAcpAgentSettingsRequest): string {
+  return JSON.stringify({
+    force: request.force === true,
+    probeCapabilities: request.probeCapabilities !== false,
+    registryIds: request.registryIds
+      ? [...new Set(request.registryIds)].sort()
+      : undefined,
+  });
+}
 
 async function listAcpAgentSettings(
   request: ListAcpAgentSettingsRequest = {},
@@ -162,18 +174,17 @@ async function listAcpAgentSettings(
   if (request.refresh === false) {
     return await listAcpAgentSettingsImpl(request, service);
   }
-  const wantsForce = request.force === true;
-  if (inFlightAcpRefresh && (!wantsForce || inFlightAcpRefreshForced)) {
-    return await inFlightAcpRefresh;
+  const refreshKey = acpRefreshKey(request);
+  const inFlight = inFlightAcpRefreshes.get(refreshKey);
+  if (inFlight) {
+    return await inFlight;
   }
   const run = listAcpAgentSettingsImpl(request, service).finally(() => {
-    if (inFlightAcpRefresh === run) {
-      inFlightAcpRefresh = undefined;
-      inFlightAcpRefreshForced = false;
+    if (inFlightAcpRefreshes.get(refreshKey) === run) {
+      inFlightAcpRefreshes.delete(refreshKey);
     }
   });
-  inFlightAcpRefresh = run;
-  inFlightAcpRefreshForced = wantsForce;
+  inFlightAcpRefreshes.set(refreshKey, run);
   return await run;
 }
 
@@ -213,6 +224,10 @@ async function listAcpAgentSettingsImpl(
   const installed = await listInstalledAndLocalAcpAgents(store, {
     refreshLocal: request.refresh === true,
     ...(request.force === true ? { force: true } : {}),
+    ...(request.probeCapabilities === false
+      ? { probeCapabilities: false }
+      : {}),
+    ...(request.registryIds ? { registryIds: request.registryIds } : {}),
     ...(discoveryEnv ? { env: discoveryEnv } : {}),
   });
   if (request.refresh === true) {
@@ -328,6 +343,8 @@ async function listInstalledAndLocalAcpAgents(
   options?: {
     refreshLocal?: boolean;
     force?: boolean;
+    probeCapabilities?: boolean;
+    registryIds?: readonly string[];
     env?: NodeJS.ProcessEnv;
   },
 ): Promise<AcpInstalledAgentRecord[]> {
@@ -337,17 +354,23 @@ async function listInstalledAndLocalAcpAgents(
     try {
       const config = readDesktopSettingsConfigSafe();
       const preferences: Record<string, AcpAgentPreference> = {};
-      const enabledRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
-        (registryId) => acpAgentEnabledFor(config, registryId),
+      const requestedRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
+        (registryId) =>
+          !options.registryIds || options.registryIds.includes(registryId),
       );
-      for (const registryId of enabledRegistryIds) {
+      const discoveryRegistryIds = options.probeCapabilities === false
+        ? requestedRegistryIds
+        : requestedRegistryIds.filter((registryId) =>
+            acpAgentEnabledFor(config, registryId),
+          );
+      for (const registryId of discoveryRegistryIds) {
         const override = acpCliPathOverrideFor(config, registryId);
         if (override) {
           preferences[registryId] = { overridePath: override };
         }
       }
       discovered = await discoverLocalAcpAgentRecords({
-        enabledRegistryIds,
+        enabledRegistryIds: discoveryRegistryIds,
         ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
         ...(options?.env ? { env: options.env } : {}),
       });
@@ -365,6 +388,13 @@ async function listInstalledAndLocalAcpAgents(
           installedAt: current?.installedAt ?? record.installedAt,
           updatedAt: Math.max(current?.updatedAt ?? 0, record.updatedAt),
         } satisfies AcpInstalledAgentRecord;
+        if (
+          options.probeCapabilities === false
+          || !acpAgentEnabledFor(config, record.registryId)
+        ) {
+          store.upsertInstalledAgent(nextRecord);
+          continue;
+        }
         // Cheap local discovery (above) always runs to find newly-installed
         // agents and refresh version metadata. The EXPENSIVE runtime-capability
         // probe launches the agent over ACP, so gate it: only re-probe agents

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -152,14 +152,15 @@ async function refreshModelBackendsIfNeeded(params: {
 // from launching every agent twice in parallel. A forced caller that arrives
 // while only a non-forced pass is in flight still starts its own pass, so
 // "Discover new" is never a no-op.
-const inFlightAcpRefreshes = new Map<
-  string,
-  Promise<ListAcpAgentSettingsResponse>
->();
+type InFlightAcpRefreshes = {
+  forced?: Promise<ListAcpAgentSettingsResponse>;
+  regular?: Promise<ListAcpAgentSettingsResponse>;
+};
+
+const inFlightAcpRefreshes = new Map<string, InFlightAcpRefreshes>();
 
 function acpRefreshKey(request: ListAcpAgentSettingsRequest): string {
   return JSON.stringify({
-    force: request.force === true,
     probeCapabilities: request.probeCapabilities !== false,
     registryIds: request.registryIds
       ? [...new Set(request.registryIds)].sort()
@@ -175,16 +176,26 @@ async function listAcpAgentSettings(
     return await listAcpAgentSettingsImpl(request, service);
   }
   const refreshKey = acpRefreshKey(request);
-  const inFlight = inFlightAcpRefreshes.get(refreshKey);
+  const wantsForce = request.force === true;
+  const inFlightForScope = inFlightAcpRefreshes.get(refreshKey);
+  const inFlight = wantsForce
+    ? inFlightForScope?.forced
+    : inFlightForScope?.forced ?? inFlightForScope?.regular;
   if (inFlight) {
     return await inFlight;
   }
+  const kind = wantsForce ? "forced" : "regular";
   const run = listAcpAgentSettingsImpl(request, service).finally(() => {
-    if (inFlightAcpRefreshes.get(refreshKey) === run) {
+    const current = inFlightAcpRefreshes.get(refreshKey);
+    if (current?.[kind] !== run) return;
+    delete current[kind];
+    if (!current.forced && !current.regular) {
       inFlightAcpRefreshes.delete(refreshKey);
     }
   });
-  inFlightAcpRefreshes.set(refreshKey, run);
+  const nextInFlight = inFlightForScope ?? {};
+  nextInFlight[kind] = run;
+  inFlightAcpRefreshes.set(refreshKey, nextInFlight);
   return await run;
 }
 
@@ -378,13 +389,23 @@ async function listInstalledAndLocalAcpAgents(
       const now = Date.now();
       for (const record of discovered) {
         const current = store.getInstalledAgent(record.backendId);
+        const runtimeVersionChanged =
+          current?.version !== undefined
+          && record.version !== undefined
+          && current.version !== record.version;
         const nextRecord = {
           ...record,
-          runtimeCapabilities: current?.runtimeCapabilities,
+          runtimeCapabilities: runtimeVersionChanged
+            ? undefined
+            : current?.runtimeCapabilities,
           update: current?.update,
           updateCommand: current?.updateCommand,
-          lastDiscoveredAt: current?.lastDiscoveredAt,
-          lastDiscoveryError: current?.lastDiscoveryError,
+          lastDiscoveredAt: runtimeVersionChanged
+            ? undefined
+            : current?.lastDiscoveredAt,
+          lastDiscoveryError: runtimeVersionChanged
+            ? undefined
+            : current?.lastDiscoveryError,
           installedAt: current?.installedAt ?? record.installedAt,
           updatedAt: Math.max(current?.updatedAt ?? 0, record.updatedAt),
         } satisfies AcpInstalledAgentRecord;

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -500,7 +500,7 @@ export function ensureBootstrapProfileDir(options?: {
   const profileDir = resolveBootstrapProfileDir(options);
   const created = !fs.existsSync(profileDir);
   fs.mkdirSync(path.join(profileDir, "state"), { recursive: true });
-  writeInitialOnboardingMarker(path.join(profileDir, "config.toml"));
+  writeInitialBootstrapConfig(path.join(profileDir, "config.toml"));
   return { profileDir, created };
 }
 
@@ -545,6 +545,39 @@ function writeInitialOnboardingMarker(configPath: string): void {
     return;
   }
   fs.writeFileSync(configPath, "[onboarding]\ncompleted = false\n", "utf8");
+}
+
+/**
+ * Bootstrap is the only profile state where ACP providers start disabled.
+ * Existing and directly-created profiles retain the historical default-on
+ * behavior; wizard-created profiles inherit the explicit choices copied from
+ * this throwaway config at graduation.
+ */
+function writeInitialBootstrapConfig(configPath: string): void {
+  if (fs.existsSync(configPath)) {
+    return;
+  }
+  fs.writeFileSync(
+    configPath,
+    [
+      "[onboarding]",
+      "completed = false",
+      "",
+      "[acp_agents.gemini]",
+      "enabled = false",
+      "",
+      "[acp_agents.grok]",
+      "enabled = false",
+      "",
+      "[acp_agents.kimi]",
+      "enabled = false",
+      "",
+      "[acp_agents.qwen]",
+      "enabled = false",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
 }
 
 export function setDefaultProfileName(

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -6,6 +6,11 @@ import {
   isCanonicalProfileName,
   normalizeProfileName,
 } from "@pwragent/shared";
+import {
+  applyTomlEdits,
+  parseTomlTables,
+  type TomlEdit,
+} from "./settings/toml-editor";
 
 export { normalizeProfileName };
 
@@ -554,30 +559,24 @@ function writeInitialOnboardingMarker(configPath: string): void {
  * this throwaway config at graduation.
  */
 function writeInitialBootstrapConfig(configPath: string): void {
-  if (fs.existsSync(configPath)) {
-    return;
-  }
-  fs.writeFileSync(
-    configPath,
-    [
-      "[onboarding]",
-      "completed = false",
-      "",
-      "[acp_agents.gemini]",
-      "enabled = false",
-      "",
-      "[acp_agents.grok]",
-      "enabled = false",
-      "",
-      "[acp_agents.kimi]",
-      "enabled = false",
-      "",
-      "[acp_agents.qwen]",
-      "enabled = false",
-      "",
-    ].join("\n"),
-    "utf8",
+  const source = fs.existsSync(configPath)
+    ? fs.readFileSync(configPath, "utf8")
+    : "[onboarding]\ncompleted = false\n";
+  const tables = parseTomlTables(source, configPath);
+  const edits: TomlEdit[] = ["gemini", "grok", "kimi", "qwen"].flatMap(
+    (registryId) =>
+      tables[`acp_agents.${registryId}`]?.enabled === undefined
+        ? [{
+            op: "set" as const,
+            path: ["acp_agents", registryId, "enabled"],
+            value: false,
+          }]
+        : [],
   );
+  const next = applyTomlEdits(source, edits);
+  if (next !== source || !fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, next, "utf8");
+  }
 }
 
 export function setDefaultProfileName(

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../lib/slack-pairing-approval";
 import type { AppearanceController } from "../../lib/useAppearance";
 import type { DesktopSettingsState } from "../settings/useDesktopSettings";
+import { SettingsSwitch } from "../settings/SettingsSwitch";
 import { filterBufferedSecrets } from "./filterBufferedSecrets";
 import {
   isValidProfileName,
@@ -1897,7 +1898,9 @@ function installedOnboardingBackendNames(
       backend.id === "codex"
         ? Boolean(selectedCodexCandidate(snapshot))
         : Boolean(acpEntryFor(acpEntries, backend.id)?.installed);
-    return installed ? [backend.name] : [];
+    const enabled = backend.id === "codex"
+      || acpBackendEnabled(snapshot, backend.id);
+    return installed && enabled ? [backend.name] : [];
   });
 }
 
@@ -1919,6 +1922,16 @@ function acpEntryFor(
   return entries.find((entry) => entry.registryId === registryId);
 }
 
+function acpBackendEnabled(
+  snapshot: DesktopSettingsSnapshot | undefined,
+  registryId: Exclude<OnboardingBackendId, "codex">,
+): boolean {
+  const agents = snapshot?.acpAgents as
+    | Record<string, { enabled?: boolean } | undefined>
+    | undefined;
+  return agents?.[registryId]?.enabled !== false;
+}
+
 export function isBackendRequirementSatisfied(
   snapshot: DesktopSettingsSnapshot | undefined,
   acpEntries: readonly AcpAgentSettingsEntry[],
@@ -1935,6 +1948,12 @@ export function BackendRequirementsStep(props: {
   const [activeBackend, setActiveBackend] = useState<OnboardingBackendId>("codex");
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string>();
+  const [optimisticEnabled, setOptimisticEnabled] = useState<
+    Partial<Record<Exclude<OnboardingBackendId, "codex">, boolean>>
+  >({});
+  const [geminiLoginState, setGeminiLoginState] = useState<
+    "idle" | "running" | "ready"
+  >("idle");
   const initialAcpLoadStarted = useRef(false);
   const snapshot = props.settings.snapshot;
   const discovery = snapshot?.models.codex.discovery;
@@ -1956,7 +1975,10 @@ export function BackendRequirementsStep(props: {
     try {
       const results = await Promise.allSettled([
         props.desktopApi?.refreshCodexDiscovery?.({}),
-        props.desktopApi?.listAcpAgents?.({ refresh: true, force: true }),
+        props.desktopApi?.listAcpAgents?.({
+          refresh: true,
+          probeCapabilities: false,
+        }),
       ]);
       const codexResult = results[0];
       if (
@@ -1990,7 +2012,10 @@ export function BackendRequirementsStep(props: {
       .listAcpAgents({ refresh: false })
       .then((response) => {
         updateAcpEntries(response.entries);
-        return props.desktopApi?.listAcpAgents?.({ refresh: true });
+        return props.desktopApi?.listAcpAgents?.({
+          refresh: true,
+          probeCapabilities: false,
+        });
       })
       .then((response) => {
         if (!response) return;
@@ -2016,6 +2041,11 @@ export function BackendRequirementsStep(props: {
     activeBackend === "codex"
       ? undefined
       : acpEntryFor(props.acpEntries, activeBackend);
+  const activeAcpEnabled =
+    activeBackend === "codex"
+      ? true
+      : optimisticEnabled[activeBackend]
+        ?? acpBackendEnabled(snapshot, activeBackend);
   const activeCommand =
     activeBackend === "codex"
       ? codexCandidate?.command
@@ -2024,6 +2054,53 @@ export function BackendRequirementsStep(props: {
     activeBackend === "codex"
       ? codexCandidate?.version
       : activeAcpEntry?.version;
+
+  const setActiveAcpEnabled = async (enabled: boolean): Promise<void> => {
+    if (activeBackend === "codex") return;
+    setError(undefined);
+    const saved = await props.settings.writeConfig({
+      acpAgents: { [activeBackend]: { enabled } } as NonNullable<
+        DesktopSettingsConfigPatch["acpAgents"]
+      >,
+    });
+    if (!saved) return;
+    setOptimisticEnabled((current) => ({
+      ...current,
+      [activeBackend]: enabled,
+    }));
+    if (activeBackend === "gemini" && !enabled) {
+      setGeminiLoginState("idle");
+    }
+  };
+
+  const loginToGemini = async (): Promise<void> => {
+    if (!props.desktopApi?.listAcpAgents) {
+      setError("Gemini login is unavailable in this build.");
+      return;
+    }
+    setError(undefined);
+    setGeminiLoginState("running");
+    try {
+      const response = await props.desktopApi.listAcpAgents({
+        refresh: true,
+        force: true,
+        registryIds: ["gemini"],
+      });
+      updateAcpEntries(response.entries);
+      window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+      const gemini = acpEntryFor(response.entries, "gemini");
+      const loginError = gemini?.lastDiscoveryError ?? response.error;
+      if (loginError) {
+        setError(loginError);
+        setGeminiLoginState("idle");
+        return;
+      }
+      setGeminiLoginState("ready");
+    } catch (caught: unknown) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+      setGeminiLoginState("idle");
+    }
+  };
 
   return (
     <div className="onboarding-wizard__prereqs">
@@ -2156,6 +2233,35 @@ export function BackendRequirementsStep(props: {
         </div>
 
         <div className="onboarding-wizard__prereq-actions">
+          {activeBackend !== "codex" ? (
+            <div className="onboarding-wizard__prereq-enable">
+              <SettingsSwitch
+                checked={activeAcpEnabled}
+                disabled={props.settings.saving}
+                label={`Enable ${activeDefinition.name}`}
+                onChange={(enabled) => {
+                  void setActiveAcpEnabled(enabled);
+                }}
+              />
+              <span>Enable {activeDefinition.name}</span>
+            </div>
+          ) : null}
+          {activeBackend === "gemini"
+          && activeAcpEnabled
+          && activeAcpEntry?.installed ? (
+              <button
+                type="button"
+                className="onboarding-wizard__btn onboarding-wizard__btn--primary"
+                disabled={geminiLoginState === "running"}
+                onClick={() => void loginToGemini()}
+              >
+                {geminiLoginState === "running"
+                  ? "Waiting for Gemini login…"
+                  : geminiLoginState === "ready"
+                    ? "Gemini CLI ready"
+                    : "Log in to Gemini CLI"}
+              </button>
+            ) : null}
           <button
             type="button"
             className="onboarding-wizard__btn onboarding-wizard__btn--ghost"

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -2089,7 +2089,11 @@ export function BackendRequirementsStep(props: {
       updateAcpEntries(response.entries);
       window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
       const gemini = acpEntryFor(response.entries, "gemini");
-      const loginError = gemini?.lastDiscoveryError ?? response.error;
+      const loginError =
+        gemini?.lastDiscoveryError
+        ?? (!gemini?.installed
+          ? "Gemini CLI could not be started."
+          : undefined);
       if (loginError) {
         setError(loginError);
         setGeminiLoginState("idle");

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -214,6 +214,7 @@ describe("AI provider onboarding", () => {
       async (_request?: ListAcpAgentSettingsRequest) => ({
         fetchedAt: 1,
         entries: [gemini],
+        error: "Registry is temporarily unavailable.",
       }),
     );
     const writeConfig = vi.fn(async () => true);
@@ -272,6 +273,9 @@ describe("AI provider onboarding", () => {
         force: true,
         registryIds: ["gemini"],
       });
+      expect(
+        screen.getByRole("button", { name: /Gemini CLI ready/i }),
+      ).toBeVisible();
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -11,6 +11,7 @@ import type {
   AcpAgentSettingsEntry,
   DesktopSettingsSecretName,
   DesktopSettingsSnapshot,
+  ListAcpAgentSettingsRequest,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
@@ -161,6 +162,20 @@ describe("AI provider onboarding", () => {
     expect(
       isBackendRequirementSatisfied(noCodexSnapshot, [acpEntry("grok")]),
     ).toBe(true);
+    expect(
+      isBackendRequirementSatisfied(
+        {
+          ...noCodexSnapshot,
+          acpAgents: {
+            gemini: {
+              cliPath: { value: "", source: "default" },
+              enabled: false,
+            },
+          },
+        } as DesktopSettingsSnapshot,
+        [acpEntry("gemini")],
+      ),
+    ).toBe(false);
   });
 
   it("shows provider-specific macOS install commands without an xAI key field", () => {
@@ -191,6 +206,73 @@ describe("AI provider onboarding", () => {
     expect(screen.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
     expect(screen.queryByText(/xAI API key/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("defers Gemini startup until the operator enables it and clicks login", async () => {
+    const gemini = acpEntry("gemini");
+    const listAcpAgents = vi.fn(
+      async (_request?: ListAcpAgentSettingsRequest) => ({
+        fetchedAt: 1,
+        entries: [gemini],
+      }),
+    );
+    const writeConfig = vi.fn(async () => true);
+    const settings = {
+      snapshot: {
+        ...noCodexSnapshot,
+        acpAgents: {
+          gemini: {
+            cliPath: { value: "", source: "default" },
+            enabled: false,
+          },
+        },
+      },
+      refresh: vi.fn(async () => undefined),
+      writeConfig,
+    } as unknown as DesktopSettingsState;
+
+    render(
+      <BackendRequirementsStep
+        settings={settings}
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        acpEntries={[gemini]}
+        onAcpEntriesChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: false });
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        probeCapabilities: false,
+      });
+    });
+    expect(
+      listAcpAgents.mock.calls.some(([request]) => request?.force === true),
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole("tab", { name: /Gemini CLI/i }));
+    expect(
+      screen.queryByRole("button", { name: /Log in to Gemini CLI/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("switch", { name: /Enable Gemini CLI/i }));
+    await waitFor(() => {
+      expect(writeConfig).toHaveBeenCalledWith({
+        acpAgents: { gemini: { enabled: true } },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Log in to Gemini CLI/i }),
+    );
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        force: true,
+        registryIds: ["gemini"],
+      });
+    });
   });
 
   it("shows native Windows installers and Windows-only prerequisites", () => {
@@ -298,7 +380,10 @@ describe("AI provider onboarding", () => {
 
     await waitFor(() => {
       expect(refreshCodexDiscovery).toHaveBeenCalledOnce();
-      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true, force: true });
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        probeCapabilities: false,
+      });
       expect(applySnapshot).toHaveBeenCalledWith(noCodexSnapshot);
       expect(settingsRefresh).not.toHaveBeenCalled();
       expect(onAcpEntriesChange).toHaveBeenCalledWith([acpEntry("qwen")]);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -19708,8 +19708,16 @@ a.transcript-message__messaging-origin:focus-visible {
 .onboarding-wizard__prereq-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
   min-height: 30px;
+}
+.onboarding-wizard__prereq-enable {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
+  font: 600 11px/1.3 var(--font-sans, sans-serif);
 }
 .onboarding-wizard__prereq-error {
   color: var(--danger-text);

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -314,6 +314,18 @@ export type AcpAgentPreference = {
 export type ListAcpAgentSettingsRequest = {
   refresh?: boolean;
   /**
+   * Restrict local discovery and capability probing to these provider ids.
+   * Omit for every configured provider. Used by explicit onboarding login
+   * actions so starting Gemini never starts another CLI as a side effect.
+   */
+  registryIds?: string[];
+  /**
+   * When false, refresh executable paths and versions without launching an
+   * ACP runtime. Safe for background discovery surfaces such as onboarding,
+   * where an agent launch can begin an interactive browser login.
+   */
+  probeCapabilities?: boolean;
+  /**
    * Force a re-probe of every discovered agent's runtime capabilities,
    * bypassing the freshness window. The "Discover new" button sets this so a
    * user can always re-probe on demand. When omitted, a refresh only launches


### PR DESCRIPTION
## What changed

- keep onboarding ACP discovery limited to executable/path/version checks, without launching provider runtimes
- seed ACP providers as disabled only in fresh bootstrap onboarding, while preserving historical defaults for existing and directly-created profiles
- add an explicit enable control for ACP providers and a targeted **Log in to Gemini CLI** action
- scope explicit runtime probing to Gemini so the login action cannot launch unrelated providers
- add main-process, renderer, profile-seeding, and Electron E2E regression coverage

## Root cause

Entering Step 2 automatically called `listAcpAgents({ refresh: true })`. That refresh performed local discovery and then launched every enabled ACP runtime to discover capabilities. Starting the installed Gemini CLI initiated its browser OAuth flow even though the operator was still on the Codex tab and had not enabled or selected Gemini.

## User impact

Fresh onboarding can still detect installed provider CLIs and show their versions without opening a browser. Gemini starts only after the operator selects its tab, enables it, and clicks **Log in to Gemini CLI**.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/main/__tests__/profile.test.ts` — 62 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors (pre-existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- targeted Electron E2E: `entering AI Providers does not launch Gemini before explicit login` — passed
- broader onboarding Electron E2E: 10/11 passed locally; the remaining well-known-path fixture was superseded by this machine's real `/opt/homebrew/bin/qwen` v0.21.0 instead of the fixture's v999 binary

## Follow-up

Once this release-branch fix is accepted, forward-port it to `main`.
