### PR TITLE
fix(tests): backport graceful E2E process cleanup

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -10,8 +10,20 @@ import type {
 import { _electron as electron, expect, type ElectronApplication, type Page } from "@playwright/test";
 import { applyDesktopSettingsPatch } from "../../src/main/settings/desktop-config";
 import { SECRET_STORAGE_DISABLED_ENV } from "../../src/main/settings/desktop-secret-store";
+import {
+  isPidAlive,
+  listDescendantPids,
+  waitForPidsToExit,
+} from "./process-exit";
 
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
+/**
+ * How long teardown waits for a leftover profile process to exit after
+ * SIGTERM before giving up and letting the rm report the leak.
+ */
+const PROFILE_PROCESS_EXIT_TIMEOUT_MS = 5_000;
+/** Liveness re-check interval while waiting out PROFILE_PROCESS_EXIT_TIMEOUT_MS. */
+const PROFILE_PROCESS_EXIT_POLL_MS = 100;
 
 type LaunchResult = {
   electronApp: ElectronApplication;
@@ -330,17 +342,53 @@ async function killSpawnedProfileProcessesUnder(homeRoot: string): Promise<void>
       }
     }
   }
-  for (const pid of pids) {
-    try {
-      process.kill(pid, "SIGTERM");
-    } catch {
-      // Process already dead — that's fine.
+  // Only signal what is actually still running. A marker can outlive its
+  // process (crash, force-kill, an interrupted run), and signalling a dead pid
+  // would otherwise make us wait on nothing.
+  const livePids = [...pids].filter(isPidAlive);
+  if (livePids.length === 0) {
+    return;
+  }
+
+  // Snapshot the helper processes before signalling, while the parent is still
+  // around to be walked. `HOME` is `homeRoot` for these runs, so an Electron
+  // instance's renderer and GPU helpers hold cache handles under the very tree
+  // the rm is about to remove. They are watched, not signalled: on POSIX the
+  // main process takes its helpers down as it exits. `listDescendantPids`
+  // shells out to `ps`, so on Windows it yields nothing and the watch set stays
+  // the marker pids.
+  const watched = new Set(livePids);
+  for (const pid of livePids) {
+    for (const descendant of await listDescendantPids(pid)) {
+      watched.add(descendant);
     }
   }
-  // Give the killed processes a moment to release their open file
-  // handles before we attempt the rm. SIGTERM is async; without
-  // this sleep we still race against the OS.
-  if (pids.size > 0) {
-    await new Promise((resolve) => setTimeout(resolve, 500));
+
+  for (const pid of livePids) {
+    try {
+      // Node maps SIGTERM to TerminateProcess on Windows, so the wait below is
+      // for the OS to release handles there rather than for a graceful drain.
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Exited between the liveness check and the signal.
+    }
+  }
+
+  // Wait for the processes to actually exit rather than sleeping a fixed
+  // interval and hoping. These children are mid-write to `<homeRoot>`, and the
+  // rm below races their open handles — ENOTEMPTY on POSIX, EBUSY/EPERM on
+  // Windows. This path only runs when a runtime marker outlived its process's
+  // own cleanup, so a generous ceiling has no cost in the ordinary path.
+  const remaining = await waitForPidsToExit(
+    watched,
+    PROFILE_PROCESS_EXIT_TIMEOUT_MS,
+    PROFILE_PROCESS_EXIT_POLL_MS,
+  );
+  if (remaining.length > 0) {
+    // Deliberately no SIGKILL here. A survivor is a real leak, and letting the
+    // rm below fail reports it instead of hiding it behind a kill.
+    console.warn(
+      `[pwragent-e2e-teardown] profile processes still alive ${PROFILE_PROCESS_EXIT_TIMEOUT_MS}ms after SIGTERM: ${remaining.join(", ")}`,
+    );
   }
 }

--- a/apps/desktop/e2e/fixtures/process-exit.ts
+++ b/apps/desktop/e2e/fixtures/process-exit.ts
@@ -1,0 +1,83 @@
+import { execFile } from "node:child_process";
+
+/**
+ * Whether `pid` is still running.
+ *
+ * `EPERM` means the process exists but is not ours to signal, so it counts as
+ * alive. Treating it as gone would race cleanup against a live writer.
+ */
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export function collectDescendantPids(
+  rootPid: number,
+  processTable: string,
+): number[] {
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of processTable.split("\n")) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+    if (!match) {
+      continue;
+    }
+    const childPid = Number(match[1]);
+    const parentPid = Number(match[2]);
+    const children = childrenByParent.get(parentPid);
+    if (children) {
+      children.push(childPid);
+    } else {
+      childrenByParent.set(parentPid, [childPid]);
+    }
+  }
+
+  const descendants: number[] = [];
+  const queue = [rootPid];
+  while (queue.length > 0) {
+    const parentPid = queue.shift();
+    if (parentPid === undefined) {
+      break;
+    }
+    for (const childPid of childrenByParent.get(parentPid) ?? []) {
+      descendants.push(childPid);
+      queue.push(childPid);
+    }
+  }
+  return descendants;
+}
+
+/**
+ * Snapshot a POSIX process tree while its root still exists. Windows has no
+ * `ps`; resolving an empty output keeps the caller's watch set limited to the
+ * known marker pid there.
+ */
+export async function listDescendantPids(rootPid: number): Promise<number[]> {
+  const stdout = await new Promise<string>((resolve) => {
+    execFile(
+      "ps",
+      ["-axo", "pid=,ppid="],
+      { timeout: 5_000 },
+      (_error, output) => resolve(output ?? ""),
+    );
+  });
+  return collectDescendantPids(rootPid, stdout);
+}
+
+/** Wait until every watched pid exits or the bounded polling window expires. */
+export async function waitForPidsToExit(
+  pids: Iterable<number>,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs;
+  let remaining = [...pids].filter(isPidAlive);
+  while (remaining.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    remaining = remaining.filter(isPidAlive);
+  }
+  return remaining;
+}

