### PR TITLE
fix(desktop): synchronize Codex CWD after workspace handoff

### DIFF
--- a/apps/desktop/e2e/workspace-handoff-flows.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-flows.spec.ts
@@ -130,7 +130,13 @@ async function createHandoffFixture(testId: string): Promise<HandoffFixture> {
                 name: "Replay Codex",
                 version: "1.0.0",
               },
-              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+              methods: [
+                "thread/list",
+                "thread/read",
+                "thread/settings/update",
+                "skills/list",
+                "turn/start",
+              ],
             },
           },
           {
@@ -185,6 +191,12 @@ async function createHandoffFixture(testId: string): Promise<HandoffFixture> {
                 hasPreviousPage: false,
               },
             },
+          },
+          {
+            id: "thread-settings-update-1",
+            kind: "response",
+            method: "thread/settings/update",
+            result: {},
           },
         ],
       },

--- a/apps/desktop/e2e/workspace-handoff-flows.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-flows.spec.ts
@@ -130,13 +130,7 @@ async function createHandoffFixture(testId: string): Promise<HandoffFixture> {
                 name: "Replay Codex",
                 version: "1.0.0",
               },
-              methods: [
-                "thread/list",
-                "thread/read",
-                "thread/settings/update",
-                "skills/list",
-                "turn/start",
-              ],
+              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
             },
           },
           {
@@ -191,12 +185,6 @@ async function createHandoffFixture(testId: string): Promise<HandoffFixture> {
                 hasPreviousPage: false,
               },
             },
-          },
-          {
-            id: "thread-settings-update-1",
-            kind: "response",
-            method: "thread/settings/update",
-            result: {},
           },
         ],
       },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1486,6 +1486,10 @@ class MockBackendClient {
       sha?: string | null;
     } | null;
   };
+  lastUpdateThreadWorkspaceParams?: {
+    threadId: string;
+    cwd: string;
+  };
   lastSetThreadPermissionsParams?: {
     threadId: string;
     cwd?: string;
@@ -1678,6 +1682,14 @@ class MockBackendClient {
     } | null;
   }): Promise<{ threadId: string }> {
     this.lastUpdateThreadMetadataParams = params;
+    return { threadId: params.threadId };
+  }
+
+  async updateThreadWorkspace(params: {
+    threadId: string;
+    cwd: string;
+  }): Promise<{ threadId: string }> {
+    this.lastUpdateThreadWorkspaceParams = params;
     return { threadId: params.threadId };
   }
 
@@ -10504,7 +10516,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("does not let Codex source metadata replace active handoff workspace overlays", async () => {
+  it("lets fresh Codex source metadata replace stale handoff workspace overlays", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const handoffWorktreePath = "/Users/huntharo/projects/ProjectA/.worktrees/thread-1";
     const localThread: AppServerThreadSummary = {
@@ -10557,13 +10569,20 @@ script = "echo setup"
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({
-      extraLinkedDirectories: [handoffDirectory],
+      extraLinkedDirectories: [
+        {
+          id: expectedDir(projectA),
+          label: "ProjectA",
+          path: expectedDir(projectA),
+          kind: "local",
+        },
+      ],
     });
 
     await registry.close();
   });
 
-  it("does not let Codex source worktree metadata replace active handoff workspace overlays", async () => {
+  it("lets fresh Codex source worktree metadata replace stale handoff workspace overlays", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const codexWorktreePath =
       "/Users/huntharo/.codex/profiles/sstk/worktrees/original/ProjectA";
@@ -10619,13 +10638,21 @@ script = "echo setup"
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({
-      extraLinkedDirectories: [handoffDirectory],
+      extraLinkedDirectories: [
+        {
+          id: expectedDir(codexWorktreePath),
+          label: "ProjectA",
+          path: expectedDir(projectA),
+          worktreePath: expectedDir(codexWorktreePath),
+          kind: "worktree",
+        },
+      ],
     });
 
     await registry.close();
   });
 
-  it("does not backfill Codex worktree metadata over active handoff workspace overlays", async () => {
+  it("backfills fresh Codex worktree metadata over stale handoff workspace overlays", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const codexWorktreePath =
       "/Users/huntharo/.codex/profiles/sstk/worktrees/original/ProjectA";
@@ -10693,11 +10720,19 @@ script = "echo setup"
       callerReason: "startup-prewarm",
     });
 
-    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+    expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({
-      extraLinkedDirectories: [handoffDirectory],
+      extraLinkedDirectories: [
+        {
+          id: expectedDir(codexWorktreePath),
+          label: "ProjectA",
+          path: expectedDir(projectA),
+          worktreePath: expectedDir(codexWorktreePath),
+          kind: "worktree",
+        },
+      ],
     });
 
     await registry.close();
@@ -38293,6 +38328,10 @@ script = "printf setup"
         branch: "feature/handoff",
       },
     });
+    expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
+      threadId: "thread-1",
+      cwd: "/repo/app/.worktrees/app-feature-handoff",
+    });
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({
@@ -39073,6 +39112,10 @@ script = "printf setup"
       gitInfo: {
         branch: "HEAD",
       },
+    });
+    expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
+      threadId: "thread-1",
+      cwd: "/repo/app",
     });
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1593,6 +1593,7 @@ class MockBackendClient {
       };
       startReviewDelay?: Promise<unknown>;
       startReviewError?: Error;
