### PR TITLE
fix(desktop): make transcript page order durable

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -851,6 +851,206 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("keeps the latest page authoritative across dirty older-page overlap", async () => {
+    const initialTail = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "tail-first",
+          role: "user",
+          text: "Tail first",
+          createdAt: 200,
+        }),
+        messageEntry({
+          id: "tail-last",
+          text: "Tail last",
+          createdAt: 300,
+        }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "tail-first",
+    });
+    const dirtyOlderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "older-entry",
+          role: "user",
+          text: "Older entry",
+          createdAt: 100,
+        }),
+        messageEntry({
+          id: "tail-last",
+          text: "Tail last",
+          createdAt: 300,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(dirtyOlderPage);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Older entry",
+      "message:Tail first",
+      "message:Tail last",
+    ]);
+  });
+
+  it("does not prepend a post-compaction live turn ahead of refreshed history", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const completedTurn = {
+      id: "turn-after-compaction",
+      status: "completed" as const,
+      startedAt: 500,
+      completedAt: 700,
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "recent-before-compaction",
+          role: "user",
+          text: "Recent history",
+          createdAt: 300,
+        }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "recent-before-compaction",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "older-before-compaction",
+          role: "user",
+          text: "Older history",
+          createdAt: 100,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "recent-before-compaction",
+          role: "user",
+          text: "Recent history",
+          createdAt: 300,
+        }),
+        {
+          ...messageEntry({
+            id: "auto-fix-user",
+            role: "user",
+            text: "Auto-fix started",
+            createdAt: 500,
+          }),
+          turn: completedTurn,
+        },
+        {
+          ...messageEntry({
+            id: "auto-fix-final",
+            text: "Auto-fix finished",
+            createdAt: 700,
+          }),
+          phase: "final" as const,
+          turn: completedTurn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "recent-before-compaction",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValue(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result, rerender, unmount } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Older history",
+      "message:Recent history",
+    ]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/compacted",
+          params: { threadId: "thread-1" },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: completedTurn.id,
+            item: {
+              id: "auto-fix-user",
+              type: "userMessage",
+              text: "Auto-fix started",
+            },
+          },
+        },
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Auto-fix started",
+    ]);
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Recent history",
+        "message:Auto-fix started",
+        "message:Auto-fix finished",
+      ]);
+    });
+    unmount();
+  });
+
   it("releases older-history loading when a fresher hydration supersedes it", async () => {
     const initialTail = readThreadResponse({
       entries: [

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -879,8 +879,86 @@ describe("useThreadSessionState", () => {
         }),
         messageEntry({
           id: "tail-last",
-          text: "Tail last",
+          text: "Stale tail last",
           createdAt: 300,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const laggingRefreshedTail = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "tail-later",
+          text: "Tail later",
+          createdAt: 400,
+        }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "tail-later",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(dirtyOlderPage)
+      .mockResolvedValueOnce(laggingRefreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } }
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Older entry",
+      "message:Tail first",
+      "message:Tail last",
+    ]);
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Older entry",
+        "message:Tail first",
+        "message:Tail last",
+        "message:Tail later",
+      ]);
+    });
+  });
+
+  it("preserves repeated transcript content with distinct entry ids", async () => {
+    const initialTail = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "repeat-newer",
+          text: "Still working.",
+          createdAt: 300,
+        }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "repeat-newer",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "repeat-older",
+          text: "Still working.",
+          createdAt: 200,
         }),
       ],
       hasPreviousPage: false,
