### PR TITLE
fix(desktop): reap integrated terminals on shutdown

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-policy.ts
@@ -77,6 +77,7 @@ export type ElectronShutdownSummary = {
   forceExitOutcome: ElectronCloseExecution["forceExitOutcome"];
   phases: {
     rendererWindow: ElectronShutdownPhaseSummary;
+    integratedTerminal: ElectronShutdownPhaseSummary;
     messaging: ElectronShutdownPhaseSummary;
     federation: ElectronShutdownPhaseSummary;
     mcpConnections: ElectronShutdownPhaseSummary;
@@ -252,6 +253,7 @@ export function buildElectronShutdownSummary(params: {
     forceExitOutcome: params.execution.forceExitOutcome,
     phases: {
       rendererWindow: summarizePhase(params.events, "renderer-window"),
+      integratedTerminal: summarizePhase(params.events, "integrated-terminal"),
       messaging: summarizePhase(params.events, "messaging"),
       federation: summarizePhase(params.events, "federation"),
       mcpConnections: summarizePhase(params.events, "mcp-connections"),

--- a/apps/desktop/src/main/__tests__/e2e-shutdown-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-shutdown-diagnostics.test.ts
@@ -71,7 +71,7 @@ describe("E2E shutdown diagnostics", () => {
           schemaVersion: 1,
           kind: "phase",
           launchId: "launch-2",
-          phase: "app-server",
+          phase: "integrated-terminal",
           outcome: "timed-out",
           durationMs: 7_500,
           homeRoot: "/Users/alice/private-home",
@@ -88,7 +88,7 @@ describe("E2E shutdown diagnostics", () => {
         schemaVersion: 1,
         kind: "phase",
         launchId: "launch-2",
-        phase: "app-server",
+        phase: "integrated-terminal",
         outcome: "timed-out",
         durationMs: 7_500,
       }]);

--- a/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-policy.test.ts
@@ -166,6 +166,7 @@ describe("Electron shutdown policy", () => {
       events: [
         phaseEvent("overall", "started", 0),
         phaseEvent("renderer-window", "completed", 8),
+        phaseEvent("integrated-terminal", "timed-out", 2_000),
         phaseEvent("messaging", "started", 0),
         phaseEvent("federation", "started", 0),
         phaseEvent("mcp-connections", "completed", 12),
@@ -182,6 +183,7 @@ describe("Electron shutdown policy", () => {
 
     expect(summary.phases).toEqual({
       rendererWindow: { durationMs: 8, outcome: "completed" },
+      integratedTerminal: { durationMs: 2_000, outcome: "timed-out" },
       messaging: { durationMs: null, outcome: "interrupted" },
       federation: { durationMs: null, outcome: "interrupted" },
       mcpConnections: { durationMs: 12, outcome: "completed" },
@@ -216,10 +218,11 @@ function phaseEvent(
   phase:
     | "overall"
     | "renderer-window"
+    | "integrated-terminal"
     | "messaging"
     | "federation"
     | "mcp-connections",
-  outcome: "started" | "completed",
+  outcome: "started" | "completed" | "timed-out",
   durationMs: number,
 ) {
   return {
@@ -245,6 +248,7 @@ function trippedSummary(): ElectronShutdownSummary {
     forceExitOutcome: "exited",
     phases: {
       rendererWindow: phase,
+      integratedTerminal: phase,
       messaging: phase,
       federation: phase,
       mcpConnections: phase,

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1468,6 +1468,7 @@ describe("bootstrapApp", () => {
     appEventHandlers.get("activate")?.();
 
     expect(createMainWindowMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
   });
 
   it("does not recreate a window from Dock activation during an update install", async () => {
@@ -1506,9 +1507,16 @@ describe("bootstrapApp", () => {
     onFocus();
 
     expect(createMainWindowMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
   });
 
   it("awaits async resource disposal before completing quit", async () => {
+    let finishTerminalShutdown!: () => void;
+    disposeIntegratedTerminalIpcHandlersMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishTerminalShutdown = resolve;
+      }),
+    );
     startupProfilerInstance.start.mockResolvedValue();
 
     await import("../index");
@@ -1516,9 +1524,16 @@ describe("bootstrapApp", () => {
 
     const event = { preventDefault: vi.fn() };
     appEventHandlers.get("before-quit")?.(event);
-    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(disposeIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1),
+    );
 
     expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(quitMock).not.toHaveBeenCalled();
+
+    finishTerminalShutdown();
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
+
     expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeFederationIpcHandlersMock).toHaveBeenCalledTimes(1);
@@ -1969,8 +1984,9 @@ describe("bootstrapApp", () => {
     }
 
     sigtermHandler("SIGTERM");
-    await flushMicrotasks();
-    expect(disposeDesktopFederationRuntimeMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(disposeDesktopFederationRuntimeMock).toHaveBeenCalledTimes(1),
+    );
 
     // The federation phase runs out its timeout (and the barrier its
     // global deadline) without ever reaching the post-stop release.

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -564,11 +564,18 @@ describe("resolveTerminalShell", () => {
     expect(service.listSessions()).toHaveLength(1);
   });
 
-  it("removes pty listeners before killing sessions during shutdown", async () => {
+  it("closes the pty master and awaits shell exit during shutdown", async () => {
     const disposable = { dispose: vi.fn() };
+    const shutdownExitDisposable = { dispose: vi.fn() };
+    const exitListeners: Array<(event: { exitCode: number }) => void> = [];
     const pty = fakePty({
       onData: vi.fn(() => disposable),
-      onExit: vi.fn(() => disposable),
+      onExit: vi.fn((listener) => {
+        exitListeners.push(listener);
+        return exitListeners.length === 1
+          ? disposable
+          : shutdownExitDisposable;
+      }),
     });
     const service = new IntegratedTerminalService({
       loadNodePty: async () => ({
@@ -586,15 +593,28 @@ describe("resolveTerminalShell", () => {
       fakeWebContents(),
     );
 
-    service.dispose();
+    const disposing = service.dispose();
+    let disposed = false;
+    void disposing.then(() => {
+      disposed = true;
+    });
+    await Promise.resolve();
 
     expect(disposable.dispose).toHaveBeenCalledTimes(2);
-    expect(pty.kill).toHaveBeenCalledTimes(1);
+    expect((pty as TestPty).destroy).toHaveBeenCalledTimes(1);
+    expect(pty.kill).not.toHaveBeenCalled();
+    expect(disposed).toBe(false);
     expect(service.getQuitSnapshot()).toEqual({
       count: 0,
       sessionIds: [],
       threads: [],
     });
+
+    exitListeners[1]?.({ exitCode: 0 });
+    await disposing;
+
+    expect(disposed).toBe(true);
+    expect(shutdownExitDisposable.dispose).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -612,7 +632,11 @@ function fakeWebContents(): WebContents & {
   };
 }
 
-function fakePty(overrides: Partial<IPty> = {}): IPty {
+type TestPty = IPty & {
+  destroy: ReturnType<typeof vi.fn>;
+};
+
+function fakePty(overrides: Partial<IPty> = {}): TestPty {
   return {
     pid: 123,
     cols: 80,
@@ -620,6 +644,7 @@ function fakePty(overrides: Partial<IPty> = {}): IPty {
     process: "sh",
     handleFlowControl: false,
     clear: vi.fn(),
+    destroy: vi.fn(),
     kill: vi.fn(),
     onData: vi.fn(() => ({ dispose: vi.fn() })),
     onExit: vi.fn(() => ({ dispose: vi.fn() })),
@@ -628,5 +653,5 @@ function fakePty(overrides: Partial<IPty> = {}): IPty {
     resize: vi.fn(),
     write: vi.fn(),
     ...overrides,
-  };
+  } as TestPty;
 }

--- a/apps/desktop/src/main/e2e-shutdown-diagnostics.ts
+++ b/apps/desktop/src/main/e2e-shutdown-diagnostics.ts
@@ -14,6 +14,7 @@ export const E2E_SHUTDOWN_LAUNCH_ID_ENV =
 export const E2E_SHUTDOWN_PHASES = [
   "overall",
   "renderer-window",
+  "integrated-terminal",
   "messaging",
   "federation",
   "app-server",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -209,6 +209,7 @@ const mainLog = getMainLogger("pwragent:main");
 const mainProcessStartedAt = Date.now();
 const RENDERER_WINDOW_SHUTDOWN_TIMEOUT_MS = 2_000;
 const MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS = 12_000;
+const INTEGRATED_TERMINAL_SHUTDOWN_TIMEOUT_MS = 2_000;
 const MESSAGING_SHUTDOWN_TIMEOUT_MS = 4_000;
 const FEDERATION_SHUTDOWN_TIMEOUT_MS = 4_000;
 const APP_SERVER_SHUTDOWN_TIMEOUT_MS = 7_500;
@@ -237,6 +238,7 @@ let mainProcessResourcesDisposed = false;
 let federationLeaseReleasedSync = false;
 let mainProcessShutdownComplete = false;
 let mainProcessShutdownPromise: Promise<void> | undefined;
+let integratedTerminalShutdownPromise: Promise<void> | undefined;
 let rendererWindowShutdownPromise: Promise<void> | undefined;
 let finalQuitPromise: Promise<void> | undefined;
 let quitInProgress = false;
@@ -501,7 +503,9 @@ function disposeMainProcessResourcesSync(options?: {
   disposeFederationIpcHandlers();
   disposeStarMapIpcHandlers();
   disposeImageNormalizationIpcHandlers();
-  disposeIntegratedTerminalIpcHandlers();
+  integratedTerminalShutdownPromise ??= Promise.resolve(
+    disposeIntegratedTerminalIpcHandlers(),
+  );
   disposeMcpConnectionIpcHandlers();
   // Detached env-action trees (`pnpm dev` and friends) were previously just
   // abandoned here. They keep their stdio pipes, so they *usually* died of
@@ -653,6 +657,15 @@ const runMainProcessShutdownBarrier = createShutdownBarrier({
     },
   },
   phases: [
+    {
+      name: "integrated-terminal",
+      timeoutMs: INTEGRATED_TERMINAL_SHUTDOWN_TIMEOUT_MS,
+      run: async () => {
+        await (integratedTerminalShutdownPromise ??= Promise.resolve(
+          disposeIntegratedTerminalIpcHandlers(),
+        ));
+      },
+    },
     {
       name: "messaging",
       timeoutMs: MESSAGING_SHUTDOWN_TIMEOUT_MS,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -730,6 +730,7 @@ function toE2eShutdownPhase(
   phase: string,
 ): Exclude<E2eShutdownPhase, "overall" | "renderer-window"> | undefined {
   switch (phase) {
+    case "integrated-terminal":
     case "messaging":
     case "federation":
     case "app-server":

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -33,6 +33,7 @@ import {
 
 let service: IntegratedTerminalService | undefined;
 let federationBridge: FederationTerminalBridge | undefined;
+let serviceDisposalPromise: Promise<void> | undefined;
 
 function broadcastSessions(
   sessions: IntegratedTerminalSessionSummary[],
@@ -56,9 +57,12 @@ function broadcastSessions(
 }
 
 export function registerIntegratedTerminalIpcHandlers(): void {
-  service ??= new IntegratedTerminalService({
-    onSessionsChanged: broadcastSessions,
-  });
+  if (!service) {
+    service = new IntegratedTerminalService({
+      onSessionsChanged: broadcastSessions,
+    });
+    serviceDisposalPromise = undefined;
+  }
   federationBridge ??= new FederationTerminalBridge({
     localSessionsFor: () => service?.listSessions() ?? [],
   });
@@ -163,20 +167,21 @@ export function registerIntegratedTerminalIpcHandlers(): void {
   );
 }
 
-export function disposeIntegratedTerminalIpcHandlers(): void {
+export function disposeIntegratedTerminalIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(INTEGRATED_TERMINAL_CREATE_CHANNEL);
   ipcMain.removeHandler(INTEGRATED_TERMINAL_WRITE_CHANNEL);
   ipcMain.removeHandler(INTEGRATED_TERMINAL_RESIZE_CHANNEL);
   ipcMain.removeHandler(INTEGRATED_TERMINAL_CLOSE_CHANNEL);
   ipcMain.removeHandler(INTEGRATED_TERMINAL_LIST_CHANNEL);
   ipcMain.removeHandler(INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL);
-  service?.dispose();
+  serviceDisposalPromise ??= service?.dispose() ?? Promise.resolve();
   service = undefined;
   // Drops the viewer-side registry without sending pty.close for each
   // session: this runs at app shutdown, where the federation runtime is
   // tearing down anyway and the owner's disconnect reap ends the shells.
   federationBridge?.dispose();
   federationBridge = undefined;
+  return serviceDisposalPromise;
 }
 
 export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnapshot {

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -31,6 +31,7 @@ const DEFAULT_ROWS = 18;
 const MAX_COLUMNS = 500;
 const MAX_ROWS = 200;
 const OUTPUT_BUFFER_LIMIT = 128 * 1024;
+const PTY_SHUTDOWN_FORCE_KILL_MS = 500;
 
 type TerminalSession = {
   sessionId: string;
@@ -48,6 +49,16 @@ type TerminalSession = {
 };
 
 type NodePtyModule = typeof import("node-pty");
+
+/**
+ * node-pty's concrete terminals expose `destroy()` even though its public
+ * `IPty` type omits the method. On Unix it closes the PTY master and then
+ * sends SIGHUP once the master stream has closed; `kill()` only sends the
+ * signal and leaves the master open.
+ */
+type DestroyablePty = IPty & {
+  destroy?: () => void;
+};
 
 /**
  * One shell holding up the quit. The owning peer travels with the thread key
@@ -112,6 +123,7 @@ export class IntegratedTerminalService {
    *  in one window used to install 10 and trip Node's max-listeners warning. */
   private readonly subscribedWebContents = new Set<WebContents>();
   private disposing = false;
+  private disposePromise: Promise<void> | undefined;
 
   constructor(options: IntegratedTerminalServiceOptions = {}) {
     this.loadNodePty = options.loadNodePty ?? loadNodePty;
@@ -271,11 +283,18 @@ export class IntegratedTerminalService {
     }
   }
 
-  dispose(): void {
-    this.disposing = true;
-    for (const session of Array.from(this.sessionsById.values())) {
-      this.disposeSessionForShutdown(session);
+  dispose(): Promise<void> {
+    if (this.disposePromise) {
+      return this.disposePromise;
     }
+    this.disposing = true;
+    this.disposePromise = Promise.all(
+      Array.from(this.sessionsById.values()).map((session) =>
+        this.disposeSessionForShutdown(session),
+      ),
+    ).then(() => undefined);
+    this.subscribedWebContents.clear();
+    return this.disposePromise;
   }
 
   getQuitSnapshot(): IntegratedTerminalQuitSnapshot {
@@ -450,15 +469,59 @@ export class IntegratedTerminalService {
     this.emitSessionsChanged();
   }
 
-  private disposeSessionForShutdown(session: TerminalSession): void {
+  private async disposeSessionForShutdown(
+    session: TerminalSession,
+  ): Promise<void> {
+    // Keep a dedicated exit subscription outside `session.disposables`: the
+    // renderer-facing listeners must be removed before teardown, but shutdown
+    // itself cannot complete until node-pty reports that waitpid finished and
+    // its master stream closed.
+    let exitDisposable: IDisposable | undefined;
+    const exited = new Promise<void>((resolve) => {
+      exitDisposable = session.pty.onExit(() => resolve());
+    });
     this.deleteSession(session);
     try {
-      session.pty.kill();
+      const destroy = (session.pty as DestroyablePty).destroy;
+      if (destroy) {
+        destroy.call(session.pty);
+      } else {
+        // Preserve compatibility with test doubles or a future node-pty
+        // implementation that removes the concrete destroy method.
+        session.pty.kill();
+      }
     } catch (error) {
       this.logger.warn("shutdown-kill-failed", {
         error: error instanceof Error ? error.message : String(error),
         sessionId: session.sessionId,
       });
+      exitDisposable?.dispose();
+      throw error;
+    }
+    let forceKillTimer: NodeJS.Timeout | undefined;
+    if (this.platform !== "win32") {
+      forceKillTimer = setTimeout(() => {
+        this.logger.warn("shutdown-force-kill", {
+          graceMs: PTY_SHUTDOWN_FORCE_KILL_MS,
+          sessionId: session.sessionId,
+        });
+        try {
+          session.pty.kill("SIGKILL");
+        } catch (error) {
+          this.logger.warn("shutdown-force-kill-failed", {
+            error: error instanceof Error ? error.message : String(error),
+            sessionId: session.sessionId,
+          });
+        }
+      }, PTY_SHUTDOWN_FORCE_KILL_MS);
+    }
+    try {
+      await exited;
+    } finally {
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+      }
+      exitDisposable?.dispose();
     }
   }
 


### PR DESCRIPTION
## Summary

- close each integrated terminal's PTY master during app shutdown instead of only sending SIGHUP
- keep a dedicated node-pty exit subscription and await shell reaping before the terminal shutdown phase completes
- escalate to SIGKILL after a 500 ms grace period on POSIX
- include integrated-terminal disposal in the main-process shutdown barrier

## Root cause

The shutdown path removed the session's exit listener, called `IPty.kill()`, and returned immediately. On macOS, node-pty's `kill()` only signals the shell PID with SIGHUP; it does not close the PTY master or wait for the native exit/waitpid callback. The main process could therefore report resource shutdown complete while the shell and PTY were still live.

## Impact

App quit now starts terminal teardown synchronously, closes the master through node-pty's concrete `destroy()` path, and does not advance past the integrated-terminal shutdown phase until node-pty reports the process exited. A bounded barrier still prevents an indefinitely stuck terminal from hanging app quit.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts` (86 passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- native macOS node-pty smoke test confirmed `destroy()` delivered exit and the shell PID no longer existed
