### PR TITLE
fix(messaging): route default Agent media from Slack threads

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1807,6 +1807,167 @@ describe("MessagingController", () => {
     expect(JSON.stringify(harness.delivered)).toContain("find the thread");
   });
 
+  it("routes an addressed image through an unbound conversation default Agent", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      title: "Search Agent",
+      agent: {
+        name: "Search Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({
+      channel: "slack",
+      downloadAttachment: vi.fn(async ({ attachment }) => ({
+        data: new Uint8Array([137, 80, 78, 71]),
+        fileName: attachment.name,
+        mimeType: "image/png",
+        sizeBytes: 4,
+      })),
+      navigation,
+    });
+    const channel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "channel" as const,
+        title: "t-search-bots",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    await seedConversationDefaultAgent(harness.store, channel);
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("What am I seeing?", {
+        botMention: true,
+        channel,
+      }),
+      id: "event-default-agent-image",
+      kind: "media",
+      attachments: [
+        {
+          id: "image-1",
+          kind: "image",
+          name: "search-dashboard.png",
+          disposition: "available",
+          mimeType: "image/png",
+          sizeBytes: 4,
+        },
+      ],
+      disposition: "available",
+    });
+
+    await expect(
+      harness.store.findActiveBindingForChannel(channel),
+    ).resolves.toBeUndefined();
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        input: [
+          { type: "text", text: "What am I seeing?" },
+          {
+            type: "image",
+            name: "search-dashboard.png",
+            url: "data:image/png;base64,AQID",
+          },
+        ],
+        threadId: "thread-1",
+      }),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({ title: "Choose a thread" }),
+    );
+  });
+
+  it("routes an addressed Slack thread image through its parent channel default Agent", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      title: "Search Agent",
+      agent: {
+        name: "Search Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({
+      channel: "slack",
+      downloadAttachment: vi.fn(async ({ attachment }) => ({
+        data: new Uint8Array([137, 80, 78, 71]),
+        fileName: attachment.name,
+        mimeType: "image/png",
+        sizeBytes: 4,
+      })),
+      navigation,
+    });
+    const parentChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "channel" as const,
+        title: "t-search-bots",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    const threadChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "thread" as const,
+        parentId: "1786655046.300089",
+        parentConversationId: "C012SEARCH",
+        parentTitle: "t-search-bots",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    await seedConversationDefaultAgent(harness.store, parentChannel);
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("What am I seeing?", {
+        botMention: true,
+        channel: threadChannel,
+      }),
+      id: "event-thread-default-agent-image",
+      kind: "media",
+      attachments: [
+        {
+          id: "image-1",
+          kind: "image",
+          name: "search-dashboard.png",
+          disposition: "available",
+          mimeType: "image/png",
+          sizeBytes: 4,
+        },
+      ],
+      disposition: "available",
+    });
+
+    await expect(
+      harness.store.findActiveBindingForChannel(threadChannel),
+    ).resolves.toBeUndefined();
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        input: [
+          { type: "text", text: "What am I seeing?" },
+          {
+            type: "image",
+            name: "search-dashboard.png",
+            url: "data:image/png;base64,AQID",
+          },
+        ],
+        threadId: "thread-1",
+      }),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({ title: "PwrAgent commands" }),
+    );
+  });
+
   it("anchors Slack Agent Route working cards to the inbound channel message", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1882,6 +1882,75 @@ describe("MessagingController", () => {
     );
   });
 
+  it("denies default Agent media when the actor lacks message.reply", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Search Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const records: unknown[] = [];
+    const downloadAttachment = vi.fn(async () => ({
+      data: new Uint8Array([137, 80, 78, 71]),
+      fileName: "search-dashboard.png",
+      mimeType: "image/png",
+      sizeBytes: 4,
+    }));
+    const harness = await createHarness({
+      activityLog: () =>
+        ({ record: (entry: unknown) => records.push(entry) }) as never,
+      channel: "slack",
+      downloadAttachment,
+      navigation,
+      rbacPolicy: rbacProviderGranting(["thread.status.view"]),
+    });
+    const channel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "channel" as const,
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    await seedConversationDefaultAgent(harness.store, channel);
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("What am I seeing?", {
+        botMention: true,
+        channel,
+      }),
+      id: "event-denied-default-agent-image",
+      kind: "media",
+      attachments: [
+        {
+          id: "image-1",
+          kind: "image",
+          name: "search-dashboard.png",
+          disposition: "available",
+          mimeType: "image/png",
+          sizeBytes: 4,
+        },
+      ],
+      disposition: "available",
+    });
+
+    expect(downloadAttachment).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        kind: "inbound-rejected",
+        payload: expect.objectContaining({
+          permission: "message.reply",
+          reason: "unauthorized-capability",
+        }),
+      }),
+    );
+  });
+
   it("routes an addressed Slack thread image through its parent channel default Agent", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -603,6 +603,47 @@ describe("SqliteMessagingStore", () => {
       ]);
   });
 
