### PR TITLE
fix(desktop): rebuild the sub-agent details dialog

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -394,8 +394,9 @@ describe("ThreadContextPanel", () => {
       /^Ended .*:\d{2}:\d{2} [AP]M$/,
     );
 
-    // Details (renamed from the disabled History button) opens a modal with
-    // the request, latest message, model, and token/pricing breakdown.
+    // Details (renamed from the disabled History button) opens a modal that
+    // leads with identity — never the prompt, which can run to hundreds of
+    // words — over the task, latest message, and token/pricing breakdown.
     const detailsButtons = screen.getAllByRole("button", { name: "Details" });
     expect(detailsButtons[0]).toBeEnabled();
     detailsButtons[0]!.focus();
@@ -403,12 +404,15 @@ describe("ThreadContextPanel", () => {
     const dialog = screen.getByRole("dialog");
     const modal = within(dialog);
     expect(
-      modal.getByRole("heading", { level: 2, name: "Watch CI until it completes." }),
+      modal.getByRole("heading", { level: 2, name: "Poincare" }),
+    ).toBeInTheDocument();
+    expect(modal.getByRole("heading", { name: "Task" })).toBeInTheDocument();
+    expect(
+      modal.getByText("Watch CI until it completes."),
     ).toBeInTheDocument();
     expect(modal.getByText("Latest message")).toBeInTheDocument();
-    expect(modal.getByText("Name")).toBeInTheDocument();
-    expect(modal.getByText("Poincare")).toBeInTheDocument();
-    expect(modal.getByText("Provider")).toBeInTheDocument();
+    expect(modal.getByText("Source")).toBeInTheDocument();
+    expect(modal.getByText("PwrAgent task monitor")).toBeInTheDocument();
     expect(modal.getByText("OpenAI")).toBeInTheDocument();
     expect(modal.getByText("Lint is still running.")).toBeInTheDocument();
     expect(modal.getByText("Tokens & pricing")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1,6 +1,14 @@
 import "@testing-library/jest-dom/vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThreadLinkProvider } from "../../../lib/thread-links";
 import { TranscriptList } from "../TranscriptList";
@@ -455,10 +463,14 @@ describe("TranscriptList", () => {
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    const dialog = screen.getByRole("dialog", {
+      name: "Sub-agent details: PwrAgent task monitor",
+    });
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText(task)).toBeInTheDocument();
     expect(
-      screen.getByRole("dialog", { name: `Sub-agent details: ${task}` }),
+      within(dialog).getByText("All required checks passed."),
     ).toBeInTheDocument();
-    expect(screen.getByText("All required checks passed.")).toBeInTheDocument();
   });
 
   it("renders PR automation prompts as compact expandable PwrAgent cards", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -1,18 +1,22 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { AppServerBackendKind, ThreadSubAgentSummary } from "@pwragent/shared";
 import { CloseIcon } from "../../../icons";
 import { formatBackendLabel } from "../../../lib/backend-label";
+import { copyText } from "../../../lib/copy-text";
 import { useDesktopApi } from "../../../lib/desktop-api";
 import { formatTimestamp } from "./context-rail-shared";
 import {
   formatSubAgentUsageEstimates,
   formatSubAgentUsageSummary,
   formatTokenCount,
+  isTerminalSubAgent,
   type PricingDisplayOptions,
+  subAgentCompletedAt,
   subAgentStatusLabel,
   subAgentTone,
 } from "./subagent-format";
+import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
 import { RailStatusChip } from "./RailStatusChip";
 import { isCodexNativeSubAgent, subAgentOriginLabel } from "./subagent-kind";
 
@@ -26,16 +30,32 @@ type SubAgentDetailsModalProps = {
 
 /**
  * Centered, in-window detail view for a single sub-agent — opened from the
- * card's Details button. Mirrors {@link ImageLightbox}: a fixed
- * scrim that closes on backdrop click or Escape, portaled to the body so it
- * escapes the context rail's clipping + transforms. Surfaces the request,
- * final response, run timing, model, and token/pricing usage.
+ * card's Details button. Mirrors {@link ImageLightbox}: a fixed scrim that
+ * closes on backdrop click or Escape, portaled to the body so it escapes the
+ * context rail's clipping + transforms.
+ *
+ * Layout deliberately reads as the rail card, expanded: a pinned header
+ * carrying identity (status, name, provider/model, timing) over a scrolling
+ * body. The task prompt is a clamped block inside that body rather than the
+ * dialog's headline — a monitor prompt runs to hundreds of words and pushed
+ * every fact worth reading below the fold.
  */
 export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const { onClose, subAgent } = props;
   const contentRef = useRef<HTMLDivElement>(null);
   const desktopApi = useDesktopApi();
   const openSubAgentTranscriptWindow = desktopApi?.openSubAgentTranscriptWindow;
+
+  // The dialog stays mounted while the sub-agent streams updates, and the
+  // opener hands us a fresh `onClose` on every one of those renders. Reading
+  // it through a ref keeps the focus effect below a true mount/unmount effect:
+  // re-running it would re-focus the header on each poll, and the browser
+  // would scroll the focused element into view — silently yanking a
+  // half-read prompt back to the top.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   // Dialog focus management: move focus into the dialog on open, keep Tab
   // cycling within it (so focus can't fall behind the scrim), restore focus
@@ -54,7 +74,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (event.key !== "Tab") {
@@ -84,19 +104,21 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
       window.removeEventListener("keydown", handleKeyDown, true);
       restoreFocus?.focus?.();
     };
-  }, [onClose]);
+  }, []);
 
   const tone = subAgentTone(subAgent.status);
   const usage = subAgent.monitorUsage;
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
   const fastMode = subAgent.preferredFastMode ?? usage?.fastMode;
+  const running = !isTerminalSubAgent(subAgent);
+  const now = useNowWhileActive(running);
   const transcriptThreadId =
     isCodexNativeSubAgent(subAgent) &&
     subAgent.monitorThreadId &&
     subAgent.monitorThreadId !== props.parentThreadId
       ? subAgent.monitorThreadId
       : undefined;
-  const backendLabel = subAgent.backend ? formatBackendLabel(subAgent.backend) : undefined;
+  const backendLabel = formatBackendLabel(subAgent.backend ?? props.defaultBackend);
   const usageEstimates = usage
     ? formatSubAgentUsageEstimates({
         displayOptions: props.pricingDisplayOptions,
@@ -105,9 +127,17 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
       })
     : undefined;
   const originLabel = subAgentOriginLabel(subAgent);
-  const ariaLabel = subAgent.agentName
-    ? `${subAgent.agentName}: ${subAgent.task}`
-    : subAgent.task;
+  const runtimeDetails = [
+    model,
+    subAgent.preferredReasoningEffort,
+    fastMode ? "Fast" : undefined,
+  ].filter((value): value is string => Boolean(value));
+  // Identity first: a name if the spawner gave one, otherwise what kind of
+  // sub-agent this is. Never the prompt.
+  const headline = subAgent.agentName ?? originLabel ?? "Sub-agent";
+  // The headline already says what spawned this when there is no agent name,
+  // so the Source fact would only restate it.
+  const showSourceFact = Boolean(subAgent.agentName && originLabel);
 
   if (typeof document === "undefined") {
     return null;
@@ -118,7 +148,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
       className="subagent-modal"
       role="dialog"
       aria-modal="true"
-      aria-label={`Sub-agent details: ${ariaLabel}`}
+      aria-label={`Sub-agent details: ${headline}`}
       onClick={props.onClose}
     >
       <div
@@ -126,10 +156,31 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
         className="subagent-modal__content"
         onClick={(event) => event.stopPropagation()}
       >
+        {/* A plain div, not <header>: inside the dialog it would expose a
+            stray banner landmark. */}
         <div className="subagent-modal__head">
-          <RailStatusChip tone={tone} alert={tone === "error"}>
-            {subAgentStatusLabel(subAgent.status)}
-          </RailStatusChip>
+          <div className="subagent-modal__identity">
+            <p className="subagent-modal__status-line">
+              <RailStatusChip tone={tone} alert={tone === "error"}>
+                {subAgentStatusLabel(subAgent.status)}
+              </RailStatusChip>
+            </p>
+            <h2 className="subagent-modal__title">{headline}</h2>
+            <p className="rail-card__runtime">
+              <span className="rail-card__provider-chip">{backendLabel}</span>
+              {runtimeDetails.length > 0 ? (
+                <span className="rail-card__model">
+                  {runtimeDetails.join(" · ")}
+                </span>
+              ) : null}
+            </p>
+            <RailCardTiming
+              completedAt={subAgentCompletedAt(subAgent)}
+              now={now}
+              running={running}
+              startedAt={subAgent.createdAt}
+            />
+          </div>
           <div className="subagent-modal__actions">
             {openSubAgentTranscriptWindow && transcriptThreadId ? (
               <button
@@ -159,112 +210,180 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
           </div>
         </div>
 
-        <h2 className="subagent-modal__title">{subAgent.task}</h2>
+        <div className="subagent-modal__body">
+          <ClampedTextSection copyable heading="Task" text={subAgent.task} />
 
-        <dl className="subagent-modal__facts">
-          {subAgent.agentName ? (
-            <div>
-              <dt>Name</dt>
-              <dd>{subAgent.agentName}</dd>
-            </div>
-          ) : null}
-          {originLabel ? (
-            <div>
-              <dt>Source</dt>
-              <dd>{originLabel}</dd>
-            </div>
-          ) : null}
-          {backendLabel ? (
-            <div>
-              <dt>Provider</dt>
-              <dd>{backendLabel}</dd>
-            </div>
-          ) : null}
-          {model ? (
-            <div>
-              <dt>Model</dt>
-              <dd className="subagent-modal__mono">{model}</dd>
-            </div>
-          ) : null}
-          {subAgent.preferredReasoningEffort ? (
-            <div>
-              <dt>Reasoning</dt>
-              <dd>{subAgent.preferredReasoningEffort}</dd>
-            </div>
-          ) : null}
-          {fastMode !== undefined ? (
-            <div>
-              <dt>Fast mode</dt>
-              <dd>{fastMode ? "On" : "Off"}</dd>
-            </div>
-          ) : null}
-          <div>
-            <dt>Started</dt>
-            <dd>{formatTimestamp(subAgent.createdAt)}</dd>
-          </div>
-          {subAgent.completedAt ? (
-            <div>
-              <dt>Ended</dt>
-              <dd>{formatTimestamp(subAgent.completedAt)}</dd>
-            </div>
-          ) : null}
-        </dl>
+          <ClampedTextSection
+            heading="Latest message"
+            placeholder="No messages yet."
+            text={subAgent.lastMessage}
+          />
 
-        <section className="subagent-modal__section">
-          <h3>Latest message</h3>
-          <p className="subagent-modal__body">
-            {subAgent.lastMessage ?? "No messages yet."}
-          </p>
-        </section>
+          {/* Only facts the pinned header does not already carry. Provider,
+              model, effort, fast mode, and the start time live up there; a dl
+              repeating them one scroll down is noise, not detail. */}
+          {showSourceFact || subAgent.completedAt !== undefined ? (
+            <section className="subagent-modal__section">
+              <div className="subagent-modal__section-head">
+                <h3>Run</h3>
+              </div>
+              <dl className="subagent-modal__facts">
+                {showSourceFact ? (
+                  <div>
+                    <dt>Source</dt>
+                    <dd>{originLabel}</dd>
+                  </div>
+                ) : null}
+                {subAgent.completedAt !== undefined ? (
+                  <div>
+                    <dt>Ended</dt>
+                    <dd>{formatTimestamp(subAgent.completedAt)}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            </section>
+          ) : null}
 
-        {usage ? (
-          <section className="subagent-modal__section">
-            <h3>Tokens &amp; pricing</h3>
-            <dl className="subagent-modal__facts">
-              {usage.tokenUsage.inputTokens !== undefined ? (
-                <div>
-                  <dt>Input</dt>
-                  <dd>{formatTokenCount(usage.tokenUsage.inputTokens)}</dd>
-                </div>
+          {usage ? (
+            <section className="subagent-modal__section">
+              <div className="subagent-modal__section-head">
+                <h3>Tokens &amp; pricing</h3>
+              </div>
+              <dl className="subagent-modal__facts">
+                {usage.tokenUsage.inputTokens !== undefined ? (
+                  <div>
+                    <dt>Input</dt>
+                    <dd>{formatTokenCount(usage.tokenUsage.inputTokens)}</dd>
+                  </div>
+                ) : null}
+                {usage.tokenUsage.outputTokens !== undefined ? (
+                  <div>
+                    <dt>Output</dt>
+                    <dd>{formatTokenCount(usage.tokenUsage.outputTokens)}</dd>
+                  </div>
+                ) : null}
+                {usage.tokenUsage.reasoningOutputTokens !== undefined ? (
+                  <div>
+                    <dt>Reasoning</dt>
+                    <dd>{formatTokenCount(usage.tokenUsage.reasoningOutputTokens)}</dd>
+                  </div>
+                ) : null}
+                {usage.tokenUsage.totalTokens !== undefined ? (
+                  <div>
+                    <dt>Total</dt>
+                    <dd>{formatTokenCount(usage.tokenUsage.totalTokens)}</dd>
+                  </div>
+                ) : null}
+                {usageEstimates ? (
+                  <div>
+                    <dt>Cost</dt>
+                    <dd>{usageEstimates}</dd>
+                  </div>
+                ) : null}
+              </dl>
+              {usage.summary ? (
+                <p className="subagent-modal__usage-summary">
+                  {formatSubAgentUsageSummary({
+                    displayOptions: props.pricingDisplayOptions,
+                    model,
+                    usage,
+                  })}
+                </p>
               ) : null}
-              {usage.tokenUsage.outputTokens !== undefined ? (
-                <div>
-                  <dt>Output</dt>
-                  <dd>{formatTokenCount(usage.tokenUsage.outputTokens)}</dd>
-                </div>
-              ) : null}
-              {usage.tokenUsage.reasoningOutputTokens !== undefined ? (
-                <div>
-                  <dt>Reasoning</dt>
-                  <dd>{formatTokenCount(usage.tokenUsage.reasoningOutputTokens)}</dd>
-                </div>
-              ) : null}
-              {usage.tokenUsage.totalTokens !== undefined ? (
-                <div>
-                  <dt>Total</dt>
-                  <dd>{formatTokenCount(usage.tokenUsage.totalTokens)}</dd>
-                </div>
-              ) : null}
-              {usageEstimates ? (
-                <div>
-                  <dt>Cost</dt>
-                  <dd>{usageEstimates}</dd>
-                </div>
-              ) : null}
-            </dl>
-            {usage.summary ? (
-              <p className="subagent-modal__usage-summary">
-                {formatSubAgentUsageSummary({
-                  displayOptions: props.pricingDisplayOptions,
-                  model,
-                  usage,
-                })}
-              </p>
-            ) : null}
-          </section>
-        ) : null}
+            </section>
+          ) : null}
+        </div>
       </div>
     </div>,
     document.body,
+  );
+}
+
+type ClampedTextSectionProps = {
+  copyable?: boolean;
+  heading: string;
+  placeholder?: string;
+  text?: string;
+};
+
+/**
+ * A long free-text block (task prompt, latest message) clamped to a few lines
+ * with an in-place expander. The toggle only appears once the text actually
+ * overflows, measured after layout rather than guessed from length — a
+ * wrapped prompt's line count depends on the dialog width.
+ */
+function ClampedTextSection(props: ClampedTextSectionProps) {
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const text = props.text;
+
+  useLayoutEffect(() => {
+    const element = textRef.current;
+    if (!element || expanded) {
+      return;
+    }
+    setOverflowing(element.scrollHeight > element.clientHeight + 1);
+  }, [expanded, text]);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timerId = window.setTimeout(() => setCopied(false), 1_500);
+    return () => window.clearTimeout(timerId);
+  }, [copied]);
+
+  if (!text) {
+    return (
+      <section className="subagent-modal__section">
+        <div className="subagent-modal__section-head">
+          <h3>{props.heading}</h3>
+        </div>
+        <p className="subagent-modal__body-text subagent-modal__body-text--empty">
+          {props.placeholder ?? "—"}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="subagent-modal__section">
+      <div className="subagent-modal__section-head">
+        <h3>{props.heading}</h3>
+        <div className="subagent-modal__section-actions">
+          {overflowing ? (
+            <button
+              type="button"
+              className="subagent-modal__text-action"
+              aria-expanded={expanded}
+              onClick={() => setExpanded((current) => !current)}
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          ) : null}
+          {props.copyable ? (
+            <button
+              type="button"
+              className="subagent-modal__text-action"
+              onClick={() => {
+                void copyText(text).then(() => setCopied(true));
+              }}
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <p
+        ref={textRef}
+        className={`subagent-modal__body-text${
+          expanded ? " subagent-modal__body-text--expanded" : ""
+        }`}
+      >
+        {text}
+      </p>
+    </section>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -69,7 +69,15 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
         ) ?? [],
       ).filter((el) => !el.hasAttribute("disabled"));
 
-    focusables()[0]?.focus();
+    // Close explicitly, not `focusables()[0]`: the header's timing line is
+    // tabbable once the run settles (its duration carries the exact end
+    // timestamp), and it precedes the actions in DOM order. Taking the first
+    // focusable would open a finished sub-agent with focus parked on a span
+    // and its tooltip already showing.
+    const closeButton = contentRef.current?.querySelector<HTMLElement>(
+      ".subagent-modal__close",
+    );
+    (closeButton ?? focusables()[0])?.focus();
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -324,7 +332,21 @@ function ClampedTextSection(props: ClampedTextSectionProps) {
     if (!element || expanded) {
       return;
     }
-    setOverflowing(element.scrollHeight > element.clientHeight + 1);
+    const measure = () => {
+      setOverflowing(element.scrollHeight > element.clientHeight + 1);
+    };
+    measure();
+    // Whether the clamp bites depends on how the text wraps, which depends on
+    // width — so a resized window can start truncating a block that measured
+    // as fitting. Without re-measuring, the rest of the text is unreachable:
+    // clipped, with no expander offered. ResizeObserver is absent under jsdom;
+    // the initial measure is enough there.
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
   }, [expanded, text]);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -34,7 +34,13 @@ type SubAgentsPanelProps = {
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
   const { onDetailsModalOpenChange } = props;
-  const [detailsFor, setDetailsFor] = useState<ThreadSubAgentSummary | null>(null);
+  // Track the open dialog by id, not by the summary object: the snapshot the
+  // Details button was clicked with goes stale the moment the sub-agent
+  // streams another update, and the dialog would sit on frozen status, timing,
+  // and usage until it was closed and reopened.
+  const [detailsForId, setDetailsForId] = useState<string | null>(null);
+  const detailsFor =
+    subAgents.find((subAgent) => subAgent.monitorId === detailsForId) ?? null;
   const hasRunningSubAgent = subAgents.some(
     (subAgent) => !isTerminalSubAgent(subAgent),
   );
@@ -46,13 +52,24 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
     return () => onDetailsModalOpenChange?.(false);
   }, [onDetailsModalOpenChange]);
 
+  // The tracked sub-agent can leave the list under us (thread switch, overlay
+  // rewrite). Release the rail's pinned-open state rather than stranding it.
+  const detailsMissing = detailsForId !== null && detailsFor === null;
+  useEffect(() => {
+    if (!detailsMissing) {
+      return;
+    }
+    setDetailsForId(null);
+    onDetailsModalOpenChange?.(false);
+  }, [detailsMissing, onDetailsModalOpenChange]);
+
   const openDetails = (subAgent: ThreadSubAgentSummary): void => {
     onDetailsModalOpenChange?.(true);
-    setDetailsFor(subAgent);
+    setDetailsForId(subAgent.monitorId);
   };
 
   const closeDetails = (): void => {
-    setDetailsFor(null);
+    setDetailsForId(null);
     onDetailsModalOpenChange?.(false);
   };
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
@@ -1,0 +1,122 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ThreadSubAgentSummary } from "@pwragent/shared";
+import { SubAgentDetailsModal } from "../SubAgentDetailsModal";
+
+afterEach(() => {
+  cleanup();
+});
+
+const LONG_TASK = [
+  "Monitor only the already-launched Terminal-owned M4 cold-restart operation.",
+  "Do not start, retry, stop, edit, or reinterpret anything. The durable run",
+  "state is under local-state/m4-handoff/force-cold-restart-terminal-run.",
+].join(" ");
+
+const subAgent: ThreadSubAgentSummary = {
+  monitorId: "monitor-1",
+  task: LONG_TASK,
+  status: "running",
+  createdAt: 1_800_000_000_000,
+  updatedAt: 1_800_000_000_000,
+  backend: "codex",
+  monitorThreadId: "monitor-thread",
+  monitorTurnId: "monitor-turn",
+  preferredModel: "gpt-5.6-luna",
+  preferredReasoningEffort: "medium",
+  lastMessage: "Still running: stage=waiting_for_fresh_runtime.",
+};
+
+function renderModal(overrides?: Partial<ThreadSubAgentSummary>) {
+  return render(
+    <SubAgentDetailsModal
+      defaultBackend="codex"
+      parentThreadId="parent-thread"
+      subAgent={{ ...subAgent, ...overrides }}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+describe("SubAgentDetailsModal", () => {
+  it("headlines the sub-agent identity and files the prompt under Task", () => {
+    renderModal({ agentName: "Deployment watcher" });
+
+    expect(
+      screen.getByRole("heading", { level: 2 }),
+    ).toHaveTextContent("Deployment watcher");
+    expect(screen.getByRole("dialog")).toHaveAccessibleName(
+      "Sub-agent details: Deployment watcher",
+    );
+    expect(screen.getByRole("heading", { name: "Task" })).toBeInTheDocument();
+    expect(screen.getByText(LONG_TASK)).toBeInTheDocument();
+  });
+
+  it("falls back to the spawner label when the sub-agent has no name", () => {
+    renderModal();
+
+    expect(
+      screen.getByRole("heading", { level: 2 }),
+    ).toHaveTextContent("PwrAgent task monitor");
+  });
+
+  it("keeps focus in place when the sub-agent streams an update", () => {
+    const { rerender } = renderModal();
+
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    copyButton.focus();
+    expect(document.activeElement).toBe(copyButton);
+
+    // A streamed update re-renders the opener, which hands the dialog a fresh
+    // `onClose`. Re-running the focus effect here would pull focus back to the
+    // header and scroll the body to the top under the reader.
+    rerender(
+      <SubAgentDetailsModal
+        defaultBackend="codex"
+        parentThreadId="parent-thread"
+        subAgent={{ ...subAgent, updatedAt: subAgent.updatedAt + 1_000 }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Copy" }),
+    );
+  });
+
+  it("closes on Escape after the opener handed over a new callback", () => {
+    const firstClose = vi.fn();
+    const secondClose = vi.fn();
+    const { rerender } = render(
+      <SubAgentDetailsModal
+        defaultBackend="codex"
+        parentThreadId="parent-thread"
+        subAgent={subAgent}
+        onClose={firstClose}
+      />,
+    );
+
+    rerender(
+      <SubAgentDetailsModal
+        defaultBackend="codex"
+        parentThreadId="parent-thread"
+        subAgent={subAgent}
+        onClose={secondClose}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(secondClose).toHaveBeenCalledTimes(1);
+    expect(firstClose).not.toHaveBeenCalled();
+  });
+
+  it("reports live status and runtime facts in the pinned header", () => {
+    renderModal({ status: "failure" });
+
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    expect(screen.getByText("gpt-5.6-luna · medium")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
@@ -61,6 +61,20 @@ describe("SubAgentDetailsModal", () => {
     ).toHaveTextContent("PwrAgent task monitor");
   });
 
+  it("opens with focus on Close even once the run has settled", () => {
+    // A settled run makes the header's duration tabbable (it carries the exact
+    // end timestamp), and it sits ahead of the actions in DOM order. Focus
+    // must still land on a control, not on that span with its tooltip open.
+    renderModal({
+      status: "success",
+      completedAt: subAgent.createdAt + 1_000,
+      updatedAt: subAgent.createdAt + 1_000,
+    });
+
+    expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("keeps focus in place when the sub-agent streams an update", () => {
     const { rerender } = renderModal();
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -128,6 +128,28 @@ describe("SubAgentsPanel", () => {
     });
   });
 
+  it("keeps an open details dialog on the live sub-agent record", () => {
+    const { rerender } = render(<SubAgentsPanel thread={thread} />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Details" })[0]!);
+    expect(screen.getByRole("dialog")).toHaveTextContent("Running");
+
+    rerender(
+      <SubAgentsPanel
+        thread={{
+          ...thread,
+          subAgents: thread.subAgents!.map((subAgent) =>
+            subAgent.monitorId === "monitor-1"
+              ? { ...subAgent, status: "success" as const }
+              : subAgent,
+          ),
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("dialog")).toHaveTextContent("Completed");
+  });
+
   it("targets the owning instance when stopping a remote sub-agent", async () => {
     const stopSubAgent = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -20534,14 +20534,15 @@ a.transcript-message__messaging-origin:focus-visible {
   background: var(--scrim-opaque);
 }
 
+/* The dialog itself never scrolls: the identity header stays pinned and only
+   the detail body below it moves, so status, model, and elapsed time remain
+   readable while a long prompt is being read. */
 .subagent-modal__content {
   display: flex;
   flex-direction: column;
-  gap: 14px;
   width: min(100%, 560px);
   max-height: min(100vh - 96px, 720px);
-  overflow-y: auto;
-  padding: 20px;
+  overflow: hidden;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: var(--bg-panel);
@@ -20549,9 +20550,33 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .subagent-modal__head {
   display: flex;
-  align-items: center;
+  flex: 0 0 auto;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.subagent-modal__identity {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.subagent-modal__status-line {
+  margin: 0;
+}
+
+.subagent-modal__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  padding: 16px 20px 20px;
 }
 
 .subagent-modal__close {
@@ -20591,13 +20616,19 @@ a.transcript-message__messaging-origin:focus-visible {
   white-space: nowrap;
 }
 
+/* Identity, not the prompt. Two lines is plenty for an agent name or the
+   "PwrAgent task monitor" fallback; the task text lives in the body. */
 .subagent-modal__title {
   margin: 0;
   color: var(--text-primary);
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 650;
   line-height: 1.3;
   overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .subagent-modal__facts {
@@ -20623,16 +20654,24 @@ a.transcript-message__messaging-origin:focus-visible {
   overflow-wrap: anywhere;
 }
 
-.subagent-modal__mono {
-  font-family: var(--font-mono);
-}
-
 .subagent-modal__section {
   display: flex;
   flex-direction: column;
   gap: 6px;
   padding-top: 14px;
   border-top: 1px solid var(--border-subtle);
+}
+
+.subagent-modal__section:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.subagent-modal__section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .subagent-modal__section h3 {
@@ -20644,7 +20683,34 @@ a.transcript-message__messaging-origin:focus-visible {
   text-transform: uppercase;
 }
 
-.subagent-modal__body,
+.subagent-modal__section-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 10px;
+}
+
+.subagent-modal__text-action {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.subagent-modal__text-action:hover {
+  color: var(--accent-bright);
+}
+
+.subagent-modal__text-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.subagent-modal__body-text,
 .subagent-modal__usage-summary {
   margin: 0;
   color: var(--text-secondary);
@@ -20652,6 +20718,24 @@ a.transcript-message__messaging-origin:focus-visible {
   line-height: 1.45;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+}
+
+/* Collapsed by default so a several-hundred-word monitor prompt cannot bury
+   the rest of the dialog. `Show more` renders only when this actually clips. */
+.subagent-modal__body-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.subagent-modal__body-text--expanded {
+  display: block;
+  overflow: visible;
+}
+
+.subagent-modal__body-text--empty {
+  color: var(--text-muted);
 }
 
 .subagent-modal__usage-summary {


### PR DESCRIPTION
The Sub-agent **Details** dialog was hard to use in exactly the case it exists for — reading a long-running monitor.

## What was wrong

**It scrolled itself back to the top.** The focus-management effect in `SubAgentDetailsModal` listed `onClose` as a dependency, and the opener (`SubAgentsPanel`, `TranscriptMessage`) builds a fresh callback on every render. Every streamed sub-agent update therefore tore the effect down and re-ran it, calling `focusables()[0].focus()` — and the browser scrolls a newly focused element into view. A prompt you were halfway through jumped back to the top a few times a minute.

**The prompt was the headline.** A monitor prompt runs to hundreds of words, so the dialog opened with a wall of 17px semibold text and pushed status, model, timing, and usage below the fold.

**The content was frozen.** The panel stored the `ThreadSubAgentSummary` object the Details button was clicked with, so status, elapsed time, and usage in the open dialog never updated — the dialog re-rendered constantly but always with the snapshot from open time.

## What changed

- `onClose` moved into a ref; the focus effect is now a true mount/unmount effect. Escape still closes via the latest callback.
- The dialog reads as the rail card, expanded: a **pinned header** (status chip, agent name or spawner label, provider chip + model · effort, started + live duration) over a **scrolling body**. Only the body scrolls, so identity stays visible.
- Task and Latest message are clamped blocks with an in-place **Show more / Show less**, rendered only when the text actually overflows (measured after layout, since wrap depends on dialog width). Task gets a **Copy** action.
- `Run details` shed everything the header already carries (provider, model, reasoning, fast mode, start time) and keeps only `Source` and `Ended`.
- `SubAgentsPanel` tracks the open dialog **by `monitorId`** and re-derives the summary from the live list, so the dialog stays current; if the sub-agent leaves the list the rail's pinned-open state is released rather than stranded.
- The header is a `div`, not `<header>` — inside `role="dialog"` the latter exposed a stray `banner` landmark.

## Verification

- New `SubAgentDetailsModal.test.tsx` pins the focus-retention regression, the identity-not-prompt headline, and Escape using the latest `onClose`.
- New `SubAgentsPanel` case pins that an open dialog follows a `running → success` transition.
- Full renderer suite: 180 files / 2810 tests pass. `typecheck`, `lint:eslint`, `lint:colors`, `lint:boundaries` clean.
- Layout checked in a browser against the real `app.css` in both themes, including the pinned-header-plus-scrolling-body behavior at a constrained height.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
