### PR TITLE
fix(desktop): reconcile orphaned sub-agents

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -16605,6 +16605,7 @@ command = "pnpm dev"
         status: "running",
         backend: "codex",
         agentName: "PwrAgent",
+        ownerRuntimeInstanceId: expect.any(String),
         preferredModel: "gpt-5.6-luna",
         preferredReasoningEffort: "low",
         lastMessage: "Generating a title.",
@@ -16871,6 +16872,75 @@ command = "pnpm dev"
       }),
     });
 
+    await registry.close();
+  });
+
+  it("starts a fresh title-helper duration after an earlier attempt is terminal", async () => {
+    const monitorId = "system:title-helper:codex:thread-title-helper-parent";
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-title-helper-parent": {
+          backend: "codex",
+          threadId: "thread-title-helper-parent",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId,
+              task: "Name this thread",
+              status: "failure",
+              createdAt: 1_000,
+              updatedAt: 2_000,
+              completedAt: 2_000,
+              outcome: "failure",
+              ownerRuntimeInstanceId: "runtime-old",
+              completionSource: {
+                type: "pwragent_fallback",
+                reason: "system_title_helper",
+                recoveryAttempted: false,
+                terminalStatus: "failed",
+              },
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
+    });
+
+    await (registry as unknown as {
+      persistTitleHelperSubAgent(params: {
+        backend: "codex";
+        threadId: string;
+        status: "running";
+      }): Promise<void>;
+    }).persistTitleHelperSubAgent({
+      backend: "codex",
+      threadId: "thread-title-helper-parent",
+      status: "running",
+    });
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-title-helper-parent",
+    });
+    const subAgent = overlay?.subAgents?.find(
+      (candidate) => candidate.monitorId === monitorId,
+    );
+    expect(subAgent).toMatchObject({
+      status: "running",
+      ownerRuntimeInstanceId: "runtime-current",
+      lastMessage: "Generating a title.",
+    });
+    expect(subAgent?.createdAt).toBeGreaterThan(2_000);
+    expect(subAgent?.updatedAt).toBe(subAgent?.createdAt);
+    expect(subAgent?.completedAt).toBeUndefined();
+    expect(subAgent?.outcome).toBeUndefined();
+    expect(subAgent?.completionSource).toBeUndefined();
     await registry.close();
   });
 
@@ -34719,6 +34789,37 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("reconciles orphaned sub-agents before serving threads after startup", async () => {
+    const reconcileOrphanedThreadSubAgents = vi.fn(async () => ({
+      repairedSubAgents: 0,
+      repairedThreads: 0,
+      skippedLiveOwners: 1,
+      skippedOwnerlessWithOtherRuntimes: 1,
+    }));
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      reconcileOrphanedThreadSubAgents,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => [
+        "runtime-current",
+        "runtime-other",
+      ],
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+    expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledOnce();
+    expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledWith({
+      currentRuntimeInstanceId: "runtime-current",
+      liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
+      sessionStartedAt: expect.any(Number),
+    });
+    await registry.close();
+  });
+
   it("stops active task monitors without starting recovery", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "turn/interrupt"] },
@@ -34729,6 +34830,8 @@ script = "printf setup"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
     });
     await registry.publishLocalEvent({
       backend: "codex",
@@ -34797,6 +34900,7 @@ script = "printf setup"
           status: "cancelled",
           outcome: "cancelled",
           lastMessage: "Stopped by user.",
+          ownerRuntimeInstanceId: "runtime-current",
         }),
       ],
     });
@@ -34960,6 +35064,7 @@ script = "printf setup"
               status: "running",
               createdAt: 1,
               updatedAt: 1,
+              ownerRuntimeInstanceId: "runtime-current",
               backend: "codex",
               monitorThreadId: "child-thread",
               monitorTurnId: "parent-turn",
