### PR TITLE
fix(desktop): show directory name for skill file chips

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -411,11 +411,14 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
             name: skillNameFromPath(skillPath, label),
             path: skillPath,
           };
+          const chipLabel = label.toLowerCase() === "skill.md"
+            ? skillNameFromPath(skillPath, label)
+            : label;
 
           return (
             <SkillChip
               editorName={editorApplication?.name}
-              label={label || undefined}
+              label={chipLabel || undefined}
               onOpenInEditor={editorApplication && props.desktopApi?.openApplication
                 ? openSkillMarkdownInEditor
                 : undefined}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -631,6 +631,19 @@ describe("ThreadMarkdown", () => {
       .toBeInTheDocument();
   });
 
+  it("labels a SKILL.md link with its skill directory name", () => {
+    const skillPath = [
+      "/Users/huntharo/pwrdrvr/PwrSuiteLab/.agents/skills",
+      "restart-wedged-macos-gha-runner/SKILL.md",
+    ].join("/");
+
+    render(<ThreadMarkdown text={`[SKILL.md](${skillPath})`} />);
+
+    expect(screen.getByText("restart-wedged-macos-gha-runner"))
+      .toBeInTheDocument();
+    expect(screen.queryByText("SKILL.md")).not.toBeInTheDocument();
+  });
+
   it("shows skill paths and replaces text selection with skill file actions", async () => {
     const skillPath = "/Users/huntharo/.codex/skills/frontend-design/SKILL.md";
     const openApplication = vi.fn(async () => ({ opened: true as const }));


### PR DESCRIPTION
## What changed

- Render a transcript skill chip labeled `SKILL.md` using the containing skill directory name.
- Preserve intentional labels such as `$frontend-design` or descriptive link text.
- Add a regression test based on a nested `.agents/skills/<name>/SKILL.md` link.

## Why

Skill links that display the filename make every chip read `SKILL.md`, hiding which skill the link refers to. The path already identifies the skill directory, so the chip should surface that name.

## Root cause

Thread markdown correctly derived the skill name from the target path, but always passed the Markdown link text as the chip label override.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx`
- `pnpm lint:eslint`
- `pnpm typecheck`
