### PR TITLE
fix(desktop): third sidebar density pass — directory rhythm, divider bands, cluster inset

### DIFF
--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:630b093d1f542292510cd079353f46c83c79dbf66c1d8c8aa86eb89238bfc450
-size 128698
+oid sha256:8df1f979ed894eb6ef68fb2b5406d99f42d383778687074eabf1eb11171c1279
+size 128662

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -406,8 +406,11 @@ function getDirectoryRowLinkedDirectoryMode(
 }
 
 /**
- * One activity count in a directory header: the indicator alone, then the
- * number. The words ("active", "to review") moved into the tooltip — a
+ * One activity count in a directory header: the number, then the indicator
+ * (mark last, so the trailing count's mark sits at one x on every row — see
+ * the inline comment; when both counts render, the leading scanner still
+ * moves with the review digits). The words ("active", "to review") moved
+ * into the tooltip — a
  * directory row is a dense line already carrying a chevron, a folder glyph,
  * an elided path, and a new-thread button, and two trailing phrases pushed
  * the label it belongs to down to a few characters.
@@ -447,8 +450,15 @@ function DirectoryCount(props: {
         }
         onMouseLeave={tooltip.hide}
       >
-        {props.indicator}
+        {/* Count BEFORE the mark. The meta block is right-aligned, so
+            the mark (cookie / scanner) is the last thing before the row
+            edge and lands at one x on every directory; the count is
+            variable-width (1–3 digits) and grows LEFT into empty space.
+            Mark-first put the cookie left of the digits, so it zigzagged
+            row to row with the digit count — a ragged column of the one
+            glyph the eye scans the rail for. */}
         <span>{props.count}</span>
+        {props.indicator}
       </span>
       {tooltip.tooltipNode}
     </>

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -13,7 +13,7 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
-import { PinIcon, SmileyIcon } from "../../icons";
+import { MoreVerticalIcon, PinIcon, SmileyIcon } from "../../icons";
 import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
@@ -558,7 +558,13 @@ export function ThreadRow(props: ThreadRowProps) {
             });
           }}
         >
-          ...
+          {/* Vertical dots (⋮), not a horizontal ellipsis: two glyphs to
+              the left the title ellipsizes, so "…" here reads as the
+              truncation mark rather than a menu affordance. Shares
+              MoreVerticalIcon with the pricing-panel and automations
+              kebabs. (StarMapCardMenu and CompactComposer still draw a
+              literal ⋯ — separate surfaces, not yet unified.) */}
+          <MoreVerticalIcon size={14} aria-hidden="true" />
         </button>
       </div>
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -230,9 +230,17 @@ describe("Tangerine Terminal theme contract", () => {
           + ".thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--pinned .thread-row__heading,\n"
           + ".thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row--pinned .thread-row__heading",
       ),
-    ).toMatch(/padding-right:\s*44px;/);
+    ).toMatch(/padding-right:\s*46px;/);
     expect(extractRuleBody(css, ".thread-row__actions")).toMatch(
-      /right:\s*9px;[\s\S]*gap:\s*4px;/,
+      /right:\s*11px;[\s\S]*gap:\s*4px;/,
+    );
+    // The cluster's 11px offset and the reserve inequality's first term
+    // both derive from the card's inline padding (10px + 1px border), so
+    // that literal belongs in the same pin set: shrink the card padding
+    // and 11/46 stay green while the kebab drifts off the content edge
+    // and the pin loses its clearance.
+    expect(extractRuleBody(css, ".thread-row")).toMatch(
+      /padding:\s*4px 10px;/,
     );
     // Not extractRuleBody: the bare selector would match the shared
     // pin+kebab chrome rule first; this anchors the standalone width
