### PR TITLE
feat(desktop): price Grok 4.6 usage

### DIFF
--- a/apps/desktop/e2e/fixtures/thread-pricing-panel/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/thread-pricing-panel/replay.fixture.json
@@ -38,7 +38,7 @@
             "inInbox": true,
             "reason": "new-thread"
           },
-          "updatedAt": 1781616385000
+          "updatedAt": 1783598401000
         }
       ]
     },
@@ -164,7 +164,7 @@
             "type": "activity",
             "id": "usage-xai-priced",
             "summary": "Turn usage: 400 uncached in · 0 cached · 120 out · $0.002 list price",
-            "createdAt": 1781616395000,
+            "createdAt": 1783598400000,
             "status": "completed",
             "details": [
               {
@@ -181,8 +181,8 @@
               "backend": "codex",
               "cachedInputCostMicros": 0,
               "cachedInputTokens": 0,
-              "completedAt": 1781616396000,
-              "createdAt": 1781616395000,
+              "completedAt": 1783598401000,
+              "createdAt": 1783598400000,
               "currency": "USD",
               "fastMode": false,
               "inputTokens": 400,

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -850,7 +850,7 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
         cachedInputTokens: 128,
         completedAt: Date.UTC(2026, 7, 15),
         createdAt: Date.UTC(2026, 7, 15),
-        inputTokens: 255_459,
+        inputTokens: 155_459,
         model: "grok-4.6",
         outputTokens: 266,
         priceStatus: "unpriced",
@@ -858,10 +858,11 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
         pricingCatalogId: undefined,
         pricingCatalogVersion: undefined,
         pricingRateId: undefined,
+        provider: "xai",
         reasoningOutputTokens: 130,
         totalCostMicros: 0,
-        totalTokens: 255_725,
-        uncachedInputTokens: 255_331,
+        totalTokens: 155_725,
+        uncachedInputTokens: 155_331,
         usageLineId: "line-grok-4-6",
       }),
     });
@@ -876,16 +877,62 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       pricingCatalogId: "xai-api",
       pricingCatalogVersion: "2026-08-12",
       pricingRateId:
-        "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
+        "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
       provider: "xai",
-      totalCostMicros: 1_024_644,
+      totalCostMicros: 312_322,
     });
     expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
     expect(pricing.summaries[0]).toMatchObject({
       pricedUsageLineCount: 1,
       provider: "xai",
-      totalCostMicros: 1_024_644,
+      totalCostMicros: 312_322,
       unpricedUsageLineCount: 0,
+    });
+  });
+
+  it("leaves ambiguous Grok 4.6 long-context turn aggregates unpriced", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        backend: "acp:grok",
+        cachedInputTokens: 128,
+        completedAt: Date.UTC(2026, 7, 15),
+        createdAt: Date.UTC(2026, 7, 15),
+        inputTokens: 255_459,
+        model: "grok-4.6",
+        outputTokens: 266,
+        priceStatus: "unpriced",
+        priceUnavailableReason: "missing-rate",
+        pricingCatalogId: undefined,
+        pricingCatalogVersion: undefined,
+        pricingRateId: undefined,
+        provider: "xai",
+        reasoningOutputTokens: 130,
+        totalCostMicros: 0,
+        totalTokens: 255_725,
+        uncachedInputTokens: 255_331,
+        usageLineId: "line-grok-4-6-aggregate",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "acp:grok",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      priceStatus: "unpriced",
+      priceUnavailableReason: "missing-rate",
+      provider: "xai",
+      totalCostMicros: 0,
+    });
+    expect(pricing.lines[0]?.pricingCatalogId).toBeUndefined();
+    expect(pricing.lines[0]?.pricingCatalogVersion).toBeUndefined();
+    expect(pricing.lines[0]?.pricingRateId).toBeUndefined();
+    expect(pricing.summaries[0]).toMatchObject({
+      pricedUsageLineCount: 0,
+      provider: "xai",
+      totalCostMicros: 0,
+      unpricedUsageLineCount: 1,
     });
   });
 
@@ -983,13 +1030,15 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     await store.upsertThreadUsageLine({ line: buildUsageLine() });
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
+        createdAt: Date.UTC(2026, 6, 26),
         model: "grok-4.5",
-        outputCostMicros: 2_000,
+        outputCostMicros: 1_800,
         provider: "xai",
         pricingCatalogId: "xai-api",
         pricingCatalogVersion: "2026-07-17",
         pricingRateId: "xai:2026-07-17:grok-4.5:standard",
