### PR TITLE
fix(desktop): backport sub-agent lifecycle ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26245,6 +26245,7 @@ script = "printf setup"
       codexClient: new MockBackendClient({ threads: [] }),
       overlayStore,
       runtimeInstanceId: "runtime-current",
+      registrySessionId: "registry-current",
       resolveLiveProfileRuntimeInstanceIds: () => [
         "runtime-current",
         "runtime-other",
@@ -26255,6 +26256,7 @@ script = "printf setup"
     expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledOnce();
     expect(reconcileOrphanedThreadSubAgents).toHaveBeenCalledWith({
       currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
       liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
       sessionStartedAt: expect.any(Number),
     });
@@ -26285,7 +26287,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("stops active task monitors without starting recovery", async () => {
+  it("stops blocked active task monitors without starting recovery", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "turn/interrupt"] },
       models: TEST_TASK_MONITOR_MODELS,
@@ -26299,6 +26301,7 @@ script = "printf setup"
       }),
       overlayStore,
       runtimeInstanceId: "runtime-current",
+      registrySessionId: "registry-current",
       resolveLiveProfileRuntimeInstanceIds: () => ["runtime-current"],
     });
     await registry.publishLocalEvent({
@@ -26331,6 +26334,28 @@ script = "printf setup"
       (delegationResponse as { contentItems: Array<{ text: string }> })
         .contentItems[0]?.text ?? "{}",
     ).monitorId as string;
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "monitor-thread",
+        turnId: "turn-1",
+        callId: "call-2",
+        requestId: "call-2",
+        namespace: "pwragent_task_monitors",
+        tool: "inject_progress",
+        arguments: {
+          monitorId,
+          status: "blocked",
+          message: "Waiting for an external dependency.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "blocked" })],
+    });
 
     await expect(registry.stopSubAgent({
       backend: "codex",
@@ -26357,6 +26382,7 @@ script = "printf setup"
           outcome: "cancelled",
           lastMessage: "Stopped by user.",
           ownerRuntimeInstanceId: "runtime-current",
+          ownerRegistrySessionId: "registry-current",
         }),
       ],
     });

