### PR TITLE
feat(agent-core): support Grok ACP steering, rewind, and budgets

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -81,6 +81,19 @@ describe("describeInstalledAcpBackend", () => {
     expect(gemini.capabilities.startReview).toBe(false);
   });
 
+  it("advertises ACP steering only for Grok", () => {
+    const grok = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:grok" as AcpBackendId,
+      registryId: "grok",
+      name: "Grok",
+    });
+    const gemini = describeInstalledAcpBackend(buildInstalledAgent());
+
+    expect(grok.capabilities.steerTurn).toBe(true);
+    expect(gemini.capabilities.steerTurn).toBe(false);
+  });
+
   it("advertises Grok 4.5 reasoning efforts in launchpad options", () => {
     const backend = describeInstalledAcpBackend({
       ...buildInstalledAgent(),

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -60,6 +60,136 @@ function readRawAcpSessionPayload(
 }
 
 describe("AcpAgentClient", () => {
+  it("sends Grok steering and workflow-budget extension payloads", async () => {
+    const transport = new FakeAcpAgentTransport({
+      "session/new": { sessionId: "grok-session" },
+      "_x.ai/session/steer": {
+        result: { status: "queued", delivery: "currentTurn" },
+      },
+      "_x.ai/session/workflow_budget": {
+        result: { defaultAgentBudget: 64, maxAgentBudget: 256 },
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+    });
+    await client.initialize();
+    const session = await client.startSession({
+      executionMode: "default",
+      mcpServers: "none",
+    });
+
+    await expect(client.steerSession({
+      sessionId: session.sessionId,
+      text: "Add berries",
+      content: [{ type: "text", text: "Add berries" }],
+      interjectionId: "steer-1",
+    })).resolves.toEqual({ delivery: "currentTurn" });
+    await expect(client.configureWorkflowBudget({
+      sessionId: session.sessionId,
+      defaultAgentBudget: 64,
+      maxAgentBudget: 256,
+    })).resolves.toEqual({ defaultAgentBudget: 64, maxAgentBudget: 256 });
+
+    expect(transport.requests.slice(-2)).toEqual([
+      {
+        method: "_x.ai/session/steer",
+        params: {
+          sessionId: "grok-session",
+          text: "Add berries",
+          interjectionId: "steer-1",
+          content: [{ type: "text", text: "Add berries" }],
+        },
+        timeoutMs: 20_000,
+      },
+      {
+        method: "_x.ai/session/workflow_budget",
+        params: {
+          sessionId: "grok-session",
+          defaultAgentBudget: 64,
+          maxAgentBudget: 256,
+        },
+        timeoutMs: 20_000,
+      },
+    ]);
+  });
+
+  it("lists and executes Grok conversation-only rewind extensions", async () => {
+    const transport = new FakeAcpAgentTransport({
+      "session/new": { sessionId: "grok-session" },
+      "_x.ai/rewind/points": {
+        rewind_points: [
+          {
+            prompt_index: 0,
+            created_at: "2026-08-14T12:00:00Z",
+            num_file_snapshots: 2,
+            has_file_changes: true,
+            prompt_preview: "Write a breakfast poem",
+          },
+        ],
+      },
+      "_x.ai/rewind/execute": {
+        success: true,
+        prompt_text: "Write a breakfast poem",
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 2000,
+    });
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      mcpServers: "none",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      kind: "user_message_chunk",
+      content: "Write a breakfast poem",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      kind: "agent_message_chunk",
+      content: "Toast in the morning",
+    });
+
+    await expect(client.listRewindPoints(session.sessionId)).resolves.toEqual([
+      {
+        promptIndex: 0,
+        createdAt: Date.parse("2026-08-14T12:00:00Z"),
+        fileSnapshotCount: 2,
+        hasFileChanges: true,
+        promptPreview: "Write a breakfast poem",
+      },
+    ]);
+    await expect(client.rewindSession({
+      sessionId: session.sessionId,
+      targetPromptIndex: 0,
+    })).resolves.toEqual({ promptText: "Write a breakfast poem" });
+
+    expect(transport.requests.slice(-2)).toEqual([
+      {
+        method: "_x.ai/rewind/points",
+        params: { sessionId: "grok-session" },
+        timeoutMs: 20_000,
+      },
+      {
+        method: "_x.ai/rewind/execute",
+        params: {
+          sessionId: "grok-session",
+          targetPromptIndex: 0,
+          force: true,
+          mode: "conversation_only",
+        },
+        timeoutMs: 20_000,
+      },
+    ]);
+    expect(client.readReplay(session.sessionId).entries).toEqual([]);
+  });
+
   it("tracks non-turn RPCs until their transport requests settle", async () => {
     const sessionResponse = createDeferred<unknown>();
     const runtimeOptionResponse = createDeferred<unknown>();

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -168,7 +168,10 @@ describe("AcpAgentClient", () => {
     await expect(client.rewindSession({
       sessionId: session.sessionId,
       targetPromptIndex: 0,
-    })).resolves.toEqual({ promptText: "Write a breakfast poem" });
+    })).resolves.toEqual({
+      promptText: "Write a breakfast poem",
+      updatedAt: 2000,
+    });
 
     expect(transport.requests.slice(-2)).toEqual([
       {
@@ -188,6 +191,41 @@ describe("AcpAgentClient", () => {
       },
     ]);
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
+  });
+
+  it("keeps provider rewind success authoritative when local history is incomplete", async () => {
+    const transport = new FakeAcpAgentTransport({
+      "session/new": { sessionId: "grok-session" },
+      "_x.ai/rewind/execute": {
+        success: true,
+        prompt_text: "Provider-only prompt",
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 3000,
+    });
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      mcpServers: "none",
+    });
+
+    await expect(client.rewindSession({
+      sessionId: session.sessionId,
+      targetPromptIndex: 4,
+    })).resolves.toEqual({
+      promptText: "Provider-only prompt",
+      updatedAt: 3000,
+    });
+    expect(client.readReplay(session.sessionId).entries).toEqual([]);
+    expect(store.getSession("acp:grok", session.sessionId)).toMatchObject({
+      status: "idle",
+      updatedAt: 3000,
+    });
   });
 
   it("tracks non-turn RPCs until their transport requests settle", async () => {

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -7,6 +7,42 @@ import {
 import grokReviewSession from "./fixtures/grok-managed-review-session.json";
 
 describe("AcpSessionReplayNormalizer", () => {
+  it("rewinds the local replay to the selected user prompt boundary", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    for (const [receivedAt, role, content] of [
+      [1000, "user", "First prompt"],
+      [1001, "assistant", "First answer"],
+      [2000, "user", "Second prompt"],
+      [2001, "assistant", "Second answer"],
+    ] as const) {
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt,
+        update: {
+          kind: role === "user" ? "user_message_chunk" : "agent_message_chunk",
+          content,
+        },
+      });
+    }
+
+    const replay = normalizer.rewindToPromptIndex(1);
+
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "First prompt",
+      "First answer",
+    ]);
+    expect(replay.lastUserMessage).toBe("First prompt");
+    expect(replay.lastAssistantMessage).toBe("First answer");
+    expect(replay.threadStatus).toBe("idle");
+  });
+
+  it("rejects a rewind target that is not present", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    expect(() => normalizer.rewindToPromptIndex(0)).toThrow(
+      "ACP rewind target 0 was not found",
+    );
+  });
+
   it("keeps inferred provider work inside user-message boundaries", () => {
     const replay = inferAcpReplayTurns({
       entries: [

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -43,6 +43,26 @@ describe("AcpSessionReplayNormalizer", () => {
     );
   });
 
+  it("clears incomplete local history after an authoritative provider rewind", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        kind: "user_message_chunk",
+        content: "Only locally observed prompt",
+      },
+    });
+
+    const replay = normalizer.rewindToPromptIndex(3, {
+      missingTarget: "clear",
+    });
+
+    expect(replay.entries).toEqual([]);
+    expect(replay.messages).toEqual([]);
+    expect(replay.threadStatus).toBe("idle");
+  });
+
   it("keeps inferred provider work inside user-message boundaries", () => {
     const replay = inferAcpReplayTurns({
       entries: [

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2207,6 +2207,17 @@ type AcpSteerSession = (params: {
   interjectionId: string;
 }) => Promise<{ delivery: "currentTurn" | "nextTurn" }>;
 
+type AcpRewindSession = (params: {
+  sessionId: string;
+  targetPromptIndex: number;
+}) => Promise<{ promptText?: string; updatedAt: number }>;
+
+type AcpConfigureWorkflowBudget = (params: {
+  sessionId: string;
+  defaultAgentBudget?: number;
+  maxAgentBudget?: number;
+}) => Promise<{ defaultAgentBudget: number; maxAgentBudget: number }>;
+
 function createKimiAcpRegistry(options?: {
   acpBackendId?: AcpBackendId;
   installedAgent?: AcpInstalledAgentRecord;
@@ -2237,6 +2248,8 @@ function createKimiAcpRegistry(options?: {
   createScratchProjectDirectory?: () => Promise<string>;
   startSession?: KimiStartSession;
   steerSession?: AcpSteerSession;
+  rewindSession?: AcpRewindSession;
+  configureWorkflowBudget?: AcpConfigureWorkflowBudget;
 }) {
   const acpBackendId =
     options?.installedAgent?.backendId
@@ -2255,6 +2268,12 @@ function createKimiAcpRegistry(options?: {
   const steerSession: AcpSteerSession =
     options?.steerSession
     ?? vi.fn(async () => ({ delivery: "currentTurn" as const }));
+  const rewindSession: AcpRewindSession =
+    options?.rewindSession
+    ?? vi.fn(async () => ({ promptText: "Breakfast", updatedAt: 3000 }));
+  const configureWorkflowBudget: AcpConfigureWorkflowBudget =
+    options?.configureWorkflowBudget
+    ?? vi.fn(async () => ({ defaultAgentBudget: 128, maxAgentBudget: 1024 }));
   const replay: AppServerThreadReplay =
     options?.replay ?? {
       entries: [],
@@ -2315,6 +2334,8 @@ function createKimiAcpRegistry(options?: {
       sessions.find((session) => session.sessionId === params.sessionId)?.acpRuntime
       ?? { updatedAt: 1000 }),
     steerSession,
+    rewindSession,
+    configureWorkflowBudget,
   };
   const registry = new DesktopBackendRegistry({
     codexClient: options?.codexClient ?? new MockBackendClient({ threads: [] }),
@@ -2349,6 +2370,8 @@ function createKimiAcpRegistry(options?: {
     sessions,
     startPrompt,
     steerSession,
+    rewindSession,
+    configureWorkflowBudget,
   };
 }
 
@@ -2446,6 +2469,31 @@ async function emitCompletedTurn(
           id: turnId,
           status: "completed",
           output: [],
+        },
+      },
+    },
+  });
+}
+
+async function emitStartedTurn(
+  registry: DesktopBackendRegistry,
+  backend: AppServerBackendKind,
+  threadId: string,
+  turnId: string,
+): Promise<void> {
+  await (
+    registry as unknown as { emit(event: AgentEvent): Promise<void> }
+  ).emit({
+    backend,
+    notification: {
+      method: "turn/started",
+      params: {
+        threadId,
+        turnId,
+        turn: {
+          id: turnId,
+          status: "in_progress",
+          startedAt: Date.now(),
         },
       },
     },
@@ -17254,6 +17302,7 @@ command = "pnpm dev"
       installedAgent,
       sessions,
     });
+    await emitStartedTurn(registry, backend, "grok-session-1", "turn-1");
 
     await expect(registry.steerTurn({
       backend,
@@ -17273,6 +17322,252 @@ command = "pnpm dev"
       content: [{ type: "text", text: "Add blueberries" }],
       interjectionId: "grok-steer-1",
     });
+
+    await registry.close();
+  });
+
+  it("rejects a stale Grok steer before it can reach a replacement turn", async () => {
+    const backend = "acp:grok" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: backend,
+      sessionId: "grok-session-stale",
+      title: "Breakfast poem",
+      createdAt: 1000,
+      updatedAt: 2000,
+      executionMode: "default",
+      status: "active",
+    }];
+    const installedAgent = {
+      ...createKimiAgentRecord(backend),
+      registryId: "grok",
+      name: "Grok Build",
+    };
+    const { registry, steerSession } = createKimiAcpRegistry({
+      acpBackendId: backend,
+      installedAgent,
+      sessions,
+    });
+    await emitStartedTurn(
+      registry,
+      backend,
+      "grok-session-stale",
+      "turn-b",
+    );
+
+    await expect(registry.steerTurn({
+      backend,
+      threadId: "grok-session-stale",
+      expectedTurnId: "turn-a",
+      input: [{ type: "text", text: "Add blueberries" }],
+      requestId: "grok-steer-stale",
+    })).rejects.toThrow(
+      "expected active turn id `turn-a` but found `turn-b`",
+    );
+    expect(steerSession).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
+  it("projects Grok next-turn steering and leaves its message context unbound", async () => {
+    const backend = "acp:grok" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: backend,
+      sessionId: "grok-session-next",
+      title: "Breakfast poem",
+      createdAt: 1000,
+      updatedAt: 2000,
+      executionMode: "default",
+      status: "active",
+    }];
+    const installedAgent = {
+      ...createKimiAgentRecord(backend),
+      registryId: "grok",
+      name: "Grok Build",
+    };
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId: backend,
+      installedAgent,
+      sessions,
+      steerSession: vi.fn(async () => ({ delivery: "nextTurn" as const })),
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+    await emitStartedTurn(registry, backend, "grok-session-next", "turn-a");
+
+    await expect(registry.steerTurn(
+      {
+        backend,
+        threadId: "grok-session-next",
+        expectedTurnId: "turn-a",
+        input: [{ type: "text", text: "Add blueberries" }],
+        requestId: "grok-steer-next",
+      },
+      { kind: "pwragent" },
+    )).resolves.toMatchObject({
+      disposition: "queued",
+      turnId: "turn-a",
+    });
+
+    await emitCompletedTurn(registry, backend, "grok-session-next", "turn-a");
+    await emitStartedTurn(registry, backend, "grok-session-next", "turn-b");
+    await (
+      registry as unknown as { emit(event: AgentEvent): Promise<void> }
+    ).emit({
+      backend,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "grok-session-next",
+          turnId: "turn-b",
+          item: {
+            id: "next-turn-user-message",
+            type: "userMessage",
+            text: "Add blueberries",
+          },
+        },
+      },
+    });
+
+    const nextTurnUserMessageEvent = events.find((event) => {
+      if (event.notification.method !== "item/completed") {
+        return false;
+      }
+      const item = event.notification.params.item as { id?: string };
+      return item.id === "next-turn-user-message";
+    });
+    expect(nextTurnUserMessageEvent).toMatchObject({
+      notification: {
+        params: {
+          turnId: "turn-b",
+          item: {
+            origin: { kind: "pwragent" },
+          },
+        },
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("serializes destructive Grok rewind with the next ACP prompt start", async () => {
+    const backend = "acp:grok" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: backend,
+      sessionId: "grok-session-rewind-lock",
+      title: "Breakfast poem",
+      createdAt: 1000,
+      updatedAt: 2000,
+      executionMode: "default",
+      status: "idle",
+    }];
+    const rewindDeferred = createDeferred<{
+      promptText?: string;
+      updatedAt: number;
+    }>();
+    const events: AgentEvent[] = [];
+    const installedAgent = {
+      ...createKimiAgentRecord(backend),
+      registryId: "grok",
+      name: "Grok Build",
+    };
+    const rewindSession = vi.fn(async () => await rewindDeferred.promise);
+    const { registry, startPrompt } = createKimiAcpRegistry({
+      acpBackendId: backend,
+      installedAgent,
+      sessions,
+      rewindSession,
+    });
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const rewind = registry.rewindAcpThread({
+      backend,
+      threadId: "grok-session-rewind-lock",
+      targetPromptIndex: 0,
+    });
+    await waitForCondition(() => rewindSession.mock.calls.length === 1);
+    const start = registry.startTurn({
+      backend,
+      threadId: "grok-session-rewind-lock",
+      input: [{ type: "text", text: "Write another poem" }],
+    });
+    await flushAsync();
+    expect(startPrompt).not.toHaveBeenCalled();
+
+    rewindDeferred.resolve({ promptText: "Breakfast poem", updatedAt: 3000 });
+    await expect(rewind).resolves.toMatchObject({
+      promptText: "Breakfast poem",
+      updatedAt: 3000,
+    });
+    await expect(start).resolves.toMatchObject({ turnId: "turn-1" });
+    expect(events).toContainEqual({
+      backend,
+      notification: {
+        method: "thread/rewound",
+        params: {
+          threadId: "grok-session-rewind-lock",
+          targetPromptIndex: 0,
+          updatedAt: 3000,
+        },
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("serializes Grok workflow-budget changes with ACP prompt starts", async () => {
+    const backend = "acp:grok" as const;
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: backend,
+      sessionId: "grok-session-budget-lock",
+      title: "Breakfast poem",
+      createdAt: 1000,
+      updatedAt: 2000,
+      executionMode: "default",
+      status: "idle",
+    }];
+    const budgetDeferred = createDeferred<{
+      defaultAgentBudget: number;
+      maxAgentBudget: number;
+    }>();
+    const installedAgent = {
+      ...createKimiAgentRecord(backend),
+      registryId: "grok",
+      name: "Grok Build",
+    };
+    const configureWorkflowBudget = vi.fn(
+      async () => await budgetDeferred.promise,
+    );
+    const { registry, startPrompt } = createKimiAcpRegistry({
+      acpBackendId: backend,
+      installedAgent,
+      sessions,
+      configureWorkflowBudget,
+    });
+
+    const configure = registry.configureGrokWorkflowBudget({
+      backend,
+      threadId: "grok-session-budget-lock",
+      defaultAgentBudget: 4,
+      maxAgentBudget: 8,
+    });
+    await waitForCondition(() => configureWorkflowBudget.mock.calls.length === 1);
+    const start = registry.startTurn({
+      backend,
+      threadId: "grok-session-budget-lock",
+      input: [{ type: "text", text: "Write another poem" }],
+    });
+    await flushAsync();
+    expect(startPrompt).not.toHaveBeenCalled();
+
+    budgetDeferred.resolve({ defaultAgentBudget: 4, maxAgentBudget: 8 });
+    await expect(configure).resolves.toMatchObject({
+      policy: { defaultAgentBudget: 4, maxAgentBudget: 8 },
+    });
+    await expect(start).resolves.toMatchObject({ turnId: "turn-1" });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2200,6 +2200,13 @@ type KimiStartPrompt = (params: {
   turnId?: string;
 }) => { sessionId: string; turnId: string };
 
+type AcpSteerSession = (params: {
+  sessionId: string;
+  text: string;
+  content: unknown[];
+  interjectionId: string;
+}) => Promise<{ delivery: "currentTurn" | "nextTurn" }>;
+
 function createKimiAcpRegistry(options?: {
   acpBackendId?: AcpBackendId;
   installedAgent?: AcpInstalledAgentRecord;
@@ -2229,6 +2236,7 @@ function createKimiAcpRegistry(options?: {
   availableCommandsOnSessionStart?: AppServerAvailableCommandSummary[];
   createScratchProjectDirectory?: () => Promise<string>;
   startSession?: KimiStartSession;
+  steerSession?: AcpSteerSession;
 }) {
   const acpBackendId =
     options?.installedAgent?.backendId
@@ -2244,6 +2252,9 @@ function createKimiAcpRegistry(options?: {
   const startPrompt: KimiStartPrompt =
     options?.startPrompt ??
     vi.fn(() => ({ sessionId, turnId: "turn-1" }));
+  const steerSession: AcpSteerSession =
+    options?.steerSession
+    ?? vi.fn(async () => ({ delivery: "currentTurn" as const }));
   const replay: AppServerThreadReplay =
     options?.replay ?? {
       entries: [],
@@ -2303,6 +2314,7 @@ function createKimiAcpRegistry(options?: {
     }): Promise<BackendAcpSessionRuntimeState> =>
       sessions.find((session) => session.sessionId === params.sessionId)?.acpRuntime
       ?? { updatedAt: 1000 }),
+    steerSession,
   };
   const registry = new DesktopBackendRegistry({
     codexClient: options?.codexClient ?? new MockBackendClient({ threads: [] }),
@@ -2336,6 +2348,7 @@ function createKimiAcpRegistry(options?: {
     sendControlPrompt,
     sessions,
     startPrompt,
+    steerSession,
   };
 }
 
@@ -17214,6 +17227,52 @@ command = "pnpm dev"
     ).rejects.toThrow("expected active turn id `turn-0` but found `turn-1`");
 
     expect(codexClient.steerTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("steers an active Grok turn through its ACP extension", async () => {
+    const backend = "acp:grok" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: backend,
+        sessionId: "grok-session-1",
+        title: "Breakfast poem",
+        createdAt: 1000,
+        updatedAt: 2000,
+        executionMode: "default",
+        status: "active",
+      },
+    ];
+    const installedAgent = {
+      ...createKimiAgentRecord(backend),
+      registryId: "grok",
+      name: "Grok Build",
+    };
+    const { registry, steerSession } = createKimiAcpRegistry({
+      acpBackendId: backend,
+      installedAgent,
+      sessions,
+    });
+
+    await expect(registry.steerTurn({
+      backend,
+      threadId: "grok-session-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "Add blueberries" }],
+      requestId: "grok-steer-1",
+    })).resolves.toEqual({
+      backend,
+      threadId: "grok-session-1",
+      turnId: "turn-1",
+      disposition: "steered",
+    });
+    expect(steerSession).toHaveBeenCalledWith({
+      sessionId: "grok-session-1",
+      text: "Add blueberries",
+      content: [{ type: "text", text: "Add blueberries" }],
+      interjectionId: "grok-steer-1",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4933,6 +4933,24 @@ describe("MessagingController", () => {
       backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
       notification: {
+        method: "thread/rewound",
+        params: {
+          threadId: "remote-thread",
+          targetPromptIndex: 0,
+          updatedAt: 3_000,
+        },
+      },
+    });
+    expect(getNavigationSnapshot).toHaveBeenCalledWith({
+      backend: "all",
+      federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+    });
+
+    getNavigationSnapshot.mockClear();
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+      notification: {
         method: "account/updated",
         params: {},
       },

--- a/apps/desktop/src/main/__tests__/steer-turn-admission.test.ts
+++ b/apps/desktop/src/main/__tests__/steer-turn-admission.test.ts
@@ -15,6 +15,25 @@ const request: SteerTurnRequest = {
 };
 
 describe("admitSteerTurn", () => {
+  it("preserves provider next-turn steering delivery", async () => {
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      disposition: "queued" as const,
+    }));
+    const create = vi.fn();
+
+    await expect(admitSteerTurn({ steerTurn }, { create }, request))
+      .resolves.toEqual({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        disposition: "queued",
+      });
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it("durably schedules the accepted fallback when the target is stale", async () => {
     const steerTurn = vi.fn(async () => {
       throw new Error("expected active turn id `turn-1` but found `turn-2`");

--- a/apps/desktop/src/main/acp/acp-agent-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-agent-capabilities.ts
@@ -1,29 +1,35 @@
 export type AcpAgentCapabilities = {
   liveWorkspaceHandoff: boolean;
   managedReview: boolean;
+  steerTurn: boolean;
 };
 
 const DEFAULT_ACP_AGENT_CAPABILITIES: AcpAgentCapabilities = {
   liveWorkspaceHandoff: false,
   managedReview: false,
+  steerTurn: false,
 };
 
 const ACP_AGENT_CAPABILITY_CATALOG: Record<string, AcpAgentCapabilities> = {
   gemini: {
     liveWorkspaceHandoff: false,
     managedReview: false,
+    steerTurn: false,
   },
   kimi: {
     liveWorkspaceHandoff: false,
     managedReview: true,
+    steerTurn: false,
   },
   grok: {
     liveWorkspaceHandoff: false,
     managedReview: true,
+    steerTurn: true,
   },
   qwen: {
     liveWorkspaceHandoff: false,
     managedReview: false,
+    steerTurn: false,
   },
 };
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -427,7 +427,7 @@ export class AcpAgentClient {
   async rewindSession(params: {
     sessionId: string;
     targetPromptIndex: number;
-  }): Promise<{ promptText?: string }> {
+  }): Promise<{ promptText?: string; updatedAt: number }> {
     return await this.withOperation(async () => {
       const result = asRecord(await this.options.transport.request(
         "_x.ai/rewind/execute",
@@ -446,6 +446,7 @@ export class AcpAgentClient {
       }
       this.normalizerFor(params.sessionId).rewindToPromptIndex(
         params.targetPromptIndex,
+        { missingTarget: "clear" },
       );
       const receivedAt = this.now();
       this.appendHistoryUpdate(params.sessionId, receivedAt, {
@@ -454,6 +455,7 @@ export class AcpAgentClient {
       });
       this.updateSessionStatus(params.sessionId, "idle", receivedAt);
       return {
+        updatedAt: receivedAt,
         promptText:
           readStringValue(result, "prompt_text")
           ?? readStringValue(result, "promptText"),

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -1,5 +1,6 @@
 import type {
   AcpBackendId,
+  AcpThreadRewindPoint,
   AppServerAvailableCommandSummary,
   AppServerPendingRequestNotification,
   AppServerTranscriptPhase,
@@ -9,6 +10,7 @@ import type {
   BackendAcpRuntimeConfigOption,
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
+  GrokWorkflowBudgetPolicy,
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
@@ -80,6 +82,7 @@ export type AcpJsonRpcTransport = {
 const ACP_PROTOCOL_VERSION = 1;
 const ACP_PROMPT_REQUEST_TIMEOUT_MS = 60 * 60_000;
 const ACP_PROVIDER_STATUS_REQUEST_TIMEOUT_MS = 20_000;
+const ACP_REWIND_REQUEST_TIMEOUT_MS = 20_000;
 
 export type AcpMcpServerConfig =
   | {
@@ -378,6 +381,144 @@ export class AcpAgentClient {
       ACP_PROVIDER_STATUS_REQUEST_TIMEOUT_MS,
     );
     return normalizeGrokBillingStatus(result);
+  }
+
+  async listRewindPoints(sessionId: string): Promise<AcpThreadRewindPoint[]> {
+    return await this.withOperation(async () => {
+      const result = asRecord(await this.options.transport.request(
+        "_x.ai/rewind/points",
+        { sessionId: this.protocolSessionIdFor(sessionId) },
+        ACP_REWIND_REQUEST_TIMEOUT_MS,
+      ));
+      const points = Array.isArray(result?.rewind_points)
+        ? result.rewind_points
+        : Array.isArray(result?.rewindPoints)
+          ? result.rewindPoints
+          : [];
+      return points.flatMap((value) => {
+        const point = asRecord(value);
+        const promptIndex = readFiniteNumber(point, "prompt_index")
+          ?? readFiniteNumber(point, "promptIndex");
+        if (promptIndex === undefined || !Number.isInteger(promptIndex)) {
+          return [];
+        }
+        const createdAtValue = point?.created_at ?? point?.createdAt;
+        const createdAt = normalizeRewindTimestamp(createdAtValue);
+        return [{
+          promptIndex,
+          ...(createdAt !== undefined ? { createdAt } : {}),
+          fileSnapshotCount:
+            readFiniteNumber(point, "num_file_snapshots")
+            ?? readFiniteNumber(point, "fileSnapshotCount")
+            ?? 0,
+          hasFileChanges:
+            readBooleanValue(point, "has_file_changes")
+            ?? readBooleanValue(point, "hasFileChanges")
+            ?? false,
+          promptPreview:
+            readStringValue(point, "prompt_preview")
+            ?? readStringValue(point, "promptPreview")
+            ?? `Prompt ${promptIndex + 1}`,
+        }];
+      });
+    });
+  }
+
+  async rewindSession(params: {
+    sessionId: string;
+    targetPromptIndex: number;
+  }): Promise<{ promptText?: string }> {
+    return await this.withOperation(async () => {
+      const result = asRecord(await this.options.transport.request(
+        "_x.ai/rewind/execute",
+        {
+          sessionId: this.protocolSessionIdFor(params.sessionId),
+          targetPromptIndex: params.targetPromptIndex,
+          force: true,
+          mode: "conversation_only",
+        },
+        ACP_REWIND_REQUEST_TIMEOUT_MS,
+      ));
+      if (readBooleanValue(result, "success") !== true) {
+        throw new Error(
+          readStringValue(result, "error") ?? "Grok could not rewind this conversation",
+        );
+      }
+      this.normalizerFor(params.sessionId).rewindToPromptIndex(
+        params.targetPromptIndex,
+      );
+      const receivedAt = this.now();
+      this.appendHistoryUpdate(params.sessionId, receivedAt, {
+        kind: "pwragent_rewind_marker",
+        targetPromptIndex: params.targetPromptIndex,
+      });
+      this.updateSessionStatus(params.sessionId, "idle", receivedAt);
+      return {
+        promptText:
+          readStringValue(result, "prompt_text")
+          ?? readStringValue(result, "promptText"),
+      };
+    });
+  }
+
+  async steerSession(params: {
+    sessionId: string;
+    text: string;
+    content: AcpPromptContentBlock[];
+    interjectionId: string;
+  }): Promise<{ delivery: "currentTurn" | "nextTurn" }> {
+    return await this.withOperation(async () => {
+      const response = asRecord(await this.options.transport.request(
+        "_x.ai/session/steer",
+        {
+          sessionId: this.protocolSessionIdFor(params.sessionId),
+          text: params.text,
+          interjectionId: params.interjectionId,
+          content: params.content,
+        },
+        ACP_REWIND_REQUEST_TIMEOUT_MS,
+      ));
+      const result = asRecord(response?.result) ?? response;
+      const delivery = readStringValue(result, "delivery");
+      if (delivery !== "currentTurn" && delivery !== "nextTurn") {
+        throw new Error("Grok steering response did not identify its delivery turn");
+      }
+      return { delivery };
+    });
+  }
+
+  async configureWorkflowBudget(params: {
+    sessionId: string;
+    defaultAgentBudget?: number;
+    maxAgentBudget?: number;
+  }): Promise<GrokWorkflowBudgetPolicy> {
+    return await this.withOperation(async () => {
+      const response = asRecord(await this.options.transport.request(
+        "_x.ai/session/workflow_budget",
+        {
+          sessionId: this.protocolSessionIdFor(params.sessionId),
+          ...(params.defaultAgentBudget !== undefined
+            ? { defaultAgentBudget: params.defaultAgentBudget }
+            : {}),
+          ...(params.maxAgentBudget !== undefined
+            ? { maxAgentBudget: params.maxAgentBudget }
+            : {}),
+        },
+        ACP_REWIND_REQUEST_TIMEOUT_MS,
+      ));
+      const result = asRecord(response?.result) ?? response;
+      const defaultAgentBudget = readFiniteNumber(result, "defaultAgentBudget");
+      const maxAgentBudget = readFiniteNumber(result, "maxAgentBudget");
+      if (
+        defaultAgentBudget === undefined
+        || maxAgentBudget === undefined
+        || !Number.isInteger(defaultAgentBudget)
+        || !Number.isInteger(maxAgentBudget)
+      ) {
+        throw new Error("Grok workflow-budget response was invalid");
+      }
+      return { defaultAgentBudget, maxAgentBudget };
+    });
   }
 
   async startSession(params: {
@@ -1986,4 +2127,39 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function readFiniteNumber(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readBooleanValue(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function readStringValue(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function normalizeRewindTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -322,7 +322,10 @@ export class AcpSessionReplayNormalizer {
     return this.replay();
   }
 
-  rewindToPromptIndex(targetPromptIndex: number): AppServerThreadReplay {
+  rewindToPromptIndex(
+    targetPromptIndex: number,
+    options: { missingTarget?: "clear" | "throw" } = {},
+  ): AppServerThreadReplay {
     if (!Number.isInteger(targetPromptIndex) || targetPromptIndex < 0) {
       throw new Error("ACP rewind target must be a non-negative prompt index");
     }
@@ -340,7 +343,14 @@ export class AcpSessionReplayNormalizer {
       promptIndex += 1;
     }
     if (boundary === this.entries.length && promptIndex <= targetPromptIndex) {
-      throw new Error(`ACP rewind target ${targetPromptIndex} was not found`);
+      if (options.missingTarget !== "clear") {
+        throw new Error(`ACP rewind target ${targetPromptIndex} was not found`);
+      }
+      // The provider is authoritative after it accepts an irreversible
+      // rewind. If local history was incomplete, retaining any of it would
+      // risk showing turns that Grok has already discarded. Clear the replay
+      // and let session/load hydrate the provider's retained branch.
+      boundary = 0;
     }
 
     this.entries = this.entries.slice(0, boundary);
@@ -484,6 +494,7 @@ export class AcpSessionReplayNormalizer {
       } else if (kind === "pwragent_rewind_marker") {
         this.rewindToPromptIndex(
           readNumber(update.update, "targetPromptIndex") ?? -1,
+          { missingTarget: "clear" },
         );
       } else {
         // An unrecognized kind is worth a breadcrumb — it is how new protocol

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -322,6 +322,49 @@ export class AcpSessionReplayNormalizer {
     return this.replay();
   }
 
+  rewindToPromptIndex(targetPromptIndex: number): AppServerThreadReplay {
+    if (!Number.isInteger(targetPromptIndex) || targetPromptIndex < 0) {
+      throw new Error("ACP rewind target must be a non-negative prompt index");
+    }
+    let promptIndex = 0;
+    let boundary = this.entries.length;
+    for (let index = 0; index < this.entries.length; index += 1) {
+      const entry = this.entries[index];
+      if (entry?.type !== "message" || entry.role !== "user") {
+        continue;
+      }
+      if (promptIndex === targetPromptIndex) {
+        boundary = index;
+        break;
+      }
+      promptIndex += 1;
+    }
+    if (boundary === this.entries.length && promptIndex <= targetPromptIndex) {
+      throw new Error(`ACP rewind target ${targetPromptIndex} was not found`);
+    }
+
+    this.entries = this.entries.slice(0, boundary);
+    const retainedMessageIds = new Set(
+      this.entries
+        .filter(
+          (entry): entry is AppServerThreadEntry & { type: "message" } =>
+            entry.type === "message",
+        )
+        .map((entry) => entry.id),
+    );
+    this.messages = this.messages.filter((message) =>
+      retainedMessageIds.has(message.id)
+    );
+    this.currentTurnId = undefined;
+    this.currentTurnStartedAt = undefined;
+    this.activeAssistantMessageId = undefined;
+    this.activeAssistantMessagePhase = undefined;
+    this.assistantMessageSequence = 0;
+    this.knownToolCallIds.clear();
+    this.status = "idle";
+    return this.replay();
+  }
+
   apply(update: AcpSessionUpdate): AppServerThreadReplay {
     const kind = readKind(update.update);
     const createdAt =
@@ -438,6 +481,10 @@ export class AcpSessionReplayNormalizer {
           receivedAt: createdAt,
           waitingForAgent: readBoolean(update.update, "waitingForAgent"),
         });
+      } else if (kind === "pwragent_rewind_marker") {
+        this.rewindToPromptIndex(
+          readNumber(update.update, "targetPromptIndex") ?? -1,
+        );
       } else {
         // An unrecognized kind is worth a breadcrumb — it is how new protocol
         // traffic gets spotted — but it must not be destructive. The bubble

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -98,7 +98,7 @@ export type PwrAgentFederatedThreadControlResult = {
   backend: StopThreadToolArgs["backend"];
   threadId: StopThreadToolArgs["threadId"];
   turnId: string;
-  disposition: "interrupted" | "steered";
+  disposition: "interrupted" | "queued" | "steered";
   idempotentReplay?: boolean;
   instanceId: string;
   instanceLabel: string;

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import {
   type AcpBackendId,
+  type AcpThreadRewindPoint,
   type AgentEvent,
   type AppServerBackendKind,
   type AppServerNotification,
@@ -17,6 +18,7 @@ import {
   type BackendLaunchpadOptions,
   type BackendModelOption,
   type BackendSummary,
+  type GrokWorkflowBudgetPolicy,
   type ThreadExecutionMode,
   isAcpBackendId,
 } from "@pwragent/shared";
@@ -128,14 +130,18 @@ export type AcpRuntimeClient = Pick<
     Pick<
       AcpAgentClient,
       | "didSessionLoadReplayHistory"
+      | "configureWorkflowBudget"
       | "hasActiveOperations"
       | "hasActiveTurns"
       | "hasRetainableSessions"
+      | "listRewindPoints"
       | "ownsSession"
       | "readProviderStatus"
       | "sendControlPrompt"
       | "setRuntimeOption"
+      | "steerSession"
       | "supportsSessionLoad"
+      | "rewindSession"
     >
   >;
 
@@ -317,7 +323,7 @@ export function buildAcpCapabilities(
     startReview: agentCapabilities?.managedReview === true,
     reviewRunner: agentCapabilities?.managedReview === true,
     interruptTurn: true,
-    steerTurn: false,
+    steerTurn: agentCapabilities?.steerTurn === true,
     transcriptPagination: false,
     toolUse: true,
     approvalRequests: true,
@@ -1392,6 +1398,119 @@ export class AcpBackendAdapter {
         session,
       });
     }
+  }
+
+  async listRewindPoints(
+    backend: AcpBackendId,
+    sessionId: string,
+  ): Promise<AcpThreadRewindPoint[]> {
+    const session = this.requireIdleGrokRewindSession(backend, sessionId);
+    const client = await this.getClientForSession(backend, sessionId);
+    if (!client.listRewindPoints) {
+      throw new Error("Installed Grok Build does not support conversation rewind");
+    }
+    await client.ensureSession(session);
+    return await client.listRewindPoints(sessionId);
+  }
+
+  async rewindSession(params: {
+    backend: AcpBackendId;
+    sessionId: string;
+    targetPromptIndex: number;
+  }): Promise<{ promptText?: string }> {
+    const session = this.requireIdleGrokRewindSession(
+      params.backend,
+      params.sessionId,
+    );
+    const client = await this.getClientForSession(
+      params.backend,
+      params.sessionId,
+    );
+    if (!client.rewindSession) {
+      throw new Error("Installed Grok Build does not support conversation rewind");
+    }
+    await client.ensureSession(session);
+    return await client.rewindSession({
+      sessionId: params.sessionId,
+      targetPromptIndex: params.targetPromptIndex,
+    });
+  }
+
+  async steerSession(params: {
+    backend: AcpBackendId;
+    content: AcpPromptContentBlock[];
+    interjectionId: string;
+    sessionId: string;
+    text: string;
+  }): Promise<{ delivery: "currentTurn" | "nextTurn" }> {
+    if (params.backend !== "acp:grok") {
+      throw new Error(`ACP backend ${params.backend} does not support turn steering`);
+    }
+    const session = this.getSession(params.backend, params.sessionId);
+    if (!session) {
+      throw new Error(`ACP session not found: ${params.sessionId}`);
+    }
+    if (session.status !== "active") {
+      throw new Error("The Grok turn finished before steering was accepted");
+    }
+    const client = await this.getClientForSession(
+      params.backend,
+      params.sessionId,
+    );
+    if (!client.steerSession) {
+      throw new Error("Installed Grok Build does not support turn steering over ACP");
+    }
+    return await client.steerSession({
+      sessionId: params.sessionId,
+      text: params.text,
+      content: params.content,
+      interjectionId: params.interjectionId,
+    });
+  }
+
+  async configureWorkflowBudget(params: {
+    backend: "acp:grok";
+    sessionId: string;
+    defaultAgentBudget?: number;
+    maxAgentBudget?: number;
+  }): Promise<GrokWorkflowBudgetPolicy> {
+    const session = this.getSession(params.backend, params.sessionId);
+    if (!session) {
+      throw new Error(`ACP session not found: ${params.sessionId}`);
+    }
+    if (session.status === "active") {
+      throw new Error("Wait for the active Grok turn to finish before changing budgets");
+    }
+    const client = await this.getClientForSession(
+      params.backend,
+      params.sessionId,
+    );
+    if (!client.configureWorkflowBudget) {
+      throw new Error("Installed Grok Build does not support workflow budget controls");
+    }
+    await client.ensureSession(session);
+    return await client.configureWorkflowBudget({
+      sessionId: params.sessionId,
+      defaultAgentBudget: params.defaultAgentBudget,
+      maxAgentBudget: params.maxAgentBudget,
+    });
+  }
+
+  private requireIdleGrokRewindSession(
+    backend: AcpBackendId,
+    sessionId: string,
+  ): AcpSessionMetadata {
+    if (backend !== "acp:grok") {
+      throw new Error("Conversation rewind is only available for Grok Build threads");
+    }
+    const session = this.getSession(backend, sessionId);
+    if (!session) {
+      throw new Error(`ACP session not found: ${sessionId}`);
+    }
+    if (session.status === "active") {
+      throw new Error("Wait for the active Grok turn to finish before rewinding");
+    }
+    return session;
   }
 
   async getClient(backend: AcpBackendId): Promise<AcpRuntimeClient> {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1417,7 +1417,7 @@ export class AcpBackendAdapter {
     backend: AcpBackendId;
     sessionId: string;
     targetPromptIndex: number;
-  }): Promise<{ promptText?: string }> {
+  }): Promise<{ promptText?: string; updatedAt: number }> {
     const session = this.requireIdleGrokRewindSession(
       params.backend,
       params.sessionId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -56,6 +56,10 @@ import {
 import { pageNormalizedReplay } from "./thread-replay-pagination";
 import {
   type AcpBackendId,
+  type ListAcpThreadRewindPointsRequest,
+  type ListAcpThreadRewindPointsResponse,
+  type RewindAcpThreadRequest,
+  type RewindAcpThreadResponse,
   buildAppendPinRank,
   buildThreadMarkdownLink,
   buildThreadUrl,
@@ -111,6 +115,8 @@ import {
   type CancelQueuedTurnResponse,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
+  type ConfigureGrokWorkflowBudgetRequest,
+  type ConfigureGrokWorkflowBudgetResponse,
   type ControlActiveTurnRequest,
   type ControlActiveTurnResponse,
   type ForkThreadRequest,
@@ -14132,15 +14138,56 @@ export class DesktopBackendRegistry {
     }
   }
 
+  async listAcpThreadRewindPoints(
+    request: ListAcpThreadRewindPointsRequest,
+  ): Promise<ListAcpThreadRewindPointsResponse> {
+    const rewindPoints = await this.acpBackend.listRewindPoints(
+      request.backend,
+      request.threadId,
+    );
+    return {
+      backend: request.backend,
+      threadId: request.threadId,
+      rewindPoints,
+    };
+  }
+
+  async rewindAcpThread(
+    request: RewindAcpThreadRequest,
+  ): Promise<RewindAcpThreadResponse> {
+    const result = await this.acpBackend.rewindSession({
+      backend: request.backend,
+      sessionId: request.threadId,
+      targetPromptIndex: request.targetPromptIndex,
+    });
+    return {
+      backend: request.backend,
+      threadId: request.threadId,
+      targetPromptIndex: request.targetPromptIndex,
+      ...(result.promptText ? { promptText: result.promptText } : {}),
+    };
+  }
+
+  async configureGrokWorkflowBudget(
+    request: ConfigureGrokWorkflowBudgetRequest,
+  ): Promise<ConfigureGrokWorkflowBudgetResponse> {
+    const policy = await this.acpBackend.configureWorkflowBudget({
+      backend: request.backend,
+      sessionId: request.threadId,
+      defaultAgentBudget: request.defaultAgentBudget,
+      maxAgentBudget: request.maxAgentBudget,
+    });
+    return {
+      backend: request.backend,
+      threadId: request.threadId,
+      policy,
+    };
+  }
+
   private async submitSteerTurn(
     params: SteerTurnRequest,
     messageOrigin?: AppServerThreadMessageOrigin,
   ): Promise<SteerTurnResponse> {
-    if (isAcpBackendId(params.backend)) {
-      throw new Error(
-        "ACP backend " + params.backend + " does not support turn steering",
-      );
-    }
     const input = await enrichLocalFileInputs(params.input, {
       privateStorageRoots: this.localFilePrivateStorageRoots,
     });
@@ -14152,6 +14199,40 @@ export class DesktopBackendRegistry {
       origin: messageOrigin,
       text: extractFirstMeaningfulTextInput(params.input),
     });
+    if (isAcpBackendId(params.backend)) {
+      const promptPayload = inputToAcpPrompt(input);
+      if (!promptPayload) {
+        this.forgetPendingThreadMessageContext(pendingMessageContextId);
+        throw new Error("ACP steering requires text or image input");
+      }
+      const text = promptPayload.prompt
+        || promptPayload.promptContent.flatMap((block) =>
+          block.type === "text" && block.text.trim() ? [block.text] : []
+        )[0]
+        || "Additional image context.";
+      try {
+        await this.acpBackend.steerSession({
+          backend: params.backend,
+          content: promptPayload.promptContent,
+          interjectionId: params.requestId,
+          sessionId: params.threadId,
+          text,
+        });
+      } catch (error) {
+        this.forgetPendingThreadMessageContext(pendingMessageContextId);
+        throw error;
+      }
+      this.bindPendingThreadMessageContext(
+        pendingMessageContextId,
+        params.expectedTurnId,
+      );
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        turnId: params.expectedTurnId,
+        disposition: "steered",
+      };
+    }
     const steerWithClient = async (
       client: BackendClient,
     ): Promise<{ threadId: string; turnId: string }> => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13565,7 +13565,8 @@ export class DesktopBackendRegistry {
           threadId: steered.threadId,
           requestId: request.requestId,
           turnId: steered.turnId,
-          disposition: "steered",
+          disposition:
+            steered.disposition === "queued" ? "queued" : "steered",
         };
       } catch (error) {
         if (error instanceof ActiveTurnControlPreconditionError) {
@@ -13649,6 +13650,35 @@ export class DesktopBackendRegistry {
       },
     });
     return params;
+  }
+
+  private assertExpectedAcpSteerTurn(params: {
+    backend: AcpBackendId;
+    threadId: string;
+    expectedTurnId: string;
+  }): void {
+    const active = this.getActiveTurnForThread(params);
+    if (!active) {
+      throw new Error(`Thread ${params.threadId} has no active turn to steer`);
+    }
+    if (active.turnId !== params.expectedTurnId) {
+      throw new Error(
+        `expected active turn id \`${params.expectedTurnId}\` but found \`${active.turnId}\``,
+      );
+    }
+  }
+
+  private assertIdleAcpThreadMutation(params: {
+    action: string;
+    backend: AcpBackendId;
+    threadId: string;
+  }): void {
+    const active = this.getActiveTurnForThread(params);
+    if (active) {
+      throw new Error(
+        `Wait for active turn ${active.turnId} to finish before ${params.action}`,
+      );
+    }
   }
 
   async interruptTurn(params: {
@@ -14155,15 +14185,37 @@ export class DesktopBackendRegistry {
   async rewindAcpThread(
     request: RewindAcpThreadRequest,
   ): Promise<RewindAcpThreadResponse> {
-    const result = await this.acpBackend.rewindSession({
+    const result = await this.acpSessionPromptLocks.run(
+      executionModeQueueKey(request.backend, request.threadId),
+      async () => {
+        this.assertIdleAcpThreadMutation({
+          backend: request.backend,
+          threadId: request.threadId,
+          action: "rewinding",
+        });
+        return await this.acpBackend.rewindSession({
+          backend: request.backend,
+          sessionId: request.threadId,
+          targetPromptIndex: request.targetPromptIndex,
+        });
+      },
+    );
+    await this.emit({
       backend: request.backend,
-      sessionId: request.threadId,
-      targetPromptIndex: request.targetPromptIndex,
+      notification: {
+        method: "thread/rewound",
+        params: {
+          threadId: request.threadId,
+          targetPromptIndex: request.targetPromptIndex,
+          updatedAt: result.updatedAt,
+        },
+      },
     });
     return {
       backend: request.backend,
       threadId: request.threadId,
       targetPromptIndex: request.targetPromptIndex,
+      updatedAt: result.updatedAt,
       ...(result.promptText ? { promptText: result.promptText } : {}),
     };
   }
@@ -14171,12 +14223,22 @@ export class DesktopBackendRegistry {
   async configureGrokWorkflowBudget(
     request: ConfigureGrokWorkflowBudgetRequest,
   ): Promise<ConfigureGrokWorkflowBudgetResponse> {
-    const policy = await this.acpBackend.configureWorkflowBudget({
-      backend: request.backend,
-      sessionId: request.threadId,
-      defaultAgentBudget: request.defaultAgentBudget,
-      maxAgentBudget: request.maxAgentBudget,
-    });
+    const policy = await this.acpSessionPromptLocks.run(
+      executionModeQueueKey(request.backend, request.threadId),
+      async () => {
+        this.assertIdleAcpThreadMutation({
+          backend: request.backend,
+          threadId: request.threadId,
+          action: "changing workflow budgets",
+        });
+        return await this.acpBackend.configureWorkflowBudget({
+          backend: request.backend,
+          sessionId: request.threadId,
+          defaultAgentBudget: request.defaultAgentBudget,
+          maxAgentBudget: request.maxAgentBudget,
+        });
+      },
+    );
     return {
       backend: request.backend,
       threadId: request.threadId,
@@ -14191,6 +14253,64 @@ export class DesktopBackendRegistry {
     const input = await enrichLocalFileInputs(params.input, {
       privateStorageRoots: this.localFilePrivateStorageRoots,
     });
+    if (isAcpBackendId(params.backend)) {
+      const acpBackend = params.backend;
+      const promptPayload = inputToAcpPrompt(input);
+      if (!promptPayload) {
+        throw new Error("ACP steering requires text or image input");
+      }
+      const pendingMessageContextId = await this.registerPendingThreadMessageContext({
+        backend: params.backend,
+        input,
+        threadId: params.threadId,
+        origin: messageOrigin,
+        text: extractFirstMeaningfulTextInput(params.input),
+      });
+      const text = promptPayload.prompt
+        || promptPayload.promptContent.flatMap((block) =>
+          block.type === "text" && block.text.trim() ? [block.text] : []
+        )[0]
+        || "Additional image context.";
+      let result: { delivery: "currentTurn" | "nextTurn" };
+      try {
+        result = await this.acpSessionPromptLocks.run(
+          executionModeQueueKey(acpBackend, params.threadId),
+          async () => {
+            this.assertExpectedAcpSteerTurn({
+              backend: acpBackend,
+              threadId: params.threadId,
+              expectedTurnId: params.expectedTurnId,
+            });
+            return await this.acpBackend.steerSession({
+              backend: acpBackend,
+              content: promptPayload.promptContent,
+              interjectionId: params.requestId,
+              sessionId: params.threadId,
+              text,
+            });
+          },
+        );
+      } catch (error) {
+        this.forgetPendingThreadMessageContext(pendingMessageContextId);
+        throw error;
+      }
+      if (result.delivery === "currentTurn") {
+        this.bindPendingThreadMessageContext(
+          pendingMessageContextId,
+          params.expectedTurnId,
+        );
+      }
+      // A next-turn steer has no turn id yet. Leave its message context
+      // unbound so the next turn/started or matching user item can claim its
+      // origin and image parts instead of attaching them to the finished turn.
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        turnId: params.expectedTurnId,
+        disposition:
+          result.delivery === "nextTurn" ? "queued" : "steered",
+      };
+    }
     const pendingMessageContextId = await this.registerPendingThreadMessageContext({
       backend: params.backend,
       input,
@@ -14199,40 +14319,6 @@ export class DesktopBackendRegistry {
       origin: messageOrigin,
       text: extractFirstMeaningfulTextInput(params.input),
     });
-    if (isAcpBackendId(params.backend)) {
-      const promptPayload = inputToAcpPrompt(input);
-      if (!promptPayload) {
-        this.forgetPendingThreadMessageContext(pendingMessageContextId);
-        throw new Error("ACP steering requires text or image input");
-      }
-      const text = promptPayload.prompt
-        || promptPayload.promptContent.flatMap((block) =>
-          block.type === "text" && block.text.trim() ? [block.text] : []
-        )[0]
-        || "Additional image context.";
-      try {
-        await this.acpBackend.steerSession({
-          backend: params.backend,
-          content: promptPayload.promptContent,
-          interjectionId: params.requestId,
-          sessionId: params.threadId,
-          text,
-        });
-      } catch (error) {
-        this.forgetPendingThreadMessageContext(pendingMessageContextId);
-        throw error;
-      }
-      this.bindPendingThreadMessageContext(
-        pendingMessageContextId,
-        params.expectedTurnId,
-      );
-      return {
-        backend: params.backend,
-        threadId: params.threadId,
-        turnId: params.expectedTurnId,
-        disposition: "steered",
-      };
-    }
     const steerWithClient = async (
       client: BackendClient,
     ): Promise<{ threadId: string; turnId: string }> => {
@@ -18900,6 +18986,7 @@ export class DesktopBackendRegistry {
       method === "thread/name/updated" ||
       method === "thread/parent/cleared" ||
       method === "thread/parent/set" ||
+      method === "thread/rewound" ||
       method === "thread/started" ||
       method === "thread/status/changed" ||
       method === "thread/subAgents/updated" ||
@@ -25227,7 +25314,7 @@ export class DesktopBackendRegistry {
             backend: AppServerBackendKind;
             threadId: string;
             turnId: string;
-            disposition: "interrupted" | "steered";
+            disposition: "interrupted" | "queued" | "steered";
             idempotentReplay?: boolean;
           }
         | undefined;
@@ -25358,7 +25445,8 @@ export class DesktopBackendRegistry {
             ok: true,
             data: {
               ...base,
-              disposition: "steered",
+              disposition:
+                result.disposition === "queued" ? "queued" : "steered",
               promptPreview: truncateThreadInspectionText(request.args.prompt, 240),
             },
           };

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -17,6 +17,8 @@ import {
   type CodexEnvironmentSetupProgressEvent,
   type CompactThreadRequest,
   type CompactThreadResponse,
+  type ConfigureGrokWorkflowBudgetRequest,
+  type ConfigureGrokWorkflowBudgetResponse,
   type ForkThreadRequest,
   type ForkThreadResponse,
   type MaterializeDirectoryLaunchpadRequest,
@@ -26,6 +28,8 @@ import {
   type StopSubAgentRequest,
   type StopSubAgentResponse,
   type LatestCodexConfigWarningResponse,
+  type ListAcpThreadRewindPointsRequest,
+  type ListAcpThreadRewindPointsResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
   type ListCodexMcpServersRequest,
@@ -36,6 +40,8 @@ import {
   type QueueThreadExecutionModeResponse,
   type RetainThreadBranchDriftRequest,
   type RetainThreadBranchDriftResponse,
+  type RewindAcpThreadRequest,
+  type RewindAcpThreadResponse,
   type ReloadCodexMcpConfigRequest,
   type ReloadCodexMcpConfigResponse,
   type ReloadCodexMcpServersResponse,
@@ -93,8 +99,10 @@ import {
   AGENT_EVENT_CHANNEL,
   AGENT_FORK_THREAD_CHANNEL,
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
+  AGENT_LIST_ACP_THREAD_REWIND_POINTS_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
+  AGENT_CONFIGURE_GROK_WORKFLOW_BUDGET_CHANNEL,
   AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
   AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
   CODEX_MCP_SERVERS_LIST_CHANNEL,
@@ -106,6 +114,7 @@ import {
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_REWIND_ACP_THREAD_CHANNEL,
   AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
   AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
   AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
@@ -914,6 +923,57 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_LIST_ACP_THREAD_REWIND_POINTS_CHANNEL);
+  ipcMain.handle(
+    AGENT_LIST_ACP_THREAD_REWIND_POINTS_CHANNEL,
+    async (
+      _event,
+      request: ListAcpThreadRewindPointsRequest,
+    ): Promise<ListAcpThreadRewindPointsResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        throw new Error("Conversation rewind is not available from a remote viewer yet");
+      }
+      return await registry.listAcpThreadRewindPoints(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_REWIND_ACP_THREAD_CHANNEL);
+  ipcMain.handle(
+    AGENT_REWIND_ACP_THREAD_CHANNEL,
+    async (
+      _event,
+      request: RewindAcpThreadRequest,
+    ): Promise<RewindAcpThreadResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        throw new Error("Conversation rewind is not available from a remote viewer yet");
+      }
+      return await registry.rewindAcpThread(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_CONFIGURE_GROK_WORKFLOW_BUDGET_CHANNEL);
+  ipcMain.handle(
+    AGENT_CONFIGURE_GROK_WORKFLOW_BUDGET_CHANNEL,
+    async (
+      _event,
+      request: ConfigureGrokWorkflowBudgetRequest,
+    ): Promise<ConfigureGrokWorkflowBudgetResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        throw new Error("Grok workflow budgets are not available from a remote viewer yet");
+      }
+      return await registry.configureGrokWorkflowBudget(request);
+    },
+  );
+
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);
   ipcMain.handle(
     AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
@@ -1265,6 +1325,9 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_STOP_SUB_AGENT_CHANNEL);
   ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);
+  ipcMain.removeHandler(AGENT_LIST_ACP_THREAD_REWIND_POINTS_CHANNEL);
+  ipcMain.removeHandler(AGENT_REWIND_ACP_THREAD_CHANNEL);
+  ipcMain.removeHandler(AGENT_CONFIGURE_GROK_WORKFLOW_BUDGET_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);
   ipcMain.removeHandler(AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL);
   ipcMain.removeHandler(AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1458,6 +1458,7 @@ export class MessagingController {
     if (
       event.notification.method === "thread/executionMode/updated" ||
       event.notification.method === "thread/modelSettings/updated" ||
+      event.notification.method === "thread/rewound" ||
       event.notification.method === "thread/prAutoDispatch/updated" ||
       event.notification.method === "thread/prAutoDispatch/pendingUpdated" ||
       event.notification.method === "thread/codexEnvironment/updated" ||

--- a/apps/desktop/src/main/scheduled-actions/steer-turn-admission.ts
+++ b/apps/desktop/src/main/scheduled-actions/steer-turn-admission.ts
@@ -13,7 +13,9 @@ export async function admitSteerTurn(
 ): Promise<SteerTurnResponse> {
   try {
     const response = await registry.steerTurn(request);
-    return { ...response, disposition: "steered" };
+    return response.disposition
+      ? response
+      : { ...response, disposition: "steered" };
   } catch (error) {
     if (!request.fallback || !isStaleSteerError(error)) throw error;
     const scheduled = await scheduler.create(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -26,6 +26,8 @@ import type {
   DesktopTextSize,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
+  ConfigureGrokWorkflowBudgetRequest,
+  ConfigureGrokWorkflowBudgetResponse,
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
   ForkThreadRequest,
@@ -62,9 +64,13 @@ import type {
   ReloadCodexMcpServersRequest,
   RemoveCodexMcpServerRequest,
   RemoveCodexMcpServerResponse,
+  RewindAcpThreadRequest,
+  RewindAcpThreadResponse,
   StartCodexMcpServerLoginRequest,
   StartCodexMcpServerLoginResponse,
   LatestCodexConfigWarningResponse,
+  ListAcpThreadRewindPointsRequest,
+  ListAcpThreadRewindPointsResponse,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
@@ -424,9 +430,11 @@ import {
   AGENT_EVENT_CHANNEL,
   AGENT_FORK_THREAD_CHANNEL,
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
+  AGENT_LIST_ACP_THREAD_REWIND_POINTS_CHANNEL,
   APPEARANCE_CHANGED_EVENT_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
+  AGENT_CONFIGURE_GROK_WORKFLOW_BUDGET_CHANNEL,
   AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
   AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
   CODEX_MCP_SERVERS_LIST_CHANNEL,
@@ -438,6 +446,7 @@ import {
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_REWIND_ACP_THREAD_CHANNEL,
   AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
   AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
   AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
@@ -1462,6 +1471,21 @@ const desktopApi = Object.freeze({
     request: SteerTurnRequest
   ): Promise<SteerTurnResponse> =>
     await ipcRenderer.invoke(AGENT_STEER_TURN_CHANNEL, request),
+  listAcpThreadRewindPoints: async (
+    request: ListAcpThreadRewindPointsRequest,
+  ): Promise<ListAcpThreadRewindPointsResponse> =>
+    await ipcRenderer.invoke(AGENT_LIST_ACP_THREAD_REWIND_POINTS_CHANNEL, request),
+  rewindAcpThread: async (
+    request: RewindAcpThreadRequest,
+  ): Promise<RewindAcpThreadResponse> =>
+    await ipcRenderer.invoke(AGENT_REWIND_ACP_THREAD_CHANNEL, request),
+  configureGrokWorkflowBudget: async (
+    request: ConfigureGrokWorkflowBudgetRequest,
+  ): Promise<ConfigureGrokWorkflowBudgetResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_CONFIGURE_GROK_WORKFLOW_BUDGET_CHANNEL,
+      request,
+    ),
   setThreadExecutionMode: async (
     request: SetThreadExecutionModeRequest
   ): Promise<SetThreadExecutionModeResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1546,6 +1546,7 @@ function DesktopAppShell(props: {
     launchpadError: navigation.launchpadError,
     onProviderSelected: refreshSelectedAcpProvider,
     onShowNotice: showAppNotice,
+    onReloadThread: session.reload,
     initialLoadDurationMs: session.initialLoadDurationMs,
     loading: session.loading,
     loadingMore: session.loadingMore,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -483,7 +483,7 @@ type QueuedTurnDraft = {
 type PendingSteerDraft = QueuedTurnDraft & {
   clearComposerDraftOnAdmission?: boolean;
   expectedTurnId: string;
-  status: "pending" | "steering";
+  status: "pending" | "queued" | "steering";
 };
 
 function scheduledActionFailureMessage(action: {
@@ -5466,9 +5466,12 @@ export function Composer(props: ComposerProps) {
       }
 
       if (
-        pendingSteer?.status === "steering" &&
-        event.notification.method === "item/completed" &&
-        notificationIncludesDraftContent(event.notification.params, pendingSteer)
+        (
+          pendingSteer?.status === "steering"
+          || pendingSteer?.status === "queued"
+        )
+        && event.notification.method === "item/completed"
+        && notificationIncludesDraftContent(event.notification.params, pendingSteer)
       ) {
         if (steeringRequestIdRef.current === pendingSteer.id) {
           steeringRequestIdRef.current = undefined;
@@ -5523,7 +5526,10 @@ export function Composer(props: ComposerProps) {
         ) {
           props.removeOptimisticMessage?.(activeOptimisticMessageId);
         }
-        props.onPendingStatusChange?.(undefined);
+        const providerQueuedSteer = pendingSteer?.status === "queued";
+        props.onPendingStatusChange?.(
+          providerQueuedSteer ? "Queued" : undefined,
+        );
         if (clearsReleasedQueuedTurn) {
           globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
         }
@@ -5538,7 +5544,9 @@ export function Composer(props: ComposerProps) {
             composerScopeKey,
           );
         }
-        setPendingSteer(undefined);
+        if (!providerQueuedSteer) {
+          setPendingSteer(undefined);
+        }
         updateActiveTurnId(undefined);
         props.onActiveTurnIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
@@ -5561,12 +5569,17 @@ export function Composer(props: ComposerProps) {
         ) {
           return;
         }
-        props.onPendingStatusChange?.(undefined);
+        const providerQueuedSteer = pendingSteer?.status === "queued";
+        props.onPendingStatusChange?.(
+          providerQueuedSteer ? "Queued" : undefined,
+        );
         updateSending(false);
         setInterrupting(false);
         setSteering(false);
         steeringRequestIdRef.current = undefined;
-        setPendingSteer(undefined);
+        if (!providerQueuedSteer) {
+          setPendingSteer(undefined);
+        }
         updateActiveTurnId(undefined);
         props.onActiveTurnIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
@@ -7096,6 +7109,18 @@ export function Composer(props: ComposerProps) {
       // the backend has taken it — a throw below must leave the thread in the
       // Attention queue.
       props.onUserRepliedToThread?.(props.thread);
+      if (response.disposition === "queued") {
+        if (steeringRequestIdRef.current === pending.id) {
+          steeringRequestIdRef.current = undefined;
+        }
+        updatePendingSteer((current) =>
+          current?.id === pending.id
+            ? { ...current, status: "queued" }
+            : current
+        );
+        setSendError(undefined);
+        props.onPendingStatusChange?.("Queued");
+      }
       if (response.disposition === "scheduled" && response.scheduledAction) {
         const action = response.scheduledAction;
         const failureMessage = scheduledActionFailureMessage(action);
@@ -10246,7 +10271,11 @@ export function Composer(props: ComposerProps) {
         >
           <div className="composer__queued-copy">
             <span className="composer__queued-label">
-              {pendingSteer.status === "steering" ? "Steering now" : "Pending steer"}
+              {pendingSteer.status === "steering"
+                ? "Steering now"
+                : pendingSteer.status === "queued"
+                  ? "Queued by Grok"
+                  : "Pending steer"}
             </span>
             <span className="composer__queued-text">
               {formatDraftPreview(pendingSteer)}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -7571,6 +7571,123 @@ describe("Composer", () => {
     expect(screen.queryByText("Steering now")).not.toBeInTheDocument();
   });
 
+  it("keeps a Grok next-turn steer projected until its queued message arrives", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "acp:grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const steerTurn = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      threadId: "grok-thread",
+      turnId: "turn-a",
+      disposition: "queued" as const,
+    }));
+
+    render(
+      <Composer
+        activeTurnId="turn-a"
+        backends={[
+          {
+            ...backendSummary("acp:grok", {
+              models: [
+                {
+                  id: "grok-4.6",
+                  label: "Grok 4.6",
+                  current: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("acp:grok").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "grok-thread",
+          title: "Grok steer queue",
+          titleSource: "explicit",
+          source: "acp:grok",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Mention blueberries" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Queued by Grok")).toBeInTheDocument();
+    });
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "acp:grok",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "grok-thread",
+            turnId: "turn-a",
+            turn: { id: "turn-a", status: "completed" },
+          },
+        },
+      });
+    });
+    expect(screen.getByText("Queued by Grok")).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "acp:grok",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "grok-thread",
+            turnId: "turn-b",
+            turn: { id: "turn-b", status: "in_progress" },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "acp:grok",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "grok-thread",
+            turnId: "turn-b",
+            item: {
+              id: "queued-user-message",
+              type: "userMessage",
+              text: "Mention blueberries",
+            },
+          },
+        },
+      });
+    });
+
+    expect(screen.queryByText("Queued by Grok")).not.toBeInTheDocument();
+  });
+
   it("clears an image-only pending steer after Codex acknowledges the image", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -9,6 +9,8 @@ import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { TerminalIcon } from "../../icons/TerminalIcon";
+import { HistoryIcon } from "../../icons/HistoryIcon";
+import { SubAgentsIcon } from "../../icons/SubAgentsIcon";
 import { StarMapIcon } from "../../icons/StarMapIcon";
 import { PanelToggleButtons } from "../chrome/PanelToggleButtons";
 import {
@@ -82,6 +84,14 @@ type ThreadHeaderProps = {
    * have to thread history state; App always supplies it.
    */
   history?: HistoryNavControls;
+  rewind?: {
+    disabledReason?: string;
+    onOpen: () => void;
+  };
+  workflowBudget?: {
+    disabledReason?: string;
+    onOpen: () => void;
+  };
 };
 
 function missingDirectoryPath(thread: NavigationThreadSummary): string | undefined {
@@ -113,6 +123,8 @@ export function ThreadHeader(props: ThreadHeaderProps) {
   // slow, edge-clipping native `title`.
   const terminalTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const rewindTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const workflowBudgetTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const starMapLabel = "Open Star Map";
   // A collapsed-but-running terminal gets its own affordance: the toggle wears
   // a live dot and says so, otherwise the shell is invisible from here.
@@ -202,6 +214,74 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           </div>
         </div>
         <div className="thread-header__chrome">
+          {props.rewind ? (
+            <button
+              aria-disabled={props.rewind.disabledReason ? true : undefined}
+              aria-label={props.rewind.disabledReason ?? "Rewind Grok conversation"}
+              className={`thread-header__rewind-toggle${
+                props.rewind.disabledReason ? " is-disabled" : ""
+              }`}
+              type="button"
+              onBlur={rewindTooltip.hide}
+              onClick={() => {
+                rewindTooltip.hide();
+                if (!props.rewind?.disabledReason) {
+                  props.rewind?.onOpen();
+                }
+              }}
+              onFocus={(event) =>
+                rewindTooltip.show(
+                  event.currentTarget,
+                  props.rewind?.disabledReason ?? "Rewind conversation",
+                )
+              }
+              onMouseEnter={(event) =>
+                rewindTooltip.show(
+                  event.currentTarget,
+                  props.rewind?.disabledReason ?? "Rewind conversation",
+                )
+              }
+              onMouseLeave={rewindTooltip.hide}
+            >
+              <HistoryIcon size={14} />
+            </button>
+          ) : null}
+          {rewindTooltip.tooltipNode}
+          {props.workflowBudget ? (
+            <button
+              aria-disabled={props.workflowBudget.disabledReason ? true : undefined}
+              aria-label={
+                props.workflowBudget.disabledReason ?? "Configure Grok workflow budgets"
+              }
+              className={`thread-header__rewind-toggle${
+                props.workflowBudget.disabledReason ? " is-disabled" : ""
+              }`}
+              type="button"
+              onBlur={workflowBudgetTooltip.hide}
+              onClick={() => {
+                workflowBudgetTooltip.hide();
+                if (!props.workflowBudget?.disabledReason) {
+                  props.workflowBudget?.onOpen();
+                }
+              }}
+              onFocus={(event) =>
+                workflowBudgetTooltip.show(
+                  event.currentTarget,
+                  props.workflowBudget?.disabledReason ?? "Configure workflow budgets",
+                )
+              }
+              onMouseEnter={(event) =>
+                workflowBudgetTooltip.show(
+                  event.currentTarget,
+                  props.workflowBudget?.disabledReason ?? "Configure workflow budgets",
+                )
+              }
+              onMouseLeave={workflowBudgetTooltip.hide}
+            >
+              <SubAgentsIcon size={14} />
+            </button>
+          ) : null}
+          {workflowBudgetTooltip.tooltipNode}
           {props.layout && !isWindows ? (
             <PanelToggleButtons
               sidebarOpen={props.layout.sidebarOpen}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import type {
   AppServerAvailableCommandSummary,
+  AcpThreadRewindPoint,
   AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
   AppServerReviewTarget,
@@ -1034,6 +1035,7 @@ export type ThreadViewProps = {
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
+  onReloadThread?: () => Promise<void>;
   onLiveTranscriptEntry?: (entry: AppServerThreadEntry) => void;
   onMaterializeLaunchpad?: (
     directoryKey: string,
@@ -1134,6 +1136,22 @@ type BranchDriftDialogState = {
   observedBranch: string;
   reason: "focus" | "turn";
   threadKey: string;
+};
+
+type RewindDialogState = {
+  busy: boolean;
+  error?: string;
+  loading: boolean;
+  points: AcpThreadRewindPoint[];
+  selectedPromptIndex?: number;
+};
+
+type WorkflowBudgetDialogState = {
+  busy: boolean;
+  defaultAgentBudget: string;
+  error?: string;
+  loading: boolean;
+  maxAgentBudget: string;
 };
 
 type PendingTranscriptTurnTarget =
@@ -1319,6 +1337,9 @@ export function ThreadView(props: ThreadViewProps) {
   const onEditedFilesDockChange = props.onEditedFilesDockChange ?? noop;
   const onActionRunsDockChange = props.onActionRunsDockChange ?? noop;
   const onToggleSidebar = props.onToggleSidebar ?? noop;
+  const [rewindDialog, setRewindDialog] = useState<RewindDialogState>();
+  const [workflowBudgetDialog, setWorkflowBudgetDialog] =
+    useState<WorkflowBudgetDialogState>();
   // Transcript element the in-thread find bar (⌘F) searches + highlights.
   const transcriptPanelRef = useRef<HTMLElement>(null);
 
@@ -1342,6 +1363,8 @@ export function ThreadView(props: ThreadViewProps) {
     setLaunchpadSetupProgress(undefined);
     setSetupFailureContinuing(false);
     setSetupFailureContinueError(undefined);
+    setRewindDialog(undefined);
+    setWorkflowBudgetDialog(undefined);
   }, [
     props.selectedLaunchpad?.directoryKey,
     props.pendingForkEnvironmentSetup?.directoryKey,
@@ -1448,6 +1471,196 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadKey = selectedThread
     ? buildThreadIdentityKey(selectedThread.source, selectedThread.id)
     : undefined;
+  const rewindDesktopApi = props.desktopApi;
+  const onRefreshNavigationAfterRewind = props.onRefreshNavigation;
+  const onReloadThreadAfterRewind = props.onReloadThread;
+  const onShowRewindNotice = props.onShowNotice;
+  const openRewindDialog = useCallback(async (): Promise<void> => {
+    if (!selectedThread || selectedThread.source !== "acp:grok") {
+      return;
+    }
+    const listRewindPoints = rewindDesktopApi?.listAcpThreadRewindPoints;
+    if (!listRewindPoints) {
+      setRewindDialog({
+        busy: false,
+        error: "This PwrAgent build does not expose Grok conversation rewind.",
+        loading: false,
+        points: [],
+      });
+      return;
+    }
+    setRewindDialog({ busy: false, loading: true, points: [] });
+    try {
+      const response = await listRewindPoints({
+        backend: "acp:grok",
+        threadId: selectedThread.id,
+      });
+      const points = [...response.rewindPoints].sort(
+        (left, right) => right.promptIndex - left.promptIndex,
+      );
+      setRewindDialog({
+        busy: false,
+        loading: false,
+        points,
+        selectedPromptIndex: points[0]?.promptIndex,
+      });
+    } catch (error) {
+      setRewindDialog({
+        busy: false,
+        error: error instanceof Error ? error.message : String(error),
+        loading: false,
+        points: [],
+      });
+    }
+  }, [rewindDesktopApi, selectedThread]);
+  const executeRewind = useCallback(async (): Promise<void> => {
+    if (
+      !selectedThread
+      || selectedThread.source !== "acp:grok"
+      || rewindDialog?.selectedPromptIndex === undefined
+    ) {
+      return;
+    }
+    const rewindAcpThread = rewindDesktopApi?.rewindAcpThread;
+    if (!rewindAcpThread) {
+      setRewindDialog((current) => current
+        ? { ...current, error: "This PwrAgent build cannot rewind Grok threads." }
+        : current);
+      return;
+    }
+    setRewindDialog((current) => current
+      ? { ...current, busy: true, error: undefined }
+      : current);
+    try {
+      await rewindAcpThread({
+        backend: "acp:grok",
+        threadId: selectedThread.id,
+        targetPromptIndex: rewindDialog.selectedPromptIndex,
+      });
+      await onRefreshNavigationAfterRewind?.();
+      await onReloadThreadAfterRewind?.();
+      setRewindDialog(undefined);
+      onShowRewindNotice?.({
+        id: `grok-rewind:${selectedThread.id}`,
+        message: "The active Grok conversation was rewound. Files were not changed.",
+        title: "Conversation rewound",
+        tone: "success",
+      });
+    } catch (error) {
+      setRewindDialog((current) => current
+        ? {
+            ...current,
+            busy: false,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        : current);
+    }
+  }, [
+    onRefreshNavigationAfterRewind,
+    onReloadThreadAfterRewind,
+    onShowRewindNotice,
+    rewindDesktopApi,
+    rewindDialog?.selectedPromptIndex,
+    selectedThread,
+  ]);
+  const openWorkflowBudgetDialog = useCallback(async (): Promise<void> => {
+    if (!selectedThread || selectedThread.source !== "acp:grok") {
+      return;
+    }
+    const configureWorkflowBudget = rewindDesktopApi?.configureGrokWorkflowBudget;
+    if (!configureWorkflowBudget) {
+      setWorkflowBudgetDialog({
+        busy: false,
+        defaultAgentBudget: "",
+        error: "This PwrAgent build does not expose Grok workflow budgets.",
+        loading: false,
+        maxAgentBudget: "",
+      });
+      return;
+    }
+    setWorkflowBudgetDialog({
+      busy: false,
+      defaultAgentBudget: "",
+      loading: true,
+      maxAgentBudget: "",
+    });
+    try {
+      const response = await configureWorkflowBudget({
+        backend: "acp:grok",
+        threadId: selectedThread.id,
+      });
+      setWorkflowBudgetDialog({
+        busy: false,
+        defaultAgentBudget: String(response.policy.defaultAgentBudget),
+        loading: false,
+        maxAgentBudget: String(response.policy.maxAgentBudget),
+      });
+    } catch (error) {
+      setWorkflowBudgetDialog({
+        busy: false,
+        defaultAgentBudget: "",
+        error: error instanceof Error ? error.message : String(error),
+        loading: false,
+        maxAgentBudget: "",
+      });
+    }
+  }, [rewindDesktopApi, selectedThread]);
+  const saveWorkflowBudget = useCallback(async (): Promise<void> => {
+    if (!selectedThread || selectedThread.source !== "acp:grok" || !workflowBudgetDialog) {
+      return;
+    }
+    const defaultAgentBudget = Number(workflowBudgetDialog.defaultAgentBudget);
+    const maxAgentBudget = Number(workflowBudgetDialog.maxAgentBudget);
+    const validInteger = (value: number): boolean =>
+      Number.isInteger(value) && value >= 1 && value <= 1024;
+    if (!validInteger(defaultAgentBudget) || !validInteger(maxAgentBudget)) {
+      setWorkflowBudgetDialog((current) => current
+        ? { ...current, error: "Budgets must be whole numbers from 1 to 1024." }
+        : current);
+      return;
+    }
+    if (defaultAgentBudget > maxAgentBudget) {
+      setWorkflowBudgetDialog((current) => current
+        ? { ...current, error: "The default cannot exceed the enforced maximum." }
+        : current);
+      return;
+    }
+    const configureWorkflowBudget = rewindDesktopApi?.configureGrokWorkflowBudget;
+    if (!configureWorkflowBudget) {
+      return;
+    }
+    setWorkflowBudgetDialog((current) => current
+      ? { ...current, busy: true, error: undefined }
+      : current);
+    try {
+      await configureWorkflowBudget({
+        backend: "acp:grok",
+        threadId: selectedThread.id,
+        defaultAgentBudget,
+        maxAgentBudget,
+      });
+      setWorkflowBudgetDialog(undefined);
+      onShowRewindNotice?.({
+        id: `grok-workflow-budget:${selectedThread.id}`,
+        message: `New workflows default to ${defaultAgentBudget} child-agent calls, with an enforced maximum of ${maxAgentBudget}.`,
+        title: "Workflow budgets updated",
+        tone: "success",
+      });
+    } catch (error) {
+      setWorkflowBudgetDialog((current) => current
+        ? {
+            ...current,
+            busy: false,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        : current);
+    }
+  }, [
+    onShowRewindNotice,
+    rewindDesktopApi,
+    selectedThread,
+    workflowBudgetDialog,
+  ]);
   const [mcpInventoryRequest, setMcpInventoryRequest] =
     useState<McpInventoryPanelRequest>();
   const mcpInventoryRequestSequence = useRef(0);
@@ -3139,6 +3352,32 @@ export function ThreadView(props: ThreadViewProps) {
         masthead={props.mastheadActions}
         history={props.historyNav}
         starMap={props.starMap}
+        rewind={
+          selectedThread?.source === "acp:grok"
+          && selectedThread.federation?.ref.target.scope !== "remote"
+            ? {
+                disabledReason: props.threadBusy
+                  ? "Wait for the active Grok turn to finish before rewinding"
+                  : undefined,
+                onOpen: () => {
+                  void openRewindDialog();
+                },
+              }
+            : undefined
+        }
+        workflowBudget={
+          selectedThread?.source === "acp:grok"
+          && selectedThread.federation?.ref.target.scope !== "remote"
+            ? {
+                disabledReason: props.threadBusy
+                  ? "Wait for the active Grok turn to finish before changing budgets"
+                  : undefined,
+                onOpen: () => {
+                  void openWorkflowBudgetDialog();
+                },
+              }
+            : undefined
+        }
       />
 
       <div
@@ -3497,6 +3736,212 @@ export function ThreadView(props: ThreadViewProps) {
               : undefined
           }
         />
+      ) : null}
+
+      {rewindDialog ? (
+        <div className="workspace-handoff-modal">
+          <div
+            aria-labelledby="grok-rewind-title"
+            aria-modal="true"
+            className="workspace-handoff-dialog rewind-dialog"
+            role="dialog"
+          >
+            <div className="workspace-handoff-dialog__header">
+              <h2 id="grok-rewind-title">Rewind Grok conversation</h2>
+              <button
+                aria-label="Close rewind dialog"
+                className="workspace-handoff-dialog__close"
+                disabled={rewindDialog.busy}
+                type="button"
+                onClick={() => setRewindDialog(undefined)}
+              >
+                x
+              </button>
+            </div>
+            <p>
+              Choose the prompt to remove. That prompt and every later turn will be
+              discarded from Grok&apos;s active conversation.
+            </p>
+            {rewindDialog.loading ? (
+              <p role="status">Loading rewind points...</p>
+            ) : rewindDialog.points.length > 0 ? (
+              <div
+                aria-label="Grok conversation rewind points"
+                className="rewind-dialog__points"
+                role="radiogroup"
+              >
+                {rewindDialog.points.map((point) => (
+                  <button
+                    aria-checked={
+                      rewindDialog.selectedPromptIndex === point.promptIndex
+                    }
+                    className="rewind-dialog__point"
+                    disabled={rewindDialog.busy}
+                    key={point.promptIndex}
+                    role="radio"
+                    type="button"
+                    onClick={() => setRewindDialog((current) => current
+                      ? { ...current, selectedPromptIndex: point.promptIndex }
+                      : current)}
+                  >
+                    <span>{point.promptPreview}</span>
+                    <small>
+                      Prompt {point.promptIndex + 1}
+                      {point.createdAt
+                        ? ` · ${new Date(point.createdAt).toLocaleString()}`
+                        : ""}
+                    </small>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p role="status">This conversation has no rewind points.</p>
+            )}
+            <p className="rewind-dialog__warning">
+              Files stay exactly as they are. Grok does not provide undo for the
+              discarded conversation branch, and PwrAgent cannot fork ACP threads yet.
+            </p>
+            {rewindDialog.error ? (
+              <p className="rewind-dialog__error" role="alert">
+                {rewindDialog.error}
+              </p>
+            ) : null}
+            <div className="rewind-dialog__actions">
+              <button
+                disabled={rewindDialog.busy}
+                type="button"
+                onClick={() => setRewindDialog(undefined)}
+              >
+                Cancel
+              </button>
+              <button
+                className="rewind-dialog__confirm"
+                disabled={
+                  rewindDialog.busy
+                  || rewindDialog.loading
+                  || rewindDialog.selectedPromptIndex === undefined
+                }
+                type="button"
+                onClick={() => {
+                  void executeRewind();
+                }}
+              >
+                {rewindDialog.busy ? "Rewinding..." : "Rewind conversation"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {workflowBudgetDialog ? (
+        <div className="workspace-handoff-modal">
+          <div
+            aria-labelledby="grok-workflow-budget-title"
+            aria-modal="true"
+            className="workspace-handoff-dialog rewind-dialog"
+            role="dialog"
+          >
+            <div className="workspace-handoff-dialog__header">
+              <h2 id="grok-workflow-budget-title">Grok workflow budgets</h2>
+              <button
+                aria-label="Close workflow budget dialog"
+                className="workspace-handoff-dialog__close"
+                disabled={workflowBudgetDialog.busy}
+                type="button"
+                onClick={() => setWorkflowBudgetDialog(undefined)}
+              >
+                x
+              </button>
+            </div>
+            <p>
+              These limits apply to child-agent calls in model-launched workflows for
+              this resident Grok session.
+            </p>
+            {workflowBudgetDialog.loading ? (
+              <p role="status">Loading workflow budgets...</p>
+            ) : (
+              <div className="workflow-budget-dialog__fields">
+                <label>
+                  <span>Default when omitted</span>
+                  <input
+                    disabled={workflowBudgetDialog.busy}
+                    max={1024}
+                    min={1}
+                    step={1}
+                    type="number"
+                    value={workflowBudgetDialog.defaultAgentBudget}
+                    onChange={(event) => setWorkflowBudgetDialog((current) =>
+                      current
+                        ? {
+                            ...current,
+                            defaultAgentBudget: event.target.value,
+                            error: undefined,
+                          }
+                        : current)}
+                  />
+                  <small>
+                    Used only when a workflow does not pass its own agent_budget.
+                  </small>
+                </label>
+                <label>
+                  <span>Enforced maximum</span>
+                  <input
+                    disabled={workflowBudgetDialog.busy}
+                    max={1024}
+                    min={1}
+                    step={1}
+                    type="number"
+                    value={workflowBudgetDialog.maxAgentBudget}
+                    onChange={(event) => setWorkflowBudgetDialog((current) =>
+                      current
+                        ? {
+                            ...current,
+                            error: undefined,
+                            maxAgentBudget: event.target.value,
+                          }
+                        : current)}
+                  />
+                  <small>
+                    Explicit workflow budgets above this value are rejected, not clamped.
+                  </small>
+                </label>
+              </div>
+            )}
+            <p>
+              Valid range: 1-1024. The policy is session-only and resets when the
+              Grok process restarts; existing workflow runs keep their admitted budget.
+            </p>
+            {workflowBudgetDialog.error ? (
+              <p className="rewind-dialog__error" role="alert">
+                {workflowBudgetDialog.error}
+              </p>
+            ) : null}
+            <div className="rewind-dialog__actions">
+              <button
+                disabled={workflowBudgetDialog.busy}
+                type="button"
+                onClick={() => setWorkflowBudgetDialog(undefined)}
+              >
+                Cancel
+              </button>
+              <button
+                className="button--primary"
+                disabled={
+                  workflowBudgetDialog.busy
+                  || workflowBudgetDialog.loading
+                  || !workflowBudgetDialog.defaultAgentBudget
+                  || !workflowBudgetDialog.maxAgentBudget
+                }
+                type="button"
+                onClick={() => {
+                  void saveWorkflowBudget();
+                }}
+              >
+                {workflowBudgetDialog.busy ? "Saving..." : "Save budgets"}
+              </button>
+            </div>
+          </div>
+        </div>
       ) : null}
 
       {branchDriftDialog && selectedThread ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
@@ -100,4 +100,36 @@ describe("ThreadHeader", () => {
     expect(toggle).toHaveAttribute("aria-pressed", "false");
     expect(toggle).toHaveTextContent("");
   });
+
+  it("opens Grok conversation rewind from the header control", () => {
+    const onOpen = vi.fn();
+    render(
+      <ThreadHeader
+        rewind={{ onOpen }}
+        thread={{ ...thread, source: "acp:grok" }}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Rewind Grok conversation" }),
+    );
+
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("opens Grok workflow budgets from the header control", () => {
+    const onOpen = vi.fn();
+    render(
+      <ThreadHeader
+        thread={{ ...thread, source: "acp:grok" }}
+        workflowBudget={{ onOpen }}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Configure Grok workflow budgets" }),
+    );
+
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -234,6 +234,131 @@ describe("ThreadView", () => {
     cleanup();
   });
 
+  it("rewinds Grok with the explicit conversation-only UI flow", async () => {
+    const listAcpThreadRewindPoints = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      threadId: "grok-thread",
+      rewindPoints: [
+        {
+          promptIndex: 0,
+          fileSnapshotCount: 1,
+          hasFileChanges: true,
+          promptPreview: "Write a breakfast poem",
+        },
+      ],
+    }));
+    const rewindAcpThread = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      threadId: "grok-thread",
+      targetPromptIndex: 0,
+    }));
+    const onReloadThread = vi.fn(async () => undefined);
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        desktopApi={{ listAcpThreadRewindPoints, rewindAcpThread }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        onLoadOlder={async () => undefined}
+        onReloadThread={onReloadThread}
+        removeOptimisticMessage={(_id) => undefined}
+        selectedThread={{
+          id: "grok-thread",
+          title: "Breakfast",
+          titleSource: "explicit",
+          source: "acp:grok",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Rewind Grok conversation" }),
+    );
+    expect(await screen.findByText("Write a breakfast poem")).toBeInTheDocument();
+    expect(screen.getByText(/Files stay exactly as they are/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Rewind conversation" }));
+
+    await waitFor(() => {
+      expect(rewindAcpThread).toHaveBeenCalledWith({
+        backend: "acp:grok",
+        threadId: "grok-thread",
+        targetPromptIndex: 0,
+      });
+      expect(onReloadThread).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("reads and updates distinct Grok workflow default and maximum budgets", async () => {
+    const configureGrokWorkflowBudget = vi
+      .fn()
+      .mockResolvedValueOnce({
+        backend: "acp:grok",
+        threadId: "grok-thread",
+        policy: { defaultAgentBudget: 128, maxAgentBudget: 1024 },
+      })
+      .mockResolvedValueOnce({
+        backend: "acp:grok",
+        threadId: "grok-thread",
+        policy: { defaultAgentBudget: 64, maxAgentBudget: 256 },
+      });
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        desktopApi={{ configureGrokWorkflowBudget }}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        selectedThread={{
+          id: "grok-thread",
+          title: "Breakfast",
+          titleSource: "explicit",
+          source: "acp:grok",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Configure Grok workflow budgets" }),
+    );
+    const defaultInput = await screen.findByRole("spinbutton", {
+      name: /Default when omitted/,
+    });
+    const maximumInput = screen.getByRole("spinbutton", {
+      name: /Enforced maximum/,
+    });
+    fireEvent.change(defaultInput, { target: { value: "64" } });
+    fireEvent.change(maximumInput, { target: { value: "256" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save budgets" }));
+
+    await waitFor(() => {
+      expect(configureGrokWorkflowBudget).toHaveBeenLastCalledWith({
+        backend: "acp:grok",
+        threadId: "grok-thread",
+        defaultAgentBudget: 64,
+        maxAgentBudget: 256,
+      });
+    });
+  });
+
   it("shows draggable empty thread chrome with messaging status", async () => {
     const statuses = [
       {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -251,6 +251,7 @@ describe("ThreadView", () => {
       backend: "acp:grok" as const,
       threadId: "grok-thread",
       targetPromptIndex: 0,
+      updatedAt: 2000,
     }));
     const onReloadThread = vi.fn(async () => undefined);
     render(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -4311,6 +4311,64 @@ describe("useThreadNavigation", () => {
     expect(result.current.threads[0]?.title).toBe("Newer remote title");
   });
 
+  it("patches thread activity immediately when a rewind notification arrives", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const navigationSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: ["acp:grok:grok-thread"],
+      threads: [{
+        id: "grok-thread",
+        title: "Breakfast poem",
+        titleSource: "explicit",
+        source: "acp:grok",
+        linkedDirectories: [],
+        inbox: { inInbox: true, reason: "new-thread" },
+        threadStatus: "active",
+        updatedAt: 1_000,
+      }],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => navigationSnapshot),
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(1);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:grok",
+        notification: {
+          method: "thread/rewound",
+          params: {
+            threadId: "grok-thread",
+            targetPromptIndex: 0,
+            updatedAt: 2_000,
+          },
+        },
+      });
+    });
+
+    expect(result.current.threads[0]).toMatchObject({
+      id: "grok-thread",
+      threadStatus: "idle",
+      updatedAt: 2_000,
+    });
+  });
+
   it("isolates observed names for same-id threads owned by different peers", async () => {
     const firstTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1631,6 +1631,76 @@ describe("useThreadSessionState", () => {
     unmount();
   });
 
+  it("invalidates loaded transcript history after a rewind notification", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [messageEntry({
+          id: "discarded-message",
+          role: "assistant",
+          text: "Discarded branch",
+          createdAt: 1_000,
+        })],
+        hasPreviousPage: false,
+      }))
+      .mockResolvedValue(readThreadResponse({
+        entries: [messageEntry({
+          id: "retained-message",
+          role: "assistant",
+          text: "Retained branch",
+          createdAt: 900,
+        })],
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+    await waitForThreadHydration(result);
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Discarded branch",
+    ]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/rewound",
+          params: {
+            threadId: "thread-1",
+            targetPromptIndex: 0,
+            updatedAt: 2_000,
+          },
+        },
+      });
+    });
+    expect(result.current.entries).toEqual([]);
+
+    rerender({ updatedAt: 2_000 });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Retained branch",
+      ]);
+    });
+  });
+
   it("releases older-history loading when a fresher hydration supersedes it", async () => {
     const initialTail = readThreadResponse({
       entries: [

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -74,6 +74,8 @@ import type {
   DraftAutomationPromptResponse,
   ConfigureFederationTailscaleRequest,
   ConfigureFederationTailscaleResponse,
+  ConfigureGrokWorkflowBudgetRequest,
+  ConfigureGrokWorkflowBudgetResponse,
   GetAutomationRunArtifactRequest,
   GetAutomationRunArtifactResponse,
   EnsureDirectoryLaunchpadRequest,
@@ -87,6 +89,8 @@ import type {
   StopSubAgentRequest,
   StopSubAgentResponse,
   LatestCodexConfigWarningResponse,
+  ListAcpThreadRewindPointsRequest,
+  ListAcpThreadRewindPointsResponse,
   ListAutomationReplayCandidatesRequest,
   ListAutomationReplayCandidatesResponse,
   OpenAutomationRunWindowRequest,
@@ -288,6 +292,8 @@ import type {
   QueueThreadExecutionModeResponse,
   ReloadCodexMcpConfigRequest,
   ReloadCodexMcpConfigResponse,
+  RewindAcpThreadRequest,
+  RewindAcpThreadResponse,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
@@ -694,6 +700,15 @@ export type DesktopApi = {
     request: StopSubAgentRequest,
   ) => Promise<StopSubAgentResponse>;
   steerTurn?: (request: SteerTurnRequest) => Promise<SteerTurnResponse>;
+  listAcpThreadRewindPoints?: (
+    request: ListAcpThreadRewindPointsRequest,
+  ) => Promise<ListAcpThreadRewindPointsResponse>;
+  rewindAcpThread?: (
+    request: RewindAcpThreadRequest,
+  ) => Promise<RewindAcpThreadResponse>;
+  configureGrokWorkflowBudget?: (
+    request: ConfigureGrokWorkflowBudgetRequest,
+  ) => Promise<ConfigureGrokWorkflowBudgetResponse>;
   setThreadExecutionMode?: (
     request: SetThreadExecutionModeRequest
   ) => Promise<SetThreadExecutionModeResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1796,6 +1796,46 @@ function applyThreadNameUpdate(
     : snapshot;
 }
 
+function applyThreadRewindUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
+    threadId: string;
+    updatedAt: number;
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (
+      thread.source !== params.backend
+      || thread.id !== params.threadId
+      || !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
+      return thread;
+    }
+    const updatedAt = Math.max(thread.updatedAt ?? 0, params.updatedAt);
+    if (thread.updatedAt === updatedAt && thread.threadStatus === "idle") {
+      return thread;
+    }
+    changed = true;
+    return {
+      ...thread,
+      threadStatus: "idle" as const,
+      updatedAt,
+    };
+  });
+
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
 function applyThreadStatusUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -4001,6 +4041,33 @@ export function useThreadNavigation(
             titleSource: "explicit",
           };
         });
+        return;
+      }
+
+      if (method === "thread/rewound") {
+        const { threadId, updatedAt } = event.notification.params as {
+          threadId: string;
+          updatedAt: number;
+        };
+        setState((current) => ({
+          ...current,
+          response: applyThreadRewindUpdate(current.response, {
+            backend: event.backend,
+            federationTarget: event.federationTarget,
+            threadId,
+            updatedAt,
+          }),
+        }));
+        setOptimisticThread((current) =>
+          current && agentEventMatchesThread(event, current, threadId)
+            ? {
+                ...current,
+                threadStatus: "idle",
+                updatedAt: Math.max(current.updatedAt ?? 0, updatedAt),
+              }
+            : current
+        );
+        scheduleRefresh();
         return;
       }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3617,6 +3617,7 @@ export function useThreadSessionState(params: {
   loading: boolean;
   loadingMore: boolean;
   loadOlder: () => Promise<void>;
+  reload: () => Promise<void>;
   messages: AppServerThreadMessage[];
   contextWindow?: ThreadContextWindowState;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
@@ -4054,6 +4055,12 @@ export function useThreadSessionState(params: {
       updateSession,
     ]
   );
+
+  const reload = useCallback(async (): Promise<void> => {
+    if (thread) {
+      await loadLatest(thread);
+    }
+  }, [loadLatest, thread]);
 
   useEffect(() => {
     if (!threadKey) {
@@ -6111,6 +6118,7 @@ export function useThreadSessionState(params: {
     loading: selectedSession?.loading ?? false,
     loadingMore: selectedSession?.loadingMore ?? false,
     loadOlder,
+    reload,
     messages,
     contextWindow: selectedSession?.contextWindow,
     pendingAssistantMessage: selectedSession?.pendingAssistantMessage,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3469,6 +3469,7 @@ const TRANSIENT_MESSAGE_SETTLEMENT_METHODS = new Set([
   "item/mcpToolCall/progress",
   "item/started",
   "thread/compacted",
+  "thread/rewound",
   "turn/cancelled",
   "turn/completed",
   "turn/failed",
@@ -3504,7 +3505,10 @@ function transitionTransientMessagesAtBoundary(
   current: ThreadSessionEntry,
   notification: AppServerNotification
 ): ThreadSessionEntry {
-  if (notification.method === "thread/compacted") {
+  if (
+    notification.method === "thread/compacted"
+    || notification.method === "thread/rewound"
+  ) {
     if (
       !current.transientMessage &&
       current.settledTransientMessages.length === 0
@@ -3547,6 +3551,7 @@ function transitionTransientMessagesAtBoundary(
   if (
     notification.method !== "turn/started" &&
     notification.method !== "thread/compacted" &&
+    notification.method !== "thread/rewound" &&
     statusType !== "idle" &&
     notificationTurnId &&
     transientTurnId &&
@@ -5366,7 +5371,10 @@ export function useThreadSessionState(params: {
           }
         }
 
-        if (event.notification.method === "thread/compacted") {
+        if (
+          event.notification.method === "thread/compacted"
+          || event.notification.method === "thread/rewound"
+        ) {
           delete loadedHistoryIndexesRef.current[targetThreadKey];
           return {
             ...current,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1621,7 +1621,8 @@ textarea,
   pointer-events: none;
 }
 
-.thread-header__terminal-toggle {
+.thread-header__terminal-toggle,
+.thread-header__rewind-toggle {
   display: inline-flex;
   width: 24px;
   height: 24px;
@@ -1642,16 +1643,20 @@ textarea,
 }
 
 .thread-header__terminal-toggle,
-.thread-header__terminal-toggle * {
+.thread-header__terminal-toggle *,
+.thread-header__rewind-toggle,
+.thread-header__rewind-toggle * {
   -webkit-app-region: no-drag;
 }
 
-.thread-header__terminal-toggle:hover {
+.thread-header__terminal-toggle:hover,
+.thread-header__rewind-toggle:hover {
   background: var(--bg-row-active);
   color: var(--text-primary);
 }
 
-.thread-header__terminal-toggle:focus-visible {
+.thread-header__terminal-toggle:focus-visible,
+.thread-header__rewind-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
@@ -1660,13 +1665,15 @@ textarea,
    stays visible (the terminal exists as a concept) but reads inert, with the
    tooltip carrying the reason. aria-disabled, not disabled, so hover still
    reaches it and the tooltip can explain why. */
-.thread-header__terminal-toggle.is-disabled {
+.thread-header__terminal-toggle.is-disabled,
+.thread-header__rewind-toggle.is-disabled {
   color: var(--text-muted);
   opacity: 0.45;
   cursor: default;
 }
 
-.thread-header__terminal-toggle.is-disabled:hover {
+.thread-header__terminal-toggle.is-disabled:hover,
+.thread-header__rewind-toggle.is-disabled:hover {
   background: transparent;
   color: var(--text-muted);
 }
@@ -23391,6 +23398,141 @@ a.transcript-message__messaging-origin:focus-visible {
   font-weight: 600;
   line-height: 1.35;
   overflow-wrap: break-word;
+}
+
+.rewind-dialog {
+  width: min(560px, 100%);
+}
+
+.rewind-dialog__points {
+  display: grid;
+  max-height: min(320px, 45vh);
+  gap: 6px;
+  margin-top: 14px;
+  overflow-y: auto;
+}
+
+.rewind-dialog__point {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rewind-dialog__point:hover,
+.rewind-dialog__point:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  outline: none;
+}
+
+.rewind-dialog__point[aria-checked="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+}
+
+.rewind-dialog__point small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.workspace-handoff-dialog p.rewind-dialog__warning {
+  color: var(--danger-text);
+}
+
+.workspace-handoff-dialog p.rewind-dialog__error {
+  color: var(--danger-text);
+}
+
+.rewind-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.rewind-dialog__actions button {
+  padding: 6px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.rewind-dialog__actions button:hover:not(:disabled),
+.rewind-dialog__actions button:focus-visible:not(:disabled) {
+  border-color: var(--border-strong);
+  outline: none;
+}
+
+.rewind-dialog__actions .rewind-dialog__confirm {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger-text);
+}
+
+.rewind-dialog__actions button:disabled,
+.rewind-dialog__point:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+}
+
+.workflow-budget-dialog__fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.workflow-budget-dialog__fields label {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.workflow-budget-dialog__fields input {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.workflow-budget-dialog__fields input:focus-visible {
+  border-color: var(--accent-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.workflow-budget-dialog__fields small {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.35;
+}
+
+@media (max-width: 620px) {
+  .workflow-budget-dialog__fields {
+    grid-template-columns: 1fr;
+  }
 }
 
 .workspace-handoff-dialog__summary {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -99,6 +99,11 @@ export const CODEX_MCP_SERVER_REMOVE_CHANNEL = "codex-mcp-server:remove";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
 export const AGENT_STOP_SUB_AGENT_CHANNEL = "agent:stop-sub-agent";
 export const AGENT_STEER_TURN_CHANNEL = "agent:steer-turn";
+export const AGENT_LIST_ACP_THREAD_REWIND_POINTS_CHANNEL =
+  "agent:list-acp-thread-rewind-points";
+export const AGENT_REWIND_ACP_THREAD_CHANNEL = "agent:rewind-acp-thread";
+export const AGENT_CONFIGURE_GROK_WORKFLOW_BUDGET_CHANNEL =
+  "agent:configure-grok-workflow-budget";
 export const AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL = "agent:set-thread-execution-mode";
 export const AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL =
   "agent:queue-thread-execution-mode";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -1,4 +1,5 @@
 import type {
+  AcpBackendId,
   AppServerBackendKind,
   AppServerMcpElicitationResponse,
   AppServerNotification,
@@ -530,6 +531,59 @@ export type SteerTurnResponse = {
   turnId: string;
   disposition?: "steered" | "scheduled";
   scheduledAction?: ScheduledThreadAction;
+};
+
+export type AcpThreadRewindPoint = {
+  promptIndex: number;
+  createdAt?: number;
+  fileSnapshotCount: number;
+  hasFileChanges: boolean;
+  promptPreview: string;
+};
+
+export type ListAcpThreadRewindPointsRequest = {
+  backend: AcpBackendId;
+  federationTarget?: FederationTarget;
+  threadId: ThreadIdentifier;
+};
+
+export type ListAcpThreadRewindPointsResponse = {
+  backend: AcpBackendId;
+  threadId: ThreadIdentifier;
+  rewindPoints: AcpThreadRewindPoint[];
+};
+
+export type RewindAcpThreadRequest = {
+  backend: AcpBackendId;
+  federationTarget?: FederationTarget;
+  threadId: ThreadIdentifier;
+  targetPromptIndex: number;
+};
+
+export type RewindAcpThreadResponse = {
+  backend: AcpBackendId;
+  threadId: ThreadIdentifier;
+  targetPromptIndex: number;
+  promptText?: string;
+};
+
+export type GrokWorkflowBudgetPolicy = {
+  defaultAgentBudget: number;
+  maxAgentBudget: number;
+};
+
+export type ConfigureGrokWorkflowBudgetRequest = {
+  backend: "acp:grok";
+  federationTarget?: FederationTarget;
+  threadId: ThreadIdentifier;
+  defaultAgentBudget?: number;
+  maxAgentBudget?: number;
+};
+
+export type ConfigureGrokWorkflowBudgetResponse = {
+  backend: "acp:grok";
+  threadId: ThreadIdentifier;
+  policy: GrokWorkflowBudgetPolicy;
 };
 
 export type SetThreadExecutionModeRequest = {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -366,7 +366,7 @@ export type ControlActiveTurnResponse =
       threadId: ThreadIdentifier;
       requestId: string;
       turnId: string;
-      disposition: "interrupted" | "steered";
+      disposition: "interrupted" | "queued" | "steered";
       idempotentReplay?: boolean;
     }
   | {
@@ -529,7 +529,7 @@ export type SteerTurnResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   turnId: string;
-  disposition?: "steered" | "scheduled";
+  disposition?: "queued" | "steered" | "scheduled";
   scheduledAction?: ScheduledThreadAction;
 };
 
@@ -564,6 +564,7 @@ export type RewindAcpThreadResponse = {
   backend: AcpBackendId;
   threadId: ThreadIdentifier;
   targetPromptIndex: number;
+  updatedAt: number;
   promptText?: string;
 };
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1472,6 +1472,14 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/rewound";
+      params: {
+        threadId: string;
+        targetPromptIndex: number;
+        updatedAt: number;
+      };
+    }
+  | {
       method: "thread/executionMode/updated";
       params: {
         threadId: string;


### PR DESCRIPTION
## What

- route active Grok ACP turns through the new `_x.ai/session/steer` extension
- add a Grok-only transcript rewind control backed by `_x.ai/rewind/points` and `_x.ai/rewind/execute`
- add separate default and enforced-maximum workflow agent-budget controls backed by `_x.ai/session/workflow_budget`
- preserve local replay correctness after an in-place rewind

## Why

Grok Build 1.0.4 added native-TUI steering, but the stable ACP surface had no equivalent. Grok Build 1.0.1 added per-workflow agent budgets and conversation rewind, but PwrAgent had no controls for either feature.

## Safety and scope

- rewind always uses `conversation_only`; it never rewinds files
- the confirmation dialog explicitly warns that discarded conversation turns cannot be restored
- controls are limited to local Grok ACP threads and disabled while a turn is active
- workflow budget changes are resident-session policy and do not alter already-running workflows
- remote viewer support is deliberately excluded for now

## Paired Grok change

Requires https://github.com/pwrdrvr/grok-build/pull/7 for ACP steering and enforced workflow-budget policy. Rewind uses extensions already present in the current Grok build.

## Validation

- 902 focused tests across 8 ACP, registry, IPC, and renderer files
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- live configured-account smoke test against the paired release build: policy changed from 128/1024 to 4/8 and a tiny breakfast-poem steer reported `currentTurn`
- paired Grok release binary built successfully
