### PR TITLE
test(desktop): migrate visual baselines to lossless WebP

### DIFF
--- a/.agents/skills/macos-vm-e2e-lab/SKILL.md
+++ b/.agents/skills/macos-vm-e2e-lab/SKILL.md
@@ -77,21 +77,44 @@ until you explicitly ask to view the VM.
 
 ## Visual-regression goldens
 
-PwrAgent's macOS golden images are PNG files under
+PwrAgent's macOS golden images are lossless WebP files under
 `apps/desktop/e2e/*.spec.ts-snapshots/` and are intentionally tracked in Git
-LFS. Generate or update them only inside this VM lab, matching the macOS/ARM64
-CI renderer:
+LFS. Generate or update them only inside the authoritative PwrSuiteLab Tart VM,
+matching the macOS/ARM64 CI renderer.
+
+The bundled setup above does not install PwrSuiteLab. It is a separately
+managed checkout with its own access and provisioning policy. Use available
+workspace/directory tools, PwrAgent Federation tools, or MCP resources to find
+an existing local PwrSuiteLab checkout; do not assume a pathname or clone,
+install, or provision it as part of a baseline update. If no checkout is
+discoverable, ask the operator for the appropriate lab pointer.
 
 ```bash
-cd ~/pwragent-mac-vm
-./run-e2e.sh --local /absolute/path/to/PwrAgent \
-  e2e/visual-regression.spec.ts --update-snapshots
+suite_lab_root="<PwrSuiteLab checkout discovered with tools/MCP>"
+pwragent_root="$(git rev-parse --show-toplevel)"
+"$suite_lab_root/macos-tart/run-e2e.sh" --confirm-live-run \
+  --workload pwragent --local "$pwragent_root" \
+  e2e/visual-regression.spec.ts
 ```
 
-Review the generated files before committing them. `git lfs status` should
-list each new `.png` baseline as an LFS object rather than an ordinary Git
-blob. Do not generate macOS goldens on a Linux host or compare them against a
-different platform's output.
+The controller accepts only a clean worktree and transports committed `HEAD`.
+Use this checkpoint workflow:
+
+1. Commit the code-under-test checkpoint, confirm the worktree is clean, and
+   run the focused spec. A missing or changed baseline can fail while emitting
+   reviewable `*-actual.webp` artifacts.
+2. Review the retrieved artifacts and promote approved files to their
+   `*-darwin.webp` baseline names.
+3. Stage the promoted files explicitly and check `git lfs status`; every WebP
+   baseline must be an LFS object rather than an ordinary Git blob. Commit a
+   disposable checkpoint containing the promoted baselines and confirm the
+   worktree is clean again.
+4. Rerun the same focused spec so the VM verifies the exact committed
+   references. Amend or squash the disposable checkpoint only after that run
+   passes.
+
+Do not generate macOS goldens on a Linux host or an active developer desktop,
+and do not compare them against a different platform's output.
 
 ## Self-hosted GitHub Actions runner
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -29,7 +29,7 @@ apps/desktop/src/main/pr-status/github-pr-fetcher.ts text eol=lf diff
 # Playwright's macOS visual-regression baselines are generated on the matching
 # ARM64 VM runner. Keep this deliberately narrow so product imagery stays
 # ordinary Git content while infrequently changed golden assets use LFS.
