### PR TITLE
feat(desktop): add Dock profile launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ apps/desktop/dist/
 # pnpm deploy stage (release.mjs materializes a flat node_modules tree here)
 apps/desktop/release-stage/
 apps/desktop/build/bundled-agents/grok/
+apps/desktop/build/native/
 
 # Release-time secrets — must never land in the repo
 .envrc.release

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -2,6 +2,10 @@ appId: com.pwrdrvr.pwragent
 productName: PwrAgent
 copyright: "Copyright © 2026 PwrDrvr LLC."
 
+# Dock tile plug-ins are nested code. Sign the staged bundle before
+# electron-builder seals the parent PwrAgent.app for notarization.
+afterPack: "scripts/afterpack-sign-dock-tile-plugin.mjs"
+
 # Pinned so `pnpm deploy --prod` works — electron lives in devDependencies
 # and is therefore not present in the deploy stage's node_modules.
 # Keep this in sync with the apps/desktop Electron version resolved in
@@ -115,11 +119,15 @@ mac:
   helperRendererBundleId: com.pwrdrvr.pwragent.helper.Renderer
   helperGPUBundleId: com.pwrdrvr.pwragent.helper.GPU
   helperPluginBundleId: com.pwrdrvr.pwragent.helper.Plugin
+  extraFiles:
+    - from: build/native/PwrAgentDockTilePlugin.plugin
+      to: PlugIns/PwrAgentDockTilePlugin.plugin
   extendInfo:
     NSHumanReadableCopyright: "Copyright © 2026 PwrDrvr LLC."
     NSUserNotificationAlertStyle: alert
     LSMinimumSystemVersion: "12.0"
     LSApplicationCategoryType: public.app-category.developer-tools
+    NSDockTilePlugIn: PwrAgentDockTilePlugin.plugin
   target:
     - target: dmg
       arch: [universal]

--- a/apps/desktop/native/dock-tile-plugin/Info.plist
+++ b/apps/desktop/native/dock-tile-plugin/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>PwrAgent Dock Tile Plugin</string>
+  <key>CFBundleExecutable</key>
+  <string>PwrAgentDockTilePlugin</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.pwrdrvr.pwragent.dock-tile-plugin</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>PwrAgentDockTilePlugin</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+  <key>NSPrincipalClass</key>
+  <string>PwrAgentDockTilePlugin_com_pwrdrvr_pwragent</string>
+</dict>
+</plist>

--- a/apps/desktop/native/dock-tile-plugin/PwrAgentDockTilePlugin.m
+++ b/apps/desktop/native/dock-tile-plugin/PwrAgentDockTilePlugin.m
@@ -15,7 +15,10 @@
 
 - (NSMenu *)dockMenu {
   NSDictionary *snapshot = [self loadProfileSnapshot];
-  NSArray<NSDictionary *> *profiles = [self sortedProfilesFromSnapshot:snapshot];
+  NSString *pwragentHome = [self pwragentHomeFromSnapshot:snapshot];
+  NSArray<NSDictionary *> *profiles = pwragentHome == nil
+    ? @[]
+    : [self sortedProfilesFromSnapshot:snapshot];
 
   NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
   menu.autoenablesItems = NO;
@@ -45,7 +48,10 @@
         action:@selector(openProfile:)
         keyEquivalent:@""];
       item.target = self;
