### PR TITLE
fix(desktop): keep branch picker inside launchpad

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2128,9 +2128,10 @@ function BranchPicker(props: {
   }, [open]);
 
   // The popover is anchored to the trigger, which sits near the right edge of
-  // the composer toolbar — keep it inside the viewport by nudging it back in
-  // when it would overflow either gutter. Runs before paint so there's no
-  // visible jump, and re-clamps on resize while open.
+  // the composer toolbar. In the launchpad, keep it inside the settings row so
+  // it cannot extend beneath the thread sidebar; dialog uses fall back to the
+  // viewport gutters. Runs before paint so there's no visible jump, and
+  // re-clamps on resize while open.
   useLayoutEffect(() => {
     if (!open) {
       setMenuShift(0);
@@ -2143,8 +2144,15 @@ function BranchPicker(props: {
       }
       const gutter = 12;
       const rect = menu.getBoundingClientRect();
-      const overflowRight = rect.right - (window.innerWidth - gutter);
-      const overflowLeft = gutter - rect.left;
+      const composerSetup = menu.closest<HTMLElement>(".composer__setup");
+      const composerBounds = composerSetup?.getBoundingClientRect();
+      const leftBoundary = Math.max(gutter, composerBounds?.left ?? gutter);
+      const rightBoundary = Math.min(
+        window.innerWidth - gutter,
+        composerBounds?.right ?? window.innerWidth - gutter,
+      );
+      const overflowRight = rect.right - rightBoundary;
+      const overflowLeft = leftBoundary - rect.left;
       setMenuShift((current) => {
         if (overflowRight > 0) {
           return current - overflowRight;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2075,10 +2075,14 @@ function BranchPicker(props: {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const [menuShift, setMenuShift] = useState(0);
+  const [menuWidthLimit, setMenuWidthLimit] = useState<number>();
   const listboxId = useId();
   const selectedLabelId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuShiftRef = useRef(0);
+  const menuWidthLimitRef = useRef<number | undefined>(undefined);
+  const naturalMenuWidthRef = useRef(0);
   const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -2134,7 +2138,11 @@ function BranchPicker(props: {
   // re-clamps on resize while open.
   useLayoutEffect(() => {
     if (!open) {
+      menuShiftRef.current = 0;
+      menuWidthLimitRef.current = undefined;
+      naturalMenuWidthRef.current = 0;
       setMenuShift(0);
+      setMenuWidthLimit(undefined);
       return;
     }
     const clamp = (): void => {
@@ -2147,21 +2155,41 @@ function BranchPicker(props: {
       const composerSetup = menu.closest<HTMLElement>(".composer__setup");
       const composerBounds = composerSetup?.getBoundingClientRect();
       const leftBoundary = Math.max(gutter, composerBounds?.left ?? gutter);
-      const rightBoundary = Math.min(
-        window.innerWidth - gutter,
-        composerBounds?.right ?? window.innerWidth - gutter,
+      const rightBoundary = Math.max(
+        leftBoundary,
+        Math.min(
+          window.innerWidth - gutter,
+          composerBounds?.right ?? window.innerWidth - gutter,
+        ),
       );
-      const overflowRight = rect.right - rightBoundary;
-      const overflowLeft = leftBoundary - rect.left;
-      setMenuShift((current) => {
-        if (overflowRight > 0) {
-          return current - overflowRight;
-        }
-        if (overflowLeft > 0) {
-          return current + overflowLeft;
-        }
-        return current;
-      });
+      const availableWidth = Math.max(0, rightBoundary - leftBoundary);
+      naturalMenuWidthRef.current = Math.max(
+        naturalMenuWidthRef.current,
+        rect.width,
+      );
+      const targetWidth = Math.min(
+        naturalMenuWidthRef.current,
+        availableWidth,
+      );
+      const nextWidthLimit =
+        targetWidth < naturalMenuWidthRef.current ? targetWidth : undefined;
+      const unshiftedRight = rect.right - menuShiftRef.current;
+      const unshiftedLeft = unshiftedRight - targetWidth;
+      const maxLeft = rightBoundary - targetWidth;
+      const targetLeft = Math.min(
+        Math.max(unshiftedLeft, leftBoundary),
+        maxLeft,
+      );
+      const nextShift = targetLeft - unshiftedLeft;
+
+      if (menuWidthLimitRef.current !== nextWidthLimit) {
+        menuWidthLimitRef.current = nextWidthLimit;
+        setMenuWidthLimit(nextWidthLimit);
+      }
+      if (menuShiftRef.current !== nextShift) {
+        menuShiftRef.current = nextShift;
+        setMenuShift(nextShift);
+      }
     };
     clamp();
     window.addEventListener("resize", clamp);
@@ -2312,7 +2340,19 @@ function BranchPicker(props: {
           className="branch-picker__menu"
           ref={menuRef}
           style={
-            menuShift ? { transform: `translateX(${menuShift}px)` } : undefined
+            menuShift || menuWidthLimit !== undefined
+              ? {
+                  ...(menuShift
+                    ? { transform: `translateX(${menuShift}px)` }
+                    : {}),
+                  ...(menuWidthLimit !== undefined
+                    ? {
+                        maxWidth: `${menuWidthLimit}px`,
+                        minWidth: `${menuWidthLimit}px`,
+                      }
+                    : {}),
+                }
+              : undefined
           }
         >
           <div className="branch-picker__search">

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -13372,6 +13372,71 @@ describe("Composer", () => {
     ).toHaveAttribute("aria-selected", "true");
   });
 
+  it("keeps the launchpad branch menu inside the composer settings row", () => {
+    const rect = (left: number, right: number): DOMRect => ({
+      bottom: 800,
+      height: 400,
+      left,
+      right,
+      top: 400,
+      width: right - left,
+      x: left,
+      y: 400,
+      toJSON: () => ({}),
+    });
+    const bounds = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("composer__setup")) {
+          return rect(408, 996);
+        }
+        if (this.classList.contains("branch-picker__menu")) {
+          return rect(188, 628);
+        }
+        return rect(0, 0);
+      });
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "main",
+            branches: ["main", "releases/1.0"],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+
+    expect(screen.getByRole("listbox").parentElement).toHaveStyle({
+      transform: "translateX(220px)",
+    });
+    bounds.mockRestore();
+  });
+
   it("shows a sticky toast when worktree branch status is unavailable", async () => {
     const onShowNotice = vi.fn();
     render(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -13437,6 +13437,73 @@ describe("Composer", () => {
     bounds.mockRestore();
   });
 
+  it("shrinks the launchpad branch menu to fit a narrow settings row", () => {
+    const rect = (left: number, right: number): DOMRect => ({
+      bottom: 800,
+      height: 400,
+      left,
+      right,
+      top: 400,
+      width: right - left,
+      x: left,
+      y: 400,
+      toJSON: () => ({}),
+    });
+    const bounds = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("composer__setup")) {
+          return rect(408, 708);
+        }
+        if (this.classList.contains("branch-picker__menu")) {
+          return rect(268, 628);
+        }
+        return rect(0, 0);
+      });
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "main",
+            branches: ["main", "releases/1.0"],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+
+    expect(screen.getByRole("listbox").parentElement).toHaveStyle({
+      maxWidth: "300px",
+      minWidth: "300px",
+      transform: "translateX(80px)",
+    });
+    bounds.mockRestore();
+  });
+
   it("shows a sticky toast when worktree branch status is unavailable", async () => {
     const onShowNotice = vi.fn();
     render(


### PR DESCRIPTION
## Summary

- clamp the new-thread launchpad branch picker to the composer settings row
- shrink the branch menu when the available composer row is narrower than its normal minimum width
- preserve viewport-gutter clamping for branch pickers outside the launchpad
- add a regression test using the reported sidebar/composer geometry

## Root cause

The branch menu was right-anchored and only clamped to the browser viewport. When the trigger sat near the left edge of the transcript pane, the menu could extend underneath the higher-layer thread sidebar and appear chopped.

## User impact

The full branch picker now stays visible within the transcript/composer column instead of disappearing behind the thread list.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (287 tests)
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
