### PR TITLE
feat(desktop): visualize replay cost in the incident explorer

### DIFF
--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -608,3 +608,26 @@ function buildOutputInvocation(outputChars: number): ThreadToolInvocationRecord 
     turnId: "turn-1",
   };
 }
+
+describe("mcp invocation identity", () => {
+  it("categorizes by the protocol item type and keeps the server", () => {
+    /* The item declares itself: {type: "mcpToolCall", server, tool}. The
+       name-substring fallback filed Context7's `query-docs` under unknown
+       while `list_mcp_resources` matched by accident. */
+    expect(normalizeToolInvocationCommand({
+      itemType: "mcpToolCall",
+      server: "context7",
+      toolName: "query-docs",
+    })).toEqual({
+      category: "mcp",
+      normalizedCommand: "context7/query-docs",
+    });
+  });
+
+  it("still categorizes as mcp when the server is not recorded", () => {
+    expect(normalizeToolInvocationCommand({
+      itemType: "mcpToolCall",
+      toolName: "query-docs",
+    })).toEqual({ category: "mcp", normalizedCommand: "query-docs" });
+  });
+});

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -6,16 +6,23 @@ import type {
   ThreadToolInvocationRecord,
   ThreadToolInvocationStatus,
 } from "@pwragent/shared";
-import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import {
+  buildThreadToolIncidentPrompt,
+  TOOL_OUTPUT_CAP_CHARS,
+  TOOL_OUTPUT_TOKEN_CHAR_RATIO,
+  TOOL_OUTPUT_WARNING_CHARS,
+} from "@pwragent/shared";
 import { redactCommandText } from "../util/redact-command-text";
 
-const OUTPUT_TOKEN_CHAR_RATIO = 4;
+/* Shared with the incident explorer so its meters are drawn against the same
+   cap this detector reasons about. */
+const OUTPUT_TOKEN_CHAR_RATIO = TOOL_OUTPUT_TOKEN_CHAR_RATIO;
 const NOISY_POLL_LOOKBACK_MS = 5 * 60 * 1000;
 const NOISY_POLL_MIN_INVOCATIONS = 5;
 const NOISY_POLL_MIN_INTERVAL_MS = 15_000;
 const NOISY_POLL_MAX_INTERVAL_MS = 75_000;
