### PR TITLE
fix(desktop): show Agent provenance for federated thread creation

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -616,19 +616,30 @@ describe("federation agent tools service", () => {
       },
     });
 
-    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
-      directoryKey: "dir:/Users/op/pwragent",
-      launchpad: expect.objectContaining({
-        backend: "codex",
-        executionMode: "full-access",
-        workMode: "worktree",
-        model: "gpt-5.5-codex-max",
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      {
         directoryKey: "dir:/Users/op/pwragent",
-        directoryLabel: "PwrAgent",
-        prompt: "",
-      }),
-      input: [{ type: "text", text: "Fix the recorder crash" }],
-    });
+        launchpad: expect.objectContaining({
+          backend: "codex",
+          executionMode: "full-access",
+          workMode: "worktree",
+          model: "gpt-5.5-codex-max",
+          directoryKey: "dir:/Users/op/pwragent",
+          directoryLabel: "PwrAgent",
+          prompt: "",
+        }),
+        input: [{ type: "text", text: "Fix the recorder crash" }],
+      },
+      {
+        messageOrigin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "thread-1",
+          },
+        },
+      },
+    );
     const data = (response as { ok: true; data: CreateInstanceThreadResult })
       .data;
     expect(data).toMatchObject({
@@ -696,10 +707,25 @@ describe("federation agent tools service", () => {
       args: {
         instanceId: "pwr_studio",
         projectKey: "dir:/repo",
+        input: "Deploy the recoverable runner",
         workMode: "local",
       },
     });
 
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "Deploy the recoverable runner" }],
+      }),
+      {
+        messageOrigin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "thread-1",
+          },
+        },
+      },
+    );
     const data = (response as { ok: true; data: CreateInstanceThreadResult })
       .data;
     expect(data.threadUrl).toContain("instanceId=pwr_studio");
@@ -810,6 +836,9 @@ describe("federation agent tools service", () => {
         parentThreadBackend: "acp:grok",
         parentThreadInstanceId: "pwr_root",
       }),
