### PR TITLE
fix(desktop): complete cross-provider reviews

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18586,6 +18586,143 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("completes a Codex review child against its ACP parent", async () => {
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const parentThreadId = "grok-parent-with-codex-review";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startThreadResult: { threadId: "codex-review-child" },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        [`${acpBackendId}:${parentThreadId}`]: {
+          backend: acpBackendId,
+          threadId: parentThreadId,
+          executionMode: "full-access",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      codexClient,
+      overlayStore,
+      sessionId: parentThreadId,
+      sessions: [{
+        backendId: acpBackendId,
+        sessionId: parentThreadId,
+        title: "Grok parent",
+        cwd: "/repo/worktree",
+        createdAt: 1_000,
+        updatedAt: 1_000,
+        executionMode: "full-access",
+        status: "idle",
+      }],
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const response = await registry.startReview({
+      backend: acpBackendId,
+      reviewBackend: "codex",
+      threadId: parentThreadId,
+      target: { type: "baseBranch", branch: "origin/main" },
+      delivery: "inline",
+    });
+    expect(response).toMatchObject({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      reviewThreadId: "codex-review-child",
+      turnId: "turn-1",
+    });
+
+    const approvalResponse = codexClient.emitRequest({
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: response.reviewThreadId,
+        turnId: response.turnId,
+        itemId: "review-command",
+        requestId: "review-approval",
+        command: "git diff origin/main...HEAD",
+      },
+    } as AppServerPendingRequestNotification);
+    await waitForCondition(() => events.some((event) =>
+      event.notification.method === "item/commandExecution/requestApproval"
+    ));
+    expect(events.find((event) =>
+      event.notification.method === "item/commandExecution/requestApproval"
+    )).toMatchObject({
+      backend: acpBackendId,
+      notification: {
+        params: {
+          threadId: parentThreadId,
+          turnId: response.turnId,
+          requestId: "review-approval",
+        },
+      },
+    });
+    await registry.submitServerRequest({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      turnId: response.turnId,
+      requestId: "review-approval",
+      response: { decision: "accept" },
+    });
+    await expect(approvalResponse).resolves.toEqual({ decision: "accept" });
+
+    const reviewOutput = JSON.stringify({
+      findings: [],
+      overall_correctness: "patch is correct",
+      overall_explanation: "No blocking findings.",
+      overall_confidence_score: 0.98,
+    });
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: response.reviewThreadId,
+        turnId: response.turnId,
+        turn: {
+          id: response.turnId,
+          status: "completed",
+          output: [{ type: "text", text: reviewOutput }],
+        },
+      },
+    });
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+    });
+    expect(overlay?.subAgents).toEqual([
+      expect.objectContaining({
+        backend: "codex",
+        monitorThreadId: response.reviewThreadId,
+        monitorTurnId: response.turnId,
+        outcome: "success",
+        status: "success",
+      }),
+    ]);
+    expect(overlay?.managedReviewEntries).toEqual([
+      expect.objectContaining({
+        id: `managed-review:${response.turnId}:started`,
+      }),
+      expect.objectContaining({
+        id: `managed-review:${response.turnId}:result`,
+        output: expect.objectContaining({
+          overall_correctness: "patch is correct",
+        }),
+        turn: expect.objectContaining({
+          id: response.turnId,
+          status: "completed",
+        }),
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("normalizes file-change approval diffs and omits empty placeholders", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2620,6 +2620,7 @@ type TaskMonitorDelegationRecord = {
 };
 
 type ReviewSubAgentRecord = {
+  /** Backend running the review child. */
   backend: AppServerBackendKind;
   createdAt: number;
   displayText: string;
@@ -2627,6 +2628,8 @@ type ReviewSubAgentRecord = {
   latestUsage?: TaskMonitorUsageSnapshot;
   mode: "managed" | "native";
   model?: string;
+  /** Backend owning the thread being reviewed. */
+  parentBackend: AppServerBackendKind;
   parentThreadId: string;
   serviceTier?: string;
   reviewThreadId: string;
@@ -12908,12 +12911,13 @@ export class DesktopBackendRegistry {
       this.reservedAcpStartThreadKeys.delete(acpReviewReservationKey);
     }
     const reviewSubAgentRecord: ReviewSubAgentRecord = {
-      backend: params.backend,
+      backend: reviewBackend,
       createdAt: Date.now(),
       displayText: reviewTaskLabel(params.target),
       ...(modelSettings.fastMode !== undefined ? { fastMode: modelSettings.fastMode } : {}),
       ...(modelSettings.model ? { model: modelSettings.model } : {}),
       mode: managedMode ? "managed" : "native",
+      parentBackend: params.backend,
       parentThreadId: result.threadId,
       reviewThreadId: result.reviewThreadId || result.threadId,
       ...(modelSettings.serviceTier ? { serviceTier: modelSettings.serviceTier } : {}),
@@ -12930,7 +12934,9 @@ export class DesktopBackendRegistry {
     await this.persistReviewSubAgent(reviewSubAgentRecord);
     backendRegistryLog.info("code review started", {
       mode: reviewSubAgentRecord.mode,
+      parentBackend: reviewSubAgentRecord.parentBackend,
       parentThreadId: reviewSubAgentRecord.parentThreadId,
+      reviewBackend: reviewSubAgentRecord.backend,
       reviewThreadId: reviewSubAgentRecord.reviewThreadId,
       turnId: reviewSubAgentRecord.turnId,
     });
@@ -13069,12 +13075,12 @@ export class DesktopBackendRegistry {
       },
     };
     await this.overlayStore.upsertManagedReviewEntry({
-      backend: record.backend,
+      backend: record.parentBackend,
       threadId: record.parentThreadId,
       entry,
     });
     await this.emit({
-      backend: record.backend,
+      backend: record.parentBackend,
       notification: {
         method: "turn/started",
         params: {
@@ -13089,7 +13095,7 @@ export class DesktopBackendRegistry {
       },
     });
     await this.emit({
-      backend: record.backend,
+      backend: record.parentBackend,
       notification: {
         method: "item/completed",
         params: {
@@ -13647,15 +13653,15 @@ export class DesktopBackendRegistry {
       turnId: params.turnId,
     });
     if (managedReview) {
-      if (isAcpBackendId(params.backend)) {
+      if (isAcpBackendId(managedReview.backend)) {
         const childLockKey = executionModeQueueKey(
-          params.backend,
+          managedReview.backend,
           managedReview.reviewThreadId,
         );
         await this.acpSessionPromptLocks.run(
           childLockKey,
           async () => await this.interruptAcpTurn({
-            backend: params.backend,
+            backend: managedReview.backend,
             threadId: managedReview.reviewThreadId,
             turnId: managedReview.turnId,
           }),
@@ -19645,7 +19651,7 @@ export class DesktopBackendRegistry {
         });
         if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
           const line = buildTaskMonitorUsageLine({
-            backend: event.backend,
+            backend: reviewRecord.parentBackend,
             fastMode,
             model,
             monitorId: reviewSubAgentId(reviewRecord.turnId),
@@ -19660,14 +19666,14 @@ export class DesktopBackendRegistry {
           logUnpricedThreadUsageLine(line);
           await this.overlayStore.upsertThreadUsageLine({ line });
           await this.emitThreadPricingUpdated({
-            backend: event.backend,
+            backend: reviewRecord.parentBackend,
             threadId: line.parentThreadId ?? line.threadId,
           });
         }
         return;
       }
       const reviewUsagePersisted = await this.persistExistingReviewSubAgentUsage({
-        backend: event.backend,
+        backend: completedReviewRecord?.parentBackend ?? event.backend,
         parentThreadId:
           completedReviewRecord?.parentThreadId ?? notification.params.threadId,
         reviewThreadId:
@@ -19684,7 +19690,7 @@ export class DesktopBackendRegistry {
         });
         if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
           const line = buildTaskMonitorUsageLine({
-            backend: event.backend,
+            backend: completedReviewRecord?.parentBackend ?? event.backend,
             fastMode,
             model,
             monitorId: reviewSubAgentId(notification.params.turnId),
@@ -19701,7 +19707,7 @@ export class DesktopBackendRegistry {
           logUnpricedThreadUsageLine(line);
           await this.overlayStore.upsertThreadUsageLine({ line });
           await this.emitThreadPricingUpdated({
-            backend: event.backend,
+            backend: completedReviewRecord?.parentBackend ?? event.backend,
             threadId: line.parentThreadId ?? line.threadId,
           });
         }
@@ -21184,7 +21190,7 @@ export class DesktopBackendRegistry {
     > = {},
   ): Promise<void> {
     const existingOverlay = await this.overlayStore.getThreadOverlayState({
-      backend: record.backend,
+      backend: record.parentBackend,
       threadId: record.parentThreadId,
     });
     const monitorId = reviewSubAgentId(record.turnId);
@@ -21222,13 +21228,13 @@ export class DesktopBackendRegistry {
     };
 
     await this.overlayStore.upsertThreadSubAgent({
-      backend: record.backend,
+      backend: record.parentBackend,
       threadId: record.parentThreadId,
       subAgent,
     });
-    this.invalidateThreadListCache(record.backend);
+    this.invalidateThreadListCache(record.parentBackend);
     await this.emit({
-      backend: record.backend,
+      backend: record.parentBackend,
       notification: {
         method: "thread/subAgents/updated",
         params: {
@@ -21292,7 +21298,7 @@ export class DesktopBackendRegistry {
     return Array.from(this.activeReviewSubAgents.values()).find(
       (record) =>
         record.mode === "managed"
-        && record.backend === params.backend
+        && record.parentBackend === params.backend
         && record.parentThreadId === params.parentThreadId
         && record.turnId === params.turnId,
     );
@@ -21349,13 +21355,13 @@ export class DesktopBackendRegistry {
         },
       };
       await this.overlayStore.upsertManagedReviewEntry({
-        backend: params.record.backend,
+        backend: params.record.parentBackend,
         threadId: params.record.parentThreadId,
         entry,
-        pendingContext: isAcpBackendId(params.record.backend),
+        pendingContext: isAcpBackendId(params.record.parentBackend),
       });
       await this.emit({
-        backend: params.record.backend,
+        backend: params.record.parentBackend,
         notification: {
           method: "item/completed",
           params: {
@@ -21378,7 +21384,7 @@ export class DesktopBackendRegistry {
         turnId: params.record.turnId,
       });
       await this.emit({
-        backend: params.record.backend,
+        backend: params.record.parentBackend,
         notification: {
           method: "turn/completed",
           params: {
@@ -21404,7 +21410,7 @@ export class DesktopBackendRegistry {
     });
     if (params.method === "turn/cancelled") {
       await this.emit({
-        backend: params.record.backend,
+        backend: params.record.parentBackend,
         notification: {
           method: "turn/cancelled",
           params: {
@@ -21428,7 +21434,7 @@ export class DesktopBackendRegistry {
       >
     ).params.turn?.error?.message;
     await this.emit({
-      backend: params.record.backend,
+      backend: params.record.parentBackend,
       notification: {
         method: "turn/failed",
         params: {
@@ -23484,38 +23490,41 @@ export class DesktopBackendRegistry {
           },
         } as AppServerPendingRequestNotification
       : request;
+    const routedBackend = managedReview?.parentBackend ?? backend;
     if (managedReview) {
       backendRegistryLog.info("managed review request routed to parent", {
         method: request.method,
+        parentBackend: managedReview.parentBackend,
         parentThreadId: managedReview.parentThreadId,
         requestId: request.params.requestId,
+        reviewBackend: managedReview.backend,
         reviewThreadId: managedReview.reviewThreadId,
         turnId: managedReview.turnId,
       });
     }
 
     const key = buildPendingRequestKey({
-      backend,
+      backend: routedBackend,
       threadId: routedRequest.params.threadId,
       requestId: routedRequest.params.requestId,
     });
 
     return await new Promise<SubmitServerRequestRequest["response"]>((resolve, reject) => {
       this.pendingServerRequests.set(key, {
-        backend,
+        backend: routedBackend,
         notification: routedRequest,
         resolve,
         reject,
       });
 
       void this.emit({
-        backend,
+        backend: routedBackend,
         notification: routedRequest as AppServerNotification,
       }).catch((error) => {
         backendRegistryLog.error(
           "failed to publish pending server request; keeping request pending",
           {
-            backend,
+            backend: routedBackend,
             error: error instanceof Error ? error.message : String(error),
             requestId: routedRequest.params.requestId,
             threadId: routedRequest.params.threadId,
@@ -29294,7 +29303,7 @@ export class DesktopBackendRegistry {
     // the pipeline would write a second tool-invocation row per item and add
     // parent-keyed entries to the file-change approval-context cache.
     await this.emitToListeners({
-      backend: event.backend,
+      backend: record.parentBackend,
       notification: {
         ...event.notification,
         params: {


### PR DESCRIPTION
## What changed

- keep the review child's backend separate from the reviewed parent thread's backend
- match terminal events and control requests against the actual reviewer backend
- route persisted state, live activity, usage, and approval prompts through the parent backend/thread
- add a Grok-parent/Codex-review regression covering approval routing and successful completion

## Root cause

Managed review records used one backend field for two identities. A Grok parent with a Codex reviewer was persisted as a running Grok sub-agent, while terminal events arrived from Codex, so the matcher never completed the card. The same mismatch could route a child approval request to a backend/thread pair that had no visible parent surface.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (515 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `pnpm lint:electron-version`
- `pnpm licenses:check`
