### PR TITLE
fix(tests): backport VideoToolbox E2E mitigation

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -194,7 +194,24 @@ export async function launchElectronApp(params: {
   env[SECRET_STORAGE_DISABLED_ENV] = "1";
 
   const electronApp = await electron.launch({
-    args: [path.resolve(fixtureDir, "../../out/main/index.js")],
+    args: [
+      path.resolve(fixtureDir, "../../out/main/index.js"),
+      // Hardware video codecs leak kernel objects inside a
+      // Virtualization.framework guest (the Tart macOS VMs): every
+      // VideoToolbox init creates an
+      // AppleVideoToolboxParavirtualizationUserClient that the vmapple
+      // paravirt driver never frees, even at process death. Chromium
+      // initializes them once per app launch, so a suite run leaks
+      // roughly one per spec. Past ~1.1k live clients the driver's
+      // IOService::newUserClient wedges, every new Electron helper
+      // hangs at birth in-kernel, and app teardown blocks ~6s per spec
+      // until the guest is rebooted. --disable-gpu and
+      // disableHardwareAcceleration() do NOT cover media codecs, so
+      // the codec switches have to be explicit. Harmless elsewhere:
+      // no spec plays video.
+      "--disable-accelerated-video-decode",
+      "--disable-accelerated-video-encode",
+    ],
     cwd: path.resolve(fixtureDir, "../.."),
     env,
   });


### PR DESCRIPTION
## What changed

Backports the complete code change from #1168 onto `releases/1.0`:

- launch Electron E2E apps with `--disable-accelerated-video-decode`
- launch Electron E2E apps with `--disable-accelerated-video-encode`

This PR contains one commit changing one test-fixture file. No shutdown budgets, lifecycle handlers, workflow topology, dependencies, Electron version, or production behavior changed.

## Root cause

The `releases/1.0` macOS lanes were enabled by #1552 without the fixture change from #1168. In Virtualization.framework/Tart guests, Chromium hardware media initialization leaks `AppleVideoToolboxParavirtualizationUserClient` kernel objects. The leak accumulates across jobs on persistent guests; after enough Electron launches, a new helper wedges during kernel initialization and the Electron root waits roughly six seconds during every teardown.

This matches the observed progression:

- PwrAgent's managed renderer, messaging, and app-server shutdown completed in about 113 ms while the Electron root plus one helper remained alive.
- The first slow 1.0 run affected only the busier M2 guest; the M5 guest passed the same commit normally and degraded after more release jobs.
- Electron 41.10.3 did not change the behavior.
- Adding only these two flags on the diagnostic stack restored both protected macOS lanes to the normal 2–3-minute range.

`--disable-gpu` and `disableHardwareAcceleration()` do not cover hardware media codecs, so both explicit switches are required.

Source PR: #1168

## Validation

Validated again after rebasing directly onto current `releases/1.0`:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e e2e/app-quit-lifecycle.spec.ts` — 3 passed
- `git diff --check`