@@ -243,6 +251,15 @@ describe("Tangerine Terminal theme contract", () => {
     // in-flow button carried: at the XS title notch a chipless card
     // computes to 23.75px, so covering the card alone is not enough.
     expect(extractRuleBody(css, ".thread-row__open")).toMatch(
+      /min-height:\s*24px;/,
+    );
+
+    // The directory summary button is a 2.5.8 target too. The third
+    // density pass took its block padding to 2px (content ~20px), so
+    // this min-height is the ONLY thing holding the button — and the
+    // selected-directory highlight box that shares its chrome — at the
+    // floor. Padding is free to move; this is not.
+    expect(extractRuleBody(css, ".directory-row__summary")).toMatch(
       /min-height:\s*24px;/,
     );
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4076,7 +4076,14 @@ textarea,
      boundary (which would antialias-shift the visual goldens). At the
      md notch (13px) this resolves to 1. */
   top: round(calc(4px + (var(--sidebar-title-size) * 1.25 + 2px) / 2 - 12px), 1px);
-  right: 9px;
+  /* 11px (from 9): the card's own right inset is 10px padding + 1px
+     border, so 9 put the kebab's edge 2px inside the border while its
+     6px corner radius sat against the card's 8px one — the two curves
+     read as touching. 11 lines the cluster's right edge up with the
+     content edge every chip and the timestamp already respect, giving
+     the same visible air the row's left side keeps. The pinned-row
+     heading reserve below derives from this offset — move both. */
+  right: 11px;
   z-index: 3;
   display: flex;
   align-items: center;
@@ -4115,9 +4122,11 @@ textarea,
 }
 
 .thread-row__overflow-button {
+  /* 26px is the pinned cluster-side literal the pinned-row heading
+     reserve derives from, and the 24px-tall button reads as a
+     slightly wider pill next to the square 24px add-reaction chip on
+     purpose. */
   width: 26px;
-  font-size: 13px;
-  font-weight: 700;
 }
 
 /* The hover-only add-reaction chip rides in the same cluster; match the
@@ -4163,18 +4172,18 @@ textarea,
    for them; the transition on `.thread-row__heading` glides the dock
    in step with the cluster's 120ms fade.
 
-   44px derivation, all border-box worst case. The cluster zone spans
-   69px from the card's right border: 9px offset + 26px kebab + 4px gap
-   + the add-reaction chip's RENDERED width of 30px (its `min-width:
-   24px` is a floor — the 14px smiley plus the base chip's 0 8px
-   padding is what actually paints). The pin's border box must clear
-   that zone: card padding 10px + header gap 12px + timestamp + reserve
-   − the pin's 3px `margin-right: -3px` overhang ≥ 69px + 4px air. The
-   narrowest timestamp ("1h"/"2d") measures ~13px at its fixed 12px
-   font, giving reserve ≥ 41px; 44px leaves 3px of real slack at every
-   title-size notch. The cluster-side literals in this arithmetic are
-   pinned by theme-contract next to this rule's own pin, so a cluster
-   resize fails a test instead of silently re-covering the pin.
+   46px derivation, all border-box worst case. The cluster zone spans
+   71px from the card's right border: 11px offset + 26px kebab + 4px
+   gap + the add-reaction chip's RENDERED width of 30px (its
+   `min-width: 24px` is a floor — the 14px smiley plus the base chip's
+   0 8px padding is what actually paints). The pin's border box must
+   clear that zone: card padding 10px + header gap 12px + timestamp +
+   reserve − the pin's 3px `margin-right: -3px` overhang ≥ 71px + 4px
+   air. The narrowest timestamp ("1h"/"2d") measures ~13px at its fixed
+   12px font, giving reserve ≥ 43px; 46px leaves 3px of real slack at
+   every title-size notch. The cluster-side literals in this arithmetic
+   are pinned by theme-contract next to this rule's own pin, so a
+   cluster resize fails a test instead of silently re-covering the pin.
 
    Scoped by the row's `--pinned` modifier (set by ThreadRow from the
    same expression that renders the pin — a plain class match instead
@@ -4183,7 +4192,7 @@ textarea,
    cluster's reveal states in the fade/reveal rules above (the cluster
    pin's states are absent because pinned rows never render it).
    Deliberate over-reserve: on a surface without a reaction handler the
-   revealed cluster is kebab-only (35px zone) and the rest-state gap
+   revealed cluster is kebab-only (37px zone) and the rest-state gap
    already clears it, so the reserve protects nothing there — accepted,
    since every production surface wires reactions and a narrower
    conditional would re-add the `:has()` scan this class avoids. */
@@ -4191,7 +4200,7 @@ textarea,
 .thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row--pinned .thread-row__heading,
 .thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--pinned .thread-row__heading,
 .thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row--pinned .thread-row__heading {
-  padding-right: 44px;
+  padding-right: 46px;
 }
 
 .thread-row__pin-button:hover,
@@ -5497,10 +5506,16 @@ textarea,
      section instead of only the sticky header. Plan 2026-05-09-002
      Unit K follow-up. */
   position: relative;
-  /* 2px top (was 4): with the hairline gone and the summary's own
-     min-height slack, 4px pushed collapsed directories ~20px of blank
-     label-to-label; 2px + the 2px list gap + the summary slack lands
-     at ~10px. */
+  /* 2px top pad is the ONLY seam between directory rows: unlike the
+     thread lanes, `.directory-list` zeroes the `.sidebar-list` gap
+     (see that rule), so this pad is doing seam work, not rhythm — it
+     keeps a selected summary's accent border and its hovered
+     neighbour's fill from kissing, and keeps the 3px drop-indicator
+     bar (`.is-drop-target-*`, at -3px) landing between rows instead
+     of inside the row above. Third density pass: the collapsed-lens
+     pitch is 24px summary (min-height-bound at every notch ≤13px) +
+     this 2px = 26px, down from ~29; the summary's block padding
+     (4→2) is what closed the gap, not this pad. */
   padding: 2px 0 0;
 }
 
