### PR TITLE
fix(desktop): fit the main window to scaled displays

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -231,6 +231,41 @@ test.describe("Onboarding wizard", () => {
         }),
       ).toBeVisible();
 
+      const geometry = await app.electronApp.evaluate(
+        ({ BrowserWindow, screen }) => {
+          const mainWindow = BrowserWindow.getAllWindows()[0];
+          if (!mainWindow) {
+            throw new Error("Expected the onboarding BrowserWindow");
+          }
+          const bounds = mainWindow.getBounds();
+          return {
+            bounds,
+            workArea: screen.getDisplayMatching(bounds).workArea,
+          };
+        },
+      );
+      expect(geometry.bounds.x).toBeGreaterThanOrEqual(geometry.workArea.x);
+      expect(geometry.bounds.y).toBeGreaterThanOrEqual(geometry.workArea.y);
+      expect(geometry.bounds.x + geometry.bounds.width).toBeLessThanOrEqual(
+        geometry.workArea.x + geometry.workArea.width,
+      );
+      expect(geometry.bounds.y + geometry.bounds.height).toBeLessThanOrEqual(
+        geometry.workArea.y + geometry.workArea.height,
+      );
+
+      const wizard = await app.window.locator(".onboarding-wizard").boundingBox();
+      const viewport = await app.window.evaluate(() => ({
+        height: globalThis.innerHeight,
+        width: globalThis.innerWidth,
+      }));
+      expect(wizard).not.toBeNull();
+      expect(
+        Math.abs((wizard!.x + wizard!.width / 2) - viewport.width / 2),
+      ).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs((wizard!.y + wizard!.height / 2) - viewport.height / 2),
+      ).toBeLessThanOrEqual(1);
+
       // Get started → Thread presentation.
       await app.window.getByRole("button", { name: /Get started/i }).click();
       await expect(

--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -304,6 +304,24 @@ describe("createMainWindow", () => {
     );
   });
 
+  it("keeps the main window and its resize minimums inside the cursor display work area", async () => {
+    getDisplayNearestPointMock.mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1152, height: 696 },
+    });
+
+    const { createMainWindow } = await import("../window");
+    createMainWindow();
+
+    expect(browserWindowState.options).toMatchObject({
+      x: 0,
+      y: 0,
+      width: 1152,
+      height: 696,
+      minWidth: 960,
+      minHeight: 640,
+    });
+  });
+
   it("registers the main window for messaging push-event channels", async () => {
     const { createMainWindow } = await import("../window");
     const { debugListRegisteredWindows } = await import("../window-channels");

--- a/apps/desktop/src/main/__tests__/window-placement.test.ts
+++ b/apps/desktop/src/main/__tests__/window-placement.test.ts
@@ -113,4 +113,22 @@ describe("window placement", () => {
     });
     expect(electronMock.getDisplayNearestPoint).toHaveBeenCalledWith(cursor);
   });
+
+  it("fits oversized main-window bounds inside the cursor display work area", async () => {
+    const cursor = { x: 400, y: 200 };
+    electronMock.getCursorScreenPoint.mockReturnValue(cursor);
+    electronMock.getDisplayNearestPoint.mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1152, height: 696 },
+    });
+
+    const { boundsForCursorDisplay } = await import("../window-placement");
+
+    expect(boundsForCursorDisplay(1440, 960)).toEqual({
+      x: 0,
+      y: 0,
+      width: 1152,
+      height: 696,
+    });
+    expect(electronMock.getDisplayNearestPoint).toHaveBeenCalledWith(cursor);
+  });
 });

--- a/apps/desktop/src/main/window-placement.ts
+++ b/apps/desktop/src/main/window-placement.ts
@@ -9,6 +9,11 @@ type WindowPosition = {
   y: number;
 };
 
