### PR TITLE
fix(desktop): offer new worktrees from local threads

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -2136,18 +2136,32 @@ export function Sidebar(props: SidebarProps) {
                         </button>
                       </>
                     ) : (
-                      <button
-                        role="menuitem"
-                        type="button"
-                        onClick={() =>
-                          createSubthreadFromContextMenu(
-                            contextMenu.thread,
-                            "local",
-                          )
-                        }
-                      >
-                        Sub-thread in Local
-                      </button>
+                      <>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            createSubthreadFromContextMenu(
+                              contextMenu.thread,
+                              "local",
+                            )
+                          }
+                        >
+                          Sub-thread in Local
+                        </button>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            createSubthreadFromContextMenu(
+                              contextMenu.thread,
+                              "new-worktree",
+                            )
+                          }
+                        >
+                          Sub-thread in New Worktree
+                        </button>
+                      </>
                     )
                   ) : null}
                   {contextMenuCanFork ? (
@@ -2179,18 +2193,32 @@ export function Sidebar(props: SidebarProps) {
                         </button>
                       </>
                     ) : (
-                      <button
-                        role="menuitem"
-                        type="button"
-                        onClick={() =>
-                          forkThreadFromContextMenu(
-                            contextMenu.thread,
-                            "local",
-                          )
-                        }
-                      >
-                        Fork in Local
-                      </button>
+                      <>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            forkThreadFromContextMenu(
+                              contextMenu.thread,
+                              "local",
+                            )
+                          }
+                        >
+                          Fork in Local
+                        </button>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            forkThreadFromContextMenu(
+                              contextMenu.thread,
+                              "new-worktree",
+                            )
+                          }
+                        >
+                          Fork into New Worktree
+                        </button>
+                      </>
                     )
                   ) : null}
                 </div>

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1494,7 +1494,7 @@ describe("Sidebar", () => {
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
-  it("opens a local sub-thread launchpad only for local parent threads", () => {
+  it("offers Local and New Worktree sub-thread launchpads for local parents", () => {
     const onCreateSubthread = vi.fn(async () => undefined);
     render(
       <Sidebar
@@ -1515,10 +1515,14 @@ describe("Sidebar", () => {
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Local checkout cleanup" }));
     expect(screen.queryByRole("menuitem", { name: "Sub-thread in Same Worktree" })).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: "Sub-thread in New Worktree" })).toBeNull();
     fireEvent.click(screen.getByRole("menuitem", { name: "Sub-thread in Local" }));
 
     expect(onCreateSubthread).toHaveBeenCalledWith(localThread, "local");
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Local checkout cleanup" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sub-thread in New Worktree" }));
+
+    expect(onCreateSubthread).toHaveBeenCalledWith(localThread, "new-worktree");
   });
 
   it("forks a Codex thread from the thread context menu", () => {
@@ -1555,7 +1559,7 @@ describe("Sidebar", () => {
     expect(onForkThread).toHaveBeenCalledWith(sharedThread, "new-worktree");
   });
 
-  it("forks local parent threads in Local instead of Same Worktree", () => {
+  it("offers Local and New Worktree forks for local parent threads", () => {
     const onForkThread = vi.fn(async () => undefined);
     const forkBackends: BackendSummary[] = [
       {
@@ -1585,10 +1589,14 @@ describe("Sidebar", () => {
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Local checkout cleanup" }));
     expect(screen.queryByRole("menuitem", { name: "Fork into Same Worktree" })).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: "Fork into New Worktree" })).toBeNull();
     fireEvent.click(screen.getByRole("menuitem", { name: "Fork in Local" }));
 
     expect(onForkThread).toHaveBeenCalledWith(localThread, "local");
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Local checkout cleanup" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Fork into New Worktree" }));
+
+    expect(onForkThread).toHaveBeenCalledWith(localThread, "new-worktree");
   });
 
   it("hides fork actions when the backend does not advertise fork support", () => {


### PR DESCRIPTION
## Summary

- I expose New Worktree alongside Local when creating a sub-thread or fork from a Local-backed thread.
- I keep Same Worktree wording and behavior for threads that already live in a managed worktree.
- I added regression coverage for both menu choices and their dispatched workspace modes.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` (164 tests passed)
- `pnpm lint:eslint` (0 errors; 35 existing warnings)
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Notes

- The workspace selector already supported creating a new worktree from a Local checkout. The context menu's Local branch rendered only one action, so the supported New Worktree path was unreachable from that menu.
