### PR TITLE
test(desktop): upload first abnormal shutdown logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,6 +499,16 @@ jobs:
             apps/desktop/test-results/
           retention-days: 30
 
+      - name: Upload first abnormal Electron shutdown logs
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        timeout-minutes: 10
+        with:
+          name: desktop-e2e-macos-lane-${{ matrix.lane }}-first-shutdown-failure
+          path: apps/desktop/test-results/electron-shutdown-first-failure/
+          if-no-files-found: ignore
+          retention-days: 30
+
   live-agent-core:
     name: Live Agent Core
     if: ${{ github.event_name == 'pull_request' }}

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -24,6 +24,11 @@ import {
   waitForPidsToExit,
 } from "./process-exit";
 import {
+  captureFirstElectronShutdownFailure,
+  E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV,
+  type ElectronProcessTreeSnapshot,
+} from "./electron-shutdown-artifacts";
+import {
   appendElectronShutdownSummary,
   assertElectronShutdownCircuitClosed,
   buildElectronShutdownSummary,
@@ -69,6 +74,8 @@ type ElectronCloseOptions = {
   circuitEnabled?: boolean;
   circuitStateFile?: string;
   diagnosticsFile?: string;
+  failureArtifactDir?: string;
+  homeRoot?: string;
   launchId?: string;
 };
 
@@ -180,6 +187,9 @@ export async function launchElectronApp(params: {
   });
   const diagnosticsFile =
     process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
+  const failureArtifactDir = circuitEnabled
+    ? process.env[E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV]
+    : undefined;
   const launchId = randomUUID();
   const homeRoot =
     params.homeRoot ??
@@ -290,6 +300,8 @@ export async function launchElectronApp(params: {
       circuitEnabled,
       circuitStateFile,
       diagnosticsFile,
+      failureArtifactDir,
+      homeRoot,
       launchId,
     }),
   );
@@ -475,6 +487,7 @@ export async function closeElectronApplication(
       options,
     );
   }
