### PR TITLE
feat(desktop): dedicated Federation Star Map window

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -369,11 +369,14 @@ existing replay-fixture harness and runs `@axe-core/playwright`'s
 Things to know when extending the audit:
 
 - **Surface coverage.** Each `test(...)` block drives the renderer to a
-  state (open thread, settings overlay, settings → messaging, the Star
-  Map layer, the Star Map intake dialog) and then calls `runAxe(window)`.
-  Add a new block per surface you want gated; go through
-  `launchAuditApp()`, which emulates reduced motion and takes an optional
-  `fixturePath` / `theme`.
+  state (open thread, settings overlay, settings → messaging, the
+  dedicated Star Map window, the Star Map intake dialog) and then calls
+  `runAxe(window)`. Add a new block per surface you want gated; go
+  through `launchAuditApp()`, which emulates reduced motion and takes an
+  optional `fixturePath` / `theme`. A surface in a secondary
+  BrowserWindow is a different Playwright `Page`: pass THAT page to
+  `runAxe`, and re-emulate reduced motion on it — `launchAuditApp` only
+  configured the main window's page.
 - **Seed the fixture so the surface is actually populated.** The smoke
   fixture's thread reaches no Star Map lane — `deriveInboxState` keeps a
   first-snapshot thread out of the inbox, and an idle thread with no PR
@@ -825,11 +828,13 @@ budget is a record of what a path costs, not permission for it to cost that.
     cards stay one family. Plain text tooltips keep `.viewport-tooltip`.
   - **Check the layer your trigger lives in.** The portal renders on
     `document.body`, and `.app-shell` opens no stacking context, so
-    full-window layers (Settings and Star Map at `z-index: 120`) sit in the
-    same root stacking context and will paint OVER a tooltip left at the
-    default 90. Anything reachable from those surfaces needs an explicit
-    higher layer — see `.messaging-status-tooltip`, `.pr-status-card`, and
-    `.star-map-card__tooltip`.
+    full-window layers (Settings at `z-index: 120`) sit in the same root
+    stacking context and will paint OVER a tooltip left at the default
+    90. Anything reachable from those surfaces needs an explicit higher
+    layer — see `.messaging-status-tooltip` and `.pr-status-card`. The
+    dedicated Star Map window has the same shape: `.star-map-window`
+    opens a stacking context that scopes the card z-scale, so its portal
+    tooltips (`.star-map-card__tooltip`) also carry an explicit layer.
   - **A card with content worth hearing needs `aria-describedby`.** Point the
     trigger at the hook's `tooltipId` while `visible`; nothing else references
     the portal, so an unwired card is sighted-only. Do not solve this by

--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -71,6 +71,31 @@ async function launchAuditApp(options?: {
   return app;
 }
 
+/**
+ * Poll `electronApp.windows()` for the dedicated Star Map window. The
+ * BrowserWindow is created with `show: false`, so Playwright's `window`
+ * event fires before the URL has loaded; polling sidesteps the race
+ * (same pattern as `appearance-broadcast.spec.ts`).
+ */
+async function waitForStarMapWindow(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+): Promise<Page> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    for (const candidate of app.electronApp.windows()) {
+      if (candidate.url().includes("#star-map")) {
+        return candidate;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(
+    `Star Map window did not open; current windows: ${app.electronApp
+      .windows()
+      .map((win) => win.url())
+      .join(", ")}`,
+  );
+}
+
 // The smoke thread never reaches the Star Map: `deriveInboxState` keeps a
 // first-snapshot thread out of the inbox, and with no PR, no unpushed
 // commits and an idle status it matches none of the attention categories,
@@ -431,16 +456,27 @@ for (const theme of AUDIT_THEMES) {
     // for as long as it sat there bare every active thread failed
     // `aria-required-children` (critical) with nothing to catch it: the
     // idle fixture never renders the live region, and the Star Map blocks
-    // do use an active fixture but the map layer covers the thread view.
-    // It now renders inside a listitem wrapper. This block is the gate on
-    // that, so keep the fixture active and the scan unscoped.
+    // audit a different window entirely. It now renders inside a listitem
+    // wrapper. This block is the gate on that, so keep the fixture active
+    // and the scan unscoped.
     test("star map fixture surfaces have no violations", async () => {
       const app = await launchAuditApp({ fixturePath: STAR_MAP_FIXTURE, theme });
       try {
         const attentionThread = app.window
           .getByRole("button", { name: /Star map attention thread/i })
           .first();
-        const starMap = app.window.getByRole("region", {
+
+        await expect(attentionThread).toBeVisible();
+        // The map lives in its own OS window; the header control spawns
+        // it and every map assertion below runs against that window.
+        await app.window.getByRole("button", { name: "Open Star Map" }).click();
+        const mapWindow = await waitForStarMapWindow(app);
+        // The audit harness emulates reduced motion per Page, and the map
+        // window is a different Page than the one `launchAuditApp`
+        // configured — without this the card rise animation leaves text
+        // mid-fade and axe reports phantom contrast misses.
+        await mapWindow.emulateMedia({ reducedMotion: "reduce" });
+        const starMap = mapWindow.getByRole("region", {
           name: "Star Map",
           exact: true,
         });
@@ -448,55 +484,38 @@ for (const theme of AUDIT_THEMES) {
           name: "Open thread: Star map attention thread",
         });
 
-        await test.step("star map layer", async () => {
-          await expect(attentionThread).toBeVisible();
-          await app.window.getByRole("button", { name: "Open Star Map" }).click();
+        await test.step("star map window", async () => {
           await expect(starMap).toBeVisible();
           // Gate on a card rather than only the map body: cards populate
-          // after the layer mounts, and an empty map skips the card contrast.
+          // after the window mounts, and an empty map skips the card contrast.
           await expect(starMapCard).toBeVisible();
-          await runAxe(app.window, "star map layer");
-
-          await starMap
-            .getByRole("button", { name: "Close Star Map" })
-            .click();
-          await expect(starMap).toHaveCount(0);
-          await expect(
-            app.window.getByRole("button", { name: "Open Star Map" }),
-          ).toBeVisible();
+          await runAxe(mapWindow, "star map window");
         });
 
         await test.step("star map intake dialog", async () => {
-          await expect(
-            app.window.getByRole("button", { name: "Open Star Map" }),
-          ).toBeVisible();
-          await app.window.getByRole("button", { name: "Open Star Map" }).click();
           await expect(starMap).toBeVisible();
           await expect(starMapCard).toBeVisible();
           // The [+] beside the local body carries the runner hostname, so
           // match the stable copy rather than a machine-specific label.
           await starMap.getByRole("button", { name: /^New thread on / }).click();
-          const intake = app.window.getByRole("dialog", {
+          const intake = mapWindow.getByRole("dialog", {
             name: /^New thread on /,
           });
           await expect(intake).toBeVisible();
           await expect(
             intake.getByRole("button", { name: "Start thread" }),
           ).toBeVisible();
-          await runAxe(app.window, "star map intake dialog");
+          await runAxe(mapWindow, "star map intake dialog");
 
           await intake
             .getByRole("button", { name: "Close", exact: true })
             .click();
           await expect(intake).toHaveCount(0);
-          await starMap
-            .getByRole("button", { name: "Close Star Map" })
-            .click();
-          await expect(starMap).toHaveCount(0);
-          await expect(attentionThread).toBeVisible();
         });
 
         await test.step("open thread view with an active thread", async () => {
+          // Runs in the MAIN window; the map window staying open no
+          // longer covers the thread view.
           await attentionThread.click();
           await expect(app.window.getByText("The star map is live.")).toBeVisible();
           // Assert the live region is actually painted. Without this the

--- a/apps/desktop/e2e/star-map-chat-card-history.spec.ts
+++ b/apps/desktop/e2e/star-map-chat-card-history.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 import {
   startInProcessFederationGateway,
@@ -43,6 +43,31 @@ const TOTAL_TRANSCRIPT_BYTES = ENTRY_COUNT * BYTES_PER_ENTRY;
 const MAX_TRANSCRIPT_NODES = 4_000;
 /** Likewise: a bounded open is well under a megabyte. */
 const MAX_OPEN_BYTES = 4_000_000;
+
+/**
+ * Poll `electronApp.windows()` for the dedicated Star Map window. The
+ * BrowserWindow is created with `show: false`, so Playwright's `window`
+ * event fires before the URL has loaded; polling sidesteps the race
+ * (same pattern as `appearance-broadcast.spec.ts`).
+ */
+async function waitForStarMapWindow(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+): Promise<Page> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    for (const candidate of app.electronApp.windows()) {
+      if (candidate.url().includes("#star-map")) {
+        return candidate;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(
+    `Star Map window did not open; current windows: ${app.electronApp
+      .windows()
+      .map((win) => win.url())
+      .join(", ")}`,
+  );
+}
 
 async function createLocalControlFixture(): Promise<{
   cleanup: () => Promise<void>;
@@ -138,9 +163,11 @@ test.describe("star map chat card history", () => {
     ).toBeVisible({ timeout: 30_000 });
     await window.getByRole("button", { name: "Exit Settings" }).click();
 
-    // Open the map and the peer's thread as a floating chat card.
+    // Open the map — a dedicated OS window — and the peer's thread as a
+    // floating chat card inside it.
     await window.getByRole("button", { name: "Open Star Map" }).click();
-    const starMap = window.getByRole("region", {
+    const mapWindow = await waitForStarMapWindow(app);
+    const starMap = mapWindow.getByRole("region", {
       name: "Star Map",
       exact: true,
     });
@@ -152,7 +179,7 @@ test.describe("star map chat card history", () => {
     await expect(card).toBeVisible({ timeout: 30_000 });
     await card.click();
 
-    const chatCard = window.getByRole("region", {
+    const chatCard = mapWindow.getByRole("region", {
       name: `Chat: ${THREAD_TITLE}`,
     });
     await expect(chatCard).toBeVisible();

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -1,23 +1,57 @@
 // The Star Map's core triage loop, end to end in a real Electron launch:
 // open the map, pick a card, read the thread without leaving the map,
-// escalate into the full thread view, and come back.
+// and escalate into the full thread view.
 //
-// The escalation step is the one worth pinning. Clicking a card used to
-// navigate away to the thread shell; it now floats a chat card OVER the
-// map, and the trip to the full view moved onto the card's own expand
-// control. "Back to map" then un-floats without closing the map. Three
-// separate pieces of state (map open, card open, thread floating) have to
-// agree, and nothing below this level catches them disagreeing.
+// The map lives in its own OS window ("Federation Star Map"). Opening it
+// from the main window's header control spawns that window; opening it
+// again focuses the existing one instead of spawning a second. Reading a
+// thread floats a chat card OVER the map inside the map window, and the
+// escalation on the card's expand control crosses windows: the MAIN
+// window navigates to the thread while the map window stays up behind
+// it. Nothing below the E2E level exercises that cross-window handoff.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 
 const THREAD_TITLE = "Star map attention thread";
 
-test("opens a thread from the star map and returns to the map", async () => {
+/**
+ * Poll `electronApp.windows()` for a window whose URL carries the map
+ * hash. The BrowserWindow is created with `show: false`, so Playwright's
+ * `window` event fires before the URL has loaded; polling sidesteps the
+ * race (same pattern as `appearance-broadcast.spec.ts`).
+ */
+async function waitForStarMapWindow(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+): Promise<Page> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    for (const candidate of app.electronApp.windows()) {
+      if (candidate.url().includes("#star-map")) {
+        return candidate;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(
+    `Star Map window did not open; current windows: ${app.electronApp
+      .windows()
+      .map((win) => win.url())
+      .join(", ")}`,
+  );
+}
+
+function countStarMapWindows(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+): number {
+  return app.electronApp
+    .windows()
+    .filter((win) => win.url().includes("#star-map")).length;
+}
+
+test("opens a thread from the star map window in the main window", async () => {
   const app = await launchElectronApp({
     fixturePath: path.resolve(specDir, "fixtures/star-map/replay.fixture.json"),
   });
@@ -27,15 +61,13 @@ test("opens a thread from the star map and returns to the map", async () => {
       app.window.getByRole("button", { name: new RegExp(THREAD_TITLE, "i") }).first(),
     ).toBeVisible();
 
-    // The map layer covers the app chrome, so the header toggle that
-    // opens it is not the same control that closes it — the layer brings
-    // its own "Close map". Both carry the "Close Star Map" name, hence
-    // the scoping on every locator below.
     await app.window.getByRole("button", { name: "Open Star Map" }).click();
+    const mapWindow = await waitForStarMapWindow(app);
+
     // `exact` matters here: role-name matching is substring by default,
     // and once a chat card opens its "Chat: Star map attention thread"
     // region matches "Star Map" too.
-    const starMap = app.window.getByRole("region", {
+    const starMap = mapWindow.getByRole("region", {
       name: "Star Map",
       exact: true,
     });
@@ -47,6 +79,14 @@ test("opens a thread from the star map and returns to the map", async () => {
       starMap.getByRole("button", { name: /^Open this instance / }),
     ).toBeVisible();
 
+    // Singleton: the header control focuses the existing map window
+    // rather than spawning a sibling. A second window would be created
+    // asynchronously, so give it a moment to (not) appear before
+    // counting.
+    await app.window.getByRole("button", { name: "Open Star Map" }).click();
+    await app.window.waitForTimeout(1_000);
+    expect(countStarMapWindows(app)).toBe(1);
+
     const card = starMap.getByRole("button", {
       name: `Open thread: ${THREAD_TITLE}`,
     });
@@ -54,43 +94,33 @@ test("opens a thread from the star map and returns to the map", async () => {
     await card.click();
 
     // A chat card, not a navigation: the map is still up behind it.
-    const chatCard = app.window.getByRole("region", {
+    const chatCard = mapWindow.getByRole("region", {
       name: `Chat: ${THREAD_TITLE}`,
     });
     await expect(chatCard).toBeVisible();
     await expect(chatCard.getByText("The star map is live.")).toBeVisible();
     await expect(starMap).toBeVisible();
 
-    await app.window
+    await mapWindow
       .getByRole("button", {
         name: `Open ${THREAD_TITLE} in the full thread view`,
       })
       .click();
 
-    // Full thread view, floated over the map rather than replacing it.
+    // Cross-window escalation: the MAIN window shows the full thread
+    // view; the map window keeps the map and the chat card.
     await expect(
       app.window.getByRole("heading", { level: 2, name: THREAD_TITLE }),
     ).toBeVisible();
     await expect(app.window.getByText("The star map is live.").first()).toBeVisible();
-    const backToMap = app.window.getByRole("button", { name: "Back to map" });
-    await expect(backToMap).toBeVisible();
-    await expect(app.window.locator("main.app-main--star-map-float")).toHaveCount(1);
-
-    await backToMap.click();
-
-    // Un-floats without closing the map: the float chrome goes, the map
-    // stays, and the thread is still reachable as a card.
-    await expect(backToMap).toHaveCount(0);
-    await expect(app.window.locator("main.app-main--star-map-float")).toHaveCount(0);
     await expect(starMap).toBeVisible();
-    await expect(card).toBeVisible();
+    await expect(chatCard).toBeVisible();
 
-    // And the map's own exit lands back on the thread shell.
-    await starMap.getByRole("button", { name: "Close Star Map" }).click();
-    await expect(starMap).toHaveCount(0);
+    // The map carries no in-surface exit anymore — closing is the OS
+    // window's job.
     await expect(
-      app.window.getByRole("button", { name: "Open Star Map" }),
-    ).toBeVisible();
+      starMap.getByRole("button", { name: "Close Star Map" }),
+    ).toHaveCount(0);
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/main/__tests__/star-map-window-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-window-ipc.test.ts
@@ -1,0 +1,174 @@
+// The Star Map window's cross-window IPC surface: opening (or focusing)
+// the dedicated map window, and routing its navigation actions back to
+// the primary main window. The federation filter is the part worth
+// pinning — a remote-viewer window subscribes to the same show-thread
+// channel but fronts another instance's threads, so sending it a local
+// thread would land nowhere.
+import type { WebContents } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL,
+  STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL,
+  STAR_MAP_OPEN_WINDOW_CHANNEL,
+  WINDOW_SHOW_THREAD_CHANNEL,
+} from "../../shared/ipc";
+import { registerStarMapIpcHandlers } from "../ipc/star-map";
+import { isFederationWindowWebContents } from "../window";
+import { subscribersForChannel } from "../window-channels";
+import { requestShowThread } from "../window-show-thread";
+import { showStarMapWindow } from "../star-map-window";
+
+const { handlers, fromWebContentsMock } = vi.hoisted(() => ({
+  handlers: new Map<
+    string,
+    (event: unknown, ...args: unknown[]) => Promise<unknown>
+  >(),
+  fromWebContentsMock: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    fromWebContents: fromWebContentsMock,
+  },
+  ipcMain: {
+    handle: vi.fn(
+      (
+        channel: string,
+        handler: (event: unknown, ...args: unknown[]) => Promise<unknown>,
+      ) => {
+        handlers.set(channel, handler);
+      },
+    ),
+    removeHandler: vi.fn(),
+  },
+}));
+
+vi.mock("../app-server/desktop-overlay-store", () => ({
+  getDesktopOverlayStore: vi.fn(),
+}));
+vi.mock("../app-server/star-map-intake", () => ({
+  dispatchStarMapIntake: vi.fn(),
+}));
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: vi.fn(),
+}));
+vi.mock("../window", () => ({
+  isFederationWindowWebContents: vi.fn(),
+}));
+vi.mock("../window-channels", () => ({
+  subscribersForChannel: vi.fn(),
+}));
+vi.mock("../window-show-thread", () => ({
+  requestShowThread: vi.fn(),
+}));
+vi.mock("../star-map-window", () => ({
+  showStarMapWindow: vi.fn(),
+}));
+
+function handlerFor(channel: string) {
+  const handler = handlers.get(channel);
+  if (!handler) {
+    throw new Error(`No handler registered for ${channel}`);
+  }
+  return handler;
+}
+
+describe("star map window IPC", () => {
+  beforeEach(() => {
+    handlers.clear();
+    fromWebContentsMock.mockReset();
+    vi.mocked(isFederationWindowWebContents).mockReset();
+    vi.mocked(subscribersForChannel).mockReset();
+    vi.mocked(requestShowThread).mockReset();
+    vi.mocked(showStarMapWindow).mockReset();
+    registerStarMapIpcHandlers();
+  });
+
+  it("opens the map window on the invoking window's display", async () => {
+    const sender = {} as WebContents;
+    const sourceWindow = { id: 7 };
+    fromWebContentsMock.mockReturnValue(sourceWindow);
+
+    await handlerFor(STAR_MAP_OPEN_WINDOW_CHANNEL)({ sender });
+
+    expect(fromWebContentsMock).toHaveBeenCalledWith(sender);
+    expect(showStarMapWindow).toHaveBeenCalledWith({
+      sourceWindow,
+    });
+  });
+
+  it("routes a thread open to the first non-federation main window", async () => {
+    const federationContents = { id: 1 } as WebContents;
+    const mainContents = { id: 2 } as WebContents;
+    vi.mocked(subscribersForChannel).mockReturnValue([
+      federationContents,
+      mainContents,
+    ]);
+    vi.mocked(isFederationWindowWebContents).mockImplementation(
+      (contents) => contents === federationContents,
+    );
+    const request = { backend: "codex", threadId: "thread-1" };
+
+    await handlerFor(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL)({}, request);
+
+    expect(subscribersForChannel).toHaveBeenCalledWith(
+      WINDOW_SHOW_THREAD_CHANNEL,
+    );
+    expect(requestShowThread).toHaveBeenCalledWith(request, {
+      preferWebContents: mainContents,
+    });
+  });
+
+  it("drops a thread open when only federation windows subscribe", async () => {
+    const federationContents = { id: 1 } as WebContents;
+    vi.mocked(subscribersForChannel).mockReturnValue([federationContents]);
+    vi.mocked(isFederationWindowWebContents).mockReturnValue(true);
+
+    await handlerFor(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL)(
+      {},
+      { backend: "codex", threadId: "thread-1" },
+    );
+
+    expect(requestShowThread).not.toHaveBeenCalled();
+  });
+
+  it("ignores a malformed thread-open payload", async () => {
+    await handlerFor(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL)(
+      {},
+      { backend: "codex" },
+    );
+
+    expect(subscribersForChannel).not.toHaveBeenCalled();
+    expect(requestShowThread).not.toHaveBeenCalled();
+  });
+
+  it("focuses the main window without navigating", async () => {
+    const mainContents = { id: 2 } as WebContents;
+    vi.mocked(subscribersForChannel).mockReturnValue([mainContents]);
+    vi.mocked(isFederationWindowWebContents).mockReturnValue(false);
+    const mainWindow = {
+      focus: vi.fn(),
+      isDestroyed: () => false,
+      isMinimized: () => true,
+      restore: vi.fn(),
+      show: vi.fn(),
+    };
+    fromWebContentsMock.mockReturnValue(mainWindow);
+
+    await handlerFor(STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL)({});
+
+    expect(mainWindow.restore).toHaveBeenCalledOnce();
+    expect(mainWindow.show).toHaveBeenCalledOnce();
+    expect(mainWindow.focus).toHaveBeenCalledOnce();
+    expect(requestShowThread).not.toHaveBeenCalled();
+  });
+
+  it("no-ops the focus request with no main window", async () => {
+    vi.mocked(subscribersForChannel).mockReturnValue([]);
+
+    await expect(
+      handlerFor(STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL)({}),
+    ).resolves.toBeUndefined();
+    expect(fromWebContentsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/ipc/star-map.ts
+++ b/apps/desktop/src/main/ipc/star-map.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { BrowserWindow, ipcMain, type WebContents } from "electron";
 import type {
   FederationTarget,
   ReadStarMapArrangementResponse,
@@ -12,18 +12,75 @@ import {
   isStarMapArrangementEntry,
 } from "@pwragent/shared";
 import {
+  STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL,
   STAR_MAP_INTAKE_CHANNEL,
+  STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL,
+  STAR_MAP_OPEN_WINDOW_CHANNEL,
   STAR_MAP_READ_ARRANGEMENT_CHANNEL,
   STAR_MAP_SET_CARD_POSITION_CHANNEL,
+  WINDOW_SHOW_THREAD_CHANNEL,
 } from "../../shared/ipc";
+import type { WindowShowThreadRequest } from "../../shared/window-show-thread";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { dispatchStarMapIntake } from "../app-server/star-map-intake";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import { isFederationWindowWebContents } from "../window";
+import { subscribersForChannel } from "../window-channels";
+import { requestShowThread } from "../window-show-thread";
+import { showStarMapWindow } from "../star-map-window";
+
+/**
+ * The main window the Star Map window's cross-window actions target.
+ * Federation remote-viewer windows subscribe to the same channel but
+ * front another instance's threads, so they are never a valid target
+ * for a local thread.
+ */
+function primaryMainWindowWebContents(): WebContents | undefined {
+  return subscribersForChannel(WINDOW_SHOW_THREAD_CHANNEL).find(
+    (subscriber) => !isFederationWindowWebContents(subscriber),
+  );
+}
 
 export function registerStarMapIpcHandlers(): void {
   ipcMain.removeHandler(STAR_MAP_READ_ARRANGEMENT_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_SET_CARD_POSITION_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_INTAKE_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_OPEN_WINDOW_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL);
+  ipcMain.handle(STAR_MAP_OPEN_WINDOW_CHANNEL, async (event): Promise<void> => {
+    showStarMapWindow({
+      sourceWindow: BrowserWindow.fromWebContents(event.sender),
+    });
+  });
+  ipcMain.handle(
+    STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL,
+    async (_event, request: WindowShowThreadRequest): Promise<void> => {
+      if (
+        typeof request?.backend !== "string"
+        || typeof request?.threadId !== "string"
+      ) {
+        return;
+      }
+      const target = primaryMainWindowWebContents();
+      if (!target) {
+        return;
+      }
+      requestShowThread(request, { preferWebContents: target });
+    },
+  );
+  ipcMain.handle(STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL, async (): Promise<void> => {
+    const target = primaryMainWindowWebContents();
+    const window = target ? BrowserWindow.fromWebContents(target) : undefined;
+    if (!window || window.isDestroyed()) {
+      return;
+    }
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
+  });
   ipcMain.handle(
     STAR_MAP_INTAKE_CHANNEL,
     async (
@@ -84,4 +141,7 @@ export function disposeStarMapIpcHandlers(): void {
   ipcMain.removeHandler(STAR_MAP_READ_ARRANGEMENT_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_SET_CARD_POSITION_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_INTAKE_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_OPEN_WINDOW_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL);
 }

--- a/apps/desktop/src/main/star-map-window.ts
+++ b/apps/desktop/src/main/star-map-window.ts
@@ -1,0 +1,130 @@
+import { BrowserWindow } from "electron";
+import { getMainLogger } from "./log";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_STAR_MAP,
+  registerWindowChannels,
+} from "./window-channels";
+import {
+  AGENT_EVENT_CHANNEL,
+  APPEARANCE_CHANGED_EVENT_CHANNEL,
+} from "../shared/ipc";
+import {
+  readBootstrapAppearance,
+  themedWindowAdditionalArguments,
+  themedWindowBackgroundColor,
+} from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
+  showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
+} from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
+
+const log = getMainLogger("pwragent:star-map-window");
+const STAR_MAP_WINDOW_TITLE = "Federation Star Map";
+const STAR_MAP_WINDOW_WIDTH = 1280;
+const STAR_MAP_WINDOW_HEIGHT = 820;
+
+/**
+ * Hash that the renderer (`main.tsx`) reads to decide whether to mount
+ * the full app shell or just the Star Map surface. Loaded windows pass
+ * through unchanged on reload, so the hash survives DevTools refreshes
+ * and renderer crashes.
+ */
+const STAR_MAP_HASH = "star-map";
+
+let starMapWindow: BrowserWindow | undefined;
+
+/**
+ * Spawn (or focus, if already open) the dedicated Federation Star Map
+ * window. The window reuses the same renderer bundle as the main
+ * window — `main.tsx` reads `window.location.hash` and mounts a
+ * standalone Star Map surface instead of the full app shell.
+ *
+ * Distinct OS window: own traffic lights, own focus, own lifecycle.
+ * Closing the window does NOT affect the main window. Reopening
+ * focuses the existing window when one is already open.
+ */
+export function showStarMapWindow(source: WindowPlacementSource = {}): void {
+  if (starMapWindow && !starMapWindow.isDestroyed()) {
+    positionWindowForSourceDisplay(starMapWindow, source);
+    showAndFocusAuxiliaryWindow(starMapWindow);
+    return;
+  }
+
+  const appearance = readBootstrapAppearance();
+  const window = new BrowserWindow({
+    ...placementForSourceDisplay(
+      STAR_MAP_WINDOW_WIDTH,
+      STAR_MAP_WINDOW_HEIGHT,
+      source,
+    ),
+    width: STAR_MAP_WINDOW_WIDTH,
+    height: STAR_MAP_WINDOW_HEIGHT,
+    minWidth: 800,
+    minHeight: 560,
+    show: false,
+    title: STAR_MAP_WINDOW_TITLE,
+    ...auxiliaryWindowChromeOptions(),
+    // Unlike the other auxiliary windows, the Star Map is meant to live
+    // full-screen on its own macOS Space while the operator keeps the
+    // regular windows in windowed mode — so native fullscreen stays ON
+    // for this one.
+    fullscreenable: true,
+    backgroundColor: themedWindowBackgroundColor(appearance),
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      additionalArguments: themedWindowAdditionalArguments(appearance),
+    },
+  });
+  registerAuxiliaryWindowTitle(window, STAR_MAP_WINDOW_TITLE);
+  hideAuxiliaryWindowMenuBar(window);
+
+  applyWindowSecurityHardening(window);
+  // The map is a live surface: thread status, star-map arrangement
+  // deltas, and federation peer changes all arrive as agent events, so
+  // this window subscribes to that push channel (unlike the polling
+  // Messaging Activity window). Appearance broadcasts keep the theme in
+  // sync when the operator changes it from another window. The window is
+  // deliberately registered WITHOUT a federation target: remote-scoped
+  // event delivery is gated per-webContents by the renderer's own
+  // `setFederationEventSubscriptions` registration instead.
+  registerWindowChannels(window, WINDOW_KIND_STAR_MAP, [
+    AGENT_EVENT_CHANNEL,
+    APPEARANCE_CHANGED_EVENT_CHANNEL,
+  ]);
+
+  const rendererEntry = getRendererEntry();
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${STAR_MAP_HASH}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash: STAR_MAP_HASH });
+  }
+
+  showAuxiliaryWindowWhenReady(window);
+
+  window.on("closed", () => {
+    // The top-of-function "already-open" guard prevents two star map
+    // windows from coexisting, so the singleton always points at the
+    // window that just closed. No need to compare references.
+    starMapWindow = undefined;
+    log.debug("star map window closed");
+  });
+
+  starMapWindow = window;
+  log.debug("star map window created");
+}

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -34,6 +34,7 @@ import type { FederationRemoteTarget } from "@pwragent/shared";
  *  per-window registration sites. */
 export const WINDOW_KIND_MAIN = "main" as const;
 export const WINDOW_KIND_MESSAGING_ACTIVITY = "messaging-activity" as const;
+export const WINDOW_KIND_STAR_MAP = "star-map" as const;
 export const WINDOW_KIND_CHANGELOG = "changelog" as const;
 export const WINDOW_KIND_LICENSE_DOCUMENT = "license-document" as const;
 export const WINDOW_KIND_APP_LOGS = "app-logs" as const;
@@ -43,6 +44,7 @@ export const WINDOW_KIND_AUTOMATION_RUN = "automation-run" as const;
 export type WindowKind =
   | typeof WINDOW_KIND_MAIN
   | typeof WINDOW_KIND_MESSAGING_ACTIVITY
+  | typeof WINDOW_KIND_STAR_MAP
   | typeof WINDOW_KIND_CHANGELOG
   | typeof WINDOW_KIND_LICENSE_DOCUMENT
   | typeof WINDOW_KIND_APP_LOGS

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -543,7 +543,10 @@ import {
   FEDERATION_REVOKE_PEER_CHANNEL,
   FEDERATION_SET_CELESTIAL_ICON_CHANNEL,
   FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL,
+  STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL,
   STAR_MAP_INTAKE_CHANNEL,
+  STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL,
+  STAR_MAP_OPEN_WINDOW_CHANNEL,
   STAR_MAP_READ_ARRANGEMENT_CHANNEL,
   STAR_MAP_SET_CARD_POSITION_CHANNEL,
   FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
@@ -1038,6 +1041,17 @@ const desktopApi = Object.freeze({
     request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
   ): Promise<StarMapIntakeResponse> =>
     await ipcRenderer.invoke(STAR_MAP_INTAKE_CHANNEL, request),
+  openStarMapWindow: async (): Promise<void> => {
+    await ipcRenderer.invoke(STAR_MAP_OPEN_WINDOW_CHANNEL);
+  },
+  openStarMapThreadInMainWindow: async (
+    request: WindowShowThreadRequest,
+  ): Promise<void> => {
+    await ipcRenderer.invoke(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL, request);
+  },
+  focusMainWindowFromStarMap: async (): Promise<void> => {
+    await ipcRenderer.invoke(STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL);
+  },
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -143,10 +143,6 @@ const LazySettingsScreen = lazy(async () => ({
   default: (await import("./features/settings/SettingsScreen")).SettingsScreen,
 }));
 
-const LazyStarMapScreen = lazy(async () => ({
-  default: (await import("./features/star-map/StarMapScreen")).StarMapScreen,
-}));
-
 const LazyOnboardingWizard = lazy(async () => ({
   default: (await import("./features/onboarding/OnboardingWizard")).OnboardingWizard,
 }));
@@ -266,22 +262,8 @@ function DesktopAppShell(props: {
     DEFAULT_ACTION_RUNS_DOCK,
   );
   const [mainView, setMainView] = useState<
-    "thread" | "settings" | "automations" | "search" | "star-map"
+    "thread" | "settings" | "automations" | "search"
   >("thread");
-  // Star Map floating thread: while the map is up, a clicked local thread
-  // elevates the (already mounted) main ThreadView into a floating card
-  // over the map instead of remounting a second instance.
-  const [starMapFloatOpen, setStarMapFloatOpen] = useState(false);
-  const appMainRef = useRef<HTMLElement>(null);
-  // Each float session starts at the default position. Without the reset, a
-  // drag from the previous session persists in the element's CSS vars and a
-  // card once shoved mostly off-screen would reopen unreachable.
-  useEffect(() => {
-    if (starMapFloatOpen) {
-      appMainRef.current?.style.removeProperty("--star-map-float-dx");
-      appMainRef.current?.style.removeProperty("--star-map-float-dy");
-    }
-  }, [starMapFloatOpen]);
   // In-thread find bar (⌘F). `manualFindOpen` is the ⌘F toggle; `findRequest`
   // is a deep-link from a search result (seeded query + its target thread).
   // The bar is open when either applies (see `threadFindOpen` below).
@@ -1520,20 +1502,16 @@ function DesktopAppShell(props: {
     onCreateThreadOnFederationTarget: createThreadOnFederationTarget,
   };
   // The Star Map is a whole-federation surface owned by the primary window;
-  // federation remote-viewer windows never render its toggle.
+  // federation remote-viewer windows never render its toggle. The map
+  // itself lives in a dedicated OS window — the control opens (or
+  // focuses) it via main-process IPC.
   const starMapControls = readRendererFederationTarget()
     ? undefined
     : {
-        active: mainView === "star-map",
-        onToggle: () => {
-          setStarMapFloatOpen(false);
-          setMainView(mainView === "star-map" ? "thread" : "star-map");
+        onOpen: () => {
+          void desktopApi?.openStarMapWindow?.();
         },
       };
-  const closeStarMap = () => {
-    setStarMapFloatOpen(false);
-    setMainView("thread");
-  };
   const threadViewProps = {
     activeFederationOwnerLabel,
     activeFederationTarget,
@@ -2116,97 +2094,14 @@ function DesktopAppShell(props: {
         />
 
         <main
-          ref={appMainRef}
           className={`app-main${
             threadDetailPending ? " app-main--thread-detail-pending" : ""
           }${
             !peerConnectivity.connected
               ? " app-main--federation-disconnected"
               : ""
-          }${
-            mainView === "star-map" && starMapFloatOpen
-              ? " app-main--star-map-float"
-              : ""
           }`}
         >
-          {mainView === "star-map" && starMapFloatOpen ? (
-            <div
-              className="star-map-float-handle"
-              onPointerDown={(event) => {
-                if (event.button !== 0) return;
-                if (
-                  event.target instanceof HTMLElement
-                  && event.target.closest("button")
-                ) {
-                  return;
-                }
-                const main = event.currentTarget.closest("main");
-                if (!(main instanceof HTMLElement)) return;
-                event.preventDefault();
-                const startX = event.clientX;
-                const startY = event.clientY;
-                const baseX =
-                  Number.parseFloat(
-                    main.style.getPropertyValue("--star-map-float-dx"),
-                  ) || 0;
-                const baseY =
-                  Number.parseFloat(
-                    main.style.getPropertyValue("--star-map-float-dy"),
-                  ) || 0;
-                // Clamp drags so a strip of the card (and its handle row)
-                // always stays on-screen — an off-screen float has no other
-                // recovery affordance.
-                const MIN_VISIBLE_PX = 160;
-                const rect = main.getBoundingClientRect();
-                const untranslatedLeft = rect.left - baseX;
-                const untranslatedTop = rect.top - baseY;
-                const clampDx = (dx: number) =>
-                  Math.min(
-                    Math.max(dx, MIN_VISIBLE_PX - untranslatedLeft - rect.width),
-                    window.innerWidth - MIN_VISIBLE_PX - untranslatedLeft,
-                  );
-                const clampDy = (dy: number) =>
-                  Math.min(
-                    Math.max(dy, -untranslatedTop),
-                    window.innerHeight - MIN_VISIBLE_PX - untranslatedTop,
-                  );
-                let lastDx = baseX;
-                let lastDy = baseY;
-                let frame = 0;
-                const move = (pointerEvent: globalThis.PointerEvent) => {
-                  lastDx = clampDx(baseX + pointerEvent.clientX - startX);
-                  lastDy = clampDy(baseY + pointerEvent.clientY - startY);
-                  if (!frame) {
-                    frame = requestAnimationFrame(() => {
-                      frame = 0;
-                      main.style.setProperty("--star-map-float-dx", `${lastDx}px`);
-                      main.style.setProperty("--star-map-float-dy", `${lastDy}px`);
-                    });
-                  }
-                };
-                const stop = () => {
-                  window.removeEventListener("pointermove", move);
-                  window.removeEventListener("pointerup", stop);
-                  window.removeEventListener("pointercancel", stop);
-                };
-                window.addEventListener("pointermove", move);
-                window.addEventListener("pointerup", stop);
-                window.addEventListener("pointercancel", stop);
-              }}
-            >
-              <span className="star-map-float-handle__grip" aria-hidden="true" />
-              <span className="star-map-float-handle__title">
-                {navigation.selectedThread?.title ?? ""}
-              </span>
-              <button
-                type="button"
-                className="star-map-float-handle__close"
-                onClick={() => setStarMapFloatOpen(false)}
-              >
-                Back to map
-              </button>
-            </div>
-          ) : null}
           {!peerConnectivity.connected ? (
             // The runtime keeps reconnecting on its own; this banner
             // explains why the window went read-only (composer disabled,
@@ -2320,45 +2215,6 @@ function DesktopAppShell(props: {
                   void navigation.showThread(target);
                 }}
                 onShowNotice={showAppNotice}
-              />
-            </Suspense>
-          </div>
-        ) : null}
-
-        {mainView === "star-map" ? (
-          <div
-            className={`app-shell__star-map-layer${
-              starMapFloatOpen ? " is-floating" : ""
-            }`}
-          >
-            <Suspense fallback={null}>
-              <LazyStarMapScreen
-                desktopApi={desktopApi}
-                localThreads={navigation.threads}
-                // Not part of `sessionKeys`: those are only trusted for the
-                // local instance's cards, because thinking/approval keys are
-                // inferred from an unscoped event stream. A draft is this
-                // window's own composer state, so it is authoritative for
-                // every card it matches, local or remote.
-                draftThreadKeys={draftThreadKeys}
-                sessionKeys={{
-                  approvalRequestThreadKeys: session.approvalRequestThreadKeys,
-                  inputRequestThreadKeys: session.inputRequestThreadKeys,
-                  thinkingThreadKeys: session.thinkingThreadKeys,
-                }}
-                localInstanceLabel={
-                  settings.snapshot?.federation.instanceLabel.value
-                }
-                floating={starMapFloatOpen}
-                onClose={closeStarMap}
-                onOpenLocalThread={(thread) => {
-                  navigation.selectThread(thread);
-                  setStarMapFloatOpen(true);
-                }}
-                onFocusLocalInstance={closeStarMap}
-                onRefreshLocalThreads={() => {
-                  void navigation.refresh?.();
-                }}
               />
             </Suspense>
           </div>

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -130,12 +130,9 @@ export function AppTitleBar(props: {
           {props.starMap && !isFederationWindow ? (
             <button
               type="button"
-              aria-label={props.starMap.active ? "Close Star Map" : "Open Star Map"}
-              aria-pressed={props.starMap.active}
-              className={`thread-header__star-map-toggle${
-                props.starMap.active ? " is-open" : ""
-              }`}
-              onClick={props.starMap.onToggle}
+              aria-label="Open Star Map"
+              className="thread-header__star-map-toggle"
+              onClick={props.starMap.onOpen}
             >
               <StarMapIcon size={14} />
             </button>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -18,7 +18,6 @@ import {
   type FederationPeerSummary,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
-import { CloseIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { useCelestialIcons } from "../../lib/useCelestialIcons";
 import { useFederationHealth } from "../../lib/useFederationHealth";
@@ -254,12 +253,9 @@ type StarMapScreenProps = {
   draftThreadKeys?: Record<string, boolean>;
   /** Fallback label for the local instance card (instanceLabel setting). */
   localInstanceLabel?: string;
-  /** A thread is floating over the map; the map shoves left behind it. */
-  floating: boolean;
-  onClose: () => void;
-  /** Open a local thread floating over the map. */
+  /** Open a local thread in the main window's full thread view. */
   onOpenLocalThread: (thread: NavigationThreadSummary) => void;
-  /** The local instance card's open action: back to the thread shell. */
+  /** The local instance card's open action: focus the main window. */
   onFocusLocalInstance: () => void;
   /** Refresh the App's navigation snapshot (after intake creates locally). */
   onRefreshLocalThreads?: () => void;
@@ -405,14 +401,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const topAnchoredView = !orbitMode && !projectsMode;
 
-  // Focus the layer on open AND whenever the floating thread closes -
-  // "Back to map" leaves focus inside <main>, and without a refocus the
-  // layer's Escape-to-close handler would never hear the key again.
+  // Focus the layer on mount so the camera keys and the Escape
+  // selection-unwind work without the operator clicking into the map
+  // first.
   useEffect(() => {
-    if (!props.floating) {
-      layerRef.current?.focus();
-    }
-  }, [props.floating]);
+    layerRef.current?.focus();
+  }, []);
 
   // The constellation lays out in pixels of the real viewport, not
   // percentages - lanes need true widths to guarantee cards never overlap.
@@ -1300,11 +1294,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
    *
    * A map you fly over should move the way every other map you fly over
    * moves, and the pointer gestures alone leave the operator's other hand
-   * with nothing to do. Disabled while a thread floats over the map: the
-   * map has shoved aside and `w` belongs to the composer.
+   * with nothing to do.
    */
   const heldCameraKeys = useStarMapCameraKeys({
-    enabled: !props.floating,
     layerRef,
     liveViewRef: viewRef,
     canvas: panZoomCanvas,
@@ -2704,20 +2696,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
   return (
     <div
       ref={layerRef}
-      className={`star-map${props.floating ? " star-map--floating" : ""}`}
+      className="star-map"
       role="region"
       aria-label="Star Map"
       tabIndex={-1}
       onKeyDown={(event) => {
         if (event.key === "Escape") {
           event.stopPropagation();
-          // Escape unwinds one layer at a time: drop the selection first,
-          // and only close the map once there is nothing left to drop.
+          // Escape unwinds the selection; with nothing left to drop it
+          // deliberately does nothing. The map lives in its own OS window
+          // now, and closing a whole window is the OS chrome's job — an
+          // Escape that tears the window down would punish the reflexive
+          // "dismiss the popover" tap.
           if (selection.size > 0) {
             setSelection(new Set());
-            return;
           }
-          props.onClose();
         }
       }}
     >
@@ -3157,17 +3150,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
           </button>
         </p>
       ) : null}
-      {/* The map layer covers the app chrome, including the header toggle
-          that opened it, so it must carry its own way out. */}
-      <button
-        type="button"
-        className="star-map__close"
-        aria-label="Close Star Map"
-        onClick={props.onClose}
-      >
-        <CloseIcon size={14} />
-        <span>Close map</span>
-      </button>
       <div className="star-map__chrome">
         {/* Same wordmark primitive as the sidebar/Settings nav so the brand
             reads identically across every window (theme-contract test). */}
@@ -3229,9 +3211,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
           </span>
         </div>
       ) : null}
-      {/* Bottom-left: the keys the map flies with. Hidden while a thread
-          floats over the map, because the camera is off then. */}
-      {props.floating ? null : <StarMapKeyHint held={heldCameraKeys} />}
+      {/* Bottom-left: the keys the map flies with. */}
+      <StarMapKeyHint held={heldCameraKeys} />
       {/* The only thing on the surface that admits a selection exists.
           `role="status"` so the count is heard, not just seen — the cards
           themselves carry no selected state to a screen reader. */}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -1,0 +1,101 @@
+import { useEffect } from "react";
+import { getDesktopApi, useDesktopApi } from "../../lib/desktop-api";
+import { useThreadNavigation } from "../../lib/useThreadNavigation";
+import { useThreadSessionState } from "../../lib/useThreadSessionState";
+import { useThreadDraftIndicators } from "../../lib/useThreadDraftIndicators";
+import { useComposerDraftStore } from "../composer/useComposerDraftStore";
+import { useDurableComposerDraftStore } from "../composer/useDurableComposerDraftStore";
+import { useDesktopSettings } from "../settings/useDesktopSettings";
+import { StarMapScreen } from "./StarMapScreen";
+
+/**
+ * Root component for the dedicated Federation Star Map BrowserWindow.
+ *
+ * Mounted by `main.tsx` when `window.location.hash === "#star-map"`. The
+ * spawn entry point is `showStarMapWindow()` in the main process.
+ * Window-close goes through the OS traffic-light buttons; the map carries
+ * no in-chrome Close button.
+ *
+ * The map used to live as a full-window layer inside the main shell and
+ * received its data as props from `App`. As a standalone window it sources
+ * the same inputs itself: the local navigation snapshot (live-patched over
+ * `agent:event`, which the main process subscribes this window to),
+ * event-derived session keys, and this window's own composer-draft
+ * indicators. Cross-window navigation ("Open in full view", the local
+ * instance card) goes back through main-process IPC that focuses the main
+ * window.
+ */
+export function StarMapWindow() {
+  const desktopApi = useDesktopApi();
+  const settings = useDesktopSettings(desktopApi);
+  const navigation = useThreadNavigation(desktopApi, { enabled: true });
+  // No selected thread in this window — the hook only contributes its
+  // event-derived approval/input/thinking key maps to the map's cards.
+  const session = useThreadSessionState({ desktopApi });
+  const baseComposerDraftStore = useComposerDraftStore();
+  const composerDraftStore = useDurableComposerDraftStore(
+    baseComposerDraftStore,
+    desktopApi,
+  );
+  const draftThreadKeys = useThreadDraftIndicators({
+    composerDraftStore,
+    threads: navigation.threads,
+  });
+
+  // The renderer-side document title is what macOS shows in the Window
+  // menu (the BrowserWindow's `title` option gets overridden by `<title>`
+  // in `index.html`, which is shared with the main window).
+  useEffect(() => {
+    document.title = "Federation Star Map";
+  }, []);
+
+  // Windows draws its caption buttons in a frameless overlay, so the
+  // window needs a painted drag strip the way every other aux window
+  // does. macOS keeps the map full-bleed: the map's own top chrome
+  // already reserves the stoplight gutter and the native title-bar band
+  // handles dragging. Linux keeps its normal OS frame.
+  const isWindows = getDesktopApi()?.platform === "win32";
+
+  return (
+    <div className="star-map-window">
+      {isWindows ? (
+        <header className="activity-titlebar">
+          <p className="activity-titlebar__brand">
+            Pwr<span className="activity-titlebar__brand-accent">Agent</span>
+          </p>
+          <div className="activity-titlebar__breadcrumb">
+            <span className="activity-titlebar__eyebrow">Federation</span>
+            <span aria-hidden="true" className="activity-titlebar__separator">
+              ›
+            </span>
+            <span className="activity-titlebar__current">Star Map</span>
+          </div>
+          <div className="activity-titlebar__spacer" />
+        </header>
+      ) : null}
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={navigation.threads}
+        draftThreadKeys={draftThreadKeys}
+        sessionKeys={{
+          approvalRequestThreadKeys: session.approvalRequestThreadKeys,
+          inputRequestThreadKeys: session.inputRequestThreadKeys,
+          thinkingThreadKeys: session.thinkingThreadKeys,
+        }}
+        localInstanceLabel={settings.snapshot?.federation.instanceLabel.value}
+        onOpenLocalThread={(thread) => {
+          void desktopApi?.openStarMapThreadInMainWindow?.({
+            backend: thread.source,
+            threadId: thread.id,
+          });
+        }}
+        onFocusLocalInstance={() => {
+          void desktopApi?.focusMainWindowFromStarMap?.();
+        }}
+        onRefreshLocalThreads={() => {
+          void navigation.refresh?.();
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -84,8 +84,6 @@ describe("StarMapScreen", () => {
         sessionKeys={{}}
         draftThreadKeys={{ "codex:t1": true }}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -131,8 +129,6 @@ describe("StarMapScreen", () => {
         localThreads={[]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -192,8 +188,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -244,8 +238,6 @@ describe("StarMapScreen", () => {
           localThreads={[unreadThread("t1")]}
           sessionKeys={{}}
           localInstanceLabel="Mac-Mini-M4"
-          floating={false}
-          onClose={() => undefined}
           onOpenLocalThread={() => undefined}
           onFocusLocalInstance={() => undefined}
         />,
@@ -306,8 +298,6 @@ describe("StarMapScreen", () => {
         localThreads={[]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -391,8 +381,6 @@ describe("StarMapScreen", () => {
         localThreads={[]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -457,8 +445,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1"), unreadThread("t2")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -506,8 +492,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1"), unreadThread("t2")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -559,8 +543,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1"), unreadThread("t2")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -598,8 +580,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -626,8 +606,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={onOpenLocalThread}
         onFocusLocalInstance={() => undefined}
       />,
@@ -670,8 +648,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -699,8 +675,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -730,8 +704,6 @@ describe("StarMapScreen", () => {
         desktopApi={buildDesktopApi()}
         localThreads={[unreadThread("t2")]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -773,8 +745,6 @@ describe("StarMapScreen", () => {
         desktopApi={buildDesktopApi()}
         localThreads={[unreadThread("t3")]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -784,59 +754,57 @@ describe("StarMapScreen", () => {
     ).toBeTruthy();
   });
 
-  it("closes on Escape", async () => {
-    const onClose = vi.fn();
+  it("swallows a bare Escape — closing the window is the OS chrome's job", () => {
+    const outerKeyDown = vi.fn();
     render(
-      <StarMapScreen
-        desktopApi={buildDesktopApi()}
-        localThreads={[]}
-        sessionKeys={{}}
-        floating={false}
-        onClose={onClose}
-        onOpenLocalThread={() => undefined}
-        onFocusLocalInstance={() => undefined}
-      />,
+      <div onKeyDown={outerKeyDown}>
+        <StarMapScreen
+          desktopApi={buildDesktopApi()}
+          localThreads={[]}
+          sessionKeys={{}}
+          onOpenLocalThread={() => undefined}
+          onFocusLocalInstance={() => undefined}
+        />
+      </div>,
     );
     fireEvent.keyDown(screen.getByRole("region", { name: "Star Map" }), {
       key: "Escape",
     });
-    expect(onClose).toHaveBeenCalledTimes(1);
+    // With nothing selected, Escape neither escapes the map (the reflexive
+    // "dismiss the popover" tap must not reach a window-level handler) nor
+    // tears anything down.
+    expect(outerKeyDown).not.toHaveBeenCalled();
+    expect(screen.getByRole("region", { name: "Star Map" })).toBeTruthy();
   });
 
-  it("refocuses the layer when the floating thread closes so Escape works again", () => {
-    const props = {
-      desktopApi: buildDesktopApi(),
-      localThreads: [],
-      sessionKeys: {},
-      onClose: () => undefined,
-      onOpenLocalThread: () => undefined,
-      onFocusLocalInstance: () => undefined,
-    };
-    const { rerender } = render(<StarMapScreen {...props} floating />);
-    const region = screen.getByRole("region", { name: "Star Map" });
-    // While the float is up, focus lives in the thread view — simulate it
-    // being elsewhere, then close the float.
-    (document.activeElement as HTMLElement | null)?.blur?.();
-    expect(document.activeElement).not.toBe(region);
-    rerender(<StarMapScreen {...props} floating={false} />);
-    expect(document.activeElement).toBe(region);
-  });
-
-  it("offers a visible exit because the map covers the header toggle", async () => {
-    const onClose = vi.fn();
+  it("focuses the layer on mount so the camera keys work immediately", () => {
     render(
       <StarMapScreen
         desktopApi={buildDesktopApi()}
         localThreads={[]}
         sessionKeys={{}}
-        floating={false}
-        onClose={onClose}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Close Star Map" }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(
+      screen.getByRole("region", { name: "Star Map" }),
+    );
+  });
+
+  it("carries no in-map close affordance — the map lives in its own window", () => {
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[]}
+        sessionKeys={{}}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Close Star Map" }),
+    ).toBeNull();
   });
 
   it("disambiguates two profiles on one machine, local included", async () => {
@@ -869,8 +837,6 @@ describe("StarMapScreen", () => {
         desktopApi={desktopApi}
         localThreads={[]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -933,8 +899,6 @@ describe("StarMapScreen", () => {
         desktopApi={desktopApi}
         localThreads={[]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -990,8 +954,6 @@ describe("StarMapScreen", () => {
           } as unknown as NavigationThreadSummary,
         ]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1030,8 +992,6 @@ describe("StarMapScreen", () => {
         desktopApi={buildDesktopApi()}
         localThreads={[thread]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1077,8 +1037,6 @@ describe("StarMapScreen", () => {
         desktopApi={desktopApi}
         localThreads={[]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1109,8 +1067,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
         onRefreshLocalThreads={onRefreshLocalThreads}
@@ -1147,8 +1103,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1176,8 +1130,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1211,8 +1163,6 @@ describe("StarMapScreen", () => {
           localThreads={[unreadThread("t1")]}
           sessionKeys={{}}
           localInstanceLabel="Mac-Mini-M4"
-          floating={false}
-          onClose={() => undefined}
           onOpenLocalThread={() => undefined}
           onFocusLocalInstance={() => undefined}
         />,
@@ -1291,8 +1241,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1"), unreadThread("t2")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1364,8 +1312,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1402,8 +1348,6 @@ describe("StarMapScreen", () => {
         localThreads={[unreadThread("t1")]}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1425,8 +1369,6 @@ describe("StarMapScreen", () => {
         desktopApi={buildDesktopApi()}
         localThreads={[unreadThread("t9")]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1454,8 +1396,6 @@ describe("StarMapScreen", () => {
         desktopApi={buildDesktopApi()}
         localThreads={[unreadThread("t10")]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1488,8 +1428,6 @@ describe("StarMapScreen", () => {
         desktopApi={buildDesktopApi()}
         localThreads={[]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1534,8 +1472,6 @@ describe("StarMapScreen", () => {
         desktopApi={desktopApi}
         localThreads={[]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -1561,8 +1497,6 @@ describe("StarMapScreen", () => {
         desktopApi={buildDesktopApi()}
         localThreads={[]}
         sessionKeys={{}}
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
@@ -114,15 +114,13 @@ function controlAnimationFrames() {
   };
 }
 
-async function openMap(floating = false) {
+async function openMap() {
   const rendered = render(
     <StarMapScreen
       desktopApi={buildDesktopApi()}
       localThreads={Array.from({ length: 9 }, (_, index) => thread(`t${index}`))}
       sessionKeys={{}}
       localInstanceLabel="Mac-Mini-M4"
-      floating={floating}
-      onClose={() => undefined}
       onOpenLocalThread={() => undefined}
       onFocusLocalInstance={() => undefined}
     />,
@@ -346,16 +344,4 @@ describe("star map keyboard camera", () => {
     await flushFrame();
   });
 
-  it("hands the keyboard back to the thread floating over the map", async () => {
-    // The map has shoved aside and the operator is in a composer, where `w`
-    // means `w`.
-    await openMap(true);
-    expect(document.querySelector(".star-map__key-hint")).toBeNull();
-    const before = readTransform();
-
-    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
-    await flushFrame();
-
-    expect(readTransform()).toEqual(before);
-  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -66,8 +66,6 @@ function renderOrbit(
       localThreads={threads}
       sessionKeys={{}}
       localInstanceLabel="Mac-Mini-M4"
-      floating={false}
-      onClose={() => undefined}
       onOpenLocalThread={() => undefined}
       onFocusLocalInstance={() => undefined}
     />,
@@ -79,8 +77,6 @@ function renderOrbit(
         localThreads={next}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -545,8 +541,6 @@ describe("star map load card overview fixes", () => {
         localThreads={threads}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-drag-scale.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-drag-scale.test.tsx
@@ -95,8 +95,6 @@ describe("card drag under zoom", () => {
           ]}
           sessionKeys={{}}
           localInstanceLabel="Mac-Mini-M4"
-          floating={false}
-          onClose={() => undefined}
           onOpenLocalThread={() => undefined}
           onFocusLocalInstance={() => undefined}
         />,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
@@ -49,8 +49,6 @@ function screen(threads: readonly NavigationThreadSummary[]) {
       desktopApi={buildDesktopApi()}
       localThreads={threads}
       sessionKeys={{}}
-      floating={false}
-      onClose={() => undefined}
       onOpenLocalThread={() => undefined}
       onFocusLocalInstance={() => undefined}
     />

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -62,7 +62,6 @@ function renderMap(
   count: number,
   overrides?: {
     desktopApi?: DesktopApi;
-    onClose?: () => void;
     onRefreshLocalThreads?: () => void;
   },
 ) {
@@ -75,8 +74,6 @@ function renderMap(
       )}
       sessionKeys={{}}
       localInstanceLabel="Mac-Mini-M4"
-      floating={false}
-      onClose={overrides?.onClose ?? (() => undefined)}
       onOpenLocalThread={() => undefined}
       onFocusLocalInstance={() => undefined}
       onRefreshLocalThreads={overrides?.onRefreshLocalThreads}
@@ -300,9 +297,8 @@ describe("star map selection is amendable", () => {
     expect(selectedShells()).toHaveLength(before);
   });
 
-  it("drops the selection on Escape before it closes the map", async () => {
-    const onClose = vi.fn();
-    renderMap(4, { onClose });
+  it("drops the selection on Escape, and a second press is a no-op", async () => {
+    renderMap(4);
     await ready();
     await sweepEverything();
     await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
@@ -312,11 +308,13 @@ describe("star map selection is amendable", () => {
     fireEvent.keyDown(layer, { key: "Escape" });
 
     await waitFor(() => expect(selectedShells()).toHaveLength(0));
-    expect(onClose).not.toHaveBeenCalled();
 
-    // Nothing left to unwind, so the second press closes.
+    // Nothing left to unwind. The map lives in its own OS window, so a
+    // bare Escape deliberately does nothing — closing is the OS chrome's
+    // job, and the map must survive the reflexive dismiss tap.
     fireEvent.keyDown(layer, { key: "Escape" });
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.querySelector(".star-map")).not.toBeNull();
+    expect(selectedShells()).toHaveLength(0);
   });
 
   it("takes a card back out of the selection on a modifier-click", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -118,8 +118,6 @@ function renderMap(props: { threads: NavigationThreadSummary[] }) {
       localThreads={props.threads}
       sessionKeys={{}}
       localInstanceLabel="Mac-Mini-M4"
-      floating={false}
-      onClose={() => undefined}
       onOpenLocalThread={() => undefined}
       onFocusLocalInstance={() => undefined}
     />,
@@ -154,8 +152,6 @@ describe("star map view stability", () => {
         localThreads={threads(8)}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -189,8 +185,6 @@ describe("star map view stability", () => {
         localThreads={threads(5)}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,
@@ -261,8 +255,6 @@ describe("star map view stability", () => {
         localThreads={threads(4)}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
         onOpenLocalThread={() => undefined}
         onFocusLocalInstance={() => undefined}
       />,

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapCameraKeys.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapCameraKeys.ts
@@ -24,11 +24,6 @@ const NO_KEYS: ReadonlySet<StarMapCameraKey> = new Set();
  * never per frame, so it costs one render per press rather than per frame.
  */
 export function useStarMapCameraKeys(params: {
-  /**
-   * Off while a thread floats over the map: the map has shoved aside and
-   * the operator is working in the thread, where `w` means `w`.
-   */
-  enabled: boolean;
   /** Keydown is scoped here, so the map only flies while it has focus. */
   layerRef: RefObject<HTMLElement | null>;
   /** The transformed canvas, written directly during flight. */
@@ -83,11 +78,11 @@ export function useStarMapCameraKeys(params: {
     };
   });
 
-  const { enabled, layerRef, liveViewRef } = params;
+  const { layerRef, liveViewRef } = params;
 
   useEffect(() => {
     const layer = layerRef.current;
-    if (!enabled || !layer) return;
+    if (!layer) return;
 
     let frame = 0;
     let last = 0;
@@ -221,7 +216,7 @@ export function useStarMapCameraKeys(params: {
       heldRef.current = NO_KEYS;
       setHeld(NO_KEYS);
     };
-  }, [enabled, layerRef, liveViewRef]);
+  }, [layerRef, liveViewRef]);
 
   return held;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -36,9 +36,13 @@ type ThreadHeaderLayoutControls = {
   onToggleTerminal: () => void;
 };
 
+/**
+ * The header's Star Map control. The map lives in its own OS window, so
+ * this is a launcher, not a toggle — opening again focuses the existing
+ * window instead of closing anything.
+ */
 export type StarMapToggleControls = {
-  active: boolean;
-  onToggle: () => void;
+  onOpen: () => void;
 };
 
 type ThreadHeaderProps = {
@@ -109,7 +113,7 @@ export function ThreadHeader(props: ThreadHeaderProps) {
   // slow, edge-clipping native `title`.
   const terminalTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });
-  const starMapLabel = props.starMap?.active ? "Close Star Map" : "Open Star Map";
+  const starMapLabel = "Open Star Map";
   // A collapsed-but-running terminal gets its own affordance: the toggle wears
   // a live dot and says so, otherwise the shell is invisible from here.
   const terminalCollapsedRunning =
@@ -244,14 +248,11 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           {props.starMap ? (
             <button
               type="button"
-              className={`thread-header__star-map-toggle${
-                props.starMap.active ? " is-open" : ""
-              }`}
+              className="thread-header__star-map-toggle"
               aria-label={starMapLabel}
-              aria-pressed={props.starMap.active}
               onClick={() => {
                 starMapTooltip.hide();
-                props.starMap?.onToggle();
+                props.starMap?.onOpen();
               }}
               onMouseEnter={(event) =>
                 starMapTooltip.show(event.currentTarget, starMapLabel)

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -59,7 +59,7 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
   const sidebarHidden = props.layout ? !props.layout.sidebarOpen : false;
   const showMasthead = sidebarHidden && !isWindows && Boolean(props.masthead);
   const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });
-  const starMapLabel = props.starMap?.active ? "Close Star Map" : "Open Star Map";
+  const starMapLabel = "Open Star Map";
 
   return (
     <header className="thread-header thread-header--placeholder">
@@ -114,14 +114,11 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
           {props.starMap ? (
             <button
               type="button"
-              className={`thread-header__star-map-toggle${
-                props.starMap.active ? " is-open" : ""
-              }`}
+              className="thread-header__star-map-toggle"
               aria-label={starMapLabel}
-              aria-pressed={props.starMap.active}
               onClick={() => {
                 starMapTooltip.hide();
-                props.starMap?.onToggle();
+                props.starMap?.onOpen();
               }}
               onMouseEnter={(event) =>
                 starMapTooltip.show(event.currentTarget, starMapLabel)

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -590,6 +590,14 @@ export type DesktopApi = {
   dispatchStarMapIntake?: (
     request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
   ) => Promise<StarMapIntakeResponse>;
+  /** Spawns or focuses the dedicated Federation Star Map window. */
+  openStarMapWindow?: () => Promise<void>;
+  /** From the Star Map window: focus the main window and open a thread there. */
+  openStarMapThreadInMainWindow?: (
+    request: WindowShowThreadRequest,
+  ) => Promise<void>;
+  /** From the Star Map window: focus the main window without navigating. */
+  focusMainWindowFromStarMap?: () => Promise<void>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -141,6 +141,9 @@ const AutomationRunWindow = lazy(async () => ({
   default: (await import("./features/automations/AutomationRunWindow"))
     .AutomationRunWindow,
 }));
+const StarMapWindow = lazy(async () => ({
+  default: (await import("./features/star-map/StarMapWindow")).StarMapWindow,
+}));
 
 /**
  * Routes recognized by `chooseRoot` below. The Messaging Activity
@@ -161,6 +164,10 @@ const routes: Array<{
   {
     match: (hash) => hash === "messaging-activity",
     render: () => <MessagingActivityWindow />,
+  },
+  {
+    match: (hash) => hash === "star-map",
+    render: () => <StarMapWindow />,
   },
   {
     match: (hash) => hash === "changelog",

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -860,18 +860,14 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
-  it("layers app toasts above the full-window Star Map", () => {
-    const starMapLayerRule = extractRuleBody(
-      css,
-      ".app-shell__star-map-layer",
-    );
-    const toastStackRule = extractRuleBody(css, ".app-toast-stack");
-    const readZIndex = (rule: string): number =>
-      Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
-
-    expect(readZIndex(toastStackRule)).toBeGreaterThan(
-      readZIndex(starMapLayerRule),
-    );
+  it("scopes the Star Map window's card z-scale inside its own stacking context", () => {
+    // The dedicated map window's root must open a stacking context: the
+    // map's internal card z-scale runs to STAR_MAP_CARD_MAX_Z (4000), and
+    // without the containment those cards would out-stack every
+    // body-portaled tooltip in the window.
+    const windowRule = extractRuleBody(css, ".star-map-window");
+    expect(windowRule).toContain("position: relative;");
+    expect(windowRule).toMatch(/z-index:\s*\d+;/);
   });
 
   it("right-aligns the keyboard shortcut hint chip on context menu items", () => {
@@ -1449,16 +1445,16 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toMatch(/\n\.pr-status-card__dot--\w+\s*[,{]/);
   });
 
-  it("layers the PR hover card above the full-window Star Map", () => {
-    // PR chips render inside `.app-shell__star-map-layer` (z-index 120), and
-    // `.app-shell` opens no stacking context, so a portal at the usual 90
-    // paints underneath the map.
-    const layer = extractRuleBody(css, ".app-shell__star-map-layer");
+  it("layers the PR hover card above the Star Map window root", () => {
+    // PR chips render on cards inside `.star-map-window`, whose stacking
+    // context scopes the card z-scale — the portal only has to beat the
+    // window root's own z-index, not the cards inside it.
+    const windowRule = extractRuleBody(css, ".star-map-window");
     const card = extractRuleBody(css, ".pr-status-card");
-    const layerZ = Number(layer.match(/z-index:\s*(\d+);/)?.[1]);
+    const windowZ = Number(windowRule.match(/z-index:\s*(\d+);/)?.[1]);
     const cardZ = Number(card.match(/z-index:\s*(\d+);/)?.[1]);
-    expect(Number.isFinite(layerZ)).toBe(true);
-    expect(cardZ).toBeGreaterThan(layerZ);
+    expect(Number.isFinite(windowZ)).toBe(true);
+    expect(cardZ).toBeGreaterThan(windowZ);
   });
 
   it("keeps thinking scanner variants on one shared visible sweep", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5104,13 +5104,13 @@ textarea,
    Every section inside is optional; see PrStatusCard.tsx for why. */
 .pr-status-card {
   position: fixed;
-  /* 140, not the 90 most portal tooltips use, because PR chips render inside
-     the Star Map layer (`.app-shell__star-map-layer`, z-index 120) as well as
-     the normal shell. `.app-shell` is `position: relative` with `z-index: auto`
-     and so opens no stacking context, which puts that layer in the ROOT
-     stacking context alongside this portal — at 90 the card paints UNDER the
-     map it was opened from. Same reason `.messaging-status-tooltip` sits at
-     140 over the Settings overlay. */
+  /* 140, not the 90 most portal tooltips use, because PR chips render over
+     full-window overlay surfaces (the Settings layer at 120) as well as the
+     normal shell. `.app-shell` is `position: relative` with `z-index: auto`
+     and so opens no stacking context, which puts those layers in the ROOT
+     stacking context alongside this portal — at 90 the card paints UNDER
+     the overlay it was opened from. Same reason `.messaging-status-tooltip`
+     sits at 140 over the Settings overlay. */
   z-index: 140;
   width: 272px;
   max-width: calc(100vw - 32px);
@@ -6683,7 +6683,7 @@ textarea,
 .app-toast-stack {
   position: fixed;
   /* App-level notices must remain visible over full-window surfaces such as
-     Star Map (120) and its floating thread (130). */
+     the Settings layer (120). */
   z-index: 140;
   left: 16px;
   bottom: 16px;
@@ -10570,19 +10570,21 @@ textarea,
   outline-offset: 1px;
 }
 
-.thread-header__star-map-toggle.is-open {
-  color: var(--accent-bright);
-}
-
-/* Full-window layer over the app shell (same tier as Settings). A faint
-   accent aurora washes down from the top of the sky; the stars are a
-   seeded SVG field colored from --text-primary so they read as space in
-   both themes. */
-.app-shell__star-map-layer {
+/* Root container of the dedicated Star Map window. A faint accent aurora
+   washes down from the top of the sky; the stars are a seeded SVG field
+   colored from --text-primary so they read as space in both themes.
+   `position: relative; z-index: 0` opens a stacking context — the map's
+   internal card z-scale (up to STAR_MAP_CARD_MAX_Z) stays scoped inside
+   it, exactly as the old full-window layer's z-index did, so cards can't
+   paint over the body-portaled tooltips (`.star-map-card__tooltip`,
+   `.pr-status-card`). */
+.star-map-window {
   display: flex;
-  position: absolute;
-  z-index: 120;
-  inset: 0;
+  position: relative;
+  z-index: 0;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
   min-width: 0;
   min-height: 0;
   background:
@@ -10607,12 +10609,6 @@ textarea,
   position: absolute;
   inset: 0;
   transition: transform 240ms ease, opacity 240ms ease;
-}
-
-/* A floating thread shoves the map off to the left behind it. */
-.star-map--floating .star-map__viewport {
-  transform: translateX(-36%);
-  opacity: 0.85;
 }
 
 .star-map__sky {
@@ -11161,37 +11157,6 @@ textarea,
   50% {
     opacity: 0.45;
   }
-}
-
-/* The map covers the app chrome (including the header toggle that opened
-   it), so it carries its own exit. Top-RIGHT to stay clear of the macOS
-   traffic lights. */
-.star-map__close {
-  display: inline-flex;
-  position: absolute;
-  top: 14px;
-  right: 16px;
-  z-index: 4;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--bg-panel) 85%, transparent);
-  color: var(--text-secondary);
-  font-size: 11px;
-  cursor: pointer;
-  -webkit-app-region: no-drag;
-}
-
-.star-map__close:hover {
-  border-color: var(--accent-border);
-  color: var(--text-primary);
-}
-
-.star-map__close:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
 }
 
 .star-map__cloud {
@@ -12302,8 +12267,6 @@ textarea,
    the window can still be moved while the map is open. */
 .star-map__filters,
 .star-map__filters *,
-.star-map__close,
-.star-map__close *,
 .star-map-instance,
 .star-map-instance *,
 .star-map-card,
@@ -12314,71 +12277,6 @@ textarea,
 .star-map__cluster-label *,
 .star-map__cluster-overflow {
   -webkit-app-region: no-drag;
-}
-
-/* Floating thread over the map: the already-mounted main pane elevates
-   above the layer as a movable rounded card. */
-.app-main--star-map-float {
-  position: absolute;
-  z-index: 130;
-  inset: 24px 24px 24px 264px;
-  flex-direction: column;
-  border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  background: var(--bg-app);
-  box-shadow: var(--shadow-popover);
-  overflow: hidden;
-  transform: translate(
-    var(--star-map-float-dx, 0px),
-    var(--star-map-float-dy, 0px)
-  );
-}
-
-.star-map-float-handle {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 10px;
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-panel);
-  cursor: grab;
-  user-select: none;
-}
-
-.star-map-float-handle:active {
-  cursor: grabbing;
-}
-
-.star-map-float-handle__grip {
-  width: 28px;
-  height: 4px;
-  border-radius: 2px;
-  background: var(--border-strong);
-}
-
-.star-map-float-handle__title {
-  flex: 1;
-  overflow: hidden;
-  color: var(--text-muted);
-  font-size: 12px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.star-map-float-handle__close {
-  padding: 3px 10px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 11px;
-  cursor: pointer;
-}
-
-.star-map-float-handle__close:hover {
-  border-color: var(--accent-border);
-  color: var(--text-primary);
 }
 
 /* Floating chat cards.
@@ -18208,9 +18106,10 @@ a.transcript-message__messaging-origin:focus-visible {
   z-index: 140;
 }
 
-/* Star Map thread-card title tooltip — same escape, same fix: its trigger sits
-   inside `.app-shell__star-map-layer` (z-index 120), which shares the root
-   stacking context with this portal because `.app-shell` opens none. */
+/* Star Map thread-card title tooltip — same escape, same fix: its trigger
+   sits inside `.star-map-window` (the dedicated map window's stacking
+   context), and the map's internal card z-scale would otherwise bury a
+   body-portaled tooltip left at the default 90. */
 .star-map-card__tooltip {
   z-index: 140;
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -21,6 +21,28 @@ export const FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL =
 export const STAR_MAP_READ_ARRANGEMENT_CHANNEL = "star-map:read-arrangement";
 export const STAR_MAP_SET_CARD_POSITION_CHANNEL = "star-map:set-card-position";
 export const STAR_MAP_INTAKE_CHANNEL = "star-map:intake";
+/**
+ * Fire-and-forget IPC: opens the dedicated Federation Star Map window
+ * (or focuses it if already open). The map is a separate BrowserWindow
+ * with its own traffic lights and lifecycle — see `showStarMapWindow`
+ * in `apps/desktop/src/main/star-map-window.ts`.
+ */
+export const STAR_MAP_OPEN_WINDOW_CHANNEL = "star-map:open-window";
+/**
+ * Renderer → main invoke from the Star Map window: focus the primary
+ * (non-federation) main window and navigate it to a thread. The main
+ * process resolves the target window and relays the request over
+ * `WINDOW_SHOW_THREAD_CHANNEL`.
+ */
+export const STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL =
+  "star-map:open-thread-in-main";
+/**
+ * Renderer → main invoke from the Star Map window: focus the primary
+ * (non-federation) main window without navigating it anywhere — the
+ * local instance card's "open" action.
+ */
+export const STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL =
+  "star-map:focus-main-window";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";


### PR DESCRIPTION
Moves the Star Map out of the main window's full-screen overlay layer into its own singleton OS window titled **Federation Star Map**, so an operator can keep the map full-screen on its own macOS Space (3-finger-swipe) while using the regular windows in windowed mode.

Stacked on #1608 (orbit default lens + test seeds); retargets to `main` when that merges.

## What changed

**Main process**
- `star-map-window.ts`, modeled closely on `messaging-activity-window.ts`: singleton with a focus-if-open guard, `auxiliaryWindowChromeOptions()`, `registerAuxiliaryWindowTitle`, appearance bootstrap, and hash-routing into the shared renderer bundle (`#star-map`). Two deliberate deviations from the aux-window template:
  - `fullscreenable: true` — the own-Space fullscreen behavior is the product intent, so the green stoplight keeps native fullscreen instead of the aux-window windowed zoom.
  - `registerWindowChannels(window, WINDOW_KIND_STAR_MAP, [AGENT_EVENT_CHANNEL, APPEARANCE_CHANGED_EVENT_CHANNEL])` — the map is a live push-driven surface, unlike the polling Messaging Activity window. It is registered **without** a federation target; remote-scoped event delivery still goes through the renderer's own `setFederationEventSubscriptions` registration, which the main process already cleans up on webContents destroy.
- New IPC in `ipc/star-map.ts`: `star-map:open-window`, plus the cross-window paths `star-map:open-thread-in-main` (reuses `requestShowThread`, preferring the first **non-federation** subscriber so a remote-viewer window never receives a local thread) and `star-map:focus-main-window` (the local instance card's open action). Covered by a new `star-map-window-ipc.test.ts`.

**Renderer**
- `StarMapWindow.tsx` root: sources the map's inputs itself — `useThreadNavigation` (live local snapshot over `agent:event`), `useThreadSessionState` with no thread (the event-derived approval/input/thinking key maps), this window's own durable composer-draft indicators, and the instance label from settings. Renders an `.activity-titlebar` drag strip on **win32 only** (frameless WCO needs one); macOS stays full-bleed because the map's own chrome already reserves the stoplight gutter and the native title-bar band handles dragging, and Linux keeps its OS frame.
- `StarMapScreen` loses `floating` and `onClose`. "Open in full view" and the instance card cross windows via the new IPC. The in-window layer (`.app-shell__star-map-layer`), `star-map--floating`, the float handle, and the "Close map" button are removed; the header control becomes a launcher (`StarMapToggleControls.onOpen`, no pressed state).
- Stacking-context contract preserved: the old layer's `z-index: 120` is what scoped the map's internal card z-scale (up to 4000) away from body-portaled tooltips at 140. `.star-map-window` now opens that stacking context (`position: relative; z-index: 0`), and the theme-contract test pins it.

**Escape semantics** (operator preference was left open): Escape still unwinds the selection; with nothing left to drop it now deliberately does **nothing** — closing a whole window is the OS chrome's job, and a reflexive "dismiss the popover" tap shouldn't tear the window down. Unit tests pin both halves.

**Known scope cut**: `localStorage` is shared per-origin, so stored map preferences (lens, layout) carry into the new window automatically (per #1608). Draft chips in the map window read the machine-wide draft store once at window mount — same freshness rule every secondary window already has.

## Tests
- `star-map-thread-flow.spec.ts` rewritten for the window model: spawn, singleton focus-not-spawn guard, chat card in the map window, cross-window escalation into the main window, and no in-map close affordance.
- `star-map-chat-card-history.spec.ts` reads the chat card from the map window (enrollment stays in the main window).
- `a11y.spec.ts` star-map blocks audit the new window in both themes, with reduced motion re-emulated on the map window's Page (it's a different Page than `launchAuditApp` configured).
- Renderer vitest harnesses drop `floating`/`onClose`; new tests pin Escape-swallowing, focus-on-mount, and the absent close button. `useStarMapCameraKeys` loses its now-constant `enabled` option.
- Visual goldens: none touch the map (verified) — no changes.

`pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `pnpm lint:colors`, `pnpm lint:sql`, `pnpm lint:codex-storage`, `pnpm typecheck`, and the star-map + theme-contract + window-IPC vitest suites (477 tests) all pass. Desktop E2E not run locally (lab-only policy); the three touched specs need a lab/CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)