-      item.representedObject = name;
+      item.representedObject = @{
+        @"profile": name,
+        @"pwragentHome": pwragentHome,
+      };
       item.enabled = YES;
       if ([name isEqualToString:defaultProfile]) {
         item.state = NSControlStateValueOn;
@@ -65,8 +71,18 @@
 }
 
 - (void)openProfile:(NSMenuItem *)sender {
-  NSString *profile = sender.representedObject;
+  NSDictionary *launch = sender.representedObject;
+  if (![launch isKindOfClass:[NSDictionary class]]) {
+    return;
+  }
+  NSString *profile = launch[@"profile"];
+  NSString *pwragentHome = launch[@"pwragentHome"];
   if (![profile isKindOfClass:[NSString class]] || profile.length == 0) {
+    return;
+  }
+  if (![pwragentHome isKindOfClass:[NSString class]]
+      || !pwragentHome.isAbsolutePath
+      || pwragentHome.length > 4096) {
     return;
   }
 
@@ -78,6 +94,9 @@
   NSWorkspaceOpenConfiguration *configuration =
     [NSWorkspaceOpenConfiguration configuration];
   configuration.arguments = @[@"--profile", profile];
+  configuration.environment = @{
+    @"PWRAGENT_HOME": [pwragentHome stringByStandardizingPath],
+  };
   configuration.activates = YES;
   configuration.createsNewApplicationInstance = YES;
 
@@ -92,8 +111,16 @@
 }
 
 - (NSDictionary *)loadProfileSnapshot {
-  NSURL *snapshotURL = [[NSURL fileURLWithPath:NSHomeDirectory()]
-    URLByAppendingPathComponent:@".pwragent/dock-profiles.json"];
+  NSURL *cachesURL = [[[NSFileManager defaultManager]
+    URLsForDirectory:NSCachesDirectory
+    inDomains:NSUserDomainMask] firstObject];
+  if (cachesURL == nil) {
+    return @{};
+  }
+  NSURL *snapshotURL = [[cachesURL
+    URLByAppendingPathComponent:@"com.pwrdrvr.pwragent"
+    isDirectory:YES]
+    URLByAppendingPathComponent:@"dock-profiles.json"];
   NSData *data = [NSData dataWithContentsOfURL:snapshotURL];
   if (data == nil) {
     return @{};
@@ -105,10 +132,21 @@
     return @{};
   }
   NSDictionary *snapshot = value;
-  if (![snapshot[@"schemaVersion"] isEqual:@1]) {
+  if (![snapshot[@"schemaVersion"] isEqual:@2]) {
     return @{};
   }
   return snapshot;
+}
+
+- (NSString *)pwragentHomeFromSnapshot:(NSDictionary *)snapshot {
+  NSString *pwragentHome = snapshot[@"pwragentHome"];
+  if (![pwragentHome isKindOfClass:[NSString class]]
+      || !pwragentHome.isAbsolutePath
+      || pwragentHome.length == 0
+      || pwragentHome.length > 4096) {
+    return nil;
+  }
+  return [pwragentHome stringByStandardizingPath];
 }
 
 - (NSArray<NSDictionary *> *)sortedProfilesFromSnapshot:(NSDictionary *)snapshot {

--- a/apps/desktop/native/dock-tile-plugin/PwrAgentDockTilePlugin.m
+++ b/apps/desktop/native/dock-tile-plugin/PwrAgentDockTilePlugin.m
@@ -1,0 +1,178 @@
+#import <AppKit/AppKit.h>
+
+@interface PwrAgentDockTilePlugin_com_pwrdrvr_pwragent : NSObject <NSDockTilePlugIn>
+
+@property(nonatomic, strong) NSMenu *retainedDockMenu;
+
+@end
+
+@implementation PwrAgentDockTilePlugin_com_pwrdrvr_pwragent
+
+- (void)setDockTile:(NSDockTile *)dockTile {
+  // The profile launcher only customizes the menu. Keeping this method empty
+  // also avoids asking Dock to repaint the application icon.
+}
+
+- (NSMenu *)dockMenu {
+  NSDictionary *snapshot = [self loadProfileSnapshot];
+  NSArray<NSDictionary *> *profiles = [self sortedProfilesFromSnapshot:snapshot];
+
+  NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
+  menu.autoenablesItems = NO;
+
+  NSMenuItem *openProfileItem = [[NSMenuItem alloc]
+    initWithTitle:@"Open Profile"
+    action:nil
+    keyEquivalent:@""];
+  NSMenu *profileMenu = [[NSMenu alloc] initWithTitle:@"Open Profile"];
+  profileMenu.autoenablesItems = NO;
+
+  if (profiles.count == 0) {
+    NSMenuItem *emptyItem = [[NSMenuItem alloc]
+      initWithTitle:@"Open PwrAgent to Load Profiles"
+      action:nil
+      keyEquivalent:@""];
+    emptyItem.enabled = NO;
+    [profileMenu addItem:emptyItem];
+  } else {
+    NSString *defaultProfile = snapshot[@"defaultProfile"];
+    for (NSDictionary *profile in profiles) {
+      NSString *name = profile[@"name"];
+      NSString *displayName = profile[@"displayName"];
+      NSString *label = displayName.length > 0 ? displayName : name;
+      NSMenuItem *item = [[NSMenuItem alloc]
+        initWithTitle:label
+        action:@selector(openProfile:)
+        keyEquivalent:@""];
+      item.target = self;
+      item.representedObject = name;
+      item.enabled = YES;
+      if ([name isEqualToString:defaultProfile]) {
+        item.state = NSControlStateValueOn;
+      }
+      [profileMenu addItem:item];
+    }
+  }
+
+  openProfileItem.submenu = profileMenu;
+  [menu addItem:openProfileItem];
+
+  // NSDockTilePlugIn menus must remain alive until Dock is finished handling
+  // the click. A strong property is intentional; returning an autoreleased
+  // menu can make its items silently ignore selection.
+  self.retainedDockMenu = menu;
+  return menu;
+}
+
+- (void)openProfile:(NSMenuItem *)sender {
+  NSString *profile = sender.representedObject;
+  if (![profile isKindOfClass:[NSString class]] || profile.length == 0) {
+    return;
+  }
+
+  NSURL *applicationURL = [self containingApplicationURL];
+  if (applicationURL == nil) {
+    return;
+  }
+
+  NSWorkspaceOpenConfiguration *configuration =
+    [NSWorkspaceOpenConfiguration configuration];
+  configuration.arguments = @[@"--profile", profile];
+  configuration.activates = YES;
+  configuration.createsNewApplicationInstance = YES;
+
+  [[NSWorkspace sharedWorkspace]
+    openApplicationAtURL:applicationURL
+    configuration:configuration
+    completionHandler:^(NSRunningApplication *application, NSError *error) {
+      if (error != nil) {
+        NSLog(@"PwrAgent Dock profile launch failed: %@", error);
+      }
+    }];
+}
+
+- (NSDictionary *)loadProfileSnapshot {
+  NSURL *snapshotURL = [[NSURL fileURLWithPath:NSHomeDirectory()]
+    URLByAppendingPathComponent:@".pwragent/dock-profiles.json"];
+  NSData *data = [NSData dataWithContentsOfURL:snapshotURL];
+  if (data == nil) {
+    return @{};
+  }
+
+  NSError *error = nil;
+  id value = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+  if (error != nil || ![value isKindOfClass:[NSDictionary class]]) {
+    return @{};
+  }
+  NSDictionary *snapshot = value;
+  if (![snapshot[@"schemaVersion"] isEqual:@1]) {
+    return @{};
+  }
+  return snapshot;
+}
+
+- (NSArray<NSDictionary *> *)sortedProfilesFromSnapshot:(NSDictionary *)snapshot {
+  id rawProfiles = snapshot[@"profiles"];
+  if (![rawProfiles isKindOfClass:[NSArray class]]) {
+    return @[];
+  }
+
+  NSMutableArray<NSDictionary *> *profiles = [NSMutableArray array];
+  for (id value in rawProfiles) {
+    if (![value isKindOfClass:[NSDictionary class]]) {
+      continue;
+    }
+    NSString *name = value[@"name"];
+    if (![name isKindOfClass:[NSString class]]
+        || name.length == 0
+        || name.length > 128) {
+      continue;
+    }
+    NSString *displayName = value[@"displayName"];
+    if (![displayName isKindOfClass:[NSString class]]
+        || displayName.length > 256) {
+      displayName = nil;
+    }
+    [profiles addObject:displayName.length > 0
+      ? @{ @"name": name, @"displayName": displayName }
+      : @{ @"name": name }];
+    if (profiles.count >= 100) {
+      break;
+    }
+  }
+
+  NSString *defaultProfile = snapshot[@"defaultProfile"];
+  [profiles sortUsingComparator:^NSComparisonResult(
+    NSDictionary *left,
+    NSDictionary *right
+  ) {
+    NSString *leftName = left[@"name"];
+    NSString *rightName = right[@"name"];
+    if ([leftName isEqualToString:defaultProfile]) {
+      return [rightName isEqualToString:defaultProfile]
+        ? NSOrderedSame
+        : NSOrderedAscending;
+    }
+    if ([rightName isEqualToString:defaultProfile]) {
+      return NSOrderedDescending;
+    }
+    NSString *leftLabel = left[@"displayName"] ?: leftName;
+    NSString *rightLabel = right[@"displayName"] ?: rightName;
+    return [leftLabel localizedCaseInsensitiveCompare:rightLabel];
+  }];
+  return profiles;
+}
+
+- (NSURL *)containingApplicationURL {
+  NSBundle *pluginBundle = [NSBundle bundleForClass:[self class]];
+  NSURL *applicationURL = pluginBundle.bundleURL;
+  for (NSUInteger index = 0; index < 3; index += 1) {
+    applicationURL = applicationURL.URLByDeletingLastPathComponent;
+  }
+  if (![[applicationURL.pathExtension lowercaseString] isEqualToString:@"app"]) {
+    return nil;
+  }
+  return applicationURL;
+}
+
+@end

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,7 @@
     "analyze:protocol-capture": "tsx ./scripts/analyze-protocol-capture.ts",
     "analyze:startup-cpu-profile": "tsx ./scripts/analyze-startup-cpu-profile.ts",
     "build": "electron-vite build",
+    "build:native:dock": "node ./scripts/build-dock-tile-plugin.mjs",
     "capture:codex-usage": "tsx ./scripts/capture-codex-usage-protocol.ts",
     "postbuild": "node ./scripts/check-main-bundle-boundary.mjs",
     "dev": "node ./scripts/dev.mjs --",

--- a/apps/desktop/scripts/afterpack-sign-dock-tile-plugin.mjs
+++ b/apps/desktop/scripts/afterpack-sign-dock-tile-plugin.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+function discoverSigningIdentity(context) {
+  const configuredIdentity = context.packager?.config?.mac?.identity;
+  if (configuredIdentity === "-") return null;
+  if (typeof configuredIdentity === "string" && configuredIdentity) {
+    return configuredIdentity;
+  }
+  if (process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY) {
+    return process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY;
+  }
+  if (process.env.CSC_NAME) return process.env.CSC_NAME;
+
+  try {
+    const output = execSync("security find-identity -v -p codesigning", {
+      encoding: "utf8",
+    });
+    return output.match(/"(Developer ID Application: [^"]+)"/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isReleaseContext(context) {
+  if (process.env.CSC_LINK) return true;
+  if (process.env.npm_lifecycle_event === "release") return true;
+  return Boolean(context.packager?.config?.mac?.notarize);
+}
+
+export default async function afterPackSignDockTilePlugin(context) {
+  if (context.electronPlatformName !== "darwin") return;
+
+  const appName = context.packager.appInfo.productFilename;
+  const pluginPath = join(
+    context.appOutDir,
+    `${appName}.app`,
+    "Contents",
+    "PlugIns",
+    "PwrAgentDockTilePlugin.plugin",
+  );
+  if (!existsSync(pluginPath)) {
+    throw new Error(
+      `[afterpack-sign-dock-tile-plugin] missing ${pluginPath}`,
+    );
+  }
+
+  const identity = discoverSigningIdentity(context);
+  if (identity === null && isReleaseContext(context)) {
+    throw new Error(
+      "[afterpack-sign-dock-tile-plugin] release build has no "
+        + "Developer ID Application identity; refusing to leave the nested "
+        + "Dock plug-in ad-hoc signed",
+    );
+  }
+
+  const args = [
+    "--sign",
+    identity ?? "-",
+    "--force",
+    "--options",
+    "runtime",
+  ];
+  if (identity !== null) args.push("--timestamp");
+  args.push(pluginPath);
+
+  console.log(
+    `[afterpack-sign-dock-tile-plugin] signing with ${identity ?? "ad-hoc identity"}`,
+  );
+  const result = spawnSync("codesign", args, { stdio: "inherit" });
+  if (result.status !== 0) {
+    throw new Error(
+      `[afterpack-sign-dock-tile-plugin] codesign failed (exit ${result.status})`,
+    );
+  }
+}

--- a/apps/desktop/scripts/build-dock-tile-plugin.mjs
+++ b/apps/desktop/scripts/build-dock-tile-plugin.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+if (process.platform !== "darwin") {
+  console.log("[build-dock-tile-plugin] non-macOS platform — skipping");
+  process.exit(0);
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = resolve(scriptDir, "..");
+const sourceRoot = join(desktopRoot, "native", "dock-tile-plugin");
+const outputBundle = join(
+  desktopRoot,
+  "build",
+  "native",
+  "PwrAgentDockTilePlugin.plugin",
+);
+const contentsDir = join(outputBundle, "Contents");
+const executableDir = join(contentsDir, "MacOS");
+const executablePath = join(executableDir, "PwrAgentDockTilePlugin");
+
+rmSync(outputBundle, { force: true, recursive: true });
+mkdirSync(executableDir, { recursive: true });
+copyFileSync(join(sourceRoot, "Info.plist"), join(contentsDir, "Info.plist"));
+
+const compile = spawnSync(
+  "xcrun",
+  [
+    "clang",
+    "-fobjc-arc",
+    "-O2",
+    "-bundle",
+    "-arch",
+    "arm64",
+    "-arch",
+    "x86_64",
+    "-mmacosx-version-min=12.0",
+    "-framework",
+    "AppKit",
+    "-framework",
+    "Foundation",
+    join(sourceRoot, "PwrAgentDockTilePlugin.m"),
+    "-o",
+    executablePath,
+  ],
+  { stdio: "inherit" },
+);
+if (compile.status !== 0 || !existsSync(executablePath)) {
+  throw new Error(
+    `[build-dock-tile-plugin] compilation failed (exit ${compile.status})`,
+  );
+}
+
+const sign = spawnSync(
+  "codesign",
+  ["--sign", "-", "--force", "--options", "runtime", outputBundle],
+  { stdio: "inherit" },
+);
+if (sign.status !== 0) {
+  throw new Error(
+    `[build-dock-tile-plugin] ad-hoc signing failed (exit ${sign.status})`,
+  );
+}
+
+console.log(
+  `[build-dock-tile-plugin] universal bundle → ${outputBundle}`,
+);

--- a/apps/desktop/scripts/dock-tile-plugin-config.test.mjs
+++ b/apps/desktop/scripts/dock-tile-plugin-config.test.mjs
@@ -41,9 +41,31 @@ describe("macOS Dock tile plug-in packaging", () => {
       "native/dock-tile-plugin/PwrAgentDockTilePlugin.m",
     );
 
-    expect(source).toContain(".pwragent/dock-profiles.json");
+    expect(source).toContain("NSCachesDirectory");
+    expect(source).toContain("com.pwrdrvr.pwragent");
     expect(source).toContain("@[@\"--profile\", profile]");
+    expect(source).toContain("@\"PWRAGENT_HOME\"");
+    expect(source).toContain("configuration.environment");
     expect(source).toContain("openApplicationAtURL:applicationURL");
     expect(source).not.toMatch(/NSTask|\/bin\/sh|sqlite/i);
+  });
+
+  it("imports CSC_LINK before the afterPack signing hook runs", async () => {
+    const releaseScript = await readDesktopFile("scripts/release.mjs");
+    const decodeIndex = releaseScript.indexOf("maybeDecodeCscLink();");
+    const keychainIndex = releaseScript.indexOf(
+      "maybePrepareCodesignKeychain();",
+    );
+    const builderIndex = releaseScript.indexOf(
+      "runChecked(\"node\", [electronBuilderCli(), ...cleanedArgs]",
+    );
+
+    expect(decodeIndex).toBeGreaterThan(0);
+    expect(keychainIndex).toBeGreaterThan(decodeIndex);
+    expect(builderIndex).toBeGreaterThan(keychainIndex);
+    expect(releaseScript).toContain(
+      "process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY ??= identity",
+    );
+    expect(releaseScript).toContain("process.env.CSC_KEYCHAIN = keychainPath");
   });
 });

