### PR TITLE
fix(desktop): show directory name for skill file chips

### DIFF
--- a/apps/desktop/e2e/thread-markdown.spec.ts
+++ b/apps/desktop/e2e/thread-markdown.spec.ts
@@ -33,11 +33,9 @@ test("renders markdown content in thread summaries and transcript messages", asy
       transcript.locator(".skill-chip", { hasText: "$frontend-design" })
     ).toBeVisible();
     await expect(
-      transcript.getByRole("link", { name: "ce:work" })
-    ).toHaveAttribute(
-      "href",
-      "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
-    );
+      transcript.locator(".skill-chip", { hasText: "ce:work" })
+    ).toBeVisible();
+    await expect(transcript.getByRole("link", { name: "ce:work" })).toHaveCount(0);
     await expect(
       transcript.locator("strong", { hasText: "markdown" })
     ).toBeVisible();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -257,7 +257,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
 
         if (
           skillPath &&
-          (skillsByPath.has(skillPath) || label.startsWith("$"))
+          (
+            isSkillMarkdownPath(skillPath)
+            || skillsByPath.has(skillPath)
+            || label.startsWith("$")
+          )
         ) {
           const skill = skillsByPath.get(skillPath) ?? {
             name: skillNameFromPath(skillPath, label),
@@ -885,6 +889,10 @@ function normalizeSkillPath(href: string): string | undefined {
   }
 
   return undefined;
+}
+
+function isSkillMarkdownPath(filePath: string): boolean {
+  return /(?:^|\/)SKILL\.md$/i.test(filePath);
 }
 
 function skillNameFromPath(filePath: string, label: string): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -260,11 +260,14 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
           (skillsByPath.has(skillPath) || label.startsWith("$"))
         ) {
           const skill = skillsByPath.get(skillPath) ?? {
-            name: label.replace(/^\$/, "") || skillPath.split("/").pop() || "skill",
+            name: skillNameFromPath(skillPath, label),
             path: skillPath,
           };
+          const chipLabel = label.toLowerCase() === "skill.md"
+            ? skillNameFromPath(skillPath, label)
+            : label;
 
-          return <SkillChip label={label || undefined} skill={skill} />;
+          return <SkillChip label={chipLabel || undefined} skill={skill} />;
         }
 
         if (!href) {
@@ -882,6 +885,14 @@ function normalizeSkillPath(href: string): string | undefined {
   }
 
   return undefined;
+}
+
+function skillNameFromPath(filePath: string, label: string): string {
+  const segments = filePath.split("/").filter(Boolean);
+  if (segments.at(-1)?.toLowerCase() === "skill.md" && segments.length > 1) {
+    return segments.at(-2) ?? "skill";
+  }
+  return label.replace(/^\$/, "") || segments.at(-1) || "skill";
 }
 
 function localFileTargetFromHref(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -309,6 +309,32 @@ describe("ThreadMarkdown", () => {
     expect(screen.queryByRole("link", { name: "$frontend-design" })).not.toBeInTheDocument();
   });
 
+  it("labels a SKILL.md link with its skill directory name", () => {
+    const skillPath = [
+      "/Users/huntharo/pwrdrvr/PwrSuiteLab/.agents/skills",
+      "restart-wedged-macos-gha-runner/SKILL.md",
+    ].join("/");
+
+    render(
+      <ThreadMarkdown
+        skills={[
+          {
+            name: "restart-wedged-macos-gha-runner",
+            description: "Restart a wedged macOS GitHub Actions runner.",
+            path: skillPath,
+            enabled: true,
+          },
+        ]}
+        text={`[SKILL.md](${skillPath}) and [runner recovery guide](${skillPath})`}
+      />
+    );
+
+    expect(screen.getByText("restart-wedged-macos-gha-runner"))
+      .toBeInTheDocument();
+    expect(screen.getByText("runner recovery guide")).toBeInTheDocument();
+    expect(screen.queryByText("SKILL.md")).not.toBeInTheDocument();
+  });
+
   it("renders emoji, italic, strikethrough, and inline code", () => {
     render(
       <ThreadMarkdown

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -42,16 +42,16 @@ describe("ThreadMarkdown", () => {
   it("renders markdown formatting and local file links", () => {
     render(
       <ThreadMarkdown
-        text={"Use **bold** text and open [`ce:work`](/Users/huntharo/.codex/skills/ce-work/SKILL.md)."}
+        text={"Use **bold** text and open [`AGENTS.md`](/Users/huntharo/PwrAgent/AGENTS.md)."}
       />
     );
 
     expect(screen.getByText("bold", { selector: "strong" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "ce:work" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
       "href",
-      "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
+      "file:///Users/huntharo/PwrAgent/AGENTS.md"
     );
-    expect(screen.getByRole("link", { name: "ce:work" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
       "title",
       "Open in PwrAgent"
     );
@@ -317,14 +317,6 @@ describe("ThreadMarkdown", () => {
 
     render(
       <ThreadMarkdown
-        skills={[
-          {
-            name: "restart-wedged-macos-gha-runner",
-            description: "Restart a wedged macOS GitHub Actions runner.",
-            path: skillPath,
-            enabled: true,
-          },
-        ]}
         text={`[SKILL.md](${skillPath}) and [runner recovery guide](${skillPath})`}
       />
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -322,15 +322,14 @@ describe("TranscriptList", () => {
       />
     );
 
-    expect(screen.getByRole("link", { name: "ce:work" })).toHaveAttribute(
-      "href",
-      "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
-    );
+    const skillChip = screen.getByText("ce:work").closest(".skill-chip");
+    expect(skillChip).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "ce:work" })).not.toBeInTheDocument();
     expect(screen.getByText("Check Unit 4", { selector: "strong" })).toBeInTheDocument();
     expect(screen.getByText("Keep Unit 3 isolated")).toBeInTheDocument();
     expect(screen.getByText("pnpm test -- --project desktop-renderer")).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "ce:work" }).closest("article")
+      skillChip?.closest("article")
     ).toHaveClass("transcript-message--user");
     expect(
       screen.getByText("pnpm test -- --project desktop-renderer").closest("article")


### PR DESCRIPTION
## What changed

- Backported the transcript skill-chip label fix to the 1.0 renderer.
- Recognize local `SKILL.md` paths as skill chips before the lazily loaded skill list is available.
- Display generic `SKILL.md` link labels using the containing skill directory name.
- Preserve intentional labels such as `$frontend-design` and descriptive Markdown link text.
- Adapt unit and replay-backed E2E coverage to the 1.0 skill-chip behavior.

## Why

Newly opened transcripts can contain skill-file links before `useThreadSkills` loads autocomplete metadata. Those links must still render as identifiable skill chips.

## Root cause

`ThreadMarkdown` always passed the Markdown link text as the chip label override, and the 1.0 guard only recognized skill links already present in `skillsByPath` or explicitly labeled with `$`.

## 1.0 adaptation

The 1.1 actionable skill-chip stack was not imported. This adds the small `SKILL.md` path predicate needed to recognize unloaded skill links and reuses the focused path-label derivation.

## Provenance

Backport of #1605.
Source squash: `6d15607ef99173bea30cac2dd8f776385fcc024e`.

## Migration and config audit

No migrations, schemas, TOML, runtime config, or config files changed.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` — 100 passed
- `pnpm --filter @pwragent/desktop test:e2e e2e/thread-markdown.spec.ts` — 1 passed after a full desktop build
- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — 49 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing warnings only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `git diff --check`