-        totalCostMicros: 3_000,
+        totalCostMicros: 3_460,
+        uncachedInputCostMicros: 1_600,
         usageLineId: "xai-line-1",
       }),
     });
@@ -1008,7 +1057,7 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       }),
       expect.objectContaining({
         provider: "xai",
-        totalCostMicros: 3_000,
+        totalCostMicros: 3_460,
         usageLineCount: 1,
       }),
     ]);

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -843,6 +843,52 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("reprices persisted Grok 4.6 usage under the xAI provider", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        backend: "acp:grok",
+        cachedInputTokens: 128,
+        completedAt: Date.UTC(2026, 7, 15),
+        createdAt: Date.UTC(2026, 7, 15),
+        inputTokens: 255_459,
+        model: "grok-4.6",
+        outputTokens: 266,
+        priceStatus: "unpriced",
+        priceUnavailableReason: "missing-rate",
+        pricingCatalogId: undefined,
+        pricingCatalogVersion: undefined,
+        pricingRateId: undefined,
+        reasoningOutputTokens: 130,
+        totalCostMicros: 0,
+        totalTokens: 255_725,
+        uncachedInputTokens: 255_331,
+        usageLineId: "line-grok-4-6",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "acp:grok",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      priceStatus: "priced",
+      pricingCatalogId: "xai-api",
+      pricingCatalogVersion: "2026-08-12",
+      pricingRateId:
+        "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
+      provider: "xai",
+      totalCostMicros: 1_024_644,
+    });
+    expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
+    expect(pricing.summaries[0]).toMatchObject({
+      pricedUsageLineCount: 1,
+      provider: "xai",
+      totalCostMicros: 1_024_644,
+      unpricedUsageLineCount: 0,
+    });
+  });
+
   it("reprices persisted Qwen ACP usage under the Qwen provider", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -6220,6 +6220,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
   if (
     line.provider !== "openai"
     && line.provider !== "qwen"
+    && line.provider !== "xai"
   ) {
     return line;
   }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -2503,7 +2503,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          service_tier,
          uncached_input_tokens
        FROM thread_usage_lines
-       WHERE provider IN ('openai', 'qwen')
+       WHERE provider IN ('openai', 'qwen', 'xai')
          AND scope != 'fork-baseline'`,
     )
     .all() as Array<{

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -286,6 +286,86 @@ describe("token usage pricing", () => {
     });
   });
 
+  it("prices Grok 4.6 usage with the xAI list rate", () => {
+    const cost = estimateTokenUsageCost({
+      at: Date.UTC(2026, 7, 15),
+      cachedInputTokens: 128,
+      model: "grok-4.6",
+      outputTokens: 266,
+      reasoningOutputTokens: 130,
+      uncachedInputTokens: 255_331,
+    });
+
+    expect(cost).toMatchObject({
+      cachedInputCostMicros: 128,
+      cachedInputUsdPerMillion: 1,
+      catalogId: "xai-api",
+      catalogVersion: "2026-08-12",
+      displayName: "Grok 4.6 Standard (>=200K input)",
+      inputUsdPerMillion: 4,
+      model: "grok-4.6",
+      outputCostMicros: 3_192,
+      outputTokensIncludeReasoning: true,
+      outputUsdPerMillion: 12,
+      provider: "xai",
+      rateId: "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
+      serviceTier: "standard",
+      totalCostMicros: 1_024_644,
+      totalUsd: 1.024644,
+      uncachedInputCostMicros: 1_021_324,
+    });
+  });
+
+  it("prices the Grok 4.6 latest alias", () => {
+    expect(
+      estimateTokenUsageCost({
+        at: Date.UTC(2026, 7, 15),
+        cachedInputTokens: 50_000,
+        model: "grok-4.6-latest",
+        outputTokens: 100_000,
+        uncachedInputTokens: 50_000,
+      }),
+    ).toMatchObject({
+      cachedInputUsdPerMillion: 0.5,
+      inputUsdPerMillion: 2,
+      outputUsdPerMillion: 6,
+      rateId: "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
+      totalCostMicros: 725_000,
+    });
+  });
+
+  it("switches Grok 4.6 to long-context pricing at 200K input tokens", () => {
+    const estimateAtInputTokens = (inputTokens: number) =>
+      estimateTokenUsageCost({
+        at: Date.UTC(2026, 7, 15),
+        cachedInputTokens: 0,
+        model: "grok-4.6",
+        outputTokens: 0,
+        uncachedInputTokens: inputTokens,
+      });
+
+    expect(estimateAtInputTokens(199_999)).toMatchObject({
+      inputUsdPerMillion: 2,
+      rateId: "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
+    });
+    expect(estimateAtInputTokens(200_000)).toMatchObject({
+      inputUsdPerMillion: 4,
+      rateId: "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
+    });
+  });
+
+  it("does not price Grok 4.6 usage before its launch date", () => {
+    expect(
+      estimateTokenUsageCost({
+        at: Date.UTC(2026, 7, 11, 23, 59, 59),
+        cachedInputTokens: 0,
+        model: "grok-4.6",
+        outputTokens: 100,
+        uncachedInputTokens: 100,
+      }),
+    ).toBeUndefined();
+  });
+
   it("prices Qwen ACP ModelStudio usage with the International list rate", () => {
     const cost = estimateTokenUsageCost({
       at: Date.UTC(2026, 6, 28),
@@ -401,6 +481,32 @@ describe("token usage pricing", () => {
         provider: "openai",
         rateId: "openai:2026-07-30:gpt-5.6-luna:priority",
         serviceTier: "priority",
+      }),
+    );
+    expect(listTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        cachedInputUsdPerMillion: 0.5,
+        catalogId: "xai-api",
+        catalogVersion: "2026-08-12",
+        displayName: "Grok 4.6 Standard (<200K input)",
+        inputUsdPerMillion: 2,
+        model: "grok-4.6",
+        outputUsdPerMillion: 6,
+        provider: "xai",
+        rateId: "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
+      }),
+    );
+    expect(listTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        cachedInputUsdPerMillion: 1,
+        catalogId: "xai-api",
+        catalogVersion: "2026-08-12",
+        displayName: "Grok 4.6 Standard (>=200K input)",
+        inputUsdPerMillion: 4,
+        model: "grok-4.6",
+        outputUsdPerMillion: 12,
+        provider: "xai",
+        rateId: "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
       }),
     );
     expect(listTokenUsagePricingRates()).toContainEqual(

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -290,6 +290,7 @@ describe("token usage pricing", () => {
     const cost = estimateTokenUsageCost({
       at: Date.UTC(2026, 7, 15),
       cachedInputTokens: 128,
+      inputTokensAreSingleRequest: true,
       model: "grok-4.6",
       outputTokens: 266,
       reasoningOutputTokens: 130,
@@ -334,11 +335,15 @@ describe("token usage pricing", () => {
     });
   });
 
-  it("switches Grok 4.6 to long-context pricing at 200K input tokens", () => {
-    const estimateAtInputTokens = (inputTokens: number) =>
+  it("requires single-request evidence for Grok 4.6 long-context pricing", () => {
+    const estimateAtInputTokens = (
+      inputTokens: number,
+      inputTokensAreSingleRequest?: boolean,
+    ) =>
       estimateTokenUsageCost({
         at: Date.UTC(2026, 7, 15),
         cachedInputTokens: 0,
+        inputTokensAreSingleRequest,
         model: "grok-4.6",
         outputTokens: 0,
         uncachedInputTokens: inputTokens,
@@ -348,7 +353,8 @@ describe("token usage pricing", () => {
       inputUsdPerMillion: 2,
       rateId: "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
     });
-    expect(estimateAtInputTokens(200_000)).toMatchObject({
+    expect(estimateAtInputTokens(200_000)).toBeUndefined();
+    expect(estimateAtInputTokens(200_000, true)).toMatchObject({
       inputUsdPerMillion: 4,
       rateId: "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
     });

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -214,6 +214,8 @@ type PricingCatalogEntry = {
   outputTokensIncludeReasoning?: boolean;
   provider: TokenUsagePricingProvider;
   rateBandId?: string;
+  // Per-request thresholds cannot be selected safely from multi-call totals.
+  requiresSingleRequestInput?: boolean;
   serviceTier: TokenUsagePricingServiceTier;
 };
 
@@ -521,6 +523,7 @@ const XAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     outputUsdPerMillion: 12,
     provider: "xai",
     rateBandId: "input-gte-200k",
+    requiresSingleRequestInput: true,
     serviceTier: "standard",
   },
   {
@@ -750,6 +753,8 @@ export function estimateTokenUsageCost(params: {
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
+  // True only when the input count is known to belong to one model request.
+  inputTokensAreSingleRequest?: boolean;
   outputTokensIncludeReasoning?: boolean;
   model?: string;
   outputTokens: number;
@@ -765,6 +770,7 @@ function estimateTokenUsageCostFromCatalog(
     cachedInputTokens: number;
     at?: number;
     fastMode?: boolean;
+    inputTokensAreSingleRequest?: boolean;
     outputTokensIncludeReasoning?: boolean;
     model?: string;
     outputTokens: number;
@@ -786,6 +792,7 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
+        params.inputTokensAreSingleRequest,
       ),
   );
   const provider = matchingEntries[0]?.provider;
@@ -813,6 +820,7 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
+        params.inputTokensAreSingleRequest,
       ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
@@ -1090,10 +1098,14 @@ function pricingEntryMatchesModel(
 function pricingEntryMatchesInputTokens(
   entry: PricingCatalogEntry,
   inputTokens: number,
+  inputTokensAreSingleRequest: boolean | undefined,
 ): boolean {
   return (
-    entry.maximumInputTokens === undefined
-    || inputTokens <= entry.maximumInputTokens
+    (!entry.requiresSingleRequestInput || inputTokensAreSingleRequest === true)
+    && (
+      entry.maximumInputTokens === undefined
+      || inputTokens <= entry.maximumInputTokens
+    )
   );
 }
 

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -263,6 +263,9 @@ const OPENAI_CODEX_FAST_RATE_MULTIPLIERS = {
 const XAI_PRICING_CATALOG_ID = "xai-api";
 const XAI_PRICING_CATALOG_VERSION = "2026-07-17";
 const XAI_GROK45_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 8);
+// https://docs.x.ai/developers/pricing
+const XAI_GROK46_PRICING_CATALOG_VERSION = "2026-08-12";
+const XAI_GROK46_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 7, 12);
 // ModelStudio Standard, Singapore / International list pricing:
 // https://www.alibabacloud.com/help/en/model-studio/model-pricing
 // Implicit-cache hits cost 20% of the normal input-token rate:
@@ -487,6 +490,39 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
 ];
 
 const XAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  {
+    aliases: ["grok-4.6-latest"],
+    cachedInputUsdPerMillion: 0.5,
+    catalogId: XAI_PRICING_CATALOG_ID,
+    catalogVersion: XAI_GROK46_PRICING_CATALOG_VERSION,
+    displayModel: "Grok 4.6",
+    displayTier: "Standard (<200K input)",
+    effectiveFrom: XAI_GROK46_PRICING_EFFECTIVE_FROM,
+    inputUsdPerMillion: 2,
+    maximumInputTokens: 199_999,
+    model: "grok-4.6",
+    outputTokensIncludeReasoning: true,
+    outputUsdPerMillion: 6,
+    provider: "xai",
+    rateBandId: "input-lt-200k",
+    serviceTier: "standard",
+  },
+  {
+    aliases: ["grok-4.6-latest"],
+    cachedInputUsdPerMillion: 1,
+    catalogId: XAI_PRICING_CATALOG_ID,
+    catalogVersion: XAI_GROK46_PRICING_CATALOG_VERSION,
+    displayModel: "Grok 4.6",
+    displayTier: "Standard (>=200K input)",
+    effectiveFrom: XAI_GROK46_PRICING_EFFECTIVE_FROM,
+    inputUsdPerMillion: 4,
+    model: "grok-4.6",
+    outputTokensIncludeReasoning: true,
+    outputUsdPerMillion: 12,
+    provider: "xai",
+    rateBandId: "input-gte-200k",
+    serviceTier: "standard",
+  },
   {
     aliases: [
       "grok-4.5-build",


### PR DESCRIPTION
## Summary

- I added Grok 4.6 standard API pricing for uncached input, cached input, and output tokens, including the doubled rates at the 200K-token long-context threshold.
- I added support for both `grok-4.6` and `grok-4.6-latest`, with the August 12, 2026 catalog effective date.
- I extended pricing repair to persisted xAI records and require single-request evidence before applying long-context rates, leaving ambiguous multi-call turn aggregates unpriced.

## Verification

- I ran `pnpm test packages/shared/src/__tests__/token-usage-pricing.test.ts apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts apps/desktop/src/main/__tests__/state-db.test.ts` (84 tests passed).
- I ran `pnpm lint:eslint` (no errors; existing warning baseline only).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- Grok 4.6 keeps Grok 4.5's uncached input and output rates, but its cached-input rate is higher: $0.50/M below 200K and $1/M at or above 200K.
