### PR TITLE
fix(messaging): keep Slack working cards active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Messaging - Add opt-in Slack Live Working Updates cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes.
+- Messaging - Add opt-in Slack Live Working Updates cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with phase-aware plan headlines, ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes.
 
 ## v1.1.0-beta.1 - 2026-08-09
 

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -33,7 +33,12 @@ const baseConfig = {
 
 function slackWorkingCardIntent(
   sequence: number,
-  options: { isFinal?: boolean; key?: string; phase?: "completed" | "failed" } = {},
+  options: {
+    displayHint?: "timeline" | "plan" | "dense";
+    isFinal?: boolean;
+    key?: string;
+    phase?: "completed" | "failed";
+  } = {},
 ): MessagingSurfaceIntent {
   const isFinal = options.isFinal ?? false;
   return {
@@ -43,7 +48,7 @@ function slackWorkingCardIntent(
     createdAt: sequence,
     fallbackText: `Tool update: activity ${sequence}`,
     card: {
-      displayHint: "plan",
+      displayHint: options.displayHint ?? "plan",
       isFinal,
       key: options.key ?? "slack-binding-1\0turn-1",
       phase: options.phase ?? (isFinal ? "completed" : "working"),
@@ -4803,6 +4808,60 @@ describe("SlackAdapter", () => {
 
       await vi.advanceTimersByTimeAsync(5_000);
       expect(startAttempts).toBe(2);
+      await adapter.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the original display mode when a queued start receives a terminal snapshot", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const startedStreams: Array<{
+        chunks: SlackStreamChunk[];
+        taskDisplayMode: "timeline" | "plan" | "dense";
+      }> = [];
+      let startAttempts = 0;
+      const api = fakeApi({});
+      api.startStream = async (params) => {
+        startAttempts += 1;
+        startedStreams.push(params);
+        if (startAttempts === 1) {
+          throw Object.assign(new Error("rate_limited"), {
+            status: 429,
+            retryAfterMs: 5_000,
+          });
+        }
+        return { channel: params.channel, ts: "1700000000.900001" };
+      };
+      const adapter = new SlackAdapter({
+        config: { ...baseConfig, liveWorkingCards: true },
+        callbackHandleStore: fakeStore(),
+        api,
+        socketClient: fakeSocket(),
+      });
+
+      await adapter.deliver(slackWorkingCardIntent(1, {
+        displayHint: "timeline",
+        key: "queued-timeline-card",
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await adapter.deliver(slackWorkingCardIntent(2, {
+        isFinal: true,
+        key: "queued-timeline-card",
+      }));
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(startedStreams).toHaveLength(2);
+      expect(startedStreams.map((call) => call.taskDisplayMode)).toEqual([
+        "timeline",
+        "timeline",
+      ]);
+      expect(startedStreams[1]?.chunks).not.toContainEqual(expect.objectContaining({
+        type: "plan_update",
+      }));
       await adapter.stop();
     } finally {
       vi.useRealTimers();

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -4160,20 +4160,32 @@ describe("SlackAdapter", () => {
     expect(stoppedStreams).toHaveLength(1);
     expect(JSON.stringify(startedStreams[0])).not.toContain("x".repeat(257));
     expect((startedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
-      .toEqual([expect.objectContaining({
-        id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:1$/),
-        details: "0ms",
-      })]);
+      .toEqual([
+        {
+          title: "Working on your request",
+          type: "plan_update",
+        },
+        expect.objectContaining({
+          id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:1$/),
+          details: "0ms",
+        }),
+      ]);
     expect((appendedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
       .toEqual([expect.objectContaining({
         id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:2$/),
         details: "0ms",
       })]);
     expect((stoppedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
-      .toEqual([expect.objectContaining({
-        id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:3$/),
-        details: "0ms",
-      })]);
+      .toEqual([
+        {
+          title: "Work completed",
+          type: "plan_update",
+        },
+        expect.objectContaining({
+          id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:3$/),
+          details: "0ms",
+        }),
+      ]);
   });
 
   it("anchors a channel-root Agent Route card to its inbound user message", async () => {
@@ -4225,7 +4237,7 @@ describe("SlackAdapter", () => {
     ]);
   });
 
-  it("renders waiting visibly and closes cancelled tasks without an error state", async () => {
+  it("renders waiting in the plan headline and closes cancelled tasks without an error state", async () => {
     const appendedStreams: unknown[] = [];
     const startedStreams: unknown[] = [];
     const adapter = new SlackAdapter({
@@ -4271,9 +4283,12 @@ describe("SlackAdapter", () => {
       chunks: SlackStreamChunk[];
     }).chunks;
     expect(appendedChunks).toContainEqual({
-      markdown_text: "*Waiting for your input*",
-      type: "markdown_text",
+      title: "Waiting for your input",
+      type: "plan_update",
     });
+    expect(appendedChunks).not.toContainEqual(expect.objectContaining({
+      type: "markdown_text",
+    }));
   });
 
   it("falls back to the classic text Working Update without stream APIs", async () => {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -92,6 +92,13 @@ const SLACK_DIRECTORY_MAX_PAGES = 10;
 const SLACK_WORKING_CARD_TOMBSTONE_MAX = 200;
 const SLACK_WORKING_CARD_RETRY_MS = 3_000;
 const SLACK_WORKING_CARD_STOP_MAX_FAILURES = 3;
+const SLACK_WORKING_CARD_PLAN_TITLES = {
+  queued: "Starting work",
+  working: "Working on your request",
+  waiting: "Waiting for your input",
+  completed: "Work completed",
+  failed: "Work failed",
+} as const;
 const SLACK_WORKING_CARD_BUCKETS = {
   start: { method: "chat.startStream", limit: 20 },
   append: { method: "chat.appendStream", limit: 100 },
@@ -177,6 +184,10 @@ export type SlackStreamChunk =
       status: "pending" | "in_progress" | "complete" | "error";
       title: string;
       type: "task_update";
+    }
+  | {
+      title: string;
+      type: "plan_update";
     }
   | {
       markdown_text: string;
@@ -341,6 +352,7 @@ type SlackWorkingCardQueueState = {
   pumping: boolean;
   retryMethod?: SlackWorkingCardMethod;
   retryTimer?: ReturnType<typeof setTimeout>;
+  taskDisplayMode: SlackWorkingCardIntent["card"]["displayHint"];
   target: SlackWorkingCardTarget;
   ts?: string;
 };
@@ -1898,6 +1910,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       lastDeliveredSequence: 0,
       nonRateFailureCount: 0,
       pumping: false,
+      taskDisplayMode: intent.card.displayHint,
       target: workingTarget,
     };
     if (!current) {
@@ -2124,6 +2137,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     intent: SlackWorkingCardIntent,
     state: SlackWorkingCardQueueState,
   ): SlackStreamChunk[] {
+    const phaseChanged = state.lastDeliveredPhase !== intent.card.phase;
     const chunks = intent.card.tasks
       .map((task, index) => this.workingCardTaskSlot(intent, task, index))
       .filter(
@@ -2132,8 +2146,16 @@ export class SlackAdapter implements SlackProviderAdapter {
       )
       .map(({ fingerprint: _fingerprint, ...chunk }) => chunk);
     if (
-      intent.card.phase === "waiting"
-      && state.lastDeliveredPhase !== "waiting"
+      phaseChanged
+      && state.taskDisplayMode === "plan"
+    ) {
+      chunks.unshift({
+        type: "plan_update",
+        title: SLACK_WORKING_CARD_PLAN_TITLES[intent.card.phase],
+      });
+    } else if (
+      phaseChanged
+      && intent.card.phase === "waiting"
     ) {
       chunks.unshift({
         type: "markdown_text",

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -1997,7 +1997,7 @@ export class SlackAdapter implements SlackProviderAdapter {
             const result = await this.api.startStream!({
               channel: state.target.channelId,
               chunks,
-              taskDisplayMode: intent.card.displayHint,
+              taskDisplayMode: state.taskDisplayMode,
               threadTs: state.target.threadTs,
               ...(intent.audit?.actor.platformUserId
                 ? { recipientUserId: intent.audit.actor.platformUserId }


### PR DESCRIPTION
## What changed

- Send explicit phase-aware plan-update headlines for Slack Working Updates cards in plan mode.
- Keep the active card labeled “Working on your request” until the turn actually reaches a terminal state.
- Surface waiting, completed, and failed phases in the collapsed plan headline.
- Preserve timeline and dense rendering without synthetic active-tool tracking.

## Root cause

PwrAgent streamed only completed task rows and did not send a plan title. Slack therefore inferred “Thinking completed” as soon as the card opened, even though the encompassing agent turn was still running.

## Validation

- Slack adapter tests: 104 passed
- Slack provider typecheck
- Full typed and untyped ESLint
- Dependency-boundary validation
- Git diff check