### PR TITLE
fix(tests): backport fail-fast Electron shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,9 +478,12 @@ jobs:
         # Tart's AppleParavirtGPU can reset under Electron load. The early
         # PWRAGENT_E2E_DISABLE_GPU gate selects software rendering before
         # Electron initializes, while ordinary host E2E keeps GPU coverage.
+        # The shutdown circuit is macOS-lane-only: two consecutive closes at
+        # or above 4s (or requiring force-kill) stop this shard after cleanup.
         timeout-minutes: 20
         env:
           PWRAGENT_E2E_DISABLE_GPU: "1"
+          PWRAGENT_E2E_SHUTDOWN_CIRCUIT_BREAKER: "1"
         run: >-
           pnpm --filter @pwragent/desktop test:e2e
           --shard=${{ matrix.lane }}/2

--- a/apps/desktop/e2e/app-quit-lifecycle.spec.ts
+++ b/apps/desktop/e2e/app-quit-lifecycle.spec.ts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, test, type ElectronApplication } from "@playwright/test";
+import {
+  expect,
+  test,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test";
+import { createBoundedOutputMatcher } from "./fixtures/bounded-output-matcher";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 /**
@@ -42,7 +48,6 @@ type QuitOutcome = {
   exited: boolean;
   exitCode: number | null;
   signalCode: NodeJS.Signals | null;
-  output: string;
 };
 
 /**
@@ -63,7 +68,6 @@ function requestQuit(electronApp: ElectronApplication): void {
 /** Wait for real process exit, bounded by the product's own shutdown ceiling. */
 async function awaitExit(
   electronApp: ElectronApplication,
-  captured: () => string,
 ): Promise<QuitOutcome> {
   const child = electronApp.process();
   const startedAt = Date.now();
@@ -91,32 +95,47 @@ async function awaitExit(
     exited: child.exitCode !== null || child.signalCode !== null,
     exitCode: child.exitCode,
     signalCode: child.signalCode,
-    output: captured(),
   };
-}
-
-/**
- * Mirror the main process's console transport into a buffer. electron-log
- * keeps its console transport enabled outside Vitest, so every `mainLog` line
- * the quit path emits ("quit in progress", "shutdown barrier completed", …)
- * shows up here — which is what turns a failure into a diagnosis instead of a
- * timeout.
- */
-function captureMainProcessOutput(electronApp: ElectronApplication): () => string {
-  const chunks: string[] = [];
-  const child = electronApp.process();
-  child.stdout?.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
-  child.stderr?.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
-  return () => chunks.join("");
 }
 
 function describeOutcome(label: string, outcome: QuitOutcome): string {
   return [
     `${label} did not exit within ${QUIT_BUDGET_MS}ms after app.quit().`,
     `elapsedMs=${outcome.elapsedMs} exitCode=${String(outcome.exitCode)} signal=${String(outcome.signalCode)}`,
-    "--- main process output ---",
-    outcome.output.slice(-16_000),
+    "See the sanitized pwragent-e2e-shutdown JSON in the job log and Playwright artifact.",
   ].join("\n");
+}
+
+/** Observe one fixed acknowledgement without retaining or printing raw logs. */
+function watchMainProcessOutputFor(
+  electronApp: ElectronApplication,
+  expected: string,
+): () => boolean {
+  const matcher = createBoundedOutputMatcher(expected);
+  const inspect = (chunk: Buffer): void => {
+    matcher.inspect(chunk.toString());
+  };
+  const child = electronApp.process();
+  child.stdout?.on("data", inspect);
+  child.stderr?.on("data", inspect);
+  return matcher.matched;
+}
+
+async function setQuitConfirmationEnabled(
+  page: Page,
+  enabled: boolean,
+): Promise<void> {
+  await page.evaluate(async (nextEnabled) => {
+    await (
+      window as unknown as {
+        pwragent: {
+          writeSettingsConfig: (request: unknown) => Promise<unknown>;
+        };
+      }
+    ).pwragent.writeSettingsConfig({
+      patch: { general: { confirmQuitWithInProgressThreads: nextEnabled } },
+    });
+  }, enabled);
 }
 
 test("exits the process when a profile-backed session is asked to quit", async () => {
@@ -125,11 +144,9 @@ test("exits the process when a profile-backed session is asked to quit", async (
   const app = await launchElectronApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
   });
-  const captured = captureMainProcessOutput(app.electronApp);
-
   try {
     requestQuit(app.electronApp);
-    const outcome = await awaitExit(app.electronApp, captured);
+    const outcome = await awaitExit(app.electronApp);
     expect(outcome.exited, describeOutcome("profile-backed app", outcome)).toBe(
       true,
     );
@@ -158,22 +175,16 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
   const app = await launchElectronApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
   });
-  const captured = captureMainProcessOutput(app.electronApp);
+  const repeatAcknowledged = watchMainProcessOutputFor(
+    app.electronApp,
+    "quit requested while confirmation is open",
+  );
+  let dialog: Page | undefined;
 
   try {
     // The shared harness seeds confirmation OFF so specs close cleanly. This
     // spec is about the confirmation, so turn it back on the way the app does.
-    await app.window.evaluate(async () => {
-      await (
-        window as unknown as {
-          pwragent: {
-            writeSettingsConfig: (request: unknown) => Promise<unknown>;
-          };
-        }
-      ).pwragent.writeSettingsConfig({
-        patch: { general: { confirmQuitWithInProgressThreads: true } },
-      });
-    });
+    await setQuitConfirmationEnabled(app.window, true);
 
     await app.window
       .getByRole("button", { name: /Replay smoke thread/i })
@@ -202,23 +213,24 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
 
     const dialogPromise = app.electronApp.waitForEvent("window");
     requestQuit(app.electronApp);
-    const dialog = await dialogPromise;
+    const activeDialog = await dialogPromise;
+    dialog = activeDialog;
     await expect(
-      dialog.getByRole("heading", { name: "Quit PwrAgent?" }),
+      activeDialog.getByRole("heading", { name: "Quit PwrAgent?" }),
     ).toBeVisible();
 
     // Stand in for the impatient operator's second Cmd+Q: a keystroke on the
     // dialog cancels the auto-quit permanently, so nothing but the dialog will
     // ever settle this request.
-    await dialog.keyboard.press("ArrowDown");
+    await activeDialog.keyboard.press("ArrowDown");
     await expect
-      .poll(async () => await dialog.locator("#countdown").innerText())
+      .poll(async () => await activeDialog.locator("#countdown").innerText())
       .toBe("Auto-quit cancelled. Choose an option below.");
 
     requestQuit(app.electronApp);
     await expect
-      .poll(() => captured())
-      .toContain("quit requested while confirmation is open");
+      .poll(repeatAcknowledged)
+      .toBe(true);
     // The repeat request raises the existing prompt; it must not stack a second
     // dialog on top of it.
     expect(
@@ -227,14 +239,20 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
 
     // Answering it has to actually reach process exit — the countdown is gone,
     // so this is the only remaining path out.
-    await dialog.locator("#quit").dispatchEvent("click");
-    const outcome = await awaitExit(app.electronApp, captured);
+    await activeDialog.locator("#quit").dispatchEvent("click");
+    const outcome = await awaitExit(app.electronApp);
     expect(
       outcome.exited,
       describeOutcome("app with quit confirmation answered", outcome),
     ).toBe(true);
     expect(outcome.signalCode).toBeNull();
   } finally {
+    await setQuitConfirmationEnabled(app.window, false).catch(() => undefined);
+    if (dialog && !dialog.isClosed()) {
+      await dialog.locator("#quit").dispatchEvent("click").catch(
+        () => undefined,
+      );
+    }
     await app.close();
   }
 });
@@ -249,14 +267,12 @@ test("exits the process when the first-run wizard is asked to quit", async () =>
     suppressOnboarding: false,
     requiresReplayDriver: false,
   });
