### PR TITLE
fix(desktop): persist both update axes when one is changed

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -395,12 +395,18 @@ function SettingsSectionBody(props: {
         }}
         onUpdateChannelChange={async (channel: DesktopUpdateChannel) => {
           await props.settings.writeConfig({
-            updates: { channel },
+            updates: {
+              channel,
+              train: props.snapshot.updates.train.value,
+            },
           });
         }}
         onUpdateTrainChange={async (train: DesktopUpdateTrain) => {
           await props.settings.writeConfig({
-            updates: { train },
+            updates: {
+              train,
+              channel: props.snapshot.updates.channel.value,
+            },
           });
         }}
         onPastedImageMaxPatchesChange={async (pastedImageMaxPatches) => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -848,6 +848,7 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         updates: {
           train: "beta",
+          channel: "latest",
         },
       });
     });
@@ -856,6 +857,7 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         updates: {
           channel: "prerelease",
+          train: "stable",
         },
       });
     });
@@ -5088,6 +5090,52 @@ describe("SettingsScreen", () => {
         "Enabled Auto-fix PR for 2 existing threads with a primary attached pull request.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("keeps an inferred Beta train when the operator picks Latest", async () => {
+    const settings = createSettingsState(
+      createSnapshot({
+        updates: {
+          channel: { value: "prerelease", source: "default" },
+          train: { value: "beta", source: "default" },
+        },
+      }),
+    );
+    const desktopApi = {
+      readAppUpdateReleaseVersions: vi.fn(async () => ({
+        fetchedAt: 1,
+        stable: {
+          latest: { version: "v1.0.1" },
+          prerelease: { version: "v1.0.1" },
+        },
+        beta: {
+          latest: { version: "v1.1.0-beta.2" },
+          prerelease: { version: "v1.1.0-alpha.7" },
+        },
+      })),
+    };
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /Beta/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /Latest/ }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        updates: {
+          channel: "latest",
+          train: "beta",
+        },
+      });
+    });
   });
 
   it("blocks settings edits when the config file cannot be parsed", () => {


### PR DESCRIPTION
## Summary

#1673 shipped Settings → Updates as two axes (Stable|Beta × Latest|Prerelease), but `SettingsScreen` wrote only the axis the operator just changed. `resolveUpdateSelection` infers Beta/Prerelease from an alpha/beta binary only when **both** `updates.train` and `updates.channel` are absent. After a one-axis write, the missing key defaults to Stable/Latest.

An inferred Beta/Prerelease install that clicked Latest therefore persisted `channel=latest` and then fell back to **Stable/Latest**.

This PR writes the current resolved value of the other axis from `snapshot.updates` whenever one axis changes. Same fix as `3377140c3` on the 1.0 backport (#1682).

`resolveUpdateSelection`'s legacy rule is unchanged: a config with only `channel=prerelease` still stays on Stable.

## Verification

- [x] `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (67 passed)
- [x] `pnpm --filter @pwragent/desktop typecheck`
- [x] New test: inferred `train=beta` / `channel=prerelease` (`source=default`); click Latest; expect `writeConfig({ updates: { channel: "latest", train: "beta" } })`

## Notes

- Front-port of the 1.0 backport commit `3377140c3`.
- Does not change `resolveUpdateSelection`.