@@ -5611,16 +5626,25 @@ textarea,
      matched the masthead's button height, but rows are list entries
      and don't need that hit-target generosity; at 32 the leftover
      slack was still the largest blank band in the collapsed
-     Directories lens. 24 fits the 16px title line + block padding
-     with ~3px of slack, and the 24px launchpad cluster still fills
-     the row exactly on hover. */
+     Directories lens. 24 is the WCAG 2.5.8 target floor for the whole
+     summary button, not a content fit: the content box is ~20px (16px
+     line + 2px block padding each side), so this floor is what binds
+     the collapsed-lens pitch and the selected-directory highlight box
+     at every title notch ≤13px. Pinned by theme-contract; the padding
+     below is free to move, this is not. The 24px launchpad cluster
+     fills the row exactly on hover. */
   min-height: 24px;
   /* Lateral inset: 4px on the left sits before the disclosure chevron
      and folder icon; 6px on the right still clears the selected-row
      border for the meta block (attention count pill) without stranding
      the count away from the launchpad icon beside it. Was 10px, the
-     largest share of an 18px count-to-icon gap. */
-  padding: 4px 6px 4px 4px;
+     largest share of an 18px count-to-icon gap.
+
+     Block inset 2px (from 4) in the third density pass: at 4px the
+     summary alone was 24–28px and label-to-label measured ~29px for a
+     16px label — the loosest rhythm left in the lens. At 2px the
+     min-height floor binds and the pitch is 24 + the row's 2px seam. */
+  padding: 2px 6px 2px 4px;
 }
 
 .directory-row__summary:focus,
