### PR TITLE
fix(messaging): isolate stale adapter startup cleanup

### DIFF
--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -75,6 +75,15 @@ settles, whether that promise resolves or rejects. Providers must therefore not
 gate cleanup solely on a final `started` flag, and repeated cleanup must not
 leave listeners or connections behind.
 
+A cancelled startup may settle after `stop()` and after a newer `start()` has
+begun on the same adapter instance. A generation-stale startup must never call
+the adapter-wide public `stop()`: that would invalidate and tear down the newer
+lifecycle. It may clean up only resources it created and still owns. Track that
+ownership with the captured lifecycle generation or resource identity, and make
+late resource acquisition close that specific socket, server, subscription, or
+polling loop. If the stale startup has not acquired a resource, it simply
+returns.
+
 ## Opaque State
 
 Adapters own routing and surface state. PwrAgent may persist and echo

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -105,7 +105,60 @@ describe("discord adapter", () => {
     await startPromise;
 
     expect(gateway.start).not.toHaveBeenCalled();
-    expect(gateway.close).toHaveBeenCalledTimes(2);
+    expect(gateway.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let stale reconciliation stop a newer lifecycle", async () => {
+    let resolveFirstCommands!: (value: DiscordApplicationCommand[]) => void;
+    let resolveSecondCommands!: (value: DiscordApplicationCommand[]) => void;
+    const firstCommands = new Promise<DiscordApplicationCommand[]>((resolve) => {
+      resolveFirstCommands = resolve;
+    });
+    const secondCommands = new Promise<DiscordApplicationCommand[]>((resolve) => {
+      resolveSecondCommands = resolve;
+    });
+    const listApplicationCommands = vi.fn()
+      .mockImplementationOnce(async () => await firstCommands)
+      .mockImplementationOnce(async () => await secondCommands);
+    let gatewayOpen = false;
+    const gateway: DiscordGatewayConnection = {
+      close: vi.fn(async () => {
+        gatewayOpen = false;
+      }),
+      onEvent: vi.fn(() => () => undefined),
+      start: vi.fn(async () => {
+        gatewayOpen = true;
+      }),
+    };
+    const adapter = new DiscordAdapter({
+      api: createApi({ listApplicationCommands }),
+      config: {
+        applicationId: TEST_CHANNEL_ID,
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      gateway,
+    });
+
+    const staleStart = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(listApplicationCommands).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    const currentStart = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(listApplicationCommands).toHaveBeenCalledTimes(2);
+    });
+    resolveSecondCommands([]);
+    await currentStart;
+    resolveFirstCommands([]);
+    await staleStart;
+
+    expect(gateway.start).toHaveBeenCalledTimes(1);
+    expect(gateway.close).toHaveBeenCalledTimes(1);
+    expect(gatewayOpen).toBe(true);
   });
 
   it("declares backend-owned scheduling as Discord application commands", () => {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -391,16 +391,20 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     const lifecycleGeneration = ++this.lifecycleGeneration;
     await this.reconcileApplicationCommands();
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
     this.listener = listener;
-    this.unsubscribeGateway = this.gateway.onEvent(async (event) => {
+    const unsubscribeGateway = this.gateway.onEvent(async (event) => {
       await this.handleGatewayEvent(event);
     });
+    this.unsubscribeGateway = unsubscribeGateway;
     await this.gateway.start();
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
+      unsubscribeGateway();
+      if (this.unsubscribeGateway === unsubscribeGateway) {
+        this.unsubscribeGateway = undefined;
+        this.listener = undefined;
+      }
     }
   }
 

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -140,6 +140,50 @@ describe("FeishuAdapter", () => {
     );
   });
 
+  it("does not let stale identity lookup stop a newer lifecycle", async () => {
+    let resolveFirstBotInfo!: (value: Awaited<ReturnType<FeishuApi["getBotInfo"]>>) => void;
+    const firstBotInfo = new Promise<Awaited<ReturnType<FeishuApi["getBotInfo"]>>>(
+      (resolve) => {
+        resolveFirstBotInfo = resolve;
+      },
+    );
+    const api = fakeApi({});
+    const botInfo = await api.getBotInfo();
+    api.getBotInfo = vi.fn()
+      .mockImplementationOnce(async () => await firstBotInfo)
+      .mockResolvedValueOnce(botInfo);
+    let connectionOpen = false;
+    const close = vi.fn(() => {
+      connectionOpen = false;
+    });
+    const { inboundMode: _inboundMode, ...persistentConfig } = baseConfig;
+    const adapter = new FeishuAdapter({
+      config: persistentConfig,
+      callbackHandleStore: fakeStore(),
+      api,
+      wsClientFactory: () => ({
+        close,
+        start: vi.fn(async () => {
+          connectionOpen = true;
+        }),
+      }),
+    });
+
+    const staleStart = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.getBotInfo).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    const currentStart = adapter.start(async () => undefined);
+    await currentStart;
+    resolveFirstBotInfo(botInfo);
+    await staleStart;
+
+    expect(close).not.toHaveBeenCalled();
+    expect(connectionOpen).toBe(true);
+  });
+
   it("declares Feishu capabilities", () => {
     const adapter = new FeishuAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -316,7 +316,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   private readonly config: FeishuMessagingConfig;
   private readonly logger: FeishuProviderLogger;
   private readonly now: () => number;
-  private readonly server: Server;
+  private server: Server | undefined;
   private readonly signingSecret: string;
   private readonly wsClientFactory: FeishuWsClientFactory;
   private authorizedActorIdsValue: string[];
@@ -325,7 +325,6 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   private botOpenId: string | undefined;
   private listener: FeishuInboundListener | undefined;
   private started = false;
-  private webhookListening = false;
   private wsClient: FeishuWsClient | undefined;
   private lifecycleGeneration = 0;
   private readonly diagnosticListeners = new Set<MessagingAdapterDiagnosticListener>();
@@ -369,9 +368,6 @@ export class FeishuAdapter implements FeishuProviderAdapter {
         loggerLevel: lark.LoggerLevel.info,
         source: "pwragent",
       });
-    });
-    this.server = createServer((request, response) => {
-      void this.handleWebhookRequest(request, response);
     });
   }
 
