### PR TITLE
feat(desktop): backport Stable and Beta update channels

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -36,6 +36,22 @@ Read these files before changing release metadata:
 - Always use a leading-`v` tag such as `v1.0.0-alpha.5`.
 - The tag version, `apps/desktop/package.json` version, and
   `CHANGELOG.md` release heading must match.
+- Desktop Settings expose two axes: **channel** (Stable or Beta) and
+  **track** (Latest or Prerelease). Encode those slots in the tag suffix
+  so GitHub `/releases/latest` stays on the Stable Latest train:
+  - Stable Latest: `v1.0.5` (no suffix; GitHub Latest)
+  - Stable Prerelease: `v1.0.6-prerelease.1` (GitHub Pre-release)
+  - Beta Latest: `v1.1.0-beta.3` (GitHub Pre-release; smoke-checked `main`)
+  - Beta Prerelease: `v1.1.0-alpha.7` (GitHub Pre-release; may not install)
+- Keep `-prerelease.N` for Stable RCs. Do not reuse `-beta` for 1.0 RCs;
+  `-beta` is the Beta Latest identifier.
+- `main` tags with a prerelease suffix must stay GitHub Pre-release so they
+  never steal `/releases/latest` from the Stable train.
+- To promote a smoked alpha to beta, bump `apps/desktop/package.json` and
+  add a CHANGELOG heading from `X.Y.Z-alpha.N` to `X.Y.Z-beta.M`, commit,
+  and tag that commit. The tree can otherwise match the alpha. Do not add
+  a second tag to the alpha SHA: the metadata gate and the baked app
+  version both come from `package.json`.
 - Before moving `main` to a new major/minor train, verify that the prior train's
   maintenance branch exists. For example, before preparing `1.1.0-beta.1` from a
   current `1.0.*` `main`, check for `origin/releases/1.0`. If it is missing,

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -8,6 +8,14 @@ const windowSendMock = vi.fn();
 const checkForUpdatesMock = vi.fn();
 const setFeedURLMock = vi.fn();
 const resolveUpdateChannelMock = vi.fn();
+const resolveUpdateTrainMock = vi.fn();
+const configWrittenListeners = new Set<() => void>();
+const onConfigWrittenMock = vi.fn((listener: () => void) => {
+  configWrittenListeners.add(listener);
+  return () => {
+    configWrittenListeners.delete(listener);
+  };
+});
 const logInfoMock = vi.fn();
 const logWarnMock = vi.fn();
 const fetchMock = vi.fn();
@@ -56,6 +64,8 @@ vi.mock("electron-updater", () => ({
 vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: vi.fn(() => ({
     resolveUpdateChannel: resolveUpdateChannelMock,
+    resolveUpdateTrain: resolveUpdateTrainMock,
+    onConfigWritten: onConfigWrittenMock,
   })),
 }));
 
@@ -157,6 +167,10 @@ describe("auto updater", () => {
     });
     resolveUpdateChannelMock.mockReset();
     resolveUpdateChannelMock.mockReturnValue("latest");
+    resolveUpdateTrainMock.mockReset();
+    resolveUpdateTrainMock.mockReturnValue("stable");
+    configWrittenListeners.clear();
+    onConfigWrittenMock.mockClear();
     logInfoMock.mockReset();
     logWarnMock.mockReset();
     autoUpdaterMock.allowPrerelease = false;
@@ -281,6 +295,10 @@ describe("auto updater", () => {
       status: "no-update",
       version: "1.0.0-beta.7",
     });
+    expect(updater.readAppUpdateStatus()).toEqual({
+      status: "no-update",
+      version: "1.0.0-beta.7",
+    });
     expect(checkForUpdatesMock).not.toHaveBeenCalled();
 
     resolveUpdateChannelMock.mockReturnValue("prerelease");
@@ -290,6 +308,64 @@ describe("auto updater", () => {
       version: "1.0.0-beta.8",
     });
     expect(checkForUpdatesMock).not.toHaveBeenCalled();
+  });
+
+  it("does not offer a downloaded update after switching trains", async () => {
+    resolveUpdateTrainMock.mockReturnValue("beta");
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    mockGitHubReleases([
+      githubRelease("v1.1.0-beta.2", { prerelease: true }),
+      githubRelease("v1.0.0"),
+    ]);
+    checkForUpdatesMock.mockResolvedValue({
+      updateInfo: { version: "1.1.0-beta.2" },
+    });
+    autoUpdaterMock.currentVersion = { version: "1.0.0" };
+    const updater = await importAutoUpdater();
+    const requestQuit = vi.fn(async (performQuit: () => void) => {
+      performQuit();
+      return true;
+    });
+
+    updater.initAutoUpdater();
+    updater.registerAppUpdateIpcHandlers({ requestQuit });
+    await vi.waitFor(() => {
+      expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+    });
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.1.0-beta.2" });
+    expect(updater.readAppUpdateStatus()).toEqual({
+      status: "downloaded",
+      version: "1.1.0-beta.2",
+    });
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
+
+    resolveUpdateTrainMock.mockReturnValue("stable");
+    for (const listener of configWrittenListeners) {
+      listener();
+    }
+
+    expect(updater.readAppUpdateStatus()).toEqual({
+      status: "no-update",
+      version: "1.0.0",
+    });
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false);
+    const install = ipcHandlers.get("app:install-update");
+    await expect(install?.()).resolves.toEqual({
+      status: "error",
+      message: "The downloaded update is not for the selected channel.",
+    });
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+
+    resolveUpdateTrainMock.mockReturnValue("beta");
+    for (const listener of configWrittenListeners) {
+      listener();
+    }
+
+    expect(updater.readAppUpdateStatus()).toEqual({
+      status: "downloaded",
+      version: "1.1.0-beta.2",
+    });
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
   });
 
   it("skips electron-updater on Linux package builds", async () => {
@@ -344,6 +420,31 @@ describe("auto updater", () => {
       url: "https://github.com/pwrdrvr/PwrAgent/releases/download/v1.0.0-beta.36/",
     });
     expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins the beta train to the smoke-checked main-train tag", async () => {
+    resolveUpdateTrainMock.mockReturnValue("beta");
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    mockGitHubReleases([
+      githubRelease("v1.1.0-beta.2", { prerelease: true }),
+      githubRelease("v1.1.0-alpha.7", { prerelease: true }),
+      githubRelease("v1.0.0"),
+    ]);
+    checkForUpdatesMock.mockResolvedValue({
+      updateInfo: { version: "1.1.0-beta.2" },
+    });
+    autoUpdaterMock.currentVersion = { version: "1.0.0" };
+    const updater = await importAutoUpdater();
+
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "available",
+      version: "1.1.0-beta.2",
+    });
+    expect(setFeedURLMock).toHaveBeenCalledWith({
+      provider: "generic",
+      url: "https://github.com/pwrdrvr/PwrAgent/releases/download/v1.1.0-beta.2/",
+    });
+    expect(autoUpdaterMock.allowPrerelease).toBe(true);
   });
 
   it("does not ask electron-updater to check a tag-only newer release", async () => {
@@ -544,6 +645,103 @@ describe("selectChannelReleases", () => {
     const { latest, prerelease } = selectChannelReleases(releases);
     expect(latest?.tag_name).toBe("v1.0.0-beta.8");
     expect(prerelease?.tag_name).toBe("v1.0.0-beta.9");
+  });
+
+  it("classifies main-train alpha and beta without stealing stable latest", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0-beta.2", prerelease: true, draft: false },
+      { tag_name: "v1.1.0-alpha.7", prerelease: true, draft: false },
+      { tag_name: "v1.0.1-prerelease.1", prerelease: true, draft: false },
+      { tag_name: "v1.0.0", prerelease: false, draft: false },
+      { tag_name: "v1.0.0-beta.41", prerelease: true, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.0");
+    expect(selected.stablePrerelease?.tag_name).toBe("v1.0.1-prerelease.1");
+    expect(selected.betaLatest?.tag_name).toBe("v1.1.0-beta.2");
+    expect(selected.betaPrerelease?.tag_name).toBe("v1.1.0-beta.2");
+    expect(selected.latest?.tag_name).toBe("v1.0.0");
+    expect(selected.prerelease?.tag_name).toBe("v1.0.1-prerelease.1");
+  });
+
+  it("keeps legacy 1.0 beta prereleases on the stable prerelease track", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.0.0-beta.41", prerelease: true, draft: false },
+      { tag_name: "v1.0.0-beta.8", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.0-beta.8");
+    expect(selected.stablePrerelease?.tag_name).toBe("v1.0.0-beta.41");
+    expect(selected.betaLatest).toBeUndefined();
+    expect(selected.betaPrerelease).toBeUndefined();
+  });
+
+  it("promotes a same-core alpha to beta latest once the beta tag exists", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0-beta.1", prerelease: true, draft: false },
+      { tag_name: "v1.1.0-alpha.7", prerelease: true, draft: false },
+      { tag_name: "v1.0.0", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.betaLatest?.tag_name).toBe("v1.1.0-beta.1");
+    expect(selected.betaPrerelease?.tag_name).toBe("v1.1.0-beta.1");
+  });
+
+  it("does not put shipped 1.0.0-beta tags on the Beta train after 1.0.1", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.0.1", prerelease: false, draft: false },
+      { tag_name: "v1.0.1-prerelease.5", prerelease: true, draft: false },
+      { tag_name: "v1.0.0", prerelease: false, draft: false },
+      { tag_name: "v1.0.0-beta.50", prerelease: false, draft: false },
+      { tag_name: "v1.0.0-beta.48", prerelease: true, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.1");
+    expect(selected.stablePrerelease?.tag_name).toBe("v1.0.1");
+    expect(selected.betaLatest).toBeUndefined();
+    expect(selected.betaPrerelease).toBeUndefined();
+  });
+
+  it("does not advertise leftover same-core betas after that train becomes Latest", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0", prerelease: false, draft: false },
+      { tag_name: "v1.1.0-beta.3", prerelease: true, draft: false },
+      { tag_name: "v1.1.0-alpha.7", prerelease: true, draft: false },
+      { tag_name: "v1.0.1", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.1.0");
+    expect(selected.betaLatest).toBeUndefined();
+    expect(selected.betaPrerelease).toBeUndefined();
+  });
+
+  it("keeps a newer main-train alpha on Beta after Stable is promoted", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0", prerelease: false, draft: false },
+      { tag_name: "v1.1.0-beta.3", prerelease: true, draft: false },
+      { tag_name: "v1.2.0-alpha.1", prerelease: true, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.1.0");
+    expect(selected.betaLatest).toBeUndefined();
+    expect(selected.betaPrerelease?.tag_name).toBe("v1.2.0-alpha.1");
+  });
+
+  it("shows an alpha as beta prerelease before a beta exists", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0-alpha.7", prerelease: true, draft: false },
+      { tag_name: "v1.0.0", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.betaLatest).toBeUndefined();
+    expect(selected.betaPrerelease?.tag_name).toBe("v1.1.0-alpha.7");
   });
 
   it("ignores drafts in both channels", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -258,7 +258,7 @@ describe("desktopSettingsPatchToEdits — updates", () => {
     ]);
   });
 
