### PR TITLE
fix(desktop): correct composer autocomplete listbox semantics

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -135,6 +135,11 @@ const COPY_CHIP_FIXTURE = path.resolve(
   "fixtures/a11y-copy-chips/replay.fixture.json",
 );
 
+const COMPOSER_AUTOCOMPLETE_FIXTURE = path.resolve(
+  specDir,
+  "fixtures/skill-autocomplete-interactions/replay.fixture.json",
+);
+
 const WCAG_AA_TAGS = [
   "wcag2a",
   "wcag2aa",
@@ -177,6 +182,8 @@ async function runAxe(
      * genuinely needs it.
      */
     include?: string;
+    /** Run only the named axe rules when a regression gate is rule-specific. */
+    rules?: string[];
   },
 ): Promise<void> {
   // setLegacyMode is required under Electron: the default analyze()
@@ -187,9 +194,12 @@ async function runAxe(
   // cross-origin iframes, so the legacy single-context path covers
   // everything we render anyway. See
   // https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright/error-handling.md
-  let builder = new AxeBuilder({ page: window })
-    .withTags(WCAG_AA_TAGS)
-    .setLegacyMode(true);
+  let builder = new AxeBuilder({ page: window }).setLegacyMode(true);
+  if (options?.rules) {
+    builder = builder.withRules(options.rules);
+  } else {
+    builder = builder.withTags(WCAG_AA_TAGS);
+  }
   if (options?.include) {
     builder = builder.include(options.include);
   }
@@ -364,6 +374,65 @@ for (const theme of AUDIT_THEMES) {
             }),
           ).toBeVisible();
           await runAxe(app.window, "sidebar rows carrying copy chips");
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    // The default smoke fixture never opens a composer autocomplete, so its
+    // listboxes and active-descendant targets otherwise remain outside the
+    // gate. Audit both shapes: `$` is the shared listbox-of-options pattern,
+    // while `@` also carries real Add buttons that must stay outside the
+    // listbox rather than masquerading as directory options.
+    test("composer autocomplete listbox semantics are valid", async () => {
+      const app = await launchAuditApp({
+        theme,
+        fixturePath: COMPOSER_AUTOCOMPLETE_FIXTURE,
+      });
+      try {
+        await app.window
+          .getByRole("button", { name: /Skill autocomplete replay/i })
+          .first()
+          .click();
+        const textbox = app.window.getByRole("textbox", { name: "Reply" });
+        await expect(textbox).toBeVisible();
+
+        await test.step("skills autocomplete", async () => {
+          await textbox.fill("$ce");
+          const skills = app.window.getByRole("listbox", { name: "Skills" });
+          const activeOption = skills.getByRole("option").first();
+          await expect(activeOption).toBeVisible();
+          await expect(activeOption).toHaveAttribute("aria-selected", "true");
+          await expect(textbox).toHaveAttribute(
+            "aria-activedescendant",
+            await activeOption.getAttribute("id") ?? "missing-option-id",
+          );
+          await runAxe(app.window, "skills autocomplete", {
+            rules: ["aria-required-children", "aria-required-parent"],
+          });
+        });
+
+        await test.step("directory autocomplete with sibling actions", async () => {
+          await textbox.fill("@");
+          const directories = app.window.getByRole("listbox", {
+            name: "Directories",
+          });
+          await expect(directories.getByRole("option").first()).toBeVisible();
+          await expect(directories.getByRole("button")).toHaveCount(0);
+          await expect(
+            app.window.getByRole("button", { name: "+ Add directory…" }),
+          ).toBeVisible();
+          await expect(
+            app.window.getByRole("button", { name: "+ Add file…" }),
+          ).toBeVisible();
+          await runAxe(
+            app.window,
+            "directory autocomplete with sibling actions",
+            {
+              rules: ["aria-required-children", "aria-required-parent"],
+            },
+          );
         });
       } finally {
         await app.close();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -241,7 +241,7 @@ async function typeSkillChip(
   optionName: RegExp,
 ) {
   await app.window.keyboard.type(triggerText);
-  const option = app.window.getByRole("button", { name: optionName });
+  const option = app.window.getByRole("option", { name: optionName });
   await option.focus();
   await expect(option).toBeFocused();
   await app.window.keyboard.press("Enter");
@@ -266,10 +266,10 @@ test("directory launchpad loads skill autocomplete from user and local scope", a
     await app.window.getByRole("textbox", { name: "New thread" }).fill("$");
 
     await expect(
-      app.window.getByRole("button", { name: /\$frontend-design/i }),
+      app.window.getByRole("option", { name: /\$frontend-design/i }),
     ).toBeVisible();
     await expect(
-      app.window.getByRole("button", { name: /\$desktop-e2e-fixture-seeding/i }),
+      app.window.getByRole("option", { name: /\$desktop-e2e-fixture-seeding/i }),
     ).toBeVisible();
   } finally {
     await app.close();
@@ -295,7 +295,7 @@ test("directory launchpad keyboard typing updates the composer once", async () =
       )
       .toBe("$ce");
     await expect(
-      app.window.getByRole("button", { name: /\$ce:brainstorm/i }),
+      app.window.getByRole("option", { name: /\$ce:brainstorm/i }),
     ).toBeVisible();
   } finally {
     await app.close();
@@ -641,7 +641,7 @@ test("directory launchpad skill autocomplete honors markdown offsets after forma
     await expect(tiptapInput).toHaveAttribute("data-value", "## heading\n\n$ce:b");
     const listbox = app.window.getByRole("listbox", { name: "Skills" });
     await expect(listbox).toBeVisible();
-    const brainstormOption = listbox.getByRole("button", {
+    const brainstormOption = listbox.getByRole("option", {
       name: /\$ce:brainstorm/i,
     });
     await expect(brainstormOption).toBeVisible();
@@ -674,7 +674,7 @@ test("directory launchpad Tiptap composer selects focused skills as undoable inl
     await textbox.focus();
     await app.window.keyboard.type("$front");
 
-    const option = app.window.getByRole("button", { name: /\$frontend-design/i });
+    const option = app.window.getByRole("option", { name: /\$frontend-design/i });
     await option.focus();
     await expect(option).toBeFocused();
     await app.window.keyboard.press("Enter");

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -32,8 +32,8 @@ async function openSkillAutocompleteThread(
 async function getActiveOptionIndex(
   listbox: Locator,
 ): Promise<number> {
-  return await listbox.getByRole("button").evaluateAll((buttons) =>
-    buttons.findIndex((button) => button.getAttribute("aria-selected") === "true"),
+  return await listbox.getByRole("option").evaluateAll((options) =>
+    options.findIndex((option) => option.getAttribute("aria-selected") === "true"),
   );
 }
 
@@ -76,14 +76,14 @@ test("thread reply Tiptap skill autocomplete filters and commits the reported mu
     await app.window.keyboard.type(":p");
     let firstOption = app.window
       .getByRole("listbox", { name: "Skills" })
-      .getByRole("button")
+      .getByRole("option")
       .first();
     await expect(firstOption).toContainText("$ce:plan");
 
     await app.window.keyboard.type("lan");
     firstOption = app.window
       .getByRole("listbox", { name: "Skills" })
-      .getByRole("button")
+      .getByRole("option")
       .first();
     await expect(firstOption).toContainText("$ce:plan");
 
@@ -142,7 +142,7 @@ test("thread reply Tiptap slash review autocomplete stays open on exact command 
 
     const commands = app.window.getByRole("listbox", { name: "Commands" });
     await expect(commands).toBeVisible();
-    await expect(commands.getByRole("button", { name: /\/review/i })).toBeVisible();
+    await expect(commands.getByRole("option", { name: /\/review/i })).toBeVisible();
   } finally {
     await app.close();
   }
@@ -204,7 +204,7 @@ test("thread reply Tiptap skill insertion preserves rich Markdown blocks", async
 
     await app.window.keyboard.type("$ce:plan");
     await expect(
-      app.window.getByRole("button", { name: /\$ce:plan/i }),
+      app.window.getByRole("option", { name: /\$ce:plan/i }),
     ).toBeVisible();
     await app.window.keyboard.press("Enter");
 
@@ -240,7 +240,7 @@ test("thread reply Tiptap Tab insertion keeps caret after chip and copy-paste pr
     await textbox.focus();
     await app.window.keyboard.type("Let's use $ce:plan");
     await expect(
-      app.window.getByRole("button", { name: /\$ce:plan/i }),
+      app.window.getByRole("option", { name: /\$ce:plan/i }),
     ).toBeVisible();
     await app.window.keyboard.press("Tab");
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1830,7 +1830,7 @@ describe("App", () => {
     });
 
     expect(
-      await screen.findByRole("button", { name: /\$frontend-design/i }, { timeout: 5_000 })
+      await screen.findByRole("option", { name: /\$frontend-design/i }, { timeout: 5_000 })
     ).toBeInTheDocument();
   }, 10_000);
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -11100,6 +11100,7 @@ export function Composer(props: ComposerProps) {
                 }}
                 aria-selected={index === activeSkillIndex}
                 className={`composer__autocomplete-option${index === activeSkillIndex ? " is-active" : ""}`}
+                role="option"
                 tabIndex={index === activeSkillIndex ? 0 : -1}
                 type="button"
                 onMouseDown={(event) => {
@@ -11144,6 +11145,7 @@ export function Composer(props: ComposerProps) {
                 }}
                 aria-selected={index === activeSlashIndex}
                 className={`composer__autocomplete-option${index === activeSlashIndex ? " is-active" : ""}`}
+                role="option"
                 tabIndex={index === activeSlashIndex ? 0 : -1}
                 type="button"
                 onMouseDown={(event) => {
@@ -11179,46 +11181,50 @@ export function Composer(props: ComposerProps) {
           <div
             className={`composer__autocomplete composer__autocomplete--directories composer__autocomplete--${autocompleteLayout.placement}`}
             ref={autocompleteListRef}
-            role="listbox"
-            aria-label="Directories"
-            id={directoryRefListboxId}
             style={{ maxHeight: autocompleteLayout.maxHeight }}
           >
-            {filteredDirectoryRefs.map((directory, index) => (
-              <button
-                key={directory.key}
-                id={`${directoryRefListboxId}-option-${index}`}
-                ref={(node) => {
-                  autocompleteOptionRefs.current[index] = node;
-                }}
-                aria-selected={index === activeDirectoryRefIndex}
-                className={`composer__autocomplete-option${index === activeDirectoryRefIndex ? " is-active" : ""}`}
-                tabIndex={index === activeDirectoryRefIndex ? 0 : -1}
-                type="button"
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  applyDirectoryReference(directory);
-                }}
-                onClick={() => {
-                  applyDirectoryReference(directory);
-                }}
-                onFocus={() => {
-                  setActiveDirectoryRefIndex(index);
-                }}
-                onKeyDown={handleAutocompleteKeyDown}
-              >
-                <span className="composer__autocomplete-title">
-                  <FolderIcon size={13} aria-hidden="true" />
-                  <HighlightedAutocompleteLabel
-                    label={directory.label}
-                    query={directoryRefTrigger?.query ?? ""}
-                  />
-                </span>
-                <span className="composer__autocomplete-meta">
-                  {buildDirectoryReferenceInsertText(directory)}
-                </span>
-              </button>
-            ))}
+            <div
+              aria-label="Directories"
+              id={directoryRefListboxId}
+              role="listbox"
+            >
+              {filteredDirectoryRefs.map((directory, index) => (
+                <button
+                  key={directory.key}
+                  id={`${directoryRefListboxId}-option-${index}`}
+                  ref={(node) => {
+                    autocompleteOptionRefs.current[index] = node;
+                  }}
+                  aria-selected={index === activeDirectoryRefIndex}
+                  className={`composer__autocomplete-option${index === activeDirectoryRefIndex ? " is-active" : ""}`}
+                  role="option"
+                  tabIndex={index === activeDirectoryRefIndex ? 0 : -1}
+                  type="button"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    applyDirectoryReference(directory);
+                  }}
+                  onClick={() => {
+                    applyDirectoryReference(directory);
+                  }}
+                  onFocus={() => {
+                    setActiveDirectoryRefIndex(index);
+                  }}
+                  onKeyDown={handleAutocompleteKeyDown}
+                >
+                  <span className="composer__autocomplete-title">
+                    <FolderIcon size={13} aria-hidden="true" />
+                    <HighlightedAutocompleteLabel
+                      label={directory.label}
+                      query={directoryRefTrigger?.query ?? ""}
+                    />
+                  </span>
+                  <span className="composer__autocomplete-meta">
+                    {buildDirectoryReferenceInsertText(directory)}
+                  </span>
+                </button>
+              ))}
+            </div>
             {props.onPickDirectoryForReference ||
             props.desktopApi?.pickFileFromDisk ? (
               <div
@@ -11323,6 +11329,7 @@ export function Composer(props: ComposerProps) {
                       }}
                       aria-selected={index === activeHashReferenceIndex}
                       className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
+                      role="option"
                       tabIndex={index === activeHashReferenceIndex ? 0 : -1}
                       // The visible label is one clamped line; hovering the
                       // row still gives the operator the whole title.
@@ -11401,6 +11408,7 @@ export function Composer(props: ComposerProps) {
                     }}
                     aria-selected={index === activeHashReferenceIndex}
                     className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
+                    role="option"
                     tabIndex={index === activeHashReferenceIndex ? 0 : -1}
                     title={pullRequest.title || pullRequest.url}
                     type="button"

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1643,7 +1643,9 @@ describe("Composer", () => {
     });
     const autocomplete = screen.getByRole("listbox", { name: "Directories" });
     for (const name of ["+ Add directory…", "+ Add file…"]) {
-      const action = within(autocomplete).getByRole("button", { name });
+      const action = screen.getByRole("button", { name });
+      expect(within(autocomplete).queryByRole("button", { name }))
+        .not.toBeInTheDocument();
       expect(action).toBeDisabled();
       expect(action).toHaveAttribute("title", REMOTE_NATIVE_PICKER_TOOLTIP);
     }
@@ -2388,7 +2390,7 @@ describe("Composer", () => {
       name: "Threads and pull requests",
     });
     expect(
-      within(listbox).getByRole("button", { name: /#Bob's Best Thread 3000/ }),
+      within(listbox).getByRole("option", { name: /#Bob's Best Thread 3000/ }),
     ).toBeInTheDocument();
   });
 
@@ -2545,7 +2547,7 @@ describe("Composer", () => {
       name: "Threads and pull requests",
     });
     expect(
-      within(listbox).getByRole("button", { name: /#Bob's Best Thread 3000/ }),
+      within(listbox).getByRole("option", { name: /#Bob's Best Thread 3000/ }),
     ).toBeInTheDocument();
   });
 
@@ -2587,7 +2589,7 @@ describe("Composer", () => {
       name: "Threads and pull requests",
     });
     expect(
-      within(listbox).getByRole("button", { name: /#Bob's Best Thread 3000/ }),
+      within(listbox).getByRole("option", { name: /#Bob's Best Thread 3000/ }),
     ).toBeInTheDocument();
   });
 
@@ -2634,7 +2636,7 @@ describe("Composer", () => {
       name: "Threads and pull requests",
     });
     expect(
-      within(listbox).getByRole("button", {
+      within(listbox).getByRole("option", {
         name: /#Bob's Best Thread 3000/,
       }),
     ).toBeInTheDocument();
@@ -2715,10 +2717,10 @@ describe("Composer", () => {
     // Referencing the thread you are writing in is never useful, and on a
     // bare `#` it would otherwise sort first as the most recent thread.
     expect(
-      within(listbox).queryByRole("button", { name: /#Current thread/ }),
+      within(listbox).queryByRole("option", { name: /#Current thread/ }),
     ).not.toBeInTheDocument();
 
-    const options = within(listbox).getAllByRole("button");
+    const options = within(listbox).getAllByRole("option");
     expect(options).toHaveLength(1);
     const label = options[0]!.querySelector(".composer__autocomplete-label");
     expect(label).toHaveTextContent(
@@ -2781,7 +2783,7 @@ describe("Composer", () => {
     const listbox = await screen.findByRole("listbox", {
       name: "Threads and pull requests",
     });
-    const option = within(listbox).getByRole("button", {
+    const option = within(listbox).getByRole("option", {
       name: /#Implement hash references/,
     });
     expect(option.querySelector(".composer__autocomplete-match"))
@@ -2822,7 +2824,7 @@ describe("Composer", () => {
       name: "Threads and pull requests",
     });
 
-    const option = within(listbox).getAllByRole("button")[0]!;
+    const option = within(listbox).getAllByRole("option")[0]!;
     // The id is the label when there is no title; the meta row's own id
     // fallback would only repeat it.
     expect(option.querySelector(".composer__autocomplete-title"))
@@ -2965,7 +2967,7 @@ describe("Composer", () => {
     const listbox = await screen.findByRole("listbox", {
       name: "Threads and pull requests",
     });
-    const threadOption = within(listbox).getByRole("button", {
+    const threadOption = within(listbox).getByRole("option", {
       name: /#Implement hash references/,
     });
     expect(threadOption.querySelector(".composer__autocomplete-meta"))
@@ -2975,7 +2977,7 @@ describe("Composer", () => {
 
     // The PR row's subject is clamped to one line like every other row,
     // with the full text on the row for hover.
-    const pullRequestOption = within(listbox).getByRole("button", {
+    const pullRequestOption = within(listbox).getByRole("option", {
       name: /pwrdrvr\/PwrAgent#123/,
     });
     expect(pullRequestOption).toHaveAttribute("title", pullRequest.title);
@@ -3123,7 +3125,7 @@ describe("Composer", () => {
     const listbox = await screen.findByRole("listbox", {
       name: "Threads and pull requests",
     });
-    const remoteOption = await within(listbox).findByRole("button", {
+    const remoteOption = await within(listbox).findByRole("option", {
       name: /#Remote fix/,
     });
     expect(jumpSearchRemoteThreads).toHaveBeenCalledWith({
@@ -11922,7 +11924,7 @@ describe("Composer", () => {
     expect(screen.getByRole("listbox", { name: "Commands" })).toHaveClass(
       "composer__autocomplete"
     );
-    fireEvent.click(screen.getByRole("button", { name: /\/review/i }));
+    fireEvent.click(screen.getByRole("option", { name: /\/review/i }));
 
     expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
@@ -11962,7 +11964,7 @@ describe("Composer", () => {
 
     const commands = screen.getByRole("listbox", { name: "Commands" });
     expect(commands).toBeInTheDocument();
-    expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
+    expect(within(commands).getByRole("option", { name: /\/review/i })).toBeInTheDocument();
   });
 
   it("keeps slash review autocomplete visible while editing the prefix", async () => {
@@ -11996,7 +11998,7 @@ describe("Composer", () => {
 
       const commands = screen.getByRole("listbox", { name: "Commands" });
       expect(commands).toBeInTheDocument();
-      expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
+      expect(within(commands).getByRole("option", { name: /\/review/i })).toBeInTheDocument();
     }
   });
 
@@ -12035,7 +12037,7 @@ describe("Composer", () => {
 
     fireEvent.change(textarea, { target: { value: "/re" } });
     const commands = screen.getByRole("listbox", { name: "Commands" });
-    expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
+    expect(within(commands).getByRole("option", { name: /\/review/i })).toBeInTheDocument();
   });
 
   it.each([
@@ -12084,7 +12086,7 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "/r" } });
 
     const commands = screen.getByRole("listbox", { name: "Commands" });
-    expect(within(commands).getAllByRole("button", { name: /\/review/i })).toHaveLength(2);
+    expect(within(commands).getAllByRole("option", { name: /\/review/i })).toHaveLength(2);
     expect(within(commands).getByText("PwrAgent")).toBeInTheDocument();
     expect(within(commands).getByText(providerLabel)).toBeInTheDocument();
   });
@@ -12264,15 +12266,15 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "/r" } });
     expect(
       within(screen.getByRole("listbox", { name: "Commands" })).getByRole(
-        "button",
+        "option",
         { name: /\/review/i },
       ),
     ).toHaveAttribute("aria-selected", "true");
 
     fireEvent.change(textarea, { target: { value: "/co" } });
     const commands = screen.getByRole("listbox", { name: "Commands" });
-    expect(within(commands).queryByRole("button", { name: /\/review/i })).not.toBeInTheDocument();
-    expect(within(commands).getByRole("button", { name: /\/compact/i })).toHaveAttribute(
+    expect(within(commands).queryByRole("option", { name: /\/review/i })).not.toBeInTheDocument();
+    expect(within(commands).getByRole("option", { name: /\/compact/i })).toHaveAttribute(
       "aria-selected",
       "true",
     );
@@ -12338,7 +12340,7 @@ describe("Composer", () => {
 
     const commands = screen.getByRole("listbox", { name: "Commands" });
     fireEvent.click(
-      within(commands).getByRole("button", { name: /\/skill:frontend-design/i }),
+      within(commands).getByRole("option", { name: /\/skill:frontend-design/i }),
     );
 
     await waitFor(() => {
@@ -14784,9 +14786,9 @@ describe("Composer", () => {
       });
 
       const listbox = screen.getByRole("listbox", { name: "Directories" });
-      expect(listbox).toHaveClass("composer__autocomplete--directories");
+      expect(listbox.parentElement).toHaveClass("composer__autocomplete--directories");
       fireEvent.click(
-        within(listbox).getByRole("button", { name: /catalog-portal/ })
+        within(listbox).getByRole("option", { name: /catalog-portal/ })
       );
 
       // The commit mints a zero-width chip: the plain draft keeps only
@@ -15029,13 +15031,15 @@ describe("Composer", () => {
       });
 
       const listbox = screen.getByRole("listbox", { name: "Directories" });
+      expect(within(listbox).getAllByRole("option")).toHaveLength(1);
+      expect(within(listbox).queryByRole("button")).not.toBeInTheDocument();
       // Only the file action renders — this composer has no
       // onPickDirectoryForReference, so the directory action is hidden.
       expect(
-        within(listbox).queryByRole("button", { name: "+ Add directory…" })
+        screen.queryByRole("button", { name: "+ Add directory…" })
       ).not.toBeInTheDocument();
       expect(
-        within(listbox).getByRole("button", { name: "+ Add file…" })
+        screen.getByRole("button", { name: "+ Add file…" })
       ).toBeInTheDocument();
       await clickButton("+ Add file…");
 
@@ -15485,7 +15489,7 @@ describe("Composer", () => {
     fireEvent.change(input, { target: { value: "/deploy" } });
     expect(
       within(screen.getByRole("listbox", { name: "Commands" })).getByRole(
-        "button",
+        "option",
         { name: /\/deployaudit/i },
       ),
     ).toHaveAttribute("aria-selected", "true");
@@ -16070,7 +16074,7 @@ describe("Composer", () => {
     });
 
     const options = within(screen.getByRole("listbox", { name: "Skills" }))
-      .getAllByRole("button")
+      .getAllByRole("option")
       .map((option) => option.textContent ?? "");
 
     expect(options[0]).toContain("$ce:plan");
@@ -16093,7 +16097,7 @@ describe("Composer", () => {
     });
 
     let options = within(screen.getByRole("listbox", { name: "Skills" }))
-      .getAllByRole("button")
+      .getAllByRole("option")
       .map((option) => option.textContent ?? "");
 
     expect(options.some((option) => option.includes("$ce:plan"))).toBe(true);
@@ -16103,7 +16107,7 @@ describe("Composer", () => {
     });
 
     options = within(screen.getByRole("listbox", { name: "Skills" }))
-      .getAllByRole("button")
+      .getAllByRole("option")
       .map((option) => option.textContent ?? "");
 
     expect(options[0]).toContain("$ce:plan");
@@ -19166,7 +19170,7 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "$ce:pl" } });
 
-    const option = screen.getByRole("button", { name: /\$ce:plan/i });
+    const option = screen.getByRole("option", { name: /\$ce:plan/i });
     option.focus();
     fireEvent.keyDown(option, { key: "Enter" });
 
@@ -19213,7 +19217,7 @@ describe("Composer", () => {
     const listbox = screen.getByRole("listbox", { name: "Skills" });
     const getActiveOptionIndex = (): number =>
       within(listbox)
-        .getAllByRole("button")
+        .getAllByRole("option")
         .findIndex((option) => option.getAttribute("aria-selected") === "true");
 
     expect(getActiveOptionIndex()).toBe(0);
@@ -19267,7 +19271,7 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "$ce:pl" } });
 
-    const option = screen.getByRole("button", { name: /\$ce:plan/i });
+    const option = screen.getByRole("option", { name: /\$ce:plan/i });
     option.focus();
     fireEvent.keyDown(option, { key: "Escape" });
 


### PR DESCRIPTION
## Summary

- expose composer autocomplete rows as `option` elements within their existing `listbox` containers
- keep the directory picker's “Add directory” and “Add file” controls as real buttons outside the listbox
- update unit and Electron interaction coverage to use the corrected roles
- add a focused axe regression gate for required listbox/option parent-child semantics in dark and light themes

## Why

The composer rendered autocomplete popovers with `role="listbox"`, but their selectable rows retained the implicit `button` role. That produced an invalid ARIA hierarchy and made the active-descendant contract misleading to assistive technology.

This preserves the existing mouse and keyboard behavior while correcting the accessibility tree across skill, slash-command, directory, thread, and pull-request results.

Closes #1374.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` — 288 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors
- `pnpm --filter @pwragent/desktop test:e2e e2e/skill-autocomplete-interactions.spec.ts e2e/directory-launchpad-skills.spec.ts` — 18 passed; two temporary-directory cleanup flakes passed on immediate isolated rerun
- `pnpm --filter @pwragent/desktop test:e2e e2e/a11y.spec.ts --grep "composer autocomplete"` — 2 passed