+  it("inherits a parent channel conversation default in a child thread", async () => {
+    const store = await createStore();
+    const parentChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "channel" as const,
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    const threadChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "thread" as const,
+        parentId: "1786655046.300089",
+        parentConversationId: "C012SEARCH",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "parent-channel-default",
+        scope: { kind: "conversation", channel: parentChannel },
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "parent-channel-agent",
+        },
+      }),
+    );
+
+    await expect(store.findActiveDefaultAgentAssignmentsForChannel(threadChannel))
+      .resolves.toMatchObject([
+        {
+          id: "parent-channel-default",
+          target: { threadId: "parent-channel-agent" },
+        },
+      ]);
+  });
+
   it("enforces one active assignment per scope in the database", async () => {
     const store = await createStore();
     await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -258,6 +258,34 @@ describe("SqliteMessagingStore", () => {
     ]);
   });
 
+  it("preserves normalized parent identity on observed Discord threads", async () => {
+    const store = await createStore();
+    await store.upsertObservedSurface({
+      channel: "discord",
+      conversation: {
+        id: "thread-channel-1",
+        kind: "thread",
+        parentConversationId: "parent-channel-1",
+        parentConversationParentId: "guild-1",
+        parentId: "guild-1",
+        workspaceId: "guild-1",
+      },
+    }, 1000);
+
+    await expect(store.findObservedSurfaces()).resolves.toEqual([
+      expect.objectContaining({
+        channel: {
+          channel: "discord",
+          conversation: expect.objectContaining({
+            id: "thread-channel-1",
+            parentConversationId: "parent-channel-1",
+            parentConversationParentId: "guild-1",
+          }),
+        },
+      }),
+    ]);
+  });
+
   it("remembers bound conversations as observed surfaces", async () => {
     const store = await createStore();
     await store.upsertBinding(buildBinding({
@@ -640,6 +668,49 @@ describe("SqliteMessagingStore", () => {
         {
           id: "parent-channel-default",
           target: { threadId: "parent-channel-agent" },
+        },
+      ]);
+  });
+
+  it("preserves Discord parent identity when inheriting a channel default", async () => {
+    const store = await createStore();
+    const parentChannel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "parent-channel-1",
+        kind: "channel" as const,
+        parentId: "guild-1",
+        workspaceId: "guild-1",
+      },
+    };
+    const threadChannel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "thread-channel-1",
+        kind: "thread" as const,
+        parentConversationId: "parent-channel-1",
+        parentConversationParentId: "guild-1",
+        parentId: "guild-1",
+        workspaceId: "guild-1",
+      },
+    };
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "discord-parent-channel-default",
+        scope: { kind: "conversation", channel: parentChannel },
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "discord-parent-channel-agent",
+        },
+      }),
+    );
+
+    await expect(store.findActiveDefaultAgentAssignmentsForChannel(threadChannel))
+      .resolves.toMatchObject([
+        {
+          id: "discord-parent-channel-default",
+          target: { threadId: "discord-parent-channel-agent" },
         },
       ]);
   });

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -669,6 +669,49 @@ describe("MessagingStore", () => {
       ]);
   });
 
