### PR TITLE
perf(desktop): amortize transcript history paging

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
@@ -1,0 +1,210 @@
+import type {
+  AppServerReadThreadResponse,
+  AppServerThreadEntry,
+  AppServerThreadMessageEntry,
+} from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import {
+  combineTranscriptEntries,
+  combineTranscriptResponse,
+  createTranscriptHistoryIndex,
+  prependTranscriptHistoryPage,
+  type LoadedTranscriptHistory,
+  type TranscriptHistoryPage,
+} from "../segmented-transcript";
+
+function message(id: string, text = id): AppServerThreadMessageEntry {
+  return {
+    type: "message",
+    id,
+    role: "assistant",
+    text,
+  };
+}
+
+function response(
+  entries: AppServerThreadEntry[],
+  previousCursor?: string,
+): AppServerReadThreadResponse {
+  return {
+    backend: "codex",
+    fetchedAt: 1,
+    threadId: "thread-1",
+    replay: {
+      entries,
+      messages: entries.flatMap((entry) =>
+        entry.type === "message"
+          ? [{
+              id: entry.id,
+              role: entry.role,
+              text: entry.text,
+            }]
+          : []
+      ),
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: Boolean(previousCursor),
+        ...(previousCursor ? { previousCursor } : {}),
+      },
+    },
+  };
+}
+
+function historyPages(
+  history: LoadedTranscriptHistory | undefined,
+): TranscriptHistoryPage[] {
+  const pages: TranscriptHistoryPage[] = [];
+  let page = history?.oldestPage;
+  while (page) {
+    pages.push(page);
+    page = page.newerPage;
+  }
+  return pages;
+}
+
+describe("segmented transcript history", () => {
+  it("keeps array behavior while the tail remains authoritative by exact id", () => {
+    const index = createTranscriptHistoryIndex();
+    const tail = [message("tail", "Authoritative tail")];
+    const history = prependTranscriptHistoryPage({
+      history: undefined,
+      index,
+      page: response([
+        message("older", "Repeated"),
+        message("repeat-distinct", "Repeated"),
+        message("tail", "Stale overlap"),
+      ]),
+      tailEntries: tail,
+    });
+    const entries = combineTranscriptEntries(history, index, tail);
+
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries).toHaveLength(3);
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "older",
+      "repeat-distinct",
+      "tail",
+    ]);
+    const lastEntry = entries.at(-1);
+    expect(lastEntry?.type === "message" && lastEntry.text).toBe(
+      "Authoritative tail",
+    );
+    expect(entries.slice(-2).map((entry) => entry.id)).toEqual([
+      "repeat-distinct",
+      "tail",
+    ]);
+
+    const combinedResponse = combineTranscriptResponse({
+      history,
+      index,
+      response: response(tail, "tail-cursor"),
+    });
+    expect(combinedResponse?.replay.messages.map((item) => item.id)).toEqual([
+      "older",
+      "repeat-distinct",
+      "tail",
+    ]);
+    expect(combinedResponse?.replay.pagination.hasPreviousPage).toBe(false);
+  });
+
+  it("pins a linear history-storage work budget as pages accumulate", () => {
+    const pageCount = 100;
+    const entriesPerPage = 50;
+    const index = createTranscriptHistoryIndex();
+    let history: LoadedTranscriptHistory | undefined;
+    let allocatedHistoryEntrySlots = 0;
+    let copiedPriorEntrySlots = 0;
+
+    for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+      const retainedPages = historyPages(history);
+      const retainedArrays = new Set(retainedPages.map((page) => page.entries));
+      history = prependTranscriptHistoryPage({
+        history,
+        index,
+        page: response(
+          Array.from({ length: entriesPerPage }, (_value, entryIndex) =>
+            message(`page-${pageIndex}-entry-${entryIndex}`)
+          ),
+          pageIndex + 1 < pageCount ? `cursor-${pageIndex + 1}` : undefined,
+        ),
+        tailEntries: [],
+      });
+
+      const nextPages = historyPages(history);
+      const nextArrays = new Set(nextPages.map((page) => page.entries));
+      for (const retainedPage of retainedPages) {
+        if (!nextArrays.has(retainedPage.entries)) {
+          copiedPriorEntrySlots += retainedPage.entries.length;
+        }
+      }
+      const newArrays = nextPages.filter(
+        (page) => !retainedArrays.has(page.entries)
+      );
+      allocatedHistoryEntrySlots += newArrays.reduce(
+        (total, page) => total + page.entries.length,
+        0,
+      );
+
+      // Creating the public array view is O(1) in transcript entries. It must
+      // not flatten the page chain merely to report its length.
+      expect(combineTranscriptEntries(history, index, [])).toHaveLength(
+        (pageIndex + 1) * entriesPerPage,
+      );
+    }
+
+    const loadedEntries = pageCount * entriesPerPage;
+    const legacyGrowingArrayEntryCopies =
+      entriesPerPage * pageCount * (pageCount + 1) / 2;
+    expect({
+      allocatedHistoryEntrySlots,
+      copiedPriorEntrySlots,
+      loadedEntries,
+    }).toEqual({
+      allocatedHistoryEntrySlots: 5_000,
+      copiedPriorEntrySlots: 0,
+      loadedEntries: 5_000,
+    });
+    expect(legacyGrowingArrayEntryCopies).toBe(252_500);
+  });
+
+  it("keeps live-tail window work independent of loaded history entries", () => {
+    const index = createTranscriptHistoryIndex();
+    let history: LoadedTranscriptHistory | undefined;
+    let retainedHistoryIdReads = 0;
+
+    for (let pageIndex = 0; pageIndex < 20; pageIndex += 1) {
+      const entries = Array.from(
+        { length: 50 },
+        (_value, entryIndex): AppServerThreadMessageEntry => {
+          const id = `history-${pageIndex}-${entryIndex}`;
+          return {
+            type: "message",
+            get id() {
+              retainedHistoryIdReads += 1;
+              return id;
+            },
+            role: "assistant",
+            text: id,
+          };
+        },
+      );
+      history = prependTranscriptHistoryPage({
+        history,
+        index,
+        page: response(entries, `cursor-${pageIndex}`),
+        tailEntries: [],
+      });
+    }
+
+    retainedHistoryIdReads = 0;
+    let tail: AppServerThreadEntry[] = [];
+    for (let liveIndex = 0; liveIndex < 100; liveIndex += 1) {
+      tail = [...tail, message(`live-${liveIndex}`)];
+      const entries = combineTranscriptEntries(history, index, tail);
+      expect(entries).toHaveLength(1_000 + tail.length);
+      expect(entries.slice(-1)[0]?.id).toBe(`live-${liveIndex}`);
+    }
+
+    expect(retainedHistoryIdReads).toBe(0);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
@@ -207,4 +207,47 @@ describe("segmented transcript history", () => {
 
     expect(retainedHistoryIdReads).toBe(0);
   });
+
+  it("pins linear work for reverse numeric-index searches", () => {
+    const index = createTranscriptHistoryIndex();
+    let history: LoadedTranscriptHistory | undefined;
+    let retainedHistoryIdReads = 0;
+
+    for (let pageIndex = 0; pageIndex < 20; pageIndex += 1) {
+      const entries = Array.from(
+        { length: 50 },
+        (_value, entryIndex): AppServerThreadMessageEntry => {
+          const id = `history-${pageIndex}-${entryIndex}`;
+          return {
+            type: "message",
+            get id() {
+              retainedHistoryIdReads += 1;
+              return id;
+            },
+            role: "assistant",
+            text: id,
+          };
+        },
+      );
+      history = prependTranscriptHistoryPage({
+        history,
+        index,
+        page: response(entries, `cursor-${pageIndex}`),
+        tailEntries: [],
+      });
+    }
+
+    retainedHistoryIdReads = 0;
+    const entries = combineTranscriptEntries(history, index, []);
+    let found = false;
+    for (let entryIndex = entries.length - 1; entryIndex >= 0; entryIndex -= 1) {
+      if (entries[entryIndex]?.id === "missing-entry") {
+        found = true;
+        break;
+      }
+    }
+
+    expect(found).toBe(false);
+    expect(retainedHistoryIdReads).toBe(2_000);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -389,6 +389,82 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("stitches many older pages without weakening exact-id overlap rules", async () => {
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({
+            id: "tail",
+            text: "Authoritative tail",
+            createdAt: 500,
+          }),
+        ],
+        hasPreviousPage: true,
+        previousCursor: "page-1",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({ id: "page-1", text: "Repeated", createdAt: 400 }),
+          messageEntry({ id: "tail", text: "Stale tail", createdAt: 500 }),
+        ],
+        hasPreviousPage: true,
+        previousCursor: "page-2",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({ id: "page-2", text: "Repeated", createdAt: 300 }),
+          messageEntry({ id: "page-1", text: "Stale page 1", createdAt: 400 }),
+        ],
+        hasPreviousPage: true,
+        previousCursor: "page-3",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({ id: "page-3", text: "Oldest", createdAt: 200 }),
+        ],
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    for (let pageIndex = 0; pageIndex < 3; pageIndex += 1) {
+      await act(async () => {
+        await result.current.loadOlder();
+      });
+    }
+
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "page-3",
+      "page-2",
+      "page-1",
+      "tail",
+    ]);
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Oldest",
+      "message:Repeated",
+      "message:Repeated",
+      "message:Authoritative tail",
+    ]);
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      "page-3",
+      "page-2",
+      "page-1",
+      "tail",
+    ]);
+    expect(result.current.response?.replay.pagination.hasPreviousPage).toBe(false);
+  });
+
   it("replaces an overlapping live tail when hydrated message ids change", async () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
+++ b/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
@@ -378,8 +378,10 @@ function createSegmentedArray<T extends { id: string }>(
         };
       }
       if (isArrayIndex(property)) {
-        return materialized?.[Number(property)]
-          ?? readSegmentedIndex(source, Number(property), length);
+        // Existing renderer searches walk this array backwards with numeric
+        // indexing. Materialize on the first indexed read so that one scan is
+        // O(n) rather than traversing the page chain once per entry (O(n²)).
+        return materialize()[Number(property)];
       }
       return Reflect.get(target, property, proxy);
     },

