### PR TITLE
feat(desktop): add tool-output incident explorer

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -3316,6 +3316,7 @@ describe("app server ipc", () => {
     expect(readThread).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-large",
+      includeAllToolInvocations: undefined,
       includeTurns: undefined,
       before: undefined,
       limit: undefined,
@@ -3331,7 +3332,7 @@ describe("app server ipc", () => {
     expect(output).not.toContain("x".repeat(60_000));
   });
 
-  it("forwards inspection-only transcript reads to the backend registry", async () => {
+  it("forwards inspection-only full-accounting reads to the backend registry", async () => {
     const { APP_SERVER_READ_THREAD_CHANNEL } = await import("../../shared/ipc");
     readThread.mockResolvedValueOnce({
       backend: "codex",
@@ -3352,12 +3353,18 @@ describe("app server ipc", () => {
 
     await handlers.get(APP_SERVER_READ_THREAD_CHANNEL)?.(
       {},
-      { backend: "codex", threadId: "sub-agent-1", viewOnly: true },
+      {
+        backend: "codex",
+        includeAllToolInvocations: true,
+        threadId: "sub-agent-1",
+        viewOnly: true,
+      },
     );
 
     expect(readThread).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "sub-agent-1",
+      includeAllToolInvocations: true,
       includeTurns: undefined,
       before: undefined,
       limit: undefined,

--- a/apps/desktop/src/main/__tests__/applications-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/applications-ipc.test.ts
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => {
     ),
     remoteBackend,
     remoteBackendForTarget: vi.fn(() => remoteBackend),
+    showToolOutputIncidentExplorerWindow: vi.fn(),
   };
 });
 
@@ -86,6 +87,11 @@ vi.mock("../subagent-transcript-window", () => ({
   showSubAgentTranscriptWindow: vi.fn(),
 }));
 
+vi.mock("../tool-output-incident-explorer-window", () => ({
+  showToolOutputIncidentExplorerWindow:
+    mocks.showToolOutputIncidentExplorerWindow,
+}));
+
 describe("application IPC", () => {
   beforeEach(() => {
     mocks.handlers.clear();
@@ -94,6 +100,7 @@ describe("application IPC", () => {
     mocks.discoverDesktopApplications.mockClear();
     mocks.openDesktopApplication.mockClear();
     mocks.remoteBackendForTarget.mockClear();
+    mocks.showToolOutputIncidentExplorerWindow.mockClear();
   });
 
   it("opens applications on the selected federation peer", async () => {
@@ -139,5 +146,31 @@ describe("application IPC", () => {
     expect(mocks.readApplications).toHaveBeenCalledTimes(1);
     expect(mocks.discoverDesktopApplications).not.toHaveBeenCalled();
     expect(response).toEqual({ applications: remoteApplications });
+  });
+
+  it("opens the thread-scoped tool-output incident explorer", async () => {
+    const { registerApplicationIpcHandlers } = await import("../ipc/applications");
+    const { TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    registerApplicationIpcHandlers();
+
+    const response = await mocks.handlers.get(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+    )?.({ sender: "sender" }, {
+      backend: "codex",
+      threadId: "thread-1",
+      title: "Noisy work",
+    });
+
+    expect(mocks.showToolOutputIncidentExplorerWindow).toHaveBeenCalledWith(
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        title: "Noisy work",
+      },
+      { sourceWindow: undefined },
+    );
+    expect(response).toEqual({ opened: true });
   });
 });

--- a/apps/desktop/src/main/__tests__/applications-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/applications-ipc.test.ts
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => {
     ),
     remoteBackend,
     remoteBackendForTarget: vi.fn(() => remoteBackend),
+    showThreadFromToolOutputIncidentExplorer: vi.fn(),
     showToolOutputIncidentExplorerWindow: vi.fn(),
   };
 });
@@ -88,6 +89,8 @@ vi.mock("../subagent-transcript-window", () => ({
 }));
 
 vi.mock("../tool-output-incident-explorer-window", () => ({
+  showThreadFromToolOutputIncidentExplorer:
+    mocks.showThreadFromToolOutputIncidentExplorer,
   showToolOutputIncidentExplorerWindow:
     mocks.showToolOutputIncidentExplorerWindow,
 }));
@@ -100,6 +103,7 @@ describe("application IPC", () => {
     mocks.discoverDesktopApplications.mockClear();
     mocks.openDesktopApplication.mockClear();
     mocks.remoteBackendForTarget.mockClear();
+    mocks.showThreadFromToolOutputIncidentExplorer.mockClear();
     mocks.showToolOutputIncidentExplorerWindow.mockClear();
   });
 
@@ -172,5 +176,22 @@ describe("application IPC", () => {
       { sourceWindow: undefined },
     );
     expect(response).toEqual({ opened: true });
+  });
+
+  it("routes incident-explorer thread navigation through its owner", async () => {
+    const { registerApplicationIpcHandlers } = await import("../ipc/applications");
+    const { TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    registerApplicationIpcHandlers();
+    const sender = { id: 42 };
+    const request = { backend: "codex" as const, threadId: "thread-1" };
+
+    await mocks.handlers.get(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
+    )?.({ sender }, request);
+
+    expect(mocks.showThreadFromToolOutputIncidentExplorer)
+      .toHaveBeenCalledWith(sender, request);
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AppServerBackendKind } from "@pwragent/shared";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
@@ -42,6 +42,82 @@ function createOverlayStoreMock() {
 }
 
 describe("DesktopBackendRegistry replay integration", () => {
+  it("pages normalized history and persists one completed analysis batch", async () => {
+    const replayClient = ReplayClient.fromFixture({
+      metadata: {
+        backend: "codex",
+        scenario: "tool-output-history-analysis",
+      },
+      steps: [
+        {
+          id: "initialize-analysis",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: { name: "Replay Codex", version: "1.0.0" },
+            methods: ["thread/read"],
+          },
+        },
+        {
+          id: "read-analysis-latest",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [],
+            messages: [],
+            pagination: {
+              hasPreviousPage: true,
+              previousCursor: "older-page",
+              supportsPagination: true,
+            },
+          },
+        },
+        {
+          id: "read-analysis-oldest",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [],
+            messages: [],
+            pagination: {
+              hasPreviousPage: false,
+              supportsPagination: true,
+            },
+          },
+        },
+      ],
+    });
+    const persistThreadToolHistoryAnalysis = vi.fn(async () => undefined);
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      persistThreadToolHistoryAnalysis,
+      readThreadToolAccounting: async () => ({
+        alerts: [],
+        invocations: [],
+        summaries: [],
+      }),
+    } as unknown as OverlayStoreLike;
+    const registry = new DesktopBackendRegistry({
+      codexClient: replayClient,
+      overlayStore,
+    });
+
+    const response = await registry.analyzeThreadToolHistory({
+      backend: "codex",
+      threadId: "fork-thread",
+    });
+
+    expect(response.coverage).toMatchObject({
+      completeness: "complete",
+      pageCount: 2,
+    });
+    expect(persistThreadToolHistoryAnalysis).toHaveBeenCalledOnce();
+    expect(persistThreadToolHistoryAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "fork-thread" }),
+    );
+    await registry.close();
+  });
+
   it("routes replay notifications through registry events and resolves replay requests through submitServerRequest", async () => {
     const replayClient = ReplayClient.fromFixture({
       metadata: {

--- a/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
@@ -88,14 +88,15 @@ describe("DesktopBackendRegistry replay integration", () => {
       ],
     });
     const persistThreadToolHistoryAnalysis = vi.fn(async () => undefined);
+    const readThreadToolAccounting = vi.fn(async () => ({
+      alerts: [],
+      invocations: [],
+      summaries: [],
+    }));
     const overlayStore = {
       ...createOverlayStoreMock(),
       persistThreadToolHistoryAnalysis,
-      readThreadToolAccounting: async () => ({
-        alerts: [],
-        invocations: [],
-        summaries: [],
-      }),
+      readThreadToolAccounting,
     } as unknown as OverlayStoreLike;
     const registry = new DesktopBackendRegistry({
       codexClient: replayClient,
@@ -115,6 +116,11 @@ describe("DesktopBackendRegistry replay integration", () => {
     expect(persistThreadToolHistoryAnalysis).toHaveBeenCalledWith(
       expect.objectContaining({ threadId: "fork-thread" }),
     );
+    expect(readThreadToolAccounting).toHaveBeenCalledWith({
+      backend: "codex",
+      includeAllInvocations: true,
+      threadId: "fork-thread",
+    });
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19059,7 +19059,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("persists a live large-output alert at the warning threshold without completion", async () => {
+  it("persists and aggregates live large-output alerts without completion", async () => {
     vi.useFakeTimers();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
@@ -19088,7 +19088,10 @@ command = "pnpm dev"
       const emit = (registry as unknown as {
         emit(event: AgentEvent): Promise<void>;
       }).emit.bind(registry);
-      const stream = async (delta: string): Promise<void> => {
+      const stream = async (
+        delta: string,
+        itemId = "cmd-1",
+      ): Promise<void> => {
         await emit({
           backend: "codex",
           notification: {
@@ -19096,7 +19099,7 @@ command = "pnpm dev"
             params: {
               threadId: "thread-1",
               turnId: "turn-1",
-              itemId: "cmd-1",
+              itemId,
               delta,
             },
           },
@@ -19140,8 +19143,33 @@ command = "pnpm dev"
           noisy: true,
           noisyReason: "large-output",
           outputChars: 2_000,
+          outputState: "available",
+          source: "live",
           status: "in_progress",
+          suggestedPrompt: expect.stringContaining("commandExecution"),
         }),
+      });
+
+      await stream("x".repeat(4_000), "cmd-2");
+      expect(persistThreadToolInvocationBoundary).toHaveBeenCalledTimes(2);
+      expect(persistThreadToolInvocationBoundary.mock.calls[1]?.[0]).toMatchObject({
+        alerts: [
+          {
+            invocationCount: 2,
+            invocationIds: [
+              "tool:codex:thread-1:turn-1:cmd-1",
+              "tool:codex:thread-1:turn-1:cmd-2",
+            ],
+            totalOutputChars: 8_000,
+            worstOutputChars: 4_000,
+          },
+        ],
+        invocation: {
+          invocationId: "tool:codex:thread-1:turn-1:cmd-2",
+          outputChars: 4_000,
+          outputState: "available",
+          source: "live",
+        },
       });
 
       await registry.close();

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -117,5 +117,12 @@
     "observedWalBytes": 32960,
     "rowsChanged": 2,
     "statements": 2
+  },
+  "tool-output-history-analysis": {
+    "commits": 1,
+    "note": "replace 25 deterministic history findings plus coverage metadata in one explicit analysis transaction",
+    "observedWalBytes": 28840,
+    "rowsChanged": 26,
+    "statements": 27
   }
 }

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -289,6 +289,54 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
       deltas.reduce((sum, delta) => sum + delta.length, 0),
     );
   });
+
+  it("replaces deterministic history findings without touching live records", async () => {
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation({ invocationId: "live-1", source: "live" }),
+    });
+    const historical = [
+      buildInvocation({
+        findingId: "history-1",
+        invocationId: "history-1",
+        source: "history",
+      }),
+      buildInvocation({
+        findingId: "history-2",
+        invocationId: "history-2",
+        source: "history",
+      }),
+    ];
+    const coverage = {
+      analyzedAt: 1_800_000_000_000,
+      analyzerVersion: "1",
+      completeness: "complete" as const,
+      entryCount: 4,
+      invocationCount: historical.length,
+      missingOutputCount: 0,
+      pageCount: 1,
+      scannedThrough: "oldest-entry",
+    };
+    await store.persistThreadToolHistoryAnalysis({
+      backend: "codex",
+      coverage,
+      invocations: historical,
+      threadId: "thread-1",
+    });
+    await store.persistThreadToolHistoryAnalysis({
+      backend: "codex",
+      coverage,
+      invocations: historical,
+      threadId: "thread-1",
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(accounting.analysis).toEqual(coverage);
+    expect(accounting.invocations.map((entry) => entry.invocationId).sort())
+      .toEqual(["history-1", "history-2", "live-1"]);
+  });
 });
 
 function buildInvocation(

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -337,6 +337,48 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
     expect(accounting.invocations.map((entry) => entry.invocationId).sort())
       .toEqual(["history-1", "history-2", "live-1"]);
   });
+
+  it("returns every finding only for an explicit unbounded accounting read", async () => {
+    const historical = Array.from({ length: 225 }, (_, index) =>
+      buildInvocation({
+        findingId: `history-${index}`,
+        invocationId: `history-${index}`,
+        itemId: `detail-${index}`,
+        noisy: true,
+        observedAt: 1_800_000_000_000 + index,
+        source: "history",
+      })
+    );
+    await store.persistThreadToolHistoryAnalysis({
+      backend: "codex",
+      coverage: {
+        analyzedAt: 1_800_000_001_000,
+        analyzerVersion: "1",
+        completeness: "complete",
+        entryCount: 225,
+        invocationCount: 225,
+        missingOutputCount: 0,
+        pageCount: 3,
+      },
+      invocations: historical,
+      threadId: "thread-1",
+    });
+
+    const ordinary = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const explorer = await store.readThreadToolAccounting({
+      backend: "codex",
+      includeAllInvocations: true,
+      threadId: "thread-1",
+    });
+
+    expect(ordinary.invocations).toHaveLength(200);
+    expect(explorer.invocations).toHaveLength(225);
+    expect(new Set(explorer.invocations.map((entry) => entry.invocationId)).size)
+      .toBe(225);
+  });
 });
 
 function buildInvocation(

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -89,6 +89,40 @@ describe("sqlite write metrics", () => {
     expect(metrics?.commits).toBe(1);
   });
 
+  it("persists one explicit history analysis in one transaction", async () => {
+    const invocations = Array.from({ length: 25 }, (_, index) => ({
+      ...buildInvocation(`history-tool-${index}`),
+      findingId: `history-tool-${index}`,
+      source: "history" as const,
+    }));
+    // This runs only on an explicit Analyze/Refresh action. Even at 20 manual
+    // analyses per day, one commit each is 20 commits/day; findings scale the
+    // statements inside the transaction, never the number of WAL flushes.
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.persistThreadToolHistoryAnalysis({
+        backend: "codex",
+        coverage: {
+          analyzedAt: 1_800_000_000_000,
+          analyzerVersion: "1",
+          completeness: "complete",
+          entryCount: 50,
+          invocationCount: invocations.length,
+          missingOutputCount: 0,
+          pageCount: 2,
+          scannedThrough: "oldest-entry",
+        },
+        invocations,
+        threadId: "thread-1",
+      });
+    });
+
+    expectSqliteWriteBudget({
+      note: "replace 25 deterministic history findings plus coverage metadata in one explicit analysis transaction",
+      scenario: "tool-output-history-analysis",
+      writes,
+    });
+  });
+
   it("holds each completed questionnaire transcript record to one commit", async () => {
     // This path runs once per completed questionnaire, never per streamed
     // event. At 100 questionnaires/day, one commit each is 100 commits/day;

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -449,14 +449,16 @@ describe("StateDb", () => {
   it("creates thread tool accounting tables", () => {
     const tables = stateDb.raw
       .prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?) ORDER BY name`,
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?) ORDER BY name`,
       )
       .all(
         "thread_tool_invocation_alerts",
         "thread_tool_invocations",
+        "thread_tool_analysis",
       ) as Array<{ name: string }>;
 
     expect(tables.map((table) => table.name)).toEqual([
+      "thread_tool_analysis",
       "thread_tool_invocation_alerts",
       "thread_tool_invocations",
     ]);

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -7,6 +7,7 @@ import {
   buildToolOutputMetrics,
   detectLargeToolOutput,
   detectNoisyPolling,
+  mergeLargeToolOutputIncident,
   normalizeToolInvocationCommand,
   toolInvocationFromNotification,
 } from "../app-server/tool-invocation-accounting";
@@ -461,6 +462,108 @@ describe("tool invocation accounting", () => {
     });
 
     expect(detection).toBeUndefined();
+  });
+
+  it("aggregates cases by turn and keeps a stable worst-case summary", () => {
+    const first = detectLargeToolOutput({
+      current: buildOutputInvocation(8_000),
+      previousOutputChars: 0,
+    })!;
+    const firstIncident = mergeLargeToolOutputIncident({ detection: first });
+    const second = detectLargeToolOutput({
+      current: {
+        ...buildOutputInvocation(12_000),
+        invocationId: "command-2",
+        itemId: "command-2",
+      },
+      previousOutputChars: 0,
+    })!;
+    const secondIncident = mergeLargeToolOutputIncident({
+      current: firstIncident.aggregate,
+      detection: second,
+    });
+
+    expect(secondIncident.shouldNotify).toBe(true);
+    expect(secondIncident.aggregate.alert).toMatchObject({
+      invocationCount: 2,
+      totalOutputChars: 20_000,
+      worstInvocationId: "command-2",
+      worstOutputChars: 12_000,
+    });
+  });
+
+  it("does not rewrite a live warning at terminal completion", () => {
+    const live = detectLargeToolOutput({
+      current: buildOutputInvocation(4_000),
+      previousOutputChars: 0,
+    })!;
+    const incident = mergeLargeToolOutputIncident({ detection: live });
+    const terminal = detectLargeToolOutput({
+      current: { ...buildOutputInvocation(4_000), status: "completed" },
+    })!;
+    const completed = mergeLargeToolOutputIncident({
+      current: incident.aggregate,
+      detection: terminal,
+    });
+
+    expect(completed.shouldNotify).toBe(false);
+  });
+
+  it("aggregates repeated polling cases under the turn and alert kind", () => {
+    const records = Array.from({ length: 6 }, (_, index) => ({
+      ...buildPollingInvocation(
+        `wait-${index + 1}`,
+        1_800_000_000_000 + index * 30_000,
+        (index + 1) * 10,
+      ),
+      normalizedCommand: undefined,
+      sessionId: undefined,
+      toolName: "wait",
+      turnId: "turn-1",
+    }));
+    const firstDetection = detectNoisyPolling({
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
+    })!;
+    const firstIncident = mergeLargeToolOutputIncident({
+      detection: firstDetection,
+    });
+    const secondIncident = mergeLargeToolOutputIncident({
+      current: firstIncident.aggregate,
+      detection: detectNoisyPolling({
+        current: records[5]!,
+        now: records[5]!.observedAt,
+        recent: records.slice(0, 5),
+      })!,
+    });
+
+    expect(secondIncident.aggregate.alert).toMatchObject({
+      alertId: "noisy-polling:codex:thread-1:turn-1",
+      invocationCount: 6,
+      totalOutputChars: 210,
+      worstInvocationId: "wait-6",
+      worstOutputChars: 60,
+    });
+  });
+
+  it("reopens a case only when it escalates to critical", () => {
+    const warning = mergeLargeToolOutputIncident({
+      detection: detectLargeToolOutput({
+        current: buildOutputInvocation(4_000),
+        previousOutputChars: 0,
+      })!,
+    });
+    const critical = mergeLargeToolOutputIncident({
+      current: warning.aggregate,
+      detection: detectLargeToolOutput({
+        current: buildOutputInvocation(40_000),
+        previousOutputChars: 4_000,
+      })!,
+    });
+
+    expect(critical.shouldNotify).toBe(true);
+    expect(critical.aggregate.alert.severity).toBe("critical");
   });
 });
 

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const windows: Array<{
+    isDestroyed: ReturnType<typeof vi.fn>;
+    loadFile: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    webContents: object;
+  }> = [];
+  const BrowserWindow = vi.fn(function BrowserWindowMock(
+    this: unknown,
+    _options: unknown,
+  ) {
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      loadFile: vi.fn(async () => undefined),
+      on: vi.fn(),
+      webContents: {},
+    };
+    windows.push(window);
+    return window;
+  });
+  return {
+    applyWindowSecurityHardening: vi.fn(),
+    BrowserWindow,
+    registerWindowChannels: vi.fn(),
+    showAndFocusAuxiliaryWindow: vi.fn(),
+    windows,
+  };
+});
+
+vi.mock("electron", () => ({ BrowserWindow: mocks.BrowserWindow }));
+vi.mock("../log", () => ({
+  getMainLogger: () => ({ debug: vi.fn() }),
+}));
+vi.mock("../window", () => ({
+  applyWindowSecurityHardening: mocks.applyWindowSecurityHardening,
+  getPreloadPath: () => "/preload.js",
+  getRendererEntry: () => ({ kind: "file", value: "/renderer.html" }),
+}));
+vi.mock("../window-channels", () => ({
+  WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER: "tool-output-incident-explorer",
+  registerWindowChannels: mocks.registerWindowChannels,
+}));
+vi.mock("../settings/appearance-bootstrap", () => ({
+  readBootstrapAppearance: () => ({ theme: "dark" }),
+  themedWindowAdditionalArguments: () => ["--appearance=dark"],
+  themedWindowBackgroundColor: () => "#000000",
+}));
+vi.mock("../auxiliary-window-chrome", () => ({
+  auxiliaryWindowChromeOptions: () => ({ frame: true }),
+  hideAuxiliaryWindowMenuBar: vi.fn(),
+  registerAuxiliaryWindowTitle: vi.fn(),
+  showAndFocusAuxiliaryWindow: mocks.showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady: vi.fn(),
+}));
+vi.mock("../window-placement", () => ({
+  placementForSourceDisplay: () => ({ x: 10, y: 20 }),
+  positionWindowForSourceDisplay: vi.fn(),
+}));
+
+describe("tool-output incident explorer window", () => {
+  beforeEach(() => {
+    mocks.BrowserWindow.mockClear();
+    mocks.windows.length = 0;
+    mocks.applyWindowSecurityHardening.mockClear();
+    mocks.registerWindowChannels.mockClear();
+    mocks.showAndFocusAuxiliaryWindow.mockClear();
+  });
+
+  it("creates one hardened inspection-only window per thread", async () => {
+    const { showToolOutputIncidentExplorerWindow } = await import(
+      "../tool-output-incident-explorer-window"
+    );
+    const request = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      title: "Noisy work",
+    };
+    showToolOutputIncidentExplorerWindow(request);
+    showToolOutputIncidentExplorerWindow(request);
+
+    expect(mocks.BrowserWindow).toHaveBeenCalledTimes(1);
+    expect(mocks.BrowserWindow.mock.calls[0]?.[0]).toMatchObject({
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+    expect(mocks.applyWindowSecurityHardening).toHaveBeenCalledOnce();
+    expect(mocks.registerWindowChannels).toHaveBeenCalledWith(
+      mocks.windows[0],
+      "tool-output-incident-explorer",
+      expect.any(Array),
+    );
+    expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
+      "/renderer.html",
+      {
+        hash: "tool-output-incidents/codex/thread-1/Noisy%20work",
+      },
+    );
+    expect(mocks.showAndFocusAuxiliaryWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => {
     isDestroyed: ReturnType<typeof vi.fn>;
     loadFile: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
-    webContents: object;
+    webContents: { send: ReturnType<typeof vi.fn> };
   }> = [];
   const BrowserWindow = vi.fn(function BrowserWindowMock(
     this: unknown,
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => {
       isDestroyed: vi.fn(() => false),
       loadFile: vi.fn(async () => undefined),
       on: vi.fn(),
-      webContents: {},
+      webContents: { send: vi.fn() },
     };
     windows.push(window);
     return window;
@@ -101,5 +101,8 @@ describe("tool-output incident explorer window", () => {
       },
     );
     expect(mocks.showAndFocusAuxiliaryWindow).toHaveBeenCalledOnce();
+    expect(mocks.windows[0]?.webContents.send).toHaveBeenCalledWith(
+      "tool-output-incident-explorer:refresh",
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -5,7 +5,11 @@ const mocks = vi.hoisted(() => {
     isDestroyed: ReturnType<typeof vi.fn>;
     loadFile: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
-    webContents: { send: ReturnType<typeof vi.fn> };
+    webContents: {
+      id: number;
+      isDestroyed: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
+    };
   }> = [];
   const BrowserWindow = vi.fn(function BrowserWindowMock(
     this: unknown,
@@ -15,7 +19,11 @@ const mocks = vi.hoisted(() => {
       isDestroyed: vi.fn(() => false),
       loadFile: vi.fn(async () => undefined),
       on: vi.fn(),
-      webContents: { send: vi.fn() },
+      webContents: {
+        id: windows.length + 1,
+        isDestroyed: vi.fn(() => false),
+        send: vi.fn(),
+      },
     };
     windows.push(window);
     return window;
@@ -25,6 +33,7 @@ const mocks = vi.hoisted(() => {
     BrowserWindow,
     registerWindowChannels: vi.fn(),
     showAndFocusAuxiliaryWindow: vi.fn(),
+    requestShowThread: vi.fn(),
     windows,
   };
 });
@@ -58,6 +67,9 @@ vi.mock("../window-placement", () => ({
   placementForSourceDisplay: () => ({ x: 10, y: 20 }),
   positionWindowForSourceDisplay: vi.fn(),
 }));
+vi.mock("../window-show-thread", () => ({
+  requestShowThread: mocks.requestShowThread,
+}));
 
 describe("tool-output incident explorer window", () => {
   beforeEach(() => {
@@ -66,6 +78,7 @@ describe("tool-output incident explorer window", () => {
     mocks.applyWindowSecurityHardening.mockClear();
     mocks.registerWindowChannels.mockClear();
     mocks.showAndFocusAuxiliaryWindow.mockClear();
+    mocks.requestShowThread.mockClear();
   });
 
   it("creates one hardened inspection-only window per thread", async () => {
@@ -76,6 +89,7 @@ describe("tool-output incident explorer window", () => {
       backend: "codex" as const,
       threadId: "thread-1",
       title: "Noisy work",
+      projectLabel: "PwrAgent",
     };
     showToolOutputIncidentExplorerWindow(request);
     showToolOutputIncidentExplorerWindow(request);
@@ -97,12 +111,47 @@ describe("tool-output incident explorer window", () => {
     expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
       "/renderer.html",
       {
-        hash: "tool-output-incidents/codex/thread-1/Noisy%20work",
+        hash: "tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent",
       },
     );
     expect(mocks.showAndFocusAuxiliaryWindow).toHaveBeenCalledOnce();
     expect(mocks.windows[0]?.webContents.send).toHaveBeenCalledWith(
       "tool-output-incident-explorer:refresh",
+      request,
     );
+  });
+
+  it("routes a thread-chip click back to the explorer's exact owner window", async () => {
+    const {
+      showThreadFromToolOutputIncidentExplorer,
+      showToolOutputIncidentExplorerWindow,
+    } = await import("../tool-output-incident-explorer-window");
+    const ownerWebContents = {
+      isDestroyed: vi.fn(() => false),
+      send: vi.fn(),
+    };
+    const sourceWindow = {
+      isDestroyed: vi.fn(() => false),
+      webContents: ownerWebContents,
+    };
+    showToolOutputIncidentExplorerWindow({
+      backend: "acp:grok",
+      threadId: "thread-owned",
+      title: "Owned thread",
+    }, { sourceWindow } as never);
+
+    showThreadFromToolOutputIncidentExplorer(
+      mocks.windows[0]!.webContents as never,
+      { backend: "acp:grok", threadId: "thread-owned" },
+    );
+
+    expect(mocks.requestShowThread).toHaveBeenCalledWith(
+      { backend: "acp:grok", threadId: "thread-owned" },
+      { preferWebContents: ownerWebContents },
+    );
+    expect(() => showThreadFromToolOutputIncidentExplorer(
+      mocks.windows[0]!.webContents as never,
+      { backend: "acp:grok", threadId: "another-thread" },
+    )).toThrow("can only open its own thread");
   });
 });

--- a/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
@@ -1,0 +1,127 @@
+import type { AppServerThreadReplay } from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import { analyzeNormalizedToolReplay } from "../app-server/tool-output-replay-analyzer";
+
+describe("normalized tool-output replay analyzer", () => {
+  it("classifies structured MCP output and proposes targeted pagination", () => {
+    const analysis = analyzeNormalizedToolReplay({
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex",
+      complete: true,
+      pages: [replayWithDetail({
+        displayCommand: "mcp__github__search({\"query\":\"is:open\"})",
+        output: JSON.stringify({ items: Array.from({ length: 600 }, (_, id) => ({ id })) }),
+        source: "tool",
+      })],
+      threadId: "thread-mcp",
+    });
+
+    expect(analysis.invocations[0]).toMatchObject({
+      category: "mcp",
+      noisy: true,
+      source: "history",
+    });
+    expect(analysis.invocations[0]?.suggestedPrompt).toContain(
+      "request only targeted fields and use pagination",
+    );
+    expect(analysis.invocations[0]?.suggestedPrompt).toContain(
+      "mcp__github__search",
+    );
+  });
+
+  it("marks compacted and truncated replay coverage incomplete", () => {
+    const compacted = replayWithDetail({
+      displayCommand: "sed -n '1,10000p' giant.log",
+      label: "Output compacted out of context",
+      source: "shell",
+    });
+    const truncated = replayWithDetail({
+      displayCommand: "rg error .",
+      output: `${"match\n".repeat(900)}output truncated`,
+      source: "shell",
+    });
+    const analysis = analyzeNormalizedToolReplay({
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex",
+      complete: true,
+      pages: [compacted, truncated],
+      threadId: "thread-partial",
+    });
+
+    expect(analysis.coverage).toMatchObject({
+      completeness: "partial",
+      missingOutputCount: 1,
+      pageCount: 2,
+    });
+    expect(analysis.coverage.explanation).toContain("lower bound");
+    expect(analysis.invocations.map((entry) => entry.outputState)).toEqual([
+      "compacted",
+      "truncated",
+    ]);
+  });
+
+  it("attributes inherited normalized replay to a fork with idempotent IDs", () => {
+    const inheritedReplay = replayWithDetail({
+      displayCommand: "cat inherited-build.log",
+      output: "x".repeat(5_000),
+      source: "shell",
+    });
+    const params = {
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex" as const,
+      complete: true,
+      pages: [inheritedReplay, inheritedReplay],
+      threadId: "fork-thread-id",
+    };
+    const first = analyzeNormalizedToolReplay(params);
+    const second = analyzeNormalizedToolReplay(params);
+
+    expect(first.invocations[0]).toMatchObject({
+      threadId: "fork-thread-id",
+      turnId: "inherited-turn",
+    });
+    expect(first.invocations).toHaveLength(1);
+    expect(first.coverage.entryCount).toBe(1);
+    expect(second.invocations[0]?.invocationId)
+      .toBe(first.invocations[0]?.invocationId);
+  });
+});
+
+function replayWithDetail(params: {
+  displayCommand: string;
+  label?: string;
+  output?: string;
+  source: "agent" | "shell" | "tool";
+}): AppServerThreadReplay {
+  return {
+    entries: [{
+      type: "activity",
+      id: `activity-${params.displayCommand.slice(0, 8)}`,
+      createdAt: 1_700_000_000_000,
+      status: "completed",
+      summary: "Tool call",
+      details: [{
+        id: "detail-1",
+        kind: "command",
+        label: params.label ?? params.displayCommand,
+        status: "completed",
+        command: {
+          displayCommand: params.displayCommand,
+          exitCode: 0,
+          ...(params.output !== undefined ? { output: params.output } : {}),
+          source: params.source,
+        },
+      }],
+      turn: {
+        id: "inherited-turn",
+        status: "completed",
+        completedAt: 1_700_000_000_100,
+      },
+    }],
+    messages: [],
+    pagination: {
+      hasPreviousPage: false,
+      supportsPagination: true,
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
@@ -18,6 +18,7 @@ describe("normalized tool-output replay analyzer", () => {
 
     expect(analysis.invocations[0]).toMatchObject({
       category: "mcp",
+      itemId: "detail-1",
       noisy: true,
       source: "history",
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6669,8 +6669,8 @@ export class DesktopBackendRegistry {
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes every flush and streamed alert boundary so a timer-driven write
-   * `item/completed` write it accumulated before — the store keeps the
-   * terminal status and stops summing once a row is terminal, so an
+   * can never land after the `item/completed` write it accumulated before. The
+   * store keeps the terminal status and stops summing once a row is terminal, so an
    * out-of-order delta flush would silently under-count the command's output.
    */
   private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8839,6 +8839,9 @@ export class DesktopBackendRegistry {
       typeof this.overlayStore.readThreadToolAccounting === "function"
         ? await this.overlayStore.readThreadToolAccounting({
             backend,
+            ...(request.includeAllToolInvocations
+              ? { includeAllInvocations: true }
+              : {}),
             threadId: request.threadId,
           })
         : undefined;
@@ -10578,6 +10581,9 @@ export class DesktopBackendRegistry {
       typeof this.overlayStore.readThreadToolAccounting === "function"
         ? await this.overlayStore.readThreadToolAccounting({
             backend,
+            ...(request.includeAllToolInvocations
+              ? { includeAllInvocations: true }
+              : {}),
             threadId: request.threadId,
           })
         : undefined;
@@ -10656,6 +10662,7 @@ export class DesktopBackendRegistry {
     });
     const accounting = await this.overlayStore.readThreadToolAccounting({
       backend: request.backend,
+      includeAllInvocations: true,
       threadId: request.threadId,
     });
     await this.emitThreadToolAccountingUpdated({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -90,6 +90,8 @@ import {
   type AppServerTurnInputItem,
   type AppServerAvailableCommandSummary,
   type AppServerBackendKind,
+  type AnalyzeThreadToolHistoryRequest,
+  type AnalyzeThreadToolHistoryResponse,
   type AppServerCollaborationModeRequest,
   type BackendAccountSummary,
   type BackendAcpRuntimeCapabilities,
@@ -443,11 +445,14 @@ import {
 import {
   detectLargeToolOutput,
   detectNoisyPolling,
+  mergeLargeToolOutputIncident,
   mergeStreamedToolInvocationDeltas,
   mergeToolInvocationLifecycleWithStreamedOutput,
   toolAccountingLookbackSince,
   toolInvocationFromNotification,
+  type ToolOutputIncidentAggregate,
 } from "./tool-invocation-accounting";
+import { analyzeNormalizedToolReplay } from "./tool-output-replay-analyzer";
 import {
   ThreadTitleGenerationService,
   type ThreadTitleGenerator,
@@ -6657,6 +6662,10 @@ export class DesktopBackendRegistry {
     ThreadToolInvocationRecord[]
   >();
   private readonly persistedToolInvocationAlertCounts = new Map<string, number>();
+  private readonly liveToolOutputIncidents = new Map<
+    string,
+    ToolOutputIncidentAggregate
+  >();
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes every flush and streamed alert boundary so a timer-driven write
@@ -10590,6 +10599,70 @@ export class DesktopBackendRegistry {
         : {}),
       replay: replayWithMessageOrigins,
     };
+  }
+
+  async analyzeThreadToolHistory(
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse> {
+    this.assertNotBootstrap("analyzeThreadToolHistory");
+    if (typeof this.overlayStore.persistThreadToolHistoryAnalysis !== "function") {
+      throw new Error("Tool-output history analysis storage is unavailable.");
+    }
+
+    const pages: AppServerThreadReplay[] = [];
+    const seenCursors = new Set<string>();
+    let before: string | undefined;
+    let complete = false;
+    for (let page = 0; page < 1_000; page += 1) {
+      let response: AppServerReadThreadResponse;
+      try {
+        response = await this.readThread({
+          backend: request.backend,
+          ...(before ? { before } : {}),
+          limit: 100,
+          threadId: request.threadId,
+          viewOnly: true,
+        });
+      } catch (error) {
+        if (pages.length === 0) {
+          throw error;
+        }
+        break;
+      }
+      pages.push(response.replay);
+      if (!response.replay.pagination.hasPreviousPage) {
+        complete = true;
+        break;
+      }
+      const cursor = response.replay.pagination.previousCursor;
+      if (!cursor || seenCursors.has(cursor)) {
+        break;
+      }
+      seenCursors.add(cursor);
+      before = cursor;
+    }
+
+    const analysis = analyzeNormalizedToolReplay({
+      backend: request.backend,
+      complete,
+      pages,
+      threadId: request.threadId,
+    });
+    await this.overlayStore.persistThreadToolHistoryAnalysis({
+      backend: request.backend,
+      coverage: analysis.coverage,
+      invocations: analysis.invocations,
+      threadId: request.threadId,
+    });
+    const accounting = await this.overlayStore.readThreadToolAccounting({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+    await this.emitThreadToolAccountingUpdated({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+    return { accounting, coverage: analysis.coverage };
   }
 
   async getThreadTranscriptImageRoots(params: {
@@ -21761,6 +21834,23 @@ export class DesktopBackendRegistry {
   }
 
   private async recordToolInvocationAccounting(event: AgentEvent): Promise<void> {
+    if (
+      event.notification.method === "turn/completed"
+      || event.notification.method === "turn/failed"
+      || event.notification.method === "turn/interrupted"
+    ) {
+      const params = readRecord(event.notification.params);
+      const threadId = readNonEmptyString(params?.threadId);
+      const turnId = readNonEmptyString(params?.turnId);
+      if (threadId && turnId) {
+        this.liveToolOutputIncidents.delete(
+          `large-output:${event.backend}:${threadId}:${turnId}`,
+        );
+        this.liveToolOutputIncidents.delete(
+          `noisy-polling:${event.backend}:${threadId}:${turnId}`,
+        );
+      }
+    }
     if (typeof this.overlayStore.upsertThreadToolInvocation !== "function") {
       return;
     }
@@ -21787,14 +21877,25 @@ export class DesktopBackendRegistry {
         previousOutputChars: buffered.previousOutputChars,
       });
       if (detection) {
+        const incident = mergeLargeToolOutputIncident({
+          current: this.liveToolOutputIncidents.get(detection.alert.alertId),
+          detection,
+        });
+        this.liveToolOutputIncidents.set(
+          incident.aggregate.alert.alertId,
+          incident.aggregate,
+        );
+        if (!incident.shouldNotify) {
+          return;
+        }
         const stored = await this.persistStreamedToolInvocationAlertBoundary({
-          alert: detection.alert,
+          alert: incident.aggregate.alert,
           invocationId: invocation.invocationId,
         });
         await this.emitThreadToolAccountingUpdated({
           backend: stored.backend,
           threadId: stored.threadId,
-          triggeredAlerts: [detection.alert],
+          triggeredAlerts: [incident.aggregate.alert],
         });
       }
       return;
@@ -21810,10 +21911,31 @@ export class DesktopBackendRegistry {
     }
     let shouldNotify = event.notification.method === "item/completed";
     const triggeredAlerts: ThreadToolInvocationAlert[] = [];
-    const largeOutputDetection = detectLargeToolOutput({
+    const rawLargeOutputDetection = detectLargeToolOutput({
       current: invocationWithStreamedOutput,
       now,
     });
+    const largeOutputIncident = rawLargeOutputDetection
+      ? mergeLargeToolOutputIncident({
+          current: this.liveToolOutputIncidents.get(
+            rawLargeOutputDetection.alert.alertId,
+          ),
+          detection: rawLargeOutputDetection,
+        })
+      : undefined;
+    if (largeOutputIncident) {
+      this.liveToolOutputIncidents.set(
+        largeOutputIncident.aggregate.alert.alertId,
+        largeOutputIncident.aggregate,
+      );
+    }
+    const largeOutputDetection = largeOutputIncident
+      ? {
+          alert: largeOutputIncident.aggregate.alert,
+          cases: rawLargeOutputDetection!.cases,
+          invocationIds: rawLargeOutputDetection!.invocationIds,
+        }
+      : undefined;
     const isVolatileDeferredCheck =
       invocationWithStreamedOutput.category === "polling"
       && (
@@ -21823,7 +21945,7 @@ export class DesktopBackendRegistry {
     const volatileRecent = isVolatileDeferredCheck
       ? this.readVolatileDeferredChecks(invocationWithStreamedOutput, now)
       : [];
-    const pollingDetection =
+    const rawPollingDetection =
       typeof this.overlayStore.readRecentThreadToolInvocations === "function"
       ? detectNoisyPolling({
           current: invocationWithStreamedOutput,
@@ -21848,6 +21970,28 @@ export class DesktopBackendRegistry {
             }),
           ],
         })
+      : undefined;
+    const pollingIncident = rawPollingDetection
+      ? mergeLargeToolOutputIncident({
+          current: this.liveToolOutputIncidents.get(
+            rawPollingDetection.alert.alertId,
+          ),
+          detection: rawPollingDetection,
+        })
+      : undefined;
+    if (pollingIncident) {
+      this.liveToolOutputIncidents.set(
+        pollingIncident.aggregate.alert.alertId,
+        pollingIncident.aggregate,
+      );
+    }
+    const pollingDetection = pollingIncident
+      ? {
+          alert: pollingIncident.aggregate.alert,
+          cases: rawPollingDetection!.cases,
+          invocationIds: pollingIncident.aggregate.alert.invocationIds ?? [],
+          lookbackSince: rawPollingDetection!.lookbackSince,
+        }
       : undefined;
     if (isVolatileDeferredCheck) {
       this.rememberVolatileDeferredCheck(invocationWithStreamedOutput, now);
@@ -21896,7 +22040,7 @@ export class DesktopBackendRegistry {
           pollingDetection.alert.invocationCount,
         );
       }
-      if (pollingDetection) {
+      if (pollingDetection && pollingIncident?.shouldNotify) {
         await this.emitThreadToolAccountingUpdated({
           backend: invocationWithStreamedOutput.backend,
           threadId: invocationWithStreamedOutput.threadId,
@@ -21911,13 +22055,20 @@ export class DesktopBackendRegistry {
             (invocationId) => invocationId !== invocation.invocationId,
           )
         : [];
-    const invocationToPersist = noisyReason
-      ? {
-          ...invocation,
-          noisy: true,
-          noisyReason,
-        }
-      : invocation;
+    const suggestedPrompt = pollingDetection?.alert.suggestedPrompt
+      ?? largeOutputDetection?.alert.suggestedPrompt;
+    const invocationToPersist = {
+      ...invocation,
+      outputState: invocation.outputTruncated ? "truncated" as const : "available" as const,
+      source: "live" as const,
+      ...(noisyReason
+        ? {
+            noisy: true,
+            noisyReason,
+          }
+        : {}),
+      ...(suggestedPrompt ? { suggestedPrompt } : {}),
+    };
     let stored: ThreadToolInvocationRecord;
     if (
       typeof this.overlayStore.persistThreadToolInvocationBoundary === "function"
@@ -21965,11 +22116,11 @@ export class DesktopBackendRegistry {
         pollingDetection.alert.invocationCount,
       );
     }
-    if (largeOutputDetection) {
+    if (largeOutputDetection && largeOutputIncident?.shouldNotify) {
       triggeredAlerts.push(largeOutputDetection.alert);
       shouldNotify = true;
     }
-    if (pollingDetection) {
+    if (pollingDetection && pollingIncident?.shouldNotify) {
       triggeredAlerts.push(pollingDetection.alert);
       shouldNotify = true;
     }
@@ -22034,6 +22185,9 @@ export class DesktopBackendRegistry {
       ...pending,
       noisy: true,
       noisyReason: "large-output",
+      outputState: pending.outputTruncated ? "truncated" as const : "available" as const,
+      source: "live" as const,
+      suggestedPrompt: params.alert.suggestedPrompt,
     };
     const persisted = this.toolInvocationDeltaFlushChain.then(async () => {
       try {

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -6,6 +6,7 @@ import type {
   ThreadToolInvocationRecord,
   ThreadToolInvocationStatus,
 } from "@pwragent/shared";
+import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
 import { redactCommandText } from "../util/redact-command-text";
 
 const OUTPUT_TOKEN_CHAR_RATIO = 4;
@@ -41,14 +42,101 @@ export type NormalizedToolCommand = {
 
 export type NoisyPollingDetection = {
   alert: ThreadToolInvocationAlert;
+  cases: Record<string, { outputChars: number }>;
   invocationIds: string[];
   lookbackSince: number;
 };
 
 export type LargeToolOutputDetection = {
   alert: ThreadToolInvocationAlert;
+  cases: Record<string, { outputChars: number }>;
   invocationIds: string[];
 };
+
+export type ToolOutputIncidentAggregate = {
+  alert: ThreadToolInvocationAlert;
+  cases: Record<string, {
+    outputChars: number;
+    severity: ThreadToolInvocationAlert["severity"];
+  }>;
+};
+
+export function mergeLargeToolOutputIncident(params: {
+  current?: ToolOutputIncidentAggregate;
+  detection: LargeToolOutputDetection | NoisyPollingDetection;
+}): {
+  aggregate: ToolOutputIncidentAggregate;
+  shouldNotify: boolean;
+} {
+  const incoming = params.detection.alert;
+  const previousCases = params.current?.cases ?? {};
+  const newInvocationIds = params.detection.invocationIds.filter(
+    (invocationId) => !previousCases[invocationId],
+  );
+  const escalated = params.detection.invocationIds.some((invocationId) =>
+    previousCases[invocationId]?.severity === "warning"
+    && incoming.severity === "critical"
+  );
+  const cases = { ...previousCases };
+  for (const invocationId of params.detection.invocationIds) {
+    const incidentCase = params.detection.cases[invocationId];
+    cases[invocationId] = {
+      outputChars: incidentCase?.outputChars ?? 0,
+      severity: incoming.severity,
+    };
+  }
+  const entries = Object.entries(cases);
+  const totalOutputChars = entries.reduce(
+    (sum, [, incidentCase]) => sum + incidentCase.outputChars,
+    0,
+  );
+  const [worstInvocationId, worstCase] = entries.reduce(
+    (worst, entry) => entry[1].outputChars > worst[1].outputChars ? entry : worst,
+  );
+  const severity = entries.some(([, incidentCase]) => incidentCase.severity === "critical")
+    ? "critical" as const
+    : "warning" as const;
+  const estimatedOutputTokens = Math.ceil(totalOutputChars / OUTPUT_TOKEN_CHAR_RATIO);
+  const caseCount = entries.length;
+  const subject = incoming.kind === "noisy-polling"
+    ? `repeated queued check${caseCount === 1 ? "" : "s"}`
+    : `noisy tool-output case${caseCount === 1 ? "" : "s"}`;
+  const message = `${caseCount.toLocaleString()} ${subject} in this turn produced ${totalOutputChars.toLocaleString()} characters (~${estimatedOutputTokens.toLocaleString()} tokens). The worst case produced ${worstCase.outputChars.toLocaleString()} characters.`;
+  const alert: ThreadToolInvocationAlert = {
+    ...(params.current?.alert ?? incoming),
+    alertId: incoming.alertId,
+    estimatedOutputTokens,
+    firstObservedAt: Math.min(
+      params.current?.alert.firstObservedAt ?? incoming.firstObservedAt,
+      incoming.firstObservedAt,
+    ),
+    invocationCount: caseCount,
+    invocationIds: entries.map(([id]) => id),
+    lastObservedAt: Math.max(
+      params.current?.alert.lastObservedAt ?? incoming.lastObservedAt,
+      incoming.lastObservedAt,
+    ),
+    message,
+    severity,
+    suggestedPrompt: incoming.suggestedPrompt,
+    totalOutputChars,
+    updatedAt: incoming.updatedAt,
+    worstInvocationId,
+    worstOutputChars: worstCase.outputChars,
+  };
+  return {
+    aggregate: { alert, cases },
+    shouldNotify:
+      newInvocationIds.length > 0 || escalated,
+  };
+}
+
+export function buildToolInvocationSteeringPrompt(params: {
+  invocation: ThreadToolInvocationRecord;
+  reason: string;
+}): string {
+  return buildThreadToolIncidentPrompt(params);
+}
 
 export function toolInvocationFromNotification(params: {
   backend: AppServerBackendKind;
@@ -439,11 +527,10 @@ export function detectNoisyPolling(params: {
       : `process ${current.processId}`;
   const message =
     `${records.length.toLocaleString()} queued checks on ${sessionLabel} are repeatedly waking the model and replaying its accumulated context. The checks returned ${totalOutputChars.toLocaleString()} chars (~${estimatedOutputTokens.toLocaleString()} output tokens), but replay cost applies even when they return little or nothing.`;
-  const suggestedPrompt = [
-    "Stop polling this long-running process in the main thread.",
-    "Use PwrAgent's create_monitor_delegation tool with the durable command, cwd, log/status files, poll cadence, and terminal success/failure criteria.",
-    "Continue unrelated work here, and let the monitor report completion back to this thread.",
-  ].join(" ");
+  const suggestedPrompt = buildToolInvocationSteeringPrompt({
+    invocation: current,
+    reason: "repeated queued checks are waking the model and replaying accumulated context",
+  });
 
   return {
     alert: {
@@ -451,10 +538,7 @@ export function detectNoisyPolling(params: {
         "noisy-polling",
         current.backend,
         current.threadId,
-        current.toolName,
-        isTurnScopedPolling
-          ? current.turnId
-          : current.sessionId ?? current.processId ?? "unknown",
+        current.turnId ?? "no-turn",
       ].join(":"),
       averageIntervalMs,
       backend: current.backend,
@@ -475,6 +559,10 @@ export function detectNoisyPolling(params: {
       totalOutputChars,
       updatedAt: now,
     },
+    cases: Object.fromEntries(records.map((record) => [
+      record.invocationId,
+      { outputChars: record.outputChars },
+    ])),
     invocationIds: records.map((record) => record.invocationId),
     lookbackSince,
   };
@@ -510,15 +598,25 @@ export function detectLargeToolOutput(params: {
   const message = critical
     ? `This tool produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), reaching or exceeding the observed model-visible output cap. The retained portion will replay on subsequent inference items.`
     : `This tool has produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), about ${estimatedCapPercentage.toLocaleString()}% of the observed model-visible output cap. Continuing unfiltered will enlarge every later context replay.`;
-  const suggestedPrompt = [
-    "Treat this command as extremely noisy.",
-    "For subsequent executions, redirect full stdout and stderr to a local log and return only the command, exit code, concise summary, key failure blocks, and a bounded tail.",
-    "Use an installed output-reduction wrapper when available, and retrieve targeted raw sections only when needed.",
-  ].join(" ");
+  const noisyReason = critical
+    ? "output reached or exceeded the observed model-visible cap"
+    : "large output will be replayed on later inference items";
+  const suggestedPrompt = buildToolInvocationSteeringPrompt({
+    invocation: {
+      ...current,
+      outputState: current.outputTruncated ? "truncated" : "available",
+    },
+    reason: noisyReason,
+  });
 
   return {
     alert: {
-      alertId: ["large-output", current.invocationId].join(":"),
+      alertId: [
+        "large-output",
+        current.backend,
+        current.threadId,
+        current.turnId ?? "no-turn",
+      ].join(":"),
       backend: current.backend,
       createdAt: now,
       estimatedOutputTokens: current.estimatedOutputTokens,
@@ -536,6 +634,9 @@ export function detectLargeToolOutput(params: {
       toolName: current.toolName,
       totalOutputChars: current.outputChars,
       updatedAt: now,
+    },
+    cases: {
+      [current.invocationId]: { outputChars: current.outputChars },
     },
     invocationIds: [current.invocationId],
   };
@@ -616,6 +717,9 @@ function normalizeShellCommand(command: string | undefined): string | undefined 
 }
 
 function categoryForToolName(toolName: string): ThreadToolInvocationCategory {
+  if (/^mcp(?:__|ToolCall$)/i.test(toolName) || toolName.includes("mcp")) {
+    return "mcp";
+  }
   if (
     toolName === "read_file" ||
     toolName === "list_files" ||

--- a/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
+++ b/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
@@ -85,7 +85,10 @@ export function analyzeNormalizedToolReplay(params: {
             : {}),
           findingId: invocationId,
           invocationId,
-          itemId: entry.id,
+          // Normalized activity entries group several protocol items. The
+          // command detail id is the identity Tool Calls uses to retrieve the
+          // retained output; the entry id cannot locate that detail later.
+          itemId: detail.id,
           noisy: Boolean(reason),
           ...(reason ? { noisyReason: reason } : {}),
           ...(normalized.normalizedCommand

--- a/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
+++ b/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
@@ -1,0 +1,249 @@
+import type {
+  AppServerBackendKind,
+  AppServerThreadActivityDetail,
+  AppServerThreadReplay,
+  ThreadToolAnalysisCoverage,
+  ThreadToolInvocationCategory,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import {
+  buildToolInvocationSteeringPrompt,
+  buildToolOutputMetrics,
+  normalizeToolInvocationCommand,
+} from "./tool-invocation-accounting";
+
+export const TOOL_OUTPUT_ANALYZER_VERSION = "1";
+const LARGE_OUTPUT_CHARS = 4_000;
+const CRITICAL_OUTPUT_CHARS = 40_000;
+const POLLING_MIN_CASES = 5;
+
+export type ToolOutputReplayAnalysis = {
+  coverage: ThreadToolAnalysisCoverage;
+  invocations: ThreadToolInvocationRecord[];
+};
+
+export function analyzeNormalizedToolReplay(params: {
+  analyzedAt?: number;
+  backend: AppServerBackendKind;
+  complete: boolean;
+  pages: AppServerThreadReplay[];
+  threadId: string;
+}): ToolOutputReplayAnalysis {
+  const analyzedAt = params.analyzedAt ?? Date.now();
+  const invocationsById = new Map<string, ThreadToolInvocationRecord>();
+  const seenEntryIds = new Set<string>();
+  const missingOutputIds = new Set<string>();
+  let scannedThrough: string | undefined;
+
+  for (const replay of params.pages) {
+    for (const entry of replay.entries) {
+      seenEntryIds.add(entry.id);
+      scannedThrough = entry.id;
+      if (entry.type !== "activity") {
+        continue;
+      }
+      for (const detail of entry.details) {
+        if (!detail.command) {
+          continue;
+        }
+        const outputState = readOutputState(detail);
+        const metrics = buildToolOutputMetrics(detail.command.output, {
+          outputTruncated: outputState === "truncated",
+        });
+        const toolName = toolNameForDetail(detail);
+        const normalized = normalizeToolInvocationCommand({
+          command: detail.command.rawCommand ?? detail.command.displayCommand,
+          toolName,
+        });
+        const category = categoryForReplayDetail(detail, normalized.category);
+        const observedAt = entry.createdAt ?? entry.turn?.completedAt
+          ?? entry.turn?.startedAt ?? analyzedAt;
+        const invocationId = deterministicFindingId([
+          params.backend,
+          params.threadId,
+          entry.turn?.id ?? "no-turn",
+          entry.id,
+          detail.id,
+        ]);
+        if (outputState === "unavailable" || outputState === "compacted") {
+          missingOutputIds.add(invocationId);
+        } else {
+          missingOutputIds.delete(invocationId);
+        }
+        const reason = classifyNoisyReason({
+          category,
+          outputChars: metrics.outputChars,
+          outputState,
+        });
+        const invocation: ThreadToolInvocationRecord = {
+          ...metrics,
+          backend: params.backend,
+          category,
+          ...(entry.turn?.completedAt ? { completedAt: entry.turn.completedAt } : {}),
+          ...(detail.command.exitCode !== undefined
+            ? { exitCode: detail.command.exitCode }
+            : {}),
+          findingId: invocationId,
+          invocationId,
+          itemId: entry.id,
+          noisy: Boolean(reason),
+          ...(reason ? { noisyReason: reason } : {}),
+          ...(normalized.normalizedCommand
+            ? { normalizedCommand: normalized.normalizedCommand }
+            : {}),
+          observedAt,
+          outputState,
+          source: "history",
+          status: activityStatusToInvocationStatus(detail.status ?? entry.status),
+          ...(entry.turn?.startedAt ? { startedAt: entry.turn.startedAt } : {}),
+          threadId: params.threadId,
+          toolName,
+          ...(entry.turn?.id ? { turnId: entry.turn.id } : {}),
+          updatedAt: analyzedAt,
+          outputTruncated: outputState === "truncated",
+        };
+        invocationsById.set(
+          invocationId,
+          reason
+            ? {
+                ...invocation,
+                suggestedPrompt: buildToolInvocationSteeringPrompt({
+                  invocation,
+                  reason: humanizeReason(reason),
+                }),
+              }
+            : invocation,
+        );
+      }
+    }
+  }
+
+  const invocations = [...invocationsById.values()];
+  markRepeatedPolling(invocations);
+  const entryCount = seenEntryIds.size;
+  const missingOutputCount = missingOutputIds.size;
+  const complete = params.complete && missingOutputCount === 0;
+  const explanation = complete
+    ? undefined
+    : missingOutputCount > 0
+      ? `${missingOutputCount.toLocaleString()} tool result${missingOutputCount === 1 ? " was" : "s were"} unavailable or compacted in normalized replay, so totals are a lower bound.`
+      : "The App Server did not provide complete replay pagination, so totals cover only the available normalized history.";
+  return {
+    coverage: {
+      analyzedAt,
+      analyzerVersion: TOOL_OUTPUT_ANALYZER_VERSION,
+      completeness: complete ? "complete" : "partial",
+      entryCount,
+      invocationCount: invocations.length,
+      missingOutputCount,
+      pageCount: params.pages.length,
+      ...(scannedThrough ? { scannedThrough } : {}),
+      ...(explanation ? { explanation } : {}),
+    },
+    invocations,
+  };
+}
+
+function readOutputState(
+  detail: AppServerThreadActivityDetail,
+): ThreadToolInvocationRecord["outputState"] {
+  const output = detail.command?.output;
+  const context = [detail.label, detail.markdown, output].filter(Boolean).join(" ");
+  if (/compact(?:ed|ion)|removed from context/i.test(context)) {
+    return "compacted";
+  }
+  if (/truncated|additional lines omitted|output clipped/i.test(context)) {
+    return "truncated";
+  }
+  return output === undefined ? "unavailable" : "available";
+}
+
+function toolNameForDetail(detail: AppServerThreadActivityDetail): string {
+  if (detail.command?.source === "tool") {
+    return /^mcp__|\bmcp\b/i.test(detail.command.displayCommand)
+      ? "mcpToolCall"
+      : "toolCall";
+  }
+  if (detail.command?.source === "agent") {
+    return "subAgent";
+  }
+  return "commandExecution";
+}
+
+function categoryForReplayDetail(
+  detail: AppServerThreadActivityDetail,
+  category: ThreadToolInvocationCategory,
+): ThreadToolInvocationCategory {
+  if (
+    detail.command?.source === "tool"
+    && /^mcp__|\bmcp\b/i.test(detail.command.displayCommand)
+  ) {
+    return "mcp";
+  }
+  return category;
+}
+
+function classifyNoisyReason(params: {
+  category: ThreadToolInvocationCategory;
+  outputChars: number;
+  outputState: ThreadToolInvocationRecord["outputState"];
+}): string | undefined {
+  if (params.outputChars >= CRITICAL_OUTPUT_CHARS) {
+    return "large-output-critical";
+  }
+  if (params.outputChars < LARGE_OUTPUT_CHARS) {
+    return undefined;
+  }
+  if (params.category === "file-io") return "broad-file-read";
+  if (params.category === "search") return "broad-search";
+  if (params.category === "build-test" || params.category === "package-manager") {
+    return "verbose-build-test";
+  }
+  if (params.category === "mcp") return "broad-mcp-result";
+  return params.outputState === "truncated"
+    ? "large-truncated-output"
+    : "large-output";
+}
+
+function humanizeReason(reason: string): string {
+  return reason.replaceAll("-", " ");
+}
+
+function activityStatusToInvocationStatus(
+  status: AppServerThreadActivityDetail["status"],
+): ThreadToolInvocationRecord["status"] {
+  if (status === "in_progress") return "in_progress";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "cancelled";
+  return "completed";
+}
+
+function markRepeatedPolling(invocations: ThreadToolInvocationRecord[]): void {
+  const byTurn = new Map<string, ThreadToolInvocationRecord[]>();
+  for (const invocation of invocations) {
+    if (invocation.category !== "polling") continue;
+    const key = invocation.turnId ?? "no-turn";
+    byTurn.set(key, [...(byTurn.get(key) ?? []), invocation]);
+  }
+  for (const records of byTurn.values()) {
+    if (records.length < POLLING_MIN_CASES) continue;
+    for (const record of records) {
+      record.noisy = true;
+      record.noisyReason = "repeat-polling-output";
+      record.suggestedPrompt = buildToolInvocationSteeringPrompt({
+        invocation: record,
+        reason: "repeated polling wakes the model and replays accumulated context",
+      });
+    }
+  }
+}
+
+function deterministicFindingId(parts: string[]): string {
+  let hash = 2166136261;
+  const identity = parts.join("\u001f");
+  for (let index = 0; index < identity.length; index += 1) {
+    hash ^= identity.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `history-tool:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4616,6 +4616,9 @@ function localBackendOperations(): FederationBackendOperations {
         ...(request.includeTurns !== undefined
           ? { includeTurns: request.includeTurns }
           : {}),
+        ...(request.includeAllToolInvocations !== undefined
+          ? { includeAllToolInvocations: request.includeAllToolInvocations }
+          : {}),
         before: request.before,
         limit: request.limit,
         ...(request.viewOnly !== undefined

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -45,6 +45,8 @@ import {
   type PersistThreadUsageActivityResponse,
   type AppServerReadThreadRequest,
   type AppServerReadThreadResponse,
+  type AnalyzeThreadToolHistoryRequest,
+  type AnalyzeThreadToolHistoryResponse,
   type GetThreadFileDiffRequest,
   type GetThreadFileDiffResponse,
   type EnsureDirectoryLaunchpadRequest,
@@ -214,6 +216,7 @@ import {
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
   APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
@@ -1761,6 +1764,12 @@ class DesktopAppServerService {
     return sanitizeRendererPayload(
       shapeReadThreadFileDiffsForRenderer(materialized),
     );
+  }
+
+  async analyzeThreadToolHistory(
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse> {
+    return await getDesktopBackendRegistry().analyzeThreadToolHistory(request);
   }
 
   async persistThreadUsageActivity(
@@ -7415,6 +7424,15 @@ export function registerAppServerIpcHandlers(): void {
       });
     }
   );
+  ipcMain.removeHandler(APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL);
+  ipcMain.handle(
+    APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
+    async (
+      _event,
+      request: AnalyzeThreadToolHistoryRequest,
+    ): Promise<AnalyzeThreadToolHistoryResponse> =>
+      await appServerService.analyzeThreadToolHistory(request),
+  );
   ipcMain.removeHandler(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL);
   ipcMain.handle(
     APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
@@ -8196,6 +8214,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
+  ipcMain.removeHandler(APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_THREAD_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1723,7 +1723,10 @@ class DesktopAppServerService {
           backend: request.backend,
           threadId: request.threadId,
           before: request.before,
+          includeAllToolInvocations: request.includeAllToolInvocations,
+          includeTurns: request.includeTurns,
           limit: request.limit,
+          viewOnly: request.viewOnly,
         });
     }
     const backend = request.backend ?? "codex";
@@ -1731,6 +1734,7 @@ class DesktopAppServerService {
     const response = await registry.readThread({
       backend,
       threadId: request.threadId,
+      includeAllToolInvocations: request.includeAllToolInvocations,
       includeTurns: request.includeTurns,
       before: request.before,
       limit: request.limit,

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -29,14 +29,19 @@ import {
   PATH_REVEAL_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
 } from "../../shared/ipc";
+import type { WindowShowThreadRequest } from "../../shared/window-show-thread";
 import {
   readMarkdownFileViewerSnapshot,
   showMarkdownFileViewerWindow,
 } from "../markdown-files-window";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { showSubAgentTranscriptWindow } from "../subagent-transcript-window";
-import { showToolOutputIncidentExplorerWindow } from "../tool-output-incident-explorer-window";
+import {
+  showThreadFromToolOutputIncidentExplorer,
+  showToolOutputIncidentExplorerWindow,
+} from "../tool-output-incident-explorer-window";
 import {
   discoverDesktopApplications,
   openDesktopApplication,
@@ -234,6 +239,13 @@ export function registerApplicationIpcHandlers(): void {
       return { opened: true };
     },
   );
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL);
+  ipcMain.handle(
+    TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
+    async (event, request: WindowShowThreadRequest): Promise<void> => {
+      showThreadFromToolOutputIncidentExplorer(event.sender, request);
+    },
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
@@ -245,4 +257,5 @@ export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL);
   ipcMain.removeHandler(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL);
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -10,6 +10,8 @@ import {
   type OpenMarkdownFileViewerResponse,
   type OpenSubAgentTranscriptWindowRequest,
   type OpenSubAgentTranscriptWindowResponse,
+  type OpenToolOutputIncidentExplorerWindowRequest,
+  type OpenToolOutputIncidentExplorerWindowResponse,
   type OpenPathRequest,
   type OpenPathResponse,
   type ReadMarkdownFileRequest,
@@ -26,6 +28,7 @@ import {
   PATH_OPEN_CHANNEL,
   PATH_REVEAL_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
 } from "../../shared/ipc";
 import {
   readMarkdownFileViewerSnapshot,
@@ -33,6 +36,7 @@ import {
 } from "../markdown-files-window";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { showSubAgentTranscriptWindow } from "../subagent-transcript-window";
+import { showToolOutputIncidentExplorerWindow } from "../tool-output-incident-explorer-window";
 import {
   discoverDesktopApplications,
   openDesktopApplication,
@@ -217,6 +221,19 @@ export function registerApplicationIpcHandlers(): void {
       return { opened: true };
     },
   );
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL);
+  ipcMain.handle(
+    TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+    async (
+      event,
+      request: OpenToolOutputIncidentExplorerWindowRequest,
+    ): Promise<OpenToolOutputIncidentExplorerWindowResponse> => {
+      showToolOutputIncidentExplorerWindow(request, {
+        sourceWindow: BrowserWindow.fromWebContents(event.sender),
+      });
+      return { opened: true };
+    },
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
@@ -227,4 +244,5 @@ export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_OPEN_CHANNEL);
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL);
   ipcMain.removeHandler(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL);
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL);
 }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1847,8 +1847,10 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
 
   async readThreadToolAccounting(params: {
     backend: ThreadOverlayState["backend"];
+    includeAllInvocations?: boolean;
     threadId: string;
   }): Promise<ThreadToolAccounting> {
+    const invocationLimit = params.includeAllInvocations ? -1 : 200;
     const invocationRows = this.stateDb.raw
       .prepare(
         `SELECT *
@@ -1856,9 +1858,13 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
          WHERE backend = ?
            AND thread_id = ?
          ORDER BY observed_at DESC, invocation_id DESC
-         LIMIT 200`,
+         LIMIT ?`,
       )
-      .all(params.backend, params.threadId) as ThreadToolInvocationRow[];
+      .all(
+        params.backend,
+        params.threadId,
+        invocationLimit,
+      ) as ThreadToolInvocationRow[];
     const summaryRows = this.stateDb.raw
       .prepare(
         `SELECT

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -24,6 +24,7 @@ import type {
   ThreadMessagingBindingTransition,
   ThreadOverlayState,
   ThreadToolAccounting,
+  ThreadToolAnalysisCoverage,
   ThreadToolInvocationAlert,
   ThreadToolInvocationRecord,
   ThreadToolInvocationStatus,
@@ -1588,6 +1589,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       .prepare(
         `INSERT INTO thread_tool_invocations (
           invocation_id,
+          finding_id,
           backend,
           thread_id,
           turn_id,
@@ -1611,10 +1613,14 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           info_lines,
           debug_lines,
           output_truncated,
+          output_state,
+          source,
           noisy,
-          noisy_reason
+          noisy_reason,
+          suggested_prompt
         ) VALUES (
           @invocationId,
+          @findingId,
           @backend,
           @threadId,
           @turnId,
@@ -1638,11 +1644,15 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           @infoLines,
           @debugLines,
           @outputTruncated,
+          @outputState,
+          @source,
           @noisy,
-          @noisyReason
+          @noisyReason,
+          @suggestedPrompt
         )
         ON CONFLICT(invocation_id) DO UPDATE SET
           backend = excluded.backend,
+          finding_id = excluded.finding_id,
           thread_id = excluded.thread_id,
           turn_id = excluded.turn_id,
           item_id = excluded.item_id,
@@ -1669,8 +1679,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           info_lines = excluded.info_lines,
           debug_lines = excluded.debug_lines,
           output_truncated = excluded.output_truncated,
+          output_state = excluded.output_state,
+          source = excluded.source,
           noisy = excluded.noisy,
-          noisy_reason = excluded.noisy_reason`,
+          noisy_reason = excluded.noisy_reason,
+          suggested_prompt = excluded.suggested_prompt`,
       )
       .run(toThreadToolInvocationRowParams(merged));
 
@@ -1733,6 +1746,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           alert_id,
           backend,
           thread_id,
+          turn_id,
           kind,
           severity,
           tool_name,
@@ -1741,8 +1755,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           first_observed_at,
           last_observed_at,
           invocation_count,
+          invocation_ids,
           total_output_chars,
           estimated_output_tokens,
+          worst_invocation_id,
+          worst_output_chars,
           average_interval_ms,
           message,
           suggested_prompt,
@@ -1752,6 +1769,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           @alertId,
           @backend,
           @threadId,
+          @turnId,
           @kind,
           @severity,
           @toolName,
@@ -1760,8 +1778,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           @firstObservedAt,
           @lastObservedAt,
           @invocationCount,
+          @invocationIds,
           @totalOutputChars,
           @estimatedOutputTokens,
+          @worstInvocationId,
+          @worstOutputChars,
           @averageIntervalMs,
           @message,
           @suggestedPrompt,
@@ -1771,6 +1792,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         ON CONFLICT(alert_id) DO UPDATE SET
           backend = excluded.backend,
           thread_id = excluded.thread_id,
+          turn_id = excluded.turn_id,
           kind = excluded.kind,
           severity = excluded.severity,
           tool_name = excluded.tool_name,
@@ -1779,8 +1801,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           first_observed_at = MIN(thread_tool_invocation_alerts.first_observed_at, excluded.first_observed_at),
           last_observed_at = MAX(thread_tool_invocation_alerts.last_observed_at, excluded.last_observed_at),
           invocation_count = excluded.invocation_count,
+          invocation_ids = excluded.invocation_ids,
           total_output_chars = excluded.total_output_chars,
           estimated_output_tokens = excluded.estimated_output_tokens,
+          worst_invocation_id = excluded.worst_invocation_id,
+          worst_output_chars = excluded.worst_output_chars,
           average_interval_ms = excluded.average_interval_ms,
           message = excluded.message,
           suggested_prompt = excluded.suggested_prompt,
@@ -1867,12 +1892,69 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
          LIMIT 20`,
       )
       .all(params.backend, params.threadId) as ThreadToolInvocationAlertRow[];
+    const analysisRow = this.stateDb.raw
+      .prepare(
+        `SELECT * FROM thread_tool_analysis
+         WHERE backend = ? AND thread_id = ?`,
+      )
+      .get(params.backend, params.threadId) as ThreadToolAnalysisRow | undefined;
 
     return {
+      ...(analysisRow ? { analysis: threadToolAnalysisFromRow(analysisRow) } : {}),
       alerts: alertRows.map(threadToolInvocationAlertFromRow),
       invocations: invocationRows.map(threadToolInvocationFromRow),
       summaries: summaryRows.map(threadToolInvocationSummaryFromRow),
     };
+  }
+
+  async persistThreadToolHistoryAnalysis(params: {
+    backend: ThreadOverlayState["backend"];
+    coverage: ThreadToolAnalysisCoverage;
+    invocations: ThreadToolInvocationRecord[];
+    threadId: string;
+  }): Promise<void> {
+    this.stateDb.raw.transaction(() => {
+      this.stateDb.raw
+        .prepare(
+          `DELETE FROM thread_tool_invocations
+           WHERE backend = ? AND thread_id = ? AND source = 'history'`,
+        )
+        .run(params.backend, params.threadId);
+      for (const invocation of params.invocations) {
+        this.upsertThreadToolInvocationSync({ invocation });
+      }
+      this.stateDb.raw
+        .prepare(
+          `INSERT INTO thread_tool_analysis (
+            backend, thread_id, analyzer_version, analyzed_at, completeness,
+            entry_count, invocation_count, missing_output_count, page_count,
+            scanned_through, explanation
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(backend, thread_id) DO UPDATE SET
+            analyzer_version = excluded.analyzer_version,
+            analyzed_at = excluded.analyzed_at,
+            completeness = excluded.completeness,
+            entry_count = excluded.entry_count,
+            invocation_count = excluded.invocation_count,
+            missing_output_count = excluded.missing_output_count,
+            page_count = excluded.page_count,
+            scanned_through = excluded.scanned_through,
+            explanation = excluded.explanation`,
+        )
+        .run(
+          params.backend,
+          params.threadId,
+          params.coverage.analyzerVersion,
+          params.coverage.analyzedAt,
+          params.coverage.completeness,
+          params.coverage.entryCount,
+          params.coverage.invocationCount,
+          params.coverage.missingOutputCount,
+          params.coverage.pageCount,
+          params.coverage.scannedThrough ?? null,
+          params.coverage.explanation ?? null,
+        );
+    })();
   }
 
   readRecentThreadToolInvocations(params: {
@@ -5976,6 +6058,7 @@ type ThreadPricingAggregateRow = Omit<
 
 type ThreadToolInvocationRow = {
   invocation_id: string;
+  finding_id: string | null;
   backend: ThreadToolInvocationRecord["backend"];
   thread_id: string;
   turn_id: string | null;
@@ -5999,8 +6082,11 @@ type ThreadToolInvocationRow = {
   info_lines: number;
   debug_lines: number;
   output_truncated: number;
+  output_state: ThreadToolInvocationRecord["outputState"] | null;
+  source: NonNullable<ThreadToolInvocationRecord["source"]>;
   noisy: number;
   noisy_reason: string | null;
+  suggested_prompt: string | null;
 };
 
 type ThreadToolInvocationSummaryRow = {
@@ -6022,6 +6108,7 @@ type ThreadToolInvocationAlertRow = {
   alert_id: string;
   backend: ThreadToolInvocationAlert["backend"];
   thread_id: string;
+  turn_id: string | null;
   kind: ThreadToolInvocationAlert["kind"];
   severity: ThreadToolInvocationAlert["severity"];
   tool_name: string;
@@ -6030,13 +6117,28 @@ type ThreadToolInvocationAlertRow = {
   first_observed_at: number;
   last_observed_at: number;
   invocation_count: number;
+  invocation_ids: string | null;
   total_output_chars: number;
   estimated_output_tokens: number;
+  worst_invocation_id: string | null;
+  worst_output_chars: number | null;
   average_interval_ms: number | null;
   message: string;
   suggested_prompt: string;
   created_at: number;
   updated_at: number;
+};
+
+type ThreadToolAnalysisRow = {
+  analyzer_version: string;
+  analyzed_at: number;
+  completeness: ThreadToolAnalysisCoverage["completeness"];
+  entry_count: number;
+  invocation_count: number;
+  missing_output_count: number;
+  page_count: number;
+  scanned_through: string | null;
+  explanation: string | null;
 };
 
 function normalizeThreadToolInvocation(
@@ -6440,6 +6542,7 @@ function toThreadToolInvocationRowParams(
     exitCode: invocation.exitCode ?? null,
     infoLines: invocation.infoLines,
     invocationId: invocation.invocationId,
+    findingId: invocation.findingId ?? null,
     itemId: invocation.itemId,
     noisy: invocation.noisy ? 1 : 0,
     noisyReason: invocation.noisyReason ?? null,
@@ -6448,14 +6551,17 @@ function toThreadToolInvocationRowParams(
     outputChars: invocation.outputChars,
     outputLines: invocation.outputLines,
     outputTruncated: invocation.outputTruncated ? 1 : 0,
+    outputState: invocation.outputState ?? null,
     processId: invocation.processId ?? null,
     sessionId: invocation.sessionId ?? null,
+    source: invocation.source ?? "live",
     startedAt: invocation.startedAt ?? null,
     status: invocation.status,
     threadId: invocation.threadId,
     toolName: invocation.toolName,
     turnId: invocation.turnId ?? null,
     updatedAt: invocation.updatedAt,
+    suggestedPrompt: invocation.suggestedPrompt ?? null,
     warningLines: invocation.warningLines,
   };
 }
@@ -6471,6 +6577,9 @@ function toThreadToolInvocationAlertRowParams(
     estimatedOutputTokens: alert.estimatedOutputTokens,
     firstObservedAt: alert.firstObservedAt,
     invocationCount: alert.invocationCount,
+    invocationIds: alert.invocationIds
+      ? JSON.stringify(alert.invocationIds)
+      : null,
     kind: alert.kind,
     lastObservedAt: alert.lastObservedAt,
     message: alert.message,
@@ -6479,9 +6588,12 @@ function toThreadToolInvocationAlertRowParams(
     severity: alert.severity,
     suggestedPrompt: alert.suggestedPrompt,
     threadId: alert.threadId,
+    turnId: alert.turnId ?? null,
     toolName: alert.toolName,
     totalOutputChars: alert.totalOutputChars,
     updatedAt: alert.updatedAt,
+    worstInvocationId: alert.worstInvocationId ?? null,
+    worstOutputChars: alert.worstOutputChars ?? null,
   };
 }
 
@@ -6593,6 +6705,7 @@ function threadToolInvocationFromRow(
     ...(row.exit_code !== null ? { exitCode: row.exit_code } : {}),
     infoLines: row.info_lines,
     invocationId: row.invocation_id,
+    ...(row.finding_id ? { findingId: row.finding_id } : {}),
     itemId: row.item_id,
     noisy: Boolean(row.noisy),
     ...(row.noisy_reason ? { noisyReason: row.noisy_reason } : {}),
@@ -6601,14 +6714,17 @@ function threadToolInvocationFromRow(
     outputChars: row.output_chars,
     outputLines: row.output_lines,
     outputTruncated: Boolean(row.output_truncated),
+    ...(row.output_state ? { outputState: row.output_state } : {}),
     ...(row.process_id ? { processId: row.process_id } : {}),
     ...(row.session_id ? { sessionId: row.session_id } : {}),
+    source: row.source,
     ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
     status: row.status,
     threadId: row.thread_id,
     toolName: row.tool_name,
     ...(row.turn_id ? { turnId: row.turn_id } : {}),
     updatedAt: row.updated_at,
+    ...(row.suggested_prompt ? { suggestedPrompt: row.suggested_prompt } : {}),
     warningLines: row.warning_lines,
   };
 }
@@ -6645,6 +6761,9 @@ function threadToolInvocationAlertFromRow(
     estimatedOutputTokens: row.estimated_output_tokens,
     firstObservedAt: row.first_observed_at,
     invocationCount: row.invocation_count,
+    ...(row.invocation_ids
+      ? { invocationIds: readStringArrayJson(row.invocation_ids) }
+      : {}),
     kind: row.kind,
     lastObservedAt: row.last_observed_at,
     message: row.message,
@@ -6653,10 +6772,44 @@ function threadToolInvocationAlertFromRow(
     severity: row.severity,
     suggestedPrompt: row.suggested_prompt,
     threadId: row.thread_id,
+    ...(row.turn_id ? { turnId: row.turn_id } : {}),
     toolName: row.tool_name,
     totalOutputChars: row.total_output_chars,
     updatedAt: row.updated_at,
+    ...(row.worst_invocation_id
+      ? { worstInvocationId: row.worst_invocation_id }
+      : {}),
+    ...(row.worst_output_chars !== null
+      ? { worstOutputChars: row.worst_output_chars }
+      : {}),
   };
+}
+
+function threadToolAnalysisFromRow(
+  row: ThreadToolAnalysisRow,
+): ThreadToolAnalysisCoverage {
+  return {
+    analyzedAt: row.analyzed_at,
+    analyzerVersion: row.analyzer_version,
+    completeness: row.completeness,
+    entryCount: row.entry_count,
+    invocationCount: row.invocation_count,
+    missingOutputCount: row.missing_output_count,
+    pageCount: row.page_count,
+    ...(row.scanned_through ? { scannedThrough: row.scanned_through } : {}),
+    ...(row.explanation ? { explanation: row.explanation } : {}),
+  };
+}
+
+function readStringArrayJson(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      : [];
+  } catch {
+    return [];
+  }
 }
 
 function threadPricingSummaryFromRow(row: ThreadPricingSummaryRow): ThreadPricingSummary {
@@ -6699,6 +6852,7 @@ export type OverlayStoreLike = Pick<
   | "markThreadToolInvocationNoisy"
   | "upsertThreadToolInvocationAlert"
   | "readThreadToolAccounting"
+  | "persistThreadToolHistoryAnalysis"
   | "readRecentThreadToolInvocations"
   | "upsertThreadSubAgent"
   | "setThreadReaction"

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 50;
+export const CURRENT_STATE_DB_USER_VERSION = 51;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -847,6 +847,7 @@ CREATE TABLE IF NOT EXISTS thread_pricing_summaries (
 const THREAD_TOOL_ACCOUNTING_SCHEMA = `
 CREATE TABLE IF NOT EXISTS thread_tool_invocations (
   invocation_id             TEXT PRIMARY KEY,
+  finding_id                TEXT,
   backend                   TEXT NOT NULL,
   thread_id                 TEXT NOT NULL,
   turn_id                   TEXT,
@@ -870,8 +871,11 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocations (
   info_lines                INTEGER NOT NULL,
   debug_lines               INTEGER NOT NULL,
   output_truncated          INTEGER NOT NULL,
+  output_state              TEXT,
+  source                    TEXT NOT NULL DEFAULT 'live',
   noisy                     INTEGER NOT NULL,
-  noisy_reason              TEXT
+  noisy_reason              TEXT,
+  suggested_prompt          TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_thread_tool_invocations_read_thread
   ON thread_tool_invocations(backend, thread_id, observed_at DESC, invocation_id DESC);
@@ -884,6 +888,7 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocation_alerts (
   alert_id                  TEXT PRIMARY KEY,
   backend                   TEXT NOT NULL,
   thread_id                 TEXT NOT NULL,
+  turn_id                   TEXT,
   kind                      TEXT NOT NULL,
   severity                  TEXT NOT NULL,
   tool_name                 TEXT NOT NULL,
@@ -892,8 +897,11 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocation_alerts (
   first_observed_at         INTEGER NOT NULL,
   last_observed_at          INTEGER NOT NULL,
   invocation_count          INTEGER NOT NULL,
+  invocation_ids            TEXT,
   total_output_chars        INTEGER NOT NULL,
   estimated_output_tokens   INTEGER NOT NULL,
+  worst_invocation_id       TEXT,
+  worst_output_chars        INTEGER,
   average_interval_ms       INTEGER,
   message                   TEXT NOT NULL,
   suggested_prompt          TEXT NOT NULL,
@@ -902,6 +910,21 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocation_alerts (
 );
 CREATE INDEX IF NOT EXISTS idx_thread_tool_invocation_alerts_read_thread
   ON thread_tool_invocation_alerts(backend, thread_id, updated_at DESC, alert_id DESC);
+
+CREATE TABLE IF NOT EXISTS thread_tool_analysis (
+  backend                   TEXT NOT NULL,
+  thread_id                 TEXT NOT NULL,
+  analyzer_version          TEXT NOT NULL,
+  analyzed_at               INTEGER NOT NULL,
+  completeness              TEXT NOT NULL,
+  entry_count               INTEGER NOT NULL,
+  invocation_count          INTEGER NOT NULL,
+  missing_output_count      INTEGER NOT NULL,
+  page_count                INTEGER NOT NULL,
+  scanned_through           TEXT,
+  explanation               TEXT,
+  PRIMARY KEY (backend, thread_id)
+);
 `;
 
 const THREAD_MESSAGE_ORIGIN_SCHEMA = `
@@ -1465,6 +1488,12 @@ LEFT JOIN federation_peers
         // Additive table, no data migration; the same DDL also lives in
         // `ensureCurrentSchema` so re-instantiated dbs converge.
         db.exec(ACP_AVAILABLE_COMMANDS_SCHEMA);
+        db.pragma("user_version = 50");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 51) {
+      db.transaction(() => {
+        ensureThreadToolIncidentExplorerSchema(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1944,6 +1973,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensureThreadUsagePricingCumulativeColumns(db);
     ensureThreadUsagePricingIndexes(db);
     db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
+    ensureThreadToolIncidentExplorerSchema(db);
     ensureThreadMessageOriginSchema(db);
     db.exec(FEDERATION_SCHEMA);
     db.exec(REMOTE_THREAD_PIN_SCHEMA);
@@ -1961,6 +1991,62 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
   db.exec(`
 CREATE INDEX IF NOT EXISTS idx_app_runtime_instances_profile_cwd_hash
   ON app_runtime_instances(profile_name, cwd_hash, heartbeat_at DESC);
+`);
+}
+
+function ensureThreadToolIncidentExplorerSchema(
+  db: BetterSqlite3.Database,
+): void {
+  const invocationColumns = new Set(
+    (db.prepare("PRAGMA table_info(thread_tool_invocations)").all() as Array<{
+      name: string;
+    }>).map((column) => column.name),
+  );
+  if (!invocationColumns.has("finding_id")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN finding_id TEXT");
+  }
+  if (!invocationColumns.has("output_state")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN output_state TEXT");
+  }
+  if (!invocationColumns.has("source")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN source TEXT NOT NULL DEFAULT 'live'");
+  }
+  if (!invocationColumns.has("suggested_prompt")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN suggested_prompt TEXT");
+  }
+
+  const alertColumns = new Set(
+    (db.prepare("PRAGMA table_info(thread_tool_invocation_alerts)").all() as Array<{
+      name: string;
+    }>).map((column) => column.name),
+  );
+  if (!alertColumns.has("turn_id")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN turn_id TEXT");
+  }
+  if (!alertColumns.has("invocation_ids")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN invocation_ids TEXT");
+  }
+  if (!alertColumns.has("worst_invocation_id")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN worst_invocation_id TEXT");
+  }
+  if (!alertColumns.has("worst_output_chars")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN worst_output_chars INTEGER");
+  }
+  db.exec(`
+CREATE TABLE IF NOT EXISTS thread_tool_analysis (
+  backend                   TEXT NOT NULL,
+  thread_id                 TEXT NOT NULL,
+  analyzer_version          TEXT NOT NULL,
+  analyzed_at               INTEGER NOT NULL,
+  completeness              TEXT NOT NULL,
+  entry_count               INTEGER NOT NULL,
+  invocation_count          INTEGER NOT NULL,
+  missing_output_count      INTEGER NOT NULL,
+  page_count                INTEGER NOT NULL,
+  scanned_through           TEXT,
+  explanation               TEXT,
+  PRIMARY KEY (backend, thread_id)
+);
 `);
 }
 

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -1,0 +1,107 @@
+import { BrowserWindow } from "electron";
+import {
+  buildThreadIdentityKey,
+  type OpenToolOutputIncidentExplorerWindowRequest,
+} from "@pwragent/shared";
+import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
+  showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
+} from "./auxiliary-window-chrome";
+import { getMainLogger } from "./log";
+import {
+  readBootstrapAppearance,
+  themedWindowAdditionalArguments,
+  themedWindowBackgroundColor,
+} from "./settings/appearance-bootstrap";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER,
+  registerWindowChannels,
+} from "./window-channels";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
+
+const log = getMainLogger("pwragent:tool-output-incident-explorer-window");
+const HASH = "tool-output-incidents";
+const WIDTH = 1_180;
+const HEIGHT = 820;
+const TITLE_MAX_LENGTH = 240;
+const incidentWindows = new Map<string, BrowserWindow>();
+
+export function showToolOutputIncidentExplorerWindow(
+  request: OpenToolOutputIncidentExplorerWindowRequest,
+  source: WindowPlacementSource = {},
+): void {
+  const threadId = request.threadId.trim();
+  if (!threadId) {
+    throw new Error("Tool-output incident explorer requires a thread id.");
+  }
+  const title = request.title.trim() || "Thread";
+  const windowKey = buildThreadIdentityKey(request.backend, threadId);
+  const current = incidentWindows.get(windowKey);
+  if (current && !current.isDestroyed()) {
+    positionWindowForSourceDisplay(current, source);
+    showAndFocusAuxiliaryWindow(current);
+    return;
+  }
+
+  const windowTitle = `Tool-output incidents — ${title}`;
+  const appearance = readBootstrapAppearance();
+  const window = new BrowserWindow({
+    ...placementForSourceDisplay(WIDTH, HEIGHT, source),
+    width: WIDTH,
+    height: HEIGHT,
+    minWidth: 840,
+    minHeight: 600,
+    show: false,
+    title: windowTitle,
+    ...auxiliaryWindowChromeOptions(),
+    backgroundColor: themedWindowBackgroundColor(appearance),
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      additionalArguments: themedWindowAdditionalArguments(appearance),
+    },
+  });
+  registerAuxiliaryWindowTitle(window, windowTitle);
+  hideAuxiliaryWindowMenuBar(window);
+  applyWindowSecurityHardening(window);
+  registerWindowChannels(window, WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER, [
+    APPEARANCE_CHANGED_EVENT_CHANNEL,
+  ]);
+
+  const hash = [
+    HASH,
+    encodeURIComponent(request.backend),
+    encodeURIComponent(threadId),
+    encodeURIComponent(title.slice(0, TITLE_MAX_LENGTH)),
+  ].join("/");
+  const rendererEntry = getRendererEntry();
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${hash}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash });
+  }
+  showAuxiliaryWindowWhenReady(window);
+  incidentWindows.set(windowKey, window);
+  window.on("closed", () => {
+    if (incidentWindows.get(windowKey) === window) {
+      incidentWindows.delete(windowKey);
+    }
+    log.debug("tool-output incident explorer closed", { windowKey });
+  });
+  log.debug("tool-output incident explorer created", { windowKey });
+}

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -3,7 +3,10 @@ import {
   buildThreadIdentityKey,
   type OpenToolOutputIncidentExplorerWindowRequest,
 } from "@pwragent/shared";
-import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
+import {
+  APPEARANCE_CHANGED_EVENT_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+} from "../shared/ipc";
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
@@ -52,6 +55,9 @@ export function showToolOutputIncidentExplorerWindow(
   const current = incidentWindows.get(windowKey);
   if (current && !current.isDestroyed()) {
     positionWindowForSourceDisplay(current, source);
+    current.webContents.send(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+    );
     showAndFocusAuxiliaryWindow(current);
     return;
   }
@@ -81,6 +87,7 @@ export function showToolOutputIncidentExplorerWindow(
   applyWindowSecurityHardening(window);
   registerWindowChannels(window, WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER, [
     APPEARANCE_CHANGED_EVENT_CHANNEL,
+    TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
   ]);
 
   const hash = [

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -15,10 +15,10 @@ import {
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
 import { getMainLogger } from "./log";
+import { themedWindowBackgroundColor } from "./native-appearance";
 import {
   readBootstrapAppearance,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
 import {
   applyWindowSecurityHardening,

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from "electron";
+import { BrowserWindow, type WebContents } from "electron";
 import {
   buildThreadIdentityKey,
   type OpenToolOutputIncidentExplorerWindowRequest,
@@ -29,6 +29,8 @@ import {
   WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER,
   registerWindowChannels,
 } from "./window-channels";
+import type { WindowShowThreadRequest } from "../shared/window-show-thread";
+import { requestShowThread } from "./window-show-thread";
 import {
   placementForSourceDisplay,
   positionWindowForSourceDisplay,
@@ -41,6 +43,10 @@ const WIDTH = 1_180;
 const HEIGHT = 820;
 const TITLE_MAX_LENGTH = 240;
 const incidentWindows = new Map<string, BrowserWindow>();
+const incidentWindowContexts = new Map<number, {
+  owner: WebContents;
+  threadKey: string;
+}>();
 
 export function showToolOutputIncidentExplorerWindow(
   request: OpenToolOutputIncidentExplorerWindowRequest,
@@ -54,9 +60,16 @@ export function showToolOutputIncidentExplorerWindow(
   const windowKey = buildThreadIdentityKey(request.backend, threadId);
   const current = incidentWindows.get(windowKey);
   if (current && !current.isDestroyed()) {
+    if (source.sourceWindow && !source.sourceWindow.isDestroyed()) {
+      incidentWindowContexts.set(current.webContents.id, {
+        owner: source.sourceWindow.webContents,
+        threadKey: windowKey,
+      });
+    }
     positionWindowForSourceDisplay(current, source);
     current.webContents.send(
       TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+      request,
     );
     showAndFocusAuxiliaryWindow(current);
     return;
@@ -95,6 +108,7 @@ export function showToolOutputIncidentExplorerWindow(
     encodeURIComponent(request.backend),
     encodeURIComponent(threadId),
     encodeURIComponent(title.slice(0, TITLE_MAX_LENGTH)),
+    encodeURIComponent(request.projectLabel?.trim() ?? ""),
   ].join("/");
   const rendererEntry = getRendererEntry();
   if (rendererEntry.kind === "url") {
@@ -104,11 +118,35 @@ export function showToolOutputIncidentExplorerWindow(
   }
   showAuxiliaryWindowWhenReady(window);
   incidentWindows.set(windowKey, window);
+  if (source.sourceWindow && !source.sourceWindow.isDestroyed()) {
+    incidentWindowContexts.set(window.webContents.id, {
+      owner: source.sourceWindow.webContents,
+      threadKey: windowKey,
+    });
+  }
   window.on("closed", () => {
     if (incidentWindows.get(windowKey) === window) {
       incidentWindows.delete(windowKey);
     }
+    incidentWindowContexts.delete(window.webContents.id);
     log.debug("tool-output incident explorer closed", { windowKey });
   });
   log.debug("tool-output incident explorer created", { windowKey });
+}
+
+export function showThreadFromToolOutputIncidentExplorer(
+  sender: WebContents,
+  request: WindowShowThreadRequest,
+): void {
+  const context = incidentWindowContexts.get(sender.id);
+  if (!context || context.owner.isDestroyed()) {
+    throw new Error("Tool-output incident explorer has no active owner window.");
+  }
+  if (
+    buildThreadIdentityKey(request.backend, request.threadId)
+    !== context.threadKey
+  ) {
+    throw new Error("Tool-output incident explorer can only open its own thread.");
+  }
+  requestShowThread(request, { preferWebContents: context.owner });
 }

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -40,6 +40,8 @@ export const WINDOW_KIND_LICENSE_DOCUMENT = "license-document" as const;
 export const WINDOW_KIND_APP_LOGS = "app-logs" as const;
 export const WINDOW_KIND_MARKDOWN_FILES = "markdown-files" as const;
 export const WINDOW_KIND_SUB_AGENT_TRANSCRIPT = "sub-agent-transcript" as const;
+export const WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER =
+  "tool-output-incident-explorer" as const;
 export const WINDOW_KIND_AUTOMATION_RUN = "automation-run" as const;
 export type WindowKind =
   | typeof WINDOW_KIND_MAIN
@@ -50,7 +52,8 @@ export type WindowKind =
   | typeof WINDOW_KIND_APP_LOGS
   | typeof WINDOW_KIND_MARKDOWN_FILES
   | typeof WINDOW_KIND_AUTOMATION_RUN
-  | typeof WINDOW_KIND_SUB_AGENT_TRANSCRIPT;
+  | typeof WINDOW_KIND_SUB_AGENT_TRANSCRIPT
+  | typeof WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER;
 
 interface Entry {
   kind: WindowKind;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -519,6 +519,7 @@ import {
   MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
   DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
@@ -1213,6 +1214,21 @@ const desktopApi = Object.freeze({
       TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
       request,
     ),
+  onToolOutputIncidentExplorerRefresh: (
+    callback: () => void,
+  ): (() => void) => {
+    const listener = () => callback();
+    ipcRenderer.on(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+      listener,
+    );
+    return () => {
+      ipcRenderer.off(
+        TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+        listener,
+      );
+    };
+  },
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,
   ): Promise<IntegratedTerminalCreateResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -520,6 +520,7 @@ import {
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
   DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
@@ -1215,9 +1216,14 @@ const desktopApi = Object.freeze({
       request,
     ),
   onToolOutputIncidentExplorerRefresh: (
-    callback: () => void,
+    callback: (
+      request?: OpenToolOutputIncidentExplorerWindowRequest,
+    ) => void,
   ): (() => void) => {
-    const listener = () => callback();
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      request?: OpenToolOutputIncidentExplorerWindowRequest,
+    ) => callback(request);
     ipcRenderer.on(
       TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
       listener,
@@ -1228,6 +1234,14 @@ const desktopApi = Object.freeze({
         listener,
       );
     };
+  },
+  showThreadFromToolOutputIncidentExplorer: async (
+    request: WindowShowThreadRequest,
+  ): Promise<void> => {
+    await ipcRenderer.invoke(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
+      request,
+    );
   },
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,6 +98,8 @@ import type {
   ThreadSearchResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AnalyzeThreadToolHistoryRequest,
+  AnalyzeThreadToolHistoryResponse,
   GetThreadFileDiffRequest,
   GetThreadFileDiffResponse,
   PersistThreadUsageActivityRequest,
@@ -309,6 +311,8 @@ import type {
   OpenMarkdownFileViewerResponse,
   OpenSubAgentTranscriptWindowRequest,
   OpenSubAgentTranscriptWindowResponse,
+  OpenToolOutputIncidentExplorerWindowRequest,
+  OpenToolOutputIncidentExplorerWindowResponse,
   OpenPathRequest,
   OpenPathResponse,
   ReadMarkdownFileRequest,
@@ -505,6 +509,7 @@ import {
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
   APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
   APPLICATIONS_READ_CHANNEL,
   APPLICATION_OPEN_CHANNEL,
@@ -513,6 +518,7 @@ import {
   MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL,
   MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
   DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
@@ -1200,6 +1206,13 @@ const desktopApi = Object.freeze({
     request: OpenSubAgentTranscriptWindowRequest,
   ): Promise<OpenSubAgentTranscriptWindowResponse> =>
     await ipcRenderer.invoke(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL, request),
+  openToolOutputIncidentExplorerWindow: async (
+    request: OpenToolOutputIncidentExplorerWindowRequest,
+  ): Promise<OpenToolOutputIncidentExplorerWindowResponse> =>
+    await ipcRenderer.invoke(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+      request,
+    ),
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,
   ): Promise<IntegratedTerminalCreateResponse> =>
@@ -1327,6 +1340,13 @@ const desktopApi = Object.freeze({
     await invokeWithStartupProfileTiming(
       "readThread",
       APP_SERVER_READ_THREAD_CHANNEL,
+      request,
+    ),
+  analyzeThreadToolHistory: async (
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse> =>
+    await ipcRenderer.invoke(
+      APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
       request,
     ),
   getThreadFileDiff: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -104,7 +104,11 @@ import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNo
 import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
 import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/github-pr-saml-notice";
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
-import { buildToolAccountingNotice } from "./features/notifications/tool-accounting-notice";
+import {
+  buildToolAccountingNotice,
+  resolveDismissedToolIncident,
+  toolAccountingNoticeId,
+} from "./features/notifications/tool-accounting-notice";
 import {
   buildHeapSnapshotHandoffMessage,
   describeHeapSnapshotResult,
@@ -333,6 +337,10 @@ function DesktopAppShell(props: {
   // every navigation change. Kept fresh by an effect below, once
   // `navigation` is defined.
   const backendErrorThreadsRef = useRef<NavigationThreadSummary[]>([]);
+  const dismissedToolIncidentSeverityRef = useRef(new Map<
+    string,
+    ThreadToolInvocationAlert["severity"]
+  >());
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
@@ -653,12 +661,20 @@ function DesktopAppShell(props: {
           triggeredAlerts?: ThreadToolInvocationAlert[];
         };
         for (const alert of params.triggeredAlerts ?? []) {
-          const noticeId = [
-            "tool-accounting",
-            alert.backend,
-            alert.threadId,
-            alert.kind,
-          ].join(":");
+          const noticeId = toolAccountingNoticeId(alert);
+          const dismissedSeverity = dismissedToolIncidentSeverityRef.current.get(
+            noticeId,
+          );
+          const dismissalResolution = resolveDismissedToolIncident({
+            dismissedSeverity,
+            incomingSeverity: alert.severity,
+          });
+          if (dismissalResolution === "suppress") {
+            continue;
+          }
+          if (dismissalResolution === "escalate") {
+            dismissedToolIncidentSeverityRef.current.delete(noticeId);
+          }
           const matchingThread = backendErrorThreadsRef.current.find(
             (thread) =>
               thread.source === event.backend
@@ -681,41 +697,34 @@ function DesktopAppShell(props: {
               }
             : undefined;
           const dismiss = (): void => {
+            dismissedToolIncidentSeverityRef.current.set(
+              noticeId,
+              alert.severity,
+            );
             dispatchAppNotice({ type: "dismiss", id: noticeId });
           };
-          let steer: (() => void) | undefined;
-          const showNotice = (detail?: string): void => {
+          const examine = (): void => {
+            void desktopApi?.openToolOutputIncidentExplorerWindow?.({
+              backend: event.backend,
+              threadId: params.threadId,
+              title: matchingThread?.title ?? labelForThread(
+                event.backend,
+                params.threadId,
+              ),
+            });
+          };
+          const showNotice = (): void => {
             const notice = buildToolAccountingNotice({
               alert,
+              onExamine: examine,
               onDismiss: dismiss,
-              onSteer: steer,
               threadLink,
             });
             dispatchAppNotice({
               type: "show",
-              notice: detail ? { ...notice, detail } : notice,
+              notice,
             });
           };
-          if (alert.turnId && desktopApi.steerTurn) {
-            steer = (): void => {
-              void desktopApi.steerTurn?.({
-                backend: event.backend,
-                federationTarget: event.federationTarget,
-                threadId: params.threadId,
-                expectedTurnId: alert.turnId!,
-                input: [{ type: "text", text: alert.suggestedPrompt }],
-                requestId: [
-                  "tool-accounting",
-                  alert.alertId,
-                  alert.updatedAt,
-                ].join(":"),
-              }).then(dismiss).catch((error) => {
-                showNotice(
-                  `Steering failed: ${error instanceof Error ? error.message : String(error)}`,
-                );
-              });
-            };
-          }
           showNotice();
         }
         return;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -704,8 +704,10 @@ function DesktopAppShell(props: {
             dispatchAppNotice({ type: "dismiss", id: noticeId });
           };
           const examine = (): void => {
+            const projectLabel = matchingThread?.linkedDirectories[0]?.label;
             void desktopApi?.openToolOutputIncidentExplorerWindow?.({
               backend: event.backend,
+              ...(projectLabel ? { projectLabel } : {}),
               threadId: params.threadId,
               title: matchingThread?.title ?? labelForThread(
                 event.backend,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import {
   type FederationInstanceId,
   type FederationTarget,
   type MessagingChannelKind,
+  type NavigationDirectorySummary,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
   type ThreadToolInvocationAlert,
@@ -332,11 +333,12 @@ function DesktopAppShell(props: {
     useState<GithubPrSamlEnforcementEvent[]>([]);
   const [githubPrAuthenticationFailure, setGithubPrAuthenticationFailure] =
     useState<GithubPrAuthenticationFailureEvent>();
-  // Latest thread list, mirrored into a ref so the backend-error toast
-  // subscription can resolve a thread's title without re-subscribing on
-  // every navigation change. Kept fresh by an effect below, once
-  // `navigation` is defined.
+  // Latest navigation identity, mirrored into refs so the backend-error toast
+  // subscription can resolve a thread's title and configured project label
+  // without re-subscribing on every navigation change. Kept fresh by an
+  // effect below, once `navigation` is defined.
   const backendErrorThreadsRef = useRef<NavigationThreadSummary[]>([]);
+  const backendErrorDirectoriesRef = useRef<NavigationDirectorySummary[]>([]);
   const dismissedToolIncidentSeverityRef = useRef(new Map<
     string,
     ThreadToolInvocationAlert["severity"]
@@ -704,7 +706,22 @@ function DesktopAppShell(props: {
             dispatchAppNotice({ type: "dismiss", id: noticeId });
           };
           const examine = (): void => {
-            const projectLabel = matchingThread?.linkedDirectories[0]?.label;
+            const threadKey = buildThreadIdentityKey(
+              event.backend,
+              params.threadId,
+            );
+            const matchingDirectory =
+              backendErrorDirectoriesRef.current.find(
+                (directory) =>
+                  directory.kind === "directory"
+                  && directory.threadKeys.includes(threadKey),
+              )
+              ?? backendErrorDirectoriesRef.current.find((directory) =>
+                directory.threadKeys.includes(threadKey)
+              );
+            const projectLabel =
+              matchingDirectory?.label
+              ?? matchingThread?.linkedDirectories[0]?.label;
             void desktopApi?.openToolOutputIncidentExplorerWindow?.({
               backend: event.backend,
               ...(projectLabel ? { projectLabel } : {}),
@@ -1031,7 +1048,8 @@ function DesktopAppShell(props: {
   // toast subscription depend on (and re-subscribe to) the thread list.
   useEffect(() => {
     backendErrorThreadsRef.current = navigation.threads;
-  }, [navigation.threads]);
+    backendErrorDirectoriesRef.current = navigation.directories;
+  }, [navigation.directories, navigation.threads]);
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -646,12 +646,10 @@ describe("App", () => {
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
   });
 
-  it("surfaces replay-risk alerts as durable one-click steering notices", async () => {
+  it("opens the incident explorer from a replay-risk notice", async () => {
     const agentEventListeners = new Set<(event: AgentEvent) => void>();
-    const steerTurn = vi.fn(async () => ({
-      backend: "codex" as const,
-      threadId: "thread-1",
-      turnId: "turn-1",
+    const openToolOutputIncidentExplorerWindow = vi.fn(async () => ({
+      opened: true as const,
     }));
     Object.defineProperty(window, "pwragent", {
       configurable: true,
@@ -679,7 +677,7 @@ describe("App", () => {
           await new Promise<never>(() => {
             // Keep the shell mounted without needing a full settings fixture.
           }),
-        steerTurn,
+        openToolOutputIncidentExplorerWindow,
       },
     });
 
@@ -722,15 +720,14 @@ describe("App", () => {
 
     expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
     expect(screen.getByText(/Five queued checks/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Use monitor job" }));
+    fireEvent.click(screen.getByRole("button", { name: "Examine 5 cases" }));
 
     await waitFor(() => {
-      expect(steerTurn).toHaveBeenCalledWith(expect.objectContaining({
+      expect(openToolOutputIncidentExplorerWindow).toHaveBeenCalledWith({
         backend: "codex",
-        expectedTurnId: "turn-1",
         threadId: "thread-1",
-        input: [{ type: "text", text: "Stop polling and use a monitor job." }],
-      }));
+        title: "Codex thread",
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -1,30 +1,34 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ThreadToolInvocationAlert } from "@pwragent/shared";
-import { buildToolAccountingNotice } from "../tool-accounting-notice";
+import {
+  buildToolAccountingNotice,
+  resolveDismissedToolIncident,
+  toolAccountingNoticeId,
+} from "../tool-accounting-notice";
 
 describe("buildToolAccountingNotice", () => {
-  it("builds one sticky monitor action for repeated queued checks", () => {
+  it("makes the explorer the primary action for an aggregated incident", () => {
     const onDismiss = vi.fn();
-    const onSteer = vi.fn();
+    const onExamine = vi.fn();
     const notice = buildToolAccountingNotice({
       alert: buildAlert({ kind: "noisy-polling" }),
       onDismiss,
-      onSteer,
+      onExamine,
     });
 
     expect(notice).toMatchObject({
       autoDismiss: false,
-      id: "tool-accounting:codex:thread-1:noisy-polling",
+      id: "tool-accounting:codex:thread-1:turn-1:noisy-polling",
       title: "Repeated queued checks",
       tone: "warning",
     });
     expect(notice.actions?.map((action) => action.label)).toEqual([
-      "Use monitor job",
+      "Examine 5 cases",
       "Dismiss",
     ]);
     notice.actions?.[0]?.onClick();
     notice.actions?.[1]?.onClick();
-    expect(onSteer).toHaveBeenCalledOnce();
+    expect(onExamine).toHaveBeenCalledOnce();
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
@@ -32,15 +36,35 @@ describe("buildToolAccountingNotice", () => {
     const notice = buildToolAccountingNotice({
       alert: buildAlert({ kind: "large-output", severity: "critical" }),
       onDismiss: vi.fn(),
-      onSteer: vi.fn(),
+      onExamine: vi.fn(),
     });
 
     expect(notice).toMatchObject({
-      id: "tool-accounting:codex:thread-1:large-output",
+      id: "tool-accounting:codex:thread-1:turn-1:large-output",
       title: "Large tool output",
       tone: "error",
     });
-    expect(notice.actions?.[0]?.label).toBe("Steer safer output");
+    expect(notice.actions?.[0]?.label).toBe("Examine 5 cases");
+  });
+
+  it("suppresses rewrites after dismissal until a critical escalation", () => {
+    expect(resolveDismissedToolIncident({
+      dismissedSeverity: "warning",
+      incomingSeverity: "warning",
+    })).toBe("suppress");
+    expect(resolveDismissedToolIncident({
+      dismissedSeverity: "warning",
+      incomingSeverity: "critical",
+    })).toBe("escalate");
+    expect(resolveDismissedToolIncident({
+      dismissedSeverity: "critical",
+      incomingSeverity: "critical",
+    })).toBe("suppress");
+  });
+
+  it("uses a new toast identity for a new turn", () => {
+    expect(toolAccountingNoticeId(buildAlert({ turnId: "turn-1" })))
+      .not.toBe(toolAccountingNoticeId(buildAlert({ turnId: "turn-2" })));
   });
 });
 
@@ -60,6 +84,7 @@ function buildAlert(
     severity: "warning",
     suggestedPrompt: "Use a monitor.",
     threadId: "thread-1",
+    turnId: "turn-1",
     toolName: "wait",
     totalOutputChars: 0,
     updatedAt: 2,

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -4,21 +4,18 @@ import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
 export function buildToolAccountingNotice(params: {
   alert: ThreadToolInvocationAlert;
+  onExamine: () => void;
   onDismiss: () => void;
-  onSteer?: () => void;
   threadLink?: ResolvedThreadLink;
 }): AppNoticeToastNotice {
   const polling = params.alert.kind === "noisy-polling";
-  const steerAction = params.onSteer
-    ? [{
-        label: polling ? "Use monitor job" : "Steer safer output",
-        onClick: params.onSteer,
-        tone: "primary" as const,
-      }]
-    : [];
   return {
     actions: [
-      ...steerAction,
+      {
+        label: `Examine ${params.alert.invocationCount.toLocaleString()} case${params.alert.invocationCount === 1 ? "" : "s"}`,
+        onClick: params.onExamine,
+        tone: "primary" as const,
+      },
       {
         label: "Dismiss",
         onClick: params.onDismiss,
@@ -27,15 +24,32 @@ export function buildToolAccountingNotice(params: {
     ],
     autoDismiss: false,
     copyText: [params.alert.message, params.alert.suggestedPrompt].join("\n\n"),
-    id: [
-      "tool-accounting",
-      params.alert.backend,
-      params.alert.threadId,
-      params.alert.kind,
-    ].join(":"),
+    id: toolAccountingNoticeId(params.alert),
     message: params.alert.message,
     threadLink: params.threadLink,
     title: polling ? "Repeated queued checks" : "Large tool output",
     tone: params.alert.severity === "critical" ? "error" : "warning",
   };
+}
+
+export function toolAccountingNoticeId(
+  alert: ThreadToolInvocationAlert,
+): string {
+  return [
+    "tool-accounting",
+    alert.backend,
+    alert.threadId,
+    alert.turnId ?? "no-turn",
+    alert.kind,
+  ].join(":");
+}
+
+export function resolveDismissedToolIncident(params: {
+  dismissedSeverity?: ThreadToolInvocationAlert["severity"];
+  incomingSeverity: ThreadToolInvocationAlert["severity"];
+}): "escalate" | "show" | "suppress" {
+  if (!params.dismissedSeverity) return "show";
+  return params.dismissedSeverity === "warning" && params.incomingSeverity === "critical"
+    ? "escalate"
+    : "suppress";
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -116,6 +116,8 @@ type ThreadContextPanelProps = {
   toolCallEntries?: AppServerThreadEntry[];
   loadingToolCallDetailItemId?: string;
   onRequestToolCallDetails?: (invocation: ThreadToolInvocationRecord) => void;
+  onAnalyzeToolHistory?: () => void;
+  onOpenToolOutputIncidentExplorer?: () => void;
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
@@ -755,6 +757,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <ToolCallsPanel
             entries={props.toolCallEntries}
             loadingDetailItemId={props.loadingToolCallDetailItemId}
+            onAnalyzeHistory={props.onAnalyzeToolHistory}
+            onOpenIncidentExplorer={props.onOpenToolOutputIncidentExplorer}
             onRequestInvocationDetails={props.onRequestToolCallDetails}
             onScrollToTurn={props.onScrollToTurn}
             toolAccounting={props.toolAccounting}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2305,12 +2305,16 @@ export function ThreadView(props: ThreadViewProps) {
   );
   const handleOpenToolOutputIncidentExplorer = useCallback(() => {
     if (!selectedThread) return;
+    const projectLabel =
+      props.selectedDirectory?.label
+      ?? selectedThread.linkedDirectories[0]?.label;
     void desktopApi?.openToolOutputIncidentExplorerWindow?.({
       backend: selectedThread.source,
+      ...(projectLabel ? { projectLabel } : {}),
       threadId: selectedThread.id,
       title: selectedThread.title,
     });
-  }, [desktopApi, selectedThread]);
+  }, [desktopApi, props.selectedDirectory?.label, selectedThread]);
   const handleAnalyzeToolHistory = useCallback(() => {
     if (!selectedThread) return;
     void desktopApi?.analyzeThreadToolHistory?.({

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2303,6 +2303,21 @@ export function ThreadView(props: ThreadViewProps) {
       selectedThreadKey,
     ],
   );
+  const handleOpenToolOutputIncidentExplorer = useCallback(() => {
+    if (!selectedThread) return;
+    void desktopApi?.openToolOutputIncidentExplorerWindow?.({
+      backend: selectedThread.source,
+      threadId: selectedThread.id,
+      title: selectedThread.title,
+    });
+  }, [desktopApi, selectedThread]);
+  const handleAnalyzeToolHistory = useCallback(() => {
+    if (!selectedThread) return;
+    void desktopApi?.analyzeThreadToolHistory?.({
+      backend: selectedThread.source,
+      threadId: selectedThread.id,
+    });
+  }, [desktopApi, selectedThread]);
 
   const moveEditedFilesToSidebar = useCallback(() => {
     onEditedFilesDockChange("sidebar");
@@ -3464,6 +3479,8 @@ export function ThreadView(props: ThreadViewProps) {
               : undefined
           }
           onRequestToolCallDetails={handleRequestToolCallDetails}
+          onAnalyzeToolHistory={handleAnalyzeToolHistory}
+          onOpenToolOutputIncidentExplorer={handleOpenToolOutputIncidentExplorer}
           pricingDisplayOptions={props.pricingDisplayOptions}
           threadPricingSummaryEnabled={threadPricingSummaryEnabled}
           threadToolAccountingEnabled={threadToolAccountingEnabled}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -52,6 +52,13 @@ export function ToolOutputIncidentExplorerWindow() {
     void refresh();
   }, [refresh, route]);
 
+  useEffect(() => {
+    if (!desktopApi?.onToolOutputIncidentExplorerRefresh) return;
+    return desktopApi.onToolOutputIncidentExplorerRefresh(() => {
+      void refresh();
+    });
+  }, [desktopApi, refresh]);
+
   const invocations = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
     return (accounting?.invocations ?? []).filter((invocation) =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  AppServerBackendKind,
+  AppServerReadThreadResponse,
+  AppServerThreadActivityDetail,
+  ThreadToolAccounting,
+  ThreadToolInvocationCategory,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import { useDesktopApi } from "../../lib/desktop-api";
+
+const HISTORY_PAGE_LIMIT = 100;
+
+export function ToolOutputIncidentExplorerWindow() {
+  const desktopApi = useDesktopApi();
+  const route = useMemo(readIncidentRoute, []);
+  const [accounting, setAccounting] = useState<ThreadToolAccounting>();
+  const [latest, setLatest] = useState<AppServerReadThreadResponse>();
+  const [selectedId, setSelectedId] = useState<string>();
+  const [category, setCategory] = useState<ThreadToolInvocationCategory | "all">("all");
+  const [search, setSearch] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [output, setOutput] = useState<string>();
+  const [outputSearch, setOutputSearch] = useState("");
+  const [status, setStatus] = useState<string>();
+  const [loading, setLoading] = useState(true);
+  const [analyzing, setAnalyzing] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!route || !desktopApi?.readThread) return;
+    setLoading(true);
+    setStatus(undefined);
+    try {
+      const response = await desktopApi.readThread({
+        backend: route.backend,
+        limit: HISTORY_PAGE_LIMIT,
+        threadId: route.threadId,
+        viewOnly: true,
+      });
+      setLatest(response);
+      setAccounting(response.toolAccounting);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [desktopApi, route]);
+
+  useEffect(() => {
+    document.title = route ? `Tool-output incidents — ${route.title}` : "Tool-output incidents";
+    void refresh();
+  }, [refresh, route]);
+
+  const invocations = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return (accounting?.invocations ?? []).filter((invocation) =>
+      invocation.noisy
+      && (category === "all" || invocation.category === category)
+      && (
+        !normalizedSearch
+        || (invocation.normalizedCommand ?? invocation.toolName)
+          .toLowerCase()
+          .includes(normalizedSearch)
+        || invocation.noisyReason?.toLowerCase().includes(normalizedSearch)
+      )
+    );
+  }, [accounting?.invocations, category, search]);
+  const selected = invocations.find((invocation) => invocation.invocationId === selectedId)
+    ?? invocations[0];
+
+  useEffect(() => {
+    setPrompt(selected
+      ? selected.suggestedPrompt ?? buildThreadToolIncidentPrompt({
+          invocation: selected,
+          reason: selected.noisyReason ?? "large tool output",
+        })
+      : "");
+    setOutput(undefined);
+    setOutputSearch("");
+    if (!selected || !latest || !desktopApi?.readThread || !route) return;
+    let cancelled = false;
+    void readInvocationOutput({
+      backend: route.backend,
+      desktopApi,
+      initial: latest,
+      invocation: selected,
+      threadId: route.threadId,
+    }).then((value) => {
+      if (!cancelled) setOutput(value);
+    }).catch((error) => {
+      if (!cancelled) setStatus(error instanceof Error ? error.message : String(error));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopApi, latest, route, selected]);
+
+  if (!route) {
+    return <p className="incident-explorer__error">Invalid incident explorer route.</p>;
+  }
+
+  const categories = Array.from(new Set(
+    (accounting?.invocations ?? []).filter((entry) => entry.noisy).map((entry) => entry.category),
+  ));
+  const totals = invocations.reduce(
+    (sum, invocation) => ({
+      chars: sum.chars + invocation.outputChars,
+      tokens: sum.tokens + invocation.estimatedOutputTokens,
+      worst: Math.max(sum.worst, invocation.outputChars),
+    }),
+    { chars: 0, tokens: 0, worst: 0 },
+  );
+  const activeTurnId = findActiveTurnId(latest);
+  const canSteerSelected = Boolean(
+    selected?.turnId
+    && selected.turnId === activeTurnId
+    && desktopApi?.steerTurn,
+  );
+  const canSendAsNewTurn = Boolean(!activeTurnId && desktopApi?.startTurn);
+  const visibleOutputLines = filterOutputLines(output, outputSearch);
+
+  const analyze = async (): Promise<void> => {
+    if (!desktopApi?.analyzeThreadToolHistory) return;
+    setAnalyzing(true);
+    setStatus(undefined);
+    try {
+      const response = await desktopApi.analyzeThreadToolHistory({
+        backend: route.backend,
+        threadId: route.threadId,
+      });
+      setAccounting(response.accounting);
+      setStatus(
+        response.coverage.completeness === "complete"
+          ? `Analyzed ${response.coverage.invocationCount.toLocaleString()} tool calls across ${response.coverage.pageCount.toLocaleString()} page${response.coverage.pageCount === 1 ? "" : "s"}.`
+          : response.coverage.explanation ?? "Analysis is incomplete.",
+      );
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  const sendPrompt = async (): Promise<void> => {
+    if (!selected || !prompt.trim()) return;
+    setStatus(undefined);
+    try {
+      if (canSteerSelected && selected.turnId) {
+        await desktopApi?.steerTurn?.({
+          backend: route.backend,
+          expectedTurnId: selected.turnId,
+          input: [{ type: "text", text: prompt.trim() }],
+          requestId: `tool-output-incident:${selected.invocationId}:${Date.now()}`,
+          threadId: route.threadId,
+        });
+        setStatus("Steering delivered to the exact active turn.");
+      } else if (canSendAsNewTurn) {
+        await desktopApi?.startTurn?.({
+          backend: route.backend,
+          input: [{ type: "text", text: prompt.trim() }],
+          threadId: route.threadId,
+        });
+        setStatus("Prompt sent as a new turn.");
+      }
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  return (
+    <div className="incident-explorer">
+      <header className="activity-titlebar">
+        <p className="activity-titlebar__brand">
+          Pwr<span className="activity-titlebar__brand-accent">Agent</span>
+        </p>
+        <div className="activity-titlebar__breadcrumb">
+          <span className="activity-titlebar__eyebrow">Thread</span>
+          <span aria-hidden="true" className="activity-titlebar__separator">›</span>
+          <span className="activity-titlebar__current">Tool-output incidents</span>
+        </div>
+        <div className="activity-titlebar__spacer" />
+      </header>
+      <header className="incident-explorer__header">
+        <div>
+          <h1>{route.title}</h1>
+          <p>{route.backend} · {route.threadId}</p>
+        </div>
+        <div className="incident-explorer__actions">
+          <button type="button" onClick={() => void analyze()} disabled={analyzing}>
+            {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
+          </button>
+          <button type="button" onClick={() => void refresh()} disabled={loading}>Refresh</button>
+          <button type="button" onClick={() => window.close()}>Close</button>
+        </div>
+      </header>
+      <div className="incident-explorer__metrics" aria-label="Incident metrics">
+        <Metric label="Cases" value={invocations.length.toLocaleString()} />
+        <Metric label="Total output" value={`${totals.chars.toLocaleString()} chars`} />
+        <Metric label="Estimated tokens" value={totals.tokens.toLocaleString()} />
+        <Metric label="Worst case" value={`${totals.worst.toLocaleString()} chars`} />
+      </div>
+      {accounting?.analysis?.completeness === "partial" ? (
+        <p className="incident-explorer__coverage" role="status">
+          Partial coverage: {accounting.analysis.explanation}
+        </p>
+      ) : null}
+      {status ? <p className="incident-explorer__status" role="status">{status}</p> : null}
+      <div className="incident-explorer__body">
+        <aside className="incident-explorer__list" aria-label="Incident cases">
+          <div className="incident-explorer__filters">
+            <input
+              aria-label="Filter incident cases"
+              onChange={(event) => setSearch(event.currentTarget.value)}
+              placeholder="Filter cases"
+              type="search"
+              value={search}
+            />
+            <select
+              aria-label="Filter by category"
+              onChange={(event) => setCategory(event.currentTarget.value as typeof category)}
+              value={category}
+            >
+              <option value="all">All categories</option>
+              {categories.map((entry) => <option key={entry} value={entry}>{entry}</option>)}
+            </select>
+          </div>
+          {groupInvocations(invocations).map((group) => (
+            <section className="incident-explorer__group" key={group.key}>
+              <h2>{group.turnLabel} · {group.category}</h2>
+              {group.invocations.map((invocation) => (
+                <button
+                  className="incident-explorer__case"
+                  data-selected={invocation.invocationId === selected?.invocationId}
+                  key={invocation.invocationId}
+                  onClick={() => setSelectedId(invocation.invocationId)}
+                  type="button"
+                >
+                  <span>{invocation.normalizedCommand ?? invocation.toolName}</span>
+                  <small>
+                    {invocation.outputChars.toLocaleString()} chars · {formatTimestamp(invocation.observedAt)}
+                  </small>
+                </button>
+              ))}
+            </section>
+          ))}
+          {!loading && invocations.length === 0 ? (
+            <p className="incident-explorer__empty">No findings match these filters.</p>
+          ) : null}
+        </aside>
+        <main className="incident-explorer__detail">
+          {selected ? (
+            <>
+              <section className="incident-explorer__evidence">
+                <h2>Selected invocation</h2>
+                <dl>
+                  <dt>Identity</dt><dd><code>{selected.normalizedCommand ?? selected.toolName}</code></dd>
+                  <dt>Observed</dt><dd>{formatTimestamp(selected.observedAt)}</dd>
+                  <dt>Status</dt><dd>{selected.status}{selected.exitCode !== undefined ? ` · exit ${selected.exitCode}` : ""}</dd>
+                  <dt>Output</dt><dd>{selected.outputChars.toLocaleString()} chars · ~{selected.estimatedOutputTokens.toLocaleString()} tokens</dd>
+                  <dt>Availability</dt><dd>{selected.outputState ?? (selected.outputTruncated ? "truncated" : "unavailable until replay is loaded")}</dd>
+                  <dt>Reason</dt><dd>{selected.noisyReason ?? "large output"}</dd>
+                  <dt>Source</dt><dd>{selected.source ?? "live"}</dd>
+                </dl>
+              </section>
+              <section className="incident-explorer__prompt">
+                <div className="incident-explorer__section-heading">
+                  <h2>Proposed steering</h2>
+                  <button type="button" onClick={() => void desktopApi?.copyText?.(prompt)}>Copy</button>
+                </div>
+                <textarea
+                  aria-label="Editable proposed steering prompt"
+                  onChange={(event) => setPrompt(event.currentTarget.value)}
+                  rows={10}
+                  value={prompt}
+                />
+                <button
+                  className="incident-explorer__primary"
+                  disabled={!prompt.trim() || (!canSendAsNewTurn && !canSteerSelected)}
+                  onClick={() => void sendPrompt()}
+                  type="button"
+                >
+                  {canSteerSelected ? "Steer exact active turn" : "Send next turn"}
+                </button>
+                {!canSteerSelected && activeTurnId ? (
+                  <p>The selected finding belongs to another turn. It cannot steer the active turn; send it after that turn ends.</p>
+                ) : null}
+              </section>
+              <section className="incident-explorer__output">
+                <div className="incident-explorer__section-heading">
+                  <h2>Captured output</h2>
+                  <input
+                    aria-label="Search captured output"
+                    onChange={(event) => setOutputSearch(event.currentTarget.value)}
+                    placeholder="Search output"
+                    type="search"
+                    value={outputSearch}
+                  />
+                </div>
+                {output !== undefined ? (
+                  <ol className="incident-explorer__output-lines">
+                    {visibleOutputLines.map((line) => (
+                      <li key={line.number} value={line.number}>
+                        <code>{line.text || " "}</code>
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p className="incident-explorer__empty">
+                    {selected.outputState === "compacted"
+                      ? "Output was compacted out of normalized replay."
+                      : selected.outputState === "truncated"
+                        ? "Only the truncated output retained by normalized replay is available."
+                        : "Output is unavailable in the currently available normalized replay."}
+                  </p>
+                )}
+              </section>
+            </>
+          ) : null}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function Metric(props: { label: string; value: string }) {
+  return <div><span>{props.label}</span><strong>{props.value}</strong></div>;
+}
+
+function readIncidentRoute(): {
+  backend: AppServerBackendKind;
+  threadId: string;
+  title: string;
+} | undefined {
+  const [kind, backend, threadId, title] = window.location.hash.replace(/^#/, "").split("/");
+  if (kind !== "tool-output-incidents" || !backend || !threadId) return undefined;
+  return {
+    backend: decodeURIComponent(backend) as AppServerBackendKind,
+    threadId: decodeURIComponent(threadId),
+    title: title ? decodeURIComponent(title) : "Thread",
+  };
+}
+
+function findActiveTurnId(response: AppServerReadThreadResponse | undefined): string | undefined {
+  const entries = response?.replay.entries ?? [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const turn = entries[index]?.turn;
+    if (turn?.status === "in_progress") return turn.id;
+  }
+  return undefined;
+}
+
+function groupInvocations(invocations: ThreadToolInvocationRecord[]) {
+  const groups = new Map<string, {
+    category: ThreadToolInvocationCategory;
+    invocations: ThreadToolInvocationRecord[];
+    key: string;
+    turnLabel: string;
+  }>();
+  for (const invocation of invocations) {
+    const turn = invocation.turnId ?? "No turn";
+    const key = `${turn}:${invocation.category}`;
+    const group = groups.get(key) ?? {
+      category: invocation.category,
+      invocations: [],
+      key,
+      turnLabel: invocation.turnId ? `Turn ${shortId(invocation.turnId)}` : "No turn",
+    };
+    group.invocations.push(invocation);
+    groups.set(key, group);
+  }
+  return [...groups.values()];
+}
+
+async function readInvocationOutput(params: {
+  backend: AppServerBackendKind;
+  desktopApi: NonNullable<ReturnType<typeof useDesktopApi>>;
+  initial: AppServerReadThreadResponse;
+  invocation: ThreadToolInvocationRecord;
+  threadId: string;
+}): Promise<string | undefined> {
+  let response = params.initial;
+  const seen = new Set<string>();
+  for (;;) {
+    const detail = findInvocationDetail(response, params.invocation);
+    if (detail?.command?.output !== undefined) return detail.command.output;
+    const cursor = response.replay.pagination.previousCursor;
+    if (
+      !response.replay.pagination.hasPreviousPage
+      || !cursor
+      || seen.has(cursor)
+      || !params.desktopApi.readThread
+    ) return undefined;
+    seen.add(cursor);
+    response = await params.desktopApi.readThread({
+      backend: params.backend,
+      before: cursor,
+      limit: HISTORY_PAGE_LIMIT,
+      threadId: params.threadId,
+      viewOnly: true,
+    });
+  }
+}
+
+function findInvocationDetail(
+  response: AppServerReadThreadResponse,
+  invocation: ThreadToolInvocationRecord,
+): AppServerThreadActivityDetail | undefined {
+  for (const entry of response.replay.entries) {
+    if (entry.type !== "activity" || entry.id !== invocation.itemId) continue;
+    const commandDetails = entry.details.filter((detail) => detail.command);
+    return commandDetails.find((detail) =>
+      detail.command?.displayCommand === invocation.normalizedCommand
+      || detail.label === invocation.toolName
+    ) ?? commandDetails[0];
+  }
+  return undefined;
+}
+
+function filterOutputLines(output: string | undefined, query: string) {
+  if (output === undefined) return [];
+  const normalizedQuery = query.trim().toLowerCase();
+  return output.split(/\r\n|\r|\n/).map((text, index) => ({
+    number: index + 1,
+    text,
+  })).filter((line) => !normalizedQuery || line.text.toLowerCase().includes(normalizedQuery));
+}
+
+function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+function shortId(value: string): string {
+  return value.length > 12 ? `${value.slice(0, 8)}…` : value;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -37,6 +37,7 @@ export function ToolOutputIncidentExplorerWindow() {
     try {
       const response = await desktopApi.readThread({
         backend: route.backend,
+        includeAllToolInvocations: true,
         limit: HISTORY_PAGE_LIMIT,
         threadId: route.threadId,
         viewOnly: true,
@@ -460,6 +461,20 @@ function findInvocationDetail(
   let matched: AppServerThreadActivityDetail | undefined;
   for (const entry of response.replay.entries) {
     if (entry.type !== "activity") continue;
+    const entryCommandDetails = entry.details.filter((detail) => detail.command);
+    if (entry.id === invocation.itemId) {
+      return entryCommandDetails.find((detail) =>
+        detail.command?.rawCommand === invocation.normalizedCommand
+        || detail.command?.displayCommand === invocation.normalizedCommand
+      )
+        ?? entryCommandDetails.find((detail) =>
+          detail.command?.output?.length === invocation.outputChars
+        )
+        ?? entryCommandDetails.find((detail) =>
+          detail.command?.output !== undefined
+        )
+        ?? entryCommandDetails[0];
+    }
     for (const detail of entry.details) {
       if (
         !detail.command

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -8,13 +8,16 @@ import type {
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import { formatBackendLabel } from "../../lib/backend-label";
 import { useDesktopApi } from "../../lib/desktop-api";
+import { ThreadChip } from "./ThreadChip";
+import { detailMatchesInvocationItem } from "./tool-call-details";
 
 const HISTORY_PAGE_LIMIT = 100;
 
 export function ToolOutputIncidentExplorerWindow() {
   const desktopApi = useDesktopApi();
-  const route = useMemo(readIncidentRoute, []);
+  const [route, setRoute] = useState(readIncidentRoute);
   const [accounting, setAccounting] = useState<ThreadToolAccounting>();
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
@@ -54,7 +57,15 @@ export function ToolOutputIncidentExplorerWindow() {
 
   useEffect(() => {
     if (!desktopApi?.onToolOutputIncidentExplorerRefresh) return;
-    return desktopApi.onToolOutputIncidentExplorerRefresh(() => {
+    return desktopApi.onToolOutputIncidentExplorerRefresh((request) => {
+      if (request) {
+        setRoute({
+          backend: request.backend,
+          projectLabel: request.projectLabel,
+          threadId: request.threadId,
+          title: request.title,
+        });
+      }
       void refresh();
     });
   }, [desktopApi, refresh]);
@@ -181,18 +192,45 @@ export function ToolOutputIncidentExplorerWindow() {
         <p className="activity-titlebar__brand">
           Pwr<span className="activity-titlebar__brand-accent">Agent</span>
         </p>
-        <div className="activity-titlebar__breadcrumb">
-          <span className="activity-titlebar__eyebrow">Thread</span>
+        <div
+          aria-label={[
+            route.projectLabel,
+            route.title,
+            "Tool Output Incidents",
+          ].filter(Boolean).join(" > ")}
+          className="activity-titlebar__breadcrumb"
+        >
+          {route.projectLabel ? (
+            <>
+              <span className="activity-titlebar__crumb" title={route.projectLabel}>
+                {route.projectLabel}
+              </span>
+              <span aria-hidden="true" className="activity-titlebar__separator">›</span>
+            </>
+          ) : null}
+          <ThreadChip
+            link={{
+              backend: route.backend,
+              inThreadList: true,
+              threadId: route.threadId,
+              title: route.title,
+            }}
+            onOpen={() => {
+              void desktopApi?.showThreadFromToolOutputIncidentExplorer?.({
+                backend: route.backend,
+                threadId: route.threadId,
+              }).catch((error: unknown) => {
+                setStatus(error instanceof Error ? error.message : String(error));
+              });
+            }}
+          />
           <span aria-hidden="true" className="activity-titlebar__separator">›</span>
-          <span className="activity-titlebar__current">Tool-output incidents</span>
+          <span className="activity-titlebar__current">Tool Output Incidents</span>
         </div>
+        <span className="chip chip--backend">
+          {formatBackendLabel(route.backend)}
+        </span>
         <div className="activity-titlebar__spacer" />
-      </header>
-      <header className="incident-explorer__header">
-        <div>
-          <h1>{route.title}</h1>
-          <p>{route.backend} · {route.threadId}</p>
-        </div>
         <div className="incident-explorer__actions">
           <button type="button" onClick={() => void analyze()} disabled={analyzing}>
             {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
@@ -336,13 +374,19 @@ function Metric(props: { label: string; value: string }) {
 
 function readIncidentRoute(): {
   backend: AppServerBackendKind;
+  projectLabel?: string;
   threadId: string;
   title: string;
 } | undefined {
-  const [kind, backend, threadId, title] = window.location.hash.replace(/^#/, "").split("/");
+  const [kind, backend, threadId, title, projectLabel] = window.location.hash
+    .replace(/^#/, "")
+    .split("/");
   if (kind !== "tool-output-incidents" || !backend || !threadId) return undefined;
   return {
     backend: decodeURIComponent(backend) as AppServerBackendKind,
+    ...(projectLabel
+      ? { projectLabel: decodeURIComponent(projectLabel) }
+      : {}),
     threadId: decodeURIComponent(threadId),
     title: title ? decodeURIComponent(title) : "Thread",
   };
@@ -413,15 +457,19 @@ function findInvocationDetail(
   response: AppServerReadThreadResponse,
   invocation: ThreadToolInvocationRecord,
 ): AppServerThreadActivityDetail | undefined {
+  let matched: AppServerThreadActivityDetail | undefined;
   for (const entry of response.replay.entries) {
-    if (entry.type !== "activity" || entry.id !== invocation.itemId) continue;
-    const commandDetails = entry.details.filter((detail) => detail.command);
-    return commandDetails.find((detail) =>
-      detail.command?.displayCommand === invocation.normalizedCommand
-      || detail.label === invocation.toolName
-    ) ?? commandDetails[0];
+    if (entry.type !== "activity") continue;
+    for (const detail of entry.details) {
+      if (
+        !detail.command
+        || !detailMatchesInvocationItem(detail.id, invocation.itemId)
+      ) continue;
+      if (detail.command.output !== undefined) return detail;
+      matched ??= detail;
+    }
   }
-  return undefined;
+  return matched;
 }
 
 function filterOutputLines(output: string | undefined, query: string) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -158,6 +158,8 @@ type PanelOverrides = Partial<
     | "editedFileGroups"
     | "editedFilesDock"
     | "onEditedFilesDockChange"
+    | "onAnalyzeToolHistory"
+    | "onOpenToolOutputIncidentExplorer"
     | "pricing"
     | "toolAccounting"
     | "toolCallEntries"
@@ -955,6 +957,23 @@ describe("ThreadContextPanel", () => {
 
     expect(screen.getByText(/ACP captured output/)).toBeInTheDocument();
     expect(screen.queryByText(/unavailable in transcript history/)).not.toBeInTheDocument();
+  });
+
+  it("offers history analysis and the explorer from an empty Tool Calls panel", () => {
+    const onAnalyzeToolHistory = vi.fn();
+    const onOpenToolOutputIncidentExplorer = vi.fn();
+    renderPanel({
+      activeTab: "tool-calls",
+      onAnalyzeToolHistory,
+      onOpenToolOutputIncidentExplorer,
+      pinned: true,
+      threadToolAccountingEnabled: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze history" }));
+    fireEvent.click(screen.getByRole("button", { name: "Explore" }));
+    expect(onAnalyzeToolHistory).toHaveBeenCalledOnce();
+    expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledOnce();
   });
 
   it("hides the Tool calls tab while its experimental flag is off", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -20,6 +20,46 @@ afterEach(() => {
 });
 
 describe("ToolOutputIncidentExplorerWindow", () => {
+  it("uses standard thread identity chrome without exposing the raw thread id", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const showThreadFromToolOutputIncidentExplorer = vi.fn(async () => undefined);
+    installApi({
+      copyText,
+      readThread: async () => buildResponse(),
+      showThreadFromToolOutputIncidentExplorer,
+    });
+    window.location.hash =
+      "#tool-output-incidents/acp%3Agrok/thread-1/Noisy%20work/PwrAgent";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByLabelText(
+      "PwrAgent > Noisy work > Tool Output Incidents",
+    )).toBeInTheDocument();
+    expect(screen.getByText("Grok")).toHaveClass("chip--backend");
+    expect(screen.queryByText("acp:grok")).not.toBeInTheDocument();
+    expect(screen.queryByText("thread-1")).not.toBeInTheDocument();
+
+    const threadChip = screen.getByRole("button", { name: "Open thread Noisy work" });
+    fireEvent.click(threadChip);
+    await waitFor(() => expect(showThreadFromToolOutputIncidentExplorer)
+      .toHaveBeenCalledWith({ backend: "acp:grok", threadId: "thread-1" }));
+
+    fireEvent.contextMenu(threadChip);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Thread ID" }));
+    await waitFor(() => expect(copyText).toHaveBeenCalledWith("thread-1"));
+  });
+
+  it("shows Codex output whose normalized detail id extends the invocation item id", async () => {
+    installApi({ readThread: async () => buildResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText("failure")).toBeInTheDocument();
+    expect(screen.getByText("warning")).toBeInTheDocument();
+    expect(screen.queryByText(/Only the truncated output retained/))
+      .not.toBeInTheDocument();
+  });
+
   it("steers only when the finding belongs to the exact active turn", async () => {
     const steerTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -141,10 +181,10 @@ function buildResponse(
     replay: {
       entries: [{
         type: "activity",
-        id: "item-1",
+        id: "activity-1",
         createdAt: 1_800_000_000_000,
         details: [{
-          id: "detail-1",
+          id: "item-1-output",
           kind: "command",
           label: "pnpm test",
           command: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -1,0 +1,164 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type {
+  AppServerReadThreadResponse,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToolOutputIncidentExplorerWindow } from "../ToolOutputIncidentExplorerWindow";
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "pwragent");
+  window.location.hash = "";
+});
+
+describe("ToolOutputIncidentExplorerWindow", () => {
+  it("steers only when the finding belongs to the exact active turn", async () => {
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    installApi({ readThread: async () => buildResponse("turn-1"), steerTurn });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const steerButton = await screen.findByRole("button", { name: "Steer exact active turn" });
+    await waitFor(() => expect(steerButton).toBeEnabled());
+    fireEvent.click(steerButton);
+    await waitFor(() => expect(steerTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedTurnId: "turn-1",
+        threadId: "thread-1",
+      }),
+    ));
+  });
+
+  it("does not send or steer a historical finding while another turn is active", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-3",
+    }));
+    const steerTurn = vi.fn();
+    installApi({
+      readThread: async () => buildResponse("turn-2"),
+      startTurn,
+      steerTurn,
+    });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText(/cannot steer the active turn/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send next turn" })).toBeDisabled();
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(steerTurn).not.toHaveBeenCalled();
+  });
+
+  it("sends a historical finding as a new turn after the thread is idle", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-3",
+    }));
+    const steerTurn = vi.fn();
+    installApi({
+      readThread: async () => buildResponse(),
+      startTurn,
+      steerTurn,
+    });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const sendButton = await screen.findByRole("button", { name: "Send next turn" });
+    await waitFor(() => expect(sendButton).toBeEnabled());
+    fireEvent.click(sendButton);
+    await waitFor(() => expect(startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "thread-1" }),
+    ));
+    expect(steerTurn).not.toHaveBeenCalled();
+  });
+});
+
+function installApi(api: Record<string, unknown>): void {
+  Object.defineProperty(window, "pwragent", {
+    configurable: true,
+    value: api,
+  });
+}
+
+function buildResponse(activeTurnId?: string): AppServerReadThreadResponse {
+  const invocation = buildInvocation();
+  return {
+    backend: "codex",
+    fetchedAt: 1,
+    threadId: "thread-1",
+    toolAccounting: {
+      alerts: [],
+      invocations: [invocation],
+      summaries: [],
+    },
+    replay: {
+      entries: [{
+        type: "activity",
+        id: "item-1",
+        createdAt: 1_800_000_000_000,
+        details: [{
+          id: "detail-1",
+          kind: "command",
+          label: "pnpm test",
+          command: {
+            displayCommand: "pnpm test",
+            output: "failure\nwarning\n",
+            source: "shell",
+          },
+        }],
+        status: "completed",
+        summary: "Ran tests",
+        ...(activeTurnId
+          ? {
+              turn: {
+                id: activeTurnId,
+                status: "in_progress" as const,
+              },
+            }
+          : {}),
+      }],
+      messages: [],
+      pagination: {
+        hasPreviousPage: false,
+        supportsPagination: true,
+      },
+      threadStatus: "active",
+    },
+  };
+}
+
+function buildInvocation(): ThreadToolInvocationRecord {
+  return {
+    backend: "codex",
+    category: "build-test",
+    debugLines: 0,
+    errorLines: 1,
+    estimatedOutputTokens: 2_000,
+    infoLines: 0,
+    invocationId: "invocation-1",
+    itemId: "item-1",
+    noisy: true,
+    noisyReason: "verbose-build-test",
+    normalizedCommand: "pnpm test",
+    observedAt: 1_800_000_000_000,
+    outputChars: 8_000,
+    outputLines: 200,
+    outputState: "available",
+    outputTruncated: false,
+    source: "history",
+    status: "completed",
+    suggestedPrompt: "Reduce output for pnpm test.",
+    threadId: "thread-1",
+    toolName: "commandExecution",
+    turnId: "turn-1",
+    updatedAt: 1_800_000_000_000,
+    warningLines: 1,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import type {
   AppServerReadThreadResponse,
   ThreadToolInvocationRecord,
@@ -78,6 +85,31 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     ));
     expect(steerTurn).not.toHaveBeenCalled();
   });
+
+  it("refreshes the visible case snapshot when an existing window is examined again", async () => {
+    let refreshListener: (() => void) | undefined;
+    let readCount = 0;
+    installApi({
+      onToolOutputIncidentExplorerRefresh: (callback: () => void) => {
+        refreshListener = callback;
+        return () => {
+          refreshListener = undefined;
+        };
+      },
+      readThread: async () => {
+        readCount += 1;
+        return buildResponse(undefined, readCount === 1 ? 1 : 2);
+      },
+    });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+    const metrics = await screen.findByLabelText("Incident metrics");
+
+    expect(within(metrics).getByText("1")).toBeInTheDocument();
+    await act(async () => refreshListener?.());
+    await waitFor(() => expect(within(metrics).getByText("2")).toBeInTheDocument());
+    expect(readCount).toBe(2);
+  });
 });
 
 function installApi(api: Record<string, unknown>): void {
@@ -87,15 +119,23 @@ function installApi(api: Record<string, unknown>): void {
   });
 }
 
-function buildResponse(activeTurnId?: string): AppServerReadThreadResponse {
-  const invocation = buildInvocation();
+function buildResponse(
+  activeTurnId?: string,
+  invocationCount = 1,
+): AppServerReadThreadResponse {
+  const invocations = Array.from({ length: invocationCount }, (_, index) => ({
+    ...buildInvocation(),
+    invocationId: `invocation-${index + 1}`,
+    itemId: `item-${index + 1}`,
+    outputChars: 8_000 + index * 1_000,
+  }));
   return {
     backend: "codex",
     fetchedAt: 1,
     threadId: "thread-1",
     toolAccounting: {
       alerts: [],
-      invocations: [invocation],
+      invocations,
       summaries: [],
     },
     replay: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -22,10 +22,11 @@ afterEach(() => {
 describe("ToolOutputIncidentExplorerWindow", () => {
   it("uses standard thread identity chrome without exposing the raw thread id", async () => {
     const copyText = vi.fn(async () => undefined);
+    const readThread = vi.fn(async () => buildResponse());
     const showThreadFromToolOutputIncidentExplorer = vi.fn(async () => undefined);
     installApi({
       copyText,
-      readThread: async () => buildResponse(),
+      readThread,
       showThreadFromToolOutputIncidentExplorer,
     });
     window.location.hash =
@@ -38,6 +39,9 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(screen.getByText("Grok")).toHaveClass("chip--backend");
     expect(screen.queryByText("acp:grok")).not.toBeInTheDocument();
     expect(screen.queryByText("thread-1")).not.toBeInTheDocument();
+    expect(readThread).toHaveBeenCalledWith(expect.objectContaining({
+      includeAllToolInvocations: true,
+    }));
 
     const threadChip = screen.getByRole("button", { name: "Open thread Noisy work" });
     fireEvent.click(threadChip);
@@ -58,6 +62,40 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(screen.getByText("warning")).toBeInTheDocument();
     expect(screen.queryByText(/Only the truncated output retained/))
       .not.toBeInTheDocument();
+  });
+
+  it("shows historical output using the analyzer's normalized detail identity", async () => {
+    const response = buildResponse();
+    response.toolAccounting!.invocations[0]!.itemId = "historical-detail";
+    const entry = response.replay.entries[0];
+    if (entry?.type === "activity") {
+      entry.id = "historical-activity";
+      entry.details[0]!.id = "historical-detail";
+      entry.details[0]!.command!.output = "retained historical output\n";
+    }
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText("retained historical output"))
+      .toBeInTheDocument();
+  });
+
+  it("still shows findings persisted with the legacy activity entry identity", async () => {
+    const response = buildResponse();
+    response.toolAccounting!.invocations[0]!.itemId = "legacy-activity";
+    const entry = response.replay.entries[0];
+    if (entry?.type === "activity") {
+      entry.id = "legacy-activity";
+      entry.details[0]!.id = "unrelated-detail-id";
+      entry.details[0]!.command!.output = "legacy retained output\n";
+    }
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText("legacy retained output"))
+      .toBeInTheDocument();
   });
 
   it("steers only when the finding belongs to the exact active turn", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -18,6 +18,8 @@ import {
 type ToolCallsPanelProps = {
   entries?: AppServerThreadEntry[];
   loadingDetailItemId?: string;
+  onAnalyzeHistory?: () => void;
+  onOpenIncidentExplorer?: () => void;
   onRequestInvocationDetails?: (invocation: ThreadToolInvocationRecord) => void;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   toolAccounting?: ThreadToolAccounting;
@@ -48,7 +50,16 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
 
   return (
     <section className="context-panel__section tool-calls-panel">
-      <h3>Tool calls</h3>
+      <div className="tool-calls-panel__heading">
+        <h3>Tool calls</h3>
+        <button
+          className="button button--ghost"
+          onClick={props.onOpenIncidentExplorer}
+          type="button"
+        >
+          Explore
+        </button>
+      </div>
       {totals ? (
         <div className="rail-summary-card tool-call-summary-card">
           <div className="rail-summary-card__header">
@@ -89,7 +100,16 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
           </div>
         </div>
       ) : (
-        <p className="context-empty">No tool calls recorded yet.</p>
+        <div className="context-empty">
+          <p>No tool calls recorded yet.</p>
+          <button
+            className="button button--ghost"
+            onClick={props.onAnalyzeHistory}
+            type="button"
+          >
+            Analyze history
+          </button>
+        </div>
       )}
 
       {accounting?.alerts.length ? (

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -65,6 +65,8 @@ import type {
   ForkThreadResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AnalyzeThreadToolHistoryRequest,
+  AnalyzeThreadToolHistoryResponse,
   GetThreadFileDiffRequest,
   GetThreadFileDiffResponse,
   PersistThreadUsageActivityRequest,
@@ -354,6 +356,8 @@ import type {
   OpenMarkdownFileViewerResponse,
   OpenSubAgentTranscriptWindowRequest,
   OpenSubAgentTranscriptWindowResponse,
+  OpenToolOutputIncidentExplorerWindowRequest,
+  OpenToolOutputIncidentExplorerWindowResponse,
   OpenPathRequest,
   OpenPathResponse,
   ReadMarkdownFileRequest,
@@ -610,6 +614,9 @@ export type DesktopApi = {
   readThread?: (
     request: AppServerReadThreadRequest
   ) => Promise<AppServerReadThreadResponse>;
+  analyzeThreadToolHistory?: (
+    request: AnalyzeThreadToolHistoryRequest,
+  ) => Promise<AnalyzeThreadToolHistoryResponse>;
   getThreadFileDiff?: (
     request: GetThreadFileDiffRequest,
   ) => Promise<GetThreadFileDiffResponse>;
@@ -832,6 +839,9 @@ export type DesktopApi = {
   openSubAgentTranscriptWindow?: (
     request: OpenSubAgentTranscriptWindowRequest
   ) => Promise<OpenSubAgentTranscriptWindowResponse>;
+  openToolOutputIncidentExplorerWindow?: (
+    request: OpenToolOutputIncidentExplorerWindowRequest
+  ) => Promise<OpenToolOutputIncidentExplorerWindowResponse>;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -843,8 +843,11 @@ export type DesktopApi = {
     request: OpenToolOutputIncidentExplorerWindowRequest
   ) => Promise<OpenToolOutputIncidentExplorerWindowResponse>;
   onToolOutputIncidentExplorerRefresh?: (
-    callback: () => void
+    callback: (request?: OpenToolOutputIncidentExplorerWindowRequest) => void
   ) => () => void;
+  showThreadFromToolOutputIncidentExplorer?: (
+    request: WindowShowThreadRequest
+  ) => Promise<void>;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -842,6 +842,9 @@ export type DesktopApi = {
   openToolOutputIncidentExplorerWindow?: (
     request: OpenToolOutputIncidentExplorerWindowRequest
   ) => Promise<OpenToolOutputIncidentExplorerWindowResponse>;
+  onToolOutputIncidentExplorerRefresh?: (
+    callback: () => void
+  ) => () => void;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -137,6 +137,10 @@ const SubAgentTranscriptWindow = lazy(async () => ({
   default: (await import("./features/thread-detail/SubAgentTranscriptWindow"))
     .SubAgentTranscriptWindow,
 }));
+const ToolOutputIncidentExplorerWindow = lazy(async () => ({
+  default: (await import("./features/thread-detail/ToolOutputIncidentExplorerWindow"))
+    .ToolOutputIncidentExplorerWindow,
+}));
 const AutomationRunWindow = lazy(async () => ({
   default: (await import("./features/automations/AutomationRunWindow"))
     .AutomationRunWindow,
@@ -188,6 +192,10 @@ const routes: Array<{
   {
     match: (hash) => hash.startsWith("sub-agent/"),
     render: () => <SubAgentTranscriptWindow />,
+  },
+  {
+    match: (hash) => hash.startsWith("tool-output-incidents/"),
+    render: () => <ToolOutputIncidentExplorerWindow />,
   },
   {
     match: (hash) => hash.startsWith("automation-run/"),

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15116,6 +15116,269 @@ a.transcript-message__messaging-origin:focus-visible {
   outline-offset: 2px;
 }
 
+.incident-explorer {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+
+.incident-explorer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.incident-explorer__header h1,
+.incident-explorer__section-heading h2,
+.incident-explorer__evidence h2,
+.incident-explorer__prompt h2,
+.incident-explorer__output h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.incident-explorer__header p,
+.incident-explorer__prompt p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.incident-explorer__actions,
+.incident-explorer__section-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.incident-explorer__section-heading {
+  justify-content: space-between;
+}
+
+.incident-explorer button,
+.incident-explorer input,
+.incident-explorer select,
+.incident-explorer textarea {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.incident-explorer button {
+  min-height: 30px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.incident-explorer button:hover:not(:disabled),
+.incident-explorer button:focus-visible,
+.incident-explorer input:focus-visible,
+.incident-explorer select:focus-visible,
+.incident-explorer textarea:focus-visible {
+  border-color: var(--accent-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.incident-explorer button:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.incident-explorer__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__metrics > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 18px;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__metrics span {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.incident-explorer__metrics strong {
+  font-size: 14px;
+}
+
+.incident-explorer__coverage,
+.incident-explorer__status,
+.incident-explorer__error {
+  margin: 0;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--status-warning);
+  font-size: 12px;
+}
+
+.incident-explorer__body {
+  display: grid;
+  flex: 1;
+  grid-template-columns: minmax(280px, 32%) minmax(0, 1fr);
+  min-height: 0;
+}
+
+.incident-explorer__list {
+  min-height: 0;
+  overflow: auto;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--bg-sidebar);
+}
+
+.incident-explorer__filters {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__filters input,
+.incident-explorer__filters select,
+.incident-explorer__section-heading input {
+  min-width: 0;
+  padding: 7px 9px;
+}
+
+.incident-explorer__group h2 {
+  margin: 0;
+  padding: 12px 12px 6px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.incident-explorer .incident-explorer__case {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  width: 100%;
+  padding: 9px 12px;
+  border: 0;
+  border-radius: 0;
+  border-left: 2px solid transparent;
+  background: transparent;
+  text-align: left;
+}
+
+.incident-explorer .incident-explorer__case[data-selected="true"] {
+  border-left-color: var(--accent);
+  background: var(--bg-row-active);
+}
+
+.incident-explorer__case span {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.incident-explorer__case small {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.incident-explorer__detail {
+  min-height: 0;
+  overflow: auto;
+  padding: 18px;
+}
+
+.incident-explorer__evidence,
+.incident-explorer__prompt,
+.incident-explorer__output {
+  margin-bottom: 18px;
+}
+
+.incident-explorer__evidence dl {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 7px 12px;
+  margin: 12px 0 0;
+  font-size: 12px;
+}
+
+.incident-explorer__evidence dt {
+  color: var(--text-muted);
+}
+
+.incident-explorer__evidence dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.incident-explorer__evidence code,
+.incident-explorer__output-lines code {
+  font-family: var(--font-mono);
+}
+
+.incident-explorer__prompt textarea {
+  box-sizing: border-box;
+  width: 100%;
+  margin: 10px 0 8px;
+  padding: 10px;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.incident-explorer .incident-explorer__primary {
+  border-color: var(--accent-border);
+  background: var(--accent);
+  color: var(--button-text);
+  font-weight: 650;
+}
+
+.incident-explorer__output-lines {
+  max-height: 440px;
+  margin: 10px 0 0;
+  padding: 10px 10px 10px 52px;
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--terminal-bg);
+  color: var(--terminal-fg);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.incident-explorer__output-lines li::marker {
+  color: var(--text-muted);
+}
+
+.incident-explorer__empty {
+  margin: 0;
+  padding: 14px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .transcript-message__image-button {
   box-sizing: border-box;
   display: flex;
@@ -20373,6 +20636,17 @@ a.transcript-message__messaging-origin:focus-visible {
 .tool-call-instance--noisy {
   border-color: color-mix(in srgb, var(--status-warning) 45%, var(--border-subtle));
   box-shadow: inset 2px 0 0 0 var(--status-warning);
+}
+
+.tool-calls-panel__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tool-calls-panel__heading h3 {
+  margin: 0;
 }
 
 .tool-call-alert .rail-card__title {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15125,17 +15125,19 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--text-primary);
 }
 
-.incident-explorer__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-panel-elevated);
+.incident-explorer .activity-titlebar__breadcrumb {
+  flex: 0 1 auto;
+  max-width: min(62vw, 720px);
 }
 
-.incident-explorer__header h1,
+.incident-explorer .activity-titlebar__crumb {
+  max-width: min(20vw, 220px);
+}
+
+.incident-explorer .thread-chip-group {
+  flex: 0 1 auto;
+}
+
 .incident-explorer__section-heading h2,
 .incident-explorer__evidence h2,
 .incident-explorer__prompt h2,
@@ -15146,7 +15148,6 @@ a.transcript-message__messaging-origin:focus-visible {
   font-weight: 650;
 }
 
-.incident-explorer__header p,
 .incident-explorer__prompt p {
   margin: 4px 0 0;
   color: var(--text-muted);

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -474,6 +474,8 @@ export const SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL =
   "sub-agent-transcript:open-window";
 export const TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL =
   "tool-output-incident-explorer:open-window";
+export const TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL =
+  "tool-output-incident-explorer:refresh";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -476,6 +476,8 @@ export const TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL =
   "tool-output-incident-explorer:open-window";
 export const TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL =
   "tool-output-incident-explorer:refresh";
+export const TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL =
+  "tool-output-incident-explorer:show-thread";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -44,6 +44,8 @@ export const STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL =
 export const STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL =
   "star-map:focus-main-window";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
+export const APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL =
+  "app-server:analyze-thread-tool-history";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";
 export const APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL =
@@ -470,6 +472,8 @@ export const MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL =
   "markdown-file-viewer:snapshot-changed";
 export const SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL =
   "sub-agent-transcript:open-window";
+export const TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL =
+  "tool-output-incident-explorer:open-window";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -864,6 +864,12 @@ export type AppServerReadThreadRequest = {
   before?: string;
   limit?: number;
   /**
+   * Return every persisted tool invocation instead of the ordinary 200-row
+   * thread-snapshot cap. Reserved for the thread-scoped incident explorer,
+   * which must agree with explicit full-history analysis coverage.
+   */
+  includeAllToolInvocations?: boolean;
+  /**
    * Reads transcript data without applying PwrAgent's normal selected-thread
    * enrichment writes. Used by inspection-only secondary windows such as the
    * native sub-agent transcript viewer.

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -900,6 +900,7 @@ export type ThreadToolInvocationCategory =
   | "build-test"
   | "file-io"
   | "git"
+  | "mcp"
   | "package-manager"
   | "polling"
   | "search"
@@ -914,12 +915,22 @@ export type ThreadToolInvocationStatus =
   | "failed"
   | "cancelled";
 
+export type ThreadToolInvocationSource = "history" | "live";
+
+export type ThreadToolInvocationOutputState =
+  | "available"
+  | "compacted"
+  | "truncated"
+  | "unavailable";
+
 export type ThreadToolInvocationRecord = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   turnId?: string;
   itemId: string;
   invocationId: string;
+  /** Stable finding identity. Historical IDs are deterministic across rescans. */
+  findingId?: string;
   toolName: string;
   normalizedCommand?: string;
   category: ThreadToolInvocationCategory;
@@ -939,8 +950,11 @@ export type ThreadToolInvocationRecord = {
   infoLines: number;
   debugLines: number;
   outputTruncated: boolean;
+  outputState?: ThreadToolInvocationOutputState;
+  source?: ThreadToolInvocationSource;
   noisy: boolean;
   noisyReason?: string;
+  suggestedPrompt?: string;
 };
 
 export type ThreadToolInvocationSummary = {
@@ -971,8 +985,11 @@ export type ThreadToolInvocationAlert = {
   firstObservedAt: number;
   lastObservedAt: number;
   invocationCount: number;
+  invocationIds?: string[];
   totalOutputChars: number;
   estimatedOutputTokens: number;
+  worstInvocationId?: string;
+  worstOutputChars?: number;
   averageIntervalMs?: number;
   message: string;
   suggestedPrompt: string;
@@ -980,7 +997,20 @@ export type ThreadToolInvocationAlert = {
   updatedAt: number;
 };
 
+export type ThreadToolAnalysisCoverage = {
+  analyzerVersion: string;
+  analyzedAt: number;
+  completeness: "complete" | "partial";
+  entryCount: number;
+  invocationCount: number;
+  missingOutputCount: number;
+  pageCount: number;
+  scannedThrough?: string;
+  explanation?: string;
+};
+
 export type ThreadToolAccounting = {
+  analysis?: ThreadToolAnalysisCoverage;
   alerts: ThreadToolInvocationAlert[];
   invocations: ThreadToolInvocationRecord[];
   summaries: ThreadToolInvocationSummary[];

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -7,6 +7,7 @@ import type {
 
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;
+  projectLabel?: string;
   threadId: string;
   title: string;
 };

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -1,0 +1,76 @@
+import type {
+  AppServerBackendKind,
+  ThreadToolAccounting,
+  ThreadToolAnalysisCoverage,
+  ThreadToolInvocationRecord,
+} from "./normalized-app-server";
+
+export type OpenToolOutputIncidentExplorerWindowRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  title: string;
+};
+
+export type OpenToolOutputIncidentExplorerWindowResponse = {
+  opened: true;
+};
+
+export type AnalyzeThreadToolHistoryRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+};
+
+export type AnalyzeThreadToolHistoryResponse = {
+  accounting: ThreadToolAccounting;
+  coverage: ThreadToolAnalysisCoverage;
+};
+
+export function buildThreadToolIncidentPrompt(params: {
+  invocation: ThreadToolInvocationRecord;
+  reason: string;
+}): string {
+  const invocation = params.invocation;
+  const identity = invocation.normalizedCommand ?? invocation.toolName;
+  const timestamp = new Date(invocation.observedAt).toLocaleString();
+  const exitState = invocation.exitCode !== undefined
+    ? `${invocation.status} (exit ${invocation.exitCode})`
+    : invocation.status;
+  const outputState = invocation.outputState
+    ?? (invocation.outputTruncated ? "truncated" : "available");
+  const evidence = [
+    `Invocation: ${identity}`,
+    `Observed: ${timestamp}`,
+    `Status: ${exitState}`,
+    `Output: ${invocation.outputChars.toLocaleString()} characters (~${invocation.estimatedOutputTokens.toLocaleString()} tokens)`,
+    `Output state: ${outputState}`,
+    `Why flagged: ${params.reason}`,
+  ].join("\n");
+  return [
+    "Reduce the replay-amplifying tool use identified below.",
+    evidence,
+    guidanceForInvocation(invocation),
+    "Report the exact command/tool identity, exit state, concise result, failures or warnings, and only a bounded tail or targeted fields needed for the next decision.",
+  ].join("\n\n");
+}
+
+function guidanceForInvocation(invocation: ThreadToolInvocationRecord): string {
+  if (invocation.category === "file-io") {
+    return "For file reads, narrow the file set and request only the specific line ranges needed.";
+  }
+  if (invocation.category === "search") {
+    return "For search, constrain paths and patterns, then cap the number and size of returned matches.";
+  }
+  if (
+    invocation.category === "build-test"
+    || invocation.category === "package-manager"
+  ) {
+    return "For tests, lint, or builds, redirect complete stdout/stderr to a local log and return only failures, warnings, a concise summary, and a bounded tail.";
+  }
+  if (invocation.category === "polling") {
+    return "Stop polling in the main thread. Use PwrAgent's create_monitor_delegation tool with the durable command, cwd, log/status files, cadence, and terminal success/failure conditions.";
+  }
+  if (invocation.category === "mcp") {
+    return "For MCP calls, request only targeted fields and use pagination or a bounded result limit.";
+  }
+  return "Redirect complete output to a local log and retrieve only targeted sections or a bounded tail when more detail is needed.";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,6 +27,7 @@ export * from "./contracts/rbac";
 export * from "./contracts/settings";
 export * from "./contracts/scheduled-thread-actions";
 export * from "./contracts/subagent-transcript";
+export * from "./contracts/tool-output-incidents";
 export * from "./contracts/thread-link";
 export * from "./contracts/thread-tools";
 export * from "./contracts/thread-search";


### PR DESCRIPTION
## Summary

- I aggregate replay-amplifying alerts by backend, thread, turn, and kind, preserve case totals and the worst invocation, suppress rewrites after dismissal, and reopen only for a warning-to-critical escalation or a new turn.
- I replaced the toast's steering shortcut with an `Examine N cases` action and added a hardened, one-per-thread incident explorer with filters, turn/category grouping, metrics, exact evidence, searchable line-numbered output, and editable Copy/Steer/Send-next-turn controls.
- I made every proposed prompt identify the redacted invocation, local timestamp, status/exit state, character and token estimates, output availability, classification reason, and category-specific safer alternative. The explorer uses `expectedTurnId` only when the selected finding belongs to the exact active turn; it cannot steer or send while another turn is active.
- I added explicit Analyze history / Refresh analysis actions backed only by normalized App Server `thread/read` replay. The analyzer produces versioned deterministic finding IDs, reports partial coverage for compacted/truncated history, handles inherited fork replay under the fork ID, and replaces historical findings idempotently without producing live toasts.
- I persist one explicit history analysis in one sqlite transaction. The checked-in budget measures 25 findings plus coverage as 27 statements / 26 affected rows / **1 commit** (28,840 observed WAL bytes). Even at 20 manual analyses per day that is 20 commits and about 0.55 MiB of observed WAL traffic per day, rather than a commit per replay item.

## Verification

- I ran the focused Vitest suite for alert aggregation, dismissal/escalation/new-turn behavior, replay analysis, App Server pagination, sqlite persistence/write budgeting, window security/routing/IPC, the app shell, Tool Calls empty state, and explorer action gating: **13 files, 272 tests passed**.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` (0 errors; the existing 35-warning baseline remains).
- I ran `pnpm lint:boundaries`.
- I ran `pnpm lint:codex-storage`.
- I ran `pnpm lint:sql` and `pnpm lint:colors`.
- I ran `pnpm --filter @pwragent/desktop build`, including the main-bundle boundary check.
- I verified both commits have good SSH signatures.

## Notes

- This is a draft stacked on `agent/replay-amplification-alerts` / PR #1634, not on `main`.
- I deliberately use a deterministic full rescan for Refresh because normalized replay currently exposes backward paging cursors, not a durable forward cursor that is safe to persist for incremental analysis. Repeated scans replace the history-source findings in the same transaction and do not duplicate them.
- I do not persist raw tool output. The explorer retrieves output on demand through the same normalized transcript paging path used by Tool Calls and keeps it only in renderer memory.
- I did not defer any requested slice from this stack.