--- a/apps/desktop/src/main/__tests__/e2e-process-exit.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-process-exit.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  collectDescendantPids,
+  isPidAlive,
+  waitForPidsToExit,
+} from "../../../e2e/fixtures/process-exit";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("E2E process exit helpers", () => {
+  it("collects nested descendants without including unrelated processes", () => {
+    const processTable = [
+      "101 50",
+      "102 101",
+      "103 102",
+      "201 99",
+      "not a process row",
+    ].join("\n");
+
+    expect(collectDescendantPids(50, processTable)).toEqual([101, 102, 103]);
+  });
+
+  it("treats EPERM as alive and other signal errors as exited", () => {
+    const kill = vi.spyOn(process, "kill");
+    kill.mockImplementationOnce(() => {
+      throw Object.assign(new Error("not permitted"), { code: "EPERM" });
+    });
+    kill.mockImplementationOnce(() => {
+      throw Object.assign(new Error("missing"), { code: "ESRCH" });
+    });
+
+    expect(isPidAlive(101)).toBe(true);
+    expect(isPidAlive(102)).toBe(false);
+  });
+
+  it("returns immediately when every watched process has already exited", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("missing"), { code: "ESRCH" });
+    });
+
+    await expect(waitForPidsToExit([101], 5_000, 100)).resolves.toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("polls until parent and helper processes have both exited", async () => {
+    vi.useFakeTimers();
+    const livePids = new Set([101, 102]);
+    vi.spyOn(process, "kill").mockImplementation((pid) => {
+      if (!livePids.has(Number(pid))) {
+        throw Object.assign(new Error("missing"), { code: "ESRCH" });
+      }
+      return true;
+    });
+
+    const waiting = waitForPidsToExit(livePids, 5_000, 100);
+    livePids.delete(101);
+    await vi.advanceTimersByTimeAsync(100);
+    livePids.delete(102);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(waiting).resolves.toEqual([]);
+  });
+
+  it("reports survivors when the polling budget expires", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(process, "kill").mockReturnValue(true);
+
+    const waiting = waitForPidsToExit([101], 200, 100);
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(waiting).resolves.toEqual([101]);
+  });
+});


