### PR TITLE
fix(desktop): backport Windows approval diffs and paths

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -32387,6 +32387,117 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("normalizes file-change approval diffs and omits empty placeholders", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    const unifiedDiff = [
+      "--- /dev/null",
+      "+++ b/breakfasts/croissants/croissants.md",
+      "@@ -0,0 +1,1 @@",
+      "+# Butter Croissants",
+    ].join("\n");
+    const rawWindowsAddContent = [
+      "# Sunny-Side-Up Eggs",
+      "",
+      "Eggs with crisp edges make an easy breakfast.",
+      "",
+    ].join("\n");
+    const normalizedWindowsAddDiff = [
+      "--- /dev/null",
+      "+++ b/breakfasts/eggs/sunny-side-up.md",
+      "@@ -0,0 +1,3 @@",
+      "+# Sunny-Side-Up Eggs",
+      "+",
+      "+Eggs with crisp edges make an easy breakfast.",
+    ].join("\n");
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "file-change-1",
+            type: "fileChange",
+            changes: [
+              {
+                path: "breakfasts/eggs/sunny-side-up.md",
+                kind: { type: "add" },
+                diff: rawWindowsAddContent,
+              },
+              {
+                path: "breakfasts/croissants/croissants.md",
+                kind: { type: "add", content: "" },
+                diff: unifiedDiff,
+              },
+              {
+                path: "breakfasts/pancakes/pancakes.md",
+                kind: { type: "add", content: "" },
+              },
+            ],
+          },
+        },
+      },
+    } as AgentEvent);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/fileChange/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "file-change-1",
+          requestId: "approval-1",
+        },
+      },
+    } as AgentEvent);
+
+    const approval = events.find(
+      (event) => event.notification.method === "item/fileChange/requestApproval",
+    );
+    expect(approval?.notification.params).toMatchObject({
+      _pwragentApprovalContext: {
+        files: [
+          {
+            action: "add",
+            path: "breakfasts/eggs/sunny-side-up.md",
+            diff: normalizedWindowsAddDiff,
+          },
+          {
+            action: "add",
+            path: "breakfasts/croissants/croissants.md",
+            diff: unifiedDiff,
+          },
+          {
+            action: "add",
+            path: "breakfasts/pancakes/pancakes.md",
+          },
+        ],
+      },
+    });
+    const approvalParams = approval?.notification.params as
+      | Record<string, unknown>
+      | undefined;
+    const approvalContext = approvalParams?._pwragentApprovalContext as
+      | { files?: Array<{ diff?: string }> }
+      | undefined;
+    expect(approvalContext?.files?.[2]?.diff).toBeUndefined();
+
+    unsubscribe();
+    await registry.close();
+  });
+
   describe("notification wiring", () => {
     function makeRegistry(): DesktopBackendRegistry {
       return new DesktopBackendRegistry({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -206,6 +206,7 @@ import {
   isThreadSearchSemanticMode,
   type PendingRequestDecision,
   type PendingRequestApprovalContext,
+  normalizeFileChangeApprovalDiff,
   readCodexEnvironmentActionRuns,
   DEFAULT_TASK_MONITOR_MODEL,
   DEFAULT_TASK_MONITOR_POLL_INTERVAL_SECONDS,
@@ -1930,15 +1931,18 @@ function readFileChangeApprovalFile(
     readNonEmptyString(record.kind) ??
     readNonEmptyString(record.action);
   const directDiff =
-    readNonEmptyString(kind?.unified_diff) ??
-    readNonEmptyString(kind?.unifiedDiff) ??
+    readNonEmptyRawString(kind?.unified_diff) ??
+    readNonEmptyRawString(kind?.unifiedDiff) ??
     readFileChangeApprovalDiff(record) ??
     readFileChangeApprovalDiff(kind);
   const content =
     readOptionalString(kind?.content) ?? readOptionalString(record.content);
-  const diff =
-    buildFileChangeApprovalContentDiff({ action, content, filePath }) ??
-    directDiff;
+  const diff = normalizeFileChangeApprovalDiff({
+    action,
+    content,
+    directDiff,
+    path: filePath,
+  });
   return {
     ...(action ? { action } : {}),
     ...(diff ? { diff } : {}),
@@ -1954,40 +1958,18 @@ function readFileChangeApprovalDiff(
     return undefined;
   }
   const direct =
-    readNonEmptyString(record.diff) ??
-    readNonEmptyString(record.patch) ??
-    readNonEmptyString(record.unifiedDiff) ??
-    readNonEmptyString(record.unified_diff);
+    readNonEmptyRawString(record.unified_diff) ??
+    readNonEmptyRawString(record.unifiedDiff) ??
+    readNonEmptyRawString(record.patch) ??
+    readNonEmptyRawString(record.diff);
   if (direct) {
     return direct;
   }
   return readFileChangeApprovalDiff(readRecord(record.diff));
 }
 
-function buildFileChangeApprovalContentDiff(params: {
-  action: string | undefined;
-  content: string | undefined;
-  filePath: string;
-}): string | undefined {
-  if (
-    params.content === undefined ||
-    (params.action !== "add" && params.action !== "delete")
-  ) {
-    return undefined;
-  }
-
-  const lines = params.content.length ? params.content.split("\n") : [];
-  if (lines.at(-1) === "") {
-    lines.pop();
-  }
-  const hunkLineCount = lines.length;
-  const displayPath = params.filePath.replace(/^\/+/, "") || "file";
-  const header =
-    params.action === "add"
-      ? [`--- /dev/null`, `+++ b/${displayPath}`, `@@ -0,0 +1,${hunkLineCount} @@`]
-      : [`--- a/${displayPath}`, `+++ /dev/null`, `@@ -1,${hunkLineCount} +0,0 @@`];
-  const prefix = params.action === "add" ? "+" : "-";
-  return [...header, ...lines.map((line) => `${prefix}${line}`)].join("\n");
+function readNonEmptyRawString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function fileChangeApprovalContextKey(params: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -14,6 +14,7 @@ import type {
   DesktopApplicationDiscoveryCandidate,
   EditGroupCommitState,
 } from "@pwragent/shared";
+import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import { EditorIcon } from "../../icons";
 import { AppIcon } from "../../components/AppIcon";
 import { TranscriptDiff } from "./TranscriptDiff";
@@ -57,12 +58,7 @@ function toRepoRelativePath(
   if (!worktreeRoot) {
     return absolutePath;
   }
-  const root = normalizePath(worktreeRoot).replace(/\/+$/, "");
-  const full = normalizePath(absolutePath);
-  if (full === root) {
-    return absolutePath;
-  }
-  return full.startsWith(`${root}/`) ? full.slice(root.length + 1) : absolutePath;
+  return formatPathRelativeToDirectories(absolutePath, [worktreeRoot]);
 }
 
 type EditedFileGroupListProps = {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -388,6 +388,28 @@ describe("EditedFileRow path + open affordances", () => {
       screen.queryByRole("button", { name: /Open .* in editor/ }),
     ).not.toBeInTheDocument();
   });
+
+  it("shows Windows separators for a Windows worktree", () => {
+    const windowsGroup: EditedFileGroup = {
+      ...fileGroup,
+      details: [
+        {
+          ...fileGroup.details[0],
+          path: "C:/repo/apps/desktop/Foo.ts",
+        },
+      ],
+    };
+    render(
+      <EditedFileGroupList
+        groups={[windowsGroup]}
+        worktreeRoot={"C:\\repo"}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Foo\.ts/ }));
+
+    expect(screen.getByText("apps\\desktop\\Foo.ts")).toBeInTheDocument();
+  });
 });
 
 describe("EditedFileViewToggle", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3466,6 +3466,79 @@ Implementation notes remain in a readable bubble.`;
     expect(screen.getByText(/new dumb sentence/)).toBeInTheDocument();
   });
 
+  it("does not render an empty diff disclosure for a placeholder file add", () => {
+    render(
+      <TranscriptList
+        directoryPaths={["C:\\repo\\pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            changes: [
+              {
+                path: "breakfasts/eggs/sunny-side-up.md",
+                kind: {
+                  type: "add",
+                  content: "",
+                },
+              },
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(
+      screen.getByText(/File: breakfasts\\eggs\\sunny-side-up\.md/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /diff/ })).not.toBeInTheDocument();
+  });
+
+  it("renders raw Codex Windows Markdown lists as added lines", () => {
+    render(
+      <TranscriptList
+        directoryPaths={["C:\\repo\\pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            changes: [
+              {
+                path: "C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
+                kind: { type: "add" },
+                diff: [
+                  "- Fry the eggs until their edges are crisp.",
+                  "- Serve with toast.",
+                  "",
+                ].join("\n"),
+              },
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(
+      screen.getByText(/File: breakfasts\\eggs\\sunny-side-up\.md/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Hide diff.*\+2.*-0/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Fry the eggs until their edges are crisp/)).toBeInTheDocument();
+  });
+
   it("shows file-change approval context inferred from the matching activity", () => {
     render(
       <TranscriptList

--- a/packages/shared/src/__tests__/path-display.test.ts
+++ b/packages/shared/src/__tests__/path-display.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { formatPathRelativeToDirectories } from "../path-display";
+
+describe("formatPathRelativeToDirectories", () => {
+  it("uses the longest matching directory on a path-component boundary", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "/repo/worktrees/pwragent/apps/desktop/src/main.ts",
+        ["/repo", "/repo/worktrees/pwragent"],
+      ),
+    ).toBe("apps/desktop/src/main.ts");
+    expect(
+      formatPathRelativeToDirectories(
+        "/repo-other/apps/desktop/src/main.ts",
+        ["/repo"],
+      ),
+    ).toBe("/repo-other/apps/desktop/src/main.ts");
+  });
+
+  it("matches Windows paths and preserves their separators", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "C:\\repo\\worktree\\apps\\desktop\\src\\main.ts",
+        ["c:\\repo", "C:\\repo\\worktree\\"],
+      ),
+    ).toBe("apps\\desktop\\src\\main.ts");
+    expect(
+      formatPathRelativeToDirectories(
+        "C:\\repo-other\\apps\\desktop\\src\\main.ts",
+        ["c:\\repo"],
+      ),
+    ).toBe("C:\\repo-other\\apps\\desktop\\src\\main.ts");
+  });
+
+  it("uses Windows separators for protocol paths under a Windows directory", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "C:/repo/worktree/apps/desktop/src/main.ts",
+        ["C:\\repo\\worktree"],
+      ),
+    ).toBe("apps\\desktop\\src\\main.ts");
+    expect(
+      formatPathRelativeToDirectories(
+        "breakfasts/eggs/sunny-side-up.md",
+        ["C:\\repo\\worktree"],
+      ),
+    ).toBe("breakfasts\\eggs\\sunny-side-up.md");
+  });
+
+  it("matches UNC paths and preserves their separators", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "\\\\server\\share\\repo\\apps\\desktop\\src\\main.ts",
+        ["\\\\server\\share\\repo"],
+      ),
+    ).toBe("apps\\desktop\\src\\main.ts");
+    expect(
+      formatPathRelativeToDirectories(
+        "\\\\server\\share\\other\\apps\\desktop\\src\\main.ts",
+        ["\\\\server\\share\\repo"],
+      ),
+    ).toBe("\\\\server\\share\\other\\apps\\desktop\\src\\main.ts");
+  });
+
+  it("leaves POSIX relative paths unchanged when no Windows directory is known", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "apps/desktop/src/main.ts",
+        ["/repo/worktree"],
+      ),
+    ).toBe("apps/desktop/src/main.ts");
+  });
+});

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -507,4 +507,41 @@ describe("buildPendingRequestApprovalContext", () => {
       ],
     });
   });
+
+  it("normalizes raw Codex Windows add contents into a unified diff", () => {
+    const request = createRequest({
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        changes: [
+          {
+            path: "C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
+            kind: { type: "add" },
+            diff: [
+              "- Fry the eggs until their edges are crisp.",
+              "- Serve with toast.",
+              "",
+            ].join("\r\n"),
+          },
+        ],
+      },
+    });
+
+    expect(
+      buildPendingRequestApprovalContext(request, {
+        directoryPaths: ["C:\\repo\\pwragent"],
+      }),
+    ).toMatchObject({
+      action: "add",
+      displayPath: "breakfasts\\eggs\\sunny-side-up.md",
+      diff: [
+        "--- /dev/null",
+        "+++ b/C:\\repo\\pwragent\\breakfasts\\eggs\\sunny-side-up.md",
+        "@@ -0,0 +1,2 @@",
+        "+- Fry the eggs until their edges are crisp.",
+        "+- Serve with toast.",
+      ].join("\n"),
+    });
+  });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,7 @@ export * from "./directory-navigation";
 export * from "./inbox";
 export * from "./navigation-state";
 export * from "./pending-request-response";
+export * from "./path-display";
 export * from "./renderer-payload-boundary";
 export * from "./review-branches";
 export * from "./subthreads";

--- a/packages/shared/src/path-display.ts
+++ b/packages/shared/src/path-display.ts
@@ -1,0 +1,81 @@
+type NormalizedDirectoryPath = {
+  caseInsensitive: boolean;
+  normalized: string;
+  separator: "/" | "\\";
+};
+
+/**
+ * Display an absolute path relative to the longest known directory that
+ * contains it. Relative paths use the separator style of a known Windows
+ * directory; absolute paths outside the known directories are unchanged.
+ */
+export function formatPathRelativeToDirectories(
+  value: string,
+  directoryPaths: string[] | undefined,
+): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const normalizedValue = normalizePath(trimmed);
+  const valueIsWindowsPath = isWindowsPath(trimmed);
+  const roots = [...(directoryPaths ?? [])]
+    .map((root): NormalizedDirectoryPath => ({
+      caseInsensitive: valueIsWindowsPath || isWindowsPath(root),
+      normalized: normalizePath(root),
+      separator: isWindowsPath(root) ? "\\" : "/",
+    }))
+    .filter((root) => Boolean(root.normalized))
+    .sort((left, right) => right.normalized.length - left.normalized.length);
+
+  for (const root of roots) {
+    const comparisonValue = root.caseInsensitive
+      ? normalizedValue.toLowerCase()
+      : normalizedValue;
+    const comparisonRoot = root.caseInsensitive
+      ? root.normalized.toLowerCase()
+      : root.normalized;
+    if (comparisonValue === comparisonRoot) {
+      return ".";
+    }
+    const isContained = comparisonRoot === "/"
+      ? comparisonValue.startsWith("/")
+      : comparisonValue.startsWith(`${comparisonRoot}/`);
+    if (isContained) {
+      const relativeStart = comparisonRoot === "/" ? 1 : root.normalized.length + 1;
+      return formatSeparators(
+        normalizedValue.slice(relativeStart) || ".",
+        root.separator,
+      );
+    }
+  }
+
+  if (!isAbsolutePath(trimmed)) {
+    const windowsRoot = roots.find((root) => root.separator === "\\");
+    if (windowsRoot) {
+      return formatSeparators(trimmed, windowsRoot.separator);
+    }
+  }
+
+  return trimmed;
+}
+
+function formatSeparators(value: string, separator: "/" | "\\"): string {
+  return separator === "\\" ? value.replace(/\//g, "\\") : value;
+}
+
+function isAbsolutePath(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("/") || isWindowsPath(trimmed);
+}
+
+function isWindowsPath(value: string): boolean {
+  const trimmed = value.trim();
+  return /^[a-z]:[\\/]/i.test(trimmed) || /^\\\\/.test(trimmed);
+}
+
+function normalizePath(value: string): string {
+  const normalized = value.trim().replace(/\\/g, "/");
+  return normalized.length > 1 ? normalized.replace(/\/+$/, "") : normalized;
+}

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -5,6 +5,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadFileDiffRef,
 } from "./contracts/normalized-app-server";
+import { formatPathRelativeToDirectories } from "./path-display";
 
 export type PendingRequestDecision = "approve" | "decline" | "cancel";
 export type PendingRequestActionDecision =
@@ -215,12 +216,22 @@ function fileContextFromApprovalRecord(
     readFirstString(kind ?? {}, ["type", "action", "operation"]) ??
     readFirstString(record, ["action", "operation", "kind", "type"]);
   const directDiff =
-    readFirstString(kind ?? {}, ["diff", "patch", "unifiedDiff", "unified_diff"]) ??
-    readFirstString(record, ["diff", "patch", "unifiedDiff", "unified_diff"]);
+    readFirstNonEmptyRawString(
+      kind ?? {},
+      ["unifiedDiff", "unified_diff", "patch", "diff"],
+    ) ??
+    readFirstNonEmptyRawString(
+      record,
+      ["unifiedDiff", "unified_diff", "patch", "diff"],
+    );
   const content =
     readOptionalString(kind?.content) ?? readOptionalString(record.content);
-  const generatedDiff =
-    directDiff ?? contentDiffForApproval({ action, content, path });
+  const generatedDiff = normalizeFileChangeApprovalDiff({
+    action,
+    content,
+    directDiff,
+    path,
+  });
 
   return {
     ...(action ? { action } : {}),
@@ -243,29 +254,60 @@ function fileContextFromApprovalRecord(
   };
 }
 
-function contentDiffForApproval(params: {
+export function normalizeFileChangeApprovalDiff(params: {
   action: string | undefined;
   content: string | undefined;
+  directDiff: string | undefined;
   path: string;
 }): string | undefined {
   if (
-    params.content === undefined ||
+    params.directDiff
+    && (
+      (params.action !== "add" && params.action !== "delete")
+      || looksLikeUnifiedDiff(params.directDiff)
+    )
+  ) {
+    return params.directDiff;
+  }
+  const content = params.directDiff ?? params.content;
+  if (
+    content === undefined ||
     (params.action !== "add" && params.action !== "delete")
   ) {
     return undefined;
   }
   const path = params.path.replace(/^\/+/, "") || "file";
-  const lines = params.content.length ? params.content.split("\n") : [];
+  const lines = content.length ? content.split(/\r?\n/) : [];
   if (lines.at(-1) === "") {
     lines.pop();
   }
   const hunkLineCount = lines.length;
+  if (hunkLineCount === 0) {
+    return undefined;
+  }
   const header =
     params.action === "add"
       ? [`--- /dev/null`, `+++ b/${path}`, `@@ -0,0 +1,${hunkLineCount} @@`]
       : [`--- a/${path}`, `+++ /dev/null`, `@@ -1,${hunkLineCount} +0,0 @@`];
   const prefix = params.action === "add" ? "+" : "-";
   return [...header, ...lines.map((line) => `${prefix}${line}`)].join("\n");
+}
+
+function looksLikeUnifiedDiff(value: string): boolean {
+  const lines = value.split(/\r?\n/);
+  if (
+    lines.some(
+      (line) =>
+        /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(?: |$)/.test(line)
+        || /^@@@ (?:-\d+(?:,\d+)? ){2,}\+\d+(?:,\d+)? @@@(?: |$)/.test(line),
+    )
+  ) {
+    return true;
+  }
+  return lines.some(
+    (line, index) =>
+      line.startsWith("--- ") && lines[index + 1]?.startsWith("+++ "),
+  );
 }
 
 function activityMatchesItem(
@@ -325,27 +367,7 @@ export function formatApprovalPath(
   value: string,
   directoryPaths: string[] | undefined,
 ): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  const roots = [...(directoryPaths ?? [])]
-    .map((root) => normalizePath(root))
-    .filter(Boolean)
-    .sort((left, right) => right.length - left.length);
-  const normalizedValue = normalizePath(trimmed);
-
-  for (const root of roots) {
-    if (normalizedValue === root) {
-      return ".";
-    }
-    if (normalizedValue.startsWith(`${root}/`)) {
-      return normalizedValue.slice(root.length + 1) || ".";
-    }
-  }
-
-  return trimmed;
+  return formatPathRelativeToDirectories(value, directoryPaths);
 }
 
 export function buildPendingRequestResponse(
@@ -938,13 +960,21 @@ function readFirstString(
   return undefined;
 }
 
+function readFirstNonEmptyRawString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
-}
-
-function normalizePath(value: string): string {
-  const normalized = value.trim().replace(/\\/g, "/");
-  return normalized.length > 1 ? normalized.replace(/\/+$/, "") : normalized;
 }


### PR DESCRIPTION
## Summary

Backport [#1598](https://github.com/pwrdrvr/PwrAgent/pull/1598) to `releases/1.0`.

Source squash: `3216d73e46980f2cca1c3cdce878233e47270c4e`

- Prefer the real unified diff over an empty streamed `content` placeholder in file-change approval events.
- Suppress empty synthetic add/delete diffs so approval cards do not render misleading `+0 -0` disclosures.
- Render protocol-provided relative paths with Windows separators when the thread/worktree is on Windows.
- Reuse the shared path formatter in the Edits panel.

## Why

On Windows, a file-change approval could contain both a real diff and an empty `content` placeholder. The desktop event bus synthesized a zero-line diff from the placeholder before considering the real diff, producing one expanded `Hide diff +0 -0` control per file. Separately, renderer path formatting normalized Edits-panel paths to forward slashes, and relative protocol paths retained POSIX separators even when the known worktree was a Windows path.

## Adaptations for 1.0

- `packages/shared/src/path-display.ts` did not exist on `releases/1.0` (it landed later via #1204). This backport adds the presentation-only formatter plus the #1598 Windows-separator behavior and points `formatApprovalPath` at it.
- The backend-registry focused test uses public `publishLocalEvent` instead of the private `emit` helper from main.
- No Federation, Star Map, Automations, or Attention code is included. No DB/schema migration or config-shape change.

## User impact

Approval cards now show real proposed changes when supplied and omit empty diff controls when no preview exists. App-rendered approval and Edits-panel paths follow Windows separator conventions. Agent-authored Markdown is not rewritten.

## Validation

- `pnpm test packages/shared/src/__tests__/path-display.test.ts packages/shared/src/__tests__/pending-request-response.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` (111 passed)
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "normalizes file-change approval diffs and omits empty placeholders"` (1 passed, 412 skipped)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; 135 existing warnings)
- `pnpm lint:boundaries` (no dependency violations)

## Notes

- Path formatting is presentation-only.
- Real unified diffs still take precedence. Empty-file add/delete cards remain visible without a misleading `+0 -0` disclosure. Non-add/delete malformed payloads keep their raw diagnostic text.