--- a/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
@@ -456,6 +456,7 @@ describe("SqliteOverlayStore — orphaned sub-agents", () => {
 
     await expect(store.reconcileOrphanedThreadSubAgents({
       currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
       liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
       sessionStartedAt: 2_000,
     })).resolves.toEqual({
@@ -509,6 +510,77 @@ describe("SqliteOverlayStore — orphaned sub-agents", () => {
     });
   });
 
+  it("repairs a replaced registry without touching another live process", async () => {
+    await seedSubAgent("replaced-registry", {
+      monitorId: "monitor-replaced-registry",
+      task: "Owned by the replaced registry",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-current",
+      ownerRegistrySessionId: "registry-replaced",
+    });
+    await seedSubAgent("current-registry", {
+      monitorId: "monitor-current-registry",
+      task: "Owned by the current registry",
+      status: "running",
+      createdAt: 2_100,
+      updatedAt: 2_200,
+      ownerRuntimeInstanceId: "runtime-current",
+      ownerRegistrySessionId: "registry-current",
+    });
+    await seedSubAgent("other-live-process", {
+      monitorId: "monitor-other-process",
+      task: "Owned by another live process",
+      status: "running",
+      createdAt: 1_000,
+      updatedAt: 1_500,
+      ownerRuntimeInstanceId: "runtime-other",
+      ownerRegistrySessionId: "registry-other-replaced",
+    });
+
+    await expect(store.reconcileOrphanedThreadSubAgents({
+      currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
+      liveRuntimeInstanceIds: ["runtime-current", "runtime-other"],
+      sessionStartedAt: 2_000,
+    })).resolves.toEqual({
+      repairedSubAgents: 1,
+      repairedThreads: 1,
+      skippedLiveOwners: 2,
+      skippedOwnerlessWithOtherRuntimes: 0,
+    });
+
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "replaced-registry",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          status: "failure",
+          outcome: "failure",
+          ownerRuntimeInstanceId: "runtime-current",
+          ownerRegistrySessionId: "registry-replaced",
+          completionSource: expect.objectContaining({
+            reason: "owner_registry_replaced",
+          }),
+        }),
+      ],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "current-registry",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "other-live-process",
+    })).resolves.toMatchObject({
+      subAgents: [expect.objectContaining({ status: "running" })],
+    });
+  });
+
   it("repairs old ownerless work only when this is the sole runtime", async () => {
     await seedSubAgent("thread-1", {
       monitorId: "monitor-old",
@@ -527,6 +599,7 @@ describe("SqliteOverlayStore — orphaned sub-agents", () => {
 
     await expect(store.reconcileOrphanedThreadSubAgents({
       currentRuntimeInstanceId: "runtime-current",
+      currentRegistrySessionId: "registry-current",
       liveRuntimeInstanceIds: ["runtime-current"],
       sessionStartedAt: 2_000,
     })).resolves.toMatchObject({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5633,6 +5633,7 @@ export class DesktopBackendRegistry {
   >();
   private readonly taskMonitorWatchdogTimer?: NodeJS.Timeout;
   private readonly runtimeInstanceId: string;
+  private readonly registrySessionId: string;
   private readonly resolveLiveProfileRuntimeInstanceIdsFn: () => string[];
   private readonly subAgentStartupReconciliation: Promise<void>;
   /** Streamed command-output counters waiting for the next bounded flush. */
@@ -5811,6 +5812,7 @@ export class DesktopBackendRegistry {
     resolveCodexFastAllowed?: () => boolean;
     resolveGrokApiKey?: () => string | undefined;
     runtimeInstanceId?: string;
+    registrySessionId?: string;
     resolveLiveProfileRuntimeInstanceIds?: () => string[];
     acpWorktreeRepositoryResolver?: (
       cwd: string,
@@ -5819,6 +5821,7 @@ export class DesktopBackendRegistry {
     const processRuntimeIdentity = getProcessRuntimeIdentity();
     this.runtimeInstanceId =
       options?.runtimeInstanceId ?? processRuntimeIdentity.instanceId;
+    this.registrySessionId = options?.registrySessionId ?? randomUUID();
     this.resolveLiveProfileRuntimeInstanceIdsFn =
       options?.resolveLiveProfileRuntimeInstanceIds ??
       (() =>
@@ -6189,6 +6192,7 @@ export class DesktopBackendRegistry {
     }
     const result = await reconcile.call(this.overlayStore, {
       currentRuntimeInstanceId: this.runtimeInstanceId,
+      currentRegistrySessionId: this.registrySessionId,
       liveRuntimeInstanceIds,
       sessionStartedAt: this.registrySessionStartedAt,
     });
@@ -10308,7 +10312,7 @@ export class DesktopBackendRegistry {
     if (!subAgent) {
       throw new Error("Sub-agent was not found on this thread.");
     }
-    if (subAgent.status !== "running") {
+    if (subAgent.status !== "running" && subAgent.status !== "blocked") {
       throw new Error("Sub-agent is no longer running.");
     }
     const taskMonitor = this.taskMonitorDelegations.get(params.monitorId);
@@ -16111,6 +16115,8 @@ export class DesktopBackendRegistry {
       updatedAt: now,
       ownerRuntimeInstanceId:
         existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId:
+        existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: "codex",
       monitorThreadId: params.receiverThreadId,
       ...(params.call.parentTurnId
@@ -16407,6 +16413,8 @@ export class DesktopBackendRegistry {
       updatedAt: patch.updatedAt ?? Date.now(),
       ownerRuntimeInstanceId:
         existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId:
+        existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: record.backend,
       preferredModel: record.preferredModel,
       preferredReasoningEffort: record.preferredReasoningEffort,
@@ -16481,6 +16489,8 @@ export class DesktopBackendRegistry {
       updatedAt: patch.updatedAt ?? Date.now(),
       ownerRuntimeInstanceId:
         existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId:
+        existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: record.backend,
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
@@ -17946,6 +17956,9 @@ export class DesktopBackendRegistry {
       ownerRuntimeInstanceId: startsNewAttempt
         ? this.runtimeInstanceId
         : existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+      ownerRegistrySessionId: startsNewAttempt
+        ? this.registrySessionId
+        : existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: params.backend,
       agentName: "PwrAgent",
       ...(preferredModel ? { preferredModel } : {}),

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -322,6 +322,7 @@ export class SqliteOverlayStore {
    */
   async reconcileOrphanedThreadSubAgents(params: {
     currentRuntimeInstanceId: string;
+    currentRegistrySessionId: string;
     liveRuntimeInstanceIds: string[];
     sessionStartedAt: number;
   }): Promise<{
@@ -385,9 +386,15 @@ export class SqliteOverlayStore {
           }
 
           const ownerRuntimeInstanceId = subAgent.ownerRuntimeInstanceId?.trim();
+          const ownerRegistrySessionId = subAgent.ownerRegistrySessionId?.trim();
+          const belongsToReplacedCurrentRegistry =
+            ownerRuntimeInstanceId === params.currentRuntimeInstanceId
+            && Boolean(ownerRegistrySessionId)
+            && ownerRegistrySessionId !== params.currentRegistrySessionId;
           if (
             ownerRuntimeInstanceId
             && liveRuntimeInstanceIds.has(ownerRuntimeInstanceId)
+            && !belongsToReplacedCurrentRegistry
           ) {
             result.skippedLiveOwners += 1;
             return subAgent;
@@ -411,11 +418,14 @@ export class SqliteOverlayStore {
             outcome: "failure" as const,
             completedAt,
             updatedAt: completedAt,
-            lastMessage:
-              "Interrupted when its owning PwrAgent runtime stopped before reporting completion.",
+            lastMessage: belongsToReplacedCurrentRegistry
+              ? "Interrupted when its owning PwrAgent backend registry was replaced before reporting completion."
+              : "Interrupted when its owning PwrAgent runtime stopped before reporting completion.",
             completionSource: {
               type: "pwragent_fallback" as const,
-              reason: "owner_runtime_stopped",
+              reason: belongsToReplacedCurrentRegistry
+                ? "owner_registry_replaced"
+                : "owner_runtime_stopped",
               recoveryAttempted: false,
               terminalStatus: "failed" as const,
             },

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -83,7 +83,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 : undefined;
             const stopping = stoppingIds.has(subAgent.monitorId);
             const canStop =
-              subAgent.status === "running"
+              (subAgent.status === "running" || subAgent.status === "blocked")
               && Boolean(subAgent.monitorThreadId)
               && Boolean(subAgent.monitorTurnId)
               && Boolean(props.desktopApi?.stopSubAgent);

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -91,4 +91,40 @@ describe("SubAgentsPanel", () => {
     ).toHaveTextContent("Sub-agent is no longer running.");
     expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
   });
+
+  it("allows an active blocked monitor to be stopped", async () => {
+    const activeSubAgent = thread.subAgents?.[0];
+    expect(activeSubAgent).toBeDefined();
+    const stopSubAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "parent-thread",
+      monitorId: "monitor-1",
+      stoppedAt: 1_800_000_000_100,
+    }));
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent } as DesktopApi}
+        thread={{
+          ...thread,
+          subAgents: [
+            {
+              ...activeSubAgent!,
+              status: "blocked",
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(stopSubAgent).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "parent-thread",
+        monitorId: "monitor-1",
+      });
+    });
+  });
 });

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -177,6 +177,15 @@ export type ThreadSubAgentSummary = {
    * Older summaries omit it and use the conservative sole-runtime fallback.
    */
   ownerRuntimeInstanceId?: string;
+  /**
+   * Backend-registry generation that created this sub-agent attempt.
+   *
+   * A settings-driven registry replacement stays in the same process and
+   * therefore keeps the same runtime UUID. This generation id lets the new
+   * registry retire only work from its replaced predecessor. Other live
+   * processes remain authoritative through ownerRuntimeInstanceId.
+   */
+  ownerRegistrySessionId?: string;
   backend?: AppServerBackendKind;
   agentName?: string;
   preferredModel?: string;


### PR DESCRIPTION
## Summary

- backport PR #1626's backend-registry generation ownership onto the existing 1.0 runtime-UUID reconciliation
- reconcile unfinished work from a replaced same-process registry while preserving work owned by another live PwrAgent runtime
- allow active blocked monitors to be stopped through the 1.0 local backend and Sub-agents rail
- add focused overlay-store, backend-registry, and renderer regressions

## Applicability and adaptations

- Source PR: #1626.
- Applicable source commit: `2d59707644a3dbd34c75f808c0654b5e79bc0b18`.
- Source follow-up `5af6910fb4c2cd9e6e25932a13b64255b33ee39d` changes `ActiveSubAgentsStrip`, which does not exist on `releases/1.0`; no new main-only surface is imported.
- The main-only in-memory finalization assertion is not applicable to the 1.0 local Stop implementation. The adapted test persists a blocked monitor, stops it locally, verifies the active turn is interrupted, and verifies recovery is not started.
- Federation and other main-only architecture remain excluded.

## Multi-runtime safety

- A new registry generation is considered stale only when its recorded runtime UUID equals the current process UUID and its registry generation differs.
- Work owned by another live runtime is never stolen or failed, regardless of its registry generation.
- Legacy rows without a registry generation retain the existing conservative runtime-owner and sole-runtime behavior.
- Liveness-read failures continue to fail closed without reconciling persisted work.

## Persistence, migration, and config audit

- `ownerRegistrySessionId` is optional data in the existing thread-overlay JSON.
- No database schema, DDL, `user_version`, migration, config, package, or lockfile changes.
- Startup repair remains one transaction; the extra owner field rides existing writes.
- No timer, heartbeat, recurring write, or idle write is added.

## Provenance

Backport of #1626 onto the accumulated #1611 release backport, starting from `origin/releases/1.0` at `201f9436a`.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx` — 432 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors, 135 existing warnings
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `git diff --check`