@@ -34971,6 +35076,8 @@ script = "printf setup"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
     });
 
     await registry.stopSubAgent({
@@ -34999,6 +35106,121 @@ script = "printf setup"
         }),
       ],
     });
+    await registry.close();
+  });
+
+  it("locally closes an orphaned sub-agent when Stop cannot reach its old runtime", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/interrupt"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "monitor-orphaned",
+              task: "Monitor work from before a reboot",
+              status: "running",
+              createdAt: 1_000,
+              updatedAt: 1_500,
+              ownerRuntimeInstanceId: "runtime-dead",
+              backend: "codex",
+              monitorThreadId: "monitor-thread",
+              monitorTurnId: "monitor-turn",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
+    });
+
+    await expect(registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-orphaned",
+    })).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-orphaned",
+    });
+
+    expect(codexClient.interruptTurnCallCount).toBe(0);
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "monitor-orphaned",
+          status: "cancelled",
+          outcome: "cancelled",
+          completedAt: 1_500,
+          updatedAt: 1_500,
+          lastMessage:
+            "Stop was requested after its owning PwrAgent runtime had already stopped.",
+          completionSource: {
+            type: "parent_cancel",
+          },
+        }),
+      ],
+    });
+    await registry.close();
+  });
+
+  it("does not stop a sub-agent owned by another live PwrAgent instance", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/interrupt"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "monitor-other-runtime",
+              task: "Monitor work owned elsewhere",
+              status: "running",
+              createdAt: 1_000,
+              updatedAt: 1_500,
+              ownerRuntimeInstanceId: "runtime-other",
+              backend: "codex",
+              monitorThreadId: "monitor-thread",
+              monitorTurnId: "monitor-turn",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => [
+        "runtime-current",
+        "runtime-other",
+      ],
+    });
+
+    await expect(registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-other-runtime",
+    })).rejects.toThrow(
+      "Sub-agent is controlled by another live PwrAgent instance.",
+    );
+    expect(codexClient.interruptTurnCallCount).toBe(0);
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
@@ -399,3 +399,150 @@ describe("SqliteOverlayStore — thread reactions", () => {
     expect(overlay?.reactions).toEqual(["👀", "✅"]);
   });
 });