+  it("preserves Discord parent identity when inheriting a channel default", async () => {
+    const { store } = await createStore();
+    const parentChannel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "parent-channel-1",
+        kind: "channel" as const,
+        parentId: "guild-1",
+        workspaceId: "guild-1",
+      },
+    };
+    const threadChannel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "thread-channel-1",
+        kind: "thread" as const,
+        parentConversationId: "parent-channel-1",
+        parentConversationParentId: "guild-1",
+        parentId: "guild-1",
+        workspaceId: "guild-1",
+      },
+    };
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "discord-parent-channel-default",
+        scope: { kind: "conversation", channel: parentChannel },
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "discord-parent-channel-agent",
+        },
+      }),
+    );
+
+    await expect(store.findActiveDefaultAgentAssignmentsForChannel(threadChannel))
+      .resolves.toMatchObject([
+        {
+          id: "discord-parent-channel-default",
+          target: { threadId: "discord-parent-channel-agent" },
+        },
+      ]);
+  });
+
   it("rejects malformed persisted assignment scopes instead of widening them", () => {
     const migrated = migrateMessagingStoreData({
       version: 2,

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -628,6 +628,47 @@ describe("MessagingStore", () => {
       ]);
   });
 
+  it("inherits a parent channel conversation default in a child thread", async () => {
+    const { store } = await createStore();
+    const parentChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "channel" as const,
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    const threadChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SEARCH",
+        kind: "thread" as const,
+        parentId: "1786655046.300089",
+        parentConversationId: "C012SEARCH",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "parent-channel-default",
+        scope: { kind: "conversation", channel: parentChannel },
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "parent-channel-agent",
+        },
+      }),
+    );
+
+    await expect(store.findActiveDefaultAgentAssignmentsForChannel(threadChannel))
+      .resolves.toMatchObject([
+        {
+          id: "parent-channel-default",
+          target: { threadId: "parent-channel-agent" },
+        },
+      ]);
+  });
+
   it("rejects malformed persisted assignment scopes instead of widening them", () => {
     const migrated = migrateMessagingStoreData({
       version: 2,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3332,6 +3332,16 @@ export class MessagingController {
     if (assignments.length === 0) {
       return false;
     }
+    if (
+      !(await this.requirePermission(
+        event,
+        "message.reply",
+        event.kind === "media" ? "media:reply" : "message:reply",
+        { notify: false },
+      ))
+    ) {
+      return true;
+    }
 
     let navigation: NavigationSnapshot;
     try {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3323,7 +3323,7 @@ export class MessagingController {
   }
 
   private async bootstrapDefaultAgentForAcceptedMessage(
-    event: MessagingInboundTextEvent,
+    event: MessagingInboundTextEvent | MessagingInboundMediaEvent,
   ): Promise<boolean> {
     const assignments =
       await this.options.store.findActiveDefaultAgentAssignmentsForChannel(
@@ -3457,6 +3457,9 @@ export class MessagingController {
     binding = await this.revokeExpiredPrivateReplyContinuation(binding);
     if (!binding) {
       if (!await this.shouldHandleAmbientSharedMessage(event)) {
+        return;
+      }
+      if (await this.bootstrapDefaultAgentForAcceptedMessage(event)) {
         return;
       }
       await this.deliver(

--- a/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
@@ -82,6 +82,9 @@ export function buildDefaultAgentScopeLookup(
           ...(channel.conversation.isDirectMessage === true
             ? { isDirectMessage: true }
             : {}),
+          ...(channel.conversation.parentConversationParentId
+            ? { parentId: channel.conversation.parentConversationParentId }
+            : {}),
           ...(channel.conversation.workspaceId
             ? { workspaceId: channel.conversation.workspaceId }
             : {}),

--- a/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
@@ -68,6 +68,29 @@ export function buildDefaultAgentScopeLookup(
       channel: channel.channel,
       conversationId: channel.conversation.parentConversationId,
     });
+    // A conversation default selected on a parent channel also governs its
+    // child threads/topics unless the child has a more-specific exact or
+    // explicit parent assignment. Adapters provide parentConversationId so
+    // core can reconstruct this normalized lookup without reading opaque IDs.
+    scopes.push({
+      kind: "conversation",
+      channel: {
+        channel: channel.channel,
+        conversation: {
+          id: channel.conversation.parentConversationId,
+          kind: channel.conversation.isDirectMessage === true ? "dm" : "channel",
+          ...(channel.conversation.isDirectMessage === true
+            ? { isDirectMessage: true }
+            : {}),
+          ...(channel.conversation.workspaceId
+            ? { workspaceId: channel.conversation.workspaceId }
+            : {}),
+          ...(channel.conversation.parentTitle
+            ? { title: channel.conversation.parentTitle }
+            : {}),
+        },
+      },
+    });
   }
   if (channel.conversation.workspaceId) {
     scopes.push({

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -1248,6 +1248,7 @@ function mergeObservedChannel(
   for (const key of [
     "ancestorTitle",
     "parentConversationId",
+    "parentConversationParentId",
     "parentId",
     "parentTitle",
     "title",

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -284,6 +284,14 @@ returns user-visible rejection reasons for unsupported or oversized files.
 Downloaded bytes and extracted file contents are not persisted in messaging
 state.
 
+After authorization and shared-conversation response-mode checks, inbound media
+uses the same routing hierarchy as accepted text: an active binding first, then
+the effective default Agent, and only then the unbound conversation picker. A
+child thread or topic can inherit the exact conversation default configured on
+its normalized parent channel, after any exact-child or explicit-parent
+assignment. Providers must therefore preserve mention state and normalized
+`parentConversationId` metadata on media events just as they do on text events.
+
 For outbound final responses, desktop messaging core resolves structured
 assistant image parts and local Markdown image links before constructing the
 provider intent. Local files and signed loopback media are copied into the

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -291,6 +291,10 @@ child thread or topic can inherit the exact conversation default configured on
 its normalized parent channel, after any exact-child or explicit-parent
 assignment. Providers must therefore preserve mention state and normalized
 `parentConversationId` metadata on media events just as they do on text events.
+When a parent's persisted conversation identity has its own `parentId`, the
+child also carries that value as `parentConversationParentId`; this keeps route
+inheritance provider-neutral without treating the child's `parentId` as though
+it belonged to the parent.
 
 For outbound final responses, desktop messaging core resolves structured
 assistant image parts and local Markdown image links before constructing the

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -321,6 +321,13 @@ export type MessagingConversationRef = {
    */
   parentConversationId?: string;
   /**
+   * The containing conversation's own `parentId` identity component. Some
+   * providers include that value in persisted channel keys, so inheriting an
+   * exact parent-conversation route must preserve it rather than infer it from
+   * the child's differently-scoped `parentId`.
+   */
+  parentConversationParentId?: string;
+  /**
    * Normalized workspace/server/team identifier. Providers populate this at
    * their boundary; workflow code must not recover it from opaque state.
    */

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -1564,6 +1564,7 @@ describe("discord adapter", () => {
             id: TEST_CHANNEL_ID,
             kind: "thread",
             parentConversationId: parentChannelId,
+            parentConversationParentId: TEST_GUILD_ID,
             parentTitle: "p-search-signals-project",
             workspaceId: TEST_GUILD_ID,
           },

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -1612,7 +1612,10 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         parentId: guildId,
         workspaceId: guildId,
         ...(options?.isThread && breadcrumbs.parentChannelId
-          ? { parentConversationId: breadcrumbs.parentChannelId }
+          ? {
+              parentConversationId: breadcrumbs.parentChannelId,
+              parentConversationParentId: guildId,
+            }
           : {}),
         title: breadcrumbs.channelName,
         parentTitle: breadcrumbs.parentChannelName ?? breadcrumbs.guildName,

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -327,6 +327,7 @@ export type DesktopMessagingDefaultAgentScope =
         kind: MessagingConversationKind;
         parentId?: string;
         parentConversationId?: string;
+        parentConversationParentId?: string;
         workspaceId?: string;
         title?: string;
         parentTitle?: string;
@@ -381,6 +382,7 @@ export type DesktopMessagingObservedSurface = {
     kind: MessagingConversationKind;
     parentId?: string;
     parentConversationId?: string;
+    parentConversationParentId?: string;
     workspaceId?: string;
     title?: string;
     parentTitle?: string;


### PR DESCRIPTION
## Summary

- route accepted inbound media through the effective default Agent when the conversation has no active binding
- let child threads and topics inherit the exact conversation default configured on their normalized parent channel, while preserving exact-child and explicit-parent precedence
- add controller regressions for channel images and the reported Slack thread-image path, plus JSON/SQLite store parity coverage
- document the attachment routing contract

## Root cause

The media handler treated the absence of a persistent binding as terminal and immediately presented the thread picker, so it never attempted the transparent default-Agent route already used by accepted text. Separately, default lookup understood an explicit `parent` assignment but did not reconstruct the parent channel's exact `conversation` assignment from `parentConversationId`. A Slack thread therefore looked up its thread identity and broader scopes, but missed the channel default selected in Settings.

## Impact

An authorized, addressed image or file in an unbound surface now reaches its configured default Agent without creating a persistent binding. Slack thread replies inherit the channel's configured default and keep their thread-local response surface.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-store.test.ts apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts` (449 passed)
- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts` (105 passed)
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm typecheck`
- `git diff --check`

The four new focused regressions were also run before the implementation and failed on the two missing routing paths.
