### PR TITLE
fix(desktop): retain FIFO after rejected turn start

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -16257,7 +16257,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("drains submissions queued behind a rejected in-flight Codex start", async () => {
+  it("retains submissions queued behind a rejected in-flight Codex start", async () => {
     const startTurnDelay = createDeferred<void>();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -16286,12 +16286,15 @@ command = "pnpm dev"
     startTurnDelay.resolve();
 
     await expect(first).rejects.toThrow("first start failed");
-    await vi.waitFor(() => {
-      expect(codexClient.startTurnCallCount).toBe(2);
-    });
-    expect(codexClient.startTurnCalls[0]).toMatchObject({
-      threadId: "thread-1",
-      input: [{ type: "text", text: "second" }],
+    await Promise.resolve();
+    expect(codexClient.startTurnCallCount).toBe(1);
+    expect(registry.getQueuedTurnsSnapshot()).toEqual({
+      [buildThreadIdentityKey("codex", "thread-1")]: [
+        expect.objectContaining({
+          displayText: "second",
+          position: 0,
+        }),
+      ],
     });
 
     await registry.close();
@@ -25877,7 +25880,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("keeps failed workspace move state when failure continuation cannot start", async () => {
+  it("keeps failed workspace move state and queued work when failure continuation cannot start", async () => {
     const thread: AppServerThreadSummary = {
       id: "ordinary-thread",
       title: "Parent Thread",
@@ -25965,10 +25968,18 @@ script = "printf setup"
     expect(registry.canStartThreadTurnImmediately({
       backend: "codex",
       threadId: "ordinary-thread",
-    })).toBe(true);
+    })).toBe(false);
+    expect(registry.getQueuedTurnsSnapshot()).toEqual({
+      [buildThreadIdentityKey("codex", "ordinary-thread")]: [
+        expect.objectContaining({
+          displayText: "queued normal turn",
+          position: 0,
+        }),
+      ],
+    });
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
-      count: 0,
-      threadIds: [],
+      count: 1,
+      threadIds: [buildThreadIdentityKey("codex", "ordinary-thread")],
     });
 
     await registry.publishLocalEvent({
@@ -26016,7 +26027,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("releases queued turns when success continuation cannot start", async () => {
+  it("retains queued turns when success continuation cannot start", async () => {
     const thread: AppServerThreadSummary = {
       id: "ordinary-thread",
       title: "Parent Thread",
@@ -26120,10 +26131,18 @@ script = "printf setup"
     expect(registry.canStartThreadTurnImmediately({
       backend: "codex",
       threadId: "ordinary-thread",
-    })).toBe(true);
+    })).toBe(false);
+    expect(registry.getQueuedTurnsSnapshot()).toEqual({
+      [buildThreadIdentityKey("codex", "ordinary-thread")]: [
+        expect.objectContaining({
+          displayText: "queued normal turn",
+          position: 0,
+        }),
+      ],
+    });
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
-      count: 0,
-      threadIds: [],
+      count: 1,
+      threadIds: [buildThreadIdentityKey("codex", "ordinary-thread")],
     });
 
     await registry.publishLocalEvent({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -16257,6 +16257,46 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("drains submissions queued behind a rejected in-flight Codex start", async () => {
+    const startTurnDelay = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      startTurnDelay: startTurnDelay.promise,
+      startTurnErrors: [new Error("first start failed"), undefined],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const first = registry.submitTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "first" }],
+    });
+    await waitForCondition(() => codexClient.startTurnCallCount === 1);
+    await expect(
+      registry.submitTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "second" }],
+      }),
+    ).resolves.toMatchObject({ status: "queued", position: 1 });
+
+    startTurnDelay.resolve();
+
+    await expect(first).rejects.toThrow("first start failed");
+    await vi.waitFor(() => {
+      expect(codexClient.startTurnCallCount).toBe(2);
+    });
+    expect(codexClient.startTurnCalls[0]).toMatchObject({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "second" }],
+    });
+
+    await registry.close();
+  });
+
   it("does not generate a Codex title when startTurn fails before lifecycle confirmation", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
@@ -230,7 +230,7 @@ describe("ThreadTurnQueue", () => {
     expect(startedEntries).toEqual(["second"]);
   });
 
-  it("guards duplicate terminal release signals", async () => {
+  it("does not apply a coalesced idle release to a successfully started turn", async () => {
     let active = true;
     const startedEntries: string[] = [];
     const queue = new ThreadTurnQueue({
@@ -246,6 +246,7 @@ describe("ThreadTurnQueue", () => {
     });
 
     await queue.submit(buildEntry({ id: "queued-1" }));
+    await queue.submit(buildEntry({ id: "queued-2" }));
 
     active = false;
     await Promise.all([
@@ -254,6 +255,60 @@ describe("ThreadTurnQueue", () => {
     ]);
 
     expect(startedEntries).toEqual(["queued-1"]);
+    expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
+      .toMatchObject([{ id: "queued-2" }]);
+  });
+
+  it("retries a blocked queued start after a coalesced idle release", async () => {
+    let rejectFirstQueuedStart!: (reason?: unknown) => void;
+    let resolveFirstQueuedAttempt!: () => void;
+    let resolveRetriedQueuedStart!: () => void;
+    const firstQueuedStart = new Promise<never>((_resolve, reject) => {
+      rejectFirstQueuedStart = reject;
+    });
+    const firstQueuedAttempt = new Promise<void>((resolve) => {
+      resolveFirstQueuedAttempt = resolve;
+    });
+    const retriedQueuedStart = new Promise<void>((resolve) => {
+      resolveRetriedQueuedStart = resolve;
+    });
+    const startedEntries: string[] = [];
+    let queuedAttempts = 0;
+    const queue = new ThreadTurnQueue({
+      startTurn: async (entry) => {
+        startedEntries.push(entry.id);
+        if (entry.id === "queued" && queuedAttempts++ === 0) {
+          resolveFirstQueuedAttempt();
+          return await firstQueuedStart;
+        }
+        if (entry.id === "queued") {
+          resolveRetriedQueuedStart();
+        }
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}-${queuedAttempts}`,
+        };
+      },
+    });
+
+    await queue.submit(buildEntry({ id: "running" }));
+    await queue.submit(buildEntry({ id: "queued" }));
+
+    const terminalRelease = queue.releaseThread({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-running-0",
+    });
+    await firstQueuedAttempt;
+    await queue.releaseThread({ backend: "codex", threadId: "thread-1" });
+    rejectFirstQueuedStart(new Error("backend rejected queued start"));
+
+    await terminalRelease;
+    await retriedQueuedStart;
+    expect(startedEntries).toEqual(["running", "queued", "queued"]);
+    expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
+      .toEqual([]);
   });
 
   it("retains a failed queued entry and retries it before later entries", async () => {

--- a/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
@@ -151,6 +151,90 @@ describe("ThreadTurnQueue", () => {
     });
   });
 
+  it("drains a queued submission when an in-flight start rejects after release", async () => {
+    let rejectStart!: (reason?: unknown) => void;
+    let resolveSecondStarted!: () => void;
+    const starting = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const secondStarted = new Promise<void>((resolve) => {
+      resolveSecondStarted = resolve;
+    });
+    const startedEntries: string[] = [];
+    const queue = new ThreadTurnQueue({
+      startTurn: async (entry) => {
+        if (entry.id === "first") {
+          return await starting;
+        }
+        startedEntries.push(entry.id);
+        resolveSecondStarted();
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}`,
+        };
+      },
+      onLifecycle: vi.fn(),
+    });
+
+    const first = queue.submit(buildEntry({ id: "first" }));
+    await Promise.resolve();
+    await expect(queue.submit(buildEntry({ id: "second" }))).resolves.toMatchObject({
+      status: "queued",
+      position: 1,
+    });
+
+    await queue.releaseThread({ backend: "codex", threadId: "thread-1" });
+    rejectStart(new Error("backend rejected start"));
+
+    await expect(first).rejects.toThrow("backend rejected start");
+    await secondStarted;
+    expect(startedEntries).toEqual(["second"]);
+    expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
+      .toEqual([]);
+  });
+
+  it("waits for a later release when a failed start leaves the thread active", async () => {
+    let active = false;
+    let rejectStart!: (reason?: unknown) => void;
+    const starting = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const startedEntries: string[] = [];
+    const queue = new ThreadTurnQueue({
+      isThreadActive: () => active,
+      startTurn: async (entry) => {
+        if (entry.id === "first") {
+          return await starting;
+        }
+        startedEntries.push(entry.id);
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}`,
+        };
+      },
+      onLifecycle: vi.fn(),
+    });
+
+    const first = queue.submit(buildEntry({ id: "first" }));
+    await Promise.resolve();
+    await queue.submit(buildEntry({ id: "second" }));
+
+    active = true;
+    rejectStart(new Error("backend rejected start"));
+
+    await expect(first).rejects.toThrow("backend rejected start");
+    await Promise.resolve();
+    expect(startedEntries).toEqual([]);
+    expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
+      .toMatchObject([{ id: "second" }]);
+
+    active = false;
+    await queue.releaseThread({ backend: "codex", threadId: "thread-1" });
+    expect(startedEntries).toEqual(["second"]);
+  });
+
   it("guards duplicate terminal release signals", async () => {
     let active = true;
     const startedEntries: string[] = [];

--- a/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
@@ -151,14 +151,10 @@ describe("ThreadTurnQueue", () => {
     });
   });
 
-  it("drains a queued submission when an in-flight start rejects after release", async () => {
+  it("keeps queued submissions after an in-flight start rejects after release", async () => {
     let rejectStart!: (reason?: unknown) => void;
-    let resolveSecondStarted!: () => void;
     const starting = new Promise<never>((_resolve, reject) => {
       rejectStart = reject;
-    });
-    const secondStarted = new Promise<void>((resolve) => {
-      resolveSecondStarted = resolve;
     });
     const startedEntries: string[] = [];
     const queue = new ThreadTurnQueue({
@@ -167,7 +163,6 @@ describe("ThreadTurnQueue", () => {
           return await starting;
         }
         startedEntries.push(entry.id);
-        resolveSecondStarted();
         return {
           backend: entry.backend,
           threadId: entry.threadId,
@@ -188,10 +183,10 @@ describe("ThreadTurnQueue", () => {
     rejectStart(new Error("backend rejected start"));
 
     await expect(first).rejects.toThrow("backend rejected start");
-    await secondStarted;
-    expect(startedEntries).toEqual(["second"]);
+    await Promise.resolve();
+    expect(startedEntries).toEqual([]);
     expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
-      .toEqual([]);
+      .toMatchObject([{ id: "second" }]);
   });
 
   it("waits for a later release when a failed start leaves the thread active", async () => {
@@ -261,14 +256,16 @@ describe("ThreadTurnQueue", () => {
     expect(startedEntries).toEqual(["queued-1"]);
   });
 
-  it("starts later queued entries when one queued start fails", async () => {
+  it("retains a failed queued entry and retries it before later entries", async () => {
     let active = true;
+    let rejectBadEntry = true;
     const startedEntries: string[] = [];
+    const events: ThreadTurnQueueLifecycleEvent[] = [];
     const failed = new Error("backend rejected start");
     const queue = new ThreadTurnQueue({
       isThreadActive: () => active,
       startTurn: async (entry) => {
-        if (entry.id === "bad-entry") {
+        if (entry.id === "bad-entry" && rejectBadEntry) {
           throw failed;
         }
         startedEntries.push(entry.id);
@@ -278,7 +275,9 @@ describe("ThreadTurnQueue", () => {
           turnId: `turn-${entry.id}`,
         };
       },
-      onLifecycle: vi.fn(),
+      onLifecycle: (event) => {
+        events.push(event);
+      },
     });
 
     await queue.submit(buildEntry({ id: "bad-entry" }));
@@ -287,7 +286,24 @@ describe("ThreadTurnQueue", () => {
     active = false;
     await queue.releaseThread({ backend: "codex", threadId: "thread-1" });
 
-    expect(startedEntries).toEqual(["good-entry"]);
+    expect(startedEntries).toEqual([]);
+    expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
+      .toMatchObject([{ id: "bad-entry" }, { id: "good-entry" }]);
+    expect(events.map((event) => event.type)).toEqual([
+      "queued",
+      "queued",
+      "blocked",
+    ]);
+
+    rejectBadEntry = false;
+    await queue.releaseThread({ backend: "codex", threadId: "thread-1" });
+    expect(startedEntries).toEqual(["bad-entry"]);
+    await queue.releaseThread({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-bad-entry",
+    });
+    expect(startedEntries).toEqual(["bad-entry", "good-entry"]);
   });
 
   it("cancels pending queue entries by id", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7814,6 +7814,12 @@ export class DesktopBackendRegistry {
                     status: "failed",
                     errorMessage: event.error.message,
                   }
+                : event.type === "blocked"
+                  ? {
+                      ...baseParams,
+                      status: "blocked",
+                      errorMessage: event.error.message,
+                    }
                 : event.type === "cancelled"
                   ? {
                       ...baseParams,

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -129,6 +129,8 @@ type AdmittedEntry = {
   turnId?: string;
 };
 
+type StartNextResult = "none" | "started" | "blocked";
+
 const RECENT_ADMITTED_ENTRY_LIMIT = 1_000;
 
 export class ThreadTurnQueue {
@@ -137,6 +139,7 @@ export class ThreadTurnQueue {
   private readonly runningEntries = new Map<string, RunningEntry>();
   private readonly recentlyAdmittedEntries = new Map<string, AdmittedEntry>();
   private readonly releasingKeys = new Set<string>();
+  private readonly pendingReleaseKeys = new Set<string>();
 
   constructor(private readonly options: ThreadTurnQueueOptions) {}
 
@@ -283,8 +286,20 @@ export class ThreadTurnQueue {
     status?: string;
   }): Promise<void> {
     const key = this.keyFor(params);
-    if (this.releasingKeys.has(key)) return;
+    if (this.releasingKeys.has(key)) {
+      // Codex commonly follows a terminal event with a status→idle event.
+      // Keep only that no-turn-id release if it lands while we are awaiting a
+      // queued start. A rejected start emits its own synthetic terminal event
+      // with a turn id; coalescing that would retry forever. Replay the idle
+      // release only if the queued start rejects. Replaying it after a
+      // successful start would let stale idle state terminate the new turn.
+      if (params.turnId === undefined) {
+        this.pendingReleaseKeys.add(key);
+      }
+      return;
+    }
     this.releasingKeys.add(key);
+    let startResult: StartNextResult = "none";
     try {
       const running = this.runningEntries.get(key);
       if (
@@ -302,23 +317,33 @@ export class ThreadTurnQueue {
         });
       }
       if (!(this.options.isThreadActive?.(params) ?? false)) {
-        await this.startNext(key);
+        startResult = await this.startNext(key);
       }
     } finally {
       this.releasingKeys.delete(key);
+      if (
+        this.pendingReleaseKeys.delete(key)
+        && startResult === "blocked"
+      ) {
+        void this.releaseThread({
+          backend: params.backend,
+          threadId: params.threadId,
+        });
+      }
     }
   }
 
-  private async startNext(key: string): Promise<void> {
-    if (this.startingKeys.has(key) || this.runningEntries.has(key)) return;
+  private async startNext(key: string): Promise<StartNextResult> {
+    if (this.startingKeys.has(key) || this.runningEntries.has(key)) return "none";
     const queue = this.queueFor(key);
     const next = queue.shift();
-    if (!next) return;
+    if (!next) return "none";
     if (queue.length === 0) {
       this.queuedEntries.delete(key);
     }
     try {
       await this.startEntry(next, { deferFailureEvent: true });
+      return "started";
     } catch (error) {
       // A rejected start says nothing about whether this thread can safely
       // accept a different queued request. Keep this entry at the FIFO head
@@ -329,6 +354,7 @@ export class ThreadTurnQueue {
         entry: next,
         error: error instanceof Error ? error : new Error(String(error)),
       });
+      return "blocked";
     }
   }
 

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -316,6 +316,7 @@ export class ThreadTurnQueue {
 
   private async startEntry(entry: ThreadTurnQueueEntry): Promise<ThreadTurnQueueStartResult> {
     const key = this.keyFor(entry);
+    let startFailed = false;
     this.startingKeys.add(key);
     this.rememberAdmittedEntry({ entryId: entry.id });
     try {
@@ -332,13 +333,26 @@ export class ThreadTurnQueue {
       await this.emit({ type: "started", entry, turnId: result.turnId });
       return result;
     } catch (error) {
+      startFailed = true;
       this.recentlyAdmittedEntries.delete(entry.id);
       const normalized = error instanceof Error ? error : new Error(String(error));
       await this.emit({ type: "failed", entry, error: normalized });
       throw normalized;
     } finally {
       this.startingKeys.delete(key);
+      if (startFailed) {
+        void this.drainAfterFailedStart(entry);
+      }
     }
+  }
+
+  private async drainAfterFailedStart(entry: ThreadTurnQueueEntry): Promise<void> {
+    const params = {
+      backend: entry.backend,
+      threadId: entry.threadId,
+    };
+    if (this.options.isThreadActive?.(params) ?? false) return;
+    await this.startNext(this.keyFor(params));
   }
 
   private queueFor(key: string): ThreadTurnQueueEntry[] {

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -88,6 +88,16 @@ export type ThreadTurnQueueLifecycleEvent =
       error: Error;
     }
   | {
+      /**
+       * A queued entry could not start and remains at the front of its FIFO.
+       * A later terminal/idle signal may retry it; this is not a terminal
+       * failure of the queued request.
+       */
+      type: "blocked";
+      entry: ThreadTurnQueueEntry;
+      error: Error;
+    }
+  | {
       type: "cancelled";
       entry: ThreadTurnQueueEntry;
       reason?: string;
@@ -308,15 +318,25 @@ export class ThreadTurnQueue {
       this.queuedEntries.delete(key);
     }
     try {
-      await this.startEntry(next);
-    } catch {
-      await this.startNext(key);
+      await this.startEntry(next, { deferFailureEvent: true });
+    } catch (error) {
+      // A rejected start says nothing about whether this thread can safely
+      // accept a different queued request. Keep this entry at the FIFO head
+      // and wait for a later terminal/idle signal before another attempt.
+      this.queueFor(key).unshift(next);
+      await this.emit({
+        type: "blocked",
+        entry: next,
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
     }
   }
 
-  private async startEntry(entry: ThreadTurnQueueEntry): Promise<ThreadTurnQueueStartResult> {
+  private async startEntry(
+    entry: ThreadTurnQueueEntry,
+    options?: { deferFailureEvent?: boolean },
+  ): Promise<ThreadTurnQueueStartResult> {
     const key = this.keyFor(entry);
-    let startFailed = false;
     this.startingKeys.add(key);
     this.rememberAdmittedEntry({ entryId: entry.id });
     try {
@@ -333,26 +353,15 @@ export class ThreadTurnQueue {
       await this.emit({ type: "started", entry, turnId: result.turnId });
       return result;
     } catch (error) {
-      startFailed = true;
       this.recentlyAdmittedEntries.delete(entry.id);
       const normalized = error instanceof Error ? error : new Error(String(error));
-      await this.emit({ type: "failed", entry, error: normalized });
+      if (!options?.deferFailureEvent) {
+        await this.emit({ type: "failed", entry, error: normalized });
+      }
       throw normalized;
     } finally {
       this.startingKeys.delete(key);
-      if (startFailed) {
-        void this.drainAfterFailedStart(entry);
-      }
     }
-  }
-
-  private async drainAfterFailedStart(entry: ThreadTurnQueueEntry): Promise<void> {
-    const params = {
-      backend: entry.backend,
-      threadId: entry.threadId,
-    };
-    if (this.options.isThreadActive?.(params) ?? false) return;
-    await this.startNext(this.keyFor(params));
   }
 
   private queueFor(key: string): ThreadTurnQueueEntry[] {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -190,6 +190,60 @@ describe("useQueuedTurnRelease", () => {
     ).toBeUndefined();
   });
 
+  it("keeps a backend-owned queued message when its start is blocked", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-ui-1",
+      queueEntryId: "backend-queue-1",
+      text: "Backend-owned reply",
+      imageAttachments: [],
+      fileAttachments: [],
+      input: [{ type: "text", text: "Backend-owned reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi: {
+          onAgentEvent: (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+          },
+          startTurn: vi.fn(),
+        },
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      }),
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/turnQueue/updated",
+            params: {
+              threadId: "thread-a",
+              queueEntryId: "backend-queue-1",
+              origin: "manual",
+              status: "blocked",
+              errorMessage: "Thread is not ready.",
+            },
+          },
+        });
+      }
+    });
+
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a"),
+    ).toMatchObject({
+      id: "queued-ui-1",
+      queueEntryId: "backend-queue-1",
+    });
+  });
+
   it("releases the oldest queued message for a non-focused thread when its turn completes", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const startTurn = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -479,7 +479,10 @@ export function useQueuedTurnRelease(params: {
         if (
           typeof notification.threadId === "string" &&
           typeof notification.queueEntryId === "string" &&
-          notification.status !== "queued"
+          (notification.status === "started"
+            || notification.status === "failed"
+            || notification.status === "cancelled"
+            || notification.status === "terminal")
         ) {
           const scopeKey = `thread:${event.backend}:${notification.threadId}`;
           const queued = current.composerDraftStore.getQueuedTurns(scopeKey);

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1627,7 +1627,13 @@ export type AppServerNotification =
         /** Owner-clock creation time for ordering against navigation snapshots. */
         queueEntryCreatedAt?: number;
         origin: "manual" | "automation" | "messaging" | "scheduled";
-        status: "queued" | "started" | "failed" | "cancelled" | "terminal";
+        status:
+          | "queued"
+          | "started"
+          | "blocked"
+          | "failed"
+          | "cancelled"
+          | "terminal";
         /**
          * Truncated first text of the queued input on "queued" events, so
          * windows that did not submit the entry can mirror a chip without


### PR DESCRIPTION
Closes #557

## Summary

- retain the FIFO when a queued turn start is rejected instead of attempting later messages
- restore the failed entry at the FIFO head before emitting a `blocked` lifecycle update
- coalesce a terminal→idle release that arrives during a queued start, replaying it only when that start rejects
- preserve blocked queue entries in renderer draft state and include them in quit confirmation

## Root cause

A terminal/idle signal can arrive while an admitted start still owns the queue's startup reservation. The release path correctly declines to overlap that start. If the start then rejects, treating the error as proof that the next queued message is safe to send is unsound: the thread can be invalid, unready, or otherwise unable to accept a turn.

Codex commonly emits a terminal event followed by `thread/status/changed → idle`. The latter is coalesced while a queued start is pending and is replayed only after that start rejects; a successful start discards it as stale so it cannot terminate the new turn. The rejected start's own synthetic terminal notification has a turn id and is deliberately not coalesced, preventing retry loops.

## User impact

The failed immediate submission returns to the existing composer recovery path. Later FIFO entries remain queued in order, are visible as outstanding work, and are retried only after a later terminal/idle signal. A `blocked` lifecycle update keeps cross-window queue projections intact without reporting the retained request as terminally failed.

## Validation

- focused queue, registry, and queued-turn-release suites: 554 passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 35 existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`