### PR TITLE
fix(desktop): wait for terminated env process trees

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -85,6 +85,26 @@ describe("codex environment runtime", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("does not throw when the command is already gone at the timeout boundary", async () => {
+    await expect(
+      waitForCodexEnvironmentDetachedCommandGone({
+        runId: "missing-run",
+        timeoutMs: 0,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws at the timeout boundary only when a tracked pid is still alive", async () => {
+    await expect(
+      waitForCodexEnvironmentDetachedCommandGone({
+        knownPids: [process.pid],
+        pid: process.pid,
+        runId: "missing-run",
+        timeoutMs: 0,
+      }),
+    ).rejects.toThrow(/did not exit within 0ms/);
+  });
+
   it("rejects detached actions with a clear missing-cwd error before spawn", async () => {
     await expect(
       startLocalCodexEnvironmentAction({

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -10,7 +10,9 @@ import {
   listRunningDetachedCommands,
   startLocalCodexEnvironmentAction,
   stopCodexEnvironmentDetachedCommand,
+  waitForCodexEnvironmentDetachedCommandGone,
 } from "../app-server/codex-environment-runtime";
+import { collectProcessTreeIds } from "../process-tree";
 import { WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS } from "../windows-job-wrapper";
 import { resolveWindowsBashShell } from "../windows-shell";
 
@@ -72,6 +74,15 @@ const DETACHED_ACTION_TEST_TIMEOUT_MS = isWindows ? 30_000 : 15_000;
 describe("codex environment runtime", () => {
   afterEach(() => {
     mainLogEntries.length = 0;
+  });
+
+  it("treats a missing detached command as already gone", async () => {
+    await expect(
+      waitForCodexEnvironmentDetachedCommandGone({
+        runId: "missing-run",
+        timeoutMs: 200,
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("rejects detached actions with a clear missing-cwd error before spawn", async () => {
@@ -259,8 +270,8 @@ describe("codex environment runtime", () => {
   it("counts an auto-started environment action as a quit blocker", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-auto-"));
     const runId = "test-run-auto";
-    let detachedExited = false;
     let registeredPid: number | undefined;
+    let knownPids: number[] = [];
     try {
       await applyLocalCodexEnvironmentSelection({
         cwd: root,
@@ -269,9 +280,6 @@ describe("codex environment runtime", () => {
         // owner arrives without a thread id.
         owner: { backend: "codex" },
         env: { ...process.env, SHELL: spawnableShell("/bin/sh") },
-        onActionDetachedExit: () => {
-          detachedExited = true;
-        },
         selection: {
           executionTarget: "local",
           runSetup: false,
@@ -313,6 +321,9 @@ describe("codex environment runtime", () => {
         }),
       ]);
       registeredPid = running[0]?.pid;
+      // Snapshot before terminate. Windows reparents Job grandchildren after
+      // the PowerShell launcher dies, so a later parent walk cannot find them.
+      knownPids = registeredPid ? collectProcessTreeIds(registeredPid) : [];
 
       // The thread now exists; the run gets its owner and becomes linkable.
       attachDetachedCommandThreadId(runId, "thread-1");
@@ -320,13 +331,12 @@ describe("codex environment runtime", () => {
     } finally {
       const stopResult = stopCodexEnvironmentDetachedCommand(runId, "terminate");
       if (stopResult.found && !stopResult.alreadyClosed) {
-        await expectEventually(async () => {
-          if (!detachedExited) {
-            throw new Error(
-              `Detached action ${String(registeredPid)} did not exit within 5000ms: ${JSON.stringify(mainLogEntries)}`,
-            );
-          }
-        }, 5_000);
+        await waitForCodexEnvironmentDetachedCommandGone({
+          knownPids,
+          pid: registeredPid,
+          runId,
+          timeoutMs: 5_000,
+        });
       }
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -95,14 +96,27 @@ describe("codex environment runtime", () => {
   });
 
   it("throws at the timeout boundary only when a tracked pid is still alive", async () => {
-    await expect(
-      waitForCodexEnvironmentDetachedCommandGone({
-        knownPids: [process.pid],
-        pid: process.pid,
-        runId: "missing-run",
-        timeoutMs: 0,
-      }),
-    ).rejects.toThrow(/did not exit within 0ms/);
+    // Use a leaf child. process.pid on Windows desktop-main is the Vitest
+    // worker; collecting that tree does a CIM query per descendant and
+    // overruns the 30s test timeout before timeoutMs: 0 can throw.
+    const child = spawn(
+      process.execPath,
+      ["-e", "setInterval(() => undefined, 1000)"],
+      { stdio: "ignore" },
+    );
+    try {
+      expect(child.pid).toEqual(expect.any(Number));
+      await expect(
+        waitForCodexEnvironmentDetachedCommandGone({
+          knownPids: [child.pid!],
+          pid: child.pid,
+          runId: "missing-run",
+          timeoutMs: 0,
+        }),
+      ).rejects.toThrow(/did not exit within 0ms/);
+    } finally {
+      child.kill("SIGKILL");
+    }
   });
 
   it("rejects detached actions with a clear missing-cwd error before spawn", async () => {

--- a/apps/desktop/src/main/__tests__/process-tree.test.ts
+++ b/apps/desktop/src/main/__tests__/process-tree.test.ts
@@ -1,7 +1,12 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { describe, expect, it } from "vitest";
-import { terminateOwnedProcessTree } from "../process-tree";
+import {
+  collectProcessTreeIds,
+  isProcessIdAlive,
+  terminateOwnedProcessTree,
+  waitForProcessTreeGone,
+} from "../process-tree";
 
 const posixOnly = process.platform === "win32" ? it.skip : it;
 
@@ -35,5 +40,36 @@ describe("terminateOwnedProcessTree", () => {
         // The expected path already terminated the entire process group.
       }
     }
+  });
+});
+
+describe("waitForProcessTreeGone", () => {
+  it("treats a missing pid as already gone", async () => {
+    await expect(
+      waitForProcessTreeGone({ rootPid: 0, timeoutMs: 50 }),
+    ).resolves.toBe(true);
+  });
+
+  it("waits until a killed process and its snapshot pids are gone", async () => {
+    const child = spawn(
+      process.execPath,
+      ["-e", "setInterval(() => undefined, 1000)"],
+      { stdio: "ignore" },
+    );
+    const pid = child.pid;
+    expect(pid).toEqual(expect.any(Number));
+    const knownPids = collectProcessTreeIds(pid!);
+    expect(knownPids).toContain(pid);
+    expect(isProcessIdAlive(pid!)).toBe(true);
+
+    child.kill("SIGKILL");
+    await expect(
+      waitForProcessTreeGone({
+        knownPids,
+        rootPid: pid,
+        timeoutMs: 2_000,
+      }),
+    ).resolves.toBe(true);
+    expect(isProcessIdAlive(pid!)).toBe(false);
   });
 });

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -311,22 +311,37 @@ export async function waitForCodexEnvironmentDetachedCommandGone(
 ): Promise<void> {
   const timeoutMs = params.timeoutMs ?? 5_000;
   const startedAt = Date.now();
+  const remainingMs = () => timeoutMs - (Date.now() - startedAt);
   const tracked = new Set<number>(
     [...(params.knownPids ?? [])].filter(
       (pid) => Number.isInteger(pid) && pid > 0,
     ),
   );
-  if (params.pid) {
-    for (const pid of collectProcessTreeIds(params.pid)) {
-      tracked.add(pid);
-    }
+  if (params.pid && Number.isInteger(params.pid) && params.pid > 0) {
+    tracked.add(params.pid);
   }
 
+  const snapshot = () => {
+    const entry = detachedCommandProcesses.get(params.runId);
+    return {
+      closed: !entry || entry.closed(),
+      alive: [...tracked].filter((pid) => isProcessIdAlive(pid)),
+    };
+  };
+
   while (true) {
-    for (const pid of [...tracked]) {
-      if (isProcessIdAlive(pid)) {
-        for (const childPid of collectProcessTreeIds(pid)) {
-          tracked.add(childPid);
+    // Expand only while budget remains. A 5s CIM walk per live pid would
+    // otherwise ignore timeoutMs (including 0) and hang Windows CI when the
+    // tracked root is a busy process with many descendants.
+    if (remainingMs() > 0) {
+      for (const pid of [...tracked]) {
+        if (remainingMs() <= 0) {
+          break;
+        }
+        if (isProcessIdAlive(pid)) {
+          for (const childPid of collectProcessTreeIds(pid)) {
+            tracked.add(childPid);
+          }
         }
       }
     }
@@ -336,13 +351,11 @@ export async function waitForCodexEnvironmentDetachedCommandGone(
       setImmediate(resolve);
     });
 
-    const entry = detachedCommandProcesses.get(params.runId);
-    const closed = !entry || entry.closed();
-    const alive = [...tracked].filter((pid) => isProcessIdAlive(pid));
+    const { closed, alive } = snapshot();
     if (closed && alive.length === 0) {
       return;
     }
-    if (Date.now() - startedAt >= timeoutMs) {
+    if (remainingMs() <= 0) {
       throw new Error(
         `Detached environment command ${params.runId} did not exit within ${timeoutMs}ms`
           + ` (closed=${closed}, alive=[${alive.join(", ")}], pid=${String(params.pid)})`,

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -24,6 +24,10 @@ import {
 import { getMainLogger } from "../log";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import {
+  collectProcessTreeIds,
+  isProcessIdAlive,
+} from "../process-tree";
+import {
   formatWindowsJobStartupTelemetry,
   formatWindowsJobStartupTimeout,
   readWindowsJobStartupTelemetry,
@@ -288,6 +292,61 @@ export type CodexEnvironmentDetachedCommandStopResult = {
   found: boolean;
   alreadyClosed: boolean;
 };
+
+export type CodexEnvironmentDetachedCommandGoneParams = {
+  knownPids?: Iterable<number>;
+  pid?: number;
+  runId: string;
+  timeoutMs?: number;
+};
+
+/**
+ * After `stop`/`terminate`, wait for the Node close bit AND the OS process
+ * tree to die. `taskkill /T /F` returning 0 and `child.kill` on the Windows
+ * Job PowerShell launcher both race handle release; callers that `rm` the
+ * action cwd must wait here first.
+ */
+export async function waitForCodexEnvironmentDetachedCommandGone(
+  params: CodexEnvironmentDetachedCommandGoneParams,
+): Promise<void> {
+  const timeoutMs = params.timeoutMs ?? 5_000;
+  const startedAt = Date.now();
+  const tracked = new Set<number>(
+    [...(params.knownPids ?? [])].filter(
+      (pid) => Number.isInteger(pid) && pid > 0,
+    ),
+  );
+  if (params.pid) {
+    for (const pid of collectProcessTreeIds(params.pid)) {
+      tracked.add(pid);
+    }
+  }
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const entry = detachedCommandProcesses.get(params.runId);
+    const closed = !entry || entry.closed();
+    for (const pid of [...tracked]) {
+      if (isProcessIdAlive(pid)) {
+        for (const childPid of collectProcessTreeIds(pid)) {
+          tracked.add(childPid);
+        }
+      }
+    }
+    const alive = [...tracked].filter((pid) => isProcessIdAlive(pid));
+    if (closed && alive.length === 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  const entry = detachedCommandProcesses.get(params.runId);
+  const closed = !entry || entry.closed();
+  const alive = [...tracked].filter((pid) => isProcessIdAlive(pid));
+  throw new Error(
+    `Detached environment command ${params.runId} did not exit within ${timeoutMs}ms`
+      + ` (closed=${closed}, alive=[${alive.join(", ")}], pid=${String(params.pid)})`,
+  );
+}
 
 export function stopCodexEnvironmentDetachedCommand(
   terminationKey: string,

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -322,9 +322,7 @@ export async function waitForCodexEnvironmentDetachedCommandGone(
     }
   }
 
-  while (Date.now() - startedAt < timeoutMs) {
-    const entry = detachedCommandProcesses.get(params.runId);
-    const closed = !entry || entry.closed();
+  while (true) {
     for (const pid of [...tracked]) {
       if (isProcessIdAlive(pid)) {
         for (const childPid of collectProcessTreeIds(pid)) {
@@ -332,20 +330,26 @@ export async function waitForCodexEnvironmentDetachedCommandGone(
         }
       }
     }
+    // Blocking CIM walks stall the event loop, so a close handler queued
+    // during the walk cannot run until we yield.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    const entry = detachedCommandProcesses.get(params.runId);
+    const closed = !entry || entry.closed();
     const alive = [...tracked].filter((pid) => isProcessIdAlive(pid));
     if (closed && alive.length === 0) {
       return;
     }
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(
+        `Detached environment command ${params.runId} did not exit within ${timeoutMs}ms`
+          + ` (closed=${closed}, alive=[${alive.join(", ")}], pid=${String(params.pid)})`,
+      );
+    }
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
-
-  const entry = detachedCommandProcesses.get(params.runId);
-  const closed = !entry || entry.closed();
-  const alive = [...tracked].filter((pid) => isProcessIdAlive(pid));
-  throw new Error(
-    `Detached environment command ${params.runId} did not exit within ${timeoutMs}ms`
-      + ` (closed=${closed}, alive=[${alive.join(", ")}], pid=${String(params.pid)})`,
-  );
 }
 
 export function stopCodexEnvironmentDetachedCommand(

--- a/apps/desktop/src/main/process-tree.ts
+++ b/apps/desktop/src/main/process-tree.ts
@@ -19,6 +19,100 @@ export type ProcessTreeTerminationOptions = {
   forceTimeoutMs: number;
 };
 
+export type ProcessTreeWaitOptions = {
+  knownPids?: Iterable<number>;
+  pollIntervalMs?: number;
+  rootPid?: number;
+  timeoutMs?: number;
+};
+
+export function isProcessIdAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Snapshot a process and its current descendants. Call this before kill:
+ * Windows reparents grandchildren (sleep.exe) after the PowerShell/Job
+ * launcher dies, so later parent walks cannot find them.
+ */
+export function collectProcessTreeIds(rootPid: number): number[] {
+  const tracked = new Set<number>();
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
+    return [];
+  }
+  tracked.add(rootPid);
+  if (process.platform !== "win32") {
+    return [...tracked];
+  }
+
+  let added = true;
+  while (added) {
+    added = false;
+    for (const pid of [...tracked]) {
+      if (!isProcessIdAlive(pid)) {
+        continue;
+      }
+      for (const childPid of listWindowsChildProcessIds(pid)) {
+        if (!tracked.has(childPid)) {
+          tracked.add(childPid);
+          added = true;
+        }
+      }
+    }
+  }
+  return [...tracked];
+}
+
+/**
+ * Wait until the root pid and every previously observed descendant are gone.
+ * `taskkill /T /F` returning 0 is not enough: the Windows Job path
+ * `child.kill`s the PowerShell launcher and directory handles can linger
+ * until powershell/conhost/bash/sleep actually exit.
+ */
+export async function waitForProcessTreeGone(
+  options: ProcessTreeWaitOptions = {},
+): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? 50);
+  const tracked = new Set<number>(
+    [...(options.knownPids ?? [])].filter(
+      (pid) => Number.isInteger(pid) && pid > 0,
+    ),
+  );
+  if (options.rootPid) {
+    for (const pid of collectProcessTreeIds(options.rootPid)) {
+      tracked.add(pid);
+    }
+  }
+
+  const startedAt = Date.now();
+  while (true) {
+    for (const pid of [...tracked]) {
+      if (isProcessIdAlive(pid)) {
+        for (const childPid of collectProcessTreeIds(pid)) {
+          tracked.add(childPid);
+        }
+      }
+    }
+    const alive = [...tracked].filter((pid) => isProcessIdAlive(pid));
+    if (alive.length === 0) {
+      return true;
+    }
+    if (Date.now() - startedAt >= timeoutMs) {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
 function isExited(child: OwnedChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null;
 }
@@ -93,6 +187,54 @@ function waitForOwnedProcessTreeExit(
       timeoutMs,
     );
   });
+}
+
+function resolveWindowsPowerShell(): string {
+  const childEnv = buildPwrAgentChildProcessEnv(process.env);
+  const systemRoot = Object.entries(childEnv).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  return systemRoot
+    ? path.win32.join(
+        systemRoot,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      )
+    : "powershell.exe";
+}
+
+function listWindowsChildProcessIds(pid: number): number[] {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return [];
+  }
+  const result = spawnSync(
+    resolveWindowsPowerShell(),
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      `Get-CimInstance Win32_Process -Filter "ParentProcessId=${pid}" | Select-Object -ExpandProperty ProcessId`,
+    ],
+    {
+      encoding: "utf8",
+      env: buildPwrAgentChildProcessEnv(process.env),
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 5_000,
+      windowsHide: true,
+    },
+  );
+  if (result.status !== 0) {
+    return [];
+  }
+  return String(result.stdout ?? "")
+    .split(/\r?\n/)
+    .map((line) => Number(line.trim()))
+    .filter((childPid) => Number.isInteger(childPid) && childPid > 0);
 }
 
 function terminateWindowsTree(


### PR DESCRIPTION
## Summary

Wait for a terminated Codex environment action's process tree to die before deleting its cwd.

- Snapshot descendant pids **before** `terminate`. Windows reparents Job grandchildren (`sleep.exe`) after the PowerShell launcher exits, so a later parent walk cannot find them.
- After `stopCodexEnvironmentDetachedCommand(..., "terminate")`, wait for the Node `close` bit **and** those pids to disappear.
- `stop` stays synchronous. `getQuitBlockers` is unchanged.

## Why

Isolated Windows repro (private, huntharo):

- https://github.com/huntharo/pwragent-win-ebusy-repro
- https://github.com/huntharo/pwragent-win-ebusy-repro/actions/runs/31827246049
- https://github.com/huntharo/pwragent-win-ebusy-repro/actions/runs/31827635591

Cause-at-will is red with real `EBUSY` (3/3) when a Windows-native PowerShell parent holds `cwd=pwragent-env-auto-*`. That matches main's Windows Job path: `child.kill` on the PowerShell launcher. `taskkill /T /F` returning 0 is not enough.

The sibling test `stops a detached action process tree by run id` already awaits detached exit before `rm`. The auto-started quit-blocker test only waited for launcher `close`, then raced handle release.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/process-tree.test.ts apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts -t "waitForProcessTreeGone|treats a missing detached|counts an auto-started|stops a detached|kills a resistant"` (6 passed, 25 skipped)
- `pnpm --filter @pwragent/desktop typecheck`
- ESLint on the four changed files (0 errors)
- `pnpm lint:boundaries` (no dependency violations)

A full `codex-environment-runtime.test.ts` run in this worktree showed five unrelated failures: local npmrc `npm warn Unknown env config` lines leaked into setup/detached stdout. Those tests were not changed.

## Notes

This does not change PR #1628 (`releases/1.0`). The 1.0 terminate path has no Windows Job launcher; a separate backport can reuse the waiter if wanted.