### PR TITLE
fix(desktop): suppress terminal escapes in environment setup

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -589,6 +589,77 @@ describe("codex environment runtime", () => {
     }
   });
 
+  it("marks captured environment commands as non-terminal", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-non-terminal-"));
+    const shellPath = path.join(root, "test-shell.sh");
+
+    try {
+      await writeFile(
+        shellPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" != "-lc" ]; then exit 64; fi',
+          'exec /bin/sh -c "$2"',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(shellPath, 0o755);
+
+      const runtime = await applyLocalCodexEnvironmentSelection({
+        cwd: root,
+        env: {
+          ...process.env,
+          CLICOLOR_FORCE: "1",
+          COLORTERM: "truecolor",
+          FORCE_COLOR: "3",
+          ITERM_SESSION_ID: "w0t0p0:session",
+          NO_COLOR: "0",
+          SHELL: spawnableShell(shellPath),
+          TERM: "xterm-256color",
+          TERM_PROGRAM: "Apple_Terminal",
+          TERM_PROGRAM_VERSION: "455",
+          TERM_SESSION_ID: "session-id",
+        },
+        selection: {
+          environment: {
+            id: "env",
+            name: "Env",
+            sourcePath: path.join(root, "environment.toml"),
+            setupScript: [
+              `printf 'term=%s\\n' "$TERM"`,
+              `printf 'no_color=%s\\n' "$NO_COLOR"`,
+              `printf 'term_program=%s\\n' "\${TERM_PROGRAM-unset}"`,
+              `printf 'term_program_version=%s\\n' "\${TERM_PROGRAM_VERSION-unset}"`,
+              `printf 'term_session_id=%s\\n' "\${TERM_SESSION_ID-unset}"`,
+              `printf 'iterm_session_id=%s\\n' "\${ITERM_SESSION_ID-unset}"`,
+              `printf 'colorterm=%s\\n' "\${COLORTERM-unset}"`,
+              `printf 'force_color=%s\\n' "\${FORCE_COLOR-unset}"`,
+              `printf 'clicolor_force=%s\\n' "\${CLICOLOR_FORCE-unset}"`,
+            ].join("\n"),
+            actions: [],
+          },
+          executionTarget: "local",
+          runSetup: true,
+        },
+      });
+
+      expect(runtime?.setupOutput).toBe([
+        "term=dumb",
+        "no_color=1",
+        "term_program=unset",
+        "term_program_version=unset",
+        "term_session_id=unset",
+        "iterm_session_id=unset",
+        "colorterm=unset",
+        "force_color=unset",
+        "clicolor_force=unset",
+      ].join("\n"));
+    } finally {
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+
   it("runs setup commands in an interactive login shell so startup-defined functions are available", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-nvm-"));
     const shellPath = path.join(root, "test-shell.sh");

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -175,6 +175,17 @@ export const DETACHED_OUTPUT_SNAPSHOT_MS = 500;
 const DETACHED_STOP_SIGKILL_GRACE_MS = 2_000;
 const WINDOWS_JOB_STARTUP_DIAGNOSTICS_ENV =
   "PWRAGENT_WINDOWS_JOB_STARTUP_DIAGNOSTICS";
+const CAPTURED_COMMAND_TERMINAL_ENV_KEYS = new Set([
+  "CLICOLOR_FORCE",
+  "COLORTERM",
+  "FORCE_COLOR",
+  "ITERM_SESSION_ID",
+  "NO_COLOR",
+  "TERM",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TERM_SESSION_ID",
+]);
 
 export type CodexEnvironmentCommandResult = {
   durationMs?: number;
@@ -1184,10 +1195,21 @@ function sanitizeLocalEnvironmentCommandEnv(
 ): NodeJS.ProcessEnv {
   const sanitized = buildPwrAgentChildProcessEnv(env);
   for (const key of Object.keys(sanitized)) {
-    if (isParentElectronRuntimeEnvKey(key)) {
+    const upperKey = key.toUpperCase();
+    if (
+      isParentElectronRuntimeEnvKey(upperKey)
+      || CAPTURED_COMMAND_TERMINAL_ENV_KEYS.has(upperKey)
+    ) {
       delete sanitized[key];
     }
   }
+  // These commands write to pipes, not a PTY. Remove terminal-emulator
+  // identity inherited by PwrAgent so shell startup integrations do not emit
+  // terminal-only control sequences (for example Terminal.app's OSC 7 cwd
+  // update), and give tools that consult environment variables the same
+  // non-terminal signal they get from isatty(3).
+  sanitized.TERM = "dumb";
+  sanitized.NO_COLOR = "1";
   return sanitized;
 }
 


### PR DESCRIPTION
## Summary

- mark pipe-backed environment setup and action commands as non-terminal
- remove inherited terminal-session and force-color variables before spawning the shell
- set `TERM=dumb` and `NO_COLOR=1` without changing the PTY-backed integrated terminal
- add regression coverage for the sanitized command environment

## Root cause

PwrAgent captures environment command output through pipes, but inherited terminal identity such as `TERM_PROGRAM=Apple_Terminal` still reached shell startup scripts. Oh My Zsh interpreted that as a real Terminal.app session and emitted an OSC 7 current-directory control sequence. The plain-text setup output panel displayed the control-sequence payload as `]7;file://...`.

## Impact

Environment setup output no longer begins with leaked terminal control-sequence text, and captured command output consistently avoids terminal-only formatting. Real integrated terminals retain their PTY environment.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts` (28 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (no errors; existing warnings only)
- `git diff --check`