### PR TITLE
perf(desktop): keep transcript review derivation incremental

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -566,25 +566,34 @@ describe("useThreadSessionState", () => {
     const loadedEntries = pageCount * entriesPerPage;
     const legacyTriangularHistorySlots =
       entriesPerPage * pageCount * (pageCount + 1) / 2;
-    const parentHookPagingClassificationReads =
+    // The same generated hook harness measured these exact formulas at
+    // pre-#1625 9eb1ce533 and #1625 d418e6335, respectively.
+    const pre1625HookPagingClassificationReads =
+      5 * legacyTriangularHistorySlots;
+    const pre1625HookLiveClassificationReads = 4 * loadedEntries * 100;
+    const pr1625HookPagingClassificationReads =
       loadedEntries + 3 * legacyTriangularHistorySlots;
-    const parentHookLiveClassificationReads = 3 * loadedEntries * 100;
+    const pr1625HookLiveClassificationReads = 3 * loadedEntries * 100;
     expect({
       legacyTriangularHistorySlots,
       liveAppendClassificationReads: retainedEntryClassificationReads,
       loadedEntries,
-      parentHookLiveClassificationReads,
-      parentHookPagingClassificationReads,
       pagingClassificationReads,
+      pre1625HookLiveClassificationReads,
+      pre1625HookPagingClassificationReads,
+      pr1625HookLiveClassificationReads,
+      pr1625HookPagingClassificationReads,
     }).toEqual({
       legacyTriangularHistorySlots: 252_500,
       liveAppendClassificationReads: 0,
       loadedEntries: 5_000,
-      parentHookLiveClassificationReads: 1_500_000,
-      parentHookPagingClassificationReads: 762_500,
       // One classification builds replay messages and one builds the compact
       // review summary. Neither revisits a page after it has been retained.
       pagingClassificationReads: 10_000,
+      pre1625HookLiveClassificationReads: 2_000_000,
+      pre1625HookPagingClassificationReads: 1_262_500,
+      pr1625HookLiveClassificationReads: 1_500_000,
+      pr1625HookPagingClassificationReads: 762_500,
     });
   });
 