-const LARGE_OUTPUT_WARNING_CHARS = 4_000;
-const LARGE_OUTPUT_CRITICAL_CHARS = 40_000;
+const LARGE_OUTPUT_WARNING_CHARS = TOOL_OUTPUT_WARNING_CHARS;
+const LARGE_OUTPUT_CRITICAL_CHARS = TOOL_OUTPUT_CAP_CHARS;
 const ACCOUNTED_TOOL_ITEM_TYPES = new Set([
   "commandExecution",
   "dynamicToolCall",

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -242,6 +242,8 @@ export function toolInvocationFromNotification(params: {
   const normalized = normalizeToolInvocationCommand({
     args,
     command,
+    itemType,
+    ...(readString(item, "server") ? { server: readString(item, "server") } : {}),
     toolName,
   });
   const processId =
@@ -409,9 +411,23 @@ export function mergeToolInvocationLifecycleWithStreamedOutput(
 export function normalizeToolInvocationCommand(params: {
   args?: Record<string, unknown>;
   command?: string;
+  itemType?: string;
+  server?: string;
   toolName: string;
 }): NormalizedToolCommand {
   const toolName = params.toolName.trim() || "unknown";
+  /* MCP is declared by the protocol item, not inferred from the name. The
+     name-substring fallback below filed Context7's `query-docs` under
+     unknown while `list_mcp_resources` matched by luck. The server joins the
+     stored identity so surfaces can split cost per MCP. */
+  if (params.itemType === "mcpToolCall" || params.server) {
+    return {
+      category: "mcp",
+      normalizedCommand: params.server
+        ? `${params.server}/${toolName}`
+        : toolName,
+    };
+  }
   if (toolName === "write_stdin") {
     const sessionId = readString(params.args, "session_id") ??
       readString(params.args, "sessionId");

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -399,6 +399,15 @@ export function ToolOutputIncidentExplorerWindow() {
               </button>
             ))}
           </div>
+          <TurnTimeline
+            {...(currency ? { currency } : {})}
+            now={renderedAt}
+            onSelect={(row) => setTurnFilter(
+              turnFilter === row.key ? undefined : row.key,
+            )}
+            selectedKey={turnFilter}
+            timeline={turnStrip.timeline}
+          />
         </div>
       </div>
 
@@ -762,6 +771,73 @@ function TurnStrip(props: {
         </p>
       ) : null}
     </section>
+  );
+}
+
+/**
+ * The whole thread, one column per turn, in time order. Tokens above, round
+ * trips below on a shared axis — a long poll is a stretch of trip spikes with
+ * no matching output, which no ranked list can show because ranking discards
+ * adjacency. Hover carries the numbers; click filters cases to the turn.
+ */
+function TurnTimeline(props: {
+  currency?: string;
+  now: number;
+  onSelect: (row: TurnCostRow) => void;
+  selectedKey?: string;
+  timeline: TurnCostRow[];
+}) {
+  if (props.timeline.length < 2) return null;
+  const maxTokens = props.timeline.reduce(
+    (max, row) => Math.max(max, row.estimatedOutputTokens),
+    0,
+  );
+  const maxCalls = props.timeline.reduce(
+    (max, row) => Math.max(max, row.callCount),
+    0,
+  );
+  return (
+    <div className="incident-explorer__timeline-block">
+      <p className="incident-explorer__eyebrow">When it went</p>
+      <div
+        aria-label="Tool cost per turn, in order"
+        className="incident-explorer__timeline"
+        role="group"
+      >
+        {props.timeline.map((row) => {
+          const description = [
+            row.label,
+            formatTurnWhen(row.firstObservedAt, props.now),
+            `${formatCompactTokens(row.estimatedOutputTokens)} tok`,
+            `${row.callCount.toLocaleString()} ${row.callCount === 1 ? "call" : "calls"}`,
+            ...(row.costMicros !== undefined
+              ? [formatMicrosCurrency(row.costMicros, props.currency)]
+              : []),
+          ].join(" · ");
+          return (
+            <button
+              aria-label={description}
+              aria-pressed={props.selectedKey === row.key}
+              className="incident-explorer__timeline-turn"
+              key={row.key}
+              onClick={() => props.onSelect(row)}
+              title={description}
+              type="button"
+            >
+              <span aria-hidden="true" className="incident-explorer__timeline-tokens">
+                <i
+                  data-critical={row.overCapCount > 0}
+                  style={{ height: `${scaleWidth(row.estimatedOutputTokens, maxTokens)}%` }}
+                />
+              </span>
+              <span aria-hidden="true" className="incident-explorer__timeline-trips">
+                <i style={{ height: `${scaleWidth(row.callCount, maxCalls)}%` }} />
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -31,6 +31,7 @@ import {
   formatCategoryLabel,
   formatCompactTokens,
   formatInvocationIdentity,
+  formatMicrosCurrency,
   formatTurnWhen,
   invocationStatusTone,
   isOverOutputCap,
@@ -48,7 +49,7 @@ export function ToolOutputIncidentExplorerWindow() {
   const [accounting, setAccounting] = useState<ThreadToolAccounting>();
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
-  const [category, setCategory] = useState<RefinedToolCategory | "all">("all");
+  const [category, setCategory] = useState<RefinedToolCategory | "all" | "other">("all");
   const [turnFilter, setTurnFilter] = useState<string>();
   const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
@@ -118,8 +119,24 @@ export function ToolOutputIncidentExplorerWindow() {
     [allInvocations],
   );
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
-  const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
+  const usageLines = latest?.pricing?.lines;
+  const turnStrip = useMemo(
+    () => buildTurnCostStrip(allInvocations, {
+      ...(usageLines ? { usageLines } : {}),
+    }),
+    [allInvocations, usageLines],
+  );
+  const currency = usageLines?.[0]?.currency;
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
+  /* Which refined categories the active legend entry stands for. "Other" is a
+     real set, not a leftover, so selecting it filters to its members. */
+  const selectedCategories = useMemo(() => {
+    if (category === "all") return undefined;
+    const entry = composition.find((share) => share.category === category);
+    /* A refresh can retire the selected category. Showing everything is the
+       safer failure than an unexplained empty list. */
+    return entry ? new Set<RefinedToolCategory>(entry.members) : undefined;
+  }, [category, composition]);
   const repeatedCommands = useMemo(
     () => countRepeatedCommands(flagged),
     [flagged],
@@ -132,7 +149,7 @@ export function ToolOutputIncidentExplorerWindow() {
     const normalizedSearch = search.trim().toLowerCase();
     return sortIncidentCases(
       flagged.filter((invocation) =>
-        (category === "all" || refineToolCategory(invocation) === category)
+        (!selectedCategories || selectedCategories.has(refineToolCategory(invocation)))
         && (turnFilter === undefined || (invocation.turnId ?? "") === turnFilter)
         && (
           !normalizedSearch
@@ -144,7 +161,7 @@ export function ToolOutputIncidentExplorerWindow() {
       ),
       sortMode,
     );
-  }, [category, flagged, search, sortMode, turnFilter]);
+  }, [flagged, search, selectedCategories, sortMode, turnFilter]);
   const selected = invocations.find((invocation) => invocation.invocationId === selectedId)
     ?? invocations[0];
 
@@ -358,11 +375,13 @@ export function ToolOutputIncidentExplorerWindow() {
               <button
                 aria-pressed={category === entry.category}
                 className="incident-explorer__legend-item"
-                disabled={entry.category === "other"}
                 key={entry.category}
                 onClick={() => setCategory(
-                  entry.category === "other" ? "all" : entry.category,
+                  category === entry.category ? "all" : entry.category,
                 )}
+                title={entry.category === "other"
+                  ? entry.members.map(formatCategoryLabel).join(", ")
+                  : undefined}
                 type="button"
               >
                 <i
@@ -381,7 +400,9 @@ export function ToolOutputIncidentExplorerWindow() {
       </div>
 
       <TurnStrip
+        {...(currency ? { currency } : {})}
         now={renderedAt}
+        showCost={turnStrip.rows.some((row) => row.costMicros !== undefined)}
         onSelect={(row) => setTurnFilter(
           turnFilter === row.key ? undefined : row.key,
         )}
@@ -639,9 +660,11 @@ function CompositionBar(props: { composition: CategoryShare[] }) {
  * the two need to be told apart at a glance.
  */
 function TurnStrip(props: {
+  currency?: string;
   /* Captured once by the caller so every row in a render measures "ago"
      against the same instant. */
   now: number;
+  showCost: boolean;
   onSelect: (row: TurnCostRow) => void;
   selectedKey?: string;
   strip: TurnCostStrip;
@@ -663,6 +686,7 @@ function TurnStrip(props: {
         <button
           aria-pressed={props.selectedKey === row.key}
           className="incident-explorer__turn"
+          data-cost={props.showCost}
           key={row.key}
           onClick={() => props.onSelect(row)}
           type="button"
@@ -688,6 +712,13 @@ function TurnStrip(props: {
           <span className="incident-explorer__turn-number">
             {row.callCount.toLocaleString()} {row.callCount === 1 ? "call" : "calls"}
           </span>
+          {props.showCost ? (
+            <span className="incident-explorer__turn-cost">
+              {row.costMicros !== undefined
+                ? formatMicrosCurrency(row.costMicros, props.currency)
+                : "—"}
+            </span>
+          ) : null}
         </button>
       ))}
       {props.strip.hiddenTurnCount > 0 ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -4,7 +4,6 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadActivityDetail,
   ThreadToolAccounting,
-  ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import {
@@ -19,6 +18,7 @@ import { detailMatchesInvocationItem } from "./tool-call-details";
 import type {
   CategoryShare,
   IncidentSortMode,
+  RefinedToolCategory,
   TurnCostRow,
   TurnCostStrip,
 } from "./tool-output-incident-insights";
@@ -26,12 +26,16 @@ import {
   buildCategoryComposition,
   buildTurnCostStrip,
   capMeterWidth,
+  countRepeatedCommands,
   formatCapShare,
   formatCategoryLabel,
   formatCompactTokens,
   formatInvocationIdentity,
+  formatTurnWhen,
   invocationStatusTone,
   isOverOutputCap,
+  refineToolCategory,
+  repeatCountFor,
   sortIncidentCases,
   summarizeIncidents,
 } from "./tool-output-incident-insights";
@@ -44,7 +48,7 @@ export function ToolOutputIncidentExplorerWindow() {
   const [accounting, setAccounting] = useState<ThreadToolAccounting>();
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
-  const [category, setCategory] = useState<ThreadToolInvocationCategory | "all">("all");
+  const [category, setCategory] = useState<RefinedToolCategory | "all">("all");
   const [turnFilter, setTurnFilter] = useState<string>();
   const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
@@ -116,6 +120,10 @@ export function ToolOutputIncidentExplorerWindow() {
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
   const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
+  const repeatedCommands = useMemo(
+    () => countRepeatedCommands(flagged),
+    [flagged],
+  );
   /* Every turn, not just the rows the strip had room for — a case in a turn
      that fell below the row limit still belongs to that turn. */
   const turnLabels = turnStrip.labelsByKey;
@@ -124,7 +132,7 @@ export function ToolOutputIncidentExplorerWindow() {
     const normalizedSearch = search.trim().toLowerCase();
     return sortIncidentCases(
       flagged.filter((invocation) =>
-        (category === "all" || invocation.category === category)
+        (category === "all" || refineToolCategory(invocation) === category)
         && (turnFilter === undefined || (invocation.turnId ?? "") === turnFilter)
         && (
           !normalizedSearch
@@ -181,6 +189,8 @@ export function ToolOutputIncidentExplorerWindow() {
   const canSendAsNewTurn = Boolean(!activeTurnId && desktopApi?.startTurn);
   const visibleOutputLines = filterOutputLines(output, outputSearch);
   const laterTripsInTurn = selected ? countLaterTripsInTurn(allInvocations, selected) : 0;
+  /* One clock read per render, shared by every turn row. */
+  const renderedAt = Date.now();
 
   const analyze = async (): Promise<void> => {
     if (!desktopApi?.analyzeThreadToolHistory) return;
@@ -351,9 +361,7 @@ export function ToolOutputIncidentExplorerWindow() {
                 disabled={entry.category === "other"}
                 key={entry.category}
                 onClick={() => setCategory(
-                  entry.category === "other"
-                    ? "all"
-                    : entry.category as ThreadToolInvocationCategory,
+                  entry.category === "other" ? "all" : entry.category,
                 )}
                 type="button"
               >
@@ -373,6 +381,7 @@ export function ToolOutputIncidentExplorerWindow() {
       </div>
 
       <TurnStrip
+        now={renderedAt}
         onSelect={(row) => setTurnFilter(
           turnFilter === row.key ? undefined : row.key,
         )}
@@ -439,7 +448,9 @@ export function ToolOutputIncidentExplorerWindow() {
                 <CaseRow
                   invocation={invocation}
                   key={invocation.invocationId}
+                  now={renderedAt}
                   onSelect={() => setSelectedId(invocation.invocationId)}
+                  repeatCount={repeatCountFor(invocation, repeatedCommands)}
                   selected={invocation.invocationId === selected?.invocationId}
                 />
               ))}
@@ -492,9 +503,16 @@ export function ToolOutputIncidentExplorerWindow() {
                     value={selected.exitCode !== undefined ? `exit ${selected.exitCode}` : "—"}
                   />
                   <Fact
-                    label={formatCategoryLabel(selected.category)}
+                    label={formatCategoryLabel(refineToolCategory(selected))}
                     value={turnLabels.get(selected.turnId ?? "") ?? "No turn"}
                   />
+                  {repeatCountFor(selected, repeatedCommands) > 1 ? (
+                    <Fact
+                      label="repeated"
+                      tone="warning"
+                      value={`${repeatCountFor(selected, repeatedCommands)}× in this thread`}
+                    />
+                  ) : null}
                   <Fact label="observed" value={formatTimestamp(selected.observedAt)} />
                   <Fact
                     label="output"
@@ -621,6 +639,9 @@ function CompositionBar(props: { composition: CategoryShare[] }) {
  * the two need to be told apart at a glance.
  */
 function TurnStrip(props: {
+  /* Captured once by the caller so every row in a render measures "ago"
+     against the same instant. */
+  now: number;
   onSelect: (row: TurnCostRow) => void;
   selectedKey?: string;
   strip: TurnCostStrip;
@@ -648,7 +669,9 @@ function TurnStrip(props: {
         >
           <span className="incident-explorer__turn-label">
             {row.label}
-            <span>{` · ${formatClockTime(row.firstObservedAt)}`}</span>
+            <span title={new Date(row.firstObservedAt).toLocaleString()}>
+              {` · ${formatTurnWhen(row.firstObservedAt, props.now)}`}
+            </span>
           </span>
           <span aria-hidden="true" className="incident-explorer__turn-bar">
             <i
@@ -679,7 +702,9 @@ function TurnStrip(props: {
 
 function CaseRow(props: {
   invocation: ThreadToolInvocationRecord;
+  now: number;
   onSelect: () => void;
+  repeatCount: number;
   selected: boolean;
 }) {
   const invocation = props.invocation;
@@ -692,7 +717,7 @@ function CaseRow(props: {
       className="incident-explorer__case"
       data-selected={props.selected}
       onClick={props.onSelect}
-      title={command}
+      title={`${command}\n${new Date(invocation.observedAt).toLocaleString()}`}
       type="button"
     >
       <span className="incident-explorer__case-top">
@@ -701,6 +726,16 @@ function CaseRow(props: {
           {identity.detail ? <span>{` ${identity.detail}`}</span> : null}
         </span>
         <span className="incident-explorer__case-tokens">
+          {props.repeatCount > 1 ? (
+            /* Re-running the identical read is its own finding: the turn
+               either lost the earlier result or the file keeps changing. */
+            <b
+              className="incident-explorer__repeat"
+              title={`This exact command ran ${props.repeatCount} times in this thread`}
+            >
+              {props.repeatCount}×
+            </b>
+          ) : null}
           {formatCompactTokens(invocation.estimatedOutputTokens)}
         </span>
       </span>
@@ -713,7 +748,7 @@ function CaseRow(props: {
       <span className="incident-explorer__case-sub">
         {formatCapShare(invocation.outputChars, { short: true })}
         {" · "}{invocation.outputChars.toLocaleString()} chars
-        {" · "}{formatClockTime(invocation.observedAt)}
+        {" · "}{formatTurnWhen(invocation.observedAt, props.now)}
       </span>
     </button>
   );
@@ -897,9 +932,3 @@ function formatTimestamp(timestamp: number): string {
   return new Date(timestamp).toLocaleString();
 }
 
-function formatClockTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -26,6 +26,7 @@ import {
   formatCategoryLabel,
   formatCompactTokens,
   formatInvocationIdentity,
+  invocationStatusTone,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
@@ -111,10 +112,9 @@ export function ToolOutputIncidentExplorerWindow() {
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
   const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
-  const turnLabels = useMemo(
-    () => new Map(turnStrip.rows.map((row) => [row.key, row.label])),
-    [turnStrip.rows],
-  );
+  /* Every turn, not just the rows the strip had room for — a case in a turn
+     that fell below the row limit still belongs to that turn. */
+  const turnLabels = turnStrip.labelsByKey;
 
   const invocations = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
@@ -468,7 +468,7 @@ export function ToolOutputIncidentExplorerWindow() {
                 <div className="incident-explorer__facts">
                   <Fact
                     label={selected.status}
-                    tone={selected.status === "failed" ? "error" : "ok"}
+                    tone={invocationStatusTone(selected)}
                     value={selected.exitCode !== undefined ? `exit ${selected.exitCode}` : "—"}
                   />
                   <Fact
@@ -649,7 +649,7 @@ function TurnStrip(props: {
       ))}
       {props.strip.hiddenTurnCount > 0 ? (
         <p className="incident-explorer__turns-note">
-          {props.strip.hiddenTurnCount.toLocaleString()} quieter{" "}
+          {props.strip.hiddenTurnCount.toLocaleString()} lower-cost{" "}
           {props.strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown.
         </p>
       ) : null}
@@ -730,9 +730,16 @@ function countLaterTripsInTurn(
   invocations: ThreadToolInvocationRecord[],
   selected: ThreadToolInvocationRecord,
 ): number {
-  return invocations.filter((invocation) =>
+  /* A full-history analyze pass can stamp several of a turn's calls with the
+     same millisecond, so "later" falls back to persisted order rather than
+     dropping every tie and understating the replay count. */
+  const selectedIndex = invocations.indexOf(selected);
+  return invocations.filter((invocation, index) =>
     (invocation.turnId ?? "") === (selected.turnId ?? "")
-    && invocation.observedAt > selected.observedAt
+    && (
+      invocation.observedAt > selected.observedAt
+      || (invocation.observedAt === selected.observedAt && index > selectedIndex)
+    )
   ).length;
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -21,6 +21,7 @@ import type {
   RefinedToolCategory,
   TurnCostRow,
   TurnCostStrip,
+  TurnStripScope,
 } from "./tool-output-incident-insights";
 import {
   buildCategoryComposition,
@@ -51,6 +52,7 @@ export function ToolOutputIncidentExplorerWindow() {
   const [selectedId, setSelectedId] = useState<string>();
   const [category, setCategory] = useState<RefinedToolCategory | "all" | "other">("all");
   const [turnFilter, setTurnFilter] = useState<string>();
+  const [turnScope, setTurnScope] = useState<TurnStripScope>("flagged");
   const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
   const [prompt, setPrompt] = useState("");
@@ -122,9 +124,10 @@ export function ToolOutputIncidentExplorerWindow() {
   const usageLines = latest?.pricing?.lines;
   const turnStrip = useMemo(
     () => buildTurnCostStrip(allInvocations, {
+      scope: turnScope,
       ...(usageLines ? { usageLines } : {}),
     }),
-    [allInvocations, usageLines],
+    [allInvocations, turnScope, usageLines],
   );
   const currency = usageLines?.[0]?.currency;
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
@@ -402,6 +405,7 @@ export function ToolOutputIncidentExplorerWindow() {
       <TurnStrip
         {...(currency ? { currency } : {})}
         now={renderedAt}
+        onScopeChange={setTurnScope}
         showCost={turnStrip.rows.some((row) => row.costMicros !== undefined)}
         onSelect={(row) => setTurnFilter(
           turnFilter === row.key ? undefined : row.key,
@@ -665,17 +669,43 @@ function TurnStrip(props: {
      against the same instant. */
   now: number;
   showCost: boolean;
+  onScopeChange: (scope: TurnStripScope) => void;
   onSelect: (row: TurnCostRow) => void;
   selectedKey?: string;
   strip: TurnCostStrip;
 }) {
-  if (props.strip.rows.length === 0) return null;
+  if (props.strip.totalTurnCount === 0) return null;
+  const strip = props.strip;
   return (
     <section className="incident-explorer__turns" aria-label="Cost by turn">
       <div className="incident-explorer__turns-head">
         <p className="incident-explorer__eyebrow">
-          {props.strip.ordering === "cost" ? "Costliest turns" : "Cost by turn"}
+          {strip.ordering === "cost"
+            ? strip.rankedBy === "billed"
+              ? "Costliest turns · by billed cost"
+              : "Costliest turns · by output × round trips"
+            : "Cost by turn"}
         </p>
+        <div
+          aria-label="Turn scope"
+          className="incident-explorer__turns-scope"
+          role="group"
+        >
+          <button
+            aria-pressed={strip.scope === "flagged"}
+            onClick={() => props.onScopeChange("flagged")}
+            type="button"
+          >
+            Flagged ({strip.flaggedTurnCount.toLocaleString()})
+          </button>
+          <button
+            aria-pressed={strip.scope === "all"}
+            onClick={() => props.onScopeChange("all")}
+            type="button"
+          >
+            All with tool calls ({strip.totalTurnCount.toLocaleString()})
+          </button>
+        </div>
         <p className="incident-explorer__turns-legend">
           <span className="incident-explorer__turns-key" data-kind="tokens" /> output tokens
           {" · "}
@@ -721,10 +751,14 @@ function TurnStrip(props: {
           ) : null}
         </button>
       ))}
-      {props.strip.hiddenTurnCount > 0 ? (
+      {strip.hiddenTurnCount > 0 || strip.scope === "flagged" ? (
         <p className="incident-explorer__turns-note">
-          {props.strip.hiddenTurnCount.toLocaleString()} lower-cost{" "}
-          {props.strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown.
+          {strip.hiddenTurnCount > 0
+            ? `${strip.hiddenTurnCount.toLocaleString()} lower-cost ${strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown. `
+            : ""}
+          {strip.scope === "flagged"
+            ? `${(strip.totalTurnCount - strip.flaggedTurnCount).toLocaleString()} turns made only small tool calls; turns with no tool calls are never listed.`
+            : "Turns with no tool calls are never listed."}
         </p>
       ) : null}
     </section>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -7,7 +7,11 @@ import type {
   ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
-import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import {
+  buildThreadToolIncidentPrompt,
+  isFlaggedToolInvocation,
+  TOOL_OUTPUT_WARNING_CHARS,
+} from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { useDesktopApi } from "../../lib/desktop-api";
 import { ThreadChip } from "./ThreadChip";
@@ -106,7 +110,7 @@ export function ToolOutputIncidentExplorerWindow() {
     [accounting?.invocations],
   );
   const flagged = useMemo(
-    () => allInvocations.filter((invocation) => invocation.noisy),
+    () => allInvocations.filter(isFlaggedToolInvocation),
     [allInvocations],
   );
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
@@ -181,13 +185,21 @@ export function ToolOutputIncidentExplorerWindow() {
   const analyze = async (): Promise<void> => {
     if (!desktopApi?.analyzeThreadToolHistory) return;
     setAnalyzing(true);
-    setStatus(undefined);
+    setStatusTone("info");
+    /* The scan pages through the whole thread 100 entries at a time, which on
+       a long thread is tens of seconds of silence. Say so up front rather
+       than leaving a disabled button as the only feedback. */
+    setStatus("Scanning this thread's history…");
     try {
       const response = await desktopApi.analyzeThreadToolHistory({
         backend: route.backend,
         threadId: route.threadId,
       });
       setAccounting(response.accounting);
+      /* Analysis persisted new rows and new output availability; re-read so
+         the transcript pages backing captured-output retrieval match the
+         findings now on screen. */
+      void refresh();
       setStatusTone(response.coverage.completeness === "complete" ? "info" : "error");
       setStatus(
         response.coverage.completeness === "complete"
@@ -281,7 +293,9 @@ export function ToolOutputIncidentExplorerWindow() {
             onClick={() => void analyze()}
             disabled={analyzing}
           >
-            {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
+            {analyzing
+              ? "Analyzing…"
+              : accounting?.analysis ? "Refresh analysis" : "Analyze history"}
           </button>
           <button
             className="incident-explorer__button incident-explorer__button--ghost"
@@ -432,7 +446,13 @@ export function ToolOutputIncidentExplorerWindow() {
             </section>
           ))}
           {!loading && invocations.length === 0 ? (
-            <p className="incident-explorer__empty">No findings match these filters.</p>
+            <p className="incident-explorer__empty">
+              {flagged.length > 0
+                ? "No findings match these filters."
+                : allInvocations.length === 0
+                  ? "No tool calls are recorded for this thread yet."
+                  : `None of this thread's ${allInvocations.length.toLocaleString()} recorded tool calls returned more than ${TOOL_OUTPUT_WARNING_CHARS.toLocaleString()} characters.`}
+            </p>
           ) : null}
         </aside>
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -12,6 +12,24 @@ import { formatBackendLabel } from "../../lib/backend-label";
 import { useDesktopApi } from "../../lib/desktop-api";
 import { ThreadChip } from "./ThreadChip";
 import { detailMatchesInvocationItem } from "./tool-call-details";
+import type {
+  CategoryShare,
+  IncidentSortMode,
+  TurnCostRow,
+  TurnCostStrip,
+} from "./tool-output-incident-insights";
+import {
+  buildCategoryComposition,
+  buildTurnCostStrip,
+  capMeterWidth,
+  formatCapShare,
+  formatCategoryLabel,
+  formatCompactTokens,
+  formatInvocationIdentity,
+  isOverOutputCap,
+  sortIncidentCases,
+  summarizeIncidents,
+} from "./tool-output-incident-insights";
 
 const HISTORY_PAGE_LIMIT = 100;
 
@@ -22,13 +40,24 @@ export function ToolOutputIncidentExplorerWindow() {
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
   const [category, setCategory] = useState<ThreadToolInvocationCategory | "all">("all");
+  const [turnFilter, setTurnFilter] = useState<string>();
+  const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
   const [prompt, setPrompt] = useState("");
+  const [identityExpanded, setIdentityExpanded] = useState(false);
   const [output, setOutput] = useState<string>();
   const [outputSearch, setOutputSearch] = useState("");
   const [status, setStatus] = useState<string>();
+  const [statusTone, setStatusTone] = useState<"error" | "info">("info");
   const [loading, setLoading] = useState(true);
   const [analyzing, setAnalyzing] = useState(false);
+
+  /* Stable identity: `refresh` depends on it, and a refresh that changed every
+     render would re-run the effect that calls it on every render. */
+  const reportError = useCallback((error: unknown) => {
+    setStatusTone("error");
+    setStatus(error instanceof Error ? error.message : String(error));
+  }, []);
 
   const refresh = useCallback(async () => {
     if (!route || !desktopApi?.readThread) return;
@@ -45,11 +74,11 @@ export function ToolOutputIncidentExplorerWindow() {
       setLatest(response);
       setAccounting(response.toolAccounting);
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : String(error));
+      reportError(error);
     } finally {
       setLoading(false);
     }
-  }, [desktopApi, route]);
+  }, [desktopApi, reportError, route]);
 
   useEffect(() => {
     document.title = route ? `Tool-output incidents — ${route.title}` : "Tool-output incidents";
@@ -71,20 +100,39 @@ export function ToolOutputIncidentExplorerWindow() {
     });
   }, [desktopApi, refresh]);
 
+  const allInvocations = useMemo(
+    () => accounting?.invocations ?? [],
+    [accounting?.invocations],
+  );
+  const flagged = useMemo(
+    () => allInvocations.filter((invocation) => invocation.noisy),
+    [allInvocations],
+  );
+  const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
+  const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
+  const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
+  const turnLabels = useMemo(
+    () => new Map(turnStrip.rows.map((row) => [row.key, row.label])),
+    [turnStrip.rows],
+  );
+
   const invocations = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
-    return (accounting?.invocations ?? []).filter((invocation) =>
-      invocation.noisy
-      && (category === "all" || invocation.category === category)
-      && (
-        !normalizedSearch
-        || (invocation.normalizedCommand ?? invocation.toolName)
-          .toLowerCase()
-          .includes(normalizedSearch)
-        || invocation.noisyReason?.toLowerCase().includes(normalizedSearch)
-      )
+    return sortIncidentCases(
+      flagged.filter((invocation) =>
+        (category === "all" || invocation.category === category)
+        && (turnFilter === undefined || (invocation.turnId ?? "") === turnFilter)
+        && (
+          !normalizedSearch
+          || (invocation.normalizedCommand ?? invocation.toolName)
+            .toLowerCase()
+            .includes(normalizedSearch)
+          || invocation.noisyReason?.toLowerCase().includes(normalizedSearch)
+        )
+      ),
+      sortMode,
     );
-  }, [accounting?.invocations, category, search]);
+  }, [category, flagged, search, sortMode, turnFilter]);
   const selected = invocations.find((invocation) => invocation.invocationId === selectedId)
     ?? invocations[0];
 
@@ -95,6 +143,7 @@ export function ToolOutputIncidentExplorerWindow() {
           reason: selected.noisyReason ?? "large tool output",
         })
       : "");
+    setIdentityExpanded(false);
     setOutput(undefined);
     setOutputSearch("");
     if (!selected || !latest || !desktopApi?.readThread || !route) return;
@@ -108,28 +157,17 @@ export function ToolOutputIncidentExplorerWindow() {
     }).then((value) => {
       if (!cancelled) setOutput(value);
     }).catch((error) => {
-      if (!cancelled) setStatus(error instanceof Error ? error.message : String(error));
+      if (!cancelled) reportError(error);
     });
     return () => {
       cancelled = true;
     };
-  }, [desktopApi, latest, route, selected]);
+  }, [desktopApi, latest, reportError, route, selected]);
 
   if (!route) {
     return <p className="incident-explorer__error">Invalid incident explorer route.</p>;
   }
 
-  const categories = Array.from(new Set(
-    (accounting?.invocations ?? []).filter((entry) => entry.noisy).map((entry) => entry.category),
-  ));
-  const totals = invocations.reduce(
-    (sum, invocation) => ({
-      chars: sum.chars + invocation.outputChars,
-      tokens: sum.tokens + invocation.estimatedOutputTokens,
-      worst: Math.max(sum.worst, invocation.outputChars),
-    }),
-    { chars: 0, tokens: 0, worst: 0 },
-  );
   const activeTurnId = findActiveTurnId(latest);
   const canSteerSelected = Boolean(
     selected?.turnId
@@ -138,6 +176,7 @@ export function ToolOutputIncidentExplorerWindow() {
   );
   const canSendAsNewTurn = Boolean(!activeTurnId && desktopApi?.startTurn);
   const visibleOutputLines = filterOutputLines(output, outputSearch);
+  const laterTripsInTurn = selected ? countLaterTripsInTurn(allInvocations, selected) : 0;
 
   const analyze = async (): Promise<void> => {
     if (!desktopApi?.analyzeThreadToolHistory) return;
@@ -149,13 +188,14 @@ export function ToolOutputIncidentExplorerWindow() {
         threadId: route.threadId,
       });
       setAccounting(response.accounting);
+      setStatusTone(response.coverage.completeness === "complete" ? "info" : "error");
       setStatus(
         response.coverage.completeness === "complete"
           ? `Analyzed ${response.coverage.invocationCount.toLocaleString()} tool calls across ${response.coverage.pageCount.toLocaleString()} page${response.coverage.pageCount === 1 ? "" : "s"}.`
           : response.coverage.explanation ?? "Analysis is incomplete.",
       );
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : String(error));
+      reportError(error);
     } finally {
       setAnalyzing(false);
     }
@@ -173,6 +213,7 @@ export function ToolOutputIncidentExplorerWindow() {
           requestId: `tool-output-incident:${selected.invocationId}:${Date.now()}`,
           threadId: route.threadId,
         });
+        setStatusTone("info");
         setStatus("Steering delivered to the exact active turn.");
       } else if (canSendAsNewTurn) {
         await desktopApi?.startTurn?.({
@@ -180,10 +221,11 @@ export function ToolOutputIncidentExplorerWindow() {
           input: [{ type: "text", text: prompt.trim() }],
           threadId: route.threadId,
         });
+        setStatusTone("info");
         setStatus("Prompt sent as a new turn.");
       }
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : String(error));
+      reportError(error);
     }
   };
 
@@ -221,7 +263,7 @@ export function ToolOutputIncidentExplorerWindow() {
                 backend: route.backend,
                 threadId: route.threadId,
               }).catch((error: unknown) => {
-                setStatus(error instanceof Error ? error.message : String(error));
+                reportError(error);
               });
             }}
           />
@@ -233,25 +275,112 @@ export function ToolOutputIncidentExplorerWindow() {
         </span>
         <div className="activity-titlebar__spacer" />
         <div className="incident-explorer__actions">
-          <button type="button" onClick={() => void analyze()} disabled={analyzing}>
+          <button
+            className="incident-explorer__button"
+            type="button"
+            onClick={() => void analyze()}
+            disabled={analyzing}
+          >
             {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
           </button>
-          <button type="button" onClick={() => void refresh()} disabled={loading}>Refresh</button>
-          <button type="button" onClick={() => window.close()}>Close</button>
+          <button
+            className="incident-explorer__button incident-explorer__button--ghost"
+            type="button"
+            onClick={() => void refresh()}
+            disabled={loading}
+          >
+            Refresh
+          </button>
         </div>
       </header>
-      <div className="incident-explorer__metrics" aria-label="Incident metrics">
-        <Metric label="Cases" value={invocations.length.toLocaleString()} />
-        <Metric label="Total output" value={`${totals.chars.toLocaleString()} chars`} />
-        <Metric label="Estimated tokens" value={totals.tokens.toLocaleString()} />
-        <Metric label="Worst case" value={`${totals.worst.toLocaleString()} chars`} />
+
+      <div className="incident-explorer__summary" aria-label="Incident metrics">
+        <div className="incident-explorer__headline">
+          <p className="incident-explorer__eyebrow">Replay cost from flagged calls</p>
+          <p className="incident-explorer__hero">
+            <strong>{formatCompactTokens(summary.incidentTokens)}</strong>
+            <span>
+              tokens · {Math.round(summary.share * 100)}% of all tool output
+            </span>
+          </p>
+          <span
+            aria-hidden="true"
+            className="incident-explorer__meter"
+          >
+            <i style={{ width: `${Math.round(summary.share * 100)}%` }} />
+          </span>
+          <p className="incident-explorer__caption">
+            <b>{summary.caseCount}</b> {summary.caseCount === 1 ? "case" : "cases"}
+            {" · "}{summary.turnCount} {summary.turnCount === 1 ? "turn" : "turns"}
+            {" · "}{summary.incidentChars.toLocaleString()} chars
+            {" · worst "}{summary.worstChars.toLocaleString()}
+          </p>
+        </div>
+        <div className="incident-explorer__composition-group" role="group" aria-label="Filter by category">
+          <p className="incident-explorer__eyebrow">Where it went</p>
+          <CompositionBar composition={composition} />
+          <div className="incident-explorer__legend">
+            <button
+              aria-pressed={category === "all"}
+              className="incident-explorer__legend-item"
+              onClick={() => setCategory("all")}
+              type="button"
+            >
+              <i className="incident-explorer__swatch incident-explorer__swatch--all" />
+              All categories
+              <em>{formatCompactTokens(summary.incidentTokens)}</em>
+            </button>
+            {composition.map((entry, index) => (
+              <button
+                aria-pressed={category === entry.category}
+                className="incident-explorer__legend-item"
+                disabled={entry.category === "other"}
+                key={entry.category}
+                onClick={() => setCategory(
+                  entry.category === "other"
+                    ? "all"
+                    : entry.category as ThreadToolInvocationCategory,
+                )}
+                type="button"
+              >
+                <i
+                  className="incident-explorer__swatch"
+                  data-rank={Math.min(index + 1, 5)}
+                />
+                {entry.label}
+                <em>
+                  {formatCompactTokens(entry.estimatedOutputTokens)}
+                  {" · "}{Math.round(entry.share * 100)}%
+                </em>
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
+
+      <TurnStrip
+        onSelect={(row) => setTurnFilter(
+          turnFilter === row.key ? undefined : row.key,
+        )}
+        selectedKey={turnFilter}
+        strip={turnStrip}
+      />
+
       {accounting?.analysis?.completeness === "partial" ? (
         <p className="incident-explorer__coverage" role="status">
           Partial coverage: {accounting.analysis.explanation}
         </p>
       ) : null}
-      {status ? <p className="incident-explorer__status" role="status">{status}</p> : null}
+      {status ? (
+        <p
+          className="incident-explorer__status"
+          data-tone={statusTone}
+          role="status"
+        >
+          {status}
+        </p>
+      ) : null}
+
       <div className="incident-explorer__body">
         <aside className="incident-explorer__list" aria-label="Incident cases">
           <div className="incident-explorer__filters">
@@ -263,30 +392,42 @@ export function ToolOutputIncidentExplorerWindow() {
               value={search}
             />
             <select
-              aria-label="Filter by category"
-              onChange={(event) => setCategory(event.currentTarget.value as typeof category)}
-              value={category}
+              aria-label="Sort cases"
+              onChange={(event) => setSortMode(event.currentTarget.value as IncidentSortMode)}
+              value={sortMode}
             >
-              <option value="all">All categories</option>
-              {categories.map((entry) => <option key={entry} value={entry}>{entry}</option>)}
+              <option value="largest">Largest first</option>
+              <option value="newest">Newest first</option>
+              <option value="turn">By turn</option>
             </select>
           </div>
-          {groupInvocations(invocations).map((group) => (
+          {turnFilter !== undefined || category !== "all" ? (
+            <div className="incident-explorer__active-filters">
+              <span>
+                Showing {invocations.length.toLocaleString()} of {flagged.length.toLocaleString()} cases
+              </span>
+              <button
+                className="incident-explorer__button incident-explorer__button--ghost"
+                onClick={() => {
+                  setCategory("all");
+                  setTurnFilter(undefined);
+                }}
+                type="button"
+              >
+                Clear filters
+              </button>
+            </div>
+          ) : null}
+          {groupCases(invocations, sortMode, turnLabels).map((group) => (
             <section className="incident-explorer__group" key={group.key}>
-              <h2>{group.turnLabel} · {group.category}</h2>
+              {group.label ? <h3>{group.label}</h3> : null}
               {group.invocations.map((invocation) => (
-                <button
-                  className="incident-explorer__case"
-                  data-selected={invocation.invocationId === selected?.invocationId}
+                <CaseRow
+                  invocation={invocation}
                   key={invocation.invocationId}
-                  onClick={() => setSelectedId(invocation.invocationId)}
-                  type="button"
-                >
-                  <span>{invocation.normalizedCommand ?? invocation.toolName}</span>
-                  <small>
-                    {invocation.outputChars.toLocaleString()} chars · {formatTimestamp(invocation.observedAt)}
-                  </small>
-                </button>
+                  onSelect={() => setSelectedId(invocation.invocationId)}
+                  selected={invocation.invocationId === selected?.invocationId}
+                />
               ))}
             </section>
           ))}
@@ -294,54 +435,122 @@ export function ToolOutputIncidentExplorerWindow() {
             <p className="incident-explorer__empty">No findings match these filters.</p>
           ) : null}
         </aside>
+
         <main className="incident-explorer__detail">
           {selected ? (
             <>
               <section className="incident-explorer__evidence">
-                <h2>Selected invocation</h2>
-                <dl>
-                  <dt>Identity</dt><dd><code>{selected.normalizedCommand ?? selected.toolName}</code></dd>
-                  <dt>Observed</dt><dd>{formatTimestamp(selected.observedAt)}</dd>
-                  <dt>Status</dt><dd>{selected.status}{selected.exitCode !== undefined ? ` · exit ${selected.exitCode}` : ""}</dd>
-                  <dt>Output</dt><dd>{selected.outputChars.toLocaleString()} chars · ~{selected.estimatedOutputTokens.toLocaleString()} tokens</dd>
-                  <dt>Availability</dt><dd>{selected.outputState ?? (selected.outputTruncated ? "truncated" : "unavailable until replay is loaded")}</dd>
-                  <dt>Reason</dt><dd>{selected.noisyReason ?? "large output"}</dd>
-                  <dt>Source</dt><dd>{selected.source ?? "live"}</dd>
-                </dl>
-              </section>
-              <section className="incident-explorer__prompt">
                 <div className="incident-explorer__section-heading">
-                  <h2>Proposed steering</h2>
-                  <button type="button" onClick={() => void desktopApi?.copyText?.(prompt)}>Copy</button>
+                  <h2>Selected invocation</h2>
+                  <button
+                    className="incident-explorer__button incident-explorer__button--ghost"
+                    onClick={() => void desktopApi?.copyText?.(
+                      selected.normalizedCommand ?? selected.toolName,
+                    )}
+                    type="button"
+                  >
+                    Copy command
+                  </button>
                 </div>
-                <textarea
-                  aria-label="Editable proposed steering prompt"
-                  onChange={(event) => setPrompt(event.currentTarget.value)}
-                  rows={10}
-                  value={prompt}
-                />
-                <button
-                  className="incident-explorer__primary"
-                  disabled={!prompt.trim() || (!canSendAsNewTurn && !canSteerSelected)}
-                  onClick={() => void sendPrompt()}
-                  type="button"
+                <div
+                  className="incident-explorer__identity"
+                  data-expanded={identityExpanded}
                 >
-                  {canSteerSelected ? "Steer exact active turn" : "Send next turn"}
-                </button>
-                {!canSteerSelected && activeTurnId ? (
-                  <p>The selected finding belongs to another turn. It cannot steer the active turn; send it after that turn ends.</p>
-                ) : null}
+                  <code>{selected.normalizedCommand ?? selected.toolName}</code>
+                  <button
+                    className="incident-explorer__button incident-explorer__button--ghost"
+                    onClick={() => setIdentityExpanded((value) => !value)}
+                    type="button"
+                  >
+                    {identityExpanded ? "Collapse" : "Expand"}
+                  </button>
+                </div>
+                <div className="incident-explorer__facts">
+                  <Fact
+                    label={selected.status}
+                    tone={selected.status === "failed" ? "error" : "ok"}
+                    value={selected.exitCode !== undefined ? `exit ${selected.exitCode}` : "—"}
+                  />
+                  <Fact
+                    label={formatCategoryLabel(selected.category)}
+                    value={turnLabels.get(selected.turnId ?? "") ?? "No turn"}
+                  />
+                  <Fact label="observed" value={formatTimestamp(selected.observedAt)} />
+                  <Fact
+                    label="output"
+                    tone={selected.outputState === "available" ? undefined : "warning"}
+                    value={describeAvailability(selected)}
+                  />
+                  <Fact label="source" value={selected.source ?? "live"} />
+                </div>
+
+                <div className="incident-explorer__budget">
+                  <div className="incident-explorer__budget-head">
+                    <strong>{selected.estimatedOutputTokens.toLocaleString()} tokens</strong>
+                    <span>{formatCapShare(selected.outputChars)}</span>
+                  </div>
+                  <span aria-hidden="true" className="incident-explorer__meter">
+                    <i
+                      data-critical={isOverOutputCap(selected.outputChars)}
+                      style={{ width: `${capMeterWidth(selected.outputChars) * 100}%` }}
+                    />
+                  </span>
+                  <p className="incident-explorer__caption">
+                    {selected.outputChars.toLocaleString()} chars ·{" "}
+                    {laterTripsInTurn > 0
+                      ? `replayed on the ${laterTripsInTurn.toLocaleString()} later round ${laterTripsInTurn === 1 ? "trip" : "trips"} in this turn`
+                      : "no later round trips in this turn replayed it"}
+                  </p>
+                  <p className="incident-explorer__reason">
+                    {selected.noisyReason ?? "large output"}
+                  </p>
+                </div>
               </section>
+
+              <section className="incident-explorer__prompt">
+                <details className="incident-explorer__steer">
+                  <summary>Proposed steering</summary>
+                  <textarea
+                    aria-label="Editable proposed steering prompt"
+                    onChange={(event) => setPrompt(event.currentTarget.value)}
+                    rows={8}
+                    value={prompt}
+                  />
+                </details>
+                <div className="incident-explorer__prompt-actions">
+                  <button
+                    className="incident-explorer__button incident-explorer__primary"
+                    disabled={!prompt.trim() || (!canSendAsNewTurn && !canSteerSelected)}
+                    onClick={() => void sendPrompt()}
+                    type="button"
+                  >
+                    {canSteerSelected ? "Steer exact active turn" : "Send next turn"}
+                  </button>
+                  <button
+                    className="incident-explorer__button"
+                    onClick={() => void desktopApi?.copyText?.(prompt)}
+                    type="button"
+                  >
+                    Copy
+                  </button>
+                  {!canSteerSelected && activeTurnId ? (
+                    <p>The selected finding belongs to another turn. It cannot steer the active turn; send it after that turn ends.</p>
+                  ) : null}
+                </div>
+              </section>
+
               <section className="incident-explorer__output">
                 <div className="incident-explorer__section-heading">
                   <h2>Captured output</h2>
-                  <input
-                    aria-label="Search captured output"
-                    onChange={(event) => setOutputSearch(event.currentTarget.value)}
-                    placeholder="Search output"
-                    type="search"
-                    value={outputSearch}
-                  />
+                  {output !== undefined ? (
+                    <input
+                      aria-label="Search captured output"
+                      onChange={(event) => setOutputSearch(event.currentTarget.value)}
+                      placeholder="Search output"
+                      type="search"
+                      value={outputSearch}
+                    />
+                  ) : null}
                 </div>
                 {output !== undefined ? (
                   <ol className="incident-explorer__output-lines">
@@ -352,9 +561,10 @@ export function ToolOutputIncidentExplorerWindow() {
                     ))}
                   </ol>
                 ) : (
-                  <p className="incident-explorer__empty">
+                  <p className="incident-explorer__unavailable">
+                    <b>Not retained by normalized replay</b>
                     {selected.outputState === "compacted"
-                      ? "Output was compacted out of normalized replay."
+                      ? `The ${selected.outputChars.toLocaleString()} characters this call returned were compacted out. Size and category come from tool accounting, recorded when the call ran.`
                       : selected.outputState === "truncated"
                         ? "Only the truncated output retained by normalized replay is available."
                         : "Output is unavailable in the currently available normalized replay."}
@@ -369,8 +579,161 @@ export function ToolOutputIncidentExplorerWindow() {
   );
 }
 
-function Metric(props: { label: string; value: string }) {
-  return <div><span>{props.label}</span><strong>{props.value}</strong></div>;
+function CompositionBar(props: { composition: CategoryShare[] }) {
+  if (props.composition.length === 0) return null;
+  return (
+    <span aria-hidden="true" className="incident-explorer__composition">
+      {props.composition.map((entry, index) => (
+        <i
+          data-rank={Math.min(index + 1, 5)}
+          key={entry.category}
+          style={{ width: `${entry.share * 100}%` }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/**
+ * The second cost driver. A solid bar reads as volume, a tick rail reads as
+ * discrete events — deliberately different marks, because a turn that is long
+ * on trips and short on tokens is a different problem than the reverse, and
+ * the two need to be told apart at a glance.
+ */
+function TurnStrip(props: {
+  onSelect: (row: TurnCostRow) => void;
+  selectedKey?: string;
+  strip: TurnCostStrip;
+}) {
+  if (props.strip.rows.length === 0) return null;
+  return (
+    <section className="incident-explorer__turns" aria-label="Cost by turn">
+      <div className="incident-explorer__turns-head">
+        <p className="incident-explorer__eyebrow">
+          {props.strip.ordering === "cost" ? "Costliest turns" : "Cost by turn"}
+        </p>
+        <p className="incident-explorer__turns-legend">
+          <span className="incident-explorer__turns-key" data-kind="tokens" /> output tokens
+          {" · "}
+          <span className="incident-explorer__turns-key" data-kind="trips" /> round trips
+        </p>
+      </div>
+      {props.strip.rows.map((row) => (
+        <button
+          aria-pressed={props.selectedKey === row.key}
+          className="incident-explorer__turn"
+          key={row.key}
+          onClick={() => props.onSelect(row)}
+          type="button"
+        >
+          <span className="incident-explorer__turn-label">
+            {row.label}
+            <span>{` · ${formatClockTime(row.firstObservedAt)}`}</span>
+          </span>
+          <span aria-hidden="true" className="incident-explorer__turn-bar">
+            <i
+              data-critical={row.overCapCount > 0}
+              style={{ width: `${scaleWidth(row.estimatedOutputTokens, props.strip.maxTokens)}%` }}
+            />
+          </span>
+          <span className="incident-explorer__turn-number">
+            {formatCompactTokens(row.estimatedOutputTokens)} tok
+          </span>
+          <span aria-hidden="true" className="incident-explorer__turn-trips">
+            <i style={{ width: `${scaleWidth(row.callCount, props.strip.maxCallCount)}%` }} />
+          </span>
+          <span className="incident-explorer__turn-number">
+            {row.callCount.toLocaleString()} {row.callCount === 1 ? "call" : "calls"}
+          </span>
+        </button>
+      ))}
+      {props.strip.hiddenTurnCount > 0 ? (
+        <p className="incident-explorer__turns-note">
+          {props.strip.hiddenTurnCount.toLocaleString()} quieter{" "}
+          {props.strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function CaseRow(props: {
+  invocation: ThreadToolInvocationRecord;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  const invocation = props.invocation;
+  const command = invocation.normalizedCommand ?? invocation.toolName;
+  const identity = formatInvocationIdentity(command);
+  const critical = isOverOutputCap(invocation.outputChars);
+  return (
+    <button
+      aria-current={props.selected}
+      className="incident-explorer__case"
+      data-selected={props.selected}
+      onClick={props.onSelect}
+      title={command}
+      type="button"
+    >
+      <span className="incident-explorer__case-top">
+        <span className="incident-explorer__case-id">
+          <b>{identity.lead}</b>
+          {identity.detail ? <span>{` ${identity.detail}`}</span> : null}
+        </span>
+        <span className="incident-explorer__case-tokens">
+          {formatCompactTokens(invocation.estimatedOutputTokens)}
+        </span>
+      </span>
+      <span aria-hidden="true" className="incident-explorer__meter">
+        <i
+          data-critical={critical}
+          style={{ width: `${capMeterWidth(invocation.outputChars) * 100}%` }}
+        />
+      </span>
+      <span className="incident-explorer__case-sub">
+        {formatCapShare(invocation.outputChars, { short: true })}
+        {" · "}{invocation.outputChars.toLocaleString()} chars
+        {" · "}{formatClockTime(invocation.observedAt)}
+      </span>
+    </button>
+  );
+}
+
+function Fact(props: {
+  label: string;
+  tone?: "error" | "ok" | "warning";
+  value: string;
+}) {
+  return (
+    <span className="incident-explorer__fact" data-tone={props.tone}>
+      <b>{props.label}</b>
+      {props.value}
+    </span>
+  );
+}
+
+function scaleWidth(value: number, max: number): number {
+  if (max <= 0) return 0;
+  return Math.max(2, Math.round(value / max * 100));
+}
+
+function describeAvailability(invocation: ThreadToolInvocationRecord): string {
+  return invocation.outputState
+    ?? (invocation.outputTruncated ? "truncated" : "unavailable");
+}
+
+/**
+ * Round trips after this call inside the same turn. Every one of them replays
+ * this output, which is what makes a single large result compound.
+ */
+function countLaterTripsInTurn(
+  invocations: ThreadToolInvocationRecord[],
+  selected: ThreadToolInvocationRecord,
+): number {
+  return invocations.filter((invocation) =>
+    (invocation.turnId ?? "") === (selected.turnId ?? "")
+    && invocation.observedAt > selected.observedAt
+  ).length;
 }
 
 function readIncidentRoute(): {
@@ -402,26 +765,33 @@ function findActiveTurnId(response: AppServerReadThreadResponse | undefined): st
   return undefined;
 }
 
-function groupInvocations(invocations: ThreadToolInvocationRecord[]) {
+function groupCases(
+  invocations: ThreadToolInvocationRecord[],
+  sortMode: IncidentSortMode,
+  turnLabels: Map<string, string>,
+) {
+  if (sortMode !== "turn") {
+    return [{ invocations, key: "all", label: "" }];
+  }
   const groups = new Map<string, {
-    category: ThreadToolInvocationCategory;
     invocations: ThreadToolInvocationRecord[];
     key: string;
-    turnLabel: string;
+    label: string;
   }>();
   for (const invocation of invocations) {
-    const turn = invocation.turnId ?? "No turn";
-    const key = `${turn}:${invocation.category}`;
+    const key = invocation.turnId ?? "";
     const group = groups.get(key) ?? {
-      category: invocation.category,
       invocations: [],
       key,
-      turnLabel: invocation.turnId ? `Turn ${shortId(invocation.turnId)}` : "No turn",
+      label: turnLabels.get(key) ?? "Unassigned",
     };
     group.invocations.push(invocation);
     groups.set(key, group);
   }
-  return [...groups.values()];
+  return [...groups.values()].map((group) => ({
+    ...group,
+    label: `${group.label} · ${group.invocations.length} ${group.invocations.length === 1 ? "case" : "cases"}`,
+  }));
 }
 
 async function readInvocationOutput(params: {
@@ -500,6 +870,9 @@ function formatTimestamp(timestamp: number): string {
   return new Date(timestamp).toLocaleString();
 }
 
-function shortId(value: string): string {
-  return value.length > 12 ? `${value.slice(0, 8)}…` : value;
+function formatClockTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -215,6 +215,33 @@ describe("ToolOutputIncidentExplorerWindow", () => {
       .toHaveTextContent("1 call");
   });
 
+  it("widens the turn strip from flagged turns to every turn with tool calls", async () => {
+    const response = buildMultiTurnResponse();
+    /* A turn of only small calls: invisible in the flagged scope, present in
+       the all scope. */
+    response.toolAccounting!.invocations.push({
+      ...response.toolAccounting!.invocations[1]!,
+      invocationId: "invocation-quiet-turn",
+      itemId: "item-quiet-turn",
+      noisy: false,
+      observedAt: 1_800_000_005_000,
+      outputChars: 120,
+      turnId: "turn-3",
+    });
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    expect(within(turns).queryByRole("button", { name: /Turn 3/ })).toBeNull();
+
+    fireEvent.click(within(turns).getByRole("button", { name: /All with tool calls/ }));
+    expect(await within(turns).findByRole("button", { name: /Turn 3/ }))
+      .toBeInTheDocument();
+    expect(within(turns).getByRole("button", { name: /Flagged \(2\)/ }))
+      .toHaveAttribute("aria-pressed", "false");
+  });
+
   it("filters the case list to a single turn", async () => {
     installApi({ readThread: async () => buildMultiTurnResponse() });
     window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -188,6 +188,70 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     await waitFor(() => expect(within(metrics).getByText("2")).toBeInTheDocument());
     expect(readCount).toBe(2);
   });
+
+  it("ranks cases by output size and measures each against the output cap", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const cases = await screen.findByLabelText("Incident cases");
+    const rows = within(cases).getAllByRole("button", { name: /chars/ });
+    expect(rows[0]).toHaveAttribute("title", expect.stringContaining("wide-scan"));
+    expect(rows[0]).toHaveTextContent("50% of cap");
+    expect(rows[1]).toHaveTextContent("15% of cap");
+  });
+
+  it("reports round trips per turn, counting calls that were never flagged", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    /* turn-1 holds one flagged call plus two quiet ones; the quiet calls
+       replay context too, so they belong in the round-trip count. */
+    expect(within(turns).getByRole("button", { name: /Turn 1/ }))
+      .toHaveTextContent("3 calls");
+    expect(within(turns).getByRole("button", { name: /Turn 2/ }))
+      .toHaveTextContent("1 call");
+  });
+
+  it("filters the case list to a single turn", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    const cases = screen.getByLabelText("Incident cases");
+    expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(2);
+
+    const secondTurn = within(turns).getByRole("button", { name: /Turn 2/ });
+    fireEvent.click(secondTurn);
+
+    await waitFor(() => expect(secondTurn).toHaveAttribute("aria-pressed", "true"));
+    const filtered = within(cases).getAllByRole("button", { name: /chars/ });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]).toHaveAttribute("title", expect.stringContaining("pnpm test"));
+    expect(within(cases).getByText("Showing 1 of 2 cases")).toBeInTheDocument();
+
+    fireEvent.click(within(cases).getByRole("button", { name: "Clear filters" }));
+    await waitFor(() =>
+      expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(2));
+  });
+
+  it("filters by category from the composition legend", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const legend = await screen.findByRole("group", { name: "Filter by category" });
+    fireEvent.click(within(legend).getByRole("button", { name: /Tests & builds/ }));
+
+    const cases = screen.getByLabelText("Incident cases");
+    await waitFor(() =>
+      expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(1));
+    expect(within(cases).getAllByRole("button", { name: /chars/ })[0])
+      .toHaveAttribute("title", expect.stringContaining("pnpm test"));
+  });
 });
 
 function installApi(api: Record<string, unknown>): void {
@@ -247,6 +311,74 @@ function buildResponse(
         hasPreviousPage: false,
         supportsPagination: true,
       },
+      threadStatus: "active",
+    },
+  };
+}
+
+/**
+ * Two turns, mixed categories, and quiet calls alongside flagged ones — the
+ * shape the summary band and turn strip are built to read.
+ */
+function buildMultiTurnResponse(): AppServerReadThreadResponse {
+  const base = buildInvocation();
+  const invocations: ThreadToolInvocationRecord[] = [
+    {
+      ...base,
+      category: "shell",
+      estimatedOutputTokens: 5_000,
+      invocationId: "invocation-wide",
+      itemId: "item-wide",
+      normalizedCommand: "rg --files wide-scan",
+      observedAt: 1_800_000_000_000,
+      outputChars: 20_000,
+      turnId: "turn-1",
+    },
+    {
+      ...base,
+      category: "shell",
+      estimatedOutputTokens: 40,
+      invocationId: "invocation-quiet-1",
+      itemId: "item-quiet-1",
+      noisy: false,
+      normalizedCommand: "git status",
+      observedAt: 1_800_000_001_000,
+      outputChars: 160,
+      turnId: "turn-1",
+    },
+    {
+      ...base,
+      category: "shell",
+      estimatedOutputTokens: 40,
+      invocationId: "invocation-quiet-2",
+      itemId: "item-quiet-2",
+      noisy: false,
+      normalizedCommand: "git diff --stat",
+      observedAt: 1_800_000_002_000,
+      outputChars: 160,
+      turnId: "turn-1",
+    },
+    {
+      ...base,
+      category: "build-test",
+      estimatedOutputTokens: 1_500,
+      invocationId: "invocation-tests",
+      itemId: "item-tests",
+      normalizedCommand: "pnpm test",
+      observedAt: 1_800_000_003_000,
+      outputChars: 6_000,
+      turnId: "turn-2",
+    },
+  ];
+  return {
+    backend: "codex",
+    fetchedAt: 1,
+    threadId: "thread-1",
+    toolAccounting: { alerts: [], invocations, summaries: [] },
+    replay: {
+      entries: [],
+      messages: [],
+      pagination: { hasPreviousPage: false, supportsPagination: true },
       threadStatus: "active",
     },
   };

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -242,6 +242,27 @@ describe("ToolOutputIncidentExplorerWindow", () => {
       .toHaveAttribute("aria-pressed", "false");
   });
 
+  it("filters cases from the chronological timeline spark", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const timeline = await screen.findByRole("group", {
+      name: "Tool cost per turn, in order",
+    });
+    const columns = within(timeline).getAllByRole("button");
+    expect(columns).toHaveLength(2);
+    /* Hover text carries the numbers the bars encode. */
+    expect(columns[0]).toHaveAttribute("title", expect.stringMatching(/Turn 1 .*3 calls/));
+
+    fireEvent.click(columns[1]!);
+    const cases = screen.getByLabelText("Incident cases");
+    await waitFor(() =>
+      expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(1));
+    expect(within(cases).getAllByRole("button", { name: /chars/ })[0])
+      .toHaveAttribute("title", expect.stringContaining("pnpm test"));
+  });
+
   it("filters the case list to a single turn", async () => {
     installApi({ readThread: async () => buildMultiTurnResponse() });
     window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -7,6 +7,7 @@ import {
   formatCapShare,
   formatCompactTokens,
   formatInvocationIdentity,
+  invocationStatusTone,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
@@ -45,7 +46,42 @@ describe("buildTurnCostStrip", () => {
 
     expect(strip.rows).toHaveLength(1);
     expect(strip.rows[0]?.callCount).toBe(3);
-    expect(strip.rows[0]?.noisyCount).toBe(1);
+  });
+
+  it("keeps a high-round-trip turn when ranking drops rows", () => {
+    /* Ranking on output alone would cut the polling turn — the pathology the
+       tick rail exists to show — and then call it lower-cost. */
+    const polling = Array.from({ length: 40 }, (_, index) =>
+      invocation({
+        estimatedOutputTokens: 50,
+        observedAt: 1_000 + index,
+        turnId: "turn-polling",
+      }));
+    const verbose = Array.from({ length: 3 }, (_, index) =>
+      invocation({
+        estimatedOutputTokens: 5_000,
+        observedAt: 10_000 + index * 1_000,
+        turnId: `turn-verbose-${index}`,
+      }));
+    const strip = buildTurnCostStrip([...polling, ...verbose], { limit: 2 });
+
+    expect(strip.ordering).toBe("cost");
+    expect(strip.rows.map((row) => row.key)).toContain("turn-polling");
+  });
+
+  it("labels every turn, including the ones the row limit dropped", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 900, observedAt: 10, turnId: "turn-a" }),
+        invocation({ estimatedOutputTokens: 800, observedAt: 20, turnId: "turn-b" }),
+        invocation({ estimatedOutputTokens: 1, observedAt: 30, turnId: "turn-c" }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(strip.rows.map((row) => row.key)).not.toContain("turn-c");
+    /* A case in the dropped turn still has to name its turn. */
+    expect(strip.labelsByKey.get("turn-c")).toBe("Turn 3");
   });
 
   it("numbers turns chronologically and keeps the numbering when ranked by cost", () => {
@@ -161,6 +197,19 @@ describe("output cap meters", () => {
 
   it("pins rather than overflowing past the cap", () => {
     expect(capMeterWidth(400_000)).toBe(1);
+  });
+});
+
+describe("invocationStatusTone", () => {
+  it("reserves success coloring for a call that actually succeeded", () => {
+    expect(invocationStatusTone(invocation({ exitCode: 0, status: "completed" })))
+      .toBe("ok");
+    /* A non-zero exit is a failure whatever the transport status says. */
+    expect(invocationStatusTone(invocation({ exitCode: 1, status: "completed" })))
+      .toBe("error");
+    expect(invocationStatusTone(invocation({ status: "failed" }))).toBe("error");
+    expect(invocationStatusTone(invocation({ status: "cancelled" }))).toBeUndefined();
+    expect(invocationStatusTone(invocation({ status: "in_progress" }))).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -1,0 +1,208 @@
+import type { ThreadToolInvocationRecord } from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import {
+  buildCategoryComposition,
+  buildTurnCostStrip,
+  capMeterWidth,
+  formatCapShare,
+  formatCompactTokens,
+  formatInvocationIdentity,
+  isOverOutputCap,
+  sortIncidentCases,
+  summarizeIncidents,
+} from "../tool-output-incident-insights";
+
+describe("summarizeIncidents", () => {
+  it("reports flagged output as a share of all accounted output", () => {
+    const summary = summarizeIncidents([
+      invocation({ estimatedOutputTokens: 3_000, noisy: true, outputChars: 12_000 }),
+      invocation({ estimatedOutputTokens: 1_000, noisy: true, outputChars: 4_000 }),
+      invocation({ estimatedOutputTokens: 1_000, noisy: false, outputChars: 4_000 }),
+    ]);
+
+    expect(summary.caseCount).toBe(2);
+    expect(summary.incidentTokens).toBe(4_000);
+    expect(summary.totalTokens).toBe(5_000);
+    expect(summary.share).toBeCloseTo(0.8);
+    expect(summary.worstChars).toBe(12_000);
+  });
+
+  it("reports a zero share rather than dividing by zero on an empty thread", () => {
+    expect(summarizeIncidents([]).share).toBe(0);
+  });
+});
+
+describe("buildTurnCostStrip", () => {
+  it("counts every call in a turn, not only the flagged ones", () => {
+    /* The round-trip driver: a turn of quiet calls still replays the whole
+       accumulated context once per call, so a strip built from flagged rows
+       alone would under-report the turn that costs the most. */
+    const strip = buildTurnCostStrip([
+      invocation({ noisy: true, observedAt: 10, turnId: "turn-a" }),
+      invocation({ noisy: false, observedAt: 20, turnId: "turn-a" }),
+      invocation({ noisy: false, observedAt: 30, turnId: "turn-a" }),
+    ]);
+
+    expect(strip.rows).toHaveLength(1);
+    expect(strip.rows[0]?.callCount).toBe(3);
+    expect(strip.rows[0]?.noisyCount).toBe(1);
+  });
+
+  it("numbers turns chronologically and keeps the numbering when ranked by cost", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 100, observedAt: 10, turnId: "turn-a" }),
+        invocation({ estimatedOutputTokens: 900, observedAt: 20, turnId: "turn-b" }),
+        invocation({ estimatedOutputTokens: 500, observedAt: 30, turnId: "turn-c" }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(strip.ordering).toBe("cost");
+    expect(strip.rows.map((row) => row.label)).toEqual(["Turn 2", "Turn 3"]);
+    expect(strip.hiddenTurnCount).toBe(1);
+    expect(strip.maxTokens).toBe(900);
+  });
+
+  it("stays in time order while every turn fits", () => {
+    const strip = buildTurnCostStrip([
+      invocation({ estimatedOutputTokens: 900, observedAt: 20, turnId: "turn-b" }),
+      invocation({ estimatedOutputTokens: 100, observedAt: 10, turnId: "turn-a" }),
+    ]);
+
+    expect(strip.ordering).toBe("time");
+    expect(strip.rows.map((row) => row.label)).toEqual(["Turn 1", "Turn 2"]);
+    expect(strip.hiddenTurnCount).toBe(0);
+  });
+
+  it("labels calls with no turn instead of numbering them", () => {
+    const strip = buildTurnCostStrip([
+      invocation({ observedAt: 10, turnId: undefined }),
+    ]);
+
+    expect(strip.rows[0]?.label).toBe("Unassigned");
+  });
+});
+
+describe("buildCategoryComposition", () => {
+  it("ranks by output tokens and folds the tail into one entry", () => {
+    const composition = buildCategoryComposition(
+      [
+        invocation({ category: "shell", estimatedOutputTokens: 600 }),
+        invocation({ category: "search", estimatedOutputTokens: 200 }),
+        invocation({ category: "git", estimatedOutputTokens: 120 }),
+        invocation({ category: "mcp", estimatedOutputTokens: 80 }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(composition.map((entry) => entry.label))
+      .toEqual(["Shell", "Search", "Other (2)"]);
+    expect(composition[2]?.estimatedOutputTokens).toBe(200);
+    expect(composition[0]?.share).toBeCloseTo(0.6);
+  });
+});
+
+describe("sortIncidentCases", () => {
+  it("puts the biggest output first", () => {
+    const sorted = sortIncidentCases([
+      invocation({ invocationId: "small", outputChars: 4_000 }),
+      invocation({ invocationId: "big", outputChars: 17_771 }),
+    ], "largest");
+
+    expect(sorted.map((entry) => entry.invocationId)).toEqual(["big", "small"]);
+  });
+
+  it("orders by observation time for the by-turn reading", () => {
+    const sorted = sortIncidentCases([
+      invocation({ invocationId: "late", observedAt: 200 }),
+      invocation({ invocationId: "early", observedAt: 100 }),
+    ], "turn");
+
+    expect(sorted.map((entry) => entry.invocationId)).toEqual(["early", "late"]);
+  });
+});
+
+describe("formatInvocationIdentity", () => {
+  it("keeps the distinguishing tail of commands that share a long prefix", () => {
+    /* Both rows begin with the same 60 characters. A head truncation renders
+       them identical, which is the failure this elision exists to fix. */
+    const prefix = "set -o pipefail state_dir=local-state/m4-handoff/";
+    const first = formatInvocationIdentity(`${prefix}diagnose-listener-boundary`);
+    const second = formatInvocationIdentity(`${prefix}verify-helper-teardown`);
+
+    expect(`${first.lead}${first.detail}`)
+      .not.toBe(`${second.lead}${second.detail}`);
+    /* The tail survives the elision — that is what makes the rows readable
+       as two different commands rather than two copies of one. */
+    expect(first.detail).toContain("boundary");
+    expect(second.detail).toContain("teardown");
+    expect(first.lead).toBe("set -o pipefail");
+  });
+
+  it("leaves a short command whole", () => {
+    const identity = formatInvocationIdentity("pnpm test");
+    expect(identity.lead).toBe("pnpm test");
+    expect(identity.detail).toBe("");
+  });
+
+  it("flattens embedded newlines so a row stays one line", () => {
+    const identity = formatInvocationIdentity("printf 'a'\n  tail -n 90 log");
+    expect(`${identity.lead} ${identity.detail}`).not.toContain("\n");
+  });
+});
+
+describe("output cap meters", () => {
+  it("measures against the cap the analyzer flags against", () => {
+    expect(capMeterWidth(20_000)).toBeCloseTo(0.5);
+    expect(isOverOutputCap(39_999)).toBe(false);
+    expect(isOverOutputCap(40_000)).toBe(true);
+  });
+
+  it("pins rather than overflowing past the cap", () => {
+    expect(capMeterWidth(400_000)).toBe(1);
+  });
+});
+
+describe("formatCapShare", () => {
+  it("shortens the cap phrase for case rows", () => {
+    expect(formatCapShare(20_000)).toBe("50% of the output cap");
+    expect(formatCapShare(20_000, { short: true })).toBe("50% of cap");
+  });
+});
+
+describe("formatCompactTokens", () => {
+  it("keeps small counts exact and abbreviates large ones", () => {
+    expect(formatCompactTokens(940)).toBe("940");
+    expect(formatCompactTokens(4_443)).toBe("4.4k");
+    expect(formatCompactTokens(140_437)).toBe("140k");
+  });
+});
+
+function invocation(
+  overrides: Partial<ThreadToolInvocationRecord> = {},
+): ThreadToolInvocationRecord {
+  return {
+    backend: "codex",
+    category: "shell",
+    debugLines: 0,
+    errorLines: 0,
+    estimatedOutputTokens: 1_000,
+    infoLines: 0,
+    invocationId: "invocation-1",
+    itemId: "item-1",
+    noisy: true,
+    normalizedCommand: "pnpm test",
+    observedAt: 1_800_000_000_000,
+    outputChars: 4_000,
+    outputLines: 20,
+    outputTruncated: false,
+    status: "completed",
+    threadId: "thread-1",
+    toolName: "commandExecution",
+    turnId: "turn-1",
+    updatedAt: 1_800_000_000_000,
+    warningLines: 0,
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -6,8 +6,11 @@ import {
   capMeterWidth,
   formatCapShare,
   formatCompactTokens,
+  countRepeatedCommands,
   formatInvocationIdentity,
+  formatTurnWhen,
   invocationStatusTone,
+  refineToolCategory,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
@@ -256,3 +259,82 @@ function invocation(
     ...overrides,
   };
 }
+
+describe("formatTurnWhen", () => {
+  const now = new Date("2026-08-15T14:00:00Z").getTime();
+
+  it("counts minutes, then hours and minutes, for the last day", () => {
+    expect(formatTurnWhen(now - 12 * 60_000, now)).toBe("12m ago");
+    expect(formatTurnWhen(now - (3 * 3_600_000 + 20 * 60_000), now))
+      .toBe("3h 20m ago");
+    expect(formatTurnWhen(now - 5 * 3_600_000, now)).toBe("5h ago");
+  });
+
+  it("names the weekday inside a week and dates anything older", () => {
+    /* A bare clock time is ambiguous the moment a thread spans days, and
+       these threads run for days — two rows reading "2:00 PM" can be three
+       days apart. */
+    const threeDaysAgo = formatTurnWhen(now - 3 * 86_400_000, now);
+    expect(threeDaysAgo).toMatch(/^[A-Za-z]{3} /);
+    const older = formatTurnWhen(now - 30 * 86_400_000, now);
+    expect(older).toMatch(/^\d+\/\d+ /);
+  });
+});
+
+describe("countRepeatedCommands", () => {
+  it("reports commands the thread ran more than once", () => {
+    const repeats = countRepeatedCommands([
+      invocation({ normalizedCommand: "sed -n '1,420p' runbook.md" }),
+      invocation({ normalizedCommand: "sed -n '1,420p' runbook.md" }),
+      invocation({ normalizedCommand: "sed -n '1,420p' runbook.md" }),
+      invocation({ normalizedCommand: "cat README.md" }),
+    ]);
+
+    expect(repeats.get("sed -n '1,420p' runbook.md")).toBe(3);
+    expect(repeats.has("cat README.md")).toBe(false);
+  });
+});
+
+describe("refineToolCategory", () => {
+  it("separates agent instructions and skill files from bulk file reads", () => {
+    /* `file-io` was 80% of one thread's output. Knowing it was the same
+       instruction files, re-read, is the part that suggests a fix. */
+    expect(refineToolCategory({
+      category: "file-io",
+      normalizedCommand: "cat AGENTS.md",
+      toolName: "commandExecution",
+    })).toBe("agent-instructions");
+    expect(refineToolCategory({
+      category: "file-io",
+      normalizedCommand: "sed -n '1,400p' .agents/skills/manage-macos/SKILL.md",
+      toolName: "commandExecution",
+    })).toBe("skill-files");
+    expect(refineToolCategory({
+      category: "file-io",
+      normalizedCommand: "cat src/index.ts",
+      toolName: "commandExecution",
+    })).toBe("file-io");
+  });
+
+  it("leaves non-file categories alone", () => {
+    expect(refineToolCategory({
+      category: "git",
+      normalizedCommand: "git diff AGENTS.md",
+      toolName: "commandExecution",
+    })).toBe("git");
+  });
+});
+
+describe("buildCategoryComposition tail", () => {
+  it("names a single folded category instead of calling it Other", () => {
+    const composition = buildCategoryComposition([
+      invocation({ category: "file-io", estimatedOutputTokens: 500 }),
+      invocation({ category: "git", estimatedOutputTokens: 400 }),
+      invocation({ category: "search", estimatedOutputTokens: 300 }),
+      invocation({ category: "shell", estimatedOutputTokens: 200 }),
+      invocation({ category: "mcp", estimatedOutputTokens: 100 }),
+    ]);
+
+    expect(composition.at(-1)?.label).toBe("MCP");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -18,7 +18,8 @@ describe("summarizeIncidents", () => {
     const summary = summarizeIncidents([
       invocation({ estimatedOutputTokens: 3_000, noisy: true, outputChars: 12_000 }),
       invocation({ estimatedOutputTokens: 1_000, noisy: true, outputChars: 4_000 }),
-      invocation({ estimatedOutputTokens: 1_000, noisy: false, outputChars: 4_000 }),
+      /* Small and unmarked: below the size test, so not a case either way. */
+      invocation({ estimatedOutputTokens: 1_000, noisy: false, outputChars: 500 }),
     ]);
 
     expect(summary.caseCount).toBe(2);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -501,6 +501,19 @@ describe("turn strip scope and ranking", () => {
     expect(strip.totalTurnCount).toBe(2);
   });
 
+  it("exposes the unscoped chronological timeline alongside the ranked rows", () => {
+    /* The spark chart is the "when": all turns, time order, no scope — a long
+       poll only reads as a pattern when adjacency survives. */
+    const strip = buildTurnCostStrip([
+      invocation({ noisy: false, observedAt: 20, outputChars: 200, turnId: "turn-quiet" }),
+      invocation({ observedAt: 10, outputChars: 20_000, turnId: "turn-loud" }),
+    ]);
+
+    expect(strip.rows.map((row) => row.key)).toEqual(["turn-loud"]);
+    expect(strip.timeline.map((row) => row.key))
+      .toEqual(["turn-loud", "turn-quiet"]);
+  });
+
   it("keeps ordinals identical across scopes", () => {
     /* "Turn 2" must name the same turn whichever scope is active, or the
        label stops matching the case list. */

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -8,12 +8,14 @@ import {
   formatCompactTokens,
   countRepeatedCommands,
   formatInvocationIdentity,
+  formatMicrosCurrency,
   formatTurnWhen,
   invocationStatusTone,
   refineToolCategory,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
+  unwrapShellCommand,
 } from "../tool-output-incident-insights";
 
 describe("summarizeIncidents", () => {
@@ -232,9 +234,25 @@ describe("formatCompactTokens", () => {
   });
 });
 
+/* Commands whose verbs agree with the category, so a fixture that declares a
+   category is not silently re-categorized by the verb scan. */
+const COMMAND_FOR_CATEGORY: Partial<Record<string, string>> = {
+  "build-test": "vitest run",
+  "file-io": "cat notes.md",
+  git: "git status",
+  mcp: "mcp__server__call",
+  "package-manager": "pnpm install",
+  polling: "sleep 5",
+  search: "rg pattern",
+  shell: "./deploy.sh",
+  "sub-agent": "task_monitor",
+  unknown: "opaque_tool",
+};
+
 function invocation(
   overrides: Partial<ThreadToolInvocationRecord> = {},
 ): ThreadToolInvocationRecord {
+  const category = overrides.category ?? "shell";
   return {
     backend: "codex",
     category: "shell",
@@ -245,7 +263,7 @@ function invocation(
     invocationId: "invocation-1",
     itemId: "item-1",
     noisy: true,
-    normalizedCommand: "pnpm test",
+    normalizedCommand: COMMAND_FOR_CATEGORY[category] ?? "./deploy.sh",
     observedAt: 1_800_000_000_000,
     outputChars: 4_000,
     outputLines: 20,
@@ -336,5 +354,113 @@ describe("buildCategoryComposition tail", () => {
     ]);
 
     expect(composition.at(-1)?.label).toBe("MCP");
+  });
+});
+
+describe("composition members", () => {
+  it("carries the folded categories so Other can filter", () => {
+    /* "Other" was rendered as a disabled remainder — 10% of a real thread's
+       output with no way to reach it. */
+    const composition = buildCategoryComposition([
+      invocation({ category: "file-io", estimatedOutputTokens: 900 }),
+      invocation({ category: "git", estimatedOutputTokens: 800 }),
+      invocation({ category: "shell", estimatedOutputTokens: 700 }),
+      invocation({ category: "build-test", estimatedOutputTokens: 600 }),
+      invocation({ category: "mcp", estimatedOutputTokens: 500 }),
+      invocation({ category: "polling", estimatedOutputTokens: 400 }),
+    ]);
+
+    const other = composition.at(-1);
+    expect(other?.category).toBe("other");
+    expect(other?.label).toBe("Other (2)");
+    expect(other?.members.sort()).toEqual(["mcp", "polling"]);
+  });
+
+  it("gives a named entry itself as its only member", () => {
+    const composition = buildCategoryComposition([
+      invocation({ category: "git", estimatedOutputTokens: 100 }),
+    ]);
+    expect(composition[0]?.members).toEqual(["git"]);
+  });
+});
+
+describe("compound command categorization", () => {
+  it("unwraps a shell wrapper and reads every verb, not the first token", () => {
+    /* Real row from a 236-turn thread. Persisted as `shell`/`build-test`:
+       the first token is /bin/bash, and " test" matched a path. Note the
+       missing separators — redactCommandText collapses the script's newlines
+       at persist time, so the sub-commands run together. */
+    expect(refineToolCategory({
+      category: "build-test",
+      normalizedCommand:
+        "/bin/bash -c 'git diff --check git diff --stat git status --short "
+        + "--branch git diff -- tests/test-macos-images.sh'",
+      toolName: "commandExecution",
+    })).toBe("git");
+  });
+
+  it("leaves a category the persisted classifier got right", () => {
+    /* `pnpm test` is Tests & builds; the verb scan would call it a package
+       manager. It only runs when the persisted value is untrustworthy. */
+    expect(refineToolCategory({
+      category: "build-test",
+      normalizedCommand: "pnpm test",
+      toolName: "commandExecution",
+    })).toBe("build-test");
+  });
+
+  it("still separates when the verbs disagree", () => {
+    expect(refineToolCategory({
+      category: "shell",
+      normalizedCommand: "find . -name '*.ts' | xargs cat",
+      toolName: "commandExecution",
+    })).toBe("shell");
+  });
+
+  it("does not treat a git diff of a skill file as a skill read", () => {
+    expect(refineToolCategory({
+      category: "shell",
+      normalizedCommand: "git diff -- .agents/skills/build/SKILL.md",
+      toolName: "commandExecution",
+    })).toBe("git");
+  });
+
+  it("unwraps the wrapper for reads too", () => {
+    expect(unwrapShellCommand("/bin/bash -c 'cat AGENTS.md'"))
+      .toBe("cat AGENTS.md");
+    expect(refineToolCategory({
+      category: "shell",
+      normalizedCommand: "/bin/bash -c 'cat AGENTS.md'",
+      toolName: "commandExecution",
+    })).toBe("agent-instructions");
+  });
+});
+
+describe("turn cost", () => {
+  it("joins billed cost onto turns by turn id", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ observedAt: 10, turnId: "turn-a" }),
+        invocation({ observedAt: 20, turnId: "turn-b" }),
+      ],
+      {
+        usageLines: [
+          { createdAt: 1, currency: "USD", totalCostMicros: 1_500_000, turnId: "turn-a" },
+          { createdAt: 2, currency: "USD", totalCostMicros: 900_000, turnId: "turn-a" },
+        ] as never,
+      },
+    );
+
+    expect(strip.rows.find((row) => row.key === "turn-a")?.costMicros)
+      .toBe(2_400_000);
+    /* A turn the ledger has not priced reports nothing rather than zero. */
+    expect(strip.rows.find((row) => row.key === "turn-b")?.costMicros)
+      .toBeUndefined();
+  });
+
+  it("formats money in the ledger's units", () => {
+    expect(formatMicrosCurrency(2_400_000, "USD")).toBe("$2.4");
+    expect(formatMicrosCurrency(358_000_000, "USD")).toBe("$358");
+    expect(formatMicrosCurrency(2_400_000, "credits")).toBe("2.4 cr");
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -487,3 +487,69 @@ describe("turn cost", () => {
     expect(formatMicrosCurrency(2_400_000, "credits")).toBe("2.4 cr");
   });
 });
+
+describe("turn strip scope and ranking", () => {
+  it("defaults to turns with flagged calls and reports both populations", () => {
+    const strip = buildTurnCostStrip([
+      invocation({ observedAt: 10, outputChars: 20_000, turnId: "turn-loud" }),
+      invocation({ noisy: false, observedAt: 20, outputChars: 200, turnId: "turn-quiet" }),
+    ]);
+
+    expect(strip.scope).toBe("flagged");
+    expect(strip.rows.map((row) => row.key)).toEqual(["turn-loud"]);
+    expect(strip.flaggedTurnCount).toBe(1);
+    expect(strip.totalTurnCount).toBe(2);
+  });
+
+  it("keeps ordinals identical across scopes", () => {
+    /* "Turn 2" must name the same turn whichever scope is active, or the
+       label stops matching the case list. */
+    const rows = [
+      invocation({ noisy: false, observedAt: 10, outputChars: 200, turnId: "turn-quiet" }),
+      invocation({ observedAt: 20, outputChars: 20_000, turnId: "turn-loud" }),
+    ];
+    const flaggedScope = buildTurnCostStrip(rows);
+    const allScope = buildTurnCostStrip(rows, { scope: "all" });
+
+    expect(flaggedScope.rows[0]?.label).toBe("Turn 2");
+    expect(allScope.rows.map((row) => row.label)).toEqual(["Turn 1", "Turn 2"]);
+  });
+
+  it("ranks by billed cost when the ledger has priced the turns", () => {
+    /* "Costliest" next to a visible price column has to mean dollars — the
+       token/trip blend ranked turns in an order no column explained. */
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 9_000, observedAt: 10, turnId: "turn-tokens" }),
+        invocation({ estimatedOutputTokens: 1_000, observedAt: 20, turnId: "turn-dollars" }),
+        invocation({ estimatedOutputTokens: 500, observedAt: 30, turnId: "turn-cheap" }),
+      ],
+      {
+        limit: 2,
+        usageLines: [
+          { createdAt: 1, currency: "USD", totalCostMicros: 900_000, turnId: "turn-tokens" },
+          { createdAt: 2, currency: "USD", totalCostMicros: 5_000_000, turnId: "turn-dollars" },
+          { createdAt: 3, currency: "USD", totalCostMicros: 100_000, turnId: "turn-cheap" },
+        ] as never,
+      },
+    );
+
+    expect(strip.rankedBy).toBe("billed");
+    expect(strip.rows.map((row) => row.key))
+      .toEqual(["turn-dollars", "turn-tokens"]);
+  });
+
+  it("falls back to the blend when nothing is priced", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 9_000, observedAt: 10, turnId: "turn-a" }),
+        invocation({ estimatedOutputTokens: 1_000, observedAt: 20, turnId: "turn-b" }),
+        invocation({ estimatedOutputTokens: 500, observedAt: 30, turnId: "turn-c" }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(strip.rankedBy).toBe("estimate");
+    expect(strip.rows[0]?.key).toBe("turn-a");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -7,6 +7,7 @@ import {
   formatCapShare,
   formatCompactTokens,
   countRepeatedCommands,
+  formatCategoryLabel,
   formatInvocationIdentity,
   formatMicrosCurrency,
   formatTurnWhen,
@@ -433,6 +434,28 @@ describe("compound command categorization", () => {
       normalizedCommand: "/bin/bash -c 'cat AGENTS.md'",
       toolName: "commandExecution",
     })).toBe("agent-instructions");
+  });
+});
+
+describe("mcp subcategories", () => {
+  it("splits MCP by server from the persisted server/tool identity", () => {
+    /* Context7's `query-docs` was filed under Other: the old classifier
+       inferred MCP from an "mcp" substring in the tool name, which
+       `list_mcp_resources` happened to carry and `query-docs` did not. */
+    expect(refineToolCategory({
+      category: "mcp",
+      normalizedCommand: "context7/query-docs",
+      toolName: "query-docs",
+    })).toBe("mcp:context7");
+    expect(formatCategoryLabel("mcp:context7")).toBe("MCP · context7");
+  });
+
+  it("keeps a bare MCP call without a recorded server in the plain bucket", () => {
+    expect(refineToolCategory({
+      category: "mcp",
+      normalizedCommand: "query-docs",
+      toolName: "query-docs",
+    })).toBe("mcp");
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -150,7 +150,8 @@ const VERB_CATEGORIES = new Map<string, ThreadToolInvocationCategory>([
 export type RefinedToolCategory =
   | ThreadToolInvocationCategory
   | "agent-instructions"
-  | "skill-files";
+  | "skill-files"
+  | `mcp:${string}`;
 
 export function unwrapShellCommand(command: string): string {
   const match = SHELL_WRAPPER_PATTERN.exec(command.trim());
@@ -186,6 +187,13 @@ export function refineToolCategory(
   >,
 ): RefinedToolCategory {
   const raw = invocation.normalizedCommand ?? invocation.toolName;
+  /* MCP identities are persisted as `server/tool`, so the split into a
+     per-server subcategory is a prefix read — each MCP answers for its own
+     output rather than pooling under one bucket. */
+  if (invocation.category === "mcp") {
+    const server = raw.includes("/") ? raw.split("/", 1)[0] : undefined;
+    return server ? `mcp:${server}` : "mcp";
+  }
   const command = unwrapShellCommand(raw);
   /* Only second-guess the persisted category when it is untrustworthy: either
      it was computed from a shell wrapper we have now seen through, or it is
@@ -211,7 +219,8 @@ export function formatCategoryLabel(
   if (category === "other") return "Other";
   if (category === "agent-instructions") return "Agent instructions";
   if (category === "skill-files") return "Skill files";
-  return CATEGORY_LABELS[category];
+  if (category.startsWith("mcp:")) return `MCP · ${category.slice(4)}`;
+  return CATEGORY_LABELS[category as ThreadToolInvocationCategory];
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -94,6 +94,13 @@ export type TurnCostStrip = {
   rankedBy: "billed" | "estimate";
   rows: TurnCostRow[];
   scope: TurnStripScope;
+  /**
+   * Every turn with recorded tool calls, in time order and unscoped — the
+   * whole thread at a glance. The ranked rows answer "which turns cost the
+   * most"; this answers "when", which is where a long poll shows up as a
+   * stretch of round-trip spikes with no matching output.
+   */
+  timeline: TurnCostRow[];
   /** Turns with any recorded tool call — the "all" scope's population. */
   totalTurnCount: number;
   hiddenTurnCount: number;
@@ -399,6 +406,7 @@ export function buildTurnCostStrip(
     rankedBy,
     rows,
     scope,
+    timeline: chronological,
     totalTurnCount: chronological.length,
   };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -1,0 +1,318 @@
+import type {
+  ThreadToolInvocationCategory,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import { TOOL_OUTPUT_CAP_CHARS, toolOutputCapShare } from "@pwragent/shared";
+
+/**
+ * Derivations behind the incident explorer's visual summary.
+ *
+ * Two things drive replay cost, and they need separate encodings because they
+ * need separate fixes. A turn that returns one enormous tool result is a
+ * filtering problem; a turn that makes sixty small calls is a round-trip
+ * problem, because every one of those trips replays the whole accumulated
+ * context. Reading only one of them — which is all a list of output sizes can
+ * show — hides half the bill.
+ *
+ * Everything here is a pure function over records the accounting analyzer
+ * already persists. No new IPC, no new fields.
+ */
+
+/** Turn rows shown before the strip switches from timeline to ranking. */
+const DEFAULT_TURN_ROW_LIMIT = 12;
+
+/** Distinct legend entries before the tail folds into "Other". */
+const DEFAULT_CATEGORY_LIMIT = 4;
+
+/**
+ * Characters of command text a case row can show before eliding. Sized to the
+ * list's minimum column width, because CSS truncation is an end-truncation —
+ * if it ever fires it undoes the middle-elision below.
+ */
+const DEFAULT_IDENTITY_BUDGET = 38;
+
+/** Longest word-boundary prefix used as the bolded head of a case row. */
+const IDENTITY_LEAD_BUDGET = 18;
+
+export type IncidentSummary = {
+  caseCount: number;
+  incidentChars: number;
+  incidentTokens: number;
+  /** Estimated tokens across every accounted call, flagged or not. */
+  totalTokens: number;
+  totalCallCount: number;
+  /** Flagged share of all tool output, 0–1. Zero when nothing is accounted. */
+  share: number;
+  turnCount: number;
+  worstChars: number;
+};
+
+export type TurnCostRow = {
+  callCount: number;
+  estimatedOutputTokens: number;
+  firstObservedAt: number;
+  key: string;
+  label: string;
+  noisyCount: number;
+  /** Calls that reached the harness's output cap, where output is truncated. */
+  overCapCount: number;
+  outputChars: number;
+  turnId?: string;
+};
+
+export type TurnCostStrip = {
+  /** Largest single-turn values in the strip, for scaling both bars. */
+  maxCallCount: number;
+  maxTokens: number;
+  /**
+   * "time" reads as a timeline. Past the row limit that stops being legible,
+   * so the strip ranks by cost instead and reports what it dropped.
+   */
+  ordering: "cost" | "time";
+  rows: TurnCostRow[];
+  hiddenTurnCount: number;
+};
+
+export type CategoryShare = {
+  caseCount: number;
+  category: ThreadToolInvocationCategory | "other";
+  estimatedOutputTokens: number;
+  label: string;
+  /** Share of flagged output tokens, 0–1. */
+  share: number;
+};
+
+export type IncidentSortMode = "largest" | "newest" | "turn";
+
+const CATEGORY_LABELS: Record<ThreadToolInvocationCategory, string> = {
+  "build-test": "Tests & builds",
+  "file-io": "File reads",
+  git: "Git",
+  mcp: "MCP",
+  "package-manager": "Package manager",
+  polling: "Polling",
+  search: "Search",
+  shell: "Shell",
+  "sub-agent": "Sub-agents",
+  unknown: "Other",
+};
+
+export function formatCategoryLabel(
+  category: ThreadToolInvocationCategory | "other",
+): string {
+  return category === "other" ? "Other" : CATEGORY_LABELS[category];
+}
+
+export function summarizeIncidents(
+  invocations: ThreadToolInvocationRecord[],
+): IncidentSummary {
+  const flagged = invocations.filter((invocation) => invocation.noisy);
+  const turnKeys = new Set(flagged.map((invocation) => invocation.turnId ?? ""));
+  const totalTokens = sumTokens(invocations);
+  const incidentTokens = sumTokens(flagged);
+  return {
+    caseCount: flagged.length,
+    incidentChars: flagged.reduce((sum, entry) => sum + entry.outputChars, 0),
+    incidentTokens,
+    share: totalTokens > 0 ? incidentTokens / totalTokens : 0,
+    totalCallCount: invocations.length,
+    totalTokens,
+    turnCount: turnKeys.size,
+    worstChars: flagged.reduce((worst, entry) => Math.max(worst, entry.outputChars), 0),
+  };
+}
+
+/**
+ * One row per turn over EVERY accounted call, not just the flagged ones —
+ * round trips are the cost being measured here, and a turn's quiet calls
+ * replay context exactly like its loud ones do.
+ */
+export function buildTurnCostStrip(
+  invocations: ThreadToolInvocationRecord[],
+  options?: { limit?: number },
+): TurnCostStrip {
+  const limit = options?.limit ?? DEFAULT_TURN_ROW_LIMIT;
+  const groups = new Map<string, TurnCostRow>();
+  for (const invocation of invocations) {
+    const key = invocation.turnId ?? "";
+    const row = groups.get(key) ?? {
+      callCount: 0,
+      estimatedOutputTokens: 0,
+      firstObservedAt: invocation.observedAt,
+      key,
+      label: "",
+      noisyCount: 0,
+      outputChars: 0,
+      overCapCount: 0,
+      ...(invocation.turnId ? { turnId: invocation.turnId } : {}),
+    };
+    row.callCount += 1;
+    row.estimatedOutputTokens += invocation.estimatedOutputTokens;
+    row.outputChars += invocation.outputChars;
+    row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
+    if (invocation.noisy) row.noisyCount += 1;
+    if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
+    groups.set(key, row);
+  }
+
+  /* Ordinals come from time order across all turns, so "Turn 3" keeps meaning
+     the third turn even when the strip is ranked by cost or truncated. */
+  const chronological = [...groups.values()]
+    .sort((left, right) => left.firstObservedAt - right.firstObservedAt);
+  let ordinal = 0;
+  for (const row of chronological) {
+    row.label = row.turnId ? `Turn ${(ordinal += 1)}` : "Unassigned";
+  }
+
+  const ordering: TurnCostStrip["ordering"] = chronological.length > limit
+    ? "cost"
+    : "time";
+  const ordered = ordering === "cost"
+    ? [...chronological].sort((left, right) =>
+        right.estimatedOutputTokens - left.estimatedOutputTokens
+        || right.callCount - left.callCount)
+    : chronological;
+  const rows = ordered.slice(0, limit);
+  return {
+    hiddenTurnCount: chronological.length - rows.length,
+    maxCallCount: rows.reduce((max, row) => Math.max(max, row.callCount), 0),
+    maxTokens: rows.reduce((max, row) => Math.max(max, row.estimatedOutputTokens), 0),
+    ordering,
+    rows,
+  };
+}
+
+export function buildCategoryComposition(
+  invocations: ThreadToolInvocationRecord[],
+  options?: { limit?: number },
+): CategoryShare[] {
+  const limit = options?.limit ?? DEFAULT_CATEGORY_LIMIT;
+  const groups = new Map<ThreadToolInvocationCategory, CategoryShare>();
+  for (const invocation of invocations) {
+    const share = groups.get(invocation.category) ?? {
+      caseCount: 0,
+      category: invocation.category,
+      estimatedOutputTokens: 0,
+      label: formatCategoryLabel(invocation.category),
+      share: 0,
+    };
+    share.caseCount += 1;
+    share.estimatedOutputTokens += invocation.estimatedOutputTokens;
+    groups.set(invocation.category, share);
+  }
+
+  const total = sumTokens(invocations);
+  const ranked = [...groups.values()]
+    .sort((left, right) => right.estimatedOutputTokens - left.estimatedOutputTokens);
+  const head = ranked.slice(0, limit);
+  const tail = ranked.slice(limit);
+  if (tail.length > 0) {
+    head.push({
+      caseCount: tail.reduce((sum, entry) => sum + entry.caseCount, 0),
+      category: "other",
+      estimatedOutputTokens: sumEntries(tail),
+      label: `Other (${tail.length})`,
+      share: 0,
+    });
+  }
+  for (const entry of head) {
+    entry.share = total > 0 ? entry.estimatedOutputTokens / total : 0;
+  }
+  return head;
+}
+
+export function sortIncidentCases(
+  invocations: ThreadToolInvocationRecord[],
+  mode: IncidentSortMode,
+): ThreadToolInvocationRecord[] {
+  const sorted = [...invocations];
+  if (mode === "largest") {
+    return sorted.sort((left, right) =>
+      right.outputChars - left.outputChars
+      || right.observedAt - left.observedAt);
+  }
+  if (mode === "newest") {
+    return sorted.sort((left, right) => right.observedAt - left.observedAt);
+  }
+  return sorted.sort((left, right) =>
+    left.observedAt - right.observedAt
+    || right.outputChars - left.outputChars);
+}
+
+/**
+ * Case-row label. The problem this solves: shell invocations in one turn
+ * routinely share a long prefix, so a plain head-truncation renders several
+ * rows byte-identical and the list stops being a list. Eliding the middle
+ * keeps the part that actually differs — usually a path or a subcommand near
+ * the end — on screen.
+ */
+export function formatInvocationIdentity(
+  value: string,
+  budget = DEFAULT_IDENTITY_BUDGET,
+): { detail: string; lead: string } {
+  const flattened = value.replace(/\s+/g, " ").trim();
+  const lead = flattened.length <= IDENTITY_LEAD_BUDGET
+    ? flattened
+    : leadingWords(flattened, IDENTITY_LEAD_BUDGET);
+  const detail = flattened.slice(lead.length).trim();
+  return { detail: elideMiddle(detail, Math.max(12, budget - lead.length)), lead };
+}
+
+/**
+ * Longest whole-word prefix within budget, or "" when the first word alone
+ * overruns it. Returning a hard slice there would cut a path mid-segment and
+ * bold a fragment that is identical across every row in the group — exactly
+ * the sameness the elision is meant to break.
+ */
+function leadingWords(value: string, budget: number): string {
+  const boundary = value.lastIndexOf(" ", budget);
+  return boundary > 0 ? value.slice(0, boundary) : "";
+}
+
+export function capShare(outputChars: number): number {
+  return toolOutputCapShare(outputChars);
+}
+
+/** Meter width, clamped — a case past the cap pins rather than overflowing. */
+export function capMeterWidth(outputChars: number): number {
+  return Math.min(1, Math.max(0.02, capShare(outputChars)));
+}
+
+export function isOverOutputCap(outputChars: number): boolean {
+  return outputChars >= TOOL_OUTPUT_CAP_CHARS;
+}
+
+/**
+ * The short form is for case rows, where the long phrase would repeat once per
+ * row and turn the list back into prose.
+ */
+export function formatCapShare(
+  outputChars: number,
+  options?: { short?: boolean },
+): string {
+  const percentage = Math.max(1, Math.round(capShare(outputChars) * 100));
+  return options?.short
+    ? `${percentage.toLocaleString()}% of cap`
+    : `${percentage.toLocaleString()}% of the output cap`;
+}
+
+export function formatCompactTokens(tokens: number): string {
+  if (tokens < 1_000) return tokens.toLocaleString();
+  const thousands = tokens / 1_000;
+  return `${thousands >= 100 ? Math.round(thousands) : Number(thousands.toFixed(1))}k`;
+}
+
+function elideMiddle(value: string, budget: number): string {
+  if (value.length <= budget) return value;
+  const head = Math.floor((budget - 1) * 0.42);
+  const tail = budget - 1 - head;
+  return `${value.slice(0, head).trimEnd()}…${value.slice(value.length - tail).trimStart()}`;
+}
+
+function sumTokens(invocations: ThreadToolInvocationRecord[]): number {
+  return invocations.reduce((sum, entry) => sum + entry.estimatedOutputTokens, 0);
+}
+
+function sumEntries(entries: CategoryShare[]): number {
+  return entries.reduce((sum, entry) => sum + entry.estimatedOutputTokens, 0);
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -81,7 +81,7 @@ export type TurnCostStrip = {
 };
 
 export type CategoryShare = {
-  category: ThreadToolInvocationCategory | "other";
+  category: RefinedToolCategory | "other";
   estimatedOutputTokens: number;
   label: string;
   /** Share of flagged output tokens, 0–1. */
@@ -103,10 +103,80 @@ const CATEGORY_LABELS: Record<ThreadToolInvocationCategory, string> = {
   unknown: "Other",
 };
 
+/**
+ * Display-level refinements of the persisted category.
+ *
+ * The stored enum is assigned by pattern-matching the tool name or the
+ * command's first token, so every `cat`/`sed` lands in one undifferentiated
+ * `file-io` bucket. That bucket was 80% of one thread's entire output, which
+ * tells the operator where to look and nothing about what to change. Reading
+ * an agent instruction file over and over is a different problem from reading
+ * a source file once, and the command text already distinguishes them.
+ *
+ * Derived rather than persisted so it applies to threads recorded before any
+ * of this existed — the same reason the size test is derived.
+ */
+const AGENT_INSTRUCTION_PATTERN = /\b(?:AGENTS|CLAUDE)\.md\b/i;
+const SKILL_FILE_PATTERN = /\bSKILL\.md\b|[/\\]skills?[/\\]|[/\\]plugins[/\\]/i;
+
+export type RefinedToolCategory =
+  | ThreadToolInvocationCategory
+  | "agent-instructions"
+  | "skill-files";
+
+export function refineToolCategory(
+  invocation: Pick<
+    ThreadToolInvocationRecord,
+    "category" | "normalizedCommand" | "toolName"
+  >,
+): RefinedToolCategory {
+  if (invocation.category !== "file-io" && invocation.category !== "search") {
+    return invocation.category;
+  }
+  const command = invocation.normalizedCommand ?? invocation.toolName;
+  if (AGENT_INSTRUCTION_PATTERN.test(command)) return "agent-instructions";
+  if (SKILL_FILE_PATTERN.test(command)) return "skill-files";
+  return invocation.category;
+}
+
 export function formatCategoryLabel(
-  category: ThreadToolInvocationCategory | "other",
+  category: RefinedToolCategory | "other",
 ): string {
-  return category === "other" ? "Other" : CATEGORY_LABELS[category];
+  if (category === "other") return "Other";
+  if (category === "agent-instructions") return "Agent instructions";
+  if (category === "skill-files") return "Skill files";
+  return CATEGORY_LABELS[category];
+}
+
+/**
+ * Commands this thread ran more than once. Re-running the identical read is a
+ * signal in its own right: either the turn lost the earlier result to
+ * compaction, or the file is being rewritten underneath it. Both are causes
+ * of cost rather than symptoms of it, and neither is visible from any single
+ * row's size.
+ */
+export function countRepeatedCommands(
+  invocations: readonly ThreadToolInvocationRecord[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const invocation of invocations) {
+    const command = invocation.normalizedCommand;
+    if (!command) continue;
+    counts.set(command, (counts.get(command) ?? 0) + 1);
+  }
+  for (const [command, count] of counts) {
+    if (count < 2) counts.delete(command);
+  }
+  return counts;
+}
+
+export function repeatCountFor(
+  invocation: Pick<ThreadToolInvocationRecord, "normalizedCommand">,
+  repeats: Map<string, number>,
+): number {
+  return invocation.normalizedCommand
+    ? repeats.get(invocation.normalizedCommand) ?? 1
+    : 1;
 }
 
 export function summarizeIncidents(
@@ -203,16 +273,17 @@ export function buildCategoryComposition(
   options?: { limit?: number },
 ): CategoryShare[] {
   const limit = options?.limit ?? DEFAULT_CATEGORY_LIMIT;
-  const groups = new Map<ThreadToolInvocationCategory, CategoryShare>();
+  const groups = new Map<RefinedToolCategory, CategoryShare>();
   for (const invocation of invocations) {
-    const share = groups.get(invocation.category) ?? {
-      category: invocation.category,
+    const category = refineToolCategory(invocation);
+    const share = groups.get(category) ?? {
+      category,
       estimatedOutputTokens: 0,
-      label: formatCategoryLabel(invocation.category),
+      label: formatCategoryLabel(category),
       share: 0,
     };
     share.estimatedOutputTokens += invocation.estimatedOutputTokens;
-    groups.set(invocation.category, share);
+    groups.set(category, share);
   }
 
   const total = sumTokens(invocations);
@@ -220,7 +291,11 @@ export function buildCategoryComposition(
     .sort((left, right) => right.estimatedOutputTokens - left.estimatedOutputTokens);
   const head = ranked.slice(0, limit);
   const tail = ranked.slice(limit);
-  if (tail.length > 0) {
+  if (tail.length === 1 && tail[0]) {
+    /* "Other (1)" hides a real name behind a label that says less than the
+       name did — a single MCP bucket read as an unexplained remainder. */
+    head.push(tail[0]);
+  } else if (tail.length > 1) {
     head.push({
       category: "other",
       estimatedOutputTokens: sumEntries(tail),
@@ -326,7 +401,49 @@ export function formatCapShare(
 export function formatCompactTokens(tokens: number): string {
   if (tokens < 1_000) return tokens.toLocaleString();
   const thousands = tokens / 1_000;
-  return `${thousands >= 100 ? Math.round(thousands) : Number(thousands.toFixed(1))}k`;
+  return `${(thousands >= 100
+    ? Math.round(thousands)
+    : Number(thousands.toFixed(1))
+  ).toLocaleString()}k`;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * When a turn ran, at the precision that distinguishes it from its neighbours.
+ *
+ * A bare clock time is ambiguous the moment a thread spans midnight, and these
+ * threads run for days — two rows both reading "2:00 PM" are three days apart
+ * and the strip gives no hint of it.
+ */
+export function formatTurnWhen(timestamp: number, now: number): string {
+  const elapsed = now - timestamp;
+  if (elapsed < 0) return formatClock(timestamp);
+  if (elapsed < HOUR_MS) {
+    return `${Math.max(1, Math.round(elapsed / MINUTE_MS))}m ago`;
+  }
+  if (elapsed < DAY_MS) {
+    const hours = Math.floor(elapsed / HOUR_MS);
+    const minutes = Math.round((elapsed % HOUR_MS) / MINUTE_MS);
+    return minutes > 0 ? `${hours}h ${minutes}m ago` : `${hours}h ago`;
+  }
+  if (elapsed < 7 * DAY_MS) {
+    const day = new Date(timestamp)
+      .toLocaleDateString(undefined, { weekday: "short" });
+    return `${day} ${formatClock(timestamp)}`;
+  }
+  const date = new Date(timestamp)
+    .toLocaleDateString(undefined, { day: "numeric", month: "numeric" });
+  return `${date} ${formatClock(timestamp)}`;
+}
+
+function formatClock(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 function elideMiddle(value: string, budget: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -40,7 +40,6 @@ export type IncidentSummary = {
   incidentTokens: number;
   /** Estimated tokens across every accounted call, flagged or not. */
   totalTokens: number;
-  totalCallCount: number;
   /** Flagged share of all tool output, 0–1. Zero when nothing is accounted. */
   share: number;
   turnCount: number;
@@ -53,14 +52,18 @@ export type TurnCostRow = {
   firstObservedAt: number;
   key: string;
   label: string;
-  noisyCount: number;
   /** Calls that reached the harness's output cap, where output is truncated. */
   overCapCount: number;
-  outputChars: number;
   turnId?: string;
 };
 
 export type TurnCostStrip = {
+  /**
+   * Every turn's label, including turns the row limit dropped. Callers label
+   * cases from this rather than from `rows` — a case belonging to a turn that
+   * did not make the strip still belongs to a turn.
+   */
+  labelsByKey: Map<string, string>;
   /** Largest single-turn values in the strip, for scaling both bars. */
   maxCallCount: number;
   maxTokens: number;
@@ -74,7 +77,6 @@ export type TurnCostStrip = {
 };
 
 export type CategoryShare = {
-  caseCount: number;
   category: ThreadToolInvocationCategory | "other";
   estimatedOutputTokens: number;
   label: string;
@@ -115,7 +117,6 @@ export function summarizeIncidents(
     incidentChars: flagged.reduce((sum, entry) => sum + entry.outputChars, 0),
     incidentTokens,
     share: totalTokens > 0 ? incidentTokens / totalTokens : 0,
-    totalCallCount: invocations.length,
     totalTokens,
     turnCount: turnKeys.size,
     worstChars: flagged.reduce((worst, entry) => Math.max(worst, entry.outputChars), 0),
@@ -141,16 +142,12 @@ export function buildTurnCostStrip(
       firstObservedAt: invocation.observedAt,
       key,
       label: "",
-      noisyCount: 0,
-      outputChars: 0,
       overCapCount: 0,
       ...(invocation.turnId ? { turnId: invocation.turnId } : {}),
     };
     row.callCount += 1;
     row.estimatedOutputTokens += invocation.estimatedOutputTokens;
-    row.outputChars += invocation.outputChars;
     row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
-    if (invocation.noisy) row.noisyCount += 1;
     if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
     groups.set(key, row);
   }
@@ -167,14 +164,29 @@ export function buildTurnCostStrip(
   const ordering: TurnCostStrip["ordering"] = chronological.length > limit
     ? "cost"
     : "time";
+  /* Rank on BOTH axes, not just output. Sorting by tokens alone would cut the
+     80-call polling turn that returns almost nothing — the pathology the tick
+     rail exists to show — and leave the strip claiming it was "quieter". */
+  const scale = {
+    calls: chronological.reduce((max, row) => Math.max(max, row.callCount), 0),
+    tokens: chronological.reduce(
+      (max, row) => Math.max(max, row.estimatedOutputTokens),
+      0,
+    ),
+  };
+  const score = (row: TurnCostRow): number =>
+    (scale.tokens > 0 ? row.estimatedOutputTokens / scale.tokens : 0)
+    + (scale.calls > 0 ? row.callCount / scale.calls : 0);
   const ordered = ordering === "cost"
     ? [...chronological].sort((left, right) =>
-        right.estimatedOutputTokens - left.estimatedOutputTokens
+        score(right) - score(left)
+        || right.estimatedOutputTokens - left.estimatedOutputTokens
         || right.callCount - left.callCount)
     : chronological;
   const rows = ordered.slice(0, limit);
   return {
     hiddenTurnCount: chronological.length - rows.length,
+    labelsByKey: new Map(chronological.map((row) => [row.key, row.label])),
     maxCallCount: rows.reduce((max, row) => Math.max(max, row.callCount), 0),
     maxTokens: rows.reduce((max, row) => Math.max(max, row.estimatedOutputTokens), 0),
     ordering,
@@ -190,13 +202,11 @@ export function buildCategoryComposition(
   const groups = new Map<ThreadToolInvocationCategory, CategoryShare>();
   for (const invocation of invocations) {
     const share = groups.get(invocation.category) ?? {
-      caseCount: 0,
       category: invocation.category,
       estimatedOutputTokens: 0,
       label: formatCategoryLabel(invocation.category),
       share: 0,
     };
-    share.caseCount += 1;
     share.estimatedOutputTokens += invocation.estimatedOutputTokens;
     groups.set(invocation.category, share);
   }
@@ -208,7 +218,6 @@ export function buildCategoryComposition(
   const tail = ranked.slice(limit);
   if (tail.length > 0) {
     head.push({
-      caseCount: tail.reduce((sum, entry) => sum + entry.caseCount, 0),
       category: "other",
       estimatedOutputTokens: sumEntries(tail),
       label: `Other (${tail.length})`,
@@ -269,8 +278,22 @@ function leadingWords(value: string, budget: number): string {
   return boundary > 0 ? value.slice(0, boundary) : "";
 }
 
-export function capShare(outputChars: number): number {
+function capShare(outputChars: number): number {
   return toolOutputCapShare(outputChars);
+}
+
+/**
+ * Success coloring is reserved for a call that actually succeeded. A non-zero
+ * exit is a failure whatever the transport status says, and cancelled or still
+ * running is neither — those stay neutral rather than borrowing green.
+ */
+export function invocationStatusTone(
+  invocation: ThreadToolInvocationRecord,
+): "error" | "ok" | undefined {
+  if (invocation.status === "failed") return "error";
+  if (invocation.status !== "completed") return undefined;
+  if (invocation.exitCode !== undefined && invocation.exitCode !== 0) return "error";
+  return "ok";
 }
 
 /** Meter width, clamped — a case past the cap pins rather than overflowing. */

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -1,6 +1,7 @@
 import type {
   ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
+  ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
   isFlaggedToolInvocation,
@@ -52,6 +53,8 @@ export type IncidentSummary = {
 
 export type TurnCostRow = {
   callCount: number;
+  /** Billed cost of this turn, when the pricing ledger has priced it. */
+  costMicros?: number;
   estimatedOutputTokens: number;
   firstObservedAt: number;
   key: string;
@@ -84,6 +87,12 @@ export type CategoryShare = {
   category: RefinedToolCategory | "other";
   estimatedOutputTokens: number;
   label: string;
+  /**
+   * Categories this entry stands for. One for a named entry; for the folded
+   * "Other" entry, every category inside it — which is what lets that entry
+   * be a real filter rather than an unreachable remainder.
+   */
+  members: RefinedToolCategory[];
   /** Share of flagged output tokens, 0–1. */
   share: number;
 };
@@ -119,10 +128,56 @@ const CATEGORY_LABELS: Record<ThreadToolInvocationCategory, string> = {
 const AGENT_INSTRUCTION_PATTERN = /\b(?:AGENTS|CLAUDE)\.md\b/i;
 const SKILL_FILE_PATTERN = /\bSKILL\.md\b|[/\\]skills?[/\\]|[/\\]plugins[/\\]/i;
 
+/** Shell wrappers whose payload is the command we actually care about. */
+const SHELL_WRAPPER_PATTERN =
+  /^(?:\/(?:usr\/)?bin\/)?(?:ba|z|k)?sh\s+-[a-z]*c\s+(['"])([\s\S]*)\1\s*$/i;
+
+/**
+ * Command verbs we can categorize, and what they mean. Scanned across the
+ * whole command rather than read off its first token.
+ */
+const VERB_CATEGORIES = new Map<string, ThreadToolInvocationCategory>([
+  ["git", "git"],
+  ["cat", "file-io"], ["head", "file-io"], ["tail", "file-io"],
+  ["sed", "file-io"], ["awk", "file-io"], ["ls", "file-io"], ["wc", "file-io"],
+  ["rg", "search"], ["grep", "search"], ["find", "search"], ["fd", "search"],
+  ["npm", "package-manager"], ["pnpm", "package-manager"],
+  ["yarn", "package-manager"], ["bun", "package-manager"],
+  ["npx", "package-manager"],
+  ["sleep", "polling"],
+]);
+
 export type RefinedToolCategory =
   | ThreadToolInvocationCategory
   | "agent-instructions"
   | "skill-files";
+
+export function unwrapShellCommand(command: string): string {
+  const match = SHELL_WRAPPER_PATTERN.exec(command.trim());
+  return match?.[2]?.trim() ?? command;
+}
+
+/**
+ * The one category every verb in the command agrees on, or undefined when
+ * they disagree or none is recognized.
+ *
+ * Reading the first token alone gets a compound command wrong twice over: a
+ * `/bin/bash -c '…'` wrapper reports the shell rather than what it ran, and a
+ * script that is four `git` invocations in a row is plainly git work. Real
+ * example from a 236-turn thread: `/bin/bash -c 'git diff --check git diff
+ * --stat git status --short --branch git diff -- …'` was filed under
+ * "Tests & builds", because the substring " test" appeared in a path.
+ */
+function unanimousVerbCategory(
+  command: string,
+): ThreadToolInvocationCategory | undefined {
+  const found = new Set<ThreadToolInvocationCategory>();
+  for (const token of command.split(/[\s;|&()]+/)) {
+    const category = VERB_CATEGORIES.get(token.toLowerCase());
+    if (category) found.add(category);
+  }
+  return found.size === 1 ? [...found][0] : undefined;
+}
 
 export function refineToolCategory(
   invocation: Pick<
@@ -130,13 +185,24 @@ export function refineToolCategory(
     "category" | "normalizedCommand" | "toolName"
   >,
 ): RefinedToolCategory {
-  if (invocation.category !== "file-io" && invocation.category !== "search") {
-    return invocation.category;
-  }
-  const command = invocation.normalizedCommand ?? invocation.toolName;
+  const raw = invocation.normalizedCommand ?? invocation.toolName;
+  const command = unwrapShellCommand(raw);
+  /* Only second-guess the persisted category when it is untrustworthy: either
+     it was computed from a shell wrapper we have now seen through, or it is
+     one of the buckets that means "no pattern matched". `pnpm test` stays
+     Tests & builds — the verb scan is a fallback, not a better classifier. */
+  const persistedIsWeak =
+    command !== raw.trim()
+    || invocation.category === "shell"
+    || invocation.category === "unknown";
+  const category = (persistedIsWeak ? unanimousVerbCategory(command) : undefined)
+    ?? invocation.category;
+  /* Only a read gets refined by what it read. `git diff -- …/SKILL.md` is git
+     work that happens to touch a skill file, not a skill read. */
+  if (category !== "file-io" && category !== "search") return category;
   if (AGENT_INSTRUCTION_PATTERN.test(command)) return "agent-instructions";
   if (SKILL_FILE_PATTERN.test(command)) return "skill-files";
-  return invocation.category;
+  return category;
 }
 
 export function formatCategoryLabel(
@@ -204,9 +270,20 @@ export function summarizeIncidents(
  */
 export function buildTurnCostStrip(
   invocations: ThreadToolInvocationRecord[],
-  options?: { limit?: number },
+  options?: { limit?: number; usageLines?: readonly ThreadUsageLineRecord[] },
 ): TurnCostStrip {
   const limit = options?.limit ?? DEFAULT_TURN_ROW_LIMIT;
+  /* Billed cost per turn, joined by turn id. The ledger is the authority on
+     money; the token bar is an estimate from character counts, so the two are
+     reported side by side rather than one derived from the other. */
+  const costByTurn = new Map<string, number>();
+  for (const line of options?.usageLines ?? []) {
+    if (!line.turnId) continue;
+    costByTurn.set(
+      line.turnId,
+      (costByTurn.get(line.turnId) ?? 0) + line.totalCostMicros,
+    );
+  }
   const groups = new Map<string, TurnCostRow>();
   for (const invocation of invocations) {
     const key = invocation.turnId ?? "";
@@ -224,6 +301,11 @@ export function buildTurnCostStrip(
     row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
     if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
     groups.set(key, row);
+  }
+
+  for (const row of groups.values()) {
+    const cost = row.turnId ? costByTurn.get(row.turnId) : undefined;
+    if (cost !== undefined) row.costMicros = cost;
   }
 
   /* Ordinals come from time order across all turns, so "Turn 3" keeps meaning
@@ -280,6 +362,7 @@ export function buildCategoryComposition(
       category,
       estimatedOutputTokens: 0,
       label: formatCategoryLabel(category),
+      members: [category],
       share: 0,
     };
     share.estimatedOutputTokens += invocation.estimatedOutputTokens;
@@ -300,6 +383,7 @@ export function buildCategoryComposition(
       category: "other",
       estimatedOutputTokens: sumEntries(tail),
       label: `Other (${tail.length})`,
+      members: tail.map((entry) => entry.category as RefinedToolCategory),
       share: 0,
     });
   }
@@ -396,6 +480,20 @@ export function formatCapShare(
   return options?.short
     ? `${percentage.toLocaleString()}% of cap`
     : `${percentage.toLocaleString()}% of the output cap`;
+}
+
+export function formatMicrosCurrency(
+  micros: number,
+  currency: string | undefined,
+): string {
+  const units = micros / 1_000_000;
+  const rounded = units >= 100
+    ? Math.round(units)
+    : Number(units.toFixed(units >= 1 ? 2 : 3));
+  const value = rounded.toLocaleString();
+  if (!currency || currency === "USD") return `$${value}`;
+  if (currency.toLowerCase().includes("credit")) return `${value} cr`;
+  return `${value} ${currency}`;
 }
 
 export function formatCompactTokens(tokens: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -2,7 +2,11 @@ import type {
   ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
-import { TOOL_OUTPUT_CAP_CHARS, toolOutputCapShare } from "@pwragent/shared";
+import {
+  isFlaggedToolInvocation,
+  TOOL_OUTPUT_CAP_CHARS,
+  toolOutputCapShare,
+} from "@pwragent/shared";
 
 /**
  * Derivations behind the incident explorer's visual summary.
@@ -108,7 +112,7 @@ export function formatCategoryLabel(
 export function summarizeIncidents(
   invocations: ThreadToolInvocationRecord[],
 ): IncidentSummary {
-  const flagged = invocations.filter((invocation) => invocation.noisy);
+  const flagged = invocations.filter(isFlaggedToolInvocation);
   const turnKeys = new Set(flagged.map((invocation) => invocation.turnId ?? ""));
   const totalTokens = sumTokens(invocations);
   const incidentTokens = sumTokens(flagged);

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -57,6 +57,8 @@ export type TurnCostRow = {
   costMicros?: number;
   estimatedOutputTokens: number;
   firstObservedAt: number;
+  /** Calls that pass `isFlaggedToolInvocation` — the scope toggle's test. */
+  flaggedCallCount: number;
   key: string;
   label: string;
   /** Calls that reached the harness's output cap, where output is truncated. */
@@ -64,7 +66,11 @@ export type TurnCostRow = {
   turnId?: string;
 };
 
+export type TurnStripScope = "all" | "flagged";
+
 export type TurnCostStrip = {
+  /** Turns in scope that contain at least one flagged call. */
+  flaggedTurnCount: number;
   /**
    * Every turn's label, including turns the row limit dropped. Callers label
    * cases from this rather than from `rows` — a case belonging to a turn that
@@ -76,10 +82,20 @@ export type TurnCostStrip = {
   maxTokens: number;
   /**
    * "time" reads as a timeline. Past the row limit that stops being legible,
-   * so the strip ranks by cost instead and reports what it dropped.
+   * so the strip ranks instead and reports what it dropped.
    */
   ordering: "cost" | "time";
+  /**
+   * What the "cost" ordering actually ranks by, so the header can say it
+   * instead of leaving the reader to reverse-engineer the sort. "billed" is
+   * ledger money; "estimate" is the two-axis blend of output tokens and
+   * round trips, used when nothing is priced.
+   */
+  rankedBy: "billed" | "estimate";
   rows: TurnCostRow[];
+  scope: TurnStripScope;
+  /** Turns with any recorded tool call — the "all" scope's population. */
+  totalTurnCount: number;
   hiddenTurnCount: number;
 };
 
@@ -279,9 +295,14 @@ export function summarizeIncidents(
  */
 export function buildTurnCostStrip(
   invocations: ThreadToolInvocationRecord[],
-  options?: { limit?: number; usageLines?: readonly ThreadUsageLineRecord[] },
+  options?: {
+    limit?: number;
+    scope?: TurnStripScope;
+    usageLines?: readonly ThreadUsageLineRecord[];
+  },
 ): TurnCostStrip {
   const limit = options?.limit ?? DEFAULT_TURN_ROW_LIMIT;
+  const scope = options?.scope ?? "flagged";
   /* Billed cost per turn, joined by turn id. The ledger is the authority on
      money; the token bar is an estimate from character counts, so the two are
      reported side by side rather than one derived from the other. */
@@ -300,6 +321,7 @@ export function buildTurnCostStrip(
       callCount: 0,
       estimatedOutputTokens: 0,
       firstObservedAt: invocation.observedAt,
+      flaggedCallCount: 0,
       key,
       label: "",
       overCapCount: 0,
@@ -308,6 +330,7 @@ export function buildTurnCostStrip(
     row.callCount += 1;
     row.estimatedOutputTokens += invocation.estimatedOutputTokens;
     row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
+    if (isFlaggedToolInvocation(invocation)) row.flaggedCallCount += 1;
     if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
     groups.set(key, row);
   }
@@ -326,15 +349,28 @@ export function buildTurnCostStrip(
     row.label = row.turnId ? `Turn ${(ordinal += 1)}` : "Unassigned";
   }
 
-  const ordering: TurnCostStrip["ordering"] = chronological.length > limit
+  /* Ordinals are assigned before scoping, so "Turn 92" names the same turn
+     in both scopes and in the case list. */
+  const scoped = scope === "flagged"
+    ? chronological.filter((row) => row.flaggedCallCount > 0)
+    : chronological;
+
+  const ordering: TurnCostStrip["ordering"] = scoped.length > limit
     ? "cost"
     : "time";
-  /* Rank on BOTH axes, not just output. Sorting by tokens alone would cut the
-     80-call polling turn that returns almost nothing — the pathology the tick
-     rail exists to show — and leave the strip claiming it was "quieter". */
+  /* Billed money outranks any estimate: when the ledger has priced these
+     turns, "costliest" means dollars, full stop — an invented blend next to a
+     visible price column reads as a sort nobody can name. The blend remains
+     only for unpriced threads, where it still beats tokens alone (which would
+     cut the 80-call polling turn the tick rail exists to show). */
+  const rankedBy: TurnCostStrip["rankedBy"] = scoped.some(
+    (row) => row.costMicros !== undefined,
+  )
+    ? "billed"
+    : "estimate";
   const scale = {
-    calls: chronological.reduce((max, row) => Math.max(max, row.callCount), 0),
-    tokens: chronological.reduce(
+    calls: scoped.reduce((max, row) => Math.max(max, row.callCount), 0),
+    tokens: scoped.reduce(
       (max, row) => Math.max(max, row.estimatedOutputTokens),
       0,
     ),
@@ -343,19 +379,27 @@ export function buildTurnCostStrip(
     (scale.tokens > 0 ? row.estimatedOutputTokens / scale.tokens : 0)
     + (scale.calls > 0 ? row.callCount / scale.calls : 0);
   const ordered = ordering === "cost"
-    ? [...chronological].sort((left, right) =>
-        score(right) - score(left)
+    ? [...scoped].sort((left, right) =>
+        (rankedBy === "billed"
+          ? (right.costMicros ?? -1) - (left.costMicros ?? -1)
+          : 0)
+        || score(right) - score(left)
         || right.estimatedOutputTokens - left.estimatedOutputTokens
         || right.callCount - left.callCount)
-    : chronological;
+    : scoped;
   const rows = ordered.slice(0, limit);
   return {
-    hiddenTurnCount: chronological.length - rows.length,
+    flaggedTurnCount: chronological
+      .filter((row) => row.flaggedCallCount > 0).length,
+    hiddenTurnCount: scoped.length - rows.length,
     labelsByKey: new Map(chronological.map((row) => [row.key, row.label])),
     maxCallCount: rows.reduce((max, row) => Math.max(max, row.callCount), 0),
     maxTokens: rows.reduce((max, row) => Math.max(max, row.estimatedOutputTokens), 0),
     ordering,
+    rankedBy,
     rows,
+    scope,
+    totalTurnCount: chronological.length,
   };
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15425,6 +15425,17 @@ a.transcript-message__messaging-origin:focus-visible {
   display: grid;
   align-items: center;
   grid-template-columns: 128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px;
+  gap: 12px;
+  width: calc(100% + 16px);
+  margin: 0 -8px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 /* Cost rides at the end of the row, in the ledger's own units. It is the one
@@ -15442,17 +15453,6 @@ a.transcript-message__messaging-origin:focus-visible {
   font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
-  gap: 12px;
-  width: calc(100% + 16px);
-  margin: 0 -8px;
-  padding: 4px 8px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-primary);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
 }
 
 .incident-explorer__turn:hover {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15379,6 +15379,80 @@ a.transcript-message__messaging-origin:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+/* When it went: one column per turn across the whole thread, time order.
+   Tokens rise from the shared baseline, round trips hang below it, so a long
+   poll reads as trip spikes with no matching output directly above them. */
+.incident-explorer__timeline-block {
+  margin-top: 10px;
+}
+
+.incident-explorer__timeline {
+  display: flex;
+  align-items: stretch;
+  height: 40px;
+  overflow: hidden;
+}
+
+/* Column separation comes from a transparent right border rather than gap:
+   a 300-turn thread in a narrow window must compress to 1px columns instead
+   of overflowing, and gaps do not shrink. */
+.incident-explorer .incident-explorer__timeline-turn {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  min-width: 1px;
+  padding: 0;
+  border: 0;
+  border-right: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.incident-explorer .incident-explorer__timeline-turn:last-child {
+  border-right: 0;
+}
+
+.incident-explorer__timeline-turn:hover .incident-explorer__timeline-tokens i,
+.incident-explorer__timeline-turn[aria-pressed="true"] .incident-explorer__timeline-tokens i {
+  background: var(--accent-strong);
+}
+
+.incident-explorer__timeline-turn[aria-pressed="true"] {
+  background: var(--accent-soft);
+}
+
+.incident-explorer__timeline-tokens {
+  display: flex;
+  flex: 1;
+  align-items: flex-end;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__timeline-tokens i {
+  display: block;
+  width: 100%;
+  min-height: 1px;
+  background: var(--accent);
+}
+
+.incident-explorer__timeline-tokens i[data-critical="true"] {
+  background: var(--status-error);
+}
+
+.incident-explorer__timeline-trips {
+  display: flex;
+  flex: 0 0 11px;
+  align-items: flex-start;
+}
+
+.incident-explorer__timeline-trips i {
+  display: block;
+  width: 100%;
+  min-height: 1px;
+  background: color-mix(in srgb, var(--text-secondary) 66%, transparent);
+}
+
 /* Cost by turn. The solid bar is output volume; the tick rail is round trips.
    They are deliberately different marks because they are different problems:
    a turn heavy on ticks and light on bar is a polling loop, and the fix for

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15299,8 +15299,11 @@ a.transcript-message__messaging-origin:focus-visible {
   overflow: hidden;
 }
 
+/* A category the legend lists has to be visible in the bar the legend
+   explains, so a tiny share keeps a 2px mark instead of rounding away. */
 .incident-explorer__composition i {
   display: block;
+  min-width: 2px;
   height: 100%;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15425,6 +15425,23 @@ a.transcript-message__messaging-origin:focus-visible {
   display: grid;
   align-items: center;
   grid-template-columns: 128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px;
+}
+
+/* Cost rides at the end of the row, in the ledger's own units. It is the one
+   figure on this strip that is billed rather than estimated, so it takes the
+   primary text color while the estimates stay secondary. */
+.incident-explorer__turn[data-cost="true"] {
+  grid-template-columns:
+    128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px 64px;
+}
+
+.incident-explorer__turn-cost {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
   gap: 12px;
   width: calc(100% + 16px);
   margin: 0 -8px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15401,6 +15401,32 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 10px;
 }
 
+/* Scope toggle: quiet segmented pair, same visual weight as the legend so it
+   reads as a view control rather than a primary action. */
+.incident-explorer__turns-scope {
+  display: flex;
+  gap: 2px;
+  margin: 0 12px 6px auto;
+}
+
+.incident-explorer__turns-scope button {
+  padding: 2px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 10px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.incident-explorer__turns-scope button[aria-pressed="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
 .incident-explorer__turns-key {
   display: inline-block;
   width: 14px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15138,20 +15138,11 @@ a.transcript-message__messaging-origin:focus-visible {
   flex: 0 1 auto;
 }
 
-.incident-explorer__section-heading h2,
-.incident-explorer__evidence h2,
-.incident-explorer__prompt h2,
-.incident-explorer__output h2 {
+.incident-explorer h2 {
   margin: 0;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 650;
-}
-
-.incident-explorer__prompt p {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: 11px;
 }
 
 .incident-explorer__actions,
@@ -15163,9 +15154,48 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .incident-explorer__section-heading {
   justify-content: space-between;
+  margin-bottom: 9px;
 }
 
-.incident-explorer button,
+/* Three button weights, per the style guide's primary / secondary / ghost
+   rule. The window previously styled every `button` identically, which left
+   Close and the primary steering action reading as equals. */
+.incident-explorer__button {
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.incident-explorer__button--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.incident-explorer .incident-explorer__primary {
+  border-color: var(--accent-border);
+  background: var(--accent);
+  color: var(--button-text);
+  font-weight: 650;
+}
+
+.incident-explorer__button:hover:not(:disabled) {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.incident-explorer__button:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
 .incident-explorer input,
 .incident-explorer select,
 .incident-explorer textarea {
@@ -15176,50 +15206,296 @@ a.transcript-message__messaging-origin:focus-visible {
   font: inherit;
 }
 
-.incident-explorer button {
-  min-height: 30px;
-  padding: 5px 10px;
-  cursor: pointer;
-}
-
-.incident-explorer button:hover:not(:disabled),
 .incident-explorer button:focus-visible,
 .incident-explorer input:focus-visible,
 .incident-explorer select:focus-visible,
+.incident-explorer summary:focus-visible,
 .incident-explorer textarea:focus-visible {
-  border-color: var(--accent-border);
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
 }
 
-.incident-explorer button:disabled {
-  color: var(--text-muted);
-  cursor: default;
-}
-
-.incident-explorer__metrics {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.incident-explorer__metrics > div {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 12px 18px;
-  border-right: 1px solid var(--border-subtle);
-}
-
-.incident-explorer__metrics span {
+.incident-explorer__eyebrow {
+  margin: 0 0 6px;
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 650;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.incident-explorer__metrics strong {
-  font-size: 14px;
+/* Shared magnitude primitive. Same measurements as
+   `.context-usage-card__meter` so the app has one bar language. */
+.incident-explorer__meter {
+  display: block;
+  height: 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.incident-explorer__meter i {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  background: var(--accent);
+}
+
+.incident-explorer__meter i[data-critical="true"] {
+  background: var(--status-error);
+}
+
+.incident-explorer__caption {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.incident-explorer__summary {
+  display: grid;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  gap: 28px;
+  padding: 13px 18px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__hero {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 8px;
+}
+
+.incident-explorer__hero strong {
+  font-family: var(--font-mono);
+  font-size: 21px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+
+.incident-explorer__hero span {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.incident-explorer__caption b {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+/* One accent stepped down in strength rather than a categorical palette —
+   the style guide allows exactly one accent, and a five-color chart legend
+   would spend the product's whole color budget on a 5px strip. */
+.incident-explorer__composition {
+  display: flex;
+  gap: 2px;
+  height: 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.incident-explorer__composition i {
+  display: block;
+  height: 100%;
+}
+
+.incident-explorer__composition i[data-rank="1"],
+.incident-explorer__swatch[data-rank="1"] {
+  background: var(--accent);
+}
+
+.incident-explorer__composition i[data-rank="2"],
+.incident-explorer__swatch[data-rank="2"] {
+  background: color-mix(in srgb, var(--accent) 74%, transparent);
+}
+
+.incident-explorer__composition i[data-rank="3"],
+.incident-explorer__swatch[data-rank="3"] {
+  background: color-mix(in srgb, var(--accent) 54%, transparent);
+}
+
+.incident-explorer__composition i[data-rank="4"],
+.incident-explorer__swatch[data-rank="4"] {
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
+}
+
+.incident-explorer__composition i[data-rank="5"],
+.incident-explorer__swatch[data-rank="5"] {
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
+}
+
+.incident-explorer__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px 14px;
+  margin-top: 8px;
+}
+
+.incident-explorer__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.incident-explorer__legend-item[aria-pressed="true"] {
+  color: var(--text-primary);
+}
+
+.incident-explorer__legend-item:disabled {
+  cursor: default;
+}
+
+.incident-explorer__swatch {
+  display: block;
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.incident-explorer__swatch--all {
+  background: color-mix(in srgb, var(--text-primary) 24%, transparent);
+}
+
+.incident-explorer__legend-item em {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Cost by turn. The solid bar is output volume; the tick rail is round trips.
+   They are deliberately different marks because they are different problems:
+   a turn heavy on ticks and light on bar is a polling loop, and the fix for
+   it has nothing to do with filtering output. */
+.incident-explorer__turns {
+  padding: 11px 18px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__turns-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.incident-explorer__turns-legend {
+  margin: 0 0 6px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.incident-explorer__turns-key {
+  display: inline-block;
+  width: 14px;
+  height: 5px;
+  border-radius: 2px;
+  vertical-align: middle;
+}
+
+.incident-explorer__turns-key[data-kind="tokens"] {
+  background: var(--accent);
+}
+
+.incident-explorer__turns-key[data-kind="trips"] {
+  background: repeating-linear-gradient(
+    90deg,
+    var(--text-secondary) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+.incident-explorer__turn {
+  display: grid;
+  align-items: center;
+  grid-template-columns: 128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px;
+  gap: 12px;
+  width: calc(100% + 16px);
+  margin: 0 -8px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.incident-explorer__turn:hover {
+  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+}
+
+.incident-explorer__turn[aria-pressed="true"] {
+  background: var(--bg-row-active);
+  box-shadow: inset 2px 0 0 0 var(--accent);
+}
+
+.incident-explorer__turn-label {
+  overflow: hidden;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.incident-explorer__turn-label span {
+  color: var(--text-muted);
+}
+
+.incident-explorer__turn-bar,
+.incident-explorer__turn-trips {
+  height: 7px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.incident-explorer__turn-bar i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+.incident-explorer__turn-bar i[data-critical="true"] {
+  background: var(--status-error);
+}
+
+.incident-explorer__turn-trips i {
+  display: block;
+  height: 100%;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--text-secondary) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+.incident-explorer__turn-number {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.incident-explorer__turns-note {
+  margin: 7px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 .incident-explorer__coverage,
@@ -15232,10 +15508,20 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 12px;
 }
 
+/* A completed analysis is not a warning. Only the partial-coverage and
+   failure paths carry status color. */
+.incident-explorer__status[data-tone="info"] {
+  color: var(--text-secondary);
+}
+
+.incident-explorer__status[data-tone="error"] {
+  color: var(--status-error);
+}
+
 .incident-explorer__body {
   display: grid;
   flex: 1;
-  grid-template-columns: minmax(280px, 32%) minmax(0, 1fr);
+  grid-template-columns: minmax(300px, 34%) minmax(0, 1fr);
   min-height: 0;
 }
 
@@ -15250,7 +15536,7 @@ a.transcript-message__messaging-origin:focus-visible {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
-  padding: 12px;
+  padding: 11px 12px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -15258,46 +15544,96 @@ a.transcript-message__messaging-origin:focus-visible {
 .incident-explorer__filters select,
 .incident-explorer__section-heading input {
   min-width: 0;
-  padding: 7px 9px;
+  padding: 6px 9px;
+  font-size: 11px;
 }
 
-.incident-explorer__group h2 {
+.incident-explorer__active-filters {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 8px 7px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.incident-explorer__group h3 {
   margin: 0;
-  padding: 12px 12px 6px;
+  padding: 11px 12px 5px;
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 650;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.incident-explorer .incident-explorer__case {
-  display: flex;
-  align-items: stretch;
-  flex-direction: column;
+.incident-explorer__case {
+  display: block;
   width: 100%;
-  padding: 9px 12px;
+  padding: 8px 12px 9px;
   border: 0;
-  border-radius: 0;
   border-left: 2px solid transparent;
+  border-radius: 0;
   background: transparent;
+  color: var(--text-primary);
+  font: inherit;
   text-align: left;
+  cursor: pointer;
 }
 
-.incident-explorer .incident-explorer__case[data-selected="true"] {
+.incident-explorer__case:hover {
+  background: color-mix(in srgb, var(--text-primary) 3.5%, transparent);
+}
+
+.incident-explorer__case[data-selected="true"] {
   border-left-color: var(--accent);
   background: var(--bg-row-active);
 }
 
-.incident-explorer__case span {
+.incident-explorer__case-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+/* No `text-overflow: ellipsis` on purpose. The row label is already elided in
+   the middle, where the distinguishing part of a command lives; a CSS ellipsis
+   is an end-truncation and would cut that part back off. */
+.incident-explorer__case-id {
   overflow: hidden;
   font-family: var(--font-mono);
-  font-size: 11px;
-  text-overflow: ellipsis;
+  font-size: 12px;
   white-space: nowrap;
 }
 
-.incident-explorer__case small {
-  margin-top: 4px;
+.incident-explorer__case-id b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.incident-explorer__case-id span {
+  color: var(--text-muted);
+}
+
+.incident-explorer__case-tokens {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.incident-explorer__case .incident-explorer__meter {
+  height: 4px;
+  margin-top: 6px;
+}
+
+.incident-explorer__case-sub {
+  display: block;
+  margin-top: 5px;
   color: var(--text-muted);
   font-size: 10px;
 }
@@ -15305,57 +15641,172 @@ a.transcript-message__messaging-origin:focus-visible {
 .incident-explorer__detail {
   min-height: 0;
   overflow: auto;
-  padding: 18px;
+  padding: 16px 18px;
 }
 
 .incident-explorer__evidence,
 .incident-explorer__prompt,
 .incident-explorer__output {
-  margin-bottom: 18px;
+  margin-bottom: 16px;
 }
 
-.incident-explorer__evidence dl {
-  display: grid;
-  grid-template-columns: 110px minmax(0, 1fr);
-  gap: 7px 12px;
-  margin: 12px 0 0;
+/* The command is evidence, not the headline. Collapsed to one line by
+   default; a 1,100-character shell pipeline rendered in full was the loudest
+   thing in the window and the least decision-relevant. */
+.incident-explorer__identity {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px 7px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+}
+
+.incident-explorer__identity code {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.incident-explorer__identity[data-expanded="true"] {
+  align-items: flex-start;
+}
+
+.incident-explorer__identity[data-expanded="true"] code {
+  max-height: 180px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.incident-explorer__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+
+.incident-explorer__fact {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.incident-explorer__fact b {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.incident-explorer__fact[data-tone="ok"] b {
+  color: var(--status-ok);
+}
+
+.incident-explorer__fact[data-tone="warning"] b {
+  color: var(--status-warning);
+}
+
+.incident-explorer__fact[data-tone="error"] b {
+  color: var(--status-error);
+}
+
+.incident-explorer__budget {
+  margin-top: 11px;
+  padding: 11px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+}
+
+.incident-explorer__budget-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 9px;
+}
+
+.incident-explorer__budget-head strong {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.incident-explorer__budget-head span {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.incident-explorer__reason {
+  margin: 5px 0 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.incident-explorer__steer summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
   font-size: 12px;
+  list-style: none;
+  cursor: pointer;
 }
 
-.incident-explorer__evidence dt {
+.incident-explorer__steer summary::-webkit-details-marker {
+  display: none;
+}
+
+.incident-explorer__steer summary::before {
+  content: "›";
   color: var(--text-muted);
 }
 
-.incident-explorer__evidence dd {
-  margin: 0;
-  overflow-wrap: anywhere;
+.incident-explorer__steer[open] summary::before {
+  content: "⌄";
 }
 
-.incident-explorer__evidence code,
-.incident-explorer__output-lines code {
-  font-family: var(--font-mono);
-}
-
-.incident-explorer__prompt textarea {
+.incident-explorer__steer textarea {
   box-sizing: border-box;
   width: 100%;
-  margin: 10px 0 8px;
+  margin: 9px 0 0;
   padding: 10px;
-  resize: vertical;
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.5;
+  resize: vertical;
 }
 
-.incident-explorer .incident-explorer__primary {
-  border-color: var(--accent-border);
-  background: var(--accent);
-  color: var(--button-text);
-  font-weight: 650;
+.incident-explorer__prompt-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.incident-explorer__prompt-actions p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 .incident-explorer__output-lines {
-  max-height: 440px;
+  max-height: 360px;
   margin: 10px 0 0;
   padding: 10px 10px 10px 52px;
   overflow: auto;
@@ -15365,12 +15816,37 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--terminal-fg);
   font-size: 11px;
   line-height: 1.5;
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.incident-explorer__output-lines code {
+  font-family: var(--font-mono);
 }
 
 .incident-explorer__output-lines li::marker {
   color: var(--text-muted);
+}
+
+/* A message about missing output, not terminal content — so it takes the
+   panel surface rather than the terminal canvas, and the dashed border says
+   "nothing landed here" without color. */
+.incident-explorer__unavailable {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.incident-explorer__unavailable b {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .incident-explorer__empty {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15621,6 +15621,15 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--text-muted);
 }
 
+/* Repeat marker rides in the token slot: it qualifies the cost rather than
+   competing with it, so it stays smaller and takes the warning tone. */
+.incident-explorer__repeat {
+  margin-right: 6px;
+  color: var(--status-warning);
+  font-size: 10px;
+  font-weight: 650;
+}
+
 .incident-explorer__case-tokens {
   color: var(--text-secondary);
   font-family: var(--font-mono);

--- a/packages/shared/src/__tests__/tool-output-incidents.test.ts
+++ b/packages/shared/src/__tests__/tool-output-incidents.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isFlaggedToolInvocation } from "../contracts/tool-output-incidents";
+
+describe("isFlaggedToolInvocation", () => {
+  it("flags a large result even when nothing marked the row", () => {
+    /* Threads whose turns predate the detectors carry `noisy = 0` on every
+       row. Trusting the flag alone showed an empty explorer next to a fully
+       populated turn strip — 575 oversized calls in one real thread, none of
+       them listed. */
+    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 17_771 }))
+      .toBe(true);
+  });
+
+  it("keeps trusting the stored flag for patterns a single row cannot show", () => {
+    /* Polling is a pattern across invocations: a 200-char row is only a case
+       because of the fifty rows around it, which the size test cannot see. */
+    expect(isFlaggedToolInvocation({ noisy: true, outputChars: 200 }))
+      .toBe(true);
+  });
+
+  it("leaves an ordinary small result alone", () => {
+    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 3_999 }))
+      .toBe(false);
+  });
+});

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -29,6 +29,25 @@ export function toolOutputCapShare(outputChars: number): number {
   return outputChars / TOOL_OUTPUT_CAP_CHARS;
 }
 
+/**
+ * Whether an invocation counts as a case.
+ *
+ * `noisy` is written at record time — live by the detectors while a turn runs,
+ * or by the history analyzer on demand. Neither has touched a thread whose
+ * turns predate the feature, so every one of its rows reads `noisy = 0` and a
+ * surface that filters on the flag alone shows an empty screen next to a
+ * populated turn strip. The size test is re-derivable from a row we already
+ * have, so derive it rather than trusting when the row was written.
+ *
+ * The flag still matters and is ORed in, because polling is a pattern across
+ * invocations: no single row carries enough to reconstruct it.
+ */
+export function isFlaggedToolInvocation(
+  invocation: Pick<ThreadToolInvocationRecord, "noisy" | "outputChars">,
+): boolean {
+  return invocation.noisy || invocation.outputChars >= TOOL_OUTPUT_WARNING_CHARS;
+}
+
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;
   projectLabel?: string;

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -5,6 +5,30 @@ import type {
   ThreadToolInvocationRecord,
 } from "./normalized-app-server";
 
+/**
+ * Characters per output token. A coarse estimate, but the same one the
+ * accounting analyzer and the incident explorer must agree on: a meter drawn
+ * against a different ratio than the detector that flagged the case would
+ * disagree with its own reason string.
+ */
+export const TOOL_OUTPUT_TOKEN_CHAR_RATIO = 4;
+
+/**
+ * The observed model-visible output cap, in characters (~10k tokens). This is
+ * the denominator that makes a per-case meter mean something absolute: a call
+ * at 100% is one the harness will truncate, and every character under it
+ * replays on every later inference item in the turn.
+ */
+export const TOOL_OUTPUT_CAP_CHARS = 40_000;
+
+/** Output at or above this is large enough to be worth flagging on its own. */
+export const TOOL_OUTPUT_WARNING_CHARS = 4_000;
+
+/** Fraction of the observed output cap this invocation consumed. Uncapped. */
+export function toolOutputCapShare(outputChars: number): number {
+  return outputChars / TOOL_OUTPUT_CAP_CHARS;
+}
+
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;
   projectLabel?: string;


### PR DESCRIPTION
Stacked on #1647 — review that first; this PR's diff is against its branch.

## Why

The explorer measures one of the two things that drive replay cost, and renders all of it as numerals. Every quantity is a number in the same size, weight, and color, so ranking thirteen cases means reading thirteen numbers.

The missing driver is **round trips**. A turn that returns one enormous result is a filtering problem; a turn that makes sixty small calls is a round-trip problem, because each trip replays the whole accumulated context. The data to show it (`turnId`, `observedAt` on every invocation) was already persisted — nothing here adds IPC or contract fields.

## What changed

**Turn strip.** One row per turn over *every* accounted call, not just flagged ones — quiet calls replay context exactly like loud ones. Solid bar = output tokens, tick rail = round trips, deliberately different marks because they are different problems. Click to filter the case list.

**Summary band.** Leads with tokens rather than characters, against a real denominator (flagged share of all accounted tool output). The composition bar answers "where did it go" in a 5px strip and doubles as the category filter, replacing the raw-enum `<select>`. It steps one accent down in strength rather than spending the product's whole color budget on a five-color legend.

**Ranked cases with cap meters.** Sorted largest-first, measured against the observed model-visible output cap the analyzer already reasons about — an absolute denominator, so a pinned bar means "the harness will truncate this." That constant moved to `packages/shared` so the meter and the detector that flagged the case cannot drift apart; the analyzer keeps its local names and imports the values.

**Row labels elided in the middle.** Shell invocations in one turn routinely share a 60-character prefix, and head-truncation rendered several rows byte-identical. The distinguishing tail now survives; the CSS end-ellipsis that would undo it is deliberately absent (commented, so it doesn't get "fixed" back).

**Detail pane collapsed to decisions.** Identity on one line with expand, facts as compact pills instead of a seven-row `<dl>`, steering behind a disclosure. The command appeared three times on screen; now once. The budget card states the replay math concretely: *"17,771 chars · replayed on the 57 later round trips in this turn."*

**Style-guide fixes.** Button hierarchy (primary/secondary/ghost) instead of one blanket `.incident-explorer button` selector; Close dropped (duplicated the OS control); a completed analysis no longer renders in warning amber; `aria-current` / `aria-pressed` on selection and filters, which previously had no accessible state at all.

## Verification

- `pnpm typecheck`, `lint:eslint` (0 errors), `lint:colors`, `lint:boundaries` all pass.
- 27 tests across the window and a new pure-derivation module; the 8 pre-existing window tests pass unmodified.
- Rendered against the real `app.css` in a browser to check the result rather than assume it — that pass is what caught the end-ellipsis undoing the middle-elision, and a turn-strip "critical" flag that was true for every row.
- Full `pnpm test`: 4 files / 12 failures, all in `desktop-main` files untouched here (`acp-backend-adapter`, `app-server-ipc`, `backend-registry`, `codex-environment-runtime`). **Confirmed pre-existing** — the same files fail identically on the unmodified base branch, and each passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)