### PR TITLE
fix(desktop): preserve remote transcript refresh order

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -412,6 +412,442 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("keeps completed remote turns ordered when a bounded refresh advances past them", async () => {
+    const publishedTurn = {
+      id: "published-turn",
+      status: "completed" as const,
+      startedAt: 200,
+      completedAt: 500,
+    };
+    const repairTurn = {
+      id: "repair-turn",
+      status: "completed" as const,
+      startedAt: 600,
+      completedAt: 900,
+    };
+    const ciTurn = {
+      id: "ci-turn",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 1_100,
+    };
+    const repairUsage: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "repair-usage",
+      summary: "Turn usage: repair",
+      createdAt: 901,
+      details: [],
+      turn: repairTurn,
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        {
+          type: "activity",
+          id: "published-diff",
+          summary: "Edited 2 files",
+          createdAt: 300,
+          details: [],
+          turn: publishedTurn,
+        },
+        {
+          ...messageEntry({
+            id: "published-final",
+            text: "Draft PR created",
+            createdAt: 500,
+          }),
+          phase: "final" as const,
+          turn: publishedTurn,
+        },
+        {
+          type: "review",
+          id: "review-start",
+          review: "changes against origin/main",
+          displayText: "Review changes against origin/main",
+          turn: {
+            id: "review-turn",
+            status: "completed" as const,
+            startedAt: 550,
+            completedAt: 590,
+          },
+        },
+        {
+          type: "review",
+          id: "review-result",
+          review: "The release workflow is blocked.",
+          createdAt: 590,
+          turn: {
+            id: "review-turn",
+            status: "completed" as const,
+            startedAt: 550,
+            completedAt: 590,
+          },
+        },
+        repairUsage,
+      ],
+      hasPreviousPage: true,
+      previousCursor: "published-diff",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "older-history",
+            text: "Older history",
+            createdAt: 100,
+          }),
+          turn: {
+            id: "older-turn",
+            status: "completed" as const,
+          },
+        },
+      ],
+      hasPreviousPage: false,
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        repairUsage,
+        {
+          ...messageEntry({
+            id: "ci-notification",
+            role: "user",
+            text: "CI failed",
+            createdAt: 1_000,
+          }),
+          turn: ciTurn,
+        },
+        {
+          ...messageEntry({
+            id: "ci-final",
+            text: "Auto-fix is already active",
+            createdAt: 1_100,
+          }),
+          phase: "final" as const,
+          turn: ciTurn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "repair-usage",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const remoteThread = (updatedAt: number): NavigationThreadSummary => ({
+      ...buildThread({ id: "thread-1", updatedAt }),
+      federation: {
+        ref: {
+          backend: "codex",
+          target: {
+            scope: "remote",
+            instanceId: "owner-m5",
+          },
+          threadId: "thread-1",
+        },
+        instanceLabel: "Remote M5",
+        capabilities: ["thread_detail"],
+      },
+    });
+    const { result, rerender } = renderHook(
+      ({ selectedThread }: { selectedThread?: NavigationThreadSummary }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: selectedThread,
+        }),
+      {
+        initialProps: {
+          selectedThread: remoteThread(1_000) as NavigationThreadSummary | undefined,
+        },
+      },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    // Reproduce leaving the mounted thread and selecting it again after the
+    // owner advances. The retained session survives this temporary unmount.
+    rerender({ selectedThread: undefined });
+    rerender({ selectedThread: remoteThread(2_000) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries.map((entry) => entry.id)).toEqual([
+        "older-history",
+        "published-diff",
+        "published-final",
+        "review-start",
+        "review-result",
+        "repair-usage",
+        "ci-notification",
+        "ci-final",
+      ]);
+    });
+    expect(result.current.response?.replay.messages.map((message) => message.id)).toEqual([
+      "older-history",
+      "published-final",
+      "ci-notification",
+      "ci-final",
+    ]);
+    expect(readThread).toHaveBeenLastCalledWith(expect.objectContaining({
+      federationTarget: {
+        scope: "remote",
+        instanceId: "owner-m5",
+      },
+      limit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+      threadId: "thread-1",
+    }));
+  });
+
+  it("keeps an omitted completed turn before a disjoint newer tail", async () => {
+    const initialTail = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "completed-old-turn",
+            text: "Completed old turn",
+            createdAt: 200,
+          }),
+          turn: {
+            id: "old-turn",
+            status: "completed" as const,
+            completedAt: 200,
+          },
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "completed-old-turn",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "older-history",
+          text: "Older history",
+          createdAt: 100,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "new-turn",
+            text: "New turn",
+            createdAt: 300,
+          }),
+          turn: {
+            id: "new-turn",
+            status: "completed" as const,
+            completedAt: 300,
+          },
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "new-turn",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries.map((entry) => entry.id)).toEqual([
+        "older-history",
+        "completed-old-turn",
+        "new-turn",
+      ]);
+    });
+  });
+
+  it("keeps an omitted completed turn between refreshed anchors", async () => {
+    const completedMessage = (
+      id: string,
+      text: string,
+      createdAt: number,
+    ): AppServerThreadMessageEntry => ({
+      ...messageEntry({ id, text, createdAt }),
+      turn: {
+        id: `${id}-turn`,
+        status: "completed" as const,
+        completedAt: createdAt,
+      },
+    });
+    const firstAnchor = completedMessage("first-anchor", "First anchor", 200);
+    const lastAnchor = completedMessage("last-anchor", "Last anchor", 400);
+    const initialTail = readThreadResponse({
+      entries: [
+        firstAnchor,
+        completedMessage("omitted-middle", "Omitted middle", 300),
+        lastAnchor,
+      ],
+      hasPreviousPage: true,
+      previousCursor: "first-anchor",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "older-history",
+          text: "Older history",
+          createdAt: 100,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        firstAnchor,
+        lastAnchor,
+        completedMessage("new-tail", "New tail", 500),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "first-anchor",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries.map((entry) => entry.id)).toEqual([
+        "older-history",
+        "first-anchor",
+        "omitted-middle",
+        "last-anchor",
+        "new-tail",
+      ]);
+    });
+  });
+
+  it("retains a genuinely newer completed turn after a lagging refresh", async () => {
+    const anchor = {
+      ...messageEntry({
+        id: "refresh-anchor",
+        text: "Refresh anchor",
+        createdAt: 200,
+      }),
+      turn: {
+        id: "anchor-turn",
+        status: "completed" as const,
+        completedAt: 200,
+      },
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        anchor,
+        {
+          ...messageEntry({
+            id: "newer-live-turn",
+            text: "Newer live turn",
+            createdAt: 300,
+          }),
+          turn: {
+            id: "newer-turn",
+            status: "completed" as const,
+            completedAt: 300,
+          },
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "refresh-anchor",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "older-history",
+          text: "Older history",
+          createdAt: 100,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const staleTail = readThreadResponse({
+      entries: [anchor],
+      hasPreviousPage: true,
+      previousCursor: "refresh-anchor",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(staleTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries.map((entry) => entry.id)).toEqual([
+        "older-history",
+        "refresh-anchor",
+        "newer-live-turn",
+      ]);
+    });
+  });
+
   it("stitches many older pages without weakening exact-id overlap rules", async () => {
     const readThread = vi
       .fn()

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1033,6 +1033,108 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("keeps latest-page refresh work linear in retained tail entries", async () => {
+    const tailEntryCount = 100;
+    const turn = {
+      id: "large-live-turn",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 2_000,
+    };
+    let retainedTailIdReads = 0;
+    const retainedTail = Array.from(
+      { length: tailEntryCount },
+      (_value, index): AppServerThreadEntry =>
+        new Proxy(
+          {
+            ...messageEntry({
+              id: `tail-${index}`,
+              text: `Tail ${index}`,
+              createdAt: 1_000 + index,
+            }),
+            turn,
+          },
+          {
+            get(target, property, receiver) {
+              if (property === "id") {
+                retainedTailIdReads += 1;
+              }
+              return Reflect.get(target, property, receiver);
+            },
+          },
+        ),
+    );
+    const refreshedTail = [
+      ...Array.from({ length: tailEntryCount - 1 }, (_value, index) => ({
+        ...messageEntry({
+          id: `tail-${index + 1}`,
+          text: `Tail ${index + 1}`,
+          createdAt: 1_001 + index,
+        }),
+        turn,
+      })),
+      {
+        ...messageEntry({
+          id: "tail-new",
+          text: "Newest tail entry",
+          createdAt: 2_000,
+        }),
+        turn,
+      },
+    ];
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: retainedTail,
+        hasPreviousPage: true,
+        previousCursor: "older",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [messageEntry({
+          id: "older-history",
+          text: "Older history",
+          createdAt: 500,
+        })],
+        hasPreviousPage: false,
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: refreshedTail,
+        hasPreviousPage: true,
+        previousCursor: "tail-1",
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    retainedTailIdReads = 0;
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries.at(-1)?.id).toBe("tail-new");
+    });
+    // Before the indexed refresh match, this harness read retained IDs 20,607
+    // times. Keep enough slack for React's async observation without allowing
+    // the prior tail² scan back into the append path.
+    expect(retainedTailIdReads).toBeLessThanOrEqual(tailEntryCount * 8);
+  });
+
   it("coalesces reviews and suppresses duplicates across page-tail boundaries", async () => {
     const fullReview = [
       "Full review comments:",

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -637,20 +637,41 @@ function preserveRetainedTranscriptTail(
 
   // A refresh can lag the live stream. Replace only exact or uniquely
   // equivalent retained entries; keep anything the refresh omitted.
-  // This reconciliation remains a fresh-tail × retained-tail logical scan.
-  // Both inputs are the bounded newest-page tail now; loaded history pages do
-  // not participate, so pagination depth cannot amplify it.
+  // Stable IDs take the indexed linear path; only entries whose server IDs
+  // changed need the bounded logical-match fallback. Loaded history pages do
+  // not participate, so pagination depth cannot amplify either path.
   const matchedRetainedEntries = new Set<AppServerThreadEntry>();
+  const retainedEntriesById = new Map<string, AppServerThreadEntry[]>();
+  const retainedEntryIndexById = new Map<string, number>();
+  for (const retainedEntry of retainedResponse.replay.entries) {
+    const retainedEntryId = retainedEntry.id;
+    const entriesForId = retainedEntriesById.get(retainedEntryId);
+    if (entriesForId) {
+      entriesForId.push(retainedEntry);
+    } else {
+      retainedEntriesById.set(retainedEntryId, [retainedEntry]);
+    }
+  }
   const freshEntryByRetainedEntry = new Map<
     AppServerThreadEntry,
     AppServerThreadEntry
   >();
   for (const freshEntry of response.replay.entries) {
-    const retainedMatch = findUniqueTranscriptRefreshMatch(
+    const exactCandidates = retainedEntriesById.get(freshEntry.id);
+    let exactCandidateIndex = retainedEntryIndexById.get(freshEntry.id) ?? 0;
+    let retainedMatch = exactCandidates?.[exactCandidateIndex];
+    while (retainedMatch && matchedRetainedEntries.has(retainedMatch)) {
+      exactCandidateIndex += 1;
+      retainedMatch = exactCandidates?.[exactCandidateIndex];
+    }
+    if (retainedMatch) {
+      retainedEntryIndexById.set(freshEntry.id, exactCandidateIndex + 1);
+    }
+    retainedMatch ??= findUniqueLogicalTranscriptRefreshMatch(
       freshEntry,
       retainedResponse.replay.entries.filter(
         (entry) => !matchedRetainedEntries.has(entry)
-      )
+      ),
     );
     if (retainedMatch) {
       matchedRetainedEntries.add(retainedMatch);
@@ -716,34 +737,55 @@ function reconcileRetainedTranscriptTail(
     }
   }
 
+  if (pendingRetainedEntries.length === 0) {
+    return entries;
+  }
+
   // A bounded newest-page refresh advances naturally as later turns arrive.
   // Entries that fell off its front are older history, not missing live tail,
   // and must remain ahead of the newer page. Entries after the last retained
-  // anchor can still be genuinely newer live work omitted by a lagging read,
-  // so only move one when its known timestamp proves it precedes a fresh item.
-  for (const retainedEntry of pendingRetainedEntries) {
+  // anchor can still be genuinely newer live work omitted by a lagging read.
+  // Merge the two ordered suffixes in one forward pass; an unknown retained
+  // timestamp conservatively keeps that entry and the remainder at the end.
+  const mergedSuffix: AppServerThreadEntry[] = [];
+  const freshSuffix = entries.slice(trailingInsertionFloor);
+  let freshIndex = 0;
+  let retainedIndex = 0;
+  while (retainedIndex < pendingRetainedEntries.length) {
+    const retainedEntry = pendingRetainedEntries[retainedIndex]!;
     const retainedTimestamp = transcriptRefreshOrderTimestamp(retainedEntry);
-    const insertionIndex = typeof retainedTimestamp === "number"
-      ? entries.findIndex((entry, index) => {
-          if (index < trailingInsertionFloor) {
-            return false;
-          }
-          const entryTimestamp = transcriptRefreshOrderTimestamp(entry);
-          return (
-            typeof entryTimestamp === "number"
-            && entryTimestamp > retainedTimestamp
-          );
-        })
-      : -1;
-
-    if (insertionIndex === -1) {
-      entries.push(retainedEntry);
-    } else {
-      entries.splice(insertionIndex, 0, retainedEntry);
+    if (typeof retainedTimestamp !== "number") {
+      mergedSuffix.push(
+        ...freshSuffix.slice(freshIndex),
+        ...pendingRetainedEntries.slice(retainedIndex),
+      );
+      return [
+        ...entries.slice(0, trailingInsertionFloor),
+        ...mergedSuffix,
+      ];
     }
-  }
 
-  return entries;
+    while (freshIndex < freshSuffix.length) {
+      const freshEntry = freshSuffix[freshIndex]!;
+      const freshTimestamp = transcriptRefreshOrderTimestamp(freshEntry);
+      if (
+        typeof freshTimestamp === "number"
+        && freshTimestamp > retainedTimestamp
+      ) {
+        break;
+      }
+      mergedSuffix.push(freshEntry);
+      freshIndex += 1;
+    }
+    mergedSuffix.push(retainedEntry);
+    retainedIndex += 1;
+  }
+  mergedSuffix.push(...freshSuffix.slice(freshIndex));
+
+  return [
+    ...entries.slice(0, trailingInsertionFloor),
+    ...mergedSuffix,
+  ];
 }
 
 function transcriptRefreshOrderTimestamp(
@@ -760,17 +802,10 @@ function transcriptRefreshOrderTimestamp(
     : undefined;
 }
 
-function findUniqueTranscriptRefreshMatch(
+function findUniqueLogicalTranscriptRefreshMatch(
   freshEntry: AppServerThreadEntry,
   retainedEntries: AppServerThreadEntry[]
 ): AppServerThreadEntry | undefined {
-  const exactMatch = retainedEntries.find(
-    (retainedEntry) => retainedEntry.id === freshEntry.id
-  );
-  if (exactMatch) {
-    return exactMatch;
-  }
-
   const logicalMatches = retainedEntries.filter((retainedEntry) => {
     if (
       freshEntry.turn?.id &&
@@ -1197,13 +1232,12 @@ function transcriptEntriesMatch(
 
 function findUniqueTranscriptOrderSource(
   entry: AppServerThreadEntry,
-  sources: AppServerThreadEntry[]
+  sources: AppServerThreadEntry[],
+  exactSourcesById: ReadonlyMap<string, AppServerThreadEntry>,
 ): AppServerThreadEntry | undefined {
-  const exactMatches = sources.filter(
-    (source) => source.id === entry.id && typeof source.createdAt === "number"
-  );
-  if (exactMatches.length > 0) {
-    return exactMatches[0];
+  const exactMatch = exactSourcesById.get(entry.id);
+  if (exactMatch) {
+    return exactMatch;
   }
 
   const logicalMatches = sources.filter(
@@ -1228,7 +1262,11 @@ type MatchedHydratedEntry = HydratedEntryOrderMatch & {
 
 function reorderHydratedEntriesByKnownOrder(
   entries: AppServerThreadEntry[],
-  sources: AppServerThreadEntry[]
+  sources: AppServerThreadEntry[],
+  sourceByHydratedEntry: ReadonlyMap<
+    AppServerThreadEntry,
+    AppServerThreadEntry
+  >,
 ): AppServerThreadEntry[] {
   if (entries.length < 2 || sources.length === 0) {
     return entries;
@@ -1240,7 +1278,7 @@ function reorderHydratedEntriesByKnownOrder(
   });
   const hydratedEntries: HydratedEntryOrderMatch[] = entries.map(
     (entry, hydrationIndex) => {
-      const source = findUniqueTranscriptOrderSource(entry, sources);
+      const source = sourceByHydratedEntry.get(entry);
       const sourceIndex = source ? sourceIndexes.get(source) : undefined;
       return {
         entry,
@@ -1292,9 +1330,27 @@ function carryForwardTranscriptEntryOrder(
     return response;
   }
 
+  const exactSourcesById = new Map<string, AppServerThreadEntry>();
+  for (const source of sources) {
+    const sourceId = source.id;
+    if (
+      typeof source.createdAt === "number"
+      && !exactSourcesById.has(sourceId)
+    ) {
+      exactSourcesById.set(sourceId, source);
+    }
+  }
+  const sourceByHydratedEntry = new Map<
+    AppServerThreadEntry,
+    AppServerThreadEntry
+  >();
   let changed = false;
   let entries = response.replay.entries.map((entry) => {
-    const source = findUniqueTranscriptOrderSource(entry, sources);
+    const source = findUniqueTranscriptOrderSource(
+      entry,
+      sources,
+      exactSourcesById,
+    );
     if (!source) {
       return entry;
     }
@@ -1314,18 +1370,25 @@ function carryForwardTranscriptEntryOrder(
       ? source.createdAt
       : undefined;
     if (!origin && !turn && createdAt === undefined) {
+      sourceByHydratedEntry.set(entry, source);
       return entry;
     }
 
     changed = true;
-    return {
+    const hydratedEntry = {
       ...entry,
       ...(createdAt !== undefined ? { createdAt } : {}),
       ...(turn ? { turn } : {}),
       ...(origin ? { origin } : {}),
     };
+    sourceByHydratedEntry.set(hydratedEntry, source);
+    return hydratedEntry;
   });
-  const reorderedEntries = reorderHydratedEntriesByKnownOrder(entries, sources);
+  const reorderedEntries = reorderHydratedEntriesByKnownOrder(
+    entries,
+    sources,
+    sourceByHydratedEntry,
+  );
   if (reorderedEntries !== entries) {
     changed = true;
     entries = reorderedEntries;

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -641,6 +641,10 @@ function preserveRetainedTranscriptTail(
   // Both inputs are the bounded newest-page tail now; loaded history pages do
   // not participate, so pagination depth cannot amplify it.
   const matchedRetainedEntries = new Set<AppServerThreadEntry>();
+  const freshEntryByRetainedEntry = new Map<
+    AppServerThreadEntry,
+    AppServerThreadEntry
+  >();
   for (const freshEntry of response.replay.entries) {
     const retainedMatch = findUniqueTranscriptRefreshMatch(
       freshEntry,
@@ -650,14 +654,13 @@ function preserveRetainedTranscriptTail(
     );
     if (retainedMatch) {
       matchedRetainedEntries.add(retainedMatch);
+      freshEntryByRetainedEntry.set(retainedMatch, freshEntry);
     }
   }
-  const retainedTailRemainder = retainedResponse.replay.entries.filter(
-    (entry) => !matchedRetainedEntries.has(entry)
-  );
-  const entries = mergeTranscriptEntries(
+  const entries = reconcileRetainedTranscriptTail(
     response.replay.entries,
-    retainedTailRemainder,
+    retainedResponse.replay.entries,
+    freshEntryByRetainedEntry,
   );
 
   return {
@@ -672,6 +675,89 @@ function preserveRetainedTranscriptTail(
       ),
     },
   };
+}
+
+function reconcileRetainedTranscriptTail(
+  freshEntries: AppServerThreadEntry[],
+  retainedEntries: AppServerThreadEntry[],
+  freshEntryByRetainedEntry: ReadonlyMap<
+    AppServerThreadEntry,
+    AppServerThreadEntry
+  >,
+): AppServerThreadEntry[] {
+  const retainedEntriesBeforeFresh = new Map<
+    AppServerThreadEntry,
+    AppServerThreadEntry[]
+  >();
+  let pendingRetainedEntries: AppServerThreadEntry[] = [];
+  let lastMatchedFreshEntry: AppServerThreadEntry | undefined;
+
+  for (const retainedEntry of retainedEntries) {
+    const freshEntry = freshEntryByRetainedEntry.get(retainedEntry);
+    if (!freshEntry) {
+      pendingRetainedEntries.push(retainedEntry);
+      continue;
+    }
+
+    if (pendingRetainedEntries.length > 0) {
+      retainedEntriesBeforeFresh.set(freshEntry, pendingRetainedEntries);
+      pendingRetainedEntries = [];
+    }
+    lastMatchedFreshEntry = freshEntry;
+  }
+
+  const entries: AppServerThreadEntry[] = [];
+  let trailingInsertionFloor = 0;
+  for (const freshEntry of freshEntries) {
+    entries.push(...(retainedEntriesBeforeFresh.get(freshEntry) ?? []));
+    entries.push(freshEntry);
+    if (freshEntry === lastMatchedFreshEntry) {
+      trailingInsertionFloor = entries.length;
+    }
+  }
+
+  // A bounded newest-page refresh advances naturally as later turns arrive.
+  // Entries that fell off its front are older history, not missing live tail,
+  // and must remain ahead of the newer page. Entries after the last retained
+  // anchor can still be genuinely newer live work omitted by a lagging read,
+  // so only move one when its known timestamp proves it precedes a fresh item.
+  for (const retainedEntry of pendingRetainedEntries) {
+    const retainedTimestamp = transcriptRefreshOrderTimestamp(retainedEntry);
+    const insertionIndex = typeof retainedTimestamp === "number"
+      ? entries.findIndex((entry, index) => {
+          if (index < trailingInsertionFloor) {
+            return false;
+          }
+          const entryTimestamp = transcriptRefreshOrderTimestamp(entry);
+          return (
+            typeof entryTimestamp === "number"
+            && entryTimestamp > retainedTimestamp
+          );
+        })
+      : -1;
+
+    if (insertionIndex === -1) {
+      entries.push(retainedEntry);
+    } else {
+      entries.splice(insertionIndex, 0, retainedEntry);
+    }
+  }
+
+  return entries;
+}
+
+function transcriptRefreshOrderTimestamp(
+  entry: AppServerThreadEntry,
+): number | undefined {
+  if (typeof entry.createdAt === "number") {
+    return entry.createdAt;
+  }
+  if (typeof entry.turn?.startedAt === "number") {
+    return entry.turn.startedAt;
+  }
+  return typeof entry.turn?.completedAt === "number"
+    ? entry.turn.completedAt
+    : undefined;
 }
 
 function findUniqueTranscriptRefreshMatch(


### PR DESCRIPTION
## Summary

- I fixed mounted remote transcripts reordering older completed turns below newer activity after a bounded tail refresh.
- I replaced append-only retained-tail merging with anchor-aware reconciliation that keeps omitted history before or between fresh anchors while preserving genuinely newer live entries from a lagging read.
- I added regressions for the observed remote navigation/refresh sequence, disjoint page rollover, an omitted middle turn, message projection order, and the lagging-live-tail safety case.
- I indexed stable-ID hydration matches and changed suffix reconciliation to a single forward merge, reducing the 100-entry refresh harness from 20,607 retained-ID reads to roughly 600 under a checked 800-read budget.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts` — 133 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — passed with existing warnings only
- `pnpm lint:boundaries`

## Notes

- I verified through the live dev Electron instance that the owning federation instance and the renderer bridge returned the authoritative transcript in the correct order before the renderer session cache reordered it.
- I verified the local viewer database has no local thread/transcript row for the mounted thread; it stores only the expected remote pin and target metadata.
- Lightweight Navigation Refresh can trigger the affected refresh path, but it is not the source of the ordering bug.
