### PR TITLE
fix(desktop): reuse federation viewer windows

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-window.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-window.test.ts
@@ -15,7 +15,7 @@ vi.mock("../federation/federation-runtime", () => ({
   getDesktopFederationRuntime: () => runtime,
 }));
 
-type WindowEvent = "closed" | "ready-to-show";
+type WindowEvent = "closed" | "show";
 
 function createWindow(id: number) {
   const listeners = new Map<WindowEvent, Array<() => void>>();
@@ -88,9 +88,10 @@ describe("federation window", () => {
 
     expect(second).toBe(first);
     expect(createMainWindow).toHaveBeenCalledTimes(1);
-    expect(runtime.setRemoteWindowEventSubscription).toHaveBeenCalledTimes(1);
+    expect(runtime.setRemoteWindowEventSubscription).toHaveBeenCalledTimes(2);
 
-    window.emit("ready-to-show");
+    window.emit("show");
+    await Promise.resolve();
     expect(window.show).toHaveBeenCalledTimes(1);
     expect(window.focus).toHaveBeenCalledTimes(1);
     expect(window.webContents.send).toHaveBeenCalledWith(
@@ -99,12 +100,15 @@ describe("federation window", () => {
     );
   });
 
-  it("navigates a reused viewer instead of creating another window", async () => {
+  it("reuses a viewer shown through the non-mac fallback milestone", async () => {
     const window = createWindow(8);
     createMainWindow.mockReturnValue(window);
     const { createFederationWindow } = await import("../federation/federation-window");
     createFederationWindow({ peer });
-    window.emit("ready-to-show");
+    // createMainWindow emits show from either ready-to-show or its non-mac
+    // did-finish-load fallback. No ready-to-show event reaches this registry.
+    window.emit("show");
+    await Promise.resolve();
     window.webContents.send.mockClear();
     window.setMinimized(true);
 
@@ -131,7 +135,8 @@ describe("federation window", () => {
     createMainWindow.mockReturnValue(window);
     const { createFederationWindow } = await import("../federation/federation-window");
     createFederationWindow({ peer });
-    window.emit("ready-to-show");
+    window.emit("show");
+    await Promise.resolve();
     window.webContents.send.mockClear();
 
     createFederationWindow({ peer, initialLaunchpad: true });
@@ -139,6 +144,33 @@ describe("federation window", () => {
     expect(createMainWindow).toHaveBeenCalledTimes(1);
     expect(window.webContents.send).toHaveBeenCalledWith(
       WINDOW_OPEN_NEW_THREAD_CHANNEL,
+    );
+  });
+
+  it("refreshes remote event subscriptions from the latest peer capabilities", async () => {
+    const window = createWindow(14);
+    createMainWindow.mockReturnValue(window);
+    const { createFederationWindow } = await import("../federation/federation-window");
+    createFederationWindow({ peer });
+    window.emit("show");
+    await Promise.resolve();
+
+    const upgradedPeer = {
+      ...peer,
+      capabilities: [
+        "remote_window",
+        "thread_navigation",
+        "thread_detail",
+        "event_subscriptions",
+      ] as const,
+    };
+    createFederationWindow({ peer: upgradedPeer });
+
+    expect(createMainWindow).toHaveBeenCalledTimes(1);
+    expect(runtime.setRemoteWindowEventSubscription).toHaveBeenLastCalledWith(
+      window.webContents.id,
+      peer.target.instanceId,
+      upgradedPeer.capabilities,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/federation-window.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-window.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  WINDOW_OPEN_NEW_THREAD_CHANNEL,
+  WINDOW_SHOW_THREAD_CHANNEL,
+} from "../../shared/ipc";
+
+const createMainWindow = vi.hoisted(() => vi.fn());
+const runtime = vi.hoisted(() => ({
+  clearRendererEventSubscriptions: vi.fn(),
+  setRemoteWindowEventSubscription: vi.fn(),
+}));
+
+vi.mock("../window", () => ({ createMainWindow }));
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: () => runtime,
+}));
+
+type WindowEvent = "closed" | "ready-to-show";
+
+function createWindow(id: number) {
+  const listeners = new Map<WindowEvent, Array<() => void>>();
+  let destroyed = false;
+  let minimized = false;
+  let visible = false;
+  const window = {
+    id,
+    focus: vi.fn(),
+    isDestroyed: vi.fn(() => destroyed),
+    isMinimized: vi.fn(() => minimized),
+    isVisible: vi.fn(() => visible),
+    once: vi.fn((event: WindowEvent, listener: () => void) => {
+      const registered = listeners.get(event) ?? [];
+      registered.push(listener);
+      listeners.set(event, registered);
+    }),
+    restore: vi.fn(() => {
+      minimized = false;
+    }),
+    show: vi.fn(() => {
+      visible = true;
+    }),
+    webContents: {
+      id: id + 100,
+      send: vi.fn(),
+    },
+    emit(event: WindowEvent) {
+      const registered = listeners.get(event) ?? [];
+      listeners.delete(event);
+      for (const listener of registered) {
+        listener();
+      }
+      if (event === "closed") {
+        destroyed = true;
+      }
+    },
+    setMinimized(value: boolean) {
+      minimized = value;
+    },
+  };
+  return window;
+}
+
+const peer = {
+  target: { scope: "remote" as const, instanceId: "pwr_studio" },
+  label: "Studio Mac",
+  capabilities: ["remote_window", "thread_navigation"] as const,
+};
+
+describe("federation window", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    createMainWindow.mockReset();
+    runtime.clearRendererEventSubscriptions.mockReset();
+    runtime.setRemoteWindowEventSubscription.mockReset();
+  });
+
+  it("reuses one instance-wide viewer when the same peer is opened twice", async () => {
+    const window = createWindow(7);
+    createMainWindow.mockReturnValue(window);
+    const { createFederationWindow } = await import("../federation/federation-window");
+    const initialThread = {
+      backend: "codex" as const,
+      threadId: "thread-opened-during-load",
+    };
+
+    const first = createFederationWindow({ peer });
+    const second = createFederationWindow({ peer, initialThread });
+
+    expect(second).toBe(first);
+    expect(createMainWindow).toHaveBeenCalledTimes(1);
+    expect(runtime.setRemoteWindowEventSubscription).toHaveBeenCalledTimes(1);
+
+    window.emit("ready-to-show");
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+    expect(window.webContents.send).toHaveBeenCalledWith(
+      WINDOW_SHOW_THREAD_CHANNEL,
+      initialThread,
+    );
+  });
+
+  it("navigates a reused viewer instead of creating another window", async () => {
+    const window = createWindow(8);
+    createMainWindow.mockReturnValue(window);
+    const { createFederationWindow } = await import("../federation/federation-window");
+    createFederationWindow({ peer });
+    window.emit("ready-to-show");
+    window.webContents.send.mockClear();
+    window.setMinimized(true);
+
+    const initialThread = {
+      backend: "codex" as const,
+      messageId: "assistant-message-7",
+      threadId: "thread-7",
+    };
+    const reused = createFederationWindow({ peer, initialThread });
+
+    expect(reused).toBe(window);
+    expect(createMainWindow).toHaveBeenCalledTimes(1);
+    expect(window.webContents.send).toHaveBeenCalledWith(
+      WINDOW_SHOW_THREAD_CHANNEL,
+      initialThread,
+    );
+    expect(window.show).toHaveBeenCalled();
+    expect(window.focus).toHaveBeenCalled();
+    expect(window.restore).toHaveBeenCalledOnce();
+  });
+
+  it("opens the launchpad in a reused viewer", async () => {
+    const window = createWindow(9);
+    createMainWindow.mockReturnValue(window);
+    const { createFederationWindow } = await import("../federation/federation-window");
+    createFederationWindow({ peer });
+    window.emit("ready-to-show");
+    window.webContents.send.mockClear();
+
+    createFederationWindow({ peer, initialLaunchpad: true });
+
+    expect(createMainWindow).toHaveBeenCalledTimes(1);
+    expect(window.webContents.send).toHaveBeenCalledWith(
+      WINDOW_OPEN_NEW_THREAD_CHANNEL,
+    );
+  });
+
+  it("allows a fresh viewer after the existing one closes", async () => {
+    const firstWindow = createWindow(10);
+    const secondWindow = createWindow(11);
+    createMainWindow
+      .mockReturnValueOnce(firstWindow)
+      .mockReturnValueOnce(secondWindow);
+    const { createFederationWindow } = await import("../federation/federation-window");
+    createFederationWindow({ peer });
+
+    firstWindow.emit("closed");
+    const reopened = createFederationWindow({ peer });
+
+    expect(reopened).toBe(secondWindow);
+    expect(createMainWindow).toHaveBeenCalledTimes(2);
+    expect(runtime.clearRendererEventSubscriptions).toHaveBeenCalledWith(
+      firstWindow.webContents.id,
+      "remote-window",
+    );
+  });
+
+  it("keeps separate viewers for separate federation instances", async () => {
+    const firstWindow = createWindow(12);
+    const secondWindow = createWindow(13);
+    createMainWindow
+      .mockReturnValueOnce(firstWindow)
+      .mockReturnValueOnce(secondWindow);
+    const { createFederationWindow } = await import("../federation/federation-window");
+
+    const first = createFederationWindow({ peer });
+    const second = createFederationWindow({
+      peer: {
+        ...peer,
+        target: { scope: "remote", instanceId: "pwr_laptop" },
+      },
+    });
+
+    expect(first).toBe(firstWindow);
+    expect(second).toBe(secondWindow);
+    expect(createMainWindow).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/federation/federation-window.ts
+++ b/apps/desktop/src/main/federation/federation-window.ts
@@ -5,12 +5,67 @@ import type {
 import { getDesktopFederationRuntime } from "./federation-runtime";
 import { createMainWindow } from "../window";
 import type { WindowShowThreadRequest } from "../../shared/window-show-thread";
+import {
+  WINDOW_OPEN_NEW_THREAD_CHANNEL,
+  WINDOW_SHOW_THREAD_CHANNEL,
+} from "../../shared/ipc";
 
 export type FederationWindowPeer = {
   target: FederationRemoteTarget;
   label: string;
   capabilities: readonly FederationCapability[];
 };
+
+type FederationWindowRequest = {
+  initialLaunchpad?: boolean;
+  initialThread?: WindowShowThreadRequest;
+};
+
+type FederationWindowEntry = {
+  focusWhenReady: boolean;
+  pendingRequest?: FederationWindowRequest;
+  ready: boolean;
+  window: Electron.BrowserWindow;
+};
+
+/** One remote viewer per owning federation instance in this app process. */
+const federationWindows = new Map<string, FederationWindowEntry>();
+
+function focusFederationWindow(window: Electron.BrowserWindow): void {
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  window.show();
+  window.focus();
+}
+
+function sendFederationWindowRequest(
+  window: Electron.BrowserWindow,
+  request: FederationWindowRequest,
+): void {
+  if (request.initialThread) {
+    window.webContents.send(WINDOW_SHOW_THREAD_CHANNEL, request.initialThread);
+  } else if (request.initialLaunchpad) {
+    window.webContents.send(WINDOW_OPEN_NEW_THREAD_CHANNEL);
+  }
+}
+
+function reuseFederationWindow(
+  entry: FederationWindowEntry,
+  request: FederationWindowRequest,
+): Electron.BrowserWindow {
+  if (!entry.ready) {
+    entry.focusWhenReady = true;
+    if (request.initialThread || request.initialLaunchpad) {
+      entry.pendingRequest = request;
+    }
+    return entry.window;
+  }
+
+  focusFederationWindow(entry.window);
+  sendFederationWindowRequest(entry.window, request);
+  return entry.window;
+}
 
 export function createFederationWindow(options: {
   peer: FederationWindowPeer;
@@ -24,11 +79,39 @@ export function createFederationWindow(options: {
     );
   }
 
+  const instanceId = peer.target.instanceId;
+  const existing = federationWindows.get(instanceId);
+  if (existing && !existing.window.isDestroyed()) {
+    return reuseFederationWindow(existing, options);
+  }
+  federationWindows.delete(instanceId);
+
   const window = createMainWindow({
     federationLabel: peer.label,
     federationTarget: peer.target,
     ...(options.initialLaunchpad ? { initialLaunchpad: true } : {}),
     initialThread: options.initialThread,
+  });
+  const entry: FederationWindowEntry = {
+    focusWhenReady: false,
+    // createMainWindow always starts hidden and shows only after the renderer
+    // reaches ready-to-show, so the registry can safely attach synchronously.
+    ready: false,
+    window,
+  };
+  federationWindows.set(instanceId, entry);
+  window.once("ready-to-show", () => {
+    if (window.isDestroyed()) {
+      return;
+    }
+    entry.ready = true;
+    if (entry.focusWhenReady) {
+      focusFederationWindow(window);
+    }
+    if (entry.pendingRequest) {
+      sendFederationWindowRequest(window, entry.pendingRequest);
+      entry.pendingRequest = undefined;
+    }
   });
   const runtime = getDesktopFederationRuntime();
   const webContentsId = window.webContents.id;
@@ -38,6 +121,9 @@ export function createFederationWindow(options: {
     peer.capabilities,
   );
   window.once("closed", () => {
+    if (federationWindows.get(instanceId) === entry) {
+      federationWindows.delete(instanceId);
+    }
     runtime.clearRendererEventSubscriptions(webContentsId, "remote-window");
   });
   return window;

--- a/apps/desktop/src/main/federation/federation-window.ts
+++ b/apps/desktop/src/main/federation/federation-window.ts
@@ -80,8 +80,14 @@ export function createFederationWindow(options: {
   }
 
   const instanceId = peer.target.instanceId;
+  const runtime = getDesktopFederationRuntime();
   const existing = federationWindows.get(instanceId);
   if (existing && !existing.window.isDestroyed()) {
+    runtime.setRemoteWindowEventSubscription(
+      existing.window.webContents.id,
+      instanceId,
+      peer.capabilities,
+    );
     return reuseFederationWindow(existing, options);
   }
   federationWindows.delete(instanceId);
@@ -100,20 +106,25 @@ export function createFederationWindow(options: {
     window,
   };
   federationWindows.set(instanceId, entry);
-  window.once("ready-to-show", () => {
-    if (window.isDestroyed()) {
-      return;
-    }
-    entry.ready = true;
-    if (entry.focusWhenReady) {
-      focusFederationWindow(window);
-    }
-    if (entry.pendingRequest) {
-      sendFederationWindowRequest(window, entry.pendingRequest);
-      entry.pendingRequest = undefined;
-    }
+  window.once("show", () => {
+    // createMainWindow can show through ready-to-show or, on non-macOS,
+    // through its did-finish-load fallback. Defer one microtask so the
+    // creator's initial navigation is delivered first and the latest queued
+    // reuse request remains authoritative.
+    queueMicrotask(() => {
+      if (window.isDestroyed()) {
+        return;
+      }
+      entry.ready = true;
+      if (entry.focusWhenReady) {
+        focusFederationWindow(window);
+      }
+      if (entry.pendingRequest) {
+        sendFederationWindowRequest(window, entry.pendingRequest);
+        entry.pendingRequest = undefined;
+      }
+    });
   });
-  const runtime = getDesktopFederationRuntime();
   const webContentsId = window.webContents.id;
   runtime.setRemoteWindowEventSubscription(
     webContentsId,


### PR DESCRIPTION
## Summary

- keep one remote-viewer BrowserWindow per owning federation instance
- restore and focus the existing viewer on repeated menu, Star Map, link, or IPC opens
- route requested threads and launchpads into the reused viewer, including requests received while its renderer is still loading
- recognize both normal and non-mac fallback window-show paths as ready for reuse
- refresh the reused viewer's event subscription when peer capabilities change
- remove the registry entry when the viewer closes so it can be opened again normally

## Root cause

The renderer treats a remote viewer as instance-wide, but the main-process `createFederationWindow` path unconditionally constructed a new main window for every request. Two opens for the same connected peer therefore produced two independent remote viewers for the same profile and federation instance.

## Impact

A local PwrAgent process can no longer show duplicate remote viewers for the same peer. Different peers still receive separate viewers.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-window.test.ts apps/desktop/src/main/__tests__/federation-load-ipc.test.ts apps/desktop/src/main/__tests__/index.test.ts` (58 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
