### PR TITLE
fix(desktop): preserve focused thread across HMR reloads

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -23,14 +23,12 @@ import { useThreadNavigation } from "../useThreadNavigation";
 
 describe("useThreadNavigation", () => {
   beforeEach(() => {
-    window.sessionStorage.clear();
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
   });
 
   afterEach(() => {
     endNativeDragInteraction();
-    window.sessionStorage.clear();
     delete (window as unknown as {
       __pwragentNavigationPreferences?: unknown;
     }).__pwragentNavigationPreferences;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -23,12 +23,14 @@ import { useThreadNavigation } from "../useThreadNavigation";
 
 describe("useThreadNavigation", () => {
   beforeEach(() => {
+    window.sessionStorage.clear();
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
   });
 
   afterEach(() => {
     endNativeDragInteraction();
+    window.sessionStorage.clear();
     delete (window as unknown as {
       __pwragentNavigationPreferences?: unknown;
     }).__pwragentNavigationPreferences;
@@ -39,6 +41,59 @@ describe("useThreadNavigation", () => {
       __pwragentFederationLabel?: unknown;
     }).__pwragentFederationLabel;
     vi.restoreAllMocks();
+  });
+
+  it("restores the selected thread after a full renderer reload", async () => {
+    const snapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+        {
+          id: "thread-2",
+          title: "Focused before reload",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => snapshot),
+      onAgentEvent: () => () => undefined,
+    };
+    const firstRenderer = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(firstRenderer.result.current.selectedThread?.id).toBe("thread-1");
+    });
+    act(() => {
+      firstRenderer.result.current.selectThread(snapshot.threads[1]!);
+    });
+    await waitFor(() => {
+      expect(firstRenderer.result.current.selectedThread?.id).toBe("thread-2");
+    });
+    firstRenderer.unmount();
+
+    const reloadedRenderer = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(reloadedRenderer.result.current.selectedThread?.id).toBe("thread-2");
+    });
+    reloadedRenderer.unmount();
   });
 
   function createDeferred<T>(): {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -112,6 +112,7 @@ const NAVIGATION_ACTIVITY_EVENTS = [
   "paste",
   "pointerdown",
 ] as const;
+const RELOAD_SELECTION_STORAGE_KEY = "pwragent.navigation.reloadSelection";
 
 const DEFAULT_BROWSE_MODE = DEFAULT_NAVIGATION_BROWSE_MODE;
 const normalizeBrowseMode = normalizeNavigationBrowseMode;
@@ -124,6 +125,34 @@ function readBridgedBrowseMode(): BrowseMode {
     __pwragentNavigationPreferences?: { browseMode?: unknown };
   }).__pwragentNavigationPreferences;
   return normalizeBrowseMode(bridged?.browseMode);
+}
+
+function readReloadSelectionKey(): string | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  try {
+    return window.sessionStorage.getItem(RELOAD_SELECTION_STORAGE_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeReloadSelectionKey(selectionKey?: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (selectionKey) {
+      window.sessionStorage.setItem(RELOAD_SELECTION_STORAGE_KEY, selectionKey);
+    } else {
+      window.sessionStorage.removeItem(RELOAD_SELECTION_STORAGE_KEY);
+    }
+  } catch {
+    // Navigation still works when the renderer denies storage access.
+  }
 }
 
 function isRendererViewForeground(): boolean {
@@ -3013,6 +3042,7 @@ export function useThreadNavigation(
   });
   const [viewForeground, setViewForeground] = useState(isRendererViewForeground);
   const prChipLocationIndexRef = useRef<PrChipLocationIndex | undefined>(undefined);
+  const reloadSelectionKeyRef = useRef(readReloadSelectionKey());
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
   const retainedUnreadThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
@@ -3626,8 +3656,20 @@ export function useThreadNavigation(
       return;
     }
 
-    void refresh();
+    // sessionStorage is scoped to this BrowserWindow and survives the full
+    // page reload Vite uses when an HMR update reaches the renderer entry.
+    // Feed the remembered selection through the normal validated preferred-
+    // selection path so a removed thread falls back instead of stranding the
+    // detail pane on a stale key.
+    void refresh(reloadSelectionKeyRef.current);
   }, [enabled, refresh]);
+
+  useEffect(() => {
+    if (!state.response) {
+      return;
+    }
+    writeReloadSelectionKey(selectedItemKey);
+  }, [selectedItemKey, state.response]);
 
   useEffect(() => {
     if (

--- a/apps/desktop/src/renderer/src/test/setup.ts
+++ b/apps/desktop/src/renderer/src/test/setup.ts
@@ -1,4 +1,13 @@
+import { afterEach } from "vitest";
+
 const originalConsoleError = console.error.bind(console);
+
+afterEach(() => {
+  // Renderer windows keep reload-only state in sessionStorage. Vitest reuses
+  // one jsdom window across files in a worker, so clear that window-scoped
+  // state at the test boundary just as closing a real BrowserWindow would.
+  window.sessionStorage.clear();
+});
 
 console.error = (...args: unknown[]) => {
   // The renderer suite asserts the visible states around these async paths.


### PR DESCRIPTION
## Summary

- I retain the focused thread in window-local `sessionStorage` so Vite's full-page HMR fallback does not reset the operator to the first thread.
- I restore the remembered key through the existing validated preferred-selection path, so a thread that no longer exists still falls back normally.
- I clear renderer `sessionStorage` at the shared Vitest boundary, matching a real BrowserWindow lifetime and preventing cross-file test contamination.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer` (2,831 tests passed)
- `pnpm --filter @pwragent/desktop typecheck`
- ESLint on the three changed files (0 errors; existing warnings only)
- `git diff --check origin/main...HEAD`
- I previously verified this behavior end to end by focusing a non-default thread, triggering Vite's `Could not Fast Refresh` full-page reload, and confirming the same thread remained focused.

## Notes

- This branch starts at the post-revert `main` commit and contains only three renderer files. It does not contain the tool-output incident stack that was accidentally included when #1676 was retargeted.
