### PR TITLE
fix(desktop): backport branch picker layering

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1655,10 +1655,14 @@ function BranchPicker(props: {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const [menuShift, setMenuShift] = useState(0);
+  const [menuWidthLimit, setMenuWidthLimit] = useState<number>();
   const listboxId = useId();
   const selectedLabelId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuShiftRef = useRef(0);
+  const menuWidthLimitRef = useRef<number | undefined>(undefined);
+  const naturalMenuWidthRef = useRef(0);
   const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -1708,12 +1712,17 @@ function BranchPicker(props: {
   }, [open]);
 
   // The popover is anchored to the trigger, which sits near the right edge of
-  // the composer toolbar — keep it inside the viewport by nudging it back in
-  // when it would overflow either gutter. Runs before paint so there's no
-  // visible jump, and re-clamps on resize while open.
+  // the composer toolbar. In the launchpad, keep it inside the settings row so
+  // it cannot extend beneath the thread sidebar; dialog uses fall back to the
+  // viewport gutters. Runs before paint so there's no visible jump, and
+  // re-clamps on resize while open.
   useLayoutEffect(() => {
     if (!open) {
+      menuShiftRef.current = 0;
+      menuWidthLimitRef.current = undefined;
+      naturalMenuWidthRef.current = 0;
       setMenuShift(0);
+      setMenuWidthLimit(undefined);
       return;
     }
     const clamp = (): void => {
@@ -1723,17 +1732,44 @@ function BranchPicker(props: {
       }
       const gutter = 12;
       const rect = menu.getBoundingClientRect();
-      const overflowRight = rect.right - (window.innerWidth - gutter);
-      const overflowLeft = gutter - rect.left;
-      setMenuShift((current) => {
-        if (overflowRight > 0) {
-          return current - overflowRight;
-        }
-        if (overflowLeft > 0) {
-          return current + overflowLeft;
-        }
-        return current;
-      });
+      const composerSetup = menu.closest<HTMLElement>(".composer__setup");
+      const composerBounds = composerSetup?.getBoundingClientRect();
+      const leftBoundary = Math.max(gutter, composerBounds?.left ?? gutter);
+      const rightBoundary = Math.max(
+        leftBoundary,
+        Math.min(
+          window.innerWidth - gutter,
+          composerBounds?.right ?? window.innerWidth - gutter,
+        ),
+      );
+      const availableWidth = Math.max(0, rightBoundary - leftBoundary);
+      naturalMenuWidthRef.current = Math.max(
+        naturalMenuWidthRef.current,
+        rect.width,
+      );
+      const targetWidth = Math.min(
+        naturalMenuWidthRef.current,
+        availableWidth,
+      );
+      const nextWidthLimit =
+        targetWidth < naturalMenuWidthRef.current ? targetWidth : undefined;
+      const unshiftedRight = rect.right - menuShiftRef.current;
+      const unshiftedLeft = unshiftedRight - targetWidth;
+      const maxLeft = rightBoundary - targetWidth;
+      const targetLeft = Math.min(
+        Math.max(unshiftedLeft, leftBoundary),
+        maxLeft,
+      );
+      const nextShift = targetLeft - unshiftedLeft;
+
+      if (menuWidthLimitRef.current !== nextWidthLimit) {
+        menuWidthLimitRef.current = nextWidthLimit;
+        setMenuWidthLimit(nextWidthLimit);
+      }
+      if (menuShiftRef.current !== nextShift) {
+        menuShiftRef.current = nextShift;
+        setMenuShift(nextShift);
+      }
     };
     clamp();
     window.addEventListener("resize", clamp);
@@ -1884,7 +1920,19 @@ function BranchPicker(props: {
           className="branch-picker__menu"
           ref={menuRef}
           style={
-            menuShift ? { transform: `translateX(${menuShift}px)` } : undefined
+            menuShift || menuWidthLimit !== undefined
+              ? {
+                  ...(menuShift
+                    ? { transform: `translateX(${menuShift}px)` }
+                    : {}),
+                  ...(menuWidthLimit !== undefined
+                    ? {
+                        maxWidth: `${menuWidthLimit}px`,
+                        minWidth: `${menuWidthLimit}px`,
+                      }
+                    : {}),
+                }
+              : undefined
           }
         >
           <div className="branch-picker__search">

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9467,6 +9467,138 @@ describe("Composer", () => {
     ).toHaveAttribute("aria-selected", "true");
   });
 
+  it("keeps the launchpad branch menu inside the composer settings row", () => {
+    const rect = (left: number, right: number): DOMRect => ({
+      bottom: 800,
+      height: 400,
+      left,
+      right,
+      top: 400,
+      width: right - left,
+      x: left,
+      y: 400,
+      toJSON: () => ({}),
+    });
+    const bounds = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("composer__setup")) {
+          return rect(408, 996);
+        }
+        if (this.classList.contains("branch-picker__menu")) {
+          return rect(188, 628);
+        }
+        return rect(0, 0);
+      });
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "main",
+            branches: ["main", "releases/1.0"],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+
+    expect(screen.getByRole("listbox").parentElement).toHaveStyle({
+      transform: "translateX(220px)",
+    });
+    bounds.mockRestore();
+  });
+
+  it("shrinks the launchpad branch menu to fit a narrow settings row", () => {
+    const rect = (left: number, right: number): DOMRect => ({
+      bottom: 800,
+      height: 400,
+      left,
+      right,
+      top: 400,
+      width: right - left,
+      x: left,
+      y: 400,
+      toJSON: () => ({}),
+    });
+    const bounds = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("composer__setup")) {
+          return rect(408, 708);
+        }
+        if (this.classList.contains("branch-picker__menu")) {
+          return rect(268, 628);
+        }
+        return rect(0, 0);
+      });
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "main",
+            branches: ["main", "releases/1.0"],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+
+    expect(screen.getByRole("listbox").parentElement).toHaveStyle({
+      maxWidth: "300px",
+      minWidth: "300px",
+      transform: "translateX(80px)",
+    });
+    bounds.mockRestore();
+  });
+
   it("shows a sticky toast when worktree branch status is unavailable", async () => {
     const onShowNotice = vi.fn();
     render(


### PR DESCRIPTION
## Summary

- backport the branch-picker visibility fix from #1587
- clamp the launchpad branch menu to the composer settings row so it cannot extend beneath the thread sidebar
- shrink the menu when the settings row is narrower than the menu's natural width
- preserve viewport-gutter clamping for dialog and other non-launchpad uses

## Source

- Original PR: #1587
- Original squash commit: `ebdefa6649dde132af969e3abb82d1af13690b5d`

The original PR had no review discussion or screenshot attachments. Its complete diff changed only `Composer.tsx` and its focused test file. This backport manually applies that same patch to the older 1.0 composer structure; the stable patch ID matches the source squash.

## Root cause and adaptation

The right-anchored branch menu was constrained only to the browser viewport. Near the transcript pane's left edge, it could extend underneath the higher-layer thread sidebar and appear covered.

The 1.0 branch-picker implementation matches the source pre-fix implementation, so the backport keeps the source interaction, positioning, resizing, and viewport fallback behavior. It does not change CSS stacking levels, titlebar/sidebar chrome, theme tokens, or shared popover styles, and it imports no Federation, Star Map, Automations, Attention, or other 1.1-only work.

## Dependency and migration audit

- no package manifest or lockfile changes
- no new dependencies
- no database or migration changes
- no config-shape or TOML changes

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` — 210 passed
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/sidebar-resize-signal.test.ts apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — 168 passed
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` — 22 passed
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `git diff --check`