--- a/apps/desktop/scripts/dock-tile-plugin-config.test.mjs
+++ b/apps/desktop/scripts/dock-tile-plugin-config.test.mjs
@@ -67,5 +67,25 @@ describe("macOS Dock tile plug-in packaging", () => {
       "process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY ??= identity",
     );
     expect(releaseScript).toContain("process.env.CSC_KEYCHAIN = keychainPath");
+
+    const prepareStart = releaseScript.indexOf(
+      "function maybePrepareCodesignKeychain()",
+    );
+    const prepareEnd = releaseScript.indexOf(
+      "\n}\n\nif (!signStageOnly)",
+      prepareStart,
+    );
+    const prepareSource = releaseScript.slice(prepareStart, prepareEnd);
+    const createKeychainIndex = prepareSource.indexOf('"create-keychain"');
+    const cleanupIndex = prepareSource.indexOf(
+      "codesignKeychainCleanup = () =>",
+    );
+    const importIndex = prepareSource.indexOf('"import"');
+
+    expect(prepareSource).not.toContain("findDeveloperIdIdentity(null)");
+    expect(prepareSource).toContain("findDeveloperIdIdentity(keychainPath)");
+    expect(createKeychainIndex).toBeGreaterThan(0);
+    expect(cleanupIndex).toBeGreaterThan(createKeychainIndex);
+    expect(importIndex).toBeGreaterThan(cleanupIndex);
   });
 });

