### PR TITLE
fix(desktop): bridge Windows titlebar hover transitions

### DIFF
--- a/apps/desktop/e2e/windows-titlebar-hover.spec.ts
+++ b/apps/desktop/e2e/windows-titlebar-hover.spec.ts
@@ -10,6 +10,12 @@ test("keeps a Windows title-bar flyout open while the pointer crosses into it", 
     process.platform !== "win32",
     "The custom app title bar is rendered only on Windows.",
   );
+  // The lab controller accepts Playwright arguments but deliberately exposes no
+  // arbitrary environment-variable or command escape hatch. An explicit
+  // `--timeout=0` therefore doubles as the manual-inspection signal: ordinary
+  // suite runs retain their bounded timeout and self-close, while an operator
+  // can keep this exact scene visible until Electron is closed.
+  const inspectionMode = test.info().timeout === 0;
 
   const app = await launchElectronApp({
     fixturePath: path.resolve(
@@ -55,7 +61,27 @@ test("keeps a Windows title-bar flyout open while the pointer crosses into it", 
       "-webkit-app-region",
       "no-drag",
     );
+
+    if (inspectionMode) {
+      console.log(
+        [
+          "",
+          "Windows title-bar hover inspection is ready.",
+          "The pointer crossed from New thread into the open flyout.",
+          "Close the Electron window or quit the app to finish this command.",
+          "",
+        ].join("\n"),
+      );
+      await Promise.race([
+        app.window.waitForEvent("close", { timeout: 0 }).then(() => undefined),
+        app.electronApp.waitForEvent("close", { timeout: 0 }).then(() => undefined),
+      ]);
+    }
   } finally {
-    await app.close();
+    if (inspectionMode) {
+      await app.close().catch(() => undefined);
+    } else {
+      await app.close();
+    }
   }
 });