+      updateThreadWorkspaceError?: Error;
       codexHome?: string;
     }
   ) {}
@@ -1690,6 +1691,9 @@ class MockBackendClient {
     cwd: string;
   }): Promise<{ threadId: string }> {
     this.lastUpdateThreadWorkspaceParams = params;
+    if (this.options.updateThreadWorkspaceError) {
+      throw this.options.updateThreadWorkspaceError;
+    }
     return { threadId: params.threadId };
   }
 
@@ -10516,7 +10520,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("lets fresh Codex source metadata replace stale handoff workspace overlays", async () => {
+  it("preserves legacy handoff overlays while synchronizing stale local Codex metadata", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const handoffWorktreePath = "/Users/huntharo/projects/ProjectA/.worktrees/thread-1";
     const localThread: AppServerThreadSummary = {
@@ -10566,23 +10570,23 @@ script = "echo setup"
       callerReason: "startup-prewarm",
     });
 
+    await vi.waitFor(() => {
+      expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
+        threadId: "thread-1",
+        cwd: handoffWorktreePath,
+      });
+    });
+
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({
-      extraLinkedDirectories: [
-        {
-          id: expectedDir(projectA),
-          label: "ProjectA",
-          path: expectedDir(projectA),
-          kind: "local",
-        },
-      ],
+      extraLinkedDirectories: [handoffDirectory],
     });
 
     await registry.close();
   });
 
-  it("lets fresh Codex source worktree metadata replace stale handoff workspace overlays", async () => {
+  it("preserves legacy handoff overlays while synchronizing stale worktree Codex metadata", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const codexWorktreePath =
       "/Users/huntharo/.codex/profiles/sstk/worktrees/original/ProjectA";
@@ -10635,24 +10639,23 @@ script = "echo setup"
       callerReason: "startup-prewarm",
     });
 
+    await vi.waitFor(() => {
+      expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
+        threadId: "thread-1",
+        cwd: handoffWorktreePath,
+      });
+    });
+
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({
-      extraLinkedDirectories: [
-        {
-          id: expectedDir(codexWorktreePath),
-          label: "ProjectA",
-          path: expectedDir(projectA),
-          worktreePath: expectedDir(codexWorktreePath),
-          kind: "worktree",
-        },
-      ],
+      extraLinkedDirectories: [handoffDirectory],
     });
 
     await registry.close();
   });
 
