### PR TITLE
fix(desktop): show all PRs in quick jump

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -159,11 +160,42 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
       props.onClose();
       return;
     }
-    // The palette is modal: the only tab stop inside it is the field (rows are
-    // driven by aria-activedescendant, not focus), so Tab must not walk out
-    // into the dimmed app behind the scrim.
     if (event.key === "Tab") {
       event.preventDefault();
+      const target = event.target instanceof HTMLElement
+        ? event.target
+        : undefined;
+      const targetRow = target?.closest<HTMLElement>('[role="option"]');
+      const activeRow = listRef.current?.querySelector<HTMLElement>(
+        '[role="option"][aria-selected="true"]',
+      );
+      const row = targetRow ?? activeRow;
+      const chips = Array.from(
+        row?.querySelectorAll<HTMLElement>("[data-pr-chip]") ?? [],
+      );
+
+      // The field owns listbox steering through aria-activedescendant. Tab
+      // temporarily enters the active row's PR actions; once the row's chips
+      // are exhausted, focus returns to the field instead of escaping the
+      // modal into the dimmed app.
+      if (target === inputRef.current) {
+        const chip = event.shiftKey ? chips.at(-1) : chips[0];
+        (chip ?? inputRef.current)?.focus();
+        return;
+      }
+
+      const chipIndex = target ? chips.indexOf(target) : -1;
+      const nextIndex = chipIndex + (event.shiftKey ? -1 : 1);
+      const nextChip = chipIndex >= 0 ? chips[nextIndex] : undefined;
+      (nextChip ?? inputRef.current)?.focus();
+      return;
+    }
+    // Arrow and Enter steer the aria-activedescendant list only while the
+    // field owns focus. A focused PR chip handles its own activation keys.
+    if (
+      event.target !== inputRef.current
+      && document.activeElement !== inputRef.current
+    ) {
       return;
     }
     if (event.key === "ArrowDown") {
@@ -191,6 +223,12 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
   ): ReactElement => {
     const description = describeThread(thread);
     const prs = orderPullRequestsForQuery(thread, trimmed);
+    const exactPrQuery = threadHasExactPrNumberMatch(thread, trimmed)
+      ? String(Number(trimmed.replace(/^#/, "")))
+      : "";
+    const prStripResetKey = `${exactPrQuery}|${prs
+      .map((pr) => pr.url)
+      .join("|")}`;
     const key = thread.federation
       ? federatedThreadIdentityKey(thread.federation.ref)
       : buildThreadIdentityKey(thread.source, thread.id);
@@ -226,21 +264,11 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
           ) : null}
           {thread.agent ? <AgentThreadChip /> : null}
           {prs.length > 0 ? (
-            <span
-              className="jump-palette__row-prs"
-              data-overflow={prs.length > 2 ? "true" : undefined}
-              aria-label="Pull requests"
-              onWheel={scrollPullRequestsHorizontally}
-            >
-              {prs.map((pr) => (
-                <PrChip
-                  key={pr.url}
-                  pr={pr}
-                  showRepoPrefix={false}
-                  onOpen={openPullRequest}
-                />
-              ))}
-            </span>
+            <PullRequestStrip
+              prs={prs}
+              resetKey={prStripResetKey}
+              onOpen={openPullRequest}
+            />
           ) : null}
           {description.branch ? (
             // Clipped from the LEFT (`direction: rtl` in CSS) so a long
@@ -381,6 +409,39 @@ type ThreadDescription = {
   branch?: string;
   directory?: string;
 };
+
+function PullRequestStrip(props: {
+  prs: NonNullable<NavigationThreadSummary["prs"]>;
+  resetKey: string;
+  onOpen: (url: string) => void;
+}): ReactElement {
+  const stripRef = useRef<HTMLSpanElement>(null);
+
+  useLayoutEffect(() => {
+    if (stripRef.current) {
+      stripRef.current.scrollLeft = 0;
+    }
+  }, [props.resetKey]);
+
+  return (
+    <span
+      ref={stripRef}
+      className="jump-palette__row-prs"
+      data-overflow={props.prs.length > 2 ? "true" : undefined}
+      aria-label="Pull requests"
+      onWheel={scrollPullRequestsHorizontally}
+    >
+      {props.prs.map((pr) => (
+        <PrChip
+          key={pr.url}
+          pr={pr}
+          showRepoPrefix={false}
+          onOpen={props.onOpen}
+        />
+      ))}
+    </span>
+  );
+}
 
 function orderPullRequestsForQuery(
   thread: NavigationThreadSummary,

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -8,6 +8,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactElement,
+  type WheelEvent as ReactWheelEvent,
 } from "react";
 import { createPortal } from "react-dom";
 import {
@@ -25,6 +26,7 @@ import {
 import { threadMatchesQuery } from "../thread-search/thread-match";
 import { AgentThreadChip } from "./AgentThreadChip";
 import { InstanceChip } from "../federation/InstanceGlyph";
+import { PrChip } from "../pr-status/PrChip";
 
 const MAX_RESULTS = 8;
 
@@ -146,6 +148,11 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     props.onClose();
   };
 
+  const openPullRequest = (url: string): void => {
+    window.open(url, "_blank", "noopener,noreferrer");
+    props.onClose();
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (event.key === "Escape") {
       event.preventDefault();
@@ -182,7 +189,8 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     thread: NavigationThreadSummary,
     index: number,
   ): ReactElement => {
-    const description = describeThread(thread, trimmed);
+    const description = describeThread(thread);
+    const prs = orderPullRequestsForQuery(thread, trimmed);
     const key = thread.federation
       ? federatedThreadIdentityKey(thread.federation.ref)
       : buildThreadIdentityKey(thread.source, thread.id);
@@ -217,8 +225,22 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
             />
           ) : null}
           {thread.agent ? <AgentThreadChip /> : null}
-          {description.pr ? (
-            <span className="jump-palette__row-pr">{description.pr}</span>
+          {prs.length > 0 ? (
+            <span
+              className="jump-palette__row-prs"
+              data-overflow={prs.length > 2 ? "true" : undefined}
+              aria-label="Pull requests"
+              onWheel={scrollPullRequestsHorizontally}
+            >
+              {prs.map((pr) => (
+                <PrChip
+                  key={pr.url}
+                  pr={pr}
+                  showRepoPrefix={false}
+                  onOpen={openPullRequest}
+                />
+              ))}
+            </span>
           ) : null}
           {description.branch ? (
             // Clipped from the LEFT (`direction: rtl` in CSS) so a long
@@ -356,26 +378,50 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
 }
 
 type ThreadDescription = {
-  /** Rendered with its `#`, e.g. `#1483`. */
-  pr?: string;
   branch?: string;
   directory?: string;
 };
 
-function describeThread(
+function orderPullRequestsForQuery(
   thread: NavigationThreadSummary,
   query: string,
+): NonNullable<NavigationThreadSummary["prs"]> {
+  const prs = thread.prs ?? [];
+  if (!threadHasExactPrNumberMatch(thread, query)) {
+    return prs;
+  }
+  const number = Number(query.trim().replace(/^#/, ""));
+  return [
+    ...prs.filter((pr) => pr.number === number),
+    ...prs.filter((pr) => pr.number !== number),
+  ];
+}
+
+function scrollPullRequestsHorizontally(
+  event: ReactWheelEvent<HTMLSpanElement>,
+): void {
+  const strip = event.currentTarget;
+  const delta = event.deltaX || event.deltaY;
+  if (delta === 0 || strip.scrollWidth <= strip.clientWidth) {
+    return;
+  }
+  const maxScrollLeft = strip.scrollWidth - strip.clientWidth;
+  const nextScrollLeft = Math.max(
+    0,
+    Math.min(maxScrollLeft, strip.scrollLeft + delta),
+  );
+  if (nextScrollLeft === strip.scrollLeft) {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  strip.scrollLeft = nextScrollLeft;
+}
+
+function describeThread(
+  thread: NavigationThreadSummary,
 ): ThreadDescription {
   const description: ThreadDescription = {};
-  const pr = threadHasExactPrNumberMatch(thread, query)
-    ? (thread.prs ?? []).find(
-        (candidate) =>
-          candidate.number === Number(query.trim().replace(/^#/, "")),
-      )
-    : (thread.prs ?? [])[0];
-  if (pr) {
-    description.pr = `#${pr.number}`;
-  }
   if (thread.gitBranch) {
     description.branch = thread.gitBranch;
   }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -92,6 +92,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
@@ -233,6 +234,84 @@ describe("SidebarSearchPopup", () => {
     });
     fireEvent.wheel(strip, { cancelable: true, deltaY: 40 });
     expect(strip.scrollLeft).toBe(40);
+    await settleRemoteSearch();
+  });
+
+  it("resets a retained PR strip when the query moves an exact match first", async () => {
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({
+            id: "stacked",
+            title: "Stacked pull requests",
+            prs: [pr(16), pr(18), pr(21)],
+          }),
+        ]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "Stacked" } });
+    const strip = screen.getByLabelText("Pull requests");
+    Object.defineProperty(strip, "scrollLeft", {
+      configurable: true,
+      value: 40,
+      writable: true,
+    });
+
+    fireEvent.change(input, { target: { value: "18" } });
+
+    const chips = Array.from(document.querySelectorAll("[data-pr-chip]"));
+    expect(chips.map((chip) => chip.textContent)).toEqual(["#18", "#16", "#21"]);
+    expect(strip.scrollLeft).toBe(0);
+    await settleRemoteSearch();
+  });
+
+  it("tabs through the active row PR chips and activates one without jumping", async () => {
+    const onJumpToThread = vi.fn();
+    const onClose = vi.fn();
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({
+            id: "stacked",
+            title: "Stacked pull requests",
+            prs: [pr(16), pr(18)],
+          }),
+        ]}
+        onJumpToThread={onJumpToThread}
+        onClose={onClose}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "Stacked" } });
+    const chips = screen.getAllByRole("button", {
+      name: /Open pwrdrvr\/PwrAgent#/,
+    });
+    const firstChip = chips[0]!;
+    const secondChip = chips[1]!;
+
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect(firstChip).toHaveFocus();
+    fireEvent.keyDown(firstChip, { key: "Tab" });
+    expect(secondChip).toHaveFocus();
+    fireEvent.keyDown(secondChip, { key: "Tab" });
+    expect(input).toHaveFocus();
+    fireEvent.keyDown(input, { key: "Tab", shiftKey: true });
+    expect(secondChip).toHaveFocus();
+
+    fireEvent.keyDown(secondChip, { key: "Enter" });
+    expect(open).toHaveBeenCalledWith(
+      "https://github.com/pwrdrvr/PwrAgent/pull/18",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(onJumpToThread).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
     await settleRemoteSearch();
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -194,6 +194,48 @@ describe("SidebarSearchPopup", () => {
     await settleRemoteSearch();
   });
 
+  it("renders every PR and moves an exact match into the visible pair", async () => {
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({
+            id: "stacked",
+            title: "Stacked pull requests",
+            prs: [
+              pr(16, "PwrSuiteLab"),
+              pr(18, "PwrSuiteLab"),
+              pr(21, "PwrSuiteLab"),
+            ],
+          }),
+        ]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "18" },
+    });
+
+    const chips = Array.from(document.querySelectorAll("[data-pr-chip]"));
+    expect(chips).toHaveLength(3);
+    expect(chips.map((chip) => chip.textContent)).toEqual(["#18", "#16", "#21"]);
+    expect(document.querySelector(".jump-palette__row-prs")).toHaveAttribute(
+      "data-overflow",
+      "true",
+    );
+
+    const strip = screen.getByLabelText("Pull requests");
+    Object.defineProperties(strip, {
+      clientWidth: { configurable: true, value: 126 },
+      scrollWidth: { configurable: true, value: 260 },
+      scrollLeft: { configurable: true, value: 0, writable: true },
+    });
+    fireEvent.wheel(strip, { cancelable: true, deltaY: 40 });
+    expect(strip.scrollLeft).toBe(40);
+    await settleRemoteSearch();
+  });
+
   it("arrows from local into remote rows and Enter selects the remote thread", async () => {
     const onJumpToThread = vi.fn();
     const onJumpToRemoteThread = vi.fn();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1206,13 +1206,36 @@ textarea,
   white-space: nowrap;
 }
 
-.jump-palette__row-pr {
+.jump-palette__row-prs {
   flex: none;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: none;
+}
+
+.jump-palette__row-prs[data-overflow="true"] {
+  max-width: 126px;
+}
+
+.jump-palette__row-prs::-webkit-scrollbar {
+  display: none;
+}
+
+.jump-palette__row-prs .pr-chip {
+  flex: none;
+  height: 19px;
+  gap: 4px;
+  padding: 0 6px;
+  font-size: 10px;
+}
+
+.jump-palette__row-prs .pr-chip__dot {
+  width: 6px;
+  height: 6px;
 }
 
 /* `direction: rtl` puts the ellipsis at the START, so a long `agent/…` prefix


### PR DESCRIPTION
## Summary

- I render every pull request attached to a quick-jump result using the shared status-aware PR chip.
- I constrain rows with more than two PRs to a horizontally scrollable strip and translate wheel input while more PRs remain in that direction.
- I move an exact PR-number match to the front of the strip so it is immediately visible.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx`
- `pnpm lint:eslint -- apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx`
- `pnpm typecheck`
- `pnpm lint:colors`
- `pnpm lint:boundaries`

## Notes

- The two visually identical search rows in the reported screenshot are distinct forked threads with different thread IDs, so this change intentionally preserves both rows.
- Remote search results remain separated under “Other instances” with an instance chip, and an already-local backend/thread identity is still filtered from the remote section.
