### PR TITLE
fix(desktop): price Grok 4.6 account usage

### DIFF
--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -118,6 +118,13 @@
     "rowsChanged": 2,
     "statements": 2
   },
+  "thread-pricing-lazy-repair": {
+    "commits": 1,
+    "note": "one thread load lazily reprices 25 usage rows in ten-row progress batches; a second load is read-only",
+    "observedWalBytes": 49440,
+    "rowsChanged": 27,
+    "statements": 27
+  },
   "tool-output-history-analysis": {
     "commits": 1,
     "note": "replace 25 deterministic history findings plus coverage metadata in one explicit analysis transaction",

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -876,8 +876,7 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       priceStatus: "priced",
       pricingCatalogId: "xai-api",
       pricingCatalogVersion: "2026-08-12",
-      pricingRateId:
-        "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
+      pricingRateId: "xai:2026-08-12:grok-4.6:standard",
       provider: "xai",
       totalCostMicros: 312_322,
     });
@@ -890,7 +889,7 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
-  it("leaves ambiguous Grok 4.6 long-context turn aggregates unpriced", async () => {
+  it("prices Grok 4.6 build turn aggregates above 200K at the account rate", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
         backend: "acp:grok",
@@ -898,7 +897,7 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
         completedAt: Date.UTC(2026, 7, 15),
         createdAt: Date.UTC(2026, 7, 15),
         inputTokens: 255_459,
-        model: "grok-4.6",
+        model: "grok-4.6-build",
         outputTokens: 266,
         priceStatus: "unpriced",
         priceUnavailableReason: "missing-rate",
@@ -920,20 +919,88 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
 
     expect(pricing.lines[0]).toMatchObject({
-      priceStatus: "unpriced",
-      priceUnavailableReason: "missing-rate",
+      priceStatus: "priced",
+      pricingCatalogId: "xai-api",
+      pricingCatalogVersion: "2026-08-12",
+      pricingRateId: "xai:2026-08-12:grok-4.6:standard",
       provider: "xai",
-      totalCostMicros: 0,
+      totalCostMicros: 512_322,
     });
-    expect(pricing.lines[0]?.pricingCatalogId).toBeUndefined();
-    expect(pricing.lines[0]?.pricingCatalogVersion).toBeUndefined();
-    expect(pricing.lines[0]?.pricingRateId).toBeUndefined();
+    expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
     expect(pricing.summaries[0]).toMatchObject({
-      pricedUsageLineCount: 0,
+      pricedUsageLineCount: 1,
       provider: "xai",
-      totalCostMicros: 0,
-      unpricedUsageLineCount: 1,
+      totalCostMicros: 512_322,
+      unpricedUsageLineCount: 0,
     });
+  });
+
+  it("lazily reprices older rows in groups of ten while each group makes progress", async () => {
+    await seedUnpricedGrokUsageLines({ count: 25, idPrefix: "lazy" });
+    stateDb.raw
+      .prepare(
+        `UPDATE thread_usage_lines
+         SET model = 'grok-4.6-build'
+         WHERE thread_id = 'thread-1'`,
+      )
+      .run();
+
+    const pricing = await store.readThreadPricing({
+      backend: "acp:grok",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(25);
+    expect(
+      pricing.lines.every((line) => line.priceStatus === "priced"),
+    ).toBe(true);
+    expect(
+      pricing.lines.every(
+        (line) =>
+          line.pricingRateId === "xai:2026-08-12:grok-4.6:standard",
+      ),
+    ).toBe(true);
+    expect(pricing.summaries).toEqual([
+      expect.objectContaining({
+        pricedUsageLineCount: 25,
+        provider: "xai",
+        totalCostMicros: 3_987_650,
+        unpricedUsageLineCount: 0,
+      }),
+    ]);
+  });
+
+  it("stops lazy repricing after ten consecutive rows make no progress", async () => {
+    await seedUnpricedGrokUsageLines({ count: 20, idPrefix: "stop" });
+    stateDb.raw
+      .prepare(
+        `UPDATE thread_usage_lines
+         SET model = 'grok-4.6-build'
+         WHERE usage_line_id IN (
+           SELECT usage_line_id
+           FROM thread_usage_lines
+           ORDER BY created_at ASC
+           LIMIT 10
+         )`,
+      )
+      .run();
+
+    const pricing = await store.readThreadPricing({
+      backend: "acp:grok",
+      threadId: "thread-1",
+    });
+
+    expect(
+      pricing.lines
+        .filter((line) => line.model === "grok-4.6-build")
+        .every((line) => line.priceStatus === "unpriced"),
+    ).toBe(true);
+    expect(pricing.summaries).toEqual([
+      expect.objectContaining({
+        pricedUsageLineCount: 0,
+        unpricedUsageLineCount: 20,
+      }),
+    ]);
   });
 
   it("reprices persisted Qwen ACP usage under the Qwen provider", async () => {
@@ -1258,4 +1325,39 @@ function buildUsageLine(
     usageLineId: "line-1",
     ...overrides,
   };
+}
+
+async function seedUnpricedGrokUsageLines(params: {
+  count: number;
+  idPrefix: string;
+}): Promise<void> {
+  const createdAt = Date.UTC(2026, 7, 15);
+  for (let index = 0; index < params.count; index += 1) {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        backend: "acp:grok",
+        cachedInputCostMicros: 0,
+        cachedInputTokens: 315_776,
+        createdAt: createdAt + index,
+        inputTokens: 316_222,
+        model: "unknown-grok-model",
+        outputCostMicros: 0,
+        outputTokens: 121,
+        priceStatus: "unpriced",
+        priceUnavailableReason: "missing-rate",
+        pricingCatalogId: undefined,
+        pricingCatalogVersion: undefined,
+        pricingRateId: undefined,
+        provider: "openai",
+        reasoningOutputTokens: 50,
+        sourceItemId: `item-${params.idPrefix}-${index}`,
+        totalCostMicros: 0,
+        totalTokens: 316_343,
+        turnId: `turn-${params.idPrefix}-${index}`,
+        uncachedInputCostMicros: 0,
+        uncachedInputTokens: 446,
+        usageLineId: `line-${params.idPrefix}-${index}`,
+      }),
+    });
+  }
 }

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -448,6 +448,44 @@ describe("sqlite write metrics", () => {
     }
   });
 
