### PR TITLE
fix(desktop): preserve HMR window state

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -3316,6 +3316,7 @@ describe("app server ipc", () => {
     expect(readThread).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-large",
+      includeAllToolInvocations: undefined,
       includeTurns: undefined,
       before: undefined,
       limit: undefined,
@@ -3331,7 +3332,7 @@ describe("app server ipc", () => {
     expect(output).not.toContain("x".repeat(60_000));
   });
 
-  it("forwards inspection-only transcript reads to the backend registry", async () => {
+  it("forwards inspection-only full-accounting reads to the backend registry", async () => {
     const { APP_SERVER_READ_THREAD_CHANNEL } = await import("../../shared/ipc");
     readThread.mockResolvedValueOnce({
       backend: "codex",
@@ -3352,12 +3353,18 @@ describe("app server ipc", () => {
 
     await handlers.get(APP_SERVER_READ_THREAD_CHANNEL)?.(
       {},
-      { backend: "codex", threadId: "sub-agent-1", viewOnly: true },
+      {
+        backend: "codex",
+        includeAllToolInvocations: true,
+        threadId: "sub-agent-1",
+        viewOnly: true,
+      },
     );
 
     expect(readThread).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "sub-agent-1",
+      includeAllToolInvocations: true,
       includeTurns: undefined,
       before: undefined,
       limit: undefined,

--- a/apps/desktop/src/main/__tests__/applications-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/applications-ipc.test.ts
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => {
     ),
     remoteBackend,
     remoteBackendForTarget: vi.fn(() => remoteBackend),
+    showToolOutputIncidentExplorerWindow: vi.fn(),
   };
 });
 
@@ -86,6 +87,11 @@ vi.mock("../subagent-transcript-window", () => ({
   showSubAgentTranscriptWindow: vi.fn(),
 }));
 
+vi.mock("../tool-output-incident-explorer-window", () => ({
+  showToolOutputIncidentExplorerWindow:
+    mocks.showToolOutputIncidentExplorerWindow,
+}));
+
 describe("application IPC", () => {
   beforeEach(() => {
     mocks.handlers.clear();
@@ -94,6 +100,7 @@ describe("application IPC", () => {
     mocks.discoverDesktopApplications.mockClear();
     mocks.openDesktopApplication.mockClear();
     mocks.remoteBackendForTarget.mockClear();
+    mocks.showToolOutputIncidentExplorerWindow.mockClear();
   });
 
   it("opens applications on the selected federation peer", async () => {
@@ -139,5 +146,31 @@ describe("application IPC", () => {
     expect(mocks.readApplications).toHaveBeenCalledTimes(1);
     expect(mocks.discoverDesktopApplications).not.toHaveBeenCalled();
     expect(response).toEqual({ applications: remoteApplications });
+  });
+
+  it("opens the thread-scoped tool-output incident explorer", async () => {
+    const { registerApplicationIpcHandlers } = await import("../ipc/applications");
+    const { TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    registerApplicationIpcHandlers();
+
+    const response = await mocks.handlers.get(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+    )?.({ sender: "sender" }, {
+      backend: "codex",
+      threadId: "thread-1",
+      title: "Noisy work",
+    });
+
+    expect(mocks.showToolOutputIncidentExplorerWindow).toHaveBeenCalledWith(
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        title: "Noisy work",
+      },
+      { sourceWindow: undefined },
+    );
+    expect(response).toEqual({ opened: true });
   });
 });

--- a/apps/desktop/src/main/__tests__/applications-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/applications-ipc.test.ts
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => {
     ),
     remoteBackend,
     remoteBackendForTarget: vi.fn(() => remoteBackend),
+    showThreadFromToolOutputIncidentExplorer: vi.fn(),
     showToolOutputIncidentExplorerWindow: vi.fn(),
   };
 });
@@ -88,6 +89,8 @@ vi.mock("../subagent-transcript-window", () => ({
 }));
 
 vi.mock("../tool-output-incident-explorer-window", () => ({
+  showThreadFromToolOutputIncidentExplorer:
+    mocks.showThreadFromToolOutputIncidentExplorer,
   showToolOutputIncidentExplorerWindow:
     mocks.showToolOutputIncidentExplorerWindow,
 }));
@@ -100,6 +103,7 @@ describe("application IPC", () => {
     mocks.discoverDesktopApplications.mockClear();
     mocks.openDesktopApplication.mockClear();
     mocks.remoteBackendForTarget.mockClear();
+    mocks.showThreadFromToolOutputIncidentExplorer.mockClear();
     mocks.showToolOutputIncidentExplorerWindow.mockClear();
   });
 
@@ -172,5 +176,22 @@ describe("application IPC", () => {
       { sourceWindow: undefined },
     );
     expect(response).toEqual({ opened: true });
+  });
+
+  it("routes incident-explorer thread navigation through its owner", async () => {
+    const { registerApplicationIpcHandlers } = await import("../ipc/applications");
+    const { TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    registerApplicationIpcHandlers();
+    const sender = { id: 42 };
+    const request = { backend: "codex" as const, threadId: "thread-1" };
+
+    await mocks.handlers.get(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
+    )?.({ sender }, request);
+
+    expect(mocks.showThreadFromToolOutputIncidentExplorer)
+      .toHaveBeenCalledWith(sender, request);
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AppServerBackendKind } from "@pwragent/shared";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
@@ -42,6 +42,82 @@ function createOverlayStoreMock() {
 }
 
 describe("DesktopBackendRegistry replay integration", () => {
+  it("pages normalized history and persists one completed analysis batch", async () => {
+    const replayClient = ReplayClient.fromFixture({
+      metadata: {
+        backend: "codex",
+        scenario: "tool-output-history-analysis",
+      },
+      steps: [
+        {
+          id: "initialize-analysis",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: { name: "Replay Codex", version: "1.0.0" },
+            methods: ["thread/read"],
+          },
+        },
+        {
+          id: "read-analysis-latest",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [],
+            messages: [],
+            pagination: {
+              hasPreviousPage: true,
+              previousCursor: "older-page",
+              supportsPagination: true,
+            },
+          },
+        },
+        {
+          id: "read-analysis-oldest",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [],
+            messages: [],
+            pagination: {
+              hasPreviousPage: false,
+              supportsPagination: true,
+            },
+          },
+        },
+      ],
+    });
+    const persistThreadToolHistoryAnalysis = vi.fn(async () => undefined);
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      persistThreadToolHistoryAnalysis,
+      readThreadToolAccounting: async () => ({
+        alerts: [],
+        invocations: [],
+        summaries: [],
+      }),
+    } as unknown as OverlayStoreLike;
+    const registry = new DesktopBackendRegistry({
+      codexClient: replayClient,
+      overlayStore,
+    });
+
+    const response = await registry.analyzeThreadToolHistory({
+      backend: "codex",
+      threadId: "fork-thread",
+    });
+
+    expect(response.coverage).toMatchObject({
+      completeness: "complete",
+      pageCount: 2,
+    });
+    expect(persistThreadToolHistoryAnalysis).toHaveBeenCalledOnce();
+    expect(persistThreadToolHistoryAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "fork-thread" }),
+    );
+    await registry.close();
+  });
+
   it("routes replay notifications through registry events and resolves replay requests through submitServerRequest", async () => {
     const replayClient = ReplayClient.fromFixture({
       metadata: {

--- a/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
@@ -88,14 +88,15 @@ describe("DesktopBackendRegistry replay integration", () => {
       ],
     });
     const persistThreadToolHistoryAnalysis = vi.fn(async () => undefined);
+    const readThreadToolAccounting = vi.fn(async () => ({
+      alerts: [],
+      invocations: [],
+      summaries: [],
+    }));
     const overlayStore = {
       ...createOverlayStoreMock(),
       persistThreadToolHistoryAnalysis,
-      readThreadToolAccounting: async () => ({
-        alerts: [],
-        invocations: [],
-        summaries: [],
-      }),
+      readThreadToolAccounting,
     } as unknown as OverlayStoreLike;
     const registry = new DesktopBackendRegistry({
       codexClient: replayClient,
@@ -115,6 +116,11 @@ describe("DesktopBackendRegistry replay integration", () => {
     expect(persistThreadToolHistoryAnalysis).toHaveBeenCalledWith(
       expect.objectContaining({ threadId: "fork-thread" }),
     );
+    expect(readThreadToolAccounting).toHaveBeenCalledWith({
+      backend: "codex",
+      includeAllInvocations: true,
+      threadId: "fork-thread",
+    });
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19059,7 +19059,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("persists a live large-output alert at the warning threshold without completion", async () => {
+  it("persists and aggregates live large-output alerts without completion", async () => {
     vi.useFakeTimers();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
@@ -19088,7 +19088,10 @@ command = "pnpm dev"
       const emit = (registry as unknown as {
         emit(event: AgentEvent): Promise<void>;
       }).emit.bind(registry);
-      const stream = async (delta: string): Promise<void> => {
+      const stream = async (
+        delta: string,
+        itemId = "cmd-1",
+      ): Promise<void> => {
         await emit({
           backend: "codex",
           notification: {
@@ -19096,7 +19099,7 @@ command = "pnpm dev"
             params: {
               threadId: "thread-1",
               turnId: "turn-1",
-              itemId: "cmd-1",
+              itemId,
               delta,
             },
           },
@@ -19140,8 +19143,33 @@ command = "pnpm dev"
           noisy: true,
           noisyReason: "large-output",
           outputChars: 2_000,
+          outputState: "available",
+          source: "live",
           status: "in_progress",
+          suggestedPrompt: expect.stringContaining("commandExecution"),
         }),
+      });
+
+      await stream("x".repeat(4_000), "cmd-2");
+      expect(persistThreadToolInvocationBoundary).toHaveBeenCalledTimes(2);
+      expect(persistThreadToolInvocationBoundary.mock.calls[1]?.[0]).toMatchObject({
+        alerts: [
+          {
+            invocationCount: 2,
+            invocationIds: [
+              "tool:codex:thread-1:turn-1:cmd-1",
+              "tool:codex:thread-1:turn-1:cmd-2",
+            ],
+            totalOutputChars: 8_000,
+            worstOutputChars: 4_000,
+          },
+        ],
+        invocation: {
+          invocationId: "tool:codex:thread-1:turn-1:cmd-2",
+          outputChars: 4_000,
+          outputState: "available",
+          source: "live",
+        },
       });
 
       await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19059,7 +19059,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("emits a live large-output alert at the warning threshold without another sqlite write", async () => {
+  it("persists a live large-output alert at the warning threshold without completion", async () => {
     vi.useFakeTimers();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
@@ -19067,8 +19067,12 @@ command = "pnpm dev"
     const upsertThreadToolInvocation = vi.fn(
       async (params: { invocation: unknown }) => params.invocation,
     );
+    const persistThreadToolInvocationBoundary = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
     const overlayStore = {
       ...createOverlayStoreMock(),
+      persistThreadToolInvocationBoundary,
       upsertThreadToolInvocation,
     };
     const registry = new DesktopBackendRegistry({
@@ -19122,9 +19126,26 @@ command = "pnpm dev"
           },
         ],
       });
+      expect(persistThreadToolInvocationBoundary).toHaveBeenCalledTimes(1);
+      expect(persistThreadToolInvocationBoundary).toHaveBeenCalledWith({
+        alerts: [
+          expect.objectContaining({
+            kind: "large-output",
+            severity: "warning",
+            totalOutputChars: 4_000,
+          }),
+        ],
+        invocation: expect.objectContaining({
+          invocationId: "tool:codex:thread-1:turn-1:cmd-1",
+          noisy: true,
+          noisyReason: "large-output",
+          outputChars: 2_000,
+          status: "in_progress",
+        }),
+      });
 
       await registry.close();
-      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(2);
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19059,6 +19059,77 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("emits a live large-output alert at the warning threshold without another sqlite write", async () => {
+    vi.useFakeTimers();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const upsertThreadToolInvocation = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      upsertThreadToolInvocation,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: overlayStore as never,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    try {
+      const emit = (registry as unknown as {
+        emit(event: AgentEvent): Promise<void>;
+      }).emit.bind(registry);
+      const stream = async (delta: string): Promise<void> => {
+        await emit({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "cmd-1",
+              delta,
+            },
+          },
+        } as AgentEvent);
+      };
+
+      await stream("x".repeat(2_000));
+      await vi.advanceTimersByTimeAsync(250);
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
+
+      // The warning total spans sqlite flush windows. A detector tied to the
+      // 250ms pending-write buffer would see two harmless 2,000-char chunks
+      // and never report that the command reached 4,000.
+      await stream("x".repeat(2_000));
+      const alertEvent = events.find(
+        (event) =>
+          event.notification.method === "thread/toolAccounting/updated",
+      );
+      expect(alertEvent?.notification.params).toMatchObject({
+        threadId: "thread-1",
+        triggeredAlerts: [
+          {
+            kind: "large-output",
+            severity: "warning",
+            totalOutputChars: 4_000,
+            turnId: "turn-1",
+          },
+        ],
+      });
+
+      await registry.close();
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("flushes buffered command output on the timer, without a lifecycle event", async () => {
     // A command can stream for minutes before it completes. Nothing else in
     // this suite exercises the timer — every other case flushes through

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -146,6 +146,10 @@ describe("codex environment runtime", () => {
   it("runs detached actions with the provided hydrated environment", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-runtime-"));
     const outputPath = path.join(root, "env.txt");
+    let resolveDetachedExit!: (event: { exitCode: number | null }) => void;
+    const detachedExit = new Promise<{ exitCode: number | null }>((resolve) => {
+      resolveDetachedExit = resolve;
+    });
 
     try {
       const result = await startLocalCodexEnvironmentAction({
@@ -155,6 +159,7 @@ describe("codex environment runtime", () => {
           ...process.env,
           PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
         },
+        onDetachedExit: resolveDetachedExit,
         runtime: {
           environmentId: "env",
           environmentName: "Env",
@@ -180,6 +185,10 @@ describe("codex environment runtime", () => {
       await expect(expectEventually(async () => await readFile(outputPath, "utf8"))).resolves.toBe(
         "hydrated",
       );
+      // File creation proves the shell ran, not that the detached Windows Job
+      // and its PowerShell launcher have released their cwd handles. Await the
+      // owner lifecycle before deleting that cwd.
+      await expect(detachedExit).resolves.toMatchObject({ exitCode: 0 });
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -29,10 +29,17 @@
   },
   "composer-draft-typing": {
     "commits": 70,
-    "note": "70 direct store saves (a stress case for prefix collapse, NOT the app's typing cadence \u2014 the renderer coalesces to one save per 5s): exactly one journal row survives, and commits track save calls because each save is its own transaction",
+    "note": "70 direct store saves (a stress case for prefix collapse, NOT the app's typing cadence — the renderer coalesces to one save per 5s): exactly one journal row survives, and commits track save calls because each save is its own transaction",
     "observedWalBytes": 1738640,
     "rowsChanged": 140,
     "statements": 209
+  },
+  "deferred-check-alert": {
+    "commits": 1,
+    "note": "five in-memory 30-second deferred checks and one persisted alert boundary",
+    "observedWalBytes": 12360,
+    "rowsChanged": 1,
+    "statements": 1
   },
   "federated-child-archive-ungroup": {
     "commits": 2,
@@ -93,8 +100,8 @@
   "streamed-command-output": {
     "commits": 2,
     "note": "500 streamed output deltas plus the completion for one command",
-    "observedWalBytes": 37080,
-    "rowsChanged": 2,
-    "statements": 2
+    "observedWalBytes": 49440,
+    "rowsChanged": 3,
+    "statements": 3
   }
 }

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -98,11 +98,18 @@
     "statements": 8
   },
   "streamed-command-output": {
-    "commits": 2,
+    "commits": 3,
     "note": "500 streamed output deltas plus the completion for one command",
-    "observedWalBytes": 49440,
-    "rowsChanged": 3,
-    "statements": 3
+    "observedWalBytes": 74160,
+    "rowsChanged": 5,
+    "statements": 5
+  },
+  "streamed-large-output-alert-boundary": {
+    "commits": 1,
+    "note": "one threshold-crossing streamed output window and its alert",
+    "observedWalBytes": 32960,
+    "rowsChanged": 2,
+    "statements": 2
   },
   "structured-mcp-output-alert": {
     "commits": 1,

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -103,5 +103,12 @@
     "observedWalBytes": 49440,
     "rowsChanged": 3,
     "statements": 3
+  },
+  "structured-mcp-output-alert": {
+    "commits": 1,
+    "note": "one large structured MCP result and its alert in one boundary",
+    "observedWalBytes": 32960,
+    "rowsChanged": 2,
+    "statements": 2
   }
 }

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -117,5 +117,12 @@
     "observedWalBytes": 32960,
     "rowsChanged": 2,
     "statements": 2
+  },
+  "tool-output-history-analysis": {
+    "commits": 1,
+    "note": "replace 25 deterministic history findings plus coverage metadata in one explicit analysis transaction",
+    "observedWalBytes": 28840,
+    "rowsChanged": 26,
+    "statements": 27
   }
 }

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -289,6 +289,54 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
       deltas.reduce((sum, delta) => sum + delta.length, 0),
     );
   });
+
+  it("replaces deterministic history findings without touching live records", async () => {
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation({ invocationId: "live-1", source: "live" }),
+    });
+    const historical = [
+      buildInvocation({
+        findingId: "history-1",
+        invocationId: "history-1",
+        source: "history",
+      }),
+      buildInvocation({
+        findingId: "history-2",
+        invocationId: "history-2",
+        source: "history",
+      }),
+    ];
+    const coverage = {
+      analyzedAt: 1_800_000_000_000,
+      analyzerVersion: "1",
+      completeness: "complete" as const,
+      entryCount: 4,
+      invocationCount: historical.length,
+      missingOutputCount: 0,
+      pageCount: 1,
+      scannedThrough: "oldest-entry",
+    };
+    await store.persistThreadToolHistoryAnalysis({
+      backend: "codex",
+      coverage,
+      invocations: historical,
+      threadId: "thread-1",
+    });
+    await store.persistThreadToolHistoryAnalysis({
+      backend: "codex",
+      coverage,
+      invocations: historical,
+      threadId: "thread-1",
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(accounting.analysis).toEqual(coverage);
+    expect(accounting.invocations.map((entry) => entry.invocationId).sort())
+      .toEqual(["history-1", "history-2", "live-1"]);
+  });
 });
 
 function buildInvocation(

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -337,6 +337,48 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
     expect(accounting.invocations.map((entry) => entry.invocationId).sort())
       .toEqual(["history-1", "history-2", "live-1"]);
   });
+
+  it("returns every finding only for an explicit unbounded accounting read", async () => {
+    const historical = Array.from({ length: 225 }, (_, index) =>
+      buildInvocation({
+        findingId: `history-${index}`,
+        invocationId: `history-${index}`,
+        itemId: `detail-${index}`,
+        noisy: true,
+        observedAt: 1_800_000_000_000 + index,
+        source: "history",
+      })
+    );
+    await store.persistThreadToolHistoryAnalysis({
+      backend: "codex",
+      coverage: {
+        analyzedAt: 1_800_000_001_000,
+        analyzerVersion: "1",
+        completeness: "complete",
+        entryCount: 225,
+        invocationCount: 225,
+        missingOutputCount: 0,
+        pageCount: 3,
+      },
+      invocations: historical,
+      threadId: "thread-1",
+    });
+
+    const ordinary = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const explorer = await store.readThreadToolAccounting({
+      backend: "codex",
+      includeAllInvocations: true,
+      threadId: "thread-1",
+    });
+
+    expect(ordinary.invocations).toHaveLength(200);
+    expect(explorer.invocations).toHaveLength(225);
+    expect(new Set(explorer.invocations.map((entry) => entry.invocationId)).size)
+      .toBe(225);
+  });
 });
 
 function buildInvocation(

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -216,6 +216,58 @@ describe("sqlite write metrics", () => {
     await registry.close();
   });
 
+  it("persists a streamed large-output alert boundary in one commit", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    const { writes } = await measureSqliteWrites(async () => {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: "thread-streaming-alert",
+            turnId: "turn-1",
+            itemId: "cmd-1",
+            delta: "x".repeat(4_100),
+          },
+        },
+      } as AgentEvent);
+    });
+
+    expectSqliteWriteBudget({
+      note: "one threshold-crossing streamed output window and its alert",
+      scenario: "streamed-large-output-alert-boundary",
+      writes,
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-streaming-alert",
+    });
+    expect(accounting.alerts).toEqual([
+      expect.objectContaining({
+        kind: "large-output",
+        totalOutputChars: 4_100,
+      }),
+    ]);
+    expect(accounting.invocations).toEqual([
+      expect.objectContaining({
+        noisy: true,
+        noisyReason: "large-output",
+        outputChars: 4_100,
+        status: "in_progress",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("holds five deferred checks and their first alert to one commit", async () => {
     vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -216,6 +216,55 @@ describe("sqlite write metrics", () => {
     await registry.close();
   });
 
+  it("holds five deferred checks and their first alert to one commit", async () => {
+    vi.useFakeTimers();
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    try {
+      const { writes } = await measureSqliteWrites(async () => {
+        for (let index = 0; index < 5; index += 1) {
+          vi.setSystemTime(1_800_000_000_000 + index * 30_000);
+          await emit({
+            backend: "codex",
+            notification: {
+              method: "item/completed",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                item: {
+                  id: `wait-${index + 1}`,
+                  type: "functionCall",
+                  name: "wait",
+                  status: "completed",
+                  arguments: {
+                    cell_id: `cell-${index + 1}`,
+                    yield_time_ms: 30_000,
+                  },
+                  functionCallOutput: "still running",
+                },
+              },
+            },
+          } as AgentEvent);
+        }
+      });
+
+      expectSqliteWriteBudget({
+        note: "five in-memory 30-second deferred checks and one persisted alert boundary",
+        scenario: "deferred-check-alert",
+        writes,
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
   it("holds a burst of live token usage to one commit", async () => {
     vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -265,6 +265,48 @@ describe("sqlite write metrics", () => {
     }
   });
 
+  it("holds one large structured MCP result and its alert to one commit", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    const { writes } = await measureSqliteWrites(async () => {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "mcp-1",
+              type: "mcpToolCall",
+              server: "playwright",
+              tool: "browser_tabs",
+              status: "completed",
+              arguments: { action: "list" },
+              result: {
+                content: [{ type: "text", text: "x".repeat(4_100) }],
+              },
+            },
+          },
+        },
+      } as AgentEvent);
+    });
+
+    expectSqliteWriteBudget({
+      note: "one large structured MCP result and its alert in one boundary",
+      scenario: "structured-mcp-output-alert",
+      writes,
+    });
+
+    await registry.close();
+  });
+
   it("holds a burst of live token usage to one commit", async () => {
     vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -89,6 +89,40 @@ describe("sqlite write metrics", () => {
     expect(metrics?.commits).toBe(1);
   });
 
+  it("persists one explicit history analysis in one transaction", async () => {
+    const invocations = Array.from({ length: 25 }, (_, index) => ({
+      ...buildInvocation(`history-tool-${index}`),
+      findingId: `history-tool-${index}`,
+      source: "history" as const,
+    }));
+    // This runs only on an explicit Analyze/Refresh action. Even at 20 manual
+    // analyses per day, one commit each is 20 commits/day; findings scale the
+    // statements inside the transaction, never the number of WAL flushes.
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.persistThreadToolHistoryAnalysis({
+        backend: "codex",
+        coverage: {
+          analyzedAt: 1_800_000_000_000,
+          analyzerVersion: "1",
+          completeness: "complete",
+          entryCount: 50,
+          invocationCount: invocations.length,
+          missingOutputCount: 0,
+          pageCount: 2,
+          scannedThrough: "oldest-entry",
+        },
+        invocations,
+        threadId: "thread-1",
+      });
+    });
+
+    expectSqliteWriteBudget({
+      note: "replace 25 deterministic history findings plus coverage metadata in one explicit analysis transaction",
+      scenario: "tool-output-history-analysis",
+      writes,
+    });
+  });
+
   it("holds each completed questionnaire transcript record to one commit", async () => {
     // This path runs once per completed questionnaire, never per streamed
     // event. At 100 questionnaires/day, one commit each is 100 commits/day;

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -449,14 +449,16 @@ describe("StateDb", () => {
   it("creates thread tool accounting tables", () => {
     const tables = stateDb.raw
       .prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?) ORDER BY name`,
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?) ORDER BY name`,
       )
       .all(
         "thread_tool_invocation_alerts",
         "thread_tool_invocations",
+        "thread_tool_analysis",
       ) as Array<{ name: string }>;
 
     expect(tables.map((table) => table.name)).toEqual([
+      "thread_tool_analysis",
       "thread_tool_invocation_alerts",
       "thread_tool_invocations",
     ]);

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -7,6 +7,7 @@ import {
   buildToolOutputMetrics,
   detectLargeToolOutput,
   detectNoisyPolling,
+  mergeLargeToolOutputIncident,
   normalizeToolInvocationCommand,
   toolInvocationFromNotification,
 } from "../app-server/tool-invocation-accounting";
@@ -461,6 +462,108 @@ describe("tool invocation accounting", () => {
     });
 
     expect(detection).toBeUndefined();
+  });
+
+  it("aggregates cases by turn and keeps a stable worst-case summary", () => {
+    const first = detectLargeToolOutput({
+      current: buildOutputInvocation(8_000),
+      previousOutputChars: 0,
+    })!;
+    const firstIncident = mergeLargeToolOutputIncident({ detection: first });
+    const second = detectLargeToolOutput({
+      current: {
+        ...buildOutputInvocation(12_000),
+        invocationId: "command-2",
+        itemId: "command-2",
+      },
+      previousOutputChars: 0,
+    })!;
+    const secondIncident = mergeLargeToolOutputIncident({
+      current: firstIncident.aggregate,
+      detection: second,
+    });
+
+    expect(secondIncident.shouldNotify).toBe(true);
+    expect(secondIncident.aggregate.alert).toMatchObject({
+      invocationCount: 2,
+      totalOutputChars: 20_000,
+      worstInvocationId: "command-2",
+      worstOutputChars: 12_000,
+    });
+  });
+
+  it("does not rewrite a live warning at terminal completion", () => {
+    const live = detectLargeToolOutput({
+      current: buildOutputInvocation(4_000),
+      previousOutputChars: 0,
+    })!;
+    const incident = mergeLargeToolOutputIncident({ detection: live });
+    const terminal = detectLargeToolOutput({
+      current: { ...buildOutputInvocation(4_000), status: "completed" },
+    })!;
+    const completed = mergeLargeToolOutputIncident({
+      current: incident.aggregate,
+      detection: terminal,
+    });
+
+    expect(completed.shouldNotify).toBe(false);
+  });
+
+  it("aggregates repeated polling cases under the turn and alert kind", () => {
+    const records = Array.from({ length: 6 }, (_, index) => ({
+      ...buildPollingInvocation(
+        `wait-${index + 1}`,
+        1_800_000_000_000 + index * 30_000,
+        (index + 1) * 10,
+      ),
+      normalizedCommand: undefined,
+      sessionId: undefined,
+      toolName: "wait",
+      turnId: "turn-1",
+    }));
+    const firstDetection = detectNoisyPolling({
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
+    })!;
+    const firstIncident = mergeLargeToolOutputIncident({
+      detection: firstDetection,
+    });
+    const secondIncident = mergeLargeToolOutputIncident({
+      current: firstIncident.aggregate,
+      detection: detectNoisyPolling({
+        current: records[5]!,
+        now: records[5]!.observedAt,
+        recent: records.slice(0, 5),
+      })!,
+    });
+
+    expect(secondIncident.aggregate.alert).toMatchObject({
+      alertId: "noisy-polling:codex:thread-1:turn-1",
+      invocationCount: 6,
+      totalOutputChars: 210,
+      worstInvocationId: "wait-6",
+      worstOutputChars: 60,
+    });
+  });
+
+  it("reopens a case only when it escalates to critical", () => {
+    const warning = mergeLargeToolOutputIncident({
+      detection: detectLargeToolOutput({
+        current: buildOutputInvocation(4_000),
+        previousOutputChars: 0,
+      })!,
+    });
+    const critical = mergeLargeToolOutputIncident({
+      current: warning.aggregate,
+      detection: detectLargeToolOutput({
+        current: buildOutputInvocation(40_000),
+        previousOutputChars: 4_000,
+      })!,
+    });
+
+    expect(critical.shouldNotify).toBe(true);
+    expect(critical.aggregate.alert.severity).toBe("critical");
   });
 });
 

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -5,6 +5,7 @@ import type {
 import { describe, expect, it } from "vitest";
 import {
   buildToolOutputMetrics,
+  detectLargeToolOutput,
   detectNoisyPolling,
   normalizeToolInvocationCommand,
   toolInvocationFromNotification,
@@ -44,6 +45,24 @@ describe("tool invocation accounting", () => {
     ).toEqual({
       category: "shell",
       normalizedCommand: "write stdin session 40500",
+    });
+    expect(
+      normalizeToolInvocationCommand({
+        args: { cell_id: "cell-9", yield_time_ms: 30_000 },
+        toolName: "wait",
+      }),
+    ).toEqual({
+      category: "polling",
+      normalizedCommand: "wait cell cell-9",
+    });
+    expect(
+      normalizeToolInvocationCommand({
+        command: "sleep 30",
+        toolName: "commandExecution",
+      }),
+    ).toEqual({
+      category: "polling",
+      normalizedCommand: "sleep 30",
     });
   });
 
@@ -240,30 +259,145 @@ describe("tool invocation accounting", () => {
     });
   });
 
-  it("detects repeated noisy write_stdin polling against one process session", () => {
+  it("accounts deferred wait function calls as polling", () => {
+    const invocation = toolInvocationFromNotification({
+      backend: "codex",
+      now: 1_800_000_030_000,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "wait-1",
+            type: "functionCall",
+            name: "wait",
+            status: "completed",
+            arguments: { cell_id: "cell-9", yield_time_ms: 30_000 },
+            functionCallOutput: "still running",
+          },
+        },
+      } as AppServerNotification,
+    });
+
+    expect(invocation).toMatchObject({
+      category: "polling",
+      normalizedCommand: "wait cell cell-9",
+      outputChars: 13,
+      sessionId: "cell-9",
+      toolName: "wait",
+      turnId: "turn-1",
+    });
+  });
+
+  it("detects five low-output write_stdin polls against one process session", () => {
     const records = [
-      buildPollingInvocation("tool-1", 1_800_000_000_000, 9_000),
-      buildPollingInvocation("tool-2", 1_800_000_030_000, 8_000),
-      buildPollingInvocation("tool-3", 1_800_000_060_000, 7_000),
+      buildPollingInvocation("tool-1", 1_800_000_000_000, 0),
+      buildPollingInvocation("tool-2", 1_800_000_030_000, 0),
+      buildPollingInvocation("tool-3", 1_800_000_060_000, 0),
+      buildPollingInvocation("tool-4", 1_800_000_090_000, 0),
+      buildPollingInvocation("tool-5", 1_800_000_120_000, 0),
     ];
 
     const detection = detectNoisyPolling({
-      current: records[2]!,
-      now: records[2]!.observedAt,
-      recent: records.slice(0, 2),
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
     });
 
-    expect(detection?.invocationIds).toEqual(["tool-1", "tool-2", "tool-3"]);
+    expect(detection?.invocationIds).toEqual([
+      "tool-1",
+      "tool-2",
+      "tool-3",
+      "tool-4",
+      "tool-5",
+    ]);
     expect(detection?.alert).toMatchObject({
-      estimatedOutputTokens: 6_000,
-      invocationCount: 3,
+      estimatedOutputTokens: 0,
+      invocationCount: 5,
       kind: "noisy-polling",
       sessionId: "40500",
-      totalOutputChars: 24_000,
+      totalOutputChars: 0,
     });
     expect(detection?.alert.suggestedPrompt).toContain(
       "create_monitor_delegation",
     );
+  });
+
+  it("groups deferred waits by turn even when each check has a new cell", () => {
+    const records = Array.from({ length: 5 }, (_, index) => ({
+      ...buildPollingInvocation(
+        `wait-${index + 1}`,
+        1_800_000_000_000 + index * 30_000,
+        12,
+      ),
+      normalizedCommand: `wait cell cell-${index + 1}`,
+      sessionId: `cell-${index + 1}`,
+      toolName: "wait",
+      turnId: "turn-1",
+    }));
+
+    const detection = detectNoisyPolling({
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
+    });
+
+    expect(detection?.alert).toMatchObject({
+      invocationCount: 5,
+      kind: "noisy-polling",
+      toolName: "wait",
+      turnId: "turn-1",
+    });
+  });
+
+  it("detects repeated shell sleeps as queued checks in one turn", () => {
+    const records = Array.from({ length: 5 }, (_, index) => ({
+      ...buildPollingInvocation(
+        `sleep-${index + 1}`,
+        1_800_000_000_000 + index * 30_000,
+        0,
+      ),
+      normalizedCommand: "sleep 30",
+      sessionId: undefined,
+      toolName: "commandExecution",
+      turnId: "turn-1",
+    }));
+
+    const detection = detectNoisyPolling({
+      current: records[4]!,
+      now: records[4]!.observedAt,
+      recent: records.slice(0, 4),
+    });
+
+    expect(detection?.alert).toMatchObject({
+      invocationCount: 5,
+      kind: "noisy-polling",
+      toolName: "commandExecution",
+      turnId: "turn-1",
+    });
+  });
+
+  it("warns at ten percent of the observed output cap and escalates at the cap", () => {
+    const warning = detectLargeToolOutput({
+      current: buildOutputInvocation(4_000),
+      previousOutputChars: 3_999,
+    });
+    const critical = detectLargeToolOutput({
+      current: buildOutputInvocation(40_000),
+      previousOutputChars: 39_999,
+    });
+
+    expect(warning?.alert).toMatchObject({
+      kind: "large-output",
+      severity: "warning",
+      totalOutputChars: 4_000,
+    });
+    expect(critical?.alert).toMatchObject({
+      kind: "large-output",
+      severity: "critical",
+      totalOutputChars: 40_000,
+    });
   });
 
   it("does not flag non-empty stdin writes as polling", () => {
@@ -310,5 +444,17 @@ function buildPollingInvocation(
     toolName: "write_stdin",
     updatedAt: observedAt,
     warningLines: 0,
+  };
+}
+
+function buildOutputInvocation(outputChars: number): ThreadToolInvocationRecord {
+  return {
+    ...buildPollingInvocation("command-1", 1_800_000_000_000, outputChars, "shell"),
+    estimatedOutputTokens: Math.ceil(outputChars / 4),
+    normalizedCommand: "pnpm test",
+    outputLines: 500,
+    status: "in_progress",
+    toolName: "commandExecution",
+    turnId: "turn-1",
   };
 }

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -214,6 +214,53 @@ describe("tool invocation accounting", () => {
     },
   );
 
+  it.each([
+    {
+      label: "structured object result",
+      result: {
+        tabs: [{ title: "x".repeat(4_100) }],
+      },
+    },
+    {
+      label: "MCP content array",
+      result: {
+        content: [{ type: "text", text: "x".repeat(4_100) }],
+      },
+    },
+  ])("accounts a large $label", ({ result }) => {
+    const invocation = toolInvocationFromNotification({
+      backend: "codex",
+      now: 1_800_000_030_000,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "mcp-1",
+            type: "mcpToolCall",
+            server: "playwright",
+            tool: "browser_tabs",
+            status: "completed",
+            arguments: { action: "list" },
+            result,
+          },
+        },
+      } as AppServerNotification,
+    });
+
+    expect(invocation).toMatchObject({
+      outputChars: JSON.stringify(result).length,
+      status: "completed",
+      toolName: "browser_tabs",
+    });
+    expect(detectLargeToolOutput({ current: invocation! })?.alert).toMatchObject({
+      kind: "large-output",
+      severity: "warning",
+      toolName: "browser_tabs",
+    });
+  });
+
   it("marks completed command invocations failed from success false or exit code", () => {
     const successFalseInvocation = toolInvocationFromNotification({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -608,3 +608,26 @@ function buildOutputInvocation(outputChars: number): ThreadToolInvocationRecord 
     turnId: "turn-1",
   };
 }
+
+describe("mcp invocation identity", () => {
+  it("categorizes by the protocol item type and keeps the server", () => {
+    /* The item declares itself: {type: "mcpToolCall", server, tool}. The
+       name-substring fallback filed Context7's `query-docs` under unknown
+       while `list_mcp_resources` matched by accident. */
+    expect(normalizeToolInvocationCommand({
+      itemType: "mcpToolCall",
+      server: "context7",
+      toolName: "query-docs",
+    })).toEqual({
+      category: "mcp",
+      normalizedCommand: "context7/query-docs",
+    });
+  });
+
+  it("still categorizes as mcp when the server is not recorded", () => {
+    expect(normalizeToolInvocationCommand({
+      itemType: "mcpToolCall",
+      toolName: "query-docs",
+    })).toEqual({ category: "mcp", normalizedCommand: "query-docs" });
+  });
+});

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -154,4 +154,32 @@ describe("tool-output incident explorer window", () => {
       { backend: "acp:grok", threadId: "another-thread" },
     )).toThrow("can only open its own thread");
   });
+
+  it("cleans up after Electron destroys the closed window", async () => {
+    const { showToolOutputIncidentExplorerWindow } = await import(
+      "../tool-output-incident-explorer-window"
+    );
+    const request = {
+      backend: "codex" as const,
+      threadId: "thread-destroyed",
+      title: "Destroyed window",
+    };
+    showToolOutputIncidentExplorerWindow(request);
+    const window = mocks.windows[0]!;
+    const closedHandler = window.on.mock.calls.find(
+      ([event]) => event === "closed",
+    )?.[1] as (() => void) | undefined;
+    expect(closedHandler).toBeDefined();
+
+    Object.defineProperty(window, "webContents", {
+      configurable: true,
+      get: () => {
+        throw new Error("Object has been destroyed");
+      },
+    });
+
+    expect(() => closedHandler?.()).not.toThrow();
+    showToolOutputIncidentExplorerWindow(request);
+    expect(mocks.BrowserWindow).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const windows: Array<{
+    isDestroyed: ReturnType<typeof vi.fn>;
+    loadFile: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    webContents: object;
+  }> = [];
+  const BrowserWindow = vi.fn(function BrowserWindowMock(
+    this: unknown,
+    _options: unknown,
+  ) {
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      loadFile: vi.fn(async () => undefined),
+      on: vi.fn(),
+      webContents: {},
+    };
+    windows.push(window);
+    return window;
+  });
+  return {
+    applyWindowSecurityHardening: vi.fn(),
+    BrowserWindow,
+    registerWindowChannels: vi.fn(),
+    showAndFocusAuxiliaryWindow: vi.fn(),
+    windows,
+  };
+});
+
+vi.mock("electron", () => ({ BrowserWindow: mocks.BrowserWindow }));
+vi.mock("../log", () => ({
+  getMainLogger: () => ({ debug: vi.fn() }),
+}));
+vi.mock("../window", () => ({
+  applyWindowSecurityHardening: mocks.applyWindowSecurityHardening,
+  getPreloadPath: () => "/preload.js",
+  getRendererEntry: () => ({ kind: "file", value: "/renderer.html" }),
+}));
+vi.mock("../window-channels", () => ({
+  WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER: "tool-output-incident-explorer",
+  registerWindowChannels: mocks.registerWindowChannels,
+}));
+vi.mock("../settings/appearance-bootstrap", () => ({
+  readBootstrapAppearance: () => ({ theme: "dark" }),
+  themedWindowAdditionalArguments: () => ["--appearance=dark"],
+  themedWindowBackgroundColor: () => "#000000",
+}));
+vi.mock("../auxiliary-window-chrome", () => ({
+  auxiliaryWindowChromeOptions: () => ({ frame: true }),
+  hideAuxiliaryWindowMenuBar: vi.fn(),
+  registerAuxiliaryWindowTitle: vi.fn(),
+  showAndFocusAuxiliaryWindow: mocks.showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady: vi.fn(),
+}));
+vi.mock("../window-placement", () => ({
+  placementForSourceDisplay: () => ({ x: 10, y: 20 }),
+  positionWindowForSourceDisplay: vi.fn(),
+}));
+
+describe("tool-output incident explorer window", () => {
+  beforeEach(() => {
+    mocks.BrowserWindow.mockClear();
+    mocks.windows.length = 0;
+    mocks.applyWindowSecurityHardening.mockClear();
+    mocks.registerWindowChannels.mockClear();
+    mocks.showAndFocusAuxiliaryWindow.mockClear();
+  });
+
+  it("creates one hardened inspection-only window per thread", async () => {
+    const { showToolOutputIncidentExplorerWindow } = await import(
+      "../tool-output-incident-explorer-window"
+    );
+    const request = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      title: "Noisy work",
+    };
+    showToolOutputIncidentExplorerWindow(request);
+    showToolOutputIncidentExplorerWindow(request);
+
+    expect(mocks.BrowserWindow).toHaveBeenCalledTimes(1);
+    expect(mocks.BrowserWindow.mock.calls[0]?.[0]).toMatchObject({
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+    expect(mocks.applyWindowSecurityHardening).toHaveBeenCalledOnce();
+    expect(mocks.registerWindowChannels).toHaveBeenCalledWith(
+      mocks.windows[0],
+      "tool-output-incident-explorer",
+      expect.any(Array),
+    );
+    expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
+      "/renderer.html",
+      {
+        hash: "tool-output-incidents/codex/thread-1/Noisy%20work",
+      },
+    );
+    expect(mocks.showAndFocusAuxiliaryWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => {
     isDestroyed: ReturnType<typeof vi.fn>;
     loadFile: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
-    webContents: object;
+    webContents: { send: ReturnType<typeof vi.fn> };
   }> = [];
   const BrowserWindow = vi.fn(function BrowserWindowMock(
     this: unknown,
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => {
       isDestroyed: vi.fn(() => false),
       loadFile: vi.fn(async () => undefined),
       on: vi.fn(),
-      webContents: {},
+      webContents: { send: vi.fn() },
     };
     windows.push(window);
     return window;
@@ -101,5 +101,8 @@ describe("tool-output incident explorer window", () => {
       },
     );
     expect(mocks.showAndFocusAuxiliaryWindow).toHaveBeenCalledOnce();
+    expect(mocks.windows[0]?.webContents.send).toHaveBeenCalledWith(
+      "tool-output-incident-explorer:refresh",
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -5,7 +5,11 @@ const mocks = vi.hoisted(() => {
     isDestroyed: ReturnType<typeof vi.fn>;
     loadFile: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
-    webContents: { send: ReturnType<typeof vi.fn> };
+    webContents: {
+      id: number;
+      isDestroyed: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
+    };
   }> = [];
   const BrowserWindow = vi.fn(function BrowserWindowMock(
     this: unknown,
@@ -15,7 +19,11 @@ const mocks = vi.hoisted(() => {
       isDestroyed: vi.fn(() => false),
       loadFile: vi.fn(async () => undefined),
       on: vi.fn(),
-      webContents: { send: vi.fn() },
+      webContents: {
+        id: windows.length + 1,
+        isDestroyed: vi.fn(() => false),
+        send: vi.fn(),
+      },
     };
     windows.push(window);
     return window;
@@ -25,6 +33,7 @@ const mocks = vi.hoisted(() => {
     BrowserWindow,
     registerWindowChannels: vi.fn(),
     showAndFocusAuxiliaryWindow: vi.fn(),
+    requestShowThread: vi.fn(),
     windows,
   };
 });
@@ -58,6 +67,9 @@ vi.mock("../window-placement", () => ({
   placementForSourceDisplay: () => ({ x: 10, y: 20 }),
   positionWindowForSourceDisplay: vi.fn(),
 }));
+vi.mock("../window-show-thread", () => ({
+  requestShowThread: mocks.requestShowThread,
+}));
 
 describe("tool-output incident explorer window", () => {
   beforeEach(() => {
@@ -66,6 +78,7 @@ describe("tool-output incident explorer window", () => {
     mocks.applyWindowSecurityHardening.mockClear();
     mocks.registerWindowChannels.mockClear();
     mocks.showAndFocusAuxiliaryWindow.mockClear();
+    mocks.requestShowThread.mockClear();
   });
 
   it("creates one hardened inspection-only window per thread", async () => {
@@ -76,6 +89,7 @@ describe("tool-output incident explorer window", () => {
       backend: "codex" as const,
       threadId: "thread-1",
       title: "Noisy work",
+      projectLabel: "PwrAgent",
     };
     showToolOutputIncidentExplorerWindow(request);
     showToolOutputIncidentExplorerWindow(request);
@@ -97,12 +111,47 @@ describe("tool-output incident explorer window", () => {
     expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
       "/renderer.html",
       {
-        hash: "tool-output-incidents/codex/thread-1/Noisy%20work",
+        hash: "tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent",
       },
     );
     expect(mocks.showAndFocusAuxiliaryWindow).toHaveBeenCalledOnce();
     expect(mocks.windows[0]?.webContents.send).toHaveBeenCalledWith(
       "tool-output-incident-explorer:refresh",
+      request,
     );
+  });
+
+  it("routes a thread-chip click back to the explorer's exact owner window", async () => {
+    const {
+      showThreadFromToolOutputIncidentExplorer,
+      showToolOutputIncidentExplorerWindow,
+    } = await import("../tool-output-incident-explorer-window");
+    const ownerWebContents = {
+      isDestroyed: vi.fn(() => false),
+      send: vi.fn(),
+    };
+    const sourceWindow = {
+      isDestroyed: vi.fn(() => false),
+      webContents: ownerWebContents,
+    };
+    showToolOutputIncidentExplorerWindow({
+      backend: "acp:grok",
+      threadId: "thread-owned",
+      title: "Owned thread",
+    }, { sourceWindow } as never);
+
+    showThreadFromToolOutputIncidentExplorer(
+      mocks.windows[0]!.webContents as never,
+      { backend: "acp:grok", threadId: "thread-owned" },
+    );
+
+    expect(mocks.requestShowThread).toHaveBeenCalledWith(
+      { backend: "acp:grok", threadId: "thread-owned" },
+      { preferWebContents: ownerWebContents },
+    );
+    expect(() => showThreadFromToolOutputIncidentExplorer(
+      mocks.windows[0]!.webContents as never,
+      { backend: "acp:grok", threadId: "another-thread" },
+    )).toThrow("can only open its own thread");
   });
 });

--- a/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
@@ -1,0 +1,127 @@
+import type { AppServerThreadReplay } from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import { analyzeNormalizedToolReplay } from "../app-server/tool-output-replay-analyzer";
+
+describe("normalized tool-output replay analyzer", () => {
+  it("classifies structured MCP output and proposes targeted pagination", () => {
+    const analysis = analyzeNormalizedToolReplay({
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex",
+      complete: true,
+      pages: [replayWithDetail({
+        displayCommand: "mcp__github__search({\"query\":\"is:open\"})",
+        output: JSON.stringify({ items: Array.from({ length: 600 }, (_, id) => ({ id })) }),
+        source: "tool",
+      })],
+      threadId: "thread-mcp",
+    });
+
+    expect(analysis.invocations[0]).toMatchObject({
+      category: "mcp",
+      noisy: true,
+      source: "history",
+    });
+    expect(analysis.invocations[0]?.suggestedPrompt).toContain(
+      "request only targeted fields and use pagination",
+    );
+    expect(analysis.invocations[0]?.suggestedPrompt).toContain(
+      "mcp__github__search",
+    );
+  });
+
+  it("marks compacted and truncated replay coverage incomplete", () => {
+    const compacted = replayWithDetail({
+      displayCommand: "sed -n '1,10000p' giant.log",
+      label: "Output compacted out of context",
+      source: "shell",
+    });
+    const truncated = replayWithDetail({
+      displayCommand: "rg error .",
+      output: `${"match\n".repeat(900)}output truncated`,
+      source: "shell",
+    });
+    const analysis = analyzeNormalizedToolReplay({
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex",
+      complete: true,
+      pages: [compacted, truncated],
+      threadId: "thread-partial",
+    });
+
+    expect(analysis.coverage).toMatchObject({
+      completeness: "partial",
+      missingOutputCount: 1,
+      pageCount: 2,
+    });
+    expect(analysis.coverage.explanation).toContain("lower bound");
+    expect(analysis.invocations.map((entry) => entry.outputState)).toEqual([
+      "compacted",
+      "truncated",
+    ]);
+  });
+
+  it("attributes inherited normalized replay to a fork with idempotent IDs", () => {
+    const inheritedReplay = replayWithDetail({
+      displayCommand: "cat inherited-build.log",
+      output: "x".repeat(5_000),
+      source: "shell",
+    });
+    const params = {
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex" as const,
+      complete: true,
+      pages: [inheritedReplay, inheritedReplay],
+      threadId: "fork-thread-id",
+    };
+    const first = analyzeNormalizedToolReplay(params);
+    const second = analyzeNormalizedToolReplay(params);
+
+    expect(first.invocations[0]).toMatchObject({
+      threadId: "fork-thread-id",
+      turnId: "inherited-turn",
+    });
+    expect(first.invocations).toHaveLength(1);
+    expect(first.coverage.entryCount).toBe(1);
+    expect(second.invocations[0]?.invocationId)
+      .toBe(first.invocations[0]?.invocationId);
+  });
+});
+
+function replayWithDetail(params: {
+  displayCommand: string;
+  label?: string;
+  output?: string;
+  source: "agent" | "shell" | "tool";
+}): AppServerThreadReplay {
+  return {
+    entries: [{
+      type: "activity",
+      id: `activity-${params.displayCommand.slice(0, 8)}`,
+      createdAt: 1_700_000_000_000,
+      status: "completed",
+      summary: "Tool call",
+      details: [{
+        id: "detail-1",
+        kind: "command",
+        label: params.label ?? params.displayCommand,
+        status: "completed",
+        command: {
+          displayCommand: params.displayCommand,
+          exitCode: 0,
+          ...(params.output !== undefined ? { output: params.output } : {}),
+          source: params.source,
+        },
+      }],
+      turn: {
+        id: "inherited-turn",
+        status: "completed",
+        completedAt: 1_700_000_000_100,
+      },
+    }],
+    messages: [],
+    pagination: {
+      hasPreviousPage: false,
+      supportsPagination: true,
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
@@ -18,6 +18,7 @@ describe("normalized tool-output replay analyzer", () => {
 
     expect(analysis.invocations[0]).toMatchObject({
       category: "mcp",
+      itemId: "detail-1",
       noisy: true,
       source: "history",
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10752,6 +10752,12 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: params.threadId,
     });
+    /* The operator's dismissal/mute for this thread, so a freshly launched
+       renderer honors a decision made in an earlier session. */
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
     await this.emit({
       backend: params.backend,
       notification: {
@@ -10759,6 +10765,9 @@ export class DesktopBackendRegistry {
         params: {
           threadId: params.threadId,
           toolAccounting,
+          ...(overlay?.toolIncidentNotice
+            ? { incidentNotice: overlay.toolIncidentNotice }
+            : {}),
           ...(params.triggeredAlerts?.length
             ? { triggeredAlerts: params.triggeredAlerts }
             : {}),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6669,8 +6669,8 @@ export class DesktopBackendRegistry {
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes every flush and streamed alert boundary so a timer-driven write
-   * `item/completed` write it accumulated before — the store keeps the
-   * terminal status and stops summing once a row is terminal, so an
+   * can never land after the `item/completed` write it accumulated before. The
+   * store keeps the terminal status and stops summing once a row is terminal, so an
    * out-of-order delta flush would silently under-count the command's output.
    */
   private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8839,6 +8839,9 @@ export class DesktopBackendRegistry {
       typeof this.overlayStore.readThreadToolAccounting === "function"
         ? await this.overlayStore.readThreadToolAccounting({
             backend,
+            ...(request.includeAllToolInvocations
+              ? { includeAllInvocations: true }
+              : {}),
             threadId: request.threadId,
           })
         : undefined;
@@ -10578,6 +10581,9 @@ export class DesktopBackendRegistry {
       typeof this.overlayStore.readThreadToolAccounting === "function"
         ? await this.overlayStore.readThreadToolAccounting({
             backend,
+            ...(request.includeAllToolInvocations
+              ? { includeAllInvocations: true }
+              : {}),
             threadId: request.threadId,
           })
         : undefined;
@@ -10656,6 +10662,7 @@ export class DesktopBackendRegistry {
     });
     const accounting = await this.overlayStore.readThreadToolAccounting({
       backend: request.backend,
+      includeAllInvocations: true,
       threadId: request.threadId,
     });
     await this.emitThreadToolAccountingUpdated({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -253,6 +253,7 @@ import {
   type ThreadOverlayState,
   type ThreadWorkspaceHandoffStrategy,
   type ThreadSubAgentSummary,
+  type ThreadToolInvocationAlert,
   type ThreadToolInvocationRecord,
   type ThreadUsageLineRecord,
   type PrSummary,
@@ -440,8 +441,10 @@ import {
   createProtocolLogObserverFromEnv,
 } from "./protocol-log-observer";
 import {
+  detectLargeToolOutput,
   detectNoisyPolling,
   mergeStreamedToolInvocationDeltas,
+  mergeToolInvocationLifecycleWithStreamedOutput,
   toolAccountingLookbackSince,
   toolInvocationFromNotification,
 } from "./tool-invocation-accounting";
@@ -6322,6 +6325,8 @@ type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
     | "readThreadGitWorkingStateCache"
     | "listRemoteThreadPins"
     | "reconcileOrphanedThreadSubAgents"
+    | "markThreadToolInvocationsNoisy"
+    | "persistThreadToolInvocationBoundary"
     | "upsertThreadUsageLines"
     | "writeThreadGitWorkingStateCacheEntry"
   >
@@ -6633,6 +6638,25 @@ export class DesktopBackendRegistry {
     string,
     ThreadToolInvocationRecord
   >();
+  /**
+   * Full in-memory output totals for active commands. Flush windows clear the
+   * sqlite write buffer every 250ms, but warning thresholds must span those
+   * windows or a steady stream of small chunks never reaches 4,000 chars.
+   */
+  private readonly streamedToolInvocationOutputTotals = new Map<
+    string,
+    ThreadToolInvocationRecord
+  >();
+  /**
+   * Short-lived polling samples used only for replay-amplification detection.
+   * Persisting every `wait` / `write_stdin` check would turn the detector into
+   * a timer-driven sqlite writer, so only incident boundaries reach sqlite.
+   */
+  private readonly volatileDeferredCheckInvocations = new Map<
+    string,
+    ThreadToolInvocationRecord[]
+  >();
+  private readonly persistedToolInvocationAlertCounts = new Map<string, number>();
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes every flush so a timer-driven write can never land after the
@@ -10639,6 +10663,7 @@ export class DesktopBackendRegistry {
   private async emitThreadToolAccountingUpdated(params: {
     backend: AppServerBackendKind;
     threadId: string;
+    triggeredAlerts?: ThreadToolInvocationAlert[];
   }): Promise<void> {
     if (typeof this.overlayStore.readThreadToolAccounting !== "function") {
       return;
@@ -10654,6 +10679,9 @@ export class DesktopBackendRegistry {
         params: {
           threadId: params.threadId,
           toolAccounting,
+          ...(params.triggeredAlerts?.length
+            ? { triggeredAlerts: params.triggeredAlerts }
+            : {}),
         },
       },
     });
@@ -21752,73 +21780,258 @@ export class DesktopBackendRegistry {
       // `write_stdin`), so nothing downstream needs this write to have landed
       // before the event reaches listeners. Accumulate and let the flush timer
       // write it.
-      this.bufferStreamedToolInvocationDelta(invocation);
+      const buffered = this.bufferStreamedToolInvocationDelta(invocation);
+      const detection = detectLargeToolOutput({
+        current: buffered.current,
+        now,
+        previousOutputChars: buffered.previousOutputChars,
+      });
+      if (detection) {
+        await this.emitThreadToolAccountingUpdated({
+          backend: invocation.backend,
+          threadId: invocation.threadId,
+          triggeredAlerts: [detection.alert],
+        });
+      }
       return;
     }
+
+    const invocationWithStreamedOutput =
+      mergeToolInvocationLifecycleWithStreamedOutput(
+        invocation,
+        this.streamedToolInvocationOutputTotals.get(invocation.invocationId),
+      );
+    if (event.notification.method === "item/completed") {
+      this.streamedToolInvocationOutputTotals.delete(invocation.invocationId);
+    }
+    let shouldNotify = event.notification.method === "item/completed";
+    const triggeredAlerts: ThreadToolInvocationAlert[] = [];
+    const largeOutputDetection = detectLargeToolOutput({
+      current: invocationWithStreamedOutput,
+      now,
+    });
+    const isVolatileDeferredCheck =
+      invocationWithStreamedOutput.category === "polling"
+      && (
+        invocationWithStreamedOutput.toolName === "wait"
+        || invocationWithStreamedOutput.toolName === "write_stdin"
+      );
+    const volatileRecent = isVolatileDeferredCheck
+      ? this.readVolatileDeferredChecks(invocationWithStreamedOutput, now)
+      : [];
+    const pollingDetection =
+      typeof this.overlayStore.readRecentThreadToolInvocations === "function"
+      ? detectNoisyPolling({
+          current: invocationWithStreamedOutput,
+          now,
+          recent: [
+            ...volatileRecent,
+            ...this.overlayStore.readRecentThreadToolInvocations({
+              backend: invocationWithStreamedOutput.backend,
+              limit:
+                invocationWithStreamedOutput.toolName === "commandExecution"
+                  ? 50
+                  : 12,
+              ...(invocationWithStreamedOutput.toolName === "wait"
+                ? {}
+                : {
+                    processId: invocationWithStreamedOutput.processId,
+                    sessionId: invocationWithStreamedOutput.sessionId,
+                  }),
+              since: toolAccountingLookbackSince(now),
+              threadId: invocationWithStreamedOutput.threadId,
+              toolName: invocationWithStreamedOutput.toolName,
+            }),
+          ],
+        })
+      : undefined;
+    if (isVolatileDeferredCheck) {
+      this.rememberVolatileDeferredCheck(invocationWithStreamedOutput, now);
+    }
+    const noisyReason = pollingDetection
+      ? "repeat-polling-output"
+      : largeOutputDetection
+        ? "large-output"
+        : undefined;
 
     // Land accumulated stream output before the lifecycle row: the store stops
     // summing once a row is terminal, so a delta flushed after `item/completed`
     // would be dropped down to a MAX() and under-count the command.
     await this.flushStreamedToolInvocationDeltas();
 
-    const stored = await this.overlayStore.upsertThreadToolInvocation({
-      invocation,
-    });
-    let shouldNotify = event.notification.method === "item/completed";
+    const previousPersistedPollingCount = pollingDetection
+      ? this.persistedToolInvocationAlertCounts.get(
+          pollingDetection.alert.alertId,
+        )
+      : undefined;
+    const shouldPersistPollingAlert = Boolean(
+      pollingDetection
+      && (
+        previousPersistedPollingCount === undefined
+        || pollingDetection.alert.invocationCount
+          >= previousPersistedPollingCount * 2
+      ),
+    );
+    const alertsToPersist = [
+      ...(largeOutputDetection ? [largeOutputDetection.alert] : []),
+      ...(pollingDetection && shouldPersistPollingAlert
+        ? [pollingDetection.alert]
+        : []),
+    ];
+    if (isVolatileDeferredCheck && !largeOutputDetection) {
+      if (
+        pollingDetection
+        && shouldPersistPollingAlert
+        && typeof this.overlayStore.upsertThreadToolInvocationAlert === "function"
+      ) {
+        await this.overlayStore.upsertThreadToolInvocationAlert({
+          alert: pollingDetection.alert,
+        });
+        this.persistedToolInvocationAlertCounts.set(
+          pollingDetection.alert.alertId,
+          pollingDetection.alert.invocationCount,
+        );
+      }
+      if (pollingDetection) {
+        await this.emitThreadToolAccountingUpdated({
+          backend: invocationWithStreamedOutput.backend,
+          threadId: invocationWithStreamedOutput.threadId,
+          triggeredAlerts: [pollingDetection.alert],
+        });
+      }
+      return;
+    }
+    const previousNoisyInvocationIds =
+      pollingDetection && previousPersistedPollingCount === undefined
+        ? pollingDetection.invocationIds.filter(
+            (invocationId) => invocationId !== invocation.invocationId,
+          )
+        : [];
+    const invocationToPersist = noisyReason
+      ? {
+          ...invocation,
+          noisy: true,
+          noisyReason,
+        }
+      : invocation;
+    let stored: ThreadToolInvocationRecord;
     if (
-      typeof this.overlayStore.readRecentThreadToolInvocations === "function" &&
-      typeof this.overlayStore.markThreadToolInvocationNoisy === "function" &&
-      typeof this.overlayStore.upsertThreadToolInvocationAlert === "function"
+      typeof this.overlayStore.persistThreadToolInvocationBoundary === "function"
     ) {
-      const recent = this.overlayStore.readRecentThreadToolInvocations({
-        backend: stored.backend,
-        limit: 12,
-        processId: stored.processId,
-        sessionId: stored.sessionId,
-        since: toolAccountingLookbackSince(now),
-        threadId: stored.threadId,
-        toolName: stored.toolName,
+      stored = await this.overlayStore.persistThreadToolInvocationBoundary({
+        alerts: alertsToPersist,
+        invocation: invocationToPersist,
+        noisyInvocationIds: previousNoisyInvocationIds,
+        ...(previousNoisyInvocationIds.length
+          ? { noisyReason: "repeat-polling-output" }
+          : {}),
       });
-      const detection = detectNoisyPolling({
-        current: stored,
-        now,
-        recent,
+    } else {
+      stored = await this.overlayStore.upsertThreadToolInvocation({
+        invocation: invocationToPersist,
       });
-      if (detection) {
-        for (const invocationId of detection.invocationIds) {
-          await this.overlayStore.markThreadToolInvocationNoisy({
-            invocationId,
+      if (previousNoisyInvocationIds.length > 0) {
+        if (
+          typeof this.overlayStore.markThreadToolInvocationsNoisy === "function"
+        ) {
+          await this.overlayStore.markThreadToolInvocationsNoisy({
+            invocationIds: previousNoisyInvocationIds,
             reason: "repeat-polling-output",
           });
+        } else if (
+          typeof this.overlayStore.markThreadToolInvocationNoisy === "function"
+        ) {
+          for (const invocationId of previousNoisyInvocationIds) {
+            await this.overlayStore.markThreadToolInvocationNoisy({
+              invocationId,
+              reason: "repeat-polling-output",
+            });
+          }
         }
-        await this.overlayStore.upsertThreadToolInvocationAlert({
-          alert: detection.alert,
-        });
-        shouldNotify = true;
       }
+      if (typeof this.overlayStore.upsertThreadToolInvocationAlert === "function") {
+        for (const alert of alertsToPersist) {
+          await this.overlayStore.upsertThreadToolInvocationAlert({ alert });
+        }
+      }
+    }
+    if (pollingDetection && shouldPersistPollingAlert) {
+      this.persistedToolInvocationAlertCounts.set(
+        pollingDetection.alert.alertId,
+        pollingDetection.alert.invocationCount,
+      );
+    }
+    if (largeOutputDetection) {
+      triggeredAlerts.push(largeOutputDetection.alert);
+      shouldNotify = true;
+    }
+    if (pollingDetection) {
+      triggeredAlerts.push(pollingDetection.alert);
+      shouldNotify = true;
     }
 
     if (shouldNotify) {
       await this.emitThreadToolAccountingUpdated({
         backend: stored.backend,
         threadId: stored.threadId,
+        triggeredAlerts,
       });
     }
   }
 
   private bufferStreamedToolInvocationDelta(
     invocation: ThreadToolInvocationRecord,
-  ): void {
+  ): {
+    current: ThreadToolInvocationRecord;
+    previousOutputChars: number;
+  } {
     const accumulated = this.pendingToolInvocationDeltas.get(
       invocation.invocationId,
     );
+    const pending = accumulated
+      ? mergeStreamedToolInvocationDeltas(accumulated, invocation)
+      : invocation;
+    const accumulatedTotal = this.streamedToolInvocationOutputTotals.get(
+      invocation.invocationId,
+    );
+    const current = accumulatedTotal
+      ? mergeStreamedToolInvocationDeltas(accumulatedTotal, invocation)
+      : invocation;
     this.pendingToolInvocationDeltas.set(
       invocation.invocationId,
-      accumulated
-        ? mergeStreamedToolInvocationDeltas(accumulated, invocation)
-        : invocation,
+      pending,
     );
+    this.streamedToolInvocationOutputTotals.set(invocation.invocationId, current);
     this.scheduleStreamedToolInvocationFlush();
+    return {
+      current,
+      previousOutputChars: accumulatedTotal?.outputChars ?? 0,
+    };
+  }
+
+  private readVolatileDeferredChecks(
+    invocation: ThreadToolInvocationRecord,
+    now: number,
+  ): ThreadToolInvocationRecord[] {
+    const key = [invocation.backend, invocation.threadId].join(":");
+    const recent = (
+      this.volatileDeferredCheckInvocations.get(key) ?? []
+    ).filter((record) => record.observedAt >= toolAccountingLookbackSince(now));
+    if (recent.length > 0) {
+      this.volatileDeferredCheckInvocations.set(key, recent);
+    } else {
+      this.volatileDeferredCheckInvocations.delete(key);
+    }
+    return recent;
+  }
+
+  private rememberVolatileDeferredCheck(
+    invocation: ThreadToolInvocationRecord,
+    now: number,
+  ): void {
+    const key = [invocation.backend, invocation.threadId].join(":");
+    const recent = this.readVolatileDeferredChecks(invocation, now);
+    this.volatileDeferredCheckInvocations.set(key, [...recent, invocation]);
   }
 
   private scheduleStreamedToolInvocationFlush(): void {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6659,7 +6659,7 @@ export class DesktopBackendRegistry {
   private readonly persistedToolInvocationAlertCounts = new Map<string, number>();
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
-   * Serializes every flush so a timer-driven write can never land after the
+   * Serializes every flush and streamed alert boundary so a timer-driven write
    * `item/completed` write it accumulated before — the store keeps the
    * terminal status and stops summing once a row is terminal, so an
    * out-of-order delta flush would silently under-count the command's output.
@@ -21777,9 +21777,9 @@ export class DesktopBackendRegistry {
     if (event.notification.method === "item/commandExecution/outputDelta") {
       // Streamed output never notifies anyone (`shouldNotify` stays false for
       // deltas) and never triggers noisy-polling detection (that only looks at
-      // `write_stdin`), so nothing downstream needs this write to have landed
-      // before the event reaches listeners. Accumulate and let the flush timer
-      // write it.
+      // `write_stdin`). Ordinary deltas can wait for the flush timer; a large-
+      // output threshold crossing becomes a durable boundary before its live
+      // alert reaches listeners.
       const buffered = this.bufferStreamedToolInvocationDelta(invocation);
       const detection = detectLargeToolOutput({
         current: buffered.current,
@@ -21787,9 +21787,13 @@ export class DesktopBackendRegistry {
         previousOutputChars: buffered.previousOutputChars,
       });
       if (detection) {
+        const stored = await this.persistStreamedToolInvocationAlertBoundary({
+          alert: detection.alert,
+          invocationId: invocation.invocationId,
+        });
         await this.emitThreadToolAccountingUpdated({
-          backend: invocation.backend,
-          threadId: invocation.threadId,
+          backend: stored.backend,
+          threadId: stored.threadId,
           triggeredAlerts: [detection.alert],
         });
       }
@@ -22007,6 +22011,61 @@ export class DesktopBackendRegistry {
       current,
       previousOutputChars: accumulatedTotal?.outputChars ?? 0,
     };
+  }
+
+  /**
+   * Replace the threshold-crossing delta's ordinary buffered write with one
+   * durable invocation-plus-alert boundary. Reserving the pending delta before
+   * joining the flush chain prevents a timer drain from stealing it, while the
+   * chain still guarantees that any older window lands first.
+   */
+  private persistStreamedToolInvocationAlertBoundary(params: {
+    alert: ThreadToolInvocationAlert;
+    invocationId: string;
+  }): Promise<ThreadToolInvocationRecord> {
+    const pending = this.pendingToolInvocationDeltas.get(params.invocationId);
+    if (!pending) {
+      return Promise.reject(
+        new Error(`Missing streamed tool invocation boundary ${params.invocationId}`),
+      );
+    }
+    this.pendingToolInvocationDeltas.delete(params.invocationId);
+    const invocation = {
+      ...pending,
+      noisy: true,
+      noisyReason: "large-output",
+    };
+    const persisted = this.toolInvocationDeltaFlushChain.then(async () => {
+      try {
+        if (
+          typeof this.overlayStore.persistThreadToolInvocationBoundary === "function"
+        ) {
+          return await this.overlayStore.persistThreadToolInvocationBoundary({
+            alerts: [params.alert],
+            invocation,
+          });
+        }
+        const stored = await this.overlayStore.upsertThreadToolInvocation({
+          invocation,
+        });
+        if (
+          typeof this.overlayStore.upsertThreadToolInvocationAlert === "function"
+        ) {
+          await this.overlayStore.upsertThreadToolInvocationAlert({
+            alert: params.alert,
+          });
+        }
+        return stored;
+      } catch (error) {
+        this.requeueFailedToolInvocationDelta(invocation);
+        throw error;
+      }
+    });
+    this.toolInvocationDeltaFlushChain = persisted.then(
+      () => undefined,
+      () => undefined,
+    );
+    return persisted;
   }
 
   private readVolatileDeferredChecks(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -90,6 +90,8 @@ import {
   type AppServerTurnInputItem,
   type AppServerAvailableCommandSummary,
   type AppServerBackendKind,
+  type AnalyzeThreadToolHistoryRequest,
+  type AnalyzeThreadToolHistoryResponse,
   type AppServerCollaborationModeRequest,
   type BackendAccountSummary,
   type BackendAcpRuntimeCapabilities,
@@ -443,11 +445,14 @@ import {
 import {
   detectLargeToolOutput,
   detectNoisyPolling,
+  mergeLargeToolOutputIncident,
   mergeStreamedToolInvocationDeltas,
   mergeToolInvocationLifecycleWithStreamedOutput,
   toolAccountingLookbackSince,
   toolInvocationFromNotification,
+  type ToolOutputIncidentAggregate,
 } from "./tool-invocation-accounting";
+import { analyzeNormalizedToolReplay } from "./tool-output-replay-analyzer";
 import {
   ThreadTitleGenerationService,
   type ThreadTitleGenerator,
@@ -6657,6 +6662,10 @@ export class DesktopBackendRegistry {
     ThreadToolInvocationRecord[]
   >();
   private readonly persistedToolInvocationAlertCounts = new Map<string, number>();
+  private readonly liveToolOutputIncidents = new Map<
+    string,
+    ToolOutputIncidentAggregate
+  >();
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes every flush and streamed alert boundary so a timer-driven write
@@ -10590,6 +10599,70 @@ export class DesktopBackendRegistry {
         : {}),
       replay: replayWithMessageOrigins,
     };
+  }
+
+  async analyzeThreadToolHistory(
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse> {
+    this.assertNotBootstrap("analyzeThreadToolHistory");
+    if (typeof this.overlayStore.persistThreadToolHistoryAnalysis !== "function") {
+      throw new Error("Tool-output history analysis storage is unavailable.");
+    }
+
+    const pages: AppServerThreadReplay[] = [];
+    const seenCursors = new Set<string>();
+    let before: string | undefined;
+    let complete = false;
+    for (let page = 0; page < 1_000; page += 1) {
+      let response: AppServerReadThreadResponse;
+      try {
+        response = await this.readThread({
+          backend: request.backend,
+          ...(before ? { before } : {}),
+          limit: 100,
+          threadId: request.threadId,
+          viewOnly: true,
+        });
+      } catch (error) {
+        if (pages.length === 0) {
+          throw error;
+        }
+        break;
+      }
+      pages.push(response.replay);
+      if (!response.replay.pagination.hasPreviousPage) {
+        complete = true;
+        break;
+      }
+      const cursor = response.replay.pagination.previousCursor;
+      if (!cursor || seenCursors.has(cursor)) {
+        break;
+      }
+      seenCursors.add(cursor);
+      before = cursor;
+    }
+
+    const analysis = analyzeNormalizedToolReplay({
+      backend: request.backend,
+      complete,
+      pages,
+      threadId: request.threadId,
+    });
+    await this.overlayStore.persistThreadToolHistoryAnalysis({
+      backend: request.backend,
+      coverage: analysis.coverage,
+      invocations: analysis.invocations,
+      threadId: request.threadId,
+    });
+    const accounting = await this.overlayStore.readThreadToolAccounting({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+    await this.emitThreadToolAccountingUpdated({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+    return { accounting, coverage: analysis.coverage };
   }
 
   async getThreadTranscriptImageRoots(params: {
@@ -21761,6 +21834,23 @@ export class DesktopBackendRegistry {
   }
 
   private async recordToolInvocationAccounting(event: AgentEvent): Promise<void> {
+    if (
+      event.notification.method === "turn/completed"
+      || event.notification.method === "turn/failed"
+      || event.notification.method === "turn/interrupted"
+    ) {
+      const params = readRecord(event.notification.params);
+      const threadId = readNonEmptyString(params?.threadId);
+      const turnId = readNonEmptyString(params?.turnId);
+      if (threadId && turnId) {
+        this.liveToolOutputIncidents.delete(
+          `large-output:${event.backend}:${threadId}:${turnId}`,
+        );
+        this.liveToolOutputIncidents.delete(
+          `noisy-polling:${event.backend}:${threadId}:${turnId}`,
+        );
+      }
+    }
     if (typeof this.overlayStore.upsertThreadToolInvocation !== "function") {
       return;
     }
@@ -21787,14 +21877,25 @@ export class DesktopBackendRegistry {
         previousOutputChars: buffered.previousOutputChars,
       });
       if (detection) {
+        const incident = mergeLargeToolOutputIncident({
+          current: this.liveToolOutputIncidents.get(detection.alert.alertId),
+          detection,
+        });
+        this.liveToolOutputIncidents.set(
+          incident.aggregate.alert.alertId,
+          incident.aggregate,
+        );
+        if (!incident.shouldNotify) {
+          return;
+        }
         const stored = await this.persistStreamedToolInvocationAlertBoundary({
-          alert: detection.alert,
+          alert: incident.aggregate.alert,
           invocationId: invocation.invocationId,
         });
         await this.emitThreadToolAccountingUpdated({
           backend: stored.backend,
           threadId: stored.threadId,
-          triggeredAlerts: [detection.alert],
+          triggeredAlerts: [incident.aggregate.alert],
         });
       }
       return;
@@ -21810,10 +21911,31 @@ export class DesktopBackendRegistry {
     }
     let shouldNotify = event.notification.method === "item/completed";
     const triggeredAlerts: ThreadToolInvocationAlert[] = [];
-    const largeOutputDetection = detectLargeToolOutput({
+    const rawLargeOutputDetection = detectLargeToolOutput({
       current: invocationWithStreamedOutput,
       now,
     });
+    const largeOutputIncident = rawLargeOutputDetection
+      ? mergeLargeToolOutputIncident({
+          current: this.liveToolOutputIncidents.get(
+            rawLargeOutputDetection.alert.alertId,
+          ),
+          detection: rawLargeOutputDetection,
+        })
+      : undefined;
+    if (largeOutputIncident) {
+      this.liveToolOutputIncidents.set(
+        largeOutputIncident.aggregate.alert.alertId,
+        largeOutputIncident.aggregate,
+      );
+    }
+    const largeOutputDetection = largeOutputIncident
+      ? {
+          alert: largeOutputIncident.aggregate.alert,
+          cases: rawLargeOutputDetection!.cases,
+          invocationIds: rawLargeOutputDetection!.invocationIds,
+        }
+      : undefined;
     const isVolatileDeferredCheck =
       invocationWithStreamedOutput.category === "polling"
       && (
@@ -21823,7 +21945,7 @@ export class DesktopBackendRegistry {
     const volatileRecent = isVolatileDeferredCheck
       ? this.readVolatileDeferredChecks(invocationWithStreamedOutput, now)
       : [];
-    const pollingDetection =
+    const rawPollingDetection =
       typeof this.overlayStore.readRecentThreadToolInvocations === "function"
       ? detectNoisyPolling({
           current: invocationWithStreamedOutput,
@@ -21848,6 +21970,28 @@ export class DesktopBackendRegistry {
             }),
           ],
         })
+      : undefined;
+    const pollingIncident = rawPollingDetection
+      ? mergeLargeToolOutputIncident({
+          current: this.liveToolOutputIncidents.get(
+            rawPollingDetection.alert.alertId,
+          ),
+          detection: rawPollingDetection,
+        })
+      : undefined;
+    if (pollingIncident) {
+      this.liveToolOutputIncidents.set(
+        pollingIncident.aggregate.alert.alertId,
+        pollingIncident.aggregate,
+      );
+    }
+    const pollingDetection = pollingIncident
+      ? {
+          alert: pollingIncident.aggregate.alert,
+          cases: rawPollingDetection!.cases,
+          invocationIds: pollingIncident.aggregate.alert.invocationIds ?? [],
+          lookbackSince: rawPollingDetection!.lookbackSince,
+        }
       : undefined;
     if (isVolatileDeferredCheck) {
       this.rememberVolatileDeferredCheck(invocationWithStreamedOutput, now);
@@ -21896,7 +22040,7 @@ export class DesktopBackendRegistry {
           pollingDetection.alert.invocationCount,
         );
       }
-      if (pollingDetection) {
+      if (pollingDetection && pollingIncident?.shouldNotify) {
         await this.emitThreadToolAccountingUpdated({
           backend: invocationWithStreamedOutput.backend,
           threadId: invocationWithStreamedOutput.threadId,
@@ -21911,13 +22055,20 @@ export class DesktopBackendRegistry {
             (invocationId) => invocationId !== invocation.invocationId,
           )
         : [];
-    const invocationToPersist = noisyReason
-      ? {
-          ...invocation,
-          noisy: true,
-          noisyReason,
-        }
-      : invocation;
+    const suggestedPrompt = pollingDetection?.alert.suggestedPrompt
+      ?? largeOutputDetection?.alert.suggestedPrompt;
+    const invocationToPersist = {
+      ...invocation,
+      outputState: invocation.outputTruncated ? "truncated" as const : "available" as const,
+      source: "live" as const,
+      ...(noisyReason
+        ? {
+            noisy: true,
+            noisyReason,
+          }
+        : {}),
+      ...(suggestedPrompt ? { suggestedPrompt } : {}),
+    };
     let stored: ThreadToolInvocationRecord;
     if (
       typeof this.overlayStore.persistThreadToolInvocationBoundary === "function"
@@ -21965,11 +22116,11 @@ export class DesktopBackendRegistry {
         pollingDetection.alert.invocationCount,
       );
     }
-    if (largeOutputDetection) {
+    if (largeOutputDetection && largeOutputIncident?.shouldNotify) {
       triggeredAlerts.push(largeOutputDetection.alert);
       shouldNotify = true;
     }
-    if (pollingDetection) {
+    if (pollingDetection && pollingIncident?.shouldNotify) {
       triggeredAlerts.push(pollingDetection.alert);
       shouldNotify = true;
     }
@@ -22034,6 +22185,9 @@ export class DesktopBackendRegistry {
       ...pending,
       noisy: true,
       noisyReason: "large-output",
+      outputState: pending.outputTruncated ? "truncated" as const : "available" as const,
+      source: "live" as const,
+      suggestedPrompt: params.alert.suggestedPrompt,
     };
     const persisted = this.toolInvocationDeltaFlushChain.then(async () => {
       try {

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -6,6 +6,7 @@ import type {
   ThreadToolInvocationRecord,
   ThreadToolInvocationStatus,
 } from "@pwragent/shared";
+import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
 import { redactCommandText } from "../util/redact-command-text";
 
 const OUTPUT_TOKEN_CHAR_RATIO = 4;
@@ -41,14 +42,101 @@ export type NormalizedToolCommand = {
 
 export type NoisyPollingDetection = {
   alert: ThreadToolInvocationAlert;
+  cases: Record<string, { outputChars: number }>;
   invocationIds: string[];
   lookbackSince: number;
 };
 
 export type LargeToolOutputDetection = {
   alert: ThreadToolInvocationAlert;
+  cases: Record<string, { outputChars: number }>;
   invocationIds: string[];
 };
+
+export type ToolOutputIncidentAggregate = {
+  alert: ThreadToolInvocationAlert;
+  cases: Record<string, {
+    outputChars: number;
+    severity: ThreadToolInvocationAlert["severity"];
+  }>;
+};
+
+export function mergeLargeToolOutputIncident(params: {
+  current?: ToolOutputIncidentAggregate;
+  detection: LargeToolOutputDetection | NoisyPollingDetection;
+}): {
+  aggregate: ToolOutputIncidentAggregate;
+  shouldNotify: boolean;
+} {
+  const incoming = params.detection.alert;
+  const previousCases = params.current?.cases ?? {};
+  const newInvocationIds = params.detection.invocationIds.filter(
+    (invocationId) => !previousCases[invocationId],
+  );
+  const escalated = params.detection.invocationIds.some((invocationId) =>
+    previousCases[invocationId]?.severity === "warning"
+    && incoming.severity === "critical"
+  );
+  const cases = { ...previousCases };
+  for (const invocationId of params.detection.invocationIds) {
+    const incidentCase = params.detection.cases[invocationId];
+    cases[invocationId] = {
+      outputChars: incidentCase?.outputChars ?? 0,
+      severity: incoming.severity,
+    };
+  }
+  const entries = Object.entries(cases);
+  const totalOutputChars = entries.reduce(
+    (sum, [, incidentCase]) => sum + incidentCase.outputChars,
+    0,
+  );
+  const [worstInvocationId, worstCase] = entries.reduce(
+    (worst, entry) => entry[1].outputChars > worst[1].outputChars ? entry : worst,
+  );
+  const severity = entries.some(([, incidentCase]) => incidentCase.severity === "critical")
+    ? "critical" as const
+    : "warning" as const;
+  const estimatedOutputTokens = Math.ceil(totalOutputChars / OUTPUT_TOKEN_CHAR_RATIO);
+  const caseCount = entries.length;
+  const subject = incoming.kind === "noisy-polling"
+    ? `repeated queued check${caseCount === 1 ? "" : "s"}`
+    : `noisy tool-output case${caseCount === 1 ? "" : "s"}`;
+  const message = `${caseCount.toLocaleString()} ${subject} in this turn produced ${totalOutputChars.toLocaleString()} characters (~${estimatedOutputTokens.toLocaleString()} tokens). The worst case produced ${worstCase.outputChars.toLocaleString()} characters.`;
+  const alert: ThreadToolInvocationAlert = {
+    ...(params.current?.alert ?? incoming),
+    alertId: incoming.alertId,
+    estimatedOutputTokens,
+    firstObservedAt: Math.min(
+      params.current?.alert.firstObservedAt ?? incoming.firstObservedAt,
+      incoming.firstObservedAt,
+    ),
+    invocationCount: caseCount,
+    invocationIds: entries.map(([id]) => id),
+    lastObservedAt: Math.max(
+      params.current?.alert.lastObservedAt ?? incoming.lastObservedAt,
+      incoming.lastObservedAt,
+    ),
+    message,
+    severity,
+    suggestedPrompt: incoming.suggestedPrompt,
+    totalOutputChars,
+    updatedAt: incoming.updatedAt,
+    worstInvocationId,
+    worstOutputChars: worstCase.outputChars,
+  };
+  return {
+    aggregate: { alert, cases },
+    shouldNotify:
+      newInvocationIds.length > 0 || escalated,
+  };
+}
+
+export function buildToolInvocationSteeringPrompt(params: {
+  invocation: ThreadToolInvocationRecord;
+  reason: string;
+}): string {
+  return buildThreadToolIncidentPrompt(params);
+}
 
 export function toolInvocationFromNotification(params: {
   backend: AppServerBackendKind;
@@ -439,11 +527,10 @@ export function detectNoisyPolling(params: {
       : `process ${current.processId}`;
   const message =
     `${records.length.toLocaleString()} queued checks on ${sessionLabel} are repeatedly waking the model and replaying its accumulated context. The checks returned ${totalOutputChars.toLocaleString()} chars (~${estimatedOutputTokens.toLocaleString()} output tokens), but replay cost applies even when they return little or nothing.`;
-  const suggestedPrompt = [
-    "Stop polling this long-running process in the main thread.",
-    "Use PwrAgent's create_monitor_delegation tool with the durable command, cwd, log/status files, poll cadence, and terminal success/failure criteria.",
-    "Continue unrelated work here, and let the monitor report completion back to this thread.",
-  ].join(" ");
+  const suggestedPrompt = buildToolInvocationSteeringPrompt({
+    invocation: current,
+    reason: "repeated queued checks are waking the model and replaying accumulated context",
+  });
 
   return {
     alert: {
@@ -451,10 +538,7 @@ export function detectNoisyPolling(params: {
         "noisy-polling",
         current.backend,
         current.threadId,
-        current.toolName,
-        isTurnScopedPolling
-          ? current.turnId
-          : current.sessionId ?? current.processId ?? "unknown",
+        current.turnId ?? "no-turn",
       ].join(":"),
       averageIntervalMs,
       backend: current.backend,
@@ -475,6 +559,10 @@ export function detectNoisyPolling(params: {
       totalOutputChars,
       updatedAt: now,
     },
+    cases: Object.fromEntries(records.map((record) => [
+      record.invocationId,
+      { outputChars: record.outputChars },
+    ])),
     invocationIds: records.map((record) => record.invocationId),
     lookbackSince,
   };
@@ -510,15 +598,25 @@ export function detectLargeToolOutput(params: {
   const message = critical
     ? `This tool produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), reaching or exceeding the observed model-visible output cap. The retained portion will replay on subsequent inference items.`
     : `This tool has produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), about ${estimatedCapPercentage.toLocaleString()}% of the observed model-visible output cap. Continuing unfiltered will enlarge every later context replay.`;
-  const suggestedPrompt = [
-    "Treat this command as extremely noisy.",
-    "For subsequent executions, redirect full stdout and stderr to a local log and return only the command, exit code, concise summary, key failure blocks, and a bounded tail.",
-    "Use an installed output-reduction wrapper when available, and retrieve targeted raw sections only when needed.",
-  ].join(" ");
+  const noisyReason = critical
+    ? "output reached or exceeded the observed model-visible cap"
+    : "large output will be replayed on later inference items";
+  const suggestedPrompt = buildToolInvocationSteeringPrompt({
+    invocation: {
+      ...current,
+      outputState: current.outputTruncated ? "truncated" : "available",
+    },
+    reason: noisyReason,
+  });
 
   return {
     alert: {
-      alertId: ["large-output", current.invocationId].join(":"),
+      alertId: [
+        "large-output",
+        current.backend,
+        current.threadId,
+        current.turnId ?? "no-turn",
+      ].join(":"),
       backend: current.backend,
       createdAt: now,
       estimatedOutputTokens: current.estimatedOutputTokens,
@@ -536,6 +634,9 @@ export function detectLargeToolOutput(params: {
       toolName: current.toolName,
       totalOutputChars: current.outputChars,
       updatedAt: now,
+    },
+    cases: {
+      [current.invocationId]: { outputChars: current.outputChars },
     },
     invocationIds: [current.invocationId],
   };
@@ -616,6 +717,9 @@ function normalizeShellCommand(command: string | undefined): string | undefined 
 }
 
 function categoryForToolName(toolName: string): ThreadToolInvocationCategory {
+  if (/^mcp(?:__|ToolCall$)/i.test(toolName) || toolName.includes("mcp")) {
+    return "mcp";
+  }
   if (
     toolName === "read_file" ||
     toolName === "list_files" ||

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -6,16 +6,23 @@ import type {
   ThreadToolInvocationRecord,
   ThreadToolInvocationStatus,
 } from "@pwragent/shared";
-import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import {
+  buildThreadToolIncidentPrompt,
+  TOOL_OUTPUT_CAP_CHARS,
+  TOOL_OUTPUT_TOKEN_CHAR_RATIO,
+  TOOL_OUTPUT_WARNING_CHARS,
+} from "@pwragent/shared";
 import { redactCommandText } from "../util/redact-command-text";
 
-const OUTPUT_TOKEN_CHAR_RATIO = 4;
+/* Shared with the incident explorer so its meters are drawn against the same
+   cap this detector reasons about. */
+const OUTPUT_TOKEN_CHAR_RATIO = TOOL_OUTPUT_TOKEN_CHAR_RATIO;
 const NOISY_POLL_LOOKBACK_MS = 5 * 60 * 1000;
 const NOISY_POLL_MIN_INVOCATIONS = 5;
 const NOISY_POLL_MIN_INTERVAL_MS = 15_000;
 const NOISY_POLL_MAX_INTERVAL_MS = 75_000;
-const LARGE_OUTPUT_WARNING_CHARS = 4_000;
-const LARGE_OUTPUT_CRITICAL_CHARS = 40_000;
+const LARGE_OUTPUT_WARNING_CHARS = TOOL_OUTPUT_WARNING_CHARS;
+const LARGE_OUTPUT_CRITICAL_CHARS = TOOL_OUTPUT_CAP_CHARS;
 const ACCOUNTED_TOOL_ITEM_TYPES = new Set([
   "commandExecution",
   "dynamicToolCall",

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -242,6 +242,8 @@ export function toolInvocationFromNotification(params: {
   const normalized = normalizeToolInvocationCommand({
     args,
     command,
+    itemType,
+    ...(readString(item, "server") ? { server: readString(item, "server") } : {}),
     toolName,
   });
   const processId =
@@ -409,9 +411,23 @@ export function mergeToolInvocationLifecycleWithStreamedOutput(
 export function normalizeToolInvocationCommand(params: {
   args?: Record<string, unknown>;
   command?: string;
+  itemType?: string;
+  server?: string;
   toolName: string;
 }): NormalizedToolCommand {
   const toolName = params.toolName.trim() || "unknown";
+  /* MCP is declared by the protocol item, not inferred from the name. The
+     name-substring fallback below filed Context7's `query-docs` under
+     unknown while `list_mcp_resources` matched by luck. The server joins the
+     stored identity so surfaces can split cost per MCP. */
+  if (params.itemType === "mcpToolCall" || params.server) {
+    return {
+      category: "mcp",
+      normalizedCommand: params.server
+        ? `${params.server}/${toolName}`
+        : toolName,
+    };
+  }
   if (toolName === "write_stdin") {
     const sessionId = readString(params.args, "session_id") ??
       readString(params.args, "sessionId");

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -120,6 +120,7 @@ export function toolInvocationFromNotification(params: {
   const toolName =
     readString(item, "toolName") ??
     readString(item, "tool_name") ??
+    readString(item, "tool") ??
     readString(item, "name") ??
     readString(item, "type") ??
     "commandExecution";
@@ -696,18 +697,21 @@ function readToolOutput(
   item: Record<string, unknown> | undefined,
 ): { text?: string; truncated?: boolean } {
   const data = readRecord(item?.data);
-  const text =
-    readString(item, "aggregatedOutput") ??
-    readString(item, "aggregated_output") ??
-    readString(item, "functionCallOutput") ??
-    readString(data, "aggregatedOutput") ??
-    readString(data, "aggregated_output") ??
-    readString(data, "output") ??
-    readString(data, "text") ??
-    readString(data, "result") ??
-    readString(item, "output") ??
-    readString(item, "stdout") ??
-    readString(item, "stderr");
+  const value = [
+    item?.aggregatedOutput,
+    item?.aggregated_output,
+    item?.functionCallOutput,
+    data?.aggregatedOutput,
+    data?.aggregated_output,
+    data?.output,
+    data?.text,
+    data?.result,
+    item?.result,
+    item?.output,
+    item?.stdout,
+    item?.stderr,
+  ].find((candidate) => candidate !== undefined && candidate !== null);
+  const text = serializeToolOutputValue(value);
   const truncated =
     readBoolean(data, "outputTruncated") ??
     readBoolean(data, "output_truncated") ??
@@ -716,6 +720,23 @@ function readToolOutput(
     readBoolean(item, "output_truncated") ??
     readBoolean(item, "truncated");
   return { text, truncated };
+}
+
+function serializeToolOutputValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    // App-server notifications are JSON, so this is defensive only. If a
+    // malformed in-process test double supplies a cyclic or otherwise
+    // unserializable result, skip accounting instead of breaking event fanout.
+    return undefined;
+  }
 }
 
 function readExitCode(

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -10,10 +10,18 @@ import { redactCommandText } from "../util/redact-command-text";
 
 const OUTPUT_TOKEN_CHAR_RATIO = 4;
 const NOISY_POLL_LOOKBACK_MS = 5 * 60 * 1000;
-const NOISY_POLL_MIN_INVOCATIONS = 3;
-const NOISY_POLL_MIN_OUTPUT_CHARS = 20_000;
+const NOISY_POLL_MIN_INVOCATIONS = 5;
 const NOISY_POLL_MIN_INTERVAL_MS = 15_000;
 const NOISY_POLL_MAX_INTERVAL_MS = 75_000;
+const LARGE_OUTPUT_WARNING_CHARS = 4_000;
+const LARGE_OUTPUT_CRITICAL_CHARS = 40_000;
+const ACCOUNTED_TOOL_ITEM_TYPES = new Set([
+  "commandExecution",
+  "dynamicToolCall",
+  "functionCall",
+  "mcpToolCall",
+  "toolCall",
+]);
 
 export type ToolInvocationOutputMetrics = {
   debugLines: number;
@@ -35,6 +43,11 @@ export type NoisyPollingDetection = {
   alert: ThreadToolInvocationAlert;
   invocationIds: string[];
   lookbackSince: number;
+};
+
+export type LargeToolOutputDetection = {
+  alert: ThreadToolInvocationAlert;
+  invocationIds: string[];
 };
 
 export function toolInvocationFromNotification(params: {
@@ -91,7 +104,14 @@ export function toolInvocationFromNotification(params: {
   if (!item) {
     return undefined;
   }
-  if (readString(item, "type") !== "commandExecution") {
+  const itemType = readString(item, "type");
+  if (!itemType || !ACCOUNTED_TOOL_ITEM_TYPES.has(itemType)) {
+    return undefined;
+  }
+  if (
+    itemType !== "commandExecution"
+    && params.notification.method === "item/started"
+  ) {
     return undefined;
   }
 
@@ -111,6 +131,18 @@ export function toolInvocationFromNotification(params: {
   const metrics = buildToolOutputMetrics(output.text, {
     outputTruncated: output.truncated,
   });
+  if (
+    itemType !== "commandExecution"
+    && toolName !== "wait"
+    && toolName !== "write_stdin"
+    && metrics.outputChars < LARGE_OUTPUT_WARNING_CHARS
+  ) {
+    // Function, dynamic, and MCP calls are a much broader stream than the
+    // original command accounting surface. Persist only polling signals and
+    // genuinely large results; otherwise enabling this detector would add one
+    // sqlite commit for every ordinary local tool call.
+    return undefined;
+  }
   const normalized = normalizeToolInvocationCommand({
     args,
     command,
@@ -126,6 +158,8 @@ export function toolInvocationFromNotification(params: {
   const sessionId =
     readString(args, "session_id") ??
     readString(args, "sessionId") ??
+    readString(args, "cell_id") ??
+    readString(args, "cellId") ??
     readString(item, "sessionId") ??
     readString(item, "session_id");
   const exitCode = readExitCode(item);
@@ -249,6 +283,33 @@ export function mergeStreamedToolInvocationDeltas(
   };
 }
 
+export function mergeToolInvocationLifecycleWithStreamedOutput(
+  lifecycle: ThreadToolInvocationRecord,
+  streamed: ThreadToolInvocationRecord | undefined,
+): ThreadToolInvocationRecord {
+  if (!streamed) {
+    return lifecycle;
+  }
+  const outputChars = Math.max(lifecycle.outputChars, streamed.outputChars);
+  return {
+    ...lifecycle,
+    debugLines: Math.max(lifecycle.debugLines, streamed.debugLines),
+    errorLines: Math.max(lifecycle.errorLines, streamed.errorLines),
+    estimatedOutputTokens: Math.ceil(outputChars / OUTPUT_TOKEN_CHAR_RATIO),
+    infoLines: Math.max(lifecycle.infoLines, streamed.infoLines),
+    observedAt: Math.max(lifecycle.observedAt, streamed.observedAt),
+    outputChars,
+    outputLines: Math.max(lifecycle.outputLines, streamed.outputLines),
+    outputTruncated: lifecycle.outputTruncated || streamed.outputTruncated,
+    startedAt: Math.min(
+      lifecycle.startedAt ?? lifecycle.observedAt,
+      streamed.startedAt ?? streamed.observedAt,
+    ),
+    updatedAt: Math.max(lifecycle.updatedAt, streamed.updatedAt),
+    warningLines: Math.max(lifecycle.warningLines, streamed.warningLines),
+  };
+}
+
 export function normalizeToolInvocationCommand(params: {
   args?: Record<string, unknown>;
   command?: string;
@@ -266,6 +327,16 @@ export function normalizeToolInvocationCommand(params: {
         isPollingRead
           ? `poll session ${sessionId ?? "unknown"}`
           : `write stdin session ${sessionId ?? "unknown"}`,
+    };
+  }
+
+  if (toolName === "wait") {
+    const cellId =
+      readString(params.args, "cell_id")
+      ?? readString(params.args, "cellId");
+    return {
+      category: "polling",
+      normalizedCommand: `wait cell ${cellId ?? "unknown"}`,
     };
   }
 
@@ -300,27 +371,39 @@ export function detectNoisyPolling(params: {
   now?: number;
 }): NoisyPollingDetection | undefined {
   const current = params.current;
+  const isDeferredWait = current.toolName === "wait";
+  const isShellDelay =
+    current.category === "polling"
+    && current.normalizedCommand?.startsWith("sleep ") === true;
+  const isTurnScopedPolling = isDeferredWait || isShellDelay;
   if (
-    current.toolName !== "write_stdin" ||
+    (current.toolName !== "write_stdin" && !isTurnScopedPolling) ||
     current.category !== "polling" ||
-    (!current.sessionId && !current.processId)
+    (isTurnScopedPolling
+      ? !current.turnId
+      : (!current.sessionId && !current.processId))
   ) {
     return undefined;
   }
 
   const now = params.now ?? current.observedAt;
   const lookbackSince = now - NOISY_POLL_LOOKBACK_MS;
-  const records = [
-    current,
-    ...params.recent.filter((record) => record.invocationId !== current.invocationId),
-  ]
+  const uniqueRecords = new Map<string, ThreadToolInvocationRecord>();
+  for (const record of [...params.recent, current]) {
+    uniqueRecords.set(record.invocationId, record);
+  }
+  const records = [...uniqueRecords.values()]
     .filter(
       (record) =>
         record.toolName === current.toolName &&
         record.category === "polling" &&
         record.observedAt >= lookbackSince &&
-        (!current.sessionId || record.sessionId === current.sessionId) &&
-        (!current.processId || record.processId === current.processId),
+        (isTurnScopedPolling
+          ? record.turnId === current.turnId
+          : (
+              (!current.sessionId || record.sessionId === current.sessionId) &&
+              (!current.processId || record.processId === current.processId)
+            )),
     )
     .sort((left, right) => left.observedAt - right.observedAt);
 
@@ -340,10 +423,7 @@ export function detectNoisyPolling(params: {
     (sum, record) => sum + record.outputChars,
     0,
   );
-  if (
-    pollLikeIntervals.length < NOISY_POLL_MIN_INVOCATIONS - 1 ||
-    totalOutputChars < NOISY_POLL_MIN_OUTPUT_CHARS
-  ) {
+  if (pollLikeIntervals.length < NOISY_POLL_MIN_INVOCATIONS - 1) {
     return undefined;
   }
 
@@ -351,11 +431,13 @@ export function detectNoisyPolling(params: {
     intervals.reduce((sum, interval) => sum + interval, 0) / intervals.length,
   );
   const estimatedOutputTokens = Math.ceil(totalOutputChars / OUTPUT_TOKEN_CHAR_RATIO);
-  const sessionLabel = current.sessionId
-    ? `session ${current.sessionId}`
-    : `process ${current.processId}`;
+  const sessionLabel = isTurnScopedPolling
+    ? "the current turn"
+    : current.sessionId
+      ? `session ${current.sessionId}`
+      : `process ${current.processId}`;
   const message =
-    `Repeated write_stdin polling on ${sessionLabel} produced ${totalOutputChars.toLocaleString()} chars (~${estimatedOutputTokens.toLocaleString()} output tokens) across ${records.length.toLocaleString()} checks.`;
+    `${records.length.toLocaleString()} queued checks on ${sessionLabel} are repeatedly waking the model and replaying its accumulated context. The checks returned ${totalOutputChars.toLocaleString()} chars (~${estimatedOutputTokens.toLocaleString()} output tokens), but replay cost applies even when they return little or nothing.`;
   const suggestedPrompt = [
     "Stop polling this long-running process in the main thread.",
     "Use PwrAgent's create_monitor_delegation tool with the durable command, cwd, log/status files, poll cadence, and terminal success/failure criteria.",
@@ -369,7 +451,9 @@ export function detectNoisyPolling(params: {
         current.backend,
         current.threadId,
         current.toolName,
-        current.sessionId ?? current.processId ?? "unknown",
+        isTurnScopedPolling
+          ? current.turnId
+          : current.sessionId ?? current.processId ?? "unknown",
       ].join(":"),
       averageIntervalMs,
       backend: current.backend,
@@ -385,12 +469,74 @@ export function detectNoisyPolling(params: {
       severity: "warning",
       suggestedPrompt,
       threadId: current.threadId,
+      ...(current.turnId ? { turnId: current.turnId } : {}),
       toolName: current.toolName,
       totalOutputChars,
       updatedAt: now,
     },
     invocationIds: records.map((record) => record.invocationId),
     lookbackSince,
+  };
+}
+
+export function detectLargeToolOutput(params: {
+  current: ThreadToolInvocationRecord;
+  previousOutputChars?: number;
+  now?: number;
+}): LargeToolOutputDetection | undefined {
+  const current = params.current;
+  const previousOutputChars = params.previousOutputChars ?? 0;
+  const crossedWarning =
+    previousOutputChars < LARGE_OUTPUT_WARNING_CHARS
+    && current.outputChars >= LARGE_OUTPUT_WARNING_CHARS;
+  const crossedCritical =
+    previousOutputChars < LARGE_OUTPUT_CRITICAL_CHARS
+    && current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
+  const terminal = current.status !== "in_progress";
+  if (
+    current.outputChars < LARGE_OUTPUT_WARNING_CHARS
+    || (!crossedWarning && !crossedCritical && !terminal)
+  ) {
+    return undefined;
+  }
+
+  const now = params.now ?? current.observedAt;
+  const critical = current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
+  const estimatedCapPercentage = Math.max(
+    10,
+    Math.round(current.outputChars / LARGE_OUTPUT_CRITICAL_CHARS * 100),
+  );
+  const message = critical
+    ? `This tool produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), reaching or exceeding the observed model-visible output cap. The retained portion will replay on subsequent inference items.`
+    : `This tool has produced ${current.outputChars.toLocaleString()} characters (~${current.estimatedOutputTokens.toLocaleString()} tokens), about ${estimatedCapPercentage.toLocaleString()}% of the observed model-visible output cap. Continuing unfiltered will enlarge every later context replay.`;
+  const suggestedPrompt = [
+    "Treat this command as extremely noisy.",
+    "For subsequent executions, redirect full stdout and stderr to a local log and return only the command, exit code, concise summary, key failure blocks, and a bounded tail.",
+    "Use an installed output-reduction wrapper when available, and retrieve targeted raw sections only when needed.",
+  ].join(" ");
+
+  return {
+    alert: {
+      alertId: ["large-output", current.invocationId].join(":"),
+      backend: current.backend,
+      createdAt: now,
+      estimatedOutputTokens: current.estimatedOutputTokens,
+      firstObservedAt: current.startedAt ?? current.observedAt,
+      invocationCount: 1,
+      kind: "large-output",
+      lastObservedAt: current.observedAt,
+      message,
+      ...(current.processId ? { processId: current.processId } : {}),
+      ...(current.sessionId ? { sessionId: current.sessionId } : {}),
+      severity: critical ? "critical" : "warning",
+      suggestedPrompt,
+      threadId: current.threadId,
+      ...(current.turnId ? { turnId: current.turnId } : {}),
+      toolName: current.toolName,
+      totalOutputChars: current.outputChars,
+      updatedAt: now,
+    },
+    invocationIds: [current.invocationId],
   };
 }
 
@@ -489,6 +635,9 @@ function categoryForToolName(toolName: string): ThreadToolInvocationCategory {
 function categoryForCommand(command: string): ThreadToolInvocationCategory {
   const lower = command.toLowerCase();
   const first = lower.split(/\s+/)[0] ?? "";
+  if (first === "sleep") {
+    return "polling";
+  }
   if (first === "git") {
     return "git";
   }

--- a/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
+++ b/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
@@ -85,7 +85,10 @@ export function analyzeNormalizedToolReplay(params: {
             : {}),
           findingId: invocationId,
           invocationId,
-          itemId: entry.id,
+          // Normalized activity entries group several protocol items. The
+          // command detail id is the identity Tool Calls uses to retrieve the
+          // retained output; the entry id cannot locate that detail later.
+          itemId: detail.id,
           noisy: Boolean(reason),
           ...(reason ? { noisyReason: reason } : {}),
           ...(normalized.normalizedCommand

--- a/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
+++ b/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
@@ -1,0 +1,249 @@
+import type {
+  AppServerBackendKind,
+  AppServerThreadActivityDetail,
+  AppServerThreadReplay,
+  ThreadToolAnalysisCoverage,
+  ThreadToolInvocationCategory,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import {
+  buildToolInvocationSteeringPrompt,
+  buildToolOutputMetrics,
+  normalizeToolInvocationCommand,
+} from "./tool-invocation-accounting";
+
+export const TOOL_OUTPUT_ANALYZER_VERSION = "1";
+const LARGE_OUTPUT_CHARS = 4_000;
+const CRITICAL_OUTPUT_CHARS = 40_000;
+const POLLING_MIN_CASES = 5;
+
+export type ToolOutputReplayAnalysis = {
+  coverage: ThreadToolAnalysisCoverage;
+  invocations: ThreadToolInvocationRecord[];
+};
+
+export function analyzeNormalizedToolReplay(params: {
+  analyzedAt?: number;
+  backend: AppServerBackendKind;
+  complete: boolean;
+  pages: AppServerThreadReplay[];
+  threadId: string;
+}): ToolOutputReplayAnalysis {
+  const analyzedAt = params.analyzedAt ?? Date.now();
+  const invocationsById = new Map<string, ThreadToolInvocationRecord>();
+  const seenEntryIds = new Set<string>();
+  const missingOutputIds = new Set<string>();
+  let scannedThrough: string | undefined;
+
+  for (const replay of params.pages) {
+    for (const entry of replay.entries) {
+      seenEntryIds.add(entry.id);
+      scannedThrough = entry.id;
+      if (entry.type !== "activity") {
+        continue;
+      }
+      for (const detail of entry.details) {
+        if (!detail.command) {
+          continue;
+        }
+        const outputState = readOutputState(detail);
+        const metrics = buildToolOutputMetrics(detail.command.output, {
+          outputTruncated: outputState === "truncated",
+        });
+        const toolName = toolNameForDetail(detail);
+        const normalized = normalizeToolInvocationCommand({
+          command: detail.command.rawCommand ?? detail.command.displayCommand,
+          toolName,
+        });
+        const category = categoryForReplayDetail(detail, normalized.category);
+        const observedAt = entry.createdAt ?? entry.turn?.completedAt
+          ?? entry.turn?.startedAt ?? analyzedAt;
+        const invocationId = deterministicFindingId([
+          params.backend,
+          params.threadId,
+          entry.turn?.id ?? "no-turn",
+          entry.id,
+          detail.id,
+        ]);
+        if (outputState === "unavailable" || outputState === "compacted") {
+          missingOutputIds.add(invocationId);
+        } else {
+          missingOutputIds.delete(invocationId);
+        }
+        const reason = classifyNoisyReason({
+          category,
+          outputChars: metrics.outputChars,
+          outputState,
+        });
+        const invocation: ThreadToolInvocationRecord = {
+          ...metrics,
+          backend: params.backend,
+          category,
+          ...(entry.turn?.completedAt ? { completedAt: entry.turn.completedAt } : {}),
+          ...(detail.command.exitCode !== undefined
+            ? { exitCode: detail.command.exitCode }
+            : {}),
+          findingId: invocationId,
+          invocationId,
+          itemId: entry.id,
+          noisy: Boolean(reason),
+          ...(reason ? { noisyReason: reason } : {}),
+          ...(normalized.normalizedCommand
+            ? { normalizedCommand: normalized.normalizedCommand }
+            : {}),
+          observedAt,
+          outputState,
+          source: "history",
+          status: activityStatusToInvocationStatus(detail.status ?? entry.status),
+          ...(entry.turn?.startedAt ? { startedAt: entry.turn.startedAt } : {}),
+          threadId: params.threadId,
+          toolName,
+          ...(entry.turn?.id ? { turnId: entry.turn.id } : {}),
+          updatedAt: analyzedAt,
+          outputTruncated: outputState === "truncated",
+        };
+        invocationsById.set(
+          invocationId,
+          reason
+            ? {
+                ...invocation,
+                suggestedPrompt: buildToolInvocationSteeringPrompt({
+                  invocation,
+                  reason: humanizeReason(reason),
+                }),
+              }
+            : invocation,
+        );
+      }
+    }
+  }
+
+  const invocations = [...invocationsById.values()];
+  markRepeatedPolling(invocations);
+  const entryCount = seenEntryIds.size;
+  const missingOutputCount = missingOutputIds.size;
+  const complete = params.complete && missingOutputCount === 0;
+  const explanation = complete
+    ? undefined
+    : missingOutputCount > 0
+      ? `${missingOutputCount.toLocaleString()} tool result${missingOutputCount === 1 ? " was" : "s were"} unavailable or compacted in normalized replay, so totals are a lower bound.`
+      : "The App Server did not provide complete replay pagination, so totals cover only the available normalized history.";
+  return {
+    coverage: {
+      analyzedAt,
+      analyzerVersion: TOOL_OUTPUT_ANALYZER_VERSION,
+      completeness: complete ? "complete" : "partial",
+      entryCount,
+      invocationCount: invocations.length,
+      missingOutputCount,
+      pageCount: params.pages.length,
+      ...(scannedThrough ? { scannedThrough } : {}),
+      ...(explanation ? { explanation } : {}),
+    },
+    invocations,
+  };
+}
+
+function readOutputState(
+  detail: AppServerThreadActivityDetail,
+): ThreadToolInvocationRecord["outputState"] {
+  const output = detail.command?.output;
+  const context = [detail.label, detail.markdown, output].filter(Boolean).join(" ");
+  if (/compact(?:ed|ion)|removed from context/i.test(context)) {
+    return "compacted";
+  }
+  if (/truncated|additional lines omitted|output clipped/i.test(context)) {
+    return "truncated";
+  }
+  return output === undefined ? "unavailable" : "available";
+}
+
+function toolNameForDetail(detail: AppServerThreadActivityDetail): string {
+  if (detail.command?.source === "tool") {
+    return /^mcp__|\bmcp\b/i.test(detail.command.displayCommand)
+      ? "mcpToolCall"
+      : "toolCall";
+  }
+  if (detail.command?.source === "agent") {
+    return "subAgent";
+  }
+  return "commandExecution";
+}
+
+function categoryForReplayDetail(
+  detail: AppServerThreadActivityDetail,
+  category: ThreadToolInvocationCategory,
+): ThreadToolInvocationCategory {
+  if (
+    detail.command?.source === "tool"
+    && /^mcp__|\bmcp\b/i.test(detail.command.displayCommand)
+  ) {
+    return "mcp";
+  }
+  return category;
+}
+
+function classifyNoisyReason(params: {
+  category: ThreadToolInvocationCategory;
+  outputChars: number;
+  outputState: ThreadToolInvocationRecord["outputState"];
+}): string | undefined {
+  if (params.outputChars >= CRITICAL_OUTPUT_CHARS) {
+    return "large-output-critical";
+  }
+  if (params.outputChars < LARGE_OUTPUT_CHARS) {
+    return undefined;
+  }
+  if (params.category === "file-io") return "broad-file-read";
+  if (params.category === "search") return "broad-search";
+  if (params.category === "build-test" || params.category === "package-manager") {
+    return "verbose-build-test";
+  }
+  if (params.category === "mcp") return "broad-mcp-result";
+  return params.outputState === "truncated"
+    ? "large-truncated-output"
+    : "large-output";
+}
+
+function humanizeReason(reason: string): string {
+  return reason.replaceAll("-", " ");
+}
+
+function activityStatusToInvocationStatus(
+  status: AppServerThreadActivityDetail["status"],
+): ThreadToolInvocationRecord["status"] {
+  if (status === "in_progress") return "in_progress";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "cancelled";
+  return "completed";
+}
+
+function markRepeatedPolling(invocations: ThreadToolInvocationRecord[]): void {
+  const byTurn = new Map<string, ThreadToolInvocationRecord[]>();
+  for (const invocation of invocations) {
+    if (invocation.category !== "polling") continue;
+    const key = invocation.turnId ?? "no-turn";
+    byTurn.set(key, [...(byTurn.get(key) ?? []), invocation]);
+  }
+  for (const records of byTurn.values()) {
+    if (records.length < POLLING_MIN_CASES) continue;
+    for (const record of records) {
+      record.noisy = true;
+      record.noisyReason = "repeat-polling-output";
+      record.suggestedPrompt = buildToolInvocationSteeringPrompt({
+        invocation: record,
+        reason: "repeated polling wakes the model and replays accumulated context",
+      });
+    }
+  }
+}
+
+function deterministicFindingId(parts: string[]): string {
+  let hash = 2166136261;
+  const identity = parts.join("\u001f");
+  for (let index = 0; index < identity.length; index += 1) {
+    hash ^= identity.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `history-tool:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4616,6 +4616,9 @@ function localBackendOperations(): FederationBackendOperations {
         ...(request.includeTurns !== undefined
           ? { includeTurns: request.includeTurns }
           : {}),
+        ...(request.includeAllToolInvocations !== undefined
+          ? { includeAllToolInvocations: request.includeAllToolInvocations }
+          : {}),
         before: request.before,
         limit: request.limit,
         ...(request.viewOnly !== undefined

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -45,6 +45,8 @@ import {
   type PersistThreadUsageActivityResponse,
   type AppServerReadThreadRequest,
   type AppServerReadThreadResponse,
+  type AnalyzeThreadToolHistoryRequest,
+  type AnalyzeThreadToolHistoryResponse,
   type GetThreadFileDiffRequest,
   type GetThreadFileDiffResponse,
   type EnsureDirectoryLaunchpadRequest,
@@ -214,6 +216,7 @@ import {
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
   APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
@@ -1761,6 +1764,12 @@ class DesktopAppServerService {
     return sanitizeRendererPayload(
       shapeReadThreadFileDiffsForRenderer(materialized),
     );
+  }
+
+  async analyzeThreadToolHistory(
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse> {
+    return await getDesktopBackendRegistry().analyzeThreadToolHistory(request);
   }
 
   async persistThreadUsageActivity(
@@ -7415,6 +7424,15 @@ export function registerAppServerIpcHandlers(): void {
       });
     }
   );
+  ipcMain.removeHandler(APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL);
+  ipcMain.handle(
+    APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
+    async (
+      _event,
+      request: AnalyzeThreadToolHistoryRequest,
+    ): Promise<AnalyzeThreadToolHistoryResponse> =>
+      await appServerService.analyzeThreadToolHistory(request),
+  );
   ipcMain.removeHandler(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL);
   ipcMain.handle(
     APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
@@ -8196,6 +8214,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
+  ipcMain.removeHandler(APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_THREAD_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1723,7 +1723,10 @@ class DesktopAppServerService {
           backend: request.backend,
           threadId: request.threadId,
           before: request.before,
+          includeAllToolInvocations: request.includeAllToolInvocations,
+          includeTurns: request.includeTurns,
           limit: request.limit,
+          viewOnly: request.viewOnly,
         });
     }
     const backend = request.backend ?? "codex";
@@ -1731,6 +1734,7 @@ class DesktopAppServerService {
     const response = await registry.readThread({
       backend,
       threadId: request.threadId,
+      includeAllToolInvocations: request.includeAllToolInvocations,
       includeTurns: request.includeTurns,
       before: request.before,
       limit: request.limit,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -125,6 +125,8 @@ import {
   type SetThreadPinResponse,
   type SetThreadReactionRequest,
   type SetThreadReactionResponse,
+  type SetThreadToolIncidentNoticeRequest,
+  type SetThreadToolIncidentNoticeResponse,
   type SetNavigationBrowseModeRequest,
   type SetNavigationBrowseModeResponse,
   type ListThreadMigrationSourceThreadsRequest,
@@ -250,6 +252,7 @@ import {
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
+  NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_LIST_MODEL_SETTINGS_RECENTS_CHANNEL,
@@ -366,6 +369,7 @@ type AppServerOverlayStoreLike = OverlayStoreLike &
     | "setRemoteThreadLocalPin"
     | "listRemoteThreadPins"
     | "updateRemoteThreadPinSnapshots"
+    | "setThreadToolIncidentNotice"
   >;
 
 type ThreadPrRefreshContext = {
@@ -5747,6 +5751,40 @@ class DesktopAppServerService {
     return await fetcher.getAuthStatus();
   }
 
+  async setThreadToolIncidentNotice(
+    request: SetThreadToolIncidentNoticeRequest,
+  ): Promise<SetThreadToolIncidentNoticeResponse> {
+    /* Deliberately not federated. Dismissing or muting a cost warning is the
+       viewer's own preference about what it wants to be told, the same
+       reasoning that keeps composer drafts machine-local — a peer should not
+       inherit this operator's decision to stop being warned. */
+    const backend = request.backend ?? "codex";
+    const overlay = await this.getOverlayStore().setThreadToolIncidentNotice({
+      backend,
+      ...(request.dismissedSeverity
+        ? { dismissedSeverity: request.dismissedSeverity }
+        : {}),
+      ...(request.firstWarningAt !== undefined
+        ? { firstWarningAt: request.firstWarningAt }
+        : {}),
+      ...(request.mutedSeverity ? { mutedSeverity: request.mutedSeverity } : {}),
+      ...(request.reset ? { reset: request.reset } : {}),
+      threadId: request.threadId,
+    });
+    logDebug("setThreadToolIncidentNotice", {
+      backend,
+      dismissedSeverity: request.dismissedSeverity,
+      mutedSeverity: request.mutedSeverity,
+      reset: request.reset === true,
+      threadId: request.threadId,
+    });
+    return {
+      backend,
+      state: overlay.toolIncidentNotice ?? {},
+      threadId: request.threadId,
+    };
+  }
+
   async setThreadReaction(
     request: SetThreadReactionRequest,
   ): Promise<SetThreadReactionResponse> {
@@ -7631,6 +7669,16 @@ export function registerAppServerIpcHandlers(): void {
       request: SetThreadReactionRequest,
     ): Promise<SetThreadReactionResponse> => {
       return await appServerService.setThreadReaction(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
+    async (
+      _event,
+      request: SetThreadToolIncidentNoticeRequest,
+    ): Promise<SetThreadToolIncidentNoticeResponse> => {
+      return await appServerService.setThreadToolIncidentNotice(request);
     },
   );
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_PIN_CHANNEL);

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -29,14 +29,19 @@ import {
   PATH_REVEAL_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
 } from "../../shared/ipc";
+import type { WindowShowThreadRequest } from "../../shared/window-show-thread";
 import {
   readMarkdownFileViewerSnapshot,
   showMarkdownFileViewerWindow,
 } from "../markdown-files-window";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { showSubAgentTranscriptWindow } from "../subagent-transcript-window";
-import { showToolOutputIncidentExplorerWindow } from "../tool-output-incident-explorer-window";
+import {
+  showThreadFromToolOutputIncidentExplorer,
+  showToolOutputIncidentExplorerWindow,
+} from "../tool-output-incident-explorer-window";
 import {
   discoverDesktopApplications,
   openDesktopApplication,
@@ -234,6 +239,13 @@ export function registerApplicationIpcHandlers(): void {
       return { opened: true };
     },
   );
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL);
+  ipcMain.handle(
+    TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
+    async (event, request: WindowShowThreadRequest): Promise<void> => {
+      showThreadFromToolOutputIncidentExplorer(event.sender, request);
+    },
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
@@ -245,4 +257,5 @@ export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL);
   ipcMain.removeHandler(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL);
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -10,6 +10,8 @@ import {
   type OpenMarkdownFileViewerResponse,
   type OpenSubAgentTranscriptWindowRequest,
   type OpenSubAgentTranscriptWindowResponse,
+  type OpenToolOutputIncidentExplorerWindowRequest,
+  type OpenToolOutputIncidentExplorerWindowResponse,
   type OpenPathRequest,
   type OpenPathResponse,
   type ReadMarkdownFileRequest,
@@ -26,6 +28,7 @@ import {
   PATH_OPEN_CHANNEL,
   PATH_REVEAL_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
 } from "../../shared/ipc";
 import {
   readMarkdownFileViewerSnapshot,
@@ -33,6 +36,7 @@ import {
 } from "../markdown-files-window";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { showSubAgentTranscriptWindow } from "../subagent-transcript-window";
+import { showToolOutputIncidentExplorerWindow } from "../tool-output-incident-explorer-window";
 import {
   discoverDesktopApplications,
   openDesktopApplication,
@@ -217,6 +221,19 @@ export function registerApplicationIpcHandlers(): void {
       return { opened: true };
     },
   );
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL);
+  ipcMain.handle(
+    TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+    async (
+      event,
+      request: OpenToolOutputIncidentExplorerWindowRequest,
+    ): Promise<OpenToolOutputIncidentExplorerWindowResponse> => {
+      showToolOutputIncidentExplorerWindow(request, {
+        sourceWindow: BrowserWindow.fromWebContents(event.sender),
+      });
+      return { opened: true };
+    },
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
@@ -227,4 +244,5 @@ export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_OPEN_CHANNEL);
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL);
   ipcMain.removeHandler(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL);
+  ipcMain.removeHandler(TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL);
 }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1847,8 +1847,10 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
 
   async readThreadToolAccounting(params: {
     backend: ThreadOverlayState["backend"];
+    includeAllInvocations?: boolean;
     threadId: string;
   }): Promise<ThreadToolAccounting> {
+    const invocationLimit = params.includeAllInvocations ? -1 : 200;
     const invocationRows = this.stateDb.raw
       .prepare(
         `SELECT *
@@ -1856,9 +1858,13 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
          WHERE backend = ?
            AND thread_id = ?
          ORDER BY observed_at DESC, invocation_id DESC
-         LIMIT 200`,
+         LIMIT ?`,
       )
-      .all(params.backend, params.threadId) as ThreadToolInvocationRow[];
+      .all(
+        params.backend,
+        params.threadId,
+        invocationLimit,
+      ) as ThreadToolInvocationRow[];
     const summaryRows = this.stateDb.raw
       .prepare(
         `SELECT

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1572,6 +1572,12 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
   async upsertThreadToolInvocation(params: {
     invocation: ThreadToolInvocationRecord;
   }): Promise<ThreadToolInvocationRecord> {
+    return this.upsertThreadToolInvocationSync(params);
+  }
+
+  private upsertThreadToolInvocationSync(params: {
+    invocation: ThreadToolInvocationRecord;
+  }): ThreadToolInvocationRecord {
     const invocation = normalizeThreadToolInvocation(params.invocation);
     const existing = this.readThreadToolInvocationSync(invocation.invocationId);
     const merged = existing
@@ -1684,9 +1690,42 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       .run(params.reason, Date.now(), params.invocationId);
   }
 
+  async markThreadToolInvocationsNoisy(params: {
+    invocationIds: string[];
+    reason: string;
+  }): Promise<void> {
+    if (params.invocationIds.length === 0) {
+      return;
+    }
+    this.stateDb.raw.transaction(() => {
+      this.markThreadToolInvocationsNoisySync(params);
+    })();
+  }
+
+  private markThreadToolInvocationsNoisySync(params: {
+    invocationIds: string[];
+    reason: string;
+  }): void {
+    const update = this.stateDb.raw.prepare(
+      `UPDATE thread_tool_invocations
+       SET noisy = 1, noisy_reason = ?, updated_at = ?
+       WHERE invocation_id = ?`,
+    );
+    const updatedAt = Date.now();
+    for (const invocationId of new Set(params.invocationIds)) {
+      update.run(params.reason, updatedAt, invocationId);
+    }
+  }
+
   async upsertThreadToolInvocationAlert(params: {
     alert: ThreadToolInvocationAlert;
   }): Promise<ThreadToolInvocationAlert> {
+    return this.upsertThreadToolInvocationAlertSync(params);
+  }
+
+  private upsertThreadToolInvocationAlertSync(params: {
+    alert: ThreadToolInvocationAlert;
+  }): ThreadToolInvocationAlert {
     const alert = normalizeThreadToolInvocationAlert(params.alert);
     this.stateDb.raw
       .prepare(
@@ -1749,6 +1788,36 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       )
       .run(toThreadToolInvocationAlertRowParams(alert));
     return alert;
+  }
+
+  async persistThreadToolInvocationBoundary(params: {
+    alerts: ThreadToolInvocationAlert[];
+    invocation: ThreadToolInvocationRecord;
+    noisyInvocationIds?: string[];
+    noisyReason?: string;
+  }): Promise<ThreadToolInvocationRecord> {
+    let stored: ThreadToolInvocationRecord | undefined;
+    this.stateDb.raw.transaction(() => {
+      stored = this.upsertThreadToolInvocationSync({
+        invocation: params.invocation,
+      });
+      if (
+        params.noisyInvocationIds?.length
+        && params.noisyReason
+      ) {
+        this.markThreadToolInvocationsNoisySync({
+          invocationIds: params.noisyInvocationIds,
+          reason: params.noisyReason,
+        });
+      }
+      for (const alert of params.alerts) {
+        this.upsertThreadToolInvocationAlertSync({ alert });
+      }
+    })();
+    if (!stored) {
+      throw new Error("Tool invocation boundary transaction did not run");
+    }
+    return stored;
   }
 
   async readThreadToolAccounting(params: {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2191,6 +2191,59 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return nextState;
   }
 
+  /**
+   * Records the operator's disposition of this thread's tool-output incident.
+   * `firstWarningAt` is written once and never moved forward, so the cost
+   * window the notice reports stays anchored to the first warning even after
+   * a restart drops the older accounting rows out of the live snapshot.
+   */
+  async setThreadToolIncidentNotice(params: {
+    backend: ThreadOverlayState["backend"];
+    dismissedAt?: number;
+    dismissedSeverity?: "critical" | "warning";
+    firstWarningAt?: number;
+    mutedAt?: number;
+    mutedSeverity?: "critical" | "warning";
+    reset?: boolean;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const existing = current.toolIncidentNotice;
+    const firstWarningAt = existing?.firstWarningAt
+      ?? params.firstWarningAt;
+    const nextNotice = params.reset
+      ? (firstWarningAt !== undefined ? { firstWarningAt } : undefined)
+      : {
+          ...existing,
+          ...(firstWarningAt !== undefined ? { firstWarningAt } : {}),
+          ...(params.dismissedSeverity
+            ? {
+                dismissedSeverity: params.dismissedSeverity,
+                dismissedAt: params.dismissedAt ?? Date.now(),
+              }
+            : {}),
+          ...(params.mutedSeverity
+            ? {
+                mutedSeverity: params.mutedSeverity,
+                mutedAt: params.mutedAt ?? Date.now(),
+              }
+            : {}),
+        };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      ...(nextNotice ? { toolIncidentNotice: nextNotice } : {}),
+    };
+    if (!nextNotice) delete nextState.toolIncidentNotice;
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async setThreadArchiveTombstone(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -24,6 +24,7 @@ import type {
   ThreadMessagingBindingTransition,
   ThreadOverlayState,
   ThreadToolAccounting,
+  ThreadToolAnalysisCoverage,
   ThreadToolInvocationAlert,
   ThreadToolInvocationRecord,
   ThreadToolInvocationStatus,
@@ -1588,6 +1589,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       .prepare(
         `INSERT INTO thread_tool_invocations (
           invocation_id,
+          finding_id,
           backend,
           thread_id,
           turn_id,
@@ -1611,10 +1613,14 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           info_lines,
           debug_lines,
           output_truncated,
+          output_state,
+          source,
           noisy,
-          noisy_reason
+          noisy_reason,
+          suggested_prompt
         ) VALUES (
           @invocationId,
+          @findingId,
           @backend,
           @threadId,
           @turnId,
@@ -1638,11 +1644,15 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           @infoLines,
           @debugLines,
           @outputTruncated,
+          @outputState,
+          @source,
           @noisy,
-          @noisyReason
+          @noisyReason,
+          @suggestedPrompt
         )
         ON CONFLICT(invocation_id) DO UPDATE SET
           backend = excluded.backend,
+          finding_id = excluded.finding_id,
           thread_id = excluded.thread_id,
           turn_id = excluded.turn_id,
           item_id = excluded.item_id,
@@ -1669,8 +1679,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           info_lines = excluded.info_lines,
           debug_lines = excluded.debug_lines,
           output_truncated = excluded.output_truncated,
+          output_state = excluded.output_state,
+          source = excluded.source,
           noisy = excluded.noisy,
-          noisy_reason = excluded.noisy_reason`,
+          noisy_reason = excluded.noisy_reason,
+          suggested_prompt = excluded.suggested_prompt`,
       )
       .run(toThreadToolInvocationRowParams(merged));
 
@@ -1733,6 +1746,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           alert_id,
           backend,
           thread_id,
+          turn_id,
           kind,
           severity,
           tool_name,
@@ -1741,8 +1755,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           first_observed_at,
           last_observed_at,
           invocation_count,
+          invocation_ids,
           total_output_chars,
           estimated_output_tokens,
+          worst_invocation_id,
+          worst_output_chars,
           average_interval_ms,
           message,
           suggested_prompt,
@@ -1752,6 +1769,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           @alertId,
           @backend,
           @threadId,
+          @turnId,
           @kind,
           @severity,
           @toolName,
@@ -1760,8 +1778,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           @firstObservedAt,
           @lastObservedAt,
           @invocationCount,
+          @invocationIds,
           @totalOutputChars,
           @estimatedOutputTokens,
+          @worstInvocationId,
+          @worstOutputChars,
           @averageIntervalMs,
           @message,
           @suggestedPrompt,
@@ -1771,6 +1792,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         ON CONFLICT(alert_id) DO UPDATE SET
           backend = excluded.backend,
           thread_id = excluded.thread_id,
+          turn_id = excluded.turn_id,
           kind = excluded.kind,
           severity = excluded.severity,
           tool_name = excluded.tool_name,
@@ -1779,8 +1801,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           first_observed_at = MIN(thread_tool_invocation_alerts.first_observed_at, excluded.first_observed_at),
           last_observed_at = MAX(thread_tool_invocation_alerts.last_observed_at, excluded.last_observed_at),
           invocation_count = excluded.invocation_count,
+          invocation_ids = excluded.invocation_ids,
           total_output_chars = excluded.total_output_chars,
           estimated_output_tokens = excluded.estimated_output_tokens,
+          worst_invocation_id = excluded.worst_invocation_id,
+          worst_output_chars = excluded.worst_output_chars,
           average_interval_ms = excluded.average_interval_ms,
           message = excluded.message,
           suggested_prompt = excluded.suggested_prompt,
@@ -1867,12 +1892,69 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
          LIMIT 20`,
       )
       .all(params.backend, params.threadId) as ThreadToolInvocationAlertRow[];
+    const analysisRow = this.stateDb.raw
+      .prepare(
+        `SELECT * FROM thread_tool_analysis
+         WHERE backend = ? AND thread_id = ?`,
+      )
+      .get(params.backend, params.threadId) as ThreadToolAnalysisRow | undefined;
 
     return {
+      ...(analysisRow ? { analysis: threadToolAnalysisFromRow(analysisRow) } : {}),
       alerts: alertRows.map(threadToolInvocationAlertFromRow),
       invocations: invocationRows.map(threadToolInvocationFromRow),
       summaries: summaryRows.map(threadToolInvocationSummaryFromRow),
     };
+  }
+
+  async persistThreadToolHistoryAnalysis(params: {
+    backend: ThreadOverlayState["backend"];
+    coverage: ThreadToolAnalysisCoverage;
+    invocations: ThreadToolInvocationRecord[];
+    threadId: string;
+  }): Promise<void> {
+    this.stateDb.raw.transaction(() => {
+      this.stateDb.raw
+        .prepare(
+          `DELETE FROM thread_tool_invocations
+           WHERE backend = ? AND thread_id = ? AND source = 'history'`,
+        )
+        .run(params.backend, params.threadId);
+      for (const invocation of params.invocations) {
+        this.upsertThreadToolInvocationSync({ invocation });
+      }
+      this.stateDb.raw
+        .prepare(
+          `INSERT INTO thread_tool_analysis (
+            backend, thread_id, analyzer_version, analyzed_at, completeness,
+            entry_count, invocation_count, missing_output_count, page_count,
+            scanned_through, explanation
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(backend, thread_id) DO UPDATE SET
+            analyzer_version = excluded.analyzer_version,
+            analyzed_at = excluded.analyzed_at,
+            completeness = excluded.completeness,
+            entry_count = excluded.entry_count,
+            invocation_count = excluded.invocation_count,
+            missing_output_count = excluded.missing_output_count,
+            page_count = excluded.page_count,
+            scanned_through = excluded.scanned_through,
+            explanation = excluded.explanation`,
+        )
+        .run(
+          params.backend,
+          params.threadId,
+          params.coverage.analyzerVersion,
+          params.coverage.analyzedAt,
+          params.coverage.completeness,
+          params.coverage.entryCount,
+          params.coverage.invocationCount,
+          params.coverage.missingOutputCount,
+          params.coverage.pageCount,
+          params.coverage.scannedThrough ?? null,
+          params.coverage.explanation ?? null,
+        );
+    })();
   }
 
   readRecentThreadToolInvocations(params: {
@@ -5976,6 +6058,7 @@ type ThreadPricingAggregateRow = Omit<
 
 type ThreadToolInvocationRow = {
   invocation_id: string;
+  finding_id: string | null;
   backend: ThreadToolInvocationRecord["backend"];
   thread_id: string;
   turn_id: string | null;
@@ -5999,8 +6082,11 @@ type ThreadToolInvocationRow = {
   info_lines: number;
   debug_lines: number;
   output_truncated: number;
+  output_state: ThreadToolInvocationRecord["outputState"] | null;
+  source: NonNullable<ThreadToolInvocationRecord["source"]>;
   noisy: number;
   noisy_reason: string | null;
+  suggested_prompt: string | null;
 };
 
 type ThreadToolInvocationSummaryRow = {
@@ -6022,6 +6108,7 @@ type ThreadToolInvocationAlertRow = {
   alert_id: string;
   backend: ThreadToolInvocationAlert["backend"];
   thread_id: string;
+  turn_id: string | null;
   kind: ThreadToolInvocationAlert["kind"];
   severity: ThreadToolInvocationAlert["severity"];
   tool_name: string;
@@ -6030,13 +6117,28 @@ type ThreadToolInvocationAlertRow = {
   first_observed_at: number;
   last_observed_at: number;
   invocation_count: number;
+  invocation_ids: string | null;
   total_output_chars: number;
   estimated_output_tokens: number;
+  worst_invocation_id: string | null;
+  worst_output_chars: number | null;
   average_interval_ms: number | null;
   message: string;
   suggested_prompt: string;
   created_at: number;
   updated_at: number;
+};
+
+type ThreadToolAnalysisRow = {
+  analyzer_version: string;
+  analyzed_at: number;
+  completeness: ThreadToolAnalysisCoverage["completeness"];
+  entry_count: number;
+  invocation_count: number;
+  missing_output_count: number;
+  page_count: number;
+  scanned_through: string | null;
+  explanation: string | null;
 };
 
 function normalizeThreadToolInvocation(
@@ -6440,6 +6542,7 @@ function toThreadToolInvocationRowParams(
     exitCode: invocation.exitCode ?? null,
     infoLines: invocation.infoLines,
     invocationId: invocation.invocationId,
+    findingId: invocation.findingId ?? null,
     itemId: invocation.itemId,
     noisy: invocation.noisy ? 1 : 0,
     noisyReason: invocation.noisyReason ?? null,
@@ -6448,14 +6551,17 @@ function toThreadToolInvocationRowParams(
     outputChars: invocation.outputChars,
     outputLines: invocation.outputLines,
     outputTruncated: invocation.outputTruncated ? 1 : 0,
+    outputState: invocation.outputState ?? null,
     processId: invocation.processId ?? null,
     sessionId: invocation.sessionId ?? null,
+    source: invocation.source ?? "live",
     startedAt: invocation.startedAt ?? null,
     status: invocation.status,
     threadId: invocation.threadId,
     toolName: invocation.toolName,
     turnId: invocation.turnId ?? null,
     updatedAt: invocation.updatedAt,
+    suggestedPrompt: invocation.suggestedPrompt ?? null,
     warningLines: invocation.warningLines,
   };
 }
@@ -6471,6 +6577,9 @@ function toThreadToolInvocationAlertRowParams(
     estimatedOutputTokens: alert.estimatedOutputTokens,
     firstObservedAt: alert.firstObservedAt,
     invocationCount: alert.invocationCount,
+    invocationIds: alert.invocationIds
+      ? JSON.stringify(alert.invocationIds)
+      : null,
     kind: alert.kind,
     lastObservedAt: alert.lastObservedAt,
     message: alert.message,
@@ -6479,9 +6588,12 @@ function toThreadToolInvocationAlertRowParams(
     severity: alert.severity,
     suggestedPrompt: alert.suggestedPrompt,
     threadId: alert.threadId,
+    turnId: alert.turnId ?? null,
     toolName: alert.toolName,
     totalOutputChars: alert.totalOutputChars,
     updatedAt: alert.updatedAt,
+    worstInvocationId: alert.worstInvocationId ?? null,
+    worstOutputChars: alert.worstOutputChars ?? null,
   };
 }
 
@@ -6593,6 +6705,7 @@ function threadToolInvocationFromRow(
     ...(row.exit_code !== null ? { exitCode: row.exit_code } : {}),
     infoLines: row.info_lines,
     invocationId: row.invocation_id,
+    ...(row.finding_id ? { findingId: row.finding_id } : {}),
     itemId: row.item_id,
     noisy: Boolean(row.noisy),
     ...(row.noisy_reason ? { noisyReason: row.noisy_reason } : {}),
@@ -6601,14 +6714,17 @@ function threadToolInvocationFromRow(
     outputChars: row.output_chars,
     outputLines: row.output_lines,
     outputTruncated: Boolean(row.output_truncated),
+    ...(row.output_state ? { outputState: row.output_state } : {}),
     ...(row.process_id ? { processId: row.process_id } : {}),
     ...(row.session_id ? { sessionId: row.session_id } : {}),
+    source: row.source,
     ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
     status: row.status,
     threadId: row.thread_id,
     toolName: row.tool_name,
     ...(row.turn_id ? { turnId: row.turn_id } : {}),
     updatedAt: row.updated_at,
+    ...(row.suggested_prompt ? { suggestedPrompt: row.suggested_prompt } : {}),
     warningLines: row.warning_lines,
   };
 }
@@ -6645,6 +6761,9 @@ function threadToolInvocationAlertFromRow(
     estimatedOutputTokens: row.estimated_output_tokens,
     firstObservedAt: row.first_observed_at,
     invocationCount: row.invocation_count,
+    ...(row.invocation_ids
+      ? { invocationIds: readStringArrayJson(row.invocation_ids) }
+      : {}),
     kind: row.kind,
     lastObservedAt: row.last_observed_at,
     message: row.message,
@@ -6653,10 +6772,44 @@ function threadToolInvocationAlertFromRow(
     severity: row.severity,
     suggestedPrompt: row.suggested_prompt,
     threadId: row.thread_id,
+    ...(row.turn_id ? { turnId: row.turn_id } : {}),
     toolName: row.tool_name,
     totalOutputChars: row.total_output_chars,
     updatedAt: row.updated_at,
+    ...(row.worst_invocation_id
+      ? { worstInvocationId: row.worst_invocation_id }
+      : {}),
+    ...(row.worst_output_chars !== null
+      ? { worstOutputChars: row.worst_output_chars }
+      : {}),
   };
+}
+
+function threadToolAnalysisFromRow(
+  row: ThreadToolAnalysisRow,
+): ThreadToolAnalysisCoverage {
+  return {
+    analyzedAt: row.analyzed_at,
+    analyzerVersion: row.analyzer_version,
+    completeness: row.completeness,
+    entryCount: row.entry_count,
+    invocationCount: row.invocation_count,
+    missingOutputCount: row.missing_output_count,
+    pageCount: row.page_count,
+    ...(row.scanned_through ? { scannedThrough: row.scanned_through } : {}),
+    ...(row.explanation ? { explanation: row.explanation } : {}),
+  };
+}
+
+function readStringArrayJson(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      : [];
+  } catch {
+    return [];
+  }
 }
 
 function threadPricingSummaryFromRow(row: ThreadPricingSummaryRow): ThreadPricingSummary {
@@ -6699,6 +6852,7 @@ export type OverlayStoreLike = Pick<
   | "markThreadToolInvocationNoisy"
   | "upsertThreadToolInvocationAlert"
   | "readThreadToolAccounting"
+  | "persistThreadToolHistoryAnalysis"
   | "readRecentThreadToolInvocations"
   | "upsertThreadSubAgent"
   | "setThreadReaction"

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 50;
+export const CURRENT_STATE_DB_USER_VERSION = 51;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -847,6 +847,7 @@ CREATE TABLE IF NOT EXISTS thread_pricing_summaries (
 const THREAD_TOOL_ACCOUNTING_SCHEMA = `
 CREATE TABLE IF NOT EXISTS thread_tool_invocations (
   invocation_id             TEXT PRIMARY KEY,
+  finding_id                TEXT,
   backend                   TEXT NOT NULL,
   thread_id                 TEXT NOT NULL,
   turn_id                   TEXT,
@@ -870,8 +871,11 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocations (
   info_lines                INTEGER NOT NULL,
   debug_lines               INTEGER NOT NULL,
   output_truncated          INTEGER NOT NULL,
+  output_state              TEXT,
+  source                    TEXT NOT NULL DEFAULT 'live',
   noisy                     INTEGER NOT NULL,
-  noisy_reason              TEXT
+  noisy_reason              TEXT,
+  suggested_prompt          TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_thread_tool_invocations_read_thread
   ON thread_tool_invocations(backend, thread_id, observed_at DESC, invocation_id DESC);
@@ -884,6 +888,7 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocation_alerts (
   alert_id                  TEXT PRIMARY KEY,
   backend                   TEXT NOT NULL,
   thread_id                 TEXT NOT NULL,
+  turn_id                   TEXT,
   kind                      TEXT NOT NULL,
   severity                  TEXT NOT NULL,
   tool_name                 TEXT NOT NULL,
@@ -892,8 +897,11 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocation_alerts (
   first_observed_at         INTEGER NOT NULL,
   last_observed_at          INTEGER NOT NULL,
   invocation_count          INTEGER NOT NULL,
+  invocation_ids            TEXT,
   total_output_chars        INTEGER NOT NULL,
   estimated_output_tokens   INTEGER NOT NULL,
+  worst_invocation_id       TEXT,
+  worst_output_chars        INTEGER,
   average_interval_ms       INTEGER,
   message                   TEXT NOT NULL,
   suggested_prompt          TEXT NOT NULL,
@@ -902,6 +910,21 @@ CREATE TABLE IF NOT EXISTS thread_tool_invocation_alerts (
 );
 CREATE INDEX IF NOT EXISTS idx_thread_tool_invocation_alerts_read_thread
   ON thread_tool_invocation_alerts(backend, thread_id, updated_at DESC, alert_id DESC);
+
+CREATE TABLE IF NOT EXISTS thread_tool_analysis (
+  backend                   TEXT NOT NULL,
+  thread_id                 TEXT NOT NULL,
+  analyzer_version          TEXT NOT NULL,
+  analyzed_at               INTEGER NOT NULL,
+  completeness              TEXT NOT NULL,
+  entry_count               INTEGER NOT NULL,
+  invocation_count          INTEGER NOT NULL,
+  missing_output_count      INTEGER NOT NULL,
+  page_count                INTEGER NOT NULL,
+  scanned_through           TEXT,
+  explanation               TEXT,
+  PRIMARY KEY (backend, thread_id)
+);
 `;
 
 const THREAD_MESSAGE_ORIGIN_SCHEMA = `
@@ -1465,6 +1488,12 @@ LEFT JOIN federation_peers
         // Additive table, no data migration; the same DDL also lives in
         // `ensureCurrentSchema` so re-instantiated dbs converge.
         db.exec(ACP_AVAILABLE_COMMANDS_SCHEMA);
+        db.pragma("user_version = 50");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 51) {
+      db.transaction(() => {
+        ensureThreadToolIncidentExplorerSchema(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1944,6 +1973,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensureThreadUsagePricingCumulativeColumns(db);
     ensureThreadUsagePricingIndexes(db);
     db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
+    ensureThreadToolIncidentExplorerSchema(db);
     ensureThreadMessageOriginSchema(db);
     db.exec(FEDERATION_SCHEMA);
     db.exec(REMOTE_THREAD_PIN_SCHEMA);
@@ -1961,6 +1991,62 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
   db.exec(`
 CREATE INDEX IF NOT EXISTS idx_app_runtime_instances_profile_cwd_hash
   ON app_runtime_instances(profile_name, cwd_hash, heartbeat_at DESC);
+`);
+}
+
+function ensureThreadToolIncidentExplorerSchema(
+  db: BetterSqlite3.Database,
+): void {
+  const invocationColumns = new Set(
+    (db.prepare("PRAGMA table_info(thread_tool_invocations)").all() as Array<{
+      name: string;
+    }>).map((column) => column.name),
+  );
+  if (!invocationColumns.has("finding_id")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN finding_id TEXT");
+  }
+  if (!invocationColumns.has("output_state")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN output_state TEXT");
+  }
+  if (!invocationColumns.has("source")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN source TEXT NOT NULL DEFAULT 'live'");
+  }
+  if (!invocationColumns.has("suggested_prompt")) {
+    db.exec("ALTER TABLE thread_tool_invocations ADD COLUMN suggested_prompt TEXT");
+  }
+
+  const alertColumns = new Set(
+    (db.prepare("PRAGMA table_info(thread_tool_invocation_alerts)").all() as Array<{
+      name: string;
+    }>).map((column) => column.name),
+  );
+  if (!alertColumns.has("turn_id")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN turn_id TEXT");
+  }
+  if (!alertColumns.has("invocation_ids")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN invocation_ids TEXT");
+  }
+  if (!alertColumns.has("worst_invocation_id")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN worst_invocation_id TEXT");
+  }
+  if (!alertColumns.has("worst_output_chars")) {
+    db.exec("ALTER TABLE thread_tool_invocation_alerts ADD COLUMN worst_output_chars INTEGER");
+  }
+  db.exec(`
+CREATE TABLE IF NOT EXISTS thread_tool_analysis (
+  backend                   TEXT NOT NULL,
+  thread_id                 TEXT NOT NULL,
+  analyzer_version          TEXT NOT NULL,
+  analyzed_at               INTEGER NOT NULL,
+  completeness              TEXT NOT NULL,
+  entry_count               INTEGER NOT NULL,
+  invocation_count          INTEGER NOT NULL,
+  missing_output_count      INTEGER NOT NULL,
+  page_count                INTEGER NOT NULL,
+  scanned_through           TEXT,
+  explanation               TEXT,
+  PRIMARY KEY (backend, thread_id)
+);
 `);
 }
 

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -1,0 +1,107 @@
+import { BrowserWindow } from "electron";
+import {
+  buildThreadIdentityKey,
+  type OpenToolOutputIncidentExplorerWindowRequest,
+} from "@pwragent/shared";
+import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
+  showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
+} from "./auxiliary-window-chrome";
+import { getMainLogger } from "./log";
+import {
+  readBootstrapAppearance,
+  themedWindowAdditionalArguments,
+  themedWindowBackgroundColor,
+} from "./settings/appearance-bootstrap";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER,
+  registerWindowChannels,
+} from "./window-channels";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
+
+const log = getMainLogger("pwragent:tool-output-incident-explorer-window");
+const HASH = "tool-output-incidents";
+const WIDTH = 1_180;
+const HEIGHT = 820;
+const TITLE_MAX_LENGTH = 240;
+const incidentWindows = new Map<string, BrowserWindow>();
+
+export function showToolOutputIncidentExplorerWindow(
+  request: OpenToolOutputIncidentExplorerWindowRequest,
+  source: WindowPlacementSource = {},
+): void {
+  const threadId = request.threadId.trim();
+  if (!threadId) {
+    throw new Error("Tool-output incident explorer requires a thread id.");
+  }
+  const title = request.title.trim() || "Thread";
+  const windowKey = buildThreadIdentityKey(request.backend, threadId);
+  const current = incidentWindows.get(windowKey);
+  if (current && !current.isDestroyed()) {
+    positionWindowForSourceDisplay(current, source);
+    showAndFocusAuxiliaryWindow(current);
+    return;
+  }
+
+  const windowTitle = `Tool-output incidents — ${title}`;
+  const appearance = readBootstrapAppearance();
+  const window = new BrowserWindow({
+    ...placementForSourceDisplay(WIDTH, HEIGHT, source),
+    width: WIDTH,
+    height: HEIGHT,
+    minWidth: 840,
+    minHeight: 600,
+    show: false,
+    title: windowTitle,
+    ...auxiliaryWindowChromeOptions(),
+    backgroundColor: themedWindowBackgroundColor(appearance),
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      additionalArguments: themedWindowAdditionalArguments(appearance),
+    },
+  });
+  registerAuxiliaryWindowTitle(window, windowTitle);
+  hideAuxiliaryWindowMenuBar(window);
+  applyWindowSecurityHardening(window);
+  registerWindowChannels(window, WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER, [
+    APPEARANCE_CHANGED_EVENT_CHANNEL,
+  ]);
+
+  const hash = [
+    HASH,
+    encodeURIComponent(request.backend),
+    encodeURIComponent(threadId),
+    encodeURIComponent(title.slice(0, TITLE_MAX_LENGTH)),
+  ].join("/");
+  const rendererEntry = getRendererEntry();
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${hash}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash });
+  }
+  showAuxiliaryWindowWhenReady(window);
+  incidentWindows.set(windowKey, window);
+  window.on("closed", () => {
+    if (incidentWindows.get(windowKey) === window) {
+      incidentWindows.delete(windowKey);
+    }
+    log.debug("tool-output incident explorer closed", { windowKey });
+  });
+  log.debug("tool-output incident explorer created", { windowKey });
+}

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -3,7 +3,10 @@ import {
   buildThreadIdentityKey,
   type OpenToolOutputIncidentExplorerWindowRequest,
 } from "@pwragent/shared";
-import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
+import {
+  APPEARANCE_CHANGED_EVENT_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+} from "../shared/ipc";
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
@@ -52,6 +55,9 @@ export function showToolOutputIncidentExplorerWindow(
   const current = incidentWindows.get(windowKey);
   if (current && !current.isDestroyed()) {
     positionWindowForSourceDisplay(current, source);
+    current.webContents.send(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+    );
     showAndFocusAuxiliaryWindow(current);
     return;
   }
@@ -81,6 +87,7 @@ export function showToolOutputIncidentExplorerWindow(
   applyWindowSecurityHardening(window);
   registerWindowChannels(window, WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER, [
     APPEARANCE_CHANGED_EVENT_CHANNEL,
+    TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
   ]);
 
   const hash = [

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -15,10 +15,10 @@ import {
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
 import { getMainLogger } from "./log";
+import { themedWindowBackgroundColor } from "./native-appearance";
 import {
   readBootstrapAppearance,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
 import {
   applyWindowSecurityHardening,

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -118,8 +118,9 @@ export function showToolOutputIncidentExplorerWindow(
   }
   showAuxiliaryWindowWhenReady(window);
   incidentWindows.set(windowKey, window);
+  const webContentsId = window.webContents.id;
   if (source.sourceWindow && !source.sourceWindow.isDestroyed()) {
-    incidentWindowContexts.set(window.webContents.id, {
+    incidentWindowContexts.set(webContentsId, {
       owner: source.sourceWindow.webContents,
       threadKey: windowKey,
     });
@@ -128,7 +129,10 @@ export function showToolOutputIncidentExplorerWindow(
     if (incidentWindows.get(windowKey) === window) {
       incidentWindows.delete(windowKey);
     }
-    incidentWindowContexts.delete(window.webContents.id);
+    // Electron has destroyed the BrowserWindow by the time `closed` fires.
+    // Reading `window.webContents` here throws "Object has been destroyed",
+    // so retain the primitive id while the window is still live.
+    incidentWindowContexts.delete(webContentsId);
     log.debug("tool-output incident explorer closed", { windowKey });
   });
   log.debug("tool-output incident explorer created", { windowKey });

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from "electron";
+import { BrowserWindow, type WebContents } from "electron";
 import {
   buildThreadIdentityKey,
   type OpenToolOutputIncidentExplorerWindowRequest,
@@ -29,6 +29,8 @@ import {
   WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER,
   registerWindowChannels,
 } from "./window-channels";
+import type { WindowShowThreadRequest } from "../shared/window-show-thread";
+import { requestShowThread } from "./window-show-thread";
 import {
   placementForSourceDisplay,
   positionWindowForSourceDisplay,
@@ -41,6 +43,10 @@ const WIDTH = 1_180;
 const HEIGHT = 820;
 const TITLE_MAX_LENGTH = 240;
 const incidentWindows = new Map<string, BrowserWindow>();
+const incidentWindowContexts = new Map<number, {
+  owner: WebContents;
+  threadKey: string;
+}>();
 
 export function showToolOutputIncidentExplorerWindow(
   request: OpenToolOutputIncidentExplorerWindowRequest,
@@ -54,9 +60,16 @@ export function showToolOutputIncidentExplorerWindow(
   const windowKey = buildThreadIdentityKey(request.backend, threadId);
   const current = incidentWindows.get(windowKey);
   if (current && !current.isDestroyed()) {
+    if (source.sourceWindow && !source.sourceWindow.isDestroyed()) {
+      incidentWindowContexts.set(current.webContents.id, {
+        owner: source.sourceWindow.webContents,
+        threadKey: windowKey,
+      });
+    }
     positionWindowForSourceDisplay(current, source);
     current.webContents.send(
       TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+      request,
     );
     showAndFocusAuxiliaryWindow(current);
     return;
@@ -95,6 +108,7 @@ export function showToolOutputIncidentExplorerWindow(
     encodeURIComponent(request.backend),
     encodeURIComponent(threadId),
     encodeURIComponent(title.slice(0, TITLE_MAX_LENGTH)),
+    encodeURIComponent(request.projectLabel?.trim() ?? ""),
   ].join("/");
   const rendererEntry = getRendererEntry();
   if (rendererEntry.kind === "url") {
@@ -104,11 +118,35 @@ export function showToolOutputIncidentExplorerWindow(
   }
   showAuxiliaryWindowWhenReady(window);
   incidentWindows.set(windowKey, window);
+  if (source.sourceWindow && !source.sourceWindow.isDestroyed()) {
+    incidentWindowContexts.set(window.webContents.id, {
+      owner: source.sourceWindow.webContents,
+      threadKey: windowKey,
+    });
+  }
   window.on("closed", () => {
     if (incidentWindows.get(windowKey) === window) {
       incidentWindows.delete(windowKey);
     }
+    incidentWindowContexts.delete(window.webContents.id);
     log.debug("tool-output incident explorer closed", { windowKey });
   });
   log.debug("tool-output incident explorer created", { windowKey });
+}
+
+export function showThreadFromToolOutputIncidentExplorer(
+  sender: WebContents,
+  request: WindowShowThreadRequest,
+): void {
+  const context = incidentWindowContexts.get(sender.id);
+  if (!context || context.owner.isDestroyed()) {
+    throw new Error("Tool-output incident explorer has no active owner window.");
+  }
+  if (
+    buildThreadIdentityKey(request.backend, request.threadId)
+    !== context.threadKey
+  ) {
+    throw new Error("Tool-output incident explorer can only open its own thread.");
+  }
+  requestShowThread(request, { preferWebContents: context.owner });
 }

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -40,6 +40,8 @@ export const WINDOW_KIND_LICENSE_DOCUMENT = "license-document" as const;
 export const WINDOW_KIND_APP_LOGS = "app-logs" as const;
 export const WINDOW_KIND_MARKDOWN_FILES = "markdown-files" as const;
 export const WINDOW_KIND_SUB_AGENT_TRANSCRIPT = "sub-agent-transcript" as const;
+export const WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER =
+  "tool-output-incident-explorer" as const;
 export const WINDOW_KIND_AUTOMATION_RUN = "automation-run" as const;
 export type WindowKind =
   | typeof WINDOW_KIND_MAIN
@@ -50,7 +52,8 @@ export type WindowKind =
   | typeof WINDOW_KIND_APP_LOGS
   | typeof WINDOW_KIND_MARKDOWN_FILES
   | typeof WINDOW_KIND_AUTOMATION_RUN
-  | typeof WINDOW_KIND_SUB_AGENT_TRANSCRIPT;
+  | typeof WINDOW_KIND_SUB_AGENT_TRANSCRIPT
+  | typeof WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER;
 
 interface Entry {
   kind: WindowKind;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -519,6 +519,7 @@ import {
   MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
   DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
@@ -1213,6 +1214,21 @@ const desktopApi = Object.freeze({
       TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
       request,
     ),
+  onToolOutputIncidentExplorerRefresh: (
+    callback: () => void,
+  ): (() => void) => {
+    const listener = () => callback();
+    ipcRenderer.on(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+      listener,
+    );
+    return () => {
+      ipcRenderer.off(
+        TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+        listener,
+      );
+    };
+  },
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,
   ): Promise<IntegratedTerminalCreateResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -520,6 +520,7 @@ import {
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
   TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
   DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
@@ -1215,9 +1216,14 @@ const desktopApi = Object.freeze({
       request,
     ),
   onToolOutputIncidentExplorerRefresh: (
-    callback: () => void,
+    callback: (
+      request?: OpenToolOutputIncidentExplorerWindowRequest,
+    ) => void,
   ): (() => void) => {
-    const listener = () => callback();
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      request?: OpenToolOutputIncidentExplorerWindowRequest,
+    ) => callback(request);
     ipcRenderer.on(
       TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL,
       listener,
@@ -1228,6 +1234,14 @@ const desktopApi = Object.freeze({
         listener,
       );
     };
+  },
+  showThreadFromToolOutputIncidentExplorer: async (
+    request: WindowShowThreadRequest,
+  ): Promise<void> => {
+    await ipcRenderer.invoke(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL,
+      request,
+    );
   },
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -150,6 +150,8 @@ import type {
   SetThreadPinResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
+  SetThreadToolIncidentNoticeRequest,
+  SetThreadToolIncidentNoticeResponse,
   GetGhStatusRequest,
   GhStatus,
   ApproveMessagingPairingRequest,
@@ -641,6 +643,7 @@ import {
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
+  NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
@@ -1649,6 +1652,13 @@ const desktopApi = Object.freeze({
     request: SetThreadReactionRequest,
   ): Promise<SetThreadReactionResponse> =>
     await ipcRenderer.invoke(NAVIGATION_SET_THREAD_REACTION_CHANNEL, request),
+  setThreadToolIncidentNotice: async (
+    request: SetThreadToolIncidentNoticeRequest,
+  ): Promise<SetThreadToolIncidentNoticeResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
+      request,
+    ),
   setThreadPin: async (
     request: SetThreadPinRequest,
   ): Promise<SetThreadPinResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,6 +98,8 @@ import type {
   ThreadSearchResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AnalyzeThreadToolHistoryRequest,
+  AnalyzeThreadToolHistoryResponse,
   GetThreadFileDiffRequest,
   GetThreadFileDiffResponse,
   PersistThreadUsageActivityRequest,
@@ -309,6 +311,8 @@ import type {
   OpenMarkdownFileViewerResponse,
   OpenSubAgentTranscriptWindowRequest,
   OpenSubAgentTranscriptWindowResponse,
+  OpenToolOutputIncidentExplorerWindowRequest,
+  OpenToolOutputIncidentExplorerWindowResponse,
   OpenPathRequest,
   OpenPathResponse,
   ReadMarkdownFileRequest,
@@ -505,6 +509,7 @@ import {
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
   APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
   APPLICATIONS_READ_CHANNEL,
   APPLICATION_OPEN_CHANNEL,
@@ -513,6 +518,7 @@ import {
   MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL,
   MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
+  TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
   DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
@@ -1200,6 +1206,13 @@ const desktopApi = Object.freeze({
     request: OpenSubAgentTranscriptWindowRequest,
   ): Promise<OpenSubAgentTranscriptWindowResponse> =>
     await ipcRenderer.invoke(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL, request),
+  openToolOutputIncidentExplorerWindow: async (
+    request: OpenToolOutputIncidentExplorerWindowRequest,
+  ): Promise<OpenToolOutputIncidentExplorerWindowResponse> =>
+    await ipcRenderer.invoke(
+      TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL,
+      request,
+    ),
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,
   ): Promise<IntegratedTerminalCreateResponse> =>
@@ -1327,6 +1340,13 @@ const desktopApi = Object.freeze({
     await invokeWithStartupProfileTiming(
       "readThread",
       APP_SERVER_READ_THREAD_CHANNEL,
+      request,
+    ),
+  analyzeThreadToolHistory: async (
+    request: AnalyzeThreadToolHistoryRequest,
+  ): Promise<AnalyzeThreadToolHistoryResponse> =>
+    await ipcRenderer.invoke(
+      APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL,
       request,
     ),
   getThreadFileDiff: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -26,6 +26,7 @@ import {
   type MessagingChannelKind,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
+  type ThreadToolInvocationAlert,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { useThreadJump } from "./features/navigation/useThreadJump";
@@ -103,6 +104,7 @@ import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNo
 import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
 import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/github-pr-saml-notice";
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
+import { buildToolAccountingNotice } from "./features/notifications/tool-accounting-notice";
 import {
   buildHeapSnapshotHandoffMessage,
   describeHeapSnapshotResult,
@@ -645,6 +647,79 @@ function DesktopAppShell(props: {
       const instanceId = event.federationTarget?.scope === "remote"
         ? event.federationTarget.instanceId
         : undefined;
+      if (event.notification.method === "thread/toolAccounting/updated") {
+        const params = event.notification.params as {
+          threadId: string;
+          triggeredAlerts?: ThreadToolInvocationAlert[];
+        };
+        for (const alert of params.triggeredAlerts ?? []) {
+          const noticeId = [
+            "tool-accounting",
+            alert.backend,
+            alert.threadId,
+            alert.kind,
+          ].join(":");
+          const matchingThread = backendErrorThreadsRef.current.find(
+            (thread) =>
+              thread.source === event.backend
+              && thread.id === params.threadId
+              && federationTargetsEqual(
+                thread.federation?.ref.target,
+                event.federationTarget,
+              ),
+          );
+          const threadLink = matchingThread
+            ? {
+                backend: matchingThread.source,
+                inThreadList: true,
+                ...(instanceId ? { instanceId } : {}),
+                threadId: matchingThread.id,
+                title: matchingThread.title,
+                titleSource: matchingThread.titleSource,
+                gitBranch: matchingThread.gitBranch,
+                linkedDirectories: matchingThread.linkedDirectories,
+              }
+            : undefined;
+          const dismiss = (): void => {
+            dispatchAppNotice({ type: "dismiss", id: noticeId });
+          };
+          let steer: (() => void) | undefined;
+          const showNotice = (detail?: string): void => {
+            const notice = buildToolAccountingNotice({
+              alert,
+              onDismiss: dismiss,
+              onSteer: steer,
+              threadLink,
+            });
+            dispatchAppNotice({
+              type: "show",
+              notice: detail ? { ...notice, detail } : notice,
+            });
+          };
+          if (alert.turnId && desktopApi.steerTurn) {
+            steer = (): void => {
+              void desktopApi.steerTurn?.({
+                backend: event.backend,
+                federationTarget: event.federationTarget,
+                threadId: params.threadId,
+                expectedTurnId: alert.turnId!,
+                input: [{ type: "text", text: alert.suggestedPrompt }],
+                requestId: [
+                  "tool-accounting",
+                  alert.alertId,
+                  alert.updatedAt,
+                ].join(":"),
+              }).then(dismiss).catch((error) => {
+                showNotice(
+                  `Steering failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+              });
+            };
+          }
+          showNotice();
+        }
+        return;
+      }
       // Params are cast explicitly: the AppServerNotification union is too
       // wide for the discriminant to narrow `params` reliably here.
       if (event.notification.method === "turn/failed") {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -104,7 +104,11 @@ import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNo
 import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
 import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/github-pr-saml-notice";
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
-import { buildToolAccountingNotice } from "./features/notifications/tool-accounting-notice";
+import {
+  buildToolAccountingNotice,
+  resolveDismissedToolIncident,
+  toolAccountingNoticeId,
+} from "./features/notifications/tool-accounting-notice";
 import {
   buildHeapSnapshotHandoffMessage,
   describeHeapSnapshotResult,
@@ -333,6 +337,10 @@ function DesktopAppShell(props: {
   // every navigation change. Kept fresh by an effect below, once
   // `navigation` is defined.
   const backendErrorThreadsRef = useRef<NavigationThreadSummary[]>([]);
+  const dismissedToolIncidentSeverityRef = useRef(new Map<
+    string,
+    ThreadToolInvocationAlert["severity"]
+  >());
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
@@ -653,12 +661,20 @@ function DesktopAppShell(props: {
           triggeredAlerts?: ThreadToolInvocationAlert[];
         };
         for (const alert of params.triggeredAlerts ?? []) {
-          const noticeId = [
-            "tool-accounting",
-            alert.backend,
-            alert.threadId,
-            alert.kind,
-          ].join(":");
+          const noticeId = toolAccountingNoticeId(alert);
+          const dismissedSeverity = dismissedToolIncidentSeverityRef.current.get(
+            noticeId,
+          );
+          const dismissalResolution = resolveDismissedToolIncident({
+            dismissedSeverity,
+            incomingSeverity: alert.severity,
+          });
+          if (dismissalResolution === "suppress") {
+            continue;
+          }
+          if (dismissalResolution === "escalate") {
+            dismissedToolIncidentSeverityRef.current.delete(noticeId);
+          }
           const matchingThread = backendErrorThreadsRef.current.find(
             (thread) =>
               thread.source === event.backend
@@ -681,41 +697,34 @@ function DesktopAppShell(props: {
               }
             : undefined;
           const dismiss = (): void => {
+            dismissedToolIncidentSeverityRef.current.set(
+              noticeId,
+              alert.severity,
+            );
             dispatchAppNotice({ type: "dismiss", id: noticeId });
           };
-          let steer: (() => void) | undefined;
-          const showNotice = (detail?: string): void => {
+          const examine = (): void => {
+            void desktopApi?.openToolOutputIncidentExplorerWindow?.({
+              backend: event.backend,
+              threadId: params.threadId,
+              title: matchingThread?.title ?? labelForThread(
+                event.backend,
+                params.threadId,
+              ),
+            });
+          };
+          const showNotice = (): void => {
             const notice = buildToolAccountingNotice({
               alert,
+              onExamine: examine,
               onDismiss: dismiss,
-              onSteer: steer,
               threadLink,
             });
             dispatchAppNotice({
               type: "show",
-              notice: detail ? { ...notice, detail } : notice,
+              notice,
             });
           };
-          if (alert.turnId && desktopApi.steerTurn) {
-            steer = (): void => {
-              void desktopApi.steerTurn?.({
-                backend: event.backend,
-                federationTarget: event.federationTarget,
-                threadId: params.threadId,
-                expectedTurnId: alert.turnId!,
-                input: [{ type: "text", text: alert.suggestedPrompt }],
-                requestId: [
-                  "tool-accounting",
-                  alert.alertId,
-                  alert.updatedAt,
-                ].join(":"),
-              }).then(dismiss).catch((error) => {
-                showNotice(
-                  `Steering failed: ${error instanceof Error ? error.message : String(error)}`,
-                );
-              });
-            };
-          }
           showNotice();
         }
         return;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -679,6 +679,7 @@ function DesktopAppShell(props: {
       if (event.notification.method === "thread/toolAccounting/updated") {
         const params = event.notification.params as {
           threadId: string;
+          incidentNotice?: ThreadToolIncidentNoticeState;
           toolAccounting?: ThreadToolAccounting;
           triggeredAlerts?: ThreadToolInvocationAlert[];
         };
@@ -687,10 +688,24 @@ function DesktopAppShell(props: {
            replaces minted a durable notice per turn — a busy thread reached
            "1 of 41" in the stack with no way to clear them in bulk. */
         if (!params.toolAccounting) return;
+        /* Only a freshly tripped threshold raises the card. Folding on every
+           accounting update would re-alert on last week's calls the first
+           time an old thread runs anything, which is history, not an
+           incident. The fold still summarizes the whole thread once a new
+           alert makes it worth showing. */
+        if (!params.triggeredAlerts?.length) return;
         const noticeId = threadIncidentNoticeId({
           backend: event.backend,
           threadId: params.threadId,
         });
+        /* Persisted disposition wins over anything this session inferred: it
+           may predate this renderer entirely. */
+        if (params.incidentNotice) {
+          toolIncidentStateRef.current.set(noticeId, {
+            ...toolIncidentStateRef.current.get(noticeId),
+            ...params.incidentNotice,
+          });
+        }
         const incidentState = toolIncidentStateRef.current.get(noticeId);
         const summary = buildThreadIncidentSummary({
           accounting: params.toolAccounting,
@@ -794,6 +809,15 @@ function DesktopAppShell(props: {
             ),
           });
         };
+        /* Anchor the cost window the first time this thread warns. Recording
+           it only on dismissal would date the window to whenever the operator
+           happened to click, not to the first warning. */
+        if (
+          incidentState?.firstWarningAt === undefined
+          && summary.firstWarningAt !== undefined
+        ) {
+          persistIncident({});
+        }
         dispatchAppNotice({
           type: "show",
           notice: buildToolAccountingNotice({

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -27,7 +27,12 @@ import {
   type NavigationDirectorySummary,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
+  type ThreadToolAccounting,
+  type ThreadToolIncidentNoticeState,
   type ThreadToolInvocationAlert,
+  type ThreadUsageLineRecord,
+  type SetThreadToolIncidentNoticeRequest,
+  resolveToolIncidentVisibility,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { useThreadJump } from "./features/navigation/useThreadJump";
@@ -107,9 +112,11 @@ import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/git
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
 import {
   buildToolAccountingNotice,
-  resolveDismissedToolIncident,
-  toolAccountingNoticeId,
 } from "./features/notifications/tool-accounting-notice";
+import {
+  buildThreadIncidentSummary,
+  threadIncidentNoticeId,
+} from "./features/notifications/thread-incident-summary";
 import {
   buildHeapSnapshotHandoffMessage,
   describeHeapSnapshotResult,
@@ -339,10 +346,22 @@ function DesktopAppShell(props: {
   // effect below, once `navigation` is defined.
   const backendErrorThreadsRef = useRef<NavigationThreadSummary[]>([]);
   const backendErrorDirectoriesRef = useRef<NavigationDirectorySummary[]>([]);
-  const dismissedToolIncidentSeverityRef = useRef(new Map<
+  /* Per-thread incident disposition, keyed by notice id. Mirrors what the
+     overlay persists so a reply to a live notification does not need to wait
+     on a round trip to know whether the operator already silenced this. */
+  const toolIncidentStateRef = useRef(new Map<
     string,
-    ThreadToolInvocationAlert["severity"]
+    ThreadToolIncidentNoticeState
   >());
+  /* Usage rows for the loaded thread only — the renderer's pricing ledger is
+     session-scoped. A background thread's card therefore reports replayed
+     tokens and no money until the accounting notification carries a spend
+     figure of its own. */
+  const threadUsageLinesRef = useRef(new Map<
+    string,
+    readonly ThreadUsageLineRecord[]
+  >());
+  const showIncidentCostRef = useRef(false);
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
@@ -660,92 +679,132 @@ function DesktopAppShell(props: {
       if (event.notification.method === "thread/toolAccounting/updated") {
         const params = event.notification.params as {
           threadId: string;
+          toolAccounting?: ThreadToolAccounting;
           triggeredAlerts?: ThreadToolInvocationAlert[];
         };
-        for (const alert of params.triggeredAlerts ?? []) {
-          const noticeId = toolAccountingNoticeId(alert);
-          const dismissedSeverity = dismissedToolIncidentSeverityRef.current.get(
-            noticeId,
-          );
-          const dismissalResolution = resolveDismissedToolIncident({
-            dismissedSeverity,
-            incomingSeverity: alert.severity,
-          });
-          if (dismissalResolution === "suppress") {
-            continue;
-          }
-          if (dismissalResolution === "escalate") {
-            dismissedToolIncidentSeverityRef.current.delete(noticeId);
-          }
-          const matchingThread = backendErrorThreadsRef.current.find(
-            (thread) =>
-              thread.source === event.backend
-              && thread.id === params.threadId
-              && federationTargetsEqual(
-                thread.federation?.ref.target,
-                event.federationTarget,
-              ),
-          );
-          const threadLink = matchingThread
-            ? {
-                backend: matchingThread.source,
-                inThreadList: true,
-                ...(instanceId ? { instanceId } : {}),
-                threadId: matchingThread.id,
-                title: matchingThread.title,
-                titleSource: matchingThread.titleSource,
-                gitBranch: matchingThread.gitBranch,
-                linkedDirectories: matchingThread.linkedDirectories,
-              }
-            : undefined;
-          const dismiss = (): void => {
-            dismissedToolIncidentSeverityRef.current.set(
-              noticeId,
-              alert.severity,
-            );
-            dispatchAppNotice({ type: "dismiss", id: noticeId });
+        /* One card per thread, folded from the whole accounting snapshot,
+           rather than one per triggered alert. The per-alert loop this
+           replaces minted a durable notice per turn — a busy thread reached
+           "1 of 41" in the stack with no way to clear them in bulk. */
+        if (!params.toolAccounting) return;
+        const noticeId = threadIncidentNoticeId({
+          backend: event.backend,
+          threadId: params.threadId,
+        });
+        const incidentState = toolIncidentStateRef.current.get(noticeId);
+        const summary = buildThreadIncidentSummary({
+          accounting: params.toolAccounting,
+          backend: event.backend,
+          ...(incidentState?.firstWarningAt !== undefined
+            ? { firstWarningAt: incidentState.firstWarningAt }
+            : {}),
+          threadId: params.threadId,
+          usageLines: threadUsageLinesRef.current.get(
+            buildThreadIdentityKey(event.backend, params.threadId),
+          ),
+        });
+        if (!summary) return;
+        if (
+          resolveToolIncidentVisibility({
+            severity: summary.severity,
+            ...(incidentState ? { state: incidentState } : {}),
+          }) === "suppress"
+        ) {
+          return;
+        }
+        const matchingThread = backendErrorThreadsRef.current.find(
+          (thread) =>
+            thread.source === event.backend
+            && thread.id === params.threadId
+            && federationTargetsEqual(
+              thread.federation?.ref.target,
+              event.federationTarget,
+            ),
+        );
+        const threadLink = matchingThread
+          ? {
+              backend: matchingThread.source,
+              inThreadList: true,
+              ...(instanceId ? { instanceId } : {}),
+              threadId: matchingThread.id,
+              title: matchingThread.title,
+              titleSource: matchingThread.titleSource,
+              gitBranch: matchingThread.gitBranch,
+              linkedDirectories: matchingThread.linkedDirectories,
+            }
+          : undefined;
+        const persistIncident = (
+          patch: Omit<SetThreadToolIncidentNoticeRequest, "backend" | "threadId">,
+        ): void => {
+          const next: ThreadToolIncidentNoticeState = {
+            ...toolIncidentStateRef.current.get(noticeId),
+            ...(summary.firstWarningAt !== undefined
+              ? { firstWarningAt: summary.firstWarningAt }
+              : {}),
+            ...(patch.dismissedSeverity
+              ? { dismissedSeverity: patch.dismissedSeverity }
+              : {}),
+            ...(patch.mutedSeverity ? { mutedSeverity: patch.mutedSeverity } : {}),
           };
-          const examine = (): void => {
-            const threadKey = buildThreadIdentityKey(
+          toolIncidentStateRef.current.set(noticeId, next);
+          void desktopApi?.setThreadToolIncidentNotice?.({
+            backend: event.backend,
+            ...(summary.firstWarningAt !== undefined
+              ? { firstWarningAt: summary.firstWarningAt }
+              : {}),
+            ...patch,
+            threadId: params.threadId,
+          }).catch(() => undefined);
+        };
+        const dismiss = (): void => {
+          persistIncident({ dismissedSeverity: summary.severity });
+          dispatchAppNotice({ type: "dismiss", id: noticeId });
+        };
+        const mute = (): void => {
+          persistIncident({
+            dismissedSeverity: summary.severity,
+            mutedSeverity: summary.severity,
+          });
+          dispatchAppNotice({ type: "dismiss", id: noticeId });
+        };
+        const examine = (): void => {
+          const threadKey = buildThreadIdentityKey(
+            event.backend,
+            params.threadId,
+          );
+          const matchingDirectory =
+            backendErrorDirectoriesRef.current.find(
+              (directory) =>
+                directory.kind === "directory"
+                && directory.threadKeys.includes(threadKey),
+            )
+            ?? backendErrorDirectoriesRef.current.find((directory) =>
+              directory.threadKeys.includes(threadKey)
+            );
+          const projectLabel =
+            matchingDirectory?.label
+            ?? matchingThread?.linkedDirectories[0]?.label;
+          void desktopApi?.openToolOutputIncidentExplorerWindow?.({
+            backend: event.backend,
+            ...(projectLabel ? { projectLabel } : {}),
+            threadId: params.threadId,
+            title: matchingThread?.title ?? labelForThread(
               event.backend,
               params.threadId,
-            );
-            const matchingDirectory =
-              backendErrorDirectoriesRef.current.find(
-                (directory) =>
-                  directory.kind === "directory"
-                  && directory.threadKeys.includes(threadKey),
-              )
-              ?? backendErrorDirectoriesRef.current.find((directory) =>
-                directory.threadKeys.includes(threadKey)
-              );
-            const projectLabel =
-              matchingDirectory?.label
-              ?? matchingThread?.linkedDirectories[0]?.label;
-            void desktopApi?.openToolOutputIncidentExplorerWindow?.({
-              backend: event.backend,
-              ...(projectLabel ? { projectLabel } : {}),
-              threadId: params.threadId,
-              title: matchingThread?.title ?? labelForThread(
-                event.backend,
-                params.threadId,
-              ),
-            });
-          };
-          const showNotice = (): void => {
-            const notice = buildToolAccountingNotice({
-              alert,
-              onExamine: examine,
-              onDismiss: dismiss,
-              threadLink,
-            });
-            dispatchAppNotice({
-              type: "show",
-              notice,
-            });
-          };
-          showNotice();
-        }
+            ),
+          });
+        };
+        dispatchAppNotice({
+          type: "show",
+          notice: buildToolAccountingNotice({
+            onDismiss: dismiss,
+            onExamine: examine,
+            onMute: mute,
+            showCost: showIncidentCostRef.current,
+            summary,
+            threadLink,
+          }),
+        });
         return;
       }
       // Params are cast explicitly: the AppServerNotification union is too
@@ -1050,6 +1109,18 @@ function DesktopAppShell(props: {
     backendErrorThreadsRef.current = navigation.threads;
     backendErrorDirectoriesRef.current = navigation.directories;
   }, [navigation.directories, navigation.threads]);
+  /* Incident-notice inputs the live notification handler reads without
+     re-subscribing: which thread is on screen, whether the operator has
+     pricing display on, and the loaded thread's usage rows. */
+  useEffect(() => {
+    showIncidentCostRef.current =
+      (settings.snapshot?.experimental.threadPricingSummary?.value ?? true)
+      && (
+        (settings.snapshot?.experimental.threadPricingDisplayUsd?.value ?? true)
+        || (settings.snapshot?.experimental.threadPricingDisplayCodexCredits
+          ?.value ?? false)
+      );
+  }, [settings.snapshot?.experimental]);
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,
@@ -1638,6 +1709,16 @@ function DesktopAppShell(props: {
           void desktopApi?.openStarMapWindow?.();
         },
       };
+  useEffect(() => {
+    const thread = navigation.selectedThread;
+    const lines = session.response?.pricing?.lines;
+    if (!thread || !lines) return;
+    threadUsageLinesRef.current.set(
+      buildThreadIdentityKey(thread.source, thread.id),
+      lines,
+    );
+  }, [navigation.selectedThread, session.response?.pricing?.lines]);
+
   const threadViewProps = {
     activeFederationOwnerLabel,
     activeFederationTarget,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -704,8 +704,10 @@ function DesktopAppShell(props: {
             dispatchAppNotice({ type: "dismiss", id: noticeId });
           };
           const examine = (): void => {
+            const projectLabel = matchingThread?.linkedDirectories[0]?.label;
             void desktopApi?.openToolOutputIncidentExplorerWindow?.({
               backend: event.backend,
+              ...(projectLabel ? { projectLabel } : {}),
               threadId: params.threadId,
               title: matchingThread?.title ?? labelForThread(
                 event.backend,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import {
   type FederationInstanceId,
   type FederationTarget,
   type MessagingChannelKind,
+  type NavigationDirectorySummary,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
   type ThreadToolInvocationAlert,
@@ -332,11 +333,12 @@ function DesktopAppShell(props: {
     useState<GithubPrSamlEnforcementEvent[]>([]);
   const [githubPrAuthenticationFailure, setGithubPrAuthenticationFailure] =
     useState<GithubPrAuthenticationFailureEvent>();
-  // Latest thread list, mirrored into a ref so the backend-error toast
-  // subscription can resolve a thread's title without re-subscribing on
-  // every navigation change. Kept fresh by an effect below, once
-  // `navigation` is defined.
+  // Latest navigation identity, mirrored into refs so the backend-error toast
+  // subscription can resolve a thread's title and configured project label
+  // without re-subscribing on every navigation change. Kept fresh by an
+  // effect below, once `navigation` is defined.
   const backendErrorThreadsRef = useRef<NavigationThreadSummary[]>([]);
+  const backendErrorDirectoriesRef = useRef<NavigationDirectorySummary[]>([]);
   const dismissedToolIncidentSeverityRef = useRef(new Map<
     string,
     ThreadToolInvocationAlert["severity"]
@@ -704,7 +706,22 @@ function DesktopAppShell(props: {
             dispatchAppNotice({ type: "dismiss", id: noticeId });
           };
           const examine = (): void => {
-            const projectLabel = matchingThread?.linkedDirectories[0]?.label;
+            const threadKey = buildThreadIdentityKey(
+              event.backend,
+              params.threadId,
+            );
+            const matchingDirectory =
+              backendErrorDirectoriesRef.current.find(
+                (directory) =>
+                  directory.kind === "directory"
+                  && directory.threadKeys.includes(threadKey),
+              )
+              ?? backendErrorDirectoriesRef.current.find((directory) =>
+                directory.threadKeys.includes(threadKey)
+              );
+            const projectLabel =
+              matchingDirectory?.label
+              ?? matchingThread?.linkedDirectories[0]?.label;
             void desktopApi?.openToolOutputIncidentExplorerWindow?.({
               backend: event.backend,
               ...(projectLabel ? { projectLabel } : {}),
@@ -1031,7 +1048,8 @@ function DesktopAppShell(props: {
   // toast subscription depend on (and re-subscribe to) the thread list.
   useEffect(() => {
     backendErrorThreadsRef.current = navigation.threads;
-  }, [navigation.threads]);
+    backendErrorDirectoriesRef.current = navigation.directories;
+  }, [navigation.directories, navigation.threads]);
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -646,6 +646,94 @@ describe("App", () => {
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
   });
 
+  it("surfaces replay-risk alerts as durable one-click steering notices", async () => {
+    const agentEventListeners = new Set<(event: AgentEvent) => void>();
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+        steerTurn,
+      },
+    });
+
+    render(<App />);
+    await waitFor(() => expect(agentEventListeners.size).toBeGreaterThan(0));
+
+    act(() => {
+      const event = {
+        backend: "codex",
+        notification: {
+          method: "thread/toolAccounting/updated",
+          params: {
+            threadId: "thread-1",
+            toolAccounting: { alerts: [], invocations: [], summaries: [] },
+            triggeredAlerts: [{
+              alertId: "noisy-polling:codex:thread-1:wait:turn-1",
+              backend: "codex",
+              createdAt: 1,
+              estimatedOutputTokens: 0,
+              firstObservedAt: 1,
+              invocationCount: 5,
+              kind: "noisy-polling",
+              lastObservedAt: 2,
+              message: "Five queued checks keep replaying the turn context.",
+              severity: "warning",
+              suggestedPrompt: "Stop polling and use a monitor job.",
+              threadId: "thread-1",
+              toolName: "wait",
+              totalOutputChars: 0,
+              turnId: "turn-1",
+              updatedAt: 2,
+            }],
+          },
+        },
+      } as AgentEvent;
+      for (const listener of agentEventListeners) {
+        listener(event);
+      }
+    });
+
+    expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
+    expect(screen.getByText(/Five queued checks/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Use monitor job" }));
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledWith(expect.objectContaining({
+        backend: "codex",
+        expectedTurnId: "turn-1",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Stop polling and use a monitor job." }],
+      }));
+    });
+  });
+
   it("reveals the sidebar when adding a project from the hidden-sidebar masthead", async () => {
     const pickDirectoryFromDisk = vi.fn(async () => ({
       canceled: false as const,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -646,12 +646,10 @@ describe("App", () => {
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
   });
 
-  it("surfaces replay-risk alerts as durable one-click steering notices", async () => {
+  it("opens the incident explorer from a replay-risk notice", async () => {
     const agentEventListeners = new Set<(event: AgentEvent) => void>();
-    const steerTurn = vi.fn(async () => ({
-      backend: "codex" as const,
-      threadId: "thread-1",
-      turnId: "turn-1",
+    const openToolOutputIncidentExplorerWindow = vi.fn(async () => ({
+      opened: true as const,
     }));
     Object.defineProperty(window, "pwragent", {
       configurable: true,
@@ -679,7 +677,7 @@ describe("App", () => {
           await new Promise<never>(() => {
             // Keep the shell mounted without needing a full settings fixture.
           }),
-        steerTurn,
+        openToolOutputIncidentExplorerWindow,
       },
     });
 
@@ -722,15 +720,14 @@ describe("App", () => {
 
     expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
     expect(screen.getByText(/Five queued checks/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Use monitor job" }));
+    fireEvent.click(screen.getByRole("button", { name: "Examine 5 cases" }));
 
     await waitFor(() => {
-      expect(steerTurn).toHaveBeenCalledWith(expect.objectContaining({
+      expect(openToolOutputIncidentExplorerWindow).toHaveBeenCalledWith({
         backend: "codex",
-        expectedTurnId: "turn-1",
         threadId: "thread-1",
-        input: [{ type: "text", text: "Stop polling and use a monitor job." }],
-      }));
+        title: "Codex thread",
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -758,6 +758,84 @@ describe("App", () => {
     });
   });
 
+  it("does not raise a tool-output card when no new threshold tripped", async () => {
+    /* Accounting updates fire on every tool call. Folding on all of them
+       re-alerted about last week's calls the first time an old thread ran
+       anything. */
+    const agentEventListeners = new Set<(event: AgentEvent) => void>();
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+      },
+    });
+    render(<App />);
+    await waitFor(() => expect(agentEventListeners.size).toBeGreaterThan(0));
+
+    act(() => {
+      const event = {
+        backend: "codex",
+        notification: {
+          method: "thread/toolAccounting/updated",
+          params: {
+            threadId: "thread-1",
+            toolAccounting: {
+              alerts: [],
+              invocations: [{
+                backend: "codex",
+                category: "shell",
+                debugLines: 0,
+                errorLines: 0,
+                estimatedOutputTokens: 5_000,
+                infoLines: 0,
+                invocationId: "old-large-call",
+                itemId: "old-item",
+                noisy: true,
+                observedAt: 1_000,
+                outputChars: 20_000,
+                outputLines: 100,
+                outputTruncated: false,
+                status: "completed",
+                threadId: "thread-1",
+                toolName: "commandExecution",
+                turnId: "turn-old",
+                updatedAt: 1_000,
+                warningLines: 0,
+              }],
+              summaries: [],
+            },
+            /* No triggeredAlerts: nothing crossed a threshold just now. */
+          },
+        },
+      } as AgentEvent;
+      for (const listener of agentEventListeners) listener(event);
+    });
+
+    expect(screen.queryByText("Large tool output")).not.toBeInTheDocument();
+  });
+
   it("reveals the sidebar when adding a project from the hidden-sidebar masthead", async () => {
     const pickDirectoryFromDisk = vi.fn(async () => ({
       canceled: false as const,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -691,7 +691,32 @@ describe("App", () => {
           method: "thread/toolAccounting/updated",
           params: {
             threadId: "thread-1",
-            toolAccounting: { alerts: [], invocations: [], summaries: [] },
+            toolAccounting: {
+              alerts: [],
+              invocations: Array.from({ length: 5 }, (_, index) => ({
+                backend: "codex",
+                category: "polling",
+                debugLines: 0,
+                errorLines: 0,
+                estimatedOutputTokens: 0,
+                infoLines: 0,
+                invocationId: `wait-${index}`,
+                itemId: `item-${index}`,
+                noisy: true,
+                noisyReason: "repeat-polling-output",
+                observedAt: 1_000 + index * 30_000,
+                outputChars: 0,
+                outputLines: 0,
+                outputTruncated: false,
+                status: "completed",
+                threadId: "thread-1",
+                toolName: "wait",
+                turnId: "turn-1",
+                updatedAt: 1_000 + index * 30_000,
+                warningLines: 0,
+              })),
+              summaries: [],
+            },
             triggeredAlerts: [{
               alertId: "noisy-polling:codex:thread-1:wait:turn-1",
               backend: "codex",
@@ -719,7 +744,9 @@ describe("App", () => {
     });
 
     expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
-    expect(screen.getByText(/Five queued checks/)).toBeInTheDocument();
+    /* One consolidated card for the thread, describing the whole pattern,
+       rather than one card per turn that tripped the detector. */
+    expect(screen.getByText(/5 are repeated queued checks/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Examine 5 cases" }));
 
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -1,93 +1,268 @@
+import type {
+  ThreadToolAccounting,
+  ThreadToolInvocationRecord,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+import { resolveToolIncidentVisibility } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
-import type { ThreadToolInvocationAlert } from "@pwragent/shared";
-import {
-  buildToolAccountingNotice,
-  resolveDismissedToolIncident,
-  toolAccountingNoticeId,
-} from "../tool-accounting-notice";
+import { buildToolAccountingNotice } from "../tool-accounting-notice";
+import { buildThreadIncidentSummary } from "../thread-incident-summary";
 
-describe("buildToolAccountingNotice", () => {
-  it("makes the explorer the primary action for an aggregated incident", () => {
-    const onDismiss = vi.fn();
-    const onExamine = vi.fn();
-    const notice = buildToolAccountingNotice({
-      alert: buildAlert({ kind: "noisy-polling" }),
-      onDismiss,
-      onExamine,
+describe("buildThreadIncidentSummary", () => {
+  it("folds a thread's flagged calls into one incident", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([
+        invocation({ observedAt: 100, outputChars: 8_000, turnId: "turn-1" }),
+        invocation({ observedAt: 200, outputChars: 9_000, turnId: "turn-1" }),
+        invocation({ observedAt: 300, outputChars: 6_000, turnId: "turn-2" }),
+      ]),
+      backend: "codex",
+      threadId: "thread-1",
     });
 
-    expect(notice).toMatchObject({
-      autoDismiss: false,
-      id: "tool-accounting:codex:thread-1:turn-1:noisy-polling",
-      title: "Repeated queued checks",
-      tone: "warning",
-    });
-    expect(notice.actions?.map((action) => action.label)).toEqual([
-      "Examine 5 cases",
-      "Dismiss",
-    ]);
-    notice.actions?.[0]?.onClick();
-    notice.actions?.[1]?.onClick();
-    expect(onExamine).toHaveBeenCalledOnce();
-    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(summary?.flaggedInvocationCount).toBe(3);
+    expect(summary?.turnsWithWarnings).toBe(2);
+    expect(summary?.firstWarningAt).toBe(100);
+    expect(summary?.severity).toBe("warning");
   });
 
-  it("upserts large outputs under one critical thread incident", () => {
-    const notice = buildToolAccountingNotice({
-      alert: buildAlert({ kind: "large-output", severity: "critical" }),
-      onDismiss: vi.fn(),
-      onExamine: vi.fn(),
+  it("counts calls that hit the output cap and escalates to critical", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([
+        invocation({ observedAt: 100, outputChars: 8_000 }),
+        invocation({ observedAt: 200, outputChars: 40_000 }),
+      ]),
+      backend: "codex",
+      threadId: "thread-1",
     });
 
-    expect(notice).toMatchObject({
-      id: "tool-accounting:codex:thread-1:turn-1:large-output",
-      title: "Large tool output",
-      tone: "error",
+    expect(summary?.overCapCount).toBe(1);
+    expect(summary?.severity).toBe("critical");
+  });
+
+  it("keeps the persisted cost baseline when it predates the snapshot", () => {
+    /* A restart drops older accounting rows out of the live snapshot; the
+       cost window must not silently move up to the newest warning. */
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([invocation({ observedAt: 5_000 })]),
+      backend: "codex",
+      firstWarningAt: 1_000,
+      threadId: "thread-1",
     });
-    expect(notice.actions?.[0]?.label).toBe("Examine 5 cases");
+
+    expect(summary?.firstWarningAt).toBe(1_000);
   });
 
-  it("suppresses rewrites after dismissal until a critical escalation", () => {
-    expect(resolveDismissedToolIncident({
-      dismissedSeverity: "warning",
-      incomingSeverity: "warning",
-    })).toBe("suppress");
-    expect(resolveDismissedToolIncident({
-      dismissedSeverity: "warning",
-      incomingSeverity: "critical",
-    })).toBe("escalate");
-    expect(resolveDismissedToolIncident({
-      dismissedSeverity: "critical",
-      incomingSeverity: "critical",
-    })).toBe("suppress");
+  it("prices replayed output from the thread's own cache-served rows", () => {
+    /* Two calls in one turn: the first is replayed by the second. */
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([
+        invocation({
+          estimatedOutputTokens: 1_000,
+          observedAt: 100,
+          turnId: "turn-1",
+        }),
+        invocation({
+          estimatedOutputTokens: 500,
+          observedAt: 200,
+          turnId: "turn-1",
+        }),
+      ]),
+      backend: "codex",
+      threadId: "thread-1",
+      usageLines: [
+        /* 2,000,000 micros for 2,000,000 cached tokens → 1 micro per token. */
+        usageLine({
+          cachedInputCostMicros: 2_000_000,
+          cachedInputTokens: 2_000_000,
+          createdAt: 150,
+          totalCostMicros: 3_000_000,
+        }),
+      ],
+    });
+
+    expect(summary?.replayedTokens).toBe(1_000);
+    expect(summary?.estimatedReplayWasteMicros).toBe(1_000);
+    expect(summary?.spentSinceFirstWarningMicros).toBe(3_000_000);
   });
 
-  it("uses a new toast identity for a new turn", () => {
-    expect(toolAccountingNoticeId(buildAlert({ turnId: "turn-1" })))
-      .not.toBe(toolAccountingNoticeId(buildAlert({ turnId: "turn-2" })));
+  it("omits money when nothing cache-served has been billed", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([invocation({})]),
+      backend: "codex",
+      threadId: "thread-1",
+      usageLines: [
+        usageLine({ cachedInputCostMicros: 0, cachedInputTokens: 0 }),
+      ],
+    });
+
+    expect(summary?.estimatedReplayWasteMicros).toBeUndefined();
+  });
+
+  it("reports no incident for a thread with nothing flagged", () => {
+    expect(buildThreadIncidentSummary({
+      /* Unmarked AND small: the size test has to miss it too. */
+      accounting: accounting([invocation({ noisy: false, outputChars: 500 })]),
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
   });
 });
 
-function buildAlert(
-  overrides: Partial<ThreadToolInvocationAlert>,
-): ThreadToolInvocationAlert {
+describe("resolveToolIncidentVisibility", () => {
+  it("suppresses a warning the operator muted", () => {
+    expect(resolveToolIncidentVisibility({
+      severity: "warning",
+      state: { mutedSeverity: "warning" },
+    })).toBe("suppress");
+  });
+
+  it("lets a cap hit through a muted warning", () => {
+    /* Muting "output is getting large" must not also silence "output hit the
+       cap and was truncated" — that is the escalation the mute is scoped to
+       leave alone. */
+    expect(resolveToolIncidentVisibility({
+      severity: "critical",
+      state: { mutedSeverity: "warning" },
+    })).toBe("show");
+  });
+
+  it("suppresses everything once a critical incident is muted", () => {
+    expect(resolveToolIncidentVisibility({
+      severity: "critical",
+      state: { mutedSeverity: "critical" },
+    })).toBe("suppress");
+  });
+
+  it("re-shows an escalation past a dismissal", () => {
+    expect(resolveToolIncidentVisibility({
+      severity: "critical",
+      state: { dismissedSeverity: "warning" },
+    })).toBe("show");
+    expect(resolveToolIncidentVisibility({
+      severity: "warning",
+      state: { dismissedSeverity: "warning" },
+    })).toBe("suppress");
+  });
+});
+
+describe("buildToolAccountingNotice", () => {
+  it("carries one notice id per thread, not per turn", () => {
+    const notice = buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary: summaryFor(),
+    });
+
+    expect(notice.id).toBe("tool-accounting:codex:thread-1");
+    expect(notice.message).toContain("3 tool calls flagged across 2 turns");
+  });
+
+  it("offers a mute for a warning but not for a cap hit", () => {
+    const warning = buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      onMute: vi.fn(),
+      showCost: false,
+      summary: summaryFor(),
+    });
+    expect(warning.actions?.map((action) => action.label))
+      .toContain("Don't warn again");
+
+    const critical = buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      onMute: vi.fn(),
+      showCost: false,
+      summary: { ...summaryFor(), overCapCount: 2, severity: "critical" },
+    });
+    expect(critical.actions?.map((action) => action.label))
+      .not.toContain("Don't warn again");
+    expect(critical.title).toBe("Tool output hit the cap");
+  });
+
+  it("shows money only when pricing display is enabled", () => {
+    const summary = {
+      ...summaryFor(),
+      currency: "USD",
+      estimatedReplayWasteMicros: 1_850_000,
+      spentSinceFirstWarningMicros: 4_120_000,
+    };
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: true,
+      summary,
+    }).message).toContain("$4.12 spent since the first warning, of which about $1.85");
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary,
+    }).message).not.toContain("$4.12");
+  });
+});
+
+function summaryFor() {
   return {
-    alertId: "alert-1",
     backend: "codex",
-    createdAt: 1,
-    estimatedOutputTokens: 1_000,
-    firstObservedAt: 1,
-    invocationCount: 5,
-    kind: "noisy-polling",
-    lastObservedAt: 2,
-    message: "The turn keeps waking up.",
-    severity: "warning",
-    suggestedPrompt: "Use a monitor.",
+    flaggedInvocationCount: 3,
+    overCapCount: 0,
+    pollingInvocationCount: 0,
+    replayedTokens: 2_400,
+    severity: "warning" as const,
     threadId: "thread-1",
+    turnsWithWarnings: 2,
+  };
+}
+
+function accounting(
+  invocations: ThreadToolInvocationRecord[],
+): ThreadToolAccounting {
+  return { alerts: [], invocations, summaries: [] };
+}
+
+function invocation(
+  overrides: Partial<ThreadToolInvocationRecord>,
+): ThreadToolInvocationRecord {
+  return {
+    backend: "codex",
+    category: "shell",
+    debugLines: 0,
+    errorLines: 0,
+    estimatedOutputTokens: 2_000,
+    infoLines: 0,
+    invocationId: `invocation-${overrides.observedAt ?? 0}`,
+    itemId: "item-1",
+    noisy: true,
+    observedAt: 1_000,
+    outputChars: 8_000,
+    outputLines: 20,
+    outputTruncated: false,
+    status: "completed",
+    threadId: "thread-1",
+    toolName: "commandExecution",
     turnId: "turn-1",
-    toolName: "wait",
-    totalOutputChars: 0,
-    updatedAt: 2,
+    updatedAt: 1_000,
+    warningLines: 0,
     ...overrides,
   };
+}
+
+function usageLine(
+  overrides: Partial<ThreadUsageLineRecord>,
+): ThreadUsageLineRecord {
+  return {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 0,
+    createdAt: 1_000,
+    currency: "USD",
+    inputTokens: 0,
+    outputTokens: 0,
+    threadId: "thread-1",
+    totalCostMicros: 0,
+    ...overrides,
+  } as ThreadUsageLineRecord;
 }

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -1,30 +1,34 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ThreadToolInvocationAlert } from "@pwragent/shared";
-import { buildToolAccountingNotice } from "../tool-accounting-notice";
+import {
+  buildToolAccountingNotice,
+  resolveDismissedToolIncident,
+  toolAccountingNoticeId,
+} from "../tool-accounting-notice";
 
 describe("buildToolAccountingNotice", () => {
-  it("builds one sticky monitor action for repeated queued checks", () => {
+  it("makes the explorer the primary action for an aggregated incident", () => {
     const onDismiss = vi.fn();
-    const onSteer = vi.fn();
+    const onExamine = vi.fn();
     const notice = buildToolAccountingNotice({
       alert: buildAlert({ kind: "noisy-polling" }),
       onDismiss,
-      onSteer,
+      onExamine,
     });
 
     expect(notice).toMatchObject({
       autoDismiss: false,
-      id: "tool-accounting:codex:thread-1:noisy-polling",
+      id: "tool-accounting:codex:thread-1:turn-1:noisy-polling",
       title: "Repeated queued checks",
       tone: "warning",
     });
     expect(notice.actions?.map((action) => action.label)).toEqual([
-      "Use monitor job",
+      "Examine 5 cases",
       "Dismiss",
     ]);
     notice.actions?.[0]?.onClick();
     notice.actions?.[1]?.onClick();
-    expect(onSteer).toHaveBeenCalledOnce();
+    expect(onExamine).toHaveBeenCalledOnce();
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
@@ -32,15 +36,35 @@ describe("buildToolAccountingNotice", () => {
     const notice = buildToolAccountingNotice({
       alert: buildAlert({ kind: "large-output", severity: "critical" }),
       onDismiss: vi.fn(),
-      onSteer: vi.fn(),
+      onExamine: vi.fn(),
     });
 
     expect(notice).toMatchObject({
-      id: "tool-accounting:codex:thread-1:large-output",
+      id: "tool-accounting:codex:thread-1:turn-1:large-output",
       title: "Large tool output",
       tone: "error",
     });
-    expect(notice.actions?.[0]?.label).toBe("Steer safer output");
+    expect(notice.actions?.[0]?.label).toBe("Examine 5 cases");
+  });
+
+  it("suppresses rewrites after dismissal until a critical escalation", () => {
+    expect(resolveDismissedToolIncident({
+      dismissedSeverity: "warning",
+      incomingSeverity: "warning",
+    })).toBe("suppress");
+    expect(resolveDismissedToolIncident({
+      dismissedSeverity: "warning",
+      incomingSeverity: "critical",
+    })).toBe("escalate");
+    expect(resolveDismissedToolIncident({
+      dismissedSeverity: "critical",
+      incomingSeverity: "critical",
+    })).toBe("suppress");
+  });
+
+  it("uses a new toast identity for a new turn", () => {
+    expect(toolAccountingNoticeId(buildAlert({ turnId: "turn-1" })))
+      .not.toBe(toolAccountingNoticeId(buildAlert({ turnId: "turn-2" })));
   });
 });
 
@@ -60,6 +84,7 @@ function buildAlert(
     severity: "warning",
     suggestedPrompt: "Use a monitor.",
     threadId: "thread-1",
+    turnId: "turn-1",
     toolName: "wait",
     totalOutputChars: 0,
     updatedAt: 2,

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -6,7 +6,10 @@ import type {
 import { resolveToolIncidentVisibility } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
 import { buildToolAccountingNotice } from "../tool-accounting-notice";
-import { buildThreadIncidentSummary } from "../thread-incident-summary";
+import {
+  buildThreadIncidentSummary,
+  formatIncidentMicros,
+} from "../thread-incident-summary";
 
 describe("buildThreadIncidentSummary", () => {
   it("folds a thread's flagged calls into one incident", () => {
@@ -207,6 +210,7 @@ describe("buildToolAccountingNotice", () => {
 function summaryFor() {
   return {
     backend: "codex",
+    coversWholeThread: true,
     flaggedInvocationCount: 3,
     overCapCount: 0,
     pollingInvocationCount: 0,
@@ -266,3 +270,45 @@ function usageLine(
     ...overrides,
   } as ThreadUsageLineRecord;
 }
+
+describe("snapshot coverage", () => {
+  it("says so when the fold only saw recent activity", () => {
+    /* The live notification carries a 200-row page, so a long thread's counts
+       are recent activity — the card must not present them as totals. */
+    const capped = Array.from({ length: 200 }, (_, index) =>
+      invocation({ invocationId: `capped-${index}`, observedAt: 1_000 + index }));
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting(capped),
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(summary?.coversWholeThread).toBe(false);
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary: summary!,
+    }).message).toContain("in recent activity");
+  });
+
+  it("presents a short thread's counts as the whole thread", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([invocation({})]),
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(summary?.coversWholeThread).toBe(true);
+    expect(buildToolAccountingNotice({
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary: summary!,
+    }).message).not.toContain("in recent activity");
+  });
+
+  it("formats credits the same way the turn strip does", () => {
+    expect(formatIncidentMicros(2_400_000, "credits")).toBe("2.4 cr");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ThreadToolInvocationAlert } from "@pwragent/shared";
+import { buildToolAccountingNotice } from "../tool-accounting-notice";
+
+describe("buildToolAccountingNotice", () => {
+  it("builds one sticky monitor action for repeated queued checks", () => {
+    const onDismiss = vi.fn();
+    const onSteer = vi.fn();
+    const notice = buildToolAccountingNotice({
+      alert: buildAlert({ kind: "noisy-polling" }),
+      onDismiss,
+      onSteer,
+    });
+
+    expect(notice).toMatchObject({
+      autoDismiss: false,
+      id: "tool-accounting:codex:thread-1:noisy-polling",
+      title: "Repeated queued checks",
+      tone: "warning",
+    });
+    expect(notice.actions?.map((action) => action.label)).toEqual([
+      "Use monitor job",
+      "Dismiss",
+    ]);
+    notice.actions?.[0]?.onClick();
+    notice.actions?.[1]?.onClick();
+    expect(onSteer).toHaveBeenCalledOnce();
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("upserts large outputs under one critical thread incident", () => {
+    const notice = buildToolAccountingNotice({
+      alert: buildAlert({ kind: "large-output", severity: "critical" }),
+      onDismiss: vi.fn(),
+      onSteer: vi.fn(),
+    });
+
+    expect(notice).toMatchObject({
+      id: "tool-accounting:codex:thread-1:large-output",
+      title: "Large tool output",
+      tone: "error",
+    });
+    expect(notice.actions?.[0]?.label).toBe("Steer safer output");
+  });
+});
+
+function buildAlert(
+  overrides: Partial<ThreadToolInvocationAlert>,
+): ThreadToolInvocationAlert {
+  return {
+    alertId: "alert-1",
+    backend: "codex",
+    createdAt: 1,
+    estimatedOutputTokens: 1_000,
+    firstObservedAt: 1,
+    invocationCount: 5,
+    kind: "noisy-polling",
+    lastObservedAt: 2,
+    message: "The turn keeps waking up.",
+    severity: "warning",
+    suggestedPrompt: "Use a monitor.",
+    threadId: "thread-1",
+    toolName: "wait",
+    totalOutputChars: 0,
+    updatedAt: 2,
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
@@ -21,6 +21,17 @@ import {
  * This fold answers that instead, and it updates in place as the numbers move.
  */
 
+/**
+ * Whether the fold saw the whole thread.
+ *
+ * The live notification carries `readThreadToolAccounting`'s default page,
+ * which caps at 200 invocations — so on a long thread these counts describe
+ * recent activity, not the thread. The card says which it is rather than
+ * presenting a capped count as a total; the explorer, which reads with
+ * `includeAllToolInvocations`, is where the real totals live.
+ */
+export const INCIDENT_SNAPSHOT_INVOCATION_CAP = 200;
+
 export type ThreadIncidentSummary = {
   backend: string;
   currency?: string;
@@ -33,6 +44,8 @@ export type ThreadIncidentSummary = {
   estimatedReplayWasteMicros?: number;
   firstWarningAt?: number;
   flaggedInvocationCount: number;
+  /** False when the fold ran against a capped snapshot of a longer thread. */
+  coversWholeThread: boolean;
   lastWarningAt?: number;
   /** Calls that reached the harness output cap and were truncated. */
   overCapCount: number;
@@ -95,6 +108,7 @@ export function buildThreadIncidentSummary(params: {
       ? { estimatedReplayWasteMicros: Math.round(replayedTokens * rate) }
       : {}),
     ...(Number.isFinite(firstWarningAt) ? { firstWarningAt } : {}),
+    coversWholeThread: invocations.length < INCIDENT_SNAPSHOT_INVOCATION_CAP,
     flaggedInvocationCount: flagged.length,
     lastWarningAt: flagged.reduce(
       (latest, entry) => Math.max(latest, entry.observedAt),
@@ -167,12 +181,7 @@ export function threadIncidentNoticeId(params: {
   return ["tool-accounting", params.backend, params.threadId].join(":");
 }
 
-export function formatIncidentMicros(
-  micros: number,
-  currency: string | undefined,
-): string {
-  const units = micros / 1_000_000;
-  const rounded = units >= 100 ? Math.round(units) : Number(units.toFixed(2));
-  if (!currency || currency === "USD") return `$${rounded.toLocaleString()}`;
-  return `${rounded.toLocaleString()} ${currency}`;
-}
+/* One currency formatter for the whole feature: the card and the turn strip
+   render the same ledger units, so they must not disagree about credits or
+   sub-dollar precision. */
+export { formatMicrosCurrency as formatIncidentMicros } from "../thread-detail/tool-output-incident-insights";

--- a/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
@@ -1,0 +1,178 @@
+import type {
+  ThreadToolAccounting,
+  ThreadToolInvocationAlert,
+  ThreadToolInvocationRecord,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+import {
+  isFlaggedToolInvocation,
+  TOOL_OUTPUT_CAP_CHARS,
+} from "@pwragent/shared";
+
+/**
+ * One incident per thread, folded from every flagged tool call it has made.
+ *
+ * The alert stream is per-turn, which is why the notice stack reached "1 of
+ * 41": each threshold trip minted its own durable card, each needing its own
+ * dismissal. Nothing about that queue told the operator the thing they
+ * actually want to know — how much this thread has cost since it started
+ * misbehaving — because every card only knew about its own turn.
+ *
+ * This fold answers that instead, and it updates in place as the numbers move.
+ */
+
+export type ThreadIncidentSummary = {
+  backend: string;
+  currency?: string;
+  /**
+   * Modeled cost of replaying the flagged output. Distinct from `spentMicros`,
+   * which is money actually billed: this is the share of it attributable to
+   * carrying large tool results through later round trips. Undefined when the
+   * ledger has no cache-served rows to derive a rate from.
+   */
+  estimatedReplayWasteMicros?: number;
+  firstWarningAt?: number;
+  flaggedInvocationCount: number;
+  lastWarningAt?: number;
+  /** Calls that reached the harness output cap and were truncated. */
+  overCapCount: number;
+  /**
+   * Calls flagged as repeated queued checks. A distinct pathology from large
+   * output — the cost is the round trip, not the payload — so the single card
+   * still has to name it rather than folding it into a generic total.
+   */
+  pollingInvocationCount: number;
+  /** Tokens carried through later round trips in the same turn. */
+  replayedTokens: number;
+  severity: ThreadToolInvocationAlert["severity"];
+  /** Billed spend since the first warning, straight from the pricing ledger. */
+  spentSinceFirstWarningMicros?: number;
+  threadId: string;
+  turnsWithWarnings: number;
+};
+
+export function buildThreadIncidentSummary(params: {
+  accounting: ThreadToolAccounting;
+  backend: string;
+  /** Persisted baseline. Survives restart so the cost window does not reset. */
+  firstWarningAt?: number;
+  threadId: string;
+  usageLines?: readonly ThreadUsageLineRecord[];
+}): ThreadIncidentSummary | undefined {
+  const invocations = params.accounting.invocations;
+  /* Same predicate the explorer uses: a card that counted only rows the
+     detectors happened to mark would under-report exactly the threads whose
+     history predates them. */
+  const flagged = invocations.filter(isFlaggedToolInvocation);
+  if (flagged.length === 0) return undefined;
+
+  const observedFirst = flagged.reduce(
+    (earliest, entry) => Math.min(earliest, entry.observedAt),
+    Number.POSITIVE_INFINITY,
+  );
+  /* The persisted baseline wins when it is older: a thread that warned
+     yesterday keeps yesterday's cost window even though today's snapshot may
+     no longer carry those rows. */
+  const firstWarningAt = Math.min(
+    params.firstWarningAt ?? Number.POSITIVE_INFINITY,
+    observedFirst,
+  );
+  const overCapCount = flagged.filter(
+    (entry) => entry.outputChars >= TOOL_OUTPUT_CAP_CHARS,
+  ).length;
+  const replayedTokens = flagged.reduce(
+    (sum, entry) => sum + entry.estimatedOutputTokens * countLaterTrips(invocations, entry),
+    0,
+  );
+  const usageLines = params.usageLines ?? [];
+  const spent = sumSpendSince(usageLines, firstWarningAt);
+  const rate = deriveCachedInputMicrosPerToken(usageLines);
+
+  return {
+    backend: params.backend,
+    ...(usageLines[0]?.currency ? { currency: usageLines[0].currency } : {}),
+    ...(rate !== undefined
+      ? { estimatedReplayWasteMicros: Math.round(replayedTokens * rate) }
+      : {}),
+    ...(Number.isFinite(firstWarningAt) ? { firstWarningAt } : {}),
+    flaggedInvocationCount: flagged.length,
+    lastWarningAt: flagged.reduce(
+      (latest, entry) => Math.max(latest, entry.observedAt),
+      0,
+    ),
+    overCapCount,
+    pollingInvocationCount: flagged.filter((entry) =>
+      entry.noisyReason?.includes("poll")
+    ).length,
+    replayedTokens,
+    severity: overCapCount > 0 ? "critical" : "warning",
+    ...(spent !== undefined ? { spentSinceFirstWarningMicros: spent } : {}),
+    threadId: params.threadId,
+    turnsWithWarnings: new Set(flagged.map((entry) => entry.turnId ?? "")).size,
+  };
+}
+
+/**
+ * Every call in the same turn observed after this one. Each is a round trip
+ * that carried this output through the model again.
+ */
+function countLaterTrips(
+  invocations: readonly ThreadToolInvocationRecord[],
+  invocation: ThreadToolInvocationRecord,
+): number {
+  const index = invocations.indexOf(invocation);
+  return invocations.filter((entry, entryIndex) =>
+    (entry.turnId ?? "") === (invocation.turnId ?? "")
+    && (
+      entry.observedAt > invocation.observedAt
+      || (entry.observedAt === invocation.observedAt && entryIndex > index)
+    )
+  ).length;
+}
+
+function sumSpendSince(
+  lines: readonly ThreadUsageLineRecord[],
+  since: number,
+): number | undefined {
+  if (!Number.isFinite(since)) return undefined;
+  const matching = lines.filter((line) => line.createdAt >= since);
+  if (matching.length === 0) return undefined;
+  return matching.reduce((sum, line) => sum + line.totalCostMicros, 0);
+}
+
+/**
+ * Effective cache-served input rate, derived from the thread's own billed rows
+ * rather than a catalog lookup — replayed context is cache-served, and the
+ * ledger already knows what this thread actually paid for it. Undefined when
+ * nothing cache-served has been billed yet, in which case the caller reports
+ * replayed tokens and no money.
+ */
+function deriveCachedInputMicrosPerToken(
+  lines: readonly ThreadUsageLineRecord[],
+): number | undefined {
+  let micros = 0;
+  let tokens = 0;
+  for (const line of lines) {
+    micros += line.cachedInputCostMicros;
+    tokens += line.cachedInputTokens;
+  }
+  return tokens > 0 && micros > 0 ? micros / tokens : undefined;
+}
+
+export function threadIncidentNoticeId(params: {
+  backend: string;
+  threadId: string;
+}): string {
+  /* Deliberately no turn segment — that is what produced one card per turn. */
+  return ["tool-accounting", params.backend, params.threadId].join(":");
+}
+
+export function formatIncidentMicros(
+  micros: number,
+  currency: string | undefined,
+): string {
+  const units = micros / 1_000_000;
+  const rounded = units >= 100 ? Math.round(units) : Number(units.toFixed(2));
+  if (!currency || currency === "USD") return `$${rounded.toLocaleString()}`;
+  return `${rounded.toLocaleString()} ${currency}`;
+}

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -4,21 +4,18 @@ import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
 export function buildToolAccountingNotice(params: {
   alert: ThreadToolInvocationAlert;
+  onExamine: () => void;
   onDismiss: () => void;
-  onSteer?: () => void;
   threadLink?: ResolvedThreadLink;
 }): AppNoticeToastNotice {
   const polling = params.alert.kind === "noisy-polling";
-  const steerAction = params.onSteer
-    ? [{
-        label: polling ? "Use monitor job" : "Steer safer output",
-        onClick: params.onSteer,
-        tone: "primary" as const,
-      }]
-    : [];
   return {
     actions: [
-      ...steerAction,
+      {
+        label: `Examine ${params.alert.invocationCount.toLocaleString()} case${params.alert.invocationCount === 1 ? "" : "s"}`,
+        onClick: params.onExamine,
+        tone: "primary" as const,
+      },
       {
         label: "Dismiss",
         onClick: params.onDismiss,
@@ -27,15 +24,32 @@ export function buildToolAccountingNotice(params: {
     ],
     autoDismiss: false,
     copyText: [params.alert.message, params.alert.suggestedPrompt].join("\n\n"),
-    id: [
-      "tool-accounting",
-      params.alert.backend,
-      params.alert.threadId,
-      params.alert.kind,
-    ].join(":"),
+    id: toolAccountingNoticeId(params.alert),
     message: params.alert.message,
     threadLink: params.threadLink,
     title: polling ? "Repeated queued checks" : "Large tool output",
     tone: params.alert.severity === "critical" ? "error" : "warning",
   };
+}
+
+export function toolAccountingNoticeId(
+  alert: ThreadToolInvocationAlert,
+): string {
+  return [
+    "tool-accounting",
+    alert.backend,
+    alert.threadId,
+    alert.turnId ?? "no-turn",
+    alert.kind,
+  ].join(":");
+}
+
+export function resolveDismissedToolIncident(params: {
+  dismissedSeverity?: ThreadToolInvocationAlert["severity"];
+  incomingSeverity: ThreadToolInvocationAlert["severity"];
+}): "escalate" | "show" | "suppress" {
+  if (!params.dismissedSeverity) return "show";
+  return params.dismissedSeverity === "warning" && params.incomingSeverity === "critical"
+    ? "escalate"
+    : "suppress";
 }

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -1,0 +1,41 @@
+import type { ThreadToolInvocationAlert } from "@pwragent/shared";
+import type { ResolvedThreadLink } from "../../lib/thread-links";
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export function buildToolAccountingNotice(params: {
+  alert: ThreadToolInvocationAlert;
+  onDismiss: () => void;
+  onSteer?: () => void;
+  threadLink?: ResolvedThreadLink;
+}): AppNoticeToastNotice {
+  const polling = params.alert.kind === "noisy-polling";
+  const steerAction = params.onSteer
+    ? [{
+        label: polling ? "Use monitor job" : "Steer safer output",
+        onClick: params.onSteer,
+        tone: "primary" as const,
+      }]
+    : [];
+  return {
+    actions: [
+      ...steerAction,
+      {
+        label: "Dismiss",
+        onClick: params.onDismiss,
+        tone: "secondary",
+      },
+    ],
+    autoDismiss: false,
+    copyText: [params.alert.message, params.alert.suggestedPrompt].join("\n\n"),
+    id: [
+      "tool-accounting",
+      params.alert.backend,
+      params.alert.threadId,
+      params.alert.kind,
+    ].join(":"),
+    message: params.alert.message,
+    threadLink: params.threadLink,
+    title: polling ? "Repeated queued checks" : "Large tool output",
+    tone: params.alert.severity === "critical" ? "error" : "warning",
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -1,55 +1,108 @@
 import type { ThreadToolInvocationAlert } from "@pwragent/shared";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
+import type { ThreadIncidentSummary } from "./thread-incident-summary";
+import {
+  formatIncidentMicros,
+  threadIncidentNoticeId,
+} from "./thread-incident-summary";
 
 export function buildToolAccountingNotice(params: {
-  alert: ThreadToolInvocationAlert;
   onExamine: () => void;
   onDismiss: () => void;
+  onMute?: () => void;
+  showCost: boolean;
+  summary: ThreadIncidentSummary;
   threadLink?: ResolvedThreadLink;
 }): AppNoticeToastNotice {
-  const polling = params.alert.kind === "noisy-polling";
+  const summary = params.summary;
+  const critical = summary.severity === "critical";
   return {
     actions: [
       {
-        label: `Examine ${params.alert.invocationCount.toLocaleString()} case${params.alert.invocationCount === 1 ? "" : "s"}`,
+        label: `Examine ${summary.flaggedInvocationCount.toLocaleString()} case${summary.flaggedInvocationCount === 1 ? "" : "s"}`,
         onClick: params.onExamine,
         tone: "primary" as const,
       },
       {
         label: "Dismiss",
         onClick: params.onDismiss,
-        tone: "secondary",
+        tone: "secondary" as const,
       },
+      /* Muting is offered only below critical. Silencing "output is getting
+         large" is a reasonable call; silencing "output hit the cap and was
+         truncated" is not something to offer in one click. */
+      ...(params.onMute && !critical
+        ? [{
+            label: "Don't warn again",
+            onClick: params.onMute,
+            tone: "secondary" as const,
+          }]
+        : []),
     ],
     autoDismiss: false,
-    copyText: [params.alert.message, params.alert.suggestedPrompt].join("\n\n"),
-    id: toolAccountingNoticeId(params.alert),
-    message: params.alert.message,
+    copyText: describeToolAccountingIncident({ showCost: true, summary }),
+    id: threadIncidentNoticeId(summary),
+    message: describeToolAccountingIncident({
+      showCost: params.showCost,
+      summary,
+    }),
     threadLink: params.threadLink,
-    title: polling ? "Repeated queued checks" : "Large tool output",
-    tone: params.alert.severity === "critical" ? "error" : "warning",
+    title: critical
+      ? "Tool output hit the cap"
+      : summary.pollingInvocationCount >= summary.flaggedInvocationCount
+        ? "Repeated queued checks"
+        : "Large tool output",
+    tone: critical ? "error" : "warning",
   };
 }
 
-export function toolAccountingNoticeId(
-  alert: ThreadToolInvocationAlert,
-): string {
-  return [
-    "tool-accounting",
-    alert.backend,
-    alert.threadId,
-    alert.turnId ?? "no-turn",
-    alert.kind,
-  ].join(":");
+/**
+ * One paragraph of thread-scoped stats rather than one card per turn. Cost
+ * lines appear only when the operator has pricing display enabled and the
+ * ledger has priced rows — the rest of the card still stands without them.
+ */
+export function describeToolAccountingIncident(params: {
+  showCost: boolean;
+  summary: ThreadIncidentSummary;
+}): string {
+  const summary = params.summary;
+  const lines = [
+    `${summary.flaggedInvocationCount.toLocaleString()} tool call${summary.flaggedInvocationCount === 1 ? "" : "s"} flagged across ${summary.turnsWithWarnings.toLocaleString()} turn${summary.turnsWithWarnings === 1 ? "" : "s"}.`,
+  ];
+  if (summary.pollingInvocationCount > 0) {
+    lines.push(
+      `${summary.pollingInvocationCount.toLocaleString()} ${summary.pollingInvocationCount === 1 ? "is a repeated queued check" : "are repeated queued checks"} waking the model to replay its context.`,
+    );
+  }
+  if (summary.overCapCount > 0) {
+    lines.push(
+      `${summary.overCapCount.toLocaleString()} hit the output cap and ${summary.overCapCount === 1 ? "was" : "were"} truncated.`,
+    );
+  }
+  if (params.showCost && summary.spentSinceFirstWarningMicros !== undefined) {
+    const spent = formatIncidentMicros(
+      summary.spentSinceFirstWarningMicros,
+      summary.currency,
+    );
+    lines.push(
+      summary.estimatedReplayWasteMicros !== undefined
+        ? `${spent} spent since the first warning, of which about ${formatIncidentMicros(summary.estimatedReplayWasteMicros, summary.currency)} is replayed tool output.`
+        : `${spent} spent since the first warning.`,
+    );
+  } else if (summary.replayedTokens > 0) {
+    lines.push(
+      `About ${summary.replayedTokens.toLocaleString()} tokens of tool output have been replayed through later round trips.`,
+    );
+  }
+  return lines.join(" ");
 }
 
-export function resolveDismissedToolIncident(params: {
-  dismissedSeverity?: ThreadToolInvocationAlert["severity"];
-  incomingSeverity: ThreadToolInvocationAlert["severity"];
-}): "escalate" | "show" | "suppress" {
-  if (!params.dismissedSeverity) return "show";
-  return params.dismissedSeverity === "warning" && params.incomingSeverity === "critical"
-    ? "escalate"
-    : "suppress";
+export function toolAccountingNoticeId(
+  alert: Pick<ThreadToolInvocationAlert, "backend" | "threadId">,
+): string {
+  return threadIncidentNoticeId({
+    backend: alert.backend,
+    threadId: alert.threadId,
+  });
 }

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -67,8 +67,9 @@ export function describeToolAccountingIncident(params: {
   summary: ThreadIncidentSummary;
 }): string {
   const summary = params.summary;
+  const scope = summary.coversWholeThread ? "" : " in recent activity";
   const lines = [
-    `${summary.flaggedInvocationCount.toLocaleString()} tool call${summary.flaggedInvocationCount === 1 ? "" : "s"} flagged across ${summary.turnsWithWarnings.toLocaleString()} turn${summary.turnsWithWarnings === 1 ? "" : "s"}.`,
+    `${summary.flaggedInvocationCount.toLocaleString()} tool call${summary.flaggedInvocationCount === 1 ? "" : "s"} flagged across ${summary.turnsWithWarnings.toLocaleString()} turn${summary.turnsWithWarnings === 1 ? "" : "s"}${scope}.`,
   ];
   if (summary.pollingInvocationCount > 0) {
     lines.push(

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -85,7 +85,7 @@ export function ExperimentalSettings(props: {
       <SettingsSection
         eyebrow="Experimental"
         title="Tool Call Tracking"
-        description="Show tool-call volume, command instances, output, and noisy-polling alerts in a dedicated thread panel."
+        description="Show tool-call volume, command instances, output, and replay-risk history in a dedicated thread panel. Safety notices remain active while this is off."
         chip={threadToolAccounting.value ? "On" : "Off"}
         chipKind={threadToolAccounting.value ? "ok" : "default"}
       >

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -116,6 +116,8 @@ type ThreadContextPanelProps = {
   toolCallEntries?: AppServerThreadEntry[];
   loadingToolCallDetailItemId?: string;
   onRequestToolCallDetails?: (invocation: ThreadToolInvocationRecord) => void;
+  onAnalyzeToolHistory?: () => void;
+  onOpenToolOutputIncidentExplorer?: () => void;
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
@@ -755,6 +757,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <ToolCallsPanel
             entries={props.toolCallEntries}
             loadingDetailItemId={props.loadingToolCallDetailItemId}
+            onAnalyzeHistory={props.onAnalyzeToolHistory}
+            onOpenIncidentExplorer={props.onOpenToolOutputIncidentExplorer}
             onRequestInvocationDetails={props.onRequestToolCallDetails}
             onScrollToTurn={props.onScrollToTurn}
             toolAccounting={props.toolAccounting}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2305,12 +2305,16 @@ export function ThreadView(props: ThreadViewProps) {
   );
   const handleOpenToolOutputIncidentExplorer = useCallback(() => {
     if (!selectedThread) return;
+    const projectLabel =
+      props.selectedDirectory?.label
+      ?? selectedThread.linkedDirectories[0]?.label;
     void desktopApi?.openToolOutputIncidentExplorerWindow?.({
       backend: selectedThread.source,
+      ...(projectLabel ? { projectLabel } : {}),
       threadId: selectedThread.id,
       title: selectedThread.title,
     });
-  }, [desktopApi, selectedThread]);
+  }, [desktopApi, props.selectedDirectory?.label, selectedThread]);
   const handleAnalyzeToolHistory = useCallback(() => {
     if (!selectedThread) return;
     void desktopApi?.analyzeThreadToolHistory?.({

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2303,6 +2303,21 @@ export function ThreadView(props: ThreadViewProps) {
       selectedThreadKey,
     ],
   );
+  const handleOpenToolOutputIncidentExplorer = useCallback(() => {
+    if (!selectedThread) return;
+    void desktopApi?.openToolOutputIncidentExplorerWindow?.({
+      backend: selectedThread.source,
+      threadId: selectedThread.id,
+      title: selectedThread.title,
+    });
+  }, [desktopApi, selectedThread]);
+  const handleAnalyzeToolHistory = useCallback(() => {
+    if (!selectedThread) return;
+    void desktopApi?.analyzeThreadToolHistory?.({
+      backend: selectedThread.source,
+      threadId: selectedThread.id,
+    });
+  }, [desktopApi, selectedThread]);
 
   const moveEditedFilesToSidebar = useCallback(() => {
     onEditedFilesDockChange("sidebar");
@@ -3464,6 +3479,8 @@ export function ThreadView(props: ThreadViewProps) {
               : undefined
           }
           onRequestToolCallDetails={handleRequestToolCallDetails}
+          onAnalyzeToolHistory={handleAnalyzeToolHistory}
+          onOpenToolOutputIncidentExplorer={handleOpenToolOutputIncidentExplorer}
           pricingDisplayOptions={props.pricingDisplayOptions}
           threadPricingSummaryEnabled={threadPricingSummaryEnabled}
           threadToolAccountingEnabled={threadToolAccountingEnabled}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -52,6 +52,13 @@ export function ToolOutputIncidentExplorerWindow() {
     void refresh();
   }, [refresh, route]);
 
+  useEffect(() => {
+    if (!desktopApi?.onToolOutputIncidentExplorerRefresh) return;
+    return desktopApi.onToolOutputIncidentExplorerRefresh(() => {
+      void refresh();
+    });
+  }, [desktopApi, refresh]);
+
   const invocations = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
     return (accounting?.invocations ?? []).filter((invocation) =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -399,6 +399,15 @@ export function ToolOutputIncidentExplorerWindow() {
               </button>
             ))}
           </div>
+          <TurnTimeline
+            {...(currency ? { currency } : {})}
+            now={renderedAt}
+            onSelect={(row) => setTurnFilter(
+              turnFilter === row.key ? undefined : row.key,
+            )}
+            selectedKey={turnFilter}
+            timeline={turnStrip.timeline}
+          />
         </div>
       </div>
 
@@ -762,6 +771,73 @@ function TurnStrip(props: {
         </p>
       ) : null}
     </section>
+  );
+}
+
+/**
+ * The whole thread, one column per turn, in time order. Tokens above, round
+ * trips below on a shared axis — a long poll is a stretch of trip spikes with
+ * no matching output, which no ranked list can show because ranking discards
+ * adjacency. Hover carries the numbers; click filters cases to the turn.
+ */
+function TurnTimeline(props: {
+  currency?: string;
+  now: number;
+  onSelect: (row: TurnCostRow) => void;
+  selectedKey?: string;
+  timeline: TurnCostRow[];
+}) {
+  if (props.timeline.length < 2) return null;
+  const maxTokens = props.timeline.reduce(
+    (max, row) => Math.max(max, row.estimatedOutputTokens),
+    0,
+  );
+  const maxCalls = props.timeline.reduce(
+    (max, row) => Math.max(max, row.callCount),
+    0,
+  );
+  return (
+    <div className="incident-explorer__timeline-block">
+      <p className="incident-explorer__eyebrow">When it went</p>
+      <div
+        aria-label="Tool cost per turn, in order"
+        className="incident-explorer__timeline"
+        role="group"
+      >
+        {props.timeline.map((row) => {
+          const description = [
+            row.label,
+            formatTurnWhen(row.firstObservedAt, props.now),
+            `${formatCompactTokens(row.estimatedOutputTokens)} tok`,
+            `${row.callCount.toLocaleString()} ${row.callCount === 1 ? "call" : "calls"}`,
+            ...(row.costMicros !== undefined
+              ? [formatMicrosCurrency(row.costMicros, props.currency)]
+              : []),
+          ].join(" · ");
+          return (
+            <button
+              aria-label={description}
+              aria-pressed={props.selectedKey === row.key}
+              className="incident-explorer__timeline-turn"
+              key={row.key}
+              onClick={() => props.onSelect(row)}
+              title={description}
+              type="button"
+            >
+              <span aria-hidden="true" className="incident-explorer__timeline-tokens">
+                <i
+                  data-critical={row.overCapCount > 0}
+                  style={{ height: `${scaleWidth(row.estimatedOutputTokens, maxTokens)}%` }}
+                />
+              </span>
+              <span aria-hidden="true" className="incident-explorer__timeline-trips">
+                <i style={{ height: `${scaleWidth(row.callCount, maxCalls)}%` }} />
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -31,6 +31,7 @@ import {
   formatCategoryLabel,
   formatCompactTokens,
   formatInvocationIdentity,
+  formatMicrosCurrency,
   formatTurnWhen,
   invocationStatusTone,
   isOverOutputCap,
@@ -48,7 +49,7 @@ export function ToolOutputIncidentExplorerWindow() {
   const [accounting, setAccounting] = useState<ThreadToolAccounting>();
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
-  const [category, setCategory] = useState<RefinedToolCategory | "all">("all");
+  const [category, setCategory] = useState<RefinedToolCategory | "all" | "other">("all");
   const [turnFilter, setTurnFilter] = useState<string>();
   const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
@@ -118,8 +119,24 @@ export function ToolOutputIncidentExplorerWindow() {
     [allInvocations],
   );
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
-  const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
+  const usageLines = latest?.pricing?.lines;
+  const turnStrip = useMemo(
+    () => buildTurnCostStrip(allInvocations, {
+      ...(usageLines ? { usageLines } : {}),
+    }),
+    [allInvocations, usageLines],
+  );
+  const currency = usageLines?.[0]?.currency;
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
+  /* Which refined categories the active legend entry stands for. "Other" is a
+     real set, not a leftover, so selecting it filters to its members. */
+  const selectedCategories = useMemo(() => {
+    if (category === "all") return undefined;
+    const entry = composition.find((share) => share.category === category);
+    /* A refresh can retire the selected category. Showing everything is the
+       safer failure than an unexplained empty list. */
+    return entry ? new Set<RefinedToolCategory>(entry.members) : undefined;
+  }, [category, composition]);
   const repeatedCommands = useMemo(
     () => countRepeatedCommands(flagged),
     [flagged],
@@ -132,7 +149,7 @@ export function ToolOutputIncidentExplorerWindow() {
     const normalizedSearch = search.trim().toLowerCase();
     return sortIncidentCases(
       flagged.filter((invocation) =>
-        (category === "all" || refineToolCategory(invocation) === category)
+        (!selectedCategories || selectedCategories.has(refineToolCategory(invocation)))
         && (turnFilter === undefined || (invocation.turnId ?? "") === turnFilter)
         && (
           !normalizedSearch
@@ -144,7 +161,7 @@ export function ToolOutputIncidentExplorerWindow() {
       ),
       sortMode,
     );
-  }, [category, flagged, search, sortMode, turnFilter]);
+  }, [flagged, search, selectedCategories, sortMode, turnFilter]);
   const selected = invocations.find((invocation) => invocation.invocationId === selectedId)
     ?? invocations[0];
 
@@ -358,11 +375,13 @@ export function ToolOutputIncidentExplorerWindow() {
               <button
                 aria-pressed={category === entry.category}
                 className="incident-explorer__legend-item"
-                disabled={entry.category === "other"}
                 key={entry.category}
                 onClick={() => setCategory(
-                  entry.category === "other" ? "all" : entry.category,
+                  category === entry.category ? "all" : entry.category,
                 )}
+                title={entry.category === "other"
+                  ? entry.members.map(formatCategoryLabel).join(", ")
+                  : undefined}
                 type="button"
               >
                 <i
@@ -381,7 +400,9 @@ export function ToolOutputIncidentExplorerWindow() {
       </div>
 
       <TurnStrip
+        {...(currency ? { currency } : {})}
         now={renderedAt}
+        showCost={turnStrip.rows.some((row) => row.costMicros !== undefined)}
         onSelect={(row) => setTurnFilter(
           turnFilter === row.key ? undefined : row.key,
         )}
@@ -639,9 +660,11 @@ function CompositionBar(props: { composition: CategoryShare[] }) {
  * the two need to be told apart at a glance.
  */
 function TurnStrip(props: {
+  currency?: string;
   /* Captured once by the caller so every row in a render measures "ago"
      against the same instant. */
   now: number;
+  showCost: boolean;
   onSelect: (row: TurnCostRow) => void;
   selectedKey?: string;
   strip: TurnCostStrip;
@@ -663,6 +686,7 @@ function TurnStrip(props: {
         <button
           aria-pressed={props.selectedKey === row.key}
           className="incident-explorer__turn"
+          data-cost={props.showCost}
           key={row.key}
           onClick={() => props.onSelect(row)}
           type="button"
@@ -688,6 +712,13 @@ function TurnStrip(props: {
           <span className="incident-explorer__turn-number">
             {row.callCount.toLocaleString()} {row.callCount === 1 ? "call" : "calls"}
           </span>
+          {props.showCost ? (
+            <span className="incident-explorer__turn-cost">
+              {row.costMicros !== undefined
+                ? formatMicrosCurrency(row.costMicros, props.currency)
+                : "—"}
+            </span>
+          ) : null}
         </button>
       ))}
       {props.strip.hiddenTurnCount > 0 ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  AppServerBackendKind,
+  AppServerReadThreadResponse,
+  AppServerThreadActivityDetail,
+  ThreadToolAccounting,
+  ThreadToolInvocationCategory,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import { useDesktopApi } from "../../lib/desktop-api";
+
+const HISTORY_PAGE_LIMIT = 100;
+
+export function ToolOutputIncidentExplorerWindow() {
+  const desktopApi = useDesktopApi();
+  const route = useMemo(readIncidentRoute, []);
+  const [accounting, setAccounting] = useState<ThreadToolAccounting>();
+  const [latest, setLatest] = useState<AppServerReadThreadResponse>();
+  const [selectedId, setSelectedId] = useState<string>();
+  const [category, setCategory] = useState<ThreadToolInvocationCategory | "all">("all");
+  const [search, setSearch] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [output, setOutput] = useState<string>();
+  const [outputSearch, setOutputSearch] = useState("");
+  const [status, setStatus] = useState<string>();
+  const [loading, setLoading] = useState(true);
+  const [analyzing, setAnalyzing] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!route || !desktopApi?.readThread) return;
+    setLoading(true);
+    setStatus(undefined);
+    try {
+      const response = await desktopApi.readThread({
+        backend: route.backend,
+        limit: HISTORY_PAGE_LIMIT,
+        threadId: route.threadId,
+        viewOnly: true,
+      });
+      setLatest(response);
+      setAccounting(response.toolAccounting);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [desktopApi, route]);
+
+  useEffect(() => {
+    document.title = route ? `Tool-output incidents — ${route.title}` : "Tool-output incidents";
+    void refresh();
+  }, [refresh, route]);
+
+  const invocations = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return (accounting?.invocations ?? []).filter((invocation) =>
+      invocation.noisy
+      && (category === "all" || invocation.category === category)
+      && (
+        !normalizedSearch
+        || (invocation.normalizedCommand ?? invocation.toolName)
+          .toLowerCase()
+          .includes(normalizedSearch)
+        || invocation.noisyReason?.toLowerCase().includes(normalizedSearch)
+      )
+    );
+  }, [accounting?.invocations, category, search]);
+  const selected = invocations.find((invocation) => invocation.invocationId === selectedId)
+    ?? invocations[0];
+
+  useEffect(() => {
+    setPrompt(selected
+      ? selected.suggestedPrompt ?? buildThreadToolIncidentPrompt({
+          invocation: selected,
+          reason: selected.noisyReason ?? "large tool output",
+        })
+      : "");
+    setOutput(undefined);
+    setOutputSearch("");
+    if (!selected || !latest || !desktopApi?.readThread || !route) return;
+    let cancelled = false;
+    void readInvocationOutput({
+      backend: route.backend,
+      desktopApi,
+      initial: latest,
+      invocation: selected,
+      threadId: route.threadId,
+    }).then((value) => {
+      if (!cancelled) setOutput(value);
+    }).catch((error) => {
+      if (!cancelled) setStatus(error instanceof Error ? error.message : String(error));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopApi, latest, route, selected]);
+
+  if (!route) {
+    return <p className="incident-explorer__error">Invalid incident explorer route.</p>;
+  }
+
+  const categories = Array.from(new Set(
+    (accounting?.invocations ?? []).filter((entry) => entry.noisy).map((entry) => entry.category),
+  ));
+  const totals = invocations.reduce(
+    (sum, invocation) => ({
+      chars: sum.chars + invocation.outputChars,
+      tokens: sum.tokens + invocation.estimatedOutputTokens,
+      worst: Math.max(sum.worst, invocation.outputChars),
+    }),
+    { chars: 0, tokens: 0, worst: 0 },
+  );
+  const activeTurnId = findActiveTurnId(latest);
+  const canSteerSelected = Boolean(
+    selected?.turnId
+    && selected.turnId === activeTurnId
+    && desktopApi?.steerTurn,
+  );
+  const canSendAsNewTurn = Boolean(!activeTurnId && desktopApi?.startTurn);
+  const visibleOutputLines = filterOutputLines(output, outputSearch);
+
+  const analyze = async (): Promise<void> => {
+    if (!desktopApi?.analyzeThreadToolHistory) return;
+    setAnalyzing(true);
+    setStatus(undefined);
+    try {
+      const response = await desktopApi.analyzeThreadToolHistory({
+        backend: route.backend,
+        threadId: route.threadId,
+      });
+      setAccounting(response.accounting);
+      setStatus(
+        response.coverage.completeness === "complete"
+          ? `Analyzed ${response.coverage.invocationCount.toLocaleString()} tool calls across ${response.coverage.pageCount.toLocaleString()} page${response.coverage.pageCount === 1 ? "" : "s"}.`
+          : response.coverage.explanation ?? "Analysis is incomplete.",
+      );
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  const sendPrompt = async (): Promise<void> => {
+    if (!selected || !prompt.trim()) return;
+    setStatus(undefined);
+    try {
+      if (canSteerSelected && selected.turnId) {
+        await desktopApi?.steerTurn?.({
+          backend: route.backend,
+          expectedTurnId: selected.turnId,
+          input: [{ type: "text", text: prompt.trim() }],
+          requestId: `tool-output-incident:${selected.invocationId}:${Date.now()}`,
+          threadId: route.threadId,
+        });
+        setStatus("Steering delivered to the exact active turn.");
+      } else if (canSendAsNewTurn) {
+        await desktopApi?.startTurn?.({
+          backend: route.backend,
+          input: [{ type: "text", text: prompt.trim() }],
+          threadId: route.threadId,
+        });
+        setStatus("Prompt sent as a new turn.");
+      }
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  return (
+    <div className="incident-explorer">
+      <header className="activity-titlebar">
+        <p className="activity-titlebar__brand">
+          Pwr<span className="activity-titlebar__brand-accent">Agent</span>
+        </p>
+        <div className="activity-titlebar__breadcrumb">
+          <span className="activity-titlebar__eyebrow">Thread</span>
+          <span aria-hidden="true" className="activity-titlebar__separator">›</span>
+          <span className="activity-titlebar__current">Tool-output incidents</span>
+        </div>
+        <div className="activity-titlebar__spacer" />
+      </header>
+      <header className="incident-explorer__header">
+        <div>
+          <h1>{route.title}</h1>
+          <p>{route.backend} · {route.threadId}</p>
+        </div>
+        <div className="incident-explorer__actions">
+          <button type="button" onClick={() => void analyze()} disabled={analyzing}>
+            {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
+          </button>
+          <button type="button" onClick={() => void refresh()} disabled={loading}>Refresh</button>
+          <button type="button" onClick={() => window.close()}>Close</button>
+        </div>
+      </header>
+      <div className="incident-explorer__metrics" aria-label="Incident metrics">
+        <Metric label="Cases" value={invocations.length.toLocaleString()} />
+        <Metric label="Total output" value={`${totals.chars.toLocaleString()} chars`} />
+        <Metric label="Estimated tokens" value={totals.tokens.toLocaleString()} />
+        <Metric label="Worst case" value={`${totals.worst.toLocaleString()} chars`} />
+      </div>
+      {accounting?.analysis?.completeness === "partial" ? (
+        <p className="incident-explorer__coverage" role="status">
+          Partial coverage: {accounting.analysis.explanation}
+        </p>
+      ) : null}
+      {status ? <p className="incident-explorer__status" role="status">{status}</p> : null}
+      <div className="incident-explorer__body">
+        <aside className="incident-explorer__list" aria-label="Incident cases">
+          <div className="incident-explorer__filters">
+            <input
+              aria-label="Filter incident cases"
+              onChange={(event) => setSearch(event.currentTarget.value)}
+              placeholder="Filter cases"
+              type="search"
+              value={search}
+            />
+            <select
+              aria-label="Filter by category"
+              onChange={(event) => setCategory(event.currentTarget.value as typeof category)}
+              value={category}
+            >
+              <option value="all">All categories</option>
+              {categories.map((entry) => <option key={entry} value={entry}>{entry}</option>)}
+            </select>
+          </div>
+          {groupInvocations(invocations).map((group) => (
+            <section className="incident-explorer__group" key={group.key}>
+              <h2>{group.turnLabel} · {group.category}</h2>
+              {group.invocations.map((invocation) => (
+                <button
+                  className="incident-explorer__case"
+                  data-selected={invocation.invocationId === selected?.invocationId}
+                  key={invocation.invocationId}
+                  onClick={() => setSelectedId(invocation.invocationId)}
+                  type="button"
+                >
+                  <span>{invocation.normalizedCommand ?? invocation.toolName}</span>
+                  <small>
+                    {invocation.outputChars.toLocaleString()} chars · {formatTimestamp(invocation.observedAt)}
+                  </small>
+                </button>
+              ))}
+            </section>
+          ))}
+          {!loading && invocations.length === 0 ? (
+            <p className="incident-explorer__empty">No findings match these filters.</p>
+          ) : null}
+        </aside>
+        <main className="incident-explorer__detail">
+          {selected ? (
+            <>
+              <section className="incident-explorer__evidence">
+                <h2>Selected invocation</h2>
+                <dl>
+                  <dt>Identity</dt><dd><code>{selected.normalizedCommand ?? selected.toolName}</code></dd>
+                  <dt>Observed</dt><dd>{formatTimestamp(selected.observedAt)}</dd>
+                  <dt>Status</dt><dd>{selected.status}{selected.exitCode !== undefined ? ` · exit ${selected.exitCode}` : ""}</dd>
+                  <dt>Output</dt><dd>{selected.outputChars.toLocaleString()} chars · ~{selected.estimatedOutputTokens.toLocaleString()} tokens</dd>
+                  <dt>Availability</dt><dd>{selected.outputState ?? (selected.outputTruncated ? "truncated" : "unavailable until replay is loaded")}</dd>
+                  <dt>Reason</dt><dd>{selected.noisyReason ?? "large output"}</dd>
+                  <dt>Source</dt><dd>{selected.source ?? "live"}</dd>
+                </dl>
+              </section>
+              <section className="incident-explorer__prompt">
+                <div className="incident-explorer__section-heading">
+                  <h2>Proposed steering</h2>
+                  <button type="button" onClick={() => void desktopApi?.copyText?.(prompt)}>Copy</button>
+                </div>
+                <textarea
+                  aria-label="Editable proposed steering prompt"
+                  onChange={(event) => setPrompt(event.currentTarget.value)}
+                  rows={10}
+                  value={prompt}
+                />
+                <button
+                  className="incident-explorer__primary"
+                  disabled={!prompt.trim() || (!canSendAsNewTurn && !canSteerSelected)}
+                  onClick={() => void sendPrompt()}
+                  type="button"
+                >
+                  {canSteerSelected ? "Steer exact active turn" : "Send next turn"}
+                </button>
+                {!canSteerSelected && activeTurnId ? (
+                  <p>The selected finding belongs to another turn. It cannot steer the active turn; send it after that turn ends.</p>
+                ) : null}
+              </section>
+              <section className="incident-explorer__output">
+                <div className="incident-explorer__section-heading">
+                  <h2>Captured output</h2>
+                  <input
+                    aria-label="Search captured output"
+                    onChange={(event) => setOutputSearch(event.currentTarget.value)}
+                    placeholder="Search output"
+                    type="search"
+                    value={outputSearch}
+                  />
+                </div>
+                {output !== undefined ? (
+                  <ol className="incident-explorer__output-lines">
+                    {visibleOutputLines.map((line) => (
+                      <li key={line.number} value={line.number}>
+                        <code>{line.text || " "}</code>
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p className="incident-explorer__empty">
+                    {selected.outputState === "compacted"
+                      ? "Output was compacted out of normalized replay."
+                      : selected.outputState === "truncated"
+                        ? "Only the truncated output retained by normalized replay is available."
+                        : "Output is unavailable in the currently available normalized replay."}
+                  </p>
+                )}
+              </section>
+            </>
+          ) : null}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function Metric(props: { label: string; value: string }) {
+  return <div><span>{props.label}</span><strong>{props.value}</strong></div>;
+}
+
+function readIncidentRoute(): {
+  backend: AppServerBackendKind;
+  threadId: string;
+  title: string;
+} | undefined {
+  const [kind, backend, threadId, title] = window.location.hash.replace(/^#/, "").split("/");
+  if (kind !== "tool-output-incidents" || !backend || !threadId) return undefined;
+  return {
+    backend: decodeURIComponent(backend) as AppServerBackendKind,
+    threadId: decodeURIComponent(threadId),
+    title: title ? decodeURIComponent(title) : "Thread",
+  };
+}
+
+function findActiveTurnId(response: AppServerReadThreadResponse | undefined): string | undefined {
+  const entries = response?.replay.entries ?? [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const turn = entries[index]?.turn;
+    if (turn?.status === "in_progress") return turn.id;
+  }
+  return undefined;
+}
+
+function groupInvocations(invocations: ThreadToolInvocationRecord[]) {
+  const groups = new Map<string, {
+    category: ThreadToolInvocationCategory;
+    invocations: ThreadToolInvocationRecord[];
+    key: string;
+    turnLabel: string;
+  }>();
+  for (const invocation of invocations) {
+    const turn = invocation.turnId ?? "No turn";
+    const key = `${turn}:${invocation.category}`;
+    const group = groups.get(key) ?? {
+      category: invocation.category,
+      invocations: [],
+      key,
+      turnLabel: invocation.turnId ? `Turn ${shortId(invocation.turnId)}` : "No turn",
+    };
+    group.invocations.push(invocation);
+    groups.set(key, group);
+  }
+  return [...groups.values()];
+}
+
+async function readInvocationOutput(params: {
+  backend: AppServerBackendKind;
+  desktopApi: NonNullable<ReturnType<typeof useDesktopApi>>;
+  initial: AppServerReadThreadResponse;
+  invocation: ThreadToolInvocationRecord;
+  threadId: string;
+}): Promise<string | undefined> {
+  let response = params.initial;
+  const seen = new Set<string>();
+  for (;;) {
+    const detail = findInvocationDetail(response, params.invocation);
+    if (detail?.command?.output !== undefined) return detail.command.output;
+    const cursor = response.replay.pagination.previousCursor;
+    if (
+      !response.replay.pagination.hasPreviousPage
+      || !cursor
+      || seen.has(cursor)
+      || !params.desktopApi.readThread
+    ) return undefined;
+    seen.add(cursor);
+    response = await params.desktopApi.readThread({
+      backend: params.backend,
+      before: cursor,
+      limit: HISTORY_PAGE_LIMIT,
+      threadId: params.threadId,
+      viewOnly: true,
+    });
+  }
+}
+
+function findInvocationDetail(
+  response: AppServerReadThreadResponse,
+  invocation: ThreadToolInvocationRecord,
+): AppServerThreadActivityDetail | undefined {
+  for (const entry of response.replay.entries) {
+    if (entry.type !== "activity" || entry.id !== invocation.itemId) continue;
+    const commandDetails = entry.details.filter((detail) => detail.command);
+    return commandDetails.find((detail) =>
+      detail.command?.displayCommand === invocation.normalizedCommand
+      || detail.label === invocation.toolName
+    ) ?? commandDetails[0];
+  }
+  return undefined;
+}
+
+function filterOutputLines(output: string | undefined, query: string) {
+  if (output === undefined) return [];
+  const normalizedQuery = query.trim().toLowerCase();
+  return output.split(/\r\n|\r|\n/).map((text, index) => ({
+    number: index + 1,
+    text,
+  })).filter((line) => !normalizedQuery || line.text.toLowerCase().includes(normalizedQuery));
+}
+
+function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+function shortId(value: string): string {
+  return value.length > 12 ? `${value.slice(0, 8)}…` : value;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -37,6 +37,7 @@ export function ToolOutputIncidentExplorerWindow() {
     try {
       const response = await desktopApi.readThread({
         backend: route.backend,
+        includeAllToolInvocations: true,
         limit: HISTORY_PAGE_LIMIT,
         threadId: route.threadId,
         viewOnly: true,
@@ -460,6 +461,20 @@ function findInvocationDetail(
   let matched: AppServerThreadActivityDetail | undefined;
   for (const entry of response.replay.entries) {
     if (entry.type !== "activity") continue;
+    const entryCommandDetails = entry.details.filter((detail) => detail.command);
+    if (entry.id === invocation.itemId) {
+      return entryCommandDetails.find((detail) =>
+        detail.command?.rawCommand === invocation.normalizedCommand
+        || detail.command?.displayCommand === invocation.normalizedCommand
+      )
+        ?? entryCommandDetails.find((detail) =>
+          detail.command?.output?.length === invocation.outputChars
+        )
+        ?? entryCommandDetails.find((detail) =>
+          detail.command?.output !== undefined
+        )
+        ?? entryCommandDetails[0];
+    }
     for (const detail of entry.details) {
       if (
         !detail.command

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -8,13 +8,16 @@ import type {
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import { formatBackendLabel } from "../../lib/backend-label";
 import { useDesktopApi } from "../../lib/desktop-api";
+import { ThreadChip } from "./ThreadChip";
+import { detailMatchesInvocationItem } from "./tool-call-details";
 
 const HISTORY_PAGE_LIMIT = 100;
 
 export function ToolOutputIncidentExplorerWindow() {
   const desktopApi = useDesktopApi();
-  const route = useMemo(readIncidentRoute, []);
+  const [route, setRoute] = useState(readIncidentRoute);
   const [accounting, setAccounting] = useState<ThreadToolAccounting>();
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
@@ -54,7 +57,15 @@ export function ToolOutputIncidentExplorerWindow() {
 
   useEffect(() => {
     if (!desktopApi?.onToolOutputIncidentExplorerRefresh) return;
-    return desktopApi.onToolOutputIncidentExplorerRefresh(() => {
+    return desktopApi.onToolOutputIncidentExplorerRefresh((request) => {
+      if (request) {
+        setRoute({
+          backend: request.backend,
+          projectLabel: request.projectLabel,
+          threadId: request.threadId,
+          title: request.title,
+        });
+      }
       void refresh();
     });
   }, [desktopApi, refresh]);
@@ -181,18 +192,45 @@ export function ToolOutputIncidentExplorerWindow() {
         <p className="activity-titlebar__brand">
           Pwr<span className="activity-titlebar__brand-accent">Agent</span>
         </p>
-        <div className="activity-titlebar__breadcrumb">
-          <span className="activity-titlebar__eyebrow">Thread</span>
+        <div
+          aria-label={[
+            route.projectLabel,
+            route.title,
+            "Tool Output Incidents",
+          ].filter(Boolean).join(" > ")}
+          className="activity-titlebar__breadcrumb"
+        >
+          {route.projectLabel ? (
+            <>
+              <span className="activity-titlebar__crumb" title={route.projectLabel}>
+                {route.projectLabel}
+              </span>
+              <span aria-hidden="true" className="activity-titlebar__separator">›</span>
+            </>
+          ) : null}
+          <ThreadChip
+            link={{
+              backend: route.backend,
+              inThreadList: true,
+              threadId: route.threadId,
+              title: route.title,
+            }}
+            onOpen={() => {
+              void desktopApi?.showThreadFromToolOutputIncidentExplorer?.({
+                backend: route.backend,
+                threadId: route.threadId,
+              }).catch((error: unknown) => {
+                setStatus(error instanceof Error ? error.message : String(error));
+              });
+            }}
+          />
           <span aria-hidden="true" className="activity-titlebar__separator">›</span>
-          <span className="activity-titlebar__current">Tool-output incidents</span>
+          <span className="activity-titlebar__current">Tool Output Incidents</span>
         </div>
+        <span className="chip chip--backend">
+          {formatBackendLabel(route.backend)}
+        </span>
         <div className="activity-titlebar__spacer" />
-      </header>
-      <header className="incident-explorer__header">
-        <div>
-          <h1>{route.title}</h1>
-          <p>{route.backend} · {route.threadId}</p>
-        </div>
         <div className="incident-explorer__actions">
           <button type="button" onClick={() => void analyze()} disabled={analyzing}>
             {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
@@ -336,13 +374,19 @@ function Metric(props: { label: string; value: string }) {
 
 function readIncidentRoute(): {
   backend: AppServerBackendKind;
+  projectLabel?: string;
   threadId: string;
   title: string;
 } | undefined {
-  const [kind, backend, threadId, title] = window.location.hash.replace(/^#/, "").split("/");
+  const [kind, backend, threadId, title, projectLabel] = window.location.hash
+    .replace(/^#/, "")
+    .split("/");
   if (kind !== "tool-output-incidents" || !backend || !threadId) return undefined;
   return {
     backend: decodeURIComponent(backend) as AppServerBackendKind,
+    ...(projectLabel
+      ? { projectLabel: decodeURIComponent(projectLabel) }
+      : {}),
     threadId: decodeURIComponent(threadId),
     title: title ? decodeURIComponent(title) : "Thread",
   };
@@ -413,15 +457,19 @@ function findInvocationDetail(
   response: AppServerReadThreadResponse,
   invocation: ThreadToolInvocationRecord,
 ): AppServerThreadActivityDetail | undefined {
+  let matched: AppServerThreadActivityDetail | undefined;
   for (const entry of response.replay.entries) {
-    if (entry.type !== "activity" || entry.id !== invocation.itemId) continue;
-    const commandDetails = entry.details.filter((detail) => detail.command);
-    return commandDetails.find((detail) =>
-      detail.command?.displayCommand === invocation.normalizedCommand
-      || detail.label === invocation.toolName
-    ) ?? commandDetails[0];
+    if (entry.type !== "activity") continue;
+    for (const detail of entry.details) {
+      if (
+        !detail.command
+        || !detailMatchesInvocationItem(detail.id, invocation.itemId)
+      ) continue;
+      if (detail.command.output !== undefined) return detail;
+      matched ??= detail;
+    }
   }
-  return undefined;
+  return matched;
 }
 
 function filterOutputLines(output: string | undefined, query: string) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -140,9 +140,11 @@ export function ToolOutputIncidentExplorerWindow() {
        safer failure than an unexplained empty list. */
     return entry ? new Set<RefinedToolCategory>(entry.members) : undefined;
   }, [category, composition]);
+  /* Counted over every recorded call, not just flagged ones: a command that
+     ran eight times and tripped the size test five times repeated eight. */
   const repeatedCommands = useMemo(
-    () => countRepeatedCommands(flagged),
-    [flagged],
+    () => countRepeatedCommands(allInvocations),
+    [allInvocations],
   );
   /* Every turn, not just the rows the strip had room for — a case in a turn
      that fell below the row limit still belongs to that turn. */
@@ -827,11 +829,11 @@ function TurnTimeline(props: {
               <span aria-hidden="true" className="incident-explorer__timeline-tokens">
                 <i
                   data-critical={row.overCapCount > 0}
-                  style={{ height: `${scaleWidth(row.estimatedOutputTokens, maxTokens)}%` }}
+                  style={{ height: `${scaleWidth(row.estimatedOutputTokens, maxTokens, 0)}%` }}
                 />
               </span>
               <span aria-hidden="true" className="incident-explorer__timeline-trips">
-                <i style={{ height: `${scaleWidth(row.callCount, maxCalls)}%` }} />
+                <i style={{ height: `${scaleWidth(row.callCount, maxCalls, 0)}%` }} />
               </span>
             </button>
           );
@@ -908,9 +910,16 @@ function Fact(props: {
   );
 }
 
-function scaleWidth(value: number, max: number): number {
+/**
+ * Strip bars floor at 2% so a small-but-real value stays visible and the row
+ * stays readable. `floor: 0` is for the spark, where a turn with genuinely no
+ * output must paint nothing — a floored bar there would read as low activity
+ * instead of none, blurring the contrast the polling band depends on.
+ */
+function scaleWidth(value: number, max: number, floor = 2): number {
   if (max <= 0) return 0;
-  return Math.max(2, Math.round(value / max * 100));
+  if (value <= 0) return floor === 0 ? 0 : floor;
+  return Math.max(floor, Math.round(value / max * 100));
 }
 
 function describeAvailability(invocation: ThreadToolInvocationRecord): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -4,7 +4,6 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadActivityDetail,
   ThreadToolAccounting,
-  ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import {
@@ -19,6 +18,7 @@ import { detailMatchesInvocationItem } from "./tool-call-details";
 import type {
   CategoryShare,
   IncidentSortMode,
+  RefinedToolCategory,
   TurnCostRow,
   TurnCostStrip,
 } from "./tool-output-incident-insights";
@@ -26,12 +26,16 @@ import {
   buildCategoryComposition,
   buildTurnCostStrip,
   capMeterWidth,
+  countRepeatedCommands,
   formatCapShare,
   formatCategoryLabel,
   formatCompactTokens,
   formatInvocationIdentity,
+  formatTurnWhen,
   invocationStatusTone,
   isOverOutputCap,
+  refineToolCategory,
+  repeatCountFor,
   sortIncidentCases,
   summarizeIncidents,
 } from "./tool-output-incident-insights";
@@ -44,7 +48,7 @@ export function ToolOutputIncidentExplorerWindow() {
   const [accounting, setAccounting] = useState<ThreadToolAccounting>();
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
-  const [category, setCategory] = useState<ThreadToolInvocationCategory | "all">("all");
+  const [category, setCategory] = useState<RefinedToolCategory | "all">("all");
   const [turnFilter, setTurnFilter] = useState<string>();
   const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
@@ -116,6 +120,10 @@ export function ToolOutputIncidentExplorerWindow() {
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
   const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
+  const repeatedCommands = useMemo(
+    () => countRepeatedCommands(flagged),
+    [flagged],
+  );
   /* Every turn, not just the rows the strip had room for — a case in a turn
      that fell below the row limit still belongs to that turn. */
   const turnLabels = turnStrip.labelsByKey;
@@ -124,7 +132,7 @@ export function ToolOutputIncidentExplorerWindow() {
     const normalizedSearch = search.trim().toLowerCase();
     return sortIncidentCases(
       flagged.filter((invocation) =>
-        (category === "all" || invocation.category === category)
+        (category === "all" || refineToolCategory(invocation) === category)
         && (turnFilter === undefined || (invocation.turnId ?? "") === turnFilter)
         && (
           !normalizedSearch
@@ -181,6 +189,8 @@ export function ToolOutputIncidentExplorerWindow() {
   const canSendAsNewTurn = Boolean(!activeTurnId && desktopApi?.startTurn);
   const visibleOutputLines = filterOutputLines(output, outputSearch);
   const laterTripsInTurn = selected ? countLaterTripsInTurn(allInvocations, selected) : 0;
+  /* One clock read per render, shared by every turn row. */
+  const renderedAt = Date.now();
 
   const analyze = async (): Promise<void> => {
     if (!desktopApi?.analyzeThreadToolHistory) return;
@@ -351,9 +361,7 @@ export function ToolOutputIncidentExplorerWindow() {
                 disabled={entry.category === "other"}
                 key={entry.category}
                 onClick={() => setCategory(
-                  entry.category === "other"
-                    ? "all"
-                    : entry.category as ThreadToolInvocationCategory,
+                  entry.category === "other" ? "all" : entry.category,
                 )}
                 type="button"
               >
@@ -373,6 +381,7 @@ export function ToolOutputIncidentExplorerWindow() {
       </div>
 
       <TurnStrip
+        now={renderedAt}
         onSelect={(row) => setTurnFilter(
           turnFilter === row.key ? undefined : row.key,
         )}
@@ -439,7 +448,9 @@ export function ToolOutputIncidentExplorerWindow() {
                 <CaseRow
                   invocation={invocation}
                   key={invocation.invocationId}
+                  now={renderedAt}
                   onSelect={() => setSelectedId(invocation.invocationId)}
+                  repeatCount={repeatCountFor(invocation, repeatedCommands)}
                   selected={invocation.invocationId === selected?.invocationId}
                 />
               ))}
@@ -492,9 +503,16 @@ export function ToolOutputIncidentExplorerWindow() {
                     value={selected.exitCode !== undefined ? `exit ${selected.exitCode}` : "—"}
                   />
                   <Fact
-                    label={formatCategoryLabel(selected.category)}
+                    label={formatCategoryLabel(refineToolCategory(selected))}
                     value={turnLabels.get(selected.turnId ?? "") ?? "No turn"}
                   />
+                  {repeatCountFor(selected, repeatedCommands) > 1 ? (
+                    <Fact
+                      label="repeated"
+                      tone="warning"
+                      value={`${repeatCountFor(selected, repeatedCommands)}× in this thread`}
+                    />
+                  ) : null}
                   <Fact label="observed" value={formatTimestamp(selected.observedAt)} />
                   <Fact
                     label="output"
@@ -621,6 +639,9 @@ function CompositionBar(props: { composition: CategoryShare[] }) {
  * the two need to be told apart at a glance.
  */
 function TurnStrip(props: {
+  /* Captured once by the caller so every row in a render measures "ago"
+     against the same instant. */
+  now: number;
   onSelect: (row: TurnCostRow) => void;
   selectedKey?: string;
   strip: TurnCostStrip;
@@ -648,7 +669,9 @@ function TurnStrip(props: {
         >
           <span className="incident-explorer__turn-label">
             {row.label}
-            <span>{` · ${formatClockTime(row.firstObservedAt)}`}</span>
+            <span title={new Date(row.firstObservedAt).toLocaleString()}>
+              {` · ${formatTurnWhen(row.firstObservedAt, props.now)}`}
+            </span>
           </span>
           <span aria-hidden="true" className="incident-explorer__turn-bar">
             <i
@@ -679,7 +702,9 @@ function TurnStrip(props: {
 
 function CaseRow(props: {
   invocation: ThreadToolInvocationRecord;
+  now: number;
   onSelect: () => void;
+  repeatCount: number;
   selected: boolean;
 }) {
   const invocation = props.invocation;
@@ -692,7 +717,7 @@ function CaseRow(props: {
       className="incident-explorer__case"
       data-selected={props.selected}
       onClick={props.onSelect}
-      title={command}
+      title={`${command}\n${new Date(invocation.observedAt).toLocaleString()}`}
       type="button"
     >
       <span className="incident-explorer__case-top">
@@ -701,6 +726,16 @@ function CaseRow(props: {
           {identity.detail ? <span>{` ${identity.detail}`}</span> : null}
         </span>
         <span className="incident-explorer__case-tokens">
+          {props.repeatCount > 1 ? (
+            /* Re-running the identical read is its own finding: the turn
+               either lost the earlier result or the file keeps changing. */
+            <b
+              className="incident-explorer__repeat"
+              title={`This exact command ran ${props.repeatCount} times in this thread`}
+            >
+              {props.repeatCount}×
+            </b>
+          ) : null}
           {formatCompactTokens(invocation.estimatedOutputTokens)}
         </span>
       </span>
@@ -713,7 +748,7 @@ function CaseRow(props: {
       <span className="incident-explorer__case-sub">
         {formatCapShare(invocation.outputChars, { short: true })}
         {" · "}{invocation.outputChars.toLocaleString()} chars
-        {" · "}{formatClockTime(invocation.observedAt)}
+        {" · "}{formatTurnWhen(invocation.observedAt, props.now)}
       </span>
     </button>
   );
@@ -897,9 +932,3 @@ function formatTimestamp(timestamp: number): string {
   return new Date(timestamp).toLocaleString();
 }
 
-function formatClockTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -26,6 +26,7 @@ import {
   formatCategoryLabel,
   formatCompactTokens,
   formatInvocationIdentity,
+  invocationStatusTone,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
@@ -111,10 +112,9 @@ export function ToolOutputIncidentExplorerWindow() {
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
   const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
-  const turnLabels = useMemo(
-    () => new Map(turnStrip.rows.map((row) => [row.key, row.label])),
-    [turnStrip.rows],
-  );
+  /* Every turn, not just the rows the strip had room for — a case in a turn
+     that fell below the row limit still belongs to that turn. */
+  const turnLabels = turnStrip.labelsByKey;
 
   const invocations = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
@@ -468,7 +468,7 @@ export function ToolOutputIncidentExplorerWindow() {
                 <div className="incident-explorer__facts">
                   <Fact
                     label={selected.status}
-                    tone={selected.status === "failed" ? "error" : "ok"}
+                    tone={invocationStatusTone(selected)}
                     value={selected.exitCode !== undefined ? `exit ${selected.exitCode}` : "—"}
                   />
                   <Fact
@@ -649,7 +649,7 @@ function TurnStrip(props: {
       ))}
       {props.strip.hiddenTurnCount > 0 ? (
         <p className="incident-explorer__turns-note">
-          {props.strip.hiddenTurnCount.toLocaleString()} quieter{" "}
+          {props.strip.hiddenTurnCount.toLocaleString()} lower-cost{" "}
           {props.strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown.
         </p>
       ) : null}
@@ -730,9 +730,16 @@ function countLaterTripsInTurn(
   invocations: ThreadToolInvocationRecord[],
   selected: ThreadToolInvocationRecord,
 ): number {
-  return invocations.filter((invocation) =>
+  /* A full-history analyze pass can stamp several of a turn's calls with the
+     same millisecond, so "later" falls back to persisted order rather than
+     dropping every tie and understating the replay count. */
+  const selectedIndex = invocations.indexOf(selected);
+  return invocations.filter((invocation, index) =>
     (invocation.turnId ?? "") === (selected.turnId ?? "")
-    && invocation.observedAt > selected.observedAt
+    && (
+      invocation.observedAt > selected.observedAt
+      || (invocation.observedAt === selected.observedAt && index > selectedIndex)
+    )
   ).length;
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -21,6 +21,7 @@ import type {
   RefinedToolCategory,
   TurnCostRow,
   TurnCostStrip,
+  TurnStripScope,
 } from "./tool-output-incident-insights";
 import {
   buildCategoryComposition,
@@ -51,6 +52,7 @@ export function ToolOutputIncidentExplorerWindow() {
   const [selectedId, setSelectedId] = useState<string>();
   const [category, setCategory] = useState<RefinedToolCategory | "all" | "other">("all");
   const [turnFilter, setTurnFilter] = useState<string>();
+  const [turnScope, setTurnScope] = useState<TurnStripScope>("flagged");
   const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
   const [prompt, setPrompt] = useState("");
@@ -122,9 +124,10 @@ export function ToolOutputIncidentExplorerWindow() {
   const usageLines = latest?.pricing?.lines;
   const turnStrip = useMemo(
     () => buildTurnCostStrip(allInvocations, {
+      scope: turnScope,
       ...(usageLines ? { usageLines } : {}),
     }),
-    [allInvocations, usageLines],
+    [allInvocations, turnScope, usageLines],
   );
   const currency = usageLines?.[0]?.currency;
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
@@ -402,6 +405,7 @@ export function ToolOutputIncidentExplorerWindow() {
       <TurnStrip
         {...(currency ? { currency } : {})}
         now={renderedAt}
+        onScopeChange={setTurnScope}
         showCost={turnStrip.rows.some((row) => row.costMicros !== undefined)}
         onSelect={(row) => setTurnFilter(
           turnFilter === row.key ? undefined : row.key,
@@ -665,17 +669,43 @@ function TurnStrip(props: {
      against the same instant. */
   now: number;
   showCost: boolean;
+  onScopeChange: (scope: TurnStripScope) => void;
   onSelect: (row: TurnCostRow) => void;
   selectedKey?: string;
   strip: TurnCostStrip;
 }) {
-  if (props.strip.rows.length === 0) return null;
+  if (props.strip.totalTurnCount === 0) return null;
+  const strip = props.strip;
   return (
     <section className="incident-explorer__turns" aria-label="Cost by turn">
       <div className="incident-explorer__turns-head">
         <p className="incident-explorer__eyebrow">
-          {props.strip.ordering === "cost" ? "Costliest turns" : "Cost by turn"}
+          {strip.ordering === "cost"
+            ? strip.rankedBy === "billed"
+              ? "Costliest turns · by billed cost"
+              : "Costliest turns · by output × round trips"
+            : "Cost by turn"}
         </p>
+        <div
+          aria-label="Turn scope"
+          className="incident-explorer__turns-scope"
+          role="group"
+        >
+          <button
+            aria-pressed={strip.scope === "flagged"}
+            onClick={() => props.onScopeChange("flagged")}
+            type="button"
+          >
+            Flagged ({strip.flaggedTurnCount.toLocaleString()})
+          </button>
+          <button
+            aria-pressed={strip.scope === "all"}
+            onClick={() => props.onScopeChange("all")}
+            type="button"
+          >
+            All with tool calls ({strip.totalTurnCount.toLocaleString()})
+          </button>
+        </div>
         <p className="incident-explorer__turns-legend">
           <span className="incident-explorer__turns-key" data-kind="tokens" /> output tokens
           {" · "}
@@ -721,10 +751,14 @@ function TurnStrip(props: {
           ) : null}
         </button>
       ))}
-      {props.strip.hiddenTurnCount > 0 ? (
+      {strip.hiddenTurnCount > 0 || strip.scope === "flagged" ? (
         <p className="incident-explorer__turns-note">
-          {props.strip.hiddenTurnCount.toLocaleString()} lower-cost{" "}
-          {props.strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown.
+          {strip.hiddenTurnCount > 0
+            ? `${strip.hiddenTurnCount.toLocaleString()} lower-cost ${strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown. `
+            : ""}
+          {strip.scope === "flagged"
+            ? `${(strip.totalTurnCount - strip.flaggedTurnCount).toLocaleString()} turns made only small tool calls; turns with no tool calls are never listed.`
+            : "Turns with no tool calls are never listed."}
         </p>
       ) : null}
     </section>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -7,7 +7,11 @@ import type {
   ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
-import { buildThreadToolIncidentPrompt } from "@pwragent/shared";
+import {
+  buildThreadToolIncidentPrompt,
+  isFlaggedToolInvocation,
+  TOOL_OUTPUT_WARNING_CHARS,
+} from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { useDesktopApi } from "../../lib/desktop-api";
 import { ThreadChip } from "./ThreadChip";
@@ -106,7 +110,7 @@ export function ToolOutputIncidentExplorerWindow() {
     [accounting?.invocations],
   );
   const flagged = useMemo(
-    () => allInvocations.filter((invocation) => invocation.noisy),
+    () => allInvocations.filter(isFlaggedToolInvocation),
     [allInvocations],
   );
   const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
@@ -181,13 +185,21 @@ export function ToolOutputIncidentExplorerWindow() {
   const analyze = async (): Promise<void> => {
     if (!desktopApi?.analyzeThreadToolHistory) return;
     setAnalyzing(true);
-    setStatus(undefined);
+    setStatusTone("info");
+    /* The scan pages through the whole thread 100 entries at a time, which on
+       a long thread is tens of seconds of silence. Say so up front rather
+       than leaving a disabled button as the only feedback. */
+    setStatus("Scanning this thread's history…");
     try {
       const response = await desktopApi.analyzeThreadToolHistory({
         backend: route.backend,
         threadId: route.threadId,
       });
       setAccounting(response.accounting);
+      /* Analysis persisted new rows and new output availability; re-read so
+         the transcript pages backing captured-output retrieval match the
+         findings now on screen. */
+      void refresh();
       setStatusTone(response.coverage.completeness === "complete" ? "info" : "error");
       setStatus(
         response.coverage.completeness === "complete"
@@ -281,7 +293,9 @@ export function ToolOutputIncidentExplorerWindow() {
             onClick={() => void analyze()}
             disabled={analyzing}
           >
-            {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
+            {analyzing
+              ? "Analyzing…"
+              : accounting?.analysis ? "Refresh analysis" : "Analyze history"}
           </button>
           <button
             className="incident-explorer__button incident-explorer__button--ghost"
@@ -432,7 +446,13 @@ export function ToolOutputIncidentExplorerWindow() {
             </section>
           ))}
           {!loading && invocations.length === 0 ? (
-            <p className="incident-explorer__empty">No findings match these filters.</p>
+            <p className="incident-explorer__empty">
+              {flagged.length > 0
+                ? "No findings match these filters."
+                : allInvocations.length === 0
+                  ? "No tool calls are recorded for this thread yet."
+                  : `None of this thread's ${allInvocations.length.toLocaleString()} recorded tool calls returned more than ${TOOL_OUTPUT_WARNING_CHARS.toLocaleString()} characters.`}
+            </p>
           ) : null}
         </aside>
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -12,6 +12,24 @@ import { formatBackendLabel } from "../../lib/backend-label";
 import { useDesktopApi } from "../../lib/desktop-api";
 import { ThreadChip } from "./ThreadChip";
 import { detailMatchesInvocationItem } from "./tool-call-details";
+import type {
+  CategoryShare,
+  IncidentSortMode,
+  TurnCostRow,
+  TurnCostStrip,
+} from "./tool-output-incident-insights";
+import {
+  buildCategoryComposition,
+  buildTurnCostStrip,
+  capMeterWidth,
+  formatCapShare,
+  formatCategoryLabel,
+  formatCompactTokens,
+  formatInvocationIdentity,
+  isOverOutputCap,
+  sortIncidentCases,
+  summarizeIncidents,
+} from "./tool-output-incident-insights";
 
 const HISTORY_PAGE_LIMIT = 100;
 
@@ -22,13 +40,24 @@ export function ToolOutputIncidentExplorerWindow() {
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
   const [selectedId, setSelectedId] = useState<string>();
   const [category, setCategory] = useState<ThreadToolInvocationCategory | "all">("all");
+  const [turnFilter, setTurnFilter] = useState<string>();
+  const [sortMode, setSortMode] = useState<IncidentSortMode>("largest");
   const [search, setSearch] = useState("");
   const [prompt, setPrompt] = useState("");
+  const [identityExpanded, setIdentityExpanded] = useState(false);
   const [output, setOutput] = useState<string>();
   const [outputSearch, setOutputSearch] = useState("");
   const [status, setStatus] = useState<string>();
+  const [statusTone, setStatusTone] = useState<"error" | "info">("info");
   const [loading, setLoading] = useState(true);
   const [analyzing, setAnalyzing] = useState(false);
+
+  /* Stable identity: `refresh` depends on it, and a refresh that changed every
+     render would re-run the effect that calls it on every render. */
+  const reportError = useCallback((error: unknown) => {
+    setStatusTone("error");
+    setStatus(error instanceof Error ? error.message : String(error));
+  }, []);
 
   const refresh = useCallback(async () => {
     if (!route || !desktopApi?.readThread) return;
@@ -45,11 +74,11 @@ export function ToolOutputIncidentExplorerWindow() {
       setLatest(response);
       setAccounting(response.toolAccounting);
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : String(error));
+      reportError(error);
     } finally {
       setLoading(false);
     }
-  }, [desktopApi, route]);
+  }, [desktopApi, reportError, route]);
 
   useEffect(() => {
     document.title = route ? `Tool-output incidents — ${route.title}` : "Tool-output incidents";
@@ -71,20 +100,39 @@ export function ToolOutputIncidentExplorerWindow() {
     });
   }, [desktopApi, refresh]);
 
+  const allInvocations = useMemo(
+    () => accounting?.invocations ?? [],
+    [accounting?.invocations],
+  );
+  const flagged = useMemo(
+    () => allInvocations.filter((invocation) => invocation.noisy),
+    [allInvocations],
+  );
+  const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
+  const turnStrip = useMemo(() => buildTurnCostStrip(allInvocations), [allInvocations]);
+  const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
+  const turnLabels = useMemo(
+    () => new Map(turnStrip.rows.map((row) => [row.key, row.label])),
+    [turnStrip.rows],
+  );
+
   const invocations = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
-    return (accounting?.invocations ?? []).filter((invocation) =>
-      invocation.noisy
-      && (category === "all" || invocation.category === category)
-      && (
-        !normalizedSearch
-        || (invocation.normalizedCommand ?? invocation.toolName)
-          .toLowerCase()
-          .includes(normalizedSearch)
-        || invocation.noisyReason?.toLowerCase().includes(normalizedSearch)
-      )
+    return sortIncidentCases(
+      flagged.filter((invocation) =>
+        (category === "all" || invocation.category === category)
+        && (turnFilter === undefined || (invocation.turnId ?? "") === turnFilter)
+        && (
+          !normalizedSearch
+          || (invocation.normalizedCommand ?? invocation.toolName)
+            .toLowerCase()
+            .includes(normalizedSearch)
+          || invocation.noisyReason?.toLowerCase().includes(normalizedSearch)
+        )
+      ),
+      sortMode,
     );
-  }, [accounting?.invocations, category, search]);
+  }, [category, flagged, search, sortMode, turnFilter]);
   const selected = invocations.find((invocation) => invocation.invocationId === selectedId)
     ?? invocations[0];
 
@@ -95,6 +143,7 @@ export function ToolOutputIncidentExplorerWindow() {
           reason: selected.noisyReason ?? "large tool output",
         })
       : "");
+    setIdentityExpanded(false);
     setOutput(undefined);
     setOutputSearch("");
     if (!selected || !latest || !desktopApi?.readThread || !route) return;
@@ -108,28 +157,17 @@ export function ToolOutputIncidentExplorerWindow() {
     }).then((value) => {
       if (!cancelled) setOutput(value);
     }).catch((error) => {
-      if (!cancelled) setStatus(error instanceof Error ? error.message : String(error));
+      if (!cancelled) reportError(error);
     });
     return () => {
       cancelled = true;
     };
-  }, [desktopApi, latest, route, selected]);
+  }, [desktopApi, latest, reportError, route, selected]);
 
   if (!route) {
     return <p className="incident-explorer__error">Invalid incident explorer route.</p>;
   }
 
-  const categories = Array.from(new Set(
-    (accounting?.invocations ?? []).filter((entry) => entry.noisy).map((entry) => entry.category),
-  ));
-  const totals = invocations.reduce(
-    (sum, invocation) => ({
-      chars: sum.chars + invocation.outputChars,
-      tokens: sum.tokens + invocation.estimatedOutputTokens,
-      worst: Math.max(sum.worst, invocation.outputChars),
-    }),
-    { chars: 0, tokens: 0, worst: 0 },
-  );
   const activeTurnId = findActiveTurnId(latest);
   const canSteerSelected = Boolean(
     selected?.turnId
@@ -138,6 +176,7 @@ export function ToolOutputIncidentExplorerWindow() {
   );
   const canSendAsNewTurn = Boolean(!activeTurnId && desktopApi?.startTurn);
   const visibleOutputLines = filterOutputLines(output, outputSearch);
+  const laterTripsInTurn = selected ? countLaterTripsInTurn(allInvocations, selected) : 0;
 
   const analyze = async (): Promise<void> => {
     if (!desktopApi?.analyzeThreadToolHistory) return;
@@ -149,13 +188,14 @@ export function ToolOutputIncidentExplorerWindow() {
         threadId: route.threadId,
       });
       setAccounting(response.accounting);
+      setStatusTone(response.coverage.completeness === "complete" ? "info" : "error");
       setStatus(
         response.coverage.completeness === "complete"
           ? `Analyzed ${response.coverage.invocationCount.toLocaleString()} tool calls across ${response.coverage.pageCount.toLocaleString()} page${response.coverage.pageCount === 1 ? "" : "s"}.`
           : response.coverage.explanation ?? "Analysis is incomplete.",
       );
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : String(error));
+      reportError(error);
     } finally {
       setAnalyzing(false);
     }
@@ -173,6 +213,7 @@ export function ToolOutputIncidentExplorerWindow() {
           requestId: `tool-output-incident:${selected.invocationId}:${Date.now()}`,
           threadId: route.threadId,
         });
+        setStatusTone("info");
         setStatus("Steering delivered to the exact active turn.");
       } else if (canSendAsNewTurn) {
         await desktopApi?.startTurn?.({
@@ -180,10 +221,11 @@ export function ToolOutputIncidentExplorerWindow() {
           input: [{ type: "text", text: prompt.trim() }],
           threadId: route.threadId,
         });
+        setStatusTone("info");
         setStatus("Prompt sent as a new turn.");
       }
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : String(error));
+      reportError(error);
     }
   };
 
@@ -221,7 +263,7 @@ export function ToolOutputIncidentExplorerWindow() {
                 backend: route.backend,
                 threadId: route.threadId,
               }).catch((error: unknown) => {
-                setStatus(error instanceof Error ? error.message : String(error));
+                reportError(error);
               });
             }}
           />
@@ -233,25 +275,112 @@ export function ToolOutputIncidentExplorerWindow() {
         </span>
         <div className="activity-titlebar__spacer" />
         <div className="incident-explorer__actions">
-          <button type="button" onClick={() => void analyze()} disabled={analyzing}>
+          <button
+            className="incident-explorer__button"
+            type="button"
+            onClick={() => void analyze()}
+            disabled={analyzing}
+          >
             {accounting?.analysis ? "Refresh analysis" : "Analyze history"}
           </button>
-          <button type="button" onClick={() => void refresh()} disabled={loading}>Refresh</button>
-          <button type="button" onClick={() => window.close()}>Close</button>
+          <button
+            className="incident-explorer__button incident-explorer__button--ghost"
+            type="button"
+            onClick={() => void refresh()}
+            disabled={loading}
+          >
+            Refresh
+          </button>
         </div>
       </header>
-      <div className="incident-explorer__metrics" aria-label="Incident metrics">
-        <Metric label="Cases" value={invocations.length.toLocaleString()} />
-        <Metric label="Total output" value={`${totals.chars.toLocaleString()} chars`} />
-        <Metric label="Estimated tokens" value={totals.tokens.toLocaleString()} />
-        <Metric label="Worst case" value={`${totals.worst.toLocaleString()} chars`} />
+
+      <div className="incident-explorer__summary" aria-label="Incident metrics">
+        <div className="incident-explorer__headline">
+          <p className="incident-explorer__eyebrow">Replay cost from flagged calls</p>
+          <p className="incident-explorer__hero">
+            <strong>{formatCompactTokens(summary.incidentTokens)}</strong>
+            <span>
+              tokens · {Math.round(summary.share * 100)}% of all tool output
+            </span>
+          </p>
+          <span
+            aria-hidden="true"
+            className="incident-explorer__meter"
+          >
+            <i style={{ width: `${Math.round(summary.share * 100)}%` }} />
+          </span>
+          <p className="incident-explorer__caption">
+            <b>{summary.caseCount}</b> {summary.caseCount === 1 ? "case" : "cases"}
+            {" · "}{summary.turnCount} {summary.turnCount === 1 ? "turn" : "turns"}
+            {" · "}{summary.incidentChars.toLocaleString()} chars
+            {" · worst "}{summary.worstChars.toLocaleString()}
+          </p>
+        </div>
+        <div className="incident-explorer__composition-group" role="group" aria-label="Filter by category">
+          <p className="incident-explorer__eyebrow">Where it went</p>
+          <CompositionBar composition={composition} />
+          <div className="incident-explorer__legend">
+            <button
+              aria-pressed={category === "all"}
+              className="incident-explorer__legend-item"
+              onClick={() => setCategory("all")}
+              type="button"
+            >
+              <i className="incident-explorer__swatch incident-explorer__swatch--all" />
+              All categories
+              <em>{formatCompactTokens(summary.incidentTokens)}</em>
+            </button>
+            {composition.map((entry, index) => (
+              <button
+                aria-pressed={category === entry.category}
+                className="incident-explorer__legend-item"
+                disabled={entry.category === "other"}
+                key={entry.category}
+                onClick={() => setCategory(
+                  entry.category === "other"
+                    ? "all"
+                    : entry.category as ThreadToolInvocationCategory,
+                )}
+                type="button"
+              >
+                <i
+                  className="incident-explorer__swatch"
+                  data-rank={Math.min(index + 1, 5)}
+                />
+                {entry.label}
+                <em>
+                  {formatCompactTokens(entry.estimatedOutputTokens)}
+                  {" · "}{Math.round(entry.share * 100)}%
+                </em>
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
+
+      <TurnStrip
+        onSelect={(row) => setTurnFilter(
+          turnFilter === row.key ? undefined : row.key,
+        )}
+        selectedKey={turnFilter}
+        strip={turnStrip}
+      />
+
       {accounting?.analysis?.completeness === "partial" ? (
         <p className="incident-explorer__coverage" role="status">
           Partial coverage: {accounting.analysis.explanation}
         </p>
       ) : null}
-      {status ? <p className="incident-explorer__status" role="status">{status}</p> : null}
+      {status ? (
+        <p
+          className="incident-explorer__status"
+          data-tone={statusTone}
+          role="status"
+        >
+          {status}
+        </p>
+      ) : null}
+
       <div className="incident-explorer__body">
         <aside className="incident-explorer__list" aria-label="Incident cases">
           <div className="incident-explorer__filters">
@@ -263,30 +392,42 @@ export function ToolOutputIncidentExplorerWindow() {
               value={search}
             />
             <select
-              aria-label="Filter by category"
-              onChange={(event) => setCategory(event.currentTarget.value as typeof category)}
-              value={category}
+              aria-label="Sort cases"
+              onChange={(event) => setSortMode(event.currentTarget.value as IncidentSortMode)}
+              value={sortMode}
             >
-              <option value="all">All categories</option>
-              {categories.map((entry) => <option key={entry} value={entry}>{entry}</option>)}
+              <option value="largest">Largest first</option>
+              <option value="newest">Newest first</option>
+              <option value="turn">By turn</option>
             </select>
           </div>
-          {groupInvocations(invocations).map((group) => (
+          {turnFilter !== undefined || category !== "all" ? (
+            <div className="incident-explorer__active-filters">
+              <span>
+                Showing {invocations.length.toLocaleString()} of {flagged.length.toLocaleString()} cases
+              </span>
+              <button
+                className="incident-explorer__button incident-explorer__button--ghost"
+                onClick={() => {
+                  setCategory("all");
+                  setTurnFilter(undefined);
+                }}
+                type="button"
+              >
+                Clear filters
+              </button>
+            </div>
+          ) : null}
+          {groupCases(invocations, sortMode, turnLabels).map((group) => (
             <section className="incident-explorer__group" key={group.key}>
-              <h2>{group.turnLabel} · {group.category}</h2>
+              {group.label ? <h3>{group.label}</h3> : null}
               {group.invocations.map((invocation) => (
-                <button
-                  className="incident-explorer__case"
-                  data-selected={invocation.invocationId === selected?.invocationId}
+                <CaseRow
+                  invocation={invocation}
                   key={invocation.invocationId}
-                  onClick={() => setSelectedId(invocation.invocationId)}
-                  type="button"
-                >
-                  <span>{invocation.normalizedCommand ?? invocation.toolName}</span>
-                  <small>
-                    {invocation.outputChars.toLocaleString()} chars · {formatTimestamp(invocation.observedAt)}
-                  </small>
-                </button>
+                  onSelect={() => setSelectedId(invocation.invocationId)}
+                  selected={invocation.invocationId === selected?.invocationId}
+                />
               ))}
             </section>
           ))}
@@ -294,54 +435,122 @@ export function ToolOutputIncidentExplorerWindow() {
             <p className="incident-explorer__empty">No findings match these filters.</p>
           ) : null}
         </aside>
+
         <main className="incident-explorer__detail">
           {selected ? (
             <>
               <section className="incident-explorer__evidence">
-                <h2>Selected invocation</h2>
-                <dl>
-                  <dt>Identity</dt><dd><code>{selected.normalizedCommand ?? selected.toolName}</code></dd>
-                  <dt>Observed</dt><dd>{formatTimestamp(selected.observedAt)}</dd>
-                  <dt>Status</dt><dd>{selected.status}{selected.exitCode !== undefined ? ` · exit ${selected.exitCode}` : ""}</dd>
-                  <dt>Output</dt><dd>{selected.outputChars.toLocaleString()} chars · ~{selected.estimatedOutputTokens.toLocaleString()} tokens</dd>
-                  <dt>Availability</dt><dd>{selected.outputState ?? (selected.outputTruncated ? "truncated" : "unavailable until replay is loaded")}</dd>
-                  <dt>Reason</dt><dd>{selected.noisyReason ?? "large output"}</dd>
-                  <dt>Source</dt><dd>{selected.source ?? "live"}</dd>
-                </dl>
-              </section>
-              <section className="incident-explorer__prompt">
                 <div className="incident-explorer__section-heading">
-                  <h2>Proposed steering</h2>
-                  <button type="button" onClick={() => void desktopApi?.copyText?.(prompt)}>Copy</button>
+                  <h2>Selected invocation</h2>
+                  <button
+                    className="incident-explorer__button incident-explorer__button--ghost"
+                    onClick={() => void desktopApi?.copyText?.(
+                      selected.normalizedCommand ?? selected.toolName,
+                    )}
+                    type="button"
+                  >
+                    Copy command
+                  </button>
                 </div>
-                <textarea
-                  aria-label="Editable proposed steering prompt"
-                  onChange={(event) => setPrompt(event.currentTarget.value)}
-                  rows={10}
-                  value={prompt}
-                />
-                <button
-                  className="incident-explorer__primary"
-                  disabled={!prompt.trim() || (!canSendAsNewTurn && !canSteerSelected)}
-                  onClick={() => void sendPrompt()}
-                  type="button"
+                <div
+                  className="incident-explorer__identity"
+                  data-expanded={identityExpanded}
                 >
-                  {canSteerSelected ? "Steer exact active turn" : "Send next turn"}
-                </button>
-                {!canSteerSelected && activeTurnId ? (
-                  <p>The selected finding belongs to another turn. It cannot steer the active turn; send it after that turn ends.</p>
-                ) : null}
+                  <code>{selected.normalizedCommand ?? selected.toolName}</code>
+                  <button
+                    className="incident-explorer__button incident-explorer__button--ghost"
+                    onClick={() => setIdentityExpanded((value) => !value)}
+                    type="button"
+                  >
+                    {identityExpanded ? "Collapse" : "Expand"}
+                  </button>
+                </div>
+                <div className="incident-explorer__facts">
+                  <Fact
+                    label={selected.status}
+                    tone={selected.status === "failed" ? "error" : "ok"}
+                    value={selected.exitCode !== undefined ? `exit ${selected.exitCode}` : "—"}
+                  />
+                  <Fact
+                    label={formatCategoryLabel(selected.category)}
+                    value={turnLabels.get(selected.turnId ?? "") ?? "No turn"}
+                  />
+                  <Fact label="observed" value={formatTimestamp(selected.observedAt)} />
+                  <Fact
+                    label="output"
+                    tone={selected.outputState === "available" ? undefined : "warning"}
+                    value={describeAvailability(selected)}
+                  />
+                  <Fact label="source" value={selected.source ?? "live"} />
+                </div>
+
+                <div className="incident-explorer__budget">
+                  <div className="incident-explorer__budget-head">
+                    <strong>{selected.estimatedOutputTokens.toLocaleString()} tokens</strong>
+                    <span>{formatCapShare(selected.outputChars)}</span>
+                  </div>
+                  <span aria-hidden="true" className="incident-explorer__meter">
+                    <i
+                      data-critical={isOverOutputCap(selected.outputChars)}
+                      style={{ width: `${capMeterWidth(selected.outputChars) * 100}%` }}
+                    />
+                  </span>
+                  <p className="incident-explorer__caption">
+                    {selected.outputChars.toLocaleString()} chars ·{" "}
+                    {laterTripsInTurn > 0
+                      ? `replayed on the ${laterTripsInTurn.toLocaleString()} later round ${laterTripsInTurn === 1 ? "trip" : "trips"} in this turn`
+                      : "no later round trips in this turn replayed it"}
+                  </p>
+                  <p className="incident-explorer__reason">
+                    {selected.noisyReason ?? "large output"}
+                  </p>
+                </div>
               </section>
+
+              <section className="incident-explorer__prompt">
+                <details className="incident-explorer__steer">
+                  <summary>Proposed steering</summary>
+                  <textarea
+                    aria-label="Editable proposed steering prompt"
+                    onChange={(event) => setPrompt(event.currentTarget.value)}
+                    rows={8}
+                    value={prompt}
+                  />
+                </details>
+                <div className="incident-explorer__prompt-actions">
+                  <button
+                    className="incident-explorer__button incident-explorer__primary"
+                    disabled={!prompt.trim() || (!canSendAsNewTurn && !canSteerSelected)}
+                    onClick={() => void sendPrompt()}
+                    type="button"
+                  >
+                    {canSteerSelected ? "Steer exact active turn" : "Send next turn"}
+                  </button>
+                  <button
+                    className="incident-explorer__button"
+                    onClick={() => void desktopApi?.copyText?.(prompt)}
+                    type="button"
+                  >
+                    Copy
+                  </button>
+                  {!canSteerSelected && activeTurnId ? (
+                    <p>The selected finding belongs to another turn. It cannot steer the active turn; send it after that turn ends.</p>
+                  ) : null}
+                </div>
+              </section>
+
               <section className="incident-explorer__output">
                 <div className="incident-explorer__section-heading">
                   <h2>Captured output</h2>
-                  <input
-                    aria-label="Search captured output"
-                    onChange={(event) => setOutputSearch(event.currentTarget.value)}
-                    placeholder="Search output"
-                    type="search"
-                    value={outputSearch}
-                  />
+                  {output !== undefined ? (
+                    <input
+                      aria-label="Search captured output"
+                      onChange={(event) => setOutputSearch(event.currentTarget.value)}
+                      placeholder="Search output"
+                      type="search"
+                      value={outputSearch}
+                    />
+                  ) : null}
                 </div>
                 {output !== undefined ? (
                   <ol className="incident-explorer__output-lines">
@@ -352,9 +561,10 @@ export function ToolOutputIncidentExplorerWindow() {
                     ))}
                   </ol>
                 ) : (
-                  <p className="incident-explorer__empty">
+                  <p className="incident-explorer__unavailable">
+                    <b>Not retained by normalized replay</b>
                     {selected.outputState === "compacted"
-                      ? "Output was compacted out of normalized replay."
+                      ? `The ${selected.outputChars.toLocaleString()} characters this call returned were compacted out. Size and category come from tool accounting, recorded when the call ran.`
                       : selected.outputState === "truncated"
                         ? "Only the truncated output retained by normalized replay is available."
                         : "Output is unavailable in the currently available normalized replay."}
@@ -369,8 +579,161 @@ export function ToolOutputIncidentExplorerWindow() {
   );
 }
 
-function Metric(props: { label: string; value: string }) {
-  return <div><span>{props.label}</span><strong>{props.value}</strong></div>;
+function CompositionBar(props: { composition: CategoryShare[] }) {
+  if (props.composition.length === 0) return null;
+  return (
+    <span aria-hidden="true" className="incident-explorer__composition">
+      {props.composition.map((entry, index) => (
+        <i
+          data-rank={Math.min(index + 1, 5)}
+          key={entry.category}
+          style={{ width: `${entry.share * 100}%` }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/**
+ * The second cost driver. A solid bar reads as volume, a tick rail reads as
+ * discrete events — deliberately different marks, because a turn that is long
+ * on trips and short on tokens is a different problem than the reverse, and
+ * the two need to be told apart at a glance.
+ */
+function TurnStrip(props: {
+  onSelect: (row: TurnCostRow) => void;
+  selectedKey?: string;
+  strip: TurnCostStrip;
+}) {
+  if (props.strip.rows.length === 0) return null;
+  return (
+    <section className="incident-explorer__turns" aria-label="Cost by turn">
+      <div className="incident-explorer__turns-head">
+        <p className="incident-explorer__eyebrow">
+          {props.strip.ordering === "cost" ? "Costliest turns" : "Cost by turn"}
+        </p>
+        <p className="incident-explorer__turns-legend">
+          <span className="incident-explorer__turns-key" data-kind="tokens" /> output tokens
+          {" · "}
+          <span className="incident-explorer__turns-key" data-kind="trips" /> round trips
+        </p>
+      </div>
+      {props.strip.rows.map((row) => (
+        <button
+          aria-pressed={props.selectedKey === row.key}
+          className="incident-explorer__turn"
+          key={row.key}
+          onClick={() => props.onSelect(row)}
+          type="button"
+        >
+          <span className="incident-explorer__turn-label">
+            {row.label}
+            <span>{` · ${formatClockTime(row.firstObservedAt)}`}</span>
+          </span>
+          <span aria-hidden="true" className="incident-explorer__turn-bar">
+            <i
+              data-critical={row.overCapCount > 0}
+              style={{ width: `${scaleWidth(row.estimatedOutputTokens, props.strip.maxTokens)}%` }}
+            />
+          </span>
+          <span className="incident-explorer__turn-number">
+            {formatCompactTokens(row.estimatedOutputTokens)} tok
+          </span>
+          <span aria-hidden="true" className="incident-explorer__turn-trips">
+            <i style={{ width: `${scaleWidth(row.callCount, props.strip.maxCallCount)}%` }} />
+          </span>
+          <span className="incident-explorer__turn-number">
+            {row.callCount.toLocaleString()} {row.callCount === 1 ? "call" : "calls"}
+          </span>
+        </button>
+      ))}
+      {props.strip.hiddenTurnCount > 0 ? (
+        <p className="incident-explorer__turns-note">
+          {props.strip.hiddenTurnCount.toLocaleString()} quieter{" "}
+          {props.strip.hiddenTurnCount === 1 ? "turn is" : "turns are"} not shown.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function CaseRow(props: {
+  invocation: ThreadToolInvocationRecord;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  const invocation = props.invocation;
+  const command = invocation.normalizedCommand ?? invocation.toolName;
+  const identity = formatInvocationIdentity(command);
+  const critical = isOverOutputCap(invocation.outputChars);
+  return (
+    <button
+      aria-current={props.selected}
+      className="incident-explorer__case"
+      data-selected={props.selected}
+      onClick={props.onSelect}
+      title={command}
+      type="button"
+    >
+      <span className="incident-explorer__case-top">
+        <span className="incident-explorer__case-id">
+          <b>{identity.lead}</b>
+          {identity.detail ? <span>{` ${identity.detail}`}</span> : null}
+        </span>
+        <span className="incident-explorer__case-tokens">
+          {formatCompactTokens(invocation.estimatedOutputTokens)}
+        </span>
+      </span>
+      <span aria-hidden="true" className="incident-explorer__meter">
+        <i
+          data-critical={critical}
+          style={{ width: `${capMeterWidth(invocation.outputChars) * 100}%` }}
+        />
+      </span>
+      <span className="incident-explorer__case-sub">
+        {formatCapShare(invocation.outputChars, { short: true })}
+        {" · "}{invocation.outputChars.toLocaleString()} chars
+        {" · "}{formatClockTime(invocation.observedAt)}
+      </span>
+    </button>
+  );
+}
+
+function Fact(props: {
+  label: string;
+  tone?: "error" | "ok" | "warning";
+  value: string;
+}) {
+  return (
+    <span className="incident-explorer__fact" data-tone={props.tone}>
+      <b>{props.label}</b>
+      {props.value}
+    </span>
+  );
+}
+
+function scaleWidth(value: number, max: number): number {
+  if (max <= 0) return 0;
+  return Math.max(2, Math.round(value / max * 100));
+}
+
+function describeAvailability(invocation: ThreadToolInvocationRecord): string {
+  return invocation.outputState
+    ?? (invocation.outputTruncated ? "truncated" : "unavailable");
+}
+
+/**
+ * Round trips after this call inside the same turn. Every one of them replays
+ * this output, which is what makes a single large result compound.
+ */
+function countLaterTripsInTurn(
+  invocations: ThreadToolInvocationRecord[],
+  selected: ThreadToolInvocationRecord,
+): number {
+  return invocations.filter((invocation) =>
+    (invocation.turnId ?? "") === (selected.turnId ?? "")
+    && invocation.observedAt > selected.observedAt
+  ).length;
 }
 
 function readIncidentRoute(): {
@@ -402,26 +765,33 @@ function findActiveTurnId(response: AppServerReadThreadResponse | undefined): st
   return undefined;
 }
 
-function groupInvocations(invocations: ThreadToolInvocationRecord[]) {
+function groupCases(
+  invocations: ThreadToolInvocationRecord[],
+  sortMode: IncidentSortMode,
+  turnLabels: Map<string, string>,
+) {
+  if (sortMode !== "turn") {
+    return [{ invocations, key: "all", label: "" }];
+  }
   const groups = new Map<string, {
-    category: ThreadToolInvocationCategory;
     invocations: ThreadToolInvocationRecord[];
     key: string;
-    turnLabel: string;
+    label: string;
   }>();
   for (const invocation of invocations) {
-    const turn = invocation.turnId ?? "No turn";
-    const key = `${turn}:${invocation.category}`;
+    const key = invocation.turnId ?? "";
     const group = groups.get(key) ?? {
-      category: invocation.category,
       invocations: [],
       key,
-      turnLabel: invocation.turnId ? `Turn ${shortId(invocation.turnId)}` : "No turn",
+      label: turnLabels.get(key) ?? "Unassigned",
     };
     group.invocations.push(invocation);
     groups.set(key, group);
   }
-  return [...groups.values()];
+  return [...groups.values()].map((group) => ({
+    ...group,
+    label: `${group.label} · ${group.invocations.length} ${group.invocations.length === 1 ? "case" : "cases"}`,
+  }));
 }
 
 async function readInvocationOutput(params: {
@@ -500,6 +870,9 @@ function formatTimestamp(timestamp: number): string {
   return new Date(timestamp).toLocaleString();
 }
 
-function shortId(value: string): string {
-  return value.length > 12 ? `${value.slice(0, 8)}…` : value;
+function formatClockTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -158,6 +158,8 @@ type PanelOverrides = Partial<
     | "editedFileGroups"
     | "editedFilesDock"
     | "onEditedFilesDockChange"
+    | "onAnalyzeToolHistory"
+    | "onOpenToolOutputIncidentExplorer"
     | "pricing"
     | "toolAccounting"
     | "toolCallEntries"
@@ -955,6 +957,23 @@ describe("ThreadContextPanel", () => {
 
     expect(screen.getByText(/ACP captured output/)).toBeInTheDocument();
     expect(screen.queryByText(/unavailable in transcript history/)).not.toBeInTheDocument();
+  });
+
+  it("offers history analysis and the explorer from an empty Tool Calls panel", () => {
+    const onAnalyzeToolHistory = vi.fn();
+    const onOpenToolOutputIncidentExplorer = vi.fn();
+    renderPanel({
+      activeTab: "tool-calls",
+      onAnalyzeToolHistory,
+      onOpenToolOutputIncidentExplorer,
+      pinned: true,
+      threadToolAccountingEnabled: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze history" }));
+    fireEvent.click(screen.getByRole("button", { name: "Explore" }));
+    expect(onAnalyzeToolHistory).toHaveBeenCalledOnce();
+    expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledOnce();
   });
 
   it("hides the Tool calls tab while its experimental flag is off", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -860,7 +860,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("3 invocations")).toBeInTheDocument();
     expect(screen.getByText("6k est. tokens")).toBeInTheDocument();
     expect(screen.getByText("Diagnostics")).toBeInTheDocument();
-    expect(screen.getByText("Noisy polling detected")).toBeInTheDocument();
+    expect(screen.getByText("Repeated queued checks")).toBeInTheDocument();
     expect(screen.getByText(/Repeated write_stdin polling/)).toBeInTheDocument();
     expect(screen.getByText("write_stdin · polling")).toBeInTheDocument();
     expect(screen.queryByText("poll session 40500")).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -215,6 +215,33 @@ describe("ToolOutputIncidentExplorerWindow", () => {
       .toHaveTextContent("1 call");
   });
 
+  it("widens the turn strip from flagged turns to every turn with tool calls", async () => {
+    const response = buildMultiTurnResponse();
+    /* A turn of only small calls: invisible in the flagged scope, present in
+       the all scope. */
+    response.toolAccounting!.invocations.push({
+      ...response.toolAccounting!.invocations[1]!,
+      invocationId: "invocation-quiet-turn",
+      itemId: "item-quiet-turn",
+      noisy: false,
+      observedAt: 1_800_000_005_000,
+      outputChars: 120,
+      turnId: "turn-3",
+    });
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    expect(within(turns).queryByRole("button", { name: /Turn 3/ })).toBeNull();
+
+    fireEvent.click(within(turns).getByRole("button", { name: /All with tool calls/ }));
+    expect(await within(turns).findByRole("button", { name: /Turn 3/ }))
+      .toBeInTheDocument();
+    expect(within(turns).getByRole("button", { name: /Flagged \(2\)/ }))
+      .toHaveAttribute("aria-pressed", "false");
+  });
+
   it("filters the case list to a single turn", async () => {
     installApi({ readThread: async () => buildMultiTurnResponse() });
     window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -188,6 +188,70 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     await waitFor(() => expect(within(metrics).getByText("2")).toBeInTheDocument());
     expect(readCount).toBe(2);
   });
+
+  it("ranks cases by output size and measures each against the output cap", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const cases = await screen.findByLabelText("Incident cases");
+    const rows = within(cases).getAllByRole("button", { name: /chars/ });
+    expect(rows[0]).toHaveAttribute("title", expect.stringContaining("wide-scan"));
+    expect(rows[0]).toHaveTextContent("50% of cap");
+    expect(rows[1]).toHaveTextContent("15% of cap");
+  });
+
+  it("reports round trips per turn, counting calls that were never flagged", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    /* turn-1 holds one flagged call plus two quiet ones; the quiet calls
+       replay context too, so they belong in the round-trip count. */
+    expect(within(turns).getByRole("button", { name: /Turn 1/ }))
+      .toHaveTextContent("3 calls");
+    expect(within(turns).getByRole("button", { name: /Turn 2/ }))
+      .toHaveTextContent("1 call");
+  });
+
+  it("filters the case list to a single turn", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    const cases = screen.getByLabelText("Incident cases");
+    expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(2);
+
+    const secondTurn = within(turns).getByRole("button", { name: /Turn 2/ });
+    fireEvent.click(secondTurn);
+
+    await waitFor(() => expect(secondTurn).toHaveAttribute("aria-pressed", "true"));
+    const filtered = within(cases).getAllByRole("button", { name: /chars/ });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]).toHaveAttribute("title", expect.stringContaining("pnpm test"));
+    expect(within(cases).getByText("Showing 1 of 2 cases")).toBeInTheDocument();
+
+    fireEvent.click(within(cases).getByRole("button", { name: "Clear filters" }));
+    await waitFor(() =>
+      expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(2));
+  });
+
+  it("filters by category from the composition legend", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const legend = await screen.findByRole("group", { name: "Filter by category" });
+    fireEvent.click(within(legend).getByRole("button", { name: /Tests & builds/ }));
+
+    const cases = screen.getByLabelText("Incident cases");
+    await waitFor(() =>
+      expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(1));
+    expect(within(cases).getAllByRole("button", { name: /chars/ })[0])
+      .toHaveAttribute("title", expect.stringContaining("pnpm test"));
+  });
 });
 
 function installApi(api: Record<string, unknown>): void {
@@ -247,6 +311,74 @@ function buildResponse(
         hasPreviousPage: false,
         supportsPagination: true,
       },
+      threadStatus: "active",
+    },
+  };
+}
+
+/**
+ * Two turns, mixed categories, and quiet calls alongside flagged ones — the
+ * shape the summary band and turn strip are built to read.
+ */
+function buildMultiTurnResponse(): AppServerReadThreadResponse {
+  const base = buildInvocation();
+  const invocations: ThreadToolInvocationRecord[] = [
+    {
+      ...base,
+      category: "shell",
+      estimatedOutputTokens: 5_000,
+      invocationId: "invocation-wide",
+      itemId: "item-wide",
+      normalizedCommand: "rg --files wide-scan",
+      observedAt: 1_800_000_000_000,
+      outputChars: 20_000,
+      turnId: "turn-1",
+    },
+    {
+      ...base,
+      category: "shell",
+      estimatedOutputTokens: 40,
+      invocationId: "invocation-quiet-1",
+      itemId: "item-quiet-1",
+      noisy: false,
+      normalizedCommand: "git status",
+      observedAt: 1_800_000_001_000,
+      outputChars: 160,
+      turnId: "turn-1",
+    },
+    {
+      ...base,
+      category: "shell",
+      estimatedOutputTokens: 40,
+      invocationId: "invocation-quiet-2",
+      itemId: "item-quiet-2",
+      noisy: false,
+      normalizedCommand: "git diff --stat",
+      observedAt: 1_800_000_002_000,
+      outputChars: 160,
+      turnId: "turn-1",
+    },
+    {
+      ...base,
+      category: "build-test",
+      estimatedOutputTokens: 1_500,
+      invocationId: "invocation-tests",
+      itemId: "item-tests",
+      normalizedCommand: "pnpm test",
+      observedAt: 1_800_000_003_000,
+      outputChars: 6_000,
+      turnId: "turn-2",
+    },
+  ];
+  return {
+    backend: "codex",
+    fetchedAt: 1,
+    threadId: "thread-1",
+    toolAccounting: { alerts: [], invocations, summaries: [] },
+    replay: {
+      entries: [],
+      messages: [],
+      pagination: { hasPreviousPage: false, supportsPagination: true },
       threadStatus: "active",
     },
   };

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -20,6 +20,46 @@ afterEach(() => {
 });
 
 describe("ToolOutputIncidentExplorerWindow", () => {
+  it("uses standard thread identity chrome without exposing the raw thread id", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const showThreadFromToolOutputIncidentExplorer = vi.fn(async () => undefined);
+    installApi({
+      copyText,
+      readThread: async () => buildResponse(),
+      showThreadFromToolOutputIncidentExplorer,
+    });
+    window.location.hash =
+      "#tool-output-incidents/acp%3Agrok/thread-1/Noisy%20work/PwrAgent";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByLabelText(
+      "PwrAgent > Noisy work > Tool Output Incidents",
+    )).toBeInTheDocument();
+    expect(screen.getByText("Grok")).toHaveClass("chip--backend");
+    expect(screen.queryByText("acp:grok")).not.toBeInTheDocument();
+    expect(screen.queryByText("thread-1")).not.toBeInTheDocument();
+
+    const threadChip = screen.getByRole("button", { name: "Open thread Noisy work" });
+    fireEvent.click(threadChip);
+    await waitFor(() => expect(showThreadFromToolOutputIncidentExplorer)
+      .toHaveBeenCalledWith({ backend: "acp:grok", threadId: "thread-1" }));
+
+    fireEvent.contextMenu(threadChip);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Thread ID" }));
+    await waitFor(() => expect(copyText).toHaveBeenCalledWith("thread-1"));
+  });
+
+  it("shows Codex output whose normalized detail id extends the invocation item id", async () => {
+    installApi({ readThread: async () => buildResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText("failure")).toBeInTheDocument();
+    expect(screen.getByText("warning")).toBeInTheDocument();
+    expect(screen.queryByText(/Only the truncated output retained/))
+      .not.toBeInTheDocument();
+  });
+
   it("steers only when the finding belongs to the exact active turn", async () => {
     const steerTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -141,10 +181,10 @@ function buildResponse(
     replay: {
       entries: [{
         type: "activity",
-        id: "item-1",
+        id: "activity-1",
         createdAt: 1_800_000_000_000,
         details: [{
-          id: "detail-1",
+          id: "item-1-output",
           kind: "command",
           label: "pnpm test",
           command: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -1,0 +1,164 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type {
+  AppServerReadThreadResponse,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToolOutputIncidentExplorerWindow } from "../ToolOutputIncidentExplorerWindow";
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "pwragent");
+  window.location.hash = "";
+});
+
+describe("ToolOutputIncidentExplorerWindow", () => {
+  it("steers only when the finding belongs to the exact active turn", async () => {
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    installApi({ readThread: async () => buildResponse("turn-1"), steerTurn });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const steerButton = await screen.findByRole("button", { name: "Steer exact active turn" });
+    await waitFor(() => expect(steerButton).toBeEnabled());
+    fireEvent.click(steerButton);
+    await waitFor(() => expect(steerTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedTurnId: "turn-1",
+        threadId: "thread-1",
+      }),
+    ));
+  });
+
+  it("does not send or steer a historical finding while another turn is active", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-3",
+    }));
+    const steerTurn = vi.fn();
+    installApi({
+      readThread: async () => buildResponse("turn-2"),
+      startTurn,
+      steerTurn,
+    });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText(/cannot steer the active turn/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send next turn" })).toBeDisabled();
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(steerTurn).not.toHaveBeenCalled();
+  });
+
+  it("sends a historical finding as a new turn after the thread is idle", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-3",
+    }));
+    const steerTurn = vi.fn();
+    installApi({
+      readThread: async () => buildResponse(),
+      startTurn,
+      steerTurn,
+    });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const sendButton = await screen.findByRole("button", { name: "Send next turn" });
+    await waitFor(() => expect(sendButton).toBeEnabled());
+    fireEvent.click(sendButton);
+    await waitFor(() => expect(startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "thread-1" }),
+    ));
+    expect(steerTurn).not.toHaveBeenCalled();
+  });
+});
+
+function installApi(api: Record<string, unknown>): void {
+  Object.defineProperty(window, "pwragent", {
+    configurable: true,
+    value: api,
+  });
+}
+
+function buildResponse(activeTurnId?: string): AppServerReadThreadResponse {
+  const invocation = buildInvocation();
+  return {
+    backend: "codex",
+    fetchedAt: 1,
+    threadId: "thread-1",
+    toolAccounting: {
+      alerts: [],
+      invocations: [invocation],
+      summaries: [],
+    },
+    replay: {
+      entries: [{
+        type: "activity",
+        id: "item-1",
+        createdAt: 1_800_000_000_000,
+        details: [{
+          id: "detail-1",
+          kind: "command",
+          label: "pnpm test",
+          command: {
+            displayCommand: "pnpm test",
+            output: "failure\nwarning\n",
+            source: "shell",
+          },
+        }],
+        status: "completed",
+        summary: "Ran tests",
+        ...(activeTurnId
+          ? {
+              turn: {
+                id: activeTurnId,
+                status: "in_progress" as const,
+              },
+            }
+          : {}),
+      }],
+      messages: [],
+      pagination: {
+        hasPreviousPage: false,
+        supportsPagination: true,
+      },
+      threadStatus: "active",
+    },
+  };
+}
+
+function buildInvocation(): ThreadToolInvocationRecord {
+  return {
+    backend: "codex",
+    category: "build-test",
+    debugLines: 0,
+    errorLines: 1,
+    estimatedOutputTokens: 2_000,
+    infoLines: 0,
+    invocationId: "invocation-1",
+    itemId: "item-1",
+    noisy: true,
+    noisyReason: "verbose-build-test",
+    normalizedCommand: "pnpm test",
+    observedAt: 1_800_000_000_000,
+    outputChars: 8_000,
+    outputLines: 200,
+    outputState: "available",
+    outputTruncated: false,
+    source: "history",
+    status: "completed",
+    suggestedPrompt: "Reduce output for pnpm test.",
+    threadId: "thread-1",
+    toolName: "commandExecution",
+    turnId: "turn-1",
+    updatedAt: 1_800_000_000_000,
+    warningLines: 1,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import type {
   AppServerReadThreadResponse,
   ThreadToolInvocationRecord,
@@ -78,6 +85,31 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     ));
     expect(steerTurn).not.toHaveBeenCalled();
   });
+
+  it("refreshes the visible case snapshot when an existing window is examined again", async () => {
+    let refreshListener: (() => void) | undefined;
+    let readCount = 0;
+    installApi({
+      onToolOutputIncidentExplorerRefresh: (callback: () => void) => {
+        refreshListener = callback;
+        return () => {
+          refreshListener = undefined;
+        };
+      },
+      readThread: async () => {
+        readCount += 1;
+        return buildResponse(undefined, readCount === 1 ? 1 : 2);
+      },
+    });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+    const metrics = await screen.findByLabelText("Incident metrics");
+
+    expect(within(metrics).getByText("1")).toBeInTheDocument();
+    await act(async () => refreshListener?.());
+    await waitFor(() => expect(within(metrics).getByText("2")).toBeInTheDocument());
+    expect(readCount).toBe(2);
+  });
 });
 
 function installApi(api: Record<string, unknown>): void {
@@ -87,15 +119,23 @@ function installApi(api: Record<string, unknown>): void {
   });
 }
 
-function buildResponse(activeTurnId?: string): AppServerReadThreadResponse {
-  const invocation = buildInvocation();
+function buildResponse(
+  activeTurnId?: string,
+  invocationCount = 1,
+): AppServerReadThreadResponse {
+  const invocations = Array.from({ length: invocationCount }, (_, index) => ({
+    ...buildInvocation(),
+    invocationId: `invocation-${index + 1}`,
+    itemId: `item-${index + 1}`,
+    outputChars: 8_000 + index * 1_000,
+  }));
   return {
     backend: "codex",
     fetchedAt: 1,
     threadId: "thread-1",
     toolAccounting: {
       alerts: [],
-      invocations: [invocation],
+      invocations,
       summaries: [],
     },
     replay: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -242,6 +242,27 @@ describe("ToolOutputIncidentExplorerWindow", () => {
       .toHaveAttribute("aria-pressed", "false");
   });
 
+  it("filters cases from the chronological timeline spark", async () => {
+    installApi({ readThread: async () => buildMultiTurnResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const timeline = await screen.findByRole("group", {
+      name: "Tool cost per turn, in order",
+    });
+    const columns = within(timeline).getAllByRole("button");
+    expect(columns).toHaveLength(2);
+    /* Hover text carries the numbers the bars encode. */
+    expect(columns[0]).toHaveAttribute("title", expect.stringMatching(/Turn 1 .*3 calls/));
+
+    fireEvent.click(columns[1]!);
+    const cases = screen.getByLabelText("Incident cases");
+    await waitFor(() =>
+      expect(within(cases).getAllByRole("button", { name: /chars/ })).toHaveLength(1));
+    expect(within(cases).getAllByRole("button", { name: /chars/ })[0])
+      .toHaveAttribute("title", expect.stringContaining("pnpm test"));
+  });
+
   it("filters the case list to a single turn", async () => {
     installApi({ readThread: async () => buildMultiTurnResponse() });
     window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -22,10 +22,11 @@ afterEach(() => {
 describe("ToolOutputIncidentExplorerWindow", () => {
   it("uses standard thread identity chrome without exposing the raw thread id", async () => {
     const copyText = vi.fn(async () => undefined);
+    const readThread = vi.fn(async () => buildResponse());
     const showThreadFromToolOutputIncidentExplorer = vi.fn(async () => undefined);
     installApi({
       copyText,
-      readThread: async () => buildResponse(),
+      readThread,
       showThreadFromToolOutputIncidentExplorer,
     });
     window.location.hash =
@@ -38,6 +39,9 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(screen.getByText("Grok")).toHaveClass("chip--backend");
     expect(screen.queryByText("acp:grok")).not.toBeInTheDocument();
     expect(screen.queryByText("thread-1")).not.toBeInTheDocument();
+    expect(readThread).toHaveBeenCalledWith(expect.objectContaining({
+      includeAllToolInvocations: true,
+    }));
 
     const threadChip = screen.getByRole("button", { name: "Open thread Noisy work" });
     fireEvent.click(threadChip);
@@ -58,6 +62,40 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(screen.getByText("warning")).toBeInTheDocument();
     expect(screen.queryByText(/Only the truncated output retained/))
       .not.toBeInTheDocument();
+  });
+
+  it("shows historical output using the analyzer's normalized detail identity", async () => {
+    const response = buildResponse();
+    response.toolAccounting!.invocations[0]!.itemId = "historical-detail";
+    const entry = response.replay.entries[0];
+    if (entry?.type === "activity") {
+      entry.id = "historical-activity";
+      entry.details[0]!.id = "historical-detail";
+      entry.details[0]!.command!.output = "retained historical output\n";
+    }
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText("retained historical output"))
+      .toBeInTheDocument();
+  });
+
+  it("still shows findings persisted with the legacy activity entry identity", async () => {
+    const response = buildResponse();
+    response.toolAccounting!.invocations[0]!.itemId = "legacy-activity";
+    const entry = response.replay.entries[0];
+    if (entry?.type === "activity") {
+      entry.id = "legacy-activity";
+      entry.details[0]!.id = "unrelated-detail-id";
+      entry.details[0]!.command!.output = "legacy retained output\n";
+    }
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(await screen.findByText("legacy retained output"))
+      .toBeInTheDocument();
   });
 
   it("steers only when the finding belongs to the exact active turn", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -7,6 +7,7 @@ import {
   formatCapShare,
   formatCompactTokens,
   formatInvocationIdentity,
+  invocationStatusTone,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
@@ -45,7 +46,42 @@ describe("buildTurnCostStrip", () => {
 
     expect(strip.rows).toHaveLength(1);
     expect(strip.rows[0]?.callCount).toBe(3);
-    expect(strip.rows[0]?.noisyCount).toBe(1);
+  });
+
+  it("keeps a high-round-trip turn when ranking drops rows", () => {
+    /* Ranking on output alone would cut the polling turn — the pathology the
+       tick rail exists to show — and then call it lower-cost. */
+    const polling = Array.from({ length: 40 }, (_, index) =>
+      invocation({
+        estimatedOutputTokens: 50,
+        observedAt: 1_000 + index,
+        turnId: "turn-polling",
+      }));
+    const verbose = Array.from({ length: 3 }, (_, index) =>
+      invocation({
+        estimatedOutputTokens: 5_000,
+        observedAt: 10_000 + index * 1_000,
+        turnId: `turn-verbose-${index}`,
+      }));
+    const strip = buildTurnCostStrip([...polling, ...verbose], { limit: 2 });
+
+    expect(strip.ordering).toBe("cost");
+    expect(strip.rows.map((row) => row.key)).toContain("turn-polling");
+  });
+
+  it("labels every turn, including the ones the row limit dropped", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 900, observedAt: 10, turnId: "turn-a" }),
+        invocation({ estimatedOutputTokens: 800, observedAt: 20, turnId: "turn-b" }),
+        invocation({ estimatedOutputTokens: 1, observedAt: 30, turnId: "turn-c" }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(strip.rows.map((row) => row.key)).not.toContain("turn-c");
+    /* A case in the dropped turn still has to name its turn. */
+    expect(strip.labelsByKey.get("turn-c")).toBe("Turn 3");
   });
 
   it("numbers turns chronologically and keeps the numbering when ranked by cost", () => {
@@ -161,6 +197,19 @@ describe("output cap meters", () => {
 
   it("pins rather than overflowing past the cap", () => {
     expect(capMeterWidth(400_000)).toBe(1);
+  });
+});
+
+describe("invocationStatusTone", () => {
+  it("reserves success coloring for a call that actually succeeded", () => {
+    expect(invocationStatusTone(invocation({ exitCode: 0, status: "completed" })))
+      .toBe("ok");
+    /* A non-zero exit is a failure whatever the transport status says. */
+    expect(invocationStatusTone(invocation({ exitCode: 1, status: "completed" })))
+      .toBe("error");
+    expect(invocationStatusTone(invocation({ status: "failed" }))).toBe("error");
+    expect(invocationStatusTone(invocation({ status: "cancelled" }))).toBeUndefined();
+    expect(invocationStatusTone(invocation({ status: "in_progress" }))).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -1,0 +1,208 @@
+import type { ThreadToolInvocationRecord } from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import {
+  buildCategoryComposition,
+  buildTurnCostStrip,
+  capMeterWidth,
+  formatCapShare,
+  formatCompactTokens,
+  formatInvocationIdentity,
+  isOverOutputCap,
+  sortIncidentCases,
+  summarizeIncidents,
+} from "../tool-output-incident-insights";
+
+describe("summarizeIncidents", () => {
+  it("reports flagged output as a share of all accounted output", () => {
+    const summary = summarizeIncidents([
+      invocation({ estimatedOutputTokens: 3_000, noisy: true, outputChars: 12_000 }),
+      invocation({ estimatedOutputTokens: 1_000, noisy: true, outputChars: 4_000 }),
+      invocation({ estimatedOutputTokens: 1_000, noisy: false, outputChars: 4_000 }),
+    ]);
+
+    expect(summary.caseCount).toBe(2);
+    expect(summary.incidentTokens).toBe(4_000);
+    expect(summary.totalTokens).toBe(5_000);
+    expect(summary.share).toBeCloseTo(0.8);
+    expect(summary.worstChars).toBe(12_000);
+  });
+
+  it("reports a zero share rather than dividing by zero on an empty thread", () => {
+    expect(summarizeIncidents([]).share).toBe(0);
+  });
+});
+
+describe("buildTurnCostStrip", () => {
+  it("counts every call in a turn, not only the flagged ones", () => {
+    /* The round-trip driver: a turn of quiet calls still replays the whole
+       accumulated context once per call, so a strip built from flagged rows
+       alone would under-report the turn that costs the most. */
+    const strip = buildTurnCostStrip([
+      invocation({ noisy: true, observedAt: 10, turnId: "turn-a" }),
+      invocation({ noisy: false, observedAt: 20, turnId: "turn-a" }),
+      invocation({ noisy: false, observedAt: 30, turnId: "turn-a" }),
+    ]);
+
+    expect(strip.rows).toHaveLength(1);
+    expect(strip.rows[0]?.callCount).toBe(3);
+    expect(strip.rows[0]?.noisyCount).toBe(1);
+  });
+
+  it("numbers turns chronologically and keeps the numbering when ranked by cost", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 100, observedAt: 10, turnId: "turn-a" }),
+        invocation({ estimatedOutputTokens: 900, observedAt: 20, turnId: "turn-b" }),
+        invocation({ estimatedOutputTokens: 500, observedAt: 30, turnId: "turn-c" }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(strip.ordering).toBe("cost");
+    expect(strip.rows.map((row) => row.label)).toEqual(["Turn 2", "Turn 3"]);
+    expect(strip.hiddenTurnCount).toBe(1);
+    expect(strip.maxTokens).toBe(900);
+  });
+
+  it("stays in time order while every turn fits", () => {
+    const strip = buildTurnCostStrip([
+      invocation({ estimatedOutputTokens: 900, observedAt: 20, turnId: "turn-b" }),
+      invocation({ estimatedOutputTokens: 100, observedAt: 10, turnId: "turn-a" }),
+    ]);
+
+    expect(strip.ordering).toBe("time");
+    expect(strip.rows.map((row) => row.label)).toEqual(["Turn 1", "Turn 2"]);
+    expect(strip.hiddenTurnCount).toBe(0);
+  });
+
+  it("labels calls with no turn instead of numbering them", () => {
+    const strip = buildTurnCostStrip([
+      invocation({ observedAt: 10, turnId: undefined }),
+    ]);
+
+    expect(strip.rows[0]?.label).toBe("Unassigned");
+  });
+});
+
+describe("buildCategoryComposition", () => {
+  it("ranks by output tokens and folds the tail into one entry", () => {
+    const composition = buildCategoryComposition(
+      [
+        invocation({ category: "shell", estimatedOutputTokens: 600 }),
+        invocation({ category: "search", estimatedOutputTokens: 200 }),
+        invocation({ category: "git", estimatedOutputTokens: 120 }),
+        invocation({ category: "mcp", estimatedOutputTokens: 80 }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(composition.map((entry) => entry.label))
+      .toEqual(["Shell", "Search", "Other (2)"]);
+    expect(composition[2]?.estimatedOutputTokens).toBe(200);
+    expect(composition[0]?.share).toBeCloseTo(0.6);
+  });
+});
+
+describe("sortIncidentCases", () => {
+  it("puts the biggest output first", () => {
+    const sorted = sortIncidentCases([
+      invocation({ invocationId: "small", outputChars: 4_000 }),
+      invocation({ invocationId: "big", outputChars: 17_771 }),
+    ], "largest");
+
+    expect(sorted.map((entry) => entry.invocationId)).toEqual(["big", "small"]);
+  });
+
+  it("orders by observation time for the by-turn reading", () => {
+    const sorted = sortIncidentCases([
+      invocation({ invocationId: "late", observedAt: 200 }),
+      invocation({ invocationId: "early", observedAt: 100 }),
+    ], "turn");
+
+    expect(sorted.map((entry) => entry.invocationId)).toEqual(["early", "late"]);
+  });
+});
+
+describe("formatInvocationIdentity", () => {
+  it("keeps the distinguishing tail of commands that share a long prefix", () => {
+    /* Both rows begin with the same 60 characters. A head truncation renders
+       them identical, which is the failure this elision exists to fix. */
+    const prefix = "set -o pipefail state_dir=local-state/m4-handoff/";
+    const first = formatInvocationIdentity(`${prefix}diagnose-listener-boundary`);
+    const second = formatInvocationIdentity(`${prefix}verify-helper-teardown`);
+
+    expect(`${first.lead}${first.detail}`)
+      .not.toBe(`${second.lead}${second.detail}`);
+    /* The tail survives the elision — that is what makes the rows readable
+       as two different commands rather than two copies of one. */
+    expect(first.detail).toContain("boundary");
+    expect(second.detail).toContain("teardown");
+    expect(first.lead).toBe("set -o pipefail");
+  });
+
+  it("leaves a short command whole", () => {
+    const identity = formatInvocationIdentity("pnpm test");
+    expect(identity.lead).toBe("pnpm test");
+    expect(identity.detail).toBe("");
+  });
+
+  it("flattens embedded newlines so a row stays one line", () => {
+    const identity = formatInvocationIdentity("printf 'a'\n  tail -n 90 log");
+    expect(`${identity.lead} ${identity.detail}`).not.toContain("\n");
+  });
+});
+
+describe("output cap meters", () => {
+  it("measures against the cap the analyzer flags against", () => {
+    expect(capMeterWidth(20_000)).toBeCloseTo(0.5);
+    expect(isOverOutputCap(39_999)).toBe(false);
+    expect(isOverOutputCap(40_000)).toBe(true);
+  });
+
+  it("pins rather than overflowing past the cap", () => {
+    expect(capMeterWidth(400_000)).toBe(1);
+  });
+});
+
+describe("formatCapShare", () => {
+  it("shortens the cap phrase for case rows", () => {
+    expect(formatCapShare(20_000)).toBe("50% of the output cap");
+    expect(formatCapShare(20_000, { short: true })).toBe("50% of cap");
+  });
+});
+
+describe("formatCompactTokens", () => {
+  it("keeps small counts exact and abbreviates large ones", () => {
+    expect(formatCompactTokens(940)).toBe("940");
+    expect(formatCompactTokens(4_443)).toBe("4.4k");
+    expect(formatCompactTokens(140_437)).toBe("140k");
+  });
+});
+
+function invocation(
+  overrides: Partial<ThreadToolInvocationRecord> = {},
+): ThreadToolInvocationRecord {
+  return {
+    backend: "codex",
+    category: "shell",
+    debugLines: 0,
+    errorLines: 0,
+    estimatedOutputTokens: 1_000,
+    infoLines: 0,
+    invocationId: "invocation-1",
+    itemId: "item-1",
+    noisy: true,
+    normalizedCommand: "pnpm test",
+    observedAt: 1_800_000_000_000,
+    outputChars: 4_000,
+    outputLines: 20,
+    outputTruncated: false,
+    status: "completed",
+    threadId: "thread-1",
+    toolName: "commandExecution",
+    turnId: "turn-1",
+    updatedAt: 1_800_000_000_000,
+    warningLines: 0,
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -6,8 +6,11 @@ import {
   capMeterWidth,
   formatCapShare,
   formatCompactTokens,
+  countRepeatedCommands,
   formatInvocationIdentity,
+  formatTurnWhen,
   invocationStatusTone,
+  refineToolCategory,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
@@ -256,3 +259,82 @@ function invocation(
     ...overrides,
   };
 }
+
+describe("formatTurnWhen", () => {
+  const now = new Date("2026-08-15T14:00:00Z").getTime();
+
+  it("counts minutes, then hours and minutes, for the last day", () => {
+    expect(formatTurnWhen(now - 12 * 60_000, now)).toBe("12m ago");
+    expect(formatTurnWhen(now - (3 * 3_600_000 + 20 * 60_000), now))
+      .toBe("3h 20m ago");
+    expect(formatTurnWhen(now - 5 * 3_600_000, now)).toBe("5h ago");
+  });
+
+  it("names the weekday inside a week and dates anything older", () => {
+    /* A bare clock time is ambiguous the moment a thread spans days, and
+       these threads run for days — two rows reading "2:00 PM" can be three
+       days apart. */
+    const threeDaysAgo = formatTurnWhen(now - 3 * 86_400_000, now);
+    expect(threeDaysAgo).toMatch(/^[A-Za-z]{3} /);
+    const older = formatTurnWhen(now - 30 * 86_400_000, now);
+    expect(older).toMatch(/^\d+\/\d+ /);
+  });
+});
+
+describe("countRepeatedCommands", () => {
+  it("reports commands the thread ran more than once", () => {
+    const repeats = countRepeatedCommands([
+      invocation({ normalizedCommand: "sed -n '1,420p' runbook.md" }),
+      invocation({ normalizedCommand: "sed -n '1,420p' runbook.md" }),
+      invocation({ normalizedCommand: "sed -n '1,420p' runbook.md" }),
+      invocation({ normalizedCommand: "cat README.md" }),
+    ]);
+
+    expect(repeats.get("sed -n '1,420p' runbook.md")).toBe(3);
+    expect(repeats.has("cat README.md")).toBe(false);
+  });
+});
+
+describe("refineToolCategory", () => {
+  it("separates agent instructions and skill files from bulk file reads", () => {
+    /* `file-io` was 80% of one thread's output. Knowing it was the same
+       instruction files, re-read, is the part that suggests a fix. */
+    expect(refineToolCategory({
+      category: "file-io",
+      normalizedCommand: "cat AGENTS.md",
+      toolName: "commandExecution",
+    })).toBe("agent-instructions");
+    expect(refineToolCategory({
+      category: "file-io",
+      normalizedCommand: "sed -n '1,400p' .agents/skills/manage-macos/SKILL.md",
+      toolName: "commandExecution",
+    })).toBe("skill-files");
+    expect(refineToolCategory({
+      category: "file-io",
+      normalizedCommand: "cat src/index.ts",
+      toolName: "commandExecution",
+    })).toBe("file-io");
+  });
+
+  it("leaves non-file categories alone", () => {
+    expect(refineToolCategory({
+      category: "git",
+      normalizedCommand: "git diff AGENTS.md",
+      toolName: "commandExecution",
+    })).toBe("git");
+  });
+});
+
+describe("buildCategoryComposition tail", () => {
+  it("names a single folded category instead of calling it Other", () => {
+    const composition = buildCategoryComposition([
+      invocation({ category: "file-io", estimatedOutputTokens: 500 }),
+      invocation({ category: "git", estimatedOutputTokens: 400 }),
+      invocation({ category: "search", estimatedOutputTokens: 300 }),
+      invocation({ category: "shell", estimatedOutputTokens: 200 }),
+      invocation({ category: "mcp", estimatedOutputTokens: 100 }),
+    ]);
+
+    expect(composition.at(-1)?.label).toBe("MCP");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -18,7 +18,8 @@ describe("summarizeIncidents", () => {
     const summary = summarizeIncidents([
       invocation({ estimatedOutputTokens: 3_000, noisy: true, outputChars: 12_000 }),
       invocation({ estimatedOutputTokens: 1_000, noisy: true, outputChars: 4_000 }),
-      invocation({ estimatedOutputTokens: 1_000, noisy: false, outputChars: 4_000 }),
+      /* Small and unmarked: below the size test, so not a case either way. */
+      invocation({ estimatedOutputTokens: 1_000, noisy: false, outputChars: 500 }),
     ]);
 
     expect(summary.caseCount).toBe(2);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -501,6 +501,19 @@ describe("turn strip scope and ranking", () => {
     expect(strip.totalTurnCount).toBe(2);
   });
 
+  it("exposes the unscoped chronological timeline alongside the ranked rows", () => {
+    /* The spark chart is the "when": all turns, time order, no scope — a long
+       poll only reads as a pattern when adjacency survives. */
+    const strip = buildTurnCostStrip([
+      invocation({ noisy: false, observedAt: 20, outputChars: 200, turnId: "turn-quiet" }),
+      invocation({ observedAt: 10, outputChars: 20_000, turnId: "turn-loud" }),
+    ]);
+
+    expect(strip.rows.map((row) => row.key)).toEqual(["turn-loud"]);
+    expect(strip.timeline.map((row) => row.key))
+      .toEqual(["turn-loud", "turn-quiet"]);
+  });
+
   it("keeps ordinals identical across scopes", () => {
     /* "Turn 2" must name the same turn whichever scope is active, or the
        label stops matching the case list. */

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -8,12 +8,14 @@ import {
   formatCompactTokens,
   countRepeatedCommands,
   formatInvocationIdentity,
+  formatMicrosCurrency,
   formatTurnWhen,
   invocationStatusTone,
   refineToolCategory,
   isOverOutputCap,
   sortIncidentCases,
   summarizeIncidents,
+  unwrapShellCommand,
 } from "../tool-output-incident-insights";
 
 describe("summarizeIncidents", () => {
@@ -232,9 +234,25 @@ describe("formatCompactTokens", () => {
   });
 });
 
+/* Commands whose verbs agree with the category, so a fixture that declares a
+   category is not silently re-categorized by the verb scan. */
+const COMMAND_FOR_CATEGORY: Partial<Record<string, string>> = {
+  "build-test": "vitest run",
+  "file-io": "cat notes.md",
+  git: "git status",
+  mcp: "mcp__server__call",
+  "package-manager": "pnpm install",
+  polling: "sleep 5",
+  search: "rg pattern",
+  shell: "./deploy.sh",
+  "sub-agent": "task_monitor",
+  unknown: "opaque_tool",
+};
+
 function invocation(
   overrides: Partial<ThreadToolInvocationRecord> = {},
 ): ThreadToolInvocationRecord {
+  const category = overrides.category ?? "shell";
   return {
     backend: "codex",
     category: "shell",
@@ -245,7 +263,7 @@ function invocation(
     invocationId: "invocation-1",
     itemId: "item-1",
     noisy: true,
-    normalizedCommand: "pnpm test",
+    normalizedCommand: COMMAND_FOR_CATEGORY[category] ?? "./deploy.sh",
     observedAt: 1_800_000_000_000,
     outputChars: 4_000,
     outputLines: 20,
@@ -336,5 +354,113 @@ describe("buildCategoryComposition tail", () => {
     ]);
 
     expect(composition.at(-1)?.label).toBe("MCP");
+  });
+});
+
+describe("composition members", () => {
+  it("carries the folded categories so Other can filter", () => {
+    /* "Other" was rendered as a disabled remainder — 10% of a real thread's
+       output with no way to reach it. */
+    const composition = buildCategoryComposition([
+      invocation({ category: "file-io", estimatedOutputTokens: 900 }),
+      invocation({ category: "git", estimatedOutputTokens: 800 }),
+      invocation({ category: "shell", estimatedOutputTokens: 700 }),
+      invocation({ category: "build-test", estimatedOutputTokens: 600 }),
+      invocation({ category: "mcp", estimatedOutputTokens: 500 }),
+      invocation({ category: "polling", estimatedOutputTokens: 400 }),
+    ]);
+
+    const other = composition.at(-1);
+    expect(other?.category).toBe("other");
+    expect(other?.label).toBe("Other (2)");
+    expect(other?.members.sort()).toEqual(["mcp", "polling"]);
+  });
+
+  it("gives a named entry itself as its only member", () => {
+    const composition = buildCategoryComposition([
+      invocation({ category: "git", estimatedOutputTokens: 100 }),
+    ]);
+    expect(composition[0]?.members).toEqual(["git"]);
+  });
+});
+
+describe("compound command categorization", () => {
+  it("unwraps a shell wrapper and reads every verb, not the first token", () => {
+    /* Real row from a 236-turn thread. Persisted as `shell`/`build-test`:
+       the first token is /bin/bash, and " test" matched a path. Note the
+       missing separators — redactCommandText collapses the script's newlines
+       at persist time, so the sub-commands run together. */
+    expect(refineToolCategory({
+      category: "build-test",
+      normalizedCommand:
+        "/bin/bash -c 'git diff --check git diff --stat git status --short "
+        + "--branch git diff -- tests/test-macos-images.sh'",
+      toolName: "commandExecution",
+    })).toBe("git");
+  });
+
+  it("leaves a category the persisted classifier got right", () => {
+    /* `pnpm test` is Tests & builds; the verb scan would call it a package
+       manager. It only runs when the persisted value is untrustworthy. */
+    expect(refineToolCategory({
+      category: "build-test",
+      normalizedCommand: "pnpm test",
+      toolName: "commandExecution",
+    })).toBe("build-test");
+  });
+
+  it("still separates when the verbs disagree", () => {
+    expect(refineToolCategory({
+      category: "shell",
+      normalizedCommand: "find . -name '*.ts' | xargs cat",
+      toolName: "commandExecution",
+    })).toBe("shell");
+  });
+
+  it("does not treat a git diff of a skill file as a skill read", () => {
+    expect(refineToolCategory({
+      category: "shell",
+      normalizedCommand: "git diff -- .agents/skills/build/SKILL.md",
+      toolName: "commandExecution",
+    })).toBe("git");
+  });
+
+  it("unwraps the wrapper for reads too", () => {
+    expect(unwrapShellCommand("/bin/bash -c 'cat AGENTS.md'"))
+      .toBe("cat AGENTS.md");
+    expect(refineToolCategory({
+      category: "shell",
+      normalizedCommand: "/bin/bash -c 'cat AGENTS.md'",
+      toolName: "commandExecution",
+    })).toBe("agent-instructions");
+  });
+});
+
+describe("turn cost", () => {
+  it("joins billed cost onto turns by turn id", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ observedAt: 10, turnId: "turn-a" }),
+        invocation({ observedAt: 20, turnId: "turn-b" }),
+      ],
+      {
+        usageLines: [
+          { createdAt: 1, currency: "USD", totalCostMicros: 1_500_000, turnId: "turn-a" },
+          { createdAt: 2, currency: "USD", totalCostMicros: 900_000, turnId: "turn-a" },
+        ] as never,
+      },
+    );
+
+    expect(strip.rows.find((row) => row.key === "turn-a")?.costMicros)
+      .toBe(2_400_000);
+    /* A turn the ledger has not priced reports nothing rather than zero. */
+    expect(strip.rows.find((row) => row.key === "turn-b")?.costMicros)
+      .toBeUndefined();
+  });
+
+  it("formats money in the ledger's units", () => {
+    expect(formatMicrosCurrency(2_400_000, "USD")).toBe("$2.4");
+    expect(formatMicrosCurrency(358_000_000, "USD")).toBe("$358");
+    expect(formatMicrosCurrency(2_400_000, "credits")).toBe("2.4 cr");
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -487,3 +487,69 @@ describe("turn cost", () => {
     expect(formatMicrosCurrency(2_400_000, "credits")).toBe("2.4 cr");
   });
 });
+
+describe("turn strip scope and ranking", () => {
+  it("defaults to turns with flagged calls and reports both populations", () => {
+    const strip = buildTurnCostStrip([
+      invocation({ observedAt: 10, outputChars: 20_000, turnId: "turn-loud" }),
+      invocation({ noisy: false, observedAt: 20, outputChars: 200, turnId: "turn-quiet" }),
+    ]);
+
+    expect(strip.scope).toBe("flagged");
+    expect(strip.rows.map((row) => row.key)).toEqual(["turn-loud"]);
+    expect(strip.flaggedTurnCount).toBe(1);
+    expect(strip.totalTurnCount).toBe(2);
+  });
+
+  it("keeps ordinals identical across scopes", () => {
+    /* "Turn 2" must name the same turn whichever scope is active, or the
+       label stops matching the case list. */
+    const rows = [
+      invocation({ noisy: false, observedAt: 10, outputChars: 200, turnId: "turn-quiet" }),
+      invocation({ observedAt: 20, outputChars: 20_000, turnId: "turn-loud" }),
+    ];
+    const flaggedScope = buildTurnCostStrip(rows);
+    const allScope = buildTurnCostStrip(rows, { scope: "all" });
+
+    expect(flaggedScope.rows[0]?.label).toBe("Turn 2");
+    expect(allScope.rows.map((row) => row.label)).toEqual(["Turn 1", "Turn 2"]);
+  });
+
+  it("ranks by billed cost when the ledger has priced the turns", () => {
+    /* "Costliest" next to a visible price column has to mean dollars — the
+       token/trip blend ranked turns in an order no column explained. */
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 9_000, observedAt: 10, turnId: "turn-tokens" }),
+        invocation({ estimatedOutputTokens: 1_000, observedAt: 20, turnId: "turn-dollars" }),
+        invocation({ estimatedOutputTokens: 500, observedAt: 30, turnId: "turn-cheap" }),
+      ],
+      {
+        limit: 2,
+        usageLines: [
+          { createdAt: 1, currency: "USD", totalCostMicros: 900_000, turnId: "turn-tokens" },
+          { createdAt: 2, currency: "USD", totalCostMicros: 5_000_000, turnId: "turn-dollars" },
+          { createdAt: 3, currency: "USD", totalCostMicros: 100_000, turnId: "turn-cheap" },
+        ] as never,
+      },
+    );
+
+    expect(strip.rankedBy).toBe("billed");
+    expect(strip.rows.map((row) => row.key))
+      .toEqual(["turn-dollars", "turn-tokens"]);
+  });
+
+  it("falls back to the blend when nothing is priced", () => {
+    const strip = buildTurnCostStrip(
+      [
+        invocation({ estimatedOutputTokens: 9_000, observedAt: 10, turnId: "turn-a" }),
+        invocation({ estimatedOutputTokens: 1_000, observedAt: 20, turnId: "turn-b" }),
+        invocation({ estimatedOutputTokens: 500, observedAt: 30, turnId: "turn-c" }),
+      ],
+      { limit: 2 },
+    );
+
+    expect(strip.rankedBy).toBe("estimate");
+    expect(strip.rows[0]?.key).toBe("turn-a");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -7,6 +7,7 @@ import {
   formatCapShare,
   formatCompactTokens,
   countRepeatedCommands,
+  formatCategoryLabel,
   formatInvocationIdentity,
   formatMicrosCurrency,
   formatTurnWhen,
@@ -433,6 +434,28 @@ describe("compound command categorization", () => {
       normalizedCommand: "/bin/bash -c 'cat AGENTS.md'",
       toolName: "commandExecution",
     })).toBe("agent-instructions");
+  });
+});
+
+describe("mcp subcategories", () => {
+  it("splits MCP by server from the persisted server/tool identity", () => {
+    /* Context7's `query-docs` was filed under Other: the old classifier
+       inferred MCP from an "mcp" substring in the tool name, which
+       `list_mcp_resources` happened to carry and `query-docs` did not. */
+    expect(refineToolCategory({
+      category: "mcp",
+      normalizedCommand: "context7/query-docs",
+      toolName: "query-docs",
+    })).toBe("mcp:context7");
+    expect(formatCategoryLabel("mcp:context7")).toBe("MCP · context7");
+  });
+
+  it("keeps a bare MCP call without a recorded server in the plain bucket", () => {
+    expect(refineToolCategory({
+      category: "mcp",
+      normalizedCommand: "query-docs",
+      toolName: "query-docs",
+    })).toBe("mcp");
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -96,7 +96,11 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
         <ul className="context-list context-list--cards tool-call-alert-list">
           {accounting.alerts.map((alert) => (
             <li key={alert.alertId} className="rail-card tool-call-alert">
-              <p className="rail-card__title">Noisy polling detected</p>
+              <p className="rail-card__title">
+                {alert.kind === "noisy-polling"
+                  ? "Repeated queued checks"
+                  : "Large tool output"}
+              </p>
               <p className="rail-card__usage">{alert.message}</p>
               <p className="rail-card__usage">
                 Suggested steering: {alert.suggestedPrompt}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -18,6 +18,8 @@ import {
 type ToolCallsPanelProps = {
   entries?: AppServerThreadEntry[];
   loadingDetailItemId?: string;
+  onAnalyzeHistory?: () => void;
+  onOpenIncidentExplorer?: () => void;
   onRequestInvocationDetails?: (invocation: ThreadToolInvocationRecord) => void;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   toolAccounting?: ThreadToolAccounting;
@@ -48,7 +50,16 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
 
   return (
     <section className="context-panel__section tool-calls-panel">
-      <h3>Tool calls</h3>
+      <div className="tool-calls-panel__heading">
+        <h3>Tool calls</h3>
+        <button
+          className="button button--ghost"
+          onClick={props.onOpenIncidentExplorer}
+          type="button"
+        >
+          Explore
+        </button>
+      </div>
       {totals ? (
         <div className="rail-summary-card tool-call-summary-card">
           <div className="rail-summary-card__header">
@@ -89,7 +100,16 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
           </div>
         </div>
       ) : (
-        <p className="context-empty">No tool calls recorded yet.</p>
+        <div className="context-empty">
+          <p>No tool calls recorded yet.</p>
+          <button
+            className="button button--ghost"
+            onClick={props.onAnalyzeHistory}
+            type="button"
+          >
+            Analyze history
+          </button>
+        </div>
       )}
 
       {accounting?.alerts.length ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -150,7 +150,8 @@ const VERB_CATEGORIES = new Map<string, ThreadToolInvocationCategory>([
 export type RefinedToolCategory =
   | ThreadToolInvocationCategory
   | "agent-instructions"
-  | "skill-files";
+  | "skill-files"
+  | `mcp:${string}`;
 
 export function unwrapShellCommand(command: string): string {
   const match = SHELL_WRAPPER_PATTERN.exec(command.trim());
@@ -186,6 +187,13 @@ export function refineToolCategory(
   >,
 ): RefinedToolCategory {
   const raw = invocation.normalizedCommand ?? invocation.toolName;
+  /* MCP identities are persisted as `server/tool`, so the split into a
+     per-server subcategory is a prefix read — each MCP answers for its own
+     output rather than pooling under one bucket. */
+  if (invocation.category === "mcp") {
+    const server = raw.includes("/") ? raw.split("/", 1)[0] : undefined;
+    return server ? `mcp:${server}` : "mcp";
+  }
   const command = unwrapShellCommand(raw);
   /* Only second-guess the persisted category when it is untrustworthy: either
      it was computed from a shell wrapper we have now seen through, or it is
@@ -211,7 +219,8 @@ export function formatCategoryLabel(
   if (category === "other") return "Other";
   if (category === "agent-instructions") return "Agent instructions";
   if (category === "skill-files") return "Skill files";
-  return CATEGORY_LABELS[category];
+  if (category.startsWith("mcp:")) return `MCP · ${category.slice(4)}`;
+  return CATEGORY_LABELS[category as ThreadToolInvocationCategory];
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -94,6 +94,13 @@ export type TurnCostStrip = {
   rankedBy: "billed" | "estimate";
   rows: TurnCostRow[];
   scope: TurnStripScope;
+  /**
+   * Every turn with recorded tool calls, in time order and unscoped — the
+   * whole thread at a glance. The ranked rows answer "which turns cost the
+   * most"; this answers "when", which is where a long poll shows up as a
+   * stretch of round-trip spikes with no matching output.
+   */
+  timeline: TurnCostRow[];
   /** Turns with any recorded tool call — the "all" scope's population. */
   totalTurnCount: number;
   hiddenTurnCount: number;
@@ -399,6 +406,7 @@ export function buildTurnCostStrip(
     rankedBy,
     rows,
     scope,
+    timeline: chronological,
     totalTurnCount: chronological.length,
   };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -1,0 +1,318 @@
+import type {
+  ThreadToolInvocationCategory,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import { TOOL_OUTPUT_CAP_CHARS, toolOutputCapShare } from "@pwragent/shared";
+
+/**
+ * Derivations behind the incident explorer's visual summary.
+ *
+ * Two things drive replay cost, and they need separate encodings because they
+ * need separate fixes. A turn that returns one enormous tool result is a
+ * filtering problem; a turn that makes sixty small calls is a round-trip
+ * problem, because every one of those trips replays the whole accumulated
+ * context. Reading only one of them — which is all a list of output sizes can
+ * show — hides half the bill.
+ *
+ * Everything here is a pure function over records the accounting analyzer
+ * already persists. No new IPC, no new fields.
+ */
+
+/** Turn rows shown before the strip switches from timeline to ranking. */
+const DEFAULT_TURN_ROW_LIMIT = 12;
+
+/** Distinct legend entries before the tail folds into "Other". */
+const DEFAULT_CATEGORY_LIMIT = 4;
+
+/**
+ * Characters of command text a case row can show before eliding. Sized to the
+ * list's minimum column width, because CSS truncation is an end-truncation —
+ * if it ever fires it undoes the middle-elision below.
+ */
+const DEFAULT_IDENTITY_BUDGET = 38;
+
+/** Longest word-boundary prefix used as the bolded head of a case row. */
+const IDENTITY_LEAD_BUDGET = 18;
+
+export type IncidentSummary = {
+  caseCount: number;
+  incidentChars: number;
+  incidentTokens: number;
+  /** Estimated tokens across every accounted call, flagged or not. */
+  totalTokens: number;
+  totalCallCount: number;
+  /** Flagged share of all tool output, 0–1. Zero when nothing is accounted. */
+  share: number;
+  turnCount: number;
+  worstChars: number;
+};
+
+export type TurnCostRow = {
+  callCount: number;
+  estimatedOutputTokens: number;
+  firstObservedAt: number;
+  key: string;
+  label: string;
+  noisyCount: number;
+  /** Calls that reached the harness's output cap, where output is truncated. */
+  overCapCount: number;
+  outputChars: number;
+  turnId?: string;
+};
+
+export type TurnCostStrip = {
+  /** Largest single-turn values in the strip, for scaling both bars. */
+  maxCallCount: number;
+  maxTokens: number;
+  /**
+   * "time" reads as a timeline. Past the row limit that stops being legible,
+   * so the strip ranks by cost instead and reports what it dropped.
+   */
+  ordering: "cost" | "time";
+  rows: TurnCostRow[];
+  hiddenTurnCount: number;
+};
+
+export type CategoryShare = {
+  caseCount: number;
+  category: ThreadToolInvocationCategory | "other";
+  estimatedOutputTokens: number;
+  label: string;
+  /** Share of flagged output tokens, 0–1. */
+  share: number;
+};
+
+export type IncidentSortMode = "largest" | "newest" | "turn";
+
+const CATEGORY_LABELS: Record<ThreadToolInvocationCategory, string> = {
+  "build-test": "Tests & builds",
+  "file-io": "File reads",
+  git: "Git",
+  mcp: "MCP",
+  "package-manager": "Package manager",
+  polling: "Polling",
+  search: "Search",
+  shell: "Shell",
+  "sub-agent": "Sub-agents",
+  unknown: "Other",
+};
+
+export function formatCategoryLabel(
+  category: ThreadToolInvocationCategory | "other",
+): string {
+  return category === "other" ? "Other" : CATEGORY_LABELS[category];
+}
+
+export function summarizeIncidents(
+  invocations: ThreadToolInvocationRecord[],
+): IncidentSummary {
+  const flagged = invocations.filter((invocation) => invocation.noisy);
+  const turnKeys = new Set(flagged.map((invocation) => invocation.turnId ?? ""));
+  const totalTokens = sumTokens(invocations);
+  const incidentTokens = sumTokens(flagged);
+  return {
+    caseCount: flagged.length,
+    incidentChars: flagged.reduce((sum, entry) => sum + entry.outputChars, 0),
+    incidentTokens,
+    share: totalTokens > 0 ? incidentTokens / totalTokens : 0,
+    totalCallCount: invocations.length,
+    totalTokens,
+    turnCount: turnKeys.size,
+    worstChars: flagged.reduce((worst, entry) => Math.max(worst, entry.outputChars), 0),
+  };
+}
+
+/**
+ * One row per turn over EVERY accounted call, not just the flagged ones —
+ * round trips are the cost being measured here, and a turn's quiet calls
+ * replay context exactly like its loud ones do.
+ */
+export function buildTurnCostStrip(
+  invocations: ThreadToolInvocationRecord[],
+  options?: { limit?: number },
+): TurnCostStrip {
+  const limit = options?.limit ?? DEFAULT_TURN_ROW_LIMIT;
+  const groups = new Map<string, TurnCostRow>();
+  for (const invocation of invocations) {
+    const key = invocation.turnId ?? "";
+    const row = groups.get(key) ?? {
+      callCount: 0,
+      estimatedOutputTokens: 0,
+      firstObservedAt: invocation.observedAt,
+      key,
+      label: "",
+      noisyCount: 0,
+      outputChars: 0,
+      overCapCount: 0,
+      ...(invocation.turnId ? { turnId: invocation.turnId } : {}),
+    };
+    row.callCount += 1;
+    row.estimatedOutputTokens += invocation.estimatedOutputTokens;
+    row.outputChars += invocation.outputChars;
+    row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
+    if (invocation.noisy) row.noisyCount += 1;
+    if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
+    groups.set(key, row);
+  }
+
+  /* Ordinals come from time order across all turns, so "Turn 3" keeps meaning
+     the third turn even when the strip is ranked by cost or truncated. */
+  const chronological = [...groups.values()]
+    .sort((left, right) => left.firstObservedAt - right.firstObservedAt);
+  let ordinal = 0;
+  for (const row of chronological) {
+    row.label = row.turnId ? `Turn ${(ordinal += 1)}` : "Unassigned";
+  }
+
+  const ordering: TurnCostStrip["ordering"] = chronological.length > limit
+    ? "cost"
+    : "time";
+  const ordered = ordering === "cost"
+    ? [...chronological].sort((left, right) =>
+        right.estimatedOutputTokens - left.estimatedOutputTokens
+        || right.callCount - left.callCount)
+    : chronological;
+  const rows = ordered.slice(0, limit);
+  return {
+    hiddenTurnCount: chronological.length - rows.length,
+    maxCallCount: rows.reduce((max, row) => Math.max(max, row.callCount), 0),
+    maxTokens: rows.reduce((max, row) => Math.max(max, row.estimatedOutputTokens), 0),
+    ordering,
+    rows,
+  };
+}
+
+export function buildCategoryComposition(
+  invocations: ThreadToolInvocationRecord[],
+  options?: { limit?: number },
+): CategoryShare[] {
+  const limit = options?.limit ?? DEFAULT_CATEGORY_LIMIT;
+  const groups = new Map<ThreadToolInvocationCategory, CategoryShare>();
+  for (const invocation of invocations) {
+    const share = groups.get(invocation.category) ?? {
+      caseCount: 0,
+      category: invocation.category,
+      estimatedOutputTokens: 0,
+      label: formatCategoryLabel(invocation.category),
+      share: 0,
+    };
+    share.caseCount += 1;
+    share.estimatedOutputTokens += invocation.estimatedOutputTokens;
+    groups.set(invocation.category, share);
+  }
+
+  const total = sumTokens(invocations);
+  const ranked = [...groups.values()]
+    .sort((left, right) => right.estimatedOutputTokens - left.estimatedOutputTokens);
+  const head = ranked.slice(0, limit);
+  const tail = ranked.slice(limit);
+  if (tail.length > 0) {
+    head.push({
+      caseCount: tail.reduce((sum, entry) => sum + entry.caseCount, 0),
+      category: "other",
+      estimatedOutputTokens: sumEntries(tail),
+      label: `Other (${tail.length})`,
+      share: 0,
+    });
+  }
+  for (const entry of head) {
+    entry.share = total > 0 ? entry.estimatedOutputTokens / total : 0;
+  }
+  return head;
+}
+
+export function sortIncidentCases(
+  invocations: ThreadToolInvocationRecord[],
+  mode: IncidentSortMode,
+): ThreadToolInvocationRecord[] {
+  const sorted = [...invocations];
+  if (mode === "largest") {
+    return sorted.sort((left, right) =>
+      right.outputChars - left.outputChars
+      || right.observedAt - left.observedAt);
+  }
+  if (mode === "newest") {
+    return sorted.sort((left, right) => right.observedAt - left.observedAt);
+  }
+  return sorted.sort((left, right) =>
+    left.observedAt - right.observedAt
+    || right.outputChars - left.outputChars);
+}
+
+/**
+ * Case-row label. The problem this solves: shell invocations in one turn
+ * routinely share a long prefix, so a plain head-truncation renders several
+ * rows byte-identical and the list stops being a list. Eliding the middle
+ * keeps the part that actually differs — usually a path or a subcommand near
+ * the end — on screen.
+ */
+export function formatInvocationIdentity(
+  value: string,
+  budget = DEFAULT_IDENTITY_BUDGET,
+): { detail: string; lead: string } {
+  const flattened = value.replace(/\s+/g, " ").trim();
+  const lead = flattened.length <= IDENTITY_LEAD_BUDGET
+    ? flattened
+    : leadingWords(flattened, IDENTITY_LEAD_BUDGET);
+  const detail = flattened.slice(lead.length).trim();
+  return { detail: elideMiddle(detail, Math.max(12, budget - lead.length)), lead };
+}
+
+/**
+ * Longest whole-word prefix within budget, or "" when the first word alone
+ * overruns it. Returning a hard slice there would cut a path mid-segment and
+ * bold a fragment that is identical across every row in the group — exactly
+ * the sameness the elision is meant to break.
+ */
+function leadingWords(value: string, budget: number): string {
+  const boundary = value.lastIndexOf(" ", budget);
+  return boundary > 0 ? value.slice(0, boundary) : "";
+}
+
+export function capShare(outputChars: number): number {
+  return toolOutputCapShare(outputChars);
+}
+
+/** Meter width, clamped — a case past the cap pins rather than overflowing. */
+export function capMeterWidth(outputChars: number): number {
+  return Math.min(1, Math.max(0.02, capShare(outputChars)));
+}
+
+export function isOverOutputCap(outputChars: number): boolean {
+  return outputChars >= TOOL_OUTPUT_CAP_CHARS;
+}
+
+/**
+ * The short form is for case rows, where the long phrase would repeat once per
+ * row and turn the list back into prose.
+ */
+export function formatCapShare(
+  outputChars: number,
+  options?: { short?: boolean },
+): string {
+  const percentage = Math.max(1, Math.round(capShare(outputChars) * 100));
+  return options?.short
+    ? `${percentage.toLocaleString()}% of cap`
+    : `${percentage.toLocaleString()}% of the output cap`;
+}
+
+export function formatCompactTokens(tokens: number): string {
+  if (tokens < 1_000) return tokens.toLocaleString();
+  const thousands = tokens / 1_000;
+  return `${thousands >= 100 ? Math.round(thousands) : Number(thousands.toFixed(1))}k`;
+}
+
+function elideMiddle(value: string, budget: number): string {
+  if (value.length <= budget) return value;
+  const head = Math.floor((budget - 1) * 0.42);
+  const tail = budget - 1 - head;
+  return `${value.slice(0, head).trimEnd()}…${value.slice(value.length - tail).trimStart()}`;
+}
+
+function sumTokens(invocations: ThreadToolInvocationRecord[]): number {
+  return invocations.reduce((sum, entry) => sum + entry.estimatedOutputTokens, 0);
+}
+
+function sumEntries(entries: CategoryShare[]): number {
+  return entries.reduce((sum, entry) => sum + entry.estimatedOutputTokens, 0);
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -81,7 +81,7 @@ export type TurnCostStrip = {
 };
 
 export type CategoryShare = {
-  category: ThreadToolInvocationCategory | "other";
+  category: RefinedToolCategory | "other";
   estimatedOutputTokens: number;
   label: string;
   /** Share of flagged output tokens, 0–1. */
@@ -103,10 +103,80 @@ const CATEGORY_LABELS: Record<ThreadToolInvocationCategory, string> = {
   unknown: "Other",
 };
 
+/**
+ * Display-level refinements of the persisted category.
+ *
+ * The stored enum is assigned by pattern-matching the tool name or the
+ * command's first token, so every `cat`/`sed` lands in one undifferentiated
+ * `file-io` bucket. That bucket was 80% of one thread's entire output, which
+ * tells the operator where to look and nothing about what to change. Reading
+ * an agent instruction file over and over is a different problem from reading
+ * a source file once, and the command text already distinguishes them.
+ *
+ * Derived rather than persisted so it applies to threads recorded before any
+ * of this existed — the same reason the size test is derived.
+ */
+const AGENT_INSTRUCTION_PATTERN = /\b(?:AGENTS|CLAUDE)\.md\b/i;
+const SKILL_FILE_PATTERN = /\bSKILL\.md\b|[/\\]skills?[/\\]|[/\\]plugins[/\\]/i;
+
+export type RefinedToolCategory =
+  | ThreadToolInvocationCategory
+  | "agent-instructions"
+  | "skill-files";
+
+export function refineToolCategory(
+  invocation: Pick<
+    ThreadToolInvocationRecord,
+    "category" | "normalizedCommand" | "toolName"
+  >,
+): RefinedToolCategory {
+  if (invocation.category !== "file-io" && invocation.category !== "search") {
+    return invocation.category;
+  }
+  const command = invocation.normalizedCommand ?? invocation.toolName;
+  if (AGENT_INSTRUCTION_PATTERN.test(command)) return "agent-instructions";
+  if (SKILL_FILE_PATTERN.test(command)) return "skill-files";
+  return invocation.category;
+}
+
 export function formatCategoryLabel(
-  category: ThreadToolInvocationCategory | "other",
+  category: RefinedToolCategory | "other",
 ): string {
-  return category === "other" ? "Other" : CATEGORY_LABELS[category];
+  if (category === "other") return "Other";
+  if (category === "agent-instructions") return "Agent instructions";
+  if (category === "skill-files") return "Skill files";
+  return CATEGORY_LABELS[category];
+}
+
+/**
+ * Commands this thread ran more than once. Re-running the identical read is a
+ * signal in its own right: either the turn lost the earlier result to
+ * compaction, or the file is being rewritten underneath it. Both are causes
+ * of cost rather than symptoms of it, and neither is visible from any single
+ * row's size.
+ */
+export function countRepeatedCommands(
+  invocations: readonly ThreadToolInvocationRecord[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const invocation of invocations) {
+    const command = invocation.normalizedCommand;
+    if (!command) continue;
+    counts.set(command, (counts.get(command) ?? 0) + 1);
+  }
+  for (const [command, count] of counts) {
+    if (count < 2) counts.delete(command);
+  }
+  return counts;
+}
+
+export function repeatCountFor(
+  invocation: Pick<ThreadToolInvocationRecord, "normalizedCommand">,
+  repeats: Map<string, number>,
+): number {
+  return invocation.normalizedCommand
+    ? repeats.get(invocation.normalizedCommand) ?? 1
+    : 1;
 }
 
 export function summarizeIncidents(
@@ -203,16 +273,17 @@ export function buildCategoryComposition(
   options?: { limit?: number },
 ): CategoryShare[] {
   const limit = options?.limit ?? DEFAULT_CATEGORY_LIMIT;
-  const groups = new Map<ThreadToolInvocationCategory, CategoryShare>();
+  const groups = new Map<RefinedToolCategory, CategoryShare>();
   for (const invocation of invocations) {
-    const share = groups.get(invocation.category) ?? {
-      category: invocation.category,
+    const category = refineToolCategory(invocation);
+    const share = groups.get(category) ?? {
+      category,
       estimatedOutputTokens: 0,
-      label: formatCategoryLabel(invocation.category),
+      label: formatCategoryLabel(category),
       share: 0,
     };
     share.estimatedOutputTokens += invocation.estimatedOutputTokens;
-    groups.set(invocation.category, share);
+    groups.set(category, share);
   }
 
   const total = sumTokens(invocations);
@@ -220,7 +291,11 @@ export function buildCategoryComposition(
     .sort((left, right) => right.estimatedOutputTokens - left.estimatedOutputTokens);
   const head = ranked.slice(0, limit);
   const tail = ranked.slice(limit);
-  if (tail.length > 0) {
+  if (tail.length === 1 && tail[0]) {
+    /* "Other (1)" hides a real name behind a label that says less than the
+       name did — a single MCP bucket read as an unexplained remainder. */
+    head.push(tail[0]);
+  } else if (tail.length > 1) {
     head.push({
       category: "other",
       estimatedOutputTokens: sumEntries(tail),
@@ -326,7 +401,49 @@ export function formatCapShare(
 export function formatCompactTokens(tokens: number): string {
   if (tokens < 1_000) return tokens.toLocaleString();
   const thousands = tokens / 1_000;
-  return `${thousands >= 100 ? Math.round(thousands) : Number(thousands.toFixed(1))}k`;
+  return `${(thousands >= 100
+    ? Math.round(thousands)
+    : Number(thousands.toFixed(1))
+  ).toLocaleString()}k`;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * When a turn ran, at the precision that distinguishes it from its neighbours.
+ *
+ * A bare clock time is ambiguous the moment a thread spans midnight, and these
+ * threads run for days — two rows both reading "2:00 PM" are three days apart
+ * and the strip gives no hint of it.
+ */
+export function formatTurnWhen(timestamp: number, now: number): string {
+  const elapsed = now - timestamp;
+  if (elapsed < 0) return formatClock(timestamp);
+  if (elapsed < HOUR_MS) {
+    return `${Math.max(1, Math.round(elapsed / MINUTE_MS))}m ago`;
+  }
+  if (elapsed < DAY_MS) {
+    const hours = Math.floor(elapsed / HOUR_MS);
+    const minutes = Math.round((elapsed % HOUR_MS) / MINUTE_MS);
+    return minutes > 0 ? `${hours}h ${minutes}m ago` : `${hours}h ago`;
+  }
+  if (elapsed < 7 * DAY_MS) {
+    const day = new Date(timestamp)
+      .toLocaleDateString(undefined, { weekday: "short" });
+    return `${day} ${formatClock(timestamp)}`;
+  }
+  const date = new Date(timestamp)
+    .toLocaleDateString(undefined, { day: "numeric", month: "numeric" });
+  return `${date} ${formatClock(timestamp)}`;
+}
+
+function formatClock(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 function elideMiddle(value: string, budget: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -40,7 +40,6 @@ export type IncidentSummary = {
   incidentTokens: number;
   /** Estimated tokens across every accounted call, flagged or not. */
   totalTokens: number;
-  totalCallCount: number;
   /** Flagged share of all tool output, 0–1. Zero when nothing is accounted. */
   share: number;
   turnCount: number;
@@ -53,14 +52,18 @@ export type TurnCostRow = {
   firstObservedAt: number;
   key: string;
   label: string;
-  noisyCount: number;
   /** Calls that reached the harness's output cap, where output is truncated. */
   overCapCount: number;
-  outputChars: number;
   turnId?: string;
 };
 
 export type TurnCostStrip = {
+  /**
+   * Every turn's label, including turns the row limit dropped. Callers label
+   * cases from this rather than from `rows` — a case belonging to a turn that
+   * did not make the strip still belongs to a turn.
+   */
+  labelsByKey: Map<string, string>;
   /** Largest single-turn values in the strip, for scaling both bars. */
   maxCallCount: number;
   maxTokens: number;
@@ -74,7 +77,6 @@ export type TurnCostStrip = {
 };
 
 export type CategoryShare = {
-  caseCount: number;
   category: ThreadToolInvocationCategory | "other";
   estimatedOutputTokens: number;
   label: string;
@@ -115,7 +117,6 @@ export function summarizeIncidents(
     incidentChars: flagged.reduce((sum, entry) => sum + entry.outputChars, 0),
     incidentTokens,
     share: totalTokens > 0 ? incidentTokens / totalTokens : 0,
-    totalCallCount: invocations.length,
     totalTokens,
     turnCount: turnKeys.size,
     worstChars: flagged.reduce((worst, entry) => Math.max(worst, entry.outputChars), 0),
@@ -141,16 +142,12 @@ export function buildTurnCostStrip(
       firstObservedAt: invocation.observedAt,
       key,
       label: "",
-      noisyCount: 0,
-      outputChars: 0,
       overCapCount: 0,
       ...(invocation.turnId ? { turnId: invocation.turnId } : {}),
     };
     row.callCount += 1;
     row.estimatedOutputTokens += invocation.estimatedOutputTokens;
-    row.outputChars += invocation.outputChars;
     row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
-    if (invocation.noisy) row.noisyCount += 1;
     if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
     groups.set(key, row);
   }
@@ -167,14 +164,29 @@ export function buildTurnCostStrip(
   const ordering: TurnCostStrip["ordering"] = chronological.length > limit
     ? "cost"
     : "time";
+  /* Rank on BOTH axes, not just output. Sorting by tokens alone would cut the
+     80-call polling turn that returns almost nothing — the pathology the tick
+     rail exists to show — and leave the strip claiming it was "quieter". */
+  const scale = {
+    calls: chronological.reduce((max, row) => Math.max(max, row.callCount), 0),
+    tokens: chronological.reduce(
+      (max, row) => Math.max(max, row.estimatedOutputTokens),
+      0,
+    ),
+  };
+  const score = (row: TurnCostRow): number =>
+    (scale.tokens > 0 ? row.estimatedOutputTokens / scale.tokens : 0)
+    + (scale.calls > 0 ? row.callCount / scale.calls : 0);
   const ordered = ordering === "cost"
     ? [...chronological].sort((left, right) =>
-        right.estimatedOutputTokens - left.estimatedOutputTokens
+        score(right) - score(left)
+        || right.estimatedOutputTokens - left.estimatedOutputTokens
         || right.callCount - left.callCount)
     : chronological;
   const rows = ordered.slice(0, limit);
   return {
     hiddenTurnCount: chronological.length - rows.length,
+    labelsByKey: new Map(chronological.map((row) => [row.key, row.label])),
     maxCallCount: rows.reduce((max, row) => Math.max(max, row.callCount), 0),
     maxTokens: rows.reduce((max, row) => Math.max(max, row.estimatedOutputTokens), 0),
     ordering,
@@ -190,13 +202,11 @@ export function buildCategoryComposition(
   const groups = new Map<ThreadToolInvocationCategory, CategoryShare>();
   for (const invocation of invocations) {
     const share = groups.get(invocation.category) ?? {
-      caseCount: 0,
       category: invocation.category,
       estimatedOutputTokens: 0,
       label: formatCategoryLabel(invocation.category),
       share: 0,
     };
-    share.caseCount += 1;
     share.estimatedOutputTokens += invocation.estimatedOutputTokens;
     groups.set(invocation.category, share);
   }
@@ -208,7 +218,6 @@ export function buildCategoryComposition(
   const tail = ranked.slice(limit);
   if (tail.length > 0) {
     head.push({
-      caseCount: tail.reduce((sum, entry) => sum + entry.caseCount, 0),
       category: "other",
       estimatedOutputTokens: sumEntries(tail),
       label: `Other (${tail.length})`,
@@ -269,8 +278,22 @@ function leadingWords(value: string, budget: number): string {
   return boundary > 0 ? value.slice(0, boundary) : "";
 }
 
-export function capShare(outputChars: number): number {
+function capShare(outputChars: number): number {
   return toolOutputCapShare(outputChars);
+}
+
+/**
+ * Success coloring is reserved for a call that actually succeeded. A non-zero
+ * exit is a failure whatever the transport status says, and cancelled or still
+ * running is neither — those stay neutral rather than borrowing green.
+ */
+export function invocationStatusTone(
+  invocation: ThreadToolInvocationRecord,
+): "error" | "ok" | undefined {
+  if (invocation.status === "failed") return "error";
+  if (invocation.status !== "completed") return undefined;
+  if (invocation.exitCode !== undefined && invocation.exitCode !== 0) return "error";
+  return "ok";
 }
 
 /** Meter width, clamped — a case past the cap pins rather than overflowing. */

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -1,6 +1,7 @@
 import type {
   ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
+  ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
   isFlaggedToolInvocation,
@@ -52,6 +53,8 @@ export type IncidentSummary = {
 
 export type TurnCostRow = {
   callCount: number;
+  /** Billed cost of this turn, when the pricing ledger has priced it. */
+  costMicros?: number;
   estimatedOutputTokens: number;
   firstObservedAt: number;
   key: string;
@@ -84,6 +87,12 @@ export type CategoryShare = {
   category: RefinedToolCategory | "other";
   estimatedOutputTokens: number;
   label: string;
+  /**
+   * Categories this entry stands for. One for a named entry; for the folded
+   * "Other" entry, every category inside it — which is what lets that entry
+   * be a real filter rather than an unreachable remainder.
+   */
+  members: RefinedToolCategory[];
   /** Share of flagged output tokens, 0–1. */
   share: number;
 };
@@ -119,10 +128,56 @@ const CATEGORY_LABELS: Record<ThreadToolInvocationCategory, string> = {
 const AGENT_INSTRUCTION_PATTERN = /\b(?:AGENTS|CLAUDE)\.md\b/i;
 const SKILL_FILE_PATTERN = /\bSKILL\.md\b|[/\\]skills?[/\\]|[/\\]plugins[/\\]/i;
 
+/** Shell wrappers whose payload is the command we actually care about. */
+const SHELL_WRAPPER_PATTERN =
+  /^(?:\/(?:usr\/)?bin\/)?(?:ba|z|k)?sh\s+-[a-z]*c\s+(['"])([\s\S]*)\1\s*$/i;
+
+/**
+ * Command verbs we can categorize, and what they mean. Scanned across the
+ * whole command rather than read off its first token.
+ */
+const VERB_CATEGORIES = new Map<string, ThreadToolInvocationCategory>([
+  ["git", "git"],
+  ["cat", "file-io"], ["head", "file-io"], ["tail", "file-io"],
+  ["sed", "file-io"], ["awk", "file-io"], ["ls", "file-io"], ["wc", "file-io"],
+  ["rg", "search"], ["grep", "search"], ["find", "search"], ["fd", "search"],
+  ["npm", "package-manager"], ["pnpm", "package-manager"],
+  ["yarn", "package-manager"], ["bun", "package-manager"],
+  ["npx", "package-manager"],
+  ["sleep", "polling"],
+]);
+
 export type RefinedToolCategory =
   | ThreadToolInvocationCategory
   | "agent-instructions"
   | "skill-files";
+
+export function unwrapShellCommand(command: string): string {
+  const match = SHELL_WRAPPER_PATTERN.exec(command.trim());
+  return match?.[2]?.trim() ?? command;
+}
+
+/**
+ * The one category every verb in the command agrees on, or undefined when
+ * they disagree or none is recognized.
+ *
+ * Reading the first token alone gets a compound command wrong twice over: a
+ * `/bin/bash -c '…'` wrapper reports the shell rather than what it ran, and a
+ * script that is four `git` invocations in a row is plainly git work. Real
+ * example from a 236-turn thread: `/bin/bash -c 'git diff --check git diff
+ * --stat git status --short --branch git diff -- …'` was filed under
+ * "Tests & builds", because the substring " test" appeared in a path.
+ */
+function unanimousVerbCategory(
+  command: string,
+): ThreadToolInvocationCategory | undefined {
+  const found = new Set<ThreadToolInvocationCategory>();
+  for (const token of command.split(/[\s;|&()]+/)) {
+    const category = VERB_CATEGORIES.get(token.toLowerCase());
+    if (category) found.add(category);
+  }
+  return found.size === 1 ? [...found][0] : undefined;
+}
 
 export function refineToolCategory(
   invocation: Pick<
@@ -130,13 +185,24 @@ export function refineToolCategory(
     "category" | "normalizedCommand" | "toolName"
   >,
 ): RefinedToolCategory {
-  if (invocation.category !== "file-io" && invocation.category !== "search") {
-    return invocation.category;
-  }
-  const command = invocation.normalizedCommand ?? invocation.toolName;
+  const raw = invocation.normalizedCommand ?? invocation.toolName;
+  const command = unwrapShellCommand(raw);
+  /* Only second-guess the persisted category when it is untrustworthy: either
+     it was computed from a shell wrapper we have now seen through, or it is
+     one of the buckets that means "no pattern matched". `pnpm test` stays
+     Tests & builds — the verb scan is a fallback, not a better classifier. */
+  const persistedIsWeak =
+    command !== raw.trim()
+    || invocation.category === "shell"
+    || invocation.category === "unknown";
+  const category = (persistedIsWeak ? unanimousVerbCategory(command) : undefined)
+    ?? invocation.category;
+  /* Only a read gets refined by what it read. `git diff -- …/SKILL.md` is git
+     work that happens to touch a skill file, not a skill read. */
+  if (category !== "file-io" && category !== "search") return category;
   if (AGENT_INSTRUCTION_PATTERN.test(command)) return "agent-instructions";
   if (SKILL_FILE_PATTERN.test(command)) return "skill-files";
-  return invocation.category;
+  return category;
 }
 
 export function formatCategoryLabel(
@@ -204,9 +270,20 @@ export function summarizeIncidents(
  */
 export function buildTurnCostStrip(
   invocations: ThreadToolInvocationRecord[],
-  options?: { limit?: number },
+  options?: { limit?: number; usageLines?: readonly ThreadUsageLineRecord[] },
 ): TurnCostStrip {
   const limit = options?.limit ?? DEFAULT_TURN_ROW_LIMIT;
+  /* Billed cost per turn, joined by turn id. The ledger is the authority on
+     money; the token bar is an estimate from character counts, so the two are
+     reported side by side rather than one derived from the other. */
+  const costByTurn = new Map<string, number>();
+  for (const line of options?.usageLines ?? []) {
+    if (!line.turnId) continue;
+    costByTurn.set(
+      line.turnId,
+      (costByTurn.get(line.turnId) ?? 0) + line.totalCostMicros,
+    );
+  }
   const groups = new Map<string, TurnCostRow>();
   for (const invocation of invocations) {
     const key = invocation.turnId ?? "";
@@ -224,6 +301,11 @@ export function buildTurnCostStrip(
     row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
     if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
     groups.set(key, row);
+  }
+
+  for (const row of groups.values()) {
+    const cost = row.turnId ? costByTurn.get(row.turnId) : undefined;
+    if (cost !== undefined) row.costMicros = cost;
   }
 
   /* Ordinals come from time order across all turns, so "Turn 3" keeps meaning
@@ -280,6 +362,7 @@ export function buildCategoryComposition(
       category,
       estimatedOutputTokens: 0,
       label: formatCategoryLabel(category),
+      members: [category],
       share: 0,
     };
     share.estimatedOutputTokens += invocation.estimatedOutputTokens;
@@ -300,6 +383,7 @@ export function buildCategoryComposition(
       category: "other",
       estimatedOutputTokens: sumEntries(tail),
       label: `Other (${tail.length})`,
+      members: tail.map((entry) => entry.category as RefinedToolCategory),
       share: 0,
     });
   }
@@ -396,6 +480,20 @@ export function formatCapShare(
   return options?.short
     ? `${percentage.toLocaleString()}% of cap`
     : `${percentage.toLocaleString()}% of the output cap`;
+}
+
+export function formatMicrosCurrency(
+  micros: number,
+  currency: string | undefined,
+): string {
+  const units = micros / 1_000_000;
+  const rounded = units >= 100
+    ? Math.round(units)
+    : Number(units.toFixed(units >= 1 ? 2 : 3));
+  const value = rounded.toLocaleString();
+  if (!currency || currency === "USD") return `$${value}`;
+  if (currency.toLowerCase().includes("credit")) return `${value} cr`;
+  return `${value} ${currency}`;
 }
 
 export function formatCompactTokens(tokens: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -2,7 +2,11 @@ import type {
   ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
-import { TOOL_OUTPUT_CAP_CHARS, toolOutputCapShare } from "@pwragent/shared";
+import {
+  isFlaggedToolInvocation,
+  TOOL_OUTPUT_CAP_CHARS,
+  toolOutputCapShare,
+} from "@pwragent/shared";
 
 /**
  * Derivations behind the incident explorer's visual summary.
@@ -108,7 +112,7 @@ export function formatCategoryLabel(
 export function summarizeIncidents(
   invocations: ThreadToolInvocationRecord[],
 ): IncidentSummary {
-  const flagged = invocations.filter((invocation) => invocation.noisy);
+  const flagged = invocations.filter(isFlaggedToolInvocation);
   const turnKeys = new Set(flagged.map((invocation) => invocation.turnId ?? ""));
   const totalTokens = sumTokens(invocations);
   const incidentTokens = sumTokens(flagged);

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -57,6 +57,8 @@ export type TurnCostRow = {
   costMicros?: number;
   estimatedOutputTokens: number;
   firstObservedAt: number;
+  /** Calls that pass `isFlaggedToolInvocation` — the scope toggle's test. */
+  flaggedCallCount: number;
   key: string;
   label: string;
   /** Calls that reached the harness's output cap, where output is truncated. */
@@ -64,7 +66,11 @@ export type TurnCostRow = {
   turnId?: string;
 };
 
+export type TurnStripScope = "all" | "flagged";
+
 export type TurnCostStrip = {
+  /** Turns in scope that contain at least one flagged call. */
+  flaggedTurnCount: number;
   /**
    * Every turn's label, including turns the row limit dropped. Callers label
    * cases from this rather than from `rows` — a case belonging to a turn that
@@ -76,10 +82,20 @@ export type TurnCostStrip = {
   maxTokens: number;
   /**
    * "time" reads as a timeline. Past the row limit that stops being legible,
-   * so the strip ranks by cost instead and reports what it dropped.
+   * so the strip ranks instead and reports what it dropped.
    */
   ordering: "cost" | "time";
+  /**
+   * What the "cost" ordering actually ranks by, so the header can say it
+   * instead of leaving the reader to reverse-engineer the sort. "billed" is
+   * ledger money; "estimate" is the two-axis blend of output tokens and
+   * round trips, used when nothing is priced.
+   */
+  rankedBy: "billed" | "estimate";
   rows: TurnCostRow[];
+  scope: TurnStripScope;
+  /** Turns with any recorded tool call — the "all" scope's population. */
+  totalTurnCount: number;
   hiddenTurnCount: number;
 };
 
@@ -279,9 +295,14 @@ export function summarizeIncidents(
  */
 export function buildTurnCostStrip(
   invocations: ThreadToolInvocationRecord[],
-  options?: { limit?: number; usageLines?: readonly ThreadUsageLineRecord[] },
+  options?: {
+    limit?: number;
+    scope?: TurnStripScope;
+    usageLines?: readonly ThreadUsageLineRecord[];
+  },
 ): TurnCostStrip {
   const limit = options?.limit ?? DEFAULT_TURN_ROW_LIMIT;
+  const scope = options?.scope ?? "flagged";
   /* Billed cost per turn, joined by turn id. The ledger is the authority on
      money; the token bar is an estimate from character counts, so the two are
      reported side by side rather than one derived from the other. */
@@ -300,6 +321,7 @@ export function buildTurnCostStrip(
       callCount: 0,
       estimatedOutputTokens: 0,
       firstObservedAt: invocation.observedAt,
+      flaggedCallCount: 0,
       key,
       label: "",
       overCapCount: 0,
@@ -308,6 +330,7 @@ export function buildTurnCostStrip(
     row.callCount += 1;
     row.estimatedOutputTokens += invocation.estimatedOutputTokens;
     row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
+    if (isFlaggedToolInvocation(invocation)) row.flaggedCallCount += 1;
     if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
     groups.set(key, row);
   }
@@ -326,15 +349,28 @@ export function buildTurnCostStrip(
     row.label = row.turnId ? `Turn ${(ordinal += 1)}` : "Unassigned";
   }
 
-  const ordering: TurnCostStrip["ordering"] = chronological.length > limit
+  /* Ordinals are assigned before scoping, so "Turn 92" names the same turn
+     in both scopes and in the case list. */
+  const scoped = scope === "flagged"
+    ? chronological.filter((row) => row.flaggedCallCount > 0)
+    : chronological;
+
+  const ordering: TurnCostStrip["ordering"] = scoped.length > limit
     ? "cost"
     : "time";
-  /* Rank on BOTH axes, not just output. Sorting by tokens alone would cut the
-     80-call polling turn that returns almost nothing — the pathology the tick
-     rail exists to show — and leave the strip claiming it was "quieter". */
+  /* Billed money outranks any estimate: when the ledger has priced these
+     turns, "costliest" means dollars, full stop — an invented blend next to a
+     visible price column reads as a sort nobody can name. The blend remains
+     only for unpriced threads, where it still beats tokens alone (which would
+     cut the 80-call polling turn the tick rail exists to show). */
+  const rankedBy: TurnCostStrip["rankedBy"] = scoped.some(
+    (row) => row.costMicros !== undefined,
+  )
+    ? "billed"
+    : "estimate";
   const scale = {
-    calls: chronological.reduce((max, row) => Math.max(max, row.callCount), 0),
-    tokens: chronological.reduce(
+    calls: scoped.reduce((max, row) => Math.max(max, row.callCount), 0),
+    tokens: scoped.reduce(
       (max, row) => Math.max(max, row.estimatedOutputTokens),
       0,
     ),
@@ -343,19 +379,27 @@ export function buildTurnCostStrip(
     (scale.tokens > 0 ? row.estimatedOutputTokens / scale.tokens : 0)
     + (scale.calls > 0 ? row.callCount / scale.calls : 0);
   const ordered = ordering === "cost"
-    ? [...chronological].sort((left, right) =>
-        score(right) - score(left)
+    ? [...scoped].sort((left, right) =>
+        (rankedBy === "billed"
+          ? (right.costMicros ?? -1) - (left.costMicros ?? -1)
+          : 0)
+        || score(right) - score(left)
         || right.estimatedOutputTokens - left.estimatedOutputTokens
         || right.callCount - left.callCount)
-    : chronological;
+    : scoped;
   const rows = ordered.slice(0, limit);
   return {
-    hiddenTurnCount: chronological.length - rows.length,
+    flaggedTurnCount: chronological
+      .filter((row) => row.flaggedCallCount > 0).length,
+    hiddenTurnCount: scoped.length - rows.length,
     labelsByKey: new Map(chronological.map((row) => [row.key, row.label])),
     maxCallCount: rows.reduce((max, row) => Math.max(max, row.callCount), 0),
     maxTokens: rows.reduce((max, row) => Math.max(max, row.estimatedOutputTokens), 0),
     ordering,
+    rankedBy,
     rows,
+    scope,
+    totalTurnCount: chronological.length,
   };
 }
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -23,14 +23,12 @@ import { useThreadNavigation } from "../useThreadNavigation";
 
 describe("useThreadNavigation", () => {
   beforeEach(() => {
-    window.sessionStorage.clear();
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
   });
 
   afterEach(() => {
     endNativeDragInteraction();
-    window.sessionStorage.clear();
     delete (window as unknown as {
       __pwragentNavigationPreferences?: unknown;
     }).__pwragentNavigationPreferences;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -23,12 +23,14 @@ import { useThreadNavigation } from "../useThreadNavigation";
 
 describe("useThreadNavigation", () => {
   beforeEach(() => {
+    window.sessionStorage.clear();
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
   });
 
   afterEach(() => {
     endNativeDragInteraction();
+    window.sessionStorage.clear();
     delete (window as unknown as {
       __pwragentNavigationPreferences?: unknown;
     }).__pwragentNavigationPreferences;
@@ -39,6 +41,59 @@ describe("useThreadNavigation", () => {
       __pwragentFederationLabel?: unknown;
     }).__pwragentFederationLabel;
     vi.restoreAllMocks();
+  });
+
+  it("restores the selected thread after a full renderer reload", async () => {
+    const snapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+        {
+          id: "thread-2",
+          title: "Focused before reload",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => snapshot),
+      onAgentEvent: () => () => undefined,
+    };
+    const firstRenderer = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(firstRenderer.result.current.selectedThread?.id).toBe("thread-1");
+    });
+    act(() => {
+      firstRenderer.result.current.selectThread(snapshot.threads[1]!);
+    });
+    await waitFor(() => {
+      expect(firstRenderer.result.current.selectedThread?.id).toBe("thread-2");
+    });
+    firstRenderer.unmount();
+
+    const reloadedRenderer = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(reloadedRenderer.result.current.selectedThread?.id).toBe("thread-2");
+    });
+    reloadedRenderer.unmount();
   });
 
   function createDeferred<T>(): {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -166,6 +166,8 @@ import type {
   SetDirectoryThreadsCollapsedResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
+  SetThreadToolIncidentNoticeRequest,
+  SetThreadToolIncidentNoticeResponse,
   SetThreadParentRequest,
   SetThreadParentResponse,
   SetThreadPinRequest,
@@ -900,6 +902,9 @@ export type DesktopApi = {
   setThreadReaction?: (
     request: SetThreadReactionRequest
   ) => Promise<SetThreadReactionResponse>;
+  setThreadToolIncidentNotice?: (
+    request: SetThreadToolIncidentNoticeRequest,
+  ) => Promise<SetThreadToolIncidentNoticeResponse>;
   setThreadPin?: (
     request: SetThreadPinRequest
   ) => Promise<SetThreadPinResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -65,6 +65,8 @@ import type {
   ForkThreadResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AnalyzeThreadToolHistoryRequest,
+  AnalyzeThreadToolHistoryResponse,
   GetThreadFileDiffRequest,
   GetThreadFileDiffResponse,
   PersistThreadUsageActivityRequest,
@@ -354,6 +356,8 @@ import type {
   OpenMarkdownFileViewerResponse,
   OpenSubAgentTranscriptWindowRequest,
   OpenSubAgentTranscriptWindowResponse,
+  OpenToolOutputIncidentExplorerWindowRequest,
+  OpenToolOutputIncidentExplorerWindowResponse,
   OpenPathRequest,
   OpenPathResponse,
   ReadMarkdownFileRequest,
@@ -610,6 +614,9 @@ export type DesktopApi = {
   readThread?: (
     request: AppServerReadThreadRequest
   ) => Promise<AppServerReadThreadResponse>;
+  analyzeThreadToolHistory?: (
+    request: AnalyzeThreadToolHistoryRequest,
+  ) => Promise<AnalyzeThreadToolHistoryResponse>;
   getThreadFileDiff?: (
     request: GetThreadFileDiffRequest,
   ) => Promise<GetThreadFileDiffResponse>;
@@ -832,6 +839,9 @@ export type DesktopApi = {
   openSubAgentTranscriptWindow?: (
     request: OpenSubAgentTranscriptWindowRequest
   ) => Promise<OpenSubAgentTranscriptWindowResponse>;
+  openToolOutputIncidentExplorerWindow?: (
+    request: OpenToolOutputIncidentExplorerWindowRequest
+  ) => Promise<OpenToolOutputIncidentExplorerWindowResponse>;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -843,8 +843,11 @@ export type DesktopApi = {
     request: OpenToolOutputIncidentExplorerWindowRequest
   ) => Promise<OpenToolOutputIncidentExplorerWindowResponse>;
   onToolOutputIncidentExplorerRefresh?: (
-    callback: () => void
+    callback: (request?: OpenToolOutputIncidentExplorerWindowRequest) => void
   ) => () => void;
+  showThreadFromToolOutputIncidentExplorer?: (
+    request: WindowShowThreadRequest
+  ) => Promise<void>;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -842,6 +842,9 @@ export type DesktopApi = {
   openToolOutputIncidentExplorerWindow?: (
     request: OpenToolOutputIncidentExplorerWindowRequest
   ) => Promise<OpenToolOutputIncidentExplorerWindowResponse>;
+  onToolOutputIncidentExplorerRefresh?: (
+    callback: () => void
+  ) => () => void;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -112,6 +112,7 @@ const NAVIGATION_ACTIVITY_EVENTS = [
   "paste",
   "pointerdown",
 ] as const;
+const RELOAD_SELECTION_STORAGE_KEY = "pwragent.navigation.reloadSelection";
 
 const DEFAULT_BROWSE_MODE = DEFAULT_NAVIGATION_BROWSE_MODE;
 const normalizeBrowseMode = normalizeNavigationBrowseMode;
@@ -124,6 +125,34 @@ function readBridgedBrowseMode(): BrowseMode {
     __pwragentNavigationPreferences?: { browseMode?: unknown };
   }).__pwragentNavigationPreferences;
   return normalizeBrowseMode(bridged?.browseMode);
+}
+
+function readReloadSelectionKey(): string | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  try {
+    return window.sessionStorage.getItem(RELOAD_SELECTION_STORAGE_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeReloadSelectionKey(selectionKey?: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (selectionKey) {
+      window.sessionStorage.setItem(RELOAD_SELECTION_STORAGE_KEY, selectionKey);
+    } else {
+      window.sessionStorage.removeItem(RELOAD_SELECTION_STORAGE_KEY);
+    }
+  } catch {
+    // Navigation still works when the renderer denies storage access.
+  }
 }
 
 function isRendererViewForeground(): boolean {
@@ -2973,6 +3002,7 @@ export function useThreadNavigation(
   });
   const [viewForeground, setViewForeground] = useState(isRendererViewForeground);
   const prChipLocationIndexRef = useRef<PrChipLocationIndex | undefined>(undefined);
+  const reloadSelectionKeyRef = useRef(readReloadSelectionKey());
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
   const retainedUnreadThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
@@ -3586,8 +3616,20 @@ export function useThreadNavigation(
       return;
     }
 
-    void refresh();
+    // sessionStorage is scoped to this BrowserWindow and survives the full
+    // page reload Vite uses when an HMR update reaches the renderer entry.
+    // Feed the remembered selection through the normal validated preferred-
+    // selection path so a removed thread falls back instead of stranding the
+    // detail pane on a stale key.
+    void refresh(reloadSelectionKeyRef.current);
   }, [enabled, refresh]);
+
+  useEffect(() => {
+    if (!state.response) {
+      return;
+    }
+    writeReloadSelectionKey(selectedItemKey);
+  }, [selectedItemKey, state.response]);
 
   useEffect(() => {
     if (

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -137,6 +137,10 @@ const SubAgentTranscriptWindow = lazy(async () => ({
   default: (await import("./features/thread-detail/SubAgentTranscriptWindow"))
     .SubAgentTranscriptWindow,
 }));
+const ToolOutputIncidentExplorerWindow = lazy(async () => ({
+  default: (await import("./features/thread-detail/ToolOutputIncidentExplorerWindow"))
+    .ToolOutputIncidentExplorerWindow,
+}));
 const AutomationRunWindow = lazy(async () => ({
   default: (await import("./features/automations/AutomationRunWindow"))
     .AutomationRunWindow,
@@ -188,6 +192,10 @@ const routes: Array<{
   {
     match: (hash) => hash.startsWith("sub-agent/"),
     render: () => <SubAgentTranscriptWindow />,
+  },
+  {
+    match: (hash) => hash.startsWith("tool-output-incidents/"),
+    render: () => <ToolOutputIncidentExplorerWindow />,
   },
   {
     match: (hash) => hash.startsWith("automation-run/"),

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15425,6 +15425,17 @@ a.transcript-message__messaging-origin:focus-visible {
   display: grid;
   align-items: center;
   grid-template-columns: 128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px;
+  gap: 12px;
+  width: calc(100% + 16px);
+  margin: 0 -8px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 /* Cost rides at the end of the row, in the ledger's own units. It is the one
@@ -15442,17 +15453,6 @@ a.transcript-message__messaging-origin:focus-visible {
   font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
-  gap: 12px;
-  width: calc(100% + 16px);
-  margin: 0 -8px;
-  padding: 4px 8px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-primary);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
 }
 
 .incident-explorer__turn:hover {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15379,6 +15379,80 @@ a.transcript-message__messaging-origin:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+/* When it went: one column per turn across the whole thread, time order.
+   Tokens rise from the shared baseline, round trips hang below it, so a long
+   poll reads as trip spikes with no matching output directly above them. */
+.incident-explorer__timeline-block {
+  margin-top: 10px;
+}
+
+.incident-explorer__timeline {
+  display: flex;
+  align-items: stretch;
+  height: 40px;
+  overflow: hidden;
+}
+
+/* Column separation comes from a transparent right border rather than gap:
+   a 300-turn thread in a narrow window must compress to 1px columns instead
+   of overflowing, and gaps do not shrink. */
+.incident-explorer .incident-explorer__timeline-turn {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  min-width: 1px;
+  padding: 0;
+  border: 0;
+  border-right: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.incident-explorer .incident-explorer__timeline-turn:last-child {
+  border-right: 0;
+}
+
+.incident-explorer__timeline-turn:hover .incident-explorer__timeline-tokens i,
+.incident-explorer__timeline-turn[aria-pressed="true"] .incident-explorer__timeline-tokens i {
+  background: var(--accent-strong);
+}
+
+.incident-explorer__timeline-turn[aria-pressed="true"] {
+  background: var(--accent-soft);
+}
+
+.incident-explorer__timeline-tokens {
+  display: flex;
+  flex: 1;
+  align-items: flex-end;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__timeline-tokens i {
+  display: block;
+  width: 100%;
+  min-height: 1px;
+  background: var(--accent);
+}
+
+.incident-explorer__timeline-tokens i[data-critical="true"] {
+  background: var(--status-error);
+}
+
+.incident-explorer__timeline-trips {
+  display: flex;
+  flex: 0 0 11px;
+  align-items: flex-start;
+}
+
+.incident-explorer__timeline-trips i {
+  display: block;
+  width: 100%;
+  min-height: 1px;
+  background: color-mix(in srgb, var(--text-secondary) 66%, transparent);
+}
+
 /* Cost by turn. The solid bar is output volume; the tick rail is round trips.
    They are deliberately different marks because they are different problems:
    a turn heavy on ticks and light on bar is a polling loop, and the fix for

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15299,8 +15299,11 @@ a.transcript-message__messaging-origin:focus-visible {
   overflow: hidden;
 }
 
+/* A category the legend lists has to be visible in the bar the legend
+   explains, so a tiny share keeps a 2px mark instead of rounding away. */
 .incident-explorer__composition i {
   display: block;
+  min-width: 2px;
   height: 100%;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15425,6 +15425,23 @@ a.transcript-message__messaging-origin:focus-visible {
   display: grid;
   align-items: center;
   grid-template-columns: 128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px;
+}
+
+/* Cost rides at the end of the row, in the ledger's own units. It is the one
+   figure on this strip that is billed rather than estimated, so it takes the
+   primary text color while the estimates stay secondary. */
+.incident-explorer__turn[data-cost="true"] {
+  grid-template-columns:
+    128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px 64px;
+}
+
+.incident-explorer__turn-cost {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
   gap: 12px;
   width: calc(100% + 16px);
   margin: 0 -8px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15401,6 +15401,32 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 10px;
 }
 
+/* Scope toggle: quiet segmented pair, same visual weight as the legend so it
+   reads as a view control rather than a primary action. */
+.incident-explorer__turns-scope {
+  display: flex;
+  gap: 2px;
+  margin: 0 12px 6px auto;
+}
+
+.incident-explorer__turns-scope button {
+  padding: 2px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 10px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.incident-explorer__turns-scope button[aria-pressed="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
 .incident-explorer__turns-key {
   display: inline-block;
   width: 14px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15138,20 +15138,11 @@ a.transcript-message__messaging-origin:focus-visible {
   flex: 0 1 auto;
 }
 
-.incident-explorer__section-heading h2,
-.incident-explorer__evidence h2,
-.incident-explorer__prompt h2,
-.incident-explorer__output h2 {
+.incident-explorer h2 {
   margin: 0;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 650;
-}
-
-.incident-explorer__prompt p {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: 11px;
 }
 
 .incident-explorer__actions,
@@ -15163,9 +15154,48 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .incident-explorer__section-heading {
   justify-content: space-between;
+  margin-bottom: 9px;
 }
 
-.incident-explorer button,
+/* Three button weights, per the style guide's primary / secondary / ghost
+   rule. The window previously styled every `button` identically, which left
+   Close and the primary steering action reading as equals. */
+.incident-explorer__button {
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.incident-explorer__button--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.incident-explorer .incident-explorer__primary {
+  border-color: var(--accent-border);
+  background: var(--accent);
+  color: var(--button-text);
+  font-weight: 650;
+}
+
+.incident-explorer__button:hover:not(:disabled) {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.incident-explorer__button:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
 .incident-explorer input,
 .incident-explorer select,
 .incident-explorer textarea {
@@ -15176,50 +15206,296 @@ a.transcript-message__messaging-origin:focus-visible {
   font: inherit;
 }
 
-.incident-explorer button {
-  min-height: 30px;
-  padding: 5px 10px;
-  cursor: pointer;
-}
-
-.incident-explorer button:hover:not(:disabled),
 .incident-explorer button:focus-visible,
 .incident-explorer input:focus-visible,
 .incident-explorer select:focus-visible,
+.incident-explorer summary:focus-visible,
 .incident-explorer textarea:focus-visible {
-  border-color: var(--accent-border);
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
 }
 
-.incident-explorer button:disabled {
-  color: var(--text-muted);
-  cursor: default;
-}
-
-.incident-explorer__metrics {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.incident-explorer__metrics > div {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 12px 18px;
-  border-right: 1px solid var(--border-subtle);
-}
-
-.incident-explorer__metrics span {
+.incident-explorer__eyebrow {
+  margin: 0 0 6px;
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 650;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.incident-explorer__metrics strong {
-  font-size: 14px;
+/* Shared magnitude primitive. Same measurements as
+   `.context-usage-card__meter` so the app has one bar language. */
+.incident-explorer__meter {
+  display: block;
+  height: 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.incident-explorer__meter i {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  background: var(--accent);
+}
+
+.incident-explorer__meter i[data-critical="true"] {
+  background: var(--status-error);
+}
+
+.incident-explorer__caption {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.incident-explorer__summary {
+  display: grid;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  gap: 28px;
+  padding: 13px 18px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__hero {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 8px;
+}
+
+.incident-explorer__hero strong {
+  font-family: var(--font-mono);
+  font-size: 21px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+
+.incident-explorer__hero span {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.incident-explorer__caption b {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+/* One accent stepped down in strength rather than a categorical palette —
+   the style guide allows exactly one accent, and a five-color chart legend
+   would spend the product's whole color budget on a 5px strip. */
+.incident-explorer__composition {
+  display: flex;
+  gap: 2px;
+  height: 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.incident-explorer__composition i {
+  display: block;
+  height: 100%;
+}
+
+.incident-explorer__composition i[data-rank="1"],
+.incident-explorer__swatch[data-rank="1"] {
+  background: var(--accent);
+}
+
+.incident-explorer__composition i[data-rank="2"],
+.incident-explorer__swatch[data-rank="2"] {
+  background: color-mix(in srgb, var(--accent) 74%, transparent);
+}
+
+.incident-explorer__composition i[data-rank="3"],
+.incident-explorer__swatch[data-rank="3"] {
+  background: color-mix(in srgb, var(--accent) 54%, transparent);
+}
+
+.incident-explorer__composition i[data-rank="4"],
+.incident-explorer__swatch[data-rank="4"] {
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
+}
+
+.incident-explorer__composition i[data-rank="5"],
+.incident-explorer__swatch[data-rank="5"] {
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
+}
+
+.incident-explorer__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px 14px;
+  margin-top: 8px;
+}
+
+.incident-explorer__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.incident-explorer__legend-item[aria-pressed="true"] {
+  color: var(--text-primary);
+}
+
+.incident-explorer__legend-item:disabled {
+  cursor: default;
+}
+
+.incident-explorer__swatch {
+  display: block;
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+.incident-explorer__swatch--all {
+  background: color-mix(in srgb, var(--text-primary) 24%, transparent);
+}
+
+.incident-explorer__legend-item em {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Cost by turn. The solid bar is output volume; the tick rail is round trips.
+   They are deliberately different marks because they are different problems:
+   a turn heavy on ticks and light on bar is a polling loop, and the fix for
+   it has nothing to do with filtering output. */
+.incident-explorer__turns {
+  padding: 11px 18px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__turns-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.incident-explorer__turns-legend {
+  margin: 0 0 6px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.incident-explorer__turns-key {
+  display: inline-block;
+  width: 14px;
+  height: 5px;
+  border-radius: 2px;
+  vertical-align: middle;
+}
+
+.incident-explorer__turns-key[data-kind="tokens"] {
+  background: var(--accent);
+}
+
+.incident-explorer__turns-key[data-kind="trips"] {
+  background: repeating-linear-gradient(
+    90deg,
+    var(--text-secondary) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+.incident-explorer__turn {
+  display: grid;
+  align-items: center;
+  grid-template-columns: 128px minmax(0, 1fr) 72px minmax(0, 0.62fr) 66px;
+  gap: 12px;
+  width: calc(100% + 16px);
+  margin: 0 -8px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.incident-explorer__turn:hover {
+  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+}
+
+.incident-explorer__turn[aria-pressed="true"] {
+  background: var(--bg-row-active);
+  box-shadow: inset 2px 0 0 0 var(--accent);
+}
+
+.incident-explorer__turn-label {
+  overflow: hidden;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.incident-explorer__turn-label span {
+  color: var(--text-muted);
+}
+
+.incident-explorer__turn-bar,
+.incident-explorer__turn-trips {
+  height: 7px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.incident-explorer__turn-bar i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+.incident-explorer__turn-bar i[data-critical="true"] {
+  background: var(--status-error);
+}
+
+.incident-explorer__turn-trips i {
+  display: block;
+  height: 100%;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--text-secondary) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+.incident-explorer__turn-number {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.incident-explorer__turns-note {
+  margin: 7px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 .incident-explorer__coverage,
@@ -15232,10 +15508,20 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 12px;
 }
 
+/* A completed analysis is not a warning. Only the partial-coverage and
+   failure paths carry status color. */
+.incident-explorer__status[data-tone="info"] {
+  color: var(--text-secondary);
+}
+
+.incident-explorer__status[data-tone="error"] {
+  color: var(--status-error);
+}
+
 .incident-explorer__body {
   display: grid;
   flex: 1;
-  grid-template-columns: minmax(280px, 32%) minmax(0, 1fr);
+  grid-template-columns: minmax(300px, 34%) minmax(0, 1fr);
   min-height: 0;
 }
 
@@ -15250,7 +15536,7 @@ a.transcript-message__messaging-origin:focus-visible {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
-  padding: 12px;
+  padding: 11px 12px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -15258,46 +15544,96 @@ a.transcript-message__messaging-origin:focus-visible {
 .incident-explorer__filters select,
 .incident-explorer__section-heading input {
   min-width: 0;
-  padding: 7px 9px;
+  padding: 6px 9px;
+  font-size: 11px;
 }
 
-.incident-explorer__group h2 {
+.incident-explorer__active-filters {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 8px 7px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.incident-explorer__group h3 {
   margin: 0;
-  padding: 12px 12px 6px;
+  padding: 11px 12px 5px;
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 650;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.incident-explorer .incident-explorer__case {
-  display: flex;
-  align-items: stretch;
-  flex-direction: column;
+.incident-explorer__case {
+  display: block;
   width: 100%;
-  padding: 9px 12px;
+  padding: 8px 12px 9px;
   border: 0;
-  border-radius: 0;
   border-left: 2px solid transparent;
+  border-radius: 0;
   background: transparent;
+  color: var(--text-primary);
+  font: inherit;
   text-align: left;
+  cursor: pointer;
 }
 
-.incident-explorer .incident-explorer__case[data-selected="true"] {
+.incident-explorer__case:hover {
+  background: color-mix(in srgb, var(--text-primary) 3.5%, transparent);
+}
+
+.incident-explorer__case[data-selected="true"] {
   border-left-color: var(--accent);
   background: var(--bg-row-active);
 }
 
-.incident-explorer__case span {
+.incident-explorer__case-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+/* No `text-overflow: ellipsis` on purpose. The row label is already elided in
+   the middle, where the distinguishing part of a command lives; a CSS ellipsis
+   is an end-truncation and would cut that part back off. */
+.incident-explorer__case-id {
   overflow: hidden;
   font-family: var(--font-mono);
-  font-size: 11px;
-  text-overflow: ellipsis;
+  font-size: 12px;
   white-space: nowrap;
 }
 
-.incident-explorer__case small {
-  margin-top: 4px;
+.incident-explorer__case-id b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.incident-explorer__case-id span {
+  color: var(--text-muted);
+}
+
+.incident-explorer__case-tokens {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.incident-explorer__case .incident-explorer__meter {
+  height: 4px;
+  margin-top: 6px;
+}
+
+.incident-explorer__case-sub {
+  display: block;
+  margin-top: 5px;
   color: var(--text-muted);
   font-size: 10px;
 }
@@ -15305,57 +15641,172 @@ a.transcript-message__messaging-origin:focus-visible {
 .incident-explorer__detail {
   min-height: 0;
   overflow: auto;
-  padding: 18px;
+  padding: 16px 18px;
 }
 
 .incident-explorer__evidence,
 .incident-explorer__prompt,
 .incident-explorer__output {
-  margin-bottom: 18px;
+  margin-bottom: 16px;
 }
 
-.incident-explorer__evidence dl {
-  display: grid;
-  grid-template-columns: 110px minmax(0, 1fr);
-  gap: 7px 12px;
-  margin: 12px 0 0;
+/* The command is evidence, not the headline. Collapsed to one line by
+   default; a 1,100-character shell pipeline rendered in full was the loudest
+   thing in the window and the least decision-relevant. */
+.incident-explorer__identity {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px 7px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+}
+
+.incident-explorer__identity code {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.incident-explorer__identity[data-expanded="true"] {
+  align-items: flex-start;
+}
+
+.incident-explorer__identity[data-expanded="true"] code {
+  max-height: 180px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.incident-explorer__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+
+.incident-explorer__fact {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.incident-explorer__fact b {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.incident-explorer__fact[data-tone="ok"] b {
+  color: var(--status-ok);
+}
+
+.incident-explorer__fact[data-tone="warning"] b {
+  color: var(--status-warning);
+}
+
+.incident-explorer__fact[data-tone="error"] b {
+  color: var(--status-error);
+}
+
+.incident-explorer__budget {
+  margin-top: 11px;
+  padding: 11px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+}
+
+.incident-explorer__budget-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 9px;
+}
+
+.incident-explorer__budget-head strong {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.incident-explorer__budget-head span {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.incident-explorer__reason {
+  margin: 5px 0 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.incident-explorer__steer summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
   font-size: 12px;
+  list-style: none;
+  cursor: pointer;
 }
 
-.incident-explorer__evidence dt {
+.incident-explorer__steer summary::-webkit-details-marker {
+  display: none;
+}
+
+.incident-explorer__steer summary::before {
+  content: "›";
   color: var(--text-muted);
 }
 
-.incident-explorer__evidence dd {
-  margin: 0;
-  overflow-wrap: anywhere;
+.incident-explorer__steer[open] summary::before {
+  content: "⌄";
 }
 
-.incident-explorer__evidence code,
-.incident-explorer__output-lines code {
-  font-family: var(--font-mono);
-}
-
-.incident-explorer__prompt textarea {
+.incident-explorer__steer textarea {
   box-sizing: border-box;
   width: 100%;
-  margin: 10px 0 8px;
+  margin: 9px 0 0;
   padding: 10px;
-  resize: vertical;
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.5;
+  resize: vertical;
 }
 
-.incident-explorer .incident-explorer__primary {
-  border-color: var(--accent-border);
-  background: var(--accent);
-  color: var(--button-text);
-  font-weight: 650;
+.incident-explorer__prompt-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.incident-explorer__prompt-actions p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 .incident-explorer__output-lines {
-  max-height: 440px;
+  max-height: 360px;
   margin: 10px 0 0;
   padding: 10px 10px 10px 52px;
   overflow: auto;
@@ -15365,12 +15816,37 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--terminal-fg);
   font-size: 11px;
   line-height: 1.5;
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.incident-explorer__output-lines code {
+  font-family: var(--font-mono);
 }
 
 .incident-explorer__output-lines li::marker {
   color: var(--text-muted);
+}
+
+/* A message about missing output, not terminal content — so it takes the
+   panel surface rather than the terminal canvas, and the dashed border says
+   "nothing landed here" without color. */
+.incident-explorer__unavailable {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.incident-explorer__unavailable b {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .incident-explorer__empty {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15116,6 +15116,269 @@ a.transcript-message__messaging-origin:focus-visible {
   outline-offset: 2px;
 }
 
+.incident-explorer {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+
+.incident-explorer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.incident-explorer__header h1,
+.incident-explorer__section-heading h2,
+.incident-explorer__evidence h2,
+.incident-explorer__prompt h2,
+.incident-explorer__output h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.incident-explorer__header p,
+.incident-explorer__prompt p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.incident-explorer__actions,
+.incident-explorer__section-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.incident-explorer__section-heading {
+  justify-content: space-between;
+}
+
+.incident-explorer button,
+.incident-explorer input,
+.incident-explorer select,
+.incident-explorer textarea {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.incident-explorer button {
+  min-height: 30px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.incident-explorer button:hover:not(:disabled),
+.incident-explorer button:focus-visible,
+.incident-explorer input:focus-visible,
+.incident-explorer select:focus-visible,
+.incident-explorer textarea:focus-visible {
+  border-color: var(--accent-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.incident-explorer button:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.incident-explorer__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__metrics > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 18px;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__metrics span {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.incident-explorer__metrics strong {
+  font-size: 14px;
+}
+
+.incident-explorer__coverage,
+.incident-explorer__status,
+.incident-explorer__error {
+  margin: 0;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--status-warning);
+  font-size: 12px;
+}
+
+.incident-explorer__body {
+  display: grid;
+  flex: 1;
+  grid-template-columns: minmax(280px, 32%) minmax(0, 1fr);
+  min-height: 0;
+}
+
+.incident-explorer__list {
+  min-height: 0;
+  overflow: auto;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--bg-sidebar);
+}
+
+.incident-explorer__filters {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__filters input,
+.incident-explorer__filters select,
+.incident-explorer__section-heading input {
+  min-width: 0;
+  padding: 7px 9px;
+}
+
+.incident-explorer__group h2 {
+  margin: 0;
+  padding: 12px 12px 6px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.incident-explorer .incident-explorer__case {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  width: 100%;
+  padding: 9px 12px;
+  border: 0;
+  border-radius: 0;
+  border-left: 2px solid transparent;
+  background: transparent;
+  text-align: left;
+}
+
+.incident-explorer .incident-explorer__case[data-selected="true"] {
+  border-left-color: var(--accent);
+  background: var(--bg-row-active);
+}
+
+.incident-explorer__case span {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.incident-explorer__case small {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.incident-explorer__detail {
+  min-height: 0;
+  overflow: auto;
+  padding: 18px;
+}
+
+.incident-explorer__evidence,
+.incident-explorer__prompt,
+.incident-explorer__output {
+  margin-bottom: 18px;
+}
+
+.incident-explorer__evidence dl {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 7px 12px;
+  margin: 12px 0 0;
+  font-size: 12px;
+}
+
+.incident-explorer__evidence dt {
+  color: var(--text-muted);
+}
+
+.incident-explorer__evidence dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.incident-explorer__evidence code,
+.incident-explorer__output-lines code {
+  font-family: var(--font-mono);
+}
+
+.incident-explorer__prompt textarea {
+  box-sizing: border-box;
+  width: 100%;
+  margin: 10px 0 8px;
+  padding: 10px;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.incident-explorer .incident-explorer__primary {
+  border-color: var(--accent-border);
+  background: var(--accent);
+  color: var(--button-text);
+  font-weight: 650;
+}
+
+.incident-explorer__output-lines {
+  max-height: 440px;
+  margin: 10px 0 0;
+  padding: 10px 10px 10px 52px;
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--terminal-bg);
+  color: var(--terminal-fg);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.incident-explorer__output-lines li::marker {
+  color: var(--text-muted);
+}
+
+.incident-explorer__empty {
+  margin: 0;
+  padding: 14px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .transcript-message__image-button {
   box-sizing: border-box;
   display: flex;
@@ -20373,6 +20636,17 @@ a.transcript-message__messaging-origin:focus-visible {
 .tool-call-instance--noisy {
   border-color: color-mix(in srgb, var(--status-warning) 45%, var(--border-subtle));
   box-shadow: inset 2px 0 0 0 var(--status-warning);
+}
+
+.tool-calls-panel__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tool-calls-panel__heading h3 {
+  margin: 0;
 }
 
 .tool-call-alert .rail-card__title {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15125,17 +15125,19 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--text-primary);
 }
 
-.incident-explorer__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-panel-elevated);
+.incident-explorer .activity-titlebar__breadcrumb {
+  flex: 0 1 auto;
+  max-width: min(62vw, 720px);
 }
 
-.incident-explorer__header h1,
+.incident-explorer .activity-titlebar__crumb {
+  max-width: min(20vw, 220px);
+}
+
+.incident-explorer .thread-chip-group {
+  flex: 0 1 auto;
+}
+
 .incident-explorer__section-heading h2,
 .incident-explorer__evidence h2,
 .incident-explorer__prompt h2,
@@ -15146,7 +15148,6 @@ a.transcript-message__messaging-origin:focus-visible {
   font-weight: 650;
 }
 
-.incident-explorer__header p,
 .incident-explorer__prompt p {
   margin: 4px 0 0;
   color: var(--text-muted);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15621,6 +15621,15 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--text-muted);
 }
 
+/* Repeat marker rides in the token slot: it qualifies the cost rather than
+   competing with it, so it stays smaller and takes the warning tone. */
+.incident-explorer__repeat {
+  margin-right: 6px;
+  color: var(--status-warning);
+  font-size: 10px;
+  font-weight: 650;
+}
+
 .incident-explorer__case-tokens {
   color: var(--text-secondary);
   font-family: var(--font-mono);

--- a/apps/desktop/src/renderer/src/test/setup.ts
+++ b/apps/desktop/src/renderer/src/test/setup.ts
@@ -1,4 +1,13 @@
+import { afterEach } from "vitest";
+
 const originalConsoleError = console.error.bind(console);
+
+afterEach(() => {
+  // Renderer windows keep reload-only state in sessionStorage. Vitest reuses
+  // one jsdom window across files in a worker, so clear that window-scoped
+  // state at the test boundary just as closing a real BrowserWindow would.
+  window.sessionStorage.clear();
+});
 
 console.error = (...args: unknown[]) => {
   // The renderer suite asserts the visible states around these async paths.

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -153,6 +153,8 @@ export const NAVIGATION_SET_BROWSE_MODE_CHANNEL =
 export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";
 export const NAVIGATION_SET_THREAD_REACTION_CHANNEL =
   "navigation:set-thread-reaction";
+export const NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL =
+  "navigation:set-thread-tool-incident-notice";
 export const NAVIGATION_SET_THREAD_PIN_CHANNEL =
   "navigation:set-thread-pin";
 export const NAVIGATION_SET_THREAD_AGENT_CHANNEL =

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -474,6 +474,8 @@ export const SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL =
   "sub-agent-transcript:open-window";
 export const TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL =
   "tool-output-incident-explorer:open-window";
+export const TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL =
+  "tool-output-incident-explorer:refresh";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -476,6 +476,8 @@ export const TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL =
   "tool-output-incident-explorer:open-window";
 export const TOOL_OUTPUT_INCIDENT_EXPLORER_REFRESH_EVENT_CHANNEL =
   "tool-output-incident-explorer:refresh";
+export const TOOL_OUTPUT_INCIDENT_EXPLORER_SHOW_THREAD_CHANNEL =
+  "tool-output-incident-explorer:show-thread";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -44,6 +44,8 @@ export const STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL =
 export const STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL =
   "star-map:focus-main-window";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
+export const APP_SERVER_ANALYZE_THREAD_TOOL_HISTORY_CHANNEL =
+  "app-server:analyze-thread-tool-history";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";
 export const APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL =
@@ -470,6 +472,8 @@ export const MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL =
   "markdown-file-viewer:snapshot-changed";
 export const SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL =
   "sub-agent-transcript:open-window";
+export const TOOL_OUTPUT_INCIDENT_EXPLORER_WINDOW_OPEN_CHANNEL =
+  "tool-output-incident-explorer:open-window";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/packages/shared/src/__tests__/tool-output-incidents.test.ts
+++ b/packages/shared/src/__tests__/tool-output-incidents.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isFlaggedToolInvocation } from "../contracts/tool-output-incidents";
+
+describe("isFlaggedToolInvocation", () => {
+  it("flags a large result even when nothing marked the row", () => {
+    /* Threads whose turns predate the detectors carry `noisy = 0` on every
+       row. Trusting the flag alone showed an empty explorer next to a fully
+       populated turn strip — 575 oversized calls in one real thread, none of
+       them listed. */
+    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 17_771 }))
+      .toBe(true);
+  });
+
+  it("keeps trusting the stored flag for patterns a single row cannot show", () => {
+    /* Polling is a pattern across invocations: a 200-char row is only a case
+       because of the fifty rows around it, which the size test cannot see. */
+    expect(isFlaggedToolInvocation({ noisy: true, outputChars: 200 }))
+      .toBe(true);
+  });
+
+  it("leaves an ordinary small result alone", () => {
+    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 3_999 }))
+      .toBe(false);
+  });
+});

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -26,6 +26,7 @@ import type { DesktopGhDiscoverySnapshot } from "./settings";
 import type { BackendAcpSessionRuntimeState } from "./backend";
 import type { AutomationThreadSummary } from "./automations";
 import type { CelestialIconId } from "./celestial";
+import type { ThreadToolIncidentNoticeState } from "./tool-output-incidents";
 import type {
   FederatedThreadRef,
   FederationCapability,
@@ -1856,6 +1857,13 @@ export type ThreadOverlayState = {
    * (e.g., "needs follow-up"), not multi-user voting.
    */
   reactions?: string[];
+  /**
+   * Consolidated tool-output incident state for this thread: when it first
+   * warned, what the operator dismissed, and what they muted. Persisted so an
+   * undismissed incident is still waiting when the thread is reopened, and so
+   * the cost baseline does not reset on restart.
+   */
+  toolIncidentNotice?: ThreadToolIncidentNoticeState;
   /** User-curated position in the pinned section. Undefined means unpinned. */
   pinnedRank?: string;
   /**

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -864,6 +864,12 @@ export type AppServerReadThreadRequest = {
   before?: string;
   limit?: number;
   /**
+   * Return every persisted tool invocation instead of the ordinary 200-row
+   * thread-snapshot cap. Reserved for the thread-scoped incident explorer,
+   * which must agree with explicit full-history analysis coverage.
+   */
+  includeAllToolInvocations?: boolean;
+  /**
    * Reads transcript data without applying PwrAgent's normal selected-thread
    * enrichment writes. Used by inspection-only secondary windows such as the
    * native sub-agent transcript viewer.

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -17,6 +17,7 @@ import type {
   ThreadPrAutoDispatchPending,
 } from "./navigation";
 import type { ThreadPricingSummary, ThreadUsageLineRecord } from "../token-usage-pricing";
+import type { ThreadToolIncidentNoticeState } from "./tool-output-incidents";
 
 export type AppServerBuiltinBackendKind = "codex";
 export type AcpBackendId = `acp:${string}`;
@@ -1380,6 +1381,12 @@ export type AppServerNotification =
       params: {
         threadId: string;
         toolAccounting: ThreadToolAccounting;
+        /**
+         * The operator's persisted disposition for this thread's incident
+         * card. Carried here so a renderer that just launched knows what was
+         * dismissed or muted before it existed, without a per-thread read.
+         */
+        incidentNotice?: ThreadToolIncidentNoticeState;
         triggeredAlerts?: ThreadToolInvocationAlert[];
       };
     }

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -900,6 +900,7 @@ export type ThreadToolInvocationCategory =
   | "build-test"
   | "file-io"
   | "git"
+  | "mcp"
   | "package-manager"
   | "polling"
   | "search"
@@ -914,12 +915,22 @@ export type ThreadToolInvocationStatus =
   | "failed"
   | "cancelled";
 
+export type ThreadToolInvocationSource = "history" | "live";
+
+export type ThreadToolInvocationOutputState =
+  | "available"
+  | "compacted"
+  | "truncated"
+  | "unavailable";
+
 export type ThreadToolInvocationRecord = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   turnId?: string;
   itemId: string;
   invocationId: string;
+  /** Stable finding identity. Historical IDs are deterministic across rescans. */
+  findingId?: string;
   toolName: string;
   normalizedCommand?: string;
   category: ThreadToolInvocationCategory;
@@ -939,8 +950,11 @@ export type ThreadToolInvocationRecord = {
   infoLines: number;
   debugLines: number;
   outputTruncated: boolean;
+  outputState?: ThreadToolInvocationOutputState;
+  source?: ThreadToolInvocationSource;
   noisy: boolean;
   noisyReason?: string;
+  suggestedPrompt?: string;
 };
 
 export type ThreadToolInvocationSummary = {
@@ -971,8 +985,11 @@ export type ThreadToolInvocationAlert = {
   firstObservedAt: number;
   lastObservedAt: number;
   invocationCount: number;
+  invocationIds?: string[];
   totalOutputChars: number;
   estimatedOutputTokens: number;
+  worstInvocationId?: string;
+  worstOutputChars?: number;
   averageIntervalMs?: number;
   message: string;
   suggestedPrompt: string;
@@ -980,7 +997,20 @@ export type ThreadToolInvocationAlert = {
   updatedAt: number;
 };
 
+export type ThreadToolAnalysisCoverage = {
+  analyzerVersion: string;
+  analyzedAt: number;
+  completeness: "complete" | "partial";
+  entryCount: number;
+  invocationCount: number;
+  missingOutputCount: number;
+  pageCount: number;
+  scannedThrough?: string;
+  explanation?: string;
+};
+
 export type ThreadToolAccounting = {
+  analysis?: ThreadToolAnalysisCoverage;
   alerts: ThreadToolInvocationAlert[];
   invocations: ThreadToolInvocationRecord[];
   summaries: ThreadToolInvocationSummary[];

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -962,8 +962,9 @@ export type ThreadToolInvocationAlert = {
   alertId: string;
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
-  kind: "noisy-polling";
-  severity: "warning";
+  turnId?: string;
+  kind: "large-output" | "noisy-polling";
+  severity: "warning" | "critical";
   toolName: string;
   sessionId?: string;
   processId?: string;
@@ -1343,6 +1344,7 @@ export type AppServerNotification =
       params: {
         threadId: string;
         toolAccounting: ThreadToolAccounting;
+        triggeredAlerts?: ThreadToolInvocationAlert[];
       };
     }
   | {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -673,7 +673,8 @@ export type DesktopSettingsSnapshot = {
     /**
      * Shows the experimental Tool calls tab in the thread context rail.
      * The desktop app may still collect tool metrics while this is disabled;
-     * this only gates the operator-facing panel and noisy-polling alerts.
+     * this only gates the operator-facing panel. Replay-risk safety notices
+     * remain active because their cost grows while the turn is running.
      */
     threadToolAccounting?: DesktopSettingsValue<boolean>;
     /**

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -2,8 +2,12 @@ import type {
   AppServerBackendKind,
   ThreadToolAccounting,
   ThreadToolAnalysisCoverage,
+  ThreadToolInvocationAlert,
   ThreadToolInvocationRecord,
 } from "./normalized-app-server";
+import type { FederationTarget } from "./federation";
+
+type ThreadToolInvocationSeverity = ThreadToolInvocationAlert["severity"];
 
 /**
  * Characters per output token. A coarse estimate, but the same one the
@@ -47,6 +51,80 @@ export function isFlaggedToolInvocation(
 ): boolean {
   return invocation.noisy || invocation.outputChars >= TOOL_OUTPUT_WARNING_CHARS;
 }
+
+/**
+ * Per-thread state for the consolidated tool-output incident notice.
+ *
+ * One incident per thread, not one per turn. The alert stream is per-turn, so
+ * a busy thread minted a fresh durable notice every time it tripped a
+ * threshold — forty-one cards behind a pager, each needing its own dismissal.
+ * This is the state that lets a thread's incidents collapse into a single
+ * card that updates in place, and that survives a restart so an unread
+ * incident is still there when the operator comes back to the thread.
+ */
+export type ThreadToolIncidentNoticeState = {
+  /** When this thread first tripped a threshold. The cost baseline. */
+  firstWarningAt?: number;
+  /** Operator dismissed the card at this severity. */
+  dismissedSeverity?: ThreadToolInvocationSeverity;
+  dismissedAt?: number;
+  /**
+   * Operator asked not to be warned again at this severity. A strictly higher
+   * severity still breaks through — muting "the output is getting large" must
+   * not also mute "the output hit the cap and was truncated".
+   */
+  mutedSeverity?: ThreadToolInvocationSeverity;
+  mutedAt?: number;
+};
+
+export type ThreadToolIncidentSeverityRank = 0 | 1;
+
+/** Ordered so a comparison reads as "is this worse than what was silenced". */
+export function rankToolIncidentSeverity(
+  severity: ThreadToolInvocationSeverity,
+): ThreadToolIncidentSeverityRank {
+  return severity === "critical" ? 1 : 0;
+}
+
+/**
+ * Whether an incident at `severity` should surface, given what the operator
+ * already dismissed or muted for this thread.
+ */
+export function resolveToolIncidentVisibility(params: {
+  severity: ThreadToolInvocationSeverity;
+  state?: ThreadToolIncidentNoticeState;
+}): "show" | "suppress" {
+  const incoming = rankToolIncidentSeverity(params.severity);
+  const muted = params.state?.mutedSeverity;
+  if (muted !== undefined && incoming <= rankToolIncidentSeverity(muted)) {
+    return "suppress";
+  }
+  const dismissed = params.state?.dismissedSeverity;
+  if (dismissed !== undefined && incoming <= rankToolIncidentSeverity(dismissed)) {
+    return "suppress";
+  }
+  return "show";
+}
+
+export type SetThreadToolIncidentNoticeRequest = {
+  backend?: AppServerBackendKind;
+  federationTarget?: FederationTarget;
+  threadId: string;
+  /** Records a dismissal at this severity. */
+  dismissedSeverity?: ThreadToolInvocationSeverity;
+  /** Records a mute at this severity. Higher severities still surface. */
+  mutedSeverity?: ThreadToolInvocationSeverity;
+  /** First observed warning, recorded once so the cost baseline is stable. */
+  firstWarningAt?: number;
+  /** Clears dismissal and mute — the un-mute path. */
+  reset?: boolean;
+};
+
+export type SetThreadToolIncidentNoticeResponse = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  state: ThreadToolIncidentNoticeState;
+};
 
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -7,6 +7,7 @@ import type {
 
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;
+  projectLabel?: string;
   threadId: string;
   title: string;
 };

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -29,6 +29,25 @@ export function toolOutputCapShare(outputChars: number): number {
   return outputChars / TOOL_OUTPUT_CAP_CHARS;
 }
 
+/**
+ * Whether an invocation counts as a case.
+ *
+ * `noisy` is written at record time — live by the detectors while a turn runs,
+ * or by the history analyzer on demand. Neither has touched a thread whose
+ * turns predate the feature, so every one of its rows reads `noisy = 0` and a
+ * surface that filters on the flag alone shows an empty screen next to a
+ * populated turn strip. The size test is re-derivable from a row we already
+ * have, so derive it rather than trusting when the row was written.
+ *
+ * The flag still matters and is ORed in, because polling is a pattern across
+ * invocations: no single row carries enough to reconstruct it.
+ */
+export function isFlaggedToolInvocation(
+  invocation: Pick<ThreadToolInvocationRecord, "noisy" | "outputChars">,
+): boolean {
+  return invocation.noisy || invocation.outputChars >= TOOL_OUTPUT_WARNING_CHARS;
+}
+
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;
   projectLabel?: string;

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -5,6 +5,30 @@ import type {
   ThreadToolInvocationRecord,
 } from "./normalized-app-server";
 
+/**
+ * Characters per output token. A coarse estimate, but the same one the
+ * accounting analyzer and the incident explorer must agree on: a meter drawn
+ * against a different ratio than the detector that flagged the case would
+ * disagree with its own reason string.
+ */
+export const TOOL_OUTPUT_TOKEN_CHAR_RATIO = 4;
+
+/**
+ * The observed model-visible output cap, in characters (~10k tokens). This is
+ * the denominator that makes a per-case meter mean something absolute: a call
+ * at 100% is one the harness will truncate, and every character under it
+ * replays on every later inference item in the turn.
+ */
+export const TOOL_OUTPUT_CAP_CHARS = 40_000;
+
+/** Output at or above this is large enough to be worth flagging on its own. */
+export const TOOL_OUTPUT_WARNING_CHARS = 4_000;
+
+/** Fraction of the observed output cap this invocation consumed. Uncapped. */
+export function toolOutputCapShare(outputChars: number): number {
+  return outputChars / TOOL_OUTPUT_CAP_CHARS;
+}
+
 export type OpenToolOutputIncidentExplorerWindowRequest = {
   backend: AppServerBackendKind;
   projectLabel?: string;

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -1,0 +1,76 @@
+import type {
+  AppServerBackendKind,
+  ThreadToolAccounting,
+  ThreadToolAnalysisCoverage,
+  ThreadToolInvocationRecord,
+} from "./normalized-app-server";
+
+export type OpenToolOutputIncidentExplorerWindowRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  title: string;
+};
+
+export type OpenToolOutputIncidentExplorerWindowResponse = {
+  opened: true;
+};
+
+export type AnalyzeThreadToolHistoryRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+};
+
+export type AnalyzeThreadToolHistoryResponse = {
+  accounting: ThreadToolAccounting;
+  coverage: ThreadToolAnalysisCoverage;
+};
+
+export function buildThreadToolIncidentPrompt(params: {
+  invocation: ThreadToolInvocationRecord;
+  reason: string;
+}): string {
+  const invocation = params.invocation;
+  const identity = invocation.normalizedCommand ?? invocation.toolName;
+  const timestamp = new Date(invocation.observedAt).toLocaleString();
+  const exitState = invocation.exitCode !== undefined
+    ? `${invocation.status} (exit ${invocation.exitCode})`
+    : invocation.status;
+  const outputState = invocation.outputState
+    ?? (invocation.outputTruncated ? "truncated" : "available");
+  const evidence = [
+    `Invocation: ${identity}`,
+    `Observed: ${timestamp}`,
+    `Status: ${exitState}`,
+    `Output: ${invocation.outputChars.toLocaleString()} characters (~${invocation.estimatedOutputTokens.toLocaleString()} tokens)`,
+    `Output state: ${outputState}`,
+    `Why flagged: ${params.reason}`,
+  ].join("\n");
+  return [
+    "Reduce the replay-amplifying tool use identified below.",
+    evidence,
+    guidanceForInvocation(invocation),
+    "Report the exact command/tool identity, exit state, concise result, failures or warnings, and only a bounded tail or targeted fields needed for the next decision.",
+  ].join("\n\n");
+}
+
+function guidanceForInvocation(invocation: ThreadToolInvocationRecord): string {
+  if (invocation.category === "file-io") {
+    return "For file reads, narrow the file set and request only the specific line ranges needed.";
+  }
+  if (invocation.category === "search") {
+    return "For search, constrain paths and patterns, then cap the number and size of returned matches.";
+  }
+  if (
+    invocation.category === "build-test"
+    || invocation.category === "package-manager"
+  ) {
+    return "For tests, lint, or builds, redirect complete stdout/stderr to a local log and return only failures, warnings, a concise summary, and a bounded tail.";
+  }
+  if (invocation.category === "polling") {
+    return "Stop polling in the main thread. Use PwrAgent's create_monitor_delegation tool with the durable command, cwd, log/status files, cadence, and terminal success/failure conditions.";
+  }
+  if (invocation.category === "mcp") {
+    return "For MCP calls, request only targeted fields and use pagination or a bounded result limit.";
+  }
+  return "Redirect complete output to a local log and retrieve only targeted sections or a bounded tail when more detail is needed.";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,6 +27,7 @@ export * from "./contracts/rbac";
 export * from "./contracts/settings";
 export * from "./contracts/scheduled-thread-actions";
 export * from "./contracts/subagent-transcript";
+export * from "./contracts/tool-output-incidents";
 export * from "./contracts/thread-link";
 export * from "./contracts/thread-tools";
 export * from "./contracts/thread-search";


### PR DESCRIPTION
## Summary

- I capture the tool-output incident explorer's web-contents ID before Electron destroys the window, so its `closed` cleanup no longer throws `Object has been destroyed`.
- I retain the focused thread in window-local `sessionStorage` and restore it through the existing validated snapshot-selection path after a full renderer reload.
- I keep the August 13 React-root HMR fix in place; reverting it would restore the double-root DOM corruption that fix removed.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (133 tests passed)
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- I verified the reload behavior end to end in the isolated dev profile: I focused “Most Recent PwrSnap,” triggered the known Vite fallback (`Could not Fast Refresh` followed by `page reload src/main.tsx`), and confirmed the same thread remained focused after reload.
- I closed the isolated dev-profile app through the normal shutdown path and confirmed its log contained no `Object has been destroyed` or uncaught-exception report.

## Notes

- This is stacked on #1664 because the tool-output incident explorer that produced the shutdown exception is still in that PR stack and is not yet on `main`.
