### PR TITLE
fix(tests): backport macOS E2E GPU gate

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -173,6 +173,16 @@ const e2eShutdownDiagnostics = createE2eShutdownDiagnosticsRecorder({
   filePath: process.env[E2E_SHUTDOWN_DIAGNOSTICS_FILE_ENV],
   launchId: process.env[E2E_SHUTDOWN_LAUNCH_ID_ENV],
 });
+
+// Tart's AppleParavirtGPU can reset under sustained Electron E2E load,
+// delaying WindowServer paints or rebooting the guest. This must run before
+// Electron is ready. It is opt-in for the macOS VM lane only; normal local
+// development and host E2E continue to exercise the hardware GPU path.
+if (process.env.PWRAGENT_E2E_DISABLE_GPU === "1") {
+  app.disableHardwareAcceleration();
+  app.commandLine.appendSwitch("disable-gpu");
+}
+
 let mainProcessResourcesDisposed = false;
 let mainProcessShutdownComplete = false;
 let mainProcessShutdownPromise: Promise<void> | undefined;


### PR DESCRIPTION
## What changed

Restores the missing pre-ready GPU-disable gate from #1146 on `releases/1.0`:

- call `app.disableHardwareAcceleration()` when `PWRAGENT_E2E_DISABLE_GPU=1`
- append Chromium's `--disable-gpu` switch before Electron becomes ready

The existing macOS CI lanes already set this environment variable. This PR makes that setting effective again.

## Root cause

The release workflow inherited `PWRAGENT_E2E_DISABLE_GPU=1`, but the release main process did not inherit the #1146 code that consumes it. PR #1622 is present and correctly disables accelerated VideoToolbox encode/decode; those codec switches are complementary and do not disable the broader AppleParavirtGPU rendering path.

On the M4 runner in Actions run 31863673300, shutdown remained healthy at roughly 100–250 ms, while nearly every test after the 35th launch acquired a fixed ~15-second delay. That matches Electron launch/WindowServer paint degradation rather than the VideoToolbox teardown leak fixed by #1622.

The gate remains opt-in, so ordinary development, host E2E, and production launches are unchanged unless the dedicated environment variable is explicitly set.

Source commit: eeb8e922ca4c0ffe75b93e09875bd0688a1430d8 (#1146)

## Validation

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop build`
- `pnpm lint:eslint` (0 errors; baseline warnings only)
- `pnpm test apps/desktop/src/main/__tests__/electron-app-close.test.ts` — 4 passed
- generated main bundle contains the gated hardware-acceleration disable and `disable-gpu` switch
- `git diff --check`