-  const captured = captureMainProcessOutput(app.electronApp);
-
   try {
     await expect(
       app.window.getByRole("heading", { name: /A few short choices/i }),
     ).toBeVisible();
     requestQuit(app.electronApp);
-    const outcome = await awaitExit(app.electronApp, captured);
+    const outcome = await awaitExit(app.electronApp);
     expect(outcome.exited, describeOutcome("first-run wizard app", outcome)).toBe(
       true,
     );

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -598,7 +598,7 @@ test("directory launchpad keeps selected environment controls after snapshot rel
       { directoryKey, repoDir: fixture.repoDir },
     );
 
-    await firstApp.electronApp.close();
+    await firstApp.closeApplication();
     firstApp = undefined;
 
     secondApp = await launchElectronApp({

--- a/apps/desktop/e2e/fixtures/bounded-output-matcher.ts
+++ b/apps/desktop/e2e/fixtures/bounded-output-matcher.ts
@@ -1,0 +1,32 @@
+export type BoundedOutputMatcher = {
+  inspect(chunk: string): void;
+  matched(): boolean;
+};
+
+/**
+ * Match one fixed marker in streamed process output without retaining a log.
+ * The overlap is only large enough to recognize a marker split across chunks.
+ */
+export function createBoundedOutputMatcher(
+  expected: string,
+): BoundedOutputMatcher {
+  if (expected.length === 0) {
+    throw new Error("Expected output marker must not be empty");
+  }
+
+  let didMatch = false;
+  let overlap = "";
+  return {
+    inspect: (chunk) => {
+      if (didMatch) {
+        return;
+      }
+      const combined = `${overlap}${chunk}`;
+      didMatch = combined.includes(expected);
+      overlap = didMatch
+        ? ""
+        : combined.slice(-(expected.length - 1));
+    },
+    matched: () => didMatch,
+  };
+}

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -1,6 +1,9 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import type {
   DesktopAppearanceDensity,
@@ -11,12 +14,41 @@ import { _electron as electron, expect, type ElectronApplication, type Locator, 
 import { applyDesktopSettingsPatch } from "../../src/main/settings/desktop-config";
 import { SECRET_STORAGE_DISABLED_ENV } from "../../src/main/settings/desktop-secret-store";
 import {
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+  E2E_SHUTDOWN_LAUNCH_ID_ENV,
+  readE2eShutdownPhaseEvents,
+} from "../../src/main/e2e-shutdown-diagnostics";
+import {
   isPidAlive,
   listDescendantPids,
   waitForPidsToExit,
 } from "./process-exit";
+import {
+  appendElectronShutdownSummary,
+  assertElectronShutdownCircuitClosed,
+  buildElectronShutdownSummary,
+  classifyElectronClose,
+  E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV,
+  E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
+  ElectronShutdownCircuitOpenError,
+  executeElectronClose,
+  finalizeElectronFixtureTeardown,
+  memoizeElectronClose,
+  observedOverallShutdownDuration,
+  recordElectronShutdownCircuit,
+  type ElectronCloseExecution,
+  type ElectronShutdownSummary,
+} from "./electron-shutdown-policy";
 
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
+export const DESKTOP_MAIN_ENTRY = path.resolve(
+  fixtureDir,
+  "../../out/main/index.js",
+);
+const ELECTRON_EVALUATE_QUIT_TIMEOUT_MS = 1_000;
+const ELECTRON_CLOSE_TIMEOUT_MS = 6_000;
+const ELECTRON_FORCE_EXIT_TIMEOUT_MS = 1_000;
+const ELECTRON_TEARDOWN_TIMEOUT_MS = 20_000;
 /**
  * How long teardown waits for a leftover profile process to exit after
  * SIGTERM before giving up and letting the rm report the leak.
@@ -28,6 +60,16 @@ const PROFILE_PROCESS_EXIT_POLL_MS = 100;
 declare global {
   var __PWRAGENT_E2E_CLIPBOARD__: { text: string } | undefined;
 }
+
+type ElectronChildProcess = ReturnType<ElectronApplication["process"]>;
+type CloseResult = "closed" | "rejected" | "timeout";
+
+type ElectronCloseOptions = {
+  circuitEnabled?: boolean;
+  circuitStateFile?: string;
+  diagnosticsFile?: string;
+  launchId?: string;
+};
 
 type LaunchResult = {
   electronApp: ElectronApplication;
@@ -61,6 +103,7 @@ type LaunchResult = {
     executionMode?: ThreadExecutionMode;
     requestId: string;
   }) => Promise<void>;
+  closeApplication: () => Promise<void>;
   close: () => Promise<void>;
 };
 
@@ -126,6 +169,17 @@ export async function launchElectronApp(params: {
    */
   requiresReplayDriver?: boolean;
 }): Promise<LaunchResult> {
+  const circuitEnabled =
+    process.env[E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV] === "1";
+  const circuitStateFile =
+    process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV];
+  assertElectronShutdownCircuitClosed({
+    enabled: circuitEnabled,
+    stateFile: circuitStateFile,
+  });
+  const diagnosticsFile =
+    process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  const launchId = randomUUID();
   const homeRoot =
     params.homeRoot ??
     await mkdtemp(path.join(os.tmpdir(), "pwragent-desktop-e2e-home-"));
@@ -193,6 +247,12 @@ export async function launchElectronApp(params: {
       env[key] = value;
     }
   }
+  env[E2E_SHUTDOWN_LAUNCH_ID_ENV] = launchId;
+  if (diagnosticsFile) {
+    env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV] = diagnosticsFile;
+  } else {
+    delete env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  }
   // Every desktop E2E runs an unsigned development Electron binary. On
   // macOS, allowing that binary to reach safeStorage can open a native
   // "Keychain Not Found" modal that Playwright cannot observe or dismiss.
@@ -204,7 +264,7 @@ export async function launchElectronApp(params: {
 
   const electronApp = await electron.launch({
     args: [
-      path.resolve(fixtureDir, "../../out/main/index.js"),
+      DESKTOP_MAIN_ENTRY,
       // Hardware video codecs leak kernel objects inside a
       // Virtualization.framework guest (the Tart macOS VMs): every
       // VideoToolbox init creates an
@@ -224,115 +284,135 @@ export async function launchElectronApp(params: {
     cwd: path.resolve(fixtureDir, "../.."),
     env,
   });
-  const window = await electronApp.firstWindow();
+  const closeApplicationOnce = memoizeElectronClose(async () =>
+    await closeElectronApplication(electronApp, {
+      circuitEnabled,
+      circuitStateFile,
+      diagnosticsFile,
+      launchId,
+    }),
+  );
+  let window: Page;
+  try {
+    window = await electronApp.firstWindow();
 
-  const requiresReplayDriver = params.requiresReplayDriver ?? true;
-  if (requiresReplayDriver) {
-    await expect
-      .poll(async () =>
-        await electronApp.evaluate(() =>
-          Boolean(globalThis.__PWRAGENT_REPLAY_DRIVER__)
+    const requiresReplayDriver = params.requiresReplayDriver ?? true;
+    if (requiresReplayDriver) {
+      await expect
+        .poll(async () =>
+          await electronApp.evaluate(() =>
+            Boolean(globalThis.__PWRAGENT_REPLAY_DRIVER__)
+          )
         )
-      )
-      .toBe(true);
-  } else {
-    // Wizard specs: just wait for the renderer to mount. We don't
-    // care about the replay driver — there's no thread to replay.
-    await window.waitForLoadState("domcontentloaded");
-  }
+        .toBe(true);
+    } else {
+      // Wizard specs: just wait for the renderer to mount. We don't
+      // care about the replay driver — there's no thread to replay.
+      await window.waitForLoadState("domcontentloaded");
+    }
 
-  if (params.windowSize) {
-    await electronApp.evaluate(
-      ({ BrowserWindow }, size) => {
-        const window = BrowserWindow.getAllWindows()[0];
-        if (!window) {
-          throw new Error("Expected an Electron BrowserWindow for replay E2E sizing");
-        }
+    if (params.windowSize) {
+      await electronApp.evaluate(
+        ({ BrowserWindow }, size) => {
+          const window = BrowserWindow.getAllWindows()[0];
+          if (!window) {
+            throw new Error("Expected an Electron BrowserWindow for replay E2E sizing");
+          }
 
-        window.setMinimumSize(0, 0);
-        window.setContentSize(size.width, size.height);
+          window.setMinimumSize(0, 0);
+          window.setContentSize(size.width, size.height);
+        },
+        params.windowSize
+      );
+
+      await expect
+        .poll(async () =>
+          await window.evaluate(() => ({
+            innerHeight: globalThis.innerHeight,
+            innerWidth: globalThis.innerWidth,
+          }))
+        )
+        .toMatchObject({
+          innerHeight: params.windowSize.height,
+          innerWidth: params.windowSize.width,
+        });
+    }
+
+    return {
+      electronApp,
+      homeRoot,
+      window,
+      getClipboardSnapshot: async () =>
+        await electronApp.evaluate(() => globalThis.__PWRAGENT_E2E_CLIPBOARD__),
+      advance: async (advanceParams) => {
+        await electronApp.evaluate(async (_electron, value) => {
+          await globalThis.__PWRAGENT_REPLAY_DRIVER__?.advance(value);
+        }, advanceParams);
       },
-      params.windowSize
-    );
-
-    await expect
-      .poll(async () =>
-        await window.evaluate(() => ({
-          innerHeight: globalThis.innerHeight,
-          innerWidth: globalThis.innerWidth,
-        }))
-      )
-      .toMatchObject({
-        innerHeight: params.windowSize.height,
-        innerWidth: params.windowSize.width,
-      });
+      getPendingRequest: async (requestParams) =>
+        await electronApp.evaluate(
+          (_electron, value) =>
+            globalThis.__PWRAGENT_REPLAY_DRIVER__?.getPendingRequest(value),
+          requestParams
+        ),
+      getLastStartTurn: async (requestParams) =>
+        await electronApp.evaluate(
+          (_electron, value) =>
+            globalThis.__PWRAGENT_REPLAY_DRIVER__?.getLastStartTurn(value),
+          requestParams
+        ),
+      getLastStartReview: async (requestParams) =>
+        await electronApp.evaluate(
+          (_electron, value) =>
+            globalThis.__PWRAGENT_REPLAY_DRIVER__?.getLastStartReview(value),
+          requestParams
+        ),
+      getLastRenameThread: async (requestParams) =>
+        await electronApp.evaluate(
+          (_electron, value) =>
+            globalThis.__PWRAGENT_REPLAY_DRIVER__?.getLastRenameThread(value),
+          requestParams
+        ),
+      getInterruptTurnCalls: async (requestParams) =>
+        await electronApp.evaluate(
+          (_electron, value) =>
+            globalThis.__PWRAGENT_REPLAY_DRIVER__?.getInterruptTurnCalls(value),
+          requestParams
+        ),
+      respondToPendingRequest: async (requestParams) => {
+        await electronApp.evaluate(async (_electron, value) => {
+          await globalThis.__PWRAGENT_REPLAY_DRIVER__?.respondToPendingRequest(value);
+        }, requestParams);
+      },
+      closeApplication: async () => {
+        const summary = await closeApplicationOnce();
+        if (summary.circuit.tripped) {
+          throw new ElectronShutdownCircuitOpenError();
+        }
+      },
+      close: async () => {
+        const running = finalizeElectronFixtureTeardown({
+          closeApplication: closeApplicationOnce,
+          cleanupProfileProcesses: async () => {
+            await killSpawnedProfileProcessesUnder(homeRoot);
+          },
+          removeHomeRoot: async () => {
+            await rm(homeRoot, { recursive: true, force: true });
+          },
+        }).then(() => undefined);
+        if (await raceTeardownTimeout(running, ELECTRON_TEARDOWN_TIMEOUT_MS)) {
+          running.catch(() => undefined);
+          console.warn(
+            `[pwragent-e2e-teardown] teardown exceeded ${ELECTRON_TEARDOWN_TIMEOUT_MS}ms`,
+          );
+        }
+      },
+    };
+  } catch (error) {
+    await closeApplicationOnce().catch(() => undefined);
+    await killSpawnedProfileProcessesUnder(homeRoot).catch(() => undefined);
+    throw error;
   }
-
-  return {
-    electronApp,
-    homeRoot,
-    window,
-    getClipboardSnapshot: async () =>
-      await electronApp.evaluate(() => globalThis.__PWRAGENT_E2E_CLIPBOARD__),
-    advance: async (advanceParams) => {
-      await electronApp.evaluate(async (_electron, value) => {
-        await globalThis.__PWRAGENT_REPLAY_DRIVER__?.advance(value);
-      }, advanceParams);
-    },
-    getPendingRequest: async (requestParams) =>
-      await electronApp.evaluate(
-        (_electron, value) =>
-          globalThis.__PWRAGENT_REPLAY_DRIVER__?.getPendingRequest(value),
-        requestParams
-      ),
-    getLastStartTurn: async (requestParams) =>
-      await electronApp.evaluate(
-        (_electron, value) =>
-          globalThis.__PWRAGENT_REPLAY_DRIVER__?.getLastStartTurn(value),
-        requestParams
-      ),
-    getLastStartReview: async (requestParams) =>
-      await electronApp.evaluate(
-        (_electron, value) =>
-          globalThis.__PWRAGENT_REPLAY_DRIVER__?.getLastStartReview(value),
-        requestParams
-      ),
-    getLastRenameThread: async (requestParams) =>
-      await electronApp.evaluate(
-        (_electron, value) =>
-          globalThis.__PWRAGENT_REPLAY_DRIVER__?.getLastRenameThread(value),
-        requestParams
-      ),
-    getInterruptTurnCalls: async (requestParams) =>
-      await electronApp.evaluate(
-        (_electron, value) =>
-          globalThis.__PWRAGENT_REPLAY_DRIVER__?.getInterruptTurnCalls(value),
-        requestParams
-      ),
-    respondToPendingRequest: async (requestParams) => {
-      await electronApp.evaluate(async (_electron, value) => {
-        await globalThis.__PWRAGENT_REPLAY_DRIVER__?.respondToPendingRequest(value);
-      }, requestParams);
-    },
-    close: async () => {
-      await electronApp.close();
-      // The wizard's graduation path can spawn a detached child
-      // Electron process for the operator's chosen profile (see
-      // `openPwrAgentProfile` in `ipc/profiles.ts`). That child
-      // outlives the test's bootstrap Electron and keeps writing
-      // to `<homeRoot>/.pwragent/profiles/<name>/` (state.db
-      // heartbeats, Codex plugin clones, etc.). If we rm the
-      // tmpdir while the child is mid-write, rm races and ENOTEMPTYs.
-      //
-      // Find any live PwrAgent instances under this tmpdir via
-      // their runtime-instance heartbeat markers, kill them, then
-      // proceed with cleanup. Each marker file is a JSON blob
-      // containing the process's PID; the marker dir layout matches
-      // `startProfileRuntimeHeartbeat` in `main/profile.ts`.
-      await killSpawnedProfileProcessesUnder(homeRoot);
-      await rm(homeRoot, { recursive: true, force: true });
-    },
-  };
 }
 
 /** Locate the thread card that owns the named empty open-thread button. */
@@ -347,6 +427,238 @@ export function threadRowCard(
   return scope
     .locator(".thread-row")
     .filter({ has: page.getByRole("button", { name }) });
+}
+
+/**
+ * Close a Playwright-owned Electron app within fixed budgets. A degraded
+ * persistent runner must not turn every remaining fixture teardown into a
+ * long delay, but the complete process tree is killed only after the graceful
+ * close budget expires.
+ */
+export async function closeElectronApplication(
+  electronApp: ElectronApplication,
+  options: ElectronCloseOptions = {},
+): Promise<ElectronShutdownSummary> {
+  let child: ElectronChildProcess | undefined;
+  try {
+    child = electronApp.process();
+  } catch {
+    return recordElectronCloseSummary(
+      alreadyExitedCloseExecution(),
+      options,
+    );
+  }
+  if (!child) {
+    return recordElectronCloseSummary(
+      alreadyExitedCloseExecution(),
+      options,
+    );
+  }
+  const execution = await executeElectronClose({
+    now: performance.now.bind(performance),
+    requestQuit: async () => {
+      await withTimeout(
+        electronApp.evaluate(({ app }) => {
+          app.quit();
+        }),
+        ELECTRON_EVALUATE_QUIT_TIMEOUT_MS,
+        "Electron quit evaluation timed out",
+      );
+    },
+    startClose: () => {
+      const closePromise = electronApp.close();
+      closePromise.catch(() => undefined);
+      return closePromise;
+    },
+    waitForGracefulClose: async (closePromise) => await waitForClose(
+      closePromise,
+      ELECTRON_CLOSE_TIMEOUT_MS,
+    ),
+    hasExited: () => hasExited(child),
+    forceKillTree: async () => {
+      await killProcessTree(child);
+    },
+    waitForForcedExit: async () => await waitForProcessExit(
+      child,
+      ELECTRON_FORCE_EXIT_TIMEOUT_MS,
+    ),
+    waitForPostKillClose: async (closePromise) => {
+      await waitForClose(closePromise, ELECTRON_FORCE_EXIT_TIMEOUT_MS);
+    },
+  });
+  return recordElectronCloseSummary(execution, options);
+}
+
+function alreadyExitedCloseExecution(): ElectronCloseExecution {
+  return {
+    elapsedMs: 0,
+    forceExitOutcome: "not-needed",
+    forced: false,
+    gracefulCloseOutcome: "closed",
+    quitRequestOutcome: "completed",
+  };
+}
+
+function recordElectronCloseSummary(
+  execution: ElectronCloseExecution,
+  options: ElectronCloseOptions,
+): ElectronShutdownSummary {
+  const diagnosticsFile = options.diagnosticsFile
+    ?? process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  const launchId = options.launchId ?? "untracked";
+  const events = readE2eShutdownPhaseEvents(diagnosticsFile, launchId);
+  const classification = classifyElectronClose({
+    ...execution,
+    shutdownElapsedMs: observedOverallShutdownDuration(events),
+  });
+  const circuit = recordElectronShutdownCircuit({
+    classification,
+    enabled: options.circuitEnabled
+      ?? process.env[E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV] === "1",
+    stateFile: options.circuitStateFile
+      ?? process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV],
+  });
+  const summary = buildElectronShutdownSummary({
+    circuit,
+    classification,
+    events,
+    execution,
+    launchId,
+  });
+  appendElectronShutdownSummary(diagnosticsFile, summary);
+  console.log(`[pwragent-e2e-shutdown] ${JSON.stringify(summary)}`);
+  return summary;
+}
+
+export async function raceTeardownTimeout(
+  running: Promise<void>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<boolean>([
+      running.then(() => false),
+      new Promise<true>((resolve) => {
+        timeout = setTimeout(() => resolve(true), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  promise.catch(() => undefined);
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<T>([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function waitForClose(
+  promise: Promise<void>,
+  timeoutMs: number,
+): Promise<CloseResult> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<CloseResult>([
+      promise.then(
+        () => "closed",
+        () => "rejected",
+      ),
+      new Promise<"timeout">((resolve) => {
+        timeout = setTimeout(() => resolve("timeout"), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function hasExited(child: ElectronChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitForProcessExit(
+  child: ElectronChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (hasExited(child)) {
+    return true;
+  }
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<boolean>([
+      new Promise<true>((resolve) => {
+        child.once("exit", () => resolve(true));
+      }),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function killProcessTree(child: ElectronChildProcess): Promise<void> {
+  if (hasExited(child)) {
+    return;
+  }
+  const pid = child.pid;
+  if (pid === undefined) {
+    if (!child.killed) {
+      child.kill("SIGKILL");
+    }
+    return;
+  }
+  if (process.platform === "win32") {
+    await new Promise<void>((resolve) => {
+      execFile(
+        "taskkill",
+        ["/pid", String(pid), "/T", "/F"],
+        { timeout: 5_000 },
+        (error) => {
+          if (error && !child.killed) {
+            child.kill("SIGKILL");
+          }
+          resolve();
+        },
+      );
+    });
+    return;
+  }
+
+  const descendants = await listDescendantPids(pid);
+  if (!child.killed) {
+    child.kill("SIGKILL");
+  }
+  for (const descendant of descendants) {
+    try {
+      process.kill(descendant, "SIGKILL");
+    } catch {
+      // The descendant already exited between the ps snapshot and this kill.
+    }
+  }
 }
 
 async function killSpawnedProfileProcessesUnder(homeRoot: string): Promise<void> {

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -30,6 +30,7 @@ import {
   classifyElectronClose,
   E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV,
   E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
+  ElectronFixtureTeardownTimeoutError,
   ElectronShutdownCircuitOpenError,
   executeElectronClose,
   finalizeElectronFixtureTeardown,
@@ -400,12 +401,11 @@ export async function launchElectronApp(params: {
             await rm(homeRoot, { recursive: true, force: true });
           },
         }).then(() => undefined);
-        if (await raceTeardownTimeout(running, ELECTRON_TEARDOWN_TIMEOUT_MS)) {
-          running.catch(() => undefined);
-          console.warn(
-            `[pwragent-e2e-teardown] teardown exceeded ${ELECTRON_TEARDOWN_TIMEOUT_MS}ms`,
-          );
-        }
+        await awaitElectronFixtureTeardown({
+          closeApplication: closeApplicationOnce,
+          running,
+          timeoutMs: ELECTRON_TEARDOWN_TIMEOUT_MS,
+        });
       },
     };
   } catch (error) {
@@ -427,6 +427,27 @@ export function threadRowCard(
   return scope
     .locator(".thread-row")
     .filter({ has: page.getByRole("button", { name }) });
+}
+
+export async function awaitElectronFixtureTeardown(params: {
+  closeApplication(): Promise<ElectronShutdownSummary>;
+  running: Promise<void>;
+  timeoutMs: number;
+}): Promise<void> {
+  if (!await raceTeardownTimeout(params.running, params.timeoutMs)) {
+    return;
+  }
+
+  // The bounded close finishes before profile cleanup begins, so its memoized
+  // summary remains available even when the overall teardown budget expires.
+  // Observe the detached cleanup promise, then surface a deterministic failure
+  // instead of allowing the fixture (and potentially the shard) to pass.
+  params.running.catch(() => undefined);
+  const summary = await params.closeApplication();
+  if (summary.circuit.tripped) {
+    throw new ElectronShutdownCircuitOpenError();
+  }
+  throw new ElectronFixtureTeardownTimeoutError(params.timeoutMs);
 }
 
 /**

--- a/apps/desktop/e2e/fixtures/electron-shutdown-circuit-reporter.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-circuit-reporter.ts
@@ -1,0 +1,48 @@
+import type {
+  FullResult,
+  Reporter,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
+import {
+  ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME,
+} from "./electron-shutdown-policy";
+
+type ReporterOptions = {
+  stopRun?: () => void;
+};
+
+/** Stop Playwright gracefully so reporters finish and mark the shard failed. */
+function interruptPlaywrightRun(): void {
+  process.kill(process.pid, "SIGINT");
+}
+
+export default class ElectronShutdownCircuitReporter implements Reporter {
+  private readonly stopRun: () => void;
+  private circuitTripped = false;
+
+  constructor(options: ReporterOptions = {}) {
+    this.stopRun = options.stopRun ?? interruptPlaywrightRun;
+  }
+
+  onTestEnd(_test: TestCase, result: TestResult): void {
+    if (
+      this.circuitTripped
+      || !result.errors.some((error) =>
+        [error.message, error.stack, error.value].some((detail) =>
+          detail?.includes(ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME),
+        ),
+      )
+    ) {
+      return;
+    }
+    this.circuitTripped = true;
+    this.stopRun();
+  }
+
+  async onEnd(
+    _result: FullResult,
+  ): Promise<{ status: "failed" } | undefined> {
+    return this.circuitTripped ? { status: "failed" } : undefined;
+  }
+}

--- a/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
@@ -18,6 +18,8 @@ export const E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV =
   "PWRAGENT_E2E_SHUTDOWN_CIRCUIT_STATE_FILE";
 export const ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME =
   "ElectronShutdownCircuitOpenError";
+export const ELECTRON_FIXTURE_TEARDOWN_TIMEOUT_ERROR_NAME =
+  "ElectronFixtureTeardownTimeoutError";
 
 /**
  * A healthy replay-backed app normally closes well below the renderer's own
@@ -311,6 +313,15 @@ export class ElectronShutdownCircuitOpenError extends Error {
       ].join(" "),
     );
     this.name = ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME;
+  }
+}
+
+export class ElectronFixtureTeardownTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(
+      `Electron fixture teardown exceeded its ${timeoutMs}ms cleanup budget`,
+    );
+    this.name = ELECTRON_FIXTURE_TEARDOWN_TIMEOUT_ERROR_NAME;
   }
 }
 

--- a/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
@@ -1,0 +1,383 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type {
+  E2eShutdownPhase,
+  E2eShutdownPhaseEvent,
+} from "../../src/main/e2e-shutdown-diagnostics";
+
+export const E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_CIRCUIT_BREAKER";
+export const E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_CIRCUIT_STATE_FILE";
+export const ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME =
+  "ElectronShutdownCircuitOpenError";
+
+/**
+ * A healthy replay-backed app normally closes well below the renderer's own
+ * 2s ceiling. Four seconds leaves a second full renderer budget for loaded
+ * runners while still classifying a close before the harness's 6s force-kill.
+ */
+export const SLOW_ELECTRON_CLOSE_THRESHOLD_MS = 4_000;
+/** One isolated abnormal close is tolerated; the second consecutive one trips. */
+export const ABNORMAL_ELECTRON_CLOSE_LIMIT = 2;
+
+export type ElectronCloseClassification =
+  | "healthy"
+  | "slow"
+  | "force-killed";
+export type ElectronCloseHandshakeOutcome = "closed" | "rejected" | "timeout";
+
+export type ElectronCloseExecution = {
+  elapsedMs: number;
+  forceExitOutcome: "not-needed" | "exited" | "timed-out";
+  forced: boolean;
+  gracefulCloseOutcome: ElectronCloseHandshakeOutcome;
+  quitRequestOutcome: "completed" | "rejected";
+};
+
+export type ElectronShutdownCircuitState = {
+  schemaVersion: 1;
+  consecutiveAbnormalCloses: number;
+  open: boolean;
+};
+
+export type ElectronShutdownCircuitDecision = {
+  enabled: boolean;
+  consecutiveAbnormalCloses: number;
+  limit: number;
+  tripped: boolean;
+};
+
+export type ElectronShutdownPhaseSummary = {
+  durationMs: number | null;
+  outcome:
+    | "completed"
+    | "failed"
+    | "timed-out"
+    | "skipped"
+    | "interrupted"
+    | "not-observed";
+};
+
+export type ElectronShutdownSummary = {
+  schemaVersion: 1;
+  kind: "close-summary";
+  launchId: string;
+  classification: ElectronCloseClassification;
+  elapsedMs: number;
+  quitRequestOutcome: ElectronCloseExecution["quitRequestOutcome"];
+  gracefulCloseOutcome: ElectronCloseHandshakeOutcome;
+  forceExitOutcome: ElectronCloseExecution["forceExitOutcome"];
+  phases: {
+    rendererWindow: ElectronShutdownPhaseSummary;
+    messaging: ElectronShutdownPhaseSummary;
+    appServer: ElectronShutdownPhaseSummary;
+    overall: ElectronShutdownPhaseSummary;
+  };
+  circuit: ElectronShutdownCircuitDecision;
+};
+
+export function memoizeElectronClose(
+  closeApplication: () => Promise<ElectronShutdownSummary>,
+): () => Promise<ElectronShutdownSummary> {
+  let closePromise: Promise<ElectronShutdownSummary> | undefined;
+  return () => {
+    closePromise ??= closeApplication();
+    return closePromise;
+  };
+}
+
+type ElectronCloseActions = {
+  forceKillTree(): Promise<void>;
+  hasExited(): boolean;
+  now(): number;
+  requestQuit(): Promise<void>;
+  startClose(): Promise<void>;
+  waitForForcedExit(): Promise<boolean>;
+  waitForGracefulClose(
+    closePromise: Promise<void>,
+  ): Promise<ElectronCloseHandshakeOutcome>;
+  waitForPostKillClose(closePromise: Promise<void>): Promise<void>;
+};
+
+export async function executeElectronClose(
+  actions: ElectronCloseActions,
+): Promise<ElectronCloseExecution> {
+  const startedAt = actions.now();
+  let quitRequestOutcome: ElectronCloseExecution["quitRequestOutcome"] =
+    "completed";
+  try {
+    await actions.requestQuit();
+  } catch {
+    quitRequestOutcome = "rejected";
+  }
+
+  let closePromise: Promise<void>;
+  try {
+    closePromise = actions.startClose();
+  } catch {
+    closePromise = Promise.reject(new Error("Electron close rejected"));
+    closePromise.catch(() => undefined);
+  }
+  const gracefulCloseOutcome = await actions.waitForGracefulClose(closePromise);
+  if (actions.hasExited()) {
+    return {
+      elapsedMs: normalizeDuration(actions.now() - startedAt),
+      forceExitOutcome: "not-needed",
+      forced: false,
+      gracefulCloseOutcome,
+      quitRequestOutcome,
+    };
+  }
+
+  await actions.forceKillTree();
+  const forcedExit = await actions.waitForForcedExit();
+  await actions.waitForPostKillClose(closePromise);
+  return {
+    elapsedMs: normalizeDuration(actions.now() - startedAt),
+    forceExitOutcome: forcedExit ? "exited" : "timed-out",
+    forced: true,
+    gracefulCloseOutcome,
+    quitRequestOutcome,
+  };
+}
+
+export function classifyElectronClose(
+  execution: Pick<ElectronCloseExecution, "elapsedMs" | "forced"> & {
+    shutdownElapsedMs?: number;
+  },
+): ElectronCloseClassification {
+  if (execution.forced) {
+    return "force-killed";
+  }
+  const elapsedMs = Math.max(
+    execution.elapsedMs,
+    execution.shutdownElapsedMs ?? 0,
+  );
+  if (elapsedMs >= SLOW_ELECTRON_CLOSE_THRESHOLD_MS) {
+    return "slow";
+  }
+  return "healthy";
+}
+
+export function advanceElectronShutdownCircuit(
+  state: ElectronShutdownCircuitState,
+  classification: ElectronCloseClassification,
+  limit = ABNORMAL_ELECTRON_CLOSE_LIMIT,
+): ElectronShutdownCircuitState {
+  if (state.open) {
+    return state;
+  }
+  const consecutiveAbnormalCloses = classification === "healthy"
+    ? 0
+    : state.consecutiveAbnormalCloses + 1;
+  return {
+    schemaVersion: 1,
+    consecutiveAbnormalCloses,
+    open: consecutiveAbnormalCloses >= limit,
+  };
+}
+
+export function recordElectronShutdownCircuit(params: {
+  classification: ElectronCloseClassification;
+  enabled: boolean;
+  stateFile?: string;
+}): ElectronShutdownCircuitDecision {
+  if (!params.enabled || !params.stateFile) {
+    return {
+      enabled: false,
+      consecutiveAbnormalCloses: 0,
+      limit: ABNORMAL_ELECTRON_CLOSE_LIMIT,
+      tripped: false,
+    };
+  }
+  const previous = readCircuitState(params.stateFile);
+  const next = advanceElectronShutdownCircuit(
+    previous,
+    params.classification,
+  );
+  writeCircuitState(params.stateFile, next);
+  return {
+    enabled: true,
+    consecutiveAbnormalCloses: next.consecutiveAbnormalCloses,
+    limit: ABNORMAL_ELECTRON_CLOSE_LIMIT,
+    tripped: next.open,
+  };
+}
+
+export function assertElectronShutdownCircuitClosed(params: {
+  enabled: boolean;
+  stateFile?: string;
+}): void {
+  if (!params.enabled || !params.stateFile) {
+    return;
+  }
+  if (readCircuitState(params.stateFile).open) {
+    throw new ElectronShutdownCircuitOpenError();
+  }
+}
+
+export function resetElectronShutdownCircuit(
+  stateFile: string | undefined,
+): void {
+  if (stateFile) {
+    rmSync(stateFile, { force: true });
+  }
+}
+
+export function buildElectronShutdownSummary(params: {
+  circuit: ElectronShutdownCircuitDecision;
+  classification: ElectronCloseClassification;
+  events: E2eShutdownPhaseEvent[];
+  execution: ElectronCloseExecution;
+  launchId: string;
+}): ElectronShutdownSummary {
+  return {
+    schemaVersion: 1,
+    kind: "close-summary",
+    launchId: params.launchId,
+    classification: params.classification,
+    elapsedMs: normalizeDuration(params.execution.elapsedMs),
+    quitRequestOutcome: params.execution.quitRequestOutcome,
+    gracefulCloseOutcome: params.execution.gracefulCloseOutcome,
+    forceExitOutcome: params.execution.forceExitOutcome,
+    phases: {
+      rendererWindow: summarizePhase(params.events, "renderer-window"),
+      messaging: summarizePhase(params.events, "messaging"),
+      appServer: summarizePhase(params.events, "app-server"),
+      overall: summarizePhase(params.events, "overall"),
+    },
+    circuit: params.circuit,
+  };
+}
+
+export function observedOverallShutdownDuration(
+  events: E2eShutdownPhaseEvent[],
+): number | undefined {
+  return [...events].reverse().find(
+    (event) => event.phase === "overall" && event.outcome !== "started",
+  )?.durationMs;
+}
+
+export function appendElectronShutdownSummary(
+  filePath: string | undefined,
+  summary: ElectronShutdownSummary,
+): void {
+  if (!filePath) {
+    return;
+  }
+  try {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    // Lead with a newline so a force-killed, partially appended phase record
+    // cannot swallow the parent-authored summary into the same invalid line.
+    appendFileSync(filePath, `\n${JSON.stringify(summary)}\n`, "utf8");
+  } catch {
+    // Reporting must not replace the teardown result with an I/O failure.
+  }
+}
+
+/**
+ * Circuit failure is deliberately last: force-kill/profile cleanup and temp
+ * directory removal must finish before Playwright is told to stop the lane.
+ */
+export async function finalizeElectronFixtureTeardown(params: {
+  cleanupProfileProcesses(): Promise<void>;
+  closeApplication(): Promise<ElectronShutdownSummary>;
+  removeHomeRoot(): Promise<void>;
+}): Promise<ElectronShutdownSummary> {
+  const summary = await params.closeApplication();
+  await params.cleanupProfileProcesses();
+  await params.removeHomeRoot();
+  if (summary.circuit.tripped) {
+    throw new ElectronShutdownCircuitOpenError();
+  }
+  return summary;
+}
+
+export class ElectronShutdownCircuitOpenError extends Error {
+  constructor() {
+    super(
+      [
+        "Electron shutdown circuit opened after two consecutive abnormal closes;",
+        "stopping this macOS E2E lane after deterministic cleanup.",
+        "Recycle the cold runner guest before retrying.",
+      ].join(" "),
+    );
+    this.name = ELECTRON_SHUTDOWN_CIRCUIT_ERROR_NAME;
+  }
+}
+
+function summarizePhase(
+  events: E2eShutdownPhaseEvent[],
+  phase: E2eShutdownPhase,
+): ElectronShutdownPhaseSummary {
+  const matching = events.filter((event) => event.phase === phase);
+  const terminal = [...matching].reverse().find(
+    (event) => event.outcome !== "started",
+  );
+  if (terminal && terminal.outcome !== "started") {
+    return {
+      durationMs: normalizeDuration(terminal.durationMs),
+      outcome: terminal.outcome,
+    };
+  }
+  if (matching.some((event) => event.outcome === "started")) {
+    return { durationMs: null, outcome: "interrupted" };
+  }
+  return { durationMs: null, outcome: "not-observed" };
+}
+
+function readCircuitState(stateFile: string): ElectronShutdownCircuitState {
+  try {
+    const value = JSON.parse(readFileSync(stateFile, "utf8")) as unknown;
+    if (
+      isRecord(value)
+      && value.schemaVersion === 1
+      && typeof value.consecutiveAbnormalCloses === "number"
+      && Number.isInteger(value.consecutiveAbnormalCloses)
+      && value.consecutiveAbnormalCloses >= 0
+      && typeof value.open === "boolean"
+    ) {
+      return {
+        schemaVersion: 1,
+        consecutiveAbnormalCloses: value.consecutiveAbnormalCloses,
+        open: value.open,
+      };
+    }
+  } catch {
+    // A missing or interrupted state file starts a new closed circuit.
+  }
+  return {
+    schemaVersion: 1,
+    consecutiveAbnormalCloses: 0,
+    open: false,
+  };
+}
+
+function writeCircuitState(
+  stateFile: string,
+  state: ElectronShutdownCircuitState,
+): void {
+  mkdirSync(path.dirname(stateFile), { recursive: true });
+  const temporaryFile = `${stateFile}.${process.pid}.tmp`;
+  writeFileSync(temporaryFile, `${JSON.stringify(state)}\n`, "utf8");
+  renameSync(temporaryFile, stateFile);
+}
+
+function normalizeDuration(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/desktop/e2e/shutdown-global-setup.ts
+++ b/apps/desktop/e2e/shutdown-global-setup.ts
@@ -1,0 +1,19 @@
+import { rmSync } from "node:fs";
+import {
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+} from "../src/main/e2e-shutdown-diagnostics";
+import {
+  E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
+  resetElectronShutdownCircuit,
+} from "./fixtures/electron-shutdown-policy";
+
+/** Reset per-shard state once, before Playwright can replace a failed worker. */
+export default function globalSetup(): void {
+  const diagnosticsFile = process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  if (diagnosticsFile) {
+    rmSync(diagnosticsFile, { force: true });
+  }
+  resetElectronShutdownCircuit(
+    process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV],
+  );
+}

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,18 +1,49 @@
-import { defineConfig } from "@playwright/test";
+import path from "node:path";
+import { defineConfig, type ReporterDescription } from "@playwright/test";
+import {
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+} from "./src/main/e2e-shutdown-diagnostics";
+import {
+  E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV,
+  E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
+} from "./e2e/fixtures/electron-shutdown-policy";
+
+process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV] ??= path.join(
+  import.meta.dirname,
+  "test-results",
+  "electron-shutdown-diagnostics.jsonl",
+);
+process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV] ??= path.join(
+  import.meta.dirname,
+  "test-results",
+  "electron-shutdown-circuit.json",
+);
+
+const electronShutdownCircuitEnabled =
+  process.env[E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV] === "1";
+const reporters: ReporterDescription[] = process.env.CI
+  ? [
+      ["html", { outputFolder: "playwright-report", open: "never" }],
+      ["list"],
+    ]
+  : [["list"]];
+if (electronShutdownCircuitEnabled) {
+  reporters.push([
+    "./e2e/fixtures/electron-shutdown-circuit-reporter.ts",
+  ]);
+}
 
 export default defineConfig({
   testDir: "./e2e",
+  globalSetup: "./e2e/shutdown-global-setup.ts",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   outputDir: "./test-results",
-  reporter: process.env.CI
-    ? [
-        ["html", { outputFolder: "playwright-report", open: "never" }],
-        ["list"]
-      ]
-    : "list",
+  // The circuit reporter interrupts only for the synthetic circuit-open
+  // error. Ordinary assertion failures retain normal retry/suite behavior.
+  reporter: reporters,
   use: {
     screenshot: process.env.CI ? "only-on-failure" : "off",
     trace: "on-first-retry",

--- a/apps/desktop/src/main/__tests__/bounded-output-matcher.test.ts
+++ b/apps/desktop/src/main/__tests__/bounded-output-matcher.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBoundedOutputMatcher,
+} from "../../../e2e/fixtures/bounded-output-matcher";
+
+describe("bounded process output matcher", () => {
+  const marker = "quit requested while confirmation is open";
+
+  it("recognizes markers before trimming oversized chunks", () => {
+    const matcher = createBoundedOutputMatcher(marker);
+
+    matcher.inspect(`prefix ${marker}${" later output".repeat(100)}`);
+
+    expect(matcher.matched()).toBe(true);
+  });
+
+  it("recognizes markers split across chunks", () => {
+    const matcher = createBoundedOutputMatcher(marker);
+
+    matcher.inspect("prefix quit requested while conf");
+    matcher.inspect(`irmation is open${" later output".repeat(100)}`);
+
+    expect(matcher.matched()).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/e2e-shutdown-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-shutdown-diagnostics.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createE2eShutdownDiagnosticsRecorder,
+  readE2eShutdownPhaseEvents,
+} from "../e2e-shutdown-diagnostics";
+
+describe("E2E shutdown diagnostics", () => {
+  it("records deterministic phase and overall elapsed times", () => {
+    let now = 1_000;
+    const lines: string[] = [];
+    const recorder = createE2eShutdownDiagnosticsRecorder({
+      enabled: true,
+      launchId: "launch-1",
+      now: () => now,
+      writeLine: (line) => lines.push(line),
+    });
+
+    recorder.beginOverall();
+    recorder.beginPhase("renderer-window");
+    now = 1_125;
+    recorder.finishPhase("renderer-window", "completed", 124.6);
+    now = 1_500;
+    recorder.finishOverall("completed");
+
+    expect(lines.map((line) => JSON.parse(line))).toEqual([
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "overall",
+        outcome: "started",
+        durationMs: 0,
+      },
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "renderer-window",
+        outcome: "started",
+        durationMs: 0,
+      },
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "renderer-window",
+        outcome: "completed",
+        durationMs: 125,
+      },
+      {
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-1",
+        phase: "overall",
+        outcome: "completed",
+        durationMs: 500,
+      },
+    ]);
+  });
+
+  it("allowlists structured fields instead of replaying raw app detail", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "shutdown-diagnostics-"));
+    const filePath = path.join(root, "diagnostics.jsonl");
+    try {
+      writeFileSync(
+        filePath,
+        `${JSON.stringify({
+          schemaVersion: 1,
+          kind: "phase",
+          launchId: "launch-2",
+          phase: "app-server",
+          outcome: "timed-out",
+          durationMs: 7_500,
+          homeRoot: "/Users/alice/private-home",
+          username: "alice",
+          command: "Electron --secret token",
+          error: "raw app log with a secret",
+        })}\n`,
+        "utf8",
+      );
+
+      const events = readE2eShutdownPhaseEvents(filePath, "launch-2");
+
+      expect(events).toEqual([{
+        schemaVersion: 1,
+        kind: "phase",
+        launchId: "launch-2",
+        phase: "app-server",
+        outcome: "timed-out",
+        durationMs: 7_500,
+      }]);
+      expect(JSON.stringify(events)).not.toMatch(
+        /alice|private-home|Electron|secret|raw app log/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/electron-app-close.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-app-close.test.ts
@@ -1,6 +1,14 @@
 import type { ElectronApplication } from "@playwright/test";
 import { describe, expect, it, vi } from "vitest";
-import { closeElectronApplication } from "../../../e2e/fixtures/electron-app";
+import {
+  awaitElectronFixtureTeardown,
+  closeElectronApplication,
+} from "../../../e2e/fixtures/electron-app";
+import {
+  ElectronFixtureTeardownTimeoutError,
+  ElectronShutdownCircuitOpenError,
+  type ElectronShutdownSummary,
+} from "../../../e2e/fixtures/electron-shutdown-policy";
 
 describe("closeElectronApplication", () => {
   it("is a no-op when Playwright throws for an exited Electron handle", async () => {
@@ -28,4 +36,46 @@ describe("closeElectronApplication", () => {
     });
     expect(process).toHaveBeenCalledOnce();
   });
+
+  it("propagates an open circuit when the overall fixture teardown times out", async () => {
+    await expect(awaitElectronFixtureTeardown({
+      closeApplication: async () => shutdownSummary(true),
+      running: new Promise<void>(() => undefined),
+      timeoutMs: 0,
+    })).rejects.toThrow(ElectronShutdownCircuitOpenError);
+  });
+
+  it("fails an ordinary overall fixture teardown timeout explicitly", async () => {
+    await expect(awaitElectronFixtureTeardown({
+      closeApplication: async () => shutdownSummary(false),
+      running: new Promise<void>(() => undefined),
+      timeoutMs: 0,
+    })).rejects.toThrow(ElectronFixtureTeardownTimeoutError);
+  });
 });
+
+function shutdownSummary(tripped: boolean): ElectronShutdownSummary {
+  const phase = { durationMs: null, outcome: "not-observed" as const };
+  return {
+    schemaVersion: 1,
+    kind: "close-summary",
+    launchId: "launch-timeout",
+    classification: tripped ? "force-killed" : "healthy",
+    elapsedMs: tripped ? 6_100 : 100,
+    quitRequestOutcome: "completed",
+    gracefulCloseOutcome: tripped ? "timeout" : "closed",
+    forceExitOutcome: tripped ? "exited" : "not-needed",
+    phases: {
+      rendererWindow: phase,
+      messaging: phase,
+      appServer: phase,
+      overall: phase,
+    },
+    circuit: {
+      enabled: true,
+      consecutiveAbnormalCloses: tripped ? 2 : 0,
+      limit: 2,
+      tripped,
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/electron-app-close.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-app-close.test.ts
@@ -1,0 +1,31 @@
+import type { ElectronApplication } from "@playwright/test";
+import { describe, expect, it, vi } from "vitest";
+import { closeElectronApplication } from "../../../e2e/fixtures/electron-app";
+
+describe("closeElectronApplication", () => {
+  it("is a no-op when Playwright throws for an exited Electron handle", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const process = vi.fn(() => {
+      throw new TypeError("Cannot read properties of undefined");
+    });
+    const electronApp = { process } as unknown as ElectronApplication;
+
+    await expect(closeElectronApplication(electronApp)).resolves.toMatchObject({
+      classification: "healthy",
+      forceExitOutcome: "not-needed",
+    });
+    expect(process).toHaveBeenCalledOnce();
+  });
+
+  it("is a no-op when Playwright returns no process for an exited handle", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const process = vi.fn(() => undefined);
+    const electronApp = { process } as unknown as ElectronApplication;
+
+    await expect(closeElectronApplication(electronApp)).resolves.toMatchObject({
+      classification: "healthy",
+      forceExitOutcome: "not-needed",
+    });
+    expect(process).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/main/__tests__/electron-shutdown-circuit-reporter.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-circuit-reporter.test.ts
@@ -1,0 +1,41 @@
+import type { TestCase, TestResult } from "@playwright/test/reporter";
+import { describe, expect, it, vi } from "vitest";
+import ElectronShutdownCircuitReporter from "../../../e2e/fixtures/electron-shutdown-circuit-reporter";
+
+function resultWithError(error: { message?: string; stack?: string }): TestResult {
+  return {
+    errors: [error],
+  } as TestResult;
+}
+
+describe("Electron shutdown circuit reporter", () => {
+  it("does not stop the run for an ordinary test failure", async () => {
+    const stopRun = vi.fn();
+    const reporter = new ElectronShutdownCircuitReporter({ stopRun });
+
+    reporter.onTestEnd(
+      {} as TestCase,
+      resultWithError({ message: "ordinary assertion failed" }),
+    );
+
+    expect(stopRun).not.toHaveBeenCalled();
+    await expect(reporter.onEnd({} as never)).resolves.toBeUndefined();
+  });
+
+  it("stops and fails the run once for a circuit-open failure", async () => {
+    const stopRun = vi.fn();
+    const reporter = new ElectronShutdownCircuitReporter({ stopRun });
+    const result = resultWithError({
+      message: "circuit opened",
+      stack: "ElectronShutdownCircuitOpenError: circuit opened",
+    });
+
+    reporter.onTestEnd({} as TestCase, result);
+    reporter.onTestEnd({} as TestCase, result);
+
+    expect(stopRun).toHaveBeenCalledOnce();
+    await expect(reporter.onEnd({} as never)).resolves.toEqual({
+      status: "failed",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
@@ -1,0 +1,250 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  advanceElectronShutdownCircuit,
+  assertElectronShutdownCircuitClosed,
+  buildElectronShutdownSummary,
+  classifyElectronClose,
+  ElectronShutdownCircuitOpenError,
+  executeElectronClose,
+  finalizeElectronFixtureTeardown,
+  memoizeElectronClose,
+  recordElectronShutdownCircuit,
+  SLOW_ELECTRON_CLOSE_THRESHOLD_MS,
+  type ElectronShutdownCircuitState,
+  type ElectronShutdownSummary,
+} from "../../../e2e/fixtures/electron-shutdown-policy";
+
+const CLOSED_STATE: ElectronShutdownCircuitState = {
+  schemaVersion: 1,
+  consecutiveAbnormalCloses: 0,
+  open: false,
+};
+
+describe("Electron shutdown policy", () => {
+  it("classifies slow and force-killed closes at measured boundaries", () => {
+    expect(classifyElectronClose({
+      elapsedMs: SLOW_ELECTRON_CLOSE_THRESHOLD_MS - 1,
+      forced: false,
+    })).toBe("healthy");
+    expect(classifyElectronClose({
+      elapsedMs: SLOW_ELECTRON_CLOSE_THRESHOLD_MS,
+      forced: false,
+    })).toBe("slow");
+    expect(classifyElectronClose({
+      elapsedMs: 0,
+      forced: false,
+      shutdownElapsedMs: SLOW_ELECTRON_CLOSE_THRESHOLD_MS,
+    })).toBe("slow");
+    expect(classifyElectronClose({ elapsedMs: 1, forced: true })).toBe(
+      "force-killed",
+    );
+  });
+
+  it("tolerates one abnormal close, resets on health, and trips on two consecutive closes", () => {
+    const oneSlow = advanceElectronShutdownCircuit(CLOSED_STATE, "slow");
+    expect(oneSlow).toEqual({
+      schemaVersion: 1,
+      consecutiveAbnormalCloses: 1,
+      open: false,
+    });
+    expect(advanceElectronShutdownCircuit(oneSlow, "healthy")).toEqual(
+      CLOSED_STATE,
+    );
+    const open = advanceElectronShutdownCircuit(oneSlow, "force-killed");
+    expect(open).toEqual({
+      schemaVersion: 1,
+      consecutiveAbnormalCloses: 2,
+      open: true,
+    });
+    expect(advanceElectronShutdownCircuit(open, "healthy")).toBe(open);
+  });
+
+  it("persists the open circuit across Playwright worker replacement", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "shutdown-circuit-"));
+    const stateFile = path.join(root, "state.json");
+    try {
+      expect(recordElectronShutdownCircuit({
+        classification: "slow",
+        enabled: true,
+        stateFile,
+      }).tripped).toBe(false);
+      expect(recordElectronShutdownCircuit({
+        classification: "force-killed",
+        enabled: true,
+        stateFile,
+      })).toMatchObject({
+        consecutiveAbnormalCloses: 2,
+        tripped: true,
+      });
+      expect(() => assertElectronShutdownCircuitClosed({
+        enabled: true,
+        stateFile,
+      })).toThrow(ElectronShutdownCircuitOpenError);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("records one close result when a launch is closed repeatedly", async () => {
+    let closes = 0;
+    const summary = trippedSummary();
+    const closeOnce = memoizeElectronClose(async () => {
+      closes += 1;
+      return summary;
+    });
+
+    await expect(closeOnce()).resolves.toBe(summary);
+    await expect(closeOnce()).resolves.toBe(summary);
+    expect(closes).toBe(1);
+  });
+
+  it("force-kills only after the bounded graceful close and then waits for reaping", async () => {
+    const order: string[] = [];
+    let now = 100;
+    const closePromise = Promise.resolve();
+
+    const result = await executeElectronClose({
+      now: () => now,
+      requestQuit: async () => {
+        order.push("request-quit");
+      },
+      startClose: () => {
+        order.push("start-close");
+        return closePromise;
+      },
+      waitForGracefulClose: async (promise) => {
+        expect(promise).toBe(closePromise);
+        order.push("wait-graceful");
+        now = 6_100;
+        return "timeout";
+      },
+      hasExited: () => {
+        order.push("check-exit");
+        return false;
+      },
+      forceKillTree: async () => {
+        order.push("force-kill-tree");
+      },
+      waitForForcedExit: async () => {
+        order.push("wait-forced-exit");
+        now = 6_150;
+        return true;
+      },
+      waitForPostKillClose: async () => {
+        order.push("wait-post-kill-close");
+      },
+    });
+
+    expect(order).toEqual([
+      "request-quit",
+      "start-close",
+      "wait-graceful",
+      "check-exit",
+      "force-kill-tree",
+      "wait-forced-exit",
+      "wait-post-kill-close",
+    ]);
+    expect(result).toMatchObject({
+      elapsedMs: 6_050,
+      forced: true,
+      forceExitOutcome: "exited",
+    });
+  });
+
+  it("reports terminal, interrupted, and unobserved release phases", () => {
+    const summary = buildElectronShutdownSummary({
+      circuit: {
+        enabled: true,
+        consecutiveAbnormalCloses: 1,
+        limit: 2,
+        tripped: false,
+      },
+      classification: "force-killed",
+      events: [
+        phaseEvent("overall", "started", 0),
+        phaseEvent("renderer-window", "completed", 8),
+        phaseEvent("messaging", "started", 0),
+      ],
+      execution: {
+        elapsedMs: 6_100,
+        forceExitOutcome: "exited",
+        forced: true,
+        gracefulCloseOutcome: "timeout",
+        quitRequestOutcome: "rejected",
+      },
+      launchId: "launch-3",
+    });
+
+    expect(summary.phases).toEqual({
+      rendererWindow: { durationMs: 8, outcome: "completed" },
+      messaging: { durationMs: null, outcome: "interrupted" },
+      appServer: { durationMs: null, outcome: "not-observed" },
+      overall: { durationMs: null, outcome: "interrupted" },
+    });
+  });
+
+  it("raises a tripped circuit only after every cleanup step completes", async () => {
+    const order: string[] = [];
+    await expect(finalizeElectronFixtureTeardown({
+      closeApplication: async () => {
+        order.push("bounded-close");
+        return trippedSummary();
+      },
+      cleanupProfileProcesses: async () => {
+        order.push("profile-process-cleanup");
+      },
+      removeHomeRoot: async () => {
+        order.push("remove-home-root");
+      },
+    })).rejects.toThrow(ElectronShutdownCircuitOpenError);
+    expect(order).toEqual([
+      "bounded-close",
+      "profile-process-cleanup",
+      "remove-home-root",
+    ]);
+  });
+});
+
+function phaseEvent(
+  phase: "overall" | "renderer-window" | "messaging",
+  outcome: "started" | "completed",
+  durationMs: number,
+) {
+  return {
+    schemaVersion: 1 as const,
+    kind: "phase" as const,
+    launchId: "launch-3",
+    phase,
+    outcome,
+    durationMs,
+  };
+}
+
+function trippedSummary(): ElectronShutdownSummary {
+  const phase = { durationMs: null, outcome: "not-observed" as const };
+  return {
+    schemaVersion: 1,
+    kind: "close-summary",
+    launchId: "launch-4",
+    classification: "force-killed",
+    elapsedMs: 6_100,
+    quitRequestOutcome: "rejected",
+    gracefulCloseOutcome: "timeout",
+    forceExitOutcome: "exited",
+    phases: {
+      rendererWindow: phase,
+      messaging: phase,
+      appServer: phase,
+      overall: phase,
+    },
+    circuit: {
+      enabled: true,
+      consecutiveAbnormalCloses: 2,
+      limit: 2,
+      tripped: true,
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/shutdown-barrier.test.ts
+++ b/apps/desktop/src/main/__tests__/shutdown-barrier.test.ts
@@ -6,10 +6,15 @@ describe("createShutdownBarrier", () => {
     vi.useFakeTimers();
     try {
       const logger = { info: vi.fn(), warn: vi.fn() };
+      const observer = {
+        phaseStarted: vi.fn(),
+        phaseFinished: vi.fn(),
+      };
       const secondPhase = vi.fn(async () => undefined);
       const runShutdown = createShutdownBarrier({
         globalTimeoutMs: 100,
         logger,
+        observer,
         phases: [
           {
             name: "resistant",
@@ -41,6 +46,14 @@ describe("createShutdownBarrier", () => {
         "shutdown phase timed-out",
         expect.objectContaining({ phase: "resistant", timeoutMs: 40 }),
       );
+      expect(observer.phaseStarted.mock.calls).toEqual([
+        ["resistant"],
+        ["cleanup"],
+      ]);
+      expect(observer.phaseFinished.mock.calls).toEqual([
+        [expect.objectContaining({ name: "resistant", outcome: "timed-out" })],
+        [expect.objectContaining({ name: "cleanup", outcome: "completed" })],
+      ]);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/e2e-shutdown-diagnostics.ts
+++ b/apps/desktop/src/main/e2e-shutdown-diagnostics.ts
@@ -1,0 +1,219 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+export const E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_DIAGNOSTICS_FILE";
+export const E2E_SHUTDOWN_LAUNCH_ID_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_LAUNCH_ID";
+
+export const E2E_SHUTDOWN_PHASES = [
+  "overall",
+  "renderer-window",
+  "messaging",
+  "app-server",
+] as const;
+
+export type E2eShutdownPhase = (typeof E2E_SHUTDOWN_PHASES)[number];
+export type E2eShutdownPhaseOutcome =
+  | "started"
+  | "completed"
+  | "failed"
+  | "timed-out"
+  | "skipped";
+
+export type E2eShutdownPhaseEvent = {
+  schemaVersion: 1;
+  kind: "phase";
+  launchId: string;
+  phase: E2eShutdownPhase;
+  outcome: E2eShutdownPhaseOutcome;
+  durationMs: number;
+};
+
+type E2eShutdownDiagnosticsRecorder = {
+  beginOverall(): void;
+  beginPhase(phase: Exclude<E2eShutdownPhase, "overall">): void;
+  finishOverall(outcome: Exclude<E2eShutdownPhaseOutcome, "started">): void;
+  finishPhase(
+    phase: Exclude<E2eShutdownPhase, "overall">,
+    outcome: Exclude<E2eShutdownPhaseOutcome, "started">,
+    durationMs: number,
+  ): void;
+};
+
+type E2eShutdownDiagnosticsRecorderOptions = {
+  enabled: boolean;
+  filePath?: string;
+  launchId?: string;
+  now?: () => number;
+  writeLine?: (line: string) => void;
+};
+
+/**
+ * Record the E2E-only shutdown timeline without copying normal app logs into
+ * CI. Every persisted field is an allowlisted enum, opaque launch id, or
+ * elapsed millisecond count: no paths, usernames, commands, or error strings
+ * can cross this boundary.
+ */
+export function createE2eShutdownDiagnosticsRecorder(
+  options: E2eShutdownDiagnosticsRecorderOptions,
+): E2eShutdownDiagnosticsRecorder {
+  const now = options.now ?? performance.now.bind(performance);
+  const writeLine = options.writeLine
+    ?? createFileLineWriter(options.enabled ? options.filePath : undefined);
+  const launchId = normalizeLaunchId(options.launchId);
+  const enabled =
+    options.enabled
+    && launchId !== undefined
+    && writeLine !== undefined;
+  let overallStartedAt: number | undefined;
+
+  const write = (
+    phase: E2eShutdownPhase,
+    outcome: E2eShutdownPhaseOutcome,
+    durationMs: number,
+  ): void => {
+    if (!enabled || launchId === undefined || writeLine === undefined) {
+      return;
+    }
+    const event: E2eShutdownPhaseEvent = {
+      schemaVersion: 1,
+      kind: "phase",
+      launchId,
+      phase,
+      outcome,
+      durationMs: normalizeDuration(durationMs),
+    };
+    try {
+      writeLine(`${JSON.stringify(event)}\n`);
+    } catch {
+      // Diagnostics must never delay or block the shutdown they observe.
+    }
+  };
+
+  return {
+    beginOverall: () => {
+      if (overallStartedAt !== undefined) {
+        return;
+      }
+      overallStartedAt = now();
+      write("overall", "started", 0);
+    },
+    beginPhase: (phase) => {
+      write(phase, "started", 0);
+    },
+    finishOverall: (outcome) => {
+      const startedAt = overallStartedAt ?? now();
+      write("overall", outcome, now() - startedAt);
+    },
+    finishPhase: (phase, outcome, durationMs) => {
+      write(phase, outcome, durationMs);
+    },
+  };
+}
+
+export function readE2eShutdownPhaseEvents(
+  filePath: string | undefined,
+  launchId: string,
+): E2eShutdownPhaseEvent[] {
+  if (!filePath) {
+    return [];
+  }
+  let contents: string;
+  try {
+    contents = readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+  const events: E2eShutdownPhaseEvent[] = [];
+  for (const line of contents.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const event = parseE2eShutdownPhaseEvent(JSON.parse(line));
+      if (event?.launchId === launchId) {
+        events.push(event);
+      }
+    } catch {
+      // A force-kill can interrupt the final append. Earlier complete lines
+      // remain useful and identify the phase that was interrupted.
+    }
+  }
+  return events;
+}
+
+function createFileLineWriter(
+  filePath: string | undefined,
+): ((line: string) => void) | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  return (line) => {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    appendFileSync(filePath, line, "utf8");
+  };
+}
+
+function parseE2eShutdownPhaseEvent(
+  value: unknown,
+): E2eShutdownPhaseEvent | undefined {
+  if (!isRecord(value) || value.schemaVersion !== 1 || value.kind !== "phase") {
+    return undefined;
+  }
+  const launchId = normalizeLaunchId(value.launchId);
+  if (
+    launchId === undefined
+    || !isShutdownPhase(value.phase)
+    || !isShutdownPhaseOutcome(value.outcome)
+    || typeof value.durationMs !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    schemaVersion: 1,
+    kind: "phase",
+    launchId,
+    phase: value.phase,
+    outcome: value.outcome,
+    durationMs: normalizeDuration(value.durationMs),
+  };
+}
+
+function normalizeLaunchId(value: unknown): string | undefined {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function normalizeDuration(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value));
+}
+
+function isShutdownPhase(value: unknown): value is E2eShutdownPhase {
+  return typeof value === "string"
+    && E2E_SHUTDOWN_PHASES.includes(value as E2eShutdownPhase);
+}
+
+function isShutdownPhaseOutcome(
+  value: unknown,
+): value is E2eShutdownPhaseOutcome {
+  return value === "started"
+    || value === "completed"
+    || value === "failed"
+    || value === "timed-out"
+    || value === "skipped";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog, Menu, nativeImage, shell } from "electron";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
@@ -148,6 +149,12 @@ import {
   setUpdateInstallPreparationHandler,
 } from "./update-install-state";
 import { createShutdownBarrier } from "./shutdown-barrier";
+import {
+  createE2eShutdownDiagnosticsRecorder,
+  E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV,
+  E2E_SHUTDOWN_LAUNCH_ID_ENV,
+  type E2eShutdownPhase,
+} from "./e2e-shutdown-diagnostics";
 
 const APP_NAME = "PwrAgent";
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
@@ -161,6 +168,11 @@ const MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS = 12_000;
 const RENDERER_WINDOW_CLOSE_TIMEOUT_MS = 2_000;
 const MESSAGING_SHUTDOWN_TIMEOUT_MS = 4_000;
 const APP_SERVER_SHUTDOWN_TIMEOUT_MS = 7_500;
+const e2eShutdownDiagnostics = createE2eShutdownDiagnosticsRecorder({
+  enabled: process.env.PWRAGENT_E2E === "1" && !app.isPackaged,
+  filePath: process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV],
+  launchId: process.env[E2E_SHUTDOWN_LAUNCH_ID_ENV],
+});
 let mainProcessResourcesDisposed = false;
 let mainProcessShutdownComplete = false;
 let mainProcessShutdownPromise: Promise<void> | undefined;
@@ -424,6 +436,24 @@ function disposeMainProcessResourcesSync(): void {
 const runMainProcessShutdownBarrier = createShutdownBarrier({
   globalTimeoutMs: MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS,
   logger: mainLog,
+  observer: {
+    phaseStarted: (phase) => {
+      const diagnosticPhase = toE2eShutdownPhase(phase);
+      if (diagnosticPhase) {
+        e2eShutdownDiagnostics.beginPhase(diagnosticPhase);
+      }
+    },
+    phaseFinished: (outcome) => {
+      const diagnosticPhase = toE2eShutdownPhase(outcome.name);
+      if (diagnosticPhase) {
+        e2eShutdownDiagnostics.finishPhase(
+          diagnosticPhase,
+          outcome.outcome,
+          outcome.durationMs,
+        );
+      }
+    },
+  },
   phases: [
     {
       name: "messaging",
@@ -442,6 +472,9 @@ const runMainProcessShutdownBarrier = createShutdownBarrier({
 });
 
 async function closeRendererWindowsBeforeShutdown(): Promise<void> {
+  const startedAt = performance.now();
+  let timedOut = false;
+  e2eShutdownDiagnostics.beginPhase("renderer-window");
   const windows = BrowserWindow.getAllWindows().filter(
     (window) => !window.isDestroyed(),
   );
@@ -457,6 +490,7 @@ async function closeRendererWindowsBeforeShutdown(): Promise<void> {
             resolve();
           };
           const timeout = setTimeout(() => {
+            timedOut = true;
             mainLog.warn("renderer window close timed out; destroying", {
               windowId: window.id,
             });
@@ -492,20 +526,44 @@ async function closeRendererWindowsBeforeShutdown(): Promise<void> {
         }),
     ),
   );
+  e2eShutdownDiagnostics.finishPhase(
+    "renderer-window",
+    timedOut ? "timed-out" : "completed",
+    performance.now() - startedAt,
+  );
 }
 
 async function disposeMainProcessResources(source: string): Promise<void> {
   mainProcessShutdownPromise ??= (async () => {
-    // Renderer cleanup flushes debounced composer drafts over IPC. Keep every
-    // handler alive until all windows have closed, then tear down runtimes and
-    // finally remove the synchronous IPC surface.
-    await closeRendererWindowsBeforeShutdown();
-    await runMainProcessShutdownBarrier(source);
-    disposeMainProcessResourcesSync();
-    disposeAppState();
-    mainProcessShutdownComplete = true;
+    e2eShutdownDiagnostics.beginOverall();
+    try {
+      // Renderer cleanup flushes debounced composer drafts over IPC. Keep every
+      // handler alive until all windows have closed, then tear down runtimes and
+      // finally remove the synchronous IPC surface.
+      await closeRendererWindowsBeforeShutdown();
+      await runMainProcessShutdownBarrier(source);
+      disposeMainProcessResourcesSync();
+      disposeAppState();
+      mainProcessShutdownComplete = true;
+      e2eShutdownDiagnostics.finishOverall("completed");
+    } catch (error) {
+      e2eShutdownDiagnostics.finishOverall("failed");
+      throw error;
+    }
   })();
   await mainProcessShutdownPromise;
+}
+
+function toE2eShutdownPhase(
+  phase: string,
+): Exclude<E2eShutdownPhase, "overall" | "renderer-window"> | undefined {
+  switch (phase) {
+    case "messaging":
+    case "app-server":
+      return phase;
+    default:
+      return undefined;
+  }
 }
 
 async function prepareForUpdateInstallShutdown(): Promise<void> {

--- a/apps/desktop/src/main/shutdown-barrier.ts
+++ b/apps/desktop/src/main/shutdown-barrier.ts
@@ -22,11 +22,17 @@ export type ShutdownSummary = {
   outcomes: ShutdownPhaseOutcome[];
 };
 
+export type ShutdownBarrierObserver = {
+  phaseStarted?(phase: string): void;
+  phaseFinished?(outcome: ShutdownPhaseOutcome): void;
+};
+
 export function createShutdownBarrier(options: {
   phases: ShutdownPhase[];
   globalTimeoutMs: number;
   logger: ShutdownBarrierLogger;
   now?: () => number;
+  observer?: ShutdownBarrierObserver;
 }): (source: string) => Promise<ShutdownSummary> {
   let shutdownPromise: Promise<ShutdownSummary> | undefined;
   return (source) => {
@@ -40,6 +46,7 @@ async function runShutdownPhases(options: {
   globalTimeoutMs: number;
   logger: ShutdownBarrierLogger;
   now?: () => number;
+  observer?: ShutdownBarrierObserver;
   source: string;
 }): Promise<ShutdownSummary> {
   const now = options.now ?? Date.now;
@@ -60,6 +67,7 @@ async function runShutdownPhases(options: {
         durationMs: 0,
       };
       outcomes.push(outcome);
+      options.observer?.phaseFinished?.(outcome);
       options.logger.warn("shutdown phase skipped after global deadline", {
         source: options.source,
         phase: phase.name,
@@ -69,6 +77,7 @@ async function runShutdownPhases(options: {
 
     const phaseStartedAt = now();
     const timeoutMs = Math.min(phase.timeoutMs, remainingMs);
+    options.observer?.phaseStarted?.(phase.name);
     const result = await runPhase(phase.run, timeoutMs);
     const outcome: ShutdownPhaseOutcome = {
       name: phase.name,
@@ -77,6 +86,7 @@ async function runShutdownPhases(options: {
       ...(result.error ? { error: result.error } : {}),
     };
     outcomes.push(outcome);
+    options.observer?.phaseFinished?.(outcome);
     const detail = {
       source: options.source,
       phase: phase.name,


### PR DESCRIPTION
## Summary

Backport the fail-fast Electron shutdown circuit from source PR #1580 / squash `9d08a5d5c5aa0d860701b56afd4a0dc56fbeff7b` onto the current `releases/1.0` tip.

- emit an E2E-only, allowlisted JSONL shutdown timeline and one compact close summary per fixture
- classify closes at or above 4 seconds, or closes requiring process-tree force-kill, as abnormal
- tolerate one abnormal close and stop only the affected macOS shard after two consecutive abnormal closes
- preserve deterministic cleanup before surfacing the circuit-open failure
- replace the quit-lifecycle spec's raw log capture with a bounded fixed-marker watcher

## Source provenance correction

The handoff requested [PR #1850](https://github.com/pwrdrvr/PwrAgent/pull/1850), but that PR does not exist in this repository. The source thread and GitHub history confirmed that the number was transposed: the actual merged source is [PR #1580](https://github.com/pwrdrvr/PwrAgent/pull/1580), squash `9d08a5d5c5aa0d860701b56afd4a0dc56fbeff7b`.

The source PR has no conversation comments, inline review comments, or review submissions. Its four development commits and final squash diff were audited. No later main commit changes the shutdown circuit, reporter, diagnostics, Playwright configuration, shutdown barrier, or CI activation; the later #1586 edit to `electron-app.ts` adds unrelated thread-row locator helpers.

Requested source PR: https://github.com/pwrdrvr/PwrAgent/pull/1850  
Actual source PR: https://github.com/pwrdrvr/PwrAgent/pull/1580  
Source squash: `9d08a5d5c5aa0d860701b56afd4a0dc56fbeff7b`

## Release-branch adaptation

`releases/1.0` already contains the release-specific #1572 process-cleanup backport through PR #1579. Unlike current main, it does not have Federation, MCP shutdown phases, the E2E canary global setup, SQLite write-metrics teardown, or main's newer profile-resolution fixture architecture.

This port therefore:

- records only the shutdown phases that exist on 1.0: renderer window, messaging, app-server, and overall
- adds a narrow shutdown-only Playwright global setup to reset diagnostic/circuit files once per shard, while preserving the state across worker replacement and retries
- layers the bounded graceful-close / process-tree force-kill behavior directly onto 1.0's existing fixture and #1579 profile-process cleanup
- keeps the release branch's existing Playwright test inventory and does not import main's canary, write metrics, profile boot refactor, Federation tests, or unrelated E2E restructuring
- enables the circuit only in the existing macOS E2E run step

## CI graph, cancellation, and required checks

The release topology is preserved:

- Windows keeps `Setup Windows Dependencies` feeding `Windows verify`, `Windows desktop-main`, and `Windows renderer + packages`; label-gated packaging remains unchanged.
- Linux keeps two lanes with `strategy.fail-fast: false`, artifact upload on `!cancelled()`, and the required `Desktop E2E` aggregate using `if: always()` so a failed/cancelled Linux matrix cannot become a skipped required check.
- macOS keeps two lanes with `strategy.fail-fast: false`; a circuit trip sends SIGINT only to that Playwright shard, the custom reporter forces its final result to `failed`, the sibling shard continues, and `!cancelled()` artifact upload still runs.
- Job ids, display names, matrices, `needs`, fork guards, timeouts, and platform coverage are unchanged.

The active maintenance-branch ruleset requires `Lint`, `Build`, `Test`, and `Desktop E2E`. Those contexts remain unchanged. macOS lane conclusions remain separate visible checks, as on main; the circuit does not convert a real failure into `skipped` or `cancelled`.

## Migration and configuration audit

No database migration, schema migration, migration ordering dependency, TOML/configuration-shape change, package dependency, lockfile change, runtime profile change, or production feature is introduced. The only new environment variables are E2E harness controls and artifact paths, gated to unpackaged `PWRAGENT_E2E=1` launches.

## Validation

- `git diff --check` — passed
- Ruby Psych parse of `.github/workflows/ci.yml` — passed; no GitHub expression was added or changed
- focused shutdown/process unit suite — 7 files, 22 tests passed
- `pnpm --filter @pwragent/desktop typecheck` — passed
- `pnpm typecheck` — all 12 applicable workspace projects passed
- `pnpm lint:eslint` — 0 errors; 136 existing warnings
- explicit ESLint over changed E2E/config files — 0 errors; 2 existing `no-explicit-any` warnings in `codex-environment-setup.spec.ts`
- `pnpm lint:boundaries` — passed, 1,136 modules / 3,494 dependencies
- `pnpm --filter @pwragent/desktop build` — passed, including the main-bundle boundary check
- Playwright list with the CI circuit reporter enabled — 204 tests discovered in 66 release-branch files
- focused `e2e/app-quit-lifecycle.spec.ts` run — 3 passed; all emitted healthy structured shutdown summaries

No Prettier or auto-fix formatter was run.