+type WindowBounds = WindowPosition & {
+  width: number;
+  height: number;
+};
+
 export type WindowPlacementSource = {
   sourceBounds?: Rectangle | undefined;
   sourceWindow?: BrowserWindow | null | undefined;
@@ -44,6 +49,20 @@ export function placementForCursorDisplay(
     height,
     screen.getDisplayNearestPoint(screen.getCursorScreenPoint()),
   );
+}
+
+export function boundsForCursorDisplay(
+  width: number,
+  height: number,
+): WindowBounds {
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const fittedWidth = Math.min(width, display.workArea.width);
+  const fittedHeight = Math.min(height, display.workArea.height);
+  return {
+    ...centerWindowOnDisplay(fittedWidth, fittedHeight, display),
+    width: fittedWidth,
+    height: fittedHeight,
+  };
 }
 
 export function positionWindowForSourceDisplay(

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -63,7 +63,7 @@ import {
   navigationPreferencesAdditionalArguments,
   readBootstrapNavigationPreferences,
 } from "./navigation-browse-mode-bootstrap";
-import { placementForCursorDisplay } from "./window-placement";
+import { boundsForCursorDisplay } from "./window-placement";
 import { federationWindowTargetAdditionalArguments } from "../shared/federation-window";
 
 export { isSafeExternalOpenUrl } from "./external-url-policy";
@@ -107,6 +107,8 @@ const isWindows = process.platform === "win32";
 const moduleDirectory = dirname(fileURLToPath(import.meta.url));
 const MAIN_WINDOW_WIDTH = 1440;
 const MAIN_WINDOW_HEIGHT = 960;
+const MAIN_WINDOW_MIN_WIDTH = 960;
+const MAIN_WINDOW_MIN_HEIGHT = 640;
 const mainLog = getMainLogger("pwragent:main");
 const heapLog = getMainLogger("pwragent:heap");
 const hotCpuLog = getMainLogger("pwragent:hot-cpu");
@@ -334,6 +336,10 @@ export function createMainWindow(options?: {
   const windowTitle = mainWindowTitle(options?.federationLabel);
   const appearance = readBootstrapAppearance();
   const navigationPreferences = readBootstrapNavigationPreferences();
+  const initialBounds = boundsForCursorDisplay(
+    MAIN_WINDOW_WIDTH,
+    MAIN_WINDOW_HEIGHT,
+  );
   const windowChrome = isMac
     ? {
         titleBarStyle: "hiddenInset" as const,
@@ -355,11 +361,9 @@ export function createMainWindow(options?: {
         }
       : {};
   const window = new BrowserWindow({
-    ...placementForCursorDisplay(MAIN_WINDOW_WIDTH, MAIN_WINDOW_HEIGHT),
-    width: MAIN_WINDOW_WIDTH,
-    height: MAIN_WINDOW_HEIGHT,
-    minWidth: 1200,
-    minHeight: 760,
+    ...initialBounds,
+    minWidth: Math.min(MAIN_WINDOW_MIN_WIDTH, initialBounds.width),
+    minHeight: Math.min(MAIN_WINDOW_MIN_HEIGHT, initialBounds.height),
     show: false,
     title: windowTitle,
     ...windowChrome,


### PR DESCRIPTION
## What changed

- forward-port #1576 from `releases/1.0` to `main`
- clamp the initial main-window bounds to the cursor display's effective work area
- lower the normal resize floor from 1200×760 to 960×640, with an additional cap for smaller work areas
- add focused unit coverage for a 1152×696 DIP work area
- assert that the native window stays on-screen and the wizard is centered in main's consolidated onboarding walkthrough

## Root cause

At 125% Windows display scaling, a 1440×900 display exposes an effective Electron work area of roughly 1152×696 DIP. PwrAgent requested a 1440×960 window with a 1200×760 minimum, so Windows extended the frameless window beyond the visible work area and placed the native caption controls and wizard edge off-screen.

## Mainline adaptation

Main added federation-aware window titles and targets after the release branch; those paths are preserved. Main also consolidated onboarding E2E launches in #1413, so the geometry assertions run inside the existing full walkthrough instead of restoring the deleted standalone launch.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/app-bootstrap.test.ts apps/desktop/src/main/__tests__/window-placement.test.ts` — 18 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- production desktop build
- focused consolidated onboarding E2E — 1 passed
- original headed Windows VM verification from #1576 — 1 passed
