### PR TITLE
fix(desktop): reduce automation transcript event noise

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -732,6 +732,49 @@ describe("DesktopAutomationService", () => {
         } as AgentEvent),
       ),
     );
+    expect(store.getRunArtifact(runNow.run.id)).toBeUndefined();
+    await expect(
+      service.getRunArtifact({ runId: runNow.run.id }),
+    ).resolves.toMatchObject({
+      artifact: {
+        runId: runNow.run.id,
+        status: "running",
+        transcriptEvents: expect.arrayContaining([
+          expect.objectContaining({ kind: "invocation" }),
+          expect.objectContaining({
+            kind: "assistant_final",
+            text: "Checking the inbox now.",
+          }),
+        ]),
+      },
+    });
+    const inspectionHandler = vi.mocked(registry.setAutomationInspectionHandler).mock
+      .calls.at(-1)?.[0];
+    expect(inspectionHandler).toBeDefined();
+    await expect(inspectionHandler!({
+      operation: "get_automation_run_artifact",
+      context: { backend: "codex", threadId: "thread-1" },
+      args: { runId: runNow.run.id },
+    })).resolves.toMatchObject({
+      ok: true,
+      data: {
+        artifact: {
+          transcriptEvents: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "assistant_final",
+              text: "Checking the inbox now.",
+            }),
+          ]),
+        },
+      },
+    });
+    expect(publishedEvents).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "automation/run/transcript/updated",
+        params: { runId: runNow.run.id },
+      },
+    });
     // Streaming deltas must not be persisted as transcript events (they showed
     // up as fragment "lifecycle" lines like "]}").
     await Promise.all(

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,8 +1,8 @@
 {
   "automation-run-transcript-burst": {
     "commits": 1,
-    "note": "50 completed tool items, one buffered automation artifact write",
-    "observedWalBytes": 28840,
+    "note": "2,500 completed tool items across 50 windows, one shutdown-boundary artifact write",
+    "observedWalBytes": 704520,
     "rowsChanged": 1,
     "statements": 1
   },

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,4 +1,11 @@
 {
+  "automation-run-transcript-burst": {
+    "commits": 1,
+    "note": "50 completed tool items, one buffered automation artifact write",
+    "observedWalBytes": 28840,
+    "rowsChanged": 1,
+    "statements": 1
+  },
   "automation-run-usage": {
     "commits": 1,
     "note": "50 cumulative pricing snapshots for one run, one debounced payload write",

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -366,7 +366,7 @@ describe("sqlite write metrics", () => {
     }
   });
 
-  it("holds a burst of automation transcript events to one artifact write", async () => {
+  it("holds a long automation transcript to one boundary artifact write", async () => {
     vi.useFakeTimers();
     const automationStore = new AutomationStore(stateDb);
     const registryListeners: Array<(event: AgentEvent) => void | Promise<void>> = [];
@@ -414,44 +414,47 @@ describe("sqlite write metrics", () => {
       const runNow = await service.runNow({ automationId: created.automation.id });
 
       const { writes } = await measureSqliteWrites(async () => {
-        // Completed tool items used to rewrite the growing artifact JSON once
-        // per item. Buffer the whole burst into one periodic durability flush.
-        // The five-minute safety window caps a continuously active run at 288
-        // commits/day: 28,840 measured WAL bytes * 288 = 8,305,920 bytes/day
-        // (about 7.9 MiB). Ordinary shorter runs flush once at turn completion.
-        for (let itemIndex = 0; itemIndex < 50; itemIndex += 1) {
-          await Promise.all(
-            registryListeners.map((listener) =>
-              listener({
-                backend: "codex",
-                notification: {
-                  method: "item/completed",
-                  params: {
-                    threadId: "headless-1",
-                    turnId: "turn-1",
-                    item: {
-                      id: `tool-${itemIndex}`,
-                      type: "mcpToolCall",
-                      toolName: `tool-${itemIndex}`,
+        // Fifty five-minute windows with fifty items each model a long-running,
+        // tool-heavy automation. Periodic whole-artifact rewrites would make
+        // WAL growth quadratic as every window rewrote all prior windows.
+        // One 2,500-item boundary write measures 704,520 WAL bytes; even ten
+        // such extreme runs/day stay linear at 7,045,200 bytes (about 6.7 MiB).
+        for (let windowIndex = 0; windowIndex < 50; windowIndex += 1) {
+          for (let itemIndex = 0; itemIndex < 50; itemIndex += 1) {
+            await Promise.all(
+              registryListeners.map((listener) =>
+                listener({
+                  backend: "codex",
+                  notification: {
+                    method: "item/completed",
+                    params: {
+                      threadId: "headless-1",
+                      turnId: "turn-1",
+                      item: {
+                        id: `tool-${windowIndex}-${itemIndex}`,
+                        type: "mcpToolCall",
+                        toolName: `tool-${windowIndex}-${itemIndex}`,
+                      },
                     },
                   },
-                },
-              } as unknown as AgentEvent),
-            ),
-          );
+                } as unknown as AgentEvent),
+              ),
+            );
+          }
+          await vi.advanceTimersByTimeAsync(5 * 60_000);
+          expect(automationStore.getRunArtifact(runNow.run.id)).toBeUndefined();
         }
-        expect(automationStore.getRunArtifact(runNow.run.id)).toBeUndefined();
-        await vi.advanceTimersByTimeAsync(5 * 60_000);
+        service.dispose();
       });
 
       expectSqliteWriteBudget({
-        note: "50 completed tool items, one buffered automation artifact write",
+        note: "2,500 completed tool items across 50 windows, one shutdown-boundary artifact write",
         scenario: "automation-run-transcript-burst",
         writes,
       });
       expect(
         automationStore.getRunArtifact(runNow.run.id)?.transcriptEvents,
-      ).toHaveLength(50);
+      ).toHaveLength(2_500);
     } finally {
       service.dispose();
       vi.useRealTimers();

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -366,6 +366,98 @@ describe("sqlite write metrics", () => {
     }
   });
 
+  it("holds a burst of automation transcript events to one artifact write", async () => {
+    vi.useFakeTimers();
+    const automationStore = new AutomationStore(stateDb);
+    const registryListeners: Array<(event: AgentEvent) => void | Promise<void>> = [];
+    const registry = {
+      canStartThreadTurnImmediately: () => true,
+      getThreadAgentMetadata: async () => ({
+        name: "Agent",
+        instructionLineCount: 0,
+        instructionsTooLong: false,
+        updatedAt: 1,
+      }),
+      onEvent: (listener: (event: AgentEvent) => void | Promise<void>) => {
+        registryListeners.push(listener);
+        return () => {};
+      },
+      publishLocalEvent: async () => {},
+      setAutomationInspectionHandler: () => {},
+      startAutomationHeadlessTurn: async (params: {
+        agentThreadId: string;
+        automationRunId: string;
+        backend: string;
+      }) => ({
+        backend: params.backend,
+        headlessThreadId: "headless-1",
+        queueEntryId: `headless:${params.automationRunId}`,
+        threadId: params.agentThreadId,
+        turnId: "turn-1",
+      }),
+    } as unknown as ConstructorParameters<
+      typeof DesktopAutomationService
+    >[0]["registry"];
+    const service = new DesktopAutomationService({
+      registry,
+      store: automationStore,
+    });
+    try {
+      service.start();
+      const created = await service.create({
+        backend: "codex",
+        threadId: "thread-1",
+        name: "Transcript burst",
+        taskPrompt: "Check.",
+        schedule: { kind: "interval", every: 24, unit: "hours" },
+      });
+      const runNow = await service.runNow({ automationId: created.automation.id });
+
+      const { writes } = await measureSqliteWrites(async () => {
+        // Completed tool items used to rewrite the growing artifact JSON once
+        // per item. Buffer the whole burst into one periodic durability flush.
+        // The five-minute safety window caps a continuously active run at 288
+        // commits/day: 28,840 measured WAL bytes * 288 = 8,305,920 bytes/day
+        // (about 7.9 MiB). Ordinary shorter runs flush once at turn completion.
+        for (let itemIndex = 0; itemIndex < 50; itemIndex += 1) {
+          await Promise.all(
+            registryListeners.map((listener) =>
+              listener({
+                backend: "codex",
+                notification: {
+                  method: "item/completed",
+                  params: {
+                    threadId: "headless-1",
+                    turnId: "turn-1",
+                    item: {
+                      id: `tool-${itemIndex}`,
+                      type: "mcpToolCall",
+                      toolName: `tool-${itemIndex}`,
+                    },
+                  },
+                },
+              } as unknown as AgentEvent),
+            ),
+          );
+        }
+        expect(automationStore.getRunArtifact(runNow.run.id)).toBeUndefined();
+        await vi.advanceTimersByTimeAsync(5 * 60_000);
+      });
+
+      expectSqliteWriteBudget({
+        note: "50 completed tool items, one buffered automation artifact write",
+        scenario: "automation-run-transcript-burst",
+        writes,
+      });
+      expect(
+        automationStore.getRunArtifact(runNow.run.id)?.transcriptEvents,
+      ).toHaveLength(50);
+    } finally {
+      service.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("budgets recurring live usage timer windows", async () => {
     vi.useFakeTimers({
       toFake: ["Date", "clearTimeout", "setTimeout"],

--- a/apps/desktop/src/main/automations/automation-inspection-bus.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-bus.ts
@@ -25,7 +25,19 @@ import {
 import type { AutomationRecord, AutomationStore } from "./automation-store.js";
 
 export class AutomationInspectionBus {
-  constructor(private readonly store: AutomationStore) {}
+  private readonly readRunArtifact: (
+    runId: string,
+  ) => AutomationRunArtifact | undefined;
+
+  constructor(
+    private readonly store: AutomationStore,
+    options: {
+      readRunArtifact?: (runId: string) => AutomationRunArtifact | undefined;
+    } = {},
+  ) {
+    this.readRunArtifact =
+      options.readRunArtifact ?? ((runId) => store.getRunArtifact(runId));
+  }
 
   inspect(request: AutomationInspectionRequest): AutomationInspectionResponse {
     const operation = request.operation;
@@ -157,7 +169,7 @@ export class AutomationInspectionBus {
     args: AutomationInspectionToolArgsByOperation["get_automation_run_artifact"],
   ): AutomationInspectionToolDataByOperation["get_automation_run_artifact"] {
     const run = this.getScopedRun(args.runId, context);
-    const artifact = this.store.getRunArtifact(run.id);
+    const artifact = this.readRunArtifact(run.id);
     if (!artifact) {
       throw new AutomationInspectionError("not_found", "Automation run artifact not found.");
     }
@@ -236,7 +248,7 @@ export class AutomationInspectionBus {
 
   private toRunSummary(run: AutomationRunSummary): AutomationInspectionRunSummary {
     const automation = this.store.getAutomation(run.automationId);
-    const artifact = this.store.getRunArtifact(run.id);
+    const artifact = this.readRunArtifact(run.id);
     return {
       ...run,
       automationName: automation?.name,

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -756,12 +756,24 @@ export class AutomationStore {
     event: AutomationRunTranscriptEvent;
     now?: number;
   }): AutomationRunArtifact | undefined {
+    return this.appendRunTranscriptEvents({
+      runId: params.runId,
+      events: [params.event],
+      now: params.now,
+    });
+  }
+
+  appendRunTranscriptEvents(params: {
+    runId: string;
+    events: AutomationRunTranscriptEvent[];
+    now?: number;
+  }): AutomationRunArtifact | undefined {
     const run = this.getRun(params.runId);
     if (!run) return undefined;
     const existing = this.getRunArtifact(params.runId);
     const transcriptEvents = mergeTranscriptEvents(
       existing?.transcriptEvents ?? [],
-      [params.event],
+      params.events,
     );
     return this.upsertRunArtifact({
       runId: params.runId,

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -82,14 +82,6 @@ const RUN_ACTOR_SCAN_LIMIT = 200;
  */
 const RUN_USAGE_FLUSH_INTERVAL_MS = 1_000;
 
-/**
- * Tool-completion events can arrive in large bursts. Keep their artifact
- * rewrites off the per-item path, then flush at run completion or periodically
- * for unusually long turns so a process crash loses at most one bounded
- * window of inspection detail.
- */
-const RUN_TRANSCRIPT_FLUSH_INTERVAL_MS = 5 * 60_000;
-
 let service: DesktopAutomationService | null = null;
 let storeOverride: AutomationStore | null = null;
 
@@ -147,7 +139,6 @@ export class DesktopAutomationService {
     string,
     Map<string, AutomationRunTranscriptEvent>
   >();
-  private pendingRunTranscriptTimer: NodeJS.Timeout | undefined;
 
   constructor(
     private readonly options: {
@@ -164,7 +155,9 @@ export class DesktopAutomationService {
       runner: new HeadlessAutomationRunner(options.registry),
       gateRunner: new ShellAutomationGateRunner(),
     });
-    this.inspectionBus = new AutomationInspectionBus(options.store);
+    this.inspectionBus = new AutomationInspectionBus(options.store, {
+      readRunArtifact: (runId) => this.readRunArtifactSnapshot(runId),
+    });
   }
 
   start(): void {
@@ -222,10 +215,6 @@ export class DesktopAutomationService {
     if (this.pendingRunUsageTimer) {
       clearTimeout(this.pendingRunUsageTimer);
       this.pendingRunUsageTimer = undefined;
-    }
-    if (this.pendingRunTranscriptTimer) {
-      clearTimeout(this.pendingRunTranscriptTimer);
-      this.pendingRunTranscriptTimer = undefined;
     }
     this.flushPendingRunTranscriptEvents();
     this.flushPendingRunUsage();
@@ -466,7 +455,7 @@ export class DesktopAutomationService {
     const automation = run
       ? this.options.store.getAutomation(run.automationId, { includeDeleted: true })
       : undefined;
-    const artifact = this.options.store.getRunArtifact(request.runId);
+    const artifact = this.readRunArtifactSnapshot(request.runId);
     const rollout =
       run?.backendThreadId && automation
         ? await this.readAutomationRunRollout({
@@ -1208,6 +1197,15 @@ export class DesktopAutomationService {
       turnId,
     });
     this.bufferRunTranscriptEvent(run.id, transcriptEvent);
+    await this.options.registry.publishLocalEvent({
+      backend: event.backend,
+      notification: {
+        method: "automation/run/transcript/updated",
+        params: {
+          runId: run.id,
+        },
+      },
+    });
     if (transcriptEvent.kind !== "assistant_final" || !transcriptEvent.text?.trim()) {
       return;
     }
@@ -1254,13 +1252,40 @@ export class DesktopAutomationService {
     const pending = this.pendingRunTranscriptEvents.get(runId) ?? new Map();
     pending.set(event.id, event);
     this.pendingRunTranscriptEvents.set(runId, pending);
-    if (this.pendingRunTranscriptTimer) return;
-    const timer = setTimeout(() => {
-      this.pendingRunTranscriptTimer = undefined;
-      this.flushPendingRunTranscriptEvents();
-    }, RUN_TRANSCRIPT_FLUSH_INTERVAL_MS);
-    timer.unref?.();
-    this.pendingRunTranscriptTimer = timer;
+  }
+
+  private readRunArtifactSnapshot(
+    runId: string,
+  ): GetAutomationRunArtifactResponse["artifact"] {
+    const persisted = this.options.store.getRunArtifact(runId);
+    const pending = this.pendingRunTranscriptEvents.get(runId);
+    if (!pending || pending.size === 0) return persisted;
+    const run = this.options.store.getRun(runId);
+    if (!run) return persisted;
+    const events = [...pending.values()];
+    const latestEventAt = Math.max(...events.map((event) => event.at));
+    const automation = persisted
+      ? undefined
+      : this.options.store.getAutomation(run.automationId, { includeDeleted: true });
+    const baseEvents =
+      persisted?.transcriptEvents
+      ?? buildRunArtifactTranscript({ automation, run });
+    return {
+      runId,
+      automationId: run.automationId,
+      status: run.status,
+      finalText: persisted?.finalText,
+      errorMessage: persisted?.errorMessage,
+      outputDecision: persisted?.outputDecision,
+      actionResults: persisted?.actionResults ?? [],
+      transcriptEvents: mergeTranscriptEvents(baseEvents, events),
+      createdAt:
+        persisted?.createdAt
+        ?? run.startedAt
+        ?? run.queuedAt
+        ?? latestEventAt,
+      updatedAt: Math.max(persisted?.updatedAt ?? 0, latestEventAt),
+    };
   }
 
   private flushPendingRunTranscriptEvents(runId?: string): void {
@@ -1268,13 +1293,6 @@ export class DesktopAutomationService {
       const pending = this.pendingRunTranscriptEvents.get(runId);
       if (!pending) return;
       this.pendingRunTranscriptEvents.delete(runId);
-      if (
-        this.pendingRunTranscriptEvents.size === 0
-        && this.pendingRunTranscriptTimer
-      ) {
-        clearTimeout(this.pendingRunTranscriptTimer);
-        this.pendingRunTranscriptTimer = undefined;
-      }
       const events = [...pending.values()];
       this.options.store.appendRunTranscriptEvents({
         runId,

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -82,6 +82,14 @@ const RUN_ACTOR_SCAN_LIMIT = 200;
  */
 const RUN_USAGE_FLUSH_INTERVAL_MS = 1_000;
 
+/**
+ * Tool-completion events can arrive in large bursts. Keep their artifact
+ * rewrites off the per-item path, then flush at run completion or periodically
+ * for unusually long turns so a process crash loses at most one bounded
+ * window of inspection detail.
+ */
+const RUN_TRANSCRIPT_FLUSH_INTERVAL_MS = 5 * 60_000;
+
 let service: DesktopAutomationService | null = null;
 let storeOverride: AutomationStore | null = null;
 
@@ -135,6 +143,11 @@ export class DesktopAutomationService {
    */
   private readonly pendingRunUsage = new Map<string, AutomationRunUsage>();
   private pendingRunUsageTimer: NodeJS.Timeout | undefined;
+  private readonly pendingRunTranscriptEvents = new Map<
+    string,
+    Map<string, AutomationRunTranscriptEvent>
+  >();
+  private pendingRunTranscriptTimer: NodeJS.Timeout | undefined;
 
   constructor(
     private readonly options: {
@@ -210,6 +223,11 @@ export class DesktopAutomationService {
       clearTimeout(this.pendingRunUsageTimer);
       this.pendingRunUsageTimer = undefined;
     }
+    if (this.pendingRunTranscriptTimer) {
+      clearTimeout(this.pendingRunTranscriptTimer);
+      this.pendingRunTranscriptTimer = undefined;
+    }
+    this.flushPendingRunTranscriptEvents();
     this.flushPendingRunUsage();
     this.options.registry.setAutomationInspectionHandler?.(null);
   }
@@ -915,8 +933,10 @@ export class DesktopAutomationService {
         || params.status === "cancelled"
         || params.status === "terminal"
       ) {
-        // The run just ended — make whatever usage we have durable now. A
-        // final pricing line landing after this still flushes on the timer.
+        // The run just ended — make pending transcript and usage state durable
+        // before the terminal artifact is assembled and published. A final
+        // pricing line landing after this still flushes on its timer.
+        this.flushPendingRunTranscriptEvents(params.automationRunId);
         this.flushPendingRunUsage(params.automationRunId);
       }
       await this.publishAutomationRunUpdate({
@@ -965,8 +985,10 @@ export class DesktopAutomationService {
 
     const finalText = finalTextFromTerminalTurnNotification(event.notification);
     const errorMessage = errorMessageFromTerminalTurnNotification(event.notification);
-    // Turn end is a durability boundary for the debounced usage snapshot. A
-    // final pricing line arriving afterwards still flushes on the timer.
+    // Turn end is a durability boundary for buffered transcript events and the
+    // debounced usage snapshot. A final pricing line arriving afterwards still
+    // flushes on its timer.
+    this.flushPendingRunTranscriptEvents(activeRun.id);
     this.flushPendingRunUsage(activeRun.id);
     await this.scheduler.handleTurnQueueUpdate({
       automationRunId: activeRun.id,
@@ -1009,7 +1031,7 @@ export class DesktopAutomationService {
     const automation = this.options.store.getAutomation(run.automationId, {
       includeDeleted: true,
     });
-    automationServiceLog.info("publishing automation run update", {
+    const logFields = {
       automationId: run.automationId,
       automationName: automation?.name,
       backend: params.backend,
@@ -1020,7 +1042,7 @@ export class DesktopAutomationService {
       runId: run.id,
       runStatus: run.status,
       threadId: automation?.threadId ?? params.threadId,
-    });
+    };
     if (shouldRecordRunArtifact(params.status)) {
       const existingArtifact = this.options.store.getRunArtifact(run.id);
       const artifact = this.options.store.upsertRunArtifact({
@@ -1085,6 +1107,24 @@ export class DesktopAutomationService {
       }
     }
     const artifact = this.options.store.getRunArtifact(run.id);
+    if (
+      params.status === "terminal"
+      || params.status === "failed"
+      || params.status === "cancelled"
+    ) {
+      automationServiceLog.info("automation run completed", {
+        ...logFields,
+        actionResultCount: artifact?.actionResults?.length ?? 0,
+        durationMs:
+          run.completedAt !== undefined && run.startedAt !== undefined
+            ? run.completedAt - run.startedAt
+            : undefined,
+        outputDecision: artifact?.outputDecision?.kind,
+        transcriptEventCount: artifact?.transcriptEvents.length ?? 0,
+      });
+    } else {
+      automationServiceLog.debug("publishing automation run update", logFields);
+    }
     await this.options.registry.publishLocalEvent({
       backend: params.backend,
       notification: {
@@ -1158,7 +1198,7 @@ export class DesktopAutomationService {
       now: Date.now(),
     });
     if (!transcriptEvent) return;
-    automationServiceLog.info("captured automation run transcript event", {
+    automationServiceLog.debug("captured automation run transcript event", {
       backend: event.backend,
       eventKind: transcriptEvent.kind,
       method: event.notification.method,
@@ -1167,11 +1207,7 @@ export class DesktopAutomationService {
       threadId: notificationThreadId(event.notification),
       turnId,
     });
-    this.options.store.appendRunTranscriptEvent({
-      runId: run.id,
-      event: transcriptEvent,
-      now: transcriptEvent.at,
-    });
+    this.bufferRunTranscriptEvent(run.id, transcriptEvent);
     if (transcriptEvent.kind !== "assistant_final" || !transcriptEvent.text?.trim()) {
       return;
     }
@@ -1184,7 +1220,7 @@ export class DesktopAutomationService {
     ) {
       return;
     }
-    automationServiceLog.info("completing automation run from captured assistant final", {
+    automationServiceLog.debug("completing automation run from captured assistant final", {
       backend: event.backend,
       outputDecision: outputDecision.kind,
       runId: run.id,
@@ -1192,6 +1228,7 @@ export class DesktopAutomationService {
       threadId: notificationThreadId(event.notification),
       turnId,
     });
+    this.flushPendingRunTranscriptEvents(run.id);
     await this.scheduler.handleTurnQueueUpdate({
       automationRunId: run.id,
       status: "terminal",
@@ -1208,6 +1245,54 @@ export class DesktopAutomationService {
       threadId: automation?.threadId ?? notificationThreadId(event.notification) ?? run.id,
       finalText,
     });
+  }
+
+  private bufferRunTranscriptEvent(
+    runId: string,
+    event: AutomationRunTranscriptEvent,
+  ): void {
+    const pending = this.pendingRunTranscriptEvents.get(runId) ?? new Map();
+    pending.set(event.id, event);
+    this.pendingRunTranscriptEvents.set(runId, pending);
+    if (this.pendingRunTranscriptTimer) return;
+    const timer = setTimeout(() => {
+      this.pendingRunTranscriptTimer = undefined;
+      this.flushPendingRunTranscriptEvents();
+    }, RUN_TRANSCRIPT_FLUSH_INTERVAL_MS);
+    timer.unref?.();
+    this.pendingRunTranscriptTimer = timer;
+  }
+
+  private flushPendingRunTranscriptEvents(runId?: string): void {
+    if (runId !== undefined) {
+      const pending = this.pendingRunTranscriptEvents.get(runId);
+      if (!pending) return;
+      this.pendingRunTranscriptEvents.delete(runId);
+      if (
+        this.pendingRunTranscriptEvents.size === 0
+        && this.pendingRunTranscriptTimer
+      ) {
+        clearTimeout(this.pendingRunTranscriptTimer);
+        this.pendingRunTranscriptTimer = undefined;
+      }
+      const events = [...pending.values()];
+      this.options.store.appendRunTranscriptEvents({
+        runId,
+        events,
+        now: Math.max(...events.map((event) => event.at)),
+      });
+      return;
+    }
+    const entries = [...this.pendingRunTranscriptEvents.entries()];
+    this.pendingRunTranscriptEvents.clear();
+    for (const [id, pending] of entries) {
+      const events = [...pending.values()];
+      this.options.store.appendRunTranscriptEvents({
+        runId: id,
+        events,
+        now: Math.max(...events.map((event) => event.at)),
+      });
+    }
   }
 
   private reconcileStartupRuns(): void {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -448,6 +448,7 @@ type RelayedEventSubscription = IncomingEventSubscription & {
 };
 
 const NAVIGATION_EVENT_METHODS = new Set<string>([
+  "automation/run/transcript/updated",
   "automation/run/updated",
   "directory/pin/added",
   "directory/pin/removed",

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/use-automations.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/use-automations.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react";
+import type {
+  AgentEvent,
+  AutomationRunArtifact,
+} from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { useAutomationRunArtifact } from "../useAutomations";
+
+function artifact(transcriptText?: string): AutomationRunArtifact {
+  return {
+    runId: "run-1",
+    automationId: "automation-1",
+    status: "running",
+    actionResults: [],
+    transcriptEvents: transcriptText
+      ? [{
+          id: "event-1",
+          at: 2,
+          kind: "lifecycle",
+          text: transcriptText,
+        }]
+      : [],
+    createdAt: 1,
+    updatedAt: transcriptText ? 2 : 1,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useAutomationRunArtifact", () => {
+  it("debounces refetches when buffered transcript events change", async () => {
+    vi.useFakeTimers();
+    let listener: ((event: AgentEvent) => void) | undefined;
+    const getAutomationRunArtifact = vi.fn()
+      .mockResolvedValueOnce({ artifact: artifact() })
+      .mockResolvedValue({ artifact: artifact("Used tool: search") });
+    const desktopApi = {
+      getAutomationRunArtifact,
+      onAgentEvent: (nextListener: (event: AgentEvent) => void) => {
+        listener = nextListener;
+        return () => {
+          listener = undefined;
+        };
+      },
+    } as unknown as DesktopApi;
+
+    const { result } = renderHook(() =>
+      useAutomationRunArtifact(desktopApi, "run-1"),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getAutomationRunArtifact).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      listener?.({
+        backend: "codex",
+        notification: {
+          method: "automation/run/transcript/updated",
+          params: { runId: "run-1" },
+        },
+      });
+      listener?.({
+        backend: "codex",
+        notification: {
+          method: "automation/run/transcript/updated",
+          params: { runId: "run-1" },
+        },
+      });
+    });
+    expect(getAutomationRunArtifact).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(getAutomationRunArtifact).toHaveBeenCalledTimes(2);
+    expect(result.current.artifact?.transcriptEvents).toEqual([
+      expect.objectContaining({ text: "Used tool: search" }),
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/automations/useAutomations.ts
+++ b/apps/desktop/src/renderer/src/features/automations/useAutomations.ts
@@ -251,34 +251,59 @@ export function useAutomationRunArtifact(
 
   useEffect(() => {
     let cancelled = false;
-    if (!runId || !desktopApi?.getAutomationRunArtifact) {
+    let requestSequence = 0;
+    let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+    const getRunArtifact = desktopApi?.getAutomationRunArtifact;
+    if (!runId || !getRunArtifact) {
       setArtifact(undefined);
       setRollout(undefined);
       setLoading(false);
       return;
     }
-    setLoading(true);
-    setError(undefined);
-    void desktopApi
-      .getAutomationRunArtifact({ runId })
-      .then((response) => {
-        if (!cancelled) {
+
+    const load = async (showLoading: boolean) => {
+      const sequence = ++requestSequence;
+      if (showLoading) setLoading(true);
+      setError(undefined);
+      try {
+        const response = await getRunArtifact({ runId });
+        if (!cancelled && sequence === requestSequence) {
           setArtifact(response.artifact);
           setRollout(response.rollout);
         }
-      })
-      .catch((candidate) => {
-        if (!cancelled) {
-          setError(formatAutomationError(candidate, "Automation artifact could not be loaded."));
+      } catch (candidate) {
+        if (!cancelled && sequence === requestSequence) {
+          setError(formatAutomationError(
+            candidate,
+            "Automation artifact could not be loaded.",
+          ));
         }
-      })
-      .finally(() => {
-        if (!cancelled) {
+      } finally {
+        if (!cancelled && sequence === requestSequence) {
           setLoading(false);
         }
-      });
+      }
+    };
+
+    void load(true);
+    const unsubscribe = desktopApi.onAgentEvent?.((event) => {
+      if (
+        event.notification.method !== "automation/run/transcript/updated"
+        && event.notification.method !== "automation/run/updated"
+      ) {
+        return;
+      }
+      if (event.notification.params.runId !== runId) return;
+      if (refreshTimer) clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => {
+        refreshTimer = undefined;
+        void load(false);
+      }, 100);
+    });
     return () => {
       cancelled = true;
+      if (refreshTimer) clearTimeout(refreshTimer);
+      unsubscribe?.();
     };
   }, [desktopApi, runId]);
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1614,6 +1614,12 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "automation/run/transcript/updated";
+      params: {
+        runId: string;
+      };
+    }
+  | {
       method: "thread/turnQueue/updated";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

- demote per-transcript-item automation logs and non-terminal publication logs to debug
- replace terminal log chatter with one completion summary containing duration and artifact counts
- buffer automation transcript events in memory and merge them into active-run IPC and Agent-tool inspection reads
- debounce live renderer refetches when buffered transcript events change
- persist the accumulated transcript once at terminal or orderly shutdown boundaries
- add a checked SQLite write budget covering 2,500 events across fifty simulated five-minute windows

## Root cause

Every completed automation transcript item emitted an info-level log and synchronously rewrote the run's growing artifact JSON in its own implicit SQLite transaction. Tool-heavy runs therefore flooded normal logs and amplified WAL writes.

## Impact

Normal logs now retain the automation submission and one terminal outcome instead of a line per tool event. Active inspection remains current from the in-memory buffer without requiring SQLite writes. A 2,500-item long-run scenario is pinned to one boundary commit and 704,520 measured WAL bytes, avoiding periodic whole-history rewrites and quadratic WAL growth.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/desktop-automation-service.test.ts apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts apps/desktop/src/main/__tests__/automation-store.test.ts apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/renderer/src/features/automations/__tests__/use-automations.test.tsx`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
