### PR TITLE
feat(desktop): warn on replay-amplifying tool use

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19059,7 +19059,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("emits a live large-output alert at the warning threshold without another sqlite write", async () => {
+  it("persists a live large-output alert at the warning threshold without completion", async () => {
     vi.useFakeTimers();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
@@ -19067,8 +19067,12 @@ command = "pnpm dev"
     const upsertThreadToolInvocation = vi.fn(
       async (params: { invocation: unknown }) => params.invocation,
     );
+    const persistThreadToolInvocationBoundary = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
     const overlayStore = {
       ...createOverlayStoreMock(),
+      persistThreadToolInvocationBoundary,
       upsertThreadToolInvocation,
     };
     const registry = new DesktopBackendRegistry({
@@ -19122,9 +19126,26 @@ command = "pnpm dev"
           },
         ],
       });
+      expect(persistThreadToolInvocationBoundary).toHaveBeenCalledTimes(1);
+      expect(persistThreadToolInvocationBoundary).toHaveBeenCalledWith({
+        alerts: [
+          expect.objectContaining({
+            kind: "large-output",
+            severity: "warning",
+            totalOutputChars: 4_000,
+          }),
+        ],
+        invocation: expect.objectContaining({
+          invocationId: "tool:codex:thread-1:turn-1:cmd-1",
+          noisy: true,
+          noisyReason: "large-output",
+          outputChars: 2_000,
+          status: "in_progress",
+        }),
+      });
 
       await registry.close();
-      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(2);
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19059,6 +19059,77 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("emits a live large-output alert at the warning threshold without another sqlite write", async () => {
+    vi.useFakeTimers();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const upsertThreadToolInvocation = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      upsertThreadToolInvocation,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: overlayStore as never,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    try {
+      const emit = (registry as unknown as {
+        emit(event: AgentEvent): Promise<void>;
+      }).emit.bind(registry);
+      const stream = async (delta: string): Promise<void> => {
+        await emit({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "cmd-1",
+              delta,
+            },
+          },
+        } as AgentEvent);
+      };
+
+      await stream("x".repeat(2_000));
+      await vi.advanceTimersByTimeAsync(250);
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
+
+      // The warning total spans sqlite flush windows. A detector tied to the
+      // 250ms pending-write buffer would see two harmless 2,000-char chunks
+      // and never report that the command reached 4,000.
+      await stream("x".repeat(2_000));
+      const alertEvent = events.find(
+        (event) =>
+          event.notification.method === "thread/toolAccounting/updated",
+      );
+      expect(alertEvent?.notification.params).toMatchObject({
+        threadId: "thread-1",
+        triggeredAlerts: [
+          {
+            kind: "large-output",
+            severity: "warning",
+            totalOutputChars: 4_000,
+            turnId: "turn-1",
+          },
+        ],
+      });
+
+      await registry.close();
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("flushes buffered command output on the timer, without a lifecycle event", async () => {
     // A command can stream for minutes before it completes. Nothing else in
     // this suite exercises the timer — every other case flushes through

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -146,6 +146,10 @@ describe("codex environment runtime", () => {
   it("runs detached actions with the provided hydrated environment", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-runtime-"));
     const outputPath = path.join(root, "env.txt");
+    let resolveDetachedExit!: (event: { exitCode: number | null }) => void;
+    const detachedExit = new Promise<{ exitCode: number | null }>((resolve) => {
+      resolveDetachedExit = resolve;
+    });
 
     try {
       const result = await startLocalCodexEnvironmentAction({
@@ -155,6 +159,7 @@ describe("codex environment runtime", () => {
           ...process.env,
           PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
         },
+        onDetachedExit: resolveDetachedExit,
         runtime: {
           environmentId: "env",
           environmentName: "Env",
@@ -180,6 +185,10 @@ describe("codex environment runtime", () => {
       await expect(expectEventually(async () => await readFile(outputPath, "utf8"))).resolves.toBe(
         "hydrated",
       );
+      // File creation proves the shell ran, not that the detached Windows Job
+      // and its PowerShell launcher have released their cwd handles. Await the
+      // owner lifecycle before deleting that cwd.
+      await expect(detachedExit).resolves.toMatchObject({ exitCode: 0 });
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -29,10 +29,17 @@
   },
   "composer-draft-typing": {
     "commits": 70,
-    "note": "70 direct store saves (a stress case for prefix collapse, NOT the app's typing cadence \u2014 the renderer coalesces to one save per 5s): exactly one journal row survives, and commits track save calls because each save is its own transaction",
+    "note": "70 direct store saves (a stress case for prefix collapse, NOT the app's typing cadence — the renderer coalesces to one save per 5s): exactly one journal row survives, and commits track save calls because each save is its own transaction",
     "observedWalBytes": 1738640,
     "rowsChanged": 140,
     "statements": 209
+  },
+  "deferred-check-alert": {
+    "commits": 1,
+    "note": "five in-memory 30-second deferred checks and one persisted alert boundary",
+    "observedWalBytes": 12360,
+    "rowsChanged": 1,
+    "statements": 1
   },
   "federated-child-archive-ungroup": {
     "commits": 2,
@@ -93,8 +100,8 @@
   "streamed-command-output": {
     "commits": 2,
     "note": "500 streamed output deltas plus the completion for one command",
-    "observedWalBytes": 37080,
-    "rowsChanged": 2,
-    "statements": 2
+    "observedWalBytes": 49440,
+    "rowsChanged": 3,
+    "statements": 3
   }
 }

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -98,11 +98,18 @@
     "statements": 8
   },
   "streamed-command-output": {
-    "commits": 2,
+    "commits": 3,
     "note": "500 streamed output deltas plus the completion for one command",
-    "observedWalBytes": 49440,
-    "rowsChanged": 3,
-    "statements": 3
+    "observedWalBytes": 74160,
+    "rowsChanged": 5,
+    "statements": 5
+  },
+  "streamed-large-output-alert-boundary": {
+    "commits": 1,
+    "note": "one threshold-crossing streamed output window and its alert",
+    "observedWalBytes": 32960,
+    "rowsChanged": 2,
+    "statements": 2
   },
   "structured-mcp-output-alert": {
     "commits": 1,

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -103,5 +103,12 @@
     "observedWalBytes": 49440,
     "rowsChanged": 3,
     "statements": 3
+  },
+  "structured-mcp-output-alert": {
+    "commits": 1,
+    "note": "one large structured MCP result and its alert in one boundary",
+    "observedWalBytes": 32960,
+    "rowsChanged": 2,
+    "statements": 2
   }
 }

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -216,6 +216,58 @@ describe("sqlite write metrics", () => {
     await registry.close();
   });
 
+  it("persists a streamed large-output alert boundary in one commit", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    const { writes } = await measureSqliteWrites(async () => {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: "thread-streaming-alert",
+            turnId: "turn-1",
+            itemId: "cmd-1",
+            delta: "x".repeat(4_100),
+          },
+        },
+      } as AgentEvent);
+    });
+
+    expectSqliteWriteBudget({
+      note: "one threshold-crossing streamed output window and its alert",
+      scenario: "streamed-large-output-alert-boundary",
+      writes,
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-streaming-alert",
+    });
+    expect(accounting.alerts).toEqual([
+      expect.objectContaining({
+        kind: "large-output",
+        totalOutputChars: 4_100,
+      }),
+    ]);
+    expect(accounting.invocations).toEqual([
+      expect.objectContaining({
+        noisy: true,
+        noisyReason: "large-output",
+        outputChars: 4_100,
+        status: "in_progress",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("holds five deferred checks and their first alert to one commit", async () => {
     vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -216,6 +216,55 @@ describe("sqlite write metrics", () => {
     await registry.close();
   });
 
+  it("holds five deferred checks and their first alert to one commit", async () => {
+    vi.useFakeTimers();
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    try {
+      const { writes } = await measureSqliteWrites(async () => {
+        for (let index = 0; index < 5; index += 1) {
+          vi.setSystemTime(1_800_000_000_000 + index * 30_000);
+          await emit({
+            backend: "codex",
+            notification: {
+              method: "item/completed",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                item: {
+                  id: `wait-${index + 1}`,
+                  type: "functionCall",
+                  name: "wait",
+                  status: "completed",
+                  arguments: {
+                    cell_id: `cell-${index + 1}`,
+                    yield_time_ms: 30_000,
+                  },
+                  functionCallOutput: "still running",
+                },
+              },
+            },
+          } as AgentEvent);
+        }
+      });
+
+      expectSqliteWriteBudget({
+        note: "five in-memory 30-second deferred checks and one persisted alert boundary",
+        scenario: "deferred-check-alert",
+        writes,
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
   it("holds a burst of live token usage to one commit", async () => {
     vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -265,6 +265,48 @@ describe("sqlite write metrics", () => {
     }
   });
 
+  it("holds one large structured MCP result and its alert to one commit", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    const { writes } = await measureSqliteWrites(async () => {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "mcp-1",
+              type: "mcpToolCall",
+              server: "playwright",
+              tool: "browser_tabs",
+              status: "completed",
+              arguments: { action: "list" },
+              result: {
+                content: [{ type: "text", text: "x".repeat(4_100) }],
+              },
+            },
+          },
+        },
+      } as AgentEvent);
+    });
+
+    expectSqliteWriteBudget({
+      note: "one large structured MCP result and its alert in one boundary",
+      scenario: "structured-mcp-output-alert",
+      writes,
+    });
+
+    await registry.close();
+  });
+
   it("holds a burst of live token usage to one commit", async () => {
     vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -5,6 +5,7 @@ import type {
 import { describe, expect, it } from "vitest";
 import {
   buildToolOutputMetrics,
+  detectLargeToolOutput,
   detectNoisyPolling,
   normalizeToolInvocationCommand,
   toolInvocationFromNotification,
@@ -44,6 +45,24 @@ describe("tool invocation accounting", () => {
     ).toEqual({
       category: "shell",
       normalizedCommand: "write stdin session 40500",
+    });
+    expect(
+      normalizeToolInvocationCommand({
+        args: { cell_id: "cell-9", yield_time_ms: 30_000 },
+        toolName: "wait",
+      }),
+    ).toEqual({
+      category: "polling",
+      normalizedCommand: "wait cell cell-9",
+    });
+    expect(
+      normalizeToolInvocationCommand({
+        command: "sleep 30",
+        toolName: "commandExecution",
+      }),
+    ).toEqual({
+      category: "polling",
+      normalizedCommand: "sleep 30",
     });
   });
 
@@ -240,30 +259,145 @@ describe("tool invocation accounting", () => {
     });
   });
 
-  it("detects repeated noisy write_stdin polling against one process session", () => {
+  it("accounts deferred wait function calls as polling", () => {
+    const invocation = toolInvocationFromNotification({
+      backend: "codex",
+      now: 1_800_000_030_000,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "wait-1",
+            type: "functionCall",
+            name: "wait",
+            status: "completed",
+            arguments: { cell_id: "cell-9", yield_time_ms: 30_000 },
+            functionCallOutput: "still running",
+          },
+        },
+      } as AppServerNotification,
+    });
+
+    expect(invocation).toMatchObject({
+      category: "polling",
+      normalizedCommand: "wait cell cell-9",
+      outputChars: 13,
+      sessionId: "cell-9",
+      toolName: "wait",
+      turnId: "turn-1",
+    });
+  });
+
+  it("detects five low-output write_stdin polls against one process session", () => {
     const records = [
-      buildPollingInvocation("tool-1", 1_800_000_000_000, 9_000),
-      buildPollingInvocation("tool-2", 1_800_000_030_000, 8_000),
-      buildPollingInvocation("tool-3", 1_800_000_060_000, 7_000),
+      buildPollingInvocation("tool-1", 1_800_000_000_000, 0),
+      buildPollingInvocation("tool-2", 1_800_000_030_000, 0),
+      buildPollingInvocation("tool-3", 1_800_000_060_000, 0),
+      buildPollingInvocation("tool-4", 1_800_000_090_000, 0),
+      buildPollingInvocation("tool-5", 1_800_000_120_000, 0),
     ];
 
     const detection = detectNoisyPolling({
-      current: records[2]!,
-      now: records[2]!.observedAt,
-      recent: records.slice(0, 2),
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
     });
 
-    expect(detection?.invocationIds).toEqual(["tool-1", "tool-2", "tool-3"]);
+    expect(detection?.invocationIds).toEqual([
+      "tool-1",
+      "tool-2",
+      "tool-3",
+      "tool-4",
+      "tool-5",
+    ]);
     expect(detection?.alert).toMatchObject({
-      estimatedOutputTokens: 6_000,
-      invocationCount: 3,
+      estimatedOutputTokens: 0,
+      invocationCount: 5,
       kind: "noisy-polling",
       sessionId: "40500",
-      totalOutputChars: 24_000,
+      totalOutputChars: 0,
     });
     expect(detection?.alert.suggestedPrompt).toContain(
       "create_monitor_delegation",
     );
+  });
+
+  it("groups deferred waits by turn even when each check has a new cell", () => {
+    const records = Array.from({ length: 5 }, (_, index) => ({
+      ...buildPollingInvocation(
+        `wait-${index + 1}`,
+        1_800_000_000_000 + index * 30_000,
+        12,
+      ),
+      normalizedCommand: `wait cell cell-${index + 1}`,
+      sessionId: `cell-${index + 1}`,
+      toolName: "wait",
+      turnId: "turn-1",
+    }));
+
+    const detection = detectNoisyPolling({
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
+    });
+
+    expect(detection?.alert).toMatchObject({
+      invocationCount: 5,
+      kind: "noisy-polling",
+      toolName: "wait",
+      turnId: "turn-1",
+    });
+  });
+
+  it("detects repeated shell sleeps as queued checks in one turn", () => {
+    const records = Array.from({ length: 5 }, (_, index) => ({
+      ...buildPollingInvocation(
+        `sleep-${index + 1}`,
+        1_800_000_000_000 + index * 30_000,
+        0,
+      ),
+      normalizedCommand: "sleep 30",
+      sessionId: undefined,
+      toolName: "commandExecution",
+      turnId: "turn-1",
+    }));
+
+    const detection = detectNoisyPolling({
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
+    });
+
+    expect(detection?.alert).toMatchObject({
+      invocationCount: 5,
+      kind: "noisy-polling",
+      toolName: "commandExecution",
+      turnId: "turn-1",
+    });
+  });
+
+  it("warns at ten percent of the observed output cap and escalates at the cap", () => {
+    const warning = detectLargeToolOutput({
+      current: buildOutputInvocation(4_000),
+      previousOutputChars: 3_999,
+    });
+    const critical = detectLargeToolOutput({
+      current: buildOutputInvocation(40_000),
+      previousOutputChars: 39_999,
+    });
+
+    expect(warning?.alert).toMatchObject({
+      kind: "large-output",
+      severity: "warning",
+      totalOutputChars: 4_000,
+    });
+    expect(critical?.alert).toMatchObject({
+      kind: "large-output",
+      severity: "critical",
+      totalOutputChars: 40_000,
+    });
   });
 
   it("does not flag non-empty stdin writes as polling", () => {
@@ -310,5 +444,17 @@ function buildPollingInvocation(
     toolName: "write_stdin",
     updatedAt: observedAt,
     warningLines: 0,
+  };
+}
+
+function buildOutputInvocation(outputChars: number): ThreadToolInvocationRecord {
+  return {
+    ...buildPollingInvocation("command-1", 1_800_000_000_000, outputChars, "shell"),
+    estimatedOutputTokens: Math.ceil(outputChars / 4),
+    normalizedCommand: "pnpm test",
+    outputLines: 500,
+    status: "in_progress",
+    toolName: "commandExecution",
+    turnId: "turn-1",
   };
 }

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -214,6 +214,53 @@ describe("tool invocation accounting", () => {
     },
   );
 
+  it.each([
+    {
+      label: "structured object result",
+      result: {
+        tabs: [{ title: "x".repeat(4_100) }],
+      },
+    },
+    {
+      label: "MCP content array",
+      result: {
+        content: [{ type: "text", text: "x".repeat(4_100) }],
+      },
+    },
+  ])("accounts a large $label", ({ result }) => {
+    const invocation = toolInvocationFromNotification({
+      backend: "codex",
+      now: 1_800_000_030_000,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "mcp-1",
+            type: "mcpToolCall",
+            server: "playwright",
+            tool: "browser_tabs",
+            status: "completed",
+            arguments: { action: "list" },
+            result,
+          },
+        },
+      } as AppServerNotification,
+    });
+
+    expect(invocation).toMatchObject({
+      outputChars: JSON.stringify(result).length,
+      status: "completed",
+      toolName: "browser_tabs",
+    });
+    expect(detectLargeToolOutput({ current: invocation! })?.alert).toMatchObject({
+      kind: "large-output",
+      severity: "warning",
+      toolName: "browser_tabs",
+    });
+  });
+
   it("marks completed command invocations failed from success false or exit code", () => {
     const successFalseInvocation = toolInvocationFromNotification({
       backend: "codex",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -253,6 +253,7 @@ import {
   type ThreadOverlayState,
   type ThreadWorkspaceHandoffStrategy,
   type ThreadSubAgentSummary,
+  type ThreadToolInvocationAlert,
   type ThreadToolInvocationRecord,
   type ThreadUsageLineRecord,
   type PrSummary,
@@ -440,8 +441,10 @@ import {
   createProtocolLogObserverFromEnv,
 } from "./protocol-log-observer";
 import {
+  detectLargeToolOutput,
   detectNoisyPolling,
   mergeStreamedToolInvocationDeltas,
+  mergeToolInvocationLifecycleWithStreamedOutput,
   toolAccountingLookbackSince,
   toolInvocationFromNotification,
 } from "./tool-invocation-accounting";
@@ -6322,6 +6325,8 @@ type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
     | "readThreadGitWorkingStateCache"
     | "listRemoteThreadPins"
     | "reconcileOrphanedThreadSubAgents"
+    | "markThreadToolInvocationsNoisy"
+    | "persistThreadToolInvocationBoundary"
     | "upsertThreadUsageLines"
     | "writeThreadGitWorkingStateCacheEntry"
   >
@@ -6633,6 +6638,25 @@ export class DesktopBackendRegistry {
     string,
     ThreadToolInvocationRecord
   >();
+  /**
+   * Full in-memory output totals for active commands. Flush windows clear the
+   * sqlite write buffer every 250ms, but warning thresholds must span those
+   * windows or a steady stream of small chunks never reaches 4,000 chars.
+   */
+  private readonly streamedToolInvocationOutputTotals = new Map<
+    string,
+    ThreadToolInvocationRecord
+  >();
+  /**
+   * Short-lived polling samples used only for replay-amplification detection.
+   * Persisting every `wait` / `write_stdin` check would turn the detector into
+   * a timer-driven sqlite writer, so only incident boundaries reach sqlite.
+   */
+  private readonly volatileDeferredCheckInvocations = new Map<
+    string,
+    ThreadToolInvocationRecord[]
+  >();
+  private readonly persistedToolInvocationAlertCounts = new Map<string, number>();
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes every flush so a timer-driven write can never land after the
@@ -10639,6 +10663,7 @@ export class DesktopBackendRegistry {
   private async emitThreadToolAccountingUpdated(params: {
     backend: AppServerBackendKind;
     threadId: string;
+    triggeredAlerts?: ThreadToolInvocationAlert[];
   }): Promise<void> {
     if (typeof this.overlayStore.readThreadToolAccounting !== "function") {
       return;
@@ -10654,6 +10679,9 @@ export class DesktopBackendRegistry {
         params: {
           threadId: params.threadId,
           toolAccounting,
+          ...(params.triggeredAlerts?.length
+            ? { triggeredAlerts: params.triggeredAlerts }
+            : {}),
         },
       },
     });
@@ -21752,73 +21780,258 @@ export class DesktopBackendRegistry {
       // `write_stdin`), so nothing downstream needs this write to have landed
       // before the event reaches listeners. Accumulate and let the flush timer
       // write it.
-      this.bufferStreamedToolInvocationDelta(invocation);
+      const buffered = this.bufferStreamedToolInvocationDelta(invocation);
+      const detection = detectLargeToolOutput({
+        current: buffered.current,
+        now,
+        previousOutputChars: buffered.previousOutputChars,
+      });
+      if (detection) {
+        await this.emitThreadToolAccountingUpdated({
+          backend: invocation.backend,
+          threadId: invocation.threadId,
+          triggeredAlerts: [detection.alert],
+        });
+      }
       return;
     }
+
+    const invocationWithStreamedOutput =
+      mergeToolInvocationLifecycleWithStreamedOutput(
+        invocation,
+        this.streamedToolInvocationOutputTotals.get(invocation.invocationId),
+      );
+    if (event.notification.method === "item/completed") {
+      this.streamedToolInvocationOutputTotals.delete(invocation.invocationId);
+    }
+    let shouldNotify = event.notification.method === "item/completed";
+    const triggeredAlerts: ThreadToolInvocationAlert[] = [];
+    const largeOutputDetection = detectLargeToolOutput({
+      current: invocationWithStreamedOutput,
+      now,
+    });
+    const isVolatileDeferredCheck =
+      invocationWithStreamedOutput.category === "polling"
+      && (
+        invocationWithStreamedOutput.toolName === "wait"
+        || invocationWithStreamedOutput.toolName === "write_stdin"
+      );
+    const volatileRecent = isVolatileDeferredCheck
+      ? this.readVolatileDeferredChecks(invocationWithStreamedOutput, now)
+      : [];
+    const pollingDetection =
+      typeof this.overlayStore.readRecentThreadToolInvocations === "function"
+      ? detectNoisyPolling({
+          current: invocationWithStreamedOutput,
+          now,
+          recent: [
+            ...volatileRecent,
+            ...this.overlayStore.readRecentThreadToolInvocations({
+              backend: invocationWithStreamedOutput.backend,
+              limit:
+                invocationWithStreamedOutput.toolName === "commandExecution"
+                  ? 50
+                  : 12,
+              ...(invocationWithStreamedOutput.toolName === "wait"
+                ? {}
+                : {
+                    processId: invocationWithStreamedOutput.processId,
+                    sessionId: invocationWithStreamedOutput.sessionId,
+                  }),
+              since: toolAccountingLookbackSince(now),
+              threadId: invocationWithStreamedOutput.threadId,
+              toolName: invocationWithStreamedOutput.toolName,
+            }),
+          ],
+        })
+      : undefined;
+    if (isVolatileDeferredCheck) {
+      this.rememberVolatileDeferredCheck(invocationWithStreamedOutput, now);
+    }
+    const noisyReason = pollingDetection
+      ? "repeat-polling-output"
+      : largeOutputDetection
+        ? "large-output"
+        : undefined;
 
     // Land accumulated stream output before the lifecycle row: the store stops
     // summing once a row is terminal, so a delta flushed after `item/completed`
     // would be dropped down to a MAX() and under-count the command.
     await this.flushStreamedToolInvocationDeltas();
 
-    const stored = await this.overlayStore.upsertThreadToolInvocation({
-      invocation,
-    });
-    let shouldNotify = event.notification.method === "item/completed";
+    const previousPersistedPollingCount = pollingDetection
+      ? this.persistedToolInvocationAlertCounts.get(
+          pollingDetection.alert.alertId,
+        )
+      : undefined;
+    const shouldPersistPollingAlert = Boolean(
+      pollingDetection
+      && (
+        previousPersistedPollingCount === undefined
+        || pollingDetection.alert.invocationCount
+          >= previousPersistedPollingCount * 2
+      ),
+    );
+    const alertsToPersist = [
+      ...(largeOutputDetection ? [largeOutputDetection.alert] : []),
+      ...(pollingDetection && shouldPersistPollingAlert
+        ? [pollingDetection.alert]
+        : []),
+    ];
+    if (isVolatileDeferredCheck && !largeOutputDetection) {
+      if (
+        pollingDetection
+        && shouldPersistPollingAlert
+        && typeof this.overlayStore.upsertThreadToolInvocationAlert === "function"
+      ) {
+        await this.overlayStore.upsertThreadToolInvocationAlert({
+          alert: pollingDetection.alert,
+        });
+        this.persistedToolInvocationAlertCounts.set(
+          pollingDetection.alert.alertId,
+          pollingDetection.alert.invocationCount,
+        );
+      }
+      if (pollingDetection) {
+        await this.emitThreadToolAccountingUpdated({
+          backend: invocationWithStreamedOutput.backend,
+          threadId: invocationWithStreamedOutput.threadId,
+          triggeredAlerts: [pollingDetection.alert],
+        });
+      }
+      return;
+    }
+    const previousNoisyInvocationIds =
+      pollingDetection && previousPersistedPollingCount === undefined
+        ? pollingDetection.invocationIds.filter(
+            (invocationId) => invocationId !== invocation.invocationId,
+          )
+        : [];
+    const invocationToPersist = noisyReason
+      ? {
+          ...invocation,
+          noisy: true,
+          noisyReason,
+        }
+      : invocation;
+    let stored: ThreadToolInvocationRecord;
     if (
-      typeof this.overlayStore.readRecentThreadToolInvocations === "function" &&
-      typeof this.overlayStore.markThreadToolInvocationNoisy === "function" &&
-      typeof this.overlayStore.upsertThreadToolInvocationAlert === "function"
+      typeof this.overlayStore.persistThreadToolInvocationBoundary === "function"
     ) {
-      const recent = this.overlayStore.readRecentThreadToolInvocations({
-        backend: stored.backend,
-        limit: 12,
-        processId: stored.processId,
-        sessionId: stored.sessionId,
-        since: toolAccountingLookbackSince(now),
-        threadId: stored.threadId,
-        toolName: stored.toolName,
+      stored = await this.overlayStore.persistThreadToolInvocationBoundary({
+        alerts: alertsToPersist,
+        invocation: invocationToPersist,
+        noisyInvocationIds: previousNoisyInvocationIds,
+        ...(previousNoisyInvocationIds.length
+          ? { noisyReason: "repeat-polling-output" }
+          : {}),
       });
-      const detection = detectNoisyPolling({
-        current: stored,
-        now,
-        recent,
+    } else {
+      stored = await this.overlayStore.upsertThreadToolInvocation({
+        invocation: invocationToPersist,
       });
-      if (detection) {
-        for (const invocationId of detection.invocationIds) {
-          await this.overlayStore.markThreadToolInvocationNoisy({
-            invocationId,
+      if (previousNoisyInvocationIds.length > 0) {
+        if (
+          typeof this.overlayStore.markThreadToolInvocationsNoisy === "function"
+        ) {
+          await this.overlayStore.markThreadToolInvocationsNoisy({
+            invocationIds: previousNoisyInvocationIds,
             reason: "repeat-polling-output",
           });
+        } else if (
+          typeof this.overlayStore.markThreadToolInvocationNoisy === "function"
+        ) {
+          for (const invocationId of previousNoisyInvocationIds) {
+            await this.overlayStore.markThreadToolInvocationNoisy({
+              invocationId,
+              reason: "repeat-polling-output",
+            });
+          }
         }
-        await this.overlayStore.upsertThreadToolInvocationAlert({
-          alert: detection.alert,
-        });
-        shouldNotify = true;
       }
+      if (typeof this.overlayStore.upsertThreadToolInvocationAlert === "function") {
+        for (const alert of alertsToPersist) {
+          await this.overlayStore.upsertThreadToolInvocationAlert({ alert });
+        }
+      }
+    }
+    if (pollingDetection && shouldPersistPollingAlert) {
+      this.persistedToolInvocationAlertCounts.set(
+        pollingDetection.alert.alertId,
+        pollingDetection.alert.invocationCount,
+      );
+    }
+    if (largeOutputDetection) {
+      triggeredAlerts.push(largeOutputDetection.alert);
+      shouldNotify = true;
+    }
+    if (pollingDetection) {
+      triggeredAlerts.push(pollingDetection.alert);
+      shouldNotify = true;
     }
 
     if (shouldNotify) {
       await this.emitThreadToolAccountingUpdated({
         backend: stored.backend,
         threadId: stored.threadId,
+        triggeredAlerts,
       });
     }
   }
 
   private bufferStreamedToolInvocationDelta(
     invocation: ThreadToolInvocationRecord,
-  ): void {
+  ): {
+    current: ThreadToolInvocationRecord;
+    previousOutputChars: number;
+  } {
     const accumulated = this.pendingToolInvocationDeltas.get(
       invocation.invocationId,
     );
+    const pending = accumulated
+      ? mergeStreamedToolInvocationDeltas(accumulated, invocation)
+      : invocation;
+    const accumulatedTotal = this.streamedToolInvocationOutputTotals.get(
+      invocation.invocationId,
+    );
+    const current = accumulatedTotal
+      ? mergeStreamedToolInvocationDeltas(accumulatedTotal, invocation)
+      : invocation;
     this.pendingToolInvocationDeltas.set(
       invocation.invocationId,
-      accumulated
-        ? mergeStreamedToolInvocationDeltas(accumulated, invocation)
-        : invocation,
+      pending,
     );
+    this.streamedToolInvocationOutputTotals.set(invocation.invocationId, current);
     this.scheduleStreamedToolInvocationFlush();
+    return {
+      current,
+      previousOutputChars: accumulatedTotal?.outputChars ?? 0,
+    };
+  }
+
+  private readVolatileDeferredChecks(
+    invocation: ThreadToolInvocationRecord,
+    now: number,
+  ): ThreadToolInvocationRecord[] {
+    const key = [invocation.backend, invocation.threadId].join(":");
+    const recent = (
+      this.volatileDeferredCheckInvocations.get(key) ?? []
+    ).filter((record) => record.observedAt >= toolAccountingLookbackSince(now));
+    if (recent.length > 0) {
+      this.volatileDeferredCheckInvocations.set(key, recent);
+    } else {
+      this.volatileDeferredCheckInvocations.delete(key);
+    }
+    return recent;
+  }
+
+  private rememberVolatileDeferredCheck(
+    invocation: ThreadToolInvocationRecord,
+    now: number,
+  ): void {
+    const key = [invocation.backend, invocation.threadId].join(":");
+    const recent = this.readVolatileDeferredChecks(invocation, now);
+    this.volatileDeferredCheckInvocations.set(key, [...recent, invocation]);
   }
 
   private scheduleStreamedToolInvocationFlush(): void {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6659,7 +6659,7 @@ export class DesktopBackendRegistry {
   private readonly persistedToolInvocationAlertCounts = new Map<string, number>();
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
-   * Serializes every flush so a timer-driven write can never land after the
+   * Serializes every flush and streamed alert boundary so a timer-driven write
    * `item/completed` write it accumulated before — the store keeps the
    * terminal status and stops summing once a row is terminal, so an
    * out-of-order delta flush would silently under-count the command's output.
@@ -21777,9 +21777,9 @@ export class DesktopBackendRegistry {
     if (event.notification.method === "item/commandExecution/outputDelta") {
       // Streamed output never notifies anyone (`shouldNotify` stays false for
       // deltas) and never triggers noisy-polling detection (that only looks at
-      // `write_stdin`), so nothing downstream needs this write to have landed
-      // before the event reaches listeners. Accumulate and let the flush timer
-      // write it.
+      // `write_stdin`). Ordinary deltas can wait for the flush timer; a large-
+      // output threshold crossing becomes a durable boundary before its live
+      // alert reaches listeners.
       const buffered = this.bufferStreamedToolInvocationDelta(invocation);
       const detection = detectLargeToolOutput({
         current: buffered.current,
@@ -21787,9 +21787,13 @@ export class DesktopBackendRegistry {
         previousOutputChars: buffered.previousOutputChars,
       });
       if (detection) {
+        const stored = await this.persistStreamedToolInvocationAlertBoundary({
+          alert: detection.alert,
+          invocationId: invocation.invocationId,
+        });
         await this.emitThreadToolAccountingUpdated({
-          backend: invocation.backend,
-          threadId: invocation.threadId,
+          backend: stored.backend,
+          threadId: stored.threadId,
           triggeredAlerts: [detection.alert],
         });
       }
@@ -22007,6 +22011,61 @@ export class DesktopBackendRegistry {
       current,
       previousOutputChars: accumulatedTotal?.outputChars ?? 0,
     };
+  }
+
+  /**
+   * Replace the threshold-crossing delta's ordinary buffered write with one
+   * durable invocation-plus-alert boundary. Reserving the pending delta before
+   * joining the flush chain prevents a timer drain from stealing it, while the
+   * chain still guarantees that any older window lands first.
+   */
+  private persistStreamedToolInvocationAlertBoundary(params: {
+    alert: ThreadToolInvocationAlert;
+    invocationId: string;
+  }): Promise<ThreadToolInvocationRecord> {
+    const pending = this.pendingToolInvocationDeltas.get(params.invocationId);
+    if (!pending) {
+      return Promise.reject(
+        new Error(`Missing streamed tool invocation boundary ${params.invocationId}`),
+      );
+    }
+    this.pendingToolInvocationDeltas.delete(params.invocationId);
+    const invocation = {
+      ...pending,
+      noisy: true,
+      noisyReason: "large-output",
+    };
+    const persisted = this.toolInvocationDeltaFlushChain.then(async () => {
+      try {
+        if (
+          typeof this.overlayStore.persistThreadToolInvocationBoundary === "function"
+        ) {
+          return await this.overlayStore.persistThreadToolInvocationBoundary({
+            alerts: [params.alert],
+            invocation,
+          });
+        }
+        const stored = await this.overlayStore.upsertThreadToolInvocation({
+          invocation,
+        });
+        if (
+          typeof this.overlayStore.upsertThreadToolInvocationAlert === "function"
+        ) {
+          await this.overlayStore.upsertThreadToolInvocationAlert({
+            alert: params.alert,
+          });
+        }
+        return stored;
+      } catch (error) {
+        this.requeueFailedToolInvocationDelta(invocation);
+        throw error;
+      }
+    });
+    this.toolInvocationDeltaFlushChain = persisted.then(
+      () => undefined,
+      () => undefined,
+    );
+    return persisted;
   }
 
   private readVolatileDeferredChecks(

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -120,6 +120,7 @@ export function toolInvocationFromNotification(params: {
   const toolName =
     readString(item, "toolName") ??
     readString(item, "tool_name") ??
+    readString(item, "tool") ??
     readString(item, "name") ??
     readString(item, "type") ??
     "commandExecution";
@@ -696,18 +697,21 @@ function readToolOutput(
   item: Record<string, unknown> | undefined,
 ): { text?: string; truncated?: boolean } {
   const data = readRecord(item?.data);
-  const text =
-    readString(item, "aggregatedOutput") ??
-    readString(item, "aggregated_output") ??
-    readString(item, "functionCallOutput") ??
-    readString(data, "aggregatedOutput") ??
-    readString(data, "aggregated_output") ??
-    readString(data, "output") ??
-    readString(data, "text") ??
-    readString(data, "result") ??
-    readString(item, "output") ??
-    readString(item, "stdout") ??
-    readString(item, "stderr");
+  const value = [
+    item?.aggregatedOutput,
+    item?.aggregated_output,
+    item?.functionCallOutput,
+    data?.aggregatedOutput,
+    data?.aggregated_output,
+    data?.output,
+    data?.text,
+    data?.result,
+    item?.result,
+    item?.output,
+    item?.stdout,
+    item?.stderr,
+  ].find((candidate) => candidate !== undefined && candidate !== null);
+  const text = serializeToolOutputValue(value);
   const truncated =
     readBoolean(data, "outputTruncated") ??
     readBoolean(data, "output_truncated") ??
@@ -716,6 +720,23 @@ function readToolOutput(
     readBoolean(item, "output_truncated") ??
     readBoolean(item, "truncated");
   return { text, truncated };
+}
+
+function serializeToolOutputValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    // App-server notifications are JSON, so this is defensive only. If a
+    // malformed in-process test double supplies a cyclic or otherwise
+    // unserializable result, skip accounting instead of breaking event fanout.
+    return undefined;
+  }
 }
 
 function readExitCode(

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -10,10 +10,18 @@ import { redactCommandText } from "../util/redact-command-text";
 
 const OUTPUT_TOKEN_CHAR_RATIO = 4;
 const NOISY_POLL_LOOKBACK_MS = 5 * 60 * 1000;
-const NOISY_POLL_MIN_INVOCATIONS = 3;
-const NOISY_POLL_MIN_OUTPUT_CHARS = 20_000;
+const NOISY_POLL_MIN_INVOCATIONS = 5;
 const NOISY_POLL_MIN_INTERVAL_MS = 15_000;
 const NOISY_POLL_MAX_INTERVAL_MS = 75_000;
+const LARGE_OUTPUT_WARNING_CHARS = 4_000;
+const LARGE_OUTPUT_CRITICAL_CHARS = 40_000;
+const ACCOUNTED_TOOL_ITEM_TYPES = new Set([
+  "commandExecution",
+  "dynamicToolCall",
+  "functionCall",
+  "mcpToolCall",
+  "toolCall",
+]);
 
 export type ToolInvocationOutputMetrics = {
   debugLines: number;
@@ -35,6 +43,11 @@ export type NoisyPollingDetection = {
   alert: ThreadToolInvocationAlert;
   invocationIds: string[];
   lookbackSince: number;
+};
+
+export type LargeToolOutputDetection = {
+  alert: ThreadToolInvocationAlert;
+  invocationIds: string[];
 };
 
 export function toolInvocationFromNotification(params: {
@@ -91,7 +104,14 @@ export function toolInvocationFromNotification(params: {
   if (!item) {
     return undefined;
   }
-  if (readString(item, "type") !== "commandExecution") {
+  const itemType = readString(item, "type");
+  if (!itemType || !ACCOUNTED_TOOL_ITEM_TYPES.has(itemType)) {
+    return undefined;
+  }
+  if (
+    itemType !== "commandExecution"
+    && params.notification.method === "item/started"
+  ) {
     return undefined;
   }
 
@@ -111,6 +131,18 @@ export function toolInvocationFromNotification(params: {
   const metrics = buildToolOutputMetrics(output.text, {
     outputTruncated: output.truncated,
   });
+  if (
+    itemType !== "commandExecution"
+    && toolName !== "wait"
+    && toolName !== "write_stdin"
+    && metrics.outputChars < LARGE_OUTPUT_WARNING_CHARS
+  ) {
+    // Function, dynamic, and MCP calls are a much broader stream than the
+    // original command accounting surface. Persist only polling signals and
+    // genuinely large results; otherwise enabling this detector would add one
+    // sqlite commit for every ordinary local tool call.
+    return undefined;
+  }
   const normalized = normalizeToolInvocationCommand({
     args,
     command,
@@ -126,6 +158,8 @@ export function toolInvocationFromNotification(params: {
   const sessionId =
     readString(args, "session_id") ??
     readString(args, "sessionId") ??
+    readString(args, "cell_id") ??
+    readString(args, "cellId") ??
     readString(item, "sessionId") ??
     readString(item, "session_id");
   const exitCode = readExitCode(item);
@@ -249,6 +283,33 @@ export function mergeStreamedToolInvocationDeltas(
   };
 }
 
+export function mergeToolInvocationLifecycleWithStreamedOutput(
+  lifecycle: ThreadToolInvocationRecord,
+  streamed: ThreadToolInvocationRecord | undefined,
+): ThreadToolInvocationRecord {
+  if (!streamed) {
+    return lifecycle;
+  }
+  const outputChars = Math.max(lifecycle.outputChars, streamed.outputChars);
+  return {
+    ...lifecycle,
+    debugLines: Math.max(lifecycle.debugLines, streamed.debugLines),
+    errorLines: Math.max(lifecycle.errorLines, streamed.errorLines),
+    estimatedOutputTokens: Math.ceil(outputChars / OUTPUT_TOKEN_CHAR_RATIO),
+    infoLines: Math.max(lifecycle.infoLines, streamed.infoLines),
+    observedAt: Math.max(lifecycle.observedAt, streamed.observedAt),
+    outputChars,
+    outputLines: Math.max(lifecycle.outputLines, streamed.outputLines),
+    outputTruncated: lifecycle.outputTruncated || streamed.outputTruncated,
+    startedAt: Math.min(
+      lifecycle.startedAt ?? lifecycle.observedAt,
+      streamed.startedAt ?? streamed.observedAt,
+    ),
+    updatedAt: Math.max(lifecycle.updatedAt, streamed.updatedAt),
+    warningLines: Math.max(lifecycle.warningLines, streamed.warningLines),
+  };
+}
+
 export function normalizeToolInvocationCommand(params: {
   args?: Record<string, unknown>;
   command?: string;
@@ -266,6 +327,16 @@ export function normalizeToolInvocationCommand(params: {
         isPollingRead
           ? `poll session ${sessionId ?? "unknown"}`
           : `write stdin session ${sessionId ?? "unknown"}`,
+    };
+  }
+
+  if (toolName === "wait") {
+    const cellId =
+      readString(params.args, "cell_id")
+      ?? readString(params.args, "cellId");
+    return {
+      category: "polling",
+      normalizedCommand: `wait cell ${cellId ?? "unknown"}`,
     };
   }
 
@@ -300,27 +371,39 @@ export function detectNoisyPolling(params: {
   now?: number;
 }): NoisyPollingDetection | undefined {
   const current = params.current;
+  const isDeferredWait = current.toolName === "wait";
+  const isShellDelay =
+    current.category === "polling"
+    && current.normalizedCommand?.startsWith("sleep ") === true;
+  const isTurnScopedPolling = isDeferredWait || isShellDelay;
   if (
-    current.toolName !== "write_stdin" ||
+    (current.toolName !== "write_stdin" && !isTurnScopedPolling) ||
     current.category !== "polling" ||
-    (!current.sessionId && !current.processId)
+    (isTurnScopedPolling
+      ? !current.turnId
+      : (!current.sessionId && !current.processId))
   ) {
     return undefined;
   }
 
   const now = params.now ?? current.observedAt;
   const lookbackSince = now - NOISY_POLL_LOOKBACK_MS;
-  const records = [
-    current,
-    ...params.recent.filter((record) => record.invocationId !== current.invocationId),
-  ]
+  const uniqueRecords = new Map<string, ThreadToolInvocationRecord>();
+  for (const record of [...params.recent, current]) {
+    uniqueRecords.set(record.invocationId, record);
+  }
+  const records = [...uniqueRecords.values()]
     .filter(
       (record) =>
         record.toolName === current.toolName &&
         record.category === "polling" &&
         record.observedAt >= lookbackSince &&
-        (!current.sessionId || record.sessionId === current.sessionId) &&
-        (!current.processId || record.processId === current.processId),
+        (isTurnScopedPolling
+          ? record.turnId === current.turnId
+          : (
+              (!current.sessionId || record.sessionId === current.sessionId) &&
+              (!current.processId || record.processId === current.processId)
+            )),
     )
     .sort((left, right) => left.observedAt - right.observedAt);
 
@@ -340,10 +423,7 @@ export function detectNoisyPolling(params: {
     (sum, record) => sum + record.outputChars,
     0,
   );
-  if (
-    pollLikeIntervals.length < NOISY_POLL_MIN_INVOCATIONS - 1 ||
-    totalOutputChars < NOISY_POLL_MIN_OUTPUT_CHARS
-  ) {
+  if (pollLikeIntervals.length < NOISY_POLL_MIN_INVOCATIONS - 1) {
     return undefined;
   }
 
@@ -351,11 +431,13 @@ export function detectNoisyPolling(params: {
     intervals.reduce((sum, interval) => sum + interval, 0) / intervals.length,
   );
   const estimatedOutputTokens = Math.ceil(totalOutputChars / OUTPUT_TOKEN_CHAR_RATIO);
-  const sessionLabel = current.sessionId
-    ? `session ${current.sessionId}`
-    : `process ${current.processId}`;
+  const sessionLabel = isTurnScopedPolling
+    ? "the current turn"
+    : current.sessionId
+      ? `session ${current.sessionId}`
+      : `process ${current.processId}`;
   const message =
-    `Repeated write_stdin polling on ${sessionLabel} produced ${totalOutputChars.toLocaleString()} chars (~${estimatedOutputTokens.toLocaleString()} output tokens) across ${records.length.toLocaleString()} checks.`;
+    `${records.length.toLocaleString()} queued checks on ${sessionLabel} are repeatedly waking the model and replaying its accumulated context. The checks returned ${totalOutputChars.toLocaleString()} chars (~${estimatedOutputTokens.toLocaleString()} output tokens), but replay cost applies even when they return little or nothing.`;
   const suggestedPrompt = [
     "Stop polling this long-running process in the main thread.",
     "Use PwrAgent's create_monitor_delegation tool with the durable command, cwd, log/status files, poll cadence, and terminal success/failure criteria.",
@@ -369,7 +451,9 @@ export function detectNoisyPolling(params: {
         current.backend,
         current.threadId,
         current.toolName,
-        current.sessionId ?? current.processId ?? "unknown",
+        isTurnScopedPolling
+          ? current.turnId
+          : current.sessionId ?? current.processId ?? "unknown",
       ].join(":"),
       averageIntervalMs,
       backend: current.backend,
@@ -385,12 +469,74 @@ export function detectNoisyPolling(params: {
       severity: "warning",
       suggestedPrompt,
       threadId: current.threadId,
+      ...(current.turnId ? { turnId: current.turnId } : {}),
       toolName: current.toolName,
       totalOutputChars,
       updatedAt: now,
     },
     invocationIds: records.map((record) => record.invocationId),
     lookbackSince,
+  };
+}
+
+export function detectLargeToolOutput(params: {
+  current: ThreadToolInvocationRecord;
+  previousOutputChars?: number;
+  now?: number;
+}): LargeToolOutputDetection | undefined {
+  const current = params.current;
+  const previousOutputChars = params.previousOutputChars ?? 0;
+  const crossedWarning =
+    previousOutputChars < LARGE_OUTPUT_WARNING_CHARS
+    && current.outputChars >= LARGE_OUTPUT_WARNING_CHARS;
+  const crossedCritical =
+    previousOutputChars < LARGE_OUTPUT_CRITICAL_CHARS
+    && current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
+  const terminal = current.status !== "in_progress";
+  if (
+    current.outputChars < LARGE_OUTPUT_WARNING_CHARS
+    || (!crossedWarning && !crossedCritical && !terminal)
+  ) {
+    return undefined;
+  }
+
+  const now = params.now ?? current.observedAt;
+  const critical = current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
+  const estimatedCapPercentage = Math.max(
+    10,
+    Math.round(current.outputChars / LARGE_OUTPUT_CRITICAL_CHARS * 100),
+  );
+  const message = critical
+    ? `This tool produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), reaching or exceeding the observed model-visible output cap. The retained portion will replay on subsequent inference items.`
+    : `This tool has produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), about ${estimatedCapPercentage.toLocaleString()}% of the observed model-visible output cap. Continuing unfiltered will enlarge every later context replay.`;
+  const suggestedPrompt = [
+    "Treat this command as extremely noisy.",
+    "For subsequent executions, redirect full stdout and stderr to a local log and return only the command, exit code, concise summary, key failure blocks, and a bounded tail.",
+    "Use an installed output-reduction wrapper when available, and retrieve targeted raw sections only when needed.",
+  ].join(" ");
+
+  return {
+    alert: {
+      alertId: ["large-output", current.invocationId].join(":"),
+      backend: current.backend,
+      createdAt: now,
+      estimatedOutputTokens: current.estimatedOutputTokens,
+      firstObservedAt: current.startedAt ?? current.observedAt,
+      invocationCount: 1,
+      kind: "large-output",
+      lastObservedAt: current.observedAt,
+      message,
+      ...(current.processId ? { processId: current.processId } : {}),
+      ...(current.sessionId ? { sessionId: current.sessionId } : {}),
+      severity: critical ? "critical" : "warning",
+      suggestedPrompt,
+      threadId: current.threadId,
+      ...(current.turnId ? { turnId: current.turnId } : {}),
+      toolName: current.toolName,
+      totalOutputChars: current.outputChars,
+      updatedAt: now,
+    },
+    invocationIds: [current.invocationId],
   };
 }
 
@@ -489,6 +635,9 @@ function categoryForToolName(toolName: string): ThreadToolInvocationCategory {
 function categoryForCommand(command: string): ThreadToolInvocationCategory {
   const lower = command.toLowerCase();
   const first = lower.split(/\s+/)[0] ?? "";
+  if (first === "sleep") {
+    return "polling";
+  }
   if (first === "git") {
     return "git";
   }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1572,6 +1572,12 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
   async upsertThreadToolInvocation(params: {
     invocation: ThreadToolInvocationRecord;
   }): Promise<ThreadToolInvocationRecord> {
+    return this.upsertThreadToolInvocationSync(params);
+  }
+
+  private upsertThreadToolInvocationSync(params: {
+    invocation: ThreadToolInvocationRecord;
+  }): ThreadToolInvocationRecord {
     const invocation = normalizeThreadToolInvocation(params.invocation);
     const existing = this.readThreadToolInvocationSync(invocation.invocationId);
     const merged = existing
@@ -1684,9 +1690,42 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       .run(params.reason, Date.now(), params.invocationId);
   }
 
+  async markThreadToolInvocationsNoisy(params: {
+    invocationIds: string[];
+    reason: string;
+  }): Promise<void> {
+    if (params.invocationIds.length === 0) {
+      return;
+    }
+    this.stateDb.raw.transaction(() => {
+      this.markThreadToolInvocationsNoisySync(params);
+    })();
+  }
+
+  private markThreadToolInvocationsNoisySync(params: {
+    invocationIds: string[];
+    reason: string;
+  }): void {
+    const update = this.stateDb.raw.prepare(
+      `UPDATE thread_tool_invocations
+       SET noisy = 1, noisy_reason = ?, updated_at = ?
+       WHERE invocation_id = ?`,
+    );
+    const updatedAt = Date.now();
+    for (const invocationId of new Set(params.invocationIds)) {
+      update.run(params.reason, updatedAt, invocationId);
+    }
+  }
+
   async upsertThreadToolInvocationAlert(params: {
     alert: ThreadToolInvocationAlert;
   }): Promise<ThreadToolInvocationAlert> {
+    return this.upsertThreadToolInvocationAlertSync(params);
+  }
+
+  private upsertThreadToolInvocationAlertSync(params: {
+    alert: ThreadToolInvocationAlert;
+  }): ThreadToolInvocationAlert {
     const alert = normalizeThreadToolInvocationAlert(params.alert);
     this.stateDb.raw
       .prepare(
@@ -1749,6 +1788,36 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       )
       .run(toThreadToolInvocationAlertRowParams(alert));
     return alert;
+  }
+
+  async persistThreadToolInvocationBoundary(params: {
+    alerts: ThreadToolInvocationAlert[];
+    invocation: ThreadToolInvocationRecord;
+    noisyInvocationIds?: string[];
+    noisyReason?: string;
+  }): Promise<ThreadToolInvocationRecord> {
+    let stored: ThreadToolInvocationRecord | undefined;
+    this.stateDb.raw.transaction(() => {
+      stored = this.upsertThreadToolInvocationSync({
+        invocation: params.invocation,
+      });
+      if (
+        params.noisyInvocationIds?.length
+        && params.noisyReason
+      ) {
+        this.markThreadToolInvocationsNoisySync({
+          invocationIds: params.noisyInvocationIds,
+          reason: params.noisyReason,
+        });
+      }
+      for (const alert of params.alerts) {
+        this.upsertThreadToolInvocationAlertSync({ alert });
+      }
+    })();
+    if (!stored) {
+      throw new Error("Tool invocation boundary transaction did not run");
+    }
+    return stored;
   }
 
   async readThreadToolAccounting(params: {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -26,6 +26,7 @@ import {
   type MessagingChannelKind,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
+  type ThreadToolInvocationAlert,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { useThreadJump } from "./features/navigation/useThreadJump";
@@ -103,6 +104,7 @@ import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNo
 import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
 import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/github-pr-saml-notice";
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
+import { buildToolAccountingNotice } from "./features/notifications/tool-accounting-notice";
 import {
   buildHeapSnapshotHandoffMessage,
   describeHeapSnapshotResult,
@@ -645,6 +647,79 @@ function DesktopAppShell(props: {
       const instanceId = event.federationTarget?.scope === "remote"
         ? event.federationTarget.instanceId
         : undefined;
+      if (event.notification.method === "thread/toolAccounting/updated") {
+        const params = event.notification.params as {
+          threadId: string;
+          triggeredAlerts?: ThreadToolInvocationAlert[];
+        };
+        for (const alert of params.triggeredAlerts ?? []) {
+          const noticeId = [
+            "tool-accounting",
+            alert.backend,
+            alert.threadId,
+            alert.kind,
+          ].join(":");
+          const matchingThread = backendErrorThreadsRef.current.find(
+            (thread) =>
+              thread.source === event.backend
+              && thread.id === params.threadId
+              && federationTargetsEqual(
+                thread.federation?.ref.target,
+                event.federationTarget,
+              ),
+          );
+          const threadLink = matchingThread
+            ? {
+                backend: matchingThread.source,
+                inThreadList: true,
+                ...(instanceId ? { instanceId } : {}),
+                threadId: matchingThread.id,
+                title: matchingThread.title,
+                titleSource: matchingThread.titleSource,
+                gitBranch: matchingThread.gitBranch,
+                linkedDirectories: matchingThread.linkedDirectories,
+              }
+            : undefined;
+          const dismiss = (): void => {
+            dispatchAppNotice({ type: "dismiss", id: noticeId });
+          };
+          let steer: (() => void) | undefined;
+          const showNotice = (detail?: string): void => {
+            const notice = buildToolAccountingNotice({
+              alert,
+              onDismiss: dismiss,
+              onSteer: steer,
+              threadLink,
+            });
+            dispatchAppNotice({
+              type: "show",
+              notice: detail ? { ...notice, detail } : notice,
+            });
+          };
+          if (alert.turnId && desktopApi.steerTurn) {
+            steer = (): void => {
+              void desktopApi.steerTurn?.({
+                backend: event.backend,
+                federationTarget: event.federationTarget,
+                threadId: params.threadId,
+                expectedTurnId: alert.turnId!,
+                input: [{ type: "text", text: alert.suggestedPrompt }],
+                requestId: [
+                  "tool-accounting",
+                  alert.alertId,
+                  alert.updatedAt,
+                ].join(":"),
+              }).then(dismiss).catch((error) => {
+                showNotice(
+                  `Steering failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+              });
+            };
+          }
+          showNotice();
+        }
+        return;
+      }
       // Params are cast explicitly: the AppServerNotification union is too
       // wide for the discriminant to narrow `params` reliably here.
       if (event.notification.method === "turn/failed") {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -646,6 +646,94 @@ describe("App", () => {
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
   });
 
+  it("surfaces replay-risk alerts as durable one-click steering notices", async () => {
+    const agentEventListeners = new Set<(event: AgentEvent) => void>();
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+        steerTurn,
+      },
+    });
+
+    render(<App />);
+    await waitFor(() => expect(agentEventListeners.size).toBeGreaterThan(0));
+
+    act(() => {
+      const event = {
+        backend: "codex",
+        notification: {
+          method: "thread/toolAccounting/updated",
+          params: {
+            threadId: "thread-1",
+            toolAccounting: { alerts: [], invocations: [], summaries: [] },
+            triggeredAlerts: [{
+              alertId: "noisy-polling:codex:thread-1:wait:turn-1",
+              backend: "codex",
+              createdAt: 1,
+              estimatedOutputTokens: 0,
+              firstObservedAt: 1,
+              invocationCount: 5,
+              kind: "noisy-polling",
+              lastObservedAt: 2,
+              message: "Five queued checks keep replaying the turn context.",
+              severity: "warning",
+              suggestedPrompt: "Stop polling and use a monitor job.",
+              threadId: "thread-1",
+              toolName: "wait",
+              totalOutputChars: 0,
+              turnId: "turn-1",
+              updatedAt: 2,
+            }],
+          },
+        },
+      } as AgentEvent;
+      for (const listener of agentEventListeners) {
+        listener(event);
+      }
+    });
+
+    expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
+    expect(screen.getByText(/Five queued checks/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Use monitor job" }));
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledWith(expect.objectContaining({
+        backend: "codex",
+        expectedTurnId: "turn-1",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Stop polling and use a monitor job." }],
+      }));
+    });
+  });
+
   it("reveals the sidebar when adding a project from the hidden-sidebar masthead", async () => {
     const pickDirectoryFromDisk = vi.fn(async () => ({
       canceled: false as const,

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ThreadToolInvocationAlert } from "@pwragent/shared";
+import { buildToolAccountingNotice } from "../tool-accounting-notice";
+
+describe("buildToolAccountingNotice", () => {
+  it("builds one sticky monitor action for repeated queued checks", () => {
+    const onDismiss = vi.fn();
+    const onSteer = vi.fn();
+    const notice = buildToolAccountingNotice({
+      alert: buildAlert({ kind: "noisy-polling" }),
+      onDismiss,
+      onSteer,
+    });
+
+    expect(notice).toMatchObject({
+      autoDismiss: false,
+      id: "tool-accounting:codex:thread-1:noisy-polling",
+      title: "Repeated queued checks",
+      tone: "warning",
+    });
+    expect(notice.actions?.map((action) => action.label)).toEqual([
+      "Use monitor job",
+      "Dismiss",
+    ]);
+    notice.actions?.[0]?.onClick();
+    notice.actions?.[1]?.onClick();
+    expect(onSteer).toHaveBeenCalledOnce();
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("upserts large outputs under one critical thread incident", () => {
+    const notice = buildToolAccountingNotice({
+      alert: buildAlert({ kind: "large-output", severity: "critical" }),
+      onDismiss: vi.fn(),
+      onSteer: vi.fn(),
+    });
+
+    expect(notice).toMatchObject({
+      id: "tool-accounting:codex:thread-1:large-output",
+      title: "Large tool output",
+      tone: "error",
+    });
+    expect(notice.actions?.[0]?.label).toBe("Steer safer output");
+  });
+});
+
+function buildAlert(
+  overrides: Partial<ThreadToolInvocationAlert>,
+): ThreadToolInvocationAlert {
+  return {
+    alertId: "alert-1",
+    backend: "codex",
+    createdAt: 1,
+    estimatedOutputTokens: 1_000,
+    firstObservedAt: 1,
+    invocationCount: 5,
+    kind: "noisy-polling",
+    lastObservedAt: 2,
+    message: "The turn keeps waking up.",
+    severity: "warning",
+    suggestedPrompt: "Use a monitor.",
+    threadId: "thread-1",
+    toolName: "wait",
+    totalOutputChars: 0,
+    updatedAt: 2,
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -1,0 +1,41 @@
+import type { ThreadToolInvocationAlert } from "@pwragent/shared";
+import type { ResolvedThreadLink } from "../../lib/thread-links";
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export function buildToolAccountingNotice(params: {
+  alert: ThreadToolInvocationAlert;
+  onDismiss: () => void;
+  onSteer?: () => void;
+  threadLink?: ResolvedThreadLink;
+}): AppNoticeToastNotice {
+  const polling = params.alert.kind === "noisy-polling";
+  const steerAction = params.onSteer
+    ? [{
+        label: polling ? "Use monitor job" : "Steer safer output",
+        onClick: params.onSteer,
+        tone: "primary" as const,
+      }]
+    : [];
+  return {
+    actions: [
+      ...steerAction,
+      {
+        label: "Dismiss",
+        onClick: params.onDismiss,
+        tone: "secondary",
+      },
+    ],
+    autoDismiss: false,
+    copyText: [params.alert.message, params.alert.suggestedPrompt].join("\n\n"),
+    id: [
+      "tool-accounting",
+      params.alert.backend,
+      params.alert.threadId,
+      params.alert.kind,
+    ].join(":"),
+    message: params.alert.message,
+    threadLink: params.threadLink,
+    title: polling ? "Repeated queued checks" : "Large tool output",
+    tone: params.alert.severity === "critical" ? "error" : "warning",
+  };
+}

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -85,7 +85,7 @@ export function ExperimentalSettings(props: {
       <SettingsSection
         eyebrow="Experimental"
         title="Tool Call Tracking"
-        description="Show tool-call volume, command instances, output, and noisy-polling alerts in a dedicated thread panel."
+        description="Show tool-call volume, command instances, output, and replay-risk history in a dedicated thread panel. Safety notices remain active while this is off."
         chip={threadToolAccounting.value ? "On" : "Off"}
         chipKind={threadToolAccounting.value ? "ok" : "default"}
       >

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -860,7 +860,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("3 invocations")).toBeInTheDocument();
     expect(screen.getByText("6k est. tokens")).toBeInTheDocument();
     expect(screen.getByText("Diagnostics")).toBeInTheDocument();
-    expect(screen.getByText("Noisy polling detected")).toBeInTheDocument();
+    expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
     expect(screen.getByText(/Repeated write_stdin polling/)).toBeInTheDocument();
     expect(screen.getByText("write_stdin · polling")).toBeInTheDocument();
     expect(screen.queryByText("poll session 40500")).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -96,7 +96,11 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
         <ul className="context-list context-list--cards tool-call-alert-list">
           {accounting.alerts.map((alert) => (
             <li key={alert.alertId} className="rail-card tool-call-alert">
-              <p className="rail-card__title">Noisy polling detected</p>
+              <p className="rail-card__title">
+                {alert.kind === "noisy-polling"
+                  ? "Repeated queued checks"
+                  : "Large tool output"}
+              </p>
               <p className="rail-card__usage">{alert.message}</p>
               <p className="rail-card__usage">
                 Suggested steering: {alert.suggestedPrompt}

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -962,8 +962,9 @@ export type ThreadToolInvocationAlert = {
   alertId: string;
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
-  kind: "noisy-polling";
-  severity: "warning";
+  turnId?: string;
+  kind: "large-output" | "noisy-polling";
+  severity: "warning" | "critical";
   toolName: string;
   sessionId?: string;
   processId?: string;
@@ -1343,6 +1344,7 @@ export type AppServerNotification =
       params: {
         threadId: string;
         toolAccounting: ThreadToolAccounting;
+        triggeredAlerts?: ThreadToolInvocationAlert[];
       };
     }
   | {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -673,7 +673,8 @@ export type DesktopSettingsSnapshot = {
     /**
      * Shows the experimental Tool calls tab in the thread context rail.
      * The desktop app may still collect tool metrics while this is disabled;
-     * this only gates the operator-facing panel and noisy-polling alerts.
+     * this only gates the operator-facing panel. Replay-risk safety notices
+     * remain active because their cost grows while the turn is running.
      */
     threadToolAccounting?: DesktopSettingsValue<boolean>;
     /**


### PR DESCRIPTION
## Summary

- I detect replay-amplifying tool behavior: five deferred checks in one turn and command output crossing 4,000 or 40,000 characters.
- I surface sticky, thread-scoped notices that can steer the active turn toward a durable monitor job or bounded output handling.
- I keep ordinary `wait` and `write_stdin` samples in memory and persist only alert boundaries, avoiding a timer-driven SQLite write stream.

## Verification

- I ran the focused Vitest suite covering accounting, registry integration, SQLite budgets, notifications, and the app shell: 670 tests passed.
- I ran `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, `pnpm lint:codex-storage`, and `pnpm lint:sql`.
- I recorded the deferred-check write budget at one commit, one statement, and one changed row for the first five checks and their alert.

## Notes

- A large-output warning cannot prevent the initial command result from entering Codex context; it steers subsequent executions before that output is replayed repeatedly.
- Safety notices remain active even when the experimental Tool Calls panel is disabled.