--- a/apps/desktop/e2e/windows-titlebar-hover.spec.ts
+++ b/apps/desktop/e2e/windows-titlebar-hover.spec.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("keeps a Windows title-bar flyout open while the pointer crosses into it", async () => {
+  test.skip(
+    process.platform !== "win32",
+    "The custom app title bar is rendered only on Windows.",
+  );
+
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/smoke/replay.fixture.json",
+    ),
+  });
+
+  try {
+    const trigger = app.window.getByRole("button", { name: "New thread" });
+    await trigger.hover();
+
+    const menu = app.window.getByRole("menu", { name: "New thread options" });
+    const item = menu.getByRole("menuitem", {
+      name: "New chat without a directory",
+    });
+    await expect(item).toBeVisible();
+
+    const [triggerBox, itemBox] = await Promise.all([
+      trigger.boundingBox(),
+      item.boundingBox(),
+    ]);
+    expect(triggerBox).not.toBeNull();
+    expect(itemBox).not.toBeNull();
+    if (!triggerBox || !itemBox) {
+      throw new Error("The title-bar hover targets have no rendered bounds.");
+    }
+
+    const pointerX = triggerBox.x + triggerBox.width / 2;
+    await app.window.mouse.move(
+      pointerX,
+      triggerBox.y + triggerBox.height - 1,
+    );
+    await app.window.mouse.move(
+      pointerX,
+      itemBox.y + itemBox.height / 2,
+      { steps: 12 },
+    );
+
+    await expect(menu).toBeVisible();
+    await expect(item).toBeVisible();
+    await expect(app.window.locator(".new-thread-menu")).toHaveCSS(
+      "-webkit-app-region",
+      "no-drag",
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/e2e/windows-titlebar-hover.spec.ts
+++ b/apps/desktop/e2e/windows-titlebar-hover.spec.ts
@@ -63,11 +63,17 @@ test("keeps a Windows title-bar flyout open while the pointer crosses into it", 
     );
 
     if (inspectionMode) {
+      await app.window.mouse.move(
+        triggerBox.x + triggerBox.width / 2,
+        triggerBox.y + triggerBox.height / 2,
+        { steps: 12 },
+      );
+      await expect(menu).toBeVisible();
       console.log(
         [
           "",
           "Windows title-bar hover inspection is ready.",
-          "The pointer crossed from New thread into the open flyout.",
+          "The pointer is on New thread; move it directly down into the flyout.",
           "Close the Electron window or quit the app to finish this command.",
           "",
         ].join("\n"),

--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -6,6 +6,7 @@ import {
   type ReactElement,
 } from "react";
 import { NewThreadIcon } from "../../icons";
+import { useHoverTransitionGrace } from "../../lib/useHoverTransitionGrace";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { FederationTargetMenuSection } from "./FederationTargetMenuSection";
 import type { FederationThreadTarget } from "./federation-thread-targets";
@@ -51,6 +52,14 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuId = useId();
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const {
+    cancelHoverDismiss,
+    dismissAfterGrace,
+    dismissImmediately,
+  } = useHoverTransitionGrace(() => {
+    setOpen(false);
+    tooltip.hide();
+  });
 
   const hasDirectoryChoice = Boolean(
     props.directoryLabel && props.onCreateThreadWithoutDirectory,
@@ -80,7 +89,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
       if (event.key !== "Escape") {
         return;
       }
-      setOpen(false);
+      dismissImmediately();
       // Only pull focus back to the trigger when focus is actually inside the
       // flyout (keyboard-driven). A hover-opened menu must close without
       // stealing focus. The onFocus guard below then keeps this refocus from
@@ -91,7 +100,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [menuOpen]);
+  }, [dismissImmediately, menuOpen]);
 
   return (
     <span
@@ -99,13 +108,11 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
       className="new-thread-button"
       data-state={menuOpen ? "open" : "closed"}
       onMouseEnter={() => {
+        cancelHoverDismiss();
         setOpen(true);
         showTooltip();
       }}
-      onMouseLeave={() => {
-        setOpen(false);
-        tooltip.hide();
-      }}
+      onMouseLeave={dismissAfterGrace}
       onFocus={(event) => {
         // Only react to focus entering the wrapper from outside. Focus moving
         // within the wrapper (e.g. Escape refocusing the trigger from a menu
@@ -113,13 +120,13 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
         if (wrapperRef.current?.contains(event.relatedTarget as Node)) {
           return;
         }
+        cancelHoverDismiss();
         setOpen(true);
         showTooltip();
       }}
       onBlur={(event) => {
         if (!wrapperRef.current?.contains(event.relatedTarget as Node)) {
-          setOpen(false);
-          tooltip.hide();
+          dismissImmediately();
         }
       }}
     >
@@ -133,8 +140,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
         className="sidebar__icon-button"
         disabled={Boolean(props.creatingThread)}
         onClick={() => {
-          setOpen(false);
-          tooltip.hide();
+          dismissImmediately();
           void props.onCreateThread();
         }}
       >
@@ -142,7 +148,10 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
       </button>
 
       {menuOpen ? (
-        <div className="new-thread-menu">
+        <div
+          className="new-thread-menu"
+          onMouseEnter={cancelHoverDismiss}
+        >
           <div
             className="new-thread-menu__card"
             id={menuId}
@@ -156,7 +165,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                   role="menuitem"
                   className="new-thread-menu__item"
                   onClick={() => {
-                    setOpen(false);
+                    dismissImmediately();
                     void props.onCreateThread();
                   }}
                 >
@@ -167,7 +176,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                   role="menuitem"
                   className="new-thread-menu__item"
                   onClick={() => {
-                    setOpen(false);
+                    dismissImmediately();
                     void props.onCreateThreadWithoutDirectory?.();
                   }}
                 >
@@ -180,7 +189,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                 role="menuitem"
                 className="new-thread-menu__item"
                 onClick={() => {
-                  setOpen(false);
+                  dismissImmediately();
                   void props.onCreateThread();
                 }}
               >
@@ -193,7 +202,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                 <FederationTargetMenuSection
                   targets={props.remoteTargets}
                   onSelect={(instanceId) => {
-                    setOpen(false);
+                    dismissImmediately();
                     void props.onCreateThreadOnTarget?.(instanceId);
                   }}
                 />
@@ -208,7 +217,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                   className="new-thread-menu__item"
                   disabled={props.addingProjectDirectory}
                   onClick={() => {
-                    setOpen(false);
+                    dismissImmediately();
                     void props.onAddProjectDirectory?.();
                   }}
                 >

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -1,9 +1,13 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { HOVER_TRANSITION_GRACE_MS } from "../../../lib/useHoverTransitionGrace";
 import { NewThreadButton } from "../NewThreadButton";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe("NewThreadButton", () => {
   it("clicking runs the default action and shows no flyout without a directory", () => {
@@ -25,7 +29,10 @@ describe("NewThreadButton", () => {
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
     expect((await screen.findByRole("tooltip")).textContent).toBe("New thread");
 
+    vi.useFakeTimers();
     fireEvent.mouseLeave(button.parentElement as HTMLElement);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(HOVER_TRANSITION_GRACE_MS));
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
@@ -54,6 +61,35 @@ describe("NewThreadButton", () => {
     );
     expect(onCreateThreadWithoutDirectory).toHaveBeenCalledTimes(1);
     expect(onCreateThread).not.toHaveBeenCalled();
+  });
+
+  it("keeps the flyout mounted while the pointer crosses and cancels dismissal on re-entry", () => {
+    vi.useFakeTimers();
+    render(
+      <NewThreadButton
+        directoryLabel="PwrAgent"
+        onCreateThread={vi.fn()}
+        onCreateThreadWithoutDirectory={vi.fn()}
+      />,
+    );
+
+    const wrapper = screen.getByRole("button", { name: "New thread" })
+      .parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    // Windows can report leave at the native title-bar/content boundary even
+    // though the pointer is travelling into the descendant flyout.
+    fireEvent.mouseLeave(wrapper);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.mouseEnter(screen.getByRole("menu").parentElement as HTMLElement);
+    act(() => vi.advanceTimersByTime(HOVER_TRANSITION_GRACE_MS));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(wrapper);
+    act(() => vi.advanceTimersByTime(HOVER_TRANSITION_GRACE_MS));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
   it("offers project registration without starting or selecting a chat", async () => {

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -7,13 +7,59 @@ import type {
   MessagingPlatformStatusEvent,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { HOVER_TRANSITION_GRACE_MS } from "../../lib/useHoverTransitionGrace";
 import { MessagingStatusBar } from "./MessagingStatusBar";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe("MessagingStatusBar", () => {
+  it("keeps a hover popover mounted across the title-bar boundary grace period", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+    await screen.findByRole("button", { name: /Telegram/ });
+    const statusBar = screen.getByRole("group", {
+      name: "Messaging platform status",
+    });
+    vi.useFakeTimers();
+
+    fireEvent.pointerEnter(statusBar);
+    expect(
+      screen.getByRole("dialog", { name: "Messaging platforms" }),
+    ).toBeInTheDocument();
+    fireEvent.pointerLeave(statusBar);
+    expect(
+      screen.getByRole("dialog", { name: "Messaging platforms" }),
+    ).toBeInTheDocument();
+
+    fireEvent.pointerEnter(
+      screen.getByRole("dialog", { name: "Messaging platforms" }),
+    );
+    act(() => vi.advanceTimersByTime(HOVER_TRANSITION_GRACE_MS));
+    expect(
+      screen.getByRole("dialog", { name: "Messaging platforms" }),
+    ).toBeInTheDocument();
+
+    fireEvent.pointerLeave(statusBar);
+    act(() => vi.advanceTimersByTime(HOVER_TRANSITION_GRACE_MS));
+    expect(
+      screen.queryByRole("dialog", { name: "Messaging platforms" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders Feishu / Lark with the brand icon instead of the text fallback", async () => {
     const statuses = [
       {

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -13,6 +13,7 @@ import {
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { useHoverTransitionGrace } from "../../lib/useHoverTransitionGrace";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { useFederationPeerConnectivity } from "../../lib/useFederationPeerConnectivity";
 import { SettingsIcon } from "../../icons/SettingsIcon";
@@ -111,6 +112,14 @@ export function MessagingStatusBar(props: {
     tooltipNode: settingsTooltipNode,
   } = useViewportTooltip({
     className: "viewport-tooltip messaging-status-tooltip",
+  });
+  const {
+    cancelHoverDismiss,
+    dismissAfterGrace,
+    dismissImmediately,
+  } = useHoverTransitionGrace(() => {
+    hideSettingsTooltip();
+    setOpen(false);
   });
 
   const runtimeMessagingEnabled =
@@ -221,14 +230,12 @@ export function MessagingStatusBar(props: {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
       if (rootRef.current?.contains(event.target as Node)) return;
-      hideSettingsTooltip();
-      setOpen(false);
+      dismissImmediately();
       setPinned(false);
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
-      hideSettingsTooltip();
-      setOpen(false);
+      dismissImmediately();
       setPinned(false);
     };
     document.addEventListener("pointerdown", onPointerDown);
@@ -237,7 +244,7 @@ export function MessagingStatusBar(props: {
       document.removeEventListener("pointerdown", onPointerDown);
       document.removeEventListener("keydown", onKeyDown);
     };
-  }, [hideSettingsTooltip, open]);
+  }, [dismissImmediately, open]);
 
   const handleToggleMessaging = async (): Promise<void> => {
     if (!desktopApi?.setMessagingEnabled) {
@@ -317,11 +324,13 @@ export function MessagingStatusBar(props: {
       className="messaging-status-bar"
       role="group"
       aria-label="Messaging platform status"
-      onPointerEnter={() => setOpen(true)}
+      onPointerEnter={() => {
+        cancelHoverDismiss();
+        setOpen(true);
+      }}
       onPointerLeave={() => {
         if (!pinned) {
-          hideSettingsTooltip();
-          setOpen(false);
+          dismissAfterGrace();
         }
       }}
     >
@@ -337,11 +346,11 @@ export function MessagingStatusBar(props: {
         } messaging status.`}
         onClick={() => {
           if (pinned) {
-            hideSettingsTooltip();
-            setOpen(false);
+            dismissImmediately();
             setPinned(false);
             return;
           }
+          cancelHoverDismiss();
           setOpen(true);
           setPinned(true);
         }}
@@ -366,6 +375,7 @@ export function MessagingStatusBar(props: {
           className="messaging-status-popover"
           role="dialog"
           aria-label="Messaging platforms"
+          onPointerEnter={cancelHoverDismiss}
         >
           <div className="messaging-status-popover__panel">
             <div className="messaging-status-popover__head">
@@ -385,8 +395,7 @@ export function MessagingStatusBar(props: {
                     aria-label="Open Messaging Settings"
                     onBlur={hideSettingsTooltip}
                     onClick={() => {
-                      hideSettingsTooltip();
-                      setOpen(false);
+                      dismissImmediately();
                       setPinned(false);
                       props.onOpenSettings?.();
                     }}
@@ -467,8 +476,7 @@ export function MessagingStatusBar(props: {
                 type="button"
                 className="messaging-status-popover__activity"
                 onClick={() => {
-                  hideSettingsTooltip();
-                  setOpen(false);
+                  dismissImmediately();
                   setPinned(false);
                   props.onOpenActivity?.();
                 }}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -15,6 +15,7 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { FederationThreadTarget } from "../../chrome/federation-thread-targets";
+import { HOVER_TRANSITION_GRACE_MS } from "../../../lib/useHoverTransitionGrace";
 import { Sidebar } from "../Sidebar";
 
 /**
@@ -275,6 +276,7 @@ afterEach(() => {
     __pwragentFederationTarget?: unknown;
   }).__pwragentFederationTarget;
   vi.restoreAllMocks();
+  vi.useRealTimers();
   document
     .querySelectorAll(".thread-row--drag-image")
     .forEach((element) => element.remove());
@@ -848,7 +850,10 @@ describe("Sidebar", () => {
     fireEvent.mouseEnter(newThreadButton.parentElement as HTMLElement);
     expect((await screen.findByRole("tooltip")).textContent).toBe("New thread");
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    vi.useFakeTimers();
     fireEvent.mouseLeave(newThreadButton.parentElement as HTMLElement);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(HOVER_TRANSITION_GRACE_MS));
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     fireEvent.click(newThreadButton);
     expect(onCreateThread).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/src/lib/useHoverTransitionGrace.ts
+++ b/apps/desktop/src/renderer/src/lib/useHoverTransitionGrace.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Time allowed for a pointer to cross a native title-bar/content boundary.
+ *
+ * Electron on Windows can deliver leave from a title-bar trigger before it
+ * delivers entry to an absolutely positioned descendant below the title bar.
+ * A short grace period keeps the descendant mounted long enough for its entry
+ * event to cancel dismissal. Ordinary exits still close promptly, while
+ * explicit actions use `dismissImmediately` and remain synchronous.
+ */
+export const HOVER_TRANSITION_GRACE_MS = 300;
+
+export function useHoverTransitionGrace(onDismiss: () => void): {
+  cancelHoverDismiss: () => void;
+  dismissAfterGrace: () => void;
+  dismissImmediately: () => void;
+} {
+  const dismissRef = useRef(onDismiss);
+  const timerRef = useRef<number | null>(null);
+  dismissRef.current = onDismiss;
+
+  const cancelHoverDismiss = useCallback((): void => {
+    if (timerRef.current === null) return;
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const dismissImmediately = useCallback((): void => {
+    cancelHoverDismiss();
+    dismissRef.current();
+  }, [cancelHoverDismiss]);
+
+  const dismissAfterGrace = useCallback((): void => {
+    cancelHoverDismiss();
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      dismissRef.current();
+    }, HOVER_TRANSITION_GRACE_MS);
+  }, [cancelHoverDismiss]);
+
+  useEffect(
+    () => cancelHoverDismiss,
+    [cancelHoverDismiss],
+  );
+
+  return {
+    cancelHoverDismiss,
+    dismissAfterGrace,
+    dismissImmediately,
+  };
+}

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -550,6 +550,19 @@ describe("Tangerine Terminal theme contract", () => {
     expect(messagingTooltipRule).toContain("z-index: 140;");
   });
 
+  it("keeps every Windows title-bar control and hover bridge interactive", () => {
+    const appTitlebarRuleIndex = css.indexOf(".app-titlebar {");
+    const titlebarControlsRuleIndex = css.indexOf(
+      ".app-titlebar__left,\n.app-titlebar__left *,",
+    );
+
+    expect(appTitlebarRuleIndex).toBeGreaterThan(-1);
+    expect(titlebarControlsRuleIndex).toBeGreaterThan(appTitlebarRuleIndex);
+    expect(css).toMatch(
+      /\.app-titlebar__left,\s*\.app-titlebar__left \*,\s*\.app-titlebar__right,\s*\.app-titlebar__right \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+    );
+  });
+
   it("keeps the thread title reveal hit target to the rendered title text", () => {
     const compactTitleRule = extractRuleBody(css, ".thread-header__compact-title");
     const titleButtonRule = extractRuleBody(css, ".thread-header__title-button");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -883,14 +883,25 @@ textarea,
   -webkit-app-region: drag;
 }
 
-/* Left cluster: wordmark + menu + action buttons (all interactive → no-drag).
-   The spacer between left and right clusters stays draggable. */
+/* Left/right clusters hold interactive chrome; the spacer between them stays
+   draggable. Apply no-drag to every descendant, not only the cluster boxes.
+   Chromium can otherwise turn a descendant back into native title-bar drag
+   hit-testing — including the transparent bridge between a hover trigger and
+   its popover. On Windows that swallows pointer movement through the bridge,
+   so the wrapper receives mouseleave and closes before the pointer reaches the
+   menu. This also keeps icon/text pixels as interactive as button padding. */
+.app-titlebar__left,
+.app-titlebar__left *,
+.app-titlebar__right,
+.app-titlebar__right * {
+  -webkit-app-region: no-drag;
+}
+
 .app-titlebar__left {
   display: flex;
   align-items: center;
   gap: 8px;
   min-width: 0;
-  -webkit-app-region: no-drag;
 }
 
 .app-titlebar__spacer {
@@ -902,7 +913,6 @@ textarea,
 .app-titlebar__right {
   display: flex;
   align-items: center;
-  -webkit-app-region: no-drag;
 }
 
 /* Wordmark — reuse the sidebar brand tokens (--text-primary / --accent), sized


### PR DESCRIPTION
## Summary

- keep hover-open title-bar flyouts mounted while the pointer crosses Windows' native title-bar/content boundary
- cancel the 300 ms dismissal grace as soon as the pointer reaches the New Thread or Messaging popover
- preserve immediate dismissal for clicks, Escape, blur, and outside pointer actions
- add focused component coverage plus a Windows headed inspection mode

## Root cause

The existing transparent CSS bridge and `-webkit-app-region: no-drag` contract were sufficient for synthetic pointer input, but not for a physical Windows pointer. Electron/Windows can deliver a leave event at the native title-bar/content boundary before it delivers entry to the absolutely positioned flyout below it. Immediate unmounting therefore closed the menu before the pointer could reach it.

The shared grace hook keeps the flyout mounted long enough for its own entry handler to cancel dismissal. It applies to both hover-open title-bar surfaces so the behavior does not drift between New Thread and Messaging.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — 93 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- physical-pointer verification in the local PwrSuiteLab Windows VM confirmed direct downward entry into the New Thread flyout (`pwrlab-pwragent-e2e-20260814-152449-e5cb32fe`)

Rebased cleanly onto current `origin/main`. Main already contains #1606 (`fix(desktop): keep tooltips below Windows title bar`), which addresses the separately observed clipped tooltip top without duplicating that change here.
