### PR TITLE
feat(desktop): split the Attention tab's turn count by machine

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -75,9 +75,12 @@ import { DirectoriesList } from "./DirectoriesList";
 import { RecentsList } from "./RecentsList";
 import {
   formatActiveThreadCount,
+  formatLocalActiveThreadCount,
+  formatRemoteActiveThreadCount,
   formatReviewThreadCount,
   isThreadActive,
   isThreadNeedingAttention,
+  isThreadRemoteWork,
 } from "./ThreadRowStatus";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
@@ -495,25 +498,39 @@ export function Sidebar(props: SidebarProps) {
           ? props.recentThreads ?? props.threads
           : updatedOrderThreads;
   /**
-   * The two numbers on the Attention tab. Counted over the very rows the lens
+   * The numbers on the Attention tab. Counted over the very rows the lens
    * renders, not over `props.threads`, so the tab and the list cannot report
-   * different populations — `active + review` is the queue's length by
+   * different populations — the counts sum to the queue's length by
    * construction. A live turn wins over "to review" so one thread is never
    * counted twice; membership already guarantees a row that is not active is
    * awaiting review, which is the same split the directory headers use.
+   *
+   * Live turns split again by where they run. Only this instance's turns hold
+   * shutdown open, so "can I quit now?" is answerable from the tab alone —
+   * which it is not while one number mixes work on two machines.
    */
+  const federationWindowTarget = useMemo(
+    () => readRendererFederationTarget(),
+    [],
+  );
   const attentionCounts = useMemo(() => {
-    let active = 0;
+    let activeLocal = 0;
+    let activeRemote = 0;
     let review = 0;
     for (const thread of attentionThreads) {
-      if (isThreadActive(thread, props.thinkingThreadKeys)) {
-        active += 1;
-      } else {
+      if (!isThreadActive(thread, props.thinkingThreadKeys)) {
         review += 1;
+      } else if (isThreadRemoteWork(thread, federationWindowTarget)) {
+        activeRemote += 1;
+      } else {
+        activeLocal += 1;
       }
     }
-    return { active, review };
-  }, [attentionThreads, props.thinkingThreadKeys]);
+    return { activeLocal, activeRemote, review };
+  }, [attentionThreads, federationWindowTarget, props.thinkingThreadKeys]);
+  const remoteSignalVisible = useLingeringRemoteActiveSignal(
+    attentionCounts.activeRemote,
+  );
   const revealSelectedThreadRequest = props.revealSelectedThreadRequest;
   const selectedItemKey = props.selectedItemKey;
   const navigationThreads = props.threads;
