### PR TITLE
fix(desktop): label quit-blocking sub-agents

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -21365,6 +21365,19 @@ command = "pnpm dev"
     expect(upsertThreadSubAgent).toHaveBeenCalledTimes(1);
 
     await codexClient.emit({
+      method: "thread/status/changed",
+      params: {
+        threadId: nativeThreadId,
+        status: { type: "active" },
+      },
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-parent"],
+      subAgentThreadKeys: ["codex:thread-parent"],
+    });
+
+    await codexClient.emit({
       method: "thread/tokenUsage/updated",
       params: {
         threadId: nativeThreadId,
@@ -34033,12 +34046,23 @@ script = "printf setup"
       initializeResult: { methods: ["turn/start"] },
       models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
+      threads: [
+        {
+          id: "parent-thread",
+          title: "Deploy recoverable M2 Max runner",
+          titleSource: "explicit",
+          threadStatus: "idle",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore: createOverlayStoreMock(),
       threadTitleGenerationService: null,
     });
+    await registry.listThreads({ backend: "codex" });
     await registry.publishLocalEvent({
       backend: "codex",
       notification: {
@@ -34083,7 +34107,11 @@ script = "printf setup"
 
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
-      threadIds: ["codex:monitor-thread"],
+      threadIds: ["codex:parent-thread"],
+      subAgentThreadKeys: ["codex:parent-thread"],
+      threadTitles: {
+        "codex:parent-thread": "Deploy recoverable M2 Max runner",
+      },
     });
 
     await registry.publishLocalEvent({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18637,6 +18637,14 @@ command = "pnpm dev"
       reviewThreadId: "codex-review-child",
       turnId: "turn-1",
     });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [`${acpBackendId}:${parentThreadId}`],
+      subAgentThreadKeys: [`${acpBackendId}:${parentThreadId}`],
+      threadTitles: {
+        [`${acpBackendId}:${parentThreadId}`]: "Grok parent",
+      },
+    });
 
     const approvalResponse = codexClient.emitRequest({
       method: "item/commandExecution/requestApproval",
@@ -20830,6 +20838,10 @@ command = "pnpm dev"
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-1"],
     });
 
     await expect

--- a/apps/desktop/src/main/__tests__/quit-dialog-render.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-dialog-render.test.ts
@@ -64,6 +64,7 @@ describe("quit dialog HTML", () => {
     expect(html).toContain("Agent turns in progress");
     expect(html).toContain("Integrated terminals");
     expect(html).toContain("Environment actions");
+    expect(html).not.toContain(">Sub-agent</span>");
     expect(html).toContain(
       'href="pwragent-quit-confirmation://tok/show-thread/codex%3Aterm-0/terminal"',
     );
@@ -100,6 +101,34 @@ describe("quit dialog HTML", () => {
     expect(html).toContain("Reap Windows Worktrees");
     expect(html).toContain("Studio Mac");
     expect(html).not.toContain(">0f9c2b7a-remote<");
+  });
+
+  it("names the owning thread and labels a sub-agent blocker", () => {
+    const html = buildQuitConfirmationHtml({
+      countdownSeconds: 10,
+      inProgressThreadCount: 1,
+      terminalSessionCount: 0,
+      actionRunCount: 0,
+      items: [
+        {
+          kind: "turn",
+          backend: "codex",
+          threadId: "parent-thread",
+          threadKey: "codex:parent-thread",
+          title: "Deploy recoverable M2 Max runner",
+          isSubAgent: true,
+        },
+      ],
+      navigationPrefix: "pwragent-quit-confirmation://tok/",
+      colorScheme: "dark",
+      palette: QUIT_DIALOG_PALETTES.dark,
+    });
+
+    expect(html).toContain("Deploy recoverable M2 Max runner");
+    expect(html).toContain(">Sub-agent</span>");
+    expect(html).toContain(
+      'href="pwragent-quit-confirmation://tok/show-thread/codex%3Aparent-thread/turn"',
+    );
   });
 
   it("escapes the action detail, which carries a user-configured command", () => {

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -612,6 +612,33 @@ describe("buildQuitBlockerSnapshot", () => {
     ]);
   });
 
+  it("projects a sub-agent blocker onto its named owning thread", async () => {
+    const { buildQuitBlockerSnapshot } = await import("../quit-manager");
+
+    const snapshot = buildQuitBlockerSnapshot({
+      inProgressThreads: {
+        count: 1,
+        threadIds: ["codex:parent-thread"],
+        subAgentThreadKeys: ["codex:parent-thread"],
+        threadTitles: {
+          "codex:parent-thread": "Deploy recoverable M2 Max runner",
+        },
+      },
+      terminalSessions: { count: 0, threads: [] },
+    });
+
+    expect(snapshot.items).toEqual([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "parent-thread",
+        threadKey: "codex:parent-thread",
+        title: "Deploy recoverable M2 Max runner",
+        isSubAgent: true,
+      },
+    ]);
+  });
+
   it("carries a remote terminal's owning peer onto its row", async () => {
     const { buildQuitBlockerSnapshot } = await import("../quit-manager");
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11859,13 +11859,21 @@ export class DesktopBackendRegistry {
           record.backend === backend
           && record.monitorThreadId === threadId,
       );
-      const reviewSubAgent = !taskMonitor
+      const reviewSubAgentCandidate = !taskMonitor
         ? [...this.activeReviewSubAgents.values()].find(
             (record) =>
               record.backend === backend
               && record.reviewThreadId === threadId,
           )
         : undefined;
+      const reviewSubAgent =
+        reviewSubAgentCandidate
+        && (
+          reviewSubAgentCandidate.parentBackend !== backend
+          || reviewSubAgentCandidate.parentThreadId !== threadId
+        )
+          ? reviewSubAgentCandidate
+          : undefined;
       const nativeParentThreadId =
         !taskMonitor && !reviewSubAgent && backend === "codex"
           ? this.codexNativeSubAgentParents.get(threadId)
@@ -11877,7 +11885,7 @@ export class DesktopBackendRegistry {
           }
         : reviewSubAgent
           ? {
-              backend: reviewSubAgent.backend,
+              backend: reviewSubAgent.parentBackend,
               threadId: reviewSubAgent.parentThreadId,
             }
           : nativeParentThreadId
@@ -11887,10 +11895,10 @@ export class DesktopBackendRegistry {
         break;
       }
 
-      isSubAgent = true;
       if (parent.backend === backend && parent.threadId === threadId) {
         break;
       }
+      isSubAgent = true;
       backend = parent.backend;
       threadId = parent.threadId;
     }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8113,15 +8113,18 @@ export class DesktopBackendRegistry {
           threads,
         });
       }
+      this.rememberThreadListContexts(threads);
       return threads;
     }
 
     if (params.backend && isAcpBackendId(params.backend)) {
-      return this.listInstalledAcpThreads(
+      const threads = await this.listInstalledAcpThreads(
         params.backend,
         params.filter,
         params.archived,
       );
+      this.rememberThreadListContexts(threads);
+      return threads;
     }
 
     const threadLists = await Promise.all([
@@ -8138,9 +8141,11 @@ export class DesktopBackendRegistry {
       this.listAllInstalledAcpThreads(params.filter, params.archived),
     ]);
 
-    return threadLists
+    const threads = threadLists
       .flat()
       .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+    this.rememberThreadListContexts(threads);
+    return threads;
   }
 
   private async filterArchivedThreadsPresentInActiveList(params: {
@@ -11719,6 +11724,8 @@ export class DesktopBackendRegistry {
   getInProgressThreadSnapshotForQuit(): {
     count: number;
     threadIds: string[];
+    subAgentThreadKeys?: string[];
+    threadTitles?: Record<string, string>;
     automationRuns?: Array<{
       agentThreadId: string;
       automationName?: string;
@@ -11728,6 +11735,8 @@ export class DesktopBackendRegistry {
     }>;
   } {
     const threadKeys = new Set<string>();
+    const subAgentThreadKeys = new Set<string>();
+    const threadTitles = new Map<string, string>();
     const automationExecutionThreadKeys = new Set<string>();
     const automationRunsByKey = new Map<
       string,
@@ -11756,9 +11765,17 @@ export class DesktopBackendRegistry {
       }
     }
     const addThread = (backend: AppServerBackendKind, threadId: string): void => {
-      const threadKey = formatQuitThreadKey(backend, threadId);
+      const owner = this.resolveQuitThreadOwner({ backend, threadId });
+      const threadKey = formatQuitThreadKey(owner.backend, owner.threadId);
       if (!automationExecutionThreadKeys.has(threadKey)) {
         threadKeys.add(threadKey);
+        if (owner.isSubAgent) {
+          subAgentThreadKeys.add(threadKey);
+          const title = this.cachedQuitThreadTitle(owner.backend, owner.threadId);
+          if (title) {
+            threadTitles.set(threadKey, title);
+          }
+        }
       }
     };
     for (const threadId of this.backendActiveCodexThreadIds) {
@@ -11802,8 +11819,109 @@ export class DesktopBackendRegistry {
     return {
       count: threadIds.length + automationRuns.length,
       threadIds,
+      ...(subAgentThreadKeys.size > 0
+        ? { subAgentThreadKeys: [...subAgentThreadKeys].sort() }
+        : {}),
+      ...(threadTitles.size > 0
+        ? { threadTitles: Object.fromEntries(threadTitles) }
+        : {}),
       ...(automationRuns.length > 0 ? { automationRuns } : {}),
     };
+  }
+
+  /**
+   * Collapse a worker thread onto the ordinary thread that owns it. Quit is a
+   * thread-level decision: the worker id is intentionally ephemeral and is not
+   * present in PwrAgent's navigation or title index.
+   */
+  private resolveQuitThreadOwner(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): {
+    backend: AppServerBackendKind;
+    isSubAgent: boolean;
+    threadId: string;
+  } {
+    let backend = params.backend;
+    let threadId = params.threadId;
+    let isSubAgent = false;
+    const visited = new Set<string>();
+
+    while (true) {
+      const key = buildThreadIdentityKey(backend, threadId);
+      if (visited.has(key)) {
+        break;
+      }
+      visited.add(key);
+
+      const taskMonitor = [...this.taskMonitorDelegations.values()].find(
+        (record) =>
+          record.backend === backend
+          && record.monitorThreadId === threadId,
+      );
+      const reviewSubAgent = !taskMonitor
+        ? [...this.activeReviewSubAgents.values()].find(
+            (record) =>
+              record.backend === backend
+              && record.reviewThreadId === threadId,
+          )
+        : undefined;
+      const nativeParentThreadId =
+        !taskMonitor && !reviewSubAgent && backend === "codex"
+          ? this.codexNativeSubAgentParents.get(threadId)
+          : undefined;
+      const parent = taskMonitor
+        ? {
+            backend: taskMonitor.parentBackend,
+            threadId: taskMonitor.parentThreadId,
+          }
+        : reviewSubAgent
+          ? {
+              backend: reviewSubAgent.backend,
+              threadId: reviewSubAgent.parentThreadId,
+            }
+          : nativeParentThreadId
+            ? { backend: "codex" as const, threadId: nativeParentThreadId }
+            : undefined;
+      if (!parent) {
+        break;
+      }
+
+      isSubAgent = true;
+      if (parent.backend === backend && parent.threadId === threadId) {
+        break;
+      }
+      backend = parent.backend;
+      threadId = parent.threadId;
+    }
+
+    return { backend, isSubAgent, threadId };
+  }
+
+  /** Cached only: quit must never wait for a provider round trip to name work. */
+  private cachedQuitThreadTitle(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): string | undefined {
+    const key = buildThreadIdentityKey(backend, threadId);
+    const remembered =
+      this.observedThreadNames.get(key) ?? this.notificationThreadTitles.get(key);
+    if (remembered?.trim()) {
+      return remembered.trim();
+    }
+    for (const state of this.threadListCache.values()) {
+      const thread = state.threads?.find(
+        (candidate) =>
+          candidate.source === backend
+          && candidate.id === threadId
+          && candidate.titleSource !== "fallback",
+      );
+      const title = thread?.title.trim();
+      if (title) {
+        return title;
+      }
+    }
+    return undefined;
   }
 
   async supportsMessagingPdfTools(params: {
@@ -19244,6 +19362,12 @@ export class DesktopBackendRegistry {
             return [];
           })
         : [];
+    for (const thread of nativeSubAgentThreads) {
+      const parentThreadId = thread.codexNativeSubAgent?.parentThreadId.trim();
+      if (parentThreadId && parentThreadId !== thread.id) {
+        this.codexNativeSubAgentParents.set(thread.id, parentThreadId);
+      }
+    }
     const allThreads = groupCodexNativeSubAgents({
       nativeThreads: nativeSubAgentThreads,
       parentThreads: defaultThreads,
@@ -28906,6 +29030,18 @@ export class DesktopBackendRegistry {
     const projectLabel = readNotificationProjectLabel(record);
     if (projectLabel) {
       this.notificationThreadProjectLabels.set(key, projectLabel);
+    }
+  }
+
+  /** Keep titles already shown in navigation available to time-bounded UI. */
+  private rememberThreadListContexts(
+    threads: readonly AppServerThreadSummary[],
+  ): void {
+    for (const thread of threads) {
+      if (thread.titleSource === "fallback") {
+        continue;
+      }
+      this.rememberThreadNotificationContext(thread.source, thread.id, thread);
     }
   }
 

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -33,6 +33,8 @@ export type QuitBlockerItem = {
   target?: FederationRemoteTarget;
   /** Resolved just before the dialog opens; falls back to the thread id. */
   title?: string;
+  /** The active turn belongs to a worker owned by this thread. */
+  isSubAgent?: boolean;
   /** Secondary line — the owning peer, or an action's command and pid. */
   detail?: string;
   /** Start time for live elapsed/completion reporting in the quit prompt. */
@@ -552,7 +554,10 @@ function buildQuitItemListHtml(options: {
         const label = item.title?.trim() || item.threadId;
         const detail = item.detail?.trim();
         return `<a class="row" href="${escapeHtml(href)}">
-          <span class="row__label">${escapeHtml(label)}</span>
+          <span class="row__heading">
+            <span class="row__label">${escapeHtml(label)}</span>
+            ${item.isSubAgent ? '<span class="row__chip">Sub-agent</span>' : ""}
+          </span>
           ${detail ? `<span class="row__detail">${escapeHtml(detail)}</span>` : ""}
         </a>`;
       })
@@ -718,11 +723,29 @@ export function buildQuitConfirmationHtml(options: {
         outline-offset: 1px;
       }
       .row__label {
+        min-width: 0;
         font-size: 13px;
         font-weight: 500;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+      .row__heading {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+      }
+      .row__chip {
+        flex: 0 0 auto;
+        padding: 1px 5px;
+        border: 1px solid var(--accent-border);
+        border-radius: 8px;
+        background: var(--row-active);
+        color: var(--accent-bright);
+        font-size: 10px;
+        font-weight: 600;
+        line-height: 1.35;
       }
       .row__detail {
         color: var(--text-muted);

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -296,6 +296,8 @@ export function buildQuitBlockerSnapshot(params: {
   inProgressThreads: {
     count: number;
     threadIds: string[];
+    subAgentThreadKeys?: string[];
+    threadTitles?: Record<string, string>;
     automationRuns?: Array<{
       agentThreadId: string;
       automationName?: string;
@@ -315,6 +317,10 @@ export function buildQuitBlockerSnapshot(params: {
   const terminalThreadKeys = terminalThreads.map((thread) => thread.threadKey);
   const actionRuns = params.actionRuns ?? [];
   const automationRuns = params.inProgressThreads.automationRuns ?? [];
+  const subAgentThreadKeys = new Set(
+    params.inProgressThreads.subAgentThreadKeys ?? [],
+  );
+  const threadTitles = params.inProgressThreads.threadTitles ?? {};
 
   const items: QuitBlockerItem[] = [
     // Turns and actions are driven by THIS instance's registry and runtime,
@@ -323,6 +329,8 @@ export function buildQuitBlockerSnapshot(params: {
       kind: "turn" as const,
       ...splitQuitThreadKey(threadKey),
       threadKey,
+      ...(threadTitles[threadKey] ? { title: threadTitles[threadKey] } : {}),
+      ...(subAgentThreadKeys.has(threadKey) ? { isSubAgent: true } : {}),
     })),
     ...automationRuns.map((run) => ({
       kind: "automation" as const,


### PR DESCRIPTION
## Summary

- collapse active managed monitors, native Codex sub-agents, and detached review workers onto their owning PwrAgent thread in quit-blocker snapshots
- carry cached parent-thread titles into the quit confirmation dialog
- show a visible `Sub-agent` chip and navigate the blocker row to the parent thread
- add regression coverage for sub-agent and ordinary turn blockers

## Root cause

The quit snapshot treated an ephemeral worker thread ID as a normal PwrAgent thread. That ID was not present in navigation or title indexes, so the dialog displayed the raw ID; in the captured managed-monitor case, title resolution also timed out. The registry already knew the worker-to-parent relationship but discarded it before constructing the dialog.

## Impact

Operators can identify which real thread owns the work preventing shutdown and jump directly to that thread instead of seeing an opaque sub-agent ID.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/quit-manager.test.ts apps/desktop/src/main/__tests__/quit-dialog-render.test.ts apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` — 562 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (35 existing warnings)
- `git diff --check`