@@ -5896,10 +5920,15 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 8px;
-  /* Bottom tightened 14 → 10 with the inter-card spacing pass so the
-     seam between an expanded directory's last thread and the next
-     directory header tracks the tighter row rhythm. */
-  padding: 8px 0 10px 0;
+  /* Bottom tightened 14 → 10 → 4 across the density passes so the seam
+     between an expanded directory's last thread (or its "DIRECTORY
+     THREADS" divider) and the next directory header tracks the tighter
+     row rhythm: 4px here + the next `.directory-row`'s 2px top pad =
+     6px, the same band the thread cards keep between each other
+     (`.directory-list` zeroes the sidebar-list gap, so the row pad is
+     the only other term). Top 8 → 4 for the mirror seam under the
+     sticky header. */
+  padding: 4px 0 4px 0;
 }
 
 .directory-row__threads {
@@ -5976,8 +6005,17 @@ textarea,
   background: transparent;
   font-family: inherit;
   cursor: pointer;
+  /* Symmetric 4px above and below in the shipped configuration. The
+     base `.recents-pinned-divider` margin is 2px each side and the
+     pinned lane's list gap adds 2px below — but ABOVE the divider the
+     always-mounted `.directory-row__pin-drop-boundary` (reorder is
+     wired on every production surface) cancels that gap with its
+     `margin-block: -2px`, so the base rule alone lands 2px above vs
+     4px below. Override the top to 4px so both seams read as one band,
+     a hair wider than the 2px the cards keep between each other — it
+     is a section label, not a card. (The bottom stays at the base 2px:
+     with the list gap it totals 4.) */
   margin-top: 4px;
-  margin-bottom: 2px;
 }
 
 .directory-row__thread-divider:hover:not(:disabled) {


### PR DESCRIPTION
## Summary

Third sidebar density pass, from live review of the Directories lens.

| Finding | Fix |
|---|---|
| Collapsed directories too far apart (~29px label-to-label for a 16px label) | Summary block padding 4→2px, so its 24px `min-height` now binds and the pitch is 24 + the row's 2px seam = 26px. The summary reuses the thread-row chrome, so the **selected-directory highlight box tightens by the same 4px** — the answer to "do we have to tighten the highlight box" is yes, and it holds: the min-height keeps the box (and the WCAG 2.5.8 target) intact, and theme-contract pins that floor. (The row's 2px top pad stays — `.directory-list` zeroes the sidebar-list gap, so that pad is the only seam between rows and what keeps the drop-indicator bar landing *between* them; the review caught my first cut removing it on a wrong derivation.) |
| Blank bands around the "DIRECTORY THREADS" divider and under an expanded directory's last thread | The details block carried 8/10px padding; now 4/4 so both seams total the ~6px the cards keep between each other. The divider sits symmetrically at 4px above/below (the pin-drop boundary above it cancels the list gap the base rule counts on below — the review caught the first cut leaving it 2/4). |
| Kebab + emoji almost touching the card border | The cluster sat 2px inside the card's right border with its 6px corner against the card's 8px one — the two curves read as touching. `right: 9→11px` lines it up with the content edge every chip already respects. The pinned-row heading reserve derives from this offset, so it moves 44→46px in step; both, plus the card padding they derive from, are pinned. |
| Unread cookie zigzagging down the directory rail | Directory-header counts now render number-then-mark, so the cookie (and active scanner) sits at one x on every row and the variable digit count grows leftward. Cookie-left-of-name was considered and rejected: it would crowd the chevron/label cluster and shift every label right whether or not it had unread. |

**On horizontal vs vertical dots** — there was no distinction, just drift: the thread-row kebab rendered three literal ASCII periods (`...`), the pricing panel and automations kebabs draw `MoreVerticalIcon` (⋮), and the Star Map card and CompactComposer render a literal `⋯`. The thread row now uses `MoreVerticalIcon`. Vertical dots are the platform-conventional "more actions" mark on a compact row control; a horizontal ellipsis right beside titles that ellipsize reads as *truncation*, not a menu. (StarMapCardMenu and CompactComposer's `⋯` are left alone — separate surfaces; happy to unify in a follow-up.)

## Testing

- Full renderer suite: 2817 tests pass; typecheck, ESLint, color lint clean.
- A `/code-review --fix` pass (10 findings, all fixed) corrected the first cut: restored the row's 2px seam pad on a corrected derivation, fixed the divider asymmetry, refreshed a stale `35px` literal, folded the summary floor pin into the canonical WCAG block (and dropped a padding pin that contradicted its own comment), pinned the card padding the cluster derivation reads, and corrected the kebab-unification claim.
- Verified live on the dev profile: collapsed-directory rhythm and highlight box, divider seams above/below "DIRECTORY THREADS", the expanded-directory → next-header seam, and the cluster's border air at rest and on hover (with the new ⋮ glyph).
- Golden `todo-thread-shell-darwin.webp` regenerated on the PwrSuiteLab Tart guest per CONTRIBUTING (elicit → promote lab `actual.webp` → verify rerun passed); the committed LFS oid matches the lab actual's SHA-256. The 106 changed pixels are all in the hovered row's cluster (2px shift + new glyph); the visual fixture doesn't render collapsed directories, so the row-pad restore moved nothing captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