@@ -882,6 +891,8 @@ describe("useThreadSessionState", () => {
   });
 
   it("replaces an overlapping live tail when hydrated message ids change", async () => {
+    let now = 10_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now++);
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
       | undefined;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -8,6 +8,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
+  AppServerThreadReviewEntry,
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
@@ -62,6 +63,28 @@ function messageEntry(params: {
     role: params.role ?? "assistant",
     text: params.text,
     createdAt: params.createdAt,
+  };
+}
+
+function reviewEntry(params: {
+  createdAt: number;
+  id: string;
+  review: string;
+  turnId?: string;
+}): AppServerThreadReviewEntry {
+  return {
+    type: "review",
+    id: params.id,
+    review: params.review,
+    createdAt: params.createdAt,
+    ...(params.turnId
+      ? {
+          turn: {
+            id: params.turnId,
+            status: "completed",
+          },
+        }
+      : {}),
   };
 }
 
@@ -463,6 +486,399 @@ describe("useThreadSessionState", () => {
       "tail",
     ]);
     expect(result.current.response?.replay.pagination.hasPreviousPage).toBe(false);
+  });
+
+  it("keeps hook-level paging linear and live appends independent of retained history", async () => {
+    const pageCount = 100;
+    const entriesPerPage = 50;
+    let retainedEntryClassificationReads = 0;
+    const retainedEntry = (
+      id: string,
+      createdAt: number,
+    ): AppServerThreadEntry =>
+      new Proxy(
+        messageEntry({ id, text: id, createdAt }),
+        {
+          get(target, property, receiver) {
+            if (property === "type") {
+              retainedEntryClassificationReads += 1;
+            }
+            return Reflect.get(target, property, receiver);
+          },
+        },
+      );
+    const responses = [
+      readThreadResponse({
+        entries: [messageEntry({ id: "tail", text: "Tail", createdAt: 10_000 })],
+        hasPreviousPage: true,
+        previousCursor: "page-0",
+      }),
+      ...Array.from({ length: pageCount }, (_value, pageIndex) =>
+        readThreadResponse({
+          entries: Array.from({ length: entriesPerPage }, (_entry, entryIndex) =>
+            retainedEntry(
+              `history-${pageIndex}-${entryIndex}`,
+              5_000 - pageIndex * entriesPerPage - entryIndex,
+            )
+          ),
+          hasPreviousPage: pageIndex + 1 < pageCount,
+          ...(pageIndex + 1 < pageCount
+            ? { previousCursor: `page-${pageIndex + 1}` }
+            : {}),
+        })
+      ),
+    ];
+    retainedEntryClassificationReads = 0;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: vi.fn(async () => responses.shift()!),
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+      await act(async () => {
+        await result.current.loadOlder();
+      });
+    }
+
+    const pagingClassificationReads = retainedEntryClassificationReads;
+    expect(result.current.entries.map((entry) => entry.id)).toHaveLength(5_001);
+    retainedEntryClassificationReads = 0;
+
+    for (let liveIndex = 0; liveIndex < 100; liveIndex += 1) {
+      act(() => {
+        result.current.upsertLiveTranscriptEntry(messageEntry({
+          id: `live-${liveIndex}`,
+          text: `Live ${liveIndex}`,
+          createdAt: 20_000 + liveIndex,
+        }));
+      });
+      expect(result.current.entries.slice(-1)[0]?.id).toBe(`live-${liveIndex}`);
+    }
+
+    const loadedEntries = pageCount * entriesPerPage;
+    const legacyTriangularHistorySlots =
+      entriesPerPage * pageCount * (pageCount + 1) / 2;
+    const parentHookPagingClassificationReads =
+      loadedEntries + 3 * legacyTriangularHistorySlots;
+    const parentHookLiveClassificationReads = 3 * loadedEntries * 100;
+    expect({
+      legacyTriangularHistorySlots,
+      liveAppendClassificationReads: retainedEntryClassificationReads,
+      loadedEntries,
+      parentHookLiveClassificationReads,
+      parentHookPagingClassificationReads,
+      pagingClassificationReads,
+    }).toEqual({
+      legacyTriangularHistorySlots: 252_500,
+      liveAppendClassificationReads: 0,
+      loadedEntries: 5_000,
+      parentHookLiveClassificationReads: 1_500_000,
+      parentHookPagingClassificationReads: 762_500,
+      // One classification builds replay messages and one builds the compact
+      // review summary. Neither revisits a page after it has been retained.
+      pagingClassificationReads: 10_000,
+    });
+  });
+
+  it("coalesces reviews and suppresses duplicates across page-tail boundaries", async () => {
+    const fullReview = [
+      "Full review comments:",
+      "- [P1] Keep exact ID ordering — src/thread.ts:42",
+    ].join("\n");
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({
+            id: "review-assistant",
+            text: fullReview,
+            createdAt: 500,
+          }),
+          messageEntry({
+            id: "duplicate-assistant",
+            text: "Duplicate review summary",
+            createdAt: 600,
+          }),
+          messageEntry({ id: "repeat-a", text: "Repeated", createdAt: 700 }),
+          messageEntry({ id: "repeat-b", text: "Repeated", createdAt: 800 }),
+        ],
+        hasPreviousPage: true,
+        previousCursor: "older",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          reviewEntry({
+            id: "review-base",
+            review: "Full review comments:",
+            createdAt: 100,
+          }),
+          reviewEntry({
+            id: "review-duplicate",
+            review: "Duplicate review summary",
+            createdAt: 200,
+          }),
+        ],
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "review-base",
+      "review-duplicate",
+      "repeat-a",
+      "repeat-b",
+    ]);
+    expect(result.current.entries[0]).toMatchObject({
+      type: "review",
+      review: fullReview,
+    });
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      "repeat-a",
+      "repeat-b",
+    ]);
+    expect(result.current.messages.map((message) => message.text)).toEqual([
+      "Repeated",
+      "Repeated",
+    ]);
+  });
+
+  it("uses a live tail review to suppress a matching retained assistant message", async () => {
+    const duplicateText = "Review result delivered from the live tail";
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({ id: "recent-anchor", text: "Recent", createdAt: 300 }),
+        ],
+        hasPreviousPage: true,
+        previousCursor: "older",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({ id: "retained-duplicate", text: duplicateText, createdAt: 100 }),
+        ],
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "retained-duplicate",
+      "recent-anchor",
+    ]);
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry(
+        reviewEntry({
+          id: "live-review",
+          review: duplicateText,
+          createdAt: 500,
+        }),
+      );
+    });
+
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "recent-anchor",
+      "live-review",
+    ]);
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      "recent-anchor",
+    ]);
+  });
+
+  it("drops retained review indexes when compaction resets loaded history", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const duplicateText = "Historical review summary";
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          messageEntry({ id: "before-compact", text: duplicateText, createdAt: 300 }),
+        ],
+        hasPreviousPage: true,
+        previousCursor: "older",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          reviewEntry({ id: "historical-review", review: duplicateText, createdAt: 100 }),
+        ],
+        hasPreviousPage: false,
+      }))
+      .mockResolvedValue(readThreadResponse({
+        entries: [
+          messageEntry({ id: "after-compact", text: duplicateText, createdAt: 500 }),
+        ],
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventHandler = listener;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "historical-review",
+    ]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/compacted",
+          params: { threadId: "thread-1" },
+        },
+      });
+    });
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "after-compact",
+      ]);
+    });
+  });
+
+  it("keeps cross-page review coalescing ordered across lagging hydration", async () => {
+    let resolveRefresh:
+      | ((response: AppServerReadThreadResponse) => void)
+      | undefined;
+    const fullReview = [
+      "Full review comments:",
+      "- [P2] Preserve the loaded prefix — src/history.ts:9",
+    ].join("\n");
+    const initialTail = readThreadResponse({
+      entries: [
+        messageEntry({ id: "recent-anchor", text: "Recent", createdAt: 300 }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({ id: "oldest-anchor", text: "Oldest", createdAt: 50 }),
+        reviewEntry({
+          id: "historical-review",
+          review: "Full review comments:",
+          createdAt: 100,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const refreshPromise = new Promise<AppServerReadThreadResponse>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockImplementation(async () => await refreshPromise);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    rerender({ updatedAt: 2_000 });
+    await waitFor(() => {
+      expect(resolveRefresh).toBeDefined();
+    });
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry(messageEntry({
+        id: "live-review-output",
+        text: fullReview,
+        createdAt: 500,
+      }));
+    });
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "oldest-anchor",
+      "historical-review",
+      "recent-anchor",
+    ]);
+    expect(result.current.entries[1]).toMatchObject({ review: fullReview });
+
+    await act(async () => {
+      resolveRefresh?.(readThreadResponse({
+        entries: [
+          messageEntry({ id: "recent-anchor", text: "Recent", createdAt: 300 }),
+        ],
+        hasPreviousPage: true,
+        previousCursor: "older-again",
+      }));
+      await Promise.resolve();
+    });
+
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "oldest-anchor",
+      "historical-review",
+      "recent-anchor",
+    ]);
+    expect(result.current.entries[1]).toMatchObject({ review: fullReview });
   });
 
   it("replaces an overlapping live tail when hydrated message ids change", async () => {

--- a/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
+++ b/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
@@ -3,6 +3,15 @@ import type {
   AppServerThreadEntry,
   AppServerThreadMessage,
 } from "@pwragent/shared";
+import {
+  addTranscriptReviewSegmentToIndex,
+  createTranscriptReviewHistoryIndex,
+  deriveTranscriptReviewPresentation,
+  iterateTranscriptReviewHistoryEvents,
+  summarizeTranscriptReviewSegment,
+  type TranscriptReviewHistoryIndex,
+  type TranscriptReviewPresentation,
+} from "./transcript-review-presentation";
 
 export type TranscriptHistoryPage = {
   entries: AppServerThreadEntry[];
@@ -24,12 +33,14 @@ export type LoadedTranscriptHistory = {
 export type TranscriptHistoryIndex = {
   entryIds: Set<string>;
   messageIds: Set<string>;
+  review: TranscriptReviewHistoryIndex;
 };
 
 export function createTranscriptHistoryIndex(): TranscriptHistoryIndex {
   return {
     entryIds: new Set(),
     messageIds: new Set(),
+    review: createTranscriptReviewHistoryIndex(),
   };
 }
 
@@ -81,6 +92,7 @@ export function prependTranscriptHistoryPage(params: {
       && !params.index.entryIds.has(entry.id),
   );
   const messages = messagesForEntries(entries, params.page.replay.messages);
+  const reviewSummary = summarizeTranscriptReviewSegment(entries, messages);
 
   for (const entry of entries) {
     params.index.entryIds.add(entry.id);
@@ -88,6 +100,7 @@ export function prependTranscriptHistoryPage(params: {
   for (const message of messages) {
     params.index.messageIds.add(message.id);
   }
+  addTranscriptReviewSegmentToIndex(params.index.review, reviewSummary);
 
   const previousEntryCount = params.history?.entryCount ?? 0;
   const previousMessageCount = params.history?.messageCount ?? 0;
@@ -138,6 +151,7 @@ type SegmentedArraySource<T> = {
   historyCount: number;
   historyNewestPage: TranscriptHistoryPage | undefined;
   historyPage: TranscriptHistoryPage | undefined;
+  itemOverrides?: ReadonlyMap<string, T>;
   pageItems: (page: TranscriptHistoryPage) => readonly T[];
   tail: readonly T[];
 };
@@ -149,7 +163,7 @@ function* iterateSegmentedArray<T extends { id: string }>(
   while (page) {
     for (const item of source.pageItems(page)) {
       if (!source.excludedHistoryIds.has(item.id)) {
-        yield item;
+        yield source.itemOverrides?.get(item.id) ?? item;
       }
     }
     page = page.newerPage;
@@ -174,7 +188,7 @@ function* iterateSegmentedArrayReverse<T extends { id: string }>(
       if (source.excludedHistoryIds.has(item.id)) {
         continue;
       }
-      yield item;
+      yield source.itemOverrides?.get(item.id) ?? item;
       remainingHistoryItems -= 1;
       if (remainingHistoryItems === 0) {
         return;
@@ -417,16 +431,24 @@ export function combineTranscriptEntries(
   history: LoadedTranscriptHistory | undefined,
   index: TranscriptHistoryIndex | undefined,
   tailEntries: AppServerThreadEntry[],
+  presentation?: Pick<
+    TranscriptReviewPresentation,
+    "excludedHistoryEntryIds" | "historyEntryOverrides"
+  >,
 ): AppServerThreadEntry[] {
   if (!history?.oldestPage || !index) {
     return tailEntries;
   }
   const excludedHistoryIds = historyOverlapIds(tailEntries, index.entryIds);
+  for (const id of presentation?.excludedHistoryEntryIds ?? []) {
+    excludedHistoryIds.add(id);
+  }
   return createSegmentedArray({
     excludedHistoryIds,
     historyCount: history.entryCount,
     historyNewestPage: history.newestPage,
     historyPage: history.oldestPage,
+    itemOverrides: presentation?.historyEntryOverrides,
     pageItems: (page) => page.entries,
     tail: tailEntries,
   });
@@ -436,11 +458,18 @@ export function combineTranscriptMessages(
   history: LoadedTranscriptHistory | undefined,
   index: TranscriptHistoryIndex | undefined,
   tailMessages: AppServerThreadMessage[],
+  presentation?: Pick<
+    TranscriptReviewPresentation,
+    "excludedHistoryMessageIds"
+  >,
 ): AppServerThreadMessage[] {
   if (!history?.oldestPage || !index) {
     return tailMessages;
   }
   const excludedHistoryIds = historyOverlapIds(tailMessages, index.messageIds);
+  for (const id of presentation?.excludedHistoryMessageIds ?? []) {
+    excludedHistoryIds.add(id);
+  }
   return createSegmentedArray({
     excludedHistoryIds,
     historyCount: history.messageCount,
@@ -448,6 +477,24 @@ export function combineTranscriptMessages(
     historyPage: history.oldestPage,
     pageItems: (page) => page.messages,
     tail: tailMessages,
+  });
+}
+
+export function createTranscriptReviewPresentation(params: {
+  history: LoadedTranscriptHistory | undefined;
+  index: TranscriptHistoryIndex | undefined;
+  tailEntries: AppServerThreadEntry[];
+  tailMessages: AppServerThreadMessage[];
+}): TranscriptReviewPresentation {
+  return deriveTranscriptReviewPresentation({
+    historyEvents: params.history && params.index
+      ? iterateTranscriptReviewHistoryEvents(params.index.review)
+      : [],
+    historyIndex:
+      params.index?.review
+      ?? createTranscriptReviewHistoryIndex(),
+    tailEntries: params.tailEntries,
+    tailMessages: params.tailMessages,
   });
 }
 

--- a/apps/desktop/src/renderer/src/lib/transcript-review-presentation.ts
+++ b/apps/desktop/src/renderer/src/lib/transcript-review-presentation.ts
@@ -1,0 +1,370 @@
+import type {
+  AppServerThreadEntry,
+  AppServerThreadMessage,
+  AppServerThreadMessageEntry,
+  AppServerThreadReviewEntry,
+} from "@pwragent/shared";
+
+export type TranscriptReviewEvent =
+  | AppServerThreadMessageEntry
+  | AppServerThreadReviewEntry;
+
+export type TranscriptReviewSegmentSummary = {
+  assistantEntriesByTextHash: TranscriptTextIndex;
+  assistantMessagesByTextHash: TranscriptTextIndex;
+  events: TranscriptReviewEvent[];
+};
+
+export type TranscriptReviewHistoryIndex = {
+  assistantEntriesByTextHash: TranscriptTextIndex;
+  assistantMessagesByTextHash: TranscriptTextIndex;
+  oldestEventSegment?: TranscriptReviewEventSegment;
+};
+
+type TranscriptTextCandidate = {
+  id: string;
+  text: string;
+};
+
+type TranscriptTextIndex = Map<number, TranscriptTextCandidate[]>;
+
+type TranscriptReviewEventSegment = {
+  events: TranscriptReviewEvent[];
+  newerSegment?: TranscriptReviewEventSegment;
+};
+
+export type TranscriptReviewPresentation = {
+  excludedHistoryEntryIds: ReadonlySet<string>;
+  excludedHistoryMessageIds: ReadonlySet<string>;
+  historyEntryOverrides: ReadonlyMap<string, AppServerThreadEntry>;
+  tailEntries: AppServerThreadEntry[];
+  tailMessages: AppServerThreadMessage[];
+};
+
+type ReviewCandidate = {
+  entry: AppServerThreadReviewEntry;
+  source: "history" | "tail";
+};
+
+export function normalizeTranscriptText(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLocaleLowerCase();
+}
+
+function isPlainReviewFindingText(text: string): boolean {
+  return (
+    /\b(?:full\s+)?review comments?:/i.test(text)
+    && /(?:^|\n)\s*-\s*\[P[0-3]\]\s+.+(?:\s+—\s+|\s+-\s+).+:\d+/u.test(text)
+  );
+}
+
+function shouldUseAssistantReviewText(params: {
+  assistantText: string;
+  reviewText: string;
+}): boolean {
+  if (!isPlainReviewFindingText(params.assistantText)) {
+    return false;
+  }
+
+  const normalizedAssistant = normalizeTranscriptText(params.assistantText);
+  const normalizedReview = normalizeTranscriptText(params.reviewText);
+  return (
+    !normalizedReview
+    || normalizedAssistant === normalizedReview
+    || normalizedAssistant.startsWith(normalizedReview)
+    || normalizedAssistant.includes(normalizedReview)
+  );
+}
+
+function normalizedTextHash(normalizedText: string): number {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < normalizedText.length; index += 1) {
+    hash ^= normalizedText.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+function appendTextCandidate(
+  target: TranscriptTextIndex,
+  text: string,
+  id: string,
+): void {
+  const normalizedText = normalizeTranscriptText(text);
+  if (!normalizedText) {
+    return;
+  }
+  const hash = normalizedTextHash(normalizedText);
+  const candidates = target.get(hash);
+  const candidate = { id, text };
+  if (candidates) {
+    candidates.push(candidate);
+  } else {
+    target.set(hash, [candidate]);
+  }
+}
+
+/**
+ * Classifies one incoming page exactly once. The retained index keeps compact
+ * text-hash candidates and review-only events rather than a second flattened
+ * transcript, so adding later pages never revisits this page's entries.
+ */
+export function summarizeTranscriptReviewSegment(
+  entries: AppServerThreadEntry[],
+  messages: AppServerThreadMessage[],
+): TranscriptReviewSegmentSummary {
+  const assistantEntriesByTextHash: TranscriptTextIndex = new Map();
+  const assistantMessagesByTextHash: TranscriptTextIndex = new Map();
+  const events: TranscriptReviewEvent[] = [];
+
+  for (const entry of entries) {
+    const entryType = entry.type;
+    if (entryType === "review") {
+      events.push(entry);
+      continue;
+    }
+    if (entryType !== "message" || entry.role !== "assistant") {
+      continue;
+    }
+
+    appendTextCandidate(assistantEntriesByTextHash, entry.text, entry.id);
+    if (isPlainReviewFindingText(entry.text)) {
+      events.push(entry);
+    }
+  }
+
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      appendTextCandidate(assistantMessagesByTextHash, message.text, message.id);
+    }
+  }
+
+  return {
+    assistantEntriesByTextHash,
+    assistantMessagesByTextHash,
+    events,
+  };
+}
+
+export function createTranscriptReviewHistoryIndex(): TranscriptReviewHistoryIndex {
+  return {
+    assistantEntriesByTextHash: new Map(),
+    assistantMessagesByTextHash: new Map(),
+  };
+}
+
+function addTextCandidates(
+  target: TranscriptTextIndex,
+  source: TranscriptTextIndex,
+): void {
+  for (const [hash, candidates] of source) {
+    const targetCandidates = target.get(hash);
+    if (targetCandidates) {
+      targetCandidates.push(...candidates);
+    } else {
+      target.set(hash, [...candidates]);
+    }
+  }
+}
+
+export function addTranscriptReviewSegmentToIndex(
+  index: TranscriptReviewHistoryIndex,
+  summary: TranscriptReviewSegmentSummary,
+): void {
+  addTextCandidates(
+    index.assistantEntriesByTextHash,
+    summary.assistantEntriesByTextHash,
+  );
+  addTextCandidates(
+    index.assistantMessagesByTextHash,
+    summary.assistantMessagesByTextHash,
+  );
+  if (summary.events.length > 0) {
+    index.oldestEventSegment = {
+      events: summary.events,
+      newerSegment: index.oldestEventSegment,
+    };
+  }
+}
+
+/**
+ * Iterates only review-bearing retained segments. Ordinary transcript pages
+ * do not add a node, so live-tail review derivation is independent of both
+ * their entry count and their page count.
+ */
+export function* iterateTranscriptReviewHistoryEvents(
+  index: TranscriptReviewHistoryIndex,
+): Generator<TranscriptReviewEvent> {
+  let segment = index.oldestEventSegment;
+  while (segment) {
+    yield* segment.events;
+    segment = segment.newerSegment;
+  }
+}
+
+function reviewEvent(entry: AppServerThreadEntry): TranscriptReviewEvent | undefined {
+  if (entry.type === "review") {
+    return entry;
+  }
+  if (
+    entry.type === "message"
+    && entry.role === "assistant"
+    && isPlainReviewFindingText(entry.text)
+  ) {
+    return entry;
+  }
+  return undefined;
+}
+
+function matchingReviewCandidate(
+  candidates: ReviewCandidate[],
+  message: AppServerThreadMessageEntry,
+): ReviewCandidate | undefined {
+  return candidates.findLast((candidate) => {
+    if (
+      message.turn?.id
+      && candidate.entry.turn?.id
+      && message.turn.id !== candidate.entry.turn.id
+    ) {
+      return false;
+    }
+    return shouldUseAssistantReviewText({
+      assistantText: message.text,
+      reviewText: candidate.entry.review,
+    });
+  });
+}
+
+function addIndexedIds(
+  target: Set<string>,
+  index: TranscriptTextIndex,
+  texts: ReadonlySet<string>,
+): void {
+  for (const text of texts) {
+    const candidates = index.get(normalizedTextHash(text));
+    if (!candidates) {
+      continue;
+    }
+    for (const candidate of candidates) {
+      // The hash only narrows candidates. Preserve exact normalized-text
+      // semantics even in the event of a collision.
+      if (normalizeTranscriptText(candidate.text) === text) {
+        target.add(candidate.id);
+      }
+    }
+  }
+}
+
+function isDuplicateReviewMessage(
+  item: AppServerThreadEntry | AppServerThreadMessage,
+  reviewTexts: ReadonlySet<string>,
+): boolean {
+  return (
+    "role" in item
+    && item.role === "assistant"
+    && "text" in item
+    && typeof item.text === "string"
+    && reviewTexts.has(normalizeTranscriptText(item.text))
+  );
+}
+
+/**
+ * Replays only retained review/review-like events and exact-text hash
+ * candidates. Unrelated retained entries are never visited, while hash
+ * collisions are verified against normalized text before an ID is excluded.
+ */
+export function deriveTranscriptReviewPresentation(params: {
+  historyEvents: Iterable<TranscriptReviewEvent>;
+  historyIndex: TranscriptReviewHistoryIndex;
+  tailEntries: AppServerThreadEntry[];
+  tailMessages: AppServerThreadMessage[];
+}): TranscriptReviewPresentation {
+  const historyOverlapIds = new Set([
+    ...params.tailEntries.map((entry) => entry.id),
+    ...params.tailMessages.map((message) => message.id),
+  ]);
+  const candidates: ReviewCandidate[] = [];
+  const excludedHistoryEntryIds = new Set<string>();
+  const excludedHistoryMessageIds = new Set<string>();
+  const excludedTailEntryIds = new Set<string>();
+  const historyEntryOverrides = new Map<string, AppServerThreadEntry>();
+  const tailEntryOverrides = new Map<string, AppServerThreadEntry>();
+
+  const consumeEvent = (
+    event: TranscriptReviewEvent,
+    source: ReviewCandidate["source"],
+  ): void => {
+    if (event.type === "review") {
+      candidates.push({ entry: event, source });
+      return;
+    }
+
+    const candidate = matchingReviewCandidate(candidates, event);
+    if (!candidate) {
+      return;
+    }
+
+    candidate.entry = {
+      ...candidate.entry,
+      review: event.text,
+    };
+    if (candidate.source === "history") {
+      historyEntryOverrides.set(candidate.entry.id, candidate.entry);
+    } else {
+      tailEntryOverrides.set(candidate.entry.id, candidate.entry);
+    }
+    if (source === "history") {
+      excludedHistoryEntryIds.add(event.id);
+    } else {
+      excludedTailEntryIds.add(event.id);
+    }
+  };
+
+  for (const event of params.historyEvents) {
+    if (!historyOverlapIds.has(event.id)) {
+      consumeEvent(event, "history");
+    }
+  }
+  for (const entry of params.tailEntries) {
+    const event = reviewEvent(entry);
+    if (event) {
+      consumeEvent(event, "tail");
+    }
+  }
+
+  const reviewTexts = new Set<string>();
+  for (const candidate of candidates) {
+    const text = candidate.entry.output?.overall_explanation ?? candidate.entry.review;
+    if (text.trim()) {
+      reviewTexts.add(normalizeTranscriptText(text));
+    }
+  }
+
+  addIndexedIds(
+    excludedHistoryEntryIds,
+    params.historyIndex.assistantEntriesByTextHash,
+    reviewTexts,
+  );
+  addIndexedIds(
+    excludedHistoryMessageIds,
+    params.historyIndex.assistantMessagesByTextHash,
+    reviewTexts,
+  );
+
+  return {
+    excludedHistoryEntryIds,
+    excludedHistoryMessageIds,
+    historyEntryOverrides,
+    tailEntries: params.tailEntries.flatMap((entry) => {
+      if (
+        excludedTailEntryIds.has(entry.id)
+        || isDuplicateReviewMessage(entry, reviewTexts)
+      ) {
+        return [];
+      }
+      return [tailEntryOverrides.get(entry.id) ?? entry];
+    }),
+    tailMessages: params.tailMessages.filter(
+      (message) => !isDuplicateReviewMessage(message, reviewTexts),
+    ),
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -62,10 +62,12 @@ import {
   combineTranscriptMessages,
   combineTranscriptResponse,
   createTranscriptHistoryIndex,
+  createTranscriptReviewPresentation,
   prependTranscriptHistoryPage,
   type LoadedTranscriptHistory,
   type TranscriptHistoryIndex,
 } from "./segmented-transcript";
+import { normalizeTranscriptText } from "./transcript-review-presentation";
 
 const MAX_VIEW_ONLY_THREADS = 10;
 const EMPTY_EXPANDED_TRANSCRIPT_ACTIVITY_IDS: string[] = [];
@@ -1404,123 +1406,6 @@ function reviewEntryLabels(entry: AppServerThreadReviewEntry): string[] {
   return [entry.displayText, entry.review]
     .filter((value): value is string => Boolean(value?.trim()))
     .map((value) => normalizeReviewDisplayText(value).toLocaleLowerCase());
-}
-
-function normalizeTranscriptText(value: string): string {
-  return value.trim().replace(/\s+/g, " ").toLocaleLowerCase();
-}
-
-function isPlainReviewFindingText(text: string): boolean {
-  return (
-    /\b(?:full\s+)?review comments?:/i.test(text) &&
-    /(?:^|\n)\s*-\s*\[P[0-3]\]\s+.+(?:\s+—\s+|\s+-\s+).+:\d+/u.test(text)
-  );
-}
-
-function shouldUseAssistantReviewText(params: {
-  assistantText: string;
-  reviewText: string;
-}): boolean {
-  if (!isPlainReviewFindingText(params.assistantText)) {
-    return false;
-  }
-
-  const normalizedAssistant = normalizeTranscriptText(params.assistantText);
-  const normalizedReview = normalizeTranscriptText(params.reviewText);
-  return (
-    !normalizedReview ||
-    normalizedAssistant === normalizedReview ||
-    normalizedAssistant.startsWith(normalizedReview) ||
-    normalizedAssistant.includes(normalizedReview)
-  );
-}
-
-function coalesceReviewAssistantMessages(
-  entries: AppServerThreadEntry[]
-): AppServerThreadEntry[] {
-  let output: AppServerThreadEntry[] | undefined;
-  let entryIndex = 0;
-
-  for (const entry of entries) {
-    if (
-      entry.type === "message" &&
-      entry.role === "assistant" &&
-      shouldUseAssistantReviewText({
-        assistantText: entry.text,
-        reviewText: "",
-      })
-    ) {
-      const candidates = output ?? entries.slice(0, entryIndex);
-      const matchingReviewIndex = candidates.findLastIndex((candidate) => {
-        if (candidate.type !== "review") {
-          return false;
-        }
-        if (
-          entry.turn?.id &&
-          candidate.turn?.id &&
-          entry.turn.id !== candidate.turn.id
-        ) {
-          return false;
-        }
-        return shouldUseAssistantReviewText({
-          assistantText: entry.text,
-          reviewText: candidate.review,
-        });
-      });
-
-      if (matchingReviewIndex !== -1) {
-        output = candidates;
-        const reviewEntry = output[matchingReviewIndex] as AppServerThreadReviewEntry;
-        output[matchingReviewIndex] = {
-          ...reviewEntry,
-          review: entry.text,
-        };
-        entryIndex += 1;
-        continue;
-      }
-    }
-
-    output?.push(entry);
-    entryIndex += 1;
-  }
-
-  return output ?? entries;
-}
-
-function reviewResultTexts(entries: AppServerThreadEntry[]): Set<string> {
-  const output = new Set<string>();
-  for (const entry of entries) {
-    if (entry.type !== "review") {
-      continue;
-    }
-
-    const text = entry.output?.overall_explanation ?? entry.review;
-    if (text.trim()) {
-      output.add(normalizeTranscriptText(text));
-    }
-  }
-  return output;
-}
-
-function suppressReviewDuplicateMessages<T extends AppServerThreadMessage | AppServerThreadEntry>(
-  messagesOrEntries: T[],
-  reviewTexts: Set<string>
-): T[] {
-  if (reviewTexts.size === 0) {
-    return messagesOrEntries;
-  }
-
-  return messagesOrEntries.filter((entry) => {
-    if (
-      "role" in entry &&
-      entry.role === "assistant" &&
-      "text" in entry &&
-      typeof entry.text === "string"
-    ) {
-      return !reviewTexts.has(normalizeTranscriptText(entry.text));
-    }
-    return true;
-  });
 }
 
 function optimisticMessageEntries(
@@ -6102,55 +5987,64 @@ export function useThreadSessionState(params: {
     ],
   );
 
-  const entries = useMemo(
-    () => {
-      const mergedTailEntries = mergeTranscriptEntries(
-        selectedSession?.response?.replay.entries ?? [],
-        visibleOptimisticEntries
-      );
-      const mergedEntries = combineTranscriptEntries(
-        selectedSession?.loadedHistory,
-        selectedHistoryIndex,
-        mergedTailEntries,
-      );
-      const coalescedEntries = coalesceReviewAssistantMessages(mergedEntries);
-      return suppressReviewDuplicateMessages(
-        coalescedEntries,
-        reviewResultTexts(coalescedEntries)
-      );
-    },
+  const mergedTailEntries = useMemo(
+    () => mergeTranscriptEntries(
+      selectedSession?.response?.replay.entries ?? [],
+      visibleOptimisticEntries,
+    ),
+    [selectedSession?.response?.replay.entries, visibleOptimisticEntries],
+  );
+  const mergedTailMessages = useMemo(
+    () => mergeTranscriptMessages(
+      selectedSession?.response?.replay.messages ?? [],
+      visibleOptimisticEntries
+        .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")
+        .map(({ type: _type, ...message }) => message),
+    ),
+    [selectedSession?.response?.replay.messages, visibleOptimisticEntries],
+  );
+  const reviewPresentation = useMemo(
+    () => createTranscriptReviewPresentation({
+      history: selectedSession?.loadedHistory,
+      index: selectedHistoryIndex,
+      tailEntries: mergedTailEntries,
+      tailMessages: mergedTailMessages,
+    }),
     [
+      mergedTailEntries,
+      mergedTailMessages,
       selectedHistoryIndex,
       selectedSession?.loadedHistory,
-      selectedSession?.response?.replay.entries,
-      visibleOptimisticEntries,
+    ],
+  );
+
+  const entries = useMemo(
+    () =>
+      combineTranscriptEntries(
+        selectedSession?.loadedHistory,
+        selectedHistoryIndex,
+        reviewPresentation.tailEntries,
+        reviewPresentation,
+      ),
+    [
+      reviewPresentation,
+      selectedHistoryIndex,
+      selectedSession?.loadedHistory,
     ]
   );
 
   const messages = useMemo(
-    () => {
-      const mergedTailMessages = mergeTranscriptMessages(
-        selectedSession?.response?.replay.messages ?? [],
-        visibleOptimisticEntries
-          .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")
-          .map(({ type: _type, ...message }) => message)
-      );
-      const mergedMessages = combineTranscriptMessages(
+    () =>
+      combineTranscriptMessages(
         selectedSession?.loadedHistory,
         selectedHistoryIndex,
-        mergedTailMessages,
-      );
-      return suppressReviewDuplicateMessages(
-        mergedMessages,
-        reviewResultTexts(entries)
-      );
-    },
+        reviewPresentation.tailMessages,
+        reviewPresentation,
+      ),
     [
-      entries,
+      reviewPresentation,
       selectedHistoryIndex,
       selectedSession?.loadedHistory,
-      selectedSession?.response?.replay.messages,
-      visibleOptimisticEntries,
     ]
   );
 


### PR DESCRIPTION
## Stack

Draft, stacked on #1625 (`agent/amortize-transcript-history`). The parent branch and PR are unchanged.

Baseline points used below:

- **pre-#1625:** `9eb1ce533`, the merged #1621 commit and exact base of #1625
- **#1625:** `d418e6335`, the current head of #1625 and base of this PR
- **this PR:** `36e97d2ff`

## Why this prerequisite is included

The first benchmark attempt correctly stopped instead of pinning only the segmented-container cost: #1625 removed page-array copying, but `useThreadSessionState` still rebuilt all retained review presentation on every page and live-tail change through `coalesceReviewAssistantMessages`, `reviewResultTexts`, and `suppressReviewDuplicateMessages`. A benchmark that ignored those hook-level passes would have papered over the remaining amplification.

This change classifies each incoming retained page once, keeps compact exact-text hash candidates plus review-only event segments, and applies review coalescing/duplicate suppression as lazy overlays on the segmented transcript. Hashes only narrow candidate lookup; normalized text is rechecked before suppressing an ID.

## Checked work budgets

The same generated hook harness was run directly at all three commits. It loads 100 pages × 50 retained entries, materializes all 5,000 entries, then performs 100 live appends while reading the newest window. Its deterministic unit is retained-entry `type` classification reads.

| Scenario | Pre-#1625 (`9eb1ce533`) | #1625 (`d418e6335`) | This PR |
| --- | ---: | ---: | ---: |
| Page 100 × 50 retained entries | 1,262,500 | 762,500 | 10,000 |
| 100 live appends after 5,000 retained entries | 2,000,000 | 1,500,000 | 0 |

The checked test pins all three exact formulas. The 10,000 current paging reads are exactly two one-time classifications per incoming entry: replay-message derivation and compact review-summary construction. #1625 had 5,000 ingestion reads plus three retained-history derived scans over 252,500 triangular history slots. Pre-#1625 additionally rebuilt/classified the flattened response on page and live updates.

#1625's separate storage budget also remains intact:

| Retained-history storage/copy work | Pre-#1625 | #1625 | This PR |
| --- | ---: | ---: | ---: |
| Cumulative growing-array history slots, 100 × 50 | 252,500 | — | — |
| Allocated page entry slots | — | 5,000 | 5,000 |
| Prior-page entry slots copied | — | 0 | 0 |

Accordingly, ordinary paging classification is now Θ(H), not Θ(P² × E), and ordinary live appends do not revisit retained entries. Cross-boundary review correctness work is bounded to `R` retained review/review-like events plus `C` candidates in exact normalized-text hash buckets, rather than all `H` retained entries. These are checked operation budgets, not timing assertions.

## Output and correctness parity

Yes: this is intended to generate the same public transcript layout/output—entry order, message order, IDs, text, newest-tail authority, and review presentation—while changing only retained storage and derived-work strategy.

From pre-#1625 `9eb1ce533` through this branch, the two relevant test files have **756 added lines and zero deleted lines**. All 115 pre-existing `useThreadSessionState` tests and their assertions remain; none were removed or relaxed. One existing live-order test now uses a monotonic mocked clock because repeated runs exposed a same-millisecond `Date.now()` flake on #1625 itself; its exact ordering assertion is unchanged and passed 10/10 repeated runs.

New coverage additionally pins:

- authoritative newest tail/order and exact-ID-only page overlap
- repeated content with distinct IDs
- loaded-history provenance, pagination, compaction/non-pagination resets
- lagging hydration with preserved live-tail order
- review coalescing and duplicate suppression in both directions across history/tail boundaries
- review index reset/invalidation boundaries
- exact normalized-text verification after hash narrowing

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` — 125 passed
- inherited live-order assertion repeated 10 times — 10/10 passed with the deterministic clock
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors; 35 existing warnings
- `pnpm lint:boundaries`
- `git diff --check`
