### PR TITLE
fix(desktop): backport Windows environment process isolation

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -10,7 +11,9 @@ import {
   listRunningDetachedCommands,
   startLocalCodexEnvironmentAction,
   stopCodexEnvironmentDetachedCommand,
+  waitForCodexEnvironmentDetachedCommandGone,
 } from "../app-server/codex-environment-runtime";
+import { collectProcessTreeIds } from "../process-tree";
 import { resolveWindowsBashShell } from "../windows-shell";
 
 const mainLogEntries = vi.hoisted(
@@ -55,6 +58,48 @@ function spawnableShell(posixShell: string): string {
 describe("codex environment runtime", () => {
   afterEach(() => {
     mainLogEntries.length = 0;
+  });
+
+  it("treats a missing detached command as already gone", async () => {
+    await expect(
+      waitForCodexEnvironmentDetachedCommandGone({
+        runId: "missing-run",
+        timeoutMs: 200,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when the command is already gone at the timeout boundary", async () => {
+    await expect(
+      waitForCodexEnvironmentDetachedCommandGone({
+        runId: "missing-run",
+        timeoutMs: 0,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws at the timeout boundary only when a tracked pid is still alive", async () => {
+    // Use a leaf child. process.pid on Windows desktop-main is the Vitest
+    // worker; collecting that tree does a CIM query per descendant and
+    // overruns the 30s test timeout before timeoutMs: 0 can throw.
+    const child = spawn(
+      process.execPath,
+      ["-e", "setInterval(() => undefined, 1000)"],
+      { stdio: "ignore" },
+    );
+    try {
+      expect(child.pid).toEqual(expect.any(Number));
+      await expect(
+        waitForCodexEnvironmentDetachedCommandGone({
+          knownPids: [child.pid!],
+          pid: child.pid,
+          runId: "missing-run",
+          timeoutMs: 0,
+        }),
+      ).rejects.toThrow(/did not exit within 0ms/);
+    } finally {
+      child.kill("SIGKILL");
+    }
   });
 
   it("rejects detached actions with a clear missing-cwd error before spawn", async () => {
@@ -212,9 +257,10 @@ describe("codex environment runtime", () => {
       });
 
       if (isWindows) {
-        await expect(detachedExit).resolves.toMatchObject({
-          exitCode: expect.any(Number),
-          exitSignal: null,
+        const exit = await detachedExit;
+        expect(exit, JSON.stringify(mainLogEntries)).toMatchObject({
+          exitCode: null,
+          exitSignal: "SIGTERM",
         });
       } else {
         await expect(detachedExit).resolves.toMatchObject({
@@ -237,6 +283,8 @@ describe("codex environment runtime", () => {
   it("counts an auto-started environment action as a quit blocker", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-auto-"));
     const runId = "test-run-auto";
+    let registeredPid: number | undefined;
+    let knownPids: number[] = [];
     try {
       await applyLocalCodexEnvironmentSelection({
         cwd: root,
@@ -285,12 +333,24 @@ describe("codex environment runtime", () => {
           threadId: "",
         }),
       ]);
+      registeredPid = running[0]?.pid;
+      // Snapshot before terminate. Windows reparents Job grandchildren after
+      // the PowerShell launcher dies, so a later parent walk cannot find them.
+      knownPids = registeredPid ? collectProcessTreeIds(registeredPid) : [];
 
       // The thread now exists; the run gets its owner and becomes linkable.
       attachDetachedCommandThreadId(runId, "thread-1");
       expect(listRunningDetachedCommands()[0]?.threadId).toBe("thread-1");
     } finally {
-      stopCodexEnvironmentDetachedCommand(runId, "terminate");
+      const stopResult = stopCodexEnvironmentDetachedCommand(runId, "terminate");
+      if (stopResult.found && !stopResult.alreadyClosed) {
+        await waitForCodexEnvironmentDetachedCommandGone({
+          knownPids,
+          pid: registeredPid,
+          runId,
+          timeoutMs: 5_000,
+        });
+      }
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   }, 15_000);

--- a/apps/desktop/src/main/__tests__/process-tree.test.ts
+++ b/apps/desktop/src/main/__tests__/process-tree.test.ts
@@ -1,7 +1,12 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { describe, expect, it } from "vitest";
-import { terminateOwnedProcessTree } from "../process-tree";
+import {
+  collectProcessTreeIds,
+  isProcessIdAlive,
+  terminateOwnedProcessTree,
+  waitForProcessTreeGone,
+} from "../process-tree";
 
 const posixOnly = process.platform === "win32" ? it.skip : it;
 
@@ -35,5 +40,36 @@ describe("terminateOwnedProcessTree", () => {
         // The expected path already terminated the entire process group.
       }
     }
+  });
+});
+
+describe("waitForProcessTreeGone", () => {
+  it("treats a missing pid as already gone", async () => {
+    await expect(
+      waitForProcessTreeGone({ rootPid: 0, timeoutMs: 50 }),
+    ).resolves.toBe(true);
+  });
+
+  it("waits until a killed process and its snapshot pids are gone", async () => {
+    const child = spawn(
+      process.execPath,
+      ["-e", "setInterval(() => undefined, 1000)"],
+      { stdio: "ignore" },
+    );
+    const pid = child.pid;
+    expect(pid).toEqual(expect.any(Number));
+    const knownPids = collectProcessTreeIds(pid!);
+    expect(knownPids).toContain(pid);
+    expect(isProcessIdAlive(pid!)).toBe(true);
+
+    child.kill("SIGKILL");
+    await expect(
+      waitForProcessTreeGone({
+        knownPids,
+        rootPid: pid,
+        timeoutMs: 2_000,
+      }),
+    ).resolves.toBe(true);
+    expect(isProcessIdAlive(pid!)).toBe(false);
   });
 });

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   accessSync,
   constants,
+  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -22,7 +23,21 @@ import {
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
-import { windowsBashCandidates } from "../windows-shell";
+import {
+  collectProcessTreeIds,
+  isProcessIdAlive,
+} from "../process-tree";
+import {
+  formatWindowsJobStartupTelemetry,
+  formatWindowsJobStartupTimeout,
+  readWindowsJobStartupTelemetry,
+  startWindowsJobReadyPoll,
+  wrapCommandInWindowsJob,
+} from "../windows-job-wrapper";
+import {
+  preferStableWindowsBashPath,
+  windowsBashCandidates,
+} from "../windows-shell";
 import type { CodexEnvironmentHydrationStoreLike } from "./codex-environment-hydration-store";
 
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
@@ -162,6 +177,8 @@ export type CodexEnvironmentDetachedOutput = {
 
 export const DETACHED_OUTPUT_SNAPSHOT_MS = 500;
 const DETACHED_STOP_SIGKILL_GRACE_MS = 2_000;
+const WINDOWS_JOB_STARTUP_DIAGNOSTICS_ENV =
+  "PWRAGENT_WINDOWS_JOB_STARTUP_DIAGNOSTICS";
 
 export type CodexEnvironmentCommandResult = {
   durationMs?: number;
@@ -275,6 +292,78 @@ export type CodexEnvironmentDetachedCommandStopResult = {
   found: boolean;
   alreadyClosed: boolean;
 };
+
+export type CodexEnvironmentDetachedCommandGoneParams = {
+  knownPids?: Iterable<number>;
+  pid?: number;
+  runId: string;
+  timeoutMs?: number;
+};
+
+/**
+ * After `stop`/`terminate`, wait for the Node close bit AND the OS process
+ * tree to die. `taskkill /T /F` returning 0 and `child.kill` on the Windows
+ * Job PowerShell launcher both race handle release; callers that `rm` the
+ * action cwd must wait here first.
+ */
+export async function waitForCodexEnvironmentDetachedCommandGone(
+  params: CodexEnvironmentDetachedCommandGoneParams,
+): Promise<void> {
+  const timeoutMs = params.timeoutMs ?? 5_000;
+  const startedAt = Date.now();
+  const remainingMs = () => timeoutMs - (Date.now() - startedAt);
+  const tracked = new Set<number>(
+    [...(params.knownPids ?? [])].filter(
+      (pid) => Number.isInteger(pid) && pid > 0,
+    ),
+  );
+  if (params.pid && Number.isInteger(params.pid) && params.pid > 0) {
+    tracked.add(params.pid);
+  }
+
+  const snapshot = () => {
+    const entry = detachedCommandProcesses.get(params.runId);
+    return {
+      closed: !entry || entry.closed(),
+      alive: [...tracked].filter((pid) => isProcessIdAlive(pid)),
+    };
+  };
+
+  while (true) {
+    // Expand only while budget remains. A 5s CIM walk per live pid would
+    // otherwise ignore timeoutMs (including 0) and hang Windows CI when the
+    // tracked root is a busy process with many descendants.
+    if (remainingMs() > 0) {
+      for (const pid of [...tracked]) {
+        if (remainingMs() <= 0) {
+          break;
+        }
+        if (isProcessIdAlive(pid)) {
+          for (const childPid of collectProcessTreeIds(pid)) {
+            tracked.add(childPid);
+          }
+        }
+      }
+    }
+    // Blocking CIM walks stall the event loop, so a close handler queued
+    // during the walk cannot run until we yield.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    const { closed, alive } = snapshot();
+    if (closed && alive.length === 0) {
+      return;
+    }
+    if (remainingMs() <= 0) {
+      throw new Error(
+        `Detached environment command ${params.runId} did not exit within ${timeoutMs}ms`
+          + ` (closed=${closed}, alive=[${alive.join(", ")}], pid=${String(params.pid)})`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
 
 export function stopCodexEnvironmentDetachedCommand(
   terminationKey: string,
@@ -660,20 +749,52 @@ function runShellCommand(
   const capture = params.captureShellEnvironment
     ? createShellEnvironmentCaptureTarget()
     : undefined;
+  const useWindowsJob =
+    process.platform === "win32"
+    && (params.mode === "detach" || Boolean(params.timeoutMs));
+  const shellArgs: [string, string] = [
+    "-lc",
+    wrapShellCommand(
+      shell,
+      params.command,
+      capture?.filePath,
+      processId,
+    ),
+  ];
+  const windowsJobLaunch = useWindowsJob
+    ? wrapCommandInWindowsJob({
+        args: shellArgs,
+        command: shell,
+        cwd: params.cwd,
+        env: commandEnv,
+      })
+    : undefined;
+  const launch = windowsJobLaunch ?? {
+    args: shellArgs,
+    command: shell,
+    env: commandEnv,
+  };
 
   return new Promise((resolve, reject) => {
     const child = spawn(
-      shell,
-      ["-lc", wrapShellCommand(shell, params.command, capture?.filePath)],
+      launch.command,
+      launch.args,
       {
         cwd: params.cwd,
-        detached: params.mode === "detach" || Boolean(params.timeoutMs),
-        env: commandEnv,
+        // Windows' detached-process flag breaks inherited stdio for the
+        // PowerShell-hosted Job launcher: commands can report exit 0 without
+        // ever running. The Job already owns the complete process tree, so a
+        // second detached process group is both unnecessary and harmful.
+        detached:
+          !windowsJobLaunch
+          && (params.mode === "detach" || Boolean(params.timeoutMs)),
+        env: launch.env,
         // Pipe output even in detach mode so we can drain to a ring buffer,
         // stream to the renderer's anchored output UI, and log non-zero exits.
         // Caller still resolves on spawn for detach mode; we keep listening so
         // long-running children (e.g., `pnpm dev`) report failures.
         stdio: "pipe",
+        windowsHide: true,
       },
     );
 
@@ -684,6 +805,9 @@ function runShellCommand(
     let timeoutHandle: NodeJS.Timeout | undefined;
     let killHandle: NodeJS.Timeout | undefined;
     let forceSettleHandle: NodeJS.Timeout | undefined;
+    let windowsJobReadyPoll:
+      | ReturnType<typeof startWindowsJobReadyPoll>
+      | undefined;
 
     const appendOutput = (text: string) => {
       combinedOutput = `${combinedOutput}${text}`.slice(-32_000);
@@ -694,15 +818,14 @@ function runShellCommand(
         return;
       }
       try {
-        if (process.platform !== "win32") {
+        if (windowsJobLaunch) {
+          // The launcher is the only process outside its Job. Terminating it
+          // closes the KILL_ON_JOB_CLOSE handle and atomically terminates the
+          // shell plus every descendant, so no taskkill tree walk is needed.
+          child.kill(signal);
+        } else if (process.platform !== "win32") {
           process.kill(-child.pid, signal);
         } else {
-          // child.kill only terminates the immediate bash.exe; its children
-          // (the actual command, e.g. `sleep`) linger, which keeps the `close`
-          // event from firing (timeouts hang) and holds handles on the
-          // workspace temp dir (EBUSY on cleanup). Kill the whole process tree.
-          // Match POSIX stop semantics: SIGTERM gets a non-forced taskkill,
-          // while SIGKILL is the immediate/fallback forced termination.
           const taskkillArgs = ["/pid", String(child.pid), "/t"];
           if (signal === "SIGKILL") {
             taskkillArgs.push("/f");
@@ -711,15 +834,16 @@ function runShellCommand(
           const systemRoot = Object.entries(taskkillEnv).find(
             ([key]) => key.toUpperCase() === "SYSTEMROOT",
           )?.[1];
-          // The explicit environment is necessary to keep the renderer URL out
-          // of the helper, so resolve taskkill without relying on its PATH.
           const taskkill = systemRoot
             ? path.join(systemRoot, "System32", "taskkill.exe")
             : "taskkill";
-          spawnSync(taskkill, taskkillArgs, {
+          const result = spawnSync(taskkill, taskkillArgs, {
             env: taskkillEnv,
             stdio: "ignore",
           });
+          if (result.status !== 0) {
+            child.kill(signal);
+          }
         }
       } catch (error) {
         environmentRuntimeLog.warn("codex-environment-command-kill-failed", {
@@ -759,6 +883,8 @@ function runShellCommand(
         clearTimeout(forceSettleHandle);
         forceSettleHandle = undefined;
       }
+      windowsJobReadyPoll?.cancel();
+      windowsJobReadyPoll = undefined;
       cleanupShellEnvironmentCaptureTarget(capture);
       callback();
     };
@@ -868,6 +994,7 @@ function runShellCommand(
         processId,
         message,
       });
+      windowsJobLaunch?.cleanup();
       settle(() => {
         reject(new CodexEnvironmentCommandError(message));
       });
@@ -875,7 +1002,6 @@ function runShellCommand(
 
     if (params.mode === "detach") {
       child.once("spawn", () => {
-        registerDetachedProcess();
         // Let the parent exit independently of this child. child.unref()
         // alone doesn't suffice when stdio is "pipe": the libuv pipe
         // handles on child.stdout/stderr also keep the parent's event
@@ -901,8 +1027,52 @@ function runShellCommand(
         // Node versions where the type might tighten.
         (child.stdout as { unref?: () => void } | null)?.unref?.();
         (child.stderr as { unref?: () => void } | null)?.unref?.();
-        settle(() => {
-          resolve({ pid: child.pid });
+        const resolveStarted = () => {
+          // Do not expose the command to Stop/Quit until its Windows Job owns
+          // the shell. Otherwise an immediate stop can kill the launcher while
+          // startup is still pending and reject an action that was reported as
+          // registered.
+          registerDetachedProcess();
+          settle(() => {
+            resolve({ pid: child.pid });
+          });
+        };
+        if (!windowsJobLaunch) {
+          resolveStarted();
+          return;
+        }
+        windowsJobReadyPoll = startWindowsJobReadyPoll({
+          launch: windowsJobLaunch,
+          onReady: (startupTelemetry) => {
+            windowsJobReadyPoll = undefined;
+            if (settled || closed) return;
+            const durationMs = Date.now() - startedAt;
+            environmentRuntimeLog.info("codex-environment-windows-job-ready", {
+              processId,
+              durationMs,
+              startupPhases: startupTelemetry.phases,
+            });
+            if (
+              process.env[WINDOWS_JOB_STARTUP_DIAGNOSTICS_ENV] === "1"
+            ) {
+              process.stderr.write(
+                `Windows Job startup ready after ${durationMs}ms: ${formatWindowsJobStartupTelemetry(startupTelemetry)}\n`,
+              );
+            }
+            resolveStarted();
+          },
+          onTimeout: (startupTimeout) => {
+            windowsJobReadyPoll = undefined;
+            if (settled || closed) return;
+            terminateChild("SIGKILL");
+            settle(() => {
+              reject(
+                new CodexEnvironmentCommandError(
+                  formatWindowsJobStartupTimeout(startupTimeout),
+                ),
+              );
+            });
+          },
         });
       });
       // Even in detach mode, log non-zero exits so failed `pnpm dev` /
@@ -911,6 +1081,8 @@ function runShellCommand(
       // overlay state for the anchored env-action output UI.
       child.once("close", (code, signal) => {
         closed = true;
+        windowsJobReadyPoll?.cancel();
+        windowsJobReadyPoll = undefined;
         if (params.detachedTerminationKey) {
           const processEntry = detachedCommandProcesses.get(
             params.detachedTerminationKey,
@@ -928,6 +1100,35 @@ function runShellCommand(
         }
         const durationMs = Date.now() - startedAt;
         const output = combinedOutput.trimEnd();
+        if (!settled) {
+          const windowsStartup = windowsJobLaunch
+            ? readWindowsJobStartupTelemetry(windowsJobLaunch)
+            : undefined;
+          if (windowsJobLaunch && existsSync(windowsJobLaunch.readyFilePath)) {
+            settle(() => {
+              resolve({ pid: child.pid });
+            });
+          } else {
+            settle(() => {
+              reject(
+                new CodexEnvironmentCommandError(
+                  [
+                    "Codex environment command exited before its Windows Job became ready",
+                    windowsStartup
+                      ? `: ${formatWindowsJobStartupTelemetry(windowsStartup)}`
+                      : "",
+                    buildExitErrorSuffix(output),
+                  ].join(""),
+                  {
+                    durationMs,
+                    exitCode: typeof code === "number" ? code : undefined,
+                    output,
+                  },
+                ),
+              );
+            });
+          }
+        }
         if (code === 0) {
           environmentRuntimeLog.info("codex-environment-detached-exit", {
             processId,
@@ -966,12 +1167,14 @@ function runShellCommand(
             },
           );
         }
+        windowsJobLaunch?.cleanup();
       });
       return;
     }
 
     child.once("close", (code, signal) => {
       closed = true;
+      windowsJobLaunch?.cleanup();
       if (killHandle) {
         clearTimeout(killHandle);
         killHandle = undefined;
@@ -1207,18 +1410,25 @@ function isParentElectronRuntimeEnvKey(key: string): boolean {
 
 function resolveCommandShell(env: NodeJS.ProcessEnv): string {
   const requested = env.SHELL?.trim() || process.env.SHELL?.trim();
+  const preferredRequested = requested
+    ? preferStableWindowsBashPath(requested)
+    : undefined;
   // Windows has no /bin/sh; run the agent's bash scripts through
   // Git-for-Windows bash (already a hard dependency) instead.
   const candidates =
     process.platform === "win32"
-      ? [requested, ...windowsBashCandidates()]
+      ? [preferredRequested, requested, ...windowsBashCandidates()]
       : [requested, "/bin/zsh", "/bin/bash", "/bin/sh"];
   const inspected: Array<{ shell: string; reason: string }> = [];
 
   for (const shell of [...new Set(candidates.filter(Boolean))] as string[]) {
     const availability = inspectCommandPath(shell);
     if (availability.available) {
-      if (requested && shell !== requested) {
+      if (
+        requested
+        && shell !== requested
+        && shell !== preferredRequested
+      ) {
         environmentRuntimeLog.warn("codex-environment-shell-fallback", {
           requested,
           shell,
@@ -1344,12 +1554,14 @@ function wrapShellCommand(
   shell: string,
   command: string,
   captureEnvPath?: string,
+  processMarker?: string,
 ): string {
   return [
     ...shellStartupCommands(shell),
     '[ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
     '[ -z "${NVM_DIR:-}" ] && [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"',
     "set -e",
+    ...(processMarker ? [`: ${processMarker}`] : []),
     command,
     ...(captureEnvPath
       ? [`{ /usr/bin/env || /bin/env || env; } > ${quoteShellArg(captureEnvPath)} || true`]

--- a/apps/desktop/src/main/process-tree.ts
+++ b/apps/desktop/src/main/process-tree.ts
@@ -19,6 +19,100 @@ export type ProcessTreeTerminationOptions = {
   forceTimeoutMs: number;
 };
 
+export type ProcessTreeWaitOptions = {
+  knownPids?: Iterable<number>;
+  pollIntervalMs?: number;
+  rootPid?: number;
+  timeoutMs?: number;
+};
+
+export function isProcessIdAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Snapshot a process and its current descendants. Call this before kill:
+ * Windows reparents grandchildren (sleep.exe) after the PowerShell/Job
+ * launcher dies, so later parent walks cannot find them.
+ */
+export function collectProcessTreeIds(rootPid: number): number[] {
+  const tracked = new Set<number>();
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
+    return [];
+  }
+  tracked.add(rootPid);
+  if (process.platform !== "win32") {
+    return [...tracked];
+  }
+
+  let added = true;
+  while (added) {
+    added = false;
+    for (const pid of [...tracked]) {
+      if (!isProcessIdAlive(pid)) {
+        continue;
+      }
+      for (const childPid of listWindowsChildProcessIds(pid)) {
+        if (!tracked.has(childPid)) {
+          tracked.add(childPid);
+          added = true;
+        }
+      }
+    }
+  }
+  return [...tracked];
+}
+
+/**
+ * Wait until the root pid and every previously observed descendant are gone.
+ * `taskkill /T /F` returning 0 is not enough: the Windows Job path
+ * `child.kill`s the PowerShell launcher and directory handles can linger
+ * until powershell/conhost/bash/sleep actually exit.
+ */
+export async function waitForProcessTreeGone(
+  options: ProcessTreeWaitOptions = {},
+): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? 50);
+  const tracked = new Set<number>(
+    [...(options.knownPids ?? [])].filter(
+      (pid) => Number.isInteger(pid) && pid > 0,
+    ),
+  );
+  if (options.rootPid) {
+    for (const pid of collectProcessTreeIds(options.rootPid)) {
+      tracked.add(pid);
+    }
+  }
+
+  const startedAt = Date.now();
+  while (true) {
+    for (const pid of [...tracked]) {
+      if (isProcessIdAlive(pid)) {
+        for (const childPid of collectProcessTreeIds(pid)) {
+          tracked.add(childPid);
+        }
+      }
+    }
+    const alive = [...tracked].filter((pid) => isProcessIdAlive(pid));
+    if (alive.length === 0) {
+      return true;
+    }
+    if (Date.now() - startedAt >= timeoutMs) {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
 function isExited(child: OwnedChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null;
 }
@@ -93,6 +187,54 @@ function waitForOwnedProcessTreeExit(
       timeoutMs,
     );
   });
+}
+
+function resolveWindowsPowerShell(): string {
+  const childEnv = buildPwrAgentChildProcessEnv(process.env);
+  const systemRoot = Object.entries(childEnv).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  return systemRoot
+    ? path.win32.join(
+        systemRoot,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      )
+    : "powershell.exe";
+}
+
+function listWindowsChildProcessIds(pid: number): number[] {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return [];
+  }
+  const result = spawnSync(
+    resolveWindowsPowerShell(),
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      `Get-CimInstance Win32_Process -Filter "ParentProcessId=${pid}" | Select-Object -ExpandProperty ProcessId`,
+    ],
+    {
+      encoding: "utf8",
+      env: buildPwrAgentChildProcessEnv(process.env),
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 5_000,
+      windowsHide: true,
+    },
+  );
+  if (result.status !== 0) {
+    return [];
+  }
+  return String(result.stdout ?? "")
+    .split(/\r?\n/)
+    .map((line) => Number(line.trim()))
+    .filter((childPid) => Number.isInteger(childPid) && childPid > 0);
 }
 
 function terminateWindowsTree(


### PR DESCRIPTION
## Summary

- backport the Windows Job ownership for Codex environment commands from #1259
- use the bounded, phase-aware Job startup helpers already present on `releases/1.0` from the worktree-removal backport
- backport #1631 process-tree snapshots and exit waiting so cleanup waits for reparented descendants before removing the action workspace
- keep the Automation, renderer, and stress-harness portions of #1259 out of the 1.0 line

## Why

The Windows `codex-environment-runtime` test intermittently removed its temporary workspace immediately after terminating an auto-started action. The PowerShell launcher could close before Git Bash or `sleep.exe` released the directory, producing `EBUSY` in CI.

PR #1259 establishes atomic Windows Job ownership. PR #1631 is the direct follow-up that closes the remaining cleanup race by snapshotting descendants before termination and waiting for both the Node close state and operating-system processes to disappear.

Source PRs: #1259, #1631. Startup-readiness compatibility follows the focused runtime portions of #1277 and #1301 because `releases/1.0` already contains their newer Windows Job wrapper API through the worktree-removal backport.

## Validation

- focused shutdown and process-tree regression selection: 6 passed
- `pnpm --filter @pwragent/desktop typecheck`
- ESLint on the four changed files
- `pnpm lint:boundaries`
- `git diff --check`

The full local `codex-environment-runtime.test.ts` run had five unrelated assertions polluted by local npm configuration warnings. This is the same checkout-specific condition recorded in #1631; the focused shutdown regression tests pass.
