### PR TITLE
fix(desktop): defer Gemini onboarding login

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -38,9 +38,14 @@ const fakeProviderVersions: Record<FakeProviderName, string> = {
 
 function fakeProviderScript(): string {
   return `#!${process.execPath}
+const fs = require("node:fs");
 const path = require("node:path");
 const name = path.basename(process.argv[1]).replace(/\\.(?:cmd|c?js)$/i, "");
 const args = process.argv.slice(2);
+const execLog = process.env.PWRAGENT_E2E_PROVIDER_EXEC_LOG;
+if (execLog) {
+  fs.appendFileSync(execLog, JSON.stringify({ name, args }) + "\\n");
+}
 
 if (args.includes("--version")) {
   // Current Kimi Code reports a bare 0.x version. Its retired Python
@@ -136,6 +141,7 @@ async function launchWizardWithFakeProviders(
   const homeRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), "pwragent-provider-discovery-e2e-"),
   );
+  const execLogPath = path.join(homeRoot, "provider-exec.jsonl");
   const customBin = path.join(homeRoot, ".bin");
   const commands =
     source === "path"
@@ -167,11 +173,12 @@ async function launchWizardWithFakeProviders(
       requiresReplayDriver: false,
       env: {
         PATH: discoveryPath,
+        PWRAGENT_E2E_PROVIDER_EXEC_LOG: execLogPath,
         PWRAGENT_CODEX_COMMAND: undefined,
         SHELL: process.platform === "darwin" ? "/bin/zsh" : "/bin/bash",
       },
     });
-    return { app, commands };
+    return { app, commands, execLogPath };
   } catch (error) {
     fs.rmSync(homeRoot, { recursive: true, force: true });
     throw error;
@@ -653,6 +660,37 @@ test.describe("Onboarding wizard", () => {
             : /x\.ai\/cli\/install\.sh/i,
         ),
       ).toBeVisible();
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("entering AI Providers does not launch Gemini before explicit login", async () => {
+    test.skip(process.platform === "win32", "Unix executable discovery only");
+    const { app, execLogPath } = await launchWizardWithFakeProviders("path");
+    try {
+      await app.window.getByRole("button", { name: /Get started/i }).click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await expect(
+        app.window.getByRole("tab", { name: /Gemini CLI Installed/i }),
+      ).toBeVisible({ timeout: 20_000 });
+
+      const executions = fs
+        .readFileSync(execLogPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as {
+          name: string;
+          args: string[];
+        });
+      expect(executions.some((execution) => execution.name === "gemini")).toBe(true);
+      expect(
+        executions.some(
+          (execution) =>
+            execution.name === "gemini" && execution.args.includes("--acp"),
+        ),
+      ).toBe(false);
     } finally {
       await app.close();
     }

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -457,7 +457,7 @@ describe("PwrAgent profiles", () => {
       );
     });
 
-    it("ensureBootstrapProfileDir seeds an [onboarding] marker like a real profile", () => {
+    it("seeds onboarding with ACP providers disabled until the operator enables them", () => {
       const { env, root } = createRoot();
       const result = ensureBootstrapProfileDir({ env });
       expect(result.created).toBe(true);
@@ -470,6 +470,11 @@ describe("PwrAgent profiles", () => {
       // like a fresh real profile to the wizard's perspective.
       expect(contents).toContain("[onboarding]");
       expect(contents).toContain("completed = false");
+      expect(contents).toContain("[acp_agents.gemini]");
+      expect(contents).toContain("[acp_agents.grok]");
+      expect(contents).toContain("[acp_agents.kimi]");
+      expect(contents).toContain("[acp_agents.qwen]");
+      expect(contents.match(/enabled = false/g)).toHaveLength(4);
       expect(fs.existsSync(path.join(root, ".bootstrap", "state"))).toBe(true);
     });
 
@@ -484,6 +489,37 @@ describe("PwrAgent profiles", () => {
       const second = ensureBootstrapProfileDir({ env });
       expect(second.created).toBe(false);
       expect(fs.readFileSync(configPath, "utf8")).toContain('theme = "dark"');
+    });
+
+    it("backfills missing ACP defaults without overwriting existing choices", () => {
+      const { env, root } = createRoot();
+      const configPath = path.join(root, ".bootstrap", "config.toml");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        [
+          "[onboarding]",
+          "completed = false",
+          "",
+          "[acp_agents.gemini]",
+          "enabled = true",
+          "",
+          "[acp_agents.kimi]",
+          'cli_path = "/opt/kimi"',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      ensureBootstrapProfileDir({ env });
+
+      const contents = fs.readFileSync(configPath, "utf8");
+      expect(contents).toContain("[acp_agents.gemini]\nenabled = true");
+      expect(contents).toContain(
+        '[acp_agents.kimi]\ncli_path = "/opt/kimi"\nenabled = false',
+      );
+      expect(contents).toContain("[acp_agents.grok]\nenabled = false");
+      expect(contents).toContain("[acp_agents.qwen]\nenabled = false");
     });
 
     it("cleanupBootstrapProfile removes the dir; subsequent existence check is false", () => {

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -917,6 +917,7 @@ describe("settings ipc", () => {
             "state",
             "acp-discovery-workspace",
           ),
+          requestTimeoutMs: 10 * 60_000,
         }),
       );
       expect(
@@ -1221,6 +1222,10 @@ describe("settings ipc", () => {
       // First refresh: the agent is undiscovered → it must be probed once.
       await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
       expect(probe).toHaveBeenCalledTimes(1);
+      expect(probe).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.not.objectContaining({ requestTimeoutMs: expect.anything() }),
+      );
 
       // Second refresh: cached capabilities are fresh + version-matched → the
       // expensive probe must be skipped (no new launch).
@@ -1289,7 +1294,7 @@ describe("settings ipc", () => {
     // discovery round-trips need headroom over the 5s default under CI load.
   }, 20_000);
 
-  it("coalesces matching forced and weaker regular ACP refreshes", async () => {
+  it("coalesces forced ACP refreshes across overlapping provider scopes", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "pwragent-settings-ipc-"),
     );
@@ -1361,9 +1366,39 @@ describe("settings ipc", () => {
       await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(1));
       const forcedFollower = handler?.({}, { refresh: true, force: true });
       const regular = handler?.({}, { refresh: true });
+      const targetedForced = handler?.(
+        {},
+        { refresh: true, force: true, registryIds: ["gemini"] },
+      );
       releaseProbe?.();
-      await Promise.all([forced, forcedFollower, regular]);
+      await Promise.all([forced, forcedFollower, regular, targetedForced]);
       expect(probe).toHaveBeenCalledTimes(1);
+
+      // The reverse ordering also coordinates the actual per-provider probe:
+      // an all-provider pass may still discover the remaining providers, but
+      // it must not launch Gemini again while targeted login is in flight.
+      probe.mockImplementationOnce(
+        async () => await new Promise((resolve) => {
+          releaseProbe = () => resolve({});
+        }),
+      );
+      const targetedFirst = handler?.(
+        {},
+        { refresh: true, force: true, registryIds: ["gemini"] },
+      );
+      await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+      localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([]);
+      const allProvidersSecond = handler?.({}, { refresh: true, force: true });
+      releaseProbe?.();
+      await Promise.all([targetedFirst, allProvidersSecond]);
+      expect(probe).toHaveBeenCalledTimes(2);
+      expect(
+        localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+      ).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          enabledRegistryIds: ["grok", "kimi", "qwen"],
+        }),
+      );
     } finally {
       disposeAppState();
     }

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -860,9 +860,32 @@ describe("settings ipc", () => {
             entry.installed === false && entry.installStatus === "not-installed",
         ),
       ).toBe(true);
+      const discoveredOnly = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: true, probeCapabilities: false },
+      )) as { entries?: unknown[] } | undefined;
+      expect(discoveredOnly?.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            backendId: "acp:gemini",
+            installed: true,
+          }),
+        ]),
+      );
+      expect(
+        acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities,
+      ).not.toHaveBeenCalled();
+
+      const { applyDesktopSettingsPatch } = await import(
+        "../settings/desktop-config"
+      );
+      applyDesktopSettingsPatch(
+        path.join(tempRoot, ".bootstrap", "config.toml"),
+        { acpAgents: { gemini: { enabled: true } } },
+      );
       const refreshed = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
         {},
-        { refresh: true },
+        { refresh: true, force: true, registryIds: ["gemini"] },
       )) as { entries?: unknown[] } | undefined;
       expect(refreshed?.entries).toEqual(
         expect.arrayContaining([
@@ -895,6 +918,11 @@ describe("settings ipc", () => {
             "acp-discovery-workspace",
           ),
         }),
+      );
+      expect(
+        localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+      ).toHaveBeenLastCalledWith(
+        expect.objectContaining({ enabledRegistryIds: ["gemini"] }),
       );
       expect(
         fs.existsSync(path.join(tempRoot, "profiles", "default")),
@@ -1199,11 +1227,61 @@ describe("settings ipc", () => {
       await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
       expect(probe).toHaveBeenCalledTimes(1);
 
+      localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([
+        {
+          backendId: "acp:gemini",
+          registryId: "gemini",
+          name: "Gemini CLI",
+          version: "0.43.0",
+          distributionKind: "local",
+          distributionSource: "gemini --acp --skip-trust",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-gemini-cli",
+          installedAt: 1234,
+          updatedAt: 1234,
+          launchDescriptor: {
+            backendId: "acp:gemini",
+            registryId: "gemini",
+            distributionKind: "local",
+            command: "gemini",
+            args: ["--acp", "--skip-trust"],
+            env: {},
+          },
+        },
+      ]);
+      const discoveredOnly = (await handlers
+        .get(ACP_AGENTS_LIST_CHANNEL)
+        ?.({}, { refresh: true, probeCapabilities: false })) as
+        | {
+            entries?: Array<{
+              registryId: string;
+              runtime?: unknown;
+              lastDiscoveredAt?: number;
+              version?: string;
+            }>;
+          }
+        | undefined;
+      expect(probe).toHaveBeenCalledTimes(1);
+      expect(
+        discoveredOnly?.entries?.find((entry) => entry.registryId === "gemini"),
+      ).toMatchObject({
+        version: "0.43.0",
+        runtime: undefined,
+        lastDiscoveredAt: undefined,
+      });
+
+      // A discovery-only version change invalidates the old runtime cache, so
+      // the next ordinary refresh must probe the upgraded CLI.
+      await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
+      expect(probe).toHaveBeenCalledTimes(2);
+
       // Forced refresh ("Discover new"): re-probe regardless of freshness.
       await handlers
         .get(ACP_AGENTS_LIST_CHANNEL)
         ?.({}, { refresh: true, force: true });
-      expect(probe).toHaveBeenCalledTimes(2);
+      expect(probe).toHaveBeenCalledTimes(3);
     } finally {
       disposeAppState();
     }
@@ -1211,7 +1289,7 @@ describe("settings ipc", () => {
     // discovery round-trips need headroom over the 5s default under CI load.
   }, 20_000);
 
-  it("coalesces concurrent forced ACP refreshes onto one probe pass", async () => {
+  it("coalesces matching forced and weaker regular ACP refreshes", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "pwragent-settings-ipc-"),
     );
@@ -1270,14 +1348,21 @@ describe("settings ipc", () => {
       const probe = acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities;
       const handler = handlers.get(ACP_AGENTS_LIST_CHANNEL);
 
-      // Two rapid "Discover new" clicks fire before the first pass resolves.
-      // Both are forced, so freshness can't gate the second — only the
-      // in-flight coalescing keeps them from launching the agent twice in
-      // parallel. The second must ride the first's forced pass: one probe.
-      await Promise.all([
-        handler?.({}, { refresh: true, force: true }),
-        handler?.({}, { refresh: true, force: true }),
-      ]);
+      let releaseProbe: (() => void) | undefined;
+      probe.mockImplementationOnce(
+        async () => await new Promise((resolve) => {
+          releaseProbe = () => resolve({});
+        }),
+      );
+
+      // A non-forced caller that arrives during a stronger forced pass must
+      // ride that pass instead of launching the same runtime in parallel.
+      const forced = handler?.({}, { refresh: true, force: true });
+      await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(1));
+      const forcedFollower = handler?.({}, { refresh: true, force: true });
+      const regular = handler?.({}, { refresh: true });
+      releaseProbe?.();
+      await Promise.all([forced, forcedFollower, regular]);
       expect(probe).toHaveBeenCalledTimes(1);
     } finally {
       disposeAppState();

--- a/apps/desktop/src/main/acp/acp-runtime-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-discovery.ts
@@ -25,6 +25,7 @@ export async function discoverAcpRuntimeCapabilities(
   options: {
     cwd: string;
     now?: () => number;
+    requestTimeoutMs?: number;
     transportFactory?: (agent: AcpInstalledAgentRecord) => AcpJsonRpcTransport;
   },
 ): Promise<AcpRuntimeDiscoveryResult> {
@@ -39,7 +40,8 @@ export async function discoverAcpRuntimeCapabilities(
     options.transportFactory?.(agent) ??
     new AcpStdioJsonRpcTransport({
       launchDescriptor: agent.launchDescriptor,
-      requestTimeoutMs: ACP_DISCOVERY_REQUEST_TIMEOUT_MS,
+      requestTimeoutMs:
+        options.requestTimeoutMs ?? ACP_DISCOVERY_REQUEST_TIMEOUT_MS,
     });
   const client = new AcpAgentClient({
     backendId: agent.backendId,

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -155,8 +155,21 @@ async function refreshModelBackendsIfNeeded(params: {
 // from launching every agent twice in parallel. A forced caller that arrives
 // while only a non-forced pass is in flight still starts its own pass, so
 // "Discover new" is never a no-op.
-let inFlightAcpRefresh: Promise<ListAcpAgentSettingsResponse> | undefined;
-let inFlightAcpRefreshForced = false;
+type InFlightAcpRefreshes = {
+  forced?: Promise<ListAcpAgentSettingsResponse>;
+  regular?: Promise<ListAcpAgentSettingsResponse>;
+};
+
+const inFlightAcpRefreshes = new Map<string, InFlightAcpRefreshes>();
+
+function acpRefreshKey(request: ListAcpAgentSettingsRequest): string {
+  return JSON.stringify({
+    probeCapabilities: request.probeCapabilities !== false,
+    registryIds: request.registryIds
+      ? [...new Set(request.registryIds)].sort()
+      : undefined,
+  });
+}
 
 async function listAcpAgentSettings(
   request: ListAcpAgentSettingsRequest = {},
@@ -165,18 +178,27 @@ async function listAcpAgentSettings(
   if (request.refresh === false) {
     return await listAcpAgentSettingsImpl(request, service);
   }
+  const refreshKey = acpRefreshKey(request);
   const wantsForce = request.force === true;
-  if (inFlightAcpRefresh && (!wantsForce || inFlightAcpRefreshForced)) {
-    return await inFlightAcpRefresh;
+  const inFlightForScope = inFlightAcpRefreshes.get(refreshKey);
+  const inFlight = wantsForce
+    ? inFlightForScope?.forced
+    : inFlightForScope?.forced ?? inFlightForScope?.regular;
+  if (inFlight) {
+    return await inFlight;
   }
+  const kind = wantsForce ? "forced" : "regular";
   const run = listAcpAgentSettingsImpl(request, service).finally(() => {
-    if (inFlightAcpRefresh === run) {
-      inFlightAcpRefresh = undefined;
-      inFlightAcpRefreshForced = false;
+    const current = inFlightAcpRefreshes.get(refreshKey);
+    if (current?.[kind] !== run) return;
+    delete current[kind];
+    if (!current.forced && !current.regular) {
+      inFlightAcpRefreshes.delete(refreshKey);
     }
   });
-  inFlightAcpRefresh = run;
-  inFlightAcpRefreshForced = wantsForce;
+  const nextInFlight = inFlightForScope ?? {};
+  nextInFlight[kind] = run;
+  inFlightAcpRefreshes.set(refreshKey, nextInFlight);
   return await run;
 }
 
@@ -216,6 +238,10 @@ async function listAcpAgentSettingsImpl(
   const installed = await listInstalledAndLocalAcpAgents(store, {
     refreshLocal: request.refresh === true,
     ...(request.force === true ? { force: true } : {}),
+    ...(request.probeCapabilities === false
+      ? { probeCapabilities: false }
+      : {}),
+    ...(request.registryIds ? { registryIds: request.registryIds } : {}),
     ...(discoveryEnv ? { env: discoveryEnv } : {}),
   });
   if (request.refresh === true) {
@@ -331,6 +357,8 @@ async function listInstalledAndLocalAcpAgents(
   options?: {
     refreshLocal?: boolean;
     force?: boolean;
+    probeCapabilities?: boolean;
+    registryIds?: readonly string[];
     env?: NodeJS.ProcessEnv;
   },
 ): Promise<AcpInstalledAgentRecord[]> {
@@ -340,17 +368,23 @@ async function listInstalledAndLocalAcpAgents(
     try {
       const config = readDesktopSettingsConfigSafe();
       const preferences: Record<string, AcpAgentPreference> = {};
-      const enabledRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
-        (registryId) => acpAgentEnabledFor(config, registryId),
+      const requestedRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
+        (registryId) =>
+          !options.registryIds || options.registryIds.includes(registryId),
       );
-      for (const registryId of enabledRegistryIds) {
+      const discoveryRegistryIds = options.probeCapabilities === false
+        ? requestedRegistryIds
+        : requestedRegistryIds.filter((registryId) =>
+            acpAgentEnabledFor(config, registryId),
+          );
+      for (const registryId of discoveryRegistryIds) {
         const override = acpCliPathOverrideFor(config, registryId);
         if (override) {
           preferences[registryId] = { overridePath: override };
         }
       }
       discovered = await discoverLocalAcpAgentRecords({
-        enabledRegistryIds,
+        enabledRegistryIds: discoveryRegistryIds,
         ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
         ...(options?.env ? { env: options.env } : {}),
       });
@@ -365,16 +399,33 @@ async function listInstalledAndLocalAcpAgents(
           continue;
         }
         const current = store.getInstalledAgent(record.backendId);
+        const runtimeVersionChanged =
+          current?.version !== undefined
+          && record.version !== undefined
+          && current.version !== record.version;
         const nextRecord = {
           ...record,
-          runtimeCapabilities: current?.runtimeCapabilities,
+          runtimeCapabilities: runtimeVersionChanged
+            ? undefined
+            : current?.runtimeCapabilities,
           update: current?.update,
           updateCommand: current?.updateCommand,
-          lastDiscoveredAt: current?.lastDiscoveredAt,
-          lastDiscoveryError: current?.lastDiscoveryError,
+          lastDiscoveredAt: runtimeVersionChanged
+            ? undefined
+            : current?.lastDiscoveredAt,
+          lastDiscoveryError: runtimeVersionChanged
+            ? undefined
+            : current?.lastDiscoveryError,
           installedAt: current?.installedAt ?? record.installedAt,
           updatedAt: Math.max(current?.updatedAt ?? 0, record.updatedAt),
         } satisfies AcpInstalledAgentRecord;
+        if (
+          options.probeCapabilities === false
+          || !acpAgentEnabledFor(config, record.registryId)
+        ) {
+          store.upsertInstalledAgent(nextRecord);
+          continue;
+        }
         // Cheap local discovery (above) always runs to find newly-installed
         // agents and refresh version metadata. The EXPENSIVE runtime-capability
         // probe launches the agent over ACP, so gate it: only re-probe agents

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -147,28 +147,46 @@ async function refreshModelBackendsIfNeeded(params: {
 // so without this two passes would launch the same agents in parallel. Pure
 // cache reads (refresh === false) never launch and are not coalesced.
 //
-// We track whether the in-flight pass was forced so a caller only rides a pass
-// that satisfies it: a non-forced caller can ride any in-flight pass, but a
-// forced caller ("Discover new") only rides an in-flight *forced* pass —
-// otherwise it would silently inherit a freshness-gated pass that skipped the
-// re-probe it asked for. This is what stops two rapid "Discover new" clicks
-// from launching every agent twice in parallel. A forced caller that arrives
-// while only a non-forced pass is in flight still starts its own pass, so
-// "Discover new" is never a no-op.
-type InFlightAcpRefreshes = {
-  forced?: Promise<ListAcpAgentSettingsResponse>;
-  regular?: Promise<ListAcpAgentSettingsResponse>;
+// We track force strength and provider scope so narrower requests can ride a
+// stronger in-flight superset. When a broader request arrives second, it waits
+// for overlapping providers and refreshes only the remainder. This preserves
+// force semantics without launching the same interactive runtime twice.
+type InFlightAcpRefresh = {
+  forced: boolean;
+  probeCapabilities: boolean;
+  registryIds: ReadonlySet<string>;
+  promise: Promise<ListAcpAgentSettingsResponse>;
 };
 
-const inFlightAcpRefreshes = new Map<string, InFlightAcpRefreshes>();
+const LOCAL_ACP_REGISTRY_IDS = ["gemini", "grok", "kimi", "qwen"] as const;
+const inFlightAcpRefreshes = new Set<InFlightAcpRefresh>();
+const USER_INITIATED_ACP_PROBE_TIMEOUT_MS = 10 * 60_000;
 
-function acpRefreshKey(request: ListAcpAgentSettingsRequest): string {
-  return JSON.stringify({
-    probeCapabilities: request.probeCapabilities !== false,
-    registryIds: request.registryIds
-      ? [...new Set(request.registryIds)].sort()
-      : undefined,
-  });
+function acpRefreshRegistryIds(
+  request: ListAcpAgentSettingsRequest,
+): ReadonlySet<string> {
+  const requested = request.registryIds
+    ? new Set(request.registryIds)
+    : undefined;
+  return new Set(
+    LOCAL_ACP_REGISTRY_IDS.filter(
+      (registryId) => !requested || requested.has(registryId),
+    ),
+  );
+}
+
+function setContainsAll(
+  candidate: ReadonlySet<string>,
+  requested: ReadonlySet<string>,
+): boolean {
+  return [...requested].every((registryId) => candidate.has(registryId));
+}
+
+function setsOverlap(
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>,
+): boolean {
+  return [...left].some((registryId) => right.has(registryId));
 }
 
 async function listAcpAgentSettings(
@@ -178,28 +196,59 @@ async function listAcpAgentSettings(
   if (request.refresh === false) {
     return await listAcpAgentSettingsImpl(request, service);
   }
-  const refreshKey = acpRefreshKey(request);
   const wantsForce = request.force === true;
-  const inFlightForScope = inFlightAcpRefreshes.get(refreshKey);
-  const inFlight = wantsForce
-    ? inFlightForScope?.forced
-    : inFlightForScope?.forced ?? inFlightForScope?.regular;
-  if (inFlight) {
-    return await inFlight;
+  const probeCapabilities = request.probeCapabilities !== false;
+  const registryIds = acpRefreshRegistryIds(request);
+  const compatible = [...inFlightAcpRefreshes].filter(
+    (active) =>
+      active.probeCapabilities === probeCapabilities
+      && (!wantsForce || active.forced),
+  );
+  const superset = compatible.find((active) =>
+    setContainsAll(active.registryIds, registryIds),
+  );
+  if (superset) {
+    return await superset.promise;
   }
-  const kind = wantsForce ? "forced" : "regular";
-  const run = listAcpAgentSettingsImpl(request, service).finally(() => {
-    const current = inFlightAcpRefreshes.get(refreshKey);
-    if (current?.[kind] !== run) return;
-    delete current[kind];
-    if (!current.forced && !current.regular) {
-      inFlightAcpRefreshes.delete(refreshKey);
+
+  const overlapping = compatible.filter((active) =>
+    setsOverlap(active.registryIds, registryIds),
+  );
+  const coveredRegistryIds = new Set(
+    overlapping.flatMap((active) => [...active.registryIds]),
+  );
+  const remainingRegistryIds = [...registryIds].filter(
+    (registryId) => !coveredRegistryIds.has(registryId),
+  );
+  const run = (async () => {
+    if (overlapping.length > 0) {
+      await Promise.all(overlapping.map((entry) => entry.promise));
     }
-  });
-  const nextInFlight = inFlightForScope ?? {};
-  nextInFlight[kind] = run;
-  inFlightAcpRefreshes.set(refreshKey, nextInFlight);
-  return await run;
+    if (registryIds.size > 0 && remainingRegistryIds.length === 0) {
+      return await listAcpAgentSettingsImpl(
+        { ...request, refresh: false },
+        service,
+      );
+    }
+    return await listAcpAgentSettingsImpl(
+      request.registryIds || remainingRegistryIds.length !== registryIds.size
+        ? { ...request, registryIds: remainingRegistryIds }
+        : request,
+      service,
+    );
+  })();
+  const active: InFlightAcpRefresh = {
+    forced: wantsForce,
+    probeCapabilities,
+    registryIds,
+    promise: run,
+  };
+  inFlightAcpRefreshes.add(active);
+  try {
+    return await run;
+  } finally {
+    inFlightAcpRefreshes.delete(active);
+  }
 }
 
 async function listAcpAgentSettingsImpl(
@@ -368,7 +417,7 @@ async function listInstalledAndLocalAcpAgents(
     try {
       const config = readDesktopSettingsConfigSafe();
       const preferences: Record<string, AcpAgentPreference> = {};
-      const requestedRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
+      const requestedRegistryIds = LOCAL_ACP_REGISTRY_IDS.filter(
         (registryId) =>
           !options.registryIds || options.registryIds.includes(registryId),
       );
@@ -438,7 +487,16 @@ async function listInstalledAndLocalAcpAgents(
           })
         ) {
           store.upsertInstalledAgent(
-            await refreshAcpRuntimeCapabilities(nextRecord, discoveryCwd),
+            await refreshAcpRuntimeCapabilities(
+              nextRecord,
+              discoveryCwd,
+              // `force` is reserved for explicit UI refresh/login actions.
+              // Gemini can wait on a human browser OAuth round trip, so keep
+              // background discovery bounded while giving those actions room.
+              options.force === true
+                ? USER_INITIATED_ACP_PROBE_TIMEOUT_MS
+                : undefined,
+            ),
           );
         } else {
           store.upsertInstalledAgent(nextRecord);
@@ -472,10 +530,14 @@ async function listInstalledAndLocalAcpAgents(
 async function refreshAcpRuntimeCapabilities(
   record: AcpInstalledAgentRecord,
   cwd: string,
+  requestTimeoutMs?: number,
 ): Promise<AcpInstalledAgentRecord> {
   const now = Date.now();
   try {
-    const result = await discoverAcpRuntimeCapabilities(record, { cwd });
+    const result = await discoverAcpRuntimeCapabilities(record, {
+      cwd,
+      ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
+    });
     return {
       ...record,
       ...(result.runtimeCapabilities

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -6,6 +6,11 @@ import {
   isCanonicalProfileName,
   normalizeProfileName,
 } from "@pwragent/shared";
+import {
+  applyTomlEdits,
+  parseTomlTables,
+  type TomlEdit,
+} from "./settings/toml-editor";
 
 export { normalizeProfileName };
 
@@ -517,7 +522,7 @@ export function ensureBootstrapProfileDir(options?: {
   const profileDir = resolveBootstrapProfileDir(options);
   const created = !fs.existsSync(profileDir);
   fs.mkdirSync(path.join(profileDir, "state"), { recursive: true });
-  writeInitialOnboardingMarker(path.join(profileDir, "config.toml"));
+  writeInitialBootstrapConfig(path.join(profileDir, "config.toml"));
   return { profileDir, created };
 }
 
@@ -562,6 +567,33 @@ function writeInitialOnboardingMarker(configPath: string): void {
     return;
   }
   fs.writeFileSync(configPath, "[onboarding]\ncompleted = false\n", "utf8");
+}
+
+/**
+ * Bootstrap is the only profile state where ACP providers start disabled.
+ * Existing and directly-created profiles retain the historical default-on
+ * behavior; wizard-created profiles inherit the explicit choices copied from
+ * this throwaway config at graduation.
+ */
+function writeInitialBootstrapConfig(configPath: string): void {
+  const source = fs.existsSync(configPath)
+    ? fs.readFileSync(configPath, "utf8")
+    : "[onboarding]\ncompleted = false\n";
+  const tables = parseTomlTables(source, configPath);
+  const edits: TomlEdit[] = ["gemini", "grok", "kimi", "qwen"].flatMap(
+    (registryId) =>
+      tables[`acp_agents.${registryId}`]?.enabled === undefined
+        ? [{
+            op: "set" as const,
+            path: ["acp_agents", registryId, "enabled"],
+            value: false,
+          }]
+        : [],
+  );
+  const next = applyTomlEdits(source, edits);
+  if (next !== source || !fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, next, "utf8");
+  }
 }
 
 export function setDefaultProfileName(

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../lib/slack-pairing-approval";
 import type { AppearanceController } from "../../lib/useAppearance";
 import type { DesktopSettingsState } from "../settings/useDesktopSettings";
+import { SettingsSwitch } from "../settings/SettingsSwitch";
 import { filterBufferedSecrets } from "./filterBufferedSecrets";
 import {
   isValidProfileName,
@@ -1880,7 +1881,9 @@ function installedOnboardingBackendNames(
       backend.id === "codex"
         ? Boolean(selectedCodexCandidate(snapshot))
         : Boolean(acpEntryFor(acpEntries, backend.id)?.installed);
-    return installed ? [backend.name] : [];
+    const enabled = backend.id === "codex"
+      || acpBackendEnabled(snapshot, backend.id);
+    return installed && enabled ? [backend.name] : [];
   });
 }
 
@@ -1902,6 +1905,16 @@ function acpEntryFor(
   return entries.find((entry) => entry.registryId === registryId);
 }
 
+function acpBackendEnabled(
+  snapshot: DesktopSettingsSnapshot | undefined,
+  registryId: Exclude<OnboardingBackendId, "codex">,
+): boolean {
+  const agents = snapshot?.acpAgents as
+    | Record<string, { enabled?: boolean } | undefined>
+    | undefined;
+  return agents?.[registryId]?.enabled !== false;
+}
+
 export function isBackendRequirementSatisfied(
   snapshot: DesktopSettingsSnapshot | undefined,
   acpEntries: readonly AcpAgentSettingsEntry[],
@@ -1918,6 +1931,12 @@ export function BackendRequirementsStep(props: {
   const [activeBackend, setActiveBackend] = useState<OnboardingBackendId>("codex");
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string>();
+  const [optimisticEnabled, setOptimisticEnabled] = useState<
+    Partial<Record<Exclude<OnboardingBackendId, "codex">, boolean>>
+  >({});
+  const [geminiLoginState, setGeminiLoginState] = useState<
+    "idle" | "running" | "ready"
+  >("idle");
   const initialAcpLoadStarted = useRef(false);
   const snapshot = props.settings.snapshot;
   const discovery = snapshot?.models.codex.discovery;
@@ -1939,7 +1958,10 @@ export function BackendRequirementsStep(props: {
     try {
       const results = await Promise.allSettled([
         props.desktopApi?.refreshCodexDiscovery?.({}),
-        props.desktopApi?.listAcpAgents?.({ refresh: true, force: true }),
+        props.desktopApi?.listAcpAgents?.({
+          refresh: true,
+          probeCapabilities: false,
+        }),
       ]);
       const codexResult = results[0];
       if (
@@ -1973,7 +1995,10 @@ export function BackendRequirementsStep(props: {
       .listAcpAgents({ refresh: false })
       .then((response) => {
         updateAcpEntries(response.entries);
-        return props.desktopApi?.listAcpAgents?.({ refresh: true });
+        return props.desktopApi?.listAcpAgents?.({
+          refresh: true,
+          probeCapabilities: false,
+        });
       })
       .then((response) => {
         if (!response) return;
@@ -1999,6 +2024,11 @@ export function BackendRequirementsStep(props: {
     activeBackend === "codex"
       ? undefined
       : acpEntryFor(props.acpEntries, activeBackend);
+  const activeAcpEnabled =
+    activeBackend === "codex"
+      ? true
+      : optimisticEnabled[activeBackend]
+        ?? acpBackendEnabled(snapshot, activeBackend);
   const activeCommand =
     activeBackend === "codex"
       ? codexCandidate?.command
@@ -2007,6 +2037,57 @@ export function BackendRequirementsStep(props: {
     activeBackend === "codex"
       ? codexCandidate?.version
       : activeAcpEntry?.version;
+
+  const setActiveAcpEnabled = async (enabled: boolean): Promise<void> => {
+    if (activeBackend === "codex") return;
+    setError(undefined);
+    const saved = await props.settings.writeConfig({
+      acpAgents: { [activeBackend]: { enabled } } as NonNullable<
+        DesktopSettingsConfigPatch["acpAgents"]
+      >,
+    });
+    if (!saved) return;
+    setOptimisticEnabled((current) => ({
+      ...current,
+      [activeBackend]: enabled,
+    }));
+    if (activeBackend === "gemini" && !enabled) {
+      setGeminiLoginState("idle");
+    }
+  };
+
+  const loginToGemini = async (): Promise<void> => {
+    if (!props.desktopApi?.listAcpAgents) {
+      setError("Gemini login is unavailable in this build.");
+      return;
+    }
+    setError(undefined);
+    setGeminiLoginState("running");
+    try {
+      const response = await props.desktopApi.listAcpAgents({
+        refresh: true,
+        force: true,
+        registryIds: ["gemini"],
+      });
+      updateAcpEntries(response.entries);
+      window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+      const gemini = acpEntryFor(response.entries, "gemini");
+      const loginError =
+        gemini?.lastDiscoveryError
+        ?? (!gemini?.installed
+          ? "Gemini CLI could not be started."
+          : undefined);
+      if (loginError) {
+        setError(loginError);
+        setGeminiLoginState("idle");
+        return;
+      }
+      setGeminiLoginState("ready");
+    } catch (caught: unknown) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+      setGeminiLoginState("idle");
+    }
+  };
 
   return (
     <div className="onboarding-wizard__prereqs">
@@ -2139,6 +2220,35 @@ export function BackendRequirementsStep(props: {
         </div>
 
         <div className="onboarding-wizard__prereq-actions">
+          {activeBackend !== "codex" ? (
+            <div className="onboarding-wizard__prereq-enable">
+              <SettingsSwitch
+                checked={activeAcpEnabled}
+                disabled={props.settings.saving}
+                label={`Enable ${activeDefinition.name}`}
+                onChange={(enabled) => {
+                  void setActiveAcpEnabled(enabled);
+                }}
+              />
+              <span>Enable {activeDefinition.name}</span>
+            </div>
+          ) : null}
+          {activeBackend === "gemini"
+          && activeAcpEnabled
+          && activeAcpEntry?.installed ? (
+              <button
+                type="button"
+                className="onboarding-wizard__btn onboarding-wizard__btn--primary"
+                disabled={geminiLoginState === "running"}
+                onClick={() => void loginToGemini()}
+              >
+                {geminiLoginState === "running"
+                  ? "Waiting for Gemini login…"
+                  : geminiLoginState === "ready"
+                    ? "Gemini CLI ready"
+                    : "Log in to Gemini CLI"}
+              </button>
+            ) : null}
           <button
             type="button"
             className="onboarding-wizard__btn onboarding-wizard__btn--ghost"

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -11,6 +11,7 @@ import type {
   AcpAgentSettingsEntry,
   DesktopSettingsSecretName,
   DesktopSettingsSnapshot,
+  ListAcpAgentSettingsRequest,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
@@ -143,6 +144,20 @@ describe("AI provider onboarding", () => {
     expect(
       isBackendRequirementSatisfied(noCodexSnapshot, [acpEntry("grok")]),
     ).toBe(true);
+    expect(
+      isBackendRequirementSatisfied(
+        {
+          ...noCodexSnapshot,
+          acpAgents: {
+            gemini: {
+              cliPath: { value: "", source: "default" },
+              enabled: false,
+            },
+          },
+        } as DesktopSettingsSnapshot,
+        [acpEntry("gemini")],
+      ),
+    ).toBe(false);
   });
 
   it("shows provider-specific macOS install commands without an xAI key field", () => {
@@ -173,6 +188,77 @@ describe("AI provider onboarding", () => {
     expect(screen.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
     expect(screen.queryByText(/xAI API key/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("defers Gemini startup until the operator enables it and clicks login", async () => {
+    const gemini = acpEntry("gemini");
+    const listAcpAgents = vi.fn(
+      async (_request?: ListAcpAgentSettingsRequest) => ({
+        fetchedAt: 1,
+        entries: [gemini],
+        error: "Registry is temporarily unavailable.",
+      }),
+    );
+    const writeConfig = vi.fn(async () => true);
+    const settings = {
+      snapshot: {
+        ...noCodexSnapshot,
+        acpAgents: {
+          gemini: {
+            cliPath: { value: "", source: "default" },
+            enabled: false,
+          },
+        },
+      },
+      refresh: vi.fn(async () => undefined),
+      writeConfig,
+    } as unknown as DesktopSettingsState;
+
+    render(
+      <BackendRequirementsStep
+        settings={settings}
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        acpEntries={[gemini]}
+        onAcpEntriesChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: false });
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        probeCapabilities: false,
+      });
+    });
+    expect(
+      listAcpAgents.mock.calls.some(([request]) => request?.force === true),
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole("tab", { name: /Gemini CLI/i }));
+    expect(
+      screen.queryByRole("button", { name: /Log in to Gemini CLI/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("switch", { name: /Enable Gemini CLI/i }));
+    await waitFor(() => {
+      expect(writeConfig).toHaveBeenCalledWith({
+        acpAgents: { gemini: { enabled: true } },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Log in to Gemini CLI/i }),
+    );
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        force: true,
+        registryIds: ["gemini"],
+      });
+      expect(
+        screen.getByRole("button", { name: /Gemini CLI ready/i }),
+      ).toBeVisible();
+    });
   });
 
   it("shows native Windows installers and Windows-only prerequisites", () => {
@@ -280,7 +366,10 @@ describe("AI provider onboarding", () => {
 
     await waitFor(() => {
       expect(refreshCodexDiscovery).toHaveBeenCalledOnce();
-      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true, force: true });
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        probeCapabilities: false,
+      });
       expect(applySnapshot).toHaveBeenCalledWith(noCodexSnapshot);
       expect(settingsRefresh).not.toHaveBeenCalled();
       expect(onAcpEntriesChange).toHaveBeenCalledWith([acpEntry("qwen")]);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -26707,8 +26707,16 @@ a.transcript-message__messaging-origin:focus-visible {
 .onboarding-wizard__prereq-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
   min-height: 30px;
+}
+.onboarding-wizard__prereq-enable {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
+  font: 600 11px/1.3 var(--font-sans, sans-serif);
 }
 .onboarding-wizard__prereq-error {
   color: var(--danger-text);

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -330,6 +330,18 @@ export type AcpAgentPreference = {
 export type ListAcpAgentSettingsRequest = {
   refresh?: boolean;
   /**
+   * Restrict local discovery and capability probing to these provider ids.
+   * Omit for every configured provider. Used by explicit onboarding login
+   * actions so starting Gemini never starts another CLI as a side effect.
+   */
+  registryIds?: string[];
+  /**
+   * When false, refresh executable paths and versions without launching an
+   * ACP runtime. Safe for background discovery surfaces such as onboarding,
+   * where an agent launch can begin an interactive browser login.
+   */
+  probeCapabilities?: boolean;
+  /**
    * Force a re-probe of every discovered agent's runtime capabilities,
    * bypassing the freshness window. The "Discover new" button sets this so a
    * user can always re-probe on demand. When omitted, a refresh only launches


### PR DESCRIPTION
## Summary

Forward-port the fix from #1578 (`releases/1.0`) to `main`.

- keep onboarding provider discovery non-interactive, so merely entering AI Providers cannot launch Gemini OAuth
- require the user to enable Gemini and explicitly click Log in before starting the ACP authentication flow
- preserve capability-cache provenance and forced-refresh coalescing
- keep successful Gemini authentication independent from unrelated registry refresh errors
- backfill disabled ACP defaults into existing bootstrap configs without overwriting explicit choices

## Root cause

Onboarding startup discovery also probed installed providers' ACP capabilities. Launching Gemini for that probe can initiate its browser OAuth flow before the user selects or enables Gemini.

## Validation

- 51 focused desktop main-process tests passed
- 12 focused onboarding renderer tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- targeted onboarding E2E for “entering AI Providers does not launch Gemini before explicit login” passed

A full local onboarding E2E run passed 9/10 cases. The remaining pre-existing well-known-location case selected the host's real `/opt/homebrew/bin/qwen` (`v0.21.0`) instead of its fake home-directory fixture (`v999.0.0`); the forward-port does not change that discovery precedence.