-  it("backfills fresh Codex worktree metadata over stale handoff workspace overlays", async () => {
+  it("does not backfill stale Codex worktree metadata over a legacy handoff overlay", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const codexWorktreePath =
       "/Users/huntharo/.codex/profiles/sstk/worktrees/original/ProjectA";
@@ -10721,15 +10724,78 @@ script = "echo setup"
     });
 
     expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
+        threadId: "thread-1",
+        cwd: handoffWorktreePath,
+      });
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [handoffDirectory],
+    });
+
+    await registry.close();
+  });
+
+  it("promotes a handoff overlay after Codex acknowledges the same workspace", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const handoffWorktreePath = "/Users/huntharo/projects/ProjectA/.worktrees/thread-1";
+    const worktreeThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA worktree",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: handoffWorktreePath,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      linkedDirectories: [
+        {
+          id: projectA,
+          label: "ProjectA",
+          path: projectA,
+          worktreePath: handoffWorktreePath,
+          kind: "worktree",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({ threads: [worktreeThread] });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [
+            {
+              id: "pwragent-handoff:codex:thread-1",
+              label: "ProjectA",
+              path: projectA,
+              worktreePath: handoffWorktreePath,
+              kind: "worktree",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    expect(codexClient.lastUpdateThreadWorkspaceParams).toBeUndefined();
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({
       extraLinkedDirectories: [
         {
-          id: expectedDir(codexWorktreePath),
+          id: expectedDir(handoffWorktreePath),
           label: "ProjectA",
           path: expectedDir(projectA),
-          worktreePath: expectedDir(codexWorktreePath),
+          worktreePath: expectedDir(handoffWorktreePath),
           kind: "worktree",
         },
       ],
@@ -38343,6 +38409,99 @@ script = "printf setup"
           kind: "worktree",
         }),
       ],
+    });
+
+    await registry.close();
+  });
+
+  it("finishes committed handoff bookkeeping when Codex CWD synchronization fails", async () => {
+    const worktreePath = "/repo/app/.worktrees/app-feature-handoff";
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Move me back",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "pwragent-handoff:codex:thread-1",
+          label: "app",
+          path: "/repo/app",
+          worktreePath,
+          kind: "worktree",
+        },
+      ],
+      source: "codex",
+      gitBranch: "feature/handoff",
+      updatedAt: 2,
+    };
+    const archivedSourceWorktree: WorktreeSnapshotSummary = {
+      id: "snapshot-handoff",
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath,
+      repositoryPath: "/repo/app",
+      snapshotRef: "refs/pwragent/snapshots/snapshot-handoff",
+      snapshotCommit: "abc123",
+      sourceBranch: "feature/handoff",
+      sourceHead: "abc123",
+      createdAt: 1_000,
+      archivedAt: 1_000,
+      state: "archived",
+      ignoredFilesExcluded: true,
+    };
+    const handoff = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      direction: "worktree-to-local" as const,
+      strategy: "move-branch" as const,
+      workMode: "local" as const,
+      branch: "feature/handoff",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app",
+      linkedDirectory: {
+        id: "pwragent-handoff:codex:thread-1",
+        label: "app",
+        path: "/repo/app",
+        kind: "local" as const,
+      },
+      archivedSourceWorktree,
+      warnings: [],
+      completedAt: 1_000,
+    }));
+    const codexClient = new MockBackendClient({
+      threads: [thread],
+      updateThreadWorkspaceError: new Error("Codex connection dropped"),
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      gitWorkspaceHandoffService: { handoff } as never,
+    });
+
+    const response = await registry.handoffThreadWorkspace({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "worktree-to-local",
+    });
+
+    expect(response.warnings).toContain(
+      "Codex workspace CWD synchronization is pending and will retry automatically.",
+    );
+    expect(codexClient.lastUpdateThreadMetadataParams).toEqual({
+      threadId: "thread-1",
+      gitInfo: { branch: "feature/handoff" },
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [
+        expect.objectContaining({
+          id: "pwragent-handoff:codex:thread-1",
+          kind: "local",
+          path: "/repo/app",
+        }),
+      ],
+      worktreeSnapshots: [archivedSourceWorktree],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -9496,6 +9496,38 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("persists a thread workspace without resuming or starting a turn", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.updateThreadWorkspace({
+      threadId: "thread-workspace",
+      cwd: " /Users/example/project/.worktrees/thread-workspace ",
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const requests = transport!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown },
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/settings/update",
+        params: {
+          threadId: "thread-workspace",
+          cwd: "/Users/example/project/.worktrees/thread-workspace",
+        },
+      }),
+    );
+    expect(requests.map((request) => request.method)).not.toContain("thread/resume");
+    expect(requests.map((request) => request.method)).not.toContain("turn/start");
+
+    await client.close();
+  });
+
   it("best-effort resumes an existing thread before starting a review", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/replay-client.test.ts
+++ b/apps/desktop/src/main/__tests__/replay-client.test.ts
@@ -298,4 +298,15 @@ describe("ReplayClient", () => {
       messages: []
     });
   });
