### PR TITLE
fix(desktop): backport orphaned sub-agent reconciliation

### DIFF
--- a/apps/desktop/e2e/live-work-rail-sticky-gap.spec.ts
+++ b/apps/desktop/e2e/live-work-rail-sticky-gap.spec.ts
@@ -51,31 +51,35 @@ test("LiveWorkRail sticky edit header and file-toggle pin without a gap", async 
 
     // Scroll inside the rail body so the file-toggle engages sticky.
     const railBody = rail.locator("css=.live-work-rail__body");
-    await railBody.evaluate((el) => {
+    await expect.poll(async () => railBody.evaluate((el) => {
       el.scrollTop = 200;
-    });
+      return el.scrollTop;
+    })).toBeGreaterThan(0);
 
     // After scrolling, the edit-group header should pin at the rail body's
     // top edge, and the file toggle should pin flush beneath that header. The
     // no-gap assertion now targets the header->row seam because the transcript
     // rail keeps the edit-group header even for a single group.
     const groupHeader = rail.locator("css=.edited-file-groups__group-header");
-    const toggleTop = await fileToggle.evaluate(
-      (el) => el.getBoundingClientRect().top,
-    );
-    const bodyTop = await railBody.evaluate(
-      (el) => el.getBoundingClientRect().top,
-    );
-    const headerTop = await groupHeader.evaluate(
-      (el) => el.getBoundingClientRect().top,
-    );
-    const headerBottom = await groupHeader.evaluate(
-      (el) => el.getBoundingClientRect().bottom,
-    );
-
     // Allow 1px slack for sub-pixel rounding.
-    expect(Math.abs(headerTop - bodyTop)).toBeLessThanOrEqual(1);
-    expect(Math.abs(toggleTop - headerBottom)).toBeLessThanOrEqual(1);
+    await expect.poll(async () => {
+      const bodyTop = await railBody.evaluate(
+        (el) => el.getBoundingClientRect().top,
+      );
+      const headerTop = await groupHeader.evaluate(
+        (el) => el.getBoundingClientRect().top,
+      );
+      return Math.abs(headerTop - bodyTop);
+    }).toBeLessThanOrEqual(1);
+    await expect.poll(async () => {
+      const toggleTop = await fileToggle.evaluate(
+        (el) => el.getBoundingClientRect().top,
+      );
+      const headerBottom = await groupHeader.evaluate(
+        (el) => el.getBoundingClientRect().bottom,
+      );
+      return Math.abs(toggleTop - headerBottom);
+    }).toBeLessThanOrEqual(1);
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -4,6 +4,7 @@ import type {
   InterruptTurnRequest,
   ListBackendsRequest,
   MaterializeDirectoryLaunchpadRequest,
+  StopSubAgentRequest,
   StartReviewRequest,
   StartThreadRequest,
   StartTurnRequest,
@@ -56,6 +57,12 @@ const registry = {
     backend: request.backend,
     threadId: request.threadId,
     turnId: request.turnId,
+  })),
+  stopSubAgent: vi.fn(async (request: StopSubAgentRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    monitorId: request.monitorId,
+    stoppedAt: 1,
   })),
   steerTurn: vi.fn(async (request: SteerTurnRequest) => ({
     backend: request.backend,
@@ -121,6 +128,7 @@ describe("agent ipc", () => {
     registry.submitTurn.mockClear();
     registry.startReview.mockClear();
     registry.interruptTurn.mockClear();
+    registry.stopSubAgent.mockClear();
     registry.steerTurn.mockClear();
     registry.materializeDirectoryLaunchpad.mockClear();
     registryListener = undefined;
@@ -138,6 +146,7 @@ describe("agent ipc", () => {
       AGENT_START_THREAD_CHANNEL,
       AGENT_START_REVIEW_CHANNEL,
       AGENT_START_TURN_CHANNEL,
+      AGENT_STOP_SUB_AGENT_CHANNEL,
       AGENT_STEER_TURN_CHANNEL,
       BACKEND_LIST_CHANNEL,
     } = await import("../../shared/ipc");
@@ -189,6 +198,18 @@ describe("agent ipc", () => {
       backend: "grok",
       threadId: "thread-1",
       turnId: "turn-1",
+    });
+    expect(
+      await handlers.get(AGENT_STOP_SUB_AGENT_CHANNEL)?.({}, {
+        backend: "codex",
+        threadId: "thread-1",
+        monitorId: "monitor-1",
+      }),
+    ).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-1",
+      stoppedAt: 1,
     });
     expect(
       await handlers.get(AGENT_STEER_TURN_CHANNEL)?.({}, {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1278,6 +1278,7 @@ class MockBackendClient {
       startThreadResult?: { threadId: string };
       startTurnDelay?: Promise<unknown>;
       startTurnError?: Error;
+      startTurnResults?: Array<{ threadId: string; turnId: string }>;
       steerTurnError?: Error;
       setThreadPermissionsError?: Error;
       setThreadPermissionsDelay?: Promise<unknown>;
@@ -1489,7 +1490,8 @@ class MockBackendClient {
     }
     this.lastStartTurnParams = params;
     this.startTurnCalls.push(params);
-    return { threadId: params.threadId, turnId: "turn-1" };
+    return this.options.startTurnResults?.shift()
+      ?? { threadId: params.threadId, turnId: "turn-1" };
   }
 
   async startReview(params: {
@@ -13030,6 +13032,7 @@ command = "pnpm dev"
         status: "running",
         backend: "codex",
         agentName: "PwrAgent",
+        ownerRuntimeInstanceId: expect.any(String),
         preferredModel: "gpt-5.6-luna",
         preferredReasoningEffort: "low",
         lastMessage: "Generating a title.",
@@ -13174,6 +13177,75 @@ command = "pnpm dev"
       }),
     });
 
+    await registry.close();
+  });
+
+  it("starts a fresh title-helper duration after an earlier attempt is terminal", async () => {
+    const monitorId = "system:title-helper:codex:thread-title-helper-parent";
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-title-helper-parent": {
+          backend: "codex",
+          threadId: "thread-title-helper-parent",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId,
+              task: "Name this thread",
+              status: "failure",
+              createdAt: 1_000,
+              updatedAt: 2_000,
+              completedAt: 2_000,
+              outcome: "failure",
+              ownerRuntimeInstanceId: "runtime-old",
+              completionSource: {
+                type: "pwragent_fallback",
+                reason: "system_title_helper",
+                recoveryAttempted: false,
+                terminalStatus: "failed",
+              },
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
+    });
+
+    await (registry as unknown as {
+      persistTitleHelperSubAgent(params: {
+        backend: "codex";
+        threadId: string;
+        status: "running";
+      }): Promise<void>;
+    }).persistTitleHelperSubAgent({
+      backend: "codex",
+      threadId: "thread-title-helper-parent",
+      status: "running",
+    });
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-title-helper-parent",
+    });
+    const subAgent = overlay?.subAgents?.find(
+      (candidate) => candidate.monitorId === monitorId,
+    );
+    expect(subAgent).toMatchObject({
+      status: "running",
+      ownerRuntimeInstanceId: "runtime-current",
+      lastMessage: "Generating a title.",
+    });
+    expect(subAgent?.createdAt).toBeGreaterThan(2_000);
+    expect(subAgent?.updatedAt).toBe(subAgent?.createdAt);
+    expect(subAgent?.completedAt).toBeUndefined();
+    expect(subAgent?.outcome).toBeUndefined();
+    expect(subAgent?.completionSource).toBeUndefined();
     await registry.close();
   });
 
