### PR TITLE
fix(desktop): relaunch profile after onboarding

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -502,6 +502,10 @@ test.describe("Onboarding wizard", () => {
   });
 
   test("requested-profile bootstrap relaunches that profile after Skip", async () => {
+    test.skip(
+      process.platform === "linux",
+      "Detached profile relaunch is not reliable under headless Xvfb; the IPC regression covers Linux.",
+    );
     test.setTimeout(60_000);
     const app = await launchWizard({ PWRAGENT_PROFILE: "test2" });
     try {

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -501,6 +501,51 @@ test.describe("Onboarding wizard", () => {
     }
   });
 
+  test("requested-profile bootstrap relaunches that profile after Skip", async () => {
+    test.setTimeout(60_000);
+    const app = await launchWizard({ PWRAGENT_PROFILE: "test2" });
+    try {
+      await expect(
+        app.window.getByRole("heading", { name: /Set up.+test2/i }),
+      ).toBeVisible();
+      await app.window
+        .getByRole("button", { name: /Set up.+test2/i })
+        .click();
+      await app.window
+        .getByRole("button", { name: /Skip setup/i })
+        .click();
+
+      const proc = app.electronApp.process();
+      const exitPromise = new Promise<boolean>((resolve) => {
+        if (proc.exitCode !== null) return resolve(true);
+        const timer = setTimeout(() => resolve(false), 30_000);
+        proc.once("exit", () => {
+          clearTimeout(timer);
+          resolve(true);
+        });
+      });
+
+      await app.window
+        .getByRole("button", { name: /Skip and use default/i })
+        .click();
+
+      expect(await exitPromise).toBe(true);
+      const profileConfig = fs.readFileSync(
+        path.join(
+          app.homeRoot,
+          ".pwragent",
+          "profiles",
+          "test2",
+          "config.toml",
+        ),
+        "utf8",
+      );
+      expect(profileConfig).toContain("completed = true");
+    } finally {
+      await app.close();
+    }
+  });
+
   test("Multiple-mode finish quits the bootstrap window AND doesn't materialize a phantom 'default' profile", async () => {
     // The wizard's spawn + wait-for-alive (10s timeout) + 2s grace
     // can chew through most of the default 30s. CI Linux runners

--- a/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
@@ -72,6 +72,8 @@ afterEach(() => {
   // the process lifetime. Without this reset, a previous test's
   // PWRAGENT_PROFILE stub leaks into the next test's listing calls.
   resetCachedActiveProfileNameForTests();
+  getAppStateModeMock.mockReset();
+  getAppStateModeMock.mockReturnValue("active-profile");
   vi.unstubAllEnvs();
   spawnMock.mockClear();
   for (const root of roots.splice(0)) {
@@ -280,6 +282,32 @@ describe("profile IPC helpers", () => {
         env: expect.objectContaining({
           [PWRAGENT_PROFILE_ENV]: "my-work-profile",
           [SECRET_STORAGE_DISABLED_ENV]: "1",
+        }),
+      }),
+    );
+  });
+
+  it("launches the graduated profile when bootstrap requested the same profile", async () => {
+    const root = createRoot();
+    const env = {
+      [PWRAGENT_HOME_ENV]: root,
+      [PWRAGENT_PROFILE_ENV]: "test2",
+    } as NodeJS.ProcessEnv;
+    ensureNamedProfileExists("test2", { env });
+    vi.stubEnv(PWRAGENT_HOME_ENV, root);
+    vi.stubEnv(PWRAGENT_PROFILE_ENV, "test2");
+    getAppStateModeMock.mockReturnValue("bootstrap");
+    const { openDesktopPwrAgentProfile } = await import("../ipc/profiles");
+
+    const response = openDesktopPwrAgentProfile({ profile: "test2" });
+
+    expect(response).toEqual({ opened: true, profile: "test2" });
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(["--profile", "test2"]),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          [PWRAGENT_PROFILE_ENV]: "test2",
         }),
       }),
     );

--- a/apps/desktop/src/main/ipc/profiles.ts
+++ b/apps/desktop/src/main/ipc/profiles.ts
@@ -136,7 +136,10 @@ export function openDesktopPwrAgentProfile(
   }
 
   const activeProfile = resolveActiveProfileName();
-  if (profile === activeProfile) {
+  // Bootstrap has no active profile runtime of its own. Its requested
+  // profile name can match the profile the wizard just graduated, but that
+  // real profile still needs to be launched before bootstrap can quit.
+  if (getAppStateMode() !== "bootstrap" && profile === activeProfile) {
     return { opened: false, profile, reason: "active" };
   }
 


### PR DESCRIPTION
## Summary

Forward-port of #1589 to `main`.

- treat bootstrap as a temporary runtime even when its requested profile name matches the graduated profile
- preserve active-profile duplicate prevention and live-instance focusing
- add unit and headed Electron regressions for the `PWRAGENT_PROFILE=test2` graduation/relaunch path
- skip only the detached-process E2E under headless Linux, where the cross-platform IPC regression remains active

## Root cause

The bootstrap process resolves the requested profile name as its active profile name. After the wizard graduates that same profile, `openDesktopPwrAgentProfile` returned `reason: "active"` instead of spawning the real profile runtime. The wizard then timed out waiting for a heartbeat, kept bootstrap alive as a safety fallback, and subsequent thread creation failed because bootstrap mode forbids backend operations.

## Validation

- `pnpm exec vitest run apps/desktop/src/main/__tests__/profiles-ipc.test.ts`
- `pnpm test:desktop-e2e apps/desktop/e2e/onboarding-wizard.spec.ts --grep "requested-profile bootstrap"`
- focused ESLint on the three changed files (0 errors; one pre-existing unused-disable warning)
- production Electron build completed as part of the E2E command