+
+describe("SqliteOverlayStore — orphaned sub-agents", () => {
+  async function seedSubAgent(
+    threadId: string,
+    subAgent: ThreadSubAgentSummary,
+  ): Promise<void> {
+    await store.upsertThreadSubAgent({
+      backend: "codex",
+      threadId,
+      subAgent,
+    });
+  }
+
+  it("repairs dead owners without touching another live instance or ambiguous legacy work", async () => {
+    await seedSubAgent("dead-owner", {
+      monitorId: "monitor-dead-owner",
+      task: "Owned by a stopped runtime",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-dead",
+    });
+    await seedSubAgent("live-owner", {
+      monitorId: "monitor-live-owner",
+      task: "Owned by another live runtime",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-other",
+    });
+    await seedSubAgent("legacy-ownerless", {
+      monitorId: "monitor-legacy",
+      task: "Legacy work with no owner metadata",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+    });
+    await seedSubAgent("terminal-missing-time", {
+      monitorId: "monitor-terminal",
+      task: "Terminal work missing its stop time",
+      status: "success",
+      createdAt: 1_000,
+      updatedAt: 1_600,
+      outcome: "success",
+      ownerRuntimeInstanceId: "runtime-dead",
+    });
+
+    await expect(store.reconcileOrphanedThreadSubAgents({
+      currentRuntimeInstanceId: "runtime-current",
+      liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
+      sessionStartedAt: 2_000,
+    })).resolves.toEqual({
+      repairedSubAgents: 2,
+      repairedThreads: 2,
+      skippedLiveOwners: 1,
+      skippedOwnerlessWithOtherRuntimes: 1,
+    });
+
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "dead-owner",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "monitor-dead-owner",
+          status: "failure",
+          outcome: "failure",
+          completedAt: 1_500,
+          updatedAt: 1_500,
+          completionSource: expect.objectContaining({
+            type: "pwragent_fallback",
+            reason: "owner_runtime_stopped",
+          }),
+        }),
+      ],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "live-owner",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "legacy-ownerless",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "terminal-missing-time",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          status: "success",
+          outcome: "success",
+          completedAt: 1_600,
+        }),
+      ],
+    });
+  });
+
+  it("repairs old ownerless work only when this is the sole runtime", async () => {
+    await seedSubAgent("thread-1", {
+      monitorId: "monitor-old",
+      task: "Legacy work from before startup",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 900,
+    });
+    await seedSubAgent("thread-1", {
+      monitorId: "monitor-new",
+      task: "Work created during this runtime",
+      status: "running",
+      createdAt: 2_100,
+      updatedAt: 2_100,
+    });
+
+    await expect(store.reconcileOrphanedThreadSubAgents({
+      currentRuntimeInstanceId: "runtime-current",
+      liveRuntimeInstanceIds: ["runtime-current"],
+      sessionStartedAt: 2_000,
+    })).resolves.toMatchObject({
+      repairedSubAgents: 1,
+      repairedThreads: 1,
+    });
+
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const oldSubAgent = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === "monitor-old",
+    );
+    const newSubAgent = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === "monitor-new",
+    );
+    expect(oldSubAgent).toMatchObject({
+      status: "failure",
+      outcome: "failure",
+      completedAt: 1_000,
+      updatedAt: 1_000,
+    });
+    expect(newSubAgent).toMatchObject({ status: "running" });
+    expect(newSubAgent?.completedAt).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -23,6 +23,11 @@ import type {
 import { formatReviewCommand } from "../../shared/review-command";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import {
+  findLiveProfileRuntimeMarkers,
+  getProcessRuntimeIdentity,
+  resolveActiveProfileName,
+} from "../profile";
+import {
   getAppStateDb,
   getAppStateMode,
   isAppStateInitialized,
@@ -3188,6 +3193,15 @@ function codexNativeSubAgentIsTerminal(status: ThreadSubAgentSummary["status"]):
   return status === "success" || status === "failure" || status === "cancelled";
 }
 
+function reliableSubAgentCompletionBoundary(
+  subAgent: ThreadSubAgentSummary,
+): number {
+  return Number.isFinite(subAgent.updatedAt)
+    && subAgent.updatedAt >= subAgent.createdAt
+    ? subAgent.updatedAt
+    : subAgent.createdAt;
+}
+
 function codexNativeSubAgentNextReconciliationDelayMs(attempts: number): number {
   if (attempts <= 1) {
     return 15_000;
@@ -6322,6 +6336,7 @@ type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
     SqliteOverlayStore,
     | "readThreadGitWorkingStateCache"
     | "listRemoteThreadPins"
+    | "reconcileOrphanedThreadSubAgents"
     | "upsertThreadUsageLines"
     | "writeThreadGitWorkingStateCacheEntry"
   >
@@ -6619,6 +6634,9 @@ export class DesktopBackendRegistry {
     TaskMonitorDelegationRecord
   >();
   private readonly taskMonitorWatchdogTimer?: NodeJS.Timeout;
+  private readonly runtimeInstanceId: string;
+  private readonly resolveLiveProfileRuntimeInstanceIdsFn: () => string[];
+  private readonly subAgentStartupReconciliation: Promise<void>;
   /**
    * Streamed command-output accounting waiting to be written, keyed by
    * invocation id. Deltas fold together here instead of each one paying a
@@ -6871,10 +6889,21 @@ export class DesktopBackendRegistry {
     >;
     resolveCodexFastAllowed?: () => boolean;
     resolvePdfAnalysisEnabled?: () => boolean;
+    runtimeInstanceId?: string;
+    resolveLiveProfileRuntimeInstanceIds?: () => string[];
     acpWorktreeRepositoryResolver?: (
       cwd: string,
     ) => Promise<LinkedDirectorySummary | undefined>;
   }) {
+    const processRuntimeIdentity = getProcessRuntimeIdentity();
+    this.runtimeInstanceId =
+      options?.runtimeInstanceId ?? processRuntimeIdentity.instanceId;
+    this.resolveLiveProfileRuntimeInstanceIdsFn =
+      options?.resolveLiveProfileRuntimeInstanceIds ??
+      (() =>
+        findLiveProfileRuntimeMarkers(resolveActiveProfileName()).map(
+          (marker) => marker.instanceId,
+        ));
     this.mcpConnectionService =
       options?.mcpConnectionService === null
         ? undefined
@@ -7238,6 +7267,13 @@ export class DesktopBackendRegistry {
 
     this.subscribeClient("codex", this.codexClient);
 
+    this.subAgentStartupReconciliation =
+      this.reconcileOrphanedThreadSubAgentsAtStartup().catch((error) => {
+        backendRegistryLog.warn("sub-agent-startup-reconciliation-failed", {
+          message: error instanceof Error ? error.message : String(error),
+        });
+      });
+
     // Kick off a one-shot scan of persisted codexEnvironmentRuntime
     // entries: zombie "started" runs from a prior session become
     // "failed", and output bytes get cleared on anything finished
@@ -7270,6 +7306,44 @@ export class DesktopBackendRegistry {
    * process didn't survive the parent restart.
    */
   private readonly registrySessionStartedAt = Date.now();
+
+  private liveProfileRuntimeInstanceIds(): string[] | undefined {
+    const instanceIds = new Set<string>([this.runtimeInstanceId]);
+    try {
+      for (const instanceId of this.resolveLiveProfileRuntimeInstanceIdsFn()) {
+        const normalized = instanceId.trim();
+        if (normalized) {
+          instanceIds.add(normalized);
+        }
+      }
+    } catch (error) {
+      backendRegistryLog.warn("live-profile-runtime-read-failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+    return Array.from(instanceIds);
+  }
+
+  private async reconcileOrphanedThreadSubAgentsAtStartup(): Promise<void> {
+    const reconcile = this.overlayStore.reconcileOrphanedThreadSubAgents;
+    if (!reconcile) {
+      return;
+    }
+    const liveRuntimeInstanceIds = this.liveProfileRuntimeInstanceIds();
+    if (!liveRuntimeInstanceIds) {
+      return;
+    }
+    const result = await reconcile.call(this.overlayStore, {
+      currentRuntimeInstanceId: this.runtimeInstanceId,
+      liveRuntimeInstanceIds,
+      sessionStartedAt: this.registrySessionStartedAt,
+    });
+    if (result.repairedSubAgents > 0) {
+      backendRegistryLog.info("sub-agent-startup-reconciliation", result);
+      this.invalidateThreadListCache();
+    }
+  }
 
   private async cleanupStaleCodexEnvironmentRuntimes(): Promise<void> {
     const lister = this.overlayStore.listThreadOverlaysWithCodexEnvironmentRuntime;
@@ -7857,6 +7931,7 @@ export class DesktopBackendRegistry {
     maxPages?: number;
     skipArchivedMetadataRefresh?: boolean;
   } = {}): Promise<AppServerThreadSummary[]> {
+    await this.subAgentStartupReconciliation;
     // Hard gate: the bootstrap profile MUST NEVER serve thread data,
     // regardless of what the bootstrap config.toml's onboarding
     // flags say. Concretely this guards the post-wizard dev window:
@@ -13681,6 +13756,7 @@ export class DesktopBackendRegistry {
   async stopSubAgent(
     params: StopSubAgentRequest,
   ): Promise<StopSubAgentResponse> {
+    await this.subAgentStartupReconciliation;
     const overlay = await this.overlayStore.getThreadOverlayState({
       backend: params.backend,
       threadId: params.threadId,
@@ -13728,6 +13804,78 @@ export class DesktopBackendRegistry {
         outcome: "cancelled",
         status: "cancelled",
         updatedAt: stoppedAt,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        monitorId: params.monitorId,
+        stoppedAt,
+      };
+    }
+
+    const ownerRuntimeInstanceId = subAgent.ownerRuntimeInstanceId?.trim();
+    const resolvedLiveRuntimeInstanceIds =
+      this.liveProfileRuntimeInstanceIds();
+    if (!resolvedLiveRuntimeInstanceIds) {
+      throw new Error(
+        "PwrAgent could not determine which runtime owns this sub-agent. Try again after checking the other PwrAgent instances using this profile.",
+      );
+    }
+    const liveRuntimeInstanceIds = new Set(resolvedLiveRuntimeInstanceIds);
+    const hasOtherLiveRuntime = Array.from(liveRuntimeInstanceIds).some(
+      (instanceId) => instanceId !== this.runtimeInstanceId,
+    );
+    if (
+      ownerRuntimeInstanceId
+      && ownerRuntimeInstanceId !== this.runtimeInstanceId
+      && liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+    ) {
+      throw new Error(
+        "Sub-agent is controlled by another live PwrAgent instance.",
+      );
+    }
+    if (!ownerRuntimeInstanceId && hasOtherLiveRuntime) {
+      throw new Error(
+        "Sub-agent predates runtime ownership tracking, and another PwrAgent instance is live. Close the other instance and try again.",
+      );
+    }
+    const ownerIsOrphaned = ownerRuntimeInstanceId
+      ? !liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+      : true;
+    if (ownerIsOrphaned) {
+      const stoppedAt = Date.now();
+      const completedAt = reliableSubAgentCompletionBoundary(subAgent);
+      await this.overlayStore.upsertThreadSubAgent({
+        backend: params.backend,
+        threadId: params.threadId,
+        subAgent: {
+          ...subAgent,
+          status: "cancelled",
+          outcome: "cancelled",
+          completedAt,
+          updatedAt: completedAt,
+          lastMessage:
+            "Stop was requested after its owning PwrAgent runtime had already stopped.",
+          completionSource: {
+            type: "parent_cancel",
+          },
+        },
+      });
+      if (
+        subAgent.monitorId.startsWith("codex-native:")
+        && subAgent.monitorThreadId
+      ) {
+        this.clearCodexNativeSubAgentReconciliation(subAgent.monitorThreadId);
+      }
+      this.invalidateThreadListCache(params.backend);
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/subAgents/updated",
+          params: {
+            threadId: params.threadId,
+          },
+        },
       });
       return {
         backend: params.backend,
@@ -20689,6 +20837,8 @@ export class DesktopBackendRegistry {
       status,
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
+      ownerRuntimeInstanceId:
+        existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: "codex",
       monitorThreadId: params.receiverThreadId,
       ...(params.call.parentTurnId
@@ -20983,6 +21133,8 @@ export class DesktopBackendRegistry {
         (record.monitorThreadId ? "running" : "pending"),
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      ownerRuntimeInstanceId:
+        existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: record.backend,
       preferredModel: record.preferredModel,
       preferredReasoningEffort: record.preferredReasoningEffort,
@@ -21055,6 +21207,8 @@ export class DesktopBackendRegistry {
       status: patch.status ?? existing?.status ?? "running",
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      ownerRuntimeInstanceId:
+        existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: record.backend,
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
@@ -22786,6 +22940,16 @@ export class DesktopBackendRegistry {
       params.status === "success" ||
       params.status === "failed" ||
       params.status === "cancelled";
+    const startsNewAttempt =
+      (params.status === "pending" || params.status === "running")
+      && existing !== undefined
+      && (
+        existing.completedAt !== undefined
+        || existing.outcome !== undefined
+        || existing.completionSource !== undefined
+        || codexNativeSubAgentIsTerminal(existing.status)
+        || existing.status === "failed"
+      );
     const outcome =
       params.status === "success"
         ? "success"
@@ -22798,8 +22962,11 @@ export class DesktopBackendRegistry {
       monitorId,
       task: "Name this thread",
       status: params.status,
-      createdAt: existing?.createdAt ?? now,
+      createdAt: startsNewAttempt ? now : existing?.createdAt ?? now,
       updatedAt: now,
+      ownerRuntimeInstanceId: startsNewAttempt
+        ? this.runtimeInstanceId
+        : existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: params.backend,
       agentName: "PwrAgent",
       ...(preferredModel ? { preferredModel } : {}),

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -526,6 +526,130 @@ function stripFederationStamp(
 export class SqliteOverlayStore implements RemoteThreadTargetStore {
   constructor(private readonly stateDb: StateDb) {}
 
+  /**
+   * Finalize sub-agents whose creating PwrAgent runtime no longer exists.
+   *
+   * Every repair is committed in one transaction. New summaries identify
+   * their owner exactly. Legacy ownerless summaries are repaired only when
+   * this is the profile's sole live runtime, so opening a second PwrAgent
+   * window can never fail work still owned by the first one.
+   */
+  async reconcileOrphanedThreadSubAgents(params: {
+    currentRuntimeInstanceId: string;
+    liveRuntimeInstanceIds: string[];
+    sessionStartedAt: number;
+  }): Promise<{
+    repairedSubAgents: number;
+    repairedThreads: number;
+    skippedLiveOwners: number;
+    skippedOwnerlessWithOtherRuntimes: number;
+  }> {
+    const liveRuntimeInstanceIds = new Set(params.liveRuntimeInstanceIds);
+    liveRuntimeInstanceIds.add(params.currentRuntimeInstanceId);
+    const hasOtherLiveRuntime = Array.from(liveRuntimeInstanceIds).some(
+      (instanceId) => instanceId !== params.currentRuntimeInstanceId,
+    );
+    const result = {
+      repairedSubAgents: 0,
+      repairedThreads: 0,
+      skippedLiveOwners: 0,
+      skippedOwnerlessWithOtherRuntimes: 0,
+    };
+
+    const reconcile = this.stateDb.raw.transaction(() => {
+      const rows = this.stateDb.raw
+        .prepare(
+          `SELECT payload
+           FROM threads
+           WHERE payload LIKE '%"subAgents"%'`,
+        )
+        .all() as Array<{ payload: string }>;
+
+      for (const row of rows) {
+        let overlay: ThreadOverlayState;
+        try {
+          overlay = normalizeThreadOverlayState(
+            JSON.parse(row.payload) as ThreadOverlayState,
+          );
+        } catch {
+          continue;
+        }
+        if (!overlay.subAgents?.length) {
+          continue;
+        }
+
+        let changed = false;
+        const subAgents = overlay.subAgents.map((subAgent) => {
+          if (subAgent.completedAt !== undefined) {
+            return subAgent;
+          }
+
+          const completedAt = reliableSubAgentCompletionBoundary(subAgent);
+          if (subAgentHasTerminalEvidence(subAgent)) {
+            changed = true;
+            result.repairedSubAgents += 1;
+            return {
+              ...subAgent,
+              completedAt,
+              updatedAt: completedAt,
+              ...(subAgent.status === "failed"
+                ? { status: "failure" as const, outcome: "failure" as const }
+                : {}),
+            };
+          }
+
+          const ownerRuntimeInstanceId = subAgent.ownerRuntimeInstanceId?.trim();
+          if (
+            ownerRuntimeInstanceId
+            && liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+          ) {
+            result.skippedLiveOwners += 1;
+            return subAgent;
+          }
+          if (!ownerRuntimeInstanceId && hasOtherLiveRuntime) {
+            result.skippedOwnerlessWithOtherRuntimes += 1;
+            return subAgent;
+          }
+          if (
+            !ownerRuntimeInstanceId
+            && subAgent.createdAt >= params.sessionStartedAt
+          ) {
+            return subAgent;
+          }
+
+          changed = true;
+          result.repairedSubAgents += 1;
+          return {
+            ...subAgent,
+            status: "failure" as const,
+            outcome: "failure" as const,
+            completedAt,
+            updatedAt: completedAt,
+            lastMessage:
+              "Interrupted when its owning PwrAgent runtime stopped before reporting completion.",
+            completionSource: {
+              type: "pwragent_fallback" as const,
+              reason: "owner_runtime_stopped",
+              recoveryAttempted: false,
+              terminalStatus: "failed" as const,
+            },
+          };
+        });
+        if (!changed) {
+          continue;
+        }
+
+        result.repairedThreads += 1;
+        this.putThread(buildThreadIdentityKey(overlay.backend, overlay.threadId), {
+          ...overlay,
+          subAgents,
+        });
+      }
+    });
+    reconcile();
+    return result;
+  }
+
   async reconcileNavigationSnapshot(params: {
     backend: AppServerBackendScope;
     fetchedAt: number;
@@ -6579,3 +6703,23 @@ export type OverlayStoreLike = Pick<
   upsertThreadMessageOrigin?: SqliteOverlayStore["upsertThreadMessageOrigin"];
   readThreadMessageOrigins?: SqliteOverlayStore["readThreadMessageOrigins"];
 };
+
+function reliableSubAgentCompletionBoundary(
+  subAgent: ThreadSubAgentSummary,
+): number {
+  return Number.isFinite(subAgent.updatedAt)
+    && subAgent.updatedAt >= subAgent.createdAt
+    ? subAgent.updatedAt
+    : subAgent.createdAt;
+}
+
+function subAgentHasTerminalEvidence(subAgent: ThreadSubAgentSummary): boolean {
+  return (
+    subAgent.status === "success"
+    || subAgent.status === "failure"
+    || subAgent.status === "cancelled"
+    || subAgent.status === "failed"
+    || subAgent.outcome !== undefined
+    || subAgent.completionSource !== undefined
+  );
+}

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -255,6 +255,15 @@ export type ThreadSubAgentSummary = {
   status: ThreadSubAgentStatus;
   createdAt: number;
   updatedAt: number;
+  /**
+   * PwrAgent process-runtime UUID that created this sub-agent attempt.
+   *
+   * This lives in the existing thread-overlay JSON rather than its own sqlite
+   * column. A replacement process can therefore distinguish its own work from
+   * work still owned by another live PwrAgent instance sharing the profile.
+   * Older summaries omit it and use the conservative sole-runtime fallback.
+   */
+  ownerRuntimeInstanceId?: string;
   backend?: AppServerBackendKind;
   agentName?: string;
   preferredModel?: string;


### PR DESCRIPTION
## Summary

- I persist the creating PwrAgent runtime UUID in the existing sub-agent overlay JSON.
- I reconcile unfinished sub-agents before serving threads after startup, failing only work whose owner is demonstrably gone.
- I make Stop close orphaned work locally while preserving work owned by another live PwrAgent instance.
- I reset deterministic title-helper start times for new attempts so completed cards do not report multi-day durations.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` (527 tests passed).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` (no errors; 35 existing warnings).
- I ran `pnpm lint:sql`, `pnpm lint:boundaries`, and `pnpm lint:codex-storage`.

## Notes

- The root cause was that sub-agent cards were durable while task-monitor ownership and watchdog state were process-local, so a reboot left a durable `running` card that a fresh harness could neither observe nor stop.
- This does not require a database migration. Ownership uses the existing overlay JSON.
- Legacy ownerless work is repaired only when this is the sole live runtime for the profile. If liveness cannot be determined, reconciliation leaves the record untouched.
- Startup repairs are batched into one SQLite transaction and add no recurring or idle writes.