@@ -26155,6 +26227,460 @@ script = "printf setup"
     });
 
     unsubscribeEvents();
+    await registry.close();
+  });
+
+  it("reconciles orphaned sub-agents before serving threads after startup", async () => {
+    const reconcileOrphanedThreadSubAgents = vi.fn(async () => ({
+      repairedSubAgents: 0,
+      repairedThreads: 0,
+      skippedLiveOwners: 1,
+      skippedOwnerlessWithOtherRuntimes: 1,
+    }));
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      reconcileOrphanedThreadSubAgents,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => [
+        "runtime-current",
+        "runtime-other",
+      ],
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+    expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledOnce();
+    expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledWith({
+      currentRuntimeInstanceId: "runtime-current",
+      liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
+      sessionStartedAt: expect.any(Number),
+    });
+    await registry.close();
+  });
+
+  it("leaves persisted sub-agents untouched when runtime liveness cannot be read", async () => {
+    const reconcileOrphanedThreadSubAgents = vi.fn(async () => ({
+      repairedSubAgents: 0,
+      repairedThreads: 0,
+      skippedLiveOwners: 0,
+      skippedOwnerlessWithOtherRuntimes: 0,
+    }));
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: {
+        ...createOverlayStoreMock(),
+        reconcileOrphanedThreadSubAgents,
+      },
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => {
+        throw new Error("runtime marker directory unavailable");
+      },
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+    expect(reconcileOrphanedThreadSubAgents).not.toHaveBeenCalled();
+    await registry.close();
+  });
+
+  it("stops active task monitors without starting recovery", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/interrupt"] },
+      models: TEST_TASK_MONITOR_MODELS,
+      startThreadResult: { threadId: "monitor-thread" },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    const delegationResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_task_monitors",
+        tool: "create_monitor_delegation",
+        arguments: {
+          task: "Watch an asynchronous task until it finishes.",
+          pollIntervalSeconds: 20,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const monitorId = JSON.parse(
+      (delegationResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]?.text ?? "{}",
+    ).monitorId as string;
+
+    await expect(registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId,
+    })).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId,
+    });
+
+    expect(codexClient.lastInterruptTurnParams).toMatchObject({
+      threadId: "monitor-thread",
+      turnId: "turn-1",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId,
+          status: "cancelled",
+          outcome: "cancelled",
+          lastMessage: "Stopped by user.",
+          ownerRuntimeInstanceId: "runtime-current",
+        }),
+      ],
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "cancelled", output: [] },
+        },
+      },
+    });
+
+    expect(codexClient.startTurnCallCount).toBe(1);
+    expect(codexClient.injectedThreadItems).toHaveLength(0);
+    await registry.close();
+  });
+
+  it("stops a task monitor on its live recovery turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/interrupt"] },
+      models: TEST_TASK_MONITOR_MODELS,
+      startThreadResult: { threadId: "monitor-thread" },
+      startTurnResults: [
+        { threadId: "monitor-thread", turnId: "monitor-turn-1" },
+        { threadId: "monitor-thread", turnId: "monitor-recovery-turn" },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "parent-turn",
+          turn: { id: "parent-turn" },
+        },
+      },
+    });
+    const delegationResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "parent-turn",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_task_monitors",
+        tool: "create_monitor_delegation",
+        arguments: {
+          task: "Watch an asynchronous task until it finishes.",
+          pollIntervalSeconds: 20,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const monitorId = JSON.parse(
+      (delegationResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]?.text ?? "{}",
+    ).monitorId as string;
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "monitor-turn-1",
+          turn: {
+            id: "monitor-turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId,
+          monitorTurnId: "monitor-turn-1",
+          status: "running",
+        }),
+      ],
+    });
+
+    await registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId,
+    });
+
+    expect(codexClient.lastInterruptTurnParams).toEqual({
+      threadId: "monitor-thread",
+      turnId: "monitor-recovery-turn",
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "monitor-recovery-turn",
+          turn: {
+            id: "monitor-recovery-turn",
+            status: "cancelled",
+            output: [],
+          },
+        },
+      },
+    });
+
+    expect(codexClient.startTurnCallCount).toBe(2);
+    await registry.close();
+  });
+
+  it("stops native Codex sub-agents using the child's active turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read", "turn/interrupt"] },
+      replay: {
+        entries: [
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Working",
+            details: [],
+            turn: {
+              id: "child-turn",
+              status: "in_progress",
+            },
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "codex-native:child-thread",
+              task: "Investigate the issue",
+              status: "running",
+              createdAt: 1,
+              updatedAt: 1,
+              ownerRuntimeInstanceId: "runtime-current",
+              backend: "codex",
+              monitorThreadId: "child-thread",
+              monitorTurnId: "parent-turn",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
+    });
+
+    await registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "codex-native:child-thread",
+    });
+
+    expect(codexClient.lastReadThreadParams).toMatchObject({
+      threadId: "child-thread",
+      includeTurns: true,
+    });
+    expect(codexClient.lastInterruptTurnParams).toMatchObject({
+      threadId: "child-thread",
+      turnId: "child-turn",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "codex-native:child-thread",
+          status: "cancelled",
+          outcome: "cancelled",
+        }),
+      ],
+    });
+    await registry.close();
+  });
+
+  it("locally closes an orphaned sub-agent when Stop cannot reach its old runtime", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/interrupt"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "monitor-orphaned",
+              task: "Monitor work from before a reboot",
+              status: "running",
+              createdAt: 1_000,
+              updatedAt: 1_500,
+              ownerRuntimeInstanceId: "runtime-dead",
+              backend: "codex",
+              monitorThreadId: "monitor-thread",
+              monitorTurnId: "monitor-turn",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
+    });
+
+    await expect(registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-orphaned",
+    })).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-orphaned",
+    });
+
+    expect(codexClient.interruptTurnCallCount).toBe(0);
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "monitor-orphaned",
+          status: "cancelled",
+          outcome: "cancelled",
+          completedAt: 1_500,
+          updatedAt: 1_500,
+          lastMessage:
+            "Stop was requested after its owning PwrAgent runtime had already stopped.",
+          completionSource: {
+            type: "parent_cancel",
+          },
+        }),
+      ],
+    });
+    await registry.close();
+  });
+
+  it("does not stop a sub-agent owned by another live PwrAgent instance", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/interrupt"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "monitor-other-runtime",
+              task: "Monitor work owned elsewhere",
+              status: "running",
+              createdAt: 1_000,
+              updatedAt: 1_500,
+              ownerRuntimeInstanceId: "runtime-other",
+              backend: "codex",
+              monitorThreadId: "monitor-thread",
+              monitorTurnId: "monitor-turn",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      runtimeInstanceId: "runtime-current",
+      resolveLiveProfileRuntimeInstanceIds: () => [
+        "runtime-current",
+        "runtime-other",
+      ],
+    });
+
+    await expect(registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-other-runtime",
+    })).rejects.toThrow(
+      "Sub-agent is controlled by another live PwrAgent instance.",
+    );
+    expect(codexClient.interruptTurnCallCount).toBe(0);
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
@@ -407,3 +407,150 @@ describe("SqliteOverlayStore — thread reactions", () => {
     expect(overlay?.reactions).toEqual(["👀", "✅"]);
   });
 });
