### PR TITLE
feat(agent-core): surface rejected ACP agents

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -89,7 +89,7 @@ MIT
 - @octokit/request@10.0.13 | github:octokit/request.js
 - @octokit/request-error@7.1.1 | github:octokit/request-error.js
 - @octokit/types@17.0.0 | github:octokit/types.ts
-- @pwrdrvr/agent-acp@0.13.1 | https://github.com/pwrdrvr/agent-kit
+- @pwrdrvr/agent-acp@0.14.0 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-client@0.7.0 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-core@0.2.0 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-transport@0.1.7 | https://github.com/pwrdrvr/agent-kit
@@ -839,18 +839,18 @@ The above copyright notice and this permission notice (including the next paragr
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-@pwrdrvr/agent-acp@0.13.1 (MIT)
+@pwrdrvr/agent-acp@0.14.0 (MIT)
 -------------------------------
 
 Applies to:
-- @pwrdrvr/agent-acp@0.13.1 (MIT)
+- @pwrdrvr/agent-acp@0.14.0 (MIT)
 - @pwrdrvr/agent-client@0.7.0 (MIT)
 - @pwrdrvr/agent-core@0.2.0 (MIT)
 - @pwrdrvr/agent-transport@0.1.7 (MIT)
 - @pwrdrvr/codex-app-server-protocol@0.144.0 (MIT)
 - @pwrdrvr/codex-discovery@0.1.6 (MIT)
 
-Representative file: @pwrdrvr/agent-acp@0.13.1/LICENSE
+Representative file: @pwrdrvr/agent-acp@0.14.0/LICENSE
 
 MIT License
 

--- a/apps/desktop/e2e/fixtures/fake-agent-executables.ts
+++ b/apps/desktop/e2e/fixtures/fake-agent-executables.ts
@@ -48,6 +48,13 @@ if (process.argv.includes("--version")) {
   process.stdout.write("kimi-code 0.1.0\\n");
   process.exit(0);
 }
+// Agent Kit verifies Kimi ACP support through the exit status of
+// kimi acp --help. Keep this fixture on the same discovery contract as the
+// real CLI so a configured, executable-backed fake remains launchable.
+if (process.argv.includes("acp") && process.argv.includes("--help")) {
+  process.stdout.write("Usage: kimi acp [options]\\n");
+  process.exit(0);
+}
 const readline = require("node:readline");
 const input = readline.createInterface({ input: process.stdin });
 input.on("line", (line) => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -62,7 +62,7 @@
     "@pwragent/messaging-provider-slack": "workspace:*",
     "@pwragent/messaging-provider-telegram": "workspace:*",
     "@pwragent/shared": "workspace:*",
-    "@pwrdrvr/agent-acp": "^0.13.1",
+    "@pwrdrvr/agent-acp": "^0.14.0",
     "@pwrdrvr/agent-client": "^0.7.0",
     "@pwrdrvr/agent-core": "^0.2.0",
     "@pwrdrvr/agent-transport": "^0.1.7",

--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AcpAgentInstance } from "@pwragent/shared";
+import type {
+  AcpAgentInstance,
+  AcpRejectedAgentInstance,
+} from "@pwragent/shared";
 import type { LocalAcpDiscoveryOptions } from "@pwrdrvr/agent-acp";
 import { resolveActiveAcpInstance } from "../acp/acp-instance-resolver";
 import {
@@ -17,7 +20,11 @@ function instance(
   return { command, source, ...(version !== undefined ? { version } : {}) };
 }
 
-function group(strategyId: string, instances: AcpAgentInstance[]) {
+function group(
+  strategyId: string,
+  instances: AcpAgentInstance[],
+  rejectedInstances?: AcpRejectedAgentInstance[],
+) {
   return {
     strategyId,
     backendId: `acp:${strategyId}`,
@@ -25,6 +32,7 @@ function group(strategyId: string, instances: AcpAgentInstance[]) {
     args: ["--acp"],
     env: {},
     instances,
+    ...(rejectedInstances !== undefined ? { rejectedInstances } : {}),
     discoveredAt: 0,
   };
 }
@@ -300,6 +308,44 @@ describe("discoverLocalAcpAgentRecords", () => {
     expect(record).not.toHaveProperty("runtimeCapabilities");
   });
 
+  it("preserves rejected candidates alongside a legacy Kimi diagnostic", async () => {
+    const legacy = "/Users/me/.local/bin/kimi";
+    const rejected = "/Users/me/bin/not-kimi";
+    const discover = vi.fn(async () => [
+      group(
+        "kimi",
+        [instance(legacy, "path", "1.46.0")],
+        [
+          {
+            command: rejected,
+            source: "override",
+            reason: "acp-probe-failed",
+          },
+        ],
+      ),
+    ]);
+
+    const [record, ...rest] = await discoverLocalAcpAgentRecords({
+      discover,
+      now: () => 4242,
+      readVersionOutput: async () => "kimi, version 1.46.0",
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(record).toMatchObject({
+      installStatus: "unavailable",
+      incompatibleInstances: [expect.objectContaining({ command: legacy })],
+      rejectedInstances: [
+        {
+          command: rejected,
+          source: "override",
+          reason: "acp-probe-failed",
+        },
+      ],
+    });
+    expect(record).not.toHaveProperty("launchDescriptor");
+  });
+
   it("builds installed-agent records with a resolved launch descriptor", async () => {
     const discover = vi.fn(async () => [
       group("qwen", [
@@ -340,6 +386,47 @@ describe("discoverLocalAcpAgentRecords", () => {
       bundledGrokCommand: null,
     });
     expect(records).toEqual([]);
+  });
+
+  it("retains a detected CLI that failed ACP verification as unavailable", async () => {
+    const rejectedPath = "/usr/local/bin/qwen";
+    const discover = vi.fn(async () => [
+      group("qwen", [], [
+        {
+          command: rejectedPath,
+          version: "0.21.0",
+          source: "path",
+          reason: "acp-probe-failed",
+        },
+      ]),
+    ]);
+
+    const [record, ...rest] = await discoverLocalAcpAgentRecords({
+      discover,
+      now: () => 4242,
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(discover).toHaveBeenCalledWith(
+      expect.objectContaining({ includeRejectedCandidates: true }),
+    );
+    expect(record).toMatchObject({
+      backendId: "acp:qwen",
+      installStatus: "unavailable",
+      installedAt: 4242,
+      instances: [],
+      rejectedInstances: [
+        {
+          command: rejectedPath,
+          version: "0.21.0",
+          source: "path",
+          reason: "acp-probe-failed",
+        },
+      ],
+      lastError: `${rejectedPath} was found, but PwrAgent could not verify ACP support.`,
+    });
+    expect(record).not.toHaveProperty("launchDescriptor");
+    expect(record).not.toHaveProperty("runtimeCapabilities");
   });
 
   it("passes an empty strategy list when every provider is disabled", async () => {

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -22,6 +22,7 @@ import type {
   AcpAgentInstance,
   AcpAgentPreference,
   AcpBackendId,
+  AcpRejectedAgentInstance,
 } from "@pwragent/shared";
 import { resolveActiveAcpInstance } from "./acp-instance-resolver.js";
 import { acpAgentCapabilitiesForRegistryId } from "./acp-agent-capabilities.js";
@@ -59,6 +60,8 @@ export type AcpInstanceDiscovery = {
   instances: AcpAgentInstance[];
   /** Detected command collisions that are intentionally excluded. */
   incompatibleInstances?: AcpAgentInstance[];
+  /** Detected executables that failed ACP verification and cannot launch. */
+  rejectedInstances?: AcpRejectedAgentInstance[];
   /** The instance command currently in effect (override → picked → first). */
   activeCommand?: string;
 };
@@ -117,6 +120,7 @@ export async function discoverAcpAgentInstances(
     ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     ...(options?.env ? { env: options.env } : {}),
     ...(options?.now ? { now: options.now } : {}),
+    includeRejectedCandidates: true,
   });
   const groups = await withBundledGrok(
     discoveredGroups,
@@ -131,9 +135,11 @@ export async function discoverAcpAgentInstances(
   const byRegistryId = new Map<string, AcpInstanceDiscovery>();
   for (const group of groups) {
     const classified = await classifyGroupInstances(group, options);
+    const rejectedInstances = mapRejectedInstances(group);
     if (
       classified.instances.length === 0
       && classified.incompatibleInstances.length === 0
+      && rejectedInstances.length === 0
     ) {
       continue;
     }
@@ -146,6 +152,7 @@ export async function discoverAcpAgentInstances(
       ...(classified.incompatibleInstances.length > 0
         ? { incompatibleInstances: classified.incompatibleInstances }
         : {}),
+      ...(rejectedInstances.length > 0 ? { rejectedInstances } : {}),
       ...(active !== undefined ? { activeCommand: active.command } : {}),
     });
   }
@@ -180,6 +187,7 @@ export async function discoverLocalAcpAgentRecords(
     ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     ...(options?.env ? { env: options.env } : {}),
     ...(options?.now ? { now: options.now } : {}),
+    includeRejectedCandidates: true,
   });
   const now = options?.now?.() ?? Date.now();
   const bundledGrokCommand =
@@ -197,9 +205,11 @@ export async function discoverLocalAcpAgentRecords(
   const records: AcpInstalledAgentRecord[] = [];
   for (const group of groups) {
     const classified = await classifyGroupInstances(group, options);
+    const rejectedInstances = mapRejectedInstances(group);
     if (
       classified.instances.length === 0
       && classified.incompatibleInstances.length === 0
+      && rejectedInstances.length === 0
     ) {
       continue;
     }
@@ -216,6 +226,15 @@ export async function discoverLocalAcpAgentRecords(
           legacyKimiUnavailableRecord({
             group,
             incompatibleInstances: classified.incompatibleInstances,
+            rejectedInstances,
+            now,
+          }),
+        );
+      } else if (rejectedInstances.length > 0) {
+        records.push(
+          rejectedAcpAgentRecord({
+            group,
+            rejectedInstances,
             now,
           }),
         );
@@ -273,10 +292,22 @@ export async function discoverLocalAcpAgentRecords(
       ...(classified.incompatibleInstances.length > 0
         ? { incompatibleInstances: classified.incompatibleInstances }
         : {}),
+      ...(rejectedInstances.length > 0 ? { rejectedInstances } : {}),
       activeCommand: active.command,
     });
   }
   return records;
+}
+
+function mapRejectedInstances(
+  group: DiscoveredAcpAgentGroup,
+): AcpRejectedAgentInstance[] {
+  return (group.rejectedInstances ?? []).map((instance) => ({
+    command: instance.command,
+    ...(instance.version !== undefined ? { version: instance.version } : {}),
+    source: instance.source,
+    reason: instance.reason,
+  }));
 }
 
 async function classifyGroupInstances(
@@ -360,6 +391,7 @@ async function defaultReadVersionOutput(
 function legacyKimiUnavailableRecord(params: {
   group: DiscoveredAcpAgentGroup;
   incompatibleInstances: AcpAgentInstance[];
+  rejectedInstances: AcpRejectedAgentInstance[];
   now: number;
 }): AcpInstalledAgentRecord {
   const active = params.incompatibleInstances[0];
@@ -399,7 +431,67 @@ function legacyKimiUnavailableRecord(params: {
     registryAgent,
     instances: [],
     incompatibleInstances: params.incompatibleInstances,
+    ...(params.rejectedInstances.length > 0
+      ? { rejectedInstances: params.rejectedInstances }
+      : {}),
   };
+}
+
+function rejectedAcpAgentRecord(params: {
+  group: DiscoveredAcpAgentGroup;
+  rejectedInstances: AcpRejectedAgentInstance[];
+  now: number;
+}): AcpInstalledAgentRecord {
+  const rejected = params.rejectedInstances[0];
+  const strategy = strategyById(params.group.strategyId);
+  const registryAgent: AcpRegistryAgent = {
+    id: params.group.strategyId,
+    backendId: params.group.backendId as AcpBackendId,
+    name: params.group.name,
+    ...(rejected?.version !== undefined ? { version: rejected.version } : {}),
+    authors: strategy?.authors ?? [],
+    ...(strategy?.license !== undefined ? { license: strategy.license } : {}),
+    ...(strategy?.repositoryUrl !== undefined
+      ? { repositoryUrl: strategy.repositoryUrl }
+      : {}),
+    distributions: [],
+    distributionKinds: ["local"],
+    auth: { required: false, methods: ["agent-managed"] },
+    raw: { source: "rejected-local-cli" },
+  };
+  return {
+    backendId: params.group.backendId as AcpBackendId,
+    registryId: params.group.strategyId,
+    name: params.group.name,
+    ...(rejected?.version !== undefined ? { version: rejected.version } : {}),
+    distributionKind: "local",
+    distributionSource: `${rejected?.command ?? params.group.strategyId} (ACP verification failed)`,
+    installStatus: "unavailable",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: `local-${params.group.strategyId}-cli`,
+    installedAt: params.now,
+    updatedAt: params.now,
+    lastError: rejectedAcpCandidateMessage(rejected),
+    capabilities: acpAgentCapabilitiesForRegistryId(params.group.strategyId),
+    registryAgent,
+    instances: [],
+    rejectedInstances: params.rejectedInstances,
+  };
+}
+
+function rejectedAcpCandidateMessage(
+  rejected: AcpRejectedAgentInstance | undefined,
+): string {
+  const command = rejected?.command ?? "The detected executable";
+  switch (rejected?.reason) {
+    case "version-probe-failed":
+      return `${command} was found, but its version check failed.`;
+    case "acp-help-mismatch":
+      return `${command} was found, but its help output did not identify an ACP-capable CLI.`;
+    default:
+      return `${command} was found, but PwrAgent could not verify ACP support.`;
+  }
 }
 
 function strategiesForEnabledRegistryIds(

--- a/apps/desktop/src/main/acp/acp-registry-types.ts
+++ b/apps/desktop/src/main/acp/acp-registry-types.ts
@@ -1,6 +1,7 @@
 import type {
   AcpAgentUpdateStatus,
   AcpAgentInstance,
+  AcpRejectedAgentInstance,
   AcpBackendId,
   BackendAcpAuthStatus,
   BackendAcpDistributionKind,
@@ -116,6 +117,8 @@ export type AcpInstalledAgentRecord = {
   instances?: AcpAgentInstance[];
   /** Detected provider-name collisions that must not be launched. */
   incompatibleInstances?: AcpAgentInstance[];
+  /** Detected executables that failed ACP verification and must not launch. */
+  rejectedInstances?: AcpRejectedAgentInstance[];
   activeCommand?: string;
   update?: AcpAgentUpdateStatus;
   updateCommand?: string;

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -675,6 +675,9 @@ export function installedAcpAgentSettingsEntry(
     ...(record.incompatibleInstances !== undefined
       ? { incompatibleInstances: record.incompatibleInstances }
       : {}),
+    ...(record.rejectedInstances !== undefined
+      ? { rejectedInstances: record.rejectedInstances }
+      : {}),
     ...(record.activeCommand !== undefined
       ? { activeCommand: record.activeCommand }
       : {}),

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -283,6 +283,7 @@ function AcpAgentSection(props: {
 }) {
   const { entry, enabled } = props;
   const instances = entry.instances ?? [];
+  const rejectedInstances = entry.rejectedInstances ?? [];
   const savedPath = props.cliPathSnapshot?.value ?? "";
   const [draft, setDraft] = useState(savedPath);
   const [pathUpdating, setPathUpdating] = useState(false);
@@ -389,56 +390,81 @@ function AcpAgentSection(props: {
         ) : null}
 
         <SettingsField
-          label="Installed paths"
+          label="Detected paths"
           sub={
             enabled
               ? "Binaries detected on this machine. The active one runs new threads — click Use to pick another."
               : "Previously detected binaries. Enable this provider and Refresh before launching new threads."
           }
-          source={`${instances.length} found`}
+          source={`${instances.length + rejectedInstances.length} found`}
           error={detail}
           control={
             <div className="settings-paths" aria-label={`${entry.name} installs`}>
-              {instances.length === 0 ? (
+              {instances.length === 0 && rejectedInstances.length === 0 ? (
                 <p className="settings-empty">Not installed.</p>
               ) : (
-                instances.map((instance) => {
-                  const active =
-                    enabled && instance.command === entry.activeCommand;
-                  const chips: SettingsPathRowChip[] = [
-                    {
-                      label: instance.source === "override" ? "override" : "path",
-                      tone: "muted",
-                    },
-                    {
-                      label: instance.version
-                        ? `v${instance.version}`
-                        : "version unknown",
-                      tone: "muted",
-                    },
-                  ];
-                  if (!active) {
-                    chips.push({ label: "available", tone: "muted" });
-                  }
-                  return (
+                <>
+                  {instances.map((instance) => {
+                    const active =
+                      enabled && instance.command === entry.activeCommand;
+                    const chips: SettingsPathRowChip[] = [
+                      {
+                        label: instance.source === "override" ? "override" : "path",
+                        tone: "muted",
+                      },
+                      {
+                        label: instance.version
+                          ? `v${instance.version}`
+                          : "version unknown",
+                        tone: "muted",
+                      },
+                    ];
+                    if (!active) {
+                      chips.push({ label: "available", tone: "muted" });
+                    }
+                    return (
+                      <SettingsPathRow
+                        key={instance.command}
+                        path={instance.command}
+                        chips={chips}
+                        selected={active}
+                        selectedLabel="Using"
+                        useLabel="Use"
+                        disabled={pathControlsDisabled}
+                        onUse={
+                          props.onCliPathChange
+                            ? () => {
+                                void commitPath(instance.command);
+                              }
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
+                  {rejectedInstances.map((instance) => (
                     <SettingsPathRow
                       key={instance.command}
                       path={instance.command}
-                      chips={chips}
-                      selected={active}
-                      selectedLabel="Using"
-                      useLabel="Use"
-                      disabled={pathControlsDisabled}
-                      onUse={
-                        props.onCliPathChange
-                          ? () => {
-                              void commitPath(instance.command);
-                            }
-                          : undefined
-                      }
+                      chips={[
+                        {
+                          label: instance.source === "override" ? "override" : "path",
+                          tone: "muted",
+                        },
+                        {
+                          label: instance.version
+                            ? `v${instance.version}`
+                            : "version unknown",
+                          tone: "muted",
+                        },
+                        {
+                          label: rejectedAcpInstanceLabel(instance.reason),
+                          tone: "muted",
+                        },
+                      ]}
+                      selected={false}
                     />
-                  );
-                })
+                  ))}
+                </>
               )}
             </div>
           }
@@ -520,4 +546,17 @@ function AcpAgentSection(props: {
       </div>
     </SettingsSection>
   );
+}
+
+function rejectedAcpInstanceLabel(
+  reason: NonNullable<AcpAgentSettingsEntry["rejectedInstances"]>[number]["reason"],
+): string {
+  switch (reason) {
+    case "version-probe-failed":
+      return "version check failed";
+    case "acp-help-mismatch":
+      return "not recognized as ACP";
+    default:
+      return "ACP check failed";
+  }
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -562,8 +562,56 @@ describe("AcpAgentsSettings", () => {
     expect(screen.getByText("Not installed.")).toBeInTheDocument();
   });
 
+  it("surfaces a detected CLI that failed ACP verification", async () => {
+    const rejectedPath = "/usr/local/bin/qwen";
+    const desktopApi = {
+      listAcpAgents: vi.fn(async () => ({
+        fetchedAt: 1000,
+        entries: [
+          {
+            backendId: "acp:qwen",
+            registryId: "qwen",
+            name: "Qwen Code",
+            authors: [],
+            distributionKind: "local",
+            distributionSource: `${rejectedPath} (ACP verification failed)`,
+            installable: false,
+            installed: false,
+            installStatus: "unavailable",
+            authStatus: "not-required",
+            verificationStatus: "not-applicable",
+            lastError: `${rejectedPath} was found, but PwrAgent could not verify ACP support.`,
+            instances: [],
+            rejectedInstances: [
+              {
+                command: rejectedPath,
+                version: "0.21.0",
+                source: "path",
+                reason: "acp-probe-failed",
+              },
+            ],
+          } satisfies AcpAgentSettingsEntry,
+        ],
+      })),
+    } as unknown as DesktopApi;
+
+    render(<AcpAgentsSettings desktopApi={desktopApi} />);
+
+    expect(await screen.findByText("Qwen Code")).toBeInTheDocument();
+    expect(screen.getByText("Detected · unavailable")).toBeInTheDocument();
+    expect(screen.getByText(rejectedPath)).toBeInTheDocument();
+    expect(screen.getByText("ACP check failed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${rejectedPath} was found, but PwrAgent could not verify ACP support.`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Not installed.")).not.toBeInTheDocument();
+  });
+
   it("renders a durable remediation card for legacy Python kimi-cli", async () => {
     const legacyPath = "/Users/me/.local/bin/kimi";
+    const rejectedPath = "/Users/me/bin/not-kimi";
     const desktopApi = {
       listAcpAgents: vi.fn(async () => ({
         fetchedAt: 1000,
@@ -585,6 +633,13 @@ describe("AcpAgentsSettings", () => {
             incompatibleInstances: [
               { command: legacyPath, version: "1.46.0", source: "path" },
             ],
+            rejectedInstances: [
+              {
+                command: rejectedPath,
+                source: "override",
+                reason: "acp-probe-failed",
+              },
+            ],
           } satisfies AcpAgentSettingsEntry,
         ],
       })),
@@ -598,6 +653,8 @@ describe("AcpAgentsSettings", () => {
     expect(screen.getByText("Action required")).toBeInTheDocument();
     expect(screen.getByText(legacyPath)).toBeInTheDocument();
     expect(screen.getByText("legacy Python")).toBeInTheDocument();
+    expect(screen.getByText(rejectedPath)).toBeInTheDocument();
+    expect(screen.getByText("ACP check failed")).toBeInTheDocument();
     expect(
       screen.getByText(
         "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",

--- a/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
+++ b/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
@@ -13,5 +13,8 @@ export function acpStatusLabel(entry: AcpAgentSettingsEntry): string {
   if (entry.installStatus === "not-installed") {
     return "Not installed";
   }
+  if (entry.rejectedInstances?.length) {
+    return "Detected · unavailable";
+  }
   return "Unavailable";
 }

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -284,6 +284,9 @@ export type AcpAgentSettingsEntry = {
    *  unsupported predecessor product. They are shown for remediation but are
    *  never eligible for launch or model discovery. */
   incompatibleInstances?: AcpAgentInstance[];
+  /** Detected executables that failed the Agent Kit ACP discovery probe.
+   *  They are diagnostic-only and must never be offered as launch targets. */
+  rejectedInstances?: AcpRejectedAgentInstance[];
   activeCommand?: string;
   enabled?: boolean;
   preference?: AcpAgentPreference;
@@ -316,6 +319,11 @@ export type AcpAgentInstance = {
   version?: string;
   /** How the path was found: user override, a `PATH` match, or a fallback path. */
   source: AcpAgentInstanceSource;
+};
+
+/** An executable that was found but did not pass ACP discovery. */
+export type AcpRejectedAgentInstance = AcpAgentInstance & {
+  reason: "version-probe-failed" | "acp-probe-failed" | "acp-help-mismatch";
 };
 
 /** A user's per-agent path choice. `overridePath` is a manual absolute path

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       '@pwrdrvr/agent-acp':
-        specifier: ^0.13.1
-        version: 0.13.1(zod@4.4.3)
+        specifier: ^0.14.0
+        version: 0.14.0(zod@4.4.3)
       '@pwrdrvr/agent-client':
         specifier: ^0.7.0
         version: 0.7.0
@@ -1064,8 +1064,8 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@pwrdrvr/agent-acp@0.13.1':
-    resolution: {integrity: sha512-AUPX0/+cbLaIYR23i8Z37RmaOkZrjdyIA2wTWqvZSDcWQT1wLxyGKLtKuQAq3z2Ka5Dk/hmT/PCrDTNTcVmjxw==}
+  '@pwrdrvr/agent-acp@0.14.0':
+    resolution: {integrity: sha512-BB3gjgJ7SAHRFrc1kBQy4eyuH3adSYSp24S3OuUnPmJ3/cg3jg4xxyib9ielkS8VSOdMWMcrx0XA72XUlScS3A==}
 
   '@pwrdrvr/agent-client@0.7.0':
     resolution: {integrity: sha512-b1PNsaVtcXN69HLSF5uK7yqD1AhJocURSqZT9j9EhKSUugcp+8KqLsU4m2v+PBiz/Au+FlHjWsiPz0Yz/NN/eg==}
@@ -5156,7 +5156,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@pwrdrvr/agent-acp@0.13.1(zod@4.4.3)':
+  '@pwrdrvr/agent-acp@0.14.0(zod@4.4.3)':
     dependencies:
       '@agentclientprotocol/sdk': 1.3.0(zod@4.4.3)
       '@pwrdrvr/agent-core': 0.2.0


### PR DESCRIPTION
## What

Surface executable candidates that Agent Kit detected but rejected during ACP discovery, instead of presenting their providers as not installed.

- update to `@pwrdrvr/agent-acp` 0.14.0
- retain rejected candidate paths and safe probe reasons as unavailable diagnostic records
- render detected paths as non-selectable with their verification failure

## Safety

Rejected candidates never receive a launch descriptor, runtime capability probe, or selectable `Use` action.

## Tests

- `pnpm test apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`

Addresses #646.