### PR TITLE
fix(agent-core): preserve project paths in handoffs

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -27632,14 +27632,15 @@ script = "printf setup"
       },
     } as AppServerPendingRequestNotification);
 
-    expect(response).toMatchObject({
-      success: false,
-      contentItems: [
-        {
-          type: "inputText",
-          text: expect.stringContaining("unsupported_workspace"),
-        },
-      ],
+    expect(response).toMatchObject({ success: false });
+    const failurePayload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(failurePayload).toMatchObject({
+      code: "unsupported_workspace",
+      message: expect.stringMatching(
+        /cwd was omitted[\s\S]*retry with cwd set to that project path[\s\S]*Do not switch to workspaceMode="none"/,
+      ),
     });
     expect(codexClient.lastStartThreadParams).toBeUndefined();
     expect(codexClient.lastStartTurnParams).toBeUndefined();

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -52,7 +52,7 @@ describe("pwragent thread orchestration agent tools", () => {
             type: "function",
             name: "handoff_task",
             description: expect.stringMatching(
-              /Prefer this to backend spawning.*same-project handoffs create grouped subthreads.*Cross-project handoffs are not grouped/,
+              /Prefer this to backend spawning.*pass its path as cwd.*set workspaceMode=new_worktree.*workspaceMode=none creates an unscoped scratch workspace/,
             ),
             deferLoading: false,
             inputSchema: expect.objectContaining({
@@ -67,9 +67,14 @@ describe("pwragent thread orchestration agent tools", () => {
                 }),
                 workspaceMode: expect.objectContaining({
                   enum: ["same", "same_workspace", "project_local", "new_worktree", "none"],
+                  description: expect.stringMatching(
+                    /Combine it with cwd.*unscoped scratch workspace.*Do not use `none` as a fallback/,
+                  ),
                 }),
                 cwd: expect.objectContaining({
-                  description: expect.stringContaining("Task text does not select cwd"),
+                  description: expect.stringMatching(
+                    /required when the user names another local project.*required when the user links or references a local directory.*A path in task or context does not select cwd/,
+                  ),
                 }),
                 backend: expect.objectContaining({
                   description: expect.stringContaining("`acp:grok`"),
@@ -78,7 +83,7 @@ describe("pwragent thread orchestration agent tools", () => {
                   description: expect.stringContaining("`grok-4.5`"),
                 }),
                 branchName: expect.objectContaining({
-                  description: expect.stringContaining("Existing base ref"),
+                  description: expect.stringContaining("resolves this ref in cwd"),
                 }),
               }),
             }),

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -185,7 +185,7 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "handoff_task":
-      return "Create a PwrAgent-managed thread for delegated work. Prefer this to backend spawning unless the user requests it or needs an unsupported feature. Agent settings inherit from the current turn. By default, same-project handoffs create grouped subthreads in new worktrees. Omit cwd to inherit the workspace source. Set cwd only for a user-selected project or directory. Task text never selects cwd. Cross-project handoffs are not grouped. Use fork or same_workspace only when the user requests them. Use project_local for the project checkout and none for no workspace. Provider overrides need a registered backend and exact model ID. Do not retry while startup is pending. Inspect pendingHandoffs and return threadLink verbatim.";
+      return "Create a PwrAgent-managed thread for delegated work. Prefer this to backend spawning unless the user requests it or needs an unsupported feature. Agent settings inherit from the current turn. Same-project handoffs create grouped subthreads in new worktrees by default. When the user names another local project, pass its path as cwd. Also pass cwd when the user links or references a local directory. Never put the target path only in task or context. For an isolated worktree in that project, set workspaceMode=new_worktree. Set branchName only to an existing base ref. Omit cwd only to inherit the current project. Cross-project handoffs are not grouped. Use fork or same_workspace only when the user requests them. Use project_local for the project checkout. workspaceMode=none creates an unscoped scratch workspace. Do not use none as a fallback for work in a named project. Provider overrides need a registered backend and exact model ID. Do not retry while startup is pending. Inspect pendingHandoffs and return threadLink verbatim.";
     case "attach_thread_directory":
       return "Attach another Git directory to the current PwrAgent thread. Use this for user-requested cross-project work. Omit backend for the current thread. Use workspaceMode=local for the repository or new_worktree for a managed worktree. Default Access requires confirmation for an untrusted path. This tool does not change the primary cwd. Use detach_thread_directory to remove a temporary link.";
     case "detach_thread_directory":
@@ -275,7 +275,7 @@ function inputSchemaForOperation(
           task: {
             type: "string",
             description:
-              "The concrete task for the created thread to perform. Include the user's requested work, not the parent transcript.",
+              "Give the new thread a concrete task. Include the user's requested work, not the parent transcript. Select the workspace with cwd and workspaceMode.",
           },
           title: {
             type: "string",
@@ -303,12 +303,12 @@ function inputSchemaForOperation(
             type: "string",
             enum: HANDOFF_TASK_WORKSPACE_MODES,
             description:
-              "`new_worktree` is the default for workspace handoffs. `same_workspace` requires groupingMode=subthread. `project_local` uses the project checkout. `none` uses no workspace. `same` aliases `same_workspace`.",
+              "`new_worktree` is the default for workspace handoffs. Combine it with cwd when the user selects another local project. `same_workspace` requires groupingMode=subthread. `project_local` uses the selected project checkout. `none` creates an unscoped scratch workspace. Do not use `none` as a fallback for work in a named project. `same` aliases `same_workspace`.",
           },
           cwd: {
             type: "string",
             description:
-              "Omit cwd to inherit the current workspace. Set it only for a user-selected project or directory. Task text does not select cwd.",
+              "Filesystem path of the workspace source. This field is required when the user names another local project. It is also required when the user links or references a local directory. Combine it with workspaceMode=new_worktree for an isolated worktree. Omit it only to inherit the current project. A path in task or context does not select cwd.",
           },
           messagingAttachment: {
             type: "string",
@@ -335,7 +335,7 @@ function inputSchemaForOperation(
           branchName: {
             type: "string",
             description:
-              "Existing base ref for workspaceMode=new_worktree, such as `origin/main`. This is not a new branch name. Put branch creation in the task.",
+              "Existing base ref for workspaceMode=new_worktree, such as `origin/main`. PwrAgent resolves this ref in cwd when you provide cwd. This is not a new branch name. Put branch creation in task.",
           },
         },
       };

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -25489,10 +25489,15 @@ export class DesktopBackendRegistry {
         },
       );
     } catch (error) {
-      this.failPendingThreadHandoff(handoffId, error);
+      const baseMessage = error instanceof Error ? error.message : String(error);
+      const message =
+        workspaceMode === "new_worktree" && !requestedCwd
+          ? `${baseMessage} cwd was omitted, so PwrAgent used the current project as the worktree source. If the user named a different local project, retry with cwd set to that project path. Do not switch to workspaceMode="none".`
+          : baseMessage;
+      this.failPendingThreadHandoff(handoffId, new Error(message));
       return threadOrchestrationFailure(
         workspaceMode === "new_worktree" ? "unsupported_workspace" : "internal_error",
-        error instanceof Error ? error.message : String(error),
+        message,
       );
     }
 


### PR DESCRIPTION
## Summary

- require `cwd` when a user names, links, or references another local project
- explain how `cwd`, `workspaceMode=new_worktree`, and `branchName` work together
- warn agents not to use `workspaceMode=none` as a fallback for repository work
- add the same guidance to failed inherited-worktree responses
- keep all reflected descriptions within the STE100-style 20-word sentence limit

## Root cause

A cross-project handoff first inherited the parent repository because the request omitted `cwd`. After worktree creation failed, the retry put the target path only in the task and selected `workspaceMode=none`. That mode intentionally created an unscoped scratch workspace.

The explicit cross-project mapping added in #1466 had been weakened when reflected tool guidance was simplified in #1472.

## Impact

Agents now pass a user-selected local project through the structured `cwd` field. Failure guidance also prevents a bad retry from turning repository work into a Workspaces scratch thread.

## Validation

- focused Vitest regression tests
- reflected-description 20-word and no-semicolon guard
- `pnpm lint:eslint` (zero errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
