### PR TITLE
fix(desktop): backport Windows overlay logo fix

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -764,6 +764,11 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
     );
+    // Settings uses the same Windows title strip as the main shell, so its
+    // in-nav wordmark would otherwise duplicate the one still visible there.
+    expect(css).toMatch(
+      /:root\[data-platform="win32"\]\s*\.settings-screen\s+\.settings-nav__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
+    );
   });
 
   it("mirrors thread-row drop-indicator + recents divider tokens for directory pinning", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -764,10 +764,10 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
     );
-    // Settings uses the same Windows title strip as the main shell, so its
-    // in-nav wordmark would otherwise duplicate the one still visible there.
+    // Settings and Automations use the same Windows title strip as the main
+    // shell, so their in-nav wordmarks would duplicate the one visible there.
     expect(css).toMatch(
-      /:root\[data-platform="win32"\]\s*\.settings-screen\s+\.settings-nav__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
+      /:root\[data-platform="win32"\]\s*:is\(\.settings-screen,\s*\.automations-screen\)\s*\.settings-nav__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5877,6 +5877,13 @@ textarea,
   padding-left: 0;
 }
 
+/* Windows already carries the PwrAgent wordmark in its custom title strip.
+   Drop the duplicate Settings masthead so Exit Settings starts at the top of
+   the nav, mirroring the main sidebar's Windows treatment. */
+:root[data-platform="win32"] .settings-screen .settings-nav__masthead {
+  display: none;
+}
+
 /* macOS fullscreen drops the stoplights, so the Settings nav masthead
    collapses its 80px reservation to the left edge too — mirrors the main
    `.sidebar__masthead` fullscreen behavior so the two screens stay aligned. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5878,9 +5878,11 @@ textarea,
 }
 
 /* Windows already carries the PwrAgent wordmark in its custom title strip.
-   Drop the duplicate Settings masthead so Exit Settings starts at the top of
-   the nav, mirroring the main sidebar's Windows treatment. */
-:root[data-platform="win32"] .settings-screen .settings-nav__masthead {
+   Drop the duplicate overlay masthead so the Exit row starts at the top of
+   both navs, mirroring the main sidebar's Windows treatment. */
+:root[data-platform="win32"]
+  :is(.settings-screen, .automations-screen)
+  .settings-nav__masthead {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- backport PR #1597 to the `releases/1.0` line
- hide the Settings and Automations navigation mastheads on Windows
- preserve the existing overlay mastheads on macOS and Linux
- lock the Windows-only behavior in the renderer theme contract

## Why

PwrAgent's Windows custom title strip already contains the wordmark while Settings or Automations is open. Both overlays also render the shared navigation masthead, creating a duplicate logo and unnecessary vertical chrome above their Exit rows.

The `releases/1.0` branch already contains the Windows display-work-area sizing backport (`35d3c58b`). This change applies only the overlay-logo fix from #1597 on top of that release baseline.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm lint:colors`
