### PR TITLE
test(desktop): exercise tildify path round trip

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts
@@ -65,7 +65,7 @@ describe("expandTildePath", () => {
 
   it("round-trips with tildifyPath", () => {
     const home = "/Users/huntharo";
-    const absolute = "/Users/example/Projects/catalog-portal";
+    const absolute = `${home}/Projects/catalog-portal`;
     expect(expandTildePath(tildifyPath(absolute, home), home)).toBe(absolute);
   });
 });


### PR DESCRIPTION
## Summary

- derive the round-trip fixture's absolute path from the test's declared home directory
- ensure the assertion exercises both `tildifyPath` and `expandTildePath`

## Root cause

The previous absolute path used a different home prefix, so `tildifyPath` returned it unchanged and the round-trip assertion only verified an identity path.

## Impact

Test coverage now protects the intended collapse-and-expand behavior. Production code is unchanged.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts` (15 tests passed)
- `pnpm exec eslint apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts`