@@ -443,19 +439,17 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     this.listener = listener;
     const botInfo = await this.api.getBotInfo();
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
     this.botAccount = botInfo.appName ?? botInfo.openId;
     this.botAccountDetail = botInfo.tenantKey ?? hostFromUrl(this.config.tenantUrl);
     this.botOpenId = botInfo.openId;
     if (this.config.inboundMode === "webhook") {
-      await this.listenForCallbacks();
+      await this.listenForCallbacks(lifecycleGeneration);
     } else {
       await this.startPersistentConnection(lifecycleGeneration);
     }
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
     this.started = true;
@@ -469,17 +463,9 @@ export class FeishuAdapter implements FeishuProviderAdapter {
       this.logger.warn?.("feishu persistent connection close failed", { error });
     }
     this.wsClient = undefined;
-    if (this.webhookListening || this.server.listening) {
-      await new Promise<void>((resolve, reject) => {
-        this.server.close((error) => {
-          if (error) reject(error);
-          else resolve();
-        });
-      }).catch((error) => {
-        this.logger.warn?.("feishu webhook listener close failed", { error });
-      });
-      this.webhookListening = false;
-    }
+    const server = this.server;
+    this.server = undefined;
+    await this.closeServer(server);
     this.listener = undefined;
     this.started = false;
   }
@@ -1661,19 +1647,42 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     return info;
   }
 