### PR DESCRIPTION
## Summary

Backport of #1572 from source squash `93963d53690974b808ea172a3f2f126ce336a4c1` onto the current `releases/1.0` tip.

- replace the fixed 500 ms post-SIGTERM sleep with bounded liveness polling for leftover profile processes
- snapshot and watch POSIX Electron helper descendants so cleanup does not race handles they still hold under the temporary home
- return immediately when runtime markers point only to exited processes
- report survivors after 5 seconds without hiding a real leak behind a new SIGKILL
- add focused regression coverage for descendant discovery, liveness semantics, prompt exit, helper exit, and timeout survivors

## Release-branch adaptation

The source branch has a newer custom `closeElectronApplication` force-kill wrapper whose graceful-close allowance changed from 1 second to 6 seconds in #1572. `releases/1.0` does not contain that wrapper: its harness directly awaits Playwright's `electronApp.close()`. The installed Playwright implementation calls `app.quit()` and waits for the process close event without a 1-second cutoff, so importing the main-only wrapper and its 20-second outer ceiling would add unrelated architecture and a new force-kill path rather than improve 1.0 shutdown.

This backport therefore preserves the release branch's existing graceful Electron close behavior and manually adapts the source change at the layer that exists in 1.0: leftover profile-process cleanup.

## Shutdown and platform audit

- Repeated quit requests continue to raise the existing confirmation prompt; no quit-manager behavior changes.
- Signal shutdown still bypasses confirmation, runs the bounded resource barrier, catches cleanup errors, and reaches final `app.quit()`.
- Existing production ceilings remain unchanged: 2 seconds for renderer windows, 4 seconds for messaging, 7.5 seconds for app-server cleanup, and 12 seconds globally.
- Detached environment child commands continue to be stopped by the existing synchronous shutdown path.
- PwrAgent 1.0 has no tray/headless lifetime; main-window close continues to quit auxiliary windows and the app.
- macOS/Linux watch marker processes plus descendants discovered through `ps`. Windows preserves marker-process behavior and polls until `TerminateProcess` teardown releases handles; no unsupported POSIX helper lookup is assumed there.
- No SIGKILL was added. A survivor remains observable through the warning and subsequent `rm` failure.

## Migration and configuration audit

No database/schema migration, migration-sequence dependency, configuration-shape change, package dependency, or lockfile change is present in the source PR or this backport.

## Omitted dependencies

Federation, Star Map, Automations, Attention, and other 1.1-only behavior are not included. The main-only E2E force-kill/teardown-timeout framework is also intentionally omitted; no inseparable 1.1 dependency is required for the release-specific cleanup fix.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/e2e-process-exit.test.ts apps/desktop/src/main/__tests__/quit-manager.test.ts apps/desktop/src/main/__tests__/shutdown-barrier.test.ts` — 20 passed
- `pnpm typecheck` — all 12 applicable workspace projects passed
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm exec eslint --no-ignore apps/desktop/e2e/fixtures/electron-app.ts apps/desktop/e2e/fixtures/process-exit.ts` — passed
- `pnpm lint:boundaries` — passed, 1,125 modules / 3,453 dependencies
- `pnpm --filter @pwragent/desktop test:e2e e2e/app-quit-lifecycle.spec.ts e2e/integrated-terminal.spec.ts` — build passed; first run was 6/7 because a concurrent Kimi cache write produced a transient `ENOTEMPTY`
- isolated profile-backed quit rerun — 1 passed
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/app-quit-lifecycle.spec.ts e2e/integrated-terminal.spec.ts` — clean rerun, 7 passed

Source PR: https://github.com/pwrdrvr/PwrAgent/pull/1572  
Source squash: `93963d53690974b808ea172a3f2f126ce336a4c1`