@@ -888,7 +966,7 @@ describe("useThreadSessionState", () => {
     const readThread = vi
       .fn()
       .mockResolvedValueOnce(initialTail)
-      .mockResolvedValueOnce(dirtyOlderPage);
+      .mockResolvedValueOnce(olderPage);
     const desktopApi: DesktopApi = {
       onAgentEvent: () => () => undefined,
       readThread,
@@ -906,10 +984,9 @@ describe("useThreadSessionState", () => {
       await result.current.loadOlder();
     });
 
-    expect(transcriptLabels(result.current.entries)).toEqual([
-      "message:Older entry",
-      "message:Tail first",
-      "message:Tail last",
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "repeat-older",
+      "repeat-newer",
     ]);
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -224,21 +224,12 @@ function stitchOrderedTranscriptSegments(
   olderEntries: AppServerThreadEntry[],
   newerEntries: AppServerThreadEntry[]
 ): AppServerThreadEntry[] {
-  // Page reads can overlap a moving tail. Remove only unambiguous overlap from
-  // the older segment, then preserve the newer segment's authoritative order.
-  const matchedOlderEntries = new Set<AppServerThreadEntry>();
-  for (const newerEntry of newerEntries) {
-    const olderMatch = findUniqueTranscriptRefreshMatch(
-      newerEntry,
-      olderEntries.filter((entry) => !matchedOlderEntries.has(entry))
-    );
-    if (olderMatch) {
-      matchedOlderEntries.add(olderMatch);
-    }
-  }
+  // Page reads can overlap a moving tail. Only stable IDs prove that entries
+  // overlap; repeated content with different IDs is legitimate transcript.
+  const newerEntryIds = new Set(newerEntries.map((entry) => entry.id));
 
   return [
-    ...olderEntries.filter((entry) => !matchedOlderEntries.has(entry)),
+    ...olderEntries.filter((entry) => !newerEntryIds.has(entry.id)),
     ...newerEntries,
   ];
 }
@@ -247,18 +238,9 @@ function excludeTranscriptSegment(
   entries: AppServerThreadEntry[],
   excludedSegment: AppServerThreadEntry[]
 ): AppServerThreadEntry[] {
-  const excludedEntries = new Set<AppServerThreadEntry>();
-  for (const excludedEntry of excludedSegment) {
-    const match = findUniqueTranscriptRefreshMatch(
-      excludedEntry,
-      entries.filter((entry) => !excludedEntries.has(entry))
-    );
-    if (match) {
-      excludedEntries.add(match);
-    }
-  }
+  const excludedEntryIds = new Set(excludedSegment.map((entry) => entry.id));
 
-  return entries.filter((entry) => !excludedEntries.has(entry));
+  return entries.filter((entry) => !excludedEntryIds.has(entry.id));
 }
 
 function transcriptMessagesForEntries(
@@ -5724,13 +5706,16 @@ export function useThreadSessionState(params: {
           };
         }
 
-        const loadedHistoryEntries = stitchOrderedTranscriptSegments(
-          olderResponse.replay.entries,
-          current.loadedHistoryEntries
-        );
         const retainedTail = excludeTranscriptSegment(
           current.response.replay.entries,
           current.loadedHistoryEntries
+        );
+        const loadedHistoryEntries = excludeTranscriptSegment(
+          stitchOrderedTranscriptSegments(
+            olderResponse.replay.entries,
+            current.loadedHistoryEntries
+          ),
+          retainedTail
         );
         const mergedEntries = stitchOrderedTranscriptSegments(
           loadedHistoryEntries,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -148,7 +148,7 @@ type ThreadSessionEntry = {
   initialLoadDurationMs?: number;
   interacted: boolean;
   lastTouchedAt: number;
-  loadedHistoryEntryCount: number;
+  loadedHistoryEntries: AppServerThreadEntry[];
   loading: boolean;
   loadingMore: boolean;
   needsHydrationAfterCompletion: boolean;
@@ -200,7 +200,7 @@ function createEmptyThreadSessionEntry(): ThreadSessionEntry {
     expectOwnUpdate: false,
     interacted: false,
     lastTouchedAt: Date.now(),
-    loadedHistoryEntryCount: 0,
+    loadedHistoryEntries: [],
     loading: false,
     loadingMore: false,
     needsHydrationAfterCompletion: false,
@@ -218,6 +218,76 @@ function mergeItems<T extends { id: string }>(olderItems: T[], newerItems: T[]):
   }
 
   return [...deduped.values()];
+}
+
+function stitchOrderedTranscriptSegments(
+  olderEntries: AppServerThreadEntry[],
+  newerEntries: AppServerThreadEntry[]
+): AppServerThreadEntry[] {
+  // Page reads can overlap a moving tail. Remove only unambiguous overlap from
+  // the older segment, then preserve the newer segment's authoritative order.
+  const matchedOlderEntries = new Set<AppServerThreadEntry>();
+  for (const newerEntry of newerEntries) {
+    const olderMatch = findUniqueTranscriptRefreshMatch(
+      newerEntry,
+      olderEntries.filter((entry) => !matchedOlderEntries.has(entry))
+    );
+    if (olderMatch) {
+      matchedOlderEntries.add(olderMatch);
+    }
+  }
+
+  return [
+    ...olderEntries.filter((entry) => !matchedOlderEntries.has(entry)),
+    ...newerEntries,
+  ];
+}
+
+function excludeTranscriptSegment(
+  entries: AppServerThreadEntry[],
+  excludedSegment: AppServerThreadEntry[]
+): AppServerThreadEntry[] {
+  const excludedEntries = new Set<AppServerThreadEntry>();
+  for (const excludedEntry of excludedSegment) {
+    const match = findUniqueTranscriptRefreshMatch(
+      excludedEntry,
+      entries.filter((entry) => !excludedEntries.has(entry))
+    );
+    if (match) {
+      excludedEntries.add(match);
+    }
+  }
+
+  return entries.filter((entry) => !excludedEntries.has(entry));
+}
+
+function transcriptMessagesForEntries(
+  entries: AppServerThreadEntry[],
+  ...messageSources: AppServerThreadMessage[][]
+): AppServerThreadMessage[] {
+  const messagesById = new Map(
+    messageSources.flat().map((message) => [message.id, message] as const)
+  );
+
+  return entries.flatMap((entry) => {
+    if (entry.type !== "message") {
+      return [];
+    }
+
+    const message = messagesById.get(entry.id);
+    return message
+      ? [message]
+      : [{
+          id: entry.id,
+          role: entry.role,
+          text: entry.text,
+          ...(entry.parts ? { parts: entry.parts } : {}),
+          ...(entry.origin ? { origin: entry.origin } : {}),
+          ...(entry.createdAt !== undefined
+            ? { createdAt: entry.createdAt }
+            : {}),
+        }];
+  });
 }
 
 function mergeFinalizedUsageEntry(
@@ -586,24 +656,21 @@ function mergeTranscriptMessages(
 function preserveLoadedTranscriptHistory(
   response: AppServerReadThreadResponse,
   retainedResponse: AppServerReadThreadResponse | undefined,
-  loadedHistoryEntryCount: number
+  loadedHistoryEntries: AppServerThreadEntry[]
 ): AppServerReadThreadResponse {
   if (
-    loadedHistoryEntryCount === 0 ||
+    loadedHistoryEntries.length === 0 ||
     !retainedResponse ||
     !response.replay.pagination.supportsPagination
   ) {
     return response;
   }
 
-  // The explicit boundary keeps a latest page that starts mid-turn from
-  // claiming entries that were loaded by an older-page request.
-  const retainedPrefix = retainedResponse.replay.entries.slice(
-    0,
-    loadedHistoryEntryCount
-  );
-  const retainedTail = retainedResponse.replay.entries.slice(
-    loadedHistoryEntryCount
+  // History provenance is explicit. A positional prefix becomes stale as soon
+  // as live items or a refresh mutate the combined response.
+  const retainedTail = excludeTranscriptSegment(
+    retainedResponse.replay.entries,
+    loadedHistoryEntries
   );
   // A refresh can lag the live stream. Replace only exact or uniquely
   // equivalent retained entries; keep anything the refresh omitted.
@@ -620,15 +687,9 @@ function preserveLoadedTranscriptHistory(
   const retainedTailRemainder = retainedTail.filter(
     (entry) => !matchedRetainedEntries.has(entry)
   );
-  const entries = mergeItems(
-    retainedPrefix,
+  const entries = stitchOrderedTranscriptSegments(
+    loadedHistoryEntries,
     mergeTranscriptEntries(response.replay.entries, retainedTailRemainder)
-  );
-  const messagesById = new Map(
-    [
-      ...retainedResponse.replay.messages,
-      ...response.replay.messages,
-    ].map((message) => [message.id, message] as const)
   );
 
   return {
@@ -636,25 +697,11 @@ function preserveLoadedTranscriptHistory(
     replay: {
       ...response.replay,
       entries,
-      messages: entries.flatMap((entry) => {
-        if (entry.type !== "message") {
-          return [];
-        }
-
-        const message = messagesById.get(entry.id);
-        return message
-          ? [message]
-          : [{
-              id: entry.id,
-              role: entry.role,
-              text: entry.text,
-              ...(entry.parts ? { parts: entry.parts } : {}),
-              ...(entry.origin ? { origin: entry.origin } : {}),
-              ...(entry.createdAt !== undefined
-                ? { createdAt: entry.createdAt }
-                : {}),
-            }];
-      }),
+      messages: transcriptMessagesForEntries(
+        entries,
+        retainedResponse.replay.messages,
+        response.replay.messages
+      ),
       pagination: retainedResponse.replay.pagination,
     },
   };
@@ -693,21 +740,6 @@ function findUniqueTranscriptRefreshMatch(
   });
 
   return logicalMatches.length === 1 ? logicalMatches[0] : undefined;
-}
-
-function loadedHistoryPrefixGrowth(
-  currentEntries: AppServerThreadEntry[],
-  mergedEntries: AppServerThreadEntry[]
-): number {
-  const currentFirstEntryId = currentEntries[0]?.id;
-  if (!currentFirstEntryId) {
-    return mergedEntries.length;
-  }
-
-  const currentBoundaryIndex = mergedEntries.findIndex(
-    (entry) => entry.id === currentFirstEntryId
-  );
-  return currentBoundaryIndex === -1 ? 0 : currentBoundaryIndex;
 }
 
 function isCodexImageBoundaryText(value: string): boolean {
@@ -3946,7 +3978,7 @@ export function useThreadSessionState(params: {
           const responseWithLoadedHistory = preserveLoadedTranscriptHistory(
             orderedResponse,
             current.response,
-            current.loadedHistoryEntryCount
+            current.loadedHistoryEntries
           );
           const hydratedPendingRequest = response.pendingRequest;
           const hydratedPendingUserInput =
@@ -4081,6 +4113,11 @@ export function useThreadSessionState(params: {
             initialLoadDurationMs:
               current.initialLoadDurationMs ?? response.readDurationMs,
             lastTouchedAt: Date.now(),
+            loadedHistoryEntries:
+              response.replay.pagination.supportsPagination
+              && response.replay.pagination.hasPreviousPage
+                ? current.loadedHistoryEntries
+                : [],
             loading: false,
             completionHydrationRetries,
             needsHydrationAfterCompletion,
@@ -5460,6 +5497,7 @@ export function useThreadSessionState(params: {
             failedHydrationVersion: undefined,
             hydratedUpdatedAt: undefined,
             lastTouchedAt: nextLastTouchedAt,
+            loadedHistoryEntries: [],
             pendingUsageActivityEntry: undefined,
             pendingTurnUsage: undefined,
             pendingStatusText: undefined,
@@ -5686,25 +5724,30 @@ export function useThreadSessionState(params: {
           };
         }
 
-        const mergedEntries = mergeItems(
+        const loadedHistoryEntries = stitchOrderedTranscriptSegments(
           olderResponse.replay.entries,
-          current.response.replay.entries
+          current.loadedHistoryEntries
+        );
+        const retainedTail = excludeTranscriptSegment(
+          current.response.replay.entries,
+          current.loadedHistoryEntries
+        );
+        const mergedEntries = stitchOrderedTranscriptSegments(
+          loadedHistoryEntries,
+          retainedTail
         );
         return {
           ...current,
           lastTouchedAt: Date.now(),
-          loadedHistoryEntryCount:
-            current.loadedHistoryEntryCount + loadedHistoryPrefixGrowth(
-              current.response.replay.entries,
-              mergedEntries
-            ),
+          loadedHistoryEntries,
           loadingMore: false,
           response: {
             ...olderResponse,
             replay: {
               ...olderResponse.replay,
               entries: mergedEntries,
-              messages: mergeItems(
+              messages: transcriptMessagesForEntries(
+                mergedEntries,
                 olderResponse.replay.messages,
                 current.response.replay.messages
               ),


### PR DESCRIPTION
## Summary

- track loaded transcript history as an explicit ordered segment instead of a positional prefix count
- keep the newer page/tail authoritative when paginated reads overlap
- clear loaded history provenance when `thread/compacted` invalidates the replay
- add regressions for the observed post-compaction inversion and dirty page overlap

## Root cause

A warm viewer had loaded older transcript pages, then received `thread/compacted`. The renderer cleared its replay but retained `loadedHistoryEntryCount`. When the next live turn arrived, that stale count classified the new user message as loaded history. The following hydration therefore prepended it ahead of older turns, matching the live 9:45-before-9:21 DOM order.

The count was also structurally unsafe: it encoded provenance as “the first N entries” of an array that live events and refreshes can mutate. The replacement keeps loaded history separate and reconciles overlap without changing the newer segment's order.

## Diagnosis

A fresh dev-profile PwrAgent instance mounted the same remote thread through Federation and rendered it in the correct order. Direct federated transcript reads were also ordered. That isolated the defect to warm renderer state rather than Federation transport ordering.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` (114/114)
- `pnpm typecheck`
- `pnpm lint:eslint` (existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
