### PR TITLE
feat(desktop): move Remote Instances into the Profiles menu

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1284,7 +1284,7 @@ describe("bootstrapApp", () => {
     expect(requestOpenNewThreadMock).toHaveBeenCalledOnce();
   });
 
-  it("keeps a File -> Remote Instances window subscribed to live transcript events", async () => {
+  it("keeps a Profiles -> Remote Instances window subscribed to live transcript events", async () => {
     startupProfilerInstance.start.mockResolvedValue();
     const peer = {
       target: { scope: "remote" as const, instanceId: "owner_one" },
@@ -1342,11 +1342,10 @@ describe("bootstrapApp", () => {
     const template = buildFromTemplateMock.mock.calls[0]?.[0] as
       | TestMenuItem[]
       | undefined;
-    const fileMenu = template?.find((item) => item.label === "File");
-    const remoteInstances = fileMenu?.submenu?.find(
-      (item) => item.label === "Remote Instances",
-    );
-    const owner = remoteInstances?.submenu?.find(
+    // One connected peer stays inline under the "Remote Instances" heading
+    // in the Profiles menu rather than collapsing into a submenu.
+    const profilesMenu = template?.find((item) => item.label === "Profiles");
+    const owner = profilesMenu?.submenu?.find(
       (item) => item.label === peer.label,
     );
 

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -8,6 +8,11 @@ function buildTemplate(
   options?: {
     isMac?: boolean;
     copyLocalDiagnosticsInfo?: () => void;
+    federationPeers?: Array<{ instanceId: string; label: string }>;
+    openFederationWindow?: (peer: {
+      instanceId: string;
+      label: string;
+    }) => void;
     openNewThread?: () => void;
     openProfile?: (profile: string) => void;
     openProfilesSettings?: () => void;
@@ -24,7 +29,7 @@ function buildTemplate(
     appName: "PwrAgent",
     developerMode,
     isMac: options?.isMac ?? true,
-    federationPeers: [],
+    federationPeers: options?.federationPeers ?? [],
     profiles: options?.profiles ?? [
       profile("work"),
       profile("default", { active: true, default: true }),
@@ -39,7 +44,7 @@ function buildTemplate(
       copyLocalDiagnosticsInfo: options?.copyLocalDiagnosticsInfo ?? vi.fn(),
       focusWindow: vi.fn(),
       openDocumentation: vi.fn(),
-      openFederationWindow: vi.fn(),
+      openFederationWindow: options?.openFederationWindow ?? vi.fn(),
       openIssueReporter: vi.fn(),
       openNewThread: options?.openNewThread ?? vi.fn(),
       openProfile: options?.openProfile ?? vi.fn(),
@@ -370,59 +375,120 @@ describe("buildApplicationMenuTemplate", () => {
   });
 
   describe("federation remote instances", () => {
-    it("hides the Remote Instances item when no peers are connected", () => {
-      const fileItems = submenuItems(buildTemplate(false), "File");
-      expect(
-        fileItems.some((item) => item.label === "Remote Instances"),
-      ).toBe(false);
+    function peer(index: number): { instanceId: string; label: string } {
+      return {
+        instanceId: `pwr_peer_${index}`,
+        label: `Studio-Mac-${index} / default`,
+      };
+    }
+
+    function peers(count: number): Array<{ instanceId: string; label: string }> {
+      return Array.from({ length: count }, (_unused, index) => peer(index + 1));
+    }
+
+    it("shows no Remote Instances section when no peers are connected", () => {
+      const items = submenuItems(buildTemplate(false), "Profiles");
+
+      expect(items.some((item) => item.label === "Remote Instances")).toBe(false);
     });
 
-    it("lists connected peers and routes clicks to openFederationWindow", () => {
-      const openFederationWindow = vi.fn();
-      const template = buildApplicationMenuTemplate({
-        appName: "PwrAgent",
-        developerMode: false,
-        isMac: true,
-        federationPeers: [
-          { instanceId: "pwr_gateway", label: "Studio Mac" },
-        ],
-        profiles: [],
-        windows: [],
-        actions: {
-          checkForUpdates: vi.fn(),
-          copyLocalDiagnosticsInfo: vi.fn(),
-          focusWindow: vi.fn(),
-          openDocumentation: vi.fn(),
-          openFederationWindow,
-          openIssueReporter: vi.fn(),
-          openNewThread: vi.fn(),
-          openProfile: vi.fn(),
-          openProfilesSettings: vi.fn(),
-          openSettings: vi.fn(),
-          openWebsite: vi.fn(),
-          quit: vi.fn(),
-          replayOnboarding: vi.fn(),
-          showAboutPanel: vi.fn(),
-          showChangelogWindow: vi.fn(),
-          showLicenseWindow: vi.fn(),
-          showLogsWindow: vi.fn(),
-          showThirdPartyNoticesWindow: vi.fn(),
-        },
-      });
+    it("keeps the File menu free of federation entries", () => {
+      const items = submenuItems(
+        buildTemplate(false, { federationPeers: peers(1) }),
+        "File",
+      );
 
-      const remoteInstances = submenuItems(template, "File").find(
+      expect(items.map((item) => item.label ?? item.role ?? item.type)).toEqual([
+        "New Thread",
+        "separator",
+        "close",
+      ]);
+    });
+
+    it("lists peers under the local profiles and routes clicks to openFederationWindow", () => {
+      const openFederationWindow = vi.fn();
+      const items = submenuItems(
+        buildTemplate(false, {
+          federationPeers: peers(2),
+          openFederationWindow,
+        }),
+        "Profiles",
+      );
+
+      expect(items.map((item) => item.label ?? item.type)).toEqual([
+        "default",
+        "personal",
+        "work",
+        "separator",
+        "Remote Instances",
+        "Studio-Mac-1 / default",
+        "Studio-Mac-2 / default",
+        "separator",
+        "New Profile…",
+        "Manage Profiles…",
+      ]);
+      // The heading is a label, not a target: it must not be clickable and
+      // must not carry the peers as a submenu at this count.
+      const heading = items.find((item) => item.label === "Remote Instances");
+      expect(heading?.enabled).toBe(false);
+      expect(heading?.submenu).toBeUndefined();
+
+      (items.find((item) => item.label === "Studio-Mac-2 / default")?.click as
+        | (() => void)
+        | undefined)?.();
+
+      expect(openFederationWindow).toHaveBeenCalledWith(peer(2));
+    });
+
+    it("keeps five peers inline", () => {
+      const items = submenuItems(
+        buildTemplate(false, { federationPeers: peers(5) }),
+        "Profiles",
+      );
+      const headingIndex = items.findIndex(
         (item) => item.label === "Remote Instances",
       );
-      expect(remoteInstances).toBeDefined();
+
+      expect(items[headingIndex]?.enabled).toBe(false);
+      expect(
+        items.slice(headingIndex + 1, headingIndex + 6).map((item) => item.label),
+      ).toEqual(peers(5).map((entry) => entry.label));
+    });
+
+    it("collapses past five peers into a Remote Instances submenu", () => {
+      const openFederationWindow = vi.fn();
+      const items = submenuItems(
+        buildTemplate(false, {
+          federationPeers: peers(6),
+          openFederationWindow,
+        }),
+        "Profiles",
+      );
+
+      expect(items.map((item) => item.label ?? item.type)).toEqual([
+        "default",
+        "personal",
+        "work",
+        "separator",
+        "Remote Instances",
+        "separator",
+        "New Profile…",
+        "Manage Profiles…",
+      ]);
+      const remoteInstances = items.find(
+        (item) => item.label === "Remote Instances",
+      );
+      expect(remoteInstances?.enabled).toBeUndefined();
       const peerItems = Array.isArray(remoteInstances?.submenu)
         ? remoteInstances.submenu
         : [];
-      expect(peerItems.map((item) => item.label)).toEqual(["Studio Mac"]);
-      (peerItems[0]?.click as () => void | undefined)?.();
-      expect(openFederationWindow).toHaveBeenCalledWith({
-        instanceId: "pwr_gateway",
-        label: "Studio Mac",
-      });
+      expect(peerItems.map((item) => item.label)).toEqual(
+        peers(6).map((entry) => entry.label),
+      );
+
+      (peerItems.at(-1)?.click as (() => void) | undefined)?.();
+
+      expect(openFederationWindow).toHaveBeenCalledWith(peer(6));
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -440,6 +440,61 @@ describe("buildApplicationMenuTemplate", () => {
       expect(openFederationWindow).toHaveBeenCalledWith(peer(2));
     });
 
+    it("sorts peers by label so a rebuild cannot swap rows under the pointer", () => {
+      // connectedPeerTargets() walks the gateway directory, then stored
+      // peers, then connection-only peers — an order that changes across a
+      // directory re-announcement or a federation restart, both of which
+      // rebuild this menu.
+      const items = submenuItems(
+        buildTemplate(false, {
+          federationPeers: [
+            { instanceId: "pwr_c", label: "Studio-Mac-3 / dev" },
+            { instanceId: "pwr_a", label: "Studio-Mac-1 / default" },
+            { instanceId: "pwr_b2", label: "Studio-Mac-2 / default" },
+            { instanceId: "pwr_b1", label: "Studio-Mac-2 / default" },
+          ],
+          openFederationWindow: vi.fn(),
+        }),
+        "Profiles",
+      );
+      const headingIndex = items.findIndex(
+        (item) => item.label === "Remote Instances",
+      );
+
+      expect(
+        items.slice(headingIndex + 1, headingIndex + 5).map((item) => item.label),
+      ).toEqual([
+        "Studio-Mac-1 / default",
+        "Studio-Mac-2 / default",
+        "Studio-Mac-2 / default",
+        "Studio-Mac-3 / dev",
+      ]);
+    });
+
+    it("breaks label ties by instance id so duplicate labels hold still", () => {
+      const openFederationWindow = vi.fn();
+      const items = submenuItems(
+        buildTemplate(false, {
+          federationPeers: [
+            { instanceId: "pwr_b2", label: "Studio-Mac / default" },
+            { instanceId: "pwr_b1", label: "Studio-Mac / default" },
+          ],
+          openFederationWindow,
+        }),
+        "Profiles",
+      );
+      const headingIndex = items.findIndex(
+        (item) => item.label === "Remote Instances",
+      );
+
+      (items[headingIndex + 1]?.click as (() => void) | undefined)?.();
+
+      expect(openFederationWindow).toHaveBeenCalledWith({
+        instanceId: "pwr_b1",
+        label: "Studio-Mac / default",
+      });
+    });
+
     it("keeps five peers inline", () => {
       const items = submenuItems(
         buildTemplate(false, { federationPeers: peers(5) }),

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1020,7 +1020,7 @@ function installWindowMenuRefreshHandlers(): void {
     window.on("closed", refresh);
     window.on("page-title-updated", refresh);
   });
-  // Keep File → Remote Instances in sync with peer connectivity.
+  // Keep Profiles → Remote Instances in sync with peer connectivity.
   getDesktopFederationRuntime().onPeerStatusChanged(() => {
     installApplicationMenu();
   });

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -6,6 +6,20 @@ export type ApplicationMenuFederationPeer = {
   label: string;
 };
 
+/**
+ * Heading the connected federation peers sit under inside the Profiles
+ * menu, and the label of the submenu they collapse into once there are
+ * more of them than `MAX_INLINE_FEDERATION_PEERS`.
+ */
+const REMOTE_INSTANCES_LABEL = "Remote Instances";
+
+/**
+ * How many peers stay listed inline before collapsing into a submenu.
+ * Five keeps the Profiles menu scannable in the common case (a laptop, a
+ * desktop, a couple of build machines) without a second level of clicks.
+ */
+const MAX_INLINE_FEDERATION_PEERS = 5;
+
 export type ApplicationMenuActions = {
   checkForUpdates: () => void;
   copyLocalDiagnosticsInfo: () => void;
@@ -37,7 +51,7 @@ export type ApplicationMenuOptions = {
   appName: string;
   developerMode: boolean;
   isMac: boolean;
-  /** Connected federation peers; empty hides the Remote Instances menu. */
+  /** Connected federation peers; empty hides the Remote Instances section. */
   federationPeers: ApplicationMenuFederationPeer[];
   profiles: DesktopPwrAgentProfileSummary[];
   windows: ApplicationMenuWindow[];
@@ -108,23 +122,6 @@ function buildFileMenu(options: ApplicationMenuOptions): MenuItemConstructorOpti
         accelerator: "CmdOrCtrl+N",
         click: options.actions.openNewThread,
       },
-      // Federation's browse entry point outside Settings: each connected
-      // peer opens its remote-threads window. Hidden entirely when no
-      // peer is connected so non-federation users never see the item.
-      ...(options.federationPeers.length > 0
-        ? [
-            { type: "separator" as const },
-            {
-              label: "Remote Instances",
-              submenu: options.federationPeers.map((peer) => ({
-                label: peer.label,
-                click: () => {
-                  options.actions.openFederationWindow(peer);
-                },
-              })),
-            },
-          ]
-        : []),
       { type: "separator" },
       { role: "close" },
       ...(options.isMac
@@ -187,6 +184,7 @@ function buildProfilesMenu(options: ApplicationMenuOptions): MenuItemConstructor
     label: "Profiles",
     submenu: [
       ...profileItems,
+      ...buildFederationPeerItems(options),
       { type: "separator" },
       {
         label: "New Profile…",
@@ -198,6 +196,44 @@ function buildProfilesMenu(options: ApplicationMenuOptions): MenuItemConstructor
       },
     ],
   };
+}
+
+/**
+ * Connected peers live with the local profiles because that is what a
+ * peer is to an operator: another place their work runs, addressed the
+ * same "<machine> / <profile>" way. They open a remote window instead of
+ * switching this window's profile, so they sit under their own heading
+ * rather than merging into the checkbox list above.
+ *
+ * Returns nothing when no peer is connected, so an operator who has never
+ * paired an instance never sees the heading.
+ */
+function buildFederationPeerItems(
+  options: ApplicationMenuOptions,
+): MenuItemConstructorOptions[] {
+  if (options.federationPeers.length === 0) {
+    return [];
+  }
+
+  const peerItems: MenuItemConstructorOptions[] = options.federationPeers.map(
+    (peer) => ({
+      label: peer.label,
+      click: () => {
+        options.actions.openFederationWindow(peer);
+      },
+    }),
+  );
+
+  return [
+    { type: "separator" },
+    // Past the inline budget the flat list crowds out the local profiles
+    // it sits under, so the same heading becomes the submenu that holds
+    // them. The heading label stays put either way — an operator hunting
+    // for a peer looks in the same place at three peers and at thirty.
+    ...(peerItems.length > MAX_INLINE_FEDERATION_PEERS
+      ? [{ label: REMOTE_INSTANCES_LABEL, submenu: peerItems }]
+      : [{ label: REMOTE_INSTANCES_LABEL, enabled: false }, ...peerItems]),
+  ];
 }
 
 function buildWindowMenu(options: ApplicationMenuOptions): MenuItemConstructorOptions {

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -215,14 +215,14 @@ function buildFederationPeerItems(
     return [];
   }
 
-  const peerItems: MenuItemConstructorOptions[] = options.federationPeers.map(
-    (peer) => ({
-      label: peer.label,
-      click: () => {
-        options.actions.openFederationWindow(peer);
-      },
-    }),
-  );
+  const peerItems: MenuItemConstructorOptions[] = orderPeersForMenu(
+    options.federationPeers,
+  ).map((peer) => ({
+    label: peer.label,
+    click: () => {
+      options.actions.openFederationWindow(peer);
+    },
+  }));
 
   return [
     { type: "separator" },
@@ -264,6 +264,27 @@ function buildWindowMenu(options: ApplicationMenuOptions): MenuItemConstructorOp
       ...windowItems,
     ],
   };
+}
+
+/**
+ * Peers arrive in `connectedPeerTargets()` order, which is a Map walk over
+ * the gateway directory, the stored peers, then connection-only peers —
+ * an order that survives neither a directory re-announcement nor a
+ * federation restart. The menu rebuilds on every peer status change, so
+ * leaving that order alone would let rows swap under the pointer and turn
+ * a muscle-memory click into the wrong machine's remote window. Sort by
+ * label, matching the local profiles these rows now sit beside, with the
+ * instance id breaking ties so two identically labelled peers hold still
+ * too.
+ */
+function orderPeersForMenu(
+  peers: ApplicationMenuFederationPeer[],
+): ApplicationMenuFederationPeer[] {
+  return [...peers].sort(
+    (left, right) =>
+      left.label.localeCompare(right.label)
+      || left.instanceId.localeCompare(right.instanceId),
+  );
 }
 
 function orderProfilesForMenu(


### PR DESCRIPTION
## Why

Connected federation peers lived under **File → Remote Instances**. File is about the document/window in front of you; a peer is not a file operation. To an operator a peer is *another place their work runs*, addressed the same way a local profile is — `<machine> / <profile>` — so it belongs next to the local profiles.

## What

Peers now sit in the **Profiles** menu, under a `Remote Instances` heading, between the local profile checkboxes and New/Manage Profile:

```
Profiles
  ✓ default                        ⌘1
    acp-smoke                      ⌘2
    dev                            ⌘3
    work
  ──────────────────────────
    Remote Instances               (heading, disabled)
    Harold-MBP-M2-Max
    Harold-MBP-M5-Max / default
    Harold-MBP-2018
  ──────────────────────────
    New Profile…
    Manage Profiles…
```

Up to **five** peers stay inline. Past that, the same label becomes the submenu that holds them, so a big fleet never crowds out the profiles it sits under and an operator hunting for a peer looks in the same place at three peers and at thirty:

```
  ──────────────────────────
    Remote Instances          ▸    (submenu, 6+ peers)
  ──────────────────────────
```

Nothing is shown when no peer is connected, so a non-federation operator never sees the heading. The peer labels already come from `formatFederationPeerDisplayLabel`, which composes `<machine>` or `<machine> / <profile>` depending on whether two profiles of the same machine are visible.

Behavior is otherwise unchanged — the same click still opens the peer's remote window through `openFederationWindow`, and the menu still rebuilds on `onPeerStatusChanged`.

## Not included: the per-peer celestial icon

The ask floated putting each peer's federation icon next to its name. Skipped deliberately: the identity mark is the **celestial icon** (`CelestialIconId` — sun/moon/ringed planet/tilted ringed planet/black hole), and those live as renderer SVG components with opacity layering, `evenodd` punch-outs, and rotations. A native `MenuItemConstructorOptions.icon` needs a rasterized `NativeImage`, so shipping it means either committing pre-rendered PNGs or re-drawing the geometry in the main process with `@napi-rs/canvas` — a second source of truth for the shapes either way, plus per-platform tinting (macOS template images invert for free; Windows/Linux do not). Happy to do it as a follow-up if the icons are worth that; the section heading carries the "these are remote" signal in the meantime.

## Testing

- `apps/desktop/src/main/__tests__/menu.test.ts` — new coverage for the section's absence with no peers, the File menu staying free of federation entries, the inline layout + click routing, the 5-peer inline boundary, and the 6-peer collapse into a submenu (including that the heading is non-clickable inline and IS the submenu when collapsed).
- `apps/desktop/src/main/__tests__/index.test.ts` — the live-transcript-subscription test now drives the peer from the Profiles menu.
- `pnpm lint:eslint` (0 errors), `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)