+
+describe("SqliteOverlayStore — orphaned sub-agents", () => {
+  async function seedSubAgent(
+    threadId: string,
+    subAgent: ThreadSubAgentSummary,
+  ): Promise<void> {
+    await store.upsertThreadSubAgent({
+      backend: "codex",
+      threadId,
+      subAgent,
+    });
+  }
+
+  it("repairs dead owners without touching another live instance or ambiguous legacy work", async () => {
+    await seedSubAgent("dead-owner", {
+      monitorId: "monitor-dead-owner",
+      task: "Owned by a stopped runtime",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-dead",
+    });
+    await seedSubAgent("live-owner", {
+      monitorId: "monitor-live-owner",
+      task: "Owned by another live runtime",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-other",
+    });
+    await seedSubAgent("legacy-ownerless", {
+      monitorId: "monitor-legacy",
+      task: "Legacy work with no owner metadata",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+    });
+    await seedSubAgent("terminal-missing-time", {
+      monitorId: "monitor-terminal",
+      task: "Terminal work missing its stop time",
+      status: "success",
+      createdAt: 1_000,
+      updatedAt: 1_600,
+      outcome: "success",
+      ownerRuntimeInstanceId: "runtime-dead",
+    });
+
+    await expect(store.reconcileOrphanedThreadSubAgents({
+      currentRuntimeInstanceId: "runtime-current",
+      liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
+      sessionStartedAt: 2_000,
+    })).resolves.toEqual({
+      repairedSubAgents: 2,
+      repairedThreads: 2,
+      skippedLiveOwners: 1,
+      skippedOwnerlessWithOtherRuntimes: 1,
+    });
+
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "dead-owner",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "monitor-dead-owner",
+          status: "failure",
+          outcome: "failure",
+          completedAt: 1_500,
+          updatedAt: 1_500,
+          completionSource: expect.objectContaining({
+            type: "pwragent_fallback",
+            reason: "owner_runtime_stopped",
+          }),
+        }),
+      ],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "live-owner",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "legacy-ownerless",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "terminal-missing-time",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          status: "success",
+          outcome: "success",
+          completedAt: 1_600,
+        }),
+      ],
+    });
+  });
+
+  it("repairs old ownerless work only when this is the sole runtime", async () => {
+    await seedSubAgent("thread-1", {
+      monitorId: "monitor-old",
+      task: "Legacy work from before startup",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 900,
+    });
+    await seedSubAgent("thread-1", {
+      monitorId: "monitor-new",
+      task: "Work created during this runtime",
+      status: "running",
+      createdAt: 2_100,
+      updatedAt: 2_100,
+    });
+
+    await expect(store.reconcileOrphanedThreadSubAgents({
+      currentRuntimeInstanceId: "runtime-current",
+      liveRuntimeInstanceIds: ["runtime-current"],
+      sessionStartedAt: 2_000,
+    })).resolves.toMatchObject({
+      repairedSubAgents: 1,
+      repairedThreads: 1,
+    });
+
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const oldSubAgent = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === "monitor-old",
+    );
+    const newSubAgent = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === "monitor-new",
+    );
+    expect(oldSubAgent).toMatchObject({
+      status: "failure",
+      outcome: "failure",
+      completedAt: 1_000,
+      updatedAt: 1_000,
+    });
+    expect(newSubAgent).toMatchObject({ status: "running" });
+    expect(newSubAgent?.completedAt).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14,6 +14,11 @@ import type {
   MessagingBindingRecord,
 } from "@pwragent/messaging-interface";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import {
+  findLiveProfileRuntimeMarkers,
+  getProcessRuntimeIdentity,
+  resolveActiveProfileName,
+} from "../profile";
 import { getAppStateDb, getAppStateMode } from "../state/app-state";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import { requestShowThread } from "../window-show-thread";
