### PR TITLE
fix(desktop): correct Windows approval diffs and paths

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18516,7 +18516,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("prefers a real file-change approval diff over empty streamed content", async () => {
+  it("normalizes file-change approval diffs and omits empty placeholders", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
     });
@@ -18531,11 +18531,25 @@ command = "pnpm dev"
     const emit = (registry as unknown as {
       emit(event: AgentEvent): Promise<void>;
     }).emit.bind(registry);
-    const diff = [
+    const unifiedDiff = [
+      "--- /dev/null",
+      "+++ b/breakfasts/croissants/croissants.md",
+      "@@ -0,0 +1,1 @@",
+      "+# Butter Croissants",
+    ].join("\n");
+    const rawWindowsAddContent = [
+      "# Sunny-Side-Up Eggs",
+      "",
+      "Eggs with crisp edges make an easy breakfast.",
+      "",
+    ].join("\n");
+    const normalizedWindowsAddDiff = [
       "--- /dev/null",
       "+++ b/breakfasts/eggs/sunny-side-up.md",
-      "@@ -0,0 +1,1 @@",
+      "@@ -0,0 +1,3 @@",
       "+# Sunny-Side-Up Eggs",
+      "+",
+      "+Eggs with crisp edges make an easy breakfast.",
     ].join("\n");
 
     await emit({
@@ -18551,8 +18565,13 @@ command = "pnpm dev"
             changes: [
               {
                 path: "breakfasts/eggs/sunny-side-up.md",
+                kind: { type: "add" },
+                diff: rawWindowsAddContent,
+              },
+              {
+                path: "breakfasts/croissants/croissants.md",
                 kind: { type: "add", content: "" },
-                diff,
+                diff: unifiedDiff,
               },
               {
                 path: "breakfasts/pancakes/pancakes.md",
@@ -18585,7 +18604,12 @@ command = "pnpm dev"
           {
             action: "add",
             path: "breakfasts/eggs/sunny-side-up.md",
-            diff,
+            diff: normalizedWindowsAddDiff,
+          },
+          {
+            action: "add",
+            path: "breakfasts/croissants/croissants.md",
+            diff: unifiedDiff,
           },
           {
             action: "add",
@@ -18600,7 +18624,7 @@ command = "pnpm dev"
     const approvalContext = approvalParams?._pwragentApprovalContext as
       | { files?: Array<{ diff?: string }> }
       | undefined;
-    expect(approvalContext?.files?.[1]?.diff).toBeUndefined();
+    expect(approvalContext?.files?.[2]?.diff).toBeUndefined();
 
     unsubscribe();
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18516,6 +18516,96 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("prefers a real file-change approval diff over empty streamed content", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+    const diff = [
+      "--- /dev/null",
+      "+++ b/breakfasts/eggs/sunny-side-up.md",
+      "@@ -0,0 +1,1 @@",
+      "+# Sunny-Side-Up Eggs",
+    ].join("\n");
+
+    await emit({
+      backend: "codex",
+      notification: {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "file-change-1",
+            type: "fileChange",
+            changes: [
+              {
+                path: "breakfasts/eggs/sunny-side-up.md",
+                kind: { type: "add", content: "" },
+                diff,
+              },
+              {
+                path: "breakfasts/pancakes/pancakes.md",
+                kind: { type: "add", content: "" },
+              },
+            ],
+          },
+        },
+      },
+    } as AgentEvent);
+    await emit({
+      backend: "codex",
+      notification: {
+        method: "item/fileChange/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "file-change-1",
+          requestId: "approval-1",
+        },
+      },
+    } as AgentEvent);
+
+    const approval = events.find(
+      (event) => event.notification.method === "item/fileChange/requestApproval",
+    );
+    expect(approval?.notification.params).toMatchObject({
+      _pwragentApprovalContext: {
+        files: [
+          {
+            action: "add",
+            path: "breakfasts/eggs/sunny-side-up.md",
+            diff,
+          },
+          {
+            action: "add",
+            path: "breakfasts/pancakes/pancakes.md",
+          },
+        ],
+      },
+    });
+    const approvalParams = approval?.notification.params as
+      | Record<string, unknown>
+      | undefined;
+    const approvalContext = approvalParams?._pwragentApprovalContext as
+      | { files?: Array<{ diff?: string }> }
+      | undefined;
+    expect(approvalContext?.files?.[1]?.diff).toBeUndefined();
+
+    unsubscribe();
+    await registry.close();
+  });
+
   it("mirrors managed review tool activity onto the reviewed thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2171,8 +2171,8 @@ function readFileChangeApprovalFile(
   const content =
     readOptionalString(kind?.content) ?? readOptionalString(record.content);
   const diff =
-    buildFileChangeApprovalContentDiff({ action, content, filePath }) ??
-    directDiff;
+    directDiff ??
+    buildFileChangeApprovalContentDiff({ action, content, filePath });
   return {
     ...(action ? { action } : {}),
     ...(diff ? { diff } : {}),
@@ -2215,6 +2215,9 @@ function buildFileChangeApprovalContentDiff(params: {
     lines.pop();
   }
   const hunkLineCount = lines.length;
+  if (hunkLineCount === 0) {
+    return undefined;
+  }
   const displayPath = params.filePath.replace(/^\/+/, "") || "file";
   const header =
     params.action === "add"

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -272,6 +272,7 @@ import {
   isThreadSearchSemanticMode,
   type PendingRequestDecision,
   type PendingRequestApprovalContext,
+  normalizeFileChangeApprovalDiff,
   PWRSNAP_MCP_CONNECTION_ID,
   readCodexEnvironmentActionRuns,
   DEFAULT_TASK_MONITOR_MODEL,
@@ -2164,15 +2165,18 @@ function readFileChangeApprovalFile(
     readNonEmptyString(record.kind) ??
     readNonEmptyString(record.action);
   const directDiff =
-    readNonEmptyString(kind?.unified_diff) ??
-    readNonEmptyString(kind?.unifiedDiff) ??
+    readNonEmptyRawString(kind?.unified_diff) ??
+    readNonEmptyRawString(kind?.unifiedDiff) ??
     readFileChangeApprovalDiff(record) ??
     readFileChangeApprovalDiff(kind);
   const content =
     readOptionalString(kind?.content) ?? readOptionalString(record.content);
-  const diff =
-    directDiff ??
-    buildFileChangeApprovalContentDiff({ action, content, filePath });
+  const diff = normalizeFileChangeApprovalDiff({
+    action,
+    content,
+    directDiff,
+    path: filePath,
+  });
   return {
     ...(action ? { action } : {}),
     ...(diff ? { diff } : {}),
@@ -2188,43 +2192,18 @@ function readFileChangeApprovalDiff(
     return undefined;
   }
   const direct =
-    readNonEmptyString(record.diff) ??
-    readNonEmptyString(record.patch) ??
-    readNonEmptyString(record.unifiedDiff) ??
-    readNonEmptyString(record.unified_diff);
+    readNonEmptyRawString(record.unified_diff) ??
+    readNonEmptyRawString(record.unifiedDiff) ??
+    readNonEmptyRawString(record.patch) ??
+    readNonEmptyRawString(record.diff);
   if (direct) {
     return direct;
   }
   return readFileChangeApprovalDiff(readRecord(record.diff));
 }
 
-function buildFileChangeApprovalContentDiff(params: {
-  action: string | undefined;
-  content: string | undefined;
-  filePath: string;
-}): string | undefined {
-  if (
-    params.content === undefined ||
-    (params.action !== "add" && params.action !== "delete")
-  ) {
-    return undefined;
-  }
-
-  const lines = params.content.length ? params.content.split("\n") : [];
-  if (lines.at(-1) === "") {
-    lines.pop();
-  }
-  const hunkLineCount = lines.length;
-  if (hunkLineCount === 0) {
-    return undefined;
-  }
-  const displayPath = params.filePath.replace(/^\/+/, "") || "file";
-  const header =
-    params.action === "add"
-      ? [`--- /dev/null`, `+++ b/${displayPath}`, `@@ -0,0 +1,${hunkLineCount} @@`]
-      : [`--- a/${displayPath}`, `+++ /dev/null`, `@@ -1,${hunkLineCount} +0,0 @@`];
-  const prefix = params.action === "add" ? "+" : "-";
-  return [...header, ...lines.map((line) => `${prefix}${line}`)].join("\n");
+function readNonEmptyRawString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function fileChangeApprovalContextKey(params: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -14,6 +14,7 @@ import type {
   DesktopApplicationDiscoveryCandidate,
   EditGroupCommitState,
 } from "@pwragent/shared";
+import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import { EditorIcon } from "../../icons";
 import { AppIcon } from "../../components/AppIcon";
 import { TranscriptDiff } from "./TranscriptDiff";
@@ -57,12 +58,7 @@ function toRepoRelativePath(
   if (!worktreeRoot) {
     return absolutePath;
   }
-  const root = normalizePath(worktreeRoot).replace(/\/+$/, "");
-  const full = normalizePath(absolutePath);
-  if (full === root) {
-    return absolutePath;
-  }
-  return full.startsWith(`${root}/`) ? full.slice(root.length + 1) : absolutePath;
+  return formatPathRelativeToDirectories(absolutePath, [worktreeRoot]);
 }
 
 type EditedFileGroupListProps = {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -388,6 +388,28 @@ describe("EditedFileRow path + open affordances", () => {
       screen.queryByRole("button", { name: /Open .* in editor/ }),
     ).not.toBeInTheDocument();
   });
+
+  it("shows Windows separators for a Windows worktree", () => {
+    const windowsGroup: EditedFileGroup = {
+      ...fileGroup,
+      details: [
+        {
+          ...fileGroup.details[0],
+          path: "C:/repo/apps/desktop/Foo.ts",
+        },
+      ],
+    };
+    render(
+      <EditedFileGroupList
+        groups={[windowsGroup]}
+        worktreeRoot={"C:\\repo"}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Foo\.ts/ }));
+
+    expect(screen.getByText("apps\\desktop\\Foo.ts")).toBeInTheDocument();
+  });
 });
 
 describe("EditedFileViewToggle", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -4663,7 +4663,7 @@ Implementation notes remain in a readable bubble.`;
     expect(screen.queryByRole("button", { name: /diff/ })).not.toBeInTheDocument();
   });
 
-  it("renders raw Codex Windows add contents as a counted diff", () => {
+  it("renders raw Codex Windows Markdown lists as added lines", () => {
     render(
       <TranscriptList
         directoryPaths={["C:\\repo\\pwragent"]}
@@ -4680,9 +4680,8 @@ Implementation notes remain in a readable bubble.`;
                 path: "C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
                 kind: { type: "add" },
                 diff: [
-                  "# Sunny-Side-Up Eggs",
-                  "",
-                  "Eggs with crisp edges make an easy breakfast.",
+                  "- Fry the eggs until their edges are crisp.",
+                  "- Serve with toast.",
                   "",
                 ].join("\n"),
               },
@@ -4698,9 +4697,9 @@ Implementation notes remain in a readable bubble.`;
       screen.getByText(/File: breakfasts\\eggs\\sunny-side-up\.md/),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Hide diff.*\+3.*-0/ }),
+      screen.getByRole("button", { name: /Hide diff.*\+2.*-0/ }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Eggs with crisp edges/)).toBeInTheDocument();
+    expect(screen.getByText(/Fry the eggs until their edges are crisp/)).toBeInTheDocument();
   });
 
   it("shows file-change approval context inferred from the matching activity", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -4629,6 +4629,40 @@ Implementation notes remain in a readable bubble.`;
     expect(screen.getByText(/new dumb sentence/)).toBeInTheDocument();
   });
 
+  it("does not render an empty diff disclosure for a placeholder file add", () => {
+    render(
+      <TranscriptList
+        directoryPaths={["C:\\repo\\pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            changes: [
+              {
+                path: "breakfasts/eggs/sunny-side-up.md",
+                kind: {
+                  type: "add",
+                  content: "",
+                },
+              },
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(
+      screen.getByText(/File: breakfasts\\eggs\\sunny-side-up\.md/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /diff/ })).not.toBeInTheDocument();
+  });
+
   it("shows file-change approval context inferred from the matching activity", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -4663,6 +4663,46 @@ Implementation notes remain in a readable bubble.`;
     expect(screen.queryByRole("button", { name: /diff/ })).not.toBeInTheDocument();
   });
 
+  it("renders raw Codex Windows add contents as a counted diff", () => {
+    render(
+      <TranscriptList
+        directoryPaths={["C:\\repo\\pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            changes: [
+              {
+                path: "C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
+                kind: { type: "add" },
+                diff: [
+                  "# Sunny-Side-Up Eggs",
+                  "",
+                  "Eggs with crisp edges make an easy breakfast.",
+                  "",
+                ].join("\n"),
+              },
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(
+      screen.getByText(/File: breakfasts\\eggs\\sunny-side-up\.md/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Hide diff.*\+3.*-0/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Eggs with crisp edges/)).toBeInTheDocument();
+  });
+
   it("shows file-change approval context inferred from the matching activity", () => {
     render(
       <TranscriptList

--- a/packages/shared/src/__tests__/path-display.test.ts
+++ b/packages/shared/src/__tests__/path-display.test.ts
@@ -31,4 +31,19 @@ describe("formatPathRelativeToDirectories", () => {
       ),
     ).toBe("C:\\repo-other\\apps\\desktop\\src\\main.ts");
   });
+
+  it("uses Windows separators for protocol paths under a Windows directory", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "C:/repo/worktree/apps/desktop/src/main.ts",
+        ["C:\\repo\\worktree"],
+      ),
+    ).toBe("apps\\desktop\\src\\main.ts");
+    expect(
+      formatPathRelativeToDirectories(
+        "breakfasts/eggs/sunny-side-up.md",
+        ["C:\\repo\\worktree"],
+      ),
+    ).toBe("breakfasts\\eggs\\sunny-side-up.md");
+  });
 });

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -543,4 +543,43 @@ describe("buildPendingRequestApprovalContext", () => {
       ],
     });
   });
+
+  it("normalizes raw Codex Windows add contents into a unified diff", () => {
+    const request = createRequest({
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        changes: [
+          {
+            path: "C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
+            kind: { type: "add" },
+            diff: [
+              "# Sunny-Side-Up Eggs",
+              "",
+              "Eggs with crisp edges make an easy breakfast.",
+              "",
+            ].join("\r\n"),
+          },
+        ],
+      },
+    });
+
+    expect(
+      buildPendingRequestApprovalContext(request, {
+        directoryPaths: ["C:\\repo\\pwragent"],
+      }),
+    ).toMatchObject({
+      action: "add",
+      displayPath: "breakfasts\\eggs\\sunny-side-up.md",
+      diff: [
+        "--- /dev/null",
+        "+++ b/C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
+        "@@ -0,0 +1,3 @@",
+        "+# Sunny-Side-Up Eggs",
+        "+",
+        "+Eggs with crisp edges make an easy breakfast.",
+      ].join("\n"),
+    });
+  });
 });

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -555,9 +555,8 @@ describe("buildPendingRequestApprovalContext", () => {
             path: "C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
             kind: { type: "add" },
             diff: [
-              "# Sunny-Side-Up Eggs",
-              "",
-              "Eggs with crisp edges make an easy breakfast.",
+              "- Fry the eggs until their edges are crisp.",
+              "- Serve with toast.",
               "",
             ].join("\r\n"),
           },
@@ -575,10 +574,9 @@ describe("buildPendingRequestApprovalContext", () => {
       diff: [
         "--- /dev/null",
         "+++ b/C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
-        "@@ -0,0 +1,3 @@",
-        "+# Sunny-Side-Up Eggs",
-        "+",
-        "+Eggs with crisp edges make an easy breakfast.",
+        "@@ -0,0 +1,2 @@",
+        "+- Fry the eggs until their edges are crisp.",
+        "+- Serve with toast.",
       ].join("\n"),
     });
   });

--- a/packages/shared/src/path-display.ts
+++ b/packages/shared/src/path-display.ts
@@ -1,11 +1,13 @@
 type NormalizedDirectoryPath = {
   caseInsensitive: boolean;
   normalized: string;
+  separator: "/" | "\\";
 };
 
 /**
  * Display an absolute path relative to the longest known directory that
- * contains it. Paths outside the known directories are returned unchanged.
+ * contains it. Relative paths use the separator style of a known Windows
+ * directory; absolute paths outside the known directories are unchanged.
  */
 export function formatPathRelativeToDirectories(
   value: string,
@@ -22,6 +24,7 @@ export function formatPathRelativeToDirectories(
     .map((root): NormalizedDirectoryPath => ({
       caseInsensitive: valueIsWindowsPath || isWindowsPath(root),
       normalized: normalizePath(root),
+      separator: isWindowsPath(root) ? "\\" : "/",
     }))
     .filter((root) => Boolean(root.normalized))
     .sort((left, right) => right.normalized.length - left.normalized.length);
@@ -41,11 +44,30 @@ export function formatPathRelativeToDirectories(
       : comparisonValue.startsWith(`${comparisonRoot}/`);
     if (isContained) {
       const relativeStart = comparisonRoot === "/" ? 1 : root.normalized.length + 1;
-      return trimmed.slice(relativeStart) || ".";
+      return formatSeparators(
+        normalizedValue.slice(relativeStart) || ".",
+        root.separator,
+      );
+    }
+  }
+
+  if (!isAbsolutePath(trimmed)) {
+    const windowsRoot = roots.find((root) => root.separator === "\\");
+    if (windowsRoot) {
+      return formatSeparators(trimmed, windowsRoot.separator);
     }
   }
 
   return trimmed;
+}
+
+function formatSeparators(value: string, separator: "/" | "\\"): string {
+  return separator === "\\" ? value.replace(/\//g, "\\") : value;
+}
+
+function isAbsolutePath(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("/") || isWindowsPath(trimmed);
 }
 
 function isWindowsPath(value: string): boolean {

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -298,27 +298,16 @@ function looksLikeUnifiedDiff(value: string): boolean {
   if (
     lines.some(
       (line) =>
-        line.startsWith("diff --git ")
-        || line.startsWith("@@ ")
-        || line.startsWith("@@@ "),
+        /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(?: |$)/.test(line)
+        || /^@@@ (?:-\d+(?:,\d+)? ){2,}\+\d+(?:,\d+)? @@@(?: |$)/.test(line),
     )
   ) {
     return true;
   }
-  if (
-    lines.some((line) => line.startsWith("--- "))
-    && lines.some((line) => line.startsWith("+++ "))
-  ) {
-    return true;
-  }
-  const meaningfulLines = lines.filter(Boolean);
-  return meaningfulLines.length > 0
-    && meaningfulLines.every(
-      (line) =>
-        line.startsWith("+")
-        || line.startsWith("-")
-        || line.startsWith("\\ No newline at end of file"),
-    );
+  return lines.some(
+    (line, index) =>
+      line.startsWith("--- ") && lines[index + 1]?.startsWith("+++ "),
+  );
 }
 
 function activityMatchesItem(

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -216,12 +216,22 @@ function fileContextFromApprovalRecord(
     readFirstString(kind ?? {}, ["type", "action", "operation"]) ??
     readFirstString(record, ["action", "operation", "kind", "type"]);
   const directDiff =
-    readFirstString(kind ?? {}, ["diff", "patch", "unifiedDiff", "unified_diff"]) ??
-    readFirstString(record, ["diff", "patch", "unifiedDiff", "unified_diff"]);
+    readFirstNonEmptyRawString(
+      kind ?? {},
+      ["unifiedDiff", "unified_diff", "patch", "diff"],
+    ) ??
+    readFirstNonEmptyRawString(
+      record,
+      ["unifiedDiff", "unified_diff", "patch", "diff"],
+    );
   const content =
     readOptionalString(kind?.content) ?? readOptionalString(record.content);
-  const generatedDiff =
-    directDiff ?? contentDiffForApproval({ action, content, path });
+  const generatedDiff = normalizeFileChangeApprovalDiff({
+    action,
+    content,
+    directDiff,
+    path,
+  });
 
   return {
     ...(action ? { action } : {}),
@@ -244,19 +254,30 @@ function fileContextFromApprovalRecord(
   };
 }
 
-function contentDiffForApproval(params: {
+export function normalizeFileChangeApprovalDiff(params: {
   action: string | undefined;
   content: string | undefined;
+  directDiff: string | undefined;
   path: string;
 }): string | undefined {
   if (
-    params.content === undefined ||
+    params.directDiff
+    && (
+      (params.action !== "add" && params.action !== "delete")
+      || looksLikeUnifiedDiff(params.directDiff)
+    )
+  ) {
+    return params.directDiff;
+  }
+  const content = params.directDiff ?? params.content;
+  if (
+    content === undefined ||
     (params.action !== "add" && params.action !== "delete")
   ) {
     return undefined;
   }
   const path = params.path.replace(/^\/+/, "") || "file";
-  const lines = params.content.length ? params.content.split("\n") : [];
+  const lines = content.length ? content.split(/\r?\n/) : [];
   if (lines.at(-1) === "") {
     lines.pop();
   }
@@ -270,6 +291,34 @@ function contentDiffForApproval(params: {
       : [`--- a/${path}`, `+++ /dev/null`, `@@ -1,${hunkLineCount} +0,0 @@`];
   const prefix = params.action === "add" ? "+" : "-";
   return [...header, ...lines.map((line) => `${prefix}${line}`)].join("\n");
+}
+
+function looksLikeUnifiedDiff(value: string): boolean {
+  const lines = value.split(/\r?\n/);
+  if (
+    lines.some(
+      (line) =>
+        line.startsWith("diff --git ")
+        || line.startsWith("@@ ")
+        || line.startsWith("@@@ "),
+    )
+  ) {
+    return true;
+  }
+  if (
+    lines.some((line) => line.startsWith("--- "))
+    && lines.some((line) => line.startsWith("+++ "))
+  ) {
+    return true;
+  }
+  const meaningfulLines = lines.filter(Boolean);
+  return meaningfulLines.length > 0
+    && meaningfulLines.every(
+      (line) =>
+        line.startsWith("+")
+        || line.startsWith("-")
+        || line.startsWith("\\ No newline at end of file"),
+    );
 }
 
 function activityMatchesItem(
@@ -962,6 +1011,19 @@ function readFirstString(
   for (const key of keys) {
     const value = readString(record[key]);
     if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readFirstNonEmptyRawString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
       return value;
     }
   }

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -261,6 +261,9 @@ function contentDiffForApproval(params: {
     lines.pop();
   }
   const hunkLineCount = lines.length;
+  if (hunkLineCount === 0) {
+    return undefined;
+  }
   const header =
     params.action === "add"
       ? [`--- /dev/null`, `+++ b/${path}`, `@@ -0,0 +1,${hunkLineCount} @@`]


### PR DESCRIPTION
## What changed

- prefer the real unified diff over an empty streamed `content` placeholder in file-change approval events
- suppress empty synthetic add/delete diffs so approval cards do not render misleading `+0 -0` disclosures
- render protocol-provided relative paths with Windows separators when the thread/worktree is on Windows
- reuse the shared path formatter in the Edits panel

## Why

On Windows, a file-change approval could contain both a real diff and an empty `content` placeholder. The desktop event bus synthesized a zero-line diff from the placeholder before considering the real diff, producing one expanded `Hide diff +0 -0` control per file. Separately, renderer path formatting normalized Edits-panel paths to forward slashes, and relative protocol paths retained POSIX separators even when the known worktree was a Windows path.

## User impact

Approval cards now show real proposed changes when supplied and omit empty diff controls when no preview exists. App-rendered approval and Edits-panel paths follow Windows separator conventions. Agent-authored Markdown is not rewritten.

## Validation

- `pnpm test packages/shared/src/__tests__/path-display.test.ts packages/shared/src/__tests__/pending-request-response.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` (132 passed)
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "prefers a real file-change approval diff over empty streamed content"` (1 passed, 509 skipped)
- `pnpm lint:boundaries` (no dependency violations)
- `pnpm lint:eslint` (0 errors; 35 existing warnings)
- `pnpm --filter @pwragent/desktop typecheck`

## Existing unrelated failures

A full run of `backend-registry.test.ts` exposed eight failures in ACP enablement/execution-mode/review/handoff/stop tests. At least the Kimi execution-mode and cross-provider handoff cases reproduce independently and are unrelated to the diff/path code changed here.