--- a/apps/desktop/scripts/dock-tile-plugin-config.test.mjs
+++ b/apps/desktop/scripts/dock-tile-plugin-config.test.mjs
@@ -1,0 +1,49 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const readDesktopFile = (path) =>
+  readFile(resolve(desktopRoot, path), "utf8");
+
+describe("macOS Dock tile plug-in packaging", () => {
+  it("embeds and registers the nested plug-in", async () => {
+    const builderConfig = await readDesktopFile("electron-builder.yml");
+
+    expect(builderConfig).toContain(
+      "afterPack: \"scripts/afterpack-sign-dock-tile-plugin.mjs\"",
+    );
+    expect(builderConfig).toContain(
+      "from: build/native/PwrAgentDockTilePlugin.plugin",
+    );
+    expect(builderConfig).toContain(
+      "to: PlugIns/PwrAgentDockTilePlugin.plugin",
+    );
+    expect(builderConfig).toContain(
+      "NSDockTilePlugIn: PwrAgentDockTilePlugin.plugin",
+    );
+  });
+
+  it("builds a universal loadable bundle", async () => {
+    const buildScript = await readDesktopFile(
+      "scripts/build-dock-tile-plugin.mjs",
+    );
+
+    expect(buildScript).toContain("\"-bundle\"");
+    expect(buildScript).toContain("\"arm64\"");
+    expect(buildScript).toContain("\"x86_64\"");
+    expect(buildScript).toContain("codesign");
+  });
+
+  it("launches only the containing app with a profile argument", async () => {
+    const source = await readDesktopFile(
+      "native/dock-tile-plugin/PwrAgentDockTilePlugin.m",
+    );
+
+    expect(source).toContain(".pwragent/dock-profiles.json");
+    expect(source).toContain("@[@\"--profile\", profile]");
+    expect(source).toContain("openApplicationAtURL:applicationURL");
+    expect(source).not.toMatch(/NSTask|\/bin\/sh|sqlite/i);
+  });
+});

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -523,6 +523,15 @@ if (!signStageOnly) {
   step("electron-vite build");
   runChecked("pnpm", ["--filter", "@pwragent/desktop", "build"], { cwd: repoRoot });
 
+  if (!linux && !win) {
+    step("native Dock tile plug-in build");
+    runChecked(
+      "pnpm",
+      ["--filter", "@pwragent/desktop", "build:native:dock"],
+      { cwd: repoRoot },
+    );
+  }
+
   // 3. Materialize the release stage. Windows must include electron-builder in
   // the staged tree: its protected signing job receives only this tree, and
   // Windows tar follows pnpm's workspace junctions when the workspace
@@ -707,6 +716,18 @@ if (linux) {
 }
 
 const builtApp = join(dist, "mac-universal", "PwrAgent.app");
+const dockTilePlugin = join(
+  builtApp,
+  "Contents",
+  "PlugIns",
+  "PwrAgentDockTilePlugin.plugin",
+);
+const dockTilePluginExecutable = join(
+  dockTilePlugin,
+  "Contents",
+  "MacOS",
+  "PwrAgentDockTilePlugin",
+);
 
 step("verify universal binary slices");
 runChecked("lipo", [
@@ -714,6 +735,22 @@ runChecked("lipo", [
   "-verify_arch",
   "x86_64",
   "arm64",
+]);
+runChecked("lipo", [
+  dockTilePluginExecutable,
+  "-verify_arch",
+  "x86_64",
+  "arm64",
+]);
+runChecked("plutil", [
+  "-lint",
+  join(dockTilePlugin, "Contents", "Info.plist"),
+]);
+runChecked("codesign", [
+  "--verify",
+  "--strict",
+  "--verbose=2",
+  dockTilePlugin,
 ]);
 runChecked("lipo", [
   join(

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -624,14 +624,6 @@ function maybePrepareCodesignKeychain() {
     return;
   }
 
-  const existingIdentity = findDeveloperIdIdentity(null);
-  if (existingIdentity !== null) {
-    process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY ??= existingIdentity;
-    process.env.CSC_NAME ??=
-      stripDeveloperIdApplicationPrefix(existingIdentity);
-    return;
-  }
-
   const keychainPath = join(
     tmpdir(),
     `pwragent-codesign-${process.pid}-${Date.now()}.keychain-db`,
@@ -647,6 +639,15 @@ function maybePrepareCodesignKeychain() {
     keychainPassword,
     keychainPath,
   ]);
+  codesignKeychainCleanup = () => {
+    restoreCodesignKeychains(originalKeychains, keychainPath);
+  };
+  process.once("exit", () => {
+    if (codesignKeychainCleanup !== null) {
+      codesignKeychainCleanup();
+      codesignKeychainCleanup = null;
+    }
+  });
   runQuiet("security", [
     "set-keychain-settings",
     "-lut",
@@ -693,7 +694,6 @@ function maybePrepareCodesignKeychain() {
 
   const identity = findDeveloperIdIdentity(keychainPath);
   if (identity === null) {
-    restoreCodesignKeychains(originalKeychains, keychainPath);
     throw new Error(
       `imported ${pathToFileURL(certificatePath).href} into ${keychainPath}, `
         + "but no Developer ID Application identity was found",
@@ -703,15 +703,6 @@ function maybePrepareCodesignKeychain() {
   process.env.CSC_KEYCHAIN = keychainPath;
   process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY ??= identity;
   process.env.CSC_NAME ??= stripDeveloperIdApplicationPrefix(identity);
-  codesignKeychainCleanup = () => {
-    restoreCodesignKeychains(originalKeychains, keychainPath);
-  };
-  process.once("exit", () => {
-    if (codesignKeychainCleanup !== null) {
-      codesignKeychainCleanup();
-      codesignKeychainCleanup = null;
-    }
-  });
   console.log(`  imported CSC_LINK into temporary keychain for ${identity}`);
 }
 

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -45,7 +45,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -54,6 +54,7 @@ const __dirname = dirname(__filename);
 const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "..", "..");
 const stageDir = join(desktopRoot, "release-stage");
+let codesignKeychainCleanup = null;
 const MAC_CANVAS_BINDINGS = [
   {
     binding: "skia.darwin-arm64.node",
@@ -116,6 +117,75 @@ function runChecked(file, args, opts = {}) {
   }
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
+  }
+}
+
+function runQuiet(file, args) {
+  const result = spawnSync(file, args, {
+    cwd: desktopRoot,
+    encoding: "utf8",
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    throw new Error(
+      `${file} ${args.join(" ")} failed with exit ${result.status}`
+        + (detail ? `:\n${detail}` : ""),
+    );
+  }
+  return result.stdout ?? "";
+}
+
+function parseSecurityKeychains(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^"|"$/g, ""));
+}
+
+function cscLinkFilePath() {
+  const link = process.env.CSC_LINK;
+  if (!link) return null;
+  if (link.startsWith("file://")) {
+    return fileURLToPath(link);
+  }
+  if (link.startsWith("~/")) {
+    return join(process.env.HOME ?? "", link.slice(2));
+  }
+  if (existsSync(link)) {
+    return link;
+  }
+  return null;
+}
+
+function findDeveloperIdIdentity(keychainPath) {
+  const args = ["find-identity", "-v", "-p", "codesigning"];
+  if (keychainPath) args.push(keychainPath);
+  const output = runQuiet("security", args);
+  return output.match(/"(Developer ID Application: [^"]+)"/)?.[1] ?? null;
+}
+
+function stripDeveloperIdApplicationPrefix(identity) {
+  return identity.replace(/^Developer ID Application:\s*/, "");
+}
+
+function restoreCodesignKeychains(originalKeychains, keychainPath) {
+  try {
+    runQuiet("security", [
+      "list-keychains",
+      "-d",
+      "user",
+      "-s",
+      ...originalKeychains,
+    ]);
+  } catch {
+    // Exit cleanup must not mask the original packaging result.
+  }
+  try {
+    runQuiet("security", ["delete-keychain", keychainPath]);
+  } catch {
+    // Best effort only; GitHub-hosted runners are disposable.
   }
 }
 
@@ -515,6 +585,136 @@ function maybeDecodeAppleApiKey() {
   console.log("  decoded APPLE_API_KEY_BASE64 -> temporary App Store Connect key file");
 }
 
+// Decode CI's base64 certificate before importing it for the afterPack hook.
+// electron-builder can decode CSC_LINK itself, but it does so only after
+// afterPack, which is too late for nested Dock plug-in signing.
+function maybeDecodeCscLink() {
+  const link = process.env.CSC_LINK;
+  if (!link) return;
+  if (
+    link.startsWith("http://")
+    || link.startsWith("https://")
+    || link.startsWith("file://")
+    || link.startsWith("/")
+    || link.startsWith("~/")
+    || existsSync(link)
+  ) {
+    return;
+  }
+  if (!/^[A-Za-z0-9+/=\r\n]+$/.test(link)) {
+    return;
+  }
+  const target = join(tmpdir(), "PwrAgent_Developer_ID_Application.p12");
+  writeFileSync(target, Buffer.from(link, "base64"));
+  chmodSync(target, 0o600);
+  process.env.CSC_LINK = target;
+  console.log("  decoded CSC_LINK -> temporary Developer ID certificate file");
+}
+
+// afterPack runs before electron-builder lazily imports CSC_LINK. Preload the
+// certificate into a temporary keychain so the nested plug-in and parent app
+// use the same Developer ID identity on clean release runners.
+function maybePrepareCodesignKeychain() {
+  if (process.platform !== "darwin" || !process.env.CSC_LINK) return;
+  if (!process.env.CSC_KEY_PASSWORD) {
+    throw new Error("CSC_LINK is set but CSC_KEY_PASSWORD is missing");
+  }
+  const certificatePath = cscLinkFilePath();
+  if (certificatePath === null) {
+    return;
+  }
+
+  const existingIdentity = findDeveloperIdIdentity(null);
+  if (existingIdentity !== null) {
+    process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY ??= existingIdentity;
+    process.env.CSC_NAME ??=
+      stripDeveloperIdApplicationPrefix(existingIdentity);
+    return;
+  }
+
+  const keychainPath = join(
+    tmpdir(),
+    `pwragent-codesign-${process.pid}-${Date.now()}.keychain-db`,
+  );
+  const keychainPassword = `pwragent-${process.pid}-${Date.now()}`;
+  const originalKeychains = parseSecurityKeychains(
+    runQuiet("security", ["list-keychains", "-d", "user"]),
+  );
+
+  runQuiet("security", [
+    "create-keychain",
+    "-p",
+    keychainPassword,
+    keychainPath,
+  ]);
+  runQuiet("security", [
+    "set-keychain-settings",
+    "-lut",
+    "21600",
+    keychainPath,
+  ]);
+  runQuiet("security", [
+    "unlock-keychain",
+    "-p",
+    keychainPassword,
+    keychainPath,
+  ]);
+  runQuiet("security", [
+    "import",
+    certificatePath,
+    "-k",
+    keychainPath,
+    "-P",
+    process.env.CSC_KEY_PASSWORD,
+    "-T",
+    "/usr/bin/codesign",
+    "-T",
+    "/usr/bin/security",
+    "-T",
+    "/usr/bin/productbuild",
+  ]);
+  runQuiet("security", [
+    "set-key-partition-list",
+    "-S",
+    "apple-tool:,apple:,codesign:",
+    "-s",
+    "-k",
+    keychainPassword,
+    keychainPath,
+  ]);
+  runQuiet("security", [
+    "list-keychains",
+    "-d",
+    "user",
+    "-s",
+    keychainPath,
+    ...originalKeychains,
+  ]);
+
+  const identity = findDeveloperIdIdentity(keychainPath);
+  if (identity === null) {
+    restoreCodesignKeychains(originalKeychains, keychainPath);
+    throw new Error(
+      `imported ${pathToFileURL(certificatePath).href} into ${keychainPath}, `
+        + "but no Developer ID Application identity was found",
+    );
+  }
+
+  process.env.CSC_KEYCHAIN = keychainPath;
+  process.env.PWRAGENT_DOCK_PLUGIN_SIGN_IDENTITY ??= identity;
+  process.env.CSC_NAME ??= stripDeveloperIdApplicationPrefix(identity);
+  codesignKeychainCleanup = () => {
+    restoreCodesignKeychains(originalKeychains, keychainPath);
+  };
+  process.once("exit", () => {
+    if (codesignKeychainCleanup !== null) {
+      codesignKeychainCleanup();
+      codesignKeychainCleanup = null;
+    }
+  });
+  console.log(`  imported CSC_LINK into temporary keychain for ${identity}`);
+}
+
 if (!signStageOnly) {
   // 2. Build (electron-vite -> apps/desktop/out/).
   step("license notices check");
@@ -637,6 +837,8 @@ if (win) {
 } else {
   step(`electron-builder --mac --universal (${publish ? "publish" : "no publish"}, ${dryrun ? "ad-hoc signed" : "signed"})`);
   maybeDecodeAppleApiKey();
+  maybeDecodeCscLink();
+  maybePrepareCodesignKeychain();
   builderArgs.push("--mac", "--universal");
   if (dryrun) {
     // Use ad-hoc signing (identity=-) instead of no signing (identity=null).
@@ -657,6 +859,10 @@ if (win) {
 }
 const cleanedArgs = builderArgs.filter((arg) => arg !== "");
 runChecked("node", [electronBuilderCli(), ...cleanedArgs], { cwd: stageDir });
+if (codesignKeychainCleanup !== null) {
+  codesignKeychainCleanup();
+  codesignKeychainCleanup = null;
+}
 
 // 6. Post-build asar contents check — fails if forbidden files (TS sources,
 //    tests, third-party docs, design docs, screenshots, etc.) leaked into the

--- a/apps/desktop/src/main/__tests__/dock-menu.test.ts
+++ b/apps/desktop/src/main/__tests__/dock-menu.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildDockProfileMenuTemplate } from "../dock-menu";
+
+describe("Dock profile menu", () => {
+  it("lists profiles and opens the selected profile", () => {
+    const openProfile = vi.fn();
+    const template = buildDockProfileMenuTemplate(
+      [
+        {
+          active: true,
+          canDelete: false,
+          codexProfile: {
+            codexHome: "/tmp/codex-default",
+            displayName: "Default",
+            exists: true,
+            hasAuthFile: true,
+            hasConfigFile: true,
+            name: "default",
+            selected: true,
+            source: "default",
+          },
+          default: true,
+          displayName: "Personal",
+          name: "personal",
+          profileDir: "/tmp/personal",
+        },
+        {
+          active: false,
+          canDelete: true,
+          codexProfile: {
+            codexHome: "/tmp/codex-work",
+            displayName: "Work",
+            exists: true,
+            hasAuthFile: true,
+            hasConfigFile: true,
+            name: "work",
+            selected: true,
+            source: "directory",
+          },
+          default: false,
+          name: "work",
+          profileDir: "/tmp/work",
+        },
+      ],
+      openProfile,
+    );
+
+    expect(template).toHaveLength(1);
+    expect(template[0]?.label).toBe("Open Profile");
+    expect(template[0]?.submenu).toEqual([
+      expect.objectContaining({
+        checked: true,
+        label: "Personal",
+        type: "checkbox",
+      }),
+      expect.objectContaining({
+        checked: false,
+        label: "work",
+        type: "checkbox",
+      }),
+    ]);
+
+    const firstItem = Array.isArray(template[0]?.submenu)
+      ? template[0].submenu[0]
+      : undefined;
+    if (!firstItem || typeof firstItem === "string") {
+      throw new Error("expected a profile menu item");
+    }
+    firstItem.click?.({} as never, {} as never, {} as never);
+    expect(openProfile).toHaveBeenCalledWith("personal");
+  });
+
+  it("keeps the submenu visible when there are no profiles", () => {
+    const template = buildDockProfileMenuTemplate([], vi.fn());
+
+    expect(template[0]?.submenu).toEqual([
+      {
+        enabled: false,
+        label: "No Profiles Found",
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -212,6 +212,12 @@ const resolveProfileBootDecisionMock = vi.fn<() => BootDecisionLike>(() => ({
   source: "migration",
 }));
 const cleanupBootstrapProfileMock = vi.fn();
+const buildDockProfileSnapshotMock = vi.fn(() => ({
+  schemaVersion: 2 as const,
+  pwragentHome: "/tmp/pwragent",
+  defaultProfile: "default",
+  profiles: [{ name: "default" }],
+}));
 const writeDockProfileSnapshotMock = vi.fn();
 
 vi.mock("electron", () => ({
@@ -485,6 +491,7 @@ vi.mock("../settings/desktop-settings-singleton", () => ({
 }));
 
 vi.mock("../profile", () => ({
+  buildDockProfileSnapshot: buildDockProfileSnapshotMock,
   resolveActiveProfileName: resolveActiveProfileNameMock,
   startProfileFocusRequestWatcher: startProfileFocusRequestWatcherMock,
   resolveProfileBootDecision: resolveProfileBootDecisionMock,
@@ -767,6 +774,13 @@ describe("bootstrapApp", () => {
       source: "migration",
     });
     cleanupBootstrapProfileMock.mockReset();
+    buildDockProfileSnapshotMock.mockReset();
+    buildDockProfileSnapshotMock.mockReturnValue({
+      schemaVersion: 2,
+      pwragentHome: "/tmp/pwragent",
+      defaultProfile: "default",
+      profiles: [{ name: "default" }],
+    });
     writeDockProfileSnapshotMock.mockReset();
     initializeAppStateMock.mockReset();
     startProfileFocusRequestWatcherMock.mockClear();
@@ -1805,6 +1819,12 @@ describe("bootstrapApp", () => {
 
   it("initializes app state in bootstrap mode when boot decision is no-profile-configured", async () => {
     resolveProfileBootDecisionMock.mockReturnValue({ kind: "no-profile-configured" });
+    buildDockProfileSnapshotMock.mockReturnValue({
+      schemaVersion: 2,
+      pwragentHome: "/tmp/pwragent",
+      defaultProfile: "default",
+      profiles: [],
+    });
     startupProfilerInstance.start.mockResolvedValue();
 
     await import("../index");
@@ -1818,6 +1838,25 @@ describe("bootstrapApp", () => {
     // own that dir; cleanup happens at graduation in Task E.
     expect(initializeAppStateMock).toHaveBeenCalledWith("bootstrap");
     expect(cleanupBootstrapProfileMock).not.toHaveBeenCalled();
+    expect(writeDockProfileSnapshotMock).toHaveBeenCalledWith({
+      schemaVersion: 2,
+      pwragentHome: "/tmp/pwragent",
+      defaultProfile: "default",
+      profiles: [],
+    });
+    const dockTemplate = buildFromTemplateMock.mock.calls.at(-1)?.[0] as
+      Array<{ submenu?: Array<{ enabled?: boolean; label?: string }> }>;
+    expect(dockTemplate).toEqual([
+      {
+        label: "Open Profile",
+        submenu: [
+          {
+            enabled: false,
+            label: "No Profiles Found",
+          },
+        ],
+      },
+    ]);
   });
 
   it("initializes app state in bootstrap mode when env names a missing profile", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -926,6 +926,26 @@ describe("bootstrapApp", () => {
     expect(dockSetIconMock).toHaveBeenCalledWith(nativeImageMock);
   });
 
+  it("continues startup when the Dock profile snapshot cannot be refreshed", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+    startupProfilerInstance.start.mockResolvedValue();
+    writeDockProfileSnapshotMock.mockImplementation(() => {
+      throw new Error("cache is read-only");
+    });
+
+    await import("../index");
+    await flushMicrotasks();
+
+    expect(mainLogWarnMock).toHaveBeenCalledWith(
+      "failed to refresh Dock profile snapshot",
+      { error: "cache is read-only" },
+    );
+    expect(dockSetMenuMock).toHaveBeenCalledOnce();
+    expect(createMainWindowMock).toHaveBeenCalledOnce();
+  });
+
   it("creates the first window without waiting for messaging startup", async () => {
     startupProfilerInstance.start.mockResolvedValue();
     messagingLeaseStartMock.mockReturnValue(new Promise(() => {}));

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1838,25 +1838,30 @@ describe("bootstrapApp", () => {
     // own that dir; cleanup happens at graduation in Task E.
     expect(initializeAppStateMock).toHaveBeenCalledWith("bootstrap");
     expect(cleanupBootstrapProfileMock).not.toHaveBeenCalled();
-    expect(writeDockProfileSnapshotMock).toHaveBeenCalledWith({
-      schemaVersion: 2,
-      pwragentHome: "/tmp/pwragent",
-      defaultProfile: "default",
-      profiles: [],
-    });
-    const dockTemplate = buildFromTemplateMock.mock.calls.at(-1)?.[0] as
-      Array<{ submenu?: Array<{ enabled?: boolean; label?: string }> }>;
-    expect(dockTemplate).toEqual([
-      {
-        label: "Open Profile",
-        submenu: [
-          {
-            enabled: false,
-            label: "No Profiles Found",
-          },
-        ],
-      },
-    ]);
+    if (process.platform === "darwin") {
+      expect(writeDockProfileSnapshotMock).toHaveBeenCalledWith({
+        schemaVersion: 2,
+        pwragentHome: "/tmp/pwragent",
+        defaultProfile: "default",
+        profiles: [],
+      });
+      const dockTemplate = buildFromTemplateMock.mock.calls.at(-1)?.[0] as
+        Array<{ submenu?: Array<{ enabled?: boolean; label?: string }> }>;
+      expect(dockTemplate).toEqual([
+        {
+          label: "Open Profile",
+          submenu: [
+            {
+              enabled: false,
+              label: "No Profiles Found",
+            },
+          ],
+        },
+      ]);
+    } else {
+      expect(writeDockProfileSnapshotMock).not.toHaveBeenCalled();
+      expect(dockSetMenuMock).not.toHaveBeenCalled();
+    }
   });
 
   it("initializes app state in bootstrap mode when env names a missing profile", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -175,6 +175,7 @@ const whenReadyMock = vi.fn(() => Promise.resolve());
 const quitMock = vi.fn();
 const getAllWindowsMock = vi.fn<() => unknown[]>(() => []);
 const dockSetIconMock = vi.fn();
+const dockSetMenuMock = vi.fn();
 const protocolHandleMock = vi.fn();
 const protocolRegisterSchemesAsPrivilegedMock = vi.fn();
 const nativeImageMock = {
@@ -211,6 +212,7 @@ const resolveProfileBootDecisionMock = vi.fn<() => BootDecisionLike>(() => ({
   source: "migration",
 }));
 const cleanupBootstrapProfileMock = vi.fn();
+const writeDockProfileSnapshotMock = vi.fn();
 
 vi.mock("electron", () => ({
   app: {
@@ -224,6 +226,7 @@ vi.mock("electron", () => ({
     whenReady: whenReadyMock,
     dock: {
       setIcon: dockSetIconMock,
+      setMenu: dockSetMenuMock,
     },
     on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       appEventHandlers.set(event, handler);
@@ -486,6 +489,7 @@ vi.mock("../profile", () => ({
   startProfileFocusRequestWatcher: startProfileFocusRequestWatcherMock,
   resolveProfileBootDecision: resolveProfileBootDecisionMock,
   cleanupBootstrapProfile: cleanupBootstrapProfileMock,
+  writeDockProfileSnapshot: writeDockProfileSnapshotMock,
 }));
 
 const runtimeMessagingLeaseCoordinatorMock = {
@@ -741,6 +745,7 @@ describe("bootstrapApp", () => {
     isCodexBootstrapDeferredMock.mockReturnValue(false);
     getDesktopSettingsServiceMock.mockClear();
     dockSetIconMock.mockClear();
+    dockSetMenuMock.mockClear();
     nativeImageMock.isEmpty.mockReset();
     nativeImageMock.isEmpty.mockReturnValue(false);
     nativeImageCreateFromPathMock.mockClear();
@@ -762,6 +767,7 @@ describe("bootstrapApp", () => {
       source: "migration",
     });
     cleanupBootstrapProfileMock.mockReset();
+    writeDockProfileSnapshotMock.mockReset();
     initializeAppStateMock.mockReset();
     startProfileFocusRequestWatcherMock.mockClear();
     startupProfilerInstance.start.mockReset();

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -20,6 +20,7 @@ import {
   resolveBootstrapProfileDir,
   resolveBootstrapProfilePath,
   resolveDefaultProfileName,
+  resolveDockProfileSnapshotPath,
   resolveProfileBootDecision,
   setDefaultProfileName,
   startProfileFocusRequestWatcher,
@@ -81,6 +82,25 @@ describe("PwrAgent profiles", () => {
 
     expect(resolveDefaultProfileName({ env })).toBe("work");
     expect(resolveActiveProfileName()).toBe("dev");
+  });
+
+  it("writes the profile-only snapshot consumed by the macOS Dock plug-in", () => {
+    const { env } = createRoot();
+    ensureNamedProfileExists("personal", { env });
+    ensureNamedProfileExists("work", { env });
+    setDefaultProfileName("work", { env });
+
+    const snapshot = JSON.parse(
+      fs.readFileSync(resolveDockProfileSnapshotPath({ env }), "utf8"),
+    );
+    expect(snapshot).toEqual({
+      schemaVersion: 1,
+      defaultProfile: "work",
+      profiles: [
+        { name: "personal" },
+        { name: "work" },
+      ],
+    });
   });
 
   it("seeds [onboarding] completed=false in a freshly created profile's config.toml", () => {

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -6,6 +6,7 @@ import {
   PWRAGENT_HOME_ENV,
   PWRAGENT_PROFILE_AUTO_CREATE_ENV,
   PWRAGENT_PROFILE_ENV,
+  buildDockProfileSnapshot,
   bootstrapProfileExists,
   cleanupBootstrapProfile,
   deleteProfile,
@@ -25,6 +26,7 @@ import {
   setDefaultProfileName,
   startProfileFocusRequestWatcher,
   startProfileRuntimeHeartbeat,
+  writeDockProfileSnapshot,
   normalizeProfileName,
 } from "../profile";
 
@@ -84,22 +86,49 @@ describe("PwrAgent profiles", () => {
     expect(resolveActiveProfileName()).toBe("dev");
   });
 
-  it("writes the profile-only snapshot consumed by the macOS Dock plug-in", () => {
-    const { env } = createRoot();
+  it("writes a Dock snapshot that preserves an overridden PWRAGENT_HOME", () => {
+    const { env, root } = createRoot();
+    const dockHome = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-dock-home-"));
+    roots.push(dockHome);
     ensureNamedProfileExists("personal", { env });
     ensureNamedProfileExists("work", { env });
     setDefaultProfileName("work", { env });
 
-    const snapshot = JSON.parse(
-      fs.readFileSync(resolveDockProfileSnapshotPath({ env }), "utf8"),
+    const builtSnapshot = buildDockProfileSnapshot({ env });
+    writeDockProfileSnapshot(builtSnapshot, { homeDir: dockHome });
+    const snapshotPath = resolveDockProfileSnapshotPath({ homeDir: dockHome });
+
+    const parsedSnapshot = JSON.parse(
+      fs.readFileSync(snapshotPath, "utf8"),
     );
-    expect(snapshot).toEqual({
-      schemaVersion: 1,
+    expect(parsedSnapshot).toEqual({
+      schemaVersion: 2,
+      pwragentHome: root,
       defaultProfile: "work",
       profiles: [
         { name: "personal" },
         { name: "work" },
       ],
+    });
+    expect(snapshotPath).toBe(path.join(
+      dockHome,
+      "Library",
+      "Caches",
+      "com.pwrdrvr.pwragent",
+      "dock-profiles.json",
+    ));
+    expect(fs.existsSync(path.join(root, "dock-profiles.json"))).toBe(false);
+  });
+
+  it("excludes the synthetic default profile during bootstrap", () => {
+    const { env, root } = createRoot();
+    ensureBootstrapProfileDir({ env });
+
+    expect(buildDockProfileSnapshot({ env })).toEqual({
+      schemaVersion: 2,
+      pwragentHome: root,
+      defaultProfile: "default",
+      profiles: [],
     });
   });
 

--- a/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
@@ -11,6 +11,7 @@ import {
   startProfileRuntimeHeartbeat,
 } from "../profile";
 import { SECRET_STORAGE_DISABLED_ENV } from "../settings/desktop-secret-store";
+import { PROFILES_SET_DEFAULT_CHANNEL } from "../../shared/ipc";
 
 const spawnMock = vi.fn(() => ({
   unref: vi.fn(),
@@ -21,11 +22,13 @@ const safeStorageDecryptMock = vi.fn((buf: Buffer) =>
   buf.toString("utf8").replace(/^enc:/, ""),
 );
 const safeStorageIsAvailableMock = vi.fn(() => true);
+const ipcMainHandleMock = vi.fn();
+const ipcMainRemoveHandlerMock = vi.fn();
 
 vi.mock("electron", () => ({
   ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
+    handle: ipcMainHandleMock,
+    removeHandler: ipcMainRemoveHandlerMock,
   },
   shell: {
     trashItem: vi.fn(async () => undefined),
@@ -74,6 +77,8 @@ afterEach(() => {
   resetCachedActiveProfileNameForTests();
   getAppStateModeMock.mockReset();
   getAppStateModeMock.mockReturnValue("active-profile");
+  ipcMainHandleMock.mockReset();
+  ipcMainRemoveHandlerMock.mockReset();
   vi.unstubAllEnvs();
   spawnMock.mockClear();
   for (const root of roots.splice(0)) {
@@ -167,6 +172,35 @@ describe("profile IPC helpers", () => {
       listDesktopPwrAgentProfiles().profiles.find((profile) => profile.name === "work")
         ?.default,
     ).toBe(true);
+  });
+
+  it("notifies profile listeners after changing the default profile", async () => {
+    const root = createRoot();
+    const env = {
+      [PWRAGENT_HOME_ENV]: root,
+      [PWRAGENT_PROFILE_ENV]: "dev",
+    } as NodeJS.ProcessEnv;
+    ensureNamedProfileExists("dev", { env });
+    ensureNamedProfileExists("work", { env });
+    vi.stubEnv(PWRAGENT_HOME_ENV, root);
+    vi.stubEnv(PWRAGENT_PROFILE_ENV, "dev");
+    const { registerProfilesIpcHandlers } = await import("../ipc/profiles");
+    const onProfilesChanged = vi.fn();
+
+    registerProfilesIpcHandlers({ onProfilesChanged });
+    const handler = ipcMainHandleMock.mock.calls.find(
+      ([channel]) => channel === PROFILES_SET_DEFAULT_CHANNEL,
+    )?.[1] as
+      | ((event: unknown, request: { profile: string }) => Promise<unknown>)
+      | undefined;
+    if (handler === undefined) {
+      throw new Error("profiles:set-default handler was not registered");
+    }
+
+    await expect(handler({}, { profile: "work" })).resolves.toEqual({
+      profile: "work",
+    });
+    expect(onProfilesChanged).toHaveBeenCalledOnce();
   });
 
   it("replaces inherited profile launch arguments when opening another profile", async () => {

--- a/apps/desktop/src/main/dock-menu.ts
+++ b/apps/desktop/src/main/dock-menu.ts
@@ -1,0 +1,32 @@
+import type {
+  DesktopPwrAgentProfileSummary,
+} from "@pwragent/shared";
+import type { MenuItemConstructorOptions } from "electron";
+
+export function buildDockProfileMenuTemplate(
+  profiles: DesktopPwrAgentProfileSummary[],
+  openProfile: (profile: string) => void | Promise<void>,
+): MenuItemConstructorOptions[] {
+  const profileItems: MenuItemConstructorOptions[] = profiles.length > 0
+    ? profiles.map((profile) => ({
+        label: profile.displayName || profile.name,
+        type: "checkbox",
+        checked: profile.active,
+        click: () => {
+          void openProfile(profile.name);
+        },
+      }))
+    : [
+        {
+          label: "No Profiles Found",
+          enabled: false,
+        },
+      ];
+
+  return [
+    {
+      label: "Open Profile",
+      submenu: profileItems,
+    },
+  ];
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -107,6 +107,7 @@ import {
   openDesktopPwrAgentProfile,
   registerProfilesIpcHandlers,
 } from "./ipc/profiles";
+import { buildDockProfileMenuTemplate } from "./dock-menu";
 import { registerRendererErrorIpcHandlers } from "./ipc/renderer-error";
 import {
   disposeRuntimeIdentityIpcHandlers,
@@ -178,6 +179,7 @@ import {
   resolveActiveProfileName,
   resolveProfileBootDecision,
   startProfileFocusRequestWatcher,
+  writeDockProfileSnapshot,
   type ProfileBootDecision,
   type ProfileFocusRequestWatcher,
 } from "./profile";
@@ -909,6 +911,37 @@ function installProfileFocusRequestWatcher(): void {
   );
 }
 
+function openProfileFromMenu(profile: string): Promise<void> {
+  return Promise.resolve(openDesktopPwrAgentProfile({ profile }))
+    .then(() => undefined)
+    .finally(refreshProfileMenus);
+}
+
+function installDockMenu(): void {
+  if (!isMac) return;
+  const { defaultProfile, profiles } = listDesktopPwrAgentProfiles();
+  // Refresh this on every macOS run so an upgraded installation gets a Dock
+  // menu even when its existing profiles registry did not otherwise change.
+  writeDockProfileSnapshot({
+    schemaVersion: 1,
+    defaultProfile,
+    profiles: profiles.map((profile) => ({
+      name: profile.name,
+      ...(profile.displayName ? { displayName: profile.displayName } : {}),
+    })),
+  });
+  const template = buildDockProfileMenuTemplate(
+    profiles,
+    openProfileFromMenu,
+  );
+  app.dock?.setMenu(Menu.buildFromTemplate(template));
+}
+
+function refreshProfileMenus(): void {
+  installApplicationMenu();
+  installDockMenu();
+}
+
 function installApplicationMenu(): void {
   const developerMode = getDesktopSettingsService().resolveDeveloperMode();
   const profiles = listDesktopPwrAgentProfiles().profiles;
@@ -977,9 +1010,7 @@ function installApplicationMenu(): void {
         requestOpenNewThread();
       },
       openProfile: (profile) => {
-        void Promise.resolve(openDesktopPwrAgentProfile({ profile })).finally(
-          installApplicationMenu,
-        );
+        void openProfileFromMenu(profile);
       },
       openProfilesSettings: () => {
         requestOpenSettings("profiles");
@@ -1138,7 +1169,7 @@ export function bootstrapApp(): void {
     if (bootMode === "active-profile") {
       installProfileFocusRequestWatcher();
     }
-    installApplicationMenu();
+    refreshProfileMenus();
     getDesktopBackendRegistry().setPwrAgentAppManagementHandler(
       createPwrAgentAppManagementHandler({
         startedAt: mainProcessStartedAt,
@@ -1210,7 +1241,7 @@ export function bootstrapApp(): void {
           .readTranscriptImage({ url }),
     });
     registerPreloadLogIpcHandlers();
-    registerProfilesIpcHandlers({ onProfilesChanged: installApplicationMenu });
+    registerProfilesIpcHandlers({ onProfilesChanged: refreshProfileMenus });
     registerRendererErrorIpcHandlers();
     registerBootInfoIpcHandlers({
       requestQuit: async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -174,6 +174,7 @@ import {
 } from "./auxiliary-window-chrome";
 import {
   assertUnreachableProfileBootDecision,
+  buildDockProfileSnapshot,
   cleanupBootstrapProfile,
   PWRAGENT_PROFILE_AUTO_CREATE_ENV,
   resolveActiveProfileName,
@@ -919,17 +920,15 @@ function openProfileFromMenu(profile: string): Promise<void> {
 
 function installDockMenu(): void {
   if (!isMac) return;
-  const { defaultProfile, profiles } = listDesktopPwrAgentProfiles();
+  const snapshot = buildDockProfileSnapshot();
+  const materializedProfiles = new Set(
+    snapshot.profiles.map((profile) => profile.name),
+  );
+  const profiles = listDesktopPwrAgentProfiles().profiles
+    .filter((profile) => materializedProfiles.has(profile.name));
   // Refresh this on every macOS run so an upgraded installation gets a Dock
   // menu even when its existing profiles registry did not otherwise change.
-  writeDockProfileSnapshot({
-    schemaVersion: 1,
-    defaultProfile,
-    profiles: profiles.map((profile) => ({
-      name: profile.name,
-      ...(profile.displayName ? { displayName: profile.displayName } : {}),
-    })),
-  });
+  writeDockProfileSnapshot(snapshot);
   const template = buildDockProfileMenuTemplate(
     profiles,
     openProfileFromMenu,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -928,7 +928,13 @@ function installDockMenu(): void {
     .filter((profile) => materializedProfiles.has(profile.name));
   // Refresh this on every macOS run so an upgraded installation gets a Dock
   // menu even when its existing profiles registry did not otherwise change.
-  writeDockProfileSnapshot(snapshot);
+  try {
+    writeDockProfileSnapshot(snapshot);
+  } catch (error) {
+    mainLog.warn("failed to refresh Dock profile snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
   const template = buildDockProfileMenuTemplate(
     profiles,
     openProfileFromMenu,

--- a/apps/desktop/src/main/ipc/profiles.ts
+++ b/apps/desktop/src/main/ipc/profiles.ts
@@ -504,8 +504,11 @@ export function registerProfilesIpcHandlers(
     async (
       _event,
       request: SetDefaultDesktopPwrAgentProfileRequest,
-    ): Promise<SetDefaultDesktopPwrAgentProfileResponse> =>
-      setDefaultDesktopPwrAgentProfile(request),
+    ): Promise<SetDefaultDesktopPwrAgentProfileResponse> => {
+      const response = setDefaultDesktopPwrAgentProfile(request);
+      options.onProfilesChanged?.();
+      return response;
+    },
   );
 
   ipcMain.removeHandler(PROFILES_DELETE_CHANNEL);

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -17,6 +17,7 @@ export { normalizeProfileName };
 export const PWRAGENT_PROFILE_ENV = "PWRAGENT_PROFILE";
 export const PWRAGENT_HOME_ENV = "PWRAGENT_HOME";
 export const DOCK_PROFILE_SNAPSHOT_FILENAME = "dock-profiles.json";
+export const DOCK_PROFILE_SNAPSHOT_CACHE_DIR = "com.pwrdrvr.pwragent";
 /**
  * Bypass the wizard for missing-profile boot decisions. Intended for
  * E2E fixtures and replay tests where the test harness wants to spin
@@ -74,7 +75,8 @@ export type ProfilesRegistry = {
 };
 
 export type DockProfileSnapshot = {
-  schemaVersion: 1;
+  schemaVersion: 2;
+  pwragentHome: string;
   defaultProfile: string;
   profiles: Array<{
     name: string;
@@ -414,11 +416,17 @@ export function resolveProfilesRegistryPath(options?: {
 }
 
 export function resolveDockProfileSnapshotPath(options?: {
-  env?: NodeJS.ProcessEnv;
   homeDir?: string;
 }): string {
+  // The Dock process does not inherit PWRAGENT_HOME. This is a derived cache,
+  // not authoritative configuration: it records the last-run root so the
+  // native plug-in can locate profiles and pass that root into a new launch.
+  const homeDir = options?.homeDir ?? os.homedir();
   return path.join(
-    resolvePwragentRoot(options),
+    homeDir,
+    "Library",
+    "Caches",
+    DOCK_PROFILE_SNAPSHOT_CACHE_DIR,
     DOCK_PROFILE_SNAPSHOT_FILENAME,
   );
 }
@@ -443,28 +451,52 @@ export function writeProfilesRegistry(
   const tmpPath = `${registryPath}.${process.pid}.tmp`;
   fs.writeFileSync(tmpPath, stringifyProfilesToml(registry), "utf8");
   fs.renameSync(tmpPath, registryPath);
-  writeDockProfileSnapshot(buildDockProfileSnapshot(registry), options);
 }
 
 export function writeDockProfileSnapshot(
   snapshot: DockProfileSnapshot,
-  options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
+  options?: { homeDir?: string },
 ): void {
-  writeJsonAtomic(resolveDockProfileSnapshotPath(options), snapshot);
+  const snapshotPath = resolveDockProfileSnapshotPath(options);
+  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+  writeJsonAtomic(snapshotPath, snapshot);
 }
 
 export function buildDockProfileSnapshot(
-  registry: ProfilesRegistry,
+  options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): DockProfileSnapshot {
-  return {
-    schemaVersion: 1,
-    defaultProfile: registry.default_profile ?? "default",
-    profiles: registry.profiles
+  const pwragentHome = resolvePwragentRoot(options);
+  const registry = readProfilesRegistry(options);
+  const profileEntries = new Map(
+    registry.profiles
       .filter((entry) => isValidProfileName(entry.name))
-      .map((entry) => ({
-        name: entry.name,
-        ...(entry.display_name ? { displayName: entry.display_name } : {}),
-      })),
+      .map((entry) => [entry.name, entry]),
+  );
+  const profilesDir = path.join(pwragentHome, "profiles");
+  let materializedProfileNames: string[] = [];
+  try {
+    materializedProfileNames = fs.readdirSync(profilesDir, {
+      withFileTypes: true,
+    })
+      .filter((entry) => entry.isDirectory() && isValidProfileName(entry.name))
+      .map((entry) => entry.name);
+  } catch {
+    // A fresh install has no profiles directory yet.
+  }
+
+  return {
+    schemaVersion: 2,
+    pwragentHome,
+    defaultProfile: registry.default_profile ?? "default",
+    profiles: materializedProfileNames
+      .sort((left, right) => left.localeCompare(right))
+      .map((name) => {
+        const displayName = profileEntries.get(name)?.display_name;
+        return {
+          name,
+          ...(displayName ? { displayName } : {}),
+        };
+      }),
   };
 }
 

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -16,6 +16,7 @@ export { normalizeProfileName };
 
 export const PWRAGENT_PROFILE_ENV = "PWRAGENT_PROFILE";
 export const PWRAGENT_HOME_ENV = "PWRAGENT_HOME";
+export const DOCK_PROFILE_SNAPSHOT_FILENAME = "dock-profiles.json";
 /**
  * Bypass the wizard for missing-profile boot decisions. Intended for
  * E2E fixtures and replay tests where the test harness wants to spin
@@ -70,6 +71,15 @@ export type ProfileEntry = {
 export type ProfilesRegistry = {
   default_profile?: string;
   profiles: ProfileEntry[];
+};
+
+export type DockProfileSnapshot = {
+  schemaVersion: 1;
+  defaultProfile: string;
+  profiles: Array<{
+    name: string;
+    displayName?: string;
+  }>;
 };
 
 export type ProfileRuntimeHeartbeat = {
@@ -403,6 +413,16 @@ export function resolveProfilesRegistryPath(options?: {
   return path.join(resolvePwragentRoot(options), "profiles.toml");
 }
 
+export function resolveDockProfileSnapshotPath(options?: {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}): string {
+  return path.join(
+    resolvePwragentRoot(options),
+    DOCK_PROFILE_SNAPSHOT_FILENAME,
+  );
+}
+
 export function readProfilesRegistry(options?: {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
@@ -423,6 +443,29 @@ export function writeProfilesRegistry(
   const tmpPath = `${registryPath}.${process.pid}.tmp`;
   fs.writeFileSync(tmpPath, stringifyProfilesToml(registry), "utf8");
   fs.renameSync(tmpPath, registryPath);
+  writeDockProfileSnapshot(buildDockProfileSnapshot(registry), options);
+}
+
+export function writeDockProfileSnapshot(
+  snapshot: DockProfileSnapshot,
+  options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
+): void {
+  writeJsonAtomic(resolveDockProfileSnapshotPath(options), snapshot);
+}
+
+export function buildDockProfileSnapshot(
+  registry: ProfilesRegistry,
+): DockProfileSnapshot {
+  return {
+    schemaVersion: 1,
+    defaultProfile: registry.default_profile ?? "default",
+    profiles: registry.profiles
+      .filter((entry) => isValidProfileName(entry.name))
+      .map((entry) => ({
+        name: entry.name,
+        ...(entry.display_name ? { displayName: entry.display_name } : {}),
+      })),
+  };
 }
 
 export function ensureProfileExists(options?: {


### PR DESCRIPTION
## Summary

- add a native macOS `NSDockTilePlugIn` that lists materialized PwrAgent profiles while the app is not running
- launch a selected profile directly with `--profile <name>`, without a shell or background helper
- preserve and propagate the last-run `PWRAGENT_HOME` through a derived Dock launcher cache
- keep the running-app Dock menu in sync through Electron while excluding bootstrap-only synthetic profiles
- build the plug-in as a universal arm64/x86_64 bundle and wire nested signing, packaging, and release verification
- preload CI's `CSC_LINK` into a temporary keychain so the `afterPack` hook and parent app use the same Developer ID identity

## Why

Operators with multiple PwrAgent profiles currently need to start a profile from the command line, for example with `PWRAGENT_PROFILE=101_test open /Applications/PwrAgent.app`. macOS supports Dock menus for terminated apps through `NSDockTilePlugIn`, so the installed app can provide profile selection directly from its Dock icon.

## Operator impact

After the updated app has run once, right-clicking its Dock icon exposes **Open Profile** and the configured profiles. Selecting a profile opens a new PwrAgent instance for it. Custom `PWRAGENT_HOME` roots are preserved. If no materialized profile exists yet, the menu asks the operator to open PwrAgent once to load profiles.

The derived cache lives at `~/Library/Caches/com.pwrdrvr.pwragent/dock-profiles.json`. It contains only the last-run PwrAgent root, profile names, optional display names, and the default profile. It does not read SQLite or expose configuration secrets.

## Validation

- `pnpm test` — 547 files passed; 7,851 tests passed, 3 skipped
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors (existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm --filter @pwragent/desktop build:native:dock`
- `pnpm --filter @pwragent/desktop package:dryrun`
- universal macOS packaging, plist validation, `lipo` architecture checks, strict nested/app signature verification, and packaged launch-descriptor string inspection
