### PR TITLE
fix(tests): fail fast on degraded Electron shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,9 +575,12 @@ jobs:
         # Tart's AppleParavirtGPU can reset under Electron load. The early
         # PWRAGENT_E2E_DISABLE_GPU gate selects software rendering before
         # Electron initializes, while ordinary host E2E keeps GPU coverage.
+        # The shutdown circuit is macOS-lane-only: two consecutive closes at
+        # or above 4s (or requiring force-kill) stop this shard after cleanup.
         timeout-minutes: 20
         env:
           PWRAGENT_E2E_DISABLE_GPU: "1"
+          PWRAGENT_E2E_SHUTDOWN_CIRCUIT_BREAKER: "1"
         run: >-
           pnpm --filter @pwragent/desktop test:e2e
           --shard=${{ matrix.lane }}/2

--- a/apps/desktop/e2e/app-quit-lifecycle.spec.ts
+++ b/apps/desktop/e2e/app-quit-lifecycle.spec.ts
@@ -42,7 +42,6 @@ type QuitOutcome = {
   exited: boolean;
   exitCode: number | null;
   signalCode: NodeJS.Signals | null;
-  output: string;
 };
 
 /**
@@ -63,7 +62,6 @@ function requestQuit(electronApp: ElectronApplication): void {
 /** Wait for real process exit, bounded by the product's own shutdown ceiling. */
 async function awaitExit(
   electronApp: ElectronApplication,
-  captured: () => string,
 ): Promise<QuitOutcome> {
   const child = electronApp.process();
   const startedAt = Date.now();
@@ -91,32 +89,32 @@ async function awaitExit(
     exited: child.exitCode !== null || child.signalCode !== null,
     exitCode: child.exitCode,
     signalCode: child.signalCode,
-    output: captured(),
   };
-}
-
-/**
- * Mirror the main process's console transport into a buffer. electron-log
- * keeps its console transport enabled outside Vitest, so every `mainLog` line
- * the quit path emits ("quit in progress", "shutdown barrier completed", …)
- * shows up here — which is what turns a failure into a diagnosis instead of a
- * timeout.
- */
-function captureMainProcessOutput(electronApp: ElectronApplication): () => string {
-  const chunks: string[] = [];
-  const child = electronApp.process();
-  child.stdout?.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
-  child.stderr?.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
-  return () => chunks.join("");
 }
 
 function describeOutcome(label: string, outcome: QuitOutcome): string {
   return [
     `${label} did not exit within ${QUIT_BUDGET_MS}ms after app.quit().`,
     `elapsedMs=${outcome.elapsedMs} exitCode=${String(outcome.exitCode)} signal=${String(outcome.signalCode)}`,
-    "--- main process output ---",
-    outcome.output.slice(-16_000),
+    "See the sanitized pwragent-e2e-shutdown JSON in the job log and Playwright artifact.",
   ].join("\n");
+}
+
+/** Observe one fixed acknowledgement without retaining or printing raw logs. */
+function watchMainProcessOutputFor(
+  electronApp: ElectronApplication,
+  expected: string,
+): () => boolean {
+  let matched = false;
+  let tail = "";
+  const inspect = (chunk: Buffer): void => {
+    tail = `${tail}${chunk.toString()}`.slice(-(expected.length * 2));
+    matched ||= tail.includes(expected);
+  };
+  const child = electronApp.process();
+  child.stdout?.on("data", inspect);
+  child.stderr?.on("data", inspect);
+  return () => matched;
 }
 
 test("exits the process when a profile-backed session is asked to quit", async () => {
@@ -125,11 +123,9 @@ test("exits the process when a profile-backed session is asked to quit", async (
   const app = await launchElectronApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
   });
-  const captured = captureMainProcessOutput(app.electronApp);
-
   try {
     requestQuit(app.electronApp);
-    const outcome = await awaitExit(app.electronApp, captured);
+    const outcome = await awaitExit(app.electronApp);
     expect(outcome.exited, describeOutcome("profile-backed app", outcome)).toBe(
       true,
     );
@@ -158,7 +154,10 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
   const app = await launchElectronApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
   });
-  const captured = captureMainProcessOutput(app.electronApp);
+  const repeatAcknowledged = watchMainProcessOutputFor(
+    app.electronApp,
+    "quit requested while confirmation is open",
+  );
 
   try {
     // The shared harness seeds confirmation OFF so specs close cleanly. This
@@ -217,8 +216,8 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
 
     requestQuit(app.electronApp);
     await expect
-      .poll(() => captured())
-      .toContain("quit requested while confirmation is open");
+      .poll(repeatAcknowledged)
+      .toBe(true);
     // The repeat request raises the existing prompt; it must not stack a second
     // dialog on top of it.
     expect(
@@ -228,7 +227,7 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
     // Answering it has to actually reach process exit — the countdown is gone,
     // so this is the only remaining path out.
     await dialog.locator("#quit").dispatchEvent("click");
-    const outcome = await awaitExit(app.electronApp, captured);
+    const outcome = await awaitExit(app.electronApp);
     expect(
       outcome.exited,
       describeOutcome("app with quit confirmation answered", outcome),
@@ -249,14 +248,13 @@ test("exits the process when the first-run wizard is asked to quit", async () =>
     suppressOnboarding: false,
     requiresReplayDriver: false,
   });
-  const captured = captureMainProcessOutput(app.electronApp);
 
   try {
     await expect(
       app.window.getByRole("heading", { name: /A few short choices/i }),
     ).toBeVisible();
     requestQuit(app.electronApp);
-    const outcome = await awaitExit(app.electronApp, captured);
+    const outcome = await awaitExit(app.electronApp);
     expect(outcome.exited, describeOutcome("first-run wizard app", outcome)).toBe(
       true,
     );

--- a/apps/desktop/e2e/app-quit-lifecycle.spec.ts
+++ b/apps/desktop/e2e/app-quit-lifecycle.spec.ts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, test, type ElectronApplication } from "@playwright/test";
+import {
+  expect,
+  test,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test";
+import { createBoundedOutputMatcher } from "./fixtures/bounded-output-matcher";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 /**
@@ -105,16 +111,31 @@ function watchMainProcessOutputFor(
   electronApp: ElectronApplication,
   expected: string,
 ): () => boolean {
-  let matched = false;
-  let tail = "";
+  const matcher = createBoundedOutputMatcher(expected);
   const inspect = (chunk: Buffer): void => {
-    tail = `${tail}${chunk.toString()}`.slice(-(expected.length * 2));
-    matched ||= tail.includes(expected);
+    matcher.inspect(chunk.toString());
   };
   const child = electronApp.process();
   child.stdout?.on("data", inspect);
   child.stderr?.on("data", inspect);
-  return () => matched;
+  return matcher.matched;
+}
+
+async function setQuitConfirmationEnabled(
+  page: Page,
+  enabled: boolean,
+): Promise<void> {
+  await page.evaluate(async (nextEnabled) => {
+    await (
+      window as unknown as {
+        pwragent: {
+          writeSettingsConfig: (request: unknown) => Promise<unknown>;
+        };
+      }
+    ).pwragent.writeSettingsConfig({
+      patch: { general: { confirmQuitWithInProgressThreads: nextEnabled } },
+    });
+  }, enabled);
 }
 
 test("exits the process when a profile-backed session is asked to quit", async () => {
@@ -158,21 +179,12 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
     app.electronApp,
     "quit requested while confirmation is open",
   );
+  let dialog: Page | undefined;
 
   try {
     // The shared harness seeds confirmation OFF so specs close cleanly. This
     // spec is about the confirmation, so turn it back on the way the app does.
-    await app.window.evaluate(async () => {
-      await (
-        window as unknown as {
-          pwragent: {
-            writeSettingsConfig: (request: unknown) => Promise<unknown>;
-          };
-        }
-      ).pwragent.writeSettingsConfig({
-        patch: { general: { confirmQuitWithInProgressThreads: true } },
-      });
-    });
+    await setQuitConfirmationEnabled(app.window, true);
 
     await app.window
       .getByRole("button", { name: /Replay smoke thread/i })
@@ -201,17 +213,18 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
 
     const dialogPromise = app.electronApp.waitForEvent("window");
     requestQuit(app.electronApp);
-    const dialog = await dialogPromise;
+    const activeDialog = await dialogPromise;
+    dialog = activeDialog;
     await expect(
-      dialog.getByRole("heading", { name: "Quit PwrAgent?" }),
+      activeDialog.getByRole("heading", { name: "Quit PwrAgent?" }),
     ).toBeVisible();
 
     // Stand in for the impatient operator's second Cmd+Q: a keystroke on the
     // dialog cancels the auto-quit permanently, so nothing but the dialog will
     // ever settle this request.
-    await dialog.keyboard.press("ArrowDown");
+    await activeDialog.keyboard.press("ArrowDown");
     await expect
-      .poll(async () => await dialog.locator("#countdown").innerText())
+      .poll(async () => await activeDialog.locator("#countdown").innerText())
       .toBe("Auto-quit cancelled. Choose an option below.");
 
     requestQuit(app.electronApp);
@@ -226,7 +239,7 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
 
     // Answering it has to actually reach process exit — the countdown is gone,
     // so this is the only remaining path out.
-    await dialog.locator("#quit").dispatchEvent("click");
+    await activeDialog.locator("#quit").dispatchEvent("click");
     const outcome = await awaitExit(app.electronApp);
     expect(
       outcome.exited,
@@ -234,6 +247,16 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
     ).toBe(true);
     expect(outcome.signalCode).toBeNull();
   } finally {
+    // An assertion failure must not leave this spec's deliberately blocking
+    // prompt in front of fixture teardown. Restore the shared harness default,
+    // then answer an already-open prompt so cleanup remains graceful and a
+    // test failure cannot masquerade as repeated guest degradation.
+    await setQuitConfirmationEnabled(app.window, false).catch(() => undefined);
+    if (dialog && !dialog.isClosed()) {
+      await dialog.locator("#quit").dispatchEvent("click").catch(
+        () => undefined,
+      );
+    }
     await app.close();
   }
 });

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -4,10 +4,7 @@ import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promi
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
-import {
-  closeElectronApplication,
-  launchElectronApp,
-} from "./fixtures/electron-app";
+import { launchElectronApp } from "./fixtures/electron-app";
 
 async function createCodexEnvironmentSetupFixture(params?: {
   includeExistingRunningSteps?: boolean;
@@ -613,7 +610,7 @@ test("directory launchpad keeps selected environment controls after snapshot rel
       { directoryKey, repoDir: fixture.repoDir },
     );
 
-    await closeElectronApplication(firstApp.electronApp);
+    await firstApp.closeApplication();
     firstApp = undefined;
 
     secondApp = await launchElectronApp({

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -1165,7 +1165,7 @@ test.describe("federation remote window", () => {
       expect(relationship.parentThread?.pinnedRank).toBeTruthy();
 
       const viewerHomeRoot = viewer.homeRoot;
-      await viewer.electronApp.close();
+      await viewer.closeApplication();
       // The E2E memory secret store intentionally does not survive process
       // exit. Keep federation stopped during boot so a temporary regenerated
       // identity cannot be rejected before the original keys are restored.
@@ -1207,7 +1207,7 @@ test.describe("federation remote window", () => {
       expect(relationship.parentThread?.pinnedRank).toBeTruthy();
 
       const ownerHomeRoot = owner.homeRoot;
-      await owner.electronApp.close();
+      await owner.closeApplication();
       disableE2eFederationBeforeRelaunch(ownerHomeRoot);
       const remoteParentRow = viewer.window.locator(".thread-row", {
         has: viewer.window.locator(".thread-row__title", {

--- a/apps/desktop/e2e/fixtures/bounded-output-matcher.ts
+++ b/apps/desktop/e2e/fixtures/bounded-output-matcher.ts
@@ -1,0 +1,32 @@
+export type BoundedOutputMatcher = {
+  inspect(chunk: string): void;
+  matched(): boolean;
+};
+
+/**
+ * Match one fixed marker in streamed process output without retaining a log.
+ * The overlap is only large enough to recognize a marker split across chunks.
+ */
+export function createBoundedOutputMatcher(
+  expected: string,
+): BoundedOutputMatcher {
+  if (expected.length === 0) {
+    throw new Error("Expected output marker must not be empty");
+  }
+
+  let didMatch = false;
+  let overlap = "";
+  return {
+    inspect: (chunk) => {
+      if (didMatch) {
+        return;
+      }
+      const combined = `${overlap}${chunk}`;
+      didMatch = combined.includes(expected);
+      overlap = didMatch
+        ? ""
+        : combined.slice(-(expected.length - 1));
+    },
+    matched: () => didMatch,
+  };
+}

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -1,7 +1,9 @@
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import type {
   DesktopAppearanceDensity,
@@ -28,6 +30,26 @@ import {
   E2E_MEMORY_SECRET_STORAGE_ENV,
   SECRET_STORAGE_DISABLED_ENV,
 } from "../../src/main/settings/desktop-secret-store";
+import {
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+  E2E_SHUTDOWN_LAUNCH_ID_ENV,
+  readE2eShutdownPhaseEvents,
+} from "../../src/main/e2e-shutdown-diagnostics";
+import {
+  appendElectronShutdownSummary,
+  assertElectronShutdownCircuitClosed,
+  buildElectronShutdownSummary,
+  classifyElectronClose,
+  E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV,
+  E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
+  ElectronShutdownCircuitOpenError,
+  executeElectronClose,
+  finalizeElectronFixtureTeardown,
+  observedOverallShutdownDuration,
+  recordElectronShutdownCircuit,
+  type ElectronCloseExecution,
+  type ElectronShutdownSummary,
+} from "./electron-shutdown-policy";
 
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -166,7 +188,15 @@ type LaunchResult = {
     executionMode?: ThreadExecutionMode;
     requestId: string;
   }) => Promise<void>;
+  closeApplication: () => Promise<void>;
   close: () => Promise<void>;
+};
+
+type ElectronCloseOptions = {
+  circuitEnabled?: boolean;
+  circuitStateFile?: string;
+  diagnosticsFile?: string;
+  launchId?: string;
 };
 
 type LaunchElectronAppParams = {
@@ -253,6 +283,17 @@ type LaunchElectronAppParams = {
 export async function launchElectronApp(
   params: LaunchElectronAppParams,
 ): Promise<LaunchResult> {
+  const circuitEnabled =
+    process.env[E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV] === "1";
+  const circuitStateFile =
+    process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV];
+  assertElectronShutdownCircuitClosed({
+    enabled: circuitEnabled,
+    stateFile: circuitStateFile,
+  });
+  const diagnosticsFile =
+    process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  const launchId = randomUUID();
   const homeRoot =
     params.homeRoot ??
     await mkdtemp(path.join(os.tmpdir(), "pwragent-desktop-e2e-home-"));
@@ -289,6 +330,12 @@ export async function launchElectronApp(
     } else {
       env[key] = value;
     }
+  }
+  env[E2E_SHUTDOWN_LAUNCH_ID_ENV] = launchId;
+  if (diagnosticsFile) {
+    env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV] = diagnosticsFile;
+  } else {
+    delete env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
   }
   // Every desktop E2E runs an unsigned development Electron binary. On
   // macOS, allowing that binary to reach safeStorage can open a native
@@ -364,15 +411,24 @@ export async function launchElectronApp(
   // design.
   try {
     return await finishElectronLaunch({
+      circuitEnabled,
+      circuitStateFile,
+      diagnosticsFile,
       electronApp,
       env,
       homeRoot,
+      launchId,
       params,
       seedConfigPath,
       suppressOnboarding,
     });
   } catch (error) {
-    await closeElectronApplication(electronApp).catch(() => undefined);
+    await closeElectronApplication(electronApp, {
+      circuitEnabled,
+      circuitStateFile,
+      diagnosticsFile,
+      launchId,
+    }).catch(() => undefined);
     await killSpawnedProfileProcessesUnder(homeRoot).catch(() => undefined);
     // Deliberately NOT removing `homeRoot`: on a launch failure the
     // seeded config.toml and whatever profile state exists are the
@@ -382,17 +438,25 @@ export async function launchElectronApp(
 }
 
 async function finishElectronLaunch(args: {
+  circuitEnabled: boolean;
+  circuitStateFile?: string;
+  diagnosticsFile?: string;
   electronApp: ElectronApplication;
   env: Record<string, string>;
   homeRoot: string;
+  launchId: string;
   params: LaunchElectronAppParams;
   seedConfigPath: string;
   suppressOnboarding: boolean;
 }): Promise<LaunchResult> {
   const {
+    circuitEnabled,
+    circuitStateFile,
+    diagnosticsFile,
     electronApp,
     env,
     homeRoot,
+    launchId,
     params,
     seedConfigPath,
     suppressOnboarding,
@@ -460,6 +524,17 @@ async function finishElectronLaunch(args: {
         await globalThis.__PWRAGENT_REPLAY_DRIVER__?.respondToPendingRequest(value);
       }, requestParams);
     },
+    closeApplication: async () => {
+      const summary = await closeElectronApplication(electronApp, {
+        circuitEnabled,
+        circuitStateFile,
+        diagnosticsFile,
+        launchId,
+      });
+      if (summary.circuit.tripped) {
+        throw new ElectronShutdownCircuitOpenError();
+      }
+    },
     close: async () => {
       // Bound the whole teardown. `closeElectronApplication` is already
       // internally bounded, but the profile-process sweep and the `rm`
@@ -479,29 +554,31 @@ async function finishElectronLaunch(args: {
         // surfacing as an unhandled promise rejection mid-suite.
         running.catch(() => undefined);
         console.warn(
-          `[pwragent-e2e-teardown] teardown exceeded ${ELECTRON_TEARDOWN_TIMEOUT_MS}ms for homeRoot=${homeRoot}`,
+          `[pwragent-e2e-teardown] teardown exceeded ${ELECTRON_TEARDOWN_TIMEOUT_MS}ms`,
         );
       }
     },
   };
 
   async function teardown(): Promise<void> {
-    await closeElectronApplication(electronApp);
-    // The wizard's graduation path can spawn a detached child
-    // Electron process for the operator's chosen profile (see
-    // `openPwrAgentProfile` in `ipc/profiles.ts`). That child
-    // outlives the test's bootstrap Electron and keeps writing
-    // to `<homeRoot>/.pwragent/profiles/<name>/` (state.db
-    // heartbeats, Codex plugin clones, etc.). If we rm the
-    // tmpdir while the child is mid-write, rm races and ENOTEMPTYs.
-    //
-    // Find any live PwrAgent instances under this tmpdir via
-    // their runtime-instance heartbeat markers, kill them, then
-    // proceed with cleanup. Each marker file is a JSON blob
-    // containing the process's PID; the marker dir layout matches
-    // `startProfileRuntimeHeartbeat` in `main/profile.ts`.
-    await killSpawnedProfileProcessesUnder(homeRoot);
-    await rm(homeRoot, { recursive: true, force: true });
+    await finalizeElectronFixtureTeardown({
+      closeApplication: async () =>
+        await closeElectronApplication(electronApp, {
+          circuitEnabled,
+          circuitStateFile,
+          diagnosticsFile,
+          launchId,
+        }),
+      // The wizard's graduation path can spawn a detached child Electron
+      // process for the operator's chosen profile. Sweep it only after the
+      // Playwright-owned tree has completed its bounded graceful/forced close.
+      cleanupProfileProcesses: async () => {
+        await killSpawnedProfileProcessesUnder(homeRoot);
+      },
+      removeHomeRoot: async () => {
+        await rm(homeRoot, { recursive: true, force: true });
+      },
+    });
   }
 }
 
@@ -896,7 +973,8 @@ export function configureElectronE2eSecretStorageEnv(
  */
 export async function closeElectronApplication(
   electronApp: ElectronApplication,
-): Promise<void> {
+  options: ElectronCloseOptions = {},
+): Promise<ElectronShutdownSummary> {
   let child: ElectronChildProcess | undefined;
   try {
     child = electronApp.process();
@@ -905,44 +983,94 @@ export async function closeElectronApplication(
     // before the test reaches finally. Once Playwright has disposed its
     // Electron connection, process() throws while resolving the remote
     // object; there is no remaining process tree for this helper to close.
-    return;
+    return recordElectronCloseSummary(
+      alreadyExitedCloseExecution(),
+      options,
+    );
   }
   if (!child) {
     // Depending on the Playwright client version and disposal timing,
     // `process()` can return undefined rather than throw after the channel is
     // released. That has the same no-process-left-to-clean-up meaning.
-    return;
-  }
-  try {
-    await withTimeout(
-      electronApp.evaluate(({ app }) => {
-        app.quit();
-      }),
-      ELECTRON_EVALUATE_QUIT_TIMEOUT_MS,
-      "Electron quit evaluation timed out",
+    return recordElectronCloseSummary(
+      alreadyExitedCloseExecution(),
+      options,
     );
-  } catch {
-    // A healthy process commonly closes the Playwright connection before the
-    // evaluate round-trip resolves. A wedged process also lands here; the
-    // bounded close and process-tree fallback below distinguish the two.
   }
+  const execution = await executeElectronClose({
+    now: performance.now.bind(performance),
+    requestQuit: async () => {
+      await withTimeout(
+        electronApp.evaluate(({ app }) => {
+          app.quit();
+        }),
+        ELECTRON_EVALUATE_QUIT_TIMEOUT_MS,
+        "Electron quit evaluation timed out",
+      );
+    },
+    startClose: () => {
+      const closePromise = electronApp.close();
+      closePromise.catch(() => undefined);
+      return closePromise;
+    },
+    waitForGracefulClose: async (closePromise) => await waitForClose(
+      closePromise,
+      ELECTRON_CLOSE_TIMEOUT_MS,
+    ),
+    hasExited: () => hasExited(child),
+    forceKillTree: async () => {
+      await killProcessTree(child);
+    },
+    waitForForcedExit: async () => await waitForProcessExit(
+      child,
+      ELECTRON_FORCE_EXIT_TIMEOUT_MS,
+    ),
+    waitForPostKillClose: async (closePromise) => {
+      await waitForClose(closePromise, ELECTRON_FORCE_EXIT_TIMEOUT_MS);
+    },
+  });
+  return recordElectronCloseSummary(execution, options);
+}
 
-  const closePromise = electronApp.close();
-  closePromise.catch(() => undefined);
-  const result = await waitForClose(
-    closePromise,
-    ELECTRON_CLOSE_TIMEOUT_MS,
-  );
-  if (hasExited(child)) {
-    return;
-  }
+function alreadyExitedCloseExecution(): ElectronCloseExecution {
+  return {
+    elapsedMs: 0,
+    forceExitOutcome: "not-needed",
+    forced: false,
+    gracefulCloseOutcome: "closed",
+    quitRequestOutcome: "completed",
+  };
+}
 
-  console.warn(
-    `[pwragent-e2e-teardown] graceful close failed (close=${result}, exited=${hasExited(child)}) — force-killing pid=${child.pid ?? "?"}`,
-  );
-  await killProcessTree(child);
-  await waitForProcessExit(child, ELECTRON_FORCE_EXIT_TIMEOUT_MS);
-  await waitForClose(closePromise, ELECTRON_FORCE_EXIT_TIMEOUT_MS);
+function recordElectronCloseSummary(
+  execution: ElectronCloseExecution,
+  options: ElectronCloseOptions,
+): ElectronShutdownSummary {
+  const diagnosticsFile = options.diagnosticsFile
+    ?? process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  const launchId = options.launchId ?? "untracked";
+  const events = readE2eShutdownPhaseEvents(diagnosticsFile, launchId);
+  const classification = classifyElectronClose({
+    ...execution,
+    shutdownElapsedMs: observedOverallShutdownDuration(events),
+  });
+  const circuit = recordElectronShutdownCircuit({
+    classification,
+    enabled: options.circuitEnabled
+      ?? process.env[E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV] === "1",
+    stateFile: options.circuitStateFile
+      ?? process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV],
+  });
+  const summary = buildElectronShutdownSummary({
+    circuit,
+    classification,
+    events,
+    execution,
+    launchId,
+  });
+  appendElectronShutdownSummary(diagnosticsFile, summary);
+  console.log(`[pwragent-e2e-shutdown] ${JSON.stringify(summary)}`);
+  return summary;
 }
 
 /**

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -45,6 +45,7 @@ import {
   ElectronShutdownCircuitOpenError,
   executeElectronClose,
   finalizeElectronFixtureTeardown,
+  memoizeElectronClose,
   observedOverallShutdownDuration,
   recordElectronShutdownCircuit,
   type ElectronCloseExecution,
@@ -461,6 +462,14 @@ async function finishElectronLaunch(args: {
     seedConfigPath,
     suppressOnboarding,
   } = args;
+  const closeApplicationOnce = memoizeElectronClose(async () =>
+    await closeElectronApplication(electronApp, {
+      circuitEnabled,
+      circuitStateFile,
+      diagnosticsFile,
+      launchId,
+    }),
+  );
   const window = await electronApp.firstWindow();
 
   await waitForRendererReady({
@@ -525,12 +534,7 @@ async function finishElectronLaunch(args: {
       }, requestParams);
     },
     closeApplication: async () => {
-      const summary = await closeElectronApplication(electronApp, {
-        circuitEnabled,
-        circuitStateFile,
-        diagnosticsFile,
-        launchId,
-      });
+      const summary = await closeApplicationOnce();
       if (summary.circuit.tripped) {
         throw new ElectronShutdownCircuitOpenError();
       }
@@ -562,13 +566,7 @@ async function finishElectronLaunch(args: {
 
   async function teardown(): Promise<void> {
     await finalizeElectronFixtureTeardown({
-      closeApplication: async () =>
-        await closeElectronApplication(electronApp, {
-          circuitEnabled,
-          circuitStateFile,
-          diagnosticsFile,
-          launchId,
-        }),
+      closeApplication: closeApplicationOnce,
       // The wizard's graduation path can spawn a detached child Electron
       // process for the operator's chosen profile. Sweep it only after the
       // Playwright-owned tree has completed its bounded graceful/forced close.

--- a/apps/desktop/e2e/fixtures/electron-shutdown-circuit-reporter.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-circuit-reporter.ts
@@ -1,0 +1,48 @@
+import type {
+  FullResult,
+  Reporter,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
+import {
+  ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME,
+} from "./electron-shutdown-policy";
+
+type ReporterOptions = {
+  stopRun?: () => void;
+};
+
+/** Stop Playwright gracefully so reporters and global teardown still finish. */
+function interruptPlaywrightRun(): void {
+  process.kill(process.pid, "SIGINT");
+}
+
+export default class ElectronShutdownCircuitReporter implements Reporter {
+  private readonly stopRun: () => void;
+  private circuitTripped = false;
+
+  constructor(options: ReporterOptions = {}) {
+    this.stopRun = options.stopRun ?? interruptPlaywrightRun;
+  }
+
+  onTestEnd(_test: TestCase, result: TestResult): void {
+    if (
+      this.circuitTripped
+      || !result.errors.some((error) =>
+        [error.message, error.stack, error.value].some((detail) =>
+          detail?.includes(ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME),
+        ),
+      )
+    ) {
+      return;
+    }
+    this.circuitTripped = true;
+    this.stopRun();
+  }
+
+  async onEnd(
+    _result: FullResult,
+  ): Promise<{ status: "failed" } | undefined> {
+    return this.circuitTripped ? { status: "failed" } : undefined;
+  }
+}

--- a/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
@@ -1,0 +1,371 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type {
+  E2eShutdownPhase,
+  E2eShutdownPhaseEvent,
+} from "../../src/main/e2e-shutdown-diagnostics";
+
+export const E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_CIRCUIT_BREAKER";
+export const E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_CIRCUIT_STATE_FILE";
+
+/**
+ * A healthy replay-backed app normally closes well below the renderer's own
+ * 2s ceiling. Four seconds leaves a second full renderer budget for loaded
+ * runners while still classifying a close before the harness's 6s force-kill.
+ */
+export const SLOW_ELECTRON_CLOSE_THRESHOLD_MS = 4_000;
+/** One isolated abnormal close is tolerated; the second consecutive one trips. */
+export const ABNORMAL_ELECTRON_CLOSE_LIMIT = 2;
+
+export type ElectronCloseClassification =
+  | "healthy"
+  | "slow"
+  | "force-killed";
+export type ElectronCloseHandshakeOutcome = "closed" | "rejected" | "timeout";
+
+export type ElectronCloseExecution = {
+  elapsedMs: number;
+  forceExitOutcome: "not-needed" | "exited" | "timed-out";
+  forced: boolean;
+  gracefulCloseOutcome: ElectronCloseHandshakeOutcome;
+  quitRequestOutcome: "completed" | "rejected";
+};
+
+export type ElectronShutdownCircuitState = {
+  schemaVersion: 1;
+  consecutiveAbnormalCloses: number;
+  open: boolean;
+};
+
+export type ElectronShutdownCircuitDecision = {
+  enabled: boolean;
+  consecutiveAbnormalCloses: number;
+  limit: number;
+  tripped: boolean;
+};
+
+export type ElectronShutdownPhaseSummary = {
+  durationMs: number | null;
+  outcome:
+    | "completed"
+    | "failed"
+    | "timed-out"
+    | "skipped"
+    | "interrupted"
+    | "not-observed";
+};
+
+export type ElectronShutdownSummary = {
+  schemaVersion: 1;
+  kind: "close-summary";
+  launchId: string;
+  classification: ElectronCloseClassification;
+  elapsedMs: number;
+  quitRequestOutcome: ElectronCloseExecution["quitRequestOutcome"];
+  gracefulCloseOutcome: ElectronCloseHandshakeOutcome;
+  forceExitOutcome: ElectronCloseExecution["forceExitOutcome"];
+  phases: {
+    rendererWindow: ElectronShutdownPhaseSummary;
+    messaging: ElectronShutdownPhaseSummary;
+    appServer: ElectronShutdownPhaseSummary;
+    overall: ElectronShutdownPhaseSummary;
+  };
+  circuit: ElectronShutdownCircuitDecision;
+};
+
+type ElectronCloseActions = {
+  forceKillTree(): Promise<void>;
+  hasExited(): boolean;
+  now(): number;
+  requestQuit(): Promise<void>;
+  startClose(): Promise<void>;
+  waitForForcedExit(): Promise<boolean>;
+  waitForGracefulClose(
+    closePromise: Promise<void>,
+  ): Promise<ElectronCloseHandshakeOutcome>;
+  waitForPostKillClose(closePromise: Promise<void>): Promise<void>;
+};
+
+export async function executeElectronClose(
+  actions: ElectronCloseActions,
+): Promise<ElectronCloseExecution> {
+  const startedAt = actions.now();
+  let quitRequestOutcome: ElectronCloseExecution["quitRequestOutcome"] =
+    "completed";
+  try {
+    await actions.requestQuit();
+  } catch {
+    quitRequestOutcome = "rejected";
+  }
+
+  let closePromise: Promise<void>;
+  try {
+    closePromise = actions.startClose();
+  } catch {
+    closePromise = Promise.reject(new Error("Electron close rejected"));
+    closePromise.catch(() => undefined);
+  }
+  const gracefulCloseOutcome = await actions.waitForGracefulClose(closePromise);
+  if (actions.hasExited()) {
+    return {
+      elapsedMs: normalizeDuration(actions.now() - startedAt),
+      forceExitOutcome: "not-needed",
+      forced: false,
+      gracefulCloseOutcome,
+      quitRequestOutcome,
+    };
+  }
+
+  await actions.forceKillTree();
+  const forcedExit = await actions.waitForForcedExit();
+  await actions.waitForPostKillClose(closePromise);
+  return {
+    elapsedMs: normalizeDuration(actions.now() - startedAt),
+    forceExitOutcome: forcedExit ? "exited" : "timed-out",
+    forced: true,
+    gracefulCloseOutcome,
+    quitRequestOutcome,
+  };
+}
+
+export function classifyElectronClose(
+  execution: Pick<ElectronCloseExecution, "elapsedMs" | "forced"> & {
+    shutdownElapsedMs?: number;
+  },
+): ElectronCloseClassification {
+  if (execution.forced) {
+    return "force-killed";
+  }
+  const elapsedMs = Math.max(
+    execution.elapsedMs,
+    execution.shutdownElapsedMs ?? 0,
+  );
+  if (elapsedMs >= SLOW_ELECTRON_CLOSE_THRESHOLD_MS) {
+    return "slow";
+  }
+  return "healthy";
+}
+
+export function advanceElectronShutdownCircuit(
+  state: ElectronShutdownCircuitState,
+  classification: ElectronCloseClassification,
+  limit = ABNORMAL_ELECTRON_CLOSE_LIMIT,
+): ElectronShutdownCircuitState {
+  if (state.open) {
+    return state;
+  }
+  const consecutiveAbnormalCloses = classification === "healthy"
+    ? 0
+    : state.consecutiveAbnormalCloses + 1;
+  return {
+    schemaVersion: 1,
+    consecutiveAbnormalCloses,
+    open: consecutiveAbnormalCloses >= limit,
+  };
+}
+
+export function recordElectronShutdownCircuit(params: {
+  classification: ElectronCloseClassification;
+  enabled: boolean;
+  stateFile?: string;
+}): ElectronShutdownCircuitDecision {
+  if (!params.enabled || !params.stateFile) {
+    return {
+      enabled: false,
+      consecutiveAbnormalCloses: 0,
+      limit: ABNORMAL_ELECTRON_CLOSE_LIMIT,
+      tripped: false,
+    };
+  }
+  const previous = readCircuitState(params.stateFile);
+  const next = advanceElectronShutdownCircuit(
+    previous,
+    params.classification,
+  );
+  writeCircuitState(params.stateFile, next);
+  return {
+    enabled: true,
+    consecutiveAbnormalCloses: next.consecutiveAbnormalCloses,
+    limit: ABNORMAL_ELECTRON_CLOSE_LIMIT,
+    tripped: next.open,
+  };
+}
+
+export function assertElectronShutdownCircuitClosed(params: {
+  enabled: boolean;
+  stateFile?: string;
+}): void {
+  if (!params.enabled || !params.stateFile) {
+    return;
+  }
+  if (readCircuitState(params.stateFile).open) {
+    throw new ElectronShutdownCircuitOpenError();
+  }
+}
+
+export function resetElectronShutdownCircuit(
+  stateFile: string | undefined,
+): void {
+  if (stateFile) {
+    rmSync(stateFile, { force: true });
+  }
+}
+
+export function buildElectronShutdownSummary(params: {
+  circuit: ElectronShutdownCircuitDecision;
+  classification: ElectronCloseClassification;
+  events: E2eShutdownPhaseEvent[];
+  execution: ElectronCloseExecution;
+  launchId: string;
+}): ElectronShutdownSummary {
+  return {
+    schemaVersion: 1,
+    kind: "close-summary",
+    launchId: params.launchId,
+    classification: params.classification,
+    elapsedMs: normalizeDuration(params.execution.elapsedMs),
+    quitRequestOutcome: params.execution.quitRequestOutcome,
+    gracefulCloseOutcome: params.execution.gracefulCloseOutcome,
+    forceExitOutcome: params.execution.forceExitOutcome,
+    phases: {
+      rendererWindow: summarizePhase(params.events, "renderer-window"),
+      messaging: summarizePhase(params.events, "messaging"),
+      appServer: summarizePhase(params.events, "app-server"),
+      overall: summarizePhase(params.events, "overall"),
+    },
+    circuit: params.circuit,
+  };
+}
+
+export function observedOverallShutdownDuration(
+  events: E2eShutdownPhaseEvent[],
+): number | undefined {
+  return [...events].reverse().find(
+    (event) => event.phase === "overall" && event.outcome !== "started",
+  )?.durationMs;
+}
+
+export function appendElectronShutdownSummary(
+  filePath: string | undefined,
+  summary: ElectronShutdownSummary,
+): void {
+  if (!filePath) {
+    return;
+  }
+  try {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    // Lead with a newline so a force-killed, partially appended phase record
+    // cannot swallow the parent-authored summary into the same invalid line.
+    appendFileSync(filePath, `\n${JSON.stringify(summary)}\n`, "utf8");
+  } catch {
+    // Reporting must not replace the teardown result with an I/O failure.
+  }
+}
+
+/**
+ * Circuit failure is deliberately last: force-kill/profile cleanup and temp
+ * directory removal must finish before Playwright is told to stop the lane.
+ */
+export async function finalizeElectronFixtureTeardown(params: {
+  cleanupProfileProcesses(): Promise<void>;
+  closeApplication(): Promise<ElectronShutdownSummary>;
+  removeHomeRoot(): Promise<void>;
+}): Promise<ElectronShutdownSummary> {
+  const summary = await params.closeApplication();
+  await params.cleanupProfileProcesses();
+  await params.removeHomeRoot();
+  if (summary.circuit.tripped) {
+    throw new ElectronShutdownCircuitOpenError();
+  }
+  return summary;
+}
+
+export class ElectronShutdownCircuitOpenError extends Error {
+  constructor() {
+    super(
+      [
+        "Electron shutdown circuit opened after two consecutive abnormal closes;",
+        "stopping this macOS E2E lane after deterministic cleanup.",
+        "Recycle the cold runner guest before retrying.",
+      ].join(" "),
+    );
+    this.name = "ElectronShutdownCircuitOpenError";
+  }
+}
+
+function summarizePhase(
+  events: E2eShutdownPhaseEvent[],
+  phase: E2eShutdownPhase,
+): ElectronShutdownPhaseSummary {
+  const matching = events.filter((event) => event.phase === phase);
+  const terminal = [...matching].reverse().find(
+    (event) => event.outcome !== "started",
+  );
+  if (terminal && terminal.outcome !== "started") {
+    return {
+      durationMs: normalizeDuration(terminal.durationMs),
+      outcome: terminal.outcome,
+    };
+  }
+  if (matching.some((event) => event.outcome === "started")) {
+    return { durationMs: null, outcome: "interrupted" };
+  }
+  return { durationMs: null, outcome: "not-observed" };
+}
+
+function readCircuitState(stateFile: string): ElectronShutdownCircuitState {
+  try {
+    const value = JSON.parse(readFileSync(stateFile, "utf8")) as unknown;
+    if (
+      isRecord(value)
+      && value.schemaVersion === 1
+      && typeof value.consecutiveAbnormalCloses === "number"
+      && Number.isInteger(value.consecutiveAbnormalCloses)
+      && value.consecutiveAbnormalCloses >= 0
+      && typeof value.open === "boolean"
+    ) {
+      return {
+        schemaVersion: 1,
+        consecutiveAbnormalCloses: value.consecutiveAbnormalCloses,
+        open: value.open,
+      };
+    }
+  } catch {
+    // A missing or interrupted state file starts a new closed circuit.
+  }
+  return {
+    schemaVersion: 1,
+    consecutiveAbnormalCloses: 0,
+    open: false,
+  };
+}
+
+function writeCircuitState(
+  stateFile: string,
+  state: ElectronShutdownCircuitState,
+): void {
+  mkdirSync(path.dirname(stateFile), { recursive: true });
+  const temporaryFile = `${stateFile}.${process.pid}.tmp`;
+  writeFileSync(temporaryFile, `${JSON.stringify(state)}\n`, "utf8");
+  renameSync(temporaryFile, stateFile);
+}
+
+function normalizeDuration(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
@@ -76,6 +76,8 @@ export type ElectronShutdownSummary = {
   phases: {
     rendererWindow: ElectronShutdownPhaseSummary;
     messaging: ElectronShutdownPhaseSummary;
+    federation: ElectronShutdownPhaseSummary;
+    mcpConnections: ElectronShutdownPhaseSummary;
     appServer: ElectronShutdownPhaseSummary;
     overall: ElectronShutdownPhaseSummary;
   };
@@ -239,6 +241,8 @@ export function buildElectronShutdownSummary(params: {
     phases: {
       rendererWindow: summarizePhase(params.events, "renderer-window"),
       messaging: summarizePhase(params.events, "messaging"),
+      federation: summarizePhase(params.events, "federation"),
+      mcpConnections: summarizePhase(params.events, "mcp-connections"),
       appServer: summarizePhase(params.events, "app-server"),
       overall: summarizePhase(params.events, "overall"),
     },

--- a/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
@@ -16,6 +16,8 @@ export const E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV =
   "PWRAGENT_E2E_SHUTDOWN_CIRCUIT_BREAKER";
 export const E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV =
   "PWRAGENT_E2E_SHUTDOWN_CIRCUIT_STATE_FILE";
+export const ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME =
+  "ElectronShutdownCircuitOpenError";
 
 /**
  * A healthy replay-backed app normally closes well below the renderer's own
@@ -83,6 +85,16 @@ export type ElectronShutdownSummary = {
   };
   circuit: ElectronShutdownCircuitDecision;
 };
+
+export function memoizeElectronClose(
+  closeApplication: () => Promise<ElectronShutdownSummary>,
+): () => Promise<ElectronShutdownSummary> {
+  let closePromise: Promise<ElectronShutdownSummary> | undefined;
+  return () => {
+    closePromise ??= closeApplication();
+    return closePromise;
+  };
+}
 
 type ElectronCloseActions = {
   forceKillTree(): Promise<void>;
@@ -302,7 +314,7 @@ export class ElectronShutdownCircuitOpenError extends Error {
         "Recycle the cold runner guest before retrying.",
       ].join(" "),
     );
-    this.name = "ElectronShutdownCircuitOpenError";
+    this.name = ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME;
   }
 }
 

--- a/apps/desktop/e2e/global-setup.ts
+++ b/apps/desktop/e2e/global-setup.ts
@@ -33,16 +33,22 @@
 //
 // This does not diagnose the guest-level cause and deliberately does not
 // guess at one. It makes the condition cheap and legible.
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+} from "../src/main/e2e-shutdown-diagnostics";
 import { describeCanaryFailure } from "./canary-report";
 import {
-  closeElectronApplication,
   DESKTOP_MAIN_ENTRY,
   launchElectronApp,
   withTimeout,
 } from "./fixtures/electron-app";
+import {
+  E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
+  resetElectronShutdownCircuit,
+} from "./fixtures/electron-shutdown-policy";
 
 const setupDir = path.dirname(fileURLToPath(import.meta.url));
 const SMOKE_FIXTURE = path.resolve(
@@ -60,6 +66,13 @@ const SMOKE_FIXTURE = path.resolve(
 const CANARY_TIMEOUT_MS = 60_000;
 
 export default async function globalSetup(): Promise<void> {
+  const diagnosticsFile = process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  if (diagnosticsFile) {
+    rmSync(diagnosticsFile, { force: true });
+  }
+  resetElectronShutdownCircuit(
+    process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV],
+  );
   if (!existsSync(DESKTOP_MAIN_ENTRY)) {
     // `playwright test` invoked without a build. The specs report that far
     // more clearly than a canary can, so stay out of the way.
@@ -78,7 +91,7 @@ export default async function globalSetup(): Promise<void> {
   void launching.then(
     (late) => {
       if (settled) {
-        void closeElectronApplication(late.electronApp).catch(() => undefined);
+        void late.close().catch(() => undefined);
       }
     },
     () => undefined,
@@ -110,9 +123,7 @@ export default async function globalSetup(): Promise<void> {
       // routinely does not resolve — the shared helper bounds each step and
       // force-kills the process tree, which is what every spec's `finally`
       // does. Awaiting a bare `close()` here is what hung a guest for an hour.
-      await closeElectronApplication(launched.electronApp).catch(
-        () => undefined,
-      );
+      await launched.close().catch(() => undefined);
     }
   }
 }

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { defineConfig } from "@playwright/test";
+import { defineConfig, type ReporterDescription } from "@playwright/test";
 import {
   E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
 } from "./src/main/e2e-shutdown-diagnostics";
@@ -39,6 +39,17 @@ process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV] ??= path.join(
 
 const electronShutdownCircuitEnabled =
   process.env[E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV] === "1";
+const reporters: ReporterDescription[] = process.env.CI
+  ? [
+      ["html", { outputFolder: "playwright-report", open: "never" }],
+      ["list"],
+    ]
+  : [["list"]];
+if (electronShutdownCircuitEnabled) {
+  reporters.push([
+    "./e2e/fixtures/electron-shutdown-circuit-reporter.ts",
+  ]);
+}
 
 export default defineConfig({
   testDir: "./e2e",
@@ -52,19 +63,12 @@ export default defineConfig({
   globalTeardown: "./e2e/global-teardown.ts",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
-  // Once the macOS-only fixture circuit opens, its synthetic failure exhausts
-  // the normal retry and this stops the shard instead of enumerating every
-  // remaining test against a guest already proven unhealthy.
-  maxFailures: electronShutdownCircuitEnabled ? 1 : 0,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   outputDir: "./test-results",
-  reporter: process.env.CI
-    ? [
-        ["html", { outputFolder: "playwright-report", open: "never" }],
-        ["list"]
-      ]
-    : "list",
+  // The circuit reporter interrupts only for the synthetic circuit-open
+  // error. Ordinary assertion failures retain normal retry/suite behavior.
+  reporter: reporters,
   use: {
     screenshot: process.env.CI ? "only-on-failure" : "off",
     trace: "on-first-retry",

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,5 +1,12 @@
 import path from "node:path";
 import { defineConfig } from "@playwright/test";
+import {
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+} from "./src/main/e2e-shutdown-diagnostics";
+import {
+  E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV,
+  E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
+} from "./e2e/fixtures/electron-shutdown-policy";
 
 // Every E2E run reports how much the app made sqlite write. This is the only
 // harness that drives the real write path — the main-process unit suites mock
@@ -19,6 +26,20 @@ if (process.env.PWRAGENT_DEV_SQLITE_WRITE_METRICS !== "0") {
   );
 }
 
+process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV] ??= path.join(
+  import.meta.dirname,
+  "test-results",
+  "electron-shutdown-diagnostics.jsonl",
+);
+process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV] ??= path.join(
+  import.meta.dirname,
+  "test-results",
+  "electron-shutdown-circuit.json",
+);
+
+const electronShutdownCircuitEnabled =
+  process.env[E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV] === "1";
+
 export default defineConfig({
   testDir: "./e2e",
   // One bounded Electron launch before the suite. A persistent CI guest can
@@ -31,6 +52,10 @@ export default defineConfig({
   globalTeardown: "./e2e/global-teardown.ts",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
+  // Once the macOS-only fixture circuit opens, its synthetic failure exhausts
+  // the normal retry and this stops the shard instead of enumerating every
+  // remaining test against a guest already proven unhealthy.
+  maxFailures: electronShutdownCircuitEnabled ? 1 : 0,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   outputDir: "./test-results",

--- a/apps/desktop/src/main/__tests__/bounded-output-matcher.test.ts
+++ b/apps/desktop/src/main/__tests__/bounded-output-matcher.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBoundedOutputMatcher,
+} from "../../../e2e/fixtures/bounded-output-matcher";
+
+describe("bounded process output matcher", () => {
+  const marker = "quit requested while confirmation is open";
+
+  it("recognizes markers before trimming oversized chunks", () => {
+    const matcher = createBoundedOutputMatcher(marker);
+
+    matcher.inspect(`prefix ${marker}${" later output".repeat(100)}`);
+
+    expect(matcher.matched()).toBe(true);
+  });
+
+  it("recognizes markers split across chunks", () => {
+    const matcher = createBoundedOutputMatcher(marker);
+
+    matcher.inspect("prefix quit requested while conf");
+    matcher.inspect(`irmation is open${" later output".repeat(100)}`);
+
+    expect(matcher.matched()).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
@@ -50,10 +50,9 @@ describe("desktop E2E pre-flight canary", () => {
 
   // Teardown must never gate: this app's graceful close routinely does not
   // resolve, so failing on it would fail every healthy run.
-  it("tears down through the bounded force-killing helper without gating", () => {
-    expect(globalSetupCode).toContain("closeElectronApplication");
+  it("tears down through the bounded shared fixture helper without gating", () => {
     expect(globalSetupCode).toMatch(
-      /closeElectronApplication\([\s\S]{0,80}?\)\s*\.catch\(/,
+      /await\s+launched\.close\(\)\.catch\(/,
     );
   });
 
@@ -67,11 +66,11 @@ describe("desktop E2E pre-flight canary", () => {
     expect(globalSetupCode).toContain("withTimeout(");
     expect(globalSetupCode).not.toMatch(/Promise\.race\(/);
     // Anchored on the launch promise's own handler. A looser match on
-    // `settled` near `closeElectronApplication` passes on the `finally`
+    // `settled` near `late.close()` passes on the `finally`
     // block alone, so deleting the late-success close went undetected —
     // verified by mutation, which is the only reason this reads oddly.
     expect(globalSetupCode).toMatch(
-      /launching\.then\([\s\S]{0,300}?closeElectronApplication/,
+      /launching\.then\([\s\S]{0,300}?late\.close\(\)\.catch\(/,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/e2e-shutdown-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-shutdown-diagnostics.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createE2eShutdownDiagnosticsRecorder,
+  readE2eShutdownPhaseEvents,
+} from "../e2e-shutdown-diagnostics";
+
+describe("E2E shutdown diagnostics", () => {
+  it("records deterministic phase and overall elapsed times", () => {
+    let now = 1_000;
+    const lines: string[] = [];
+    const recorder = createE2eShutdownDiagnosticsRecorder({
+      enabled: true,
+      launchId: "launch-1",
+      now: () => now,
+      writeLine: (line) => lines.push(line),
+    });
+
+    recorder.beginOverall();
+    recorder.beginPhase("renderer-window");
+    now = 1_125;
+    recorder.finishPhase("renderer-window", "completed", 124.6);
+    now = 1_500;
+    recorder.finishOverall("completed");
+
+    expect(lines.map((line) => JSON.parse(line))).toEqual([
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "overall",
+        outcome: "started",
+        durationMs: 0,
+      },
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "renderer-window",
+        outcome: "started",
+        durationMs: 0,
+      },
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "renderer-window",
+        outcome: "completed",
+        durationMs: 125,
+      },
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "overall",
+        outcome: "completed",
+        durationMs: 500,
+      },
+    ]);
+  });
+
+  it("allowlists structured fields instead of replaying raw app detail", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "shutdown-diagnostics-"));
+    const filePath = path.join(root, "diagnostics.jsonl");
+    try {
+      writeFileSync(
+        filePath,
+        `${JSON.stringify({
+          schemaVersion: 1,
+          kind: "phase",
+          launchId: "launch-2",
+          phase: "app-server",
+          outcome: "timed-out",
+          durationMs: 7_500,
+          homeRoot: "/Users/alice/private-home",
+          username: "alice",
+          command: "Electron --secret token",
+          error: "raw app log with a secret",
+        })}\n`,
+        "utf8",
+      );
+
+      const events = readE2eShutdownPhaseEvents(filePath, "launch-2");
+
+      expect(events).toEqual([{
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-2",
+        phase: "app-server",
+        outcome: "timed-out",
+        durationMs: 7_500,
+      }]);
+      expect(JSON.stringify(events)).not.toMatch(
+        /alice|private-home|Electron|secret|raw app log/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/electron-app-close.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-app-close.test.ts
@@ -4,20 +4,28 @@ import { closeElectronApplication } from "../../../e2e/fixtures/electron-app";
 
 describe("closeElectronApplication", () => {
   it("is a no-op when Playwright throws for an exited Electron handle", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
     const process = vi.fn(() => {
       throw new TypeError("Cannot read properties of undefined (reading '_object')");
     });
     const electronApp = { process } as unknown as ElectronApplication;
 
-    await expect(closeElectronApplication(electronApp)).resolves.toBeUndefined();
+    await expect(closeElectronApplication(electronApp)).resolves.toMatchObject({
+      classification: "healthy",
+      forceExitOutcome: "not-needed",
+    });
     expect(process).toHaveBeenCalledOnce();
   });
 
   it("is a no-op when Playwright returns no process for an exited Electron handle", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
     const process = vi.fn(() => undefined);
     const electronApp = { process } as unknown as ElectronApplication;
 
-    await expect(closeElectronApplication(electronApp)).resolves.toBeUndefined();
+    await expect(closeElectronApplication(electronApp)).resolves.toMatchObject({
+      classification: "healthy",
+      forceExitOutcome: "not-needed",
+    });
     expect(process).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
@@ -27,7 +27,10 @@ describe("Electron E2E fixture teardown", () => {
 
     await expect(
       closeElectronApplication(electronApp as never),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({
+      classification: "healthy",
+      forceExitOutcome: "not-needed",
+    });
   });
 
   it("keeps keychain access disabled while enabling writable screenshot storage", () => {

--- a/apps/desktop/src/main/__tests__/electron-shutdown-circuit-reporter.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-circuit-reporter.test.ts
@@ -1,0 +1,41 @@
+import type { TestCase, TestResult } from "@playwright/test/reporter";
+import { describe, expect, it, vi } from "vitest";
+import ElectronShutdownCircuitReporter from "../../../e2e/fixtures/electron-shutdown-circuit-reporter";
+
+function resultWithError(error: { message?: string; stack?: string }): TestResult {
+  return {
+    errors: [error],
+  } as TestResult;
+}
+
+describe("Electron shutdown circuit reporter", () => {
+  it("does not stop the run for an ordinary test failure", async () => {
+    const stopRun = vi.fn();
+    const reporter = new ElectronShutdownCircuitReporter({ stopRun });
+
+    reporter.onTestEnd(
+      {} as TestCase,
+      resultWithError({ message: "ordinary assertion failed" }),
+    );
+
+    expect(stopRun).not.toHaveBeenCalled();
+    await expect(reporter.onEnd({} as never)).resolves.toBeUndefined();
+  });
+
+  it("stops and fails the run once for a circuit-open failure", async () => {
+    const stopRun = vi.fn();
+    const reporter = new ElectronShutdownCircuitReporter({ stopRun });
+    const result = resultWithError({
+      message: "circuit opened",
+      stack: "ElectronShutdownCircuitOpenError: circuit opened",
+    });
+
+    reporter.onTestEnd({} as TestCase, result);
+    reporter.onTestEnd({} as TestCase, result);
+
+    expect(stopRun).toHaveBeenCalledOnce();
+    await expect(reporter.onEnd({} as never)).resolves.toEqual({
+      status: "failed",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
@@ -1,0 +1,236 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  advanceElectronShutdownCircuit,
+  assertElectronShutdownCircuitClosed,
+  buildElectronShutdownSummary,
+  classifyElectronClose,
+  ElectronShutdownCircuitOpenError,
+  executeElectronClose,
+  finalizeElectronFixtureTeardown,
+  recordElectronShutdownCircuit,
+  SLOW_ELECTRON_CLOSE_THRESHOLD_MS,
+  type ElectronShutdownCircuitState,
+  type ElectronShutdownSummary,
+} from "../../../e2e/fixtures/electron-shutdown-policy";
+
+const CLOSED_STATE: ElectronShutdownCircuitState = {
+  schemaVersion: 1,
+  consecutiveAbnormalCloses: 0,
+  open: false,
+};
+
+describe("Electron shutdown policy", () => {
+  it("classifies slow and force-killed closes at measured boundaries", () => {
+    expect(classifyElectronClose({
+      elapsedMs: SLOW_ELECTRON_CLOSE_THRESHOLD_MS - 1,
+      forced: false,
+    })).toBe("healthy");
+    expect(classifyElectronClose({
+      elapsedMs: SLOW_ELECTRON_CLOSE_THRESHOLD_MS,
+      forced: false,
+    })).toBe("slow");
+    expect(classifyElectronClose({
+      elapsedMs: 0,
+      forced: false,
+      shutdownElapsedMs: SLOW_ELECTRON_CLOSE_THRESHOLD_MS,
+    })).toBe("slow");
+    expect(classifyElectronClose({ elapsedMs: 1, forced: true })).toBe(
+      "force-killed",
+    );
+  });
+
+  it("tolerates one abnormal close, resets on health, and trips on two consecutive closes", () => {
+    const oneSlow = advanceElectronShutdownCircuit(CLOSED_STATE, "slow");
+    expect(oneSlow).toEqual({
+      schemaVersion: 1,
+      consecutiveAbnormalCloses: 1,
+      open: false,
+    });
+    expect(advanceElectronShutdownCircuit(oneSlow, "healthy")).toEqual(
+      CLOSED_STATE,
+    );
+    const open = advanceElectronShutdownCircuit(oneSlow, "force-killed");
+    expect(open).toEqual({
+      schemaVersion: 1,
+      consecutiveAbnormalCloses: 2,
+      open: true,
+    });
+    expect(advanceElectronShutdownCircuit(open, "healthy")).toBe(open);
+  });
+
+  it("persists the open circuit across Playwright worker replacement", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "shutdown-circuit-"));
+    const stateFile = path.join(root, "state.json");
+    try {
+      expect(recordElectronShutdownCircuit({
+        classification: "slow",
+        enabled: true,
+        stateFile,
+      }).tripped).toBe(false);
+      expect(recordElectronShutdownCircuit({
+        classification: "force-killed",
+        enabled: true,
+        stateFile,
+      })).toMatchObject({
+        consecutiveAbnormalCloses: 2,
+        tripped: true,
+      });
+      expect(() => assertElectronShutdownCircuitClosed({
+        enabled: true,
+        stateFile,
+      })).toThrow(ElectronShutdownCircuitOpenError);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("force-kills only after the bounded graceful close and then waits for reaping", async () => {
+    const order: string[] = [];
+    let now = 100;
+    const closePromise = Promise.resolve();
+
+    const result = await executeElectronClose({
+      now: () => now,
+      requestQuit: async () => {
+        order.push("request-quit");
+      },
+      startClose: () => {
+        order.push("start-close");
+        return closePromise;
+      },
+      waitForGracefulClose: async (promise) => {
+        expect(promise).toBe(closePromise);
+        order.push("wait-graceful");
+        now = 6_100;
+        return "timeout";
+      },
+      hasExited: () => {
+        order.push("check-exit");
+        return false;
+      },
+      forceKillTree: async () => {
+        order.push("force-kill-tree");
+      },
+      waitForForcedExit: async () => {
+        order.push("wait-forced-exit");
+        now = 6_150;
+        return true;
+      },
+      waitForPostKillClose: async () => {
+        order.push("wait-post-kill-close");
+      },
+    });
+
+    expect(order).toEqual([
+      "request-quit",
+      "start-close",
+      "wait-graceful",
+      "check-exit",
+      "force-kill-tree",
+      "wait-forced-exit",
+      "wait-post-kill-close",
+    ]);
+    expect(result).toMatchObject({
+      elapsedMs: 6_050,
+      forced: true,
+      forceExitOutcome: "exited",
+    });
+  });
+
+  it("reports terminal, interrupted, and unobserved phases structurally", () => {
+    const summary = buildElectronShutdownSummary({
+      circuit: {
+        enabled: true,
+        consecutiveAbnormalCloses: 1,
+        limit: 2,
+        tripped: false,
+      },
+      classification: "force-killed",
+      events: [
+        phaseEvent("overall", "started", 0),
+        phaseEvent("renderer-window", "completed", 8),
+        phaseEvent("messaging", "started", 0),
+      ],
+      execution: {
+        elapsedMs: 6_100,
+        forceExitOutcome: "exited",
+        forced: true,
+        gracefulCloseOutcome: "timeout",
+        quitRequestOutcome: "rejected",
+      },
+      launchId: "launch-3",
+    });
+
+    expect(summary.phases).toEqual({
+      rendererWindow: { durationMs: 8, outcome: "completed" },
+      messaging: { durationMs: null, outcome: "interrupted" },
+      appServer: { durationMs: null, outcome: "not-observed" },
+      overall: { durationMs: null, outcome: "interrupted" },
+    });
+  });
+
+  it("raises a tripped circuit only after every cleanup step completes", async () => {
+    const order: string[] = [];
+    await expect(finalizeElectronFixtureTeardown({
+      closeApplication: async () => {
+        order.push("bounded-close");
+        return trippedSummary();
+      },
+      cleanupProfileProcesses: async () => {
+        order.push("profile-process-cleanup");
+      },
+      removeHomeRoot: async () => {
+        order.push("remove-home-root");
+      },
+    })).rejects.toThrow(ElectronShutdownCircuitOpenError);
+    expect(order).toEqual([
+      "bounded-close",
+      "profile-process-cleanup",
+      "remove-home-root",
+    ]);
+  });
+});
+
+function phaseEvent(
+  phase: "overall" | "renderer-window" | "messaging",
+  outcome: "started" | "completed",
+  durationMs: number,
+) {
+  return {
+    schemaVersion: 1 as const,
+    kind: "phase" as const,
+    launchId: "launch-3",
+    phase,
+    outcome,
+    durationMs,
+  };
+}
+
+function trippedSummary(): ElectronShutdownSummary {
+  const phase = { durationMs: null, outcome: "not-observed" as const };
+  return {
+    schemaVersion: 1,
+    kind: "close-summary",
+    launchId: "launch-4",
+    classification: "force-killed",
+    elapsedMs: 6_100,
+    quitRequestOutcome: "rejected",
+    gracefulCloseOutcome: "timeout",
+    forceExitOutcome: "exited",
+    phases: {
+      rendererWindow: phase,
+      messaging: phase,
+      appServer: phase,
+      overall: phase,
+    },
+    circuit: {
+      enabled: true,
+      consecutiveAbnormalCloses: 2,
+      limit: 2,
+      tripped: true,
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
@@ -10,6 +10,7 @@ import {
   ElectronShutdownCircuitOpenError,
   executeElectronClose,
   finalizeElectronFixtureTeardown,
+  memoizeElectronClose,
   recordElectronShutdownCircuit,
   SLOW_ELECTRON_CLOSE_THRESHOLD_MS,
   type ElectronShutdownCircuitState,
@@ -85,6 +86,19 @@ describe("Electron shutdown policy", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("records one close result when a launch is closed repeatedly", async () => {
+    let closes = 0;
+    const summary = trippedSummary();
+    const closeOnce = memoizeElectronClose(async () => {
+      closes += 1;
+      return summary;
+    });
+
+    await expect(closeOnce()).resolves.toBe(summary);
+    await expect(closeOnce()).resolves.toBe(summary);
+    expect(closes).toBe(1);
   });
 
   it("force-kills only after the bounded graceful close and then waits for reaping", async () => {

--- a/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
@@ -153,6 +153,8 @@ describe("Electron shutdown policy", () => {
         phaseEvent("overall", "started", 0),
         phaseEvent("renderer-window", "completed", 8),
         phaseEvent("messaging", "started", 0),
+        phaseEvent("federation", "started", 0),
+        phaseEvent("mcp-connections", "completed", 12),
       ],
       execution: {
         elapsedMs: 6_100,
@@ -167,6 +169,8 @@ describe("Electron shutdown policy", () => {
     expect(summary.phases).toEqual({
       rendererWindow: { durationMs: 8, outcome: "completed" },
       messaging: { durationMs: null, outcome: "interrupted" },
+      federation: { durationMs: null, outcome: "interrupted" },
+      mcpConnections: { durationMs: 12, outcome: "completed" },
       appServer: { durationMs: null, outcome: "not-observed" },
       overall: { durationMs: null, outcome: "interrupted" },
     });
@@ -195,7 +199,12 @@ describe("Electron shutdown policy", () => {
 });
 
 function phaseEvent(
-  phase: "overall" | "renderer-window" | "messaging",
+  phase:
+    | "overall"
+    | "renderer-window"
+    | "messaging"
+    | "federation"
+    | "mcp-connections",
   outcome: "started" | "completed",
   durationMs: number,
 ) {
@@ -223,6 +232,8 @@ function trippedSummary(): ElectronShutdownSummary {
     phases: {
       rendererWindow: phase,
       messaging: phase,
+      federation: phase,
+      mcpConnections: phase,
       appServer: phase,
       overall: phase,
     },

--- a/apps/desktop/src/main/__tests__/shutdown-barrier.test.ts
+++ b/apps/desktop/src/main/__tests__/shutdown-barrier.test.ts
@@ -6,10 +6,15 @@ describe("createShutdownBarrier", () => {
     vi.useFakeTimers();
     try {
       const logger = { info: vi.fn(), warn: vi.fn() };
+      const observer = {
+        phaseStarted: vi.fn(),
+        phaseFinished: vi.fn(),
+      };
       const secondPhase = vi.fn(async () => undefined);
       const runShutdown = createShutdownBarrier({
         globalTimeoutMs: 100,
         logger,
+        observer,
         phases: [
           {
             name: "resistant",
@@ -41,6 +46,14 @@ describe("createShutdownBarrier", () => {
         "shutdown phase timed-out",
         expect.objectContaining({ phase: "resistant", timeoutMs: 40 }),
       );
+      expect(observer.phaseStarted.mock.calls).toEqual([
+        ["resistant"],
+        ["cleanup"],
+      ]);
+      expect(observer.phaseFinished.mock.calls).toEqual([
+        [expect.objectContaining({ name: "resistant", outcome: "timed-out" })],
+        [expect.objectContaining({ name: "cleanup", outcome: "completed" })],
+      ]);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/e2e-shutdown-diagnostics.ts
+++ b/apps/desktop/src/main/e2e-shutdown-diagnostics.ts
@@ -1,0 +1,221 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+export const E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_DIAGNOSTICS_FILE";
+export const E2E_SHUTDOWN_LAUNCH_ID_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_LAUNCH_ID";
+
+export const E2E_SHUTDOWN_PHASES = [
+  "overall",
+  "renderer-window",
+  "messaging",
+  "federation",
+  "app-server",
+  "mcp-connections",
+] as const;
+
+export type E2eShutdownPhase = (typeof E2E_SHUTDOWN_PHASES)[number];
+export type E2eShutdownPhaseOutcome =
+  | "started"
+  | "completed"
+  | "failed"
+  | "timed-out"
+  | "skipped";
+
+export type E2eShutdownPhaseEvent = {
+  schemaVersion: 1;
+  kind: "phase";
+  launchId: string;
+  phase: E2eShutdownPhase;
+  outcome: E2eShutdownPhaseOutcome;
+  durationMs: number;
+};
+
+type E2eShutdownDiagnosticsRecorder = {
+  beginOverall(): void;
+  beginPhase(phase: Exclude<E2eShutdownPhase, "overall">): void;
+  finishOverall(outcome: Exclude<E2eShutdownPhaseOutcome, "started">): void;
+  finishPhase(
+    phase: Exclude<E2eShutdownPhase, "overall">,
+    outcome: Exclude<E2eShutdownPhaseOutcome, "started">,
+    durationMs: number,
+  ): void;
+};
+
+type E2eShutdownDiagnosticsRecorderOptions = {
+  enabled: boolean;
+  filePath?: string;
+  launchId?: string;
+  now?: () => number;
+  writeLine?: (line: string) => void;
+};
+
+/**
+ * Record the E2E-only shutdown timeline without copying normal app logs into
+ * CI. Every persisted field is an allowlisted enum, opaque launch id, or
+ * elapsed millisecond count: no paths, usernames, commands, or error strings
+ * can cross this boundary.
+ */
+export function createE2eShutdownDiagnosticsRecorder(
+  options: E2eShutdownDiagnosticsRecorderOptions,
+): E2eShutdownDiagnosticsRecorder {
+  const now = options.now ?? performance.now.bind(performance);
+  const writeLine = options.writeLine
+    ?? createFileLineWriter(options.enabled ? options.filePath : undefined);
+  const launchId = normalizeLaunchId(options.launchId);
+  const enabled =
+    options.enabled
+    && launchId !== undefined
+    && writeLine !== undefined;
+  let overallStartedAt: number | undefined;
+
+  const write = (
+    phase: E2eShutdownPhase,
+    outcome: E2eShutdownPhaseOutcome,
+    durationMs: number,
+  ): void => {
+    if (!enabled || launchId === undefined || writeLine === undefined) {
+      return;
+    }
+    const event: E2eShutdownPhaseEvent = {
+      schemaVersion: 1,
+      kind: "phase",
+      launchId,
+      phase,
+      outcome,
+      durationMs: normalizeDuration(durationMs),
+    };
+    try {
+      writeLine(`${JSON.stringify(event)}\n`);
+    } catch {
+      // Diagnostics must never delay or block the shutdown they observe.
+    }
+  };
+
+  return {
+    beginOverall: () => {
+      if (overallStartedAt !== undefined) {
+        return;
+      }
+      overallStartedAt = now();
+      write("overall", "started", 0);
+    },
+    beginPhase: (phase) => {
+      write(phase, "started", 0);
+    },
+    finishOverall: (outcome) => {
+      const startedAt = overallStartedAt ?? now();
+      write("overall", outcome, now() - startedAt);
+    },
+    finishPhase: (phase, outcome, durationMs) => {
+      write(phase, outcome, durationMs);
+    },
+  };
+}
+
+export function readE2eShutdownPhaseEvents(
+  filePath: string | undefined,
+  launchId: string,
+): E2eShutdownPhaseEvent[] {
+  if (!filePath) {
+    return [];
+  }
+  let contents: string;
+  try {
+    contents = readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+  const events: E2eShutdownPhaseEvent[] = [];
+  for (const line of contents.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const event = parseE2eShutdownPhaseEvent(JSON.parse(line));
+      if (event?.launchId === launchId) {
+        events.push(event);
+      }
+    } catch {
+      // A force-kill can interrupt the final append. Earlier complete lines
+      // remain useful and identify the phase that was interrupted.
+    }
+  }
+  return events;
+}
+
+function createFileLineWriter(
+  filePath: string | undefined,
+): ((line: string) => void) | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  return (line) => {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    appendFileSync(filePath, line, "utf8");
+  };
+}
+
+function parseE2eShutdownPhaseEvent(
+  value: unknown,
+): E2eShutdownPhaseEvent | undefined {
+  if (!isRecord(value) || value.schemaVersion !== 1 || value.kind !== "phase") {
+    return undefined;
+  }
+  const launchId = normalizeLaunchId(value.launchId);
+  if (
+    launchId === undefined
+    || !isShutdownPhase(value.phase)
+    || !isShutdownPhaseOutcome(value.outcome)
+    || typeof value.durationMs !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    schemaVersion: 1,
+    kind: "phase",
+    launchId,
+    phase: value.phase,
+    outcome: value.outcome,
+    durationMs: normalizeDuration(value.durationMs),
+  };
+}
+
+function normalizeLaunchId(value: unknown): string | undefined {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function normalizeDuration(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value));
+}
+
+function isShutdownPhase(value: unknown): value is E2eShutdownPhase {
+  return typeof value === "string"
+    && E2E_SHUTDOWN_PHASES.includes(value as E2eShutdownPhase);
+}
+
+function isShutdownPhaseOutcome(
+  value: unknown,
+): value is E2eShutdownPhaseOutcome {
+  return value === "started"
+    || value === "completed"
+    || value === "failed"
+    || value === "timed-out"
+    || value === "skipped";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog, Menu, nativeImage, shell } from "electron";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
@@ -190,6 +191,12 @@ import {
   setUpdateInstallPreparationHandler,
 } from "./update-install-state";
 import { createShutdownBarrier } from "./shutdown-barrier";
+import {
+  createE2eShutdownDiagnosticsRecorder,
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+  E2E_SHUTDOWN_LAUNCH_ID_ENV,
+  type E2eShutdownPhase,
+} from "./e2e-shutdown-diagnostics";
 
 const APP_NAME = "PwrAgent";
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
@@ -205,6 +212,11 @@ const MESSAGING_SHUTDOWN_TIMEOUT_MS = 4_000;
 const FEDERATION_SHUTDOWN_TIMEOUT_MS = 4_000;
 const APP_SERVER_SHUTDOWN_TIMEOUT_MS = 7_500;
 const MCP_CONNECTION_SHUTDOWN_TIMEOUT_MS = 2_000;
+const e2eShutdownDiagnostics = createE2eShutdownDiagnosticsRecorder({
+  enabled: process.env.PWRAGENT_E2E === "1" && !app.isPackaged,
+  filePath: process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV],
+  launchId: process.env[E2E_SHUTDOWN_LAUNCH_ID_ENV],
+});
 
 // Tart's AppleParavirtGPU can reset under sustained Electron E2E load,
 // delaying WindowServer paints or rebooting the guest. This must run before
@@ -521,10 +533,17 @@ async function closeRendererWindowsBeforeResourceShutdown(
   source: string,
 ): Promise<void> {
   rendererWindowShutdownPromise ??= (async () => {
+    const startedAt = performance.now();
+    e2eShutdownDiagnostics.beginPhase("renderer-window");
     const windows = BrowserWindow.getAllWindows().filter(
       (window) => !window.isDestroyed(),
     );
     if (windows.length === 0) {
+      e2eShutdownDiagnostics.finishPhase(
+        "renderer-window",
+        "completed",
+        performance.now() - startedAt,
+      );
       return;
     }
 
@@ -602,6 +621,11 @@ async function closeRendererWindowsBeforeResourceShutdown(
       durationLimitMs: RENDERER_WINDOW_SHUTDOWN_TIMEOUT_MS,
       outcome,
     });
+    e2eShutdownDiagnostics.finishPhase(
+      "renderer-window",
+      outcome === "closed" ? "completed" : "timed-out",
+      performance.now() - startedAt,
+    );
   })();
   await rendererWindowShutdownPromise;
 }
@@ -609,6 +633,24 @@ async function closeRendererWindowsBeforeResourceShutdown(
 const runMainProcessShutdownBarrier = createShutdownBarrier({
   globalTimeoutMs: MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS,
   logger: mainLog,
+  observer: {
+    phaseStarted: (phase) => {
+      const diagnosticPhase = toE2eShutdownPhase(phase);
+      if (diagnosticPhase) {
+        e2eShutdownDiagnostics.beginPhase(diagnosticPhase);
+      }
+    },
+    phaseFinished: (outcome) => {
+      const diagnosticPhase = toE2eShutdownPhase(outcome.name);
+      if (diagnosticPhase) {
+        e2eShutdownDiagnostics.finishPhase(
+          diagnosticPhase,
+          outcome.outcome,
+          outcome.durationMs,
+        );
+      }
+    },
+  },
   phases: [
     {
       name: "messaging",
@@ -646,21 +688,42 @@ const runMainProcessShutdownBarrier = createShutdownBarrier({
 
 async function disposeMainProcessResources(source: string): Promise<void> {
   mainProcessShutdownPromise ??= (async () => {
-    // Electron emits before-quit while renderer windows are still live. Close
-    // them first so in-flight renderer work cannot cross the boundary where
-    // IPC handlers and their backing stores are disposed.
-    await closeRendererWindowsBeforeResourceShutdown(source);
-    disposeMainProcessResourcesSync({ releaseFederationLease: false });
-    await runMainProcessShutdownBarrier(source);
-    // Keep the scheduler subscribed until the app-server registry is closed.
-    // A queued registry entry can otherwise start after its durable lease was
-    // released, leaving the next process free to dispatch the same action.
-    disposeScheduledThreadActionService();
-    getExistingRuntimeLeaseManager()?.markExited();
-    disposeAppState();
-    mainProcessShutdownComplete = true;
+    e2eShutdownDiagnostics.beginOverall();
+    try {
+      // Electron emits before-quit while renderer windows are still live. Close
+      // them first so in-flight renderer work cannot cross the boundary where
+      // IPC handlers and their backing stores are disposed.
+      await closeRendererWindowsBeforeResourceShutdown(source);
+      disposeMainProcessResourcesSync({ releaseFederationLease: false });
+      await runMainProcessShutdownBarrier(source);
+      // Keep the scheduler subscribed until the app-server registry is closed.
+      // A queued registry entry can otherwise start after its durable lease was
+      // released, leaving the next process free to dispatch the same action.
+      disposeScheduledThreadActionService();
+      getExistingRuntimeLeaseManager()?.markExited();
+      disposeAppState();
+      mainProcessShutdownComplete = true;
+      e2eShutdownDiagnostics.finishOverall("completed");
+    } catch (error) {
+      e2eShutdownDiagnostics.finishOverall("failed");
+      throw error;
+    }
   })();
   await mainProcessShutdownPromise;
+}
+
+function toE2eShutdownPhase(
+  phase: string,
+): Exclude<E2eShutdownPhase, "overall" | "renderer-window"> | undefined {
+  switch (phase) {
+    case "messaging":
+    case "federation":
+    case "app-server":
+    case "mcp-connections":
+      return phase;
+    default:
+      return undefined;
+  }
 }
 
 async function prepareForUpdateInstallShutdown(): Promise<void> {

--- a/apps/desktop/src/main/shutdown-barrier.ts
+++ b/apps/desktop/src/main/shutdown-barrier.ts
@@ -22,11 +22,17 @@ export type ShutdownSummary = {
   outcomes: ShutdownPhaseOutcome[];
 };
 
+export type ShutdownBarrierObserver = {
+  phaseStarted?(phase: string): void;
+  phaseFinished?(outcome: ShutdownPhaseOutcome): void;
+};
+
 export function createShutdownBarrier(options: {
   phases: ShutdownPhase[];
   globalTimeoutMs: number;
   logger: ShutdownBarrierLogger;
   now?: () => number;
+  observer?: ShutdownBarrierObserver;
 }): (source: string) => Promise<ShutdownSummary> {
   let shutdownPromise: Promise<ShutdownSummary> | undefined;
   return (source) => {
@@ -40,6 +46,7 @@ async function runShutdownPhases(options: {
   globalTimeoutMs: number;
   logger: ShutdownBarrierLogger;
   now?: () => number;
+  observer?: ShutdownBarrierObserver;
   source: string;
 }): Promise<ShutdownSummary> {
   const now = options.now ?? Date.now;
@@ -60,6 +67,7 @@ async function runShutdownPhases(options: {
         durationMs: 0,
       };
       outcomes.push(outcome);
+      options.observer?.phaseFinished?.(outcome);
       options.logger.warn("shutdown phase skipped after global deadline", {
         source: options.source,
         phase: phase.name,
@@ -69,6 +77,7 @@ async function runShutdownPhases(options: {
 
     const phaseStartedAt = now();
     const timeoutMs = Math.min(phase.timeoutMs, remainingMs);
+    options.observer?.phaseStarted?.(phase.name);
     const result = await runPhase(phase.run, timeoutMs);
     const outcome: ShutdownPhaseOutcome = {
       name: phase.name,
@@ -77,6 +86,7 @@ async function runShutdownPhases(options: {
       ...(result.error ? { error: result.error } : {}),
     };
     outcomes.push(outcome);
+    options.observer?.phaseFinished?.(outcome);
     const detail = {
       source: options.source,
       phase: phase.name,


### PR DESCRIPTION
## Summary

Make macOS Electron E2E shutdown degeneration phase-identifiable and stop a poisoned guest promptly after the signature repeats.

- Write an E2E-only, sanitized JSONL shutdown timeline into the existing Playwright artifact directory.
- Print one compact structured close summary per fixture to the ordinary job log.
- Preserve bounded graceful quit followed by process-tree force-kill and profile cleanup.
- Enable a two-strike shutdown circuit breaker only on the macOS E2E lane.
- Replace the quit-lifecycle failure's raw app-log dump with a fixed acknowledgement watcher plus the sanitized artifact.

## Incident evidence

On 2026-08-13, macOS release-branch job 94510325634 was healthy through test 62 at roughly 1–2 seconds per test. Test 63 abruptly took 15.6 seconds, and every later passing test took about 15.5–15.8 seconds. Linked job 94512639860 then paid the same delay on nearly every passing test and hit the 20-minute job timeout.

The added roughly 14 seconds aligns with the product shutdown ceilings: renderer-window close (2s), messaging (4s), app-server (7.5s), and the 12s global barrier. Assertions continued to pass.

Pre-run evidence was clean: zero in-scope Electron processes, zero out-of-scope Electron processes, and no `com.github.Electron` saved application state. PwrGit did not use these runners, recent PwrSnap M5 jobs were healthy and cleaned up, and current main already includes PR #1572 / `93963d536909`'s bounded graceful-close and force-kill fallback. This change builds on that behavior; it does not widen timeouts or change runner cattle/lifecycle.

## Design

### Sanitized diagnostics

The main process emits allowlisted events for:

- renderer-window close
- messaging shutdown
- federation shutdown
- app-server shutdown
- MCP connection shutdown
- overall shutdown

Each event contains only a schema version, opaque launch id, fixed phase/outcome enums, and rounded elapsed milliseconds. It cannot include HOME paths, usernames, secrets, command lines, error text, or raw app logs.

The fixture correlates those events with the Playwright close handshake and writes/prints a `close-summary` containing the exact requested renderer, messaging, app-server, and overall outcome. A phase that started but was force-killed is reported as `interrupted`; a phase never reached is `not-observed`. The artifact is `apps/desktop/test-results/electron-shutdown-diagnostics.jsonl`, already covered by the workflow's Playwright artifact upload.

### Circuit breaker thresholds

A close is abnormal when either:

- graceful/product shutdown takes at least 4,000ms; or
- the harness must force-kill the Electron process tree.

The 4s threshold is twice the renderer's 2s ceiling and remains below the harness's existing 6s force-kill ceiling. Replay-backed E2E has no real messaging/federation workload, while healthy fixture closes are expected below the renderer ceiling.

One isolated abnormal close is tolerated. A healthy close resets the consecutive count. Two consecutive abnormal closes open the circuit. State lives in the Playwright output directory so it survives worker replacement/retry. Once open, the retry fails before launching another Electron, and the macOS-only `maxFailures: 1` setting terminates that shard instead of enumerating the remaining suite against a known-poisoned guest.

For the observed repeated 15.5s signature, the lane stops after at most two degraded fixture teardowns plus the immediate retry, rather than spending 15–20 minutes on passing assertions.

### Cleanup ordering

The order remains:

1. request graceful `app.quit()`
2. wait within the existing bounded close budget
3. snapshot and force-kill the full Electron process tree only if still alive
4. wait for reaping
5. sweep spawned profile processes
6. remove the fixture HOME
7. surface the circuit-breaker failure

Focused tests pin this order so diagnostics or fail-fast cannot jump ahead of cleanup.

## Canary decision

The existing Playwright global setup already performs the appropriately scoped tiny probe: it launches the same smoke fixture, obtains a real renderer window, and closes through the shared harness. This change makes that close participate in diagnostics and cleanup.

I did not add a second workflow/pre-run launch-and-close probe. It would duplicate global setup, consume another Electron launch on every shard, and still miss the incident's defining behavior: the guest was healthy through 62 tests and degenerated mid-suite. Fixture-level consecutive-close accounting observes the point where degeneration actually begins.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/e2e-shutdown-diagnostics.test.ts apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts apps/desktop/src/main/__tests__/electron-app-close.test.ts apps/desktop/src/main/__tests__/shutdown-barrier.test.ts` — 12 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors; 35 existing warnings
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build` — includes main bundle boundary check
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts --list` — 204 tests discovered in 74 files

No headed Electron run was launched on the operator's host desktop, and no Tart VM, runner registration, lab infrastructure, workflow run, or existing PR was mutated. The macOS/Tart execution is left to this draft PR's normal CI and operator review.

## Limitations and recovery

This diagnoses and limits the cost of a poisoned guest; it does not repair guest-global WindowServer, paravirtual GPU/media, or kernel state. Pre-run cleanup can remove process/application leftovers, but it cannot repair those subsystems. A cold runner guest restart remains the operational recovery before retrying the lane.
