### PR TITLE
fix(desktop): contain Windows approval prefix actions

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -4,6 +4,11 @@ import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 const approvalPendingSpecDir = path.dirname(fileURLToPath(import.meta.url));
+const approvalCommand =
+  "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName";
+const powershell =
+  "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.4.0_x64__8wekyb3d8bbwe\\pwsh.exe";
+const approvalPrefix = `${powershell} -Command ${approvalCommand}`;
 
 async function openApprovalPendingReplay() {
   const app = await launchElectronApp({
@@ -49,13 +54,57 @@ async function openApprovalPendingReplay() {
   await expect(pendingApproval.getByText("Command:")).toBeVisible();
   await expect(
     pendingApproval.locator("pre code")
-  ).toHaveText("npm view dive");
-  await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
+  ).toHaveText(approvalCommand);
   await expect(
     app.window.getByText("Waiting for approval before this turn can continue.")
   ).toBeVisible();
   await expect(
     app.window.getByRole("button", { name: "Approve Once" })
+  ).toBeVisible();
+  const allowPrefix = app.window.getByRole("button", {
+    name: `Always Allow Prefix: ${approvalPrefix}`,
+  });
+  await expect(allowPrefix).toBeVisible();
+  await expect(allowPrefix).toHaveClass(/button--ghost/);
+  await expect(allowPrefix).toHaveClass(/transcript-request__action--detailed/);
+  await expect(allowPrefix).toHaveAttribute(
+    "title",
+    `Always Allow Prefix: ${approvalPrefix}`
+  );
+  const detail = allowPrefix.locator(".transcript-request__action-detail");
+  await expect(detail).toHaveText(approvalCommand);
+  await expect(detail).not.toContainText("PowerShell");
+  const prefixLayout = await allowPrefix.evaluate((element) => {
+    const actions = element.closest(".transcript-request__actions");
+    const detail = element.querySelector("code");
+    const actionRect = element.getBoundingClientRect();
+    const actionsRect = actions?.getBoundingClientRect();
+    const style = detail ? window.getComputedStyle(detail) : undefined;
+    return {
+      actionHeight: actionRect.height,
+      actionScrollWidth: element.scrollWidth,
+      actionClientWidth: element.clientWidth,
+      fitsActions:
+        Boolean(actionsRect)
+        && actionRect.left >= actionsRect!.left
+        && actionRect.right <= actionsRect!.right,
+      overflow: style?.overflow,
+      textOverflow: style?.textOverflow,
+      whiteSpace: style?.whiteSpace,
+    };
+  });
+  expect(prefixLayout).toMatchObject({
+    fitsActions: true,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  });
+  expect(prefixLayout.actionScrollWidth).toBeLessThanOrEqual(
+    prefixLayout.actionClientWidth
+  );
+  expect(prefixLayout.actionHeight).toBeLessThan(60);
+  await expect(
+    app.window.getByRole("button", { name: "Cancel Turn" })
   ).toBeVisible();
 
   return app;
@@ -73,8 +122,7 @@ test("shows pending approval UI without duplicating the turn elsewhere", async (
     await expect(pendingApproval.getByText("Command:")).toBeVisible();
     await expect(
       pendingApproval.locator("pre code")
-    ).toHaveText("npm view dive");
-    await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
+    ).toHaveText(approvalCommand);
     await expect(
       app.window.getByText("Waiting for approval before this turn can continue.")
     ).toBeVisible();

--- a/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
@@ -129,10 +129,23 @@
         "params": {
           "threadId": "thread-approval-pending",
           "turnId": "turn-approval-2",
-          "itemId": "call-npm-view-dive",
+          "itemId": "call-windows-agent-discovery",
           "requestId": "approval-request-1",
-          "reason": "Do you want to allow network access so I can query npm metadata for the `dive` package?",
-          "command": "/bin/zsh -lc 'npm view dive'"
+          "reason": "Do you want to allow a read-only agent instruction discovery command outside the sandbox?",
+          "command": "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName",
+          "availableDecisions": [
+            "accept",
+            {
+              "acceptWithExecpolicyAmendment": {
+                "execpolicy_amendment": [
+                  "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.4.0_x64__8wekyb3d8bbwe\\pwsh.exe",
+                  "-Command",
+                  "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName"
+                ]
+              }
+            },
+            "cancel"
+          ]
         }
       }
     },

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -241,10 +241,12 @@ test("keeps workflow states and narrow desktop layout readable", async ({}, test
     await expect(composer).toBeVisible();
     await expect(approval).toContainText("Approval needed");
     await expect(approval).toContainText(
-      "Do you want to allow network access so I can query npm metadata for the dive package?"
+      "Do you want to allow a read-only agent instruction discovery command outside the sandbox?"
     );
     await expect(approval.getByText("Command:")).toBeVisible();
-    await expect(approval.locator("pre code")).toHaveText("npm view dive");
+    await expect(approval.locator("pre code")).toHaveText(
+      "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName"
+    );
     await expect(app.window.getByRole("status")).toContainText("Waiting for approval");
     await expect(app.window.locator(".thinking-scanner").first()).toBeVisible();
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -339,6 +339,97 @@ function isGenericShellToolTitle(command: string): boolean {
   return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(command.trim());
 }
 
+function isKnownShellExecutable(command: string): boolean {
+  const executable = command
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .split(/[\\/]/)
+    .at(-1)
+    ?.toLowerCase();
+
+  return Boolean(
+    executable
+    && [
+      "bash",
+      "bash.exe",
+      "cmd.exe",
+      "dash",
+      "fish",
+      "ksh",
+      "powershell.exe",
+      "pwsh.exe",
+      "sh",
+      "tcsh",
+      "zsh",
+    ].includes(executable),
+  );
+}
+
+function execpolicyPrefixDetail(rawPrefix: unknown): string {
+  if (!Array.isArray(rawPrefix)) {
+    return "";
+  }
+
+  const prefix = rawPrefix
+    .filter((part): part is string => typeof part === "string" && Boolean(part.trim()))
+    .map((part) => part.trim());
+  const commandFlagIndex = isKnownShellExecutable(prefix[0] ?? "")
+    ? prefix.findIndex((part, index) =>
+        index > 0 && /^(?:-command|-c|-lc|\/c)$/i.test(part),
+      )
+    : -1;
+  const displayParts = commandFlagIndex > 0
+    ? prefix.slice(commandFlagIndex + 1)
+    : prefix;
+  const detail = displayParts.join(" ").trim();
+  const quote = detail[0];
+
+  if (
+    detail.length > 1
+    && (quote === "\"" || quote === "'")
+    && detail.at(-1) === quote
+  ) {
+    return detail.slice(1, -1).trim();
+  }
+
+  return detail || prefix.join(" ");
+}
+
+function pendingRequestActionPresentation(action: PendingRequestAction): {
+  detail?: string;
+  label: string;
+} {
+  if (action.decision !== "accept_with_execpolicy_amendment") {
+    return { label: action.label };
+  }
+
+  const responseDecision = asRecord(action.response.decision);
+  const amendment = asRecord(
+    responseDecision?.acceptWithExecpolicyAmendment
+    ?? responseDecision?.accept_with_execpolicy_amendment,
+  );
+  const detail = execpolicyPrefixDetail(
+    amendment?.execpolicy_amendment
+    ?? amendment?.proposed_execpolicy_amendment,
+  );
+  if (detail) {
+    return {
+      detail,
+      label: "Always Allow Prefix",
+    };
+  }
+
+  const separatorIndex = action.label.indexOf(": ");
+  if (separatorIndex > 0) {
+    return {
+      detail: action.label.slice(separatorIndex + 2),
+      label: action.label.slice(0, separatorIndex),
+    };
+  }
+
+  return { label: action.label };
+}
+
 function pendingRequestPrompt(
   request: AppServerPendingRequestNotification,
   context: PendingRequestApprovalContext | undefined,
@@ -1313,23 +1404,37 @@ export function TranscriptList(props: TranscriptListProps) {
               />
               <ApprovalDiffDisclosures context={pendingApprovalContext} />
               <div className="transcript-request__actions">
-                {pendingRequestActions.map((action) => (
-                  <button
-                    className={
-                      action.style === "primary"
-                        ? "button button--primary"
-                        : "button button--ghost"
-                    }
-                    disabled={props.pendingRequestBusy}
-                    key={action.id}
-                    type="button"
-                    onClick={() => {
-                      void props.onRespondToPendingRequest?.(action);
-                    }}
-                  >
-                    {action.label}
-                  </button>
-                ))}
+                {pendingRequestActions.map((action) => {
+                  const presentation = pendingRequestActionPresentation(action);
+                  return (
+                    <button
+                      aria-label={presentation.detail ? action.label : undefined}
+                      className={[
+                        "button",
+                        action.style === "primary" ? "button--primary" : "button--ghost",
+                        presentation.detail
+                          ? "transcript-request__action--detailed"
+                          : "",
+                      ].filter(Boolean).join(" ")}
+                      disabled={props.pendingRequestBusy}
+                      key={action.id}
+                      title={presentation.detail ? action.label : undefined}
+                      type="button"
+                      onClick={() => {
+                        void props.onRespondToPendingRequest?.(action);
+                      }}
+                    >
+                      <span className="transcript-request__action-label">
+                        {presentation.label}
+                      </span>
+                      {presentation.detail ? (
+                        <code className="transcript-request__action-detail">
+                          {presentation.detail}
+                        </code>
+                      ) : null}
+                    </button>
+                  );
+                })}
               </div>
             </div>
           ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3291,6 +3291,54 @@ Implementation notes remain in a readable bubble.`;
     );
   });
 
+  it("keeps a Windows durable command prefix bounded and leads with the command", () => {
+    const powershell =
+      "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.4.0_x64__8wekyb3d8bbwe\\pwsh.exe";
+    const command =
+      "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md";
+
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            command,
+            availableDecisions: [
+              "accept",
+              {
+                acceptWithExecpolicyAmendment: {
+                  execpolicy_amendment: [powershell, "-Command", command],
+                },
+              },
+              "cancel",
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const action = screen.getByRole("button", {
+      name: `Always Allow Prefix: ${powershell} -Command ${command}`,
+    });
+    expect(action).toHaveClass("button--ghost", "transcript-request__action--detailed");
+    expect(action.querySelector(".transcript-request__action-label")).toHaveTextContent(
+      "Always Allow Prefix"
+    );
+    expect(action.querySelector(".transcript-request__action-detail")).toHaveTextContent(
+      command
+    );
+    expect(action.querySelector(".transcript-request__action-detail")).not.toHaveTextContent(
+      powershell
+    );
+  });
+
   it("derives Kimi approval commands from prompt text when command is a shell title", () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11428,6 +11428,40 @@ a.transcript-message__messaging-origin:focus-visible {
   white-space: normal;
 }
 
+.transcript-request__action--detailed {
+  flex: 0 0 100%;
+  width: 100%;
+  height: auto;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  overflow: hidden;
+  padding: 7px 10px;
+  text-align: left;
+}
+
+.transcript-request__action-label {
+  line-height: 1.2;
+}
+
+.transcript-request__action-detail {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transcript-request__action--detailed:hover:not([disabled])
+  .transcript-request__action-detail {
+  color: var(--text-primary);
+}
+
 .transcript-questionnaire__prompt,
 .transcript-mcp__prompt {
   display: flex;

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -198,6 +198,7 @@ describe("buildPendingRequestResponse", () => {
         decision: "accept_with_execpolicy_amendment",
         label: "Always allow: npm view",
         response: { decision: "allow-always-command" },
+        style: "secondary",
       }),
       expect.objectContaining({
         decision: "decline",
@@ -255,6 +256,7 @@ describe("buildPendingRequestResponse", () => {
         decision: "accept_with_execpolicy_amendment",
         label: "Always Allow Prefix: pnpm test",
         response: { decision: structuredDecision },
+        style: "secondary",
       }),
       expect.objectContaining({
         decision: "cancel",

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -566,7 +566,7 @@ function actionFromEntry(
       id: `approval:accept_with_execpolicy_amendment:${index}`,
       label: label ?? execpolicyLabel(execpolicyPayload),
       responseDecision: entry,
-      style: "primary",
+      style: "secondary",
     });
   }
 
@@ -814,12 +814,12 @@ function defaultLabel(
 function defaultStyle(decision: PendingRequestActionDecision): PendingRequestActionStyle {
   switch (decision) {
     case "accept":
-    case "accept_with_execpolicy_amendment":
     case "apply_network_policy_amendment":
       return "primary";
     case "decline":
       return "danger";
     case "accept_for_session":
+    case "accept_with_execpolicy_amendment":
     case "cancel":
       return "secondary";
   }


### PR DESCRIPTION
## What changed

- render persistent command-prefix approval as a bounded secondary action with a one-line ellipsized detail
- strip structured PowerShell, cmd, and shell launchers from the displayed prefix so the useful command leads
- preserve the full raw approval label for the accessible name, tooltip, and submitted decision
- cover the WindowsApps PowerShell path in unit and replay-backed Electron tests

## Root cause

The earlier command-prefix presentation fix was never backported to the 1.0 release branch. Its prefix formatting also joined every structured argument verbatim, so a Windows PowerShell executable under a long WindowsApps path would consume the button before the actual command appeared.

## User impact

Long Windows approval prefixes stay inside the approval card and show the start of the command from the message area instead of wrapping a launcher path across the button.

## Validation

- 86 focused Vitest tests
- approval-pending Electron replay: 3 tests
- TypeScript typecheck
- ESLint (0 errors; existing warnings only)
- renderer color lint
- dependency boundary lint