+  it("repairs a thread pricing history in one transaction", async () => {
+    for (let index = 0; index < 25; index += 1) {
+      await store.upsertThreadUsageLine({
+        line: buildUnpricedGrokUsageLine(index),
+      });
+    }
+    stateDb.raw
+      .prepare(
+        `UPDATE thread_usage_lines
+         SET model = 'grok-4.6-build'
+         WHERE thread_id = 'thread-pricing-repair'`,
+      )
+      .run();
+    resetSqliteWriteMetrics();
+
+    const { writes } = await measureSqliteWrites(async () => {
+      const pricing = await store.readThreadPricing({
+        backend: "acp:grok",
+        threadId: "thread-pricing-repair",
+      });
+      expect(pricing.lines).toHaveLength(25);
+      expect(
+        pricing.lines.every((line) => line.priceStatus === "priced"),
+      ).toBe(true);
+      await store.readThreadPricing({
+        backend: "acp:grok",
+        threadId: "thread-pricing-repair",
+      });
+    });
+
+    expectSqliteWriteBudget({
+      note:
+        "one thread load lazily reprices 25 usage rows in ten-row progress batches; a second load is read-only",
+      scenario: "thread-pricing-lazy-repair",
+      writes,
+    });
+  });
+
   it("holds a burst of automation pricing snapshots to one run-usage write", async () => {
     vi.useFakeTimers();
     const automationStore = new AutomationStore(stateDb);
@@ -1379,6 +1417,39 @@ function buildInvocation(invocationId: string) {
     toolName: "commandExecution",
     updatedAt: 1_800_000_000_000,
     warningLines: 0,
+  };
+}
+
+function buildUnpricedGrokUsageLine(index: number): ThreadUsageLineRecord {
+  const createdAt = Date.UTC(2026, 7, 15) + index;
+  return {
+    backend: "acp:grok",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 315_776,
+    createdAt,
+    currency: "USD",
+    inputTokens: 316_222,
+    model: "unknown-grok-model",
+    outputCostMicros: 0,
+    outputTokens: 121,
+    priceStatus: "unpriced",
+    priceUnavailableReason: "missing-rate",
+    provider: "openai",
+    reasoningEffort: "high",
+    reasoningOutputTokens: 50,
+    scope: "turn",
+    settingsConfidence: "exact",
+    settingsSource: "turn-context",
+    source: "hydration",
+    sourceItemId: `item-pricing-repair-${index}`,
+    status: "finalized",
+    threadId: "thread-pricing-repair",
+    totalCostMicros: 0,
+    totalTokens: 316_343,
+    turnId: `turn-pricing-repair-${index}`,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 446,
+    usageLineId: `line-pricing-repair-${index}`,
   };
 }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -76,6 +76,8 @@ import type {
   RemoteThreadTargetStore,
 } from "./remote-thread-target-store.js";
 
+const THREAD_PRICING_LAZY_REPRICE_BATCH_SIZE = 10;
+
 export type DirectoryGitStatusCacheEntry = {
   directoryKey: string;
   directoryPath?: string;
@@ -1553,6 +1555,48 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         params.threadId,
         params.threadId,
       ) as ThreadUsageLineRow[];
+
+    // Pricing catalogs can gain rates without changing sqlite's schema. When
+    // the newest card is unpriced, lazily retry this thread in ten-row groups.
+    // A group with no repairs stops the scan, so permanently unknown histories
+    // cost one bounded read rather than a full-ledger walk on every load.
+    if (lineRows[0]?.price_status === "unpriced") {
+      const repairs: Array<{
+        existing: ThreadUsageLineRow;
+        repaired: ThreadUsageLineRecord;
+      }> = [];
+      for (
+        let offset = 0;
+        offset < lineRows.length;
+        offset += THREAD_PRICING_LAZY_REPRICE_BATCH_SIZE
+      ) {
+        const batch = lineRows.slice(
+          offset,
+          offset + THREAD_PRICING_LAZY_REPRICE_BATCH_SIZE,
+        );
+        let repairedInBatch = 0;
+        for (const row of batch) {
+          if (row.price_status === "priced") {
+            continue;
+          }
+          const repaired = repriceTokenUsageLine(threadUsageLineFromRow(row));
+          if (repaired.priceStatus !== "priced") {
+            continue;
+          }
+          repairs.push({ existing: row, repaired });
+          repairedInBatch += 1;
+        }
+        if (repairedInBatch === 0) {
+          break;
+        }
+      }
+
+      if (repairs.length > 0) {
+        this.persistThreadUsagePricingRepairsSync(repairs);
+        return this.readThreadPricing(params);
+      }
+    }
+
     const summaryRows = this.stateDb.raw
       .prepare(
         `SELECT * FROM thread_pricing_summaries
@@ -1568,6 +1612,98 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       lines,
       summaries: summaryRows.map(threadPricingSummaryFromRow),
     };
+  }
+
+  private persistThreadUsagePricingRepairsSync(
+    repairs: Array<{
+      existing: ThreadUsageLineRow;
+      repaired: ThreadUsageLineRecord;
+    }>,
+  ): void {
+    const now = Date.now();
+    const updateLine = this.stateDb.raw.prepare(
+      `UPDATE thread_usage_lines
+       SET
+         price_status = @priceStatus,
+         price_unavailable_reason = @priceUnavailableReason,
+         currency = @currency,
+         pricing_catalog_id = @pricingCatalogId,
+         pricing_catalog_version = @pricingCatalogVersion,
+         pricing_rate_id = @pricingRateId,
+         uncached_input_cost_micros = @uncachedInputCostMicros,
+         cached_input_cost_micros = @cachedInputCostMicros,
+         output_cost_micros = @outputCostMicros,
+         provider = @provider,
+         total_cost_micros = @totalCostMicros,
+         updated_at = @updatedAt
+       WHERE usage_line_id = @usageLineId
+         AND price_status != 'priced'`,
+    );
+    const summaryTargets = new Map<
+      string,
+      {
+        backend: string;
+        currency: string;
+        provider: string;
+        threadId: string;
+        updatedAt: number;
+      }
+    >();
+    const queueSummary = (target: {
+      backend: string;
+      currency: string;
+      provider: string;
+      threadId: string;
+      updatedAt: number;
+    }): void => {
+      summaryTargets.set(
+        JSON.stringify([
+          target.provider,
+          target.backend,
+          target.threadId,
+          target.currency,
+        ]),
+        target,
+      );
+    };
+
+    this.stateDb.raw.transaction(() => {
+      for (const { existing, repaired } of repairs) {
+        updateLine.run({
+          cachedInputCostMicros: repaired.cachedInputCostMicros,
+          currency: repaired.currency,
+          outputCostMicros: repaired.outputCostMicros,
+          priceStatus: repaired.priceStatus,
+          priceUnavailableReason: repaired.priceUnavailableReason ?? null,
+          pricingCatalogId: repaired.pricingCatalogId ?? null,
+          pricingCatalogVersion: repaired.pricingCatalogVersion ?? null,
+          pricingRateId: repaired.pricingRateId ?? null,
+          provider: repaired.provider,
+          totalCostMicros: repaired.totalCostMicros,
+          uncachedInputCostMicros: repaired.uncachedInputCostMicros,
+          updatedAt: now,
+          usageLineId: repaired.usageLineId,
+        });
+        const threadId = repaired.parentThreadId ?? repaired.threadId;
+        queueSummary({
+          backend: existing.backend,
+          currency: existing.currency,
+          provider: existing.provider,
+          threadId: existing.parent_thread_id ?? existing.thread_id,
+          updatedAt: now,
+        });
+        queueSummary({
+          backend: repaired.backend,
+          currency: repaired.currency,
+          provider: repaired.provider,
+          threadId,
+          updatedAt: now,
+        });
+      }
+      for (const target of summaryTargets.values()) {
+        this.recomputeThreadPricingSummarySync(target);
+      }
+    })();
   }
 
   async upsertThreadToolInvocation(params: {

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -290,7 +290,6 @@ describe("token usage pricing", () => {
     const cost = estimateTokenUsageCost({
       at: Date.UTC(2026, 7, 15),
       cachedInputTokens: 128,
-      inputTokensAreSingleRequest: true,
       model: "grok-4.6",
       outputTokens: 266,
       reasoningOutputTokens: 130,
@@ -298,22 +297,22 @@ describe("token usage pricing", () => {
     });
 
     expect(cost).toMatchObject({
-      cachedInputCostMicros: 128,
-      cachedInputUsdPerMillion: 1,
+      cachedInputCostMicros: 64,
+      cachedInputUsdPerMillion: 0.5,
       catalogId: "xai-api",
       catalogVersion: "2026-08-12",
-      displayName: "Grok 4.6 Standard (>=200K input)",
-      inputUsdPerMillion: 4,
+      displayName: "Grok 4.6 Standard",
+      inputUsdPerMillion: 2,
       model: "grok-4.6",
-      outputCostMicros: 3_192,
+      outputCostMicros: 1_596,
       outputTokensIncludeReasoning: true,
-      outputUsdPerMillion: 12,
+      outputUsdPerMillion: 6,
       provider: "xai",
-      rateId: "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
+      rateId: "xai:2026-08-12:grok-4.6:standard",
       serviceTier: "standard",
-      totalCostMicros: 1_024_644,
-      totalUsd: 1.024644,
-      uncachedInputCostMicros: 1_021_324,
+      totalCostMicros: 512_322,
+      totalUsd: 0.512322,
+      uncachedInputCostMicros: 510_662,
     });
   });
 
@@ -330,33 +329,32 @@ describe("token usage pricing", () => {
       cachedInputUsdPerMillion: 0.5,
       inputUsdPerMillion: 2,
       outputUsdPerMillion: 6,
-      rateId: "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
+      rateId: "xai:2026-08-12:grok-4.6:standard",
       totalCostMicros: 725_000,
     });
   });
 
-  it("requires single-request evidence for Grok 4.6 long-context pricing", () => {
-    const estimateAtInputTokens = (
-      inputTokens: number,
-      inputTokensAreSingleRequest?: boolean,
-    ) =>
+  it("prices the Grok 4.6 ACP build alias above 200K at the account usage rate", () => {
+    expect(
       estimateTokenUsageCost({
         at: Date.UTC(2026, 7, 15),
-        cachedInputTokens: 0,
-        inputTokensAreSingleRequest,
-        model: "grok-4.6",
-        outputTokens: 0,
-        uncachedInputTokens: inputTokens,
-      });
-
-    expect(estimateAtInputTokens(199_999)).toMatchObject({
+        cachedInputTokens: 315_776,
+        model: "grok-4.6-build",
+        outputTokens: 121,
+        reasoningOutputTokens: 50,
+        uncachedInputTokens: 446,
+      }),
+    ).toMatchObject({
+      cachedInputCostMicros: 157_888,
+      cachedInputUsdPerMillion: 0.5,
       inputUsdPerMillion: 2,
-      rateId: "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
-    });
-    expect(estimateAtInputTokens(200_000)).toBeUndefined();
-    expect(estimateAtInputTokens(200_000, true)).toMatchObject({
-      inputUsdPerMillion: 4,
-      rateId: "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
+      model: "grok-4.6-build",
+      outputCostMicros: 726,
+      outputTokensIncludeReasoning: true,
+      outputUsdPerMillion: 6,
+      rateId: "xai:2026-08-12:grok-4.6:standard",
+      totalCostMicros: 159_506,
+      uncachedInputCostMicros: 892,
     });
   });
 
@@ -494,27 +492,17 @@ describe("token usage pricing", () => {
         cachedInputUsdPerMillion: 0.5,
         catalogId: "xai-api",
         catalogVersion: "2026-08-12",
-        displayName: "Grok 4.6 Standard (<200K input)",
+        displayName: "Grok 4.6 Standard",
         inputUsdPerMillion: 2,
         model: "grok-4.6",
         outputUsdPerMillion: 6,
         provider: "xai",
-        rateId: "xai:2026-08-12:grok-4.6:standard:input-lt-200k",
+        rateId: "xai:2026-08-12:grok-4.6:standard",
       }),
     );
-    expect(listTokenUsagePricingRates()).toContainEqual(
-      expect.objectContaining({
-        cachedInputUsdPerMillion: 1,
-        catalogId: "xai-api",
-        catalogVersion: "2026-08-12",
-        displayName: "Grok 4.6 Standard (>=200K input)",
-        inputUsdPerMillion: 4,
-        model: "grok-4.6",
-        outputUsdPerMillion: 12,
-        provider: "xai",
-        rateId: "xai:2026-08-12:grok-4.6:standard:input-gte-200k",
-      }),
-    );
+    expect(
+      listTokenUsagePricingRates().filter((rate) => rate.model === "grok-4.6"),
+    ).toHaveLength(1);
     expect(listTokenUsagePricingRates()).toContainEqual(
       expect.objectContaining({
         cachedInputUsdPerMillion: 0.3,

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -214,8 +214,6 @@ type PricingCatalogEntry = {
   outputTokensIncludeReasoning?: boolean;
   provider: TokenUsagePricingProvider;
   rateBandId?: string;
-  // Per-request thresholds cannot be selected safely from multi-call totals.
-  requiresSingleRequestInput?: boolean;
   serviceTier: TokenUsagePricingServiceTier;
 };
 
@@ -492,38 +490,21 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
 ];
 
 const XAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  // Grok ACP authenticates the signed-in Grok account rather than an API key.
+  // Estimate account usage at the standard rate across all context sizes.
   {
-    aliases: ["grok-4.6-latest"],
+    aliases: ["grok-4.6-build", "grok-4.6-latest"],
     cachedInputUsdPerMillion: 0.5,
     catalogId: XAI_PRICING_CATALOG_ID,
     catalogVersion: XAI_GROK46_PRICING_CATALOG_VERSION,
     displayModel: "Grok 4.6",
-    displayTier: "Standard (<200K input)",
+    displayTier: "Standard",
     effectiveFrom: XAI_GROK46_PRICING_EFFECTIVE_FROM,
     inputUsdPerMillion: 2,
-    maximumInputTokens: 199_999,
     model: "grok-4.6",
     outputTokensIncludeReasoning: true,
     outputUsdPerMillion: 6,
     provider: "xai",
-    rateBandId: "input-lt-200k",
-    serviceTier: "standard",
-  },
-  {
-    aliases: ["grok-4.6-latest"],
-    cachedInputUsdPerMillion: 1,
-    catalogId: XAI_PRICING_CATALOG_ID,
-    catalogVersion: XAI_GROK46_PRICING_CATALOG_VERSION,
-    displayModel: "Grok 4.6",
-    displayTier: "Standard (>=200K input)",
-    effectiveFrom: XAI_GROK46_PRICING_EFFECTIVE_FROM,
-    inputUsdPerMillion: 4,
-    model: "grok-4.6",
-    outputTokensIncludeReasoning: true,
-    outputUsdPerMillion: 12,
-    provider: "xai",
-    rateBandId: "input-gte-200k",
-    requiresSingleRequestInput: true,
     serviceTier: "standard",
   },
   {
@@ -753,8 +734,6 @@ export function estimateTokenUsageCost(params: {
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
-  // True only when the input count is known to belong to one model request.
-  inputTokensAreSingleRequest?: boolean;
   outputTokensIncludeReasoning?: boolean;
   model?: string;
   outputTokens: number;
@@ -770,7 +749,6 @@ function estimateTokenUsageCostFromCatalog(
     cachedInputTokens: number;
     at?: number;
     fastMode?: boolean;
-    inputTokensAreSingleRequest?: boolean;
     outputTokensIncludeReasoning?: boolean;
     model?: string;
     outputTokens: number;
@@ -792,7 +770,6 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
-        params.inputTokensAreSingleRequest,
       ),
   );
   const provider = matchingEntries[0]?.provider;
@@ -820,7 +797,6 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
-        params.inputTokensAreSingleRequest,
       ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
@@ -1098,14 +1074,10 @@ function pricingEntryMatchesModel(
 function pricingEntryMatchesInputTokens(
   entry: PricingCatalogEntry,
   inputTokens: number,
-  inputTokensAreSingleRequest: boolean | undefined,
 ): boolean {
   return (
-    (!entry.requiresSingleRequestInput || inputTokensAreSingleRequest === true)
-    && (
-      entry.maximumInputTokens === undefined
-      || inputTokens <= entry.maximumInputTokens
-    )
+    entry.maximumInputTokens === undefined
+    || inputTokens <= entry.maximumInputTokens
   );
 }
 


### PR DESCRIPTION
## Summary

- price Grok 4.6 account-backed ACP usage at the standard short-context rate for every context size
- recognize the observed `grok-4.6-build` model identifier
- lazily repair existing unpriced thread ledgers in ten-row progress batches
- keep the 1.0 line migration-free with no `user_version` change

## Root cause

The catalog only recognized `grok-4.6` and `grok-4.6-latest`, while Grok ACP can report `grok-4.6-build`. It also applied API long-context tier selection to signed-in account usage, leaving turn aggregates above 200K unpriced when single-request evidence was unavailable. Existing unpriced rows were not revisited once their schema migration had already run.

## Behavior

When a thread's newest pricing card is unpriced, the store retries rows in groups of ten. It continues while each group repairs at least one row and stops after a group makes no progress. Repaired rows and their provider summaries are persisted in one transaction. A checked-in write budget pins a 25-row repair to one commit; a second load is read-only.

## Validation

- `pnpm test packages/shared/src/__tests__/token-usage-pricing.test.ts apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `git diff --check`
