### PR TITLE
fix(desktop): hide duplicate overlay logos on Windows

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1073,10 +1073,10 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
     );
-    // Settings uses the same Windows title strip as the main shell, so its
-    // in-nav wordmark would otherwise duplicate the one still visible there.
+    // Settings and Automations use the same Windows title strip as the main
+    // shell, so their in-nav wordmarks would duplicate the one visible there.
     expect(css).toMatch(
-      /:root\[data-platform="win32"\]\s*\.settings-screen\s+\.settings-nav__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
+      /:root\[data-platform="win32"\]\s*:is\(\.settings-screen,\s*\.automations-screen\)\s*\.settings-nav__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1073,6 +1073,11 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
     );
+    // Settings uses the same Windows title strip as the main shell, so its
+    // in-nav wordmark would otherwise duplicate the one still visible there.
+    expect(css).toMatch(
+      /:root\[data-platform="win32"\]\s*\.settings-screen\s+\.settings-nav__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
+    );
   });
 
   it("mirrors thread-row drop-indicator + recents divider tokens for directory pinning", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7548,6 +7548,13 @@ textarea,
   padding-left: 0;
 }
 
+/* Windows already carries the PwrAgent wordmark in its custom title strip.
+   Drop the duplicate Settings masthead so Exit Settings starts at the top of
+   the nav, mirroring the main sidebar's Windows treatment. */
+:root[data-platform="win32"] .settings-screen .settings-nav__masthead {
+  display: none;
+}
+
 /* macOS fullscreen drops the stoplights, so the Settings nav masthead
    collapses its 80px reservation to the left edge too — mirrors the main
    `.sidebar__masthead` fullscreen behavior so the two screens stay aligned. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7549,9 +7549,11 @@ textarea,
 }
 
 /* Windows already carries the PwrAgent wordmark in its custom title strip.
-   Drop the duplicate Settings masthead so Exit Settings starts at the top of
-   the nav, mirroring the main sidebar's Windows treatment. */
-:root[data-platform="win32"] .settings-screen .settings-nav__masthead {
+   Drop the duplicate overlay masthead so the Exit row starts at the top of
+   both navs, mirroring the main sidebar's Windows treatment. */
+:root[data-platform="win32"]
+  :is(.settings-screen, .automations-screen)
+  .settings-nav__masthead {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- hide the Settings and Automations navigation mastheads on Windows
- keep the existing overlay mastheads unchanged on macOS and Linux
- lock the shared Windows-specific treatment in the renderer theme contract

## Why

PwrAgent's Windows custom title strip already shows the wordmark while Settings or Automations is open. Both overlays also rendered the shared navigation masthead, producing a duplicate logo and leaving unnecessary vertical chrome above their Exit rows.

This reuses the same Windows treatment already applied to the main sidebar: the redundant overlay masthead is hidden and the first navigation action moves into the freed space.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/styles/__tests__/automations-chrome-parity.test.ts`
- `pnpm lint:eslint`
- `pnpm lint:colors`
