### PR TITLE
fix(desktop): rehydrate active remote transcripts

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -12131,6 +12131,134 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("rehydrates an active remote thread when its navigation summary advances", async () => {
+    const activeTurn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 5_000,
+    };
+    const pendingRequest: AppServerToolRequestUserInputNotification = {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "input-1",
+        requestId: "input-request-1",
+        questions: [
+          {
+            id: "scope",
+            header: "Scope",
+            question: "How should I proceed?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              {
+                label: "Skip backport (Recommended)",
+                description: "The target branch has no affected suite.",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const initialEntry: AppServerThreadMessageEntry = {
+      type: "message",
+      id: "user-1",
+      role: "user",
+      text: "Backport the change.",
+      turn: activeTurn,
+    };
+    const caughtUpEntry: AppServerThreadMessageEntry = {
+      type: "message",
+      id: "commentary-1",
+      role: "assistant",
+      phase: "commentary",
+      text: "The release branch has no affected suite.",
+      turn: activeTurn,
+    };
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [initialEntry],
+        hasPreviousPage: false,
+        threadStatus: "active",
+      }))
+      .mockResolvedValueOnce({
+        ...readThreadResponse({
+          entries: [initialEntry, caughtUpEntry],
+          hasPreviousPage: false,
+          threadStatus: "active",
+        }),
+        pendingRequest,
+      });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const remoteThread = (updatedAt: number): NavigationThreadSummary => ({
+      ...buildThread({ id: "thread-1", updatedAt }),
+      threadStatus: "active",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: {
+            scope: "remote",
+            instanceId: "owner-m5",
+          },
+          threadId: "thread-1",
+        },
+        instanceLabel: "Remote M5",
+        capabilities: [
+          "thread_detail",
+          "pending_request_control",
+          "event_subscriptions",
+        ],
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: remoteThread(updatedAt),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    expect(readThread).toHaveBeenCalledTimes(1);
+    expect(result.current.activeTurnId).toBe("turn-1");
+    expect(result.current.pendingUserInput).toBeUndefined();
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "commentary-1",
+            text: "The release branch has no affected suite.",
+          }),
+        ]),
+      );
+      expect(result.current.pendingStatusText).toBe("Waiting for input");
+      expect(result.current.pendingUserInput).toMatchObject({
+        requestId: "input-request-1",
+        questions: [{ id: "scope" }],
+      });
+    });
+    expect(readThread).toHaveBeenLastCalledWith(expect.objectContaining({
+      federationTarget: {
+        scope: "remote",
+        instanceId: "owner-m5",
+      },
+      threadId: "thread-1",
+    }));
+  });
+
   it("cancels missed-completion reconciliation when navigation becomes active again", async () => {
     const activeTurn = {
       id: "turn-1",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -12259,6 +12259,76 @@ describe("useThreadSessionState", () => {
     }));
   });
 
+  it("does not immediately retry a failed active remote rehydration", async () => {
+    const activeTurn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 5_000,
+    };
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          {
+            type: "message",
+            id: "user-1",
+            role: "user",
+            text: "Continue remotely.",
+            turn: activeTurn,
+          },
+        ],
+        hasPreviousPage: false,
+        threadStatus: "active",
+      }))
+      .mockRejectedValue(new Error("Remote federation unavailable"));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const remoteThread = (updatedAt: number): NavigationThreadSummary => ({
+      ...buildThread({ id: "thread-1", updatedAt }),
+      threadStatus: "active",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: {
+            scope: "remote",
+            instanceId: "owner-m5",
+          },
+          threadId: "thread-1",
+        },
+        instanceLabel: "Remote M5",
+        capabilities: [
+          "thread_detail",
+          "event_subscriptions",
+        ],
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: remoteThread(updatedAt),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    expect(readThread).toHaveBeenCalledTimes(1);
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Remote federation unavailable");
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(readThread).toHaveBeenCalledTimes(2);
+    expect(result.current.activeTurnId).toBe("turn-1");
+  });
+
   it("cancels missed-completion reconciliation when navigation becomes active again", async () => {
     const activeTurn = {
       id: "turn-1",

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4254,7 +4254,24 @@ export function useThreadSessionState(params: {
       return;
     }
 
-    if (session.loading || session.activeTurnId) {
+    if (session.loading) {
+      return;
+    }
+
+    if (session.activeTurnId) {
+      const remoteSummaryAdvanced =
+        thread.federation?.ref.target.scope === "remote"
+        && thread.updatedAt != null
+        && session.hydratedUpdatedAt !== thread.updatedAt;
+      if (remoteSummaryAdvanced) {
+        // Federation events are live-only. A selected mounted thread can miss
+        // commentary or a request-user-input notification during a transport
+        // gap, then remain active indefinitely because the missing prompt is
+        // the only way to finish its turn. The owner's navigation snapshot is
+        // the durable catch-up signal: when its updatedAt advances beyond the
+        // detail snapshot we hydrated, re-read even while the turn is active.
+        void loadLatest(thread);
+      }
       return;
     }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4262,7 +4262,8 @@ export function useThreadSessionState(params: {
       const remoteSummaryAdvanced =
         thread.federation?.ref.target.scope === "remote"
         && thread.updatedAt != null
-        && session.hydratedUpdatedAt !== thread.updatedAt;
+        && session.hydratedUpdatedAt !== thread.updatedAt
+        && session.failedHydrationVersion !== hydrationVersion;
       if (remoteSummaryAdvanced) {
         // Federation events are live-only. A selected mounted thread can miss
         // commentary or a request-user-input notification during a transport


### PR DESCRIPTION
## Summary

- I rehydrate a selected mounted remote thread when its authoritative navigation summary advances, even while its turn remains active.
- I recover missed remote transcript entries and request-user-input state without adding polling or changing local active-thread hydration behavior.
- I added a regression that reproduces the stale “Thinking” transcript and verifies that the missing assistant commentary and input dialog both return.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useFederationThreadEventSubscriptions.test.tsx` — 253 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only

## Notes

- The root cause was an `activeTurnId` short-circuit in the thread-session hydration effect. Federation events are live-only, so a transport gap could omit commentary or a request-user-input notification. Although the owner’s later navigation snapshot carried a newer `updatedAt`, the active session ignored it and could remain stuck waiting for an input dialog it never rendered.
- Lightweight Navigation Refresh still merges mounted remote rows and supplied the durable freshness signal in the reported incident, so this change leaves that experiment intact.
- This targets `main` only. Federation remote mounts do not apply to `releases/1.0`.
- Federation diagnostic-copy improvements are separate in #1665.
