### PR TITLE
fix(desktop): remove ineffective PR client lazy imports

### DIFF
--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4927,6 +4927,8 @@ class DesktopAppServerService {
   private getPrGraphqlClient(): GithubGraphqlPrClient {
     if (!this.prGraphqlClient) {
       this.prGraphqlClient = new GithubGraphqlPrClient({
+        getConfiguredGhCommand: () =>
+          getDesktopSettingsService().resolveGhCommandPreference(),
         onAuthenticationFailure: (event) => {
           if (this.githubPrAuthenticationFailureNotified) {
             return;

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -4,6 +4,7 @@ import { graphql } from "@octokit/graphql";
 import type { PrSummary } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
+import { discoverGhCommands } from "../settings/gh-discovery";
 import {
   deriveChipStateFromRollup,
   deriveLifecycleState,
@@ -633,6 +634,8 @@ export type GithubGraphqlPrClientOptions = {
   ) => Promise<unknown>;
   /** Override token acquisition — tests inject a fixed token. */
   getToken?: () => Promise<string | null>;
+  /** Read the desktop's configured gh command without coupling this module to Electron. */
+  getConfiguredGhCommand?: () => string | undefined;
   /** Override the retry sleep — tests make backoff instant. */
   sleep?: (ms: number) => Promise<void>;
   batchSize?: number;
@@ -655,6 +658,9 @@ export type GithubAuthenticationFailureEvent = {
 export class GithubGraphqlPrClient {
   private readonly requestOverride: GithubGraphqlPrClientOptions["request"];
   private readonly getTokenOverride: GithubGraphqlPrClientOptions["getToken"];
+  private readonly getConfiguredGhCommand:
+    | NonNullable<GithubGraphqlPrClientOptions["getConfiguredGhCommand"]>
+    | undefined;
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly batchSize: number;
   private readonly onRepositoryAccess:
@@ -668,6 +674,7 @@ export class GithubGraphqlPrClient {
   constructor(options: GithubGraphqlPrClientOptions = {}) {
     this.requestOverride = options.request;
     this.getTokenOverride = options.getToken;
+    this.getConfiguredGhCommand = options.getConfiguredGhCommand;
     this.sleep =
       options.sleep
       ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
@@ -1107,17 +1114,8 @@ export class GithubGraphqlPrClient {
     }
 
     try {
-      // Imported lazily: gh discovery reaches the desktop settings singleton,
-      // which pulls Electron-only packages into the module graph. Keeping it
-      // out of the top-level imports means this client can be exercised (and
-      // unit-tested) as a plain Node module.
-      const [{ discoverGhCommands }, { getDesktopSettingsService }] =
-        await Promise.all([
-          import("../settings/gh-discovery"),
-          import("../settings/desktop-settings-singleton"),
-        ]);
       const discovery = await discoverGhCommands({
-        configuredCommand: getDesktopSettingsService().resolveGhCommandPreference(),
+        configuredCommand: this.getConfiguredGhCommand?.(),
         env: buildPwrAgentChildProcessEnv(process.env),
       });
       const command = discovery.selectedCommand;

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -134,7 +134,12 @@ export class GithubPrFetcher {
   >();
 
   constructor(options: GithubPrFetcherOptions = {}) {
-    this.graphqlClient = options.graphqlClient ?? new GithubGraphqlPrClient();
+    this.graphqlClient =
+      options.graphqlClient
+      ?? new GithubGraphqlPrClient({
+        getConfiguredGhCommand: () =>
+          getDesktopSettingsService().resolveGhCommandPreference(),
+      });
     this.resolveGitHubRepos =
       options.resolveGitHubRepos ?? resolveGitHubReposForDirectory;
     this.probeGhAvailable = options.probeGhAvailable;


### PR DESCRIPTION
## Summary

- statically import the Node-safe `gh` discovery module in the GitHub GraphQL client
- inject the desktop-configured `gh` command from Electron composition points
- remove the two dynamic imports that Vite could not split into separate chunks

## Why

The GraphQL client dynamically imported both `gh-discovery.ts` and the Electron-bound desktop settings singleton. Both modules were already statically imported elsewhere in the main-process graph, so Vite kept them in the main chunk and emitted mixed dynamic/static import warnings on every build.

The client still remains usable as a plain Node module: only the configured command reader is injected from desktop code, so the Electron settings singleton does not enter the client's top-level dependency graph.

## Impact

Production behavior is unchanged, including honoring the operator's configured GitHub CLI path. Desktop builds no longer emit the two GitHub PR client chunking warnings.

A separate pre-existing warning for `scheduled-thread-action-service.ts` remains out of scope.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/github-graphql-client.test.ts apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts` (100 tests)
- `pnpm --filter @pwragent/desktop build`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