-  it("removes the update channel when saving the default", () => {
+  it("persists the latest update channel so a Beta binary does not re-infer", () => {
     expect(
       desktopSettingsPatchToEdits({
         updates: {
@@ -267,8 +267,41 @@ describe("desktopSettingsPatchToEdits — updates", () => {
       }),
     ).toEqual([
       {
-        op: "delete",
+        op: "set",
         path: ["updates", "channel"],
+        value: "latest",
+      },
+    ]);
+  });
+
+  it("writes the beta update train", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        updates: {
+          train: "beta",
+        },
+      }),
+    ).toEqual([
+      {
+        op: "set",
+        path: ["updates", "train"],
+        value: "beta",
+      },
+    ]);
+  });
+
+  it("persists the stable update train so a Beta binary does not re-infer", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        updates: {
+          train: "stable",
+        },
+      }),
+    ).toEqual([
+      {
+        op: "set",
+        path: ["updates", "train"],
+        value: "stable",
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -189,6 +189,10 @@ describe("DesktopSettingsService", () => {
       value: "prerelease",
       source: "config",
     });
+    expect(snapshot.updates.train).toEqual({
+      value: "stable",
+      source: "default",
+    });
     expect(snapshot.messaging.attachments.imageProfile).toEqual({
       value: "high",
       source: "config",
@@ -248,7 +252,7 @@ describe("DesktopSettingsService", () => {
     );
   });
 
-  it("defaults the update channel and only persists prerelease", async () => {
+  it("defaults the update channel from the running app version", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");
     const service = new DesktopSettingsService({
@@ -262,35 +266,125 @@ describe("DesktopSettingsService", () => {
       value: "latest",
       source: "default",
     });
+    expect(initial.updates.train).toEqual({
+      value: "stable",
+      source: "default",
+    });
     expect(service.resolveUpdateChannel()).toBe("latest");
+    expect(service.resolveUpdateTrain()).toBe("stable");
 
     await service.writeConfigPatch({
       updates: {
         channel: "prerelease",
+        train: "beta",
       },
     });
 
     const afterPrerelease = fs.readFileSync(configPath, "utf8");
     expect(afterPrerelease).toContain("[updates]");
     expect(afterPrerelease).toContain('channel = "prerelease"');
+    expect(afterPrerelease).toContain('train = "beta"');
     expect((await service.readSettings()).updates.channel).toEqual({
       value: "prerelease",
       source: "config",
     });
+    expect((await service.readSettings()).updates.train).toEqual({
+      value: "beta",
+      source: "config",
+    });
     expect(service.resolveUpdateChannel()).toBe("prerelease");
+    expect(service.resolveUpdateTrain()).toBe("beta");
 
     await service.writeConfigPatch({
       updates: {
         channel: "latest",
+        train: "stable",
       },
     });
 
     const afterDefault = fs.readFileSync(configPath, "utf8");
-    expect(afterDefault).not.toContain("channel");
+    expect(afterDefault).toContain('channel = "latest"');
+    expect(afterDefault).toContain('train = "stable"');
     expect((await service.readSettings()).updates.channel).toEqual({
       value: "latest",
+      source: "config",
+    });
+    expect((await service.readSettings()).updates.train).toEqual({
+      value: "stable",
+      source: "config",
+    });
+  });
+
+  it("infers Beta Prerelease from an alpha desktop version", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      appVersion: "1.1.0-alpha.7",
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.updates.train).toEqual({
+      value: "beta",
       source: "default",
     });
+    expect(snapshot.updates.channel).toEqual({
+      value: "prerelease",
+      source: "default",
+    });
+    expect(service.resolveUpdateTrain()).toBe("beta");
+    expect(service.resolveUpdateChannel()).toBe("prerelease");
+  });
+
+  it("keeps a legacy prerelease config on the Stable train", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      ["[updates]", 'channel = "prerelease"', ""].join("\n"),
+    );
+    const service = new DesktopSettingsService({
+      appVersion: "1.1.0-beta.2",
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.updates.channel).toEqual({
+      value: "prerelease",
+      source: "config",
+    });
+    expect(snapshot.updates.train).toEqual({
+      value: "stable",
+      source: "default",
+    });
+    expect(service.resolveUpdateTrain()).toBe("stable");
+    expect(service.resolveUpdateChannel()).toBe("prerelease");
+  });
+
+  it("keeps an explicit Stable choice on a Beta binary", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      appVersion: "1.1.0-beta.2",
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect(service.resolveUpdateTrain()).toBe("beta");
+    await service.writeConfigPatch({
+      updates: {
+        train: "stable",
+        channel: "latest",
+      },
+    });
+    expect(service.resolveUpdateTrain()).toBe("stable");
+    expect(service.resolveUpdateChannel()).toBe("latest");
+    expect(fs.readFileSync(configPath, "utf8")).toContain('train = "stable"');
   });
 
   it("defaults developer mode from the app packaging mode and persists overrides", async () => {

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -15,6 +15,10 @@ import type {
   AppUpdateReleaseVersions,
   AppUpdateStatus,
 } from "../shared/app-metadata";
+import type {
+  DesktopUpdateChannel,
+  DesktopUpdateTrain,
+} from "@pwragent/shared";
 import { getMainLogger } from "./log";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import {
@@ -33,12 +37,13 @@ let initialized = false;
 let updateStatus: AppUpdateStatus = { status: "idle" };
 let periodicUpdateCheckTimer: ReturnType<typeof setInterval> | undefined;
 let updateCheckInFlight: Promise<AppUpdateCheckResult> | undefined;
-let updateCheckChannelInFlight: "latest" | "prerelease" | undefined;
-let downloadedUpdateChannel: "latest" | "prerelease" | undefined;
-const pendingDownloadChannelsByVersion = new Map<
-  string,
-  "latest" | "prerelease"
->();
+type UpdateSelectionKey = `${DesktopUpdateTrain}:${DesktopUpdateChannel}`;
+
+let updateCheckChannelInFlight: UpdateSelectionKey | undefined;
+let heldDownloadedUpdate:
+  | { selection: UpdateSelectionKey; version: string }
+  | undefined;
+const pendingDownloadChannelsByVersion = new Map<string, UpdateSelectionKey>();
 
 type GitHubRelease = {
   assets?: GitHubReleaseAsset[];
@@ -58,9 +63,6 @@ type GitHubReleaseAsset = {
 const MAC_UPDATE_CHANNEL_FILE = "latest-mac.yml";
 
 function setUpdateStatus(nextStatus: AppUpdateStatus): void {
-  if (nextStatus.status !== "downloaded") {
-    downloadedUpdateChannel = undefined;
-  }
   updateStatus = nextStatus;
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.isDestroyed()) {
@@ -70,15 +72,12 @@ function setUpdateStatus(nextStatus: AppUpdateStatus): void {
   }
 }
 
-function downloadedVersion(): string | undefined {
-  return updateStatus.status === "downloaded" ? updateStatus.version : undefined;
-}
-
 export function readAppUpdateStatus(): AppUpdateStatus {
+  reconcileDownloadedUpdateEligibility();
   return updateStatus;
 }
 
-function currentUpdateChannel(): "latest" | "prerelease" {
+function currentUpdateChannel(): DesktopUpdateChannel {
   try {
     return getDesktopSettingsService().resolveUpdateChannel();
   } catch (err) {
@@ -89,13 +88,38 @@ function currentUpdateChannel(): "latest" | "prerelease" {
   }
 }
 
+function currentUpdateTrain(): DesktopUpdateTrain {
+  try {
+    return getDesktopSettingsService().resolveUpdateTrain();
+  } catch (err) {
+    log.warn("failed to read update train setting", {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return "stable";
+  }
+}
+
+function updateSelectionKey(
+  updateTrain: DesktopUpdateTrain,
+  updateChannel: DesktopUpdateChannel,
+): UpdateSelectionKey {
+  return `${updateTrain}:${updateChannel}`;
+}
+
+function currentUpdateSelectionKey(): UpdateSelectionKey {
+  return updateSelectionKey(currentUpdateTrain(), currentUpdateChannel());
+}
+
 function configureAutoUpdaterChannel(
-  updateChannel: "latest" | "prerelease" = currentUpdateChannel(),
+  updateChannel: DesktopUpdateChannel = currentUpdateChannel(),
+  updateTrain: DesktopUpdateTrain = currentUpdateTrain(),
 ): void {
-  autoUpdater.allowPrerelease = updateChannel === "prerelease";
+  autoUpdater.allowPrerelease =
+    updateTrain === "beta" || updateChannel === "prerelease";
   log.info("configured auto-update channel", {
     allowPrerelease: autoUpdater.allowPrerelease,
     updateChannel,
+    updateTrain,
   });
 }
 
@@ -145,13 +169,12 @@ function preserveDownloadedStatus(nextStatus: AppUpdateStatus): boolean {
 }
 
 function setUpdateStatusUnlessDownloaded(nextStatus: AppUpdateStatus): void {
-  const currentStatus = updateStatus;
-  if (
-    currentStatus.status === "downloaded" &&
-    preserveDownloadedStatus(nextStatus)
-  ) {
+  const eligibleDownload = downloadedUpdateMatchesChannel(
+    currentUpdateSelectionKey(),
+  );
+  if (eligibleDownload && preserveDownloadedStatus(nextStatus)) {
     log.info("keeping downloaded update status during follow-up check", {
-      currentVersion: currentStatus.version,
+      currentVersion: eligibleDownload.version,
       nextStatus: nextStatus.status,
     });
     return;
@@ -160,25 +183,54 @@ function setUpdateStatusUnlessDownloaded(nextStatus: AppUpdateStatus): void {
 }
 
 function downloadedUpdateMatchesChannel(
-  updateChannel: "latest" | "prerelease",
+  updateSelection: UpdateSelectionKey,
 ): Extract<AppUpdateCheckResult, { status: "downloaded" }> | undefined {
-  if (
-    updateStatus.status !== "downloaded" ||
-    downloadedUpdateChannel !== updateChannel
-  ) {
+  if (heldDownloadedUpdate?.selection !== updateSelection) {
     return undefined;
   }
-  return { status: "downloaded", version: updateStatus.version };
+  return { status: "downloaded", version: heldDownloadedUpdate.version };
+}
+
+function syncAutoInstallOnAppQuit(updateSelection: UpdateSelectionKey): void {
+  autoUpdater.autoInstallOnAppQuit =
+    downloadedUpdateMatchesChannel(updateSelection) !== undefined
+    || heldDownloadedUpdate === undefined;
+}
+
+function reconcileDownloadedUpdateEligibility(
+  updateSelection: UpdateSelectionKey = currentUpdateSelectionKey(),
+): void {
+  const eligibleDownload = downloadedUpdateMatchesChannel(updateSelection);
+  syncAutoInstallOnAppQuit(updateSelection);
+  if (eligibleDownload) {
+    if (
+      updateStatus.status !== "downloaded"
+      || updateStatus.version !== eligibleDownload.version
+    ) {
+      setUpdateStatus(eligibleDownload);
+    }
+    return;
+  }
+  if (updateStatus.status === "downloaded") {
+    const currentVersion = autoUpdater.currentVersion?.version ?? "unknown";
+    log.info("hiding downloaded update from the unselected train", {
+      currentVersion,
+      heldSelection: heldDownloadedUpdate?.selection,
+      heldVersion: heldDownloadedUpdate?.version,
+      updateSelection,
+    });
+    setUpdateStatus({ status: "no-update", version: currentVersion });
+  }
 }
 
 function recordPendingDownloadChannel(
   version: string | undefined,
-  updateChannel: "latest" | "prerelease" | undefined,
+  updateSelection: UpdateSelectionKey | undefined,
 ): void {
-  if (!version || !updateChannel) {
+  if (!version || !updateSelection) {
     return;
   }
-  pendingDownloadChannelsByVersion.set(version, updateChannel);
+  pendingDownloadChannelsByVersion.set(version, updateSelection);
 }
 
 export async function checkForAppUpdatesNow(
@@ -204,18 +256,25 @@ export async function checkForAppUpdatesNow(
   updateCheckInFlight = (async () => {
     try {
       const updateChannel = currentUpdateChannel();
-      const downloadedResult = downloadedUpdateMatchesChannel(updateChannel);
+      const updateTrain = currentUpdateTrain();
+      const updateSelection = updateSelectionKey(updateTrain, updateChannel);
+      reconcileDownloadedUpdateEligibility(updateSelection);
+      const downloadedResult = downloadedUpdateMatchesChannel(updateSelection);
       if (downloadedResult) {
         log.info("skipping app update check; update already downloaded", {
           trigger,
           updateChannel,
+          updateTrain,
           version: downloadedResult.version,
         });
         return downloadedResult;
       }
       log.info("checking for app updates", { trigger });
-      configureAutoUpdaterChannel(updateChannel);
-      const release = await readAppUpdateReleaseForChannel(updateChannel);
+      configureAutoUpdaterChannel(updateChannel, updateTrain);
+      const release = await readAppUpdateReleaseForChannel(
+        updateChannel,
+        updateTrain,
+      );
       const currentVersion = autoUpdater.currentVersion?.version ?? "unknown";
       if (!release?.tag_name) {
         const result = { status: "no-update", version: currentVersion } as const;
@@ -223,6 +282,7 @@ export async function checkForAppUpdatesNow(
         log.info("skipping app update check; no valid GitHub release found", {
           trigger,
           updateChannel,
+          updateTrain,
         });
         return result;
       }
@@ -235,16 +295,17 @@ export async function checkForAppUpdatesNow(
           selectedRelease: release.tag_name,
           trigger,
           updateChannel,
+          updateTrain,
         });
         return result;
       }
       configureAutoUpdaterFeedForRelease(release);
-      updateCheckChannelInFlight = updateChannel;
+      updateCheckChannelInFlight = updateSelection;
       const result = await autoUpdater.checkForUpdates();
       if (result?.updateInfo?.version !== currentVersion) {
-        recordPendingDownloadChannel(result?.updateInfo?.version, updateChannel);
+        recordPendingDownloadChannel(result?.updateInfo?.version, updateSelection);
       }
-      const matchingDownloadedResult = downloadedUpdateMatchesChannel(updateChannel);
+      const matchingDownloadedResult = downloadedUpdateMatchesChannel(updateSelection);
       if (matchingDownloadedResult) {
         return matchingDownloadedResult;
       }
@@ -360,23 +421,134 @@ export function compareSemver(a: string | undefined, b: string | undefined): num
   return 0;
 }
 
-// Resolve channel slots by semver precedence, not GitHub publish order:
-//   - `latest`     → highest-precedence release that is NOT a prerelease
-//   - `prerelease` → highest-precedence release across both pools
-// Reporting `max(stable, prerelease)` for the prerelease slot guarantees the
-// prerelease channel never advertises a version older than `latest`. When no
-// newer prerelease exists, both slots show the same version, which truthfully
-// reflects what the updater would install.
+function compareSemverCore(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function firstPrereleaseId(tag: string | undefined): string | undefined {
+  const parsed = parseSemver(tag);
+  if (!parsed || parsed.pre.length === 0) {
+    return undefined;
+  }
+  return typeof parsed.pre[0] === "string" ? parsed.pre[0] : undefined;
+}
+
+function isBetaTrainIdentifier(tag: string | undefined): boolean {
+  const id = firstPrereleaseId(tag);
+  return id === "alpha" || id === "beta";
+}
+
+// Beta slots must never advertise a downgrade from Stable Latest. Historical
+// `v1.0.0-beta.N` tags, leftover `v1.1.0-beta.N` after `v1.1.0` is promoted,
+// and same-core alphas all lose to the current Latest and stay off the Beta
+// train. If there is not yet a GitHub Latest, only an alpha (or a beta that
+// has a same-core alpha) counts — a lone `-beta.N` line is the old 1.0 train.
+function isBetaTrainRelease(
+  release: GitHubRelease,
+  stableLatest: GitHubRelease | undefined,
+  releases: GitHubRelease[],
+): boolean {
+  if (release.prerelease !== true || !isBetaTrainIdentifier(release.tag_name)) {
+    return false;
+  }
+  if (stableLatest) {
+    const releaseParsed = parseSemver(release.tag_name);
+    const stableParsed = parseSemver(stableLatest.tag_name);
+    return (
+      releaseParsed !== undefined
+      && stableParsed !== undefined
+      && compareSemverCore(releaseParsed.core, stableParsed.core) > 0
+    );
+  }
+  if (firstPrereleaseId(release.tag_name) === "alpha") {
+    return true;
+  }
+  const parsed = parseSemver(release.tag_name);
+  if (!parsed) {
+    return false;
+  }
+  return releases.some((candidate) => {
+    if (candidate.draft === true || candidate.prerelease !== true) {
+      return false;
+    }
+    const other = parseSemver(candidate.tag_name);
+    return (
+      other !== undefined
+      && compareSemverCore(other.core, parsed.core) === 0
+      && other.pre[0] === "alpha"
+    );
+  });
+}
+
+function isBetaLatestRelease(
+  release: GitHubRelease,
+  stableLatest: GitHubRelease | undefined,
+  releases: GitHubRelease[],
+): boolean {
+  return (
+    firstPrereleaseId(release.tag_name) === "beta"
+    && isBetaTrainRelease(release, stableLatest, releases)
+  );
+}
+
+export type SelectedUpdateReleases = {
+  latest: GitHubRelease | undefined;
+  prerelease: GitHubRelease | undefined;
+  stableLatest: GitHubRelease | undefined;
+  stablePrerelease: GitHubRelease | undefined;
+  betaLatest: GitHubRelease | undefined;
+  betaPrerelease: GitHubRelease | undefined;
+};
+
+// Resolve slots by semver identifier and GitHub Latest, not publish order:
+//   - stable latest      → highest GitHub non-prerelease (the 1.0 / normie feed)
+//   - stable prerelease  → max(stable latest, 1.0 `-prerelease` / legacy `-beta`)
+//   - beta latest        → highest `-beta` whose core is ahead of Stable Latest
+//   - beta prerelease    → max(beta latest, highest `-alpha` on a newer core)
+// Empty Beta slots stay empty. The Settings Beta control remains selectable
+// so an operator can follow the next `main` tag after a Stable promotion.
 export function selectChannelReleases(
   releases: GitHubRelease[],
-): { latest: GitHubRelease | undefined; prerelease: GitHubRelease | undefined } {
+): SelectedUpdateReleases {
   const publicReleases = releases.filter((release) => release.draft !== true);
   const byPrecedenceDesc = [...publicReleases].sort((a, b) =>
     compareSemver(b.tag_name, a.tag_name),
   );
-  const latest = byPrecedenceDesc.find((release) => release.prerelease !== true);
-  const prerelease = byPrecedenceDesc[0];
-  return { latest, prerelease };
+  const stableLatest = byPrecedenceDesc.find(
+    (release) => release.prerelease !== true,
+  );
+  const betaLatest = byPrecedenceDesc.find((release) =>
+    isBetaLatestRelease(release, stableLatest, publicReleases),
+  );
+  const stablePrerelease = byPrecedenceDesc.find((release) => {
+    if (release === stableLatest) {
+      return true;
+    }
+    if (release.prerelease !== true) {
+      return false;
+    }
+    if (firstPrereleaseId(release.tag_name) === "alpha") {
+      return false;
+    }
+    return !isBetaLatestRelease(release, stableLatest, publicReleases);
+  });
+  const betaPrerelease = byPrecedenceDesc.find((release) =>
+    isBetaTrainRelease(release, stableLatest, publicReleases),
+  );
+  return {
+    latest: stableLatest,
+    prerelease: stablePrerelease,
+    stableLatest,
+    stablePrerelease,
+    betaLatest,
+    betaPrerelease,
+  };
 }
 
 function hasUploadedReleaseAsset(
@@ -404,8 +576,23 @@ function hasMacUpdateAssets(release: GitHubRelease): boolean {
 
 export function selectAppUpdateReleases(
   releases: GitHubRelease[],
-): { latest: GitHubRelease | undefined; prerelease: GitHubRelease | undefined } {
+): SelectedUpdateReleases {
   return selectChannelReleases(releases.filter(hasMacUpdateAssets));
+}
+
+function releaseForSelection(
+  selected: SelectedUpdateReleases,
+  updateChannel: DesktopUpdateChannel,
+  updateTrain: DesktopUpdateTrain,
+): GitHubRelease | undefined {
+  if (updateTrain === "beta") {
+    return updateChannel === "prerelease"
+      ? selected.betaPrerelease
+      : selected.betaLatest;
+  }
+  return updateChannel === "prerelease"
+    ? selected.stablePrerelease
+    : selected.stableLatest;
 }
 
 function githubReleaseHeaders(): HeadersInit {
@@ -434,14 +621,18 @@ async function fetchGitHubReleases(signal?: AbortSignal): Promise<GitHubRelease[
 }
 
 async function readAppUpdateReleaseForChannel(
-  updateChannel: "latest" | "prerelease",
+  updateChannel: DesktopUpdateChannel,
+  updateTrain: DesktopUpdateTrain,
 ): Promise<GitHubRelease | undefined> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), RELEASE_FETCH_TIMEOUT_MS);
   try {
     const releases = await fetchGitHubReleases(controller.signal);
-    const selected = selectAppUpdateReleases(releases);
-    return updateChannel === "prerelease" ? selected.prerelease : selected.latest;
+    return releaseForSelection(
+      selectAppUpdateReleases(releases),
+      updateChannel,
+      updateTrain,
+    );
   } finally {
     clearTimeout(timeout);
   }
@@ -452,21 +643,37 @@ export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVe
   const timeout = setTimeout(() => controller.abort(), RELEASE_FETCH_TIMEOUT_MS);
   try {
     const releases = await fetchGitHubReleases(controller.signal);
-    const { latest, prerelease } = selectAppUpdateReleases(releases);
+    const selected = selectAppUpdateReleases(releases);
     return {
       fetchedAt: Date.now(),
-      latest: releaseInfoFromGitHubRelease(latest, "No stable release found."),
-      prerelease: releaseInfoFromGitHubRelease(
-        prerelease,
-        "No prerelease found.",
-      ),
+      stable: {
+        latest: releaseInfoFromGitHubRelease(
+          selected.stableLatest,
+          "No stable release found.",
+        ),
+        prerelease: releaseInfoFromGitHubRelease(
+          selected.stablePrerelease,
+          "No stable prerelease found.",
+        ),
+      },
+      beta: {
+        latest: releaseInfoFromGitHubRelease(
+          selected.betaLatest,
+          "No beta release found.",
+        ),
+        prerelease: releaseInfoFromGitHubRelease(
+          selected.betaPrerelease,
+          "No beta prerelease found.",
+        ),
+      },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    const unavailable = { unavailableReason: message };
     return {
       fetchedAt: Date.now(),
-      latest: { unavailableReason: message },
-      prerelease: { unavailableReason: message },
+      stable: { latest: unavailable, prerelease: unavailable },
+      beta: { latest: unavailable, prerelease: unavailable },
     };
   } finally {
     clearTimeout(timeout);
@@ -503,6 +710,15 @@ export function initAutoUpdater(): void {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
   configureAutoUpdaterChannel();
+  try {
+    getDesktopSettingsService().onConfigWritten(() => {
+      reconcileDownloadedUpdateEligibility();
+    });
+  } catch (err) {
+    log.warn("failed to subscribe to update-selection setting changes", {
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
 
   autoUpdater.on("checking-for-update", () => {
     log.info("checking-for-update");
@@ -535,13 +751,20 @@ export function initAutoUpdater(): void {
   });
   autoUpdater.on("update-downloaded", (info) => {
     log.info("update-downloaded", { version: info.version });
-    downloadedUpdateChannel = info.version
+    const selection = info.version
       ? pendingDownloadChannelsByVersion.get(info.version)
+        ?? currentUpdateSelectionKey()
       : undefined;
     if (info.version) {
       pendingDownloadChannelsByVersion.delete(info.version);
     }
-    setUpdateStatus({ status: "downloaded", version: info.version });
+    if (info.version && selection) {
+      heldDownloadedUpdate = {
+        selection,
+        version: info.version,
+      };
+    }
+    reconcileDownloadedUpdateEligibility();
   });
   autoUpdater.on("error", (err: Error) => {
     log.warn("auto-update error", { message: err.message });
@@ -555,11 +778,16 @@ export function initAutoUpdater(): void {
 export async function installDownloadedAppUpdate(options?: {
   requestQuit?: (performQuit: () => void) => Promise<boolean>;
 }): Promise<AppUpdateInstallResult> {
-  const version = downloadedVersion();
+  const eligibleDownload = downloadedUpdateMatchesChannel(
+    currentUpdateSelectionKey(),
+  );
+  const version = eligibleDownload?.version;
   if (!version) {
     return {
       status: "error",
-      message: "No downloaded update is ready to install.",
+      message: heldDownloadedUpdate
+        ? "The downloaded update is not for the selected channel."
+        : "No downloaded update is ready to install.",
     };
   }
   try {
@@ -614,7 +842,10 @@ export function registerAppUpdateIpcHandlers(options?: {
   ipcMain.removeHandler(APP_UPDATE_RELEASES_READ_CHANNEL);
   ipcMain.handle(
     APP_UPDATE_STATUS_READ_CHANNEL,
-    async (): Promise<AppUpdateStatus> => updateStatus,
+    async (): Promise<AppUpdateStatus> => {
+      reconcileDownloadedUpdateEligibility();
+      return updateStatus;
+    },
   );
   ipcMain.handle(
     APP_UPDATE_RELEASES_READ_CHANNEL,

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -25,6 +25,7 @@ import type {
   DesktopSettingsConfigPatch,
   DesktopTextSize,
   DesktopUpdateChannel,
+  DesktopUpdateTrain,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
@@ -34,7 +35,6 @@ import {
   DESKTOP_TEXT_SIZE_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
   DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELL_DEFAULT,
-  DESKTOP_UPDATE_CHANNEL_DEFAULT,
   isDesktopAppearanceDensity,
   isDesktopAppearanceTheme,
   isDesktopTextSize,
@@ -45,6 +45,7 @@ import {
   isDesktopOnboardingCompletedSource,
   isDesktopWorktreeStorageLocation,
   isDesktopUpdateChannel,
+  isDesktopUpdateTrain,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
 import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
@@ -127,6 +128,7 @@ export type DesktopSettingsConfig = {
   };
   updates?: {
     channel?: DesktopUpdateChannel;
+    train?: DesktopUpdateTrain;
   };
   integratedTerminal?: {
     windowsShell?: DesktopIntegratedTerminalWindowsShell;
@@ -842,14 +844,14 @@ export function desktopSettingsPatchToEdits(
   }
 
   if (patch.updates?.channel !== undefined) {
-    if (patch.updates.channel === DESKTOP_UPDATE_CHANNEL_DEFAULT) {
-      edits.push({
-        op: "delete",
-        path: ["updates", "channel"],
-      });
-    } else {
-      set(["updates", "channel"], patch.updates.channel);
-    }
+    // Persist Latest/Stable too. A Beta/alpha binary infers those keys when
+    // they are absent, so deleting the default would put the operator back
+    // on the downloaded train after they chose Stable.
+    set(["updates", "channel"], patch.updates.channel);
+  }
+
+  if (patch.updates?.train !== undefined) {
+    set(["updates", "train"], patch.updates.train);
   }
 
   if (patch.integratedTerminal?.windowsShell !== undefined) {
@@ -1470,6 +1472,7 @@ function normalizeDesktopConfig(
     },
     updates: {
       channel: readUpdateChannel(updates?.channel),
+      train: readUpdateTrain(updates?.train),
     },
     integratedTerminal: {
       windowsShell: readIntegratedTerminalWindowsShell(
@@ -1982,6 +1985,14 @@ function readUpdateChannel(
   value: TomlScalar | undefined,
 ): DesktopUpdateChannel | undefined {
   return typeof value === "string" && isDesktopUpdateChannel(value)
+    ? value
+    : undefined;
+}
+
+function readUpdateTrain(
+  value: TomlScalar | undefined,
+): DesktopUpdateTrain | undefined {
+  return typeof value === "string" && isDesktopUpdateTrain(value)
     ? value
     : undefined;
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -26,6 +26,7 @@ import type {
   DesktopSettingsSnapshot,
   DesktopSettingsValue,
   DesktopUpdateChannel,
+  DesktopUpdateTrain,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
@@ -42,6 +43,8 @@ import {
   DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT,
   DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELL_DEFAULT,
   DESKTOP_UPDATE_CHANNEL_DEFAULT,
+  DESKTOP_UPDATE_TRAIN_DEFAULT,
+  inferDesktopUpdateSelection,
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
 } from "@pwragent/shared";
 import {
@@ -209,6 +212,8 @@ type DesktopSettingsServiceOptions = {
   resolveCodexShellEnv?: (
     env: NodeJS.ProcessEnv
   ) => NodeJS.ProcessEnv | undefined;
+  appVersion?: string;
+  resolveAppVersion?: () => string;
   /**
    * Side-effect hook invoked from `writeConfigPatch` whenever a write
    * touched `[general.appearance]`. The production wiring routes this
@@ -667,9 +672,7 @@ export class DesktopSettingsService {
           config.imageUploads?.pastedImageMaxPatches,
         ),
       },
-      updates: {
-        channel: this.resolveUpdateChannelValue(config.updates?.channel),
-      },
+      updates: this.resolveUpdateSelection(config.updates),
       integratedTerminal: {
         windowsShell: this.resolveIntegratedTerminalWindowsShellValue(
           config.integratedTerminal?.windowsShell,
@@ -1071,7 +1074,12 @@ export class DesktopSettingsService {
   }
 
   resolveUpdateChannel(): DesktopUpdateChannel {
-    return this.resolveUpdateChannelValue(this.readConfig().config.updates?.channel)
+    return this.resolveUpdateSelection(this.readConfig().config.updates).channel
+      .value;
+  }
+
+  resolveUpdateTrain(): DesktopUpdateTrain {
+    return this.resolveUpdateSelection(this.readConfig().config.updates).train
       .value;
   }
 
@@ -1670,12 +1678,39 @@ export class DesktopSettingsService {
     };
   }
 
-  private resolveUpdateChannelValue(
-    configValue: DesktopUpdateChannel | undefined,
-  ): DesktopSettingsValue<DesktopUpdateChannel> {
+  private currentAppVersion(): string {
+    return this.options.appVersion
+      ?? this.options.resolveAppVersion?.()
+      ?? "";
+  }
+
+  private resolveUpdateSelection(updates?: {
+    channel?: DesktopUpdateChannel;
+    train?: DesktopUpdateTrain;
+  }): {
+    channel: DesktopSettingsValue<DesktopUpdateChannel>;
+    train: DesktopSettingsValue<DesktopUpdateTrain>;
+  } {
+    // Infer the version-derived pair only when neither key exists. A
+    // pre-train config with only `channel = "prerelease"` must stay on
+    // Stable so installing a 1.1.0-beta binary does not silently move
+    // that operator onto Beta Prerelease / alphas.
+    if (updates?.channel === undefined && updates?.train === undefined) {
+      const inferred = inferDesktopUpdateSelection(this.currentAppVersion());
+      return {
+        channel: { value: inferred.channel, source: "default" },
+        train: { value: inferred.train, source: "default" },
+      };
+    }
     return {
-      value: configValue ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
-      source: configValue === undefined ? "default" : "config",
+      channel: {
+        value: updates.channel ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
+        source: updates.channel === undefined ? "default" : "config",
+      },
+      train: {
+        value: updates.train ?? DESKTOP_UPDATE_TRAIN_DEFAULT,
+        source: updates.train === undefined ? "default" : "config",
+      },
     };
   }
 

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -17,6 +17,7 @@ export function getDesktopSettingsService(): DesktopSettingsService {
     const bootstrap = getAppStateMode() === "bootstrap";
     desktopSettingsService = new DesktopSettingsService({
       defaultDeveloperMode: app.isPackaged === true ? false : true,
+      resolveAppVersion: () => app.getVersion(),
       secretStore: new DbBackedSafeStorageSecretStore(safeStorage, getAppStateDb()),
       ...(bootstrap
         ? { configPath: resolveBootstrapProfilePath("config.toml") }

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -518,6 +518,7 @@ describe("App", () => {
       },
       updates: {
         channel: { value: "latest", source: "default" },
+        train: { value: "stable", source: "default" },
       },
       integratedTerminal: {
         windowsShell: { value: "auto", source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -4,6 +4,7 @@ import type {
   DesktopHotCpuProfileTriggerMode,
   DesktopSettingsSnapshot,
   DesktopUpdateChannel,
+  DesktopUpdateTrain,
 } from "@pwragent/shared";
 import type {
   AppMetadata,
@@ -136,6 +137,14 @@ const PASTED_IMAGE_PATCH_OPTIONS: Array<{
   },
 ];
 
+const UPDATE_TRAIN_OPTIONS: Array<{
+  label: string;
+  value: DesktopUpdateTrain;
+}> = [
+  { label: "Stable", value: "stable" },
+  { label: "Beta", value: "beta" },
+];
+
 const UPDATE_CHANNEL_OPTIONS: Array<{
   label: string;
   value: DesktopUpdateChannel;
@@ -194,7 +203,12 @@ function releaseHelpText(
   if (!releases) {
     return "Release versions are loading.";
   }
-  return `Latest: ${releaseVersionText(releases.latest)}. Prerelease: ${releaseVersionText(releases.prerelease)}.`;
+  return [
+    `Stable latest: ${releaseVersionText(releases.stable.latest)}`,
+    `Stable prerelease: ${releaseVersionText(releases.stable.prerelease)}`,
+    `Beta latest: ${releaseVersionText(releases.beta.latest)}`,
+    `Beta prerelease: ${releaseVersionText(releases.beta.prerelease)}`,
+  ].join(". ");
 }
 
 function updateResultText(result: AppUpdateCheckResult): string {
@@ -238,6 +252,7 @@ export function GeneralSettings(props: {
   onConfirmQuitWithInProgressThreadsChange: (value: boolean) => Promise<void>;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
+  onUpdateTrainChange: (value: DesktopUpdateTrain) => Promise<void>;
   onNotificationsEnabledChange: (value: boolean) => Promise<void>;
   onClearMessagingAcknowledgment: () => Promise<void>;
 }) {
@@ -285,6 +300,7 @@ export function GeneralSettings(props: {
     props.snapshot.general.hotCpuProfilingHeapSnapshotLimit;
   const notificationsEnabled = props.snapshot.general.notificationsEnabled;
   const updateChannel = props.snapshot.updates.channel;
+  const updateTrain = props.snapshot.updates.train;
   const messagingAcknowledgment =
     props.snapshot.general.messagingAcknowledgment;
   const activeOption = PASTED_IMAGE_PATCH_OPTIONS.find(
@@ -613,33 +629,68 @@ export function GeneralSettings(props: {
       <SettingsSection
         eyebrow="General"
         title="Updates"
-        chip={sourceBadge(updateChannel)}
+        chip={
+          updateTrain.source === "config"
+            ? sourceBadge(updateTrain)
+            : sourceBadge(updateChannel)
+        }
       >
         <div className="settings-fields">
           <SettingsField
-            label="Update channel"
-            sub="Choose which GitHub release stream the updater follows."
-            help={
-              <>
-                {releaseHelpText(releaseVersions)}
-                {updateResult ? (
-                  <>
-                    {" "}
-                    <span
-                      className={
-                        updateResult.status === "error"
-                          ? "settings-update-channel__result settings-update-channel__result--error"
-                          : "settings-update-channel__result"
-                      }
-                      role={
-                        updateResult.status === "error" ? "alert" : undefined
-                      }
-                    >
-                      {updateResultText(updateResult)}
+            label="Release channel"
+            sub="Stable is the smoke-checked train. Beta follows main and stays selectable even when its versions are still Unavailable."
+            help={releaseHelpText(releaseVersions)}
+            error={updateTrain.error}
+            source={sourceBadge(updateTrain)}
+            control={
+              <div
+                className="settings-segmented"
+                role="radiogroup"
+                aria-label="Release channel"
+              >
+                {UPDATE_TRAIN_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    aria-checked={updateTrain.value === option.value}
+                    className={`settings-segmented__button settings-segmented__button--stacked${
+                      updateTrain.value === option.value ? " is-active" : ""
+                    }`}
+                    disabled={props.saving}
+                    role="radio"
+                    type="button"
+                    onClick={() => {
+                      void props.onUpdateTrainChange(option.value);
+                    }}
+                  >
+                    <span>{option.label}</span>
+                    <span className="settings-segmented__meta">
+                      {releaseVersionText(
+                        releaseVersions?.[option.value]?.latest,
+                      )}
                     </span>
-                  </>
-                ) : null}
-              </>
+                  </button>
+                ))}
+              </div>
+            }
+          />
+          <SettingsField
+            label="Update track"
+            sub="Latest is smoke-checked. Prerelease is newer and may not install."
+            help={
+              updateResult ? (
+                <span
+                  className={
+                    updateResult.status === "error"
+                      ? "settings-update-channel__result settings-update-channel__result--error"
+                      : "settings-update-channel__result"
+                  }
+                  role={
+                    updateResult.status === "error" ? "alert" : undefined
+                  }
+                >
+                  {updateResultText(updateResult)}
+                </span>
+              ) : undefined
             }
             error={updateChannel.error}
             source={sourceBadge(updateChannel)}
@@ -648,7 +699,7 @@ export function GeneralSettings(props: {
                 <div
                   className="settings-segmented"
                   role="radiogroup"
-                  aria-label="Update channel"
+                  aria-label="Update track"
                 >
                   {UPDATE_CHANNEL_OPTIONS.map((option) => (
                     <button
@@ -666,7 +717,9 @@ export function GeneralSettings(props: {
                     >
                       <span>{option.label}</span>
                       <span className="settings-segmented__meta">
-                        {releaseVersionText(releaseVersions?.[option.value])}
+                        {releaseVersionText(
+                          releaseVersions?.[updateTrain.value]?.[option.value],
+                        )}
                       </span>
                     </button>
                   ))}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -370,12 +370,18 @@ function SettingsSectionBody(props: {
         }}
         onUpdateChannelChange={async (channel: DesktopUpdateChannel) => {
           await props.settings.writeConfig({
-            updates: { channel },
+            updates: {
+              channel,
+              train: props.snapshot.updates.train.value,
+            },
           });
         }}
         onUpdateTrainChange={async (train: DesktopUpdateTrain) => {
           await props.settings.writeConfig({
-            updates: { train },
+            updates: {
+              train,
+              channel: props.snapshot.updates.channel.value,
+            },
           });
         }}
         onPastedImageMaxPatchesChange={async (pastedImageMaxPatches) => {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import type {
   DesktopSettingsSnapshot,
   DesktopMessagingImageProfile,
   DesktopUpdateChannel,
+  DesktopUpdateTrain,
   MessagingChannelKind,
 } from "@pwragent/shared";
 import type { AppearanceController } from "../../lib/useAppearance";
@@ -370,6 +371,11 @@ function SettingsSectionBody(props: {
         onUpdateChannelChange={async (channel: DesktopUpdateChannel) => {
           await props.settings.writeConfig({
             updates: { channel },
+          });
+        }}
+        onUpdateTrainChange={async (train: DesktopUpdateTrain) => {
+          await props.settings.writeConfig({
+            updates: { train },
           });
         }}
         onPastedImageMaxPatchesChange={async (pastedImageMaxPatches) => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -180,6 +180,7 @@ function createSnapshot(
     },
     updates: {
       channel: { value: "latest", source: "default" },
+      train: { value: "stable", source: "default" },
     },
     integratedTerminal: {
       windowsShell: { value: "auto", source: "default" },
@@ -612,8 +613,14 @@ describe("SettingsScreen", () => {
       })),
       readAppUpdateReleaseVersions: vi.fn(async () => ({
         fetchedAt: 1,
-        latest: { version: "v1.0.0" },
-        prerelease: { version: "v1.0.0-beta.7" },
+        stable: {
+          latest: { version: "v1.0.0" },
+          prerelease: { version: "v1.0.0-beta.7" },
+        },
+        beta: {
+          latest: { version: "v1.1.0-beta.2" },
+          prerelease: { version: "v1.1.0-alpha.7" },
+        },
       })),
     };
     render(
@@ -716,6 +723,18 @@ describe("SettingsScreen", () => {
     });
 
     expect(await screen.findByText("v1.0.0-beta.7")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Stable/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /Beta/ }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        updates: {
+          train: "beta",
+        },
+      });
+    });
     fireEvent.click(screen.getByRole("radio", { name: /Prerelease/ }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
@@ -3906,6 +3925,7 @@ describe("SettingsScreen", () => {
       createSnapshot({
         updates: {
           channel: { value: "prerelease", source: "config" },
+          train: { value: "stable", source: "default" },
         },
       }),
     );
@@ -3916,8 +3936,14 @@ describe("SettingsScreen", () => {
       })),
       readAppUpdateReleaseVersions: vi.fn(async () => ({
         fetchedAt: 1,
-        latest: { version: "v1.0.0" },
-        prerelease: { version: "v1.0.0-beta.7" },
+        stable: {
+          latest: { version: "v1.0.0" },
+          prerelease: { version: "v1.0.0-beta.7" },
+        },
+        beta: {
+          latest: { version: "v1.1.0-beta.2" },
+          prerelease: { version: "v1.1.0-alpha.7" },
+        },
       })),
       readAppUpdateStatus: vi.fn(async () => ({
         status: "downloaded" as const,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -732,6 +732,7 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         updates: {
           train: "beta",
+          channel: "latest",
         },
       });
     });
@@ -740,6 +741,7 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         updates: {
           channel: "prerelease",
+          train: "stable",
         },
       });
     });
@@ -3986,6 +3988,52 @@ describe("SettingsScreen", () => {
       await screen.findByText(/Update available: v1.0.0-beta.8/),
     ).toBeInTheDocument();
     expect(desktopApi.readAppUpdateStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an inferred Beta train when the operator picks Latest", async () => {
+    const settings = createSettingsState(
+      createSnapshot({
+        updates: {
+          channel: { value: "prerelease", source: "default" },
+          train: { value: "beta", source: "default" },
+        },
+      }),
+    );
+    const desktopApi = {
+      readAppUpdateReleaseVersions: vi.fn(async () => ({
+        fetchedAt: 1,
+        stable: {
+          latest: { version: "v1.0.1" },
+          prerelease: { version: "v1.0.1" },
+        },
+        beta: {
+          latest: { version: "v1.1.0-beta.2" },
+          prerelease: { version: "v1.1.0-alpha.7" },
+        },
+      })),
+    };
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /Beta/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /Latest/ }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        updates: {
+          channel: "latest",
+          train: "beta",
+        },
+      });
+    });
   });
 
   it("blocks settings edits when the config file cannot be parsed", () => {

--- a/apps/desktop/src/shared/app-metadata.ts
+++ b/apps/desktop/src/shared/app-metadata.ts
@@ -86,8 +86,13 @@ export type AppUpdateReleaseInfo = {
   unavailableReason?: string;
 };
 
-export type AppUpdateReleaseVersions = {
+export type AppUpdateReleaseSlotVersions = {
   latest: AppUpdateReleaseInfo;
   prerelease: AppUpdateReleaseInfo;
+};
+
+export type AppUpdateReleaseVersions = {
+  stable: AppUpdateReleaseSlotVersions;
+  beta: AppUpdateReleaseSlotVersions;
   fetchedAt: number;
 };

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -91,6 +91,22 @@ maintenance branches use the same PR workflow as `main`. Release workflow fixes
 are always valid backport candidates for supported maintenance branches so old
 trains do not lose the ability to ship security patches.
 
+Desktop Settings let operators pick a **channel** (Stable or Beta) and a
+**track** (Latest or Prerelease). Tag suffixes map onto those four slots:
+
+| Settings slot | Tag | GitHub flag |
+|---|---|---|
+| Stable · Latest | `v1.0.5` | Latest |
+| Stable · Prerelease | `v1.0.6-prerelease.1` | Pre-release |
+| Beta · Latest | `v1.1.0-beta.3` | Pre-release |
+| Beta · Prerelease | `v1.1.0-alpha.7` | Pre-release |
+
+Use `-prerelease.N` for Stable RCs. Use `-alpha.N` / `-beta.N` on `main`.
+Every `main` tag with a prerelease suffix must stay a GitHub Pre-release so
+it cannot steal `/releases/latest` from the Stable train. Promote a smoked
+alpha by bumping `apps/desktop/package.json` and the CHANGELOG heading to
+the beta version, then tagging that commit. Do not retag the alpha SHA.
+
 ## Cutting a release (CI path — preferred)
 
 ```bash

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { DesktopSettingsSnapshot } from "../settings";
-import { isDesktopChatReplyComposer } from "../settings";
+import {
+  inferDesktopUpdateSelection,
+  isDesktopChatReplyComposer,
+} from "../settings";
 
 describe("desktop settings contracts", () => {
   it("represents read snapshots without raw secret values", () => {
@@ -119,6 +122,7 @@ describe("desktop settings contracts", () => {
       },
       updates: {
         channel: { value: "latest", source: "default" },
+        train: { value: "stable", source: "default" },
       },
       integratedTerminal: {
         windowsShell: { value: "auto", source: "default" },
@@ -359,5 +363,33 @@ describe("desktop settings contracts", () => {
     expect(isDesktopChatReplyComposer("tiptap-wysiwyg-markdown-chips")).toBe(true);
     expect(isDesktopChatReplyComposer("custom-widget-chips")).toBe(false);
     expect(isDesktopChatReplyComposer("markdown")).toBe(false);
+  });
+});
+
+describe("inferDesktopUpdateSelection", () => {
+  it("maps website download versions onto the matching train and track", () => {
+    expect(inferDesktopUpdateSelection("1.0.1")).toEqual({
+      train: "stable",
+      channel: "latest",
+    });
+    expect(inferDesktopUpdateSelection("1.0.1-prerelease.5")).toEqual({
+      train: "stable",
+      channel: "prerelease",
+    });
+    expect(inferDesktopUpdateSelection("1.1.0-beta.2")).toEqual({
+      train: "beta",
+      channel: "latest",
+    });
+    expect(inferDesktopUpdateSelection("v1.1.0-alpha.7")).toEqual({
+      train: "beta",
+      channel: "prerelease",
+    });
+  });
+
+  it("keeps historical 1.0.0-beta builds on Stable Latest", () => {
+    expect(inferDesktopUpdateSelection("1.0.0-beta.50")).toEqual({
+      train: "stable",
+      channel: "latest",
+    });
   });
 });

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -34,6 +34,74 @@ export type DesktopUpdateChannel = (typeof DESKTOP_UPDATE_CHANNELS)[number];
 
 export const DESKTOP_UPDATE_CHANNEL_DEFAULT: DesktopUpdateChannel = "latest";
 
+export const DESKTOP_UPDATE_TRAINS = ["stable", "beta"] as const;
+
+export type DesktopUpdateTrain = (typeof DESKTOP_UPDATE_TRAINS)[number];
+
+export const DESKTOP_UPDATE_TRAIN_DEFAULT: DesktopUpdateTrain = "stable";
+
+// Last 1.0 core that used `-beta.N` as the Stable prerelease line. Builds
+// at this core stay on Stable so a website Beta download cannot be confused
+// with `v1.0.0-beta.50`.
+const LEGACY_STABLE_BETA_CORE: [number, number, number] = [1, 0, 0];
+
+function parseDesktopUpdateVersion(
+  version: string,
+): { core: [number, number, number]; pre: string[] } | undefined {
+  const trimmed = version.trim().replace(/^v/i, "");
+  const match = trimmed.match(
+    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/,
+  );
+  if (!match) {
+    return undefined;
+  }
+  const [, maj, min, patch, pre] = match;
+  return {
+    core: [Number(maj), Number(min), Number(patch)],
+    pre: pre ? pre.split(".") : [],
+  };
+}
+
+/**
+ * Map a desktop app version onto the Settings update train/track.
+ * Used only when both `updates.train` and `updates.channel` are unset so a
+ * GitHub or website download of Beta/Prerelease follows that feed. A
+ * pre-train config that only set `channel` stays on Stable.
+ */
+export function inferDesktopUpdateSelection(version: string): {
+  channel: DesktopUpdateChannel;
+  train: DesktopUpdateTrain;
+} {
+  const parsed = parseDesktopUpdateVersion(version);
+  if (!parsed || parsed.pre.length === 0) {
+    return {
+      channel: DESKTOP_UPDATE_CHANNEL_DEFAULT,
+      train: DESKTOP_UPDATE_TRAIN_DEFAULT,
+    };
+  }
+  const id = parsed.pre[0];
+  if (id === "alpha") {
+    return { channel: "prerelease", train: "beta" };
+  }
+  if (id === "prerelease" || id === "rc") {
+    return { channel: "prerelease", train: "stable" };
+  }
+  if (id === "beta") {
+    const isLegacyStableBeta =
+      parsed.core[0] === LEGACY_STABLE_BETA_CORE[0]
+      && parsed.core[1] === LEGACY_STABLE_BETA_CORE[1]
+      && parsed.core[2] === LEGACY_STABLE_BETA_CORE[2];
+    if (isLegacyStableBeta) {
+      return {
+        channel: DESKTOP_UPDATE_CHANNEL_DEFAULT,
+        train: DESKTOP_UPDATE_TRAIN_DEFAULT,
+      };
+    }
+    return { channel: "latest", train: "beta" };
+  }
+  return { channel: "prerelease", train: DESKTOP_UPDATE_TRAIN_DEFAULT };
+}
+
 export const DESKTOP_APPEARANCE_THEMES = ["system", "dark", "light"] as const;
 export type DesktopAppearanceTheme = (typeof DESKTOP_APPEARANCE_THEMES)[number];
 export const DESKTOP_APPEARANCE_THEME_DEFAULT: DesktopAppearanceTheme = "system";
@@ -306,6 +374,7 @@ export type DesktopImageUploadSettingsSnapshot = {
 
 export type DesktopUpdateSettingsSnapshot = {
   channel: DesktopSettingsValue<DesktopUpdateChannel>;
+  train: DesktopSettingsValue<DesktopUpdateTrain>;
 };
 
 export type DesktopIntegratedTerminalSettingsSnapshot = {
@@ -827,6 +896,7 @@ export type DesktopSettingsConfigPatch = {
   };
   updates?: {
     channel?: DesktopUpdateChannel;
+    train?: DesktopUpdateTrain;
   };
   integratedTerminal?: {
     windowsShell?: DesktopIntegratedTerminalWindowsShell;
@@ -1373,6 +1443,12 @@ export function isDesktopUpdateChannel(
   value: string,
 ): value is DesktopUpdateChannel {
   return DESKTOP_UPDATE_CHANNELS.includes(value as DesktopUpdateChannel);
+}
+
+export function isDesktopUpdateTrain(
+  value: string,
+): value is DesktopUpdateTrain {
+  return DESKTOP_UPDATE_TRAINS.includes(value as DesktopUpdateTrain);
 }
 
 export function isDesktopAppearanceTheme(


### PR DESCRIPTION
## Summary

Backport of #1673 onto `releases/1.0` so shipped 1.0 builds can:

- stay on Stable Latest / Stable Prerelease and ignore `main` `-alpha` / `-beta` tags
- opt into the Beta train and receive `1.1.0-beta.N` / `1.1.0-alpha.N` when the operator chooses

Settings → Updates now has two axes (Stable|Beta × Latest|Prerelease) and lists all four published versions. Installed version suffixes seed the train when both config keys are unset. A legacy `updates.channel = "prerelease"` config stays on Stable.

Conflicts with `releases/1.0` were resolved by keeping the 1.0 Settings/general layout (developer mode and hot CPU stay in General) and adding only the train/inference wiring.

## Test plan

- [x] `pnpm test apps/desktop/src/main/__tests__/auto-updater.test.ts`
- [x] `pnpm test packages/shared/src/contracts/__tests__/settings.test.ts`
- [x] `pnpm test apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts`
- [x] `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- [x] Isolated re-run of the four settings-service cases that timed out under load
- [x] `pnpm --filter @pwragent/shared typecheck`
- [x] `pnpm --filter @pwragent/desktop typecheck`