### PR TITLE
fix(desktop): delay branch and PR chip tooltips

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -351,6 +351,7 @@ export function ThreadMetaChips({
             kind: thread.gitBranch ? "expected" : "current",
           })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
+          hoverIntent
           tooltipText={branchTooltip}
           value={branchChip}
         >
@@ -368,6 +369,7 @@ export function ThreadMetaChips({
             kind: "current",
           })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--muted thread-row__chip--mono"
+          hoverIntent
           value={thread.observedGitBranch}
         >
           <span aria-hidden="true" className="thread-row__chip-icon">
@@ -519,6 +521,7 @@ function CopyableThreadChip(props: {
   "aria-label": string;
   children: ReactNode;
   className: string;
+  hoverIntent?: boolean;
   tooltipText?: string;
   value: string;
 }) {
@@ -566,7 +569,17 @@ function CopyableThreadChip(props: {
           event.stopPropagation();
           copy(event.currentTarget);
         }}
-        onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onMouseEnter={(event) =>
+          props.hoverIntent
+            ? tooltip.showWithHoverIntent(event.currentTarget, tooltipText)
+            : tooltip.show(event.currentTarget, tooltipText)
+        }
+        onMouseMove={
+          props.hoverIntent
+            ? (event) =>
+                tooltip.showWithHoverIntent(event.currentTarget, tooltipText)
+            : undefined
+        }
         onMouseLeave={tooltip.hide}
       >
         {props.children}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -351,7 +351,7 @@ export function ThreadMetaChips({
             kind: thread.gitBranch ? "expected" : "current",
           })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
-          hoverIntent
+          delayedTooltip
           tooltipText={branchTooltip}
           value={branchChip}
         >
@@ -369,7 +369,7 @@ export function ThreadMetaChips({
             kind: "current",
           })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--muted thread-row__chip--mono"
-          hoverIntent
+          delayedTooltip
           value={thread.observedGitBranch}
         >
           <span aria-hidden="true" className="thread-row__chip-icon">
@@ -521,7 +521,7 @@ function CopyableThreadChip(props: {
   "aria-label": string;
   children: ReactNode;
   className: string;
-  hoverIntent?: boolean;
+  delayedTooltip?: boolean;
   tooltipText?: string;
   value: string;
 }) {
@@ -570,15 +570,9 @@ function CopyableThreadChip(props: {
           copy(event.currentTarget);
         }}
         onMouseEnter={(event) =>
-          props.hoverIntent
-            ? tooltip.showWithHoverIntent(event.currentTarget, tooltipText)
+          props.delayedTooltip
+            ? tooltip.showAfterDelay(event.currentTarget, tooltipText)
             : tooltip.show(event.currentTarget, tooltipText)
-        }
-        onMouseMove={
-          props.hoverIntent
-            ? (event) =>
-                tooltip.showWithHoverIntent(event.currentTarget, tooltipText)
-            : undefined
         }
         onMouseLeave={tooltip.hide}
       >

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -5262,7 +5262,7 @@ describe("Sidebar", () => {
     const branchChip = screen.getByRole("button", {
       name: "Copy branch codex/thread-centric-ui",
     });
-    fireEvent.mouseEnter(branchChip);
+    fireEvent.focus(branchChip);
     await waitFor(() => {
       expect(
         screen
@@ -5274,7 +5274,7 @@ describe("Sidebar", () => {
           )
       ).toBe(true);
     });
-    fireEvent.mouseLeave(branchChip);
+    fireEvent.blur(branchChip);
     await clickElement(branchChip);
 
     expect(copyText).toHaveBeenNthCalledWith(
@@ -5327,7 +5327,7 @@ describe("Sidebar", () => {
     const branchChip = screen.getByRole("button", {
       name: "Copy branch codex/thread-centric-ui",
     });
-    fireEvent.mouseEnter(branchChip);
+    fireEvent.focus(branchChip);
 
     await waitFor(() => {
       expect(screen.getByRole("tooltip").textContent).toBe(

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -10,7 +10,7 @@ import {
   beginNativeDragInteraction,
   endNativeDragInteraction,
 } from "../../../lib/native-drag-interaction";
-import { TOOLTIP_HOVER_INTENT_DELAY_MS } from "../../../lib/useViewportTooltip";
+import { TOOLTIP_HOVER_DELAY_MS } from "../../../lib/useViewportTooltip";
 
 // Regression coverage for the unified chip-flow refactor (#188 / plan
 // 2026-05-05-001). The historical bug pattern was:
@@ -672,7 +672,7 @@ describe("ThreadRow chip flow", () => {
     expect(tooltip.querySelector(".pr-status-card__section")).toBeNull();
   });
 
-  it("waits for stationary pointer intent before showing branch and PR tooltips", () => {
+  it("uses a fixed tooltip delay that does not require a stationary pointer", () => {
     vi.useFakeTimers();
     try {
       renderRow({
@@ -698,13 +698,9 @@ describe("ThreadRow chip flow", () => {
       fireEvent.mouseEnter(branchChip);
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 
-      act(() =>
-        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
-      );
+      act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS / 2));
       fireEvent.mouseMove(branchChip, { clientX: 40, clientY: 20 });
-      act(() =>
-        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
-      );
+      act(() => vi.advanceTimersByTime((TOOLTIP_HOVER_DELAY_MS / 2) - 1));
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 
       act(() => vi.advanceTimersByTime(1));
@@ -715,13 +711,9 @@ describe("ThreadRow chip flow", () => {
         name: /Open pwrdrvr\/PwrAgent#123/,
       });
       fireEvent.mouseEnter(prChip);
-      act(() =>
-        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
-      );
+      act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS / 2));
       fireEvent.mouseMove(prChip, { clientX: 70, clientY: 20 });
-      act(() =>
-        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
-      );
+      act(() => vi.advanceTimersByTime((TOOLTIP_HOVER_DELAY_MS / 2) - 1));
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 
       act(() => vi.advanceTimersByTime(1));

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   MessagingThreadBindingSummary,
@@ -10,6 +10,7 @@ import {
   beginNativeDragInteraction,
   endNativeDragInteraction,
 } from "../../../lib/native-drag-interaction";
+import { TOOLTIP_HOVER_INTENT_DELAY_MS } from "../../../lib/useViewportTooltip";
 
 // Regression coverage for the unified chip-flow refactor (#188 / plan
 // 2026-05-05-001). The historical bug pattern was:
@@ -659,7 +660,7 @@ describe("ThreadRow chip flow", () => {
     });
     expect(prChip).not.toHaveAttribute("title");
 
-    fireEvent.mouseEnter(prChip);
+    fireEvent.focus(prChip);
 
     const tooltip = screen.getByRole("tooltip");
     expect(tooltip).toHaveClass("pr-status-card");
@@ -669,6 +670,65 @@ describe("ThreadRow chip flow", () => {
     // This row's PR predates the stats fields, so the card shows no sections at
     // all rather than zeros.
     expect(tooltip.querySelector(".pr-status-card__section")).toBeNull();
+  });
+
+  it("waits for stationary pointer intent before showing branch and PR tooltips", () => {
+    vi.useFakeTimers();
+    try {
+      renderRow({
+        thread: {
+          ...baseThread,
+          prs: [
+            {
+              provider: "github.com",
+              number: 123,
+              org: "pwrdrvr",
+              repo: "PwrAgent",
+              title: "Retain thread pull request history",
+              state: "passing",
+              url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+            },
+          ],
+        },
+      });
+
+      const branchChip = screen.getByRole("button", {
+        name: "Copy branch feat/chips",
+      });
+      fireEvent.mouseEnter(branchChip);
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+      act(() =>
+        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
+      );
+      fireEvent.mouseMove(branchChip, { clientX: 40, clientY: 20 });
+      act(() =>
+        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
+      );
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(screen.getByRole("tooltip")).toHaveTextContent("feat/chips");
+      fireEvent.mouseLeave(branchChip);
+
+      const prChip = screen.getByRole("button", {
+        name: /Open pwrdrvr\/PwrAgent#123/,
+      });
+      fireEvent.mouseEnter(prChip);
+      act(() =>
+        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
+      );
+      fireEvent.mouseMove(prChip, { clientX: 70, clientY: 20 });
+      act(() =>
+        vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS - 1),
+      );
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(screen.getByRole("tooltip")).toHaveClass("pr-status-card");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("marks Agent threads and explains their messaging role", () => {
@@ -836,7 +896,7 @@ describe("ThreadRow chip flow", () => {
     const prChip = screen.getByRole("button", {
       name: /Open pwrdrvr\/PwrAgent#123/,
     });
-    fireEvent.mouseEnter(prChip);
+    fireEvent.focus(prChip);
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
 
     // Switching apps never fires mouseleave on the chip, so the tooltip
@@ -868,7 +928,7 @@ describe("ThreadRow chip flow", () => {
     const prChip = screen.getByRole("button", {
       name: /Open pwrdrvr\/PwrAgent#123/,
     });
-    fireEvent.mouseEnter(prChip);
+    fireEvent.focus(prChip);
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
 
     fireEvent.click(prChip);
@@ -937,7 +997,7 @@ describe("ThreadRow chip flow", () => {
     const prChip = screen.getByRole("button", {
       name: /Open pwrdrvr\/PwrAgent#123/,
     });
-    fireEvent.mouseEnter(prChip);
+    fireEvent.focus(prChip);
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
 
     // The portal is position:fixed, so it detaches from its target on scroll.
@@ -971,7 +1031,7 @@ describe("ThreadRow chip flow", () => {
     expect(prChip).toHaveClass("pr-chip--merged");
     expect(prChip).not.toHaveClass("pr-chip--unknown");
 
-    fireEvent.mouseEnter(prChip);
+    fireEvent.focus(prChip);
 
     const tooltip = screen.getByRole("tooltip");
     expect(tooltip).toHaveTextContent("pwrdrvr/PwrAgent#542");

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -189,10 +189,7 @@ export function PrChip(props: PrChipProps) {
           }
         }}
         onMouseEnter={(event) =>
-          tooltipController.showWithHoverIntent(event.currentTarget, card)
-        }
-        onMouseMove={(event) =>
-          tooltipController.showWithHoverIntent(event.currentTarget, card)
+          tooltipController.showAfterDelay(event.currentTarget, card)
         }
         onMouseLeave={tooltipController.hide}
       >

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -59,6 +59,8 @@ export function PrChip(props: PrChipProps) {
   // `show` hands it to the portal on hover/focus, so a sidebar full of chips
   // mounts exactly zero cards.
   const card = <PrStatusCard pr={pr} withStatusPills={props.withStatusPills} />;
+  const latestCardRef = useRef(card);
+  latestCardRef.current = card;
   const tooltipVisible = tooltipController.visible;
 
   // Status updates keep arriving while the pointer rests on a chip, so push
@@ -70,7 +72,8 @@ export function PrChip(props: PrChipProps) {
   // very update caused. Compare the card's DATA and push only when it moved.
   // Tracking the key while hidden (rather than skipping the effect entirely)
   // is what keeps a hidden chip from pushing stale-keyed content on its next
-  // hover — `show` already hands over a freshly built card at that point.
+  // hover — the delayed callback reads `latestCardRef` when it expires, while
+  // immediate focus hands over the freshly built card directly.
   const cardKey = [
     pr.org,
     pr.repo,
@@ -189,7 +192,10 @@ export function PrChip(props: PrChipProps) {
           }
         }}
         onMouseEnter={(event) =>
-          tooltipController.showAfterDelay(event.currentTarget, card)
+          tooltipController.showAfterDelay(
+            event.currentTarget,
+            () => latestCardRef.current,
+          )
         }
         onMouseLeave={tooltipController.hide}
       >

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -188,7 +188,12 @@ export function PrChip(props: PrChipProps) {
             handleActivate(event);
           }
         }}
-        onMouseEnter={(event) => tooltipController.show(event.currentTarget, card)}
+        onMouseEnter={(event) =>
+          tooltipController.showWithHoverIntent(event.currentTarget, card)
+        }
+        onMouseMove={(event) =>
+          tooltipController.showWithHoverIntent(event.currentTarget, card)
+        }
         onMouseLeave={tooltipController.hide}
       >
         <span className="pr-chip__dot" aria-hidden="true" />
@@ -224,4 +229,3 @@ export function PrChip(props: PrChipProps) {
     </>
   );
 }
-

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PrSummary } from "@pwragent/shared";
-import { TOOLTIP_HOVER_INTENT_DELAY_MS } from "../../../lib/useViewportTooltip";
+import { TOOLTIP_HOVER_DELAY_MS } from "../../../lib/useViewportTooltip";
 import { PrChip } from "../PrChip";
 import { pullRequestCopyTargets } from "../PrChipContextMenu";
 
@@ -203,7 +203,7 @@ describe("PrChip", () => {
     }));
 
     fireEvent.mouseEnter(chip);
-    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS));
+    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS));
 
     const card = document.querySelector(".pr-status-card") as HTMLElement;
     expect(card).not.toBeNull();
@@ -234,7 +234,7 @@ describe("PrChip", () => {
     expect(document.querySelector(".pr-status-card")).toBeNull();
 
     fireEvent.mouseEnter(chip);
-    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS));
+    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS));
     expect(document.querySelector(".pr-status-card")).not.toBeNull();
 
     fireEvent.mouseLeave(chip);

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -220,6 +220,42 @@ describe("PrChip", () => {
     expect(document.querySelector(".pr-status-card")).toBeNull();
   });
 
+  it("opens delayed hover content with the latest PR data", () => {
+    vi.useFakeTimers();
+    const initialPr = basePr({
+      title: "Initial pull request title",
+      additions: 12,
+      deletions: 3,
+    });
+    const { container, rerender } = render(
+      <PrChip
+        pr={initialPr}
+        showRepoPrefix={false}
+        onOpen={vi.fn()}
+      />,
+    );
+    const chip = container.querySelector(".pr-chip") as HTMLElement;
+
+    fireEvent.mouseEnter(chip);
+    rerender(
+      <PrChip
+        pr={{
+          ...initialPr,
+          title: "Hydrated pull request title",
+          additions: 47,
+        }}
+        showRepoPrefix={false}
+        onOpen={vi.fn()}
+      />,
+    );
+    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS));
+
+    const card = document.querySelector(".pr-status-card") as HTMLElement;
+    expect(card).toHaveTextContent("Hydrated pull request title");
+    expect(card).toHaveTextContent("+47");
+    expect(card).not.toHaveTextContent("Initial pull request title");
+  });
+
   it("mounts no card at all until the chip is hovered", () => {
     vi.useFakeTimers();
     // A sidebar renders hundreds of these. The card element is built on every

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -1,7 +1,8 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PrSummary } from "@pwragent/shared";
+import { TOOLTIP_HOVER_INTENT_DELAY_MS } from "../../../lib/useViewportTooltip";
 import { PrChip } from "../PrChip";
 import { pullRequestCopyTargets } from "../PrChipContextMenu";
 
@@ -10,6 +11,7 @@ vi.mock("../../../lib/copy-text", () => ({ copyText }));
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   copyText.mockClear();
 });
 
@@ -190,6 +192,7 @@ describe("PrChip", () => {
   });
 
   it("opens a structured status card on hover", () => {
+    vi.useFakeTimers();
     const chip = renderChip(basePr({
       title: "fix(desktop): honor selected review project cwd",
       additions: 38,
@@ -200,6 +203,7 @@ describe("PrChip", () => {
     }));
 
     fireEvent.mouseEnter(chip);
+    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS));
 
     const card = document.querySelector(".pr-status-card") as HTMLElement;
     expect(card).not.toBeNull();
@@ -217,6 +221,7 @@ describe("PrChip", () => {
   });
 
   it("mounts no card at all until the chip is hovered", () => {
+    vi.useFakeTimers();
     // A sidebar renders hundreds of these. The card element is built on every
     // render but must stay an inert object — nothing in the document — until
     // `show` hands it to the portal.
@@ -229,6 +234,7 @@ describe("PrChip", () => {
     expect(document.querySelector(".pr-status-card")).toBeNull();
 
     fireEvent.mouseEnter(chip);
+    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_INTENT_DELAY_MS));
     expect(document.querySelector(".pr-status-card")).not.toBeNull();
 
     fireEvent.mouseLeave(chip);
@@ -249,7 +255,7 @@ describe("PrChip", () => {
     // Nothing to point at while hidden — a dangling reference is worse than none.
     expect(chip).not.toHaveAttribute("aria-describedby");
 
-    fireEvent.mouseEnter(chip);
+    fireEvent.focus(chip);
 
     const describedBy = chip.getAttribute("aria-describedby");
     expect(describedBy).toBeTruthy();
@@ -257,7 +263,7 @@ describe("PrChip", () => {
     expect(card).toHaveClass("pr-status-card");
     expect(card?.textContent).toContain("412");
 
-    fireEvent.mouseLeave(chip);
+    fireEvent.blur(chip);
     expect(chip).not.toHaveAttribute("aria-describedby");
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -380,7 +380,7 @@ describe("pull request links in transcript markdown", () => {
     const pendingChip = screen.getByRole("button", {
       name: /draft · checks pending/,
     });
-    fireEvent.mouseEnter(pendingChip);
+    fireEvent.focus(pendingChip);
     expect(screen.getByRole("tooltip")).toHaveTextContent(
       "Document JDK 17 for EMR jobs",
     );
@@ -494,7 +494,7 @@ describe("pull request links in transcript markdown", () => {
       initialText: "2h ago",
       updatedText: "3h ago",
     },
-  ])("updates a visible hover card when only $field changes", ({
+  ])("updates a visible status card when only $field changes", ({
     initial,
     initialText,
     selector,
@@ -515,7 +515,7 @@ describe("pull request links in transcript markdown", () => {
       </PullRequestLinkProvider>,
     );
     const markdownNode = screen.getByText("Draft PR:").parentElement;
-    fireEvent.mouseEnter(screen.getByRole("button", {
+    fireEvent.focus(screen.getByRole("button", {
       name: /Open ExampleOrg\/catalog-service#13290/,
     }));
     expect(screen.getByRole("tooltip").querySelector(selector))
@@ -563,7 +563,7 @@ describe("pull request links in transcript markdown", () => {
     const hydratedChip = screen.getByRole("button", {
       name: /draft · checks pending/,
     });
-    fireEvent.mouseEnter(hydratedChip);
+    fireEvent.focus(hydratedChip);
     expect(screen.getByRole("tooltip")).toHaveTextContent(
       "Document JDK 17 for EMR jobs",
     );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -7,10 +8,14 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useViewportTooltip } from "../useViewportTooltip";
+import {
+  TOOLTIP_HOVER_DELAY_MS,
+  useViewportTooltip,
+} from "../useViewportTooltip";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -31,6 +36,27 @@ function TooltipFixture() {
         </button>
       </div>
       <div data-testid="transcript-scroll-region" />
+      {tooltip.tooltipNode}
+    </div>
+  );
+}
+
+function DelayedTooltipFixture() {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+
+  return (
+    <div>
+      <div data-testid="sidebar-scroll-region">
+        <button
+          type="button"
+          onMouseEnter={(event) =>
+            tooltip.showAfterDelay(event.currentTarget, "Branch details")
+          }
+          onMouseLeave={tooltip.hide}
+        >
+          agent/delay-tooltip
+        </button>
+      </div>
       {tooltip.tooltipNode}
     </div>
   );
@@ -71,6 +97,28 @@ describe("useViewportTooltip", () => {
 
     fireEvent.mouseEnter(screen.getByRole("button"));
     fireEvent.scroll(screen.getByTestId("sidebar-scroll-region"));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("cancels a pending tooltip when the window loses focus", () => {
+    vi.useFakeTimers();
+    render(<DelayedTooltipFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.blur(window);
+    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("cancels a pending tooltip when scrolling moves its anchor", () => {
+    vi.useFakeTimers();
+    render(<DelayedTooltipFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.scroll(screen.getByTestId("sidebar-scroll-region"));
+    act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS));
 
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -16,6 +16,12 @@ import {
 const VIEWPORT_PADDING = 12;
 /** Gap between the tooltip and the target element (above or below). */
 const TOOLTIP_GAP = 10;
+/**
+ * Pointer dwell required before dense metadata tooltips open. Consumers opt
+ * into this path when pointer travel across many nearby targets would
+ * otherwise flash a trail of tooltips.
+ */
+export const TOOLTIP_HOVER_INTENT_DELAY_MS = 500;
 
 function tooltipViewportTop(): number {
   // On Windows the fixed custom title bar occupies the top of the renderer,
@@ -79,6 +85,11 @@ export function useViewportTooltip(options: {
   tooltipId: string;
   show: (target: HTMLElement, content: ReactNode) => void;
   /**
+   * Arm a tooltip after the pointer rests. Call on both mouse enter and mouse
+   * move so continued travel restarts the dwell instead of opening the card.
+   */
+  showWithHoverIntent: (target: HTMLElement, content: ReactNode) => void;
+  /**
    * Replace the content of an already-visible tooltip in place (no-op
    * while hidden). Keeps the current position until the re-measure pass
    * settles, so live data updates don't blink the tooltip.
@@ -91,8 +102,17 @@ export function useViewportTooltip(options: {
 } {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const targetRef = useRef<HTMLElement | null>(null);
+  const hoverIntentTimerRef = useRef<number | null>(null);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
+
+  const clearHoverIntent = useCallback((): void => {
+    if (hoverIntentTimerRef.current === null) {
+      return;
+    }
+    window.clearTimeout(hoverIntentTimerRef.current);
+    hoverIntentTimerRef.current = null;
+  }, []);
 
   // Measure the rendered tooltip and clamp position so it stays in the
   // viewport and on the side of the target where it fits. The first
@@ -144,6 +164,7 @@ export function useViewportTooltip(options: {
   }, [state]);
 
   const show = useCallback((target: HTMLElement, content: ReactNode): void => {
+    clearHoverIntent();
     if (isNativeDragInteractionActive()) {
       targetRef.current = null;
       setState(undefined);
@@ -157,16 +178,33 @@ export function useViewportTooltip(options: {
       targetBottom: rect.bottom,
       targetCenter: rect.left + rect.width / 2,
     });
-  }, []);
+  }, [clearHoverIntent]);
+
+  const showWithHoverIntent = useCallback(
+    (target: HTMLElement, content: ReactNode): void => {
+      if (targetRef.current === target) {
+        return;
+      }
+      clearHoverIntent();
+      hoverIntentTimerRef.current = window.setTimeout(() => {
+        hoverIntentTimerRef.current = null;
+        show(target, content);
+      }, TOOLTIP_HOVER_INTENT_DELAY_MS);
+    },
+    [clearHoverIntent, show],
+  );
 
   const update = useCallback((content: ReactNode): void => {
     setState((current) => (current ? { ...current, content } : current));
   }, []);
 
   const hide = useCallback((): void => {
+    clearHoverIntent();
     targetRef.current = null;
     setState(undefined);
-  }, []);
+  }, [clearHoverIntent]);
+
+  useEffect(() => clearHoverIntent, [clearHoverIntent]);
 
   // A hover tooltip is shown on pointerenter/focus, but those handlers give
   // us no dismissal signal when the window loses focus (cmd-tab away leaves
@@ -225,5 +263,13 @@ export function useViewportTooltip(options: {
         )
       : null;
 
-  return { tooltipId, show, update, hide, visible, tooltipNode };
+  return {
+    tooltipId,
+    show,
+    showWithHoverIntent,
+    update,
+    hide,
+    visible,
+    tooltipNode,
+  };
 }

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -17,11 +17,10 @@ const VIEWPORT_PADDING = 12;
 /** Gap between the tooltip and the target element (above or below). */
 const TOOLTIP_GAP = 10;
 /**
- * Pointer dwell required before dense metadata tooltips open. Consumers opt
- * into this path when pointer travel across many nearby targets would
- * otherwise flash a trail of tooltips.
+ * Short entry delay for dense metadata tooltips. It filters incidental pointer
+ * crossings without requiring the pointer to remain perfectly stationary.
  */
-export const TOOLTIP_HOVER_INTENT_DELAY_MS = 500;
+export const TOOLTIP_HOVER_DELAY_MS = 250;
 
 function tooltipViewportTop(): number {
   // On Windows the fixed custom title bar occupies the top of the renderer,
@@ -85,10 +84,10 @@ export function useViewportTooltip(options: {
   tooltipId: string;
   show: (target: HTMLElement, content: ReactNode) => void;
   /**
-   * Arm a tooltip after the pointer rests. Call on both mouse enter and mouse
-   * move so continued travel restarts the dwell instead of opening the card.
+   * Arm a tooltip after a short delay from pointer entry. Pointer movement does
+   * not restart the delay; leaving the target should call `hide` to cancel it.
    */
-  showWithHoverIntent: (target: HTMLElement, content: ReactNode) => void;
+  showAfterDelay: (target: HTMLElement, content: ReactNode) => void;
   /**
    * Replace the content of an already-visible tooltip in place (no-op
    * while hidden). Keeps the current position until the re-measure pass
@@ -102,16 +101,16 @@ export function useViewportTooltip(options: {
 } {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const targetRef = useRef<HTMLElement | null>(null);
-  const hoverIntentTimerRef = useRef<number | null>(null);
+  const hoverDelayTimerRef = useRef<number | null>(null);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
 
-  const clearHoverIntent = useCallback((): void => {
-    if (hoverIntentTimerRef.current === null) {
+  const clearHoverDelay = useCallback((): void => {
+    if (hoverDelayTimerRef.current === null) {
       return;
     }
-    window.clearTimeout(hoverIntentTimerRef.current);
-    hoverIntentTimerRef.current = null;
+    window.clearTimeout(hoverDelayTimerRef.current);
+    hoverDelayTimerRef.current = null;
   }, []);
 
   // Measure the rendered tooltip and clamp position so it stays in the
@@ -164,7 +163,7 @@ export function useViewportTooltip(options: {
   }, [state]);
 
   const show = useCallback((target: HTMLElement, content: ReactNode): void => {
-    clearHoverIntent();
+    clearHoverDelay();
     if (isNativeDragInteractionActive()) {
       targetRef.current = null;
       setState(undefined);
@@ -178,20 +177,20 @@ export function useViewportTooltip(options: {
       targetBottom: rect.bottom,
       targetCenter: rect.left + rect.width / 2,
     });
-  }, [clearHoverIntent]);
+  }, [clearHoverDelay]);
 
-  const showWithHoverIntent = useCallback(
+  const showAfterDelay = useCallback(
     (target: HTMLElement, content: ReactNode): void => {
       if (targetRef.current === target) {
         return;
       }
-      clearHoverIntent();
-      hoverIntentTimerRef.current = window.setTimeout(() => {
-        hoverIntentTimerRef.current = null;
+      clearHoverDelay();
+      hoverDelayTimerRef.current = window.setTimeout(() => {
+        hoverDelayTimerRef.current = null;
         show(target, content);
-      }, TOOLTIP_HOVER_INTENT_DELAY_MS);
+      }, TOOLTIP_HOVER_DELAY_MS);
     },
-    [clearHoverIntent, show],
+    [clearHoverDelay, show],
   );
 
   const update = useCallback((content: ReactNode): void => {
@@ -199,12 +198,12 @@ export function useViewportTooltip(options: {
   }, []);
 
   const hide = useCallback((): void => {
-    clearHoverIntent();
+    clearHoverDelay();
     targetRef.current = null;
     setState(undefined);
-  }, [clearHoverIntent]);
+  }, [clearHoverDelay]);
 
-  useEffect(() => clearHoverIntent, [clearHoverIntent]);
+  useEffect(() => clearHoverDelay, [clearHoverDelay]);
 
   // A hover tooltip is shown on pointerenter/focus, but those handlers give
   // us no dismissal signal when the window loses focus (cmd-tab away leaves
@@ -266,7 +265,7 @@ export function useViewportTooltip(options: {
   return {
     tooltipId,
     show,
-    showWithHoverIntent,
+    showAfterDelay,
     update,
     hide,
     visible,

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -44,6 +44,8 @@ type TooltipState = {
   top?: number;
 };
 
+type DelayedTooltipContent = ReactNode | (() => ReactNode);
+
 /**
  * Hook for portal-rendered tooltips that escape any clipping ancestor
  * (sidebar scroll regions, overflow:hidden chips, etc.) and clamp
@@ -87,7 +89,10 @@ export function useViewportTooltip(options: {
    * Arm a tooltip after a short delay from pointer entry. Pointer movement does
    * not restart the delay; leaving the target should call `hide` to cancel it.
    */
-  showAfterDelay: (target: HTMLElement, content: ReactNode) => void;
+  showAfterDelay: (
+    target: HTMLElement,
+    content: DelayedTooltipContent,
+  ) => void;
   /**
    * Replace the content of an already-visible tooltip in place (no-op
    * while hidden). Keeps the current position until the re-measure pass
@@ -104,6 +109,7 @@ export function useViewportTooltip(options: {
   const hoverDelayTimerRef = useRef<number | null>(null);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
+  const [delayPending, setDelayPending] = useState(false);
 
   const clearHoverDelay = useCallback((): void => {
     if (hoverDelayTimerRef.current === null) {
@@ -164,6 +170,7 @@ export function useViewportTooltip(options: {
 
   const show = useCallback((target: HTMLElement, content: ReactNode): void => {
     clearHoverDelay();
+    setDelayPending(false);
     if (isNativeDragInteractionActive()) {
       targetRef.current = null;
       setState(undefined);
@@ -180,14 +187,17 @@ export function useViewportTooltip(options: {
   }, [clearHoverDelay]);
 
   const showAfterDelay = useCallback(
-    (target: HTMLElement, content: ReactNode): void => {
+    (target: HTMLElement, content: DelayedTooltipContent): void => {
       if (targetRef.current === target) {
         return;
       }
       clearHoverDelay();
+      targetRef.current = target;
+      setDelayPending(true);
       hoverDelayTimerRef.current = window.setTimeout(() => {
         hoverDelayTimerRef.current = null;
-        show(target, content);
+        setDelayPending(false);
+        show(target, typeof content === "function" ? content() : content);
       }, TOOLTIP_HOVER_DELAY_MS);
     },
     [clearHoverDelay, show],
@@ -199,23 +209,25 @@ export function useViewportTooltip(options: {
 
   const hide = useCallback((): void => {
     clearHoverDelay();
+    setDelayPending(false);
     targetRef.current = null;
     setState(undefined);
   }, [clearHoverDelay]);
 
   useEffect(() => clearHoverDelay, [clearHoverDelay]);
 
-  // A hover tooltip is shown on pointerenter/focus, but those handlers give
+  // A hover tooltip is armed or shown on pointerenter/focus, but those handlers give
   // us no dismissal signal when the window loses focus (cmd-tab away leaves
   // the pointer "over" the chip, so no `mouseleave` fires) or when the list
   // scrolls underneath the position:fixed portal (the tooltip detaches from
   // its target and lingers). Tear it down when the viewport or an ancestor of
   // the target scrolls. A captured scroll from an unrelated pane must not
   // dismiss it — transcript auto-scrolls otherwise close sidebar tooltips.
-  // Keyed on visibility so the measure pass doesn't resubscribe each render.
+  // Keyed on activity so the measure pass doesn't resubscribe each render.
   const visible = state !== undefined;
+  const active = delayPending || visible;
   useEffect(() => {
-    if (!visible) {
+    if (!active) {
       return;
     }
     const unsubscribeNativeDrag = subscribeNativeDragInteraction((active) => {
@@ -239,7 +251,7 @@ export function useViewportTooltip(options: {
       window.removeEventListener("blur", hide);
       window.removeEventListener("scroll", onScroll, { capture: true });
     };
-  }, [visible, hide]);
+  }, [active, hide]);
 
   const tooltipNode =
     state && typeof document !== "undefined"


### PR DESCRIPTION
## Summary

- add a fixed 250 ms entry delay to branch and pull request chip tooltips
- do not restart the delay when the pointer moves, so tremor or imprecise movement does not prevent disclosure
- cancel pending tooltips when the pointer leaves
- keep keyboard-focus tooltips and click/copy feedback immediate
- add regression coverage for both branch and PR chips

## Root cause

Both chip types opened their portal tooltip directly from mouseenter, so merely crossing a chip while moving through the sidebar was treated as intentional hover.

## User impact

Moving the pointer across dense thread metadata no longer produces immediate, distracting tooltip popups. A chip reveals its details after 250 ms without requiring a perfectly stationary pointer.

## Validation

- pnpm test — 7,961 passed, 5 skipped
- pnpm typecheck
- pnpm lint:eslint — 0 errors; existing warning baseline only
- pnpm lint:boundaries