-  private async listenForCallbacks(): Promise<void> {
+  private async listenForCallbacks(lifecycleGeneration: number): Promise<void> {
     if (!this.config.callbackBaseUrl) return;
     const url = new URL(this.config.callbackBaseUrl);
     const port = url.port ? Number(url.port) : DEFAULT_CALLBACK_PORT;
     const host = url.hostname || DEFAULT_CALLBACK_HOST;
+    const server = createServer((request, response) => {
+      void this.handleWebhookRequest(request, response);
+    });
+    this.server = server;
     await new Promise<void>((resolve, reject) => {
-      this.server.once("error", reject);
-      this.server.listen(port, host, () => {
-        this.server.off("error", reject);
+      server.once("error", reject);
+      server.listen(port, host, () => {
+        server.off("error", reject);
         resolve();
       });
     });
-    this.webhookListening = true;
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.closeServer(server);
+      if (this.server === server) {
+        this.server = undefined;
+      }
+    }
+  }
+
+  private async closeServer(server: Server | undefined): Promise<void> {
+    if (!server?.listening) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    }).catch((error) => {
+      this.logger.warn?.("feishu webhook listener close failed", { error });
+    });
   }
 
   private async startPersistentConnection(

--- a/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
+++ b/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
@@ -56,6 +56,48 @@ describe("LineAdapter", () => {
     await new Promise<void>((resolve) => probe.close(() => resolve()));
   });
 
+  it("does not let stale identity lookup stop a newer lifecycle", async () => {
+    const port = await getFreePort();
+    let resolveFirstBotInfo!: (value: {
+      displayName?: string;
+      userId: string;
+    }) => void;
+    const firstBotInfo = new Promise<{
+      displayName?: string;
+      userId: string;
+    }>((resolve) => {
+      resolveFirstBotInfo = resolve;
+    });
+    const api = createApi();
+    const botInfo = {
+      displayName: "PwrAgent",
+      userId: "Uffffffffffffffffffffffffffffffff",
+    };
+    api.getBotInfo = vi.fn()
+      .mockImplementationOnce(async () => await firstBotInfo)
+      .mockResolvedValueOnce(botInfo);
+    const adapter = new LineAdapter({
+      api,
+      callbackHandleStore: createCallbackStore(),
+      config: createConfig({ callbackBaseUrl: `http://127.0.0.1:${port}/` }),
+    });
+    adapters.push(adapter);
+
+    const staleStart = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.getBotInfo).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    const currentStart = adapter.start(async () => undefined);
+    await currentStart;
+    resolveFirstBotInfo(botInfo);
+    await staleStart;
+
+    const response = await fetch(`http://127.0.0.1:${port}/`);
+    expect(response.status).toBe(405);
+  });
+
   it("verifies X-Line-Signature before processing webhook bodies", () => {
     const body = Buffer.from(JSON.stringify({ events: [] }));
     const signature = createHmac("sha256", "secret").update(body).digest("base64");

--- a/packages/messaging/providers/line/src/line-adapter.ts
+++ b/packages/messaging/providers/line/src/line-adapter.ts
@@ -196,7 +196,7 @@ export class LineAdapter implements LineProviderAdapter {
   private readonly config: LineMessagingConfig;
   private readonly logger: LineProviderLogger;
   private readonly now: () => number;
-  private readonly server: Server;
+  private server: Server | undefined;
   private readonly signingSecret: string;
   private authorizedActorIdsValue: string[];
   private listener: LineInboundListener | undefined;
@@ -219,9 +219,6 @@ export class LineAdapter implements LineProviderAdapter {
       .update(options.config.channelSecret)
       .digest("hex");
     this.botUserId = options.config.botUserId;
-    this.server = createServer((request, response) => {
-      void this.handleWebhookRequest(request, response);
-    });
   }
 
   get authorizedActorIds(): readonly string[] {
@@ -259,6 +256,9 @@ export class LineAdapter implements LineProviderAdapter {
     if (!this.botUserId && this.api) {
       try {
         const botInfo = await this.api.getBotInfo();
+        if (lifecycleGeneration !== this.lifecycleGeneration) {
+          return;
+        }
         this.botUserId = botInfo.userId;
       } catch (error) {
         this.logger.warn?.("line getBotInfo failed during startup", {
@@ -267,19 +267,25 @@ export class LineAdapter implements LineProviderAdapter {
       }
     }
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
     const bindAddress = bindAddressFromCallbackUrl(this.config.callbackBaseUrl);
+    const server = createServer((request, response) => {
+      void this.handleWebhookRequest(request, response);
+    });
+    this.server = server;
     await new Promise<void>((resolve, reject) => {
-      this.server.once("error", reject);
-      this.server.listen(bindAddress.port, bindAddress.host, () => {
-        this.server.off("error", reject);
+      server.once("error", reject);
+      server.listen(bindAddress.port, bindAddress.host, () => {
+        server.off("error", reject);
         resolve();
       });
     });
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
+      await this.closeServer(server);
+      if (this.server === server) {
+        this.server = undefined;
+      }
       return;
     }
     this.started = true;
@@ -294,19 +300,26 @@ export class LineAdapter implements LineProviderAdapter {
 
   async stop(): Promise<void> {
     this.lifecycleGeneration += 1;
+    const server = this.server;
+    this.server = undefined;
     try {
-      if (this.server.listening) {
-        await new Promise<void>((resolve, reject) => {
-          this.server.close((error) => {
-            if (error) reject(error);
-            else resolve();
-          });
-        });
-      }
+      await this.closeServer(server);
     } finally {
       this.listener = undefined;
       this.started = false;
     }
+  }
+
+  private async closeServer(server: Server | undefined): Promise<void> {
+    if (!server?.listening) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
   }
 
   onInboundRejected(listener: MessagingInboundRejectedListener): () => void {

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -177,6 +177,50 @@ describe("MattermostAdapter — capability profile", () => {
     await expect(startPromise).rejects.toThrow("identity rejected after stop");
   });
 
+  it("does not let stale identity lookup stop a newer lifecycle", async () => {
+    let resolveFirstGetMe!: (value: { id: string; username: string }) => void;
+    const firstGetMe = new Promise<{ id: string; username: string }>((resolve) => {
+      resolveFirstGetMe = resolve;
+    });
+    const client = fakeClient4({ createdPosts: [], patchedPosts: [] });
+    const identity = { id: "bot-user-id", username: "pwragent" };
+    client.getMe = vi.fn()
+      .mockImplementationOnce(async () => await firstGetMe)
+      .mockResolvedValueOnce(identity) as never;
+    let callbackServerOpen = false;
+    const callbackServer = {
+      start: vi.fn(async () => {
+        callbackServerOpen = true;
+      }),
+      stop: vi.fn(async () => {
+        callbackServerOpen = false;
+      }),
+      signContext: () => ({ hmac: "x", issuedAt: 0 }),
+    };
+    const adapter = new MattermostAdapter({
+      callbackHandleStore: fakeStore,
+      callbackServer: callbackServer as never,
+      client,
+      config: baseConfig,
+      logger: silentLogger,
+      websocketClient: fakeWebSocketClient(),
+    });
+
+    const staleStart = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(client.getMe).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    const currentStart = adapter.start(async () => undefined);
+    await currentStart;
+    resolveFirstGetMe(identity);
+    await staleStart;
+
+    expect(callbackServer.stop).toHaveBeenCalledTimes(1);
+    expect(callbackServerOpen).toBe(true);
+  });
+
   it("declares Mattermost capability profile with documented limits", () => {
     const adapter = new MattermostAdapter({
       callbackHandleStore: fakeStore,

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -452,14 +452,12 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     this.listener = listener;
     await this.callbackServer.start();
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
 
     try {
       const me = (await this.client.getMe()) as { id: string; username?: string };
       if (lifecycleGeneration !== this.lifecycleGeneration) {
-        await this.stop();
         return;
       }
       this.botUserId = me.id;
@@ -551,7 +549,6 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     if (this.config.registerSlashCommands === true) {
       await this.reconcileSlashCommandsAcrossTeams();
       if (lifecycleGeneration !== this.lifecycleGeneration) {
-        await this.stop();
         return;
       }
     } else {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -284,6 +284,49 @@ describe("SlackAdapter", () => {
     await expect(startPromise).rejects.toThrow("socket rejected after stop");
   });
 
+  it("does not let stale identity lookup stop a newer lifecycle", async () => {
+    let resolveFirstAuth!: (value: Awaited<ReturnType<SlackApi["authTest"]>>) => void;
+    const firstAuth = new Promise<Awaited<ReturnType<SlackApi["authTest"]>>>((resolve) => {
+      resolveFirstAuth = resolve;
+    });
+    const api = fakeApi({});
+    const auth = await api.authTest();
+    api.authTest = vi.fn()
+      .mockImplementationOnce(async () => await firstAuth)
+      .mockResolvedValueOnce(auth);
+    let socketOpen = false;
+    const socket: SlackSocketClient = {
+      disconnect: vi.fn(async () => {
+        socketOpen = false;
+      }),
+      off: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(async () => {
+        socketOpen = true;
+      }),
+    };
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api,
+      socketClient: socket,
+    });
+
+    const staleStart = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.authTest).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    const currentStart = adapter.start(async () => undefined);
+    await currentStart;
+    resolveFirstAuth(auth);
+    await staleStart;
+
+    expect(socket.disconnect).not.toHaveBeenCalled();
+    expect(socketOpen).toBe(true);
+  });
+
   it("declares Slack capabilities", () => {
     const adapter = new SlackAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -547,6 +547,7 @@ export class SlackAdapter implements SlackProviderAdapter {
   private listener: SlackInboundListener | undefined;
   private started = false;
   private lifecycleGeneration = 0;
+  private socketLifecycleGeneration: number | undefined;
   private socketListenersAttached = false;
   private socketStartPending = false;
 
@@ -705,7 +706,6 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.listener = listener;
     const auth = await this.api.authTest();
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
     this.botId = auth.bot_id;
@@ -721,6 +721,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       throw new Error("Slack Socket Mode requires an app token");
     }
 
+    this.socketLifecycleGeneration = lifecycleGeneration;
     this.socketClient.on("slack_event", this.handleSlackEvent);
     this.socketClient.on("interactive", this.handleInteractive);
     this.socketClient.on("slash_commands", this.handleSlashCommand);
@@ -728,8 +729,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.socketStartPending = true;
     await this.socketClient.start();
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
-      this.socketStartPending = false;
+      await this.stopSocketLifecycle(lifecycleGeneration);
       return;
     }
     this.socketStartPending = false;
@@ -740,7 +740,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     // the event handler below keeps the view fresh for apps that do subscribe.
     await this.publishAppHomes(this.authorizedActorIdsValue);
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
+      await this.stopSocketLifecycle(lifecycleGeneration);
     }
   }
 
@@ -753,10 +753,24 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.workingCardStreams.clear();
     this.workingCardTombstones.clear();
     this.workingCardRateLimits.clear();
+    await this.stopSocketLifecycle();
+    this.listener = undefined;
+  }
+
+  private async stopSocketLifecycle(
+    lifecycleGeneration?: number,
+  ): Promise<void> {
+    if (
+      lifecycleGeneration !== undefined
+      && this.socketLifecycleGeneration !== lifecycleGeneration
+    ) {
+      return;
+    }
+    const socketStartPending = this.socketStartPending;
     const shouldDisconnect =
       this.started
       || this.socketListenersAttached
-      || this.socketStartPending;
+      || socketStartPending;
     try {
       if (this.socketListenersAttached) {
         this.socketClient?.off?.("slack_event", this.handleSlackEvent);
@@ -769,7 +783,10 @@ export class SlackAdapter implements SlackProviderAdapter {
       }
     } finally {
       this.started = false;
-      this.listener = undefined;
+      if (lifecycleGeneration !== undefined || !socketStartPending) {
+        this.socketStartPending = false;
+        this.socketLifecycleGeneration = undefined;
+      }
     }
   }
 

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -202,6 +202,50 @@ describe("TelegramAdapter lifecycle", () => {
 
     expect(api.getWebhookInfo).not.toHaveBeenCalled();
   });
+
+  it("does not let stale identity lookup stop a newer lifecycle", async () => {
+    let resolveFirstGetMe!: (value: {
+      id: number;
+      is_bot: true;
+      username: string;
+    }) => void;
+    const firstGetMe = new Promise<{
+      id: number;
+      is_bot: true;
+      username: string;
+    }>((resolve) => {
+      resolveFirstGetMe = resolve;
+    });
+    const api = fakeTelegramApi();
+    const identity = { id: 123, is_bot: true as const, username: "TestBot" };
+    api.getMe = vi.fn()
+      .mockImplementationOnce(async () => await firstGetMe)
+      .mockResolvedValueOnce(identity);
+    const stop = vi.fn(async () => undefined);
+    const adapter = new TelegramAdapter({
+      bot: { api, stop },
+      config: {
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        botToken: "token",
+        channel: "telegram",
+      },
+      pollOnStart: false,
+      store: fakeCallbackStore(),
+    });
+
+    const staleStart = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.getMe).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    const currentStart = adapter.start(async () => undefined);
+    await currentStart;
+    resolveFirstGetMe(identity);
+    await staleStart;
+
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("TelegramAdapter callback persistence", () => {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -670,7 +670,6 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       });
     }
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
 
@@ -685,14 +684,12 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       throw error;
     }
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
     await this.bot.api.deleteWebhook({
       drop_pending_updates: false,
     });
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
     await this.bot.api.setMyCommands({
@@ -702,7 +699,6 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       })),
     });
     if (lifecycleGeneration !== this.lifecycleGeneration) {
-      await this.stop();
       return;
     }
 


### PR DESCRIPTION
## Summary

- prevent generation-stale adapter startups from invoking adapter-wide teardown after a stop/restart interleaving
- apply the lifecycle invariant across Discord, Slack, Telegram, LINE, Feishu, and Mattermost
- track late-acquired Slack sockets and LINE/Feishu HTTP servers by lifecycle generation or resource identity so stale cleanup cannot touch a newer transport
- document the adapter-wide lifecycle contract and add a focused same-instance regression for every affected provider

## Root cause

Each generation-based provider used public `stop()` as the cleanup path when an older `start()` resumed after its captured lifecycle generation became stale. In this ordering:

1. an older startup suspends in identity lookup, command reconciliation, or transport setup
2. `stop()` cancels that lifecycle
3. a newer `start()` successfully opens the replacement transport
4. the older await resolves and calls public `stop()`

The stale startup then increments the shared generation again and clears or closes resources owned by the replacement lifecycle.

The regression was initially reported and reproduced in Discord. The provider audit reproduced the same teardown in Slack, Telegram, LINE, Feishu, and Mattermost.

## Fix

A stale startup that owns no live resource now returns without cleanup. When resource acquisition can complete late, the adapter retains the resource's lifecycle generation or object identity and closes only that exact subscription, socket, or HTTP server. Public `stop()` remains adapter-wide and idempotent, preserving cancellation of partially-started transports.

This is expressed as a shared adapter-contract invariant rather than one generic cleanup helper: cleanup requires provider-specific ownership evidence, and a generic adapter-wide callback would recreate the race.

## Validation

- six provider adapter suites: 264 tests passed
- all seven messaging package typechecks passed
- targeted ESLint and typed ESLint passed
- `pnpm lint:boundaries` passed (1,436 modules, 4,714 dependencies)