@@ -167,6 +172,8 @@ import {
   type StartReviewToolResult,
   type StartThreadRequest,
   type StartThreadResponse,
+  type StopSubAgentRequest,
+  type StopSubAgentResponse,
   type SubmitServerRequestRequest,
   type SubmitServerRequestResponse,
   type TrustCodexProjectRequest,
@@ -2818,6 +2825,15 @@ function codexNativeSubAgentOutcome(
 
 function codexNativeSubAgentIsTerminal(status: ThreadSubAgentSummary["status"]): boolean {
   return status === "success" || status === "failure" || status === "cancelled";
+}
+
+function reliableSubAgentCompletionBoundary(
+  subAgent: ThreadSubAgentSummary,
+): number {
+  return Number.isFinite(subAgent.updatedAt)
+    && subAgent.updatedAt >= subAgent.createdAt
+    ? subAgent.updatedAt
+    : subAgent.createdAt;
 }
 
 function codexNativeSubAgentNextReconciliationDelayMs(attempts: number): number {
@@ -5634,6 +5650,9 @@ export class DesktopBackendRegistry {
     TaskMonitorDelegationRecord
   >();
   private readonly taskMonitorWatchdogTimer?: NodeJS.Timeout;
+  private readonly runtimeInstanceId: string;
+  private readonly resolveLiveProfileRuntimeInstanceIdsFn: () => string[];
+  private readonly subAgentStartupReconciliation: Promise<void>;
   /** Streamed command-output counters waiting for the next bounded flush. */
   private readonly pendingToolInvocationDeltas = new Map<
     string,
@@ -5809,10 +5828,21 @@ export class DesktopBackendRegistry {
     >;
     resolveCodexFastAllowed?: () => boolean;
     resolveGrokApiKey?: () => string | undefined;
+    runtimeInstanceId?: string;
+    resolveLiveProfileRuntimeInstanceIds?: () => string[];
     acpWorktreeRepositoryResolver?: (
       cwd: string,
     ) => Promise<LinkedDirectorySummary | undefined>;
   }) {
+    const processRuntimeIdentity = getProcessRuntimeIdentity();
+    this.runtimeInstanceId =
+      options?.runtimeInstanceId ?? processRuntimeIdentity.instanceId;
+    this.resolveLiveProfileRuntimeInstanceIdsFn =
+      options?.resolveLiveProfileRuntimeInstanceIds ??
+      (() =>
+        findLiveProfileRuntimeMarkers(resolveActiveProfileName()).map(
+          (marker) => marker.instanceId,
+        ));
     const replayClients = createReplayClientsFromEnv();
     const codexCapture = options?.codexClient
       || replayClients
@@ -6119,6 +6149,13 @@ export class DesktopBackendRegistry {
     this.subscribeClient("codex", this.codexClient);
     this.subscribeClient("grok", this.grokClient);
 
+    this.subAgentStartupReconciliation =
+      this.reconcileOrphanedThreadSubAgentsAtStartup().catch((error) => {
+        backendRegistryLog.warn("sub-agent-startup-reconciliation-failed", {
+          message: error instanceof Error ? error.message : String(error),
+        });
+      });
+
     // Kick off a one-shot scan of persisted codexEnvironmentRuntime
     // entries: zombie "started" runs from a prior session become
     // "failed", and output bytes get cleared on anything finished
@@ -6140,6 +6177,44 @@ export class DesktopBackendRegistry {
    * process didn't survive the parent restart.
    */
   private readonly registrySessionStartedAt = Date.now();
+
+  private liveProfileRuntimeInstanceIds(): string[] | undefined {
+    const instanceIds = new Set<string>([this.runtimeInstanceId]);
+    try {
+      for (const instanceId of this.resolveLiveProfileRuntimeInstanceIdsFn()) {
+        const normalized = instanceId.trim();
+        if (normalized) {
+          instanceIds.add(normalized);
+        }
+      }
+    } catch (error) {
+      backendRegistryLog.warn("live-profile-runtime-read-failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+    return Array.from(instanceIds);
+  }
+
+  private async reconcileOrphanedThreadSubAgentsAtStartup(): Promise<void> {
+    const reconcile = this.overlayStore.reconcileOrphanedThreadSubAgents;
+    if (!reconcile) {
+      return;
+    }
+    const liveRuntimeInstanceIds = this.liveProfileRuntimeInstanceIds();
+    if (!liveRuntimeInstanceIds) {
+      return;
+    }
+    const result = await reconcile.call(this.overlayStore, {
+      currentRuntimeInstanceId: this.runtimeInstanceId,
+      liveRuntimeInstanceIds,
+      sessionStartedAt: this.registrySessionStartedAt,
+    });
+    if (result.repairedSubAgents > 0) {
+      backendRegistryLog.info("sub-agent-startup-reconciliation", result);
+      this.invalidateThreadListCache();
+    }
+  }
 
   private async cleanupStaleCodexEnvironmentRuntimes(): Promise<void> {
     const lister = this.overlayStore.listThreadOverlaysWithCodexEnvironmentRuntime;
@@ -6575,6 +6650,7 @@ export class DesktopBackendRegistry {
     maxPages?: number;
     skipArchivedMetadataRefresh?: boolean;
   } = {}): Promise<AppServerThreadSummary[]> {
+    await this.subAgentStartupReconciliation;
     // Hard gate: the bootstrap profile MUST NEVER serve thread data,
     // regardless of what the bootstrap config.toml's onboarding
     // flags say. Concretely this guards the post-wizard dev window:
@@ -10233,6 +10309,200 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: result.threadId,
       turnId: result.turnId,
+    };
+  }
+
+  async stopSubAgent(
+    params: StopSubAgentRequest,
+  ): Promise<StopSubAgentResponse> {
+    await this.subAgentStartupReconciliation;
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const subAgent = overlay?.subAgents?.find(
+      (candidate) => candidate.monitorId === params.monitorId,
+    );
+    if (!subAgent) {
+      throw new Error("Sub-agent was not found on this thread.");
+    }
+    if (subAgent.status !== "running") {
+      throw new Error("Sub-agent is no longer running.");
+    }
+    const taskMonitor = this.taskMonitorDelegations.get(params.monitorId);
+    if (
+      taskMonitor
+      && taskMonitor.parentBackend === params.backend
+      && taskMonitor.parentThreadId === params.threadId
+    ) {
+      if (!taskMonitor.monitorThreadId || !taskMonitor.monitorTurnId) {
+        throw new Error("Sub-agent does not expose an active turn to stop.");
+      }
+      // A terminal notification from an interrupted monitor normally starts a
+      // recovery turn. Remove an intentionally stopped monitor first so the
+      // terminal handler cannot mistake this user action for a crash.
+      this.taskMonitorDelegations.delete(params.monitorId);
+      try {
+        const executionMode = taskMonitor.executionMode ?? "default";
+        await this.getClient("codex", executionMode).interruptTurn({
+          threadId: taskMonitor.monitorThreadId,
+          turnId: taskMonitor.monitorTurnId,
+        });
+      } catch (error) {
+        this.taskMonitorDelegations.set(params.monitorId, taskMonitor);
+        throw error;
+      }
+
+      const stoppedAt = Date.now();
+      await this.persistTaskMonitorSubAgent(taskMonitor, {
+        completedAt: stoppedAt,
+        lastMessage: "Stopped by user.",
+        outcome: "cancelled",
+        status: "cancelled",
+        updatedAt: stoppedAt,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        monitorId: params.monitorId,
+        stoppedAt,
+      };
+    }
+
+    const ownerRuntimeInstanceId = subAgent.ownerRuntimeInstanceId?.trim();
+    const resolvedLiveRuntimeInstanceIds =
+      this.liveProfileRuntimeInstanceIds();
+    if (!resolvedLiveRuntimeInstanceIds) {
+      throw new Error(
+        "PwrAgent could not determine which runtime owns this sub-agent. Try again after checking the other PwrAgent instances using this profile.",
+      );
+    }
+    const liveRuntimeInstanceIds = new Set(resolvedLiveRuntimeInstanceIds);
+    const hasOtherLiveRuntime = Array.from(liveRuntimeInstanceIds).some(
+      (instanceId) => instanceId !== this.runtimeInstanceId,
+    );
+    if (
+      ownerRuntimeInstanceId
+      && ownerRuntimeInstanceId !== this.runtimeInstanceId
+      && liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+    ) {
+      throw new Error(
+        "Sub-agent is controlled by another live PwrAgent instance.",
+      );
+    }
+    if (!ownerRuntimeInstanceId && hasOtherLiveRuntime) {
+      throw new Error(
+        "Sub-agent predates runtime ownership tracking, and another PwrAgent instance is live. Close the other instance and try again.",
+      );
+    }
+    const ownerIsOrphaned = ownerRuntimeInstanceId
+      ? !liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+      : true;
+    if (ownerIsOrphaned) {
+      const stoppedAt = Date.now();
+      const completedAt = reliableSubAgentCompletionBoundary(subAgent);
+      await this.overlayStore.upsertThreadSubAgent({
+        backend: params.backend,
+        threadId: params.threadId,
+        subAgent: {
+          ...subAgent,
+          status: "cancelled",
+          outcome: "cancelled",
+          completedAt,
+          updatedAt: completedAt,
+          lastMessage:
+            "Stop was requested after its owning PwrAgent runtime had already stopped.",
+          completionSource: {
+            type: "parent_cancel",
+          },
+        },
+      });
+      if (
+        subAgent.monitorId.startsWith("codex-native:")
+        && subAgent.monitorThreadId
+      ) {
+        this.clearCodexNativeSubAgentReconciliation(subAgent.monitorThreadId);
+      }
+      this.invalidateThreadListCache(params.backend);
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/subAgents/updated",
+          params: {
+            threadId: params.threadId,
+          },
+        },
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        monitorId: params.monitorId,
+        stoppedAt,
+      };
+    }
+
+    if (!subAgent.monitorThreadId || !subAgent.monitorTurnId) {
+      throw new Error("Sub-agent does not expose an active turn to stop.");
+    }
+
+    let turnId = subAgent.monitorTurnId;
+    if (subAgent.monitorId.startsWith("codex-native:")) {
+      try {
+        const child = await this.readThread({
+          backend: "codex",
+          threadId: subAgent.monitorThreadId,
+          includeTurns: true,
+        });
+        const activeEntry = [...child.replay.entries]
+          .reverse()
+          .find((entry) => entry.turn?.status === "in_progress");
+        turnId = activeEntry?.turn?.id ?? turnId;
+      } catch (error) {
+        backendRegistryLog.debug("native sub-agent active turn read failed", {
+          error: error instanceof Error ? error.message : String(error),
+          monitorId: subAgent.monitorId,
+          monitorThreadId: subAgent.monitorThreadId,
+        });
+      }
+    }
+
+    await this.interruptTurn({
+      backend: subAgent.backend ?? params.backend,
+      threadId: subAgent.monitorThreadId,
+      turnId,
+    });
+
+    const stoppedAt = Date.now();
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: params.backend,
+      threadId: params.threadId,
+      subAgent: {
+        ...subAgent,
+        status: "cancelled",
+        outcome: "cancelled",
+        completedAt: stoppedAt,
+        updatedAt: stoppedAt,
+        lastMessage: "Stopped by user.",
+      },
+    });
+    if (subAgent.monitorId.startsWith("codex-native:")) {
+      this.clearCodexNativeSubAgentReconciliation(subAgent.monitorThreadId);
+    }
+    this.invalidateThreadListCache(params.backend);
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: params.threadId,
+        },
+      },
+    });
+    return {
+      backend: params.backend,
+      threadId: params.threadId,
+      monitorId: params.monitorId,
+      stoppedAt,
     };
   }
 
