### PR TITLE
test(desktop): pin visual regression scale factor

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -216,6 +216,8 @@ type LaunchElectronAppParams = {
     width: number;
     height: number;
   };
+  /** Additional Chromium arguments appended after the shared E2E switches. */
+  extraArgs?: readonly string[];
   /**
    * Runs after the tmp `homeRoot` is created but before Electron
    * launches. Use this to seed
@@ -403,6 +405,7 @@ export async function launchElectronApp(
       // no spec plays video.
       "--disable-accelerated-video-decode",
       "--disable-accelerated-video-encode",
+      ...(params.extraArgs ?? []),
     ],
     cwd: path.resolve(fixtureDir, "../.."),
     env,

--- a/apps/desktop/e2e/visual-regression.spec.ts
+++ b/apps/desktop/e2e/visual-regression.spec.ts
@@ -36,11 +36,21 @@ const VISUAL_MAX_DIFF_PIXELS = 20;
 const VISUAL_CLOCK_TIME = new Date("2026-08-02T12:00:00.000Z");
 const VISUAL_APP_VERSION = "1.2.3-beta.1";
 const VISUAL_INITIAL_LOAD_DURATION = "3 ms";
+// Pin the backing scale factor. Chromium otherwise rasterizes at the attached
+// display's native scale, so the same CSS layout produces pixel-different
+// images in 1x and Retina 2x sessions. `scale: "css"` normalizes only the
+// screenshot dimensions, not that backing rasterization. The checked-in
+// goldens encode 1x output, matching the established PwrSnap visual harness.
+const VISUAL_ELECTRON_ARGS = ["--force-device-scale-factor=1"];
 
 async function waitForFonts(page: Page): Promise<void> {
   await page.evaluate(async () => {
     await document.fonts.ready;
   });
+}
+
+async function expectPinnedDeviceScale(page: Page): Promise<void> {
+  expect(await page.evaluate(() => window.devicePixelRatio)).toBe(1);
 }
 
 test.describe("visual regression", () => {
@@ -59,11 +69,16 @@ test.describe("visual regression", () => {
         specDir,
         "fixtures/codex-todo-list/replay.fixture.json",
       ),
-      env: { PWRAGENT_E2E_APP_VERSION: VISUAL_APP_VERSION },
+      env: {
+        PWRAGENT_E2E_APP_VERSION: VISUAL_APP_VERSION,
+        TZ: "UTC",
+      },
+      extraArgs: VISUAL_ELECTRON_ARGS,
       windowSize: VISUAL_WINDOW_SIZE,
     });
 
     try {
+      await expectPinnedDeviceScale(app.window);
       await app.window.clock.setFixedTime(VISUAL_CLOCK_TIME);
       await app.window
         .getByRole("button", { name: /Add AGENTS docs for media VCL/i })
@@ -122,11 +137,16 @@ test.describe("visual regression", () => {
         specDir,
         "fixtures/approval-pending/replay.fixture.json",
       ),
-      env: { PWRAGENT_E2E_APP_VERSION: VISUAL_APP_VERSION },
+      env: {
+        PWRAGENT_E2E_APP_VERSION: VISUAL_APP_VERSION,
+        TZ: "UTC",
+      },
+      extraArgs: VISUAL_ELECTRON_ARGS,
       windowSize: VISUAL_WINDOW_SIZE,
     });
 
     try {
+      await expectPinnedDeviceScale(app.window);
       await app.window.clock.setFixedTime(VISUAL_CLOCK_TIME);
       await app.window
         .getByRole("button", { name: /Approval pending replay/i })


### PR DESCRIPTION
## What changed

- force the Electron visual-regression launches to a 1x device scale factor
- assert the effective renderer device pixel ratio is 1
- pin the visual-test timezone to UTC
- leave non-visual desktop E2E launches at their native scale

## Why

Chromium backing rasterization followed the attached display scale. `scale: "css"` normalized output dimensions but not glyph and edge rasterization, so a Retina-configured self-hosted runner drifted from the existing 1x goldens. Keeping this infrastructure fix isolated makes it independently backportable to the 1.0 release branch.

## Validation

- `pnpm --filter @pwragent/desktop typecheck`
- Playwright discovery for both visual-regression tests
- authoritative Tart macOS/ARM64 run: 2 visual tests passed unchanged against the existing goldens

No snapshots or diff tolerances changed.