### PR TITLE
fix(desktop): keep tooltips below Windows title bar

### DIFF
--- a/apps/desktop/e2e/thread-row-status.spec.ts
+++ b/apps/desktop/e2e/thread-row-status.spec.ts
@@ -244,11 +244,18 @@ test("shows initiated background turns as thinking, then unread once they finish
 
     // The aggregate activity signal lives on the Attention tab now, not on
     // Directories — a live turn counts as active, never as to-review.
-    await expect(
-      app.window.getByRole("tab", {
-        name: "Attention, 1 active thread, 0 threads to review",
-      }),
-    ).toBeVisible();
+    const attentionTab = app.window.getByRole("tab", {
+      name: "Attention, 1 active thread, 0 threads to review",
+    });
+    await expect(attentionTab).toBeVisible();
+    await attentionTab.hover();
+    const attentionTooltip = app.window.getByRole("tooltip");
+    await expect(attentionTooltip).toBeVisible();
+    const appShellBounds = await app.window.locator(".app-shell").boundingBox();
+    const tooltipBounds = await attentionTooltip.boundingBox();
+    expect(appShellBounds).not.toBeNull();
+    expect(tooltipBounds).not.toBeNull();
+    expect(tooltipBounds!.y).toBeGreaterThanOrEqual(appShellBounds!.y + 12);
 
     await app.window.getByRole("tab", { name: "Directories" }).click();
     // The counts are indicator + number now; the words moved into a hover

--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -1,9 +1,19 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useViewportTooltip } from "../useViewportTooltip";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 function TooltipFixture() {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
@@ -26,6 +36,24 @@ function TooltipFixture() {
   );
 }
 
+function rectangle(rect: Partial<DOMRect>): DOMRect {
+  const x = rect.x ?? rect.left ?? 0;
+  const y = rect.y ?? rect.top ?? 0;
+  const width = rect.width ?? 0;
+  const height = rect.height ?? 0;
+  return {
+    bottom: rect.bottom ?? y + height,
+    height,
+    left: rect.left ?? x,
+    right: rect.right ?? x + width,
+    top: rect.top ?? y,
+    width,
+    x,
+    y,
+    toJSON: () => undefined,
+  };
+}
+
 describe("useViewportTooltip", () => {
   it("keeps a tooltip open when an unrelated pane scrolls", () => {
     render(<TooltipFixture />);
@@ -45,5 +73,37 @@ describe("useViewportTooltip", () => {
     fireEvent.scroll(screen.getByTestId("sidebar-scroll-region"));
 
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("places the tooltip below its target when above would overlap the app shell boundary", async () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("app-shell")) {
+          return rectangle({ top: 40, width: 1200, height: 760 });
+        }
+        if (this.getAttribute("role") === "tooltip") {
+          return rectangle({ width: 300, height: 60 });
+        }
+        if (this.tagName === "BUTTON") {
+          return rectangle({ left: 20, top: 82, width: 72, height: 26 });
+        }
+        return rectangle({});
+      },
+    );
+
+    vi.stubGlobal("innerWidth", 1200);
+    vi.stubGlobal("innerHeight", 800);
+
+    render(
+      <div className="app-shell">
+        <TooltipFixture />
+      </div>,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "118px" });
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -17,6 +17,17 @@ const VIEWPORT_PADDING = 12;
 /** Gap between the tooltip and the target element (above or below). */
 const TOOLTIP_GAP = 10;
 
+function tooltipViewportTop(): number {
+  // On Windows the fixed custom title bar occupies the top of the renderer,
+  // while `.app-shell` begins immediately below it. Portal tooltips live on
+  // document.body, so the raw viewport top would let them render underneath
+  // that higher title-bar layer. The shell boundary is also zero on platforms
+  // without the custom strip, preserving the ordinary viewport behavior.
+  const appShell = document.querySelector<HTMLElement>(".app-shell");
+  const appShellTop = appShell?.getBoundingClientRect().top ?? 0;
+  return Math.max(VIEWPORT_PADDING, appShellTop + VIEWPORT_PADDING);
+}
+
 type TooltipState = {
   content: ReactNode;
   targetTop: number;
@@ -102,11 +113,31 @@ export function useViewportTooltip(options: {
       window.innerWidth - rect.width - VIEWPORT_PADDING,
       Math.max(VIEWPORT_PADDING, state.targetCenter - rect.width / 2),
     );
-    const fitsAbove =
-      state.targetTop - rect.height - TOOLTIP_GAP >= VIEWPORT_PADDING;
-    const top = fitsAbove
-      ? state.targetTop - rect.height - TOOLTIP_GAP
-      : state.targetBottom + TOOLTIP_GAP;
+    const viewportTop = tooltipViewportTop();
+    const viewportBottom = window.innerHeight - VIEWPORT_PADDING;
+    const aboveTop = state.targetTop - rect.height - TOOLTIP_GAP;
+    const belowTop = state.targetBottom + TOOLTIP_GAP;
+    const fitsAbove = aboveTop >= viewportTop;
+    const fitsBelow = belowTop + rect.height <= viewportBottom;
+    let top: number;
+    if (fitsAbove) {
+      top = aboveTop;
+    } else if (fitsBelow) {
+      top = belowTop;
+    } else {
+      const availableAbove = Math.max(
+        0,
+        state.targetTop - TOOLTIP_GAP - viewportTop,
+      );
+      const availableBelow = Math.max(
+        0,
+        viewportBottom - state.targetBottom - TOOLTIP_GAP,
+      );
+      const preferredTop =
+        availableAbove >= availableBelow ? aboveTop : belowTop;
+      const maximumTop = Math.max(viewportTop, viewportBottom - rect.height);
+      top = Math.min(maximumTop, Math.max(viewportTop, preferredTop));
+    }
     if (state.left !== left || state.top !== top) {
       setState({ ...state, left, top });
     }


### PR DESCRIPTION
## Summary

- treat the app shell's top edge as the safe viewport boundary for portal tooltips
- flip tooltips below their trigger when placing them above would overlap the Windows title bar
- check both above and below capacity, then clamp to the larger available region when neither fully fits
- add focused unit and Electron geometry regressions for the Attention lens tooltip

## Root cause

`useViewportTooltip` positioned against the raw renderer viewport. On Windows, the fixed 40px custom title bar occupies that area at a higher layer, so a tooltip near the top could be calculated at `top: 12px` and render underneath the title bar.

## Impact

Tooltips near the top of the Windows app stay fully visible without covering the menu bar or native caption area. Other platforms keep their existing zero-offset app-shell behavior.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx`
- `pnpm --filter @pwragent/desktop test:e2e e2e/thread-row-status.spec.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- production Electron build completed as part of the focused E2E run

The dedicated Windows VM run could not start because another PwrSuiteLab controller was already active; the Windows CI lane will exercise the cross-platform Electron geometry assertion.
