### PR TITLE
fix(desktop): harden sub-agent lifecycle ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -34804,6 +34804,7 @@ script = "printf setup"
       codexClient: new MockBackendClient({ threads: [] }),
       overlayStore,
       runtimeInstanceId: "runtime-current",
+      registrySessionId: "registry-current",
       resolveLiveProfileRuntimeInstanceIds: () => [
         "runtime-current",
         "runtime-other",
@@ -34814,13 +34815,14 @@ script = "printf setup"
     expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledOnce();
     expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledWith({
       currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
       liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
       sessionStartedAt: expect.any(Number),
     });
     await registry.close();
   });
 
-  it("stops active task monitors without starting recovery", async () => {
+  it("stops blocked active task monitors without starting recovery", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "turn/interrupt"] },
       models: TEST_TASK_MONITOR_MODELS,
@@ -34831,6 +34833,7 @@ script = "printf setup"
       codexClient,
       overlayStore,
       runtimeInstanceId: "runtime-current",
+      registrySessionId: "registry-current",
       resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
     });
     await registry.publishLocalEvent({
@@ -34863,6 +34866,28 @@ script = "printf setup"
       (delegationResponse as { contentItems: Array<{ text: string }> })
         .contentItems[0]?.text ?? "{}",
     ).monitorId as string;
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "monitor-thread",
+        turnId: "turn-1",
+        callId: "call-2",
+        requestId: "call-2",
+        namespace: "pwragent_task_monitors",
+        tool: "inject_progress",
+        arguments: {
+          monitorId,
+          status: "blocked",
+          message: "Waiting for an external dependency.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "blocked" })],
+    });
     const monitorRecord = (registry as unknown as {
       taskMonitorDelegations: Map<string, { finalizationStarted?: boolean }>;
     }).taskMonitorDelegations.get(monitorId);
@@ -34901,6 +34926,7 @@ script = "printf setup"
           outcome: "cancelled",
           lastMessage: "Stopped by user.",
           ownerRuntimeInstanceId: "runtime-current",
+          ownerRegistrySessionId: "registry-current",
         }),
       ],
     });

