### PR TITLE
fix(desktop): stop splitting the Attention turn count in a peer viewer

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -513,11 +513,18 @@ export function Sidebar(props: SidebarProps) {
    * number mixes work on two machines.
    *
    * A window fronting a peer is exactly the window where that question has no
-   * content. Every row in it is that peer's work, so a "here" count would sit
-   * at zero forever, and closing the viewer interrupts none of it — telling
-   * the operator what quitting would do to work they cannot interrupt is worse
-   * than saying nothing. So a viewer keeps the plain single readout, counting
-   * the peer's turns the way an unfederated instance counts its own.
+   * content. Every row in it is that peer's work, and closing the viewer
+   * interrupts none of it — telling the operator what quitting would do to
+   * work they cannot interrupt is worse than saying nothing. So a viewer keeps
+   * the plain single readout, counting the peer's turns the way an unfederated
+   * instance counts its own.
+   *
+   * The gate has to be here rather than inside the predicate. A viewer reads
+   * its whole snapshot through the peer, and the main process stamps every row
+   * it returns as remote (`stampRemoteNavigationSnapshot`), so left to itself
+   * the split would report "0 here, everything elsewhere" — permanently, by
+   * construction rather than by state. Only the window knows it has no stake
+   * in any of it.
    */
   const splitTurnsByMachine = useMemo(
     () => readRendererFederationTarget() === undefined,

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -507,12 +507,20 @@ export function Sidebar(props: SidebarProps) {
    * counted twice; membership already guarantees a row that is not active is
    * awaiting review, which is the same split the directory headers use.
    *
-   * Live turns split again by where they run. Only this instance's turns hold
-   * shutdown open, so "can I quit now?" is answerable from the tab alone —
-   * which it is not while one number mixes work on two machines.
+   * Live turns split again by where they run, but only in a window that can
+   * see both kinds. Only this instance's turns hold shutdown open, so "can I
+   * quit now?" is answerable from the tab alone — which it is not while one
+   * number mixes work on two machines.
+   *
+   * A window fronting a peer is exactly the window where that question has no
+   * content. Every row in it is that peer's work, so a "here" count would sit
+   * at zero forever, and closing the viewer interrupts none of it — telling
+   * the operator what quitting would do to work they cannot interrupt is worse
+   * than saying nothing. So a viewer keeps the plain single readout, counting
+   * the peer's turns the way an unfederated instance counts its own.
    */
-  const federationWindowTarget = useMemo(
-    () => readRendererFederationTarget(),
+  const splitTurnsByMachine = useMemo(
+    () => readRendererFederationTarget() === undefined,
     [],
   );
   const attentionCounts = useMemo(() => {
@@ -522,14 +530,14 @@ export function Sidebar(props: SidebarProps) {
     for (const thread of attentionThreads) {
       if (!isThreadActive(thread, props.thinkingThreadKeys)) {
         review += 1;
-      } else if (isThreadRemoteWork(thread, federationWindowTarget)) {
+      } else if (splitTurnsByMachine && isThreadRemoteWork(thread)) {
         activeRemote += 1;
       } else {
         activeLocal += 1;
       }
     }
     return { activeLocal, activeRemote, review };
-  }, [attentionThreads, federationWindowTarget, props.thinkingThreadKeys]);
+  }, [attentionThreads, props.thinkingThreadKeys, splitTurnsByMachine]);
   const remoteSignalVisible = useLingeringRemoteActiveSignal(
     attentionCounts.activeRemote,
   );

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -33,11 +33,13 @@ export function formatActiveThreadCount(count: number): string {
  * the registry of the instance that owns them (see `buildQuitBlockerSnapshot`
  * in the main process), so only local work can hold this app's shutdown open.
  *
- * Only meaningful in a window that can hold both kinds. Rows in a window
- * fronting a peer carry no stamp at all — from the owner's side they are
- * local, and the stamp is only added on the way into someone else's window —
- * so a viewer must decide "is any of this mine?" from its own scope rather
- * than from this predicate. `Sidebar` does exactly that before it splits.
+ * Only meaningful in a window that can hold both kinds. A window fronting a
+ * peer reads its whole navigation snapshot through that peer, and
+ * `stampRemoteNavigationSnapshot` stamps EVERY row it returns — so this
+ * predicate answers "yes" for all of them and a local-vs-remote split there
+ * degenerates to "0 here, everything elsewhere". A viewer has to decide "is
+ * any of this mine?" from its own scope instead, which is why `Sidebar` gates
+ * on the window target before it consults this at all.
  */
 export function isThreadRemoteWork(thread: NavigationThreadSummary): boolean {
   return thread.federation?.ref.target.scope === "remote";

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -1,7 +1,4 @@
-import type {
-  FederationRemoteTarget,
-  NavigationThreadSummary,
-} from "@pwragent/shared";
+import type { NavigationThreadSummary } from "@pwragent/shared";
 import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
@@ -29,28 +26,21 @@ export function formatActiveThreadCount(count: number): string {
 }
 
 /**
- * Which machine a row's work actually runs on.
- *
- * Two things make a row remote, and only checking one of them gets it wrong on
- * a surface that matters. A federation-stamped row is a peer's thread carried
- * into an unscoped window by a pin or a mounted parent. A window that fronts a
- * peer is the other case: its snapshot comes from that peer, so every row in it
- * is the peer's work and none of them carry a stamp — from the owner's side
- * they are local, and the stamp is only added on the way into someone else's
- * window.
+ * Whether a row is a peer's thread carried into this window by a pin or a
+ * mounted parent, rather than one this instance owns.
  *
  * The distinction is load-bearing for the Attention tab: turns are driven by
  * the registry of the instance that owns them (see `buildQuitBlockerSnapshot`
  * in the main process), so only local work can hold this app's shutdown open.
+ *
+ * Only meaningful in a window that can hold both kinds. Rows in a window
+ * fronting a peer carry no stamp at all — from the owner's side they are
+ * local, and the stamp is only added on the way into someone else's window —
+ * so a viewer must decide "is any of this mine?" from its own scope rather
+ * than from this predicate. `Sidebar` does exactly that before it splits.
  */
-export function isThreadRemoteWork(
-  thread: NavigationThreadSummary,
-  federationWindowTarget?: FederationRemoteTarget,
-): boolean {
-  return (
-    federationWindowTarget !== undefined
-    || thread.federation?.ref.target.scope === "remote"
-  );
+export function isThreadRemoteWork(thread: NavigationThreadSummary): boolean {
+  return thread.federation?.ref.target.scope === "remote";
 }
 
 export function formatLocalActiveThreadCount(count: number): string {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2756,6 +2756,46 @@ describe("Sidebar", () => {
         ).toBeNull();
       });
 
+      it("does not split in a window fronting a peer, where nothing is ours to interrupt", async () => {
+        // Every row in a viewer is that peer's work, so a "here" count would
+        // sit at zero forever and "Quitting interrupts these" would describe
+        // work this window cannot interrupt at all — closing it stops nothing.
+        // The viewer counts the peer's turns the way an unfederated instance
+        // counts its own.
+        const windowWithTarget = window as typeof window & {
+          __pwragentFederationTarget?: unknown;
+        };
+        windowWithTarget.__pwragentFederationTarget = {
+          instanceId: "peer-1",
+          scope: "remote",
+        };
+        try {
+          render(
+            <Sidebar {...remoteSidebarProps([remoteActiveThread, unreadThread])} />,
+          );
+
+          // The peer's live turn lands in the ordinary readout, not a
+          // permanently-zero "here" plus a grey "elsewhere".
+          const tab = screen.getByRole("tab", {
+            name: "Attention, 1 active thread, 1 thread to review",
+          });
+          expect(
+            tab.querySelector("[data-attention-active-count]"),
+          ).toHaveAttribute("data-attention-active-count", "1");
+          expect(
+            tab.querySelector("[data-attention-remote-active-count]"),
+          ).toBeNull();
+
+          fireEvent.mouseEnter(tab);
+          const card = await screen.findByRole("tooltip");
+          expect(card).toHaveTextContent(/In progress1/);
+          expect(card.textContent).not.toContain("Quitting");
+          expect(card.textContent).not.toContain("elsewhere");
+        } finally {
+          delete windowWithTarget.__pwragentFederationTarget;
+        }
+      });
+
       it("splits local from peer turns, and says which blocks quitting", () => {
         render(
           <Sidebar


### PR DESCRIPTION
Follow-up to #1681.

## The problem

A window fronting a peer is the one window where "which of these blocks quitting?" has no content. `isThreadRemoteWork` short-circuited on the window's federation target, so in a viewer **every** row counted as remote — which meant:

- **"In progress here" was pinned at 0 forever**, by construction, not by state.
- **"Quitting interrupts these" was simply false there.** Closing a viewer interrupts nothing; the work runs on the peer.
- The tab showed two greyed zeros stacked where one readout belongs.

## The fix

The viewer keeps the plain single readout, counting the peer's turns the way an unfederated instance counts its own. The window already says whose it is in its title bar ("Remote · &lt;machine&gt;"), so an unqualified "In progress" reads correctly.

`Sidebar` now decides whether to split from its own scope — which is where that question belongs — so `isThreadRemoteWork` loses its window-target parameter and goes back to the one thing it can actually answer: is this row stamped as a peer's. Its doc says why a viewer must not ask it.

The split is unchanged in an ordinary window, where local and peer work genuinely sit side by side.

## Tests

One new case in `sidebar.test.tsx` stubs `window.__pwragentFederationTarget` and asserts the viewer gets the unqualified readout, no `data-attention-remote-active-count` element, and no "Quitting" copy in the card. Verified it fails against the pre-fix behavior — it reported the exact bad label, `"Attention, 0 active threads on this machine, 1 active thread on other instances, 1 thread to review"`.

`pnpm typecheck`, `pnpm lint:eslint` (0 errors), `lint:boundaries`, full renderer suite (184 files / 2922 tests), and a clean `electron-vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)