+      expect.objectContaining({
+        messageOrigin: expect.objectContaining({ kind: "agent" }),
+      }),
     );
     expect(mountRemoteChild).toHaveBeenCalledWith(expect.objectContaining({
       ref: {
@@ -907,6 +936,9 @@ describe("federation agent tools service", () => {
         parentThreadId: "group-root",
         parentThreadBackend: "codex",
         parentThreadInstanceId: "pwr_root",
+      }),
+      expect.objectContaining({
+        messageOrigin: expect.objectContaining({ kind: "agent" }),
       }),
     );
     expect(mountRemoteChild).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -38,6 +38,148 @@ describe("federation backend bridge", () => {
     );
   });
 
+  it("carries and authenticates Agent provenance for remote thread creation", async () => {
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "created-thread",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+      turnId: "created-turn",
+    }));
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["environment_actions"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        materializeDirectoryLaunchpad,
+      } as unknown as FederationBackendOperations,
+      resolveSourceInstance: () => ({
+        label: "Viewer Mac",
+        celestialIcon: "moon",
+      }),
+    });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "materialize-thread",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
+        params: {
+          directoryKey: "dir:/repo",
+          input: [{ type: "text", text: "Deploy the runner" }],
+          messageOrigin: {
+            kind: "agent",
+            sourceThread: {
+              backend: "codex",
+              instanceId: "spoofed_instance",
+              instanceLabel: "Spoofed Mac",
+              threadId: "source-thread",
+              title: "Runner rollout",
+            },
+          },
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      {
+        directoryKey: "dir:/repo",
+        input: [{ type: "text", text: "Deploy the runner" }],
+      },
+      expect.objectContaining({
+        sourceInstanceId: "viewer_one",
+        messageOrigin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            instanceId: "viewer_one",
+            instanceLabel: "Viewer Mac",
+            celestialIcon: "moon",
+            threadId: "source-thread",
+            title: "Runner rollout",
+          },
+        },
+      }),
+    );
+    expect(replies).toMatchObject([
+      { kind: "response", requestId: "materialize-thread" },
+    ]);
+  });
+
+  it("sends thread-creation provenance from the remote backend client", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+    const pending = client.materializeDirectoryLaunchpad(
+      {
+        directoryKey: "dir:/repo",
+        input: [{ type: "text", text: "Deploy the runner" }],
+      },
+      {
+        messageOrigin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "source-thread",
+          },
+        },
+      },
+    );
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
+      params: {
+        directoryKey: "dir:/repo",
+        input: [{ type: "text", text: "Deploy the runner" }],
+        messageOrigin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "source-thread",
+          },
+        },
+      },
+    });
+
+    rpc.receiveEnvelope({
+      id: "materialize-response",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        backend: "codex",
+        threadId: "created-thread",
+        executionMode: "default",
+        workMode: "local",
+        turnId: "created-turn",
+      },
+    });
+    await expect(pending).resolves.toMatchObject({
+      threadId: "created-thread",
+      turnId: "created-turn",
+    });
+  });
+
   it("rejects grouping RPCs from a legacy thread-navigation peer", async () => {
     const backend = {
       updateSubthreadOrder: vi.fn(),

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type {
+  AppServerThreadMessageOrigin,
   CreateInstanceThreadResult,
   CreateInstanceThreadToolArgs,
   FederationHealthStatus,
@@ -420,20 +421,30 @@ async function createInstanceThread(
     ? groupingParent.instanceId
     : undefined;
   const draft = buildLaunchpadDraft({ snapshot, directory, args });
-  const response = await backend.materializeDirectoryLaunchpad({
-    directoryKey: args.projectKey,
-    launchpad: draft,
-    ...(groupingParent
-      ? {
-          parentThreadId: groupingParent.threadId,
-          parentThreadBackend: groupingParent.backend,
-          ...(parentThreadInstanceId
-            ? { parentThreadInstanceId }
-            : {}),
-        }
-      : {}),
-    ...(args.input ? { input: [{ type: "text", text: args.input }] } : {}),
-  });
+  const messageOrigin: AppServerThreadMessageOrigin = {
+    kind: "agent",
+    sourceThread: {
+      backend: context.backend,
+      threadId: context.threadId,
+    },
+  };
+  const response = await backend.materializeDirectoryLaunchpad(
+    {
+      directoryKey: args.projectKey,
+      launchpad: draft,
+      ...(groupingParent
+        ? {
+            parentThreadId: groupingParent.threadId,
+            parentThreadBackend: groupingParent.backend,
+            ...(parentThreadInstanceId
+              ? { parentThreadInstanceId }
+              : {}),
+          }
+        : {}),
+      ...(args.input ? { input: [{ type: "text", text: args.input }] } : {}),
+    },
+    { messageOrigin },
+  );
   const mountDisposition = groupingParent && localInstanceId
     ? await mountRemoteChildAtGroupingRoot(
         runtime,

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -175,6 +175,11 @@ export type FederationStartTurnRequest = StartTurnRequest & {
   messageOrigin?: AppServerThreadMessageOrigin;
 };
 
+type FederationMaterializeDirectoryLaunchpadRequest =
+  MaterializeDirectoryLaunchpadRequest & {
+    messageOrigin?: AppServerThreadMessageOrigin;
+  };
+
 export type FederationMountRemoteChildRequest = {
   ref: FederatedThreadRef;
   summary: NavigationThreadSummary;
@@ -1178,10 +1183,20 @@ export function registerFederationBackendHandlers(params: {
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
-    async (envelope) =>
-      await params.backend.materializeDirectoryLaunchpad(
-        envelope.params as MaterializeDirectoryLaunchpadRequest,
+    async (envelope) => {
+      const {
+        messageOrigin: claimedMessageOrigin,
+        ...request
+      } = envelope.params as FederationMaterializeDirectoryLaunchpadRequest;
+      const messageOrigin = authenticateMessageOrigin({
+        messageOrigin: claimedMessageOrigin,
+        resolveSourceInstance: params.resolveSourceInstance,
+        sourceInstanceId: envelope.sourceInstanceId,
+      });
+      return await params.backend.materializeDirectoryLaunchpad(
+        request,
         {
+          ...(messageOrigin ? { messageOrigin } : {}),
           sourceInstanceId: envelope.sourceInstanceId,
           onCodexEnvironmentSetupProgress: (event) => {
             params.onEnvironmentSetupProgress?.(
@@ -1190,7 +1205,8 @@ export function registerFederationBackendHandlers(params: {
             );
           },
         },
-      ),
+      );
+    },
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.handoffThreadWorkspace,
@@ -1800,10 +1816,16 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
 
   async materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
+    options?: MaterializeDirectoryLaunchpadOptions,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
     return await this.rpc.request<MaterializeDirectoryLaunchpadResponse>({
       method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
-      params: request,
+      params: {
+        ...request,
+        ...(options?.messageOrigin
+          ? { messageOrigin: options.messageOrigin }
+          : {}),
+      } satisfies FederationMaterializeDirectoryLaunchpadRequest,
     });
   }
 


### PR DESCRIPTION
## Summary

- I preserve the source thread as Agent provenance when `create_instance_thread` supplies a new thread's initial prompt.
- I carry that provenance through local and remote launchpad materialization.
- I authenticate remote source-instance identity at the federation owner before persisting it, so caller-supplied instance labels and IDs cannot be spoofed.

## Verification

- I reproduced the bug with failing federation agent-tool tests before implementing the fix.
- I verified 55 focused federation agent-tool and backend-bridge tests pass.
- I verified `pnpm typecheck`, `pnpm lint:eslint`, and `pnpm lint:boundaries` pass (ESLint reports only the existing warning baseline).

## Notes

- The renderer already labels messages carrying `origin.kind: "agent"` as Agent and links the source thread. The missing provenance was confined to the federated thread-creation path, so no renderer change is needed.
