### PR TITLE
fix(desktop): display Windows approval prefixes

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -5,8 +5,10 @@ import { launchElectronApp } from "./fixtures/electron-app";
 
 const approvalPendingSpecDir = path.dirname(fileURLToPath(import.meta.url));
 const approvalCommand =
-  "/opt/homebrew/bin/python3.13 -m unittest scripts.github_actions.tests.test_spin_scala_environments scripts.github_actions.tests.test_spin_scala_metadata scripts.github_actions.tests.test_ci_config_contract scripts.github_actions.tests.test_classify_changes";
-const approvalPrefix = approvalCommand;
+  "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName";
+const powershell =
+  "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.4.0_x64__8wekyb3d8bbwe\\pwsh.exe";
+const approvalPrefix = `${powershell} -Command ${approvalCommand}`;
 
 async function openApprovalPendingReplay() {
   const app = await launchElectronApp({
@@ -53,7 +55,6 @@ async function openApprovalPendingReplay() {
   await expect(
     pendingApproval.locator("pre code")
   ).toHaveText(approvalCommand);
-  await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
   await expect(
     app.window.getByText("Waiting for approval before this turn can continue.")
   ).toBeVisible();
@@ -70,24 +71,37 @@ async function openApprovalPendingReplay() {
     "title",
     `Always Allow Prefix: ${approvalPrefix}`
   );
-  await expect(
-    allowPrefix.locator(".transcript-request__action-detail")
-  ).toHaveText(approvalPrefix);
+  const detail = allowPrefix.locator(".transcript-request__action-detail");
+  await expect(detail).toHaveText(approvalCommand);
+  await expect(detail).not.toContainText("PowerShell");
   const prefixLayout = await allowPrefix.evaluate((element) => {
+    const actions = element.closest(".transcript-request__actions");
     const detail = element.querySelector("code");
+    const actionRect = element.getBoundingClientRect();
+    const actionsRect = actions?.getBoundingClientRect();
     const style = detail ? window.getComputedStyle(detail) : undefined;
     return {
-      actionHeight: element.getBoundingClientRect().height,
+      actionHeight: actionRect.height,
+      actionScrollWidth: element.scrollWidth,
+      actionClientWidth: element.clientWidth,
+      fitsActions:
+        Boolean(actionsRect)
+        && actionRect.left >= actionsRect!.left
+        && actionRect.right <= actionsRect!.right,
       overflow: style?.overflow,
       textOverflow: style?.textOverflow,
       whiteSpace: style?.whiteSpace,
     };
   });
   expect(prefixLayout).toMatchObject({
+    fitsActions: true,
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   });
+  expect(prefixLayout.actionScrollWidth).toBeLessThanOrEqual(
+    prefixLayout.actionClientWidth
+  );
   expect(prefixLayout.actionHeight).toBeLessThan(60);
   await expect(
     app.window.getByRole("button", { name: "Cancel Turn" })

--- a/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
@@ -129,22 +129,18 @@
         "params": {
           "threadId": "thread-approval-pending",
           "turnId": "turn-approval-2",
-          "itemId": "call-read-only-validation",
+          "itemId": "call-windows-agent-discovery",
           "requestId": "approval-request-1",
-          "reason": "Do you want to allow a read-only validation command outside the sandbox?",
-          "command": "/opt/homebrew/bin/python3.13 -m unittest scripts.github_actions.tests.test_spin_scala_environments scripts.github_actions.tests.test_spin_scala_metadata scripts.github_actions.tests.test_ci_config_contract scripts.github_actions.tests.test_classify_changes",
+          "reason": "Do you want to allow a read-only agent instruction discovery command outside the sandbox?",
+          "command": "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName",
           "availableDecisions": [
             "accept",
             {
               "acceptWithExecpolicyAmendment": {
                 "execpolicy_amendment": [
-                  "/opt/homebrew/bin/python3.13",
-                  "-m",
-                  "unittest",
-                  "scripts.github_actions.tests.test_spin_scala_environments",
-                  "scripts.github_actions.tests.test_spin_scala_metadata",
-                  "scripts.github_actions.tests.test_ci_config_contract",
-                  "scripts.github_actions.tests.test_classify_changes"
+                  "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.4.0_x64__8wekyb3d8bbwe\\pwsh.exe",
+                  "-Command",
+                  "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName"
                 ]
               }
             },

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -253,19 +253,19 @@ test("keeps workflow states, scanner phases, and narrow desktop layout stable", 
     await expect(composer).toBeVisible();
     await expect(approval).toContainText("Approval needed");
     await expect(approval).toContainText(
-      "Do you want to allow a read-only validation command outside the sandbox?"
+      "Do you want to allow a read-only agent instruction discovery command outside the sandbox?"
     );
     await expect(approval.getByText("Command:")).toBeVisible();
-    await expect(approval.locator("pre code")).toContainText(
-      "/opt/homebrew/bin/python3.13 -m unittest"
+    await expect(approval.locator("pre code")).toHaveText(
+      "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName"
     );
     const allowPrefix = approval.getByRole("button", {
-      name: /Always Allow Prefix: \/opt\/homebrew\/bin\/python3\.13 -m unittest/,
+      name: /Always Allow Prefix: C:\\Program Files\\WindowsApps\\Microsoft\.PowerShell_.*\\pwsh\.exe -Command Get-ChildItem/,
     });
     await expect(allowPrefix).toBeVisible();
     await expect(allowPrefix).toHaveClass(/button--ghost/);
     await expect(allowPrefix.locator("code")).toContainText(
-      "scripts.github_actions.tests.test_classify_changes"
+      "Get-ChildItem -Force"
     );
     await expect(app.window.getByRole("status")).toContainText("Waiting for approval");
     await expect(app.window.locator(".thinking-scanner").first()).toBeVisible();

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/pending-approval-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/pending-approval-darwin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d05901040d672ef6e7a46d17742d044cd26ba06a636793d6b7eff193cde6a653
-size 38888
+oid sha256:6ea957c14b59c13b323515bf23f5cef0b538ae96189dd086a7c93753b9ad4480
+size 42231

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -382,6 +382,62 @@ function isGenericShellToolTitle(command: string): boolean {
   return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(command.trim());
 }
 
+function isKnownShellExecutable(command: string): boolean {
+  const executable = command
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .split(/[\\/]/)
+    .at(-1)
+    ?.toLowerCase();
+
+  return Boolean(
+    executable
+    && [
+      "bash",
+      "bash.exe",
+      "cmd.exe",
+      "dash",
+      "fish",
+      "ksh",
+      "powershell.exe",
+      "pwsh.exe",
+      "sh",
+      "tcsh",
+      "zsh",
+    ].includes(executable),
+  );
+}
+
+function execpolicyPrefixDetail(rawPrefix: unknown): string {
+  if (!Array.isArray(rawPrefix)) {
+    return "";
+  }
+
+  const prefix = rawPrefix
+    .filter((part): part is string => typeof part === "string" && Boolean(part.trim()))
+    .map((part) => part.trim());
+  const commandFlagIndex = isKnownShellExecutable(prefix[0] ?? "")
+    ? prefix.findIndex((part, index) =>
+        index > 0 && /^(?:-command|-c|-lc|\/c)$/i.test(part),
+      )
+    : -1;
+  const displayParts = commandFlagIndex > 0
+    ? prefix.slice(commandFlagIndex + 1)
+    : prefix;
+  const detail = displayParts.join(" ").trim();
+  const quote = detail[0];
+
+  if (
+    detail.length > 1
+    && (quote === "\"" || quote === "'")
+    && detail.at(-1) === quote
+  ) {
+    return detail.slice(1, -1).trim();
+  }
+
+  return detail || prefix.join(" ");
+}
+
 function pendingRequestActionPresentation(action: PendingRequestAction): {
   detail?: string;
   label: string;
@@ -395,17 +451,13 @@ function pendingRequestActionPresentation(action: PendingRequestAction): {
     responseDecision?.acceptWithExecpolicyAmendment
     ?? responseDecision?.accept_with_execpolicy_amendment,
   );
-  const rawPrefix =
+  const detail = execpolicyPrefixDetail(
     amendment?.execpolicy_amendment
-    ?? amendment?.proposed_execpolicy_amendment;
-  const structuredDetail = Array.isArray(rawPrefix)
-    ? rawPrefix
-        .filter((part): part is string => typeof part === "string" && Boolean(part.trim()))
-        .join(" ")
-    : "";
-  if (structuredDetail) {
+    ?? amendment?.proposed_execpolicy_amendment,
+  );
+  if (detail) {
     return {
-      detail: structuredDetail,
+      detail,
       label: "Always Allow Prefix",
     };
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -4501,6 +4501,54 @@ Implementation notes remain in a readable bubble.`;
     expect(screen.getByRole("button", { name: "Decline" })).toBeInTheDocument();
   });
 
+  it("keeps a Windows durable command prefix bounded and leads with the command", () => {
+    const powershell =
+      "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.4.0_x64__8wekyb3d8bbwe\\pwsh.exe";
+    const command =
+      "Get-ChildItem -Force | Select-Object Name,Mode; Get-ChildItem -Recurse -Filter AGENTS.md";
+
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            command,
+            availableDecisions: [
+              "accept",
+              {
+                acceptWithExecpolicyAmendment: {
+                  execpolicy_amendment: [powershell, "-Command", command],
+                },
+              },
+              "cancel",
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const action = screen.getByRole("button", {
+      name: `Always Allow Prefix: ${powershell} -Command ${command}`,
+    });
+    expect(action).toHaveClass("button--ghost", "transcript-request__action--detailed");
+    expect(action.querySelector(".transcript-request__action-label")).toHaveTextContent(
+      "Always Allow Prefix"
+    );
+    expect(action.querySelector(".transcript-request__action-detail")).toHaveTextContent(
+      command
+    );
+    expect(action.querySelector(".transcript-request__action-detail")).not.toHaveTextContent(
+      powershell
+    );
+  });
+
   it("derives Kimi approval commands from prompt text when command is a shell title", () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16950,6 +16950,7 @@ a.transcript-message__messaging-origin:focus-visible {
   flex-direction: column;
   align-items: flex-start;
   gap: 3px;
+  overflow: hidden;
   padding: 7px 10px;
   text-align: left;
 }


### PR DESCRIPTION
## What changed

- forward-port the Windows-specific approval-prefix handling from #1593
- strip structured PowerShell, cmd, and shell launchers from the displayed persistent prefix
- keep long prefix actions contained within the approval card
- replace the approval replay with the WindowsApps PowerShell scenario and assert the command leads the visible detail

## Root cause

Main already contained the earlier structured durable-prefix presentation, but it still joined every prefix argument verbatim. On Windows, the long PowerShell executable path and command flag consumed the button before the useful command appeared.

## User impact

The Always Allow Prefix action stays compact and shows the start of the actual command instead of a long Windows shell-launcher path.

## Validation

- TranscriptList unit suite: 95 passed
- approval-pending Electron replay: 2 passed
- focused narrow Tangerine Terminal approval test: 1 passed
- TypeScript typecheck
- ESLint: 0 errors, existing warnings only
- renderer color lint
- dependency boundary lint

The separate 1440x920 theme case could not run on the local 875px-tall renderer work area; it is unrelated to the changed approval scenario.