-apps/desktop/e2e/*.spec.ts-snapshots/*.png filter=lfs diff=lfs merge=lfs -text
+apps/desktop/e2e/*.spec.ts-snapshots/*.webp filter=lfs diff=lfs merge=lfs -text
 
 # Vendor brand-kit SVGs — verbatim files from each vendor's brand
 # kit, refreshed via the procedure documented in each vendor's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,22 +109,32 @@ repo root. The package-level
 
 ### macOS VM E2E and visual goldens
 
-Do not run a full headed Electron suite on an active desktop. On a Mac with the
-Tart lab installed, use `~/pwragent-mac-vm/run-e2e.sh --local <repo-path>` so
-the windows render on the guest display. The complete setup, shared-runner
-security model, and troubleshooting guide live in
+Do not run a full headed Electron suite on an active desktop. The authoritative
+visual workflow uses a separately managed PwrSuiteLab Tart controller so the
+windows render on the guest display; it is not installed by this repository.
+Use available workspace/directory tools, PwrAgent Federation tools, or MCP
+resources to locate an existing local PwrSuiteLab checkout. If none is
+discoverable, ask the operator for the appropriate lab pointer. The security
+model and full workflow live in
 [`.agents/skills/macos-vm-e2e-lab/SKILL.md`](.agents/skills/macos-vm-e2e-lab/SKILL.md).
 
-The small macOS/ARM64 visual-regression suite has PNG baselines under
+The small macOS/ARM64 visual-regression suite has lossless WebP baselines under
 `apps/desktop/e2e/*.spec.ts-snapshots/`. They are Git LFS objects, not ordinary
-Git blobs. Update them only inside the Tart VM with:
+Git blobs. Generate them only inside the Tart VM with:
 
 ```bash
-~/pwragent-mac-vm/run-e2e.sh --local /absolute/path/to/PwrAgent \
-  e2e/visual-regression.spec.ts --update-snapshots
+suite_lab_root="<PwrSuiteLab checkout discovered with tools/MCP>"
+pwragent_root="$(git rev-parse --show-toplevel)"
+"$suite_lab_root/macos-tart/run-e2e.sh" --confirm-live-run \
+  --workload pwragent --local "$pwragent_root" \
+  e2e/visual-regression.spec.ts
 ```
 
-Review each changed image and check `git lfs status` before committing. The CI
+Review the retrieved `*-actual.webp` artifacts, promote the approved files to
+their `*-darwin.webp` baseline names, and check `git lfs status`. The controller
+rejects a dirty worktree and transports only committed `HEAD`, so commit the
+promoted references as a disposable checkpoint before rerunning the focused
+spec. Amend or squash that checkpoint only after the VM verifies it. The CI
 lane runs on the selected-repository PwrDrvr organization runner shared with
 PwrSnap; fork PRs are deliberately excluded from that machine.
 

--- a/apps/desktop/e2e/visual-regression.spec.ts
+++ b/apps/desktop/e2e/visual-regression.spec.ts
@@ -2,13 +2,16 @@
 // surfaces. These are locator-scoped on purpose: BrowserWindow chrome and OS
 // shadows belong to native screenshot documentation, not renderer contracts.
 //
-// The reference PNG files are generated on the matching Tart VM runner and
-// stored in Git LFS. Update them from the off-desktop VM lab, never from a
-// Linux host or a developer's active desktop:
+// The reference images are lossless WebP generated on the matching Tart VM
+// runner and stored in Git LFS. Playwright infers WebP from the extension and
+// uses its lossless default at quality 100. Use workspace/MCP tools to locate
+// the separately managed PwrSuiteLab checkout, then run from a clean committed
+// worktree. See CONTRIBUTING.md for the checkpoint/promotion workflow:
 //
-//   ~/pwrdrvr/PwrSuiteLab/macos-tart/run-e2e.sh --confirm-live-run \
-//     --workload pwragent --local /path/to/PwrAgent \
-//     e2e/visual-regression.spec.ts --update-snapshots
+//   suite_lab_root="<discovered PwrSuiteLab checkout>"
+//   "$suite_lab_root/macos-tart/run-e2e.sh" --confirm-live-run \
+//     --workload pwragent --local "$(git rev-parse --show-toplevel)" \
+//     e2e/visual-regression.spec.ts
 //
 // VISUAL_MAX_DIFF_PIXELS exists because the lab guest and the CI macOS runner
 // no longer rasterize identically. A golden regenerated on the lab lands 8
@@ -120,7 +123,7 @@ test.describe("visual regression", () => {
       const shell = app.window.locator(".app-shell");
       await expect(shell).toBeVisible();
       await waitForFonts(app.window);
-      await expect(shell).toHaveScreenshot("todo-thread-shell.png", {
+      await expect(shell).toHaveScreenshot("todo-thread-shell.webp", {
         animations: "disabled",
         caret: "hide",
         maxDiffPixels: VISUAL_MAX_DIFF_PIXELS,
@@ -168,7 +171,7 @@ test.describe("visual regression", () => {
       const approval = app.window.getByRole("group", { name: "Pending approval" });
       await expect(approval).toBeVisible();
       await waitForFonts(app.window);
-      await expect(approval).toHaveScreenshot("pending-approval.png", {
+      await expect(approval).toHaveScreenshot("pending-approval.webp", {
         animations: "disabled",
         caret: "hide",
         maxDiffPixels: VISUAL_MAX_DIFF_PIXELS,

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/pending-approval-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/pending-approval-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ea957c14b59c13b323515bf23f5cef0b538ae96189dd086a7c93753b9ad4480
-size 42231

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/pending-approval-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/pending-approval-darwin.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b666b602e293e8ad987a6531cce79bd5a359856942c63754a3a87bf45902ac5
+size 49030

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fed653acdfa79bb8726aa06dcceae4d2e9b21b2a22fc7a1f36d5cee15fb8e710
-size 148464

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:630b093d1f542292510cd079353f46c83c79dbf66c1d8c8aa86eb89238bfc450
+size 128698


### PR DESCRIPTION
## Summary

- migrate the two Playwright macOS visual-regression snapshot names and narrowly scoped Git LFS rule from PNG to WebP
- promote WebP baselines generated by the authoritative PwrSuiteLab Tart macOS/ARM64 workflow; both bitstreams are lossless at Playwright's default quality 100
- document discovery of the separately managed PwrSuiteLab checkout without machine-specific paths
- document the required clean, committed checkpoint before verifying promoted baselines
- keep `VISUAL_MAX_DIFF_PIXELS = 20` unchanged

The migration inherits #1661's merged 1× Chromium backing-scale and UTC visual-environment contract. The combined Tart run passed without further baseline churn.

## Validation

- focused Tart macOS/ARM64 visual spec: 2 passed, including `devicePixelRatio === 1`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git lfs status` and `git lfs fsck HEAD`
- `webpinfo`: both baselines report `Format: Lossless` and preserve their original dimensions
- one migration commit on current `origin/main`; `git diff --check` clean
