### PR TITLE
fix(desktop): hydrate transcript skill tokens

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -143,6 +143,10 @@ function TranscriptCode(props: {
   children: ReactNode;
   className?: string;
   desktopApi?: Pick<DesktopApi, "copyText">;
+  editorName?: string;
+  onOpenSkillInEditor?: (skill: SkillActionTarget) => void;
+  onViewSkillMarkdown?: (skill: SkillActionTarget) => void;
+  skill?: AppServerSkillSummary;
   threadLinks: ThreadLinkContextValue | undefined;
 }) {
   const insideCodeBlock = useContext(CodeBlockContext);
@@ -173,6 +177,18 @@ function TranscriptCode(props: {
 
   if (insideLink) {
     return <code className="transcript-message__code">{props.children}</code>;
+  }
+
+  if (props.skill?.path) {
+    return (
+      <SkillChip
+        editorName={props.editorName}
+        onOpenInEditor={props.onOpenSkillInEditor}
+        onViewMarkdown={props.onViewSkillMarkdown}
+        skill={props.skill}
+        transcript={true}
+      />
+    );
   }
 
   const copyText = extractTextContent(props.children);
@@ -238,6 +254,17 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
             (skill): skill is AppServerSkillSummary & { path: string } => Boolean(skill.path)
           )
           .map((skill) => [skill.path, skill])
+      ),
+    [props.skills]
+  );
+  const skillsByToken = useMemo(
+    () =>
+      new Map(
+        (props.skills ?? [])
+          .filter(
+            (skill): skill is AppServerSkillSummary & { path: string } => Boolean(skill.path)
+          )
+          .map((skill) => [`$${skill.name}`, skill])
       ),
     [props.skills]
   );
@@ -516,10 +543,19 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         );
       },
       code(codeProps) {
+        const skill = skillsByToken.get(extractTextContent(codeProps.children));
         return (
           <TranscriptCode
             className={codeProps.className}
             desktopApi={props.desktopApi}
+            editorName={editorApplication?.name}
+            onOpenSkillInEditor={editorApplication && props.desktopApi?.openApplication
+              ? openSkillMarkdownInEditor
+              : undefined}
+            onViewSkillMarkdown={props.desktopApi?.readMarkdownFile
+              ? viewSkillMarkdown
+              : undefined}
+            skill={skill}
             threadLinks={threadLinks}
           >
             {codeProps.children}
@@ -651,6 +687,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       pullRequestLinks,
       sourceMarkdownText,
       skillsByPath,
+      skillsByToken,
       threadLinks,
       viewSkillMarkdown,
     ]

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -607,6 +607,47 @@ describe("ThreadMarkdown", () => {
     expect(screen.queryByRole("link", { name: "$frontend-design" })).not.toBeInTheDocument();
   });
 
+  it("hydrates inline-code skill tokens from the live skill inventory", () => {
+    const inspectSkillPath = [
+      "/Users/huntharo/github/PwrSuiteLab/.agents/skills",
+      "inspect-macos-gha-runner/SKILL.md",
+    ].join("/");
+    const manageSkillPath = [
+      "/Users/huntharo/github/PwrSuiteLab/.agents/skills",
+      "manage-macos-gha-runner/SKILL.md",
+    ].join("/");
+
+    render(
+      <ThreadMarkdown
+        skills={[
+          {
+            name: "inspect-macos-gha-runner",
+            description: "Collect read-only health evidence for a macOS runner.",
+            path: inspectSkillPath,
+            enabled: true,
+          },
+          {
+            name: "manage-macos-gha-runner",
+            description: "Pause, resume, start, and stop a macOS runner.",
+            path: manageSkillPath,
+            enabled: true,
+          },
+        ]}
+        text={[
+          "I’m using `$inspect-macos-gha-runner` to capture evidence and",
+          "`$manage-macos-gha-runner` for the restart boundary.",
+        ].join(" ")}
+      />
+    );
+
+    expect(screen.getByText("$inspect-macos-gha-runner")
+      .closest("[data-skill-chip]")).toBeInTheDocument();
+    expect(screen.getByText("$manage-macos-gha-runner")
+      .closest("[data-skill-chip]")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy inline code" }))
+      .not.toBeInTheDocument();
+  });
+
   it("renders explicit SKILL.md links as chips without live skill inventory", () => {
     const skillPath = [
       "/Users/huntharo/.codex/plugins/cache/openai-curated-remote/github",


### PR DESCRIPTION
## Summary

- I hydrate exact, path-backed inline-code `$skill-name` tokens from the thread's live skill inventory into the existing transcript skill-chip component.
- I preserve the current inline-code copy behavior for ordinary code and unknown skill tokens.
- I added a regression fixture based on the repo-local macOS runner skills that exposed the bug.

## Verification

- I verified the new regression test failed before the renderer fix and passed afterward.
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` (143 tests)
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check origin/main...HEAD`

## Notes

- The root cause was that transcript rendering only recognized composer-authored `[$skill](.../SKILL.md)` links. Codex assistant responses commonly name a skill as inline code, for example `` `$inspect-macos-gha-runner` ``, even though the matching skill path is already available from `skills/list`.
