### PR TITLE
fix(desktop): move approval CTA into thread header

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -56,8 +56,13 @@ async function openApprovalPendingReplay() {
     pendingApproval.locator("pre code")
   ).toHaveText(approvalCommand);
   await expect(
-    app.window.getByText("Waiting for approval before this turn can continue.")
+    app.window
+      .locator(".thread-header")
+      .getByText("Waiting for approval", { exact: true })
   ).toBeVisible();
+  await expect(
+    app.window.getByText("Waiting for approval before this turn can continue.")
+  ).toHaveCount(0);
   await expect(
     app.window.getByRole("button", { name: "Approve Once" })
   ).toBeVisible();
@@ -120,7 +125,9 @@ test("dismisses the pending approval UI after approval", async () => {
       app.window.getByRole("group", { name: "Pending approval" })
     ).toHaveCount(0);
     await expect(
-      app.window.getByText("Waiting for approval before this turn can continue.")
+      app.window
+        .locator(".thread-header")
+        .getByText("Waiting for approval", { exact: true })
     ).toHaveCount(0);
     await expect(
       app.window.getByRole("button", { name: "Decline" })

--- a/apps/desktop/e2e/fixtures/approval-pending/capture-recipe.md
+++ b/apps/desktop/e2e/fixtures/approval-pending/capture-recipe.md
@@ -6,7 +6,7 @@ Capture a live Codex thread that reaches a pending approval request so replay
 tests can assert both of these user-visible states:
 
 - transcript approval block with `Approval needed`
-- composer copy that says `Waiting for approval before this turn can continue.`
+- thread-header chip that says `Waiting for approval`
 
 ## Backend and Mode
 
@@ -38,7 +38,7 @@ pnpm dev
 6. Wait for all of these cues:
    - the transcript shows a pending approval group
    - the transcript includes the `Approval needed` chip
-   - the composer shows `Waiting for approval before this turn can continue.`
+   - the thread header shows the `Waiting for approval` chip
 7. Do not approve, decline, or cancel the request.
 8. Open the context rail and record the thread id before closing the app or
    exporting the capture.
@@ -57,7 +57,7 @@ for approval. Do not let the turn continue past the pending request.
 - Expected replay assertion surface:
   - `Pending approval` group is visible
   - approval prompt text is visible
-  - composer remains in waiting state
+  - thread-header approval chip is visible
 
 ## Promotion Commands
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -12074,11 +12074,7 @@ export function Composer(props: ComposerProps) {
             ? "This backend is unavailable right now. Your draft stays here until send is available again."
             : "This thread's backend is unavailable right now. You can keep drafting, but send is unavailable."}
         </p>
-      ) : props.pendingRequestActive ? (
-        <p className="composer__meta">
-          Waiting for approval before this turn can continue.
-        </p>
-      ) : props.pendingUserInputActive ? (
+      ) : !props.pendingRequestActive && props.pendingUserInputActive ? (
         <p className="composer__meta">
           Waiting for input before this turn can continue.
         </p>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -43,6 +43,7 @@ export type StarMapToggleControls = {
 
 type ThreadHeaderProps = {
   desktopApi?: DesktopApi;
+  hasApprovalRequest?: boolean;
   projectLabel?: string;
   thread: NavigationThreadSummary;
   backends?: BackendSummary[];
@@ -173,6 +174,14 @@ export function ThreadHeader(props: ThreadHeaderProps) {
             <span className="chip chip--backend">
               {formatBackendLabel(props.thread.source)}
             </span>
+            {props.hasApprovalRequest ? (
+              <span
+                aria-label="Waiting for approval"
+                className="thread-row__chip thread-row__chip--approval"
+              >
+                Waiting for approval
+              </span>
+            ) : null}
             {props.thread.agent ? (
               <span className="chip chip--mode" title={formatThreadAgentTitle(props.thread)}>
                 Agent: {props.thread.agent.name}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3111,6 +3111,7 @@ export function ThreadView(props: ThreadViewProps) {
     >
       <ThreadHeader
         desktopApi={props.desktopApi}
+        hasApprovalRequest={Boolean(props.pendingRequest)}
         projectLabel={
           props.selectedDirectory?.label
           // A remote-pinned thread whose project has no local counterpart

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
@@ -68,6 +68,19 @@ describe("ThreadHeader", () => {
     expect(chip).toHaveAttribute("title", "Inbox Triage, 1 instruction line");
   });
 
+  it("shows the approval CTA beside the thread title", () => {
+    render(
+      <ThreadHeader
+        hasApprovalRequest
+        thread={thread}
+      />,
+    );
+
+    expect(screen.getByText("Waiting for approval", { exact: true })).toHaveClass(
+      "thread-row__chip--approval",
+    );
+  });
+
   it("renders the terminal toggle as an icon-only affordance with a tooltip", () => {
     render(
       <ThreadHeader

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -5017,7 +5017,12 @@ describe("ThreadView", () => {
     );
 
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
-    expect(screen.getByText("Waiting for approval")).toBeInTheDocument();
+    expect(
+      within(document.querySelector(".thread-header")!).getByText(
+        "Waiting for approval",
+        { exact: true },
+      ),
+    ).toBeInTheDocument();
 
     rerender(
       <ThreadView
@@ -5089,6 +5094,12 @@ describe("ThreadView", () => {
 
     expect(
       screen.queryByRole("group", { name: "Pending approval" })
+    ).not.toBeInTheDocument();
+    expect(
+      within(document.querySelector(".thread-header")!).queryByText(
+        "Waiting for approval",
+        { exact: true },
+      ),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Thinking")).toBeInTheDocument();
     expect(screen.getByText("The request was handled.")).toBeInTheDocument();


### PR DESCRIPTION
## What changed

- Show the existing **Waiting for approval** CTA chip in the open thread header whenever an approval request is pending.
- Remove the redundant approval sentence from the composer metadata area so it no longer adds a full row beneath the controls.
- Update renderer and replay-backed E2E coverage, including chip dismissal after approval or resumed assistant output.

## Why

The pending approval state was rendered as a full-width composer metadata row even though the same state already had a compact CTA chip in the sidebar. That consumed scarce composer space and disappeared as a signal when the sidebar was hidden.

The header now carries the compact signal at all times, independent of sidebar visibility, while the transcript approval card remains the place where the operator acts.

## Validation

- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
- pnpm --filter @pwragent/desktop test:e2e e2e/approval-pending.spec.ts
- pnpm lint:eslint
- pnpm typecheck
- pnpm lint:colors
- pnpm lint:boundaries