### PR TITLE
feat(desktop): consolidate tool-output warnings into one card per thread

### DIFF
--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10752,6 +10752,12 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: params.threadId,
     });
+    /* The operator's dismissal/mute for this thread, so a freshly launched
+       renderer honors a decision made in an earlier session. */
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
     await this.emit({
       backend: params.backend,
       notification: {
@@ -10759,6 +10765,9 @@ export class DesktopBackendRegistry {
         params: {
           threadId: params.threadId,
           toolAccounting,
+          ...(overlay?.toolIncidentNotice
+            ? { incidentNotice: overlay.toolIncidentNotice }
+            : {}),
           ...(params.triggeredAlerts?.length
             ? { triggeredAlerts: params.triggeredAlerts }
             : {}),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -125,6 +125,8 @@ import {
   type SetThreadPinResponse,
   type SetThreadReactionRequest,
   type SetThreadReactionResponse,
+  type SetThreadToolIncidentNoticeRequest,
+  type SetThreadToolIncidentNoticeResponse,
   type SetNavigationBrowseModeRequest,
   type SetNavigationBrowseModeResponse,
   type ListThreadMigrationSourceThreadsRequest,
@@ -250,6 +252,7 @@ import {
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
+  NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_LIST_MODEL_SETTINGS_RECENTS_CHANNEL,
@@ -366,6 +369,7 @@ type AppServerOverlayStoreLike = OverlayStoreLike &
     | "setRemoteThreadLocalPin"
     | "listRemoteThreadPins"
     | "updateRemoteThreadPinSnapshots"
+    | "setThreadToolIncidentNotice"
   >;
 
 type ThreadPrRefreshContext = {
@@ -5747,6 +5751,40 @@ class DesktopAppServerService {
     return await fetcher.getAuthStatus();
   }
 
+  async setThreadToolIncidentNotice(
+    request: SetThreadToolIncidentNoticeRequest,
+  ): Promise<SetThreadToolIncidentNoticeResponse> {
+    /* Deliberately not federated. Dismissing or muting a cost warning is the
+       viewer's own preference about what it wants to be told, the same
+       reasoning that keeps composer drafts machine-local — a peer should not
+       inherit this operator's decision to stop being warned. */
+    const backend = request.backend ?? "codex";
+    const overlay = await this.getOverlayStore().setThreadToolIncidentNotice({
+      backend,
+      ...(request.dismissedSeverity
+        ? { dismissedSeverity: request.dismissedSeverity }
+        : {}),
+      ...(request.firstWarningAt !== undefined
+        ? { firstWarningAt: request.firstWarningAt }
+        : {}),
+      ...(request.mutedSeverity ? { mutedSeverity: request.mutedSeverity } : {}),
+      ...(request.reset ? { reset: request.reset } : {}),
+      threadId: request.threadId,
+    });
+    logDebug("setThreadToolIncidentNotice", {
+      backend,
+      dismissedSeverity: request.dismissedSeverity,
+      mutedSeverity: request.mutedSeverity,
+      reset: request.reset === true,
+      threadId: request.threadId,
+    });
+    return {
+      backend,
+      state: overlay.toolIncidentNotice ?? {},
+      threadId: request.threadId,
+    };
+  }
+
   async setThreadReaction(
     request: SetThreadReactionRequest,
   ): Promise<SetThreadReactionResponse> {
@@ -7631,6 +7669,16 @@ export function registerAppServerIpcHandlers(): void {
       request: SetThreadReactionRequest,
     ): Promise<SetThreadReactionResponse> => {
       return await appServerService.setThreadReaction(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
+    async (
+      _event,
+      request: SetThreadToolIncidentNoticeRequest,
+    ): Promise<SetThreadToolIncidentNoticeResponse> => {
+      return await appServerService.setThreadToolIncidentNotice(request);
     },
   );
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_PIN_CHANNEL);

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2191,6 +2191,59 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return nextState;
   }
 
+  /**
+   * Records the operator's disposition of this thread's tool-output incident.
+   * `firstWarningAt` is written once and never moved forward, so the cost
+   * window the notice reports stays anchored to the first warning even after
+   * a restart drops the older accounting rows out of the live snapshot.
+   */
+  async setThreadToolIncidentNotice(params: {
+    backend: ThreadOverlayState["backend"];
+    dismissedAt?: number;
+    dismissedSeverity?: "critical" | "warning";
+    firstWarningAt?: number;
+    mutedAt?: number;
+    mutedSeverity?: "critical" | "warning";
+    reset?: boolean;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const existing = current.toolIncidentNotice;
+    const firstWarningAt = existing?.firstWarningAt
+      ?? params.firstWarningAt;
+    const nextNotice = params.reset
+      ? (firstWarningAt !== undefined ? { firstWarningAt } : undefined)
+      : {
+          ...existing,
+          ...(firstWarningAt !== undefined ? { firstWarningAt } : {}),
+          ...(params.dismissedSeverity
+            ? {
+                dismissedSeverity: params.dismissedSeverity,
+                dismissedAt: params.dismissedAt ?? Date.now(),
+              }
+            : {}),
+          ...(params.mutedSeverity
+            ? {
+                mutedSeverity: params.mutedSeverity,
+                mutedAt: params.mutedAt ?? Date.now(),
+              }
+            : {}),
+        };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      ...(nextNotice ? { toolIncidentNotice: nextNotice } : {}),
+    };
+    if (!nextNotice) delete nextState.toolIncidentNotice;
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async setThreadArchiveTombstone(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -150,6 +150,8 @@ import type {
   SetThreadPinResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
+  SetThreadToolIncidentNoticeRequest,
+  SetThreadToolIncidentNoticeResponse,
   GetGhStatusRequest,
   GhStatus,
   ApproveMessagingPairingRequest,
@@ -641,6 +643,7 @@ import {
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
+  NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
@@ -1649,6 +1652,13 @@ const desktopApi = Object.freeze({
     request: SetThreadReactionRequest,
   ): Promise<SetThreadReactionResponse> =>
     await ipcRenderer.invoke(NAVIGATION_SET_THREAD_REACTION_CHANNEL, request),
+  setThreadToolIncidentNotice: async (
+    request: SetThreadToolIncidentNoticeRequest,
+  ): Promise<SetThreadToolIncidentNoticeResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
+      request,
+    ),
   setThreadPin: async (
     request: SetThreadPinRequest,
   ): Promise<SetThreadPinResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -679,6 +679,7 @@ function DesktopAppShell(props: {
       if (event.notification.method === "thread/toolAccounting/updated") {
         const params = event.notification.params as {
           threadId: string;
+          incidentNotice?: ThreadToolIncidentNoticeState;
           toolAccounting?: ThreadToolAccounting;
           triggeredAlerts?: ThreadToolInvocationAlert[];
         };
@@ -687,10 +688,24 @@ function DesktopAppShell(props: {
            replaces minted a durable notice per turn — a busy thread reached
            "1 of 41" in the stack with no way to clear them in bulk. */
         if (!params.toolAccounting) return;
+        /* Only a freshly tripped threshold raises the card. Folding on every
+           accounting update would re-alert on last week's calls the first
+           time an old thread runs anything, which is history, not an
+           incident. The fold still summarizes the whole thread once a new
+           alert makes it worth showing. */
+        if (!params.triggeredAlerts?.length) return;
         const noticeId = threadIncidentNoticeId({
           backend: event.backend,
           threadId: params.threadId,
         });
+        /* Persisted disposition wins over anything this session inferred: it
+           may predate this renderer entirely. */
+        if (params.incidentNotice) {
+          toolIncidentStateRef.current.set(noticeId, {
+            ...toolIncidentStateRef.current.get(noticeId),
+            ...params.incidentNotice,
+          });
+        }
         const incidentState = toolIncidentStateRef.current.get(noticeId);
         const summary = buildThreadIncidentSummary({
           accounting: params.toolAccounting,
@@ -794,6 +809,15 @@ function DesktopAppShell(props: {
             ),
           });
         };
+        /* Anchor the cost window the first time this thread warns. Recording
+           it only on dismissal would date the window to whenever the operator
+           happened to click, not to the first warning. */
+        if (
+          incidentState?.firstWarningAt === undefined
+          && summary.firstWarningAt !== undefined
+        ) {
+          persistIncident({});
+        }
         dispatchAppNotice({
           type: "show",
           notice: buildToolAccountingNotice({

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -27,7 +27,12 @@ import {
   type NavigationDirectorySummary,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
+  type ThreadToolAccounting,
+  type ThreadToolIncidentNoticeState,
   type ThreadToolInvocationAlert,
+  type ThreadUsageLineRecord,
+  type SetThreadToolIncidentNoticeRequest,
+  resolveToolIncidentVisibility,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { useThreadJump } from "./features/navigation/useThreadJump";
@@ -107,9 +112,11 @@ import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/git
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
 import {
   buildToolAccountingNotice,
-  resolveDismissedToolIncident,
-  toolAccountingNoticeId,
 } from "./features/notifications/tool-accounting-notice";
+import {
+  buildThreadIncidentSummary,
+  threadIncidentNoticeId,
+} from "./features/notifications/thread-incident-summary";
 import {
   buildHeapSnapshotHandoffMessage,
   describeHeapSnapshotResult,
@@ -339,10 +346,22 @@ function DesktopAppShell(props: {
   // effect below, once `navigation` is defined.
   const backendErrorThreadsRef = useRef<NavigationThreadSummary[]>([]);
   const backendErrorDirectoriesRef = useRef<NavigationDirectorySummary[]>([]);
-  const dismissedToolIncidentSeverityRef = useRef(new Map<
+  /* Per-thread incident disposition, keyed by notice id. Mirrors what the
+     overlay persists so a reply to a live notification does not need to wait
+     on a round trip to know whether the operator already silenced this. */
+  const toolIncidentStateRef = useRef(new Map<
     string,
-    ThreadToolInvocationAlert["severity"]
+    ThreadToolIncidentNoticeState
   >());
+  /* Usage rows for the loaded thread only — the renderer's pricing ledger is
+     session-scoped. A background thread's card therefore reports replayed
+     tokens and no money until the accounting notification carries a spend
+     figure of its own. */
+  const threadUsageLinesRef = useRef(new Map<
+    string,
+    readonly ThreadUsageLineRecord[]
+  >());
+  const showIncidentCostRef = useRef(false);
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
@@ -660,92 +679,132 @@ function DesktopAppShell(props: {
       if (event.notification.method === "thread/toolAccounting/updated") {
         const params = event.notification.params as {
           threadId: string;
+          toolAccounting?: ThreadToolAccounting;
           triggeredAlerts?: ThreadToolInvocationAlert[];
         };
-        for (const alert of params.triggeredAlerts ?? []) {
-          const noticeId = toolAccountingNoticeId(alert);
-          const dismissedSeverity = dismissedToolIncidentSeverityRef.current.get(
-            noticeId,
-          );
-          const dismissalResolution = resolveDismissedToolIncident({
-            dismissedSeverity,
-            incomingSeverity: alert.severity,
-          });
-          if (dismissalResolution === "suppress") {
-            continue;
-          }
-          if (dismissalResolution === "escalate") {
-            dismissedToolIncidentSeverityRef.current.delete(noticeId);
-          }
-          const matchingThread = backendErrorThreadsRef.current.find(
-            (thread) =>
-              thread.source === event.backend
-              && thread.id === params.threadId
-              && federationTargetsEqual(
-                thread.federation?.ref.target,
-                event.federationTarget,
-              ),
-          );
-          const threadLink = matchingThread
-            ? {
-                backend: matchingThread.source,
-                inThreadList: true,
-                ...(instanceId ? { instanceId } : {}),
-                threadId: matchingThread.id,
-                title: matchingThread.title,
-                titleSource: matchingThread.titleSource,
-                gitBranch: matchingThread.gitBranch,
-                linkedDirectories: matchingThread.linkedDirectories,
-              }
-            : undefined;
-          const dismiss = (): void => {
-            dismissedToolIncidentSeverityRef.current.set(
-              noticeId,
-              alert.severity,
-            );
-            dispatchAppNotice({ type: "dismiss", id: noticeId });
+        /* One card per thread, folded from the whole accounting snapshot,
+           rather than one per triggered alert. The per-alert loop this
+           replaces minted a durable notice per turn — a busy thread reached
+           "1 of 41" in the stack with no way to clear them in bulk. */
+        if (!params.toolAccounting) return;
+        const noticeId = threadIncidentNoticeId({
+          backend: event.backend,
+          threadId: params.threadId,
+        });
+        const incidentState = toolIncidentStateRef.current.get(noticeId);
+        const summary = buildThreadIncidentSummary({
+          accounting: params.toolAccounting,
+          backend: event.backend,
+          ...(incidentState?.firstWarningAt !== undefined
+            ? { firstWarningAt: incidentState.firstWarningAt }
+            : {}),
+          threadId: params.threadId,
+          usageLines: threadUsageLinesRef.current.get(
+            buildThreadIdentityKey(event.backend, params.threadId),
+          ),
+        });
+        if (!summary) return;
+        if (
+          resolveToolIncidentVisibility({
+            severity: summary.severity,
+            ...(incidentState ? { state: incidentState } : {}),
+          }) === "suppress"
+        ) {
+          return;
+        }
+        const matchingThread = backendErrorThreadsRef.current.find(
+          (thread) =>
+            thread.source === event.backend
+            && thread.id === params.threadId
+            && federationTargetsEqual(
+              thread.federation?.ref.target,
+              event.federationTarget,
+            ),
+        );
+        const threadLink = matchingThread
+          ? {
+              backend: matchingThread.source,
+              inThreadList: true,
+              ...(instanceId ? { instanceId } : {}),
+              threadId: matchingThread.id,
+              title: matchingThread.title,
+              titleSource: matchingThread.titleSource,
+              gitBranch: matchingThread.gitBranch,
+              linkedDirectories: matchingThread.linkedDirectories,
+            }
+          : undefined;
+        const persistIncident = (
+          patch: Omit<SetThreadToolIncidentNoticeRequest, "backend" | "threadId">,
+        ): void => {
+          const next: ThreadToolIncidentNoticeState = {
+            ...toolIncidentStateRef.current.get(noticeId),
+            ...(summary.firstWarningAt !== undefined
+              ? { firstWarningAt: summary.firstWarningAt }
+              : {}),
+            ...(patch.dismissedSeverity
+              ? { dismissedSeverity: patch.dismissedSeverity }
+              : {}),
+            ...(patch.mutedSeverity ? { mutedSeverity: patch.mutedSeverity } : {}),
           };
-          const examine = (): void => {
-            const threadKey = buildThreadIdentityKey(
+          toolIncidentStateRef.current.set(noticeId, next);
+          void desktopApi?.setThreadToolIncidentNotice?.({
+            backend: event.backend,
+            ...(summary.firstWarningAt !== undefined
+              ? { firstWarningAt: summary.firstWarningAt }
+              : {}),
+            ...patch,
+            threadId: params.threadId,
+          }).catch(() => undefined);
+        };
+        const dismiss = (): void => {
+          persistIncident({ dismissedSeverity: summary.severity });
+          dispatchAppNotice({ type: "dismiss", id: noticeId });
+        };
+        const mute = (): void => {
+          persistIncident({
+            dismissedSeverity: summary.severity,
+            mutedSeverity: summary.severity,
+          });
+          dispatchAppNotice({ type: "dismiss", id: noticeId });
+        };
+        const examine = (): void => {
+          const threadKey = buildThreadIdentityKey(
+            event.backend,
+            params.threadId,
+          );
+          const matchingDirectory =
+            backendErrorDirectoriesRef.current.find(
+              (directory) =>
+                directory.kind === "directory"
+                && directory.threadKeys.includes(threadKey),
+            )
+            ?? backendErrorDirectoriesRef.current.find((directory) =>
+              directory.threadKeys.includes(threadKey)
+            );
+          const projectLabel =
+            matchingDirectory?.label
+            ?? matchingThread?.linkedDirectories[0]?.label;
+          void desktopApi?.openToolOutputIncidentExplorerWindow?.({
+            backend: event.backend,
+            ...(projectLabel ? { projectLabel } : {}),
+            threadId: params.threadId,
+            title: matchingThread?.title ?? labelForThread(
               event.backend,
               params.threadId,
-            );
-            const matchingDirectory =
-              backendErrorDirectoriesRef.current.find(
-                (directory) =>
-                  directory.kind === "directory"
-                  && directory.threadKeys.includes(threadKey),
-              )
-              ?? backendErrorDirectoriesRef.current.find((directory) =>
-                directory.threadKeys.includes(threadKey)
-              );
-            const projectLabel =
-              matchingDirectory?.label
-              ?? matchingThread?.linkedDirectories[0]?.label;
-            void desktopApi?.openToolOutputIncidentExplorerWindow?.({
-              backend: event.backend,
-              ...(projectLabel ? { projectLabel } : {}),
-              threadId: params.threadId,
-              title: matchingThread?.title ?? labelForThread(
-                event.backend,
-                params.threadId,
-              ),
-            });
-          };
-          const showNotice = (): void => {
-            const notice = buildToolAccountingNotice({
-              alert,
-              onExamine: examine,
-              onDismiss: dismiss,
-              threadLink,
-            });
-            dispatchAppNotice({
-              type: "show",
-              notice,
-            });
-          };
-          showNotice();
-        }
+            ),
+          });
+        };
+        dispatchAppNotice({
+          type: "show",
+          notice: buildToolAccountingNotice({
+            onDismiss: dismiss,
+            onExamine: examine,
+            onMute: mute,
+            showCost: showIncidentCostRef.current,
+            summary,
+            threadLink,
+          }),
+        });
         return;
       }
       // Params are cast explicitly: the AppServerNotification union is too
@@ -1050,6 +1109,18 @@ function DesktopAppShell(props: {
     backendErrorThreadsRef.current = navigation.threads;
     backendErrorDirectoriesRef.current = navigation.directories;
   }, [navigation.directories, navigation.threads]);
+  /* Incident-notice inputs the live notification handler reads without
+     re-subscribing: which thread is on screen, whether the operator has
+     pricing display on, and the loaded thread's usage rows. */
+  useEffect(() => {
+    showIncidentCostRef.current =
+      (settings.snapshot?.experimental.threadPricingSummary?.value ?? true)
+      && (
+        (settings.snapshot?.experimental.threadPricingDisplayUsd?.value ?? true)
+        || (settings.snapshot?.experimental.threadPricingDisplayCodexCredits
+          ?.value ?? false)
+      );
+  }, [settings.snapshot?.experimental]);
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,
@@ -1638,6 +1709,16 @@ function DesktopAppShell(props: {
           void desktopApi?.openStarMapWindow?.();
         },
       };
+  useEffect(() => {
+    const thread = navigation.selectedThread;
+    const lines = session.response?.pricing?.lines;
+    if (!thread || !lines) return;
+    threadUsageLinesRef.current.set(
+      buildThreadIdentityKey(thread.source, thread.id),
+      lines,
+    );
+  }, [navigation.selectedThread, session.response?.pricing?.lines]);
+
   const threadViewProps = {
     activeFederationOwnerLabel,
     activeFederationTarget,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -758,6 +758,84 @@ describe("App", () => {
     });
   });
 
+  it("does not raise a tool-output card when no new threshold tripped", async () => {
+    /* Accounting updates fire on every tool call. Folding on all of them
+       re-alerted about last week's calls the first time an old thread ran
+       anything. */
+    const agentEventListeners = new Set<(event: AgentEvent) => void>();
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+      },
+    });
+    render(<App />);
+    await waitFor(() => expect(agentEventListeners.size).toBeGreaterThan(0));
+
+    act(() => {
+      const event = {
+        backend: "codex",
+        notification: {
+          method: "thread/toolAccounting/updated",
+          params: {
+            threadId: "thread-1",
+            toolAccounting: {
+              alerts: [],
+              invocations: [{
+                backend: "codex",
+                category: "shell",
+                debugLines: 0,
+                errorLines: 0,
+                estimatedOutputTokens: 5_000,
+                infoLines: 0,
+                invocationId: "old-large-call",
+                itemId: "old-item",
+                noisy: true,
+                observedAt: 1_000,
+                outputChars: 20_000,
+                outputLines: 100,
+                outputTruncated: false,
+                status: "completed",
+                threadId: "thread-1",
+                toolName: "commandExecution",
+                turnId: "turn-old",
+                updatedAt: 1_000,
+                warningLines: 0,
+              }],
+              summaries: [],
+            },
+            /* No triggeredAlerts: nothing crossed a threshold just now. */
+          },
+        },
+      } as AgentEvent;
+      for (const listener of agentEventListeners) listener(event);
+    });
+
+    expect(screen.queryByText("Large tool output")).not.toBeInTheDocument();
+  });
+
   it("reveals the sidebar when adding a project from the hidden-sidebar masthead", async () => {
     const pickDirectoryFromDisk = vi.fn(async () => ({
       canceled: false as const,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -691,7 +691,32 @@ describe("App", () => {
           method: "thread/toolAccounting/updated",
           params: {
             threadId: "thread-1",
-            toolAccounting: { alerts: [], invocations: [], summaries: [] },
+            toolAccounting: {
+              alerts: [],
+              invocations: Array.from({ length: 5 }, (_, index) => ({
+                backend: "codex",
+                category: "polling",
+                debugLines: 0,
+                errorLines: 0,
+                estimatedOutputTokens: 0,
+                infoLines: 0,
+                invocationId: `wait-${index}`,
+                itemId: `item-${index}`,
+                noisy: true,
+                noisyReason: "repeat-polling-output",
+                observedAt: 1_000 + index * 30_000,
+                outputChars: 0,
+                outputLines: 0,
+                outputTruncated: false,
+                status: "completed",
+                threadId: "thread-1",
+                toolName: "wait",
+                turnId: "turn-1",
+                updatedAt: 1_000 + index * 30_000,
+                warningLines: 0,
+              })),
+              summaries: [],
+            },
             triggeredAlerts: [{
               alertId: "noisy-polling:codex:thread-1:wait:turn-1",
               backend: "codex",
@@ -719,7 +744,9 @@ describe("App", () => {
     });
 
     expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
-    expect(screen.getByText(/Five queued checks/)).toBeInTheDocument();
+    /* One consolidated card for the thread, describing the whole pattern,
+       rather than one card per turn that tripped the detector. */
+    expect(screen.getByText(/5 are repeated queued checks/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Examine 5 cases" }));
 
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -1,93 +1,268 @@
+import type {
+  ThreadToolAccounting,
+  ThreadToolInvocationRecord,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+import { resolveToolIncidentVisibility } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
-import type { ThreadToolInvocationAlert } from "@pwragent/shared";
-import {
-  buildToolAccountingNotice,
-  resolveDismissedToolIncident,
-  toolAccountingNoticeId,
-} from "../tool-accounting-notice";
+import { buildToolAccountingNotice } from "../tool-accounting-notice";
+import { buildThreadIncidentSummary } from "../thread-incident-summary";
 
-describe("buildToolAccountingNotice", () => {
-  it("makes the explorer the primary action for an aggregated incident", () => {
-    const onDismiss = vi.fn();
-    const onExamine = vi.fn();
-    const notice = buildToolAccountingNotice({
-      alert: buildAlert({ kind: "noisy-polling" }),
-      onDismiss,
-      onExamine,
+describe("buildThreadIncidentSummary", () => {
+  it("folds a thread's flagged calls into one incident", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([
+        invocation({ observedAt: 100, outputChars: 8_000, turnId: "turn-1" }),
+        invocation({ observedAt: 200, outputChars: 9_000, turnId: "turn-1" }),
+        invocation({ observedAt: 300, outputChars: 6_000, turnId: "turn-2" }),
+      ]),
+      backend: "codex",
+      threadId: "thread-1",
     });
 
-    expect(notice).toMatchObject({
-      autoDismiss: false,
-      id: "tool-accounting:codex:thread-1:turn-1:noisy-polling",
-      title: "Repeated queued checks",
-      tone: "warning",
-    });
-    expect(notice.actions?.map((action) => action.label)).toEqual([
-      "Examine 5 cases",
-      "Dismiss",
-    ]);
-    notice.actions?.[0]?.onClick();
-    notice.actions?.[1]?.onClick();
-    expect(onExamine).toHaveBeenCalledOnce();
-    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(summary?.flaggedInvocationCount).toBe(3);
+    expect(summary?.turnsWithWarnings).toBe(2);
+    expect(summary?.firstWarningAt).toBe(100);
+    expect(summary?.severity).toBe("warning");
   });
 
-  it("upserts large outputs under one critical thread incident", () => {
-    const notice = buildToolAccountingNotice({
-      alert: buildAlert({ kind: "large-output", severity: "critical" }),
-      onDismiss: vi.fn(),
-      onExamine: vi.fn(),
+  it("counts calls that hit the output cap and escalates to critical", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([
+        invocation({ observedAt: 100, outputChars: 8_000 }),
+        invocation({ observedAt: 200, outputChars: 40_000 }),
+      ]),
+      backend: "codex",
+      threadId: "thread-1",
     });
 
-    expect(notice).toMatchObject({
-      id: "tool-accounting:codex:thread-1:turn-1:large-output",
-      title: "Large tool output",
-      tone: "error",
+    expect(summary?.overCapCount).toBe(1);
+    expect(summary?.severity).toBe("critical");
+  });
+
+  it("keeps the persisted cost baseline when it predates the snapshot", () => {
+    /* A restart drops older accounting rows out of the live snapshot; the
+       cost window must not silently move up to the newest warning. */
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([invocation({ observedAt: 5_000 })]),
+      backend: "codex",
+      firstWarningAt: 1_000,
+      threadId: "thread-1",
     });
-    expect(notice.actions?.[0]?.label).toBe("Examine 5 cases");
+
+    expect(summary?.firstWarningAt).toBe(1_000);
   });
 
-  it("suppresses rewrites after dismissal until a critical escalation", () => {
-    expect(resolveDismissedToolIncident({
-      dismissedSeverity: "warning",
-      incomingSeverity: "warning",
-    })).toBe("suppress");
-    expect(resolveDismissedToolIncident({
-      dismissedSeverity: "warning",
-      incomingSeverity: "critical",
-    })).toBe("escalate");
-    expect(resolveDismissedToolIncident({
-      dismissedSeverity: "critical",
-      incomingSeverity: "critical",
-    })).toBe("suppress");
+  it("prices replayed output from the thread's own cache-served rows", () => {
+    /* Two calls in one turn: the first is replayed by the second. */
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([
+        invocation({
+          estimatedOutputTokens: 1_000,
+          observedAt: 100,
+          turnId: "turn-1",
+        }),
+        invocation({
+          estimatedOutputTokens: 500,
+          observedAt: 200,
+          turnId: "turn-1",
+        }),
+      ]),
+      backend: "codex",
+      threadId: "thread-1",
+      usageLines: [
+        /* 2,000,000 micros for 2,000,000 cached tokens → 1 micro per token. */
+        usageLine({
+          cachedInputCostMicros: 2_000_000,
+          cachedInputTokens: 2_000_000,
+          createdAt: 150,
+          totalCostMicros: 3_000_000,
+        }),
+      ],
+    });
+
+    expect(summary?.replayedTokens).toBe(1_000);
+    expect(summary?.estimatedReplayWasteMicros).toBe(1_000);
+    expect(summary?.spentSinceFirstWarningMicros).toBe(3_000_000);
   });
 
-  it("uses a new toast identity for a new turn", () => {
-    expect(toolAccountingNoticeId(buildAlert({ turnId: "turn-1" })))
-      .not.toBe(toolAccountingNoticeId(buildAlert({ turnId: "turn-2" })));
+  it("omits money when nothing cache-served has been billed", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([invocation({})]),
+      backend: "codex",
+      threadId: "thread-1",
+      usageLines: [
+        usageLine({ cachedInputCostMicros: 0, cachedInputTokens: 0 }),
+      ],
+    });
+
+    expect(summary?.estimatedReplayWasteMicros).toBeUndefined();
+  });
+
+  it("reports no incident for a thread with nothing flagged", () => {
+    expect(buildThreadIncidentSummary({
+      /* Unmarked AND small: the size test has to miss it too. */
+      accounting: accounting([invocation({ noisy: false, outputChars: 500 })]),
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
   });
 });
 
-function buildAlert(
-  overrides: Partial<ThreadToolInvocationAlert>,
-): ThreadToolInvocationAlert {
+describe("resolveToolIncidentVisibility", () => {
+  it("suppresses a warning the operator muted", () => {
+    expect(resolveToolIncidentVisibility({
+      severity: "warning",
+      state: { mutedSeverity: "warning" },
+    })).toBe("suppress");
+  });
+
+  it("lets a cap hit through a muted warning", () => {
+    /* Muting "output is getting large" must not also silence "output hit the
+       cap and was truncated" — that is the escalation the mute is scoped to
+       leave alone. */
+    expect(resolveToolIncidentVisibility({
+      severity: "critical",
+      state: { mutedSeverity: "warning" },
+    })).toBe("show");
+  });
+
+  it("suppresses everything once a critical incident is muted", () => {
+    expect(resolveToolIncidentVisibility({
+      severity: "critical",
+      state: { mutedSeverity: "critical" },
+    })).toBe("suppress");
+  });
+
+  it("re-shows an escalation past a dismissal", () => {
+    expect(resolveToolIncidentVisibility({
+      severity: "critical",
+      state: { dismissedSeverity: "warning" },
+    })).toBe("show");
+    expect(resolveToolIncidentVisibility({
+      severity: "warning",
+      state: { dismissedSeverity: "warning" },
+    })).toBe("suppress");
+  });
+});
+
+describe("buildToolAccountingNotice", () => {
+  it("carries one notice id per thread, not per turn", () => {
+    const notice = buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary: summaryFor(),
+    });
+
+    expect(notice.id).toBe("tool-accounting:codex:thread-1");
+    expect(notice.message).toContain("3 tool calls flagged across 2 turns");
+  });
+
+  it("offers a mute for a warning but not for a cap hit", () => {
+    const warning = buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      onMute: vi.fn(),
+      showCost: false,
+      summary: summaryFor(),
+    });
+    expect(warning.actions?.map((action) => action.label))
+      .toContain("Don't warn again");
+
+    const critical = buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      onMute: vi.fn(),
+      showCost: false,
+      summary: { ...summaryFor(), overCapCount: 2, severity: "critical" },
+    });
+    expect(critical.actions?.map((action) => action.label))
+      .not.toContain("Don't warn again");
+    expect(critical.title).toBe("Tool output hit the cap");
+  });
+
+  it("shows money only when pricing display is enabled", () => {
+    const summary = {
+      ...summaryFor(),
+      currency: "USD",
+      estimatedReplayWasteMicros: 1_850_000,
+      spentSinceFirstWarningMicros: 4_120_000,
+    };
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: true,
+      summary,
+    }).message).toContain("$4.12 spent since the first warning, of which about $1.85");
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary,
+    }).message).not.toContain("$4.12");
+  });
+});
+
+function summaryFor() {
   return {
-    alertId: "alert-1",
     backend: "codex",
-    createdAt: 1,
-    estimatedOutputTokens: 1_000,
-    firstObservedAt: 1,
-    invocationCount: 5,
-    kind: "noisy-polling",
-    lastObservedAt: 2,
-    message: "The turn keeps waking up.",
-    severity: "warning",
-    suggestedPrompt: "Use a monitor.",
+    flaggedInvocationCount: 3,
+    overCapCount: 0,
+    pollingInvocationCount: 0,
+    replayedTokens: 2_400,
+    severity: "warning" as const,
     threadId: "thread-1",
+    turnsWithWarnings: 2,
+  };
+}
+
+function accounting(
+  invocations: ThreadToolInvocationRecord[],
+): ThreadToolAccounting {
+  return { alerts: [], invocations, summaries: [] };
+}
+
+function invocation(
+  overrides: Partial<ThreadToolInvocationRecord>,
+): ThreadToolInvocationRecord {
+  return {
+    backend: "codex",
+    category: "shell",
+    debugLines: 0,
+    errorLines: 0,
+    estimatedOutputTokens: 2_000,
+    infoLines: 0,
+    invocationId: `invocation-${overrides.observedAt ?? 0}`,
+    itemId: "item-1",
+    noisy: true,
+    observedAt: 1_000,
+    outputChars: 8_000,
+    outputLines: 20,
+    outputTruncated: false,
+    status: "completed",
+    threadId: "thread-1",
+    toolName: "commandExecution",
     turnId: "turn-1",
-    toolName: "wait",
-    totalOutputChars: 0,
-    updatedAt: 2,
+    updatedAt: 1_000,
+    warningLines: 0,
     ...overrides,
   };
+}
+
+function usageLine(
+  overrides: Partial<ThreadUsageLineRecord>,
+): ThreadUsageLineRecord {
+  return {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 0,
+    createdAt: 1_000,
+    currency: "USD",
+    inputTokens: 0,
+    outputTokens: 0,
+    threadId: "thread-1",
+    totalCostMicros: 0,
+    ...overrides,
+  } as ThreadUsageLineRecord;
 }

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -6,7 +6,10 @@ import type {
 import { resolveToolIncidentVisibility } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
 import { buildToolAccountingNotice } from "../tool-accounting-notice";
-import { buildThreadIncidentSummary } from "../thread-incident-summary";
+import {
+  buildThreadIncidentSummary,
+  formatIncidentMicros,
+} from "../thread-incident-summary";
 
 describe("buildThreadIncidentSummary", () => {
   it("folds a thread's flagged calls into one incident", () => {
@@ -207,6 +210,7 @@ describe("buildToolAccountingNotice", () => {
 function summaryFor() {
   return {
     backend: "codex",
+    coversWholeThread: true,
     flaggedInvocationCount: 3,
     overCapCount: 0,
     pollingInvocationCount: 0,
@@ -266,3 +270,45 @@ function usageLine(
     ...overrides,
   } as ThreadUsageLineRecord;
 }
+
+describe("snapshot coverage", () => {
+  it("says so when the fold only saw recent activity", () => {
+    /* The live notification carries a 200-row page, so a long thread's counts
+       are recent activity — the card must not present them as totals. */
+    const capped = Array.from({ length: 200 }, (_, index) =>
+      invocation({ invocationId: `capped-${index}`, observedAt: 1_000 + index }));
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting(capped),
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(summary?.coversWholeThread).toBe(false);
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary: summary!,
+    }).message).toContain("in recent activity");
+  });
+
+  it("presents a short thread's counts as the whole thread", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([invocation({})]),
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(summary?.coversWholeThread).toBe(true);
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary: summary!,
+    }).message).not.toContain("in recent activity");
+  });
+
+  it("formats credits the same way the turn strip does", () => {
+    expect(formatIncidentMicros(2_400_000, "credits")).toBe("2.4 cr");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
@@ -21,6 +21,17 @@ import {
  * This fold answers that instead, and it updates in place as the numbers move.
  */
 
+/**
+ * Whether the fold saw the whole thread.
+ *
+ * The live notification carries `readThreadToolAccounting`'s default page,
+ * which caps at 200 invocations — so on a long thread these counts describe
+ * recent activity, not the thread. The card says which it is rather than
+ * presenting a capped count as a total; the explorer, which reads with
+ * `includeAllToolInvocations`, is where the real totals live.
+ */
+export const INCIDENT_SNAPSHOT_INVOCATION_CAP = 200;
+
 export type ThreadIncidentSummary = {
   backend: string;
   currency?: string;
@@ -33,6 +44,8 @@ export type ThreadIncidentSummary = {
   estimatedReplayWasteMicros?: number;
   firstWarningAt?: number;
   flaggedInvocationCount: number;
+  /** False when the fold ran against a capped snapshot of a longer thread. */
+  coversWholeThread: boolean;
   lastWarningAt?: number;
   /** Calls that reached the harness output cap and were truncated. */
   overCapCount: number;
@@ -95,6 +108,7 @@ export function buildThreadIncidentSummary(params: {
       ? { estimatedReplayWasteMicros: Math.round(replayedTokens * rate) }
       : {}),
     ...(Number.isFinite(firstWarningAt) ? { firstWarningAt } : {}),
+    coversWholeThread: invocations.length < INCIDENT_SNAPSHOT_INVOCATION_CAP,
     flaggedInvocationCount: flagged.length,
     lastWarningAt: flagged.reduce(
       (latest, entry) => Math.max(latest, entry.observedAt),
@@ -167,12 +181,7 @@ export function threadIncidentNoticeId(params: {
   return ["tool-accounting", params.backend, params.threadId].join(":");
 }
 
-export function formatIncidentMicros(
-  micros: number,
-  currency: string | undefined,
-): string {
-  const units = micros / 1_000_000;
-  const rounded = units >= 100 ? Math.round(units) : Number(units.toFixed(2));
-  if (!currency || currency === "USD") return `$${rounded.toLocaleString()}`;
-  return `${rounded.toLocaleString()} ${currency}`;
-}
+/* One currency formatter for the whole feature: the card and the turn strip
+   render the same ledger units, so they must not disagree about credits or
+   sub-dollar precision. */
+export { formatMicrosCurrency as formatIncidentMicros } from "../thread-detail/tool-output-incident-insights";

--- a/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
@@ -1,0 +1,178 @@
+import type {
+  ThreadToolAccounting,
+  ThreadToolInvocationAlert,
+  ThreadToolInvocationRecord,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+import {
+  isFlaggedToolInvocation,
+  TOOL_OUTPUT_CAP_CHARS,
+} from "@pwragent/shared";
+
+/**
+ * One incident per thread, folded from every flagged tool call it has made.
+ *
+ * The alert stream is per-turn, which is why the notice stack reached "1 of
+ * 41": each threshold trip minted its own durable card, each needing its own
+ * dismissal. Nothing about that queue told the operator the thing they
+ * actually want to know — how much this thread has cost since it started
+ * misbehaving — because every card only knew about its own turn.
+ *
+ * This fold answers that instead, and it updates in place as the numbers move.
+ */
+
+export type ThreadIncidentSummary = {
+  backend: string;
+  currency?: string;
+  /**
+   * Modeled cost of replaying the flagged output. Distinct from `spentMicros`,
+   * which is money actually billed: this is the share of it attributable to
+   * carrying large tool results through later round trips. Undefined when the
+   * ledger has no cache-served rows to derive a rate from.
+   */
+  estimatedReplayWasteMicros?: number;
+  firstWarningAt?: number;
+  flaggedInvocationCount: number;
+  lastWarningAt?: number;
+  /** Calls that reached the harness output cap and were truncated. */
+  overCapCount: number;
+  /**
+   * Calls flagged as repeated queued checks. A distinct pathology from large
+   * output — the cost is the round trip, not the payload — so the single card
+   * still has to name it rather than folding it into a generic total.
+   */
+  pollingInvocationCount: number;
+  /** Tokens carried through later round trips in the same turn. */
+  replayedTokens: number;
+  severity: ThreadToolInvocationAlert["severity"];
+  /** Billed spend since the first warning, straight from the pricing ledger. */
+  spentSinceFirstWarningMicros?: number;
+  threadId: string;
+  turnsWithWarnings: number;
+};
+
+export function buildThreadIncidentSummary(params: {
+  accounting: ThreadToolAccounting;
+  backend: string;
+  /** Persisted baseline. Survives restart so the cost window does not reset. */
+  firstWarningAt?: number;
+  threadId: string;
+  usageLines?: readonly ThreadUsageLineRecord[];
+}): ThreadIncidentSummary | undefined {
+  const invocations = params.accounting.invocations;
+  /* Same predicate the explorer uses: a card that counted only rows the
+     detectors happened to mark would under-report exactly the threads whose
+     history predates them. */
+  const flagged = invocations.filter(isFlaggedToolInvocation);
+  if (flagged.length === 0) return undefined;
+
+  const observedFirst = flagged.reduce(
+    (earliest, entry) => Math.min(earliest, entry.observedAt),
+    Number.POSITIVE_INFINITY,
+  );
+  /* The persisted baseline wins when it is older: a thread that warned
+     yesterday keeps yesterday's cost window even though today's snapshot may
+     no longer carry those rows. */
+  const firstWarningAt = Math.min(
+    params.firstWarningAt ?? Number.POSITIVE_INFINITY,
+    observedFirst,
+  );
+  const overCapCount = flagged.filter(
+    (entry) => entry.outputChars >= TOOL_OUTPUT_CAP_CHARS,
+  ).length;
+  const replayedTokens = flagged.reduce(
+    (sum, entry) => sum + entry.estimatedOutputTokens * countLaterTrips(invocations, entry),
+    0,
+  );
+  const usageLines = params.usageLines ?? [];
+  const spent = sumSpendSince(usageLines, firstWarningAt);
+  const rate = deriveCachedInputMicrosPerToken(usageLines);
+
+  return {
+    backend: params.backend,
+    ...(usageLines[0]?.currency ? { currency: usageLines[0].currency } : {}),
+    ...(rate !== undefined
+      ? { estimatedReplayWasteMicros: Math.round(replayedTokens * rate) }
+      : {}),
+    ...(Number.isFinite(firstWarningAt) ? { firstWarningAt } : {}),
+    flaggedInvocationCount: flagged.length,
+    lastWarningAt: flagged.reduce(
+      (latest, entry) => Math.max(latest, entry.observedAt),
+      0,
+    ),
+    overCapCount,
+    pollingInvocationCount: flagged.filter((entry) =>
+      entry.noisyReason?.includes("poll")
+    ).length,
+    replayedTokens,
+    severity: overCapCount > 0 ? "critical" : "warning",
+    ...(spent !== undefined ? { spentSinceFirstWarningMicros: spent } : {}),
+    threadId: params.threadId,
+    turnsWithWarnings: new Set(flagged.map((entry) => entry.turnId ?? "")).size,
+  };
+}
+
+/**
+ * Every call in the same turn observed after this one. Each is a round trip
+ * that carried this output through the model again.
+ */
+function countLaterTrips(
+  invocations: readonly ThreadToolInvocationRecord[],
+  invocation: ThreadToolInvocationRecord,
+): number {
+  const index = invocations.indexOf(invocation);
+  return invocations.filter((entry, entryIndex) =>
+    (entry.turnId ?? "") === (invocation.turnId ?? "")
+    && (
+      entry.observedAt > invocation.observedAt
+      || (entry.observedAt === invocation.observedAt && entryIndex > index)
+    )
+  ).length;
+}
+
+function sumSpendSince(
+  lines: readonly ThreadUsageLineRecord[],
+  since: number,
+): number | undefined {
+  if (!Number.isFinite(since)) return undefined;
+  const matching = lines.filter((line) => line.createdAt >= since);
+  if (matching.length === 0) return undefined;
+  return matching.reduce((sum, line) => sum + line.totalCostMicros, 0);
+}
+
+/**
+ * Effective cache-served input rate, derived from the thread's own billed rows
+ * rather than a catalog lookup — replayed context is cache-served, and the
+ * ledger already knows what this thread actually paid for it. Undefined when
+ * nothing cache-served has been billed yet, in which case the caller reports
+ * replayed tokens and no money.
+ */
+function deriveCachedInputMicrosPerToken(
+  lines: readonly ThreadUsageLineRecord[],
+): number | undefined {
+  let micros = 0;
+  let tokens = 0;
+  for (const line of lines) {
+    micros += line.cachedInputCostMicros;
+    tokens += line.cachedInputTokens;
+  }
+  return tokens > 0 && micros > 0 ? micros / tokens : undefined;
+}
+
+export function threadIncidentNoticeId(params: {
+  backend: string;
+  threadId: string;
+}): string {
+  /* Deliberately no turn segment — that is what produced one card per turn. */
+  return ["tool-accounting", params.backend, params.threadId].join(":");
+}
+
+export function formatIncidentMicros(
+  micros: number,
+  currency: string | undefined,
+): string {
+  const units = micros / 1_000_000;
+  const rounded = units >= 100 ? Math.round(units) : Number(units.toFixed(2));
+  if (!currency || currency === "USD") return `$${rounded.toLocaleString()}`;
+  return `${rounded.toLocaleString()} ${currency}`;
+}

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -1,55 +1,108 @@
 import type { ThreadToolInvocationAlert } from "@pwragent/shared";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
+import type { ThreadIncidentSummary } from "./thread-incident-summary";
+import {
+  formatIncidentMicros,
+  threadIncidentNoticeId,
+} from "./thread-incident-summary";
 
 export function buildToolAccountingNotice(params: {
-  alert: ThreadToolInvocationAlert;
   onExamine: () => void;
   onDismiss: () => void;
+  onMute?: () => void;
+  showCost: boolean;
+  summary: ThreadIncidentSummary;
   threadLink?: ResolvedThreadLink;
 }): AppNoticeToastNotice {
-  const polling = params.alert.kind === "noisy-polling";
+  const summary = params.summary;
+  const critical = summary.severity === "critical";
   return {
     actions: [
       {
-        label: `Examine ${params.alert.invocationCount.toLocaleString()} case${params.alert.invocationCount === 1 ? "" : "s"}`,
+        label: `Examine ${summary.flaggedInvocationCount.toLocaleString()} case${summary.flaggedInvocationCount === 1 ? "" : "s"}`,
         onClick: params.onExamine,
         tone: "primary" as const,
       },
       {
         label: "Dismiss",
         onClick: params.onDismiss,
-        tone: "secondary",
+        tone: "secondary" as const,
       },
+      /* Muting is offered only below critical. Silencing "output is getting
+         large" is a reasonable call; silencing "output hit the cap and was
+         truncated" is not something to offer in one click. */
+      ...(params.onMute && !critical
+        ? [{
+            label: "Don't warn again",
+            onClick: params.onMute,
+            tone: "secondary" as const,
+          }]
+        : []),
     ],
     autoDismiss: false,
-    copyText: [params.alert.message, params.alert.suggestedPrompt].join("\n\n"),
-    id: toolAccountingNoticeId(params.alert),
-    message: params.alert.message,
+    copyText: describeToolAccountingIncident({ showCost: true, summary }),
+    id: threadIncidentNoticeId(summary),
+    message: describeToolAccountingIncident({
+      showCost: params.showCost,
+      summary,
+    }),
     threadLink: params.threadLink,
-    title: polling ? "Repeated queued checks" : "Large tool output",
-    tone: params.alert.severity === "critical" ? "error" : "warning",
+    title: critical
+      ? "Tool output hit the cap"
+      : summary.pollingInvocationCount >= summary.flaggedInvocationCount
+        ? "Repeated queued checks"
+        : "Large tool output",
+    tone: critical ? "error" : "warning",
   };
 }
 
-export function toolAccountingNoticeId(
-  alert: ThreadToolInvocationAlert,
-): string {
-  return [
-    "tool-accounting",
-    alert.backend,
-    alert.threadId,
-    alert.turnId ?? "no-turn",
-    alert.kind,
-  ].join(":");
+/**
+ * One paragraph of thread-scoped stats rather than one card per turn. Cost
+ * lines appear only when the operator has pricing display enabled and the
+ * ledger has priced rows — the rest of the card still stands without them.
+ */
+export function describeToolAccountingIncident(params: {
+  showCost: boolean;
+  summary: ThreadIncidentSummary;
+}): string {
+  const summary = params.summary;
+  const lines = [
+    `${summary.flaggedInvocationCount.toLocaleString()} tool call${summary.flaggedInvocationCount === 1 ? "" : "s"} flagged across ${summary.turnsWithWarnings.toLocaleString()} turn${summary.turnsWithWarnings === 1 ? "" : "s"}.`,
+  ];
+  if (summary.pollingInvocationCount > 0) {
+    lines.push(
+      `${summary.pollingInvocationCount.toLocaleString()} ${summary.pollingInvocationCount === 1 ? "is a repeated queued check" : "are repeated queued checks"} waking the model to replay its context.`,
+    );
+  }
+  if (summary.overCapCount > 0) {
+    lines.push(
+      `${summary.overCapCount.toLocaleString()} hit the output cap and ${summary.overCapCount === 1 ? "was" : "were"} truncated.`,
+    );
+  }
+  if (params.showCost && summary.spentSinceFirstWarningMicros !== undefined) {
+    const spent = formatIncidentMicros(
+      summary.spentSinceFirstWarningMicros,
+      summary.currency,
+    );
+    lines.push(
+      summary.estimatedReplayWasteMicros !== undefined
+        ? `${spent} spent since the first warning, of which about ${formatIncidentMicros(summary.estimatedReplayWasteMicros, summary.currency)} is replayed tool output.`
+        : `${spent} spent since the first warning.`,
+    );
+  } else if (summary.replayedTokens > 0) {
+    lines.push(
+      `About ${summary.replayedTokens.toLocaleString()} tokens of tool output have been replayed through later round trips.`,
+    );
+  }
+  return lines.join(" ");
 }
 
-export function resolveDismissedToolIncident(params: {
-  dismissedSeverity?: ThreadToolInvocationAlert["severity"];
-  incomingSeverity: ThreadToolInvocationAlert["severity"];
-}): "escalate" | "show" | "suppress" {
-  if (!params.dismissedSeverity) return "show";
-  return params.dismissedSeverity === "warning" && params.incomingSeverity === "critical"
-    ? "escalate"
-    : "suppress";
+export function toolAccountingNoticeId(
+  alert: Pick<ThreadToolInvocationAlert, "backend" | "threadId">,
+): string {
+  return threadIncidentNoticeId({
+    backend: alert.backend,
+    threadId: alert.threadId,
+  });
 }

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -67,8 +67,9 @@ export function describeToolAccountingIncident(params: {
   summary: ThreadIncidentSummary;
 }): string {
   const summary = params.summary;
+  const scope = summary.coversWholeThread ? "" : " in recent activity";
   const lines = [
-    `${summary.flaggedInvocationCount.toLocaleString()} tool call${summary.flaggedInvocationCount === 1 ? "" : "s"} flagged across ${summary.turnsWithWarnings.toLocaleString()} turn${summary.turnsWithWarnings === 1 ? "" : "s"}.`,
+    `${summary.flaggedInvocationCount.toLocaleString()} tool call${summary.flaggedInvocationCount === 1 ? "" : "s"} flagged across ${summary.turnsWithWarnings.toLocaleString()} turn${summary.turnsWithWarnings === 1 ? "" : "s"}${scope}.`,
   ];
   if (summary.pollingInvocationCount > 0) {
     lines.push(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -140,9 +140,11 @@ export function ToolOutputIncidentExplorerWindow() {
        safer failure than an unexplained empty list. */
     return entry ? new Set<RefinedToolCategory>(entry.members) : undefined;
   }, [category, composition]);
+  /* Counted over every recorded call, not just flagged ones: a command that
+     ran eight times and tripped the size test five times repeated eight. */
   const repeatedCommands = useMemo(
-    () => countRepeatedCommands(flagged),
-    [flagged],
+    () => countRepeatedCommands(allInvocations),
+    [allInvocations],
   );
   /* Every turn, not just the rows the strip had room for — a case in a turn
      that fell below the row limit still belongs to that turn. */
@@ -827,11 +829,11 @@ function TurnTimeline(props: {
               <span aria-hidden="true" className="incident-explorer__timeline-tokens">
                 <i
                   data-critical={row.overCapCount > 0}
-                  style={{ height: `${scaleWidth(row.estimatedOutputTokens, maxTokens)}%` }}
+                  style={{ height: `${scaleWidth(row.estimatedOutputTokens, maxTokens, 0)}%` }}
                 />
               </span>
               <span aria-hidden="true" className="incident-explorer__timeline-trips">
-                <i style={{ height: `${scaleWidth(row.callCount, maxCalls)}%` }} />
+                <i style={{ height: `${scaleWidth(row.callCount, maxCalls, 0)}%` }} />
               </span>
             </button>
           );
@@ -908,9 +910,16 @@ function Fact(props: {
   );
 }
 
-function scaleWidth(value: number, max: number): number {
+/**
+ * Strip bars floor at 2% so a small-but-real value stays visible and the row
+ * stays readable. `floor: 0` is for the spark, where a turn with genuinely no
+ * output must paint nothing — a floored bar there would read as low activity
+ * instead of none, blurring the contrast the polling band depends on.
+ */
+function scaleWidth(value: number, max: number, floor = 2): number {
   if (max <= 0) return 0;
-  return Math.max(2, Math.round(value / max * 100));
+  if (value <= 0) return floor === 0 ? 0 : floor;
+  return Math.max(floor, Math.round(value / max * 100));
 }
 
 function describeAvailability(invocation: ThreadToolInvocationRecord): string {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -166,6 +166,8 @@ import type {
   SetDirectoryThreadsCollapsedResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
+  SetThreadToolIncidentNoticeRequest,
+  SetThreadToolIncidentNoticeResponse,
   SetThreadParentRequest,
   SetThreadParentResponse,
   SetThreadPinRequest,
@@ -900,6 +902,9 @@ export type DesktopApi = {
   setThreadReaction?: (
     request: SetThreadReactionRequest
   ) => Promise<SetThreadReactionResponse>;
+  setThreadToolIncidentNotice?: (
+    request: SetThreadToolIncidentNoticeRequest,
+  ) => Promise<SetThreadToolIncidentNoticeResponse>;
   setThreadPin?: (
     request: SetThreadPinRequest
   ) => Promise<SetThreadPinResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -153,6 +153,8 @@ export const NAVIGATION_SET_BROWSE_MODE_CHANNEL =
 export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";
 export const NAVIGATION_SET_THREAD_REACTION_CHANNEL =
   "navigation:set-thread-reaction";
+export const NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL =
+  "navigation:set-thread-tool-incident-notice";
 export const NAVIGATION_SET_THREAD_PIN_CHANNEL =
   "navigation:set-thread-pin";
 export const NAVIGATION_SET_THREAD_AGENT_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -26,6 +26,7 @@ import type { DesktopGhDiscoverySnapshot } from "./settings";
 import type { BackendAcpSessionRuntimeState } from "./backend";
 import type { AutomationThreadSummary } from "./automations";
 import type { CelestialIconId } from "./celestial";
+import type { ThreadToolIncidentNoticeState } from "./tool-output-incidents";
 import type {
   FederatedThreadRef,
   FederationCapability,
@@ -1856,6 +1857,13 @@ export type ThreadOverlayState = {
    * (e.g., "needs follow-up"), not multi-user voting.
    */
   reactions?: string[];
+  /**
+   * Consolidated tool-output incident state for this thread: when it first
+   * warned, what the operator dismissed, and what they muted. Persisted so an
+   * undismissed incident is still waiting when the thread is reopened, and so
+   * the cost baseline does not reset on restart.
+   */
+  toolIncidentNotice?: ThreadToolIncidentNoticeState;
   /** User-curated position in the pinned section. Undefined means unpinned. */
   pinnedRank?: string;
   /**

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -17,6 +17,7 @@ import type {
   ThreadPrAutoDispatchPending,
 } from "./navigation";
 import type { ThreadPricingSummary, ThreadUsageLineRecord } from "../token-usage-pricing";
+import type { ThreadToolIncidentNoticeState } from "./tool-output-incidents";
 
 export type AppServerBuiltinBackendKind = "codex";
 export type AcpBackendId = `acp:${string}`;
@@ -1380,6 +1381,12 @@ export type AppServerNotification =
       params: {
         threadId: string;
         toolAccounting: ThreadToolAccounting;
+        /**
+         * The operator's persisted disposition for this thread's incident
+         * card. Carried here so a renderer that just launched knows what was
+         * dismissed or muted before it existed, without a per-thread read.
+         */
+        incidentNotice?: ThreadToolIncidentNoticeState;
         triggeredAlerts?: ThreadToolInvocationAlert[];
       };
     }

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -2,8 +2,12 @@ import type {
   AppServerBackendKind,
   ThreadToolAccounting,
   ThreadToolAnalysisCoverage,
+  ThreadToolInvocationAlert,
   ThreadToolInvocationRecord,
 } from "./normalized-app-server";
+import type { FederationTarget } from "./federation";
+
+type ThreadToolInvocationSeverity = ThreadToolInvocationAlert["severity"];
 
 /**
  * Characters per output token. A coarse estimate, but the same one the
@@ -47,6 +51,80 @@ export function isFlaggedToolInvocation(
 ): boolean {
   return invocation.noisy || invocation.outputChars >= TOOL_OUTPUT_WARNING_CHARS;
 }
+
+/**
+ * Per-thread state for the consolidated tool-output incident notice.
+ *
+ * One incident per thread, not one per turn. The alert stream is per-turn, so
+ * a busy thread minted a fresh durable notice every time it tripped a
+ * threshold — forty-one cards behind a pager, each needing its own dismissal.
+ * This is the state that lets a thread's incidents collapse into a single
+ * card that updates in place, and that survives a restart so an unread
+ * incident is still there when the operator comes back to the thread.
+ */
+export type ThreadToolIncidentNoticeState = {
+  /** When this thread first tripped a threshold. The cost baseline. */
+  firstWarningAt?: number;
+  /** Operator dismissed the card at this severity. */
+  dismissedSeverity?: ThreadToolInvocationSeverity;
+  dismissedAt?: number;
+  /**
+   * Operator asked not to be warned again at this severity. A strictly higher
+   * severity still breaks through — muting "the output is getting large" must
+   * not also mute "the output hit the cap and was truncated".
+   */
+  mutedSeverity?: ThreadToolInvocationSeverity;
+  mutedAt?: number;
+};
+
+export type ThreadToolIncidentSeverityRank = 0 | 1;
+
+/** Ordered so a comparison reads as "is this worse than what was silenced". */
+export function rankToolIncidentSeverity(
+  severity: ThreadToolInvocationSeverity,
+): ThreadToolIncidentSeverityRank {
+  return severity === "critical" ? 1 : 0;
+}
+
+/**
+ * Whether an incident at `severity` should surface, given what the operator
+ * already dismissed or muted for this thread.
+ */
+export function resolveToolIncidentVisibility(params: {
+  severity: ThreadToolInvocationSeverity;
+  state?: ThreadToolIncidentNoticeState;
+}): "show" | "suppress" {
+  const incoming = rankToolIncidentSeverity(params.severity);
+  const muted = params.state?.mutedSeverity;
+  if (muted !== undefined && incoming <= rankToolIncidentSeverity(muted)) {
+    return "suppress";
+  }
+  const dismissed = params.state?.dismissedSeverity;
+  if (dismissed !== undefined && incoming <= rankToolIncidentSeverity(dismissed)) {
+    return "suppress";
+  }
+  return "show";
+}
+
+export type SetThreadToolIncidentNoticeRequest = {
+  backend?: AppServerBackendKind;
+  federationTarget?: FederationTarget;
+  threadId: string;
+  /** Records a dismissal at this severity. */
+  dismissedSeverity?: ThreadToolInvocationSeverity;
+  /** Records a mute at this severity. Higher severities still surface. */
+  mutedSeverity?: ThreadToolInvocationSeverity;
+  /** First observed warning, recorded once so the cost baseline is stable. */
+  firstWarningAt?: number;
+  /** Clears dismissal and mute — the un-mute path. */
+  reset?: boolean;
+};
+
+export type SetThreadToolIncidentNoticeResponse = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  state: ThreadToolIncidentNoticeState;
+};
 
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;


### PR DESCRIPTION
Stacked on #1653, which is stacked on #1647. Review those first.

## The problem

The notice stack reached **"1 of 41"**. `toolAccountingNoticeId` keyed each notice by `(backend, threadId, turnId, kind)`, and durable notices never expire — so every turn that tripped a threshold minted its own card, each needing its own dismissal. There is no bulk action. Nobody works that queue; they rage-dismiss it, and the one warning that mattered goes with the rest.

## What this does

**One card per thread.** The id drops its turn segment and the card is folded from the whole accounting snapshot, so it updates in place instead of stacking. 41 → 1.

**It reports the thread, not the turn.** Calls flagged, turns affected, cap hits (truncated output), repeated queued checks, and cost.

**Two cost figures, because they answer different questions.**
- *Spend since the first warning* — billed money, straight from the pricing ledger.
- *Estimated replay waste* — the share attributable to carrying large tool results through later round trips, priced off **the thread's own cache-served rows** rather than a catalog lookup. The ledger already knows what this thread pays for cache-served input, which is what a replay is.

Both respect the existing `threadPricingDisplayUsd` / `threadPricingDisplayCodexCredits` settings. Without them, the card reports replayed tokens, which is always available.

**Disposition persists** in the thread overlay, so an incident survives a restart:
- Dismissal records its severity; a later escalation still breaks through (the existing warning→critical rule, kept).
- **"Don't warn again"** mutes at the dismissed severity only, and is offered for warnings but **not** for a cap hit — silencing "output is getting large" is a reasonable call, silencing "output hit the cap and was truncated" is not something to offer in one click.
- `firstWarningAt` is written once and never moved forward, so the cost window stays anchored after a restart drops older accounting rows out of the snapshot.

Deliberately **not federated** — what a viewer wants to be warned about is its own preference, the same reasoning that keeps composer drafts machine-local.

## Two judgment calls worth reviewing

**Polling would have been flattened.** Folding by invocation nearly lost the `noisy-polling` pathology, whose cost is the round trip rather than the payload. The summary counts it separately and the card names it (and titles itself "Repeated queued checks" when that's all there is). Caught by an existing shell test that stubbed empty invocations.

**Focus-based placement is deliberately NOT in this PR.** The plan is: global card while the thread is unfocused, retire it when the thread goes idle, show it in-thread until dismissed. I built the suppress-when-focused branch and then removed it — without the in-thread surface it renders *nothing* for the thread you're looking at, which is worse than today. That half lands with the in-thread card, together, so no intermediate state is a regression.

## Verification

- `pnpm typecheck`, `lint:eslint` (0 errors), `lint:boundaries` clean.
- 3,153 renderer + shared tests pass, including the reworked notice suite (fold, cap escalation, persisted baseline, replay pricing, mute-vs-escalation matrix).
- Not yet run in the app — I have no way to reproduce a 41-card thread locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)