@@ -15857,6 +16127,8 @@ export class DesktopBackendRegistry {
       status,
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
+      ownerRuntimeInstanceId:
+        existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: "codex",
       monitorThreadId: params.receiverThreadId,
       ...(params.call.parentTurnId
@@ -16151,6 +16423,8 @@ export class DesktopBackendRegistry {
         (record.monitorThreadId ? "running" : "pending"),
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      ownerRuntimeInstanceId:
+        existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: record.backend,
       preferredModel: record.preferredModel,
       preferredReasoningEffort: record.preferredReasoningEffort,
@@ -16223,6 +16497,8 @@ export class DesktopBackendRegistry {
       status: patch.status ?? existing?.status ?? "running",
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      ownerRuntimeInstanceId:
+        existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: record.backend,
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
@@ -17661,6 +17937,16 @@ export class DesktopBackendRegistry {
       params.status === "success" ||
       params.status === "failed" ||
       params.status === "cancelled";
+    const startsNewAttempt =
+      (params.status === "pending" || params.status === "running")
+      && existing !== undefined
+      && (
+        existing.completedAt !== undefined
+        || existing.outcome !== undefined
+        || existing.completionSource !== undefined
+        || codexNativeSubAgentIsTerminal(existing.status)
+        || existing.status === "failed"
+      );
     const outcome =
       params.status === "success"
         ? "success"
@@ -17673,8 +17959,11 @@ export class DesktopBackendRegistry {
       monitorId,
       task: "Name this thread",
       status: params.status,
-      createdAt: existing?.createdAt ?? now,
+      createdAt: startsNewAttempt ? now : existing?.createdAt ?? now,
       updatedAt: now,
+      ownerRuntimeInstanceId: startsNewAttempt
+        ? this.runtimeInstanceId
+        : existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
       backend: params.backend,
       agentName: "PwrAgent",
       ...(preferredModel ? { preferredModel } : {}),

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -17,6 +17,8 @@ import {
   type MaterializeDirectoryLaunchpadResponse,
   type InterruptTurnRequest,
   type InterruptTurnResponse,
+  type StopSubAgentRequest,
+  type StopSubAgentResponse,
   type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
@@ -64,6 +66,7 @@ import {
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
@@ -490,6 +493,33 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_STOP_SUB_AGENT_CHANNEL);
+  ipcMain.handle(
+    AGENT_STOP_SUB_AGENT_CHANNEL,
+    async (
+      _event,
+      request: StopSubAgentRequest,
+    ): Promise<StopSubAgentResponse> => {
+      logDebug("stopSubAgent", {
+        backend: request.backend,
+        threadId: request.threadId,
+        monitorId: request.monitorId,
+      });
+
+      try {
+        return await registry.stopSubAgent(request);
+      } catch (error) {
+        appServerLog.error("stopSubAgent failed", {
+          backend: request.backend,
+          threadId: request.threadId,
+          monitorId: request.monitorId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+  );
+
   ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);
   ipcMain.handle(
     AGENT_STEER_TURN_CHANNEL,
@@ -714,6 +744,7 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_COMPACT_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
+  ipcMain.removeHandler(AGENT_STOP_SUB_AGENT_CHANNEL);
   ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);
   ipcMain.removeHandler(AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL);

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -33,6 +33,7 @@ export const PWRAGENT_PROFILE_AUTO_CREATE_ENV = "PWRAGENT_PROFILE_AUTO_CREATE";
 
 const PROFILE_RUNTIME_HEARTBEAT_INTERVAL_MS = 10_000;
 const PROFILE_RUNTIME_HEARTBEAT_TTL_MS = 45_000;
+const PROFILE_RUNTIME_IDENTITY_PREFIX = "runtime-v2-";
 
 /**
  * Disk location for the throwaway "bootstrap" profile the wizard
@@ -88,7 +89,23 @@ export type ProfileRuntimeMarker = {
   heartbeatAt: number;
 };
 
+export type ProfileRuntimeIdentity = Pick<
+  ProfileRuntimeMarker,
+  "instanceId" | "processId" | "startedAt"
+>;
+
 let cachedProcessActiveProfileName: string | undefined;
+let processRuntimeIdentity: Omit<ProfileRuntimeIdentity, "processId"> | undefined;
+
+export function getProcessRuntimeIdentity(): Omit<ProfileRuntimeIdentity, "processId"> {
+  if (!processRuntimeIdentity) {
+    processRuntimeIdentity = {
+      instanceId: `${PROFILE_RUNTIME_IDENTITY_PREFIX}${randomUUID()}`,
+      startedAt: Date.now(),
+    };
+  }
+  return processRuntimeIdentity;
+}
 
 export function isValidProfileName(name: string): boolean {
   return isCanonicalProfileName(name);
@@ -652,6 +669,7 @@ export function startProfileRuntimeHeartbeat(
     intervalMs?: number;
     now?: () => number;
     processId?: number;
+    startedAt?: number;
   },
 ): ProfileRuntimeHeartbeat {
   const normalizedProfileName = normalizeProfileName(profileName);
@@ -664,7 +682,7 @@ export function startProfileRuntimeHeartbeat(
     instanceId: options?.instanceId ?? randomUUID(),
     processId,
     profileName: normalizedProfileName,
-    startedAt: now(),
+    startedAt: options?.startedAt ?? now(),
     heartbeatAt: now(),
   };
   const markerDir = resolveProfileRuntimeMarkerDir(normalizedProfileName, options);

--- a/apps/desktop/src/main/state/app-state.ts
+++ b/apps/desktop/src/main/state/app-state.ts
@@ -1,6 +1,7 @@
 import {
   ensureBootstrapProfileDir,
   ensureProfileExists,
+  getProcessRuntimeIdentity,
   resolveActiveProfilePath,
   resolveBootstrapProfilePath,
   startProfileRuntimeHeartbeat,
@@ -107,7 +108,11 @@ export function initializeAppState(
     stateDb.startGc();
 
     updateLastUsed(profileName);
-    profileRuntimeHeartbeat = startProfileRuntimeHeartbeat(profileName);
+    const processIdentity = getProcessRuntimeIdentity();
+    profileRuntimeHeartbeat = startProfileRuntimeHeartbeat(profileName, {
+      instanceId: processIdentity.instanceId,
+      startedAt: processIdentity.startedAt,
+    });
   }
 
   messagingStore = new SqliteMessagingStore(stateDb);

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -312,6 +312,130 @@ function shouldApplyAcpExecutionModeSnapshot(
 export class SqliteOverlayStore {
   constructor(private readonly stateDb: StateDb) {}
 
+  /**
+   * Finalize sub-agents whose creating PwrAgent runtime no longer exists.
+   *
+   * Every repair is committed in one transaction. New summaries identify
+   * their owner exactly. Legacy ownerless summaries are repaired only when
+   * this is the profile's sole live runtime, so opening a second PwrAgent
+   * window can never fail work still owned by the first one.
+   */
+  async reconcileOrphanedThreadSubAgents(params: {
+    currentRuntimeInstanceId: string;
+    liveRuntimeInstanceIds: string[];
+    sessionStartedAt: number;
+  }): Promise<{
+    repairedSubAgents: number;
+    repairedThreads: number;
+    skippedLiveOwners: number;
+    skippedOwnerlessWithOtherRuntimes: number;
+  }> {
+    const liveRuntimeInstanceIds = new Set(params.liveRuntimeInstanceIds);
+    liveRuntimeInstanceIds.add(params.currentRuntimeInstanceId);
+    const hasOtherLiveRuntime = Array.from(liveRuntimeInstanceIds).some(
+      (instanceId) => instanceId !== params.currentRuntimeInstanceId,
+    );
+    const result = {
+      repairedSubAgents: 0,
+      repairedThreads: 0,
+      skippedLiveOwners: 0,
+      skippedOwnerlessWithOtherRuntimes: 0,
+    };
+
+    const reconcile = this.stateDb.raw.transaction(() => {
+      const rows = this.stateDb.raw
+        .prepare(
+          `SELECT payload
+           FROM threads
+           WHERE payload LIKE '%"subAgents"%'`,
+        )
+        .all() as Array<{ payload: string }>;
+
+      for (const row of rows) {
+        let overlay: ThreadOverlayState;
+        try {
+          overlay = normalizeThreadOverlayState(
+            JSON.parse(row.payload) as ThreadOverlayState,
+          );
+        } catch {
+          continue;
+        }
+        if (!overlay.subAgents?.length) {
+          continue;
+        }
+
+        let changed = false;
+        const subAgents = overlay.subAgents.map((subAgent) => {
+          if (subAgent.completedAt !== undefined) {
+            return subAgent;
+          }
+
+          const completedAt = reliableSubAgentCompletionBoundary(subAgent);
+          if (subAgentHasTerminalEvidence(subAgent)) {
+            changed = true;
+            result.repairedSubAgents += 1;
+            return {
+              ...subAgent,
+              completedAt,
+              updatedAt: completedAt,
+              ...(subAgent.status === "failed"
+                ? { status: "failure" as const, outcome: "failure" as const }
+                : {}),
+            };
+          }
+
+          const ownerRuntimeInstanceId = subAgent.ownerRuntimeInstanceId?.trim();
+          if (
+            ownerRuntimeInstanceId
+            && liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+          ) {
+            result.skippedLiveOwners += 1;
+            return subAgent;
+          }
+          if (!ownerRuntimeInstanceId && hasOtherLiveRuntime) {
+            result.skippedOwnerlessWithOtherRuntimes += 1;
+            return subAgent;
+          }
+          if (
+            !ownerRuntimeInstanceId
+            && subAgent.createdAt >= params.sessionStartedAt
+          ) {
+            return subAgent;
+          }
+
+          changed = true;
+          result.repairedSubAgents += 1;
+          return {
+            ...subAgent,
+            status: "failure" as const,
+            outcome: "failure" as const,
+            completedAt,
+            updatedAt: completedAt,
+            lastMessage:
+              "Interrupted when its owning PwrAgent runtime stopped before reporting completion.",
+            completionSource: {
+              type: "pwragent_fallback" as const,
+              reason: "owner_runtime_stopped",
+              recoveryAttempted: false,
+              terminalStatus: "failed" as const,
+            },
+          };
+        });
+        if (!changed) {
+          continue;
+        }
+
+        result.repairedThreads += 1;
+        this.putThread(buildThreadIdentityKey(overlay.backend, overlay.threadId), {
+          ...overlay,
+          subAgents,
+        });
+      }
+    });
+    reconcile();
+    return result;
+  }
+
   async reconcileNavigationSnapshot(params: {
     backend: AppServerBackendScope;
     fetchedAt: number;
@@ -3928,8 +4052,29 @@ export type OverlayStoreLike = Pick<
   | "upsertDirectoryLaunchpad"
   | "resetDirectoryLaunchpad"
 > & {
+  reconcileOrphanedThreadSubAgents?: SqliteOverlayStore["reconcileOrphanedThreadSubAgents"];
   setThreadCodexEnvironmentRuntime?: SqliteOverlayStore["setThreadCodexEnvironmentRuntime"];
   listThreadOverlaysWithCodexEnvironmentRuntime?: SqliteOverlayStore["listThreadOverlaysWithCodexEnvironmentRuntime"];
   upsertThreadMessageOrigin?: SqliteOverlayStore["upsertThreadMessageOrigin"];
   readThreadMessageOrigins?: SqliteOverlayStore["readThreadMessageOrigins"];
 };
+
+function reliableSubAgentCompletionBoundary(
+  subAgent: ThreadSubAgentSummary,
+): number {
+  return Number.isFinite(subAgent.updatedAt)
+    && subAgent.updatedAt >= subAgent.createdAt
+    ? subAgent.updatedAt
+    : subAgent.createdAt;
+}
+
+function subAgentHasTerminalEvidence(subAgent: ThreadSubAgentSummary): boolean {
+  return (
+    subAgent.status === "success"
+    || subAgent.status === "failure"
+    || subAgent.status === "cancelled"
+    || subAgent.status === "failed"
+    || subAgent.outcome !== undefined
+    || subAgent.completionSource !== undefined
+  );
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -20,6 +20,8 @@ import type {
   ForkThreadResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  StopSubAgentRequest,
+  StopSubAgentResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
   ListAutomationLoadIssuesResponse,
@@ -288,6 +290,7 @@ import {
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
@@ -1073,6 +1076,10 @@ const desktopApi = Object.freeze({
     request: InterruptTurnRequest
   ): Promise<InterruptTurnResponse> =>
     await ipcRenderer.invoke(AGENT_INTERRUPT_TURN_CHANNEL, request),
+  stopSubAgent: async (
+    request: StopSubAgentRequest,
+  ): Promise<StopSubAgentResponse> =>
+    await ipcRenderer.invoke(AGENT_STOP_SUB_AGENT_CHANNEL, request),
   steerTurn: async (
     request: SteerTurnRequest
   ): Promise<SteerTurnResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -693,6 +693,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       case "subagents":
         return (
           <SubAgentsPanel
+            desktopApi={props.desktopApi}
+            onRefreshNavigation={props.onRefreshNavigation}
             pricingDisplayOptions={props.pricingDisplayOptions}
             thread={props.thread}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -18,8 +18,11 @@ import {
   subAgentOriginSentence,
   subAgentUsageLabel,
 } from "./subagent-kind";
+import type { DesktopApi } from "../../../lib/desktop-api";
 
 type SubAgentsPanelProps = {
+  desktopApi?: DesktopApi;
+  onRefreshNavigation?: () => Promise<void>;
   pricingDisplayOptions?: PricingDisplayOptions;
   thread: NavigationThreadSummary;
 };
@@ -28,6 +31,40 @@ type SubAgentsPanelProps = {
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
   const [detailsFor, setDetailsFor] = useState<ThreadSubAgentSummary | null>(null);
+  const [stoppingIds, setStoppingIds] = useState<Set<string>>(() => new Set());
+  const [stopErrors, setStopErrors] = useState<Record<string, string>>({});
+
+  const stopSubAgent = async (subAgent: ThreadSubAgentSummary): Promise<void> => {
+    if (!props.desktopApi?.stopSubAgent) {
+      return;
+    }
+    setStopErrors((current) => {
+      const next = { ...current };
+      delete next[subAgent.monitorId];
+      return next;
+    });
+    setStoppingIds((current) => new Set(current).add(subAgent.monitorId));
+    try {
+      await props.desktopApi.stopSubAgent({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        monitorId: subAgent.monitorId,
+      });
+      await props.onRefreshNavigation?.();
+    } catch (error) {
+      setStopErrors((current) => ({
+        ...current,
+        [subAgent.monitorId]:
+          error instanceof Error ? error.message : "Could not stop sub-agent.",
+      }));
+    } finally {
+      setStoppingIds((current) => {
+        const next = new Set(current);
+        next.delete(subAgent.monitorId);
+        return next;
+      });
+    }
+  };
 
   return (
     <section className="context-panel__section">
@@ -44,6 +81,12 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
               subAgent.lastMessage && subAgent.lastMessage !== originSentence
                 ? subAgent.lastMessage
                 : undefined;
+            const stopping = stoppingIds.has(subAgent.monitorId);
+            const canStop =
+              subAgent.status === "running"
+              && Boolean(subAgent.monitorThreadId)
+              && Boolean(subAgent.monitorTurnId)
+              && Boolean(props.desktopApi?.stopSubAgent);
             return (
               <li key={subAgent.monitorId} className="rail-card">
                 {/* Status on its own line so it never competes with the
@@ -98,13 +141,30 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                     })}
                   </p>
                 ) : null}
-                <button
-                  className="context-list__action"
-                  type="button"
-                  onClick={() => setDetailsFor(subAgent)}
-                >
-                  Details
-                </button>
+                <div className="context-list__actions rail-card__actions">
+                  <button
+                    className="context-list__action rail-card__details-action"
+                    type="button"
+                    onClick={() => setDetailsFor(subAgent)}
+                  >
+                    Details
+                  </button>
+                  {canStop ? (
+                    <button
+                      className="context-list__action context-list__action--danger"
+                      type="button"
+                      disabled={stopping}
+                      onClick={() => void stopSubAgent(subAgent)}
+                    >
+                      {stopping ? "Stopping…" : "Stop"}
+                    </button>
+                  ) : null}
+                </div>
+                {stopErrors[subAgent.monitorId] ? (
+                  <p className="rail-card__error" role="alert">
+                    {stopErrors[subAgent.monitorId]}
+                  </p>
+                ) : null}
               </li>
             );
           })}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -1,0 +1,94 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../../lib/desktop-api";
+import { SubAgentsPanel } from "../SubAgentsPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+const thread: NavigationThreadSummary = {
+  id: "parent-thread",
+  title: "Parent thread",
+  titleSource: "explicit",
+  source: "codex",
+  linkedDirectories: [],
+  inbox: { inInbox: true },
+  subAgents: [
+    {
+      monitorId: "monitor-1",
+      task: "Watch the deployment",
+      status: "running",
+      createdAt: 1_800_000_000_000,
+      updatedAt: 1_800_000_000_000,
+      backend: "codex",
+      monitorThreadId: "monitor-thread",
+      monitorTurnId: "monitor-turn",
+    },
+    {
+      monitorId: "monitor-2",
+      task: "Finished work",
+      status: "success",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_100,
+      completedAt: 1_700_000_000_100,
+      backend: "codex",
+      monitorThreadId: "finished-thread",
+      monitorTurnId: "finished-turn",
+    },
+  ],
+};
+
+describe("SubAgentsPanel", () => {
+  it("stops a running sub-agent and refreshes navigation", async () => {
+    const stopSubAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "parent-thread",
+      monitorId: "monitor-1",
+      stoppedAt: 1_800_000_000_100,
+    }));
+    const onRefreshNavigation = vi.fn(async () => undefined);
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent } as DesktopApi}
+        onRefreshNavigation={onRefreshNavigation}
+        thread={thread}
+      />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Stop" })).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(stopSubAgent).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "parent-thread",
+        monitorId: "monitor-1",
+      });
+    });
+    expect(onRefreshNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the control available and reports an interruption failure", async () => {
+    const stopSubAgent = vi.fn(async () => {
+      throw new Error("Sub-agent is no longer running.");
+    });
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent } as DesktopApi}
+        thread={thread}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(
+      await screen.findByRole("alert"),
+    ).toHaveTextContent("Sub-agent is no longer running.");
+    expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -70,6 +70,8 @@ import type {
   HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  StopSubAgentRequest,
+  StopSubAgentResponse,
   LatestCodexConfigWarningResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
@@ -455,6 +457,9 @@ export type DesktopApi = {
   interruptTurn?: (
     request: InterruptTurnRequest
   ) => Promise<InterruptTurnResponse>;
+  stopSubAgent?: (
+    request: StopSubAgentRequest,
+  ) => Promise<StopSubAgentResponse>;
   steerTurn?: (request: SteerTurnRequest) => Promise<SteerTurnResponse>;
   setThreadExecutionMode?: (
     request: SetThreadExecutionModeRequest

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12778,6 +12778,11 @@ a.transcript-message__messaging-origin:focus-visible {
   outline: none;
 }
 
+.context-list__action:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
 .context-list__action--danger {
   border-color: var(--danger-border);
   color: var(--danger-text);
@@ -14039,6 +14044,23 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .rail-card__usage {
   color: var(--text-secondary);
+}
+
+.rail-card__actions {
+  width: 100%;
+  margin-top: 2px;
+}
+
+.rail-card__details-action {
+  flex: 1 1 auto;
+}
+
+.rail-card__error {
+  margin: 0;
+  color: var(--danger-text);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .pricing-usage-row {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -32,6 +32,7 @@ export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
 export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
 export const AGENT_COMPACT_THREAD_CHANNEL = "agent:compact-thread";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
+export const AGENT_STOP_SUB_AGENT_CHANNEL = "agent:stop-sub-agent";
 export const AGENT_STEER_TURN_CHANNEL = "agent:steer-turn";
 export const AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL = "agent:set-thread-execution-mode";
 export const AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL =

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -272,6 +272,19 @@ export type InterruptTurnResponse = {
   turnId: string;
 };
 
+export type StopSubAgentRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  monitorId: string;
+};
+
+export type StopSubAgentResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  monitorId: string;
+  stoppedAt: number;
+};
+
 export type CompactThreadRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -168,6 +168,15 @@ export type ThreadSubAgentSummary = {
   status: ThreadSubAgentStatus;
   createdAt: number;
   updatedAt: number;
+  /**
+   * PwrAgent process-runtime UUID that created this sub-agent attempt.
+   *
+   * This lives in the existing thread-overlay JSON rather than its own sqlite
+   * column. A replacement process can therefore distinguish its own work from
+   * work still owned by another live PwrAgent instance sharing the profile.
+   * Older summaries omit it and use the conservative sole-runtime fallback.
+   */
+  ownerRuntimeInstanceId?: string;
   backend?: AppServerBackendKind;
   agentName?: string;
   preferredModel?: string;

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -73,6 +73,9 @@ export type TaskMonitorCompletionSource =
       type: "monitor_tool";
     }
   | {
+      type: "parent_cancel";
+    }
+  | {
       type: "pwragent_fallback";
       reason: string;
       recoveryAttempted: boolean;


### PR DESCRIPTION
## Summary

- persist the creating PwrAgent runtime UUID in the existing sub-agent overlay JSON
- reconcile unfinished sub-agents before serving threads after startup, failing only work whose recorded owner is no longer in the live profile-runtime marker set
- add the local-only Stop surface that `releases/1.0` lacked, then make Stop close orphaned work locally while refusing to touch work owned by another live PwrAgent runtime
- reset deterministic title-helper start times when a terminal helper card begins a new attempt

## 1.0 applicability and adaptations

- Backport of #1603, source squash `f3432e9a66b8216968b2d5d0f9c9e1f5cf41afb7`.
- `releases/1.0` did not contain the local Stop feature that the source fix modifies, so this includes the local-only prerequisite from #1157 / `e7764614565ad9e06ffb91ad4061c79d4ce35ab3`.
- The release branch already has profile-scoped runtime heartbeat markers with UUID, heartbeat-TTL, and PID-liveness checks. This backport gives the existing heartbeat the process runtime identity used by overlays; it does not import the 1.1 runtime lease manager.
- Federation, remote Stop routing, Star Map, Automations, Attention, scheduled actions, and other 1.1 architecture are intentionally excluded.
- 1.0 lacks the later `viewOnly` read request flag, so local native-sub-agent Stop uses the release branch's existing local thread read path to resolve the active child turn.

## Multi-runtime safety

- owner-tagged work is repaired only when its owner UUID is absent from the live profile-runtime marker set
- work owned by another live runtime is left untouched and local Stop is rejected
- legacy ownerless work is repaired only when the current runtime is the sole live runtime
- if runtime-marker liveness cannot be read, startup reconciliation does nothing and Stop fails closed
- all startup repairs are committed in one SQLite transaction; ownership adds no timer and no recurring or idle write

## Migration and config audit

- no database schema, `user_version`, DDL, migration, package, or lockfile changes
- no `config.toml` shape or config-evolution changes
- ownership remains an optional field in the existing `threads.payload` overlay JSON, so legacy rows remain readable

## Validation

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/profile.test.ts apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx` — 463 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; 136 existing warnings
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