--- a/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
@@ -448,6 +448,7 @@ describe("SqliteOverlayStore — orphaned sub-agents", () => {
 
     await expect(store.reconcileOrphanedThreadSubAgents({
       currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
       liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
       sessionStartedAt: 2_000,
     })).resolves.toEqual({
@@ -501,6 +502,77 @@ describe("SqliteOverlayStore — orphaned sub-agents", () => {
     });
   });
 
+  it("repairs a replaced registry without touching another live process", async () => {
+    await seedSubAgent("replaced-registry", {
+      monitorId: "monitor-replaced-registry",
+      task: "Owned by the replaced registry",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-current",
+      ownerRegistrySessionId: "registry-replaced",
+    });
+    await seedSubAgent("current-registry", {
+      monitorId: "monitor-current-registry",
+      task: "Owned by the current registry",
+      status: "running",
+      createdAt: 2_100,
+      updatedAt: 2_200,
+      ownerRuntimeInstanceId: "runtime-current",
+      ownerRegistrySessionId: "registry-current",
+    });
+    await seedSubAgent("other-live-process", {
+      monitorId: "monitor-other-process",
+      task: "Owned by another live process",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-other",
+      ownerRegistrySessionId: "registry-other-replaced",
+    });
+
+    await expect(store.reconcileOrphanedThreadSubAgents({
+      currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
+      liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
+      sessionStartedAt: 2_000,
+    })).resolves.toEqual({
+      repairedSubAgents: 1,
+      repairedThreads: 1,
+      skippedLiveOwners: 2,
+      skippedOwnerlessWithOtherRuntimes: 0,
+    });
+
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "replaced-registry",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          status: "failure",
+          outcome: "failure",
+          ownerRuntimeInstanceId: "runtime-current",
+          ownerRegistrySessionId: "registry-replaced",
+          completionSource: expect.objectContaining({
+            reason: "owner_registry_replaced",
+          }),
+        }),
+      ],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "current-registry",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "other-live-process",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+  });
+
   it("repairs old ownerless work only when this is the sole runtime", async () => {
     await seedSubAgent("thread-1", {
       monitorId: "monitor-old",
@@ -519,6 +591,7 @@ describe("SqliteOverlayStore — orphaned sub-agents", () => {
 
     await expect(store.reconcileOrphanedThreadSubAgents({
       currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
       liveRuntimeInstanceIds: ["runtime-current"],
       sessionStartedAt: 2_000,
     })).resolves.toMatchObject({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6635,6 +6635,7 @@ export class DesktopBackendRegistry {
   >();
   private readonly taskMonitorWatchdogTimer?: NodeJS.Timeout;
   private readonly runtimeInstanceId: string;
+  private readonly registrySessionId: string;
   private readonly resolveLiveProfileRuntimeInstanceIdsFn: () => string[];
   private readonly subAgentStartupReconciliation: Promise<void>;
   /**
@@ -6890,6 +6891,7 @@ export class DesktopBackendRegistry {
     resolveCodexFastAllowed?: () => boolean;
     resolvePdfAnalysisEnabled?: () => boolean;
     runtimeInstanceId?: string;
+    registrySessionId?: string;
     resolveLiveProfileRuntimeInstanceIds?: () => string[];
     acpWorktreeRepositoryResolver?: (
       cwd: string,
@@ -6898,6 +6900,7 @@ export class DesktopBackendRegistry {
     const processRuntimeIdentity = getProcessRuntimeIdentity();
     this.runtimeInstanceId =
       options?.runtimeInstanceId ?? processRuntimeIdentity.instanceId;
+    this.registrySessionId = options?.registrySessionId ?? randomUUID();
     this.resolveLiveProfileRuntimeInstanceIdsFn =
       options?.resolveLiveProfileRuntimeInstanceIds ??
       (() =>
@@ -7336,6 +7339,7 @@ export class DesktopBackendRegistry {
     }
     const result = await reconcile.call(this.overlayStore, {
       currentRuntimeInstanceId: this.runtimeInstanceId,
+      currentRegistrySessionId: this.registrySessionId,
       liveRuntimeInstanceIds,
       sessionStartedAt: this.registrySessionStartedAt,
     });
@@ -13767,7 +13771,7 @@ export class DesktopBackendRegistry {
     if (!subAgent) {
       throw new Error("Sub-agent was not found on this thread.");
     }
-    if (subAgent.status !== "running") {
+    if (subAgent.status !== "running" && subAgent.status !== "blocked") {
       throw new Error("Sub-agent is no longer running.");
     }
     const taskMonitor = this.taskMonitorDelegations.get(params.monitorId);
@@ -20839,6 +20843,8 @@ export class DesktopBackendRegistry {
       updatedAt: now,
       ownerRuntimeInstanceId:
         existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId:
+        existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: "codex",
       monitorThreadId: params.receiverThreadId,
       ...(params.call.parentTurnId
@@ -21135,6 +21141,8 @@ export class DesktopBackendRegistry {
       updatedAt: patch.updatedAt ?? Date.now(),
       ownerRuntimeInstanceId:
         existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId:
+        existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: record.backend,
       preferredModel: record.preferredModel,
       preferredReasoningEffort: record.preferredReasoningEffort,
@@ -21209,6 +21217,8 @@ export class DesktopBackendRegistry {
       updatedAt: patch.updatedAt ?? Date.now(),
       ownerRuntimeInstanceId:
         existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId:
+        existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: record.backend,
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
@@ -22967,6 +22977,9 @@ export class DesktopBackendRegistry {
       ownerRuntimeInstanceId: startsNewAttempt
         ? this.runtimeInstanceId
         : existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId: startsNewAttempt
+        ? this.registrySessionId
+        : existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: params.backend,
       agentName: "PwrAgent",
       ...(preferredModel ? { preferredModel } : {}),

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -536,6 +536,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
    */
   async reconcileOrphanedThreadSubAgents(params: {
     currentRuntimeInstanceId: string;
+    currentRegistrySessionId: string;
     liveRuntimeInstanceIds: string[];
     sessionStartedAt: number;
   }): Promise<{
@@ -599,9 +600,15 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           }
 
           const ownerRuntimeInstanceId = subAgent.ownerRuntimeInstanceId?.trim();
+          const ownerRegistrySessionId = subAgent.ownerRegistrySessionId?.trim();
+          const belongsToReplacedCurrentRegistry =
+            ownerRuntimeInstanceId === params.currentRuntimeInstanceId
+            && Boolean(ownerRegistrySessionId)
+            && ownerRegistrySessionId !== params.currentRegistrySessionId;
           if (
             ownerRuntimeInstanceId
             && liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+            && !belongsToReplacedCurrentRegistry
           ) {
             result.skippedLiveOwners += 1;
             return subAgent;
@@ -625,11 +632,14 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
             outcome: "failure" as const,
             completedAt,
             updatedAt: completedAt,
-            lastMessage:
-              "Interrupted when its owning PwrAgent runtime stopped before reporting completion.",
+            lastMessage: belongsToReplacedCurrentRegistry
+              ? "Interrupted when its owning PwrAgent backend registry was replaced before reporting completion."
+              : "Interrupted when its owning PwrAgent runtime stopped before reporting completion.",
             completionSource: {
               type: "pwragent_fallback" as const,
-              reason: "owner_runtime_stopped",
+              reason: belongsToReplacedCurrentRegistry
+                ? "owner_registry_replaced"
+                : "owner_runtime_stopped",
               recoveryAttempted: false,
               terminalStatus: "failed" as const,
             },

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -204,7 +204,7 @@ export function ActiveSubAgentsStrip(props: {
             const blockedRow = isBlockedSubAgent(subAgent);
             const stopping = stoppingIds.has(subAgent.monitorId);
             const canStop =
-              subAgent.status === "running"
+              (subAgent.status === "running" || blockedRow)
               && Boolean(subAgent.monitorThreadId)
               && Boolean(subAgent.monitorTurnId)
               && Boolean(props.desktopApi?.stopSubAgent);
@@ -246,10 +246,10 @@ export function ActiveSubAgentsStrip(props: {
                     screen reader — and page-wide `name: "Stop"` is the
                     established E2E handle for the composer's stop-the-turn
                     button, which this must not shadow. */}
-                {/* Always rendered, even when empty. A blocked row has no
-                    action, and without a reserved slot its state text slid
-                    right to the edge while every neighbour's stopped short —
-                    the right rail stopped being a column. */}
+                {/* Always rendered, even when empty. A row without a stoppable
+                    monitor turn has no action, and without a reserved slot its
+                    state text slid right to the edge while every neighbour's
+                    stopped short — the right rail stopped being a column. */}
                 <span className="live-strip__item-slot">
                   {failedRow ? (
                     <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -418,6 +418,27 @@ describe("ActiveSubAgentsStrip", () => {
         screen.getByRole("button", { name: "Active sub-agents (1)" }),
       ).toBeInTheDocument();
     });
+
+    it("allows a blocked monitor with an active turn to be stopped", async () => {
+      const stopSubAgent = vi.fn().mockResolvedValue({ ok: true });
+      render(
+        <ActiveSubAgentsStrip
+          desktopApi={{ stopSubAgent } as unknown as DesktopApi}
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "blocked" }),
+          ])}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /^Stop sub-agent:/ }));
+      await waitFor(() => {
+        expect(stopSubAgent).toHaveBeenCalledWith({
+          backend: "codex",
+          threadId: "parent-thread",
+          monitorId: "a",
+        });
+      });
+    });
   });
 
   describe("liveness", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -118,7 +118,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 : undefined;
             const stopping = stoppingIds.has(subAgent.monitorId);
             const canStop =
-              subAgent.status === "running"
+              (subAgent.status === "running" || subAgent.status === "blocked")
               && Boolean(subAgent.monitorThreadId)
               && Boolean(subAgent.monitorTurnId)
               && Boolean(props.desktopApi?.stopSubAgent);

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -92,6 +92,42 @@ describe("SubAgentsPanel", () => {
     expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
   });
 
+  it("allows an active blocked monitor to be stopped", async () => {
+    const activeSubAgent = thread.subAgents?.[0];
+    expect(activeSubAgent).toBeDefined();
+    const stopSubAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "parent-thread",
+      monitorId: "monitor-1",
+      stoppedAt: 1_800_000_000_100,
+    }));
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent } as DesktopApi}
+        thread={{
+          ...thread,
+          subAgents: [
+            {
+              ...activeSubAgent!,
+              status: "blocked",
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(stopSubAgent).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "parent-thread",
+        monitorId: "monitor-1",
+      });
+    });
+  });
+
   it("targets the owning instance when stopping a remote sub-agent", async () => {
     const stopSubAgent = vi.fn(async () => ({
       backend: "codex" as const,

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -264,6 +264,15 @@ export type ThreadSubAgentSummary = {
    * Older summaries omit it and use the conservative sole-runtime fallback.
    */
   ownerRuntimeInstanceId?: string;
+  /**
+   * Backend-registry generation that created this sub-agent attempt.
+   *
+   * A settings-driven registry replacement stays in the same process and
+   * therefore keeps the same runtime UUID. This generation id lets the new
+   * registry retire only work from its replaced predecessor. Other live
+   * processes remain authoritative through ownerRuntimeInstanceId.
+   */
+  ownerRegistrySessionId?: string;
   backend?: AppServerBackendKind;
   agentName?: string;
   preferredModel?: string;


### PR DESCRIPTION
## Summary

- record a backend-registry generation alongside the existing process runtime owner for every new sub-agent attempt
- reconcile work from a replaced same-process registry while preserving work owned by another live PwrAgent process
- allow active blocked task monitors to be stopped from both the backend API and the Sub-agents panel
- add focused overlay-store, backend-registry, and renderer regressions

## Root cause

Settings can dispose and recreate `DesktopBackendRegistry` without restarting Electron. The replacement registry previously reused the process runtime UUID, so persisted work from the disposed registry still appeared to have a live owner even though its clients and in-memory monitor map were gone.

Separately, `inject_progress` can persist `status: "blocked"` while the monitor thread and turn remain active, but both Stop gates accepted only the exact `"running"` status.

## Multi-runtime safety

The new registry generation is evaluated only when the recorded process owner is the current process. A sub-agent owned by another live process remains authoritative even if its generation differs or is unknown. Ownerless legacy records retain the existing conservative sole-runtime fallback.

## Persistence and write behavior

The optional generation id uses the existing thread-overlay JSON. There is no SQLite schema migration and no config change. Reconciliation continues to use the existing one-shot startup transaction; this adds no timer, heartbeat, recurring write, or idle write.

## Provenance

Follow-up to #1603 and the lifecycle review performed while backporting it in #1611.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx` — 532 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors, 35 existing warnings
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `git diff --check`
