### PR TITLE
fix(desktop): exclude current federation launch target

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -375,7 +375,10 @@ function DesktopAppShell(props: {
   const newThreadFederationTargets = useMemo(
     () =>
       desktopApi?.openFederationWindow
-        ? buildFederationThreadTargets(liveFederationHealth)
+        ? buildFederationThreadTargets(
+            liveFederationHealth,
+            readRendererFederationTarget()?.instanceId,
+          )
         : [],
     [desktopApi?.openFederationWindow, liveFederationHealth],
   );

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -441,6 +441,95 @@ describe("App", () => {
     })).not.toBeInTheDocument();
   });
 
+  it("does not offer the current remote window as a new-thread target", async () => {
+    (window as typeof window & {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "m4",
+    };
+    const windowFocusListeners = new Set<() => void>();
+    const readFederationHealth = vi.fn(async () => ({
+      health: {
+        enabled: true,
+        role: "gateway" as const,
+        status: "connected" as const,
+        instanceId: "local-instance",
+        peers: [
+          {
+            id: "m4",
+            label: "Harold-Mac-Mini-M4",
+            role: "client" as const,
+            status: "connected" as const,
+            capabilities: [
+              "remote_window",
+              "thread_navigation",
+              "environment_actions",
+            ] as const,
+          },
+          {
+            id: "laptop",
+            label: "Harold-MBP-M2-Max",
+            role: "client" as const,
+            status: "connected" as const,
+            capabilities: [
+              "remote_window",
+              "thread_navigation",
+              "environment_actions",
+            ] as const,
+          },
+        ],
+      },
+    }));
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: (listener: () => void) => {
+          windowFocusListeners.add(listener);
+          return () => {
+            windowFocusListeners.delete(listener);
+          };
+        },
+        openFederationWindow: vi.fn(),
+        readFederationHealth,
+      },
+    });
+
+    render(<App />);
+    await waitFor(() => expect(windowFocusListeners.size).toBeGreaterThan(0));
+    act(() => {
+      for (const listener of windowFocusListeners) {
+        listener();
+      }
+    });
+    await waitFor(() => expect(readFederationHealth).toHaveBeenCalled());
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    await waitFor(() => expect(button).toHaveAttribute("aria-haspopup", "menu"));
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+
+    expect(await screen.findByRole("menuitem", {
+      name: "Harold-MBP-M2-Max",
+    })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", {
+      name: "Harold-Mac-Mini-M4",
+    })).not.toBeInTheDocument();
+  });
+
   it("surfaces GitHub organization SAML enforcement as a sticky error toast", async () => {
     let samlListener:
       | ((event: {

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
@@ -92,6 +92,18 @@ describe("buildFederationThreadTargets", () => {
     expect(targets.map((target) => target.instanceId)).toEqual(["b"]);
   });
 
+  it("excludes the instance represented by a remote federation window", () => {
+    const targets = buildFederationThreadTargets(
+      health([
+        peer({ id: "m4", label: "Harold-Mac-Mini-M4" }),
+        peer({ id: "laptop", label: "Harold-MBP-M2-Max" }),
+      ]),
+      "m4",
+    );
+
+    expect(targets.map((target) => target.instanceId)).toEqual(["laptop"]);
+  });
+
   it("breaks label ties by instance id so health order cannot reshuffle rows", () => {
     // Same machine label, neither advertising a profile: the labels are equal,
     // so without a tiebreak the order would follow health order and could flip

--- a/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
@@ -59,6 +59,10 @@ function resolveAvailability(
  * that reorders under the pointer turns a misclick into a thread created on
  * the wrong machine.
  *
+ * A remote viewer already creates its context-default thread on the instance
+ * the window represents, so that instance is excluded from the separate
+ * "New chat on" choices instead of being offered twice.
+ *
  * Revoked peers are dropped — they are dead entries, not offline ones. They
  * are still passed to `formatFederationPeerDisplayLabel`, but only because it
  * filters them out itself; what the local instance's presence in that list
@@ -66,6 +70,7 @@ function resolveAvailability(
  */
 export function buildFederationThreadTargets(
   health: FederationHealthStatus | undefined,
+  currentWindowInstanceId?: string,
 ): FederationThreadTarget[] {
   if (!health) {
     return [];
@@ -77,7 +82,11 @@ export function buildFederationThreadTargets(
       : []),
   ];
   return health.peers
-    .filter((peer) => !peer.revokedAt)
+    .filter(
+      (peer) =>
+        !peer.revokedAt
+        && peer.id !== currentWindowInstanceId,
+    )
     .map((peer) => ({
       instanceId: peer.id,
       label: formatFederationPeerDisplayLabel(peer, visibleInstances),


### PR DESCRIPTION
## Summary

- Exclude the federation instance represented by a remote viewer from that viewer's "New chat on" target list.
- Preserve the other connected machines as available launch targets.
- Add pure target-builder coverage and an app-shell regression that reproduces the window-focus health refresh path.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Notes

- The remote viewer still intentionally omits "Add a Project Directory…" because the folder picker and registration flow are local-only.
