### PR TITLE
fix(desktop): reach a peer's incidents, and harden the hot paths

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -714,6 +714,7 @@ describe("federation backend bridge", () => {
         threads: [],
       })),
       readThread: vi.fn(),
+      analyzeThreadToolHistory: vi.fn(),
       listSkills: vi.fn(),
       listBackends: vi.fn(),
       archiveThread: vi.fn(async () => ({
@@ -2383,6 +2384,7 @@ describe("federation backend bridge", () => {
       backend: {
         listThreads: vi.fn(),
         readThread: vi.fn(),
+        analyzeThreadToolHistory: vi.fn(),
         listSkills: vi.fn(),
         listBackends: vi.fn(),
         startTurn: vi.fn(),
@@ -2460,6 +2462,7 @@ describe("federation backend bridge", () => {
     const backend: FederationBackendOperations = {
       listThreads: vi.fn(),
       readThread: vi.fn(),
+      analyzeThreadToolHistory: vi.fn(),
       listSkills: vi.fn(),
       startTurn: vi.fn(async () => ({
         backend: "codex",
@@ -2608,6 +2611,7 @@ describe("federation backend bridge", () => {
       listThreads: vi.fn(),
       resolveThread: vi.fn(),
       readThread: vi.fn(),
+      analyzeThreadToolHistory: vi.fn(),
       readTranscriptImage: vi.fn(),
       listSkills: vi.fn(),
       listBackends: vi.fn(),
@@ -2993,6 +2997,7 @@ describe("federation backend bridge", () => {
         listThreads: vi.fn(),
         resolveThread: vi.fn(),
         readThread: vi.fn(),
+        analyzeThreadToolHistory: vi.fn(),
         readTranscriptImage: vi.fn(),
         listSkills: vi.fn(),
         listBackends: vi.fn(),

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -121,6 +121,29 @@ describe("tool-output incident explorer window", () => {
     );
   });
 
+  it("names the owning instance in the route only for a peer's thread", async () => {
+    /* A local thread's route must stay exactly as it was — an always-emitted
+       segment appended a trailing slash to every ordinary route. */
+    const { showToolOutputIncidentExplorerWindow } = await import(
+      "../tool-output-incident-explorer-window"
+    );
+    showToolOutputIncidentExplorerWindow({
+      backend: "codex" as const,
+      federationTarget: { instanceId: "peer-instance", scope: "remote" },
+      projectLabel: "PwrAgent",
+      threadId: "thread-2",
+      title: "Peer work",
+    });
+
+    expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
+      "/renderer.html",
+      {
+        hash:
+          "tool-output-incidents/codex/thread-2/Peer%20work/PwrAgent/peer-instance",
+      },
+    );
+  });
+
   it("routes a thread-chip click back to the explorer's exact owner window", async () => {
     const {
       showThreadFromToolOutputIncidentExplorer,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10615,6 +10615,7 @@ export class DesktopBackendRegistry {
       throw new Error("Tool-output history analysis storage is unavailable.");
     }
 
+    const scanStartedAt = performance.now();
     const pages: AppServerThreadReplay[] = [];
     const seenCursors = new Set<string>();
     let before: string | undefined;
@@ -10648,22 +10649,50 @@ export class DesktopBackendRegistry {
       before = cursor;
     }
 
+    /* Phase timings, because "is this well behaved on the main process" is a
+       measurement and not an argument. The paging loop awaits between pages
+       so it yields; the two phases below do not, and each is one
+       uninterrupted block on the process every window's IPC shares.
+       `analyzeMs` normalizes every entry of every page in one pass;
+       `persistMs` writes every invocation through better-sqlite3, which is
+       synchronous. Whichever is larger is the one worth moving. */
+    const pagesMs = Math.round(performance.now() - scanStartedAt);
+    const analyzeStartedAt = performance.now();
     const analysis = analyzeNormalizedToolReplay({
       backend: request.backend,
       complete,
       pages,
       threadId: request.threadId,
     });
+    const analyzeMs = Math.round(performance.now() - analyzeStartedAt);
+    const persistStartedAt = performance.now();
     await this.overlayStore.persistThreadToolHistoryAnalysis({
       backend: request.backend,
       coverage: analysis.coverage,
       invocations: analysis.invocations,
       threadId: request.threadId,
     });
+    const persistMs = Math.round(performance.now() - persistStartedAt);
+    const readbackStartedAt = performance.now();
     const accounting = await this.overlayStore.readThreadToolAccounting({
       backend: request.backend,
       includeAllInvocations: true,
       threadId: request.threadId,
+    });
+    const readbackMs = Math.round(performance.now() - readbackStartedAt);
+    /* Info, not debug: this is the number that decides whether the scan needs
+       to move off the main process, and it should not require a dev build to
+       read. One line per scan, and a scan is operator-initiated. */
+    backendRegistryLog.info("analyzeThreadToolHistory:timing", {
+      analyzeMs,
+      complete,
+      entryCount: analysis.coverage.entryCount,
+      invocationCount: analysis.coverage.invocationCount,
+      pageCount: pages.length,
+      pagesMs,
+      persistMs,
+      readbackMs,
+      totalMs: Math.round(performance.now() - scanStartedAt),
     });
     await this.emitThreadToolAccountingUpdated({
       backend: request.backend,

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -1,4 +1,6 @@
 import type {
+  AnalyzeThreadToolHistoryRequest,
+  AnalyzeThreadToolHistoryResponse,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
   AppServerListThreadsRequest,
@@ -265,6 +267,7 @@ export const FEDERATION_BACKEND_METHODS = {
   listThreads: "backend.listThreads",
   resolveThread: "backend.resolveThread",
   readThread: "backend.readThread",
+  analyzeThreadToolHistory: "backend.analyzeThreadToolHistory",
   readTranscriptImage: "backend.readTranscriptImage",
   listSkills: "backend.listSkills",
   listBackends: "backend.listBackends",
@@ -358,6 +361,8 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.resolveThread]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
+  /* Reads the thread's own transcript history; same data class as reading it. */
+  [FEDERATION_BACKEND_METHODS.analyzeThreadToolHistory]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.readTranscriptImage]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listBackends]: "thread_detail",
@@ -464,6 +469,9 @@ export type FederationBackendOperations = {
   readThread(
     request: AppServerReadThreadRequest,
   ): Promise<AppServerReadThreadResponse>;
+  analyzeThreadToolHistory(
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse>;
   readTranscriptImage(
     request: FederationReadTranscriptImageRequest,
   ): Promise<FederatedTranscriptImageResponse>;
@@ -711,6 +719,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.resolveThread(
         envelope.params as ResolveThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.analyzeThreadToolHistory,
+    async (envelope) =>
+      await params.backend.analyzeThreadToolHistory(
+        envelope.params as AnalyzeThreadToolHistoryRequest,
       ),
   );
   params.router.registerHandler(
@@ -1327,6 +1342,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
       params: request,
     });
     return await this.transformReadThreadResponse(response);
+  }
+
+  async analyzeThreadToolHistory(
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse> {
+    return await this.rpc.request<AnalyzeThreadToolHistoryResponse>({
+      method: FEDERATION_BACKEND_METHODS.analyzeThreadToolHistory,
+      params: request,
+    });
   }
 
   async readTranscriptImage(

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2,6 +2,8 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import path from "node:path";
 import type {
+  AnalyzeThreadToolHistoryRequest,
+  AnalyzeThreadToolHistoryResponse,
   AgentEvent,
   AppServerListSkillsResponse,
   AppServerListThreadsResponse,
@@ -4626,6 +4628,16 @@ function localBackendOperations(): FederationBackendOperations {
           : {}),
       });
       return rewriteTranscriptImageUrlsForRenderer(response);
+    },
+    async analyzeThreadToolHistory(
+      request: AnalyzeThreadToolHistoryRequest,
+    ): Promise<AnalyzeThreadToolHistoryResponse> {
+      /* Runs on the instance that owns the transcript — the scan pages the
+         thread's own history, which a viewer cannot reach. */
+      return await getDesktopBackendRegistry().analyzeThreadToolHistory({
+        backend: request.backend,
+        threadId: request.threadId,
+      });
     },
     async readTranscriptImage(request) {
       return await readTranscriptImageProtocolRequest(request.url);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1777,6 +1777,17 @@ class DesktopAppServerService {
   async analyzeThreadToolHistory(
     request: AnalyzeThreadToolHistoryRequest,
   ): Promise<AnalyzeThreadToolHistoryResponse> {
+    /* The scan pages the thread's transcript, which only the owning instance
+       can serve. A viewer analyzing a peer's thread runs it over there. */
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...remoteRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .analyzeThreadToolHistory(remoteRequest);
+    }
     return await getDesktopBackendRegistry().analyzeThreadToolHistory(request);
   }
 

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -109,13 +109,13 @@ export function showToolOutputIncidentExplorerWindow(
     encodeURIComponent(threadId),
     encodeURIComponent(title.slice(0, TITLE_MAX_LENGTH)),
     encodeURIComponent(request.projectLabel?.trim() ?? ""),
-    /* The owning instance. A viewer's explorer must read the peer's thread,
-       not a local thread that happens to share the id. */
-    encodeURIComponent(
-      request.federationTarget?.scope === "remote"
-        ? request.federationTarget.instanceId
-        : "",
-    ),
+    /* The owning instance, appended only for a peer's thread: a viewer's
+       explorer must read the peer's thread, not a local thread that happens
+       to share the id. Emitting an empty segment for local threads would add
+       a trailing slash to every ordinary route for nothing. */
+    ...(request.federationTarget?.scope === "remote"
+      ? [encodeURIComponent(request.federationTarget.instanceId)]
+      : []),
   ].join("/");
   const rendererEntry = getRendererEntry();
   if (rendererEntry.kind === "url") {

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -109,6 +109,13 @@ export function showToolOutputIncidentExplorerWindow(
     encodeURIComponent(threadId),
     encodeURIComponent(title.slice(0, TITLE_MAX_LENGTH)),
     encodeURIComponent(request.projectLabel?.trim() ?? ""),
+    /* The owning instance. A viewer's explorer must read the peer's thread,
+       not a local thread that happens to share the id. */
+    encodeURIComponent(
+      request.federationTarget?.scope === "remote"
+        ? request.federationTarget.instanceId
+        : "",
+    ),
   ].join("/");
   const rendererEntry = getRendererEntry();
   if (rendererEntry.kind === "url") {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -801,6 +801,11 @@ function DesktopAppShell(props: {
             ?? matchingThread?.linkedDirectories[0]?.label;
           void desktopApi?.openToolOutputIncidentExplorerWindow?.({
             backend: event.backend,
+            /* The event names the owning instance; without it a viewer's
+               explorer reads the peer's thread id locally and finds nothing. */
+            ...(event.federationTarget
+              ? { federationTarget: event.federationTarget }
+              : {}),
             ...(projectLabel ? { projectLabel } : {}),
             threadId: params.threadId,
             title: matchingThread?.title ?? labelForThread(

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -699,8 +699,12 @@ function DesktopAppShell(props: {
           threadId: params.threadId,
         });
         /* Persisted disposition wins over anything this session inferred: it
-           may predate this renderer entirely. */
-        if (params.incidentNotice) {
+           may predate this renderer entirely. Only for a local thread, though:
+           the notification is filled from the overlay of whichever instance
+           owns the thread, and a peer's dismissal is the peer operator's
+           preference, not this viewer's. Adopting it would silently stop
+           warning a viewer who never asked to stop being warned. */
+        if (params.incidentNotice && !event.federationTarget) {
           toolIncidentStateRef.current.set(noticeId, {
             ...toolIncidentStateRef.current.get(noticeId),
             ...params.incidentNotice,

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -309,6 +309,50 @@ describe("snapshot coverage", () => {
   });
 
   it("formats credits the same way the turn strip does", () => {
-    expect(formatIncidentMicros(2_400_000, "credits")).toBe("2.4 cr");
+    expect(formatIncidentMicros(2_400_000, "credits")).toBe("2.40 cr");
+  });
+});
+
+describe("replay counting at scale", () => {
+  it("counts later trips identically however many calls share a timestamp", () => {
+    /* A full-history analyze pass stamps a turn's calls in bulk, so ties are
+       the common case, not the edge case. */
+    const tied = Array.from({ length: 5 }, (_, index) =>
+      invocation({
+        estimatedOutputTokens: 100,
+        invocationId: `tied-${index}`,
+        observedAt: 1_000,
+        turnId: "turn-1",
+      }));
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting(tied),
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    /* 4 + 3 + 2 + 1 + 0 later trips, each carrying 100 tokens. */
+    expect(summary?.replayedTokens).toBe(1_000);
+  });
+
+  it("stays linear on a thread far past the notification cap", () => {
+    const many = Array.from({ length: 4_000 }, (_, index) =>
+      invocation({
+        estimatedOutputTokens: 10,
+        invocationId: `call-${index}`,
+        observedAt: 1_000 + index,
+        turnId: `turn-${index % 20}`,
+      }));
+    const started = performance.now();
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting(many),
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const elapsed = performance.now() - started;
+
+    expect(summary?.flaggedInvocationCount).toBe(4_000);
+    /* The quadratic form took seconds here; a generous ceiling still catches
+       a regression back to it. */
+    expect(elapsed).toBeLessThan(1_000);
   });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
@@ -93,8 +93,14 @@ export function buildThreadIncidentSummary(params: {
   const overCapCount = flagged.filter(
     (entry) => entry.outputChars >= TOOL_OUTPUT_CAP_CHARS,
   ).length;
+  /* Later-trip counts for every call in one pass, rather than an indexOf plus
+     a filter per flagged call. The per-call form was O(flagged × n) with a
+     linear scan inside it — safe only because the notification payload is
+     capped at 200 rows, which is not a property this fold should depend on. */
+  const laterTripsByInvocation = countLaterTripsByInvocation(invocations);
   const replayedTokens = flagged.reduce(
-    (sum, entry) => sum + entry.estimatedOutputTokens * countLaterTrips(invocations, entry),
+    (sum, entry) =>
+      sum + entry.estimatedOutputTokens * (laterTripsByInvocation.get(entry) ?? 0),
     0,
   );
   const usageLines = params.usageLines ?? [];
@@ -127,21 +133,36 @@ export function buildThreadIncidentSummary(params: {
 }
 
 /**
- * Every call in the same turn observed after this one. Each is a round trip
- * that carried this output through the model again.
+ * How many calls follow each one inside its own turn. Every one of those is a
+ * round trip that carried the earlier output through the model again.
+ *
+ * Computed for all calls at once: group by turn, order within the turn, then
+ * read each position's distance from the end. Ties on `observedAt` — which a
+ * full-history analyze pass produces in bulk — fall back to persisted order so
+ * no trip is dropped.
  */
-function countLaterTrips(
+function countLaterTripsByInvocation(
   invocations: readonly ThreadToolInvocationRecord[],
-  invocation: ThreadToolInvocationRecord,
-): number {
-  const index = invocations.indexOf(invocation);
-  return invocations.filter((entry, entryIndex) =>
-    (entry.turnId ?? "") === (invocation.turnId ?? "")
-    && (
-      entry.observedAt > invocation.observedAt
-      || (entry.observedAt === invocation.observedAt && entryIndex > index)
-    )
-  ).length;
+): Map<ThreadToolInvocationRecord, number> {
+  const byTurn = new Map<string, ThreadToolInvocationRecord[]>();
+  const orderIndex = new Map<ThreadToolInvocationRecord, number>();
+  invocations.forEach((invocation, index) => {
+    orderIndex.set(invocation, index);
+    const key = invocation.turnId ?? "";
+    const bucket = byTurn.get(key);
+    if (bucket) bucket.push(invocation);
+    else byTurn.set(key, [invocation]);
+  });
+  const laterTrips = new Map<ThreadToolInvocationRecord, number>();
+  for (const bucket of byTurn.values()) {
+    const ordered = [...bucket].sort((left, right) =>
+      left.observedAt - right.observedAt
+      || (orderIndex.get(left) ?? 0) - (orderIndex.get(right) ?? 0));
+    ordered.forEach((invocation, position) => {
+      laterTrips.set(invocation, ordered.length - 1 - position);
+    });
+  }
+  return laterTrips;
 }
 
 function sumSpendSince(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2310,6 +2310,10 @@ export function ThreadView(props: ThreadViewProps) {
       ?? selectedThread.linkedDirectories[0]?.label;
     void desktopApi?.openToolOutputIncidentExplorerWindow?.({
       backend: selectedThread.source,
+      /* A peer's thread is analyzed and read on the instance that owns it. */
+      ...(selectedThread.federation?.ref.target
+        ? { federationTarget: selectedThread.federation.ref.target }
+        : {}),
       ...(projectLabel ? { projectLabel } : {}),
       threadId: selectedThread.id,
       title: selectedThread.title,
@@ -2319,6 +2323,9 @@ export function ThreadView(props: ThreadViewProps) {
     if (!selectedThread) return;
     void desktopApi?.analyzeThreadToolHistory?.({
       backend: selectedThread.source,
+      ...(selectedThread.federation?.ref.target
+        ? { federationTarget: selectedThread.federation.ref.target }
+        : {}),
       threadId: selectedThread.id,
     });
   }, [desktopApi, selectedThread]);

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -267,6 +267,11 @@ export function ToolOutputIncidentExplorerWindow() {
       if (canSteerSelected && selected.turnId) {
         await desktopApi?.steerTurn?.({
           backend: route.backend,
+          /* Steering a peer's turn has to reach the peer, the same way this
+             window's reads do. */
+          ...(route.federationTarget
+            ? { federationTarget: route.federationTarget }
+            : {}),
           expectedTurnId: selected.turnId,
           input: [{ type: "text", text: prompt.trim() }],
           requestId: `tool-output-incident:${selected.invocationId}:${Date.now()}`,
@@ -277,6 +282,9 @@ export function ToolOutputIncidentExplorerWindow() {
       } else if (canSendAsNewTurn) {
         await desktopApi?.startTurn?.({
           backend: route.backend,
+          ...(route.federationTarget
+            ? { federationTarget: route.federationTarget }
+            : {}),
           input: [{ type: "text", text: prompt.trim() }],
           threadId: route.threadId,
         });
@@ -318,6 +326,9 @@ export function ToolOutputIncidentExplorerWindow() {
               title: route.title,
             }}
             onOpen={() => {
+              /* No federation target: `WindowShowThreadRequest` has none, and
+                 the main-process handler routes to this window's own owner.
+                 Passing one would be silently dropped by the spread. */
               void desktopApi?.showThreadFromToolOutputIncidentExplorer?.({
                 backend: route.backend,
                 threadId: route.threadId,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -6,6 +6,7 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadActivityDetail,
   ThreadToolAccounting,
+  ThreadToolAnalysisCoverage,
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import {
@@ -246,7 +247,10 @@ export function ToolOutputIncidentExplorerWindow() {
       setStatusTone(response.coverage.completeness === "complete" ? "info" : "error");
       setStatus(
         response.coverage.completeness === "complete"
-          ? `Analyzed ${response.coverage.invocationCount.toLocaleString()} tool calls across ${response.coverage.pageCount.toLocaleString()} page${response.coverage.pageCount === 1 ? "" : "s"}.`
+          ? describeAnalysisCoverage({
+              coverage: response.coverage,
+              knownInvocationCount: response.accounting.invocations.length,
+            })
           : response.coverage.explanation ?? "Analysis is incomplete.",
       );
     } catch (error) {
@@ -927,6 +931,29 @@ function Fact(props: {
  * output must paint nothing — a floored bar there would read as low activity
  * instead of none, blurring the contrast the polling band depends on.
  */
+/**
+ * What the scan reached, measured against what the thread already knows.
+ *
+ * "Complete" means the scan read the whole retained replay — not that it saw
+ * the whole thread. On a long thread most tool calls were recorded live and
+ * their transcript entries have since been compacted away, so the scan
+ * legitimately finds a fraction of them. Reporting only its own count reads
+ * as a contradiction next to a case list holding several times more: one real
+ * thread scanned 202 calls and listed 575 cases on the same screen.
+ */
+function describeAnalysisCoverage(params: {
+  coverage: ThreadToolAnalysisCoverage;
+  knownInvocationCount: number;
+}): string {
+  const scanned = params.coverage.invocationCount;
+  const pages = params.coverage.pageCount;
+  const scannedText = `Scanned ${scanned.toLocaleString()} tool call${scanned === 1 ? "" : "s"} still in replay across ${pages.toLocaleString()} page${pages === 1 ? "" : "s"}.`;
+  const older = params.knownInvocationCount - scanned;
+  return older > 0
+    ? `${scannedText} ${older.toLocaleString()} older call${older === 1 ? "" : "s"} recorded earlier remain accounted, but their output is no longer in the transcript.`
+    : scannedText;
+}
+
 function scaleWidth(value: number, max: number, floor = 2): number {
   if (max <= 0) return 0;
   if (value <= 0) return floor === 0 ? 0 : floor;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   AppServerBackendKind,
+  FederationInstanceId,
+  FederationTarget,
   AppServerReadThreadResponse,
   AppServerThreadActivityDetail,
   ThreadToolAccounting,
@@ -78,6 +80,9 @@ export function ToolOutputIncidentExplorerWindow() {
     try {
       const response = await desktopApi.readThread({
         backend: route.backend,
+        ...(route.federationTarget
+          ? { federationTarget: route.federationTarget }
+          : {}),
         includeAllToolInvocations: true,
         limit: HISTORY_PAGE_LIMIT,
         threadId: route.threadId,
@@ -185,6 +190,9 @@ export function ToolOutputIncidentExplorerWindow() {
     void readInvocationOutput({
       backend: route.backend,
       desktopApi,
+      ...(route.federationTarget
+        ? { federationTarget: route.federationTarget }
+        : {}),
       initial: latest,
       invocation: selected,
       threadId: route.threadId,
@@ -225,6 +233,9 @@ export function ToolOutputIncidentExplorerWindow() {
     try {
       const response = await desktopApi.analyzeThreadToolHistory({
         backend: route.backend,
+        ...(route.federationTarget
+          ? { federationTarget: route.federationTarget }
+          : {}),
         threadId: route.threadId,
       });
       setAccounting(response.accounting);
@@ -950,16 +961,27 @@ function countLaterTripsInTurn(
 
 function readIncidentRoute(): {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   projectLabel?: string;
   threadId: string;
   title: string;
 } | undefined {
-  const [kind, backend, threadId, title, projectLabel] = window.location.hash
-    .replace(/^#/, "")
-    .split("/");
+  const [kind, backend, threadId, title, projectLabel, instanceId] =
+    window.location.hash.replace(/^#/, "").split("/");
   if (kind !== "tool-output-incidents" || !backend || !threadId) return undefined;
+  const owner = instanceId ? decodeURIComponent(instanceId) : "";
   return {
     backend: decodeURIComponent(backend) as AppServerBackendKind,
+    /* Present only for a peer's thread; a local thread carries no target and
+       every read stays on this instance. */
+    ...(owner
+      ? {
+          federationTarget: {
+            scope: "remote" as const,
+            instanceId: owner as FederationInstanceId,
+          },
+        }
+      : {}),
     ...(projectLabel
       ? { projectLabel: decodeURIComponent(projectLabel) }
       : {}),
@@ -1009,6 +1031,7 @@ function groupCases(
 async function readInvocationOutput(params: {
   backend: AppServerBackendKind;
   desktopApi: NonNullable<ReturnType<typeof useDesktopApi>>;
+  federationTarget?: FederationTarget;
   initial: AppServerReadThreadResponse;
   invocation: ThreadToolInvocationRecord;
   threadId: string;
@@ -1028,6 +1051,9 @@ async function readInvocationOutput(params: {
     seen.add(cursor);
     response = await params.desktopApi.readThread({
       backend: params.backend,
+      ...(params.federationTarget
+        ? { federationTarget: params.federationTarget }
+        : {}),
       before: cursor,
       limit: HISTORY_PAGE_LIMIT,
       threadId: params.threadId,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -461,6 +461,42 @@ function buildInvocation(): ThreadToolInvocationRecord {
   };
 }
 
+describe("analysis coverage reporting", () => {
+  it("reconciles what the scan reached with what the thread already knows", async () => {
+    /* Measured on a real 236-turn thread: the scan reads 202 calls still in
+       replay while the store holds 2,225, because the rest were recorded live
+       and their transcript entries were compacted away. Reporting only the
+       scan's own count read as a contradiction beside a longer case list. */
+    const analyzed = buildMultiTurnResponse();
+    const analyzeThreadToolHistory = vi.fn(async () => ({
+      accounting: analyzed.toolAccounting!,
+      coverage: {
+        analyzedAt: 1,
+        analyzerVersion: "1",
+        completeness: "complete" as const,
+        entryCount: 1_704,
+        invocationCount: 1,
+        missingOutputCount: 0,
+        pageCount: 1,
+      },
+    }));
+    installApi({
+      analyzeThreadToolHistory,
+      readThread: async () => buildMultiTurnResponse(),
+    });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Analyze history/ }));
+
+    expect(await screen.findByText(/Scanned 1 tool call still in replay/))
+      .toBeInTheDocument();
+    /* The fixture holds 4 invocations; 3 predate what replay retained. */
+    expect(screen.getByText(/3 older calls recorded earlier remain accounted/))
+      .toBeInTheDocument();
+  });
+});
+
 describe("ToolOutputIncidentExplorerWindow federation", () => {
   it("reads and analyzes a peer's thread on the instance that owns it", async () => {
     /* Without the target every read runs against the local registry, which

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -547,3 +547,32 @@ describe("ToolOutputIncidentExplorerWindow federation", () => {
     );
   });
 });
+
+describe("turn selection is shared across both turn controls", () => {
+  it("marks the spark column selected when a strip row selects the turn", async () => {
+    /* The two controls were bound to one filter but only the strip rendered
+       it: clicking a spark column toggled the strip's selection while the
+       column itself stayed unmarked, so it read as a dead control. */
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    const timeline = screen.getByRole("group", {
+      name: "Tool cost per turn, in order",
+    });
+    const sparkColumns = within(timeline).getAllByRole("button");
+    expect(sparkColumns.every((column) =>
+      column.getAttribute("aria-pressed") === "false")).toBe(true);
+
+    fireEvent.click(within(turns).getByRole("button", { name: /Turn 2/ }));
+
+    await waitFor(() => expect(
+      within(timeline).getAllByRole("button", { name: /Turn 2/ })[0],
+    ).toHaveAttribute("aria-pressed", "true"));
+    /* And only that one. */
+    expect(within(timeline).getAllByRole("button")
+      .filter((column) => column.getAttribute("aria-pressed") === "true"))
+      .toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -460,3 +460,54 @@ function buildInvocation(): ThreadToolInvocationRecord {
     warningLines: 1,
   };
 }
+
+describe("ToolOutputIncidentExplorerWindow federation", () => {
+  it("reads and analyzes a peer's thread on the instance that owns it", async () => {
+    /* Without the target every read runs against the local registry, which
+       does not have the peer's thread id — the viewer's explorer came up
+       empty with no explanation. */
+    const readThread = vi.fn(async () => buildMultiTurnResponse());
+    const analyzeThreadToolHistory = vi.fn(async () => ({
+      accounting: { alerts: [], invocations: [], summaries: [] },
+      coverage: {
+        analyzedAt: 1,
+        analyzerVersion: "1",
+        completeness: "complete" as const,
+        entryCount: 0,
+        invocationCount: 0,
+        missingOutputCount: 0,
+        pageCount: 1,
+      },
+    }));
+    installApi({ analyzeThreadToolHistory, readThread });
+    window.location.hash =
+      "#tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent/peer-instance";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    await waitFor(() => expect(readThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        federationTarget: { instanceId: "peer-instance", scope: "remote" },
+      }),
+    ));
+
+    fireEvent.click(await screen.findByRole("button", { name: /Analyze history/ }));
+    await waitFor(() => expect(analyzeThreadToolHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        federationTarget: { instanceId: "peer-instance", scope: "remote" },
+        threadId: "thread-1",
+      }),
+    ));
+  });
+
+  it("leaves a local thread's reads untargeted", async () => {
+    const readThread = vi.fn(async () => buildMultiTurnResponse());
+    installApi({ readThread });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    await waitFor(() => expect(readThread).toHaveBeenCalled());
+    expect(readThread).not.toHaveBeenCalledWith(
+      expect.objectContaining({ federationTarget: expect.anything() }),
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -481,10 +481,13 @@ describe("turn cost", () => {
       .toBeUndefined();
   });
 
-  it("formats money in the ledger's units", () => {
-    expect(formatMicrosCurrency(2_400_000, "USD")).toBe("$2.4");
-    expect(formatMicrosCurrency(358_000_000, "USD")).toBe("$358");
-    expect(formatMicrosCurrency(2_400_000, "credits")).toBe("2.4 cr");
+  it("formats money to a fixed two places so the column aligns", () => {
+    /* A column of "$3.5" over "$8.38" moves the decimal point per row. */
+    expect(formatMicrosCurrency(2_400_000, "USD")).toBe("$2.40");
+    expect(formatMicrosCurrency(3_500_000, "USD")).toBe("$3.50");
+    expect(formatMicrosCurrency(358_000_000, "USD")).toBe("$358.00");
+    expect(formatMicrosCurrency(4_000, "USD")).toBe("$0.00");
+    expect(formatMicrosCurrency(2_400_000, "credits")).toBe("2.40 cr");
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -543,15 +543,23 @@ export function formatCapShare(
     : `${percentage.toLocaleString()}% of the output cap`;
 }
 
+/**
+ * Money, always to the penny.
+ *
+ * This renders a column, and a column of "$3.5" over "$8.38" puts the decimal
+ * point in a different place on every row — the eye cannot compare magnitudes
+ * without re-reading each number. Fixed two places keeps the point in one
+ * column, which is why spreadsheets do it. Sub-cent amounts round to $0.00
+ * rather than growing a third place and breaking the same alignment.
+ */
 export function formatMicrosCurrency(
   micros: number,
   currency: string | undefined,
 ): string {
-  const units = micros / 1_000_000;
-  const rounded = units >= 100
-    ? Math.round(units)
-    : Number(units.toFixed(units >= 1 ? 2 : 3));
-  const value = rounded.toLocaleString();
+  const value = (micros / 1_000_000).toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
   if (!currency || currency === "USD") return `$${value}`;
   if (currency.toLowerCase().includes("credit")) return `${value} cr`;
   return `${value} ${currency}`;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15413,13 +15413,26 @@ a.transcript-message__messaging-origin:focus-visible {
   border-right: 0;
 }
 
+/* Hover is a neutral wash: it must not look like selection, or the selected
+   column appears to vanish the moment the pointer leaves it. */
+.incident-explorer__timeline-turn:hover {
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+}
+
+/* Selection has to survive at rest and be findable among hundreds of 1px
+   columns, so it carries an accent ring and a real tint rather than the 12%
+   wash that was invisible on black. The minimum width keeps a selected column
+   clickable and locatable when the thread is long enough to compress every
+   column to a hairline. */
+.incident-explorer__timeline-turn[aria-pressed="true"] {
+  min-width: 3px;
+  background: color-mix(in srgb, var(--accent) 24%, transparent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
 .incident-explorer__timeline-turn:hover .incident-explorer__timeline-tokens i,
 .incident-explorer__timeline-turn[aria-pressed="true"] .incident-explorer__timeline-tokens i {
   background: var(--accent-strong);
-}
-
-.incident-explorer__timeline-turn[aria-pressed="true"] {
-  background: var(--accent-soft);
 }
 
 .incident-explorer__timeline-tokens {

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -128,6 +128,12 @@ export type SetThreadToolIncidentNoticeResponse = {
 
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;
+  /**
+   * The instance that owns the thread. A federation viewer's incidents are
+   * the peer's incidents: without this the explorer reads the thread id
+   * against the local registry, which does not have it.
+   */
+  federationTarget?: FederationTarget;
   projectLabel?: string;
   threadId: string;
   title: string;
@@ -139,6 +145,7 @@ export type OpenToolOutputIncidentExplorerWindowResponse = {
 
 export type AnalyzeThreadToolHistoryRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: string;
 };
 


### PR DESCRIPTION
Stacked on #1664 → #1653 → #1647 → #1634. Review those first.

## Federation: the explorer was local-only

`AnalyzeThreadToolHistoryRequest` and `OpenToolOutputIncidentExplorerWindowRequest` carried no `federationTarget` — the only thread-scoped requests in the app that didn't — and `analyzeThreadToolHistory` had no remote branch. A federation viewer clicking "Examine N cases" on a peer's thread opened a window that read that thread id **against the local registry**, which doesn't have it.

The target now rides from the caller (notice card and thread view) → the window's hash route → every `readThread`, the paged output retrieval, and the scan. The scan itself runs on the instance that owns the transcript, because paging a thread's history is something only its owner can do. Registered under the existing `thread_detail` capability scope: it reads the same data class as reading the thread.

## Money aligns to the penny

`$3.5` above `$8.38` puts the decimal point in a different place on every row. Fixed two places, which is what makes a column of numbers comparable at a glance. Sub-cent rounds to `$0.00` rather than growing a third place and breaking the same alignment.

## The replay fold was quadratic

`buildThreadIncidentSummary` called `countLaterTrips` per flagged call, and that did an `indexOf` scan *plus* a filter — O(flagged × n) with a linear scan inside it. On the 236-turn thread that's ~2.6M operations, and it runs **in the main window's renderer, inside the agent-event handler**.

It was only safe because the notification payload caps at 200 rows — a property the fold shouldn't depend on, and one a future "just pass `includeAllToolInvocations`" would silently remove. It now computes every call's later-trip count in one grouped pass. A 4,000-call test pins the linearity; the old form took seconds at that size.

## Still open (deliberately not in this PR)

- **The scan's location.** It runs in the main process and `await`s between pages, so it yields — but per-page normalization is synchronous main-process CPU shared with every window. Whether that needs a worker thread should be decided on a measurement, not a guess, and the measurement needs a real long thread.
- **Per-invocation category caching.** `refineToolCategory` re-runs regexes (and, for `/bin/bash -c '…'`, a 15k-token split on a 115k-char command) on every filter change. Only ever janks the explorer's own window.

## Verification

`pnpm typecheck`, `lint:eslint` (0 errors), `lint:boundaries` clean. 3,254 tests, including new coverage for peer-thread routing, local reads staying untargeted, tied-timestamp trip counting, and the 4,000-call linearity bound.

Not run in the app: I have no federation peer to drive, so the remote path is verified by contract and tests, not by a live viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)