--- a/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
+++ b/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
@@ -1,0 +1,477 @@
+import type {
+  AppServerReadThreadResponse,
+  AppServerThreadEntry,
+  AppServerThreadMessage,
+} from "@pwragent/shared";
+
+export type TranscriptHistoryPage = {
+  entries: AppServerThreadEntry[];
+  entryCount: number;
+  messageCount: number;
+  messages: AppServerThreadMessage[];
+  newerPage?: TranscriptHistoryPage;
+  olderPage?: TranscriptHistoryPage;
+};
+
+export type LoadedTranscriptHistory = {
+  entryCount: number;
+  messageCount: number;
+  newestPage?: TranscriptHistoryPage;
+  oldestPage?: TranscriptHistoryPage;
+  pagination: AppServerReadThreadResponse["replay"]["pagination"];
+};
+
+export type TranscriptHistoryIndex = {
+  entryIds: Set<string>;
+  messageIds: Set<string>;
+};
+
+export function createTranscriptHistoryIndex(): TranscriptHistoryIndex {
+  return {
+    entryIds: new Set(),
+    messageIds: new Set(),
+  };
+}
+
+function messagesForEntries(
+  entries: AppServerThreadEntry[],
+  messages: AppServerThreadMessage[],
+): AppServerThreadMessage[] {
+  const messagesById = new Map(messages.map((message) => [message.id, message]));
+
+  return entries.flatMap((entry) => {
+    if (entry.type !== "message") {
+      return [];
+    }
+
+    const message = messagesById.get(entry.id);
+    return message
+      ? [message]
+      : [{
+          id: entry.id,
+          role: entry.role,
+          text: entry.text,
+          ...(entry.parts ? { parts: entry.parts } : {}),
+          ...(entry.origin ? { origin: entry.origin } : {}),
+          ...(entry.createdAt !== undefined
+            ? { createdAt: entry.createdAt }
+            : {}),
+        }];
+  });
+}
+
+/**
+ * Adds one server page without traversing or copying previously loaded pages.
+ *
+ * The index is an append-only, non-rendered companion owned by one thread
+ * session. Keeping it outside React state is deliberate: cloning a growing
+ * Set here would merely move the cumulative history copy from the entry array
+ * to the ID index.
+ */
+export function prependTranscriptHistoryPage(params: {
+  history: LoadedTranscriptHistory | undefined;
+  index: TranscriptHistoryIndex;
+  page: AppServerReadThreadResponse;
+  tailEntries: AppServerThreadEntry[];
+}): LoadedTranscriptHistory {
+  const tailEntryIds = new Set(params.tailEntries.map((entry) => entry.id));
+  const entries = params.page.replay.entries.filter(
+    (entry) =>
+      !tailEntryIds.has(entry.id)
+      && !params.index.entryIds.has(entry.id),
+  );
+  const messages = messagesForEntries(entries, params.page.replay.messages);
+
+  for (const entry of entries) {
+    params.index.entryIds.add(entry.id);
+  }
+  for (const message of messages) {
+    params.index.messageIds.add(message.id);
+  }
+
+  const previousEntryCount = params.history?.entryCount ?? 0;
+  const previousMessageCount = params.history?.messageCount ?? 0;
+  let oldestPage = params.history?.oldestPage;
+  let newestPage = params.history?.newestPage;
+  if (entries.length > 0) {
+    const page: TranscriptHistoryPage = {
+      entries,
+      entryCount: entries.length,
+      messageCount: messages.length,
+      messages,
+      newerPage: params.history?.oldestPage,
+    };
+    if (oldestPage) {
+      // This reverse link is an append-only navigation index. Older array
+      // views remain bounded by their captured entry count, so attaching the
+      // next page cannot make a previously returned view grow.
+      oldestPage.olderPage = page;
+    }
+    oldestPage = page;
+    newestPage ??= page;
+  }
+
+  return {
+    entryCount: previousEntryCount + entries.length,
+    messageCount: previousMessageCount + messages.length,
+    newestPage,
+    oldestPage,
+    pagination: params.page.replay.pagination,
+  };
+}
+
+function historyOverlapIds<T extends { id: string }>(
+  tail: readonly T[],
+  historyIds: ReadonlySet<string>,
+): Set<string> {
+  const overlap = new Set<string>();
+  for (const item of tail) {
+    if (historyIds.has(item.id)) {
+      overlap.add(item.id);
+    }
+  }
+  return overlap;
+}
+
+type SegmentedArraySource<T> = {
+  excludedHistoryIds: ReadonlySet<string>;
+  historyCount: number;
+  historyNewestPage: TranscriptHistoryPage | undefined;
+  historyPage: TranscriptHistoryPage | undefined;
+  pageItems: (page: TranscriptHistoryPage) => readonly T[];
+  tail: readonly T[];
+};
+
+function* iterateSegmentedArray<T extends { id: string }>(
+  source: SegmentedArraySource<T>,
+): Generator<T> {
+  let page = source.historyPage;
+  while (page) {
+    for (const item of source.pageItems(page)) {
+      if (!source.excludedHistoryIds.has(item.id)) {
+        yield item;
+      }
+    }
+    page = page.newerPage;
+  }
+  yield* source.tail;
+}
+
+function* iterateSegmentedArrayReverse<T extends { id: string }>(
+  source: SegmentedArraySource<T>,
+): Generator<T> {
+  for (let index = source.tail.length - 1; index >= 0; index -= 1) {
+    yield source.tail[index]!;
+  }
+
+  let remainingHistoryItems =
+    source.historyCount - source.excludedHistoryIds.size;
+  let page = source.historyNewestPage;
+  while (page && remainingHistoryItems > 0) {
+    const items = source.pageItems(page);
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const item = items[index]!;
+      if (source.excludedHistoryIds.has(item.id)) {
+        continue;
+      }
+      yield item;
+      remainingHistoryItems -= 1;
+      if (remainingHistoryItems === 0) {
+        return;
+      }
+    }
+    page = page.olderPage;
+  }
+}
+
+function normalizeSliceIndex(
+  index: number | undefined,
+  length: number,
+  fallback: number,
+): number {
+  if (index === undefined) {
+    return fallback;
+  }
+  const integer = Math.trunc(index);
+  if (integer < 0) {
+    return Math.max(length + integer, 0);
+  }
+  return Math.min(integer, length);
+}
+
+function segmentedSlice<T extends { id: string }>(
+  source: SegmentedArraySource<T>,
+  length: number,
+  start?: number,
+  end?: number,
+): T[] {
+  const normalizedStart = normalizeSliceIndex(start, length, 0);
+  const normalizedEnd = normalizeSliceIndex(end, length, length);
+  if (normalizedStart >= normalizedEnd) {
+    return [];
+  }
+
+  if (normalizedEnd === length) {
+    const output: T[] = [];
+    const requestedCount = normalizedEnd - normalizedStart;
+    for (const item of iterateSegmentedArrayReverse(source)) {
+      output.push(item);
+      if (output.length === requestedCount) {
+        break;
+      }
+    }
+    output.reverse();
+    return output;
+  }
+
+  const output: T[] = [];
+  let index = 0;
+  for (const item of iterateSegmentedArray(source)) {
+    if (index >= normalizedEnd) {
+      break;
+    }
+    if (index >= normalizedStart) {
+      output.push(item);
+    }
+    index += 1;
+  }
+  return output;
+}
+
+function readSegmentedIndex<T extends { id: string }>(
+  source: SegmentedArraySource<T>,
+  index: number,
+  length: number,
+): T | undefined {
+  if (index < 0) {
+    return undefined;
+  }
+  if (index >= length) {
+    return undefined;
+  }
+  if (index > length / 2) {
+    let currentIndex = length - 1;
+    for (const item of iterateSegmentedArrayReverse(source)) {
+      if (currentIndex === index) {
+        return item;
+      }
+      currentIndex -= 1;
+    }
+    return undefined;
+  }
+
+  let currentIndex = 0;
+  for (const item of iterateSegmentedArray(source)) {
+    if (currentIndex === index) {
+      return item;
+    }
+    currentIndex += 1;
+  }
+  return undefined;
+}
+
+function isArrayIndex(property: PropertyKey): property is string {
+  return (
+    typeof property === "string"
+    && /^(?:0|[1-9]\d*)$/u.test(property)
+  );
+}
+
+/**
+ * Presents linked pages as the array shape the rest of the renderer already
+ * consumes. Length reads and newest-window slices stay lazy; an operation
+ * that genuinely needs the whole transcript materializes it once for this
+ * view and then reuses that array.
+ */
+function createSegmentedArray<T extends { id: string }>(
+  source: SegmentedArraySource<T>,
+): T[] {
+  const length = source.historyCount - source.excludedHistoryIds.size + source.tail.length;
+  const target = new Array<T>(length);
+  let materialized: T[] | undefined;
+  const materialize = (): T[] => {
+    materialized ??= [...iterateSegmentedArray(source)];
+    return materialized;
+  };
+
+  const proxy = new Proxy(target, {
+    deleteProperty: () => false,
+    get: (_target, property) => {
+      if (property === Symbol.iterator || property === "values") {
+        return () => materialized?.values() ?? iterateSegmentedArray(source);
+      }
+      if (property === "entries") {
+        return function* entries(): Generator<[number, T]> {
+          let index = 0;
+          for (const item of iterateSegmentedArray(source)) {
+            yield [index, item];
+            index += 1;
+          }
+        };
+      }
+      if (property === "keys") {
+        return function* keys(): Generator<number> {
+          for (let index = 0; index < length; index += 1) {
+            yield index;
+          }
+        };
+      }
+      if (property === "slice") {
+        return (start?: number, end?: number) =>
+          materialized?.slice(start, end)
+          ?? segmentedSlice(source, length, start, end);
+      }
+      if (property === "at") {
+        return (index: number) => {
+          const normalizedIndex = index < 0
+            ? length + Math.trunc(index)
+            : Math.trunc(index);
+          return materialized?.at(normalizedIndex)
+            ?? readSegmentedIndex(source, normalizedIndex, length);
+        };
+      }
+      if (
+        property === "concat"
+        || property === "every"
+        || property === "filter"
+        || property === "find"
+        || property === "findIndex"
+        || property === "findLast"
+        || property === "findLastIndex"
+        || property === "flat"
+        || property === "flatMap"
+        || property === "forEach"
+        || property === "includes"
+        || property === "indexOf"
+        || property === "join"
+        || property === "lastIndexOf"
+        || property === "map"
+        || property === "reduce"
+        || property === "reduceRight"
+        || property === "some"
+        || property === "toLocaleString"
+        || property === "toString"
+      ) {
+        return (...args: unknown[]) => {
+          const method = Reflect.get(materialize(), property) as (
+            ...methodArgs: unknown[]
+          ) => unknown;
+          return method.apply(materialize(), args);
+        };
+      }
+      if (property === "toJSON") {
+        return () => materialize();
+      }
+      if (
+        property === "copyWithin"
+        || property === "fill"
+        || property === "pop"
+        || property === "push"
+        || property === "reverse"
+        || property === "shift"
+        || property === "sort"
+        || property === "splice"
+        || property === "unshift"
+      ) {
+        return () => {
+          throw new TypeError("Transcript entry views are read-only");
+        };
+      }
+      if (isArrayIndex(property)) {
+        return materialized?.[Number(property)]
+          ?? readSegmentedIndex(source, Number(property), length);
+      }
+      return Reflect.get(target, property, proxy);
+    },
+    getOwnPropertyDescriptor: (_target, property) => {
+      if (isArrayIndex(property) && Number(property) < length) {
+        return {
+          configurable: true,
+          enumerable: true,
+          value: materialize()[Number(property)],
+          writable: false,
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, property);
+    },
+    has: (_target, property) =>
+      isArrayIndex(property)
+        ? Number(property) < length
+        : Reflect.has(target, property),
+    ownKeys: () => {
+      materialize();
+      return [
+        ...Array.from({ length }, (_value, index) => String(index)),
+        "length",
+      ];
+    },
+    set: () => false,
+  });
+
+  return proxy;
+}
+
+export function combineTranscriptEntries(
+  history: LoadedTranscriptHistory | undefined,
+  index: TranscriptHistoryIndex | undefined,
+  tailEntries: AppServerThreadEntry[],
+): AppServerThreadEntry[] {
+  if (!history?.oldestPage || !index) {
+    return tailEntries;
+  }
+  const excludedHistoryIds = historyOverlapIds(tailEntries, index.entryIds);
+  return createSegmentedArray({
+    excludedHistoryIds,
+    historyCount: history.entryCount,
+    historyNewestPage: history.newestPage,
+    historyPage: history.oldestPage,
+    pageItems: (page) => page.entries,
+    tail: tailEntries,
+  });
+}
+
+export function combineTranscriptMessages(
+  history: LoadedTranscriptHistory | undefined,
+  index: TranscriptHistoryIndex | undefined,
+  tailMessages: AppServerThreadMessage[],
+): AppServerThreadMessage[] {
+  if (!history?.oldestPage || !index) {
+    return tailMessages;
+  }
+  const excludedHistoryIds = historyOverlapIds(tailMessages, index.messageIds);
+  return createSegmentedArray({
+    excludedHistoryIds,
+    historyCount: history.messageCount,
+    historyNewestPage: history.newestPage,
+    historyPage: history.oldestPage,
+    pageItems: (page) => page.messages,
+    tail: tailMessages,
+  });
+}
+
+export function combineTranscriptResponse(params: {
+  history: LoadedTranscriptHistory | undefined;
+  index: TranscriptHistoryIndex | undefined;
+  response: AppServerReadThreadResponse | undefined;
+}): AppServerReadThreadResponse | undefined {
+  if (!params.response || !params.history) {
+    return params.response;
+  }
+  return {
+    ...params.response,
+    replay: {
+      ...params.response.replay,
+      entries: combineTranscriptEntries(
+        params.history,
+        params.index,
+        params.response.replay.entries,
+      ),
+      messages: combineTranscriptMessages(
+        params.history,
+        params.index,
+        params.response.replay.messages,
+      ),
+      pagination: params.history.pagination,
+    },
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -57,6 +57,15 @@ import {
   withRendererSequence,
 } from "../features/thread-detail/live-transcript-activity";
 import { THREAD_HISTORY_PAGE_LIMIT } from "./thread-history-limits";
+import {
+  combineTranscriptEntries,
+  combineTranscriptMessages,
+  combineTranscriptResponse,
+  createTranscriptHistoryIndex,
+  prependTranscriptHistoryPage,
+  type LoadedTranscriptHistory,
+  type TranscriptHistoryIndex,
+} from "./segmented-transcript";
 
 const MAX_VIEW_ONLY_THREADS = 10;
 const EMPTY_EXPANDED_TRANSCRIPT_ACTIVITY_IDS: string[] = [];
@@ -148,7 +157,7 @@ type ThreadSessionEntry = {
   initialLoadDurationMs?: number;
   interacted: boolean;
   lastTouchedAt: number;
-  loadedHistoryEntries: AppServerThreadEntry[];
+  loadedHistory?: LoadedTranscriptHistory;
   loading: boolean;
   loadingMore: boolean;
   needsHydrationAfterCompletion: boolean;
@@ -200,7 +209,6 @@ function createEmptyThreadSessionEntry(): ThreadSessionEntry {
     expectOwnUpdate: false,
     interacted: false,
     lastTouchedAt: Date.now(),
-    loadedHistoryEntries: [],
     loading: false,
     loadingMore: false,
     needsHydrationAfterCompletion: false,
@@ -218,29 +226,6 @@ function mergeItems<T extends { id: string }>(olderItems: T[], newerItems: T[]):
   }
 
   return [...deduped.values()];
-}
-
-function stitchOrderedTranscriptSegments(
-  olderEntries: AppServerThreadEntry[],
-  newerEntries: AppServerThreadEntry[]
-): AppServerThreadEntry[] {
-  // Page reads can overlap a moving tail. Only stable IDs prove that entries
-  // overlap; repeated content with different IDs is legitimate transcript.
-  const newerEntryIds = new Set(newerEntries.map((entry) => entry.id));
-
-  return [
-    ...olderEntries.filter((entry) => !newerEntryIds.has(entry.id)),
-    ...newerEntries,
-  ];
-}
-
-function excludeTranscriptSegment(
-  entries: AppServerThreadEntry[],
-  excludedSegment: AppServerThreadEntry[]
-): AppServerThreadEntry[] {
-  const excludedEntryIds = new Set(excludedSegment.map((entry) => entry.id));
-
-  return entries.filter((entry) => !excludedEntryIds.has(entry.id));
 }
 
 function transcriptMessagesForEntries(
@@ -635,43 +620,42 @@ function mergeTranscriptMessages(
   return merged;
 }
 
-function preserveLoadedTranscriptHistory(
+function preserveRetainedTranscriptTail(
   response: AppServerReadThreadResponse,
   retainedResponse: AppServerReadThreadResponse | undefined,
-  loadedHistoryEntries: AppServerThreadEntry[]
+  hasLoadedHistory: boolean,
 ): AppServerReadThreadResponse {
   if (
-    loadedHistoryEntries.length === 0 ||
+    !hasLoadedHistory ||
     !retainedResponse ||
     !response.replay.pagination.supportsPagination
   ) {
     return response;
   }
 
-  // History provenance is explicit. A positional prefix becomes stale as soon
-  // as live items or a refresh mutate the combined response.
-  const retainedTail = excludeTranscriptSegment(
-    retainedResponse.replay.entries,
-    loadedHistoryEntries
-  );
   // A refresh can lag the live stream. Replace only exact or uniquely
   // equivalent retained entries; keep anything the refresh omitted.
+  // This reconciliation remains a fresh-tail × retained-tail logical scan.
+  // Both inputs are the bounded newest-page tail now; loaded history pages do
+  // not participate, so pagination depth cannot amplify it.
   const matchedRetainedEntries = new Set<AppServerThreadEntry>();
   for (const freshEntry of response.replay.entries) {
     const retainedMatch = findUniqueTranscriptRefreshMatch(
       freshEntry,
-      retainedTail.filter((entry) => !matchedRetainedEntries.has(entry))
+      retainedResponse.replay.entries.filter(
+        (entry) => !matchedRetainedEntries.has(entry)
+      )
     );
     if (retainedMatch) {
       matchedRetainedEntries.add(retainedMatch);
     }
   }
-  const retainedTailRemainder = retainedTail.filter(
+  const retainedTailRemainder = retainedResponse.replay.entries.filter(
     (entry) => !matchedRetainedEntries.has(entry)
   );
-  const entries = stitchOrderedTranscriptSegments(
-    loadedHistoryEntries,
-    mergeTranscriptEntries(response.replay.entries, retainedTailRemainder)
+  const entries = mergeTranscriptEntries(
+    response.replay.entries,
+    retainedTailRemainder,
   );
 
   return {
@@ -684,7 +668,6 @@ function preserveLoadedTranscriptHistory(
         retainedResponse.replay.messages,
         response.replay.messages
       ),
-      pagination: retainedResponse.replay.pagination,
     },
   };
 }
@@ -1455,7 +1438,8 @@ function shouldUseAssistantReviewText(params: {
 function coalesceReviewAssistantMessages(
   entries: AppServerThreadEntry[]
 ): AppServerThreadEntry[] {
-  const output: AppServerThreadEntry[] = [];
+  let output: AppServerThreadEntry[] | undefined;
+  let entryIndex = 0;
 
   for (const entry of entries) {
     if (
@@ -1466,7 +1450,8 @@ function coalesceReviewAssistantMessages(
         reviewText: "",
       })
     ) {
-      const matchingReviewIndex = output.findLastIndex((candidate) => {
+      const candidates = output ?? entries.slice(0, entryIndex);
+      const matchingReviewIndex = candidates.findLastIndex((candidate) => {
         if (candidate.type !== "review") {
           return false;
         }
@@ -1484,19 +1469,22 @@ function coalesceReviewAssistantMessages(
       });
 
       if (matchingReviewIndex !== -1) {
+        output = candidates;
         const reviewEntry = output[matchingReviewIndex] as AppServerThreadReviewEntry;
         output[matchingReviewIndex] = {
           ...reviewEntry,
           review: entry.text,
         };
+        entryIndex += 1;
         continue;
       }
     }
 
-    output.push(entry);
+    output?.push(entry);
+    entryIndex += 1;
   }
 
-  return output;
+  return output ?? entries;
 }
 
 function reviewResultTexts(entries: AppServerThreadEntry[]): Set<string> {
@@ -3785,12 +3773,22 @@ export function useThreadSessionState(params: {
   const selectedThreadKeyRef = useRef<string | undefined>(undefined);
   const consumedOptimisticActiveTurnKeysRef = useRef<Set<string>>(new Set());
   const lastLiveActivitySignatureRef = useRef<Record<string, string>>({});
+  const loadedHistoryIndexesRef = useRef<Record<string, TranscriptHistoryIndex>>({});
   const requestVersionsRef = useRef<Record<string, number>>({});
   const staleThinkingLogKeysRef = useRef<Set<string>>(new Set());
   const threadStatusSummarySeedRef = useRef<Record<string, string>>({});
   const [sessions, setSessions] = useState<ThreadSessionState>({});
 
   selectedThreadKeyRef.current = threadKey;
+
+  useEffect(() => {
+    const retainedThreadKeys = new Set(Object.keys(sessions));
+    for (const indexedThreadKey of Object.keys(loadedHistoryIndexesRef.current)) {
+      if (!retainedThreadKeys.has(indexedThreadKey)) {
+        delete loadedHistoryIndexesRef.current[indexedThreadKey];
+      }
+    }
+  }, [sessions]);
 
   const updateSession = useCallback(
     (
@@ -3942,6 +3940,12 @@ export function useThreadSessionState(params: {
         if (requestVersionsRef.current[targetThreadKey] !== requestVersion) {
           return;
         }
+        if (
+          !response.replay.pagination.supportsPagination
+          || !response.replay.pagination.hasPreviousPage
+        ) {
+          delete loadedHistoryIndexesRef.current[targetThreadKey];
+        }
 
         updateSession(targetThreadKey, (current) => {
           const liveTranscriptSources = [
@@ -3957,10 +3961,10 @@ export function useThreadSessionState(params: {
             transcriptOrderSources,
             liveTranscriptSources
           );
-          const responseWithLoadedHistory = preserveLoadedTranscriptHistory(
+          const responseWithRetainedTail = preserveRetainedTranscriptTail(
             orderedResponse,
             current.response,
-            current.loadedHistoryEntries
+            Boolean(current.loadedHistory),
           );
           const hydratedPendingRequest = response.pendingRequest;
           const hydratedPendingUserInput =
@@ -3985,7 +3989,7 @@ export function useThreadSessionState(params: {
             : undefined;
           const hydratedCompletedTurn = didHydrateCompletedTurn(
             current.response,
-            responseWithLoadedHistory
+            responseWithRetainedTail
           );
           const needsHydrationAfterCompletion =
             current.needsHydrationAfterCompletion && !hydratedCompletedTurn;
@@ -4017,7 +4021,7 @@ export function useThreadSessionState(params: {
             current.expectOwnUpdate
             && sessionHasInProgressReviewTurn(current, current.activeTurnId)
             && !responseHasCompletedTurn(
-              responseWithLoadedHistory,
+              responseWithRetainedTail,
               current.activeTurnId
             )
             && now < ownUpdateSettlesAt;
@@ -4029,7 +4033,7 @@ export function useThreadSessionState(params: {
             && !ownUpdateStillSettling
             && !reviewUpdateStillSettling
             && !responseHasInProgressTurn(
-              responseWithLoadedHistory,
+              responseWithRetainedTail,
               current.activeTurnId
             );
 
@@ -4042,7 +4046,7 @@ export function useThreadSessionState(params: {
             logStaleThinkingState({
               current,
               reasons: thinkingReasons,
-              response: responseWithLoadedHistory,
+              response: responseWithRetainedTail,
               targetThreadKey,
             });
           }
@@ -4058,7 +4062,7 @@ export function useThreadSessionState(params: {
           // "previous messages" groups while the turn is still writing them.
           const trailingInProgressTurn =
             !shouldClearStaleThinking && responseThreadStatus === "active"
-              ? readTrailingInProgressTurn(responseWithLoadedHistory)
+              ? readTrailingInProgressTurn(responseWithRetainedTail)
               : undefined;
           const shouldAdoptHydratedTurn =
             trailingInProgressTurn !== undefined
@@ -4095,17 +4099,17 @@ export function useThreadSessionState(params: {
             initialLoadDurationMs:
               current.initialLoadDurationMs ?? response.readDurationMs,
             lastTouchedAt: Date.now(),
-            loadedHistoryEntries:
+            loadedHistory:
               response.replay.pagination.supportsPagination
               && response.replay.pagination.hasPreviousPage
-                ? current.loadedHistoryEntries
-                : [],
+                ? current.loadedHistory
+                : undefined,
             loading: false,
             completionHydrationRetries,
             needsHydrationAfterCompletion,
             optimisticEntries: pruneOptimisticEntries(
               current.optimisticEntries,
-              responseWithLoadedHistory
+              responseWithRetainedTail
             ),
             pendingAssistantMessage: shouldClearStaleThinking
               ? undefined
@@ -4128,7 +4132,7 @@ export function useThreadSessionState(params: {
             pendingUserInput: hydratedPendingInteraction
               ? hydratedPendingUserInput
               : current.pendingUserInput,
-            response: responseWithLoadedHistory,
+            response: responseWithRetainedTail,
             staleThinkingRecheckAt:
               ownUpdateStillSettling || reviewUpdateStillSettling
               ? ownUpdateSettlesAt
@@ -5471,6 +5475,7 @@ export function useThreadSessionState(params: {
         }
 
         if (event.notification.method === "thread/compacted") {
+          delete loadedHistoryIndexesRef.current[targetThreadKey];
           return {
             ...current,
             activeTurnId: undefined,
@@ -5479,7 +5484,7 @@ export function useThreadSessionState(params: {
             failedHydrationVersion: undefined,
             hydratedUpdatedAt: undefined,
             lastTouchedAt: nextLastTouchedAt,
-            loadedHistoryEntries: [],
+            loadedHistory: undefined,
             pendingUsageActivityEntry: undefined,
             pendingTurnUsage: undefined,
             pendingStatusText: undefined,
@@ -5661,15 +5666,19 @@ export function useThreadSessionState(params: {
   ]);
 
   const selectedSession = threadKey ? sessions[threadKey] : undefined;
+  const selectedPagination =
+    selectedSession?.loadedHistory?.pagination
+    ?? selectedSession?.response?.replay.pagination;
 
   const loadOlder = useCallback(async (): Promise<void> => {
     if (
       !thread ||
       !threadKey ||
       !desktopApi?.readThread ||
-      !selectedSession?.response?.replay.pagination.supportsPagination ||
-      !selectedSession.response.replay.pagination.hasPreviousPage ||
-      !selectedSession.response.replay.pagination.previousCursor
+      selectedSession?.loadingMore ||
+      !selectedPagination?.supportsPagination ||
+      !selectedPagination.hasPreviousPage ||
+      !selectedPagination.previousCursor
     ) {
       return;
     }
@@ -5688,7 +5697,7 @@ export function useThreadSessionState(params: {
         federationTarget: thread.federation?.ref.target ??
           readRendererFederationTarget(),
         threadId: thread.id,
-        before: selectedSession.response.replay.pagination.previousCursor,
+        before: selectedPagination.previousCursor,
         limit: THREAD_HISTORY_PAGE_LIMIT,
       });
 
@@ -5696,8 +5705,16 @@ export function useThreadSessionState(params: {
         return;
       }
 
+      const historyIndex =
+        loadedHistoryIndexesRef.current[threadKey]
+        ?? createTranscriptHistoryIndex();
+      loadedHistoryIndexesRef.current[threadKey] = historyIndex;
+      let didAppendHistory = false;
+      let appendedHistorySource: LoadedTranscriptHistory | undefined;
+      let appendedHistory: LoadedTranscriptHistory | undefined;
       updateSession(threadKey, (current) => {
         if (!current.response) {
+          delete loadedHistoryIndexesRef.current[threadKey];
           return {
             ...current,
             lastTouchedAt: Date.now(),
@@ -5706,38 +5723,21 @@ export function useThreadSessionState(params: {
           };
         }
 
-        const retainedTail = excludeTranscriptSegment(
-          current.response.replay.entries,
-          current.loadedHistoryEntries
-        );
-        const loadedHistoryEntries = excludeTranscriptSegment(
-          stitchOrderedTranscriptSegments(
-            olderResponse.replay.entries,
-            current.loadedHistoryEntries
-          ),
-          retainedTail
-        );
-        const mergedEntries = stitchOrderedTranscriptSegments(
-          loadedHistoryEntries,
-          retainedTail
-        );
+        if (!didAppendHistory || appendedHistorySource !== current.loadedHistory) {
+          didAppendHistory = true;
+          appendedHistorySource = current.loadedHistory;
+          appendedHistory = prependTranscriptHistoryPage({
+            history: current.loadedHistory,
+            index: historyIndex,
+            page: olderResponse,
+            tailEntries: current.response.replay.entries,
+          });
+        }
         return {
           ...current,
           lastTouchedAt: Date.now(),
-          loadedHistoryEntries,
+          loadedHistory: appendedHistory,
           loadingMore: false,
-          response: {
-            ...olderResponse,
-            replay: {
-              ...olderResponse.replay,
-              entries: mergedEntries,
-              messages: transcriptMessagesForEntries(
-                mergedEntries,
-                olderResponse.replay.messages,
-                current.response.replay.messages
-              ),
-            },
-          },
         };
       });
     } catch (error) {
@@ -5752,7 +5752,14 @@ export function useThreadSessionState(params: {
         loadingMore: false,
       }));
     }
-  }, [desktopApi, selectedSession?.response, thread, threadKey, updateSession]);
+  }, [
+    desktopApi,
+    selectedPagination,
+    selectedSession?.loadingMore,
+    thread,
+    threadKey,
+    updateSession,
+  ]);
 
   const addOptimisticUserMessage = useCallback(
     (text: string, imageParts: AppServerThreadImagePart[] = []): string => {
@@ -6079,11 +6086,32 @@ export function useThreadSessionState(params: {
     [selectedSession?.optimisticEntries, selectedSession?.response]
   );
 
+  const selectedHistoryIndex = threadKey
+    ? loadedHistoryIndexesRef.current[threadKey]
+    : undefined;
+  const response = useMemo(
+    () => combineTranscriptResponse({
+      history: selectedSession?.loadedHistory,
+      index: selectedHistoryIndex,
+      response: selectedSession?.response,
+    }),
+    [
+      selectedHistoryIndex,
+      selectedSession?.loadedHistory,
+      selectedSession?.response,
+    ],
+  );
+
   const entries = useMemo(
     () => {
-      const mergedEntries = mergeTranscriptEntries(
+      const mergedTailEntries = mergeTranscriptEntries(
         selectedSession?.response?.replay.entries ?? [],
         visibleOptimisticEntries
+      );
+      const mergedEntries = combineTranscriptEntries(
+        selectedSession?.loadedHistory,
+        selectedHistoryIndex,
+        mergedTailEntries,
       );
       const coalescedEntries = coalesceReviewAssistantMessages(mergedEntries);
       return suppressReviewDuplicateMessages(
@@ -6091,23 +6119,39 @@ export function useThreadSessionState(params: {
         reviewResultTexts(coalescedEntries)
       );
     },
-    [selectedSession?.response?.replay.entries, visibleOptimisticEntries]
+    [
+      selectedHistoryIndex,
+      selectedSession?.loadedHistory,
+      selectedSession?.response?.replay.entries,
+      visibleOptimisticEntries,
+    ]
   );
 
   const messages = useMemo(
     () => {
-      const mergedMessages = mergeTranscriptMessages(
+      const mergedTailMessages = mergeTranscriptMessages(
         selectedSession?.response?.replay.messages ?? [],
         visibleOptimisticEntries
           .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")
           .map(({ type: _type, ...message }) => message)
+      );
+      const mergedMessages = combineTranscriptMessages(
+        selectedSession?.loadedHistory,
+        selectedHistoryIndex,
+        mergedTailMessages,
       );
       return suppressReviewDuplicateMessages(
         mergedMessages,
         reviewResultTexts(entries)
       );
     },
-    [entries, selectedSession?.response?.replay.messages, visibleOptimisticEntries]
+    [
+      entries,
+      selectedHistoryIndex,
+      selectedSession?.loadedHistory,
+      selectedSession?.response?.replay.messages,
+      visibleOptimisticEntries,
+    ]
   );
 
   const thinkingThreadKeys = useMemo(
@@ -6188,7 +6232,7 @@ export function useThreadSessionState(params: {
     approvalRequestThreadKeys,
     inputRequestThreadKeys,
     removeOptimisticMessage,
-    response: selectedSession?.response,
+    response,
     setActiveTurnId,
     setExpandedTranscriptWorkPhaseGroupIds,
     upsertLiveTranscriptEntry,


### PR DESCRIPTION
## Summary

- keep older transcript pages as linked immutable segments instead of rebuilding one growing history array
- expose an array-compatible lazy view so existing renderer ordering and pagination consumers remain unchanged
- preserve #1621's exact-ID page stitching, authoritative newest tail, explicit history provenance, compaction reset, and lagging-hydration behavior
- add deterministic storage/copy and live-tail work budgets plus a multi-page functional regression

## Root cause

`loadOlder` rebuilt the accumulated loaded-history prefix repeatedly: it stitched the new page into every prior page, excluded tail overlap from that rebuilt array, stitched history and tail again, then rebuilt transcript messages. Across many fixed-size pages, those growing-array copies are cumulative quadratic work.

This is based on the now-merged #1621 provenance model, but represents loaded history as linked page segments with append-only exact-ID indexes. Adding a page examines the incoming page and bounded tail; it does not traverse or copy prior page entries. Existing array consumers receive a lazy array-compatible view. Length reads and newest-window slices stay segmented, while an operation that genuinely needs the full transcript materializes that view once.

## Measured work

The checked deterministic budget loads 100 pages × 50 entries:

- before (one conservative growing-array rebuild per page): 252,500 cumulative history entry slots
- after: 5,000 allocated history entry slots, 0 prior-page entry slots replaced
- complexity of retained history storage/copying: **Θ(N²) → Θ(N)**

A separate budget loads 1,000 history entries, applies 100 successive live-tail updates, and takes the newest window each time. It records **0 retained-history ID reads**, so loaded-page depth no longer amplifies live tail appends/windowing.

Refresh hydration still contains PR #1514's logical reconciliation scan. It remains **Θ(fresh tail × retained tail)**, but both inputs are the bounded newest-page tail; loaded history segments no longer participate. This PR classifies and isolates that cost rather than broadening scope or weakening reconciliation correctness.

## Correctness

- newest page/tail order remains authoritative
- page overlap deduplicates only exact stable entry IDs
- repeated content with distinct IDs survives
- loaded-history provenance masks tail overlap
- non-paginated hydration and `thread/compacted` clear history provenance and indexes
- lagging hydration preserves omitted live tail entries without moving them before older history
- pagination continues from the oldest loaded page cursor

Follow-up to #1621. The requested stack base was deleted when #1621 squash-merged, so this branch was rebased onto its merged `main` commit without modifying or recreating the parent branch.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` (119/119)
- `pnpm typecheck`
- `pnpm lint:eslint` (existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
