### PR TITLE
fix(desktop): keep the in-title unpin pin clear of the hover cluster

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -986,11 +986,14 @@ export function threadRowCard(
  *
  * Do NOT right-click the open-thread button for this: on a PINNED row
  * the in-title unpin button can sit exactly at the open button's
- * center-x (it depends on title width), and since it is a SIBLING of
- * the open button, Playwright's hit-target check reports "subtree
- * intercepts pointer events" and times out — while the real app is
- * fine, because contextmenu bubbles from any row element to the
- * shell's onContextMenu. Clicking the CARD instead always passes the
+ * center-x — it depends on title width, AND on hover state: the
+ * `--pinned` heading reserve re-truncates a long title the moment the
+ * approach hover lands, shifting the pin left of where rest-state
+ * geometry puts it. Since the pin is a SIBLING of the open button,
+ * Playwright's hit-target check reports "subtree intercepts pointer
+ * events" and times out — while the real app is fine, because
+ * contextmenu bubbles from any row element to the shell's
+ * onContextMenu. Clicking the CARD instead always passes the
  * hit-target check (everything at the point is a card descendant).
  * The fixed position keeps the point in the title band, above the chip
  * flow, so a PR chip's own context menu can never swallow it.

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -146,6 +146,15 @@ export function ThreadRow(props: ThreadRowProps) {
     && props.thread.federation.peerStatus !== "connected",
   );
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
+  // One expression for "this row carries the in-title pin": the row's
+  // `--pinned` modifier class, the ", pinned" accessible-name suffix,
+  // and the in-title pin render all derive from it, so the CSS class
+  // can never disagree with the control it stands for. The modifier
+  // exists so the hover-reserve rule in app.css matches a plain class
+  // instead of a per-hover `:has()` subtree scan (same optimization the
+  // DirectoriesList header modifiers document).
+  const isPinnedRow =
+    Boolean(props.thread.pinnedRank) && !props.thread.parentThreadId;
   const [pickerOpen, setPickerOpen] = useState(false);
   const rowRef = useRef<HTMLDivElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);
@@ -287,10 +296,10 @@ export function ThreadRow(props: ThreadRowProps) {
       <div
         ref={rowRef}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
-          selected ? " is-selected" : ""
-        }${isComposerSource ? " is-composer-source" : ""}${
-          isRemoteOffline ? " is-remote-offline" : ""
-        }`}
+          isPinnedRow ? " thread-row--pinned" : ""
+        }${selected ? " is-selected" : ""}${
+          isComposerSource ? " is-composer-source" : ""
+        }${isRemoteOffline ? " is-remote-offline" : ""}`}
         // The open-thread BUTTON's rect is only the title band (see
         // `.thread-row__open` in app.css for why a card-sized button
         // rect broke axe target-size and Playwright row clicks). The