+
+  it("supports workspace updates for existing threads", async () => {
+    const client = ReplayClient.fromFixture(buildFixture());
+
+    await expect(
+      client.updateThreadWorkspace({
+        threadId: "thread-1",
+        cwd: "/tmp/pwragent-worktree",
+      }),
+    ).resolves.toEqual({ threadId: "thread-1" });
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -630,6 +630,10 @@ type BackendClient = {
       sha?: string | null;
     } | null;
   }): Promise<{ threadId: string }>;
+  updateThreadWorkspace?(params: {
+    threadId: string;
+    cwd: string;
+  }): Promise<{ threadId: string }>;
   generateTitle?: ThreadTitleGenerator["generateTitle"];
   generateStructuredObject?(params: {
     model?: string;
@@ -776,9 +780,9 @@ type BackendRegistryForkThreadRequest = ForkThreadRequest & {
  * Resolve the live workspace CWD for thread-scoped commands.
  *
  * Worktree threads must run from LinkedDirectorySummary.worktreePath; Local
- * threads run from LinkedDirectorySummary.path. Persisted environment runtime
- * cwd is intentionally not consulted here because it can lag behind a
- * Local/Worktree handoff.
+ * threads run from LinkedDirectorySummary.path. A handoff overlay projects an
+ * acknowledged workspace change immediately; source reconciliation replaces it
+ * when Codex later reports a different usable workspace.
  */
 function resolveThreadWorkspaceCwd(
   thread: AppServerThreadSummary | undefined,
@@ -1192,7 +1196,7 @@ function shouldRepairCachedDirectoryRelationship(params: {
   }
 
   if (overlayHasHandoffWorkspace(params.overlay)) {
-    return false;
+    return true;
   }
 
   if (params.directory.kind === "worktree") {
@@ -9885,6 +9889,14 @@ export class DesktopBackendRegistry {
       directory: result.linkedDirectory,
       gitBranch: resultBranch,
     });
+    await this.updateThreadWorkspaceCwd({
+      backend: request.backend,
+      threadId: request.threadId,
+      cwd: result.linkedDirectory.worktreePath ?? result.targetPath,
+    });
+    if (request.backend === "codex") {
+      this.invalidateThreadListCache("codex");
+    }
     await this.updateThreadGitBranchMetadata({
       backend: request.backend,
       threadId: request.threadId,
@@ -9903,8 +9915,7 @@ export class DesktopBackendRegistry {
       });
     }
     // Do not rewrite Codex rollout JSONL files here. Codex may still hold the
-    // session file open; replacing it can orphan later transcript writes. The
-    // next turn resolves cwd from the overlay updated above.
+    // session file open; replacing it can orphan later transcript writes.
     if (result.archivedSourceWorktree) {
       await this.overlayStore.upsertWorktreeSnapshot({
         backend: request.backend,
@@ -19532,10 +19543,6 @@ export class DesktopBackendRegistry {
       ) {
         return false;
       }
-      if (overlayHasHandoffWorkspace(params.overlaysByThreadId[thread.id])) {
-        return false;
-      }
-
       const projectKey = thread.projectKey?.trim();
       if (!isLikelyToolManagedWorktreePath(projectKey)) {
         return false;
@@ -19559,10 +19566,6 @@ export class DesktopBackendRegistry {
       > = {};
 
       for (const thread of enrichedThreads) {
-        if (overlayHasHandoffWorkspace(params.overlaysByThreadId[thread.id])) {
-          continue;
-        }
-
         const directory = buildCachedWorktreeDirectory(thread);
         if (!directory) {
           const warningKey = `${thread.id}:${thread.projectKey ?? ""}`;
@@ -22730,6 +22733,31 @@ export class DesktopBackendRegistry {
         threadId: params.threadId,
       });
     }
+  }
+
+  private async updateThreadWorkspaceCwd(params: {
+    backend: AppServerBackendKind;
+    cwd: string;
+    threadId: string;
+  }): Promise<void> {
+    if (params.backend !== "codex") {
+      return;
+    }
+
+    const cwd = params.cwd.trim();
+    if (!cwd) {
+      throw new Error("Workspace handoff did not produce a target CWD.");
+    }
+
+    await this.withCodexThreadClient(params.threadId, async (client) => {
+      if (!client.updateThreadWorkspace) {
+        throw new Error("Codex does not support updating a thread workspace CWD.");
+      }
+      await client.updateThreadWorkspace({
+        threadId: params.threadId,
+        cwd,
+      });
+    });
   }
 
   private scheduleThreadTitleGeneration(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -521,6 +521,8 @@ const REPLAY_THREAD_TITLE_ENV = "PWRAGENT_REPLAY_THREAD_TITLE";
 const THREAD_LIST_REUSE_WINDOW_MS = 5 * 60_000;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
+const CODEX_WORKSPACE_CWD_SYNC_PENDING_WARNING =
+  "Codex workspace CWD synchronization is pending and will retry automatically.";
 /**
  * Number of consecutive queued-execution-mode flush failures tolerated
  * before the queue is auto-cancelled and an explanatory `cancelled`
@@ -780,9 +782,9 @@ type BackendRegistryForkThreadRequest = ForkThreadRequest & {
  * Resolve the live workspace CWD for thread-scoped commands.
  *
  * Worktree threads must run from LinkedDirectorySummary.worktreePath; Local
- * threads run from LinkedDirectorySummary.path. A handoff overlay projects an
- * acknowledged workspace change immediately; source reconciliation replaces it
- * when Codex later reports a different usable workspace.
+ * threads run from LinkedDirectorySummary.path. A handoff overlay projects the
+ * committed workspace change immediately and remains authoritative until Codex
+ * reports that same workspace, acknowledging the provider-side synchronization.
  */
 function resolveThreadWorkspaceCwd(
   thread: AppServerThreadSummary | undefined,
@@ -1191,12 +1193,30 @@ function shouldRepairCachedDirectoryRelationship(params: {
   directory: LinkedDirectorySummary;
   overlay: ThreadOverlayState | undefined;
 }): boolean {
-  if (hasEquivalentLinkedDirectory(params.overlay, params.directory)) {
+  const handoffDirectory = params.overlay?.extraLinkedDirectories.find(
+    isHandoffDirectory,
+  );
+  if (
+    handoffDirectory
+    && linkedDirectoriesHaveSameWorkspaceIdentity(
+      handoffDirectory,
+      params.directory,
+    )
+  ) {
+    // Matching provider metadata acknowledges the CWD synchronization. Replace
+    // the temporary handoff identity with Codex's normal directory identity.
+    return true;
+  }
+
+  // The handoff overlay is also the durable retry marker. Older PwrAgent
+  // versions can leave one paired with the pre-handoff Codex CWD, so preserve
+  // it until provider metadata explicitly acknowledges the target workspace.
+  if (overlayHasHandoffWorkspace(params.overlay)) {
     return false;
   }
 
-  if (overlayHasHandoffWorkspace(params.overlay)) {
-    return true;
+  if (hasEquivalentLinkedDirectory(params.overlay, params.directory)) {
+    return false;
   }
 
   if (params.directory.kind === "worktree") {
@@ -6786,6 +6806,13 @@ export class DesktopBackendRegistry {
   private readonly attemptedTitleGenerations = new Set<string>();
   private readonly repairedDirectoryThreadKeys = new Set<string>();
   private readonly failedDirectoryRelationshipLogKeys = new Set<string>();
+  private readonly pendingCodexWorkspaceCwdSyncs = new Map<
+    string,
+    {
+      cwd: string;
+      promise: Promise<void>;
+    }
+  >();
   private fullDirectoryReconcileDispatched = false;
   private titleGenerationSequence = 0;
   /**
@@ -9889,11 +9916,26 @@ export class DesktopBackendRegistry {
       directory: result.linkedDirectory,
       gitBranch: resultBranch,
     });
-    await this.updateThreadWorkspaceCwd({
-      backend: request.backend,
-      threadId: request.threadId,
-      cwd: result.linkedDirectory.worktreePath ?? result.targetPath,
-    });
+    const workspaceCwd =
+      result.linkedDirectory.worktreePath ?? result.targetPath;
+    let workspaceCwdSyncPending = false;
+    try {
+      await this.updateThreadWorkspaceCwd({
+        backend: request.backend,
+        threadId: request.threadId,
+        cwd: workspaceCwd,
+      });
+    } catch (error) {
+      workspaceCwdSyncPending = true;
+      backendRegistryLog.warn(
+        "Codex workspace CWD synchronization failed after committed handoff; will retry",
+        {
+          error: error instanceof Error ? error.message : String(error),
+          threadId: request.threadId,
+          workspaceCwd,
+        },
+      );
+    }
     if (request.backend === "codex") {
       this.invalidateThreadListCache("codex");
     }
@@ -9924,7 +9966,15 @@ export class DesktopBackendRegistry {
       });
     }
 
-    return result;
+    return workspaceCwdSyncPending
+      ? {
+          ...result,
+          warnings: [
+            ...result.warnings,
+            CODEX_WORKSPACE_CWD_SYNC_PENDING_WARNING,
+          ],
+        }
+      : result;
   }
 
   private async assertAcpWorkspaceHandoffAllowed(params: {
@@ -18857,6 +18907,10 @@ export class DesktopBackendRegistry {
         backend: "codex",
         threadId: params.threadId,
       });
+      this.schedulePendingCodexWorkspaceCwdSyncs({
+        overlaysByThreadId: { [params.threadId]: overlay },
+        threads: [enrichedThread],
+      });
       if (!shouldRepairCachedDirectoryRelationship({ directory, overlay })) {
         return;
       }
@@ -18911,6 +18965,10 @@ export class DesktopBackendRegistry {
     const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
       backend: "codex",
       threadIds: threads.map((thread) => thread.id),
+    });
+    this.schedulePendingCodexWorkspaceCwdSyncs({
+      overlaysByThreadId,
+      threads,
     });
     const updatedOverlaysByThreadId =
       await this.backfillMissingCodexDirectoryRelationships({
@@ -19407,6 +19465,10 @@ export class DesktopBackendRegistry {
     const visibleThreads = threadsWithPending.filter(
       (thread) => overlaysByThreadId[thread.id]?.archiveTombstonedAt === undefined,
     );
+    this.schedulePendingCodexWorkspaceCwdSyncs({
+      overlaysByThreadId,
+      threads: visibleThreads,
+    });
     const reconciledOverlaysByThreadId =
       await this.reconcileCodexDirectoryRelationshipsFromSource({
         diagnostics,
@@ -19583,6 +19645,11 @@ export class DesktopBackendRegistry {
               },
             );
           }
+          continue;
+        }
+
+        const overlay = params.overlaysByThreadId[thread.id];
+        if (!shouldRepairCachedDirectoryRelationship({ directory, overlay })) {
           continue;
         }
 
@@ -22757,6 +22824,79 @@ export class DesktopBackendRegistry {
         threadId: params.threadId,
         cwd,
       });
+    });
+  }
+
+  private schedulePendingCodexWorkspaceCwdSyncs(params: {
+    overlaysByThreadId: Record<string, ThreadOverlayState | undefined>;
+    threads: AppServerThreadSummary[];
+  }): void {
+    for (const thread of params.threads) {
+      const handoffDirectory = params.overlaysByThreadId[
+        thread.id
+      ]?.extraLinkedDirectories.find(isHandoffDirectory);
+      if (!handoffDirectory) {
+        continue;
+      }
+
+      const workspaceCwd =
+        handoffDirectory.worktreePath ?? handoffDirectory.path;
+      const providerCwd =
+        thread.projectKey?.trim() || resolveThreadWorkspaceCwd(thread);
+      if (
+        normalizeLinkedDirectoryIdentityPath(providerCwd)
+        === normalizeLinkedDirectoryIdentityPath(workspaceCwd)
+      ) {
+        continue;
+      }
+
+      this.scheduleCodexWorkspaceCwdSync({
+        threadId: thread.id,
+        cwd: workspaceCwd,
+      });
+    }
+  }
+
+  private scheduleCodexWorkspaceCwdSync(params: {
+    cwd: string;
+    threadId: string;
+  }): void {
+    const pending = this.pendingCodexWorkspaceCwdSyncs.get(params.threadId);
+    if (
+      pending
+      && normalizeLinkedDirectoryIdentityPath(pending.cwd)
+        === normalizeLinkedDirectoryIdentityPath(params.cwd)
+    ) {
+      return;
+    }
+
+    const promise: Promise<void> = this.updateThreadWorkspaceCwd({
+      backend: "codex",
+      threadId: params.threadId,
+      cwd: params.cwd,
+    })
+      .then(() => {
+        this.invalidateThreadListCache("codex");
+      })
+      .catch((error) => {
+        backendRegistryLog.warn(
+          "pending Codex workspace CWD synchronization failed; will retry",
+          {
+            error: error instanceof Error ? error.message : String(error),
+            threadId: params.threadId,
+            workspaceCwd: params.cwd,
+          },
+        );
+      })
+      .finally(() => {
+        const current = this.pendingCodexWorkspaceCwdSyncs.get(params.threadId);
+        if (current?.promise === promise) {
+          this.pendingCodexWorkspaceCwdSyncs.delete(params.threadId);
+        }
+      });
+    this.pendingCodexWorkspaceCwdSyncs.set(params.threadId, {
+      cwd: params.cwd,
+      promise,
     });
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6699,6 +6699,7 @@ function buildReviewStartPayload(params: {
 
 function buildThreadSettingsUpdatePayload(params: {
   threadId: string;
+  cwd?: string;
   model?: string;
   serviceTier?: string | null;
   reasoningEffort?: string;
@@ -6707,6 +6708,10 @@ function buildThreadSettingsUpdatePayload(params: {
   const payload: CodexThreadSettingsUpdateParams = {
     threadId: params.threadId,
   };
+
+  if (params.cwd?.trim()) {
+    payload.cwd = params.cwd.trim();
+  }
 
   if (params.model?.trim()) {
     payload.model = params.model.trim();
@@ -6722,7 +6727,8 @@ function buildThreadSettingsUpdatePayload(params: {
     payload.effort = effort;
   }
 
-  return payload.model !== undefined ||
+  return payload.cwd !== undefined ||
+    payload.model !== undefined ||
     payload.serviceTier !== undefined ||
     payload.effort !== undefined
     ? payload
@@ -8502,7 +8508,13 @@ export class CodexAppServerClient {
       }).catch(() => undefined);
     }
 
-    const settingsPayload = buildThreadSettingsUpdatePayload(params);
+    const settingsPayload = buildThreadSettingsUpdatePayload({
+      threadId: params.threadId,
+      model: params.model,
+      serviceTier: params.serviceTier,
+      reasoningEffort: params.reasoningEffort,
+      fastMode: params.fastMode,
+    });
     if (settingsPayload) {
       await requestWithFallbacks({
         client: this.connection,
@@ -8626,6 +8638,29 @@ export class CodexAppServerClient {
           gitInfo: params.gitInfo,
         },
       ],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    return {
+      threadId: extractThreadIdFromValue(result) ?? params.threadId,
+    };
+  }
+
+  async updateThreadWorkspace(params: {
+    threadId: string;
+    cwd: string;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+
+    const payload = buildThreadSettingsUpdatePayload(params);
+    if (!payload) {
+      throw new Error("A non-empty workspace CWD is required.");
+    }
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/settings/update"],
+      payloads: [payload],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
 

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -256,6 +256,14 @@ export class ReplayClient {
     return { threadId: params.threadId };
   }
 
+  async updateThreadWorkspace(params: {
+    threadId: string;
+    cwd: string;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+    return { threadId: params.threadId };
+  }
+
   async advance(params: {
     stepId?: string;
     override?: ReplayStepOverride;

--- a/apps/desktop/src/main/testing/replay-runtime.ts
+++ b/apps/desktop/src/main/testing/replay-runtime.ts
@@ -175,6 +175,10 @@ type ReplayRuntimeClient = {
     threadId: string;
     name: string;
   }): Promise<{ threadId: string }>;
+  updateThreadWorkspace?(params: {
+    threadId: string;
+    cwd: string;
+  }): Promise<{ threadId: string }>;
   respondToPendingRequest?(requestId: string): Promise<void>;
 };
 


### PR DESCRIPTION
## Summary

- persist the target workspace through Codex `thread/settings/update` during an existing-thread workspace handoff
- invalidate the Codex thread cache after that acknowledgement and let fresh Codex workspace metadata repair stale handoff overlays
- retain the overlay as the immediate recovery projection and continue to avoid rollout-file rewrites

## Why

Before this change, a handoff updated only PwrAgent overlay state and Codex branch metadata. Codex could continue reporting a stale thread CWD until a later turn, which produced divergent workspace consumers.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`

Closes #423