### PR TITLE
fix(desktop): keep remote transcript thread links actionable

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -37,6 +37,7 @@ import {
   resolveThreadIdText,
   useThreadLinks,
   type ThreadLinkContextValue,
+  type ThreadLinkSource,
 } from "../../lib/thread-links";
 import {
   resolvePullRequestHref,
@@ -72,6 +73,7 @@ type ThreadMarkdownProps = {
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   skills?: AppServerSkillSummary[];
   text: string;
+  threadLinkSource?: ThreadLinkSource;
   variant?: "message" | "summary";
 };
 
@@ -141,6 +143,7 @@ function TranscriptCode(props: {
   children: ReactNode;
   className?: string;
   desktopApi?: Pick<DesktopApi, "copyText">;
+  threadLinkSource?: ThreadLinkSource;
   threadLinks: ThreadLinkContextValue | undefined;
 }) {
   const insideCodeBlock = useContext(CodeBlockContext);
@@ -158,7 +161,8 @@ function TranscriptCode(props: {
     // so an unrelated uuid stays plain code.
     const threadLink = resolveThreadIdText(
       extractTextContent(props.children),
-      props.threadLinks
+      props.threadLinks,
+      props.threadLinkSource,
     );
     if (threadLink) {
       return <ThreadChip link={threadLink} onOpen={props.threadLinks.show} />;
@@ -335,7 +339,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         }
 
         if (isThreadUrl(href)) {
-          const threadLink = resolveThreadHref(href, threadLinks);
+          const threadLink = resolveThreadHref(
+            href,
+            threadLinks,
+            props.threadLinkSource,
+          );
           if (threadLink && threadLinks) {
             return (
               <ThreadChip
@@ -514,6 +522,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
           <TranscriptCode
             className={codeProps.className}
             desktopApi={props.desktopApi}
+            threadLinkSource={props.threadLinkSource}
             threadLinks={threadLinks}
           >
             {codeProps.children}
@@ -641,6 +650,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       props.desktopApi,
       props.imageParts,
       props.onOpenImage,
+      props.threadLinkSource,
       pullRequestLinks,
       sourceMarkdownText,
       skillsByPath,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -143,7 +143,6 @@ function TranscriptCode(props: {
   children: ReactNode;
   className?: string;
   desktopApi?: Pick<DesktopApi, "copyText">;
-  threadLinkSource?: ThreadLinkSource;
   threadLinks: ThreadLinkContextValue | undefined;
 }) {
   const insideCodeBlock = useContext(CodeBlockContext);
@@ -162,7 +161,6 @@ function TranscriptCode(props: {
     const threadLink = resolveThreadIdText(
       extractTextContent(props.children),
       props.threadLinks,
-      props.threadLinkSource,
     );
     if (threadLink) {
       return <ThreadChip link={threadLink} onOpen={props.threadLinks.show} />;
@@ -522,7 +520,6 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
           <TranscriptCode
             className={codeProps.className}
             desktopApi={props.desktopApi}
-            threadLinkSource={props.threadLinkSource}
             threadLinks={threadLinks}
           >
             {codeProps.children}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1375,6 +1375,17 @@ export function ThreadView(props: ThreadViewProps) {
   }, [props.activeTurnId]);
 
   const selectedThread = props.selectedThread;
+  const transcriptThreadLinkTarget =
+    selectedThread?.federation?.ref.target ?? readRendererFederationTarget();
+  const transcriptThreadLinkSource =
+    selectedThread
+    && transcriptThreadLinkTarget
+    && isRemoteFederationTarget(transcriptThreadLinkTarget)
+      ? {
+          backend: selectedThread.source,
+          instanceId: transcriptThreadLinkTarget.instanceId,
+        }
+      : undefined;
   const celestialIcons = useCelestialIcons({ desktopApi: props.desktopApi });
   // Owning instance's identity mark: remote threads show their instance's
   // icon, local threads (and the local viewer) show the local icon.
@@ -3219,6 +3230,7 @@ export function ThreadView(props: ThreadViewProps) {
               linkedMessageRequestKey={props.linkedMessageRequestKey}
               pagination={visibleTranscriptPagination}
               parentThreadId={selectedThread!.id}
+              threadLinkSource={transcriptThreadLinkSource}
               // File-diff activity renders in the LiveWorkRail above
               // the composer (issue #495). Generic tool activity has no
               // rail body, so keep it in the transcript while the turn

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1377,15 +1377,20 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThread = props.selectedThread;
   const transcriptThreadLinkTarget =
     selectedThread?.federation?.ref.target ?? readRendererFederationTarget();
-  const transcriptThreadLinkSource =
-    selectedThread
-    && transcriptThreadLinkTarget
-    && isRemoteFederationTarget(transcriptThreadLinkTarget)
-      ? {
-          backend: selectedThread.source,
-          instanceId: transcriptThreadLinkTarget.instanceId,
-        }
+  const transcriptThreadLinkInstanceId =
+    transcriptThreadLinkTarget && isRemoteFederationTarget(transcriptThreadLinkTarget)
+      ? transcriptThreadLinkTarget.instanceId
       : undefined;
+  const transcriptThreadLinkBackend = selectedThread?.source;
+  const transcriptThreadLinkSource = useMemo(
+    () => transcriptThreadLinkBackend && transcriptThreadLinkInstanceId
+      ? {
+          backend: transcriptThreadLinkBackend,
+          instanceId: transcriptThreadLinkInstanceId,
+        }
+      : undefined,
+    [transcriptThreadLinkBackend, transcriptThreadLinkInstanceId],
+  );
   const celestialIcons = useCelestialIcons({ desktopApi: props.desktopApi });
   // Owning instance's identity mark: remote threads show their instance's
   // icon, local threads (and the local viewer) show the local icon.

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@pwragent/shared";
 import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ThreadLinkSource } from "../../lib/thread-links";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import {
   isThreadReferenceToolDetail,
@@ -31,6 +32,7 @@ type TranscriptActivityProps = {
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onExpandedChange?: (expanded: boolean) => void;
   skills?: AppServerSkillSummary[];
+  threadLinkSource?: ThreadLinkSource;
 };
 
 export function TranscriptActivity(props: TranscriptActivityProps) {
@@ -62,6 +64,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
         expanded={isExpanded}
         fileViewerContext={props.fileViewerContext}
         skills={props.skills}
+        threadLinkSource={props.threadLinkSource}
         onExpandedChange={(expanded) => {
           if (props.expanded !== undefined) {
             props.onExpandedChange?.(expanded);
@@ -173,6 +176,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
             directoryPaths={props.directoryPaths}
             fileViewerContext={props.fileViewerContext}
             skills={props.skills}
+            threadLinkSource={props.threadLinkSource}
           />
         </div>
       ) : hasDetails && isExpanded ? (
@@ -196,6 +200,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                   fileViewerContext={props.fileViewerContext}
                   skills={props.skills}
                   text={markdown}
+                  threadLinkSource={props.threadLinkSource}
                   variant="summary"
                 />
               ) : null;
@@ -275,6 +280,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                         directoryPaths={props.directoryPaths}
                         fileViewerContext={props.fileViewerContext}
                         skills={props.skills}
+                        threadLinkSource={props.threadLinkSource}
                       />
                     ) : null}
                   </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import {
   isAppServerBackendKind,
-  parseThreadUrl,
   type AppServerSkillSummary,
   formatPathRelativeToDirectories,
   type AppServerThreadActivityDetail,
@@ -10,7 +9,12 @@ import {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { copyText } from "../../lib/copy-text";
-import { useThreadLinks, type ResolvedThreadLink } from "../../lib/thread-links";
+import {
+  resolveThreadHref,
+  useThreadLinks,
+  type ResolvedThreadLink,
+  type ThreadLinkSource,
+} from "../../lib/thread-links";
 import { ThreadChip } from "./ThreadChip";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptSubAgentCall } from "./TranscriptSubAgentCall";
@@ -25,6 +29,7 @@ type TranscriptCommandOutputProps = {
   directoryPaths?: string[];
   fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
+  threadLinkSource?: ThreadLinkSource;
 };
 
 const PREVIEW_LINE_LIMIT = 12;
@@ -70,12 +75,17 @@ export function TranscriptThreadToolActivity(props: {
   expanded: boolean;
   fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
+  threadLinkSource?: ThreadLinkSource;
   onExpandedChange: (expanded: boolean) => void;
 }) {
   const threadLinks = useThreadLinks();
   const presentation = useMemo(
-    () => buildThreadToolPresentation(props.detail, threadLinks),
-    [props.detail, threadLinks],
+    () => buildThreadToolPresentation(
+      props.detail,
+      threadLinks,
+      props.threadLinkSource,
+    ),
+    [props.detail, props.threadLinkSource, threadLinks],
   );
   if (!presentation) {
     return <TranscriptCommandOutput {...props} />;
@@ -129,6 +139,7 @@ export function TranscriptThreadToolActivity(props: {
                 fileViewerContext={props.fileViewerContext}
                 skills={props.skills}
                 text={presentation.prompt}
+                threadLinkSource={props.threadLinkSource}
                 variant="summary"
               />
             </section>
@@ -137,6 +148,7 @@ export function TranscriptThreadToolActivity(props: {
             const messageLink = resolveThreadToolLink(
               message.messageUrl,
               threadLinks,
+              props.threadLinkSource,
             );
             return (
               <section
@@ -163,6 +175,7 @@ export function TranscriptThreadToolActivity(props: {
                   fileViewerContext={props.fileViewerContext}
                   skills={props.skills}
                   text={message.text}
+                  threadLinkSource={props.threadLinkSource}
                   variant="summary"
                 />
               </section>
@@ -182,6 +195,7 @@ export function TranscriptThreadToolActivity(props: {
 function buildThreadToolPresentation(
   detail: AppServerThreadActivityDetail,
   threadLinks: ReturnType<typeof useThreadLinks>,
+  threadLinkSource?: ThreadLinkSource,
 ): ThreadToolPresentation | undefined {
   const command = detail.command;
   if (!command || !isThreadReferenceToolDetail(detail)) {
@@ -206,11 +220,18 @@ function buildThreadToolPresentation(
   const preferredUrl = tool === "send_message_to_thread"
     ? readString(result, "messageUrl") ?? readString(result, "threadUrl")
     : readString(result, "threadUrl");
-  let link = resolveThreadToolLink(preferredUrl, threadLinks);
-  if (!link && threadLinks && backendValue && isAppServerBackendKind(backendValue)) {
+  let link = resolveThreadToolLink(preferredUrl, threadLinks, threadLinkSource);
+  const backend = backendValue && isAppServerBackendKind(backendValue)
+    ? backendValue
+    : threadLinkSource?.backend;
+  if (!link && threadLinks && backend) {
     link = threadLinks.resolve({
-      backend: backendValue,
-      ...(instanceId ? { instanceId } : {}),
+      backend,
+      ...(instanceId
+        ? { instanceId }
+        : threadLinkSource
+          ? { instanceId: threadLinkSource.instanceId }
+          : {}),
       ...(tool === "send_message_to_thread"
         ? { messageId: readString(result, "messageId") }
         : {}),
@@ -254,9 +275,9 @@ function buildThreadToolPresentation(
 function resolveThreadToolLink(
   value: string | undefined,
   threadLinks: ReturnType<typeof useThreadLinks>,
+  threadLinkSource?: ThreadLinkSource,
 ): ResolvedThreadLink | undefined {
-  const ref = value ? parseThreadUrl(value) : undefined;
-  return ref && threadLinks ? threadLinks.resolve(ref) : undefined;
+  return value ? resolveThreadHref(value, threadLinks, threadLinkSource) : undefined;
 }
 
 function parseJsonPayload(value: string | undefined): Record<string, unknown> | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -41,6 +41,7 @@ import { injectPermissionTransitions } from "./permission-transition-entries";
 import { injectQuestionnaireActivities } from "./questionnaire-activity-entries";
 import { injectTurnFailures } from "./turn-failure-entries";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ThreadLinkSource } from "../../lib/thread-links";
 import {
   isSidebarResizing,
   subscribeSidebarResizing,
@@ -113,6 +114,7 @@ type TranscriptListProps = {
   restoredViewport?: TranscriptViewport;
   reglueRequestKey?: number;
   threadId?: string;
+  threadLinkSource?: ThreadLinkSource;
   fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
@@ -1444,6 +1446,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   parentThreadId={props.parentThreadId ?? ""}
                   skills={skills}
                   subAgents={props.subAgents}
+                  threadLinkSource={props.threadLinkSource}
                   onActivityExpandedChange={setActivityExpanded}
                   onOpenImage={props.onOpenImage}
                   onToggle={() => {
@@ -1488,6 +1491,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   fileViewerContext={props.fileViewerContext}
                   skills={skills}
                   subAgents={props.subAgents}
+                  threadLinkSource={props.threadLinkSource}
                   onOpenImage={props.onOpenImage}
                 />
               );
@@ -1583,6 +1587,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   props.pendingRequest,
                   pendingApprovalContext,
                 )}
+                threadLinkSource={props.threadLinkSource}
               />
               <ApprovalDiffDisclosures context={pendingApprovalContext} />
               <div className="transcript-request__actions">

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1466,6 +1466,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   }}
                   onOpenImage={props.onOpenImage}
                   skills={skills}
+                  threadLinkSource={props.threadLinkSource}
                 />
               ) : item.entry.type === "plan" ? (
                 <TranscriptPlan
@@ -1473,6 +1474,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   desktopApi={props.desktopApi}
                   entry={item.entry}
                   fileViewerContext={props.fileViewerContext}
+                  threadLinkSource={props.threadLinkSource}
                 />
               ) : item.entry.type === "review" ? (
                 <TranscriptReview
@@ -1481,6 +1483,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   desktopApi={props.desktopApi}
                   entry={item.entry}
                   fileViewerContext={props.fileViewerContext}
+                  threadLinkSource={props.threadLinkSource}
                 />
               ) : (
                 <TranscriptMessage

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -25,7 +25,11 @@ import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
-import { useThreadLinks, type ResolvedThreadLink } from "../../lib/thread-links";
+import {
+  useThreadLinks,
+  type ResolvedThreadLink,
+  type ThreadLinkSource,
+} from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { InstanceChip } from "../federation/InstanceGlyph";
 import { ThreadChip } from "./ThreadChip";
@@ -52,6 +56,7 @@ type TranscriptMessageProps = {
   parentThreadId: string;
   skills: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
+  threadLinkSource?: ThreadLinkSource;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
 };
 
@@ -170,6 +175,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
                   fileViewerContext: props.fileViewerContext,
                   onOpenImage: props.onOpenImage,
                   skills: props.skills,
+                  threadLinkSource: props.threadLinkSource,
                 }),
               )}
             </div>
@@ -238,6 +244,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
                   imageParts,
                   onOpenImage: props.onOpenImage,
                   skills: props.skills,
+                  threadLinkSource: props.threadLinkSource,
                 }),
               )}
             </div>
@@ -315,6 +322,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
               imageParts,
               onOpenImage: props.onOpenImage,
               skills: props.skills,
+              threadLinkSource: props.threadLinkSource,
             })}
           </div>
         </article>
@@ -611,6 +619,7 @@ function renderMessageSegment(params: {
   index: number;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   skills: AppServerSkillSummary[];
+  threadLinkSource?: ThreadLinkSource;
 }): ReactNode {
   if (params.segment.type === "images") {
     const imageSegment = params.segment;
@@ -663,6 +672,7 @@ function renderMessageSegment(params: {
       onOpenImage={params.onOpenImage}
       skills={params.skills}
       text={params.segment.type === "table" ? params.segment.text : params.segment.part.text}
+      threadLinkSource={params.threadLinkSource}
     />
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
@@ -4,6 +4,7 @@ import type {
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ThreadLinkSource } from "../../lib/thread-links";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptPlanProps = {
@@ -14,6 +15,7 @@ type TranscriptPlanProps = {
   >;
   entry: AppServerThreadPlanEntry;
   fileViewerContext?: MarkdownFileViewerContext;
+  threadLinkSource?: ThreadLinkSource;
 };
 
 function formatPlanSummary(completedCount: number, totalCount: number): string {
@@ -83,6 +85,7 @@ export function TranscriptPlan(props: TranscriptPlanProps) {
           desktopApi={props.desktopApi}
           fileViewerContext={props.fileViewerContext}
           text={props.entry.markdown}
+          threadLinkSource={props.threadLinkSource}
         />
       ) : null}
     </aside>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -8,6 +8,7 @@ import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import { useCallback, useMemo, type MouseEvent } from "react";
 import { normalizeReviewDisplayText } from "../../../../shared/review-command";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ThreadLinkSource } from "../../lib/thread-links";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptReviewProps = {
@@ -19,6 +20,7 @@ type TranscriptReviewProps = {
   >;
   entry: AppServerThreadReviewEntry;
   fileViewerContext?: MarkdownFileViewerContext;
+  threadLinkSource?: ThreadLinkSource;
 };
 
 function formatConfidence(value: number | undefined): string | undefined {
@@ -182,6 +184,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
               desktopApi={props.desktopApi}
               fileViewerContext={props.fileViewerContext}
               text={body}
+              threadLinkSource={props.threadLinkSource}
             />
           ) : null}
         </div>
@@ -242,6 +245,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
                   desktopApi={props.desktopApi}
                   fileViewerContext={props.fileViewerContext}
                   text={finding.body}
+                  threadLinkSource={props.threadLinkSource}
                 />
                 <div className="transcript-review__location">
                   <a

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -155,6 +155,7 @@ function renderEntry(params: {
       }}
       onOpenImage={params.onOpenImage}
       skills={params.skills}
+      threadLinkSource={params.threadLinkSource}
     />
   ) : entry.type === "plan" ? (
     <TranscriptPlan
@@ -163,6 +164,7 @@ function renderEntry(params: {
       desktopApi={params.desktopApi}
       entry={entry}
       fileViewerContext={params.fileViewerContext}
+      threadLinkSource={params.threadLinkSource}
     />
   ) : entry.type === "review" ? (
     <TranscriptReview
@@ -172,6 +174,7 @@ function renderEntry(params: {
       desktopApi={params.desktopApi}
       entry={entry}
       fileViewerContext={params.fileViewerContext}
+      threadLinkSource={params.threadLinkSource}
     />
   ) : (
     <TranscriptMessage

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -8,6 +8,7 @@ import type {
   ThreadSubAgentSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ThreadLinkSource } from "../../lib/thread-links";
 import { TranscriptActivity } from "./TranscriptActivity";
 import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
@@ -31,6 +32,7 @@ type TranscriptWorkPhaseGroupProps = {
   parentThreadId?: string;
   skills: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
+  threadLinkSource?: ThreadLinkSource;
   onActivityExpandedChange?: (activityId: string, expanded: boolean) => void;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onToggle: () => void;
@@ -83,6 +85,7 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
               parentThreadId: props.parentThreadId ?? "",
               skills: props.skills,
               subAgents: props.subAgents,
+              threadLinkSource: props.threadLinkSource,
             })
           )}
         </div>
@@ -134,6 +137,7 @@ function renderEntry(params: {
   parentThreadId: string;
   skills: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
+  threadLinkSource?: ThreadLinkSource;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
 }) {
   const entry = params.entry;
@@ -179,6 +183,7 @@ function renderEntry(params: {
       parentThreadId={params.parentThreadId}
       skills={params.skills}
       subAgents={params.subAgents}
+      threadLinkSource={params.threadLinkSource}
       onOpenImage={params.onOpenImage}
     />
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -323,6 +323,20 @@ describe("thread links in transcript markdown", () => {
     });
   });
 
+  it("does not treat unrelated inline code as a remote thread", () => {
+    renderWithLinks("Use `useState` for local component state.", {
+      threadLinkSource: {
+        backend: "codex",
+        instanceId: "pwr_harold",
+      },
+      threads: [],
+    });
+
+    expect(screen.queryByRole("button", { name: /Open thread/ }))
+      .not.toBeInTheDocument();
+    expect(screen.getByText("useState")).toBeInTheDocument();
+  });
+
   it("labels a remote thread's pop-out action with its instance name", () => {
     const onOpenRemoteViewer = vi.fn();
     renderWithLinks(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -37,7 +37,15 @@ function renderWithLinks(
       messageId?: string;
       threadId: string;
     }) => void;
-    onShowThread?: (request: { backend: AppServerBackendKind; threadId: string }) => void;
+    onShowThread?: (request: {
+      backend: AppServerBackendKind;
+      instanceId?: string;
+      threadId: string;
+    }) => void;
+    threadLinkSource?: {
+      backend: AppServerBackendKind;
+      instanceId: string;
+    };
     threads?: NavigationThreadSummary[];
   } = {},
 ) {
@@ -49,7 +57,10 @@ function renderWithLinks(
       onShowThread={onShowThread}
       threads={options.threads ?? [threadSummary()]}
     >
-      <ThreadMarkdown text={text} />
+      <ThreadMarkdown
+        text={text}
+        threadLinkSource={options.threadLinkSource}
+      />
     </ThreadLinkProvider>,
   );
 }
@@ -285,6 +296,31 @@ describe("thread links in transcript markdown", () => {
       threadId: CHILD_THREAD_ID,
     });
     expect(onShowThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an unqualified handoff link actionable in a remote transcript", () => {
+    const onShowThread = vi.fn();
+    renderWithLinks(
+      `See [Remote handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex)`,
+      {
+        onShowThread,
+        threadLinkSource: {
+          backend: "codex",
+          instanceId: "pwr_harold",
+        },
+        threads: [],
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open thread Remote handoff",
+    }));
+
+    expect(onShowThread).toHaveBeenCalledWith({
+      backend: "codex",
+      instanceId: "pwr_harold",
+      threadId: CHILD_THREAD_ID,
+    });
   });
 
   it("labels a remote thread's pop-out action with its instance name", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1367,30 +1367,31 @@ describe("ThreadView", () => {
         peerStatus: "connected",
       },
     };
+    const transcriptEntries = [{
+      type: "message" as const,
+      id: "assistant-handoff",
+      role: "assistant" as const,
+      text: "See [Remote handoff](pwragent://thread/remote-child?backend=codex)",
+    }];
+    const threadViewProps = {
+      addOptimisticUserMessage: () => "optimistic-1",
+      backends: [],
+      clearPendingRequest: () => undefined,
+      composerDisabled: false,
+      desktopApi: {},
+      loading: false,
+      loadingMore: false,
+      messageCount: 1,
+      onLoadOlder: async () => undefined,
+      removeOptimisticMessage: () => undefined,
+      skills: [],
+      transcriptEntries,
+    } as unknown as Omit<ThreadViewProps, "terminals" | "selectedThread">;
 
-    render(
+    const { rerender } = render(
       <ThreadLinkProvider onShowThread={onShowThread} threads={[remoteThread]}>
         <ThreadView
-          {...({
-            addOptimisticUserMessage: () => "optimistic-1",
-            backends: [],
-            clearPendingRequest: () => undefined,
-            composerDisabled: false,
-            desktopApi: {},
-            loading: false,
-            loadingMore: false,
-            messageCount: 1,
-            onLoadOlder: async () => undefined,
-            removeOptimisticMessage: () => undefined,
-            skills: [],
-            transcriptEntries: [{
-              type: "message",
-              id: "assistant-handoff",
-              role: "assistant",
-              text:
-                "See [Remote handoff](pwragent://thread/remote-child?backend=codex)",
-            }],
-          } as unknown as Omit<ThreadViewProps, "terminals" | "selectedThread">)}
+          {...threadViewProps}
           selectedThread={remoteThread}
         />
       </ThreadLinkProvider>,
@@ -1405,6 +1406,18 @@ describe("ThreadView", () => {
       instanceId: "peer-a",
       threadId: "remote-child",
     });
+
+    const markdownParagraph = screen.getByText("See").closest("p");
+    rerender(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={[remoteThread]}>
+        <ThreadView
+          {...threadViewProps}
+          selectedThread={{ ...remoteThread, updatedAt: remoteThread.updatedAt! + 1 }}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    expect(screen.getByText("See").closest("p")).toBe(markdownParagraph);
   });
 
   it("disables the remote terminal toggle with a reason when the peer lacks remote_pty", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -18,6 +18,7 @@ import type {
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { ThreadLinkProvider } from "../../../lib/thread-links";
 import type { PendingMcpInteractionState } from "../mcp-elicitation";
 import type { PendingQuestionnaireState } from "../questionnaire";
 
@@ -1343,6 +1344,67 @@ describe("ThreadView", () => {
     expect(pane).toHaveAttribute("data-thread-key", "codex:remote-thread-1");
     // The owner resolves the cwd; the viewer must not pick one.
     expect(pane).toHaveAttribute("data-cwd", "");
+  });
+
+  it("renders unqualified handoff links as chips in a remote transcript", () => {
+    const onShowThread = vi.fn();
+    const remoteThread: NavigationThreadSummary = {
+      id: "remote-parent",
+      title: "Remote parent",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: { inInbox: true },
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "peer-a" },
+          threadId: "remote-parent",
+        },
+        instanceLabel: "Peer Mac",
+        peerStatus: "connected",
+      },
+    };
+
+    render(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={[remoteThread]}>
+        <ThreadView
+          {...({
+            addOptimisticUserMessage: () => "optimistic-1",
+            backends: [],
+            clearPendingRequest: () => undefined,
+            composerDisabled: false,
+            desktopApi: {},
+            loading: false,
+            loadingMore: false,
+            messageCount: 1,
+            onLoadOlder: async () => undefined,
+            removeOptimisticMessage: () => undefined,
+            skills: [],
+            transcriptEntries: [{
+              type: "message",
+              id: "assistant-handoff",
+              role: "assistant",
+              text:
+                "See [Remote handoff](pwragent://thread/remote-child?backend=codex)",
+            }],
+          } as unknown as Omit<ThreadViewProps, "terminals" | "selectedThread">)}
+          selectedThread={remoteThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open thread Remote handoff",
+    }));
+
+    expect(onShowThread).toHaveBeenCalledWith({
+      backend: "codex",
+      instanceId: "peer-a",
+      threadId: "remote-child",
+    });
   });
 
   it("disables the remote terminal toggle with a reason when the peer lacks remote_pty", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -243,6 +243,69 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("qualifies links in every markdown-bearing remote transcript entry", () => {
+    const onShowThread = vi.fn();
+    render(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={[]}>
+        <TranscriptList
+          entries={[
+            {
+              type: "activity",
+              id: "activity-link",
+              summary: "Activity reference",
+              details: [{
+                id: "activity-detail",
+                kind: "command",
+                label: "Activity child",
+                markdown:
+                  "[Activity child](pwragent://thread/activity-child?backend=codex)",
+              }],
+              turn: { id: "remote-turn", status: "completed" },
+            },
+            {
+              type: "plan",
+              id: "plan-link",
+              markdown: "[Plan child](pwragent://thread/plan-child?backend=codex)",
+              steps: [],
+              turn: { id: "remote-turn", status: "completed" },
+            },
+            {
+              type: "review",
+              id: "review-link",
+              review: "[Review child](pwragent://thread/review-child?backend=codex)",
+            },
+          ]}
+          loading={false}
+          loadingMore={false}
+          threadLinkSource={{ backend: "codex", instanceId: "pwr_remote" }}
+          onLoadOlder={async () => undefined}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous work" }));
+    fireEvent.click(screen.getByRole("button", { name: "Activity reference" }));
+    for (const title of ["Activity child", "Plan child", "Review child"]) {
+      fireEvent.click(screen.getByRole("button", { name: `Open thread ${title}` }));
+    }
+
+    expect(onShowThread).toHaveBeenNthCalledWith(1, {
+      backend: "codex",
+      instanceId: "pwr_remote",
+      threadId: "activity-child",
+    });
+    expect(onShowThread).toHaveBeenNthCalledWith(2, {
+      backend: "codex",
+      instanceId: "pwr_remote",
+      threadId: "plan-child",
+    });
+    expect(onShowThread).toHaveBeenNthCalledWith(3, {
+      backend: "codex",
+      instanceId: "pwr_remote",
+      threadId: "review-child",
+    });
+  });
+
   it("prefers hydrated provenance over a cached fallback thread title", () => {
     const sourceThreadId = "019fde92-318a-7541-9281-029bdc1508b5";
     const sourceThread = {

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -409,7 +409,6 @@ export function resolveThreadHref(
 export function resolveThreadIdText(
   text: string,
   links: ThreadLinkContextValue | undefined,
-  source?: ThreadLinkSource,
 ): ResolvedThreadLink | undefined {
   if (!links) {
     return undefined;
@@ -420,7 +419,7 @@ export function resolveThreadIdText(
     return undefined;
   }
 
-  return links.resolve(qualifyThreadLinkRef({ threadId: trimmed }, source));
+  return links.resolve({ threadId: trimmed });
 }
 
 function qualifyThreadLinkRef(

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -33,6 +33,11 @@ export type ResolvedThreadLink = {
   linkedDirectories?: LinkedDirectorySummary[];
 };
 
+export type ThreadLinkSource = {
+  backend: AppServerBackendKind;
+  instanceId: FederationInstanceId;
+};
+
 export type ThreadLinkContextValue = {
   /**
    * Returns the thread a link points at, or undefined when it names a thread
@@ -382,13 +387,14 @@ export function ThreadLinkProvider(props: {
 export function resolveThreadHref(
   href: string,
   links: ThreadLinkContextValue | undefined,
+  source?: ThreadLinkSource,
 ): ResolvedThreadLink | undefined {
   const ref = parseThreadUrl(href);
   if (!ref || !links) {
     return undefined;
   }
 
-  return links.resolve(ref);
+  return links.resolve(qualifyThreadLinkRef(ref, source));
 }
 
 /**
@@ -403,6 +409,7 @@ export function resolveThreadHref(
 export function resolveThreadIdText(
   text: string,
   links: ThreadLinkContextValue | undefined,
+  source?: ThreadLinkSource,
 ): ResolvedThreadLink | undefined {
   if (!links) {
     return undefined;
@@ -413,5 +420,20 @@ export function resolveThreadIdText(
     return undefined;
   }
 
-  return links.resolve({ threadId: trimmed });
+  return links.resolve(qualifyThreadLinkRef({ threadId: trimmed }, source));
+}
+
+function qualifyThreadLinkRef(
+  ref: ThreadLinkRef,
+  source: ThreadLinkSource | undefined,
+): ThreadLinkRef {
+  if (!source || ref.instanceId) {
+    return ref;
+  }
+
+  return {
+    ...ref,
+    backend: ref.backend ?? source.backend,
+    instanceId: source.instanceId,
+  };
 }


### PR DESCRIPTION
## What changed

- treat unqualified `pwragent://thread/...` links inside a remote transcript as belonging to that transcript's owning instance
- carry the remote transcript source through messages, activities, plans, reviews, grouped work, pending approvals, and thread-tool message rendering
- keep bare inline-code thread IDs gated on known navigation membership so ordinary code never becomes a synthetic remote chip
- memoize the remote source identity so unrelated remote-thread updates do not remount or reparse historical Markdown
- add component and ThreadView regression coverage for links whose child thread is not yet in the local navigation snapshot

## Why

Thread handoff links created on their owning machine omit `instanceId` because they are local there. When another PwrAgent instance displayed that remote transcript before the child thread appeared in its own navigation snapshot, link resolution failed and React rendered the label as plain text.

The renderer now supplies the enclosing transcript's remote instance as an implicit source for explicit thread URLs. Explicit link instance IDs still take precedence, bare inline code still requires a known thread, and local transcript behavior is unchanged.

## User impact

Thread references in federated transcripts stay visible and actionable as chips immediately, matching their presentation on the owning machine without misclassifying code or adding long-transcript rerender churn.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-activity.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx` (189 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