+  let processTreeSnapshot: ElectronProcessTreeSnapshot | undefined;
   const execution = await executeElectronClose({
     now: performance.now.bind(performance),
     requestQuit: async () => {
@@ -497,7 +510,7 @@ export async function closeElectronApplication(
     ),
     hasExited: () => hasExited(child),
     forceKillTree: async () => {
-      await killProcessTree(child);
+      processTreeSnapshot = await killProcessTree(child);
     },
     waitForForcedExit: async () => await waitForProcessExit(
       child,
@@ -507,7 +520,33 @@ export async function closeElectronApplication(
       await waitForClose(closePromise, ELECTRON_FORCE_EXIT_TIMEOUT_MS);
     },
   });
-  return recordElectronCloseSummary(execution, options);
+  const summary = recordElectronCloseSummary(execution, options);
+  const artifactDir = options.failureArtifactDir
+    ?? process.env[E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV];
+  if (
+    artifactDir
+    && options.homeRoot
+    && summary.classification !== "healthy"
+  ) {
+    try {
+      const captured = await captureFirstElectronShutdownFailure({
+        artifactDir,
+        homeRoot: options.homeRoot,
+        processTree: processTreeSnapshot,
+        summary,
+      });
+      if (captured) {
+        console.log(
+          `[pwragent-e2e-shutdown] captured first abnormal shutdown artifact at ${artifactDir}`,
+        );
+      }
+    } catch (error) {
+      console.warn(
+        `[pwragent-e2e-shutdown] failed to capture first abnormal shutdown artifact: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return summary;
 }
 
 function alreadyExitedCloseExecution(): ElectronCloseExecution {
@@ -641,16 +680,27 @@ async function waitForProcessExit(
   }
 }
 
-async function killProcessTree(child: ElectronChildProcess): Promise<void> {
+async function killProcessTree(
+  child: ElectronChildProcess,
+): Promise<ElectronProcessTreeSnapshot> {
+  const snapshot: ElectronProcessTreeSnapshot = {
+    capturedAt: new Date().toISOString(),
+    descendantPids: [],
+    exitCode: child.exitCode,
+    killed: child.killed,
+    platform: process.platform,
+    rootPid: child.pid ?? null,
+    signalCode: child.signalCode,
+  };
   if (hasExited(child)) {
-    return;
+    return snapshot;
   }
   const pid = child.pid;
   if (pid === undefined) {
     if (!child.killed) {
       child.kill("SIGKILL");
     }
-    return;
+    return snapshot;
   }
   if (process.platform === "win32") {
     await new Promise<void>((resolve) => {
@@ -666,10 +716,11 @@ async function killProcessTree(child: ElectronChildProcess): Promise<void> {
         },
       );
     });
-    return;
+    return snapshot;
   }
 
   const descendants = await listDescendantPids(pid);
+  snapshot.descendantPids = descendants;
   if (!child.killed) {
     child.kill("SIGKILL");
   }
@@ -680,6 +731,7 @@ async function killProcessTree(child: ElectronChildProcess): Promise<void> {
       // The descendant already exited between the ps snapshot and this kill.
     }
   }
+  return snapshot;
 }
 
 async function killSpawnedProfileProcessesUnder(homeRoot: string): Promise<void> {

--- a/apps/desktop/e2e/fixtures/electron-shutdown-artifacts.ts
+++ b/apps/desktop/e2e/fixtures/electron-shutdown-artifacts.ts
@@ -1,0 +1,152 @@
+import type { Dirent } from "node:fs";
+import {
+  copyFile,
+  mkdir,
+  open,
+  readdir,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import type { ElectronShutdownSummary } from "./electron-shutdown-policy";
+
+export const E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV =
+  "PWRAGENT_E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR";
+
+const CAPTURE_CLAIM_FILE = "capture-claimed.json";
+const MAX_MAIN_LOG_FILES = 4;
+const MAX_LOG_SEARCH_DEPTH = 6;
+
+export type ElectronProcessTreeSnapshot = {
+  capturedAt: string;
+  descendantPids: number[];
+  exitCode: number | null;
+  killed: boolean;
+  platform: NodeJS.Platform;
+  rootPid: number | null;
+  signalCode: NodeJS.Signals | null;
+};
+
+type MainLogCandidate = {
+  absolutePath: string;
+  relativePath: string;
+};
+
+/**
+ * Preserve only the first abnormal fixture from a shard. The temporary E2E
+ * home is removed during ordinary teardown, so its Electron main log must be
+ * copied before that cleanup runs. The exclusive claim keeps retries and
+ * replacement workers from overwriting the original failure evidence.
+ */
+export async function captureFirstElectronShutdownFailure(params: {
+  artifactDir: string;
+  homeRoot: string;
+  processTree?: ElectronProcessTreeSnapshot;
+  summary: ElectronShutdownSummary;
+}): Promise<boolean> {
+  if (params.summary.classification === "healthy") {
+    return false;
+  }
+
+  await mkdir(params.artifactDir, { recursive: true });
+  const claimPath = path.join(params.artifactDir, CAPTURE_CLAIM_FILE);
+  let claim: Awaited<ReturnType<typeof open>>;
+  try {
+    claim = await open(claimPath, "wx");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+
+  try {
+    await claim.writeFile(
+      `${JSON.stringify({
+        capturedAt: new Date().toISOString(),
+        launchId: params.summary.launchId,
+      }, null, 2)}\n`,
+      "utf8",
+    );
+  } finally {
+    await claim.close();
+  }
+
+  const candidates = await findMainLogs(params.homeRoot);
+  const copiedLogs: Array<{
+    artifactName: string;
+    sourceRelativePath: string;
+  }> = [];
+  const copyErrors: Array<{
+    error: string;
+    sourceRelativePath: string;
+  }> = [];
+  for (const [index, candidate] of candidates.entries()) {
+    const artifactName = `${index + 1}-${path.basename(candidate.absolutePath)}`;
+    try {
+      await copyFile(
+        candidate.absolutePath,
+        path.join(params.artifactDir, artifactName),
+      );
+      copiedLogs.push({
+        artifactName,
+        sourceRelativePath: candidate.relativePath,
+      });
+    } catch (error) {
+      copyErrors.push({
+        error: error instanceof Error ? error.message : String(error),
+        sourceRelativePath: candidate.relativePath,
+      });
+    }
+  }
+
+  await writeFile(
+    path.join(params.artifactDir, "shutdown-failure.json"),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      capturedAt: new Date().toISOString(),
+      summary: params.summary,
+      processTree: params.processTree ?? null,
+      mainLogs: copiedLogs,
+      copyErrors,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  return true;
+}
+
+async function findMainLogs(homeRoot: string): Promise<MainLogCandidate[]> {
+  const candidates: MainLogCandidate[] = [];
+  await visit(homeRoot, "", 0);
+  return candidates.slice(0, MAX_MAIN_LOG_FILES);
+
+  async function visit(
+    directory: string,
+    relativeDirectory: string,
+    depth: number,
+  ): Promise<void> {
+    if (depth > MAX_LOG_SEARCH_DEPTH || candidates.length >= MAX_MAIN_LOG_FILES) {
+      return;
+    }
+    let entries: Dirent<string>[];
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (candidates.length >= MAX_MAIN_LOG_FILES) {
+        return;
+      }
+      const absolutePath = path.join(directory, entry.name);
+      const relativePath = path.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(absolutePath, relativePath, depth + 1);
+      } else if (
+        entry.isFile()
+        && /^profile-[A-Za-z0-9._-]+\.main\.log$/.test(entry.name)
+      ) {
+        candidates.push({ absolutePath, relativePath });
+      }
+    }
+  }
+}

--- a/apps/desktop/e2e/shutdown-global-setup.ts
+++ b/apps/desktop/e2e/shutdown-global-setup.ts
@@ -6,12 +6,20 @@ import {
   E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
   resetElectronShutdownCircuit,
 } from "./fixtures/electron-shutdown-policy";
+import {
+  E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV,
+} from "./fixtures/electron-shutdown-artifacts";
 
 /** Reset per-shard state once, before Playwright can replace a failed worker. */
 export default function globalSetup(): void {
   const diagnosticsFile = process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV];
   if (diagnosticsFile) {
     rmSync(diagnosticsFile, { force: true });
+  }
+  const failureArtifactDir =
+    process.env[E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV];
+  if (failureArtifactDir) {
+    rmSync(failureArtifactDir, { force: true, recursive: true });
   }
   resetElectronShutdownCircuit(
     process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV],

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -7,6 +7,9 @@ import {
   E2E_SHUTDOWN_CIRCUIT_BREAKER_ENV,
   E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV,
 } from "./e2e/fixtures/electron-shutdown-policy";
+import {
+  E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV,
+} from "./e2e/fixtures/electron-shutdown-artifacts";
 
 process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV] ??= path.join(
   import.meta.dirname,
@@ -17,6 +20,11 @@ process.env[E2E_SHUTDOWN_CIRCUIT_STATE_FILE_ENV] ??= path.join(
   import.meta.dirname,
   "test-results",
   "electron-shutdown-circuit.json",
+);
+process.env[E2E_SHUTDOWN_FIRST_FAILURE_ARTIFACT_DIR_ENV] ??= path.join(
+  import.meta.dirname,
+  "test-results",
+  "electron-shutdown-first-failure",
 );
 
 const electronShutdownCircuitEnabled =

--- a/apps/desktop/src/main/__tests__/electron-shutdown-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-shutdown-artifacts.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  captureFirstElectronShutdownFailure,
+  type ElectronProcessTreeSnapshot,
+} from "../../../e2e/fixtures/electron-shutdown-artifacts";
+import type { ElectronShutdownSummary } from "../../../e2e/fixtures/electron-shutdown-policy";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map(async (root) =>
+      await rm(root, { force: true, recursive: true })
+    ),
+  );
+});
+
+describe("captureFirstElectronShutdownFailure", () => {
+  it("copies the first abnormal fixture main log and ignores later failures", async () => {
+    const root = await makeTemporaryRoot();
+    const artifactDir = path.join(root, "artifacts");
+    const firstHome = path.join(root, "first-home");
+    const secondHome = path.join(root, "second-home");
+    await writeMainLog(firstHome, "first failure log");
+    await writeMainLog(secondHome, "second failure log");
+
+    await expect(captureFirstElectronShutdownFailure({
+      artifactDir,
+      homeRoot: firstHome,
+      processTree: processTreeSnapshot(),
+      summary: shutdownSummary("first", "force-killed"),
+    })).resolves.toBe(true);
+    await expect(captureFirstElectronShutdownFailure({
+      artifactDir,
+      homeRoot: secondHome,
+      processTree: processTreeSnapshot(),
+      summary: shutdownSummary("second", "force-killed"),
+    })).resolves.toBe(false);
+
+    const files = await readdir(artifactDir);
+    expect(files).toContain("1-profile-default.main.log");
+    expect(await readFile(
+      path.join(artifactDir, "1-profile-default.main.log"),
+      "utf8",
+    )).toBe("first failure log");
+    const failure = JSON.parse(await readFile(
+      path.join(artifactDir, "shutdown-failure.json"),
+      "utf8",
+    )) as { summary: { launchId: string } };
+    expect(failure.summary.launchId).toBe("first");
+  });
+
+  it("does not claim the artifact directory for a healthy close", async () => {
+    const root = await makeTemporaryRoot();
+    const artifactDir = path.join(root, "artifacts");
+
+    await expect(captureFirstElectronShutdownFailure({
+      artifactDir,
+      homeRoot: path.join(root, "home"),
+      summary: shutdownSummary("healthy", "healthy"),
+    })).resolves.toBe(false);
+    await expect(readdir(artifactDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+async function makeTemporaryRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-shutdown-artifact-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+async function writeMainLog(homeRoot: string, contents: string): Promise<void> {
+  const logDir = path.join(homeRoot, "Library", "Logs", "PwrAgent");
+  await mkdir(logDir, { recursive: true });
+  await writeFile(path.join(logDir, "profile-default.main.log"), contents);
+}
+
+function processTreeSnapshot(): ElectronProcessTreeSnapshot {
+  return {
+    capturedAt: "2026-08-14T00:00:00.000Z",
+    descendantPids: [42, 43],
+    exitCode: null,
+    killed: false,
+    platform: "darwin",
+    rootPid: 41,
+    signalCode: null,
+  };
+}
+
+function shutdownSummary(
+  launchId: string,
+  classification: ElectronShutdownSummary["classification"],
+): ElectronShutdownSummary {
+  const notObserved = { durationMs: null, outcome: "not-observed" as const };
+  return {
+    schemaVersion: 1,
+    kind: "close-summary",
+    launchId,
+    classification,
+    elapsedMs: classification === "healthy" ? 100 : 7_000,
+    quitRequestOutcome: "completed",
+    gracefulCloseOutcome: classification === "healthy" ? "closed" : "timeout",
+    forceExitOutcome: classification === "force-killed" ? "exited" : "not-needed",
+    phases: {
+      rendererWindow: notObserved,
+      messaging: notObserved,
+      appServer: notObserved,
+      overall: notObserved,
+    },
+    circuit: {
+      enabled: true,
+      consecutiveAbnormalCloses: classification === "healthy" ? 0 : 1,
+      limit: 2,
+      tripped: false,
+    },
+  };
+}


### PR DESCRIPTION
## Stack

This PR is stacked directly on #1600 and should merge after it. The PR diff contains only the first-failure artifact capture; #1600 continues to own the fail-fast circuit, bounded close, and sanitized phase timeline.

## Summary

- claim the first abnormal Electron close in each macOS shard so retries and replacement workers cannot overwrite the original evidence
- preserve the structured #1600 close summary and the root/descendant PID snapshot taken immediately before process-tree force-kill
- copy up to four `profile-*.main.log` files out of the fixture temporary home before deterministic teardown removes it
- upload a separately named `desktop-e2e-macos-lane-<lane>-first-shutdown-failure` artifact for easy discovery
- continue uploading the normal Playwright artifact bundle and shutdown JSONL from #1600

## Why

The first run of #1618 confirmed that bounded teardown contains the 15-second Playwright close stall, but every observed release fixture still exhausted the 6-second graceful allowance. The one-line force-kill warning cannot identify which main-process shutdown phase is stuck.

#1600 already records allowlisted renderer-window, messaging, app-server, and overall phase outcomes. This stack preserves the corresponding full Electron main log from only the first abnormal fixture, plus the structured phase summary and process tree, before the temporary home disappears. That should distinguish a renderer close stall, app-server drain, messaging shutdown, or a process that never entered the barrier.

## Artifact contents

- `shutdown-failure.json`: close classification, phase outcomes/timings, circuit state, and pre-kill PID tree
- `1-profile-default.main.log` or bootstrap/profile equivalents when present
- `capture-claimed.json`: launch id and capture time

Only E2E temporary-home main logs are copied. Config, databases, credentials, and the rest of the temporary profile are not included.

## Validation

- focused shutdown suite: 8 files, 26 tests passed
- real `app-quit-lifecycle.spec.ts`: 3 passed with healthy structured shutdown summaries
- `pnpm typecheck`: all 12 applicable projects passed
- `pnpm lint:eslint`: 0 errors; existing warning baseline only
- targeted changed-file ESLint: passed
- `pnpm lint:boundaries`: passed
- workflow YAML parse: passed
- `git diff --check`: passed

Parent PR: #1600