@@ -1827,7 +1844,10 @@ export function Sidebar(props: SidebarProps) {
               <AttentionLensTab
                 key={mode}
                 active={props.browseMode === mode}
-                activeThreadCount={attentionCounts.active}
+                activeThreadCount={attentionCounts.activeLocal}
+                remoteActiveThreadCount={
+                  remoteSignalVisible ? attentionCounts.activeRemote : undefined
+                }
                 reviewThreadCount={attentionCounts.review}
                 onSelect={() => props.onBrowseModeChange(mode)}
               />
@@ -2810,10 +2830,52 @@ function ProfileIdentityButton(props: {
 }
 
 /**
+ * How long the remote-turn readout stays up after the last peer turn ends.
+ *
+ * The row is not a permanent fixture — an operator with no federation, or none
+ * of a peer's work running, gets exactly the tab they had before. But dropping
+ * it the instant the count hits zero would take the answer away at the moment
+ * it becomes interesting: "the peer just finished" is worth half a minute of
+ * a visible 0, and a row that vanishes mid-glance reads as a glitch.
+ */
+const REMOTE_ACTIVE_SIGNAL_LINGER_MS = 30_000;
+
+/**
+ * Whether the Attention tab shows its remote-turn readout: any peer turn
+ * running, or one that ended inside the linger window.
+ */
+function useLingeringRemoteActiveSignal(count: number): boolean {
+  const [visible, setVisible] = useState(count > 0);
+  useEffect(() => {
+    if (count > 0) {
+      setVisible(true);
+      return;
+    }
+    if (!visible) {
+      return;
+    }
+    const timer = setTimeout(
+      () => setVisible(false),
+      REMOTE_ACTIVE_SIGNAL_LINGER_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [count, visible]);
+  return visible;
+}
+
+/**
  * The Attention tab. Where the other three lenses show a static icon, this one
- * shows the two numbers it exists for: threads with a live turn, and threads
+ * shows the numbers it exists for: threads with a live turn, and threads
  * waiting to be reviewed. Each pairs the same indicator its thread rows use —
  * the scanner and the orange cookie.
+ *
+ * Live turns split in two once a peer is running work this window can see. The
+ * accent scanner counts turns on this machine, the neutral one below it counts
+ * turns on other instances, and the difference is the one that matters at
+ * quitting time: a local turn holds shutdown open and a peer's does not (see
+ * `isThreadRemoteWork`). Colour carries it because the question is asked at a
+ * glance — an operator should not have to open a tooltip to learn whether the
+ * app is safe to close.
  *
  * A zero count stays on the tab and goes grey rather than disappearing. That
  * is the point of the tab: "nothing running, nothing unread" has to be legible
@@ -2825,22 +2887,52 @@ function ProfileIdentityButton(props: {
 function AttentionLensTab(props: {
   active: boolean;
   activeThreadCount: number;
+  /**
+   * Peer turns this window can see. `undefined` means the readout is not on —
+   * no federated work has run recently — and the tab reads exactly as it does
+   * on an instance that has never federated.
+   */
+  remoteActiveThreadCount?: number;
   reviewThreadCount: number;
   onSelect: () => void;
 }) {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
-  const tooltipText = [
-    browseModeTooltips.attention,
-    `${formatActiveThreadCount(props.activeThreadCount)} · ${formatReviewThreadCount(props.reviewThreadCount)}`,
-  ].join("\n");
+  const remoteActiveThreadCount = props.remoteActiveThreadCount;
+  // Split wording only once there is something to tell apart. "2 active
+  // threads" is the whole truth on an unfederated instance, and qualifying it
+  // with "on this machine" would raise a question the operator does not have.
+  const activeLines = remoteActiveThreadCount === undefined
+    ? [formatActiveThreadCount(props.activeThreadCount)]
+    : [
+      `${formatLocalActiveThreadCount(props.activeThreadCount)} — blocks quit`,
+      `${formatRemoteActiveThreadCount(remoteActiveThreadCount)} — does not block quit`,
+    ];
+  const tooltipText = remoteActiveThreadCount === undefined
+    ? [
+      browseModeTooltips.attention,
+      `${activeLines[0]} · ${formatReviewThreadCount(props.reviewThreadCount)}`,
+    ].join("\n")
+    : [
+      browseModeTooltips.attention,
+      ...activeLines,
+      formatReviewThreadCount(props.reviewThreadCount),
+    ].join("\n");
+  const accessibleName = [
+    browseModeLabels.attention,
+    ...(remoteActiveThreadCount === undefined
+      ? [formatActiveThreadCount(props.activeThreadCount)]
+      : [
+        formatLocalActiveThreadCount(props.activeThreadCount),
+        formatRemoteActiveThreadCount(remoteActiveThreadCount),
+      ]),
+    formatReviewThreadCount(props.reviewThreadCount),
+  ].join(", ");
 
   return (
     <>
       <button
         role="tab"
-        aria-label={`${browseModeLabels.attention}, ${formatActiveThreadCount(
-          props.activeThreadCount,
-        )}, ${formatReviewThreadCount(props.reviewThreadCount)}`}
+        aria-label={accessibleName}
         aria-selected={props.active}
         className={`lens-switch__button lens-switch__button--attention${
           props.active ? " is-active" : ""
@@ -2855,27 +2947,29 @@ function AttentionLensTab(props: {
         onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipText)}
         onMouseLeave={tooltip.hide}
       >
-        <span
-          aria-hidden="true"
-          className="lens-switch__signal lens-switch__signal--active"
-          data-attention-active-count={props.activeThreadCount}
-          data-zero={props.activeThreadCount === 0 ? "true" : undefined}
-        >
-          {props.activeThreadCount === 0 ? (
-            // A static stand-in, NOT a greyed-out `ThinkingScanner`. Killing
-            // the sweep with CSS on a mounted scanner is a desync trap:
-            // `data-zero` lives on this span, so React keeps the same scanner
-            // element across the flip, its ref never re-runs, and the restarted
-            // animation is never re-pinned to the shared epoch — leaving this
-            // tab drifting against every other scanner on screen. Swapping the
-            // element type guarantees a mount, so
-            // `syncThinkingScannerAnimation` runs and the beam comes back in
-            // phase. See ThinkingScanner.tsx and PR #1187.
-            <span className="lens-switch__dormant-scanner" />
-          ) : (
-            <ThinkingScanner compact />
+        {/* One column so the second readout stacks under the first instead of
+            widening the tab. The Attention tab already floors the switch's
+            narrowest track (see `.lens-switch`), and a third readout laid out
+            across would take that room from the four icon tabs. */}
+        <span aria-hidden="true" className="lens-switch__turns">
+          <span
+            className="lens-switch__signal lens-switch__signal--active"
+            data-attention-active-count={props.activeThreadCount}
+            data-zero={props.activeThreadCount === 0 ? "true" : undefined}
+          >
+            <AttentionTurnScanner count={props.activeThreadCount} />
+            <span>{props.activeThreadCount}</span>
+          </span>
+          {remoteActiveThreadCount === undefined ? null : (
+            <span
+              className="lens-switch__signal lens-switch__signal--remote-active"
+              data-attention-remote-active-count={remoteActiveThreadCount}
+              data-zero={remoteActiveThreadCount === 0 ? "true" : undefined}
+            >
+              <AttentionTurnScanner count={remoteActiveThreadCount} />
+              <span>{remoteActiveThreadCount}</span>
+            </span>
           )}
-          <span>{props.activeThreadCount}</span>
         </span>
         <span
           aria-hidden="true"
@@ -2889,6 +2983,31 @@ function AttentionLensTab(props: {
       </button>
       {tooltip.tooltipNode}
     </>
+  );
+}
+
+/**
+ * The sweeping bar next to one of the Attention tab's turn counts, or its idle
+ * stand-in.
+ *
+ * At zero this is a static element, NOT a greyed-out `ThinkingScanner`.
+ * Killing the sweep with CSS on a mounted scanner is a desync trap: `data-zero`
+ * lives on the parent span, so React would keep the same scanner element across
+ * the flip, its ref would never re-run, and the restarted animation would never
+ * be re-pinned to the shared epoch — leaving this tab drifting against every
+ * other scanner on screen. Swapping the element type guarantees a mount, so
+ * `syncThinkingScannerAnimation` runs and the beam comes back in phase. See
+ * ThinkingScanner.tsx and PR #1187.
+ *
+ * The remote readout's beam is neutral rather than accent, but it is the same
+ * untouched component tinted by its parent's tokens — a peer's turn is running
+ * for real, so it sweeps for real, on the same epoch as the rest.
+ */
+function AttentionTurnScanner(props: { count: number }) {
+  return props.count === 0 ? (
+    <span className="lens-switch__dormant-scanner" />
+  ) : (
+    <ThinkingScanner compact />
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -2905,6 +2905,8 @@ function AttentionLensTab(props: {
   // doing the structural work. See "Structured hover cards" in AGENTS.md.
   const tooltip = useViewportTooltip({ className: "attention-card" });
   const remoteActiveThreadCount = props.remoteActiveThreadCount;
+  // Creating this element is not rendering it: it stays an inert object until
+  // `show` hands it to the portal on hover or focus.
   const card = (
     <>
       <div className="attention-card__eyebrow">{browseModeLabels.attention}</div>
@@ -2956,6 +2958,36 @@ function AttentionLensTab(props: {
       ]),
     formatReviewThreadCount(props.reviewThreadCount),
   ].join(", ");
+
+  // Turns start and end while the pointer rests on the tab, so push fresh
+  // numbers into an already-open card rather than freezing it at hover-time
+  // values — the same thing `PrChip` does for a live PR status. Freezing is
+  // not cosmetic here: the card would keep claiming there is no peer work
+  // after a peer starts a turn, on the one surface that exists to answer
+  // "can I quit now?".
+  //
+  // The key guard is not optional: a React element is a new object on every
+  // render, so feeding one straight into `update` would set state on every
+  // render that very update caused. Compare the card's DATA and push only
+  // when it moved.
+  const latestCardRef = useRef(card);
+  latestCardRef.current = card;
+  const cardKey = [
+    props.activeThreadCount,
+    remoteActiveThreadCount ?? "off",
+    props.reviewThreadCount,
+  ].join("|");
+  const pushedCardKeyRef = useRef<string | undefined>(undefined);
+  const tooltipVisible = tooltip.visible;
+  const updateTooltip = tooltip.update;
+  useEffect(() => {
+    const moved = pushedCardKeyRef.current !== cardKey;
+    pushedCardKeyRef.current = cardKey;
+    if (!moved || !tooltipVisible) {
+      return;
+    }
+    updateTooltip(latestCardRef.current);
+  }, [cardKey, tooltipVisible, updateTooltip]);
 
   return (
     <>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -305,13 +305,15 @@ const browseModeIcons = {
 
 // Nothing on the tab spells out what the lens shows now that the labels are
 // gone, so the viewport tooltip carries both the name and the explanation.
+// Attention is absent for the same reason it is absent from `browseModeIcons`:
+// it reports state rather than just naming a lens, so it hovers a structured
+// card (`AttentionLensTab`) instead of a line of text.
 const browseModeTooltips = {
-  attention: "Attention — threads in progress or waiting to be reviewed",
   drafts: "Drafts — threads with a reply you started and never sent",
   inbox: "Updated — all threads, most recently updated first",
   recents: "Created — all threads, newest created first",
   directories: "Directories — threads grouped by linked Git directory",
-} satisfies Record<BrowseMode, string>;
+} satisfies Record<Exclude<BrowseMode, "attention">, string>;
 
 /**
  * The Drafts tab's count, for the tooltip and the accessible name.
@@ -2896,27 +2898,54 @@ function AttentionLensTab(props: {
   reviewThreadCount: number;
   onSelect: () => void;
 }) {
-  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  // A card, not a text tooltip. Every other lens tab explains itself in one
+  // line; this one reports two or three counts, each with its own indicator
+  // and — once a peer is running work — a consequence. Run through
+  // `.viewport-tooltip` that became four stacked sentences with em-dashes
+  // doing the structural work. See "Structured hover cards" in AGENTS.md.
+  const tooltip = useViewportTooltip({ className: "attention-card" });
   const remoteActiveThreadCount = props.remoteActiveThreadCount;
-  // Split wording only once there is something to tell apart. "2 active
-  // threads" is the whole truth on an unfederated instance, and qualifying it
-  // with "on this machine" would raise a question the operator does not have.
-  const activeLines = remoteActiveThreadCount === undefined
-    ? [formatActiveThreadCount(props.activeThreadCount)]
-    : [
-      `${formatLocalActiveThreadCount(props.activeThreadCount)} — blocks quit`,
-      `${formatRemoteActiveThreadCount(remoteActiveThreadCount)} — does not block quit`,
-    ];
-  const tooltipText = remoteActiveThreadCount === undefined
-    ? [
-      browseModeTooltips.attention,
-      `${activeLines[0]} · ${formatReviewThreadCount(props.reviewThreadCount)}`,
-    ].join("\n")
-    : [
-      browseModeTooltips.attention,
-      ...activeLines,
-      formatReviewThreadCount(props.reviewThreadCount),
-    ].join("\n");
+  const card = (
+    <>
+      <div className="attention-card__eyebrow">{browseModeLabels.attention}</div>
+      <div className="attention-card__caption">
+        Threads in progress or waiting to be reviewed
+      </div>
+      <div className="attention-card__section">
+        <AttentionCardRow
+          count={props.activeThreadCount}
+          indicator="turn"
+          // Only qualify the row once there is something to tell it apart
+          // from. "In progress" is the whole truth on an unfederated
+          // instance, and naming the machine would raise a question the
+          // operator does not have.
+          label={
+            remoteActiveThreadCount === undefined
+              ? "In progress"
+              : "In progress here"
+          }
+          note={
+            remoteActiveThreadCount === undefined
+              ? undefined
+              : "Quitting interrupts these"
+          }
+        />
+        {remoteActiveThreadCount === undefined ? null : (
+          <AttentionCardRow
+            count={remoteActiveThreadCount}
+            indicator="remote-turn"
+            label="In progress elsewhere"
+            note="Quitting leaves these running"
+          />
+        )}
+        <AttentionCardRow
+          count={props.reviewThreadCount}
+          indicator="review"
+          label="To review"
+        />
+      </div>
+    </>
+  );
   const accessibleName = [
     browseModeLabels.attention,
     ...(remoteActiveThreadCount === undefined
@@ -2933,6 +2962,11 @@ function AttentionLensTab(props: {
       <button
         role="tab"
         aria-label={accessibleName}
+        // The card's consequence lines ("Quitting interrupts these") exist
+        // nowhere else — without this they are sighted-only, since the portal
+        // sits outside this button's subtree. Gated on `visible`: naming an
+        // absent element is a dangling reference.
+        aria-describedby={tooltip.visible ? tooltip.tooltipId : undefined}
         aria-selected={props.active}
         className={`lens-switch__button lens-switch__button--attention${
           props.active ? " is-active" : ""
@@ -2943,8 +2977,8 @@ function AttentionLensTab(props: {
           tooltip.hide();
           props.onSelect();
         }}
-        onFocus={(event) => tooltip.show(event.currentTarget, tooltipText)}
-        onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onFocus={(event) => tooltip.show(event.currentTarget, card)}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, card)}
         onMouseLeave={tooltip.hide}
       >
         {/* One column so the second readout stacks under the first instead of
@@ -3008,6 +3042,52 @@ function AttentionTurnScanner(props: { count: number }) {
     <span className="lens-switch__dormant-scanner" />
   ) : (
     <ThinkingScanner compact />
+  );
+}
+
+/**
+ * One line of the Attention hover card: the tab's own indicator, what it
+ * counts, and the count. Repeating the indicator is what ties a row to the
+ * readout the operator just hovered — a card of bare labels would make them
+ * re-derive which number is which.
+ */
+function AttentionCardRow(props: {
+  count: number;
+  indicator: "turn" | "remote-turn" | "review";
+  label: string;
+  /** What quitting does to this row's work. Omitted when nothing is at stake. */
+  note?: string;
+}) {
+  return (
+    <div
+      className="attention-card__row"
+      data-zero={props.count === 0 ? "true" : undefined}
+    >
+      <span
+        aria-hidden="true"
+        className={`lens-switch__signal lens-switch__signal--${
+          props.indicator === "review"
+            ? "review"
+            : props.indicator === "remote-turn"
+              ? "remote-active"
+              : "active"
+        }`}
+        data-zero={props.count === 0 ? "true" : undefined}
+      >
+        {props.indicator === "review" ? (
+          <span className="thread-row__status-cookie" />
+        ) : (
+          <AttentionTurnScanner count={props.count} />
+        )}
+      </span>
+      <span className="attention-card__row-text">
+        <span className="attention-card__row-label">{props.label}</span>
+        {props.note ? (
+          <span className="attention-card__row-note">{props.note}</span>
+        ) : null}
+      </span>
+      <span className="attention-card__row-value">{props.count}</span>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -1,4 +1,7 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  FederationRemoteTarget,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
@@ -23,6 +26,39 @@ export function isThreadActive(
 
 export function formatActiveThreadCount(count: number): string {
   return `${count} active thread${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Which machine a row's work actually runs on.
+ *
+ * Two things make a row remote, and only checking one of them gets it wrong on
+ * a surface that matters. A federation-stamped row is a peer's thread carried
+ * into an unscoped window by a pin or a mounted parent. A window that fronts a
+ * peer is the other case: its snapshot comes from that peer, so every row in it
+ * is the peer's work and none of them carry a stamp — from the owner's side
+ * they are local, and the stamp is only added on the way into someone else's
+ * window.
+ *
+ * The distinction is load-bearing for the Attention tab: turns are driven by
+ * the registry of the instance that owns them (see `buildQuitBlockerSnapshot`
+ * in the main process), so only local work can hold this app's shutdown open.
+ */
+export function isThreadRemoteWork(
+  thread: NavigationThreadSummary,
+  federationWindowTarget?: FederationRemoteTarget,
+): boolean {
+  return (
+    federationWindowTarget !== undefined
+    || thread.federation?.ref.target.scope === "remote"
+  );
+}
+
+export function formatLocalActiveThreadCount(count: number): string {
+  return `${formatActiveThreadCount(count)} on this machine`;
+}
+
+export function formatRemoteActiveThreadCount(count: number): string {
+  return `${formatActiveThreadCount(count)} on other instances`;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2934,6 +2934,56 @@ describe("Sidebar", () => {
       expect(tab).toHaveAttribute("aria-describedby", card.id);
     });
 
+    it("pushes fresh counts into a card the pointer is still resting on", async () => {
+      // Turns start and end while the pointer sits on the tab, and this card
+      // is where "can I quit now?" gets answered. Frozen at hover-time values
+      // it would disagree with the readout directly under it, and would keep
+      // claiming there is no peer work after a peer starts a turn.
+      const remoteActive = {
+        ...activeThread,
+        id: "thread-remote-live",
+        federation: {
+          instanceLabel: "studio",
+          ref: {
+            backend: "codex" as const,
+            target: { scope: "remote" as const, instanceId: "peer-1" },
+            threadId: "thread-remote-live",
+          },
+        },
+      };
+      const props = (threads: typeof allThreads) => ({
+        backends,
+        browseMode: "inbox" as const,
+        createThreadError: undefined,
+        directories,
+        inboxThreads: threads,
+        launchpadError: undefined,
+        loading: false,
+        creatingThread: undefined,
+        selectedItemKey: undefined,
+        threads,
+        onBrowseModeChange: () => undefined,
+        onCreateThread: async () => undefined,
+        onOpenLaunchpad: async () => undefined,
+        onSelectThread: () => undefined,
+      });
+
+      const view = render(<Sidebar {...props([activeThread, unreadThread])} />);
+      fireEvent.mouseEnter(screen.getByRole("tab", { name: /^Attention,/ }));
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        /In progress1/,
+      );
+
+      // A peer starts a turn without the pointer ever leaving the tab.
+      view.rerender(
+        <Sidebar {...props([activeThread, remoteActive, unreadThread])} />,
+      );
+
+      const card = await screen.findByRole("tooltip");
+      expect(card).toHaveTextContent(/In progress elsewhere/);
+      expect(card).toHaveTextContent(/Quitting leaves these running/);
+    });
+
     it("names the machines and what quitting does once a peer is running work", async () => {
       const remoteActive = {
         ...activeThread,

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2711,6 +2711,150 @@ describe("Sidebar", () => {
       }
     });
 
+    describe("remote turn readout", () => {
+      const remoteActiveThread = {
+        ...activeThread,
+        id: "thread-remote-active",
+        title: "Remote active thread",
+        federation: {
+          instanceLabel: "studio",
+          ref: {
+            backend: "codex" as const,
+            target: { scope: "remote" as const, instanceId: "peer-1" },
+            threadId: "thread-remote-active",
+          },
+        },
+      };
+      const remoteSidebarProps = (threads: typeof allThreads) => ({
+        backends,
+        browseMode: "inbox" as const,
+        createThreadError: undefined,
+        directories,
+        inboxThreads: threads,
+        launchpadError: undefined,
+        loading: false,
+        creatingThread: undefined,
+        selectedItemKey: undefined,
+        threads,
+        onBrowseModeChange: () => undefined,
+        onCreateThread: async () => undefined,
+        onOpenLaunchpad: async () => undefined,
+        onSelectThread: () => undefined,
+      });
+
+      it("stays off the tab entirely when no peer work has run", () => {
+        // The whole point of the second readout is that an operator who never
+        // federates sees the tab they always had. A permanent "0" would put a
+        // federation concept on every instance's sidebar.
+        render(<Sidebar {...remoteSidebarProps([activeThread, unreadThread])} />);
+
+        const tab = screen.getByRole("tab", {
+          name: "Attention, 1 active thread, 1 thread to review",
+        });
+        expect(
+          tab.querySelector("[data-attention-remote-active-count]"),
+        ).toBeNull();
+      });
+
+      it("splits local from peer turns, and says which blocks quitting", () => {
+        render(
+          <Sidebar
+            {...remoteSidebarProps([activeThread, remoteActiveThread, unreadThread])}
+          />,
+        );
+
+        const tab = screen.getByRole("tab", {
+          name:
+            "Attention, 1 active thread on this machine, "
+            + "1 active thread on other instances, 1 thread to review",
+        });
+        expect(
+          tab.querySelector("[data-attention-active-count]"),
+        ).toHaveAttribute("data-attention-active-count", "1");
+        expect(
+          tab.querySelector("[data-attention-remote-active-count]"),
+        ).toHaveAttribute("data-attention-remote-active-count", "1");
+        // Live work, so it sweeps — both readouts mount a real scanner. The
+        // remote one is neutral by token, not by being switched off.
+        expect(tab.querySelectorAll(".thinking-scanner")).toHaveLength(2);
+      });
+
+      it("holds a zeroed peer readout for the linger window, then drops it", () => {
+        vi.useFakeTimers();
+        try {
+          const view = render(
+            <Sidebar {...remoteSidebarProps([activeThread, remoteActiveThread])} />,
+          );
+
+          const settled = [
+            activeThread,
+            { ...remoteActiveThread, threadStatus: "idle" as const },
+          ];
+          view.rerender(<Sidebar {...remoteSidebarProps(settled)} />);
+
+          // A row that vanishes the instant the peer finishes takes the answer
+          // away exactly when it becomes interesting.
+          const lingering = screen.getByRole("tab", { name: /^Attention,/ });
+          const remote = lingering.querySelector(
+            "[data-attention-remote-active-count]",
+          );
+          expect(remote).toHaveAttribute(
+            "data-attention-remote-active-count",
+            "0",
+          );
+          expect(remote).toHaveAttribute("data-zero", "true");
+
+          act(() => {
+            vi.advanceTimersByTime(30_000);
+          });
+
+          expect(
+            screen
+              .getByRole("tab", { name: /^Attention,/ })
+              .querySelector("[data-attention-remote-active-count]"),
+          ).toBeNull();
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("keeps the readout up when a peer starts again mid-linger", () => {
+        vi.useFakeTimers();
+        try {
+          const idleRemote = {
+            ...remoteActiveThread,
+            threadStatus: "idle" as const,
+          };
+          const view = render(
+            <Sidebar {...remoteSidebarProps([activeThread, remoteActiveThread])} />,
+          );
+          view.rerender(
+            <Sidebar {...remoteSidebarProps([activeThread, idleRemote])} />,
+          );
+          act(() => {
+            vi.advanceTimersByTime(20_000);
+          });
+          view.rerender(
+            <Sidebar {...remoteSidebarProps([activeThread, remoteActiveThread])} />,
+          );
+
+          // The linger timer has to be cancelled, not merely outrun: firing it
+          // would blank a readout showing live peer work.
+          act(() => {
+            vi.advanceTimersByTime(30_000);
+          });
+
+          expect(
+            screen
+              .getByRole("tab", { name: /^Attention,/ })
+              .querySelector("[data-attention-remote-active-count]"),
+          ).toHaveAttribute("data-attention-remote-active-count", "1");
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+    });
+
     it("counts a live turn once, as active rather than to-review", () => {
       // A thread can be both running and unread. The tab must not report it
       // twice — same split the directory headers use.

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2915,14 +2915,62 @@ describe("Sidebar", () => {
       ).toBeInTheDocument();
     });
 
-    it("explains the lens in its tooltip, including the live counts", async () => {
+    it("explains the lens in a hover card, including the live counts", async () => {
       renderAttention();
 
       const tab = screen.getByRole("tab", { name: /^Attention,/ });
       fireEvent.mouseEnter(tab);
-      expect((await screen.findByRole("tooltip")).textContent).toBe(
-        "Attention — threads in progress or waiting to be reviewed"
-          + "\n1 active thread · 1 thread to review",
+      const card = await screen.findByRole("tooltip");
+      // A card rather than `.viewport-tooltip`: this tab reports counts, and
+      // running text made the reader parse em-dashes to find them.
+      expect(card).toHaveClass("attention-card");
+      expect(card).toHaveTextContent(
+        /AttentionThreads in progress or waiting to be reviewedIn progress1To review1/,
+      );
+      // Unfederated: no machine named, because there is nothing to tell apart.
+      expect(card.textContent).not.toContain("Quitting");
+      // The consequence lines exist nowhere else, so the card has to be
+      // reachable to a screen reader rather than sighted-only.
+      expect(tab).toHaveAttribute("aria-describedby", card.id);
+    });
+
+    it("names the machines and what quitting does once a peer is running work", async () => {
+      const remoteActive = {
+        ...activeThread,
+        id: "thread-remote-card",
+        federation: {
+          instanceLabel: "studio",
+          ref: {
+            backend: "codex" as const,
+            target: { scope: "remote" as const, instanceId: "peer-1" },
+            threadId: "thread-remote-card",
+          },
+        },
+      };
+      render(
+        <Sidebar
+          backends={backends}
+          browseMode="inbox"
+          createThreadError={undefined}
+          directories={directories}
+          inboxThreads={[activeThread, remoteActive, unreadThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey={undefined}
+          threads={[activeThread, remoteActive, unreadThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+      fireEvent.mouseEnter(screen.getByRole("tab", { name: /^Attention,/ }));
+      const card = await screen.findByRole("tooltip");
+      expect(card).toHaveTextContent(/In progress here.*Quitting interrupts these/);
+      expect(card).toHaveTextContent(
+        /In progress elsewhere.*Quitting leaves these running/,
       );
     });
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -154,4 +154,48 @@ describe("useViewportTooltip", () => {
       expect(screen.getByRole("tooltip")).toHaveStyle({ top: "118px" });
     });
   });
+
+  it("keeps clear of the macOS stoplight strip, which the app shell does not fence off", async () => {
+    // `titleBarStyle: "hiddenInset"` reserves the traffic lights INSIDE the
+    // renderer, so `.app-shell` starts at 0 and the shell-boundary clamp lets a
+    // tooltip park on top of the close/minimize/zoom buttons and the wordmark
+    // beside them. `.sidebar__masthead` is the drag strip that holds them (its
+    // 80px left padding IS their room), so its bottom is the real floor.
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("app-shell")) {
+          return rectangle({ top: 0, width: 1200, height: 800 });
+        }
+        if (this.classList.contains("sidebar__masthead")) {
+          return rectangle({ top: 0, width: 320, height: 46 });
+        }
+        if (this.getAttribute("role") === "tooltip") {
+          return rectangle({ width: 236, height: 120 });
+        }
+        if (this.tagName === "BUTTON") {
+          return rectangle({ left: 20, top: 96, width: 72, height: 26 });
+        }
+        return rectangle({});
+      },
+    );
+
+    vi.stubGlobal("innerWidth", 1200);
+    vi.stubGlobal("innerHeight", 800);
+
+    render(
+      <div className="app-shell">
+        <header className="sidebar__masthead" />
+        <TooltipFixture />
+      </div>,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+
+    await waitFor(() => {
+      // Above needs 96 − 120 − 10 = −34, which is over the stoplights. Below
+      // the 26px-tall target fits, so it flips there rather than being clamped
+      // onto the strip.
+      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "132px" });
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -155,47 +155,127 @@ describe("useViewportTooltip", () => {
     });
   });
 
-  it("keeps clear of the macOS stoplight strip, which the app shell does not fence off", async () => {
+  describe("macOS stoplight gutter", () => {
     // `titleBarStyle: "hiddenInset"` reserves the traffic lights INSIDE the
     // renderer, so `.app-shell` starts at 0 and the shell-boundary clamp lets a
     // tooltip park on top of the close/minimize/zoom buttons and the wordmark
-    // beside them. `.sidebar__masthead` is the drag strip that holds them (its
-    // 80px left padding IS their room), so its bottom is the real floor.
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
-      function getBoundingClientRect(this: HTMLElement) {
+    // beside them. Whichever strip carries the 80px reservation is the real
+    // floor.
+    function mockStoplightLayout(gutterClass: string) {
+      vi.spyOn(
+        HTMLElement.prototype,
+        "getBoundingClientRect",
+      ).mockImplementation(function getBoundingClientRect(this: HTMLElement) {
         if (this.classList.contains("app-shell")) {
           return rectangle({ top: 0, width: 1200, height: 800 });
         }
-        if (this.classList.contains("sidebar__masthead")) {
+        if (this.classList.contains(gutterClass)) {
           return rectangle({ top: 0, width: 320, height: 46 });
         }
         if (this.getAttribute("role") === "tooltip") {
-          return rectangle({ width: 236, height: 120 });
+          // Short enough that "above the target" lands at y=26 — inside the
+          // bare 12px viewport padding, but ON the 46px stoplight strip. That
+          // gap is what each case below measures.
+          return rectangle({ width: 264, height: 60 });
         }
         if (this.tagName === "BUTTON") {
           return rectangle({ left: 20, top: 96, width: 72, height: 26 });
         }
         return rectangle({});
-      },
-    );
+      });
+      vi.stubGlobal("innerWidth", 1200);
+      vi.stubGlobal("innerHeight", 800);
+    }
 
-    vi.stubGlobal("innerWidth", 1200);
-    vi.stubGlobal("innerHeight", 800);
+    afterEach(() => {
+      delete document.documentElement.dataset.platform;
+      delete document.documentElement.dataset.fullscreen;
+    });
 
-    render(
-      <div className="app-shell">
-        <header className="sidebar__masthead" />
-        <TooltipFixture />
-      </div>,
-    );
+    it("keeps clear of the sidebar masthead, which the app shell does not fence off", async () => {
+      document.documentElement.dataset.platform = "darwin";
+      mockStoplightLayout("sidebar__masthead");
 
-    fireEvent.mouseEnter(screen.getByRole("button"));
+      render(
+        <div className="app-shell">
+          <header className="sidebar__masthead" />
+          <TooltipFixture />
+        </div>,
+      );
 
-    await waitFor(() => {
-      // Above needs 96 − 120 − 10 = −34, which is over the stoplights. Below
-      // the 26px-tall target fits, so it flips there rather than being clamped
-      // onto the strip.
-      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "132px" });
+      fireEvent.mouseEnter(screen.getByRole("button"));
+
+      await waitFor(() => {
+        // Above would be 96 − 60 − 10 = 26, which is on the strip. It flips
+        // below the 26px-tall target instead of covering the traffic lights.
+        expect(screen.getByRole("tooltip")).toHaveStyle({ top: "132px" });
+      });
+    });
+
+    it("keeps clear of the thread header's cluster when the sidebar is hidden", async () => {
+      // `.sidebar` goes `display: none` in that layout, so its masthead
+      // measures zero and reserves nothing — the relocated cluster in the
+      // thread header holds the stoplight room instead. Reading only the
+      // sidebar's strip would put tooltips back on the traffic lights after a
+      // single toggle.
+      document.documentElement.dataset.platform = "darwin";
+      mockStoplightLayout("thread-header__masthead");
+
+      render(
+        <div className="app-shell" data-sidebar-hidden="true">
+          <header className="sidebar__masthead" />
+          <div className="thread-header__masthead" />
+          <TooltipFixture />
+        </div>,
+      );
+
+      fireEvent.mouseEnter(screen.getByRole("button"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveStyle({ top: "132px" });
+      });
+    });
+
+    it("does not reserve a gutter in fullscreen, where the stoplights are gone", async () => {
+      // app.css drops the 80px reservation under `[data-fullscreen="true"]`
+      // for the same reason. Flooring anyway would flip a tooltip that had
+      // room above onto the content it points at.
+      document.documentElement.dataset.platform = "darwin";
+      document.documentElement.dataset.fullscreen = "true";
+      mockStoplightLayout("sidebar__masthead");
+
+      render(
+        <div className="app-shell">
+          <header className="sidebar__masthead" />
+          <TooltipFixture />
+        </div>,
+      );
+
+      fireEvent.mouseEnter(screen.getByRole("button"));
+
+      await waitFor(() => {
+        // No gutter reserved, so y=26 is free and the tooltip keeps its
+        // preferred side rather than being flipped onto the content.
+        expect(screen.getByRole("tooltip")).toHaveStyle({ top: "26px" });
+      });
+    });
+
+    it("does not reserve a gutter off macOS, where no buttons sit in the renderer", async () => {
+      document.documentElement.dataset.platform = "linux";
+      mockStoplightLayout("sidebar__masthead");
+
+      render(
+        <div className="app-shell">
+          <header className="sidebar__masthead" />
+          <TooltipFixture />
+        </div>,
+      );
+
+      fireEvent.mouseEnter(screen.getByRole("button"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveStyle({ top: "26px" });
+      });
     });
   });
 });

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -22,6 +22,22 @@ const TOOLTIP_GAP = 10;
  */
 export const TOOLTIP_HOVER_DELAY_MS = 250;
 
+/**
+ * Strips that own the top of a window: the Windows custom title bar, and the
+ * macOS stoplight gutters (`padding-left: 80px` is the traffic lights' room).
+ * All three are `-webkit-app-region: drag`.
+ *
+ * Deliberately not every drag region. `.thread-header` and
+ * `.settings-titlebar` drag too, but they sit to the RIGHT of the stoplights
+ * and are content strips — flooring tooltips below them would push half the
+ * sidebar's tooltips down the window to protect nothing.
+ */
+const TOP_WINDOW_CHROME_SELECTORS = [
+  ".app-titlebar",
+  ".sidebar__masthead",
+  ".settings-nav__masthead",
+];
+
 function tooltipViewportTop(): number {
   // On Windows the fixed custom title bar occupies the top of the renderer,
   // while `.app-shell` begins immediately below it. Portal tooltips live on
@@ -30,7 +46,25 @@ function tooltipViewportTop(): number {
   // without the custom strip, preserving the ordinary viewport behavior.
   const appShell = document.querySelector<HTMLElement>(".app-shell");
   const appShellTop = appShell?.getBoundingClientRect().top ?? 0;
-  return Math.max(VIEWPORT_PADDING, appShellTop + VIEWPORT_PADDING);
+  let viewportTop = Math.max(VIEWPORT_PADDING, appShellTop + VIEWPORT_PADDING);
+  // macOS reserves its traffic lights INSIDE the renderer (`titleBarStyle:
+  // "hiddenInset"`), so `.app-shell` starts at 0 and the clamp above happily
+  // parks a tooltip on top of the close/minimize/zoom buttons and the wordmark
+  // beside them. Nothing about that region is hoverable content — it is native
+  // window chrome that a tooltip must never cover.
+  for (const selector of TOP_WINDOW_CHROME_SELECTORS) {
+    const chrome = document.querySelector<HTMLElement>(selector);
+    if (!chrome) {
+      continue;
+    }
+    const rect = chrome.getBoundingClientRect();
+    // Only a strip actually anchored to the top of the window is a floor. One
+    // scrolled or laid out further down is ordinary content.
+    if (rect.height > 0 && rect.top <= appShellTop + VIEWPORT_PADDING) {
+      viewportTop = Math.max(viewportTop, rect.bottom);
+    }
+  }
+  return viewportTop;
 }
 
 type TooltipState = {

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -23,18 +23,24 @@ const TOOLTIP_GAP = 10;
 export const TOOLTIP_HOVER_DELAY_MS = 250;
 
 /**
- * Strips that own the top of a window: the Windows custom title bar, and the
- * macOS stoplight gutters (`padding-left: 80px` is the traffic lights' room).
- * All three are `-webkit-app-region: drag`.
+ * The strips that reserve room for the macOS traffic lights — their
+ * `padding-left: 80px` IS the buttons' room. Which one is on screen depends on
+ * the layout: the sidebar's masthead normally, the thread header's relocated
+ * cluster when the sidebar is hidden (`.sidebar` goes `display: none` and the
+ * cluster takes over the reservation), the nav masthead in Settings.
  *
  * Deliberately not every drag region. `.thread-header` and
  * `.settings-titlebar` drag too, but they sit to the RIGHT of the stoplights
  * and are content strips — flooring tooltips below them would push half the
  * sidebar's tooltips down the window to protect nothing.
+ *
+ * `.app-titlebar` is absent for a different reason: the Windows strip sits
+ * ABOVE `.app-shell` (which carries `margin-top: var(--win-titlebar-h)`), so
+ * the shell-boundary clamp below already clears it.
  */
-const TOP_WINDOW_CHROME_SELECTORS = [
-  ".app-titlebar",
+const STOPLIGHT_GUTTER_SELECTORS = [
   ".sidebar__masthead",
+  ".thread-header__masthead",
   ".settings-nav__masthead",
 ];
 
@@ -46,25 +52,43 @@ function tooltipViewportTop(): number {
   // without the custom strip, preserving the ordinary viewport behavior.
   const appShell = document.querySelector<HTMLElement>(".app-shell");
   const appShellTop = appShell?.getBoundingClientRect().top ?? 0;
-  let viewportTop = Math.max(VIEWPORT_PADDING, appShellTop + VIEWPORT_PADDING);
+  const viewportTop = Math.max(
+    VIEWPORT_PADDING,
+    appShellTop + VIEWPORT_PADDING,
+  );
   // macOS reserves its traffic lights INSIDE the renderer (`titleBarStyle:
   // "hiddenInset"`), so `.app-shell` starts at 0 and the clamp above happily
   // parks a tooltip on top of the close/minimize/zoom buttons and the wordmark
   // beside them. Nothing about that region is hoverable content — it is native
   // window chrome that a tooltip must never cover.
-  for (const selector of TOP_WINDOW_CHROME_SELECTORS) {
-    const chrome = document.querySelector<HTMLElement>(selector);
-    if (!chrome) {
+  //
+  // Only there, though. No other platform puts window buttons inside the
+  // renderer, and macOS fullscreen hides them — which is why app.css drops the
+  // 80px reservation under `[data-fullscreen="true"]`. Flooring anyway would
+  // push tooltips below a gutter that is not on screen, flipping ones that had
+  // room above onto the content they point at.
+  const root = document.documentElement;
+  if (
+    root.dataset.platform !== "darwin"
+    || root.dataset.fullscreen === "true"
+  ) {
+    return viewportTop;
+  }
+  let gutterFloor = viewportTop;
+  for (const selector of STOPLIGHT_GUTTER_SELECTORS) {
+    const gutter = document.querySelector<HTMLElement>(selector);
+    if (!gutter) {
       continue;
     }
-    const rect = chrome.getBoundingClientRect();
+    const rect = gutter.getBoundingClientRect();
     // Only a strip actually anchored to the top of the window is a floor. One
-    // scrolled or laid out further down is ordinary content.
+    // scrolled or laid out further down is ordinary content, and a hidden one
+    // (the sidebar collapsed) measures zero and reserves nothing.
     if (rect.height > 0 && rect.top <= appShellTop + VIEWPORT_PADDING) {
-      viewportTop = Math.max(viewportTop, rect.bottom);
+      gutterFloor = Math.max(gutterFloor, rect.bottom);
     }
   }
-  return viewportTop;
+  return gutterFloor;
 }
 
 type TooltipState = {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1499,14 +1499,25 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toContain("--thinking-scanner-full-offset");
     expect(css).not.toContain("--thinking-scanner-mini-offset");
     expect(css).toContain("@keyframes pwragent-thinking-scanner-sweep");
-    expect(css).toMatch(
-      /\.thinking-scanner\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*18px;[\s\S]*?--thinking-scanner-travel:\s*44px;[\s\S]*?width:\s*62px;[\s\S]*?\}/
-    );
-    expect(css).toMatch(
-      /\.thinking-scanner--mini\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*6px;[\s\S]*?--thinking-scanner-travel:\s*10px;[\s\S]*?width:\s*16px;[\s\S]*?\}/
-    );
-    expect(css).toMatch(
-      /\.thinking-scanner__beam\s*\{[\s\S]*?animation:\s*pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;[\s\S]*?\}/
+    // Read the blocks out by selector rather than matching declarations
+    // anywhere after the first `.thinking-scanner {` in the file. A descendant
+    // rule that retints the scanner (`.lens-switch__signal--remote-active
+    // .thinking-scanner`) ends with the same three characters, so an
+    // unanchored pattern starts THERE and lazily bridges thousands of lines to
+    // collect these declarations from wherever they happen to live — which
+    // would let the geometry drift out of the base block with the test still
+    // green. `extractRuleBody` anchors on a line start and stops at the
+    // block's own closing brace.
+    const scanner = extractRuleBody(css, ".thinking-scanner");
+    expect(scanner).toMatch(/--thinking-scanner-beam-width:\s*18px;/);
+    expect(scanner).toMatch(/--thinking-scanner-travel:\s*44px;/);
+    expect(scanner).toMatch(/width:\s*62px;/);
+    const miniScanner = extractRuleBody(css, ".thinking-scanner--mini");
+    expect(miniScanner).toMatch(/--thinking-scanner-beam-width:\s*6px;/);
+    expect(miniScanner).toMatch(/--thinking-scanner-travel:\s*10px;/);
+    expect(miniScanner).toMatch(/width:\s*16px;/);
+    expect(extractRuleBody(css, ".thinking-scanner__beam")).toMatch(
+      /animation:\s*pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;/
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -322,6 +322,13 @@ describe("Tangerine Terminal theme contract", () => {
     const localTokens = new Set([
       "thinking-scanner-beam-width",
       "thinking-scanner-travel",
+      // Scanner tint indirection — defined on `.thinking-scanner`, not
+      // `:root`. Every value they resolve to IS a theme token; the locals
+      // exist so a variant (the Attention tab's remote-turn readout) can
+      // retarget the colour without restating the beam gradient.
+      "thinking-scanner-tint",
+      "thinking-scanner-tint-bright",
+      "thinking-scanner-track",
       // Sidebar rail/lane inset system — defined on `.sidebar`, not `:root`.
       "sidebar-rail-inset",
       "sidebar-lane-inset",

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3422,8 +3422,50 @@ textarea,
   font-variant-numeric: tabular-nums;
 }
 
+/* The turn readouts, stacked. One row is the common case and reads exactly as
+   it did when it was a bare child of the tab — a single-item column is its own
+   content box, so nothing moves. The second row only exists while a peer has
+   work running (or just finished), and stacking is what keeps it from taking
+   width the four icon tabs need at a 280px sidebar.
+
+   `flex-start` rather than centring: the two scanners have to share a left
+   edge, or a one-digit count above a two-digit one visibly staggers them. */
+.lens-switch__turns {
+  display: flex;
+  min-width: 0;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 2px;
+}
+
+/* Two rows have to fit the 26px tab, so the readouts drop to their own
+   line box here. Only in the stacked column: a lone readout is centred in the
+   tab and the line box never shows. */
+.lens-switch__turns .lens-switch__signal {
+  line-height: 1;
+}
+
 .lens-switch__signal--active {
   color: var(--accent-bright);
+}
+
+/* Turns on another instance. Neutral rather than accent, and that is the whole
+   point of the row: the accent means "this holds the app open", and a peer's
+   turn does not — quitting interrupts nothing that runs here. Reading the tab
+   should answer "can I quit now?" without opening anything.
+
+   Still a live sweeping scanner, not a dormant bar: the work IS running, just
+   not on this machine. */
+.lens-switch__signal--remote-active {
+  color: var(--text-muted);
+}
+
+.lens-switch__signal--remote-active .thinking-scanner {
+  --thinking-scanner-tint: var(--text-muted);
+  --thinking-scanner-tint-bright: var(--text-secondary);
+  --thinking-scanner-track: var(--bg-panel-hover);
 }
 
 .lens-switch__signal--review {
@@ -3491,6 +3533,10 @@ textarea,
 
   .lens-switch__signal {
     gap: 2px;
+  }
+
+  .lens-switch__turns {
+    gap: 1px;
   }
 }
 
@@ -18070,6 +18116,14 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .thinking-scanner {
   position: relative;
+  /* Colour, in one place, so a variant can retune the tint without restating
+     the gradient — a second copy of the beam recipe is how two scanners end up
+     shaped differently. Only the accent-carrying values are indirected; the
+     geometry and the sweep stay shared and unoverridable, since every scanner
+     in the app runs one animation on one epoch. */
+  --thinking-scanner-tint: var(--accent);
+  --thinking-scanner-tint-bright: var(--accent-bright);
+  --thinking-scanner-track: var(--accent-bg-medium);
   --thinking-scanner-beam-width: 18px;
   --thinking-scanner-travel: 44px;
   width: 62px;
@@ -18077,8 +18131,9 @@ a.transcript-message__messaging-origin:focus-visible {
   flex: 0 0 auto;
   overflow: hidden;
   border-radius: 999px;
-  background: var(--accent-bg-medium);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+  background: var(--thinking-scanner-track);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--thinking-scanner-tint) 18%, transparent);
 }
 
 .thinking-scanner--mini {
@@ -18097,13 +18152,13 @@ a.transcript-message__messaging-origin:focus-visible {
   border-radius: 999px;
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--accent) 18%, transparent) 0%,
-    color-mix(in srgb, var(--accent-bright) 95%, transparent) 48%,
-    color-mix(in srgb, var(--accent) 18%, transparent) 100%
+    color-mix(in srgb, var(--thinking-scanner-tint) 18%, transparent) 0%,
+    color-mix(in srgb, var(--thinking-scanner-tint-bright) 95%, transparent) 48%,
+    color-mix(in srgb, var(--thinking-scanner-tint) 18%, transparent) 100%
   );
   box-shadow:
-    0 0 10px color-mix(in srgb, var(--accent) 42%, transparent),
-    0 0 18px color-mix(in srgb, var(--accent) 22%, transparent);
+    0 0 10px color-mix(in srgb, var(--thinking-scanner-tint) 42%, transparent),
+    0 0 18px color-mix(in srgb, var(--thinking-scanner-tint) 22%, transparent);
   animation: pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;
   opacity: 0.76;
   transform: translateX(0);
@@ -18112,8 +18167,8 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .thinking-scanner--mini .thinking-scanner__beam {
   box-shadow:
-    0 0 8px color-mix(in srgb, var(--accent) 42%, transparent),
-    0 0 14px color-mix(in srgb, var(--accent) 22%, transparent);
+    0 0 8px color-mix(in srgb, var(--thinking-scanner-tint) 42%, transparent),
+    0 0 14px color-mix(in srgb, var(--thinking-scanner-tint) 22%, transparent);
 }
 
 @keyframes pwragent-thinking-scanner-sweep {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3422,6 +3422,108 @@ textarea,
   font-variant-numeric: tabular-nums;
 }
 
+/* The Attention tab's hover card. Every other lens tab hovers one line of
+   `.viewport-tooltip`; this one reports two or three counts, each with its own
+   indicator and a consequence, which as running text became four sentences
+   with em-dashes doing the structural work.
+
+   Measurements are `.context-usage-card`'s (width, padding, radius, shadow,
+   eyebrow, row scale) so the app's hover cards stay one family — that one
+   rather than `.pr-status-card` because both of these sit at z-index 90:
+   the lens switch is sidebar chrome and is not reachable from the Settings
+   overlay at 120, so neither needs the 140 a PR chip does. */
+.attention-card {
+  position: fixed;
+  z-index: 90;
+  width: 264px;
+  max-width: calc(100vw - 32px);
+  padding: 12px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--popover-bg);
+  box-shadow: 0 12px 28px var(--shadow-tint-soft);
+  color: var(--text-primary);
+  pointer-events: none;
+  text-align: left;
+}
+
+.attention-card__eyebrow {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.attention-card__caption {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.attention-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* The indicator column is fixed so the labels start on one line no matter
+   which indicator a row carries — a cookie is 8px and a scanner 16px, and
+   letting them size the column staggers the text. */
+.attention-card__row {
+  display: grid;
+  align-items: center;
+  gap: 0 10px;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+}
+
+/* Reuse of the tab's own readout classes, which carry the colour and the zero
+   state. Inside the card they hold only the indicator, so drop the tab's inner
+   gap and let the grid do the spacing. */
+.attention-card__row .lens-switch__signal {
+  justify-content: center;
+  gap: 0;
+}
+
+.attention-card__row-text {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.attention-card__row-label {
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.attention-card__row-note {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.attention-card__row-value {
+  align-self: center;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* Same rule the tab runs: a zero is shown, never hidden, but it stops claiming
+   the reader's eye. Keeping the card and the tab on one rule is what makes the
+   card read as the tab expanded rather than a second opinion. */
+.attention-card__row[data-zero="true"] .attention-card__row-label,
+.attention-card__row[data-zero="true"] .attention-card__row-value {
+  color: var(--text-muted);
+}
+
 /* The turn readouts, stacked. One row is the common case and reads exactly as
    it did when it was a bare child of the tab — a single-item column is its own
    content box, so nothing moves. The second row only exists while a peer has


### PR DESCRIPTION
## What

The Attention tab's live-turn readout counted work on two machines as one number. Only this instance's turns hold shutdown open — `buildQuitBlockerSnapshot` builds its turn rows from the local registry, so a peer's turn never blocks quit — which made "3 active" unanswerable for the one question the tab is glanced at for.

Local turns keep the accent scanner. Peer turns get a neutral one stacked under it:

| | |
|---|---|
| **No federation / no peer work** | unchanged — same tab, same counts, same accessible name |
| **Peer work running** | second row appears: neutral scanner + count |
| **Peer work ends** | row holds a visible `0` for 30s, then drops |

The tab's tooltip became a **hover card** in the same pass, and portal tooltips stopped painting over the macOS traffic lights.

## Design notes

**Stacked, not a third readout across.** The Attention tab already floors the lens switch's narrowest grid track; a third horizontal readout would take that room from the four icon tabs at a 280px sidebar. Measured in Chromium against the real `app.css`: the tab is **65.03px wide either way**, and the column is 22px inside the 26px button — the second row costs zero width and does not overflow.

**A federation viewer window reads 0 local.** Rows in a window fronting a peer carry no `federation` stamp — they are the owner's own threads, and the stamp is only added on the way into someone *else's* window. `isThreadRemoteWork` therefore checks the window target as well as the row, so a viewer does not claim the peer's turns as work that blocks its quit.

**The remote beam is a real, live scanner.** Same untouched `ThinkingScanner`, retinted through new `--thinking-scanner-tint` / `-tint-bright` / `-track` locals rather than a restated gradient. The work is running, so it sweeps for real and stays on the shared animation epoch (PR #1187). At zero it swaps to the existing dormant stand-in element — the same mount-guarantee the local readout uses.

**The 30s linger.** Dropping the row the instant the count hits zero takes the answer away exactly when it becomes interesting ("the peer just finished"), and a row that vanishes mid-glance reads as a glitch. The timer is cancelled, not merely outrun, when a peer starts again — pinned by a test.

## The hover card

Every other lens tab explains itself in one line. This one reports two or three counts, each with an indicator and — once split — a consequence, which through `.viewport-tooltip` rendered as four stacked sentences with em-dashes doing the structural work.

It is now a structured card on `.context-usage-card`'s measurements (that sibling rather than `.pr-status-card` because both sit at z-index 90 — a lens tab is sidebar chrome and never renders under the Settings overlay at 120). Each row repeats the indicator the tab itself shows, so the card reads as the tab expanded rather than a second opinion, and greys at zero by the same rule.

```
ATTENTION
Threads in progress or waiting to be reviewed
─────────────────────────────────────
[≡]  In progress here                  2
     Quitting interrupts these
[≡]  In progress elsewhere             1
     Quitting leaves these running
[●]  To review                        13
```

Unfederated it says just "In progress" / "To review" — no machine named, because there is nothing to tell apart. `aria-describedby` points at the card while visible: "Quitting interrupts these" exists nowhere else, and the portal sits outside the button's subtree, so without it the card is sighted-only.

## Tooltips no longer cover the traffic lights

Not specific to this tab — a pre-existing bug this card's height made obvious.

`useViewportTooltip` floors its placement at `.app-shell`'s top, which was written for the Windows custom title-bar strip, where the shell really is offset below it. macOS uses `titleBarStyle: "hiddenInset"` and reserves the traffic lights *inside* the renderer, so `.app-shell` starts at 0 and a tall tooltip was free to park on top of the close/minimize/zoom buttons and the wordmark beside them.

`tooltipViewportTop` now also floors on the top-anchored stoplight gutters (`.sidebar__masthead`, `.settings-nav__masthead` — their 80px left padding *is* the buttons' room). Deliberately not every drag region: `.thread-header` and `.settings-titlebar` drag too, but sit to the right of the stoplights, and flooring below them would push half the sidebar's tooltips down the window to protect nothing. This fixes every portal tooltip in the app, not just this one.

## Screenshots

Screenshots of the tab (local-only, split, lingering zero, narrow sidebar) and the card (unfederated, split, all-idle) in both themes are attached in review.

## Tests

- 6 new cases in `sidebar.test.tsx`: readout absent with no peer work; the split counts + accessible name + two live scanners; the zeroed linger window expiring; the timer cancelled when a peer restarts mid-linger; the card's class, copy and `aria-describedby`; the split card's consequence lines.
- 1 new case in `useViewportTooltip.test.tsx` pinning the stoplight floor.
- `theme-contract.test.tsx` records the three new `.thinking-scanner` locals with why they are local.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, and 933 renderer navigation/styles/lib/shell tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