@@ -328,9 +337,7 @@ export function ThreadRow(props: ThreadRowProps) {
           // (same pattern as the chip flow) so the in-title pin can be a
           // real unpin button without nesting a control inside this one.
           aria-label={
-            props.thread.pinnedRank && !props.thread.parentThreadId
-              ? `${props.thread.title}, pinned`
-              : props.thread.title
+            isPinnedRow ? `${props.thread.title}, pinned` : props.thread.title
           }
           aria-pressed={selected}
           className="thread-row__open"
@@ -373,7 +380,7 @@ export function ThreadRow(props: ThreadRowProps) {
           <span className="thread-row__heading">
             <ThreadRowStatus status={status} />
             <span className="thread-row__title">{props.thread.title}</span>
-            {props.thread.pinnedRank && !props.thread.parentThreadId ? (
+            {isPinnedRow ? (
               onSetThreadPin ? (
                 <button
                   aria-label="Unpin thread"

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -216,6 +216,29 @@ describe("Tangerine Terminal theme contract", () => {
       /width:\s*24px;[\s\S]*height:\s*24px;/,
     );
 
+    // A 24px target is worthless while something paints over it — the
+    // pinned-row hover reserve keeps the revealed cluster off the
+    // in-title unpin pin. Pinned (all four reveal arms + the value + the
+    // cluster-side literals it is derived from) so a cluster resize or a
+    // dropped keyboard arm revisits the derivation in the rule's comment
+    // in the same commit.
+    expect(
+      extractRuleBody(
+        css,
+        ".thread-row-shell:hover .thread-row--pinned .thread-row__heading,\n"
+          + ".thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row--pinned .thread-row__heading,\n"
+          + ".thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--pinned .thread-row__heading,\n"
+          + ".thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row--pinned .thread-row__heading",
+      ),
+    ).toMatch(/padding-right:\s*44px;/);
+    expect(extractRuleBody(css, ".thread-row__actions")).toMatch(
+      /right:\s*9px;[\s\S]*gap:\s*4px;/,
+    );
+    // Not extractRuleBody: the bare selector would match the shared
+    // pin+kebab chrome rule first; this anchors the standalone width
+    // rule's own body.
+    expect(css).toMatch(/(?:^|\n)\.thread-row__overflow-button \{[^}]*width:\s*26px;/);
+
     // And the open-thread overlay keeps the explicit floor the old
     // in-flow button carried: at the XS title notch a chipless card
     // computes to 23.75px, so covering the card alone is not enough.
@@ -675,8 +698,13 @@ describe("Tangerine Terminal theme contract", () => {
   });
 
   it("hides thread row timestamps behind focused or open row actions", () => {
+    // Pins the FULL five-selector fade list (it once silently grew a
+    // pin-button arm this regex didn't describe, so the test matched a
+    // suffix and stopped being the authoritative statement of the
+    // list). The pinned-row heading reserve mirrors this state set —
+    // its own pin lives with the target-size block above.
     expect(css).toMatch(
-      /\.thread-row-shell:hover \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__overflow-button:focus-visible\) \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__chip--add-reaction:focus-visible\) \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__chip--add-reaction\.is-open\) \.thread-row__time\s*\{[\s\S]*?opacity:\s*0;[\s\S]*?\}/
+      /\.thread-row-shell:has\(\.thread-row__pin-button:focus-visible\) \.thread-row__time,\s*\.thread-row-shell:hover \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__overflow-button:focus-visible\) \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__chip--add-reaction:focus-visible\) \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__chip--add-reaction\.is-open\) \.thread-row__time\s*\{[\s\S]*?opacity:\s*0;[\s\S]*?\}/
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4095,6 +4095,12 @@ textarea,
   min-width: 24px;
 }
 
+/* Timestamp fade — the union of every state that reveals a cluster
+   control over the time's lane. Adding a reveal state here? The pinned
+   rows' heading-reserve rule below keeps the in-title unpin pin clear
+   of the revealed cluster and mirrors this state set (minus the
+   cluster pin, which pinned rows never render) — extend it in the same
+   commit or the new state re-covers the pin. */
 .thread-row-shell:has(.thread-row__pin-button:focus-visible) .thread-row__time,
 .thread-row-shell:hover .thread-row__time,
 .thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time,
@@ -4103,12 +4109,56 @@ textarea,
   opacity: 0;
 }
 
+/* Cluster reveal. New reveal states must also join the fade list above
+   and the pinned-row heading-reserve rule below — see the fade list's
+   comment. */
 .thread-row-shell:hover .thread-row__pin-button,
 .thread-row__pin-button:focus-visible,
 .thread-row-shell:hover .thread-row__overflow-button,
 .thread-row__overflow-button:focus-visible {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* Keep the in-title unpin pin clickable while the hover cluster is
+   shown. The pin sits after the title, so a long (truncated) title
+   parks it at the heading's right edge — exactly where the revealed
+   add-reaction + kebab cluster paints, covering the unpin control at
+   the moment the pointer arrives to use it. Reserving heading padding
+   during the reveal re-truncates the title and docks the pin left of
+   the cluster. Short titles never reach the boundary, so nothing moves
+   for them; the transition on `.thread-row__heading` glides the dock
+   in step with the cluster's 120ms fade.
+
+   44px derivation, all border-box worst case. The cluster zone spans
+   69px from the card's right border: 9px offset + 26px kebab + 4px gap
+   + the add-reaction chip's RENDERED width of 30px (its `min-width:
+   24px` is a floor — the 14px smiley plus the base chip's 0 8px
+   padding is what actually paints). The pin's border box must clear
+   that zone: card padding 10px + header gap 12px + timestamp + reserve
+   − the pin's 3px `margin-right: -3px` overhang ≥ 69px + 4px air. The
+   narrowest timestamp ("1h"/"2d") measures ~13px at its fixed 12px
+   font, giving reserve ≥ 41px; 44px leaves 3px of real slack at every
+   title-size notch. The cluster-side literals in this arithmetic are
+   pinned by theme-contract next to this rule's own pin, so a cluster
+   resize fails a test instead of silently re-covering the pin.
+
+   Scoped by the row's `--pinned` modifier (set by ThreadRow from the
+   same expression that renders the pin — a plain class match instead
+   of a per-hover `:has()` subtree scan, same optimization as the
+   directory-row header modifiers). The selector list mirrors the
+   cluster's reveal states in the fade/reveal rules above (the cluster
+   pin's states are absent because pinned rows never render it).
+   Deliberate over-reserve: on a surface without a reaction handler the
+   revealed cluster is kebab-only (35px zone) and the rest-state gap
+   already clears it, so the reserve protects nothing there — accepted,
+   since every production surface wires reactions and a narrower
+   conditional would re-add the `:has()` scan this class avoids. */
+.thread-row-shell:hover .thread-row--pinned .thread-row__heading,
+.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row--pinned .thread-row__heading,
+.thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--pinned .thread-row__heading,
+.thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row--pinned .thread-row__heading {
+  padding-right: 44px;
 }
 
 .thread-row__pin-button:hover,
@@ -4430,6 +4480,12 @@ textarea,
      brings the two surfaces to parity. */
   gap: 2px;
   flex: 1 1 auto;
+  /* Glides the pinned-row hover reserve (see the `--pinned` rule near
+     the reveal lists) in step with the cluster's 120ms opacity fade,
+     instead of the title/pin snapping while the buttons are still
+     fading in. Inert on unpinned rows — nothing changes their
+     padding. */
+  transition: padding-right 120ms ease;
 }
 
 /* Always-visible in-title pin on pinned rows — and since the


### PR DESCRIPTION
## Summary

Follow-up to #1586's pin-affordance split. A long truncated title parks the always-visible in-title pin at the heading's right edge — exactly where the hover-revealed add-reaction + kebab cluster paints. Since that pin is now *the* unpin control, the cluster was covering it at the precise moment the pointer arrived to use it (screenshots in the report showed the emoji button painting over the pin).

## Fix

While the cluster is revealed (row hover, or any cluster control's focus/open state), the heading gains a right-padding reserve so the title re-truncates and the pin docks left of the cluster:

- Scoped by a new `thread-row--pinned` row modifier (derived in ThreadRow from the same expression that renders the pin) — a plain class match instead of a per-hover `:has()` subtree scan, per the file's own directory-row precedent. Unpinned rows are untouched.
- Short titles never reach the boundary, so nothing moves for them; only long (already-truncated) titles re-ellipsize during the reveal.
- Rest state is unchanged — the reserve exists only while the cluster is shown, so no golden or at-rest layout moves.
- The 44px reserve is derived in the rule comment from the 69px cluster zone — 9px offset + 26px kebab + 4px gap + the add-reaction chip's **rendered** 30px width (its `min-width: 24px` is a floor; the first cut derived from 24px and came up ~8px short, leaving a sliver of the pin's hit box under the chip) — minus card padding, header gap, the narrowest 13px timestamp, and the pin's own −3px overhang, plus 4px air. theme-contract pins the full four-arm rule, the reserve value, and the cluster-side literals it derives from, so a cluster resize or a dropped keyboard arm fails a test in the same commit.
- The dock glides with a `padding-right` transition matching the cluster's 120ms fade instead of snapping.

## Testing

- Full renderer suite: 2769 tests pass; color lint clean.
- A `/code-review --fix` pass (10 findings) hardened the first cut: corrected the reserve arithmetic (32→44px), swapped the row-level `:has()` for the `thread-row--pinned` modifier, replaced the fragile 400-char regex pin with `extractRuleBody` over all four selector arms, pinned the cluster-side literals, made the reveal-list cross-references reciprocal, and fixed the pre-existing fade-list pin that described only 4 of its 5 selectors.
- Verified live on the dev profile with a pinned, truncated-title row:
  - Hover: title re-truncates, pin docks clear of the emoji/kebab cluster (previously covered).
  - The pin's click *while the cluster is shown* unpins the thread — the exact interaction that was broken.
  - Rest state identical to before (full-width title + pin + timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
