### PR TITLE
feat(desktop): configure usage alerts

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19504,19 +19504,19 @@ command = "pnpm dev"
     });
     const emitPricing = (registry as unknown as {
       emitThreadPricingUpdated(params: {
-        activeTurnId?: string;
+        activeTurnIds?: readonly string[];
         backend: AppServerBackendKind;
         threadId: string;
       }): Promise<void>;
     }).emitThreadPricingUpdated.bind(registry);
 
     await emitPricing({
-      activeTurnId: "turn-2",
+      activeTurnIds: ["turn-2"],
       backend: "codex",
       threadId: "thread-1",
     });
     await emitPricing({
-      activeTurnId: "turn-2",
+      activeTurnIds: ["turn-2"],
       backend: "codex",
       threadId: "thread-1",
     });
@@ -19533,6 +19533,90 @@ command = "pnpm dev"
     expect(pricingEvents[1]?.notification.params).not.toHaveProperty(
       "triggeredSpendAlerts",
     );
+
+    await registry.close();
+  });
+
+  it("preserves every active turn while coalescing pricing updates", async () => {
+    const lines: ThreadUsageLineRecord[] = ["turn-a", "turn-b"].map(
+      (turnId, index) => ({
+        backend: "codex",
+        cachedInputCostMicros: 0,
+        cachedInputTokens: 0,
+        createdAt: 1_800_000_000_000 + index,
+        currency: "USD",
+        inputTokens: 0,
+        outputCostMicros: 0,
+        outputTokens: 0,
+        priceStatus: "priced",
+        provider: "openai",
+        reasoningOutputTokens: 0,
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        threadId: "thread-1",
+        totalCostMicros: 6_000_000 + index * 1_000_000,
+        totalTokens: 0,
+        turnId,
+        turnUsageAttributed: true,
+        uncachedInputCostMicros: 0,
+        uncachedInputTokens: 0,
+        usageLineId: `usage-${turnId}`,
+      }),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadPricing: vi.fn(async () => ({
+        lines,
+        summaries: [],
+      })),
+      upsertThreadUsageLines: vi.fn(async () => ({
+        lines,
+        summaries: [],
+      })),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      resolveSpendAlertPolicy: () => ({
+        activeTurnSpendEnabled: true,
+        activeTurnSpendThresholdUsd: 5,
+        threadSpendEnabled: false,
+        threadSpendThresholdUsd: 25,
+      }),
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+    const usageBatch = registry as unknown as {
+      bufferLiveThreadUsageLine(params: {
+        backend: AppServerBackendKind;
+        line: ThreadUsageLineRecord;
+        observationSequence: number;
+      }): void;
+      writePendingLiveThreadUsageLines(): Promise<void>;
+    };
+    lines.forEach((line, index) => {
+      usageBatch.bufferLiveThreadUsageLine({
+        backend: "codex",
+        line,
+        observationSequence: index + 1,
+      });
+    });
+
+    await usageBatch.writePendingLiveThreadUsageLines();
+
+    const pricingEvents = events.filter(
+      (event) => event.notification.method === "thread/pricing/updated",
+    );
+    expect(pricingEvents).toHaveLength(1);
+    expect(pricingEvents[0]?.notification.params).toMatchObject({
+      triggeredSpendAlerts: [
+        { kind: "active-turn-spend", turnId: "turn-a" },
+        { kind: "active-turn-spend", turnId: "turn-b" },
+      ],
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19440,6 +19440,103 @@ command = "pnpm dev"
     });
   });
 
+  it("emits configured spend alerts once per threshold", async () => {
+    const activeLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      cachedInputCostMicros: 0,
+      cachedInputTokens: 0,
+      createdAt: 1_800_000_000_000,
+      currency: "USD",
+      inputTokens: 0,
+      outputCostMicros: 0,
+      outputTokens: 0,
+      priceStatus: "priced",
+      provider: "openai",
+      reasoningOutputTokens: 0,
+      scope: "turn",
+      source: "live",
+      status: "pending",
+      threadId: "thread-1",
+      totalCostMicros: 5_250_000,
+      totalTokens: 0,
+      turnId: "turn-2",
+      turnUsageAttributed: true,
+      uncachedInputCostMicros: 0,
+      uncachedInputTokens: 0,
+      usageLineId: "usage-turn-2",
+    };
+    const pricing = {
+      lines: [activeLine],
+      summaries: [{
+        backend: "codex",
+        cachedInputTokens: 0,
+        currency: "USD",
+        inputTokens: 0,
+        outputTokens: 0,
+        pricedUsageLineCount: 1,
+        provider: "openai",
+        reasoningOutputTokens: 0,
+        threadId: "thread-1",
+        totalCostMicros: 30_000_000,
+        totalTokens: 0,
+        uncachedInputTokens: 0,
+        unpricedUsageLineCount: 0,
+        updatedAt: 1_800_000_000_000,
+        usageLineCount: 1,
+      }],
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: {
+        ...createOverlayStoreMock(),
+        readThreadPricing: vi.fn(async () => pricing),
+      } as never,
+      resolveSpendAlertPolicy: () => ({
+        activeTurnSpendEnabled: true,
+        activeTurnSpendThresholdUsd: 5,
+        threadSpendEnabled: true,
+        threadSpendThresholdUsd: 25,
+      }),
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+    const emitPricing = (registry as unknown as {
+      emitThreadPricingUpdated(params: {
+        activeTurnId?: string;
+        backend: AppServerBackendKind;
+        threadId: string;
+      }): Promise<void>;
+    }).emitThreadPricingUpdated.bind(registry);
+
+    await emitPricing({
+      activeTurnId: "turn-2",
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    await emitPricing({
+      activeTurnId: "turn-2",
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    const pricingEvents = events.filter(
+      (event) => event.notification.method === "thread/pricing/updated",
+    );
+    expect(pricingEvents[0]?.notification.params).toMatchObject({
+      triggeredSpendAlerts: [
+        { kind: "active-turn-spend", spendMicros: 5_250_000 },
+        { kind: "thread-spend", spendMicros: 30_000_000 },
+      ],
+    });
+    expect(pricingEvents[1]?.notification.params).not.toHaveProperty(
+      "triggeredSpendAlerts",
+    );
+
+    await registry.close();
+  });
+
   it("coalesces streamed command output into one accounting write", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19533,6 +19533,13 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore: overlayStore as never,
+      resolveToolOutputAlertPolicy: () => ({
+        outputCapHitsEnabled: true,
+        repeatedLargeOutputsEnabled: true,
+        repeatedLargeOutputMinimumCalls: 3,
+        repeatedLargeOutputMinimumPercent: 25,
+        repeatedQueuedChecksEnabled: true,
+      }),
     });
     const events: AgentEvent[] = [];
     registry.onEvent((event) => {
@@ -19561,20 +19568,18 @@ command = "pnpm dev"
         } as AgentEvent);
       };
 
-      await stream("x".repeat(10_000));
+      await stream("x".repeat(5_000));
       await vi.advanceTimersByTimeAsync(250);
       expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
 
       // The warning total spans sqlite flush windows. A detector tied to the
-      // 250ms pending-write buffer would see two harmless 10,000-char chunks
-      // and never count that the command reached half of the output cap.
-      await stream("x".repeat(10_000));
-      await stream("x".repeat(20_000), "cmd-2");
-      await stream("x".repeat(20_000), "cmd-3");
-      await stream("x".repeat(20_000), "cmd-4");
+      // 250ms pending-write buffer would see two harmless 5,000-char chunks
+      // and never count that the command reached the configured 25% threshold.
+      await stream("x".repeat(5_000));
+      await stream("x".repeat(10_000), "cmd-2");
       expect(persistThreadToolInvocationBoundary).not.toHaveBeenCalled();
 
-      await stream("x".repeat(20_000), "cmd-5");
+      await stream("x".repeat(10_000), "cmd-3");
       const alertEvent = events.find(
         (event) =>
           event.notification.method === "thread/toolAccounting/updated",
@@ -19583,10 +19588,10 @@ command = "pnpm dev"
         threadId: "thread-1",
         triggeredAlerts: [
           {
-            invocationCount: 5,
+            invocationCount: 3,
             kind: "large-output",
             severity: "warning",
-            totalOutputChars: 100_000,
+            totalOutputChars: 30_000,
             turnId: "turn-1",
           },
         ],
@@ -19597,15 +19602,15 @@ command = "pnpm dev"
           expect.objectContaining({
             kind: "large-output",
             severity: "warning",
-            invocationCount: 5,
-            totalOutputChars: 100_000,
+            invocationCount: 3,
+            totalOutputChars: 30_000,
           }),
         ],
         invocation: expect.objectContaining({
-          invocationId: "tool:codex:thread-1:turn-1:cmd-5",
+          invocationId: "tool:codex:thread-1:turn-1:cmd-3",
           noisy: true,
           noisyReason: "large-output",
-          outputChars: 20_000,
+          outputChars: 10_000,
           outputState: "available",
           source: "live",
           status: "in_progress",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19561,14 +19561,20 @@ command = "pnpm dev"
         } as AgentEvent);
       };
 
-      await stream("x".repeat(2_000));
+      await stream("x".repeat(10_000));
       await vi.advanceTimersByTimeAsync(250);
       expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
 
       // The warning total spans sqlite flush windows. A detector tied to the
-      // 250ms pending-write buffer would see two harmless 2,000-char chunks
-      // and never report that the command reached 4,000.
-      await stream("x".repeat(2_000));
+      // 250ms pending-write buffer would see two harmless 10,000-char chunks
+      // and never count that the command reached half of the output cap.
+      await stream("x".repeat(10_000));
+      await stream("x".repeat(20_000), "cmd-2");
+      await stream("x".repeat(20_000), "cmd-3");
+      await stream("x".repeat(20_000), "cmd-4");
+      expect(persistThreadToolInvocationBoundary).not.toHaveBeenCalled();
+
+      await stream("x".repeat(20_000), "cmd-5");
       const alertEvent = events.find(
         (event) =>
           event.notification.method === "thread/toolAccounting/updated",
@@ -19577,9 +19583,10 @@ command = "pnpm dev"
         threadId: "thread-1",
         triggeredAlerts: [
           {
+            invocationCount: 5,
             kind: "large-output",
             severity: "warning",
-            totalOutputChars: 4_000,
+            totalOutputChars: 100_000,
             turnId: "turn-1",
           },
         ],
@@ -19590,14 +19597,15 @@ command = "pnpm dev"
           expect.objectContaining({
             kind: "large-output",
             severity: "warning",
-            totalOutputChars: 4_000,
+            invocationCount: 5,
+            totalOutputChars: 100_000,
           }),
         ],
         invocation: expect.objectContaining({
-          invocationId: "tool:codex:thread-1:turn-1:cmd-1",
+          invocationId: "tool:codex:thread-1:turn-1:cmd-5",
           noisy: true,
           noisyReason: "large-output",
-          outputChars: 2_000,
+          outputChars: 20_000,
           outputState: "available",
           source: "live",
           status: "in_progress",
@@ -19605,30 +19613,8 @@ command = "pnpm dev"
         }),
       });
 
-      await stream("x".repeat(4_000), "cmd-2");
-      expect(persistThreadToolInvocationBoundary).toHaveBeenCalledTimes(2);
-      expect(persistThreadToolInvocationBoundary.mock.calls[1]?.[0]).toMatchObject({
-        alerts: [
-          {
-            invocationCount: 2,
-            invocationIds: [
-              "tool:codex:thread-1:turn-1:cmd-1",
-              "tool:codex:thread-1:turn-1:cmd-2",
-            ],
-            totalOutputChars: 8_000,
-            worstOutputChars: 4_000,
-          },
-        ],
-        invocation: {
-          invocationId: "tool:codex:thread-1:turn-1:cmd-2",
-          outputChars: 4_000,
-          outputState: "available",
-          source: "live",
-        },
-      });
-
       await registry.close();
-      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
+      expect(upsertThreadToolInvocation.mock.calls.length).toBeGreaterThan(1);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -173,6 +173,46 @@ describe("desktopSettingsPatchToEdits — general", () => {
       },
     ]);
   });
+
+  it("writes spend alert preferences", () => {
+    const edits = desktopSettingsPatchToEdits({
+      general: {
+        spendAlerts: {
+          activeTurnSpendEnabled: false,
+          activeTurnSpendThresholdUsd: 7.5,
+          threadSpendEnabled: true,
+          threadSpendThresholdUsd: 40,
+        },
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["general", "spend_alerts", "active_turn_spend_enabled"],
+        value: false,
+      },
+      {
+        op: "set",
+        path: [
+          "general",
+          "spend_alerts",
+          "active_turn_spend_threshold_usd",
+        ],
+        value: 7.5,
+      },
+      {
+        op: "set",
+        path: ["general", "spend_alerts", "thread_spend_enabled"],
+        value: true,
+      },
+      {
+        op: "set",
+        path: ["general", "spend_alerts", "thread_spend_threshold_usd"],
+        value: 40,
+      },
+    ]);
+  });
 });
 
 describe("desktopSettingsPatchToEdits — experimental", () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -122,6 +122,8 @@ describe("desktopSettingsPatchToEdits — general", () => {
         toolOutputAlerts: {
           outputCapHitsEnabled: false,
           repeatedLargeOutputsEnabled: true,
+          repeatedLargeOutputMinimumCalls: 7,
+          repeatedLargeOutputMinimumPercent: 65,
           repeatedQueuedChecksEnabled: false,
         },
       },
@@ -141,6 +143,24 @@ describe("desktopSettingsPatchToEdits — general", () => {
           "repeated_large_outputs_enabled",
         ],
         value: true,
+      },
+      {
+        op: "set",
+        path: [
+          "general",
+          "tool_output_alerts",
+          "repeated_large_output_minimum_calls",
+        ],
+        value: 7,
+      },
+      {
+        op: "set",
+        path: [
+          "general",
+          "tool_output_alerts",
+          "repeated_large_output_minimum_percent",
+        ],
+        value: 65,
       },
       {
         op: "set",

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -115,6 +115,44 @@ describe("desktopSettingsPatchToEdits — general", () => {
       },
     ]);
   });
+
+  it("writes tool-output alert trigger preferences", () => {
+    const edits = desktopSettingsPatchToEdits({
+      general: {
+        toolOutputAlerts: {
+          outputCapHitsEnabled: false,
+          repeatedLargeOutputsEnabled: true,
+          repeatedQueuedChecksEnabled: false,
+        },
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["general", "tool_output_alerts", "output_cap_hits_enabled"],
+        value: false,
+      },
+      {
+        op: "set",
+        path: [
+          "general",
+          "tool_output_alerts",
+          "repeated_large_outputs_enabled",
+        ],
+        value: true,
+      },
+      {
+        op: "set",
+        path: [
+          "general",
+          "tool_output_alerts",
+          "repeated_queued_checks_enabled",
+        ],
+        value: false,
+      },
+    ]);
+  });
 });
 
 describe("desktopSettingsPatchToEdits — experimental", () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -735,6 +735,8 @@ describe("DesktopSettingsService", () => {
     expect((await service.readSettings()).general.toolOutputAlerts).toEqual({
       outputCapHitsEnabled: { value: true, source: "default" },
       repeatedLargeOutputsEnabled: { value: true, source: "default" },
+      repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
+      repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
       repeatedQueuedChecksEnabled: { value: true, source: "default" },
     });
 
@@ -742,6 +744,8 @@ describe("DesktopSettingsService", () => {
       general: {
         toolOutputAlerts: {
           repeatedLargeOutputsEnabled: false,
+          repeatedLargeOutputMinimumCalls: 7,
+          repeatedLargeOutputMinimumPercent: 65,
         },
       },
     });
@@ -749,9 +753,17 @@ describe("DesktopSettingsService", () => {
     expect(fs.readFileSync(configPath, "utf8")).toContain(
       "repeated_large_outputs_enabled = false",
     );
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "repeated_large_output_minimum_calls = 7",
+    );
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "repeated_large_output_minimum_percent = 65",
+    );
     expect(service.resolveToolOutputAlertPolicy()).toEqual({
       outputCapHitsEnabled: true,
       repeatedLargeOutputsEnabled: false,
+      repeatedLargeOutputMinimumCalls: 7,
+      repeatedLargeOutputMinimumPercent: 65,
       repeatedQueuedChecksEnabled: true,
     });
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -723,6 +723,39 @@ describe("DesktopSettingsService", () => {
     });
   });
 
+  it("defaults tool-output alert triggers on and persists independent opt-outs", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect((await service.readSettings()).general.toolOutputAlerts).toEqual({
+      outputCapHitsEnabled: { value: true, source: "default" },
+      repeatedLargeOutputsEnabled: { value: true, source: "default" },
+      repeatedQueuedChecksEnabled: { value: true, source: "default" },
+    });
+
+    await service.writeConfigPatch({
+      general: {
+        toolOutputAlerts: {
+          repeatedLargeOutputsEnabled: false,
+        },
+      },
+    });
+
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "repeated_large_outputs_enabled = false",
+    );
+    expect(service.resolveToolOutputAlertPolicy()).toEqual({
+      outputCapHitsEnabled: true,
+      repeatedLargeOutputsEnabled: false,
+      repeatedQueuedChecksEnabled: true,
+    });
+  });
+
   it("defaults quit confirmation to enabled and persists overrides", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -768,6 +768,43 @@ describe("DesktopSettingsService", () => {
     });
   });
 
+  it("persists bounded active-turn and thread spend alerts", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect((await service.readSettings()).general.spendAlerts).toEqual({
+      activeTurnSpendEnabled: { value: true, source: "default" },
+      activeTurnSpendThresholdUsd: { value: 5, source: "default" },
+      threadSpendEnabled: { value: true, source: "default" },
+      threadSpendThresholdUsd: { value: 25, source: "default" },
+    });
+
+    await service.writeConfigPatch({
+      general: {
+        spendAlerts: {
+          activeTurnSpendEnabled: false,
+          activeTurnSpendThresholdUsd: 7.499,
+          threadSpendThresholdUsd: 40,
+        },
+      },
+    });
+
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "active_turn_spend_threshold_usd = 7.499",
+    );
+    expect(service.resolveSpendAlertPolicy()).toEqual({
+      activeTurnSpendEnabled: false,
+      activeTurnSpendThresholdUsd: 7.5,
+      threadSpendEnabled: true,
+      threadSpendThresholdUsd: 40,
+    });
+  });
+
   it("defaults quit confirmation to enabled and persists overrides", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -98,22 +98,22 @@
     "statements": 8
   },
   "streamed-command-output": {
-    "commits": 3,
+    "commits": 2,
     "note": "500 streamed output deltas plus the completion for one command",
-    "observedWalBytes": 74160,
-    "rowsChanged": 5,
-    "statements": 5
+    "observedWalBytes": 37080,
+    "rowsChanged": 2,
+    "statements": 2
   },
   "streamed-large-output-alert-boundary": {
     "commits": 1,
-    "note": "one threshold-crossing streamed output window and its alert",
+    "note": "five large streamed outputs and their first repeated-output alert",
     "observedWalBytes": 32960,
     "rowsChanged": 2,
     "statements": 2
   },
   "structured-mcp-output-alert": {
     "commits": 1,
-    "note": "one large structured MCP result and its alert in one boundary",
+    "note": "one capped structured MCP result and its alert in one boundary",
     "observedWalBytes": 32960,
     "rowsChanged": 2,
     "statements": 2

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -260,22 +260,24 @@ describe("sqlite write metrics", () => {
     }).emit.bind(registry);
 
     const { writes } = await measureSqliteWrites(async () => {
-      await emit({
-        backend: "codex",
-        notification: {
-          method: "item/commandExecution/outputDelta",
-          params: {
-            threadId: "thread-streaming-alert",
-            turnId: "turn-1",
-            itemId: "cmd-1",
-            delta: "x".repeat(4_100),
+      for (let index = 0; index < 5; index += 1) {
+        await emit({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              threadId: "thread-streaming-alert",
+              turnId: "turn-1",
+              itemId: `cmd-${index + 1}`,
+              delta: "x".repeat(20_100),
+            },
           },
-        },
-      } as AgentEvent);
+        } as AgentEvent);
+      }
     });
 
     expectSqliteWriteBudget({
-      note: "one threshold-crossing streamed output window and its alert",
+      note: "five large streamed outputs and their first repeated-output alert",
       scenario: "streamed-large-output-alert-boundary",
       writes,
     });
@@ -287,14 +289,15 @@ describe("sqlite write metrics", () => {
     expect(accounting.alerts).toEqual([
       expect.objectContaining({
         kind: "large-output",
-        totalOutputChars: 4_100,
+        invocationCount: 5,
+        totalOutputChars: 100_500,
       }),
     ]);
     expect(accounting.invocations).toEqual([
       expect.objectContaining({
         noisy: true,
         noisyReason: "large-output",
-        outputChars: 4_100,
+        outputChars: 20_100,
         status: "in_progress",
       }),
     ]);
@@ -351,7 +354,7 @@ describe("sqlite write metrics", () => {
     }
   });
 
-  it("holds one large structured MCP result and its alert to one commit", async () => {
+  it("holds one capped structured MCP result and its alert to one commit", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),
       overlayStore: store as never,
@@ -376,7 +379,7 @@ describe("sqlite write metrics", () => {
               status: "completed",
               arguments: { action: "list" },
               result: {
-                content: [{ type: "text", text: "x".repeat(4_100) }],
+                content: [{ type: "text", text: "x".repeat(40_100) }],
               },
             },
           },
@@ -385,7 +388,7 @@ describe("sqlite write metrics", () => {
     });
 
     expectSqliteWriteBudget({
-      note: "one large structured MCP result and its alert in one boundary",
+      note: "one capped structured MCP result and its alert in one boundary",
       scenario: "structured-mcp-output-alert",
       writes,
     });

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -448,6 +448,28 @@ describe("tool invocation accounting", () => {
     });
   });
 
+  it("uses the configured percentage of the output cap", () => {
+    const policy = {
+      outputCapHitsEnabled: true,
+      repeatedLargeOutputsEnabled: true,
+      repeatedLargeOutputMinimumCalls: 3,
+      repeatedLargeOutputMinimumPercent: 75,
+      repeatedQueuedChecksEnabled: true,
+    };
+
+    expect(detectLargeToolOutput({
+      current: buildOutputInvocation(29_999),
+      policy,
+    })).toBeUndefined();
+    expect(detectLargeToolOutput({
+      current: buildOutputInvocation(30_000),
+      policy,
+    })?.alert).toMatchObject({
+      severity: "warning",
+      totalOutputChars: 30_000,
+    });
+  });
+
   it("waits for five large outputs before notifying", () => {
     let aggregate: ReturnType<typeof mergeLargeToolOutputIncident>["aggregate"]
       | undefined;
@@ -475,6 +497,8 @@ describe("tool invocation accounting", () => {
       policy: {
         outputCapHitsEnabled: false,
         repeatedLargeOutputsEnabled: false,
+        repeatedLargeOutputMinimumCalls: 5,
+        repeatedLargeOutputMinimumPercent: 50,
         repeatedQueuedChecksEnabled: true,
       },
     })).toBeUndefined();
@@ -483,6 +507,8 @@ describe("tool invocation accounting", () => {
       policy: {
         outputCapHitsEnabled: false,
         repeatedLargeOutputsEnabled: true,
+        repeatedLargeOutputMinimumCalls: 5,
+        repeatedLargeOutputMinimumPercent: 50,
         repeatedQueuedChecksEnabled: true,
       },
     })?.alert.severity).toBe("warning");

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -219,13 +219,13 @@ describe("tool invocation accounting", () => {
     {
       label: "structured object result",
       result: {
-        tabs: [{ title: "x".repeat(4_100) }],
+        tabs: [{ title: "x".repeat(20_100) }],
       },
     },
     {
       label: "MCP content array",
       result: {
-        content: [{ type: "text", text: "x".repeat(4_100) }],
+        content: [{ type: "text", text: "x".repeat(20_100) }],
       },
     },
   ])("accounts a large $label", ({ result }) => {
@@ -426,10 +426,10 @@ describe("tool invocation accounting", () => {
     });
   });
 
-  it("warns at ten percent of the observed output cap and escalates at the cap", () => {
+  it("detects output at half of the observed cap and escalates at the cap", () => {
     const warning = detectLargeToolOutput({
-      current: buildOutputInvocation(4_000),
-      previousOutputChars: 3_999,
+      current: buildOutputInvocation(20_000),
+      previousOutputChars: 19_999,
     });
     const critical = detectLargeToolOutput({
       current: buildOutputInvocation(40_000),
@@ -439,13 +439,53 @@ describe("tool invocation accounting", () => {
     expect(warning?.alert).toMatchObject({
       kind: "large-output",
       severity: "warning",
-      totalOutputChars: 4_000,
+      totalOutputChars: 20_000,
     });
     expect(critical?.alert).toMatchObject({
       kind: "large-output",
       severity: "critical",
       totalOutputChars: 40_000,
     });
+  });
+
+  it("waits for five large outputs before notifying", () => {
+    let aggregate: ReturnType<typeof mergeLargeToolOutputIncident>["aggregate"]
+      | undefined;
+    for (let index = 0; index < 5; index += 1) {
+      const detection = detectLargeToolOutput({
+        current: {
+          ...buildOutputInvocation(20_000),
+          invocationId: `command-${index + 1}`,
+          itemId: `command-${index + 1}`,
+        },
+      })!;
+      const incident = mergeLargeToolOutputIncident({
+        current: aggregate,
+        detection,
+        minimumWarningInvocationCount: 5,
+      });
+      expect(incident.shouldNotify).toBe(index === 4);
+      aggregate = incident.aggregate;
+    }
+  });
+
+  it("lets operators disable cap-hit and repeated-output alerts independently", () => {
+    expect(detectLargeToolOutput({
+      current: buildOutputInvocation(40_000),
+      policy: {
+        outputCapHitsEnabled: false,
+        repeatedLargeOutputsEnabled: false,
+        repeatedQueuedChecksEnabled: true,
+      },
+    })).toBeUndefined();
+    expect(detectLargeToolOutput({
+      current: buildOutputInvocation(40_000),
+      policy: {
+        outputCapHitsEnabled: false,
+        repeatedLargeOutputsEnabled: true,
+        repeatedQueuedChecksEnabled: true,
+      },
+    })?.alert.severity).toBe("warning");
   });
 
   it("does not flag non-empty stdin writes as polling", () => {
@@ -466,13 +506,13 @@ describe("tool invocation accounting", () => {
 
   it("aggregates cases by turn and keeps a stable worst-case summary", () => {
     const first = detectLargeToolOutput({
-      current: buildOutputInvocation(8_000),
+      current: buildOutputInvocation(20_000),
       previousOutputChars: 0,
     })!;
     const firstIncident = mergeLargeToolOutputIncident({ detection: first });
     const second = detectLargeToolOutput({
       current: {
-        ...buildOutputInvocation(12_000),
+        ...buildOutputInvocation(24_000),
         invocationId: "command-2",
         itemId: "command-2",
       },
@@ -486,20 +526,20 @@ describe("tool invocation accounting", () => {
     expect(secondIncident.shouldNotify).toBe(true);
     expect(secondIncident.aggregate.alert).toMatchObject({
       invocationCount: 2,
-      totalOutputChars: 20_000,
+      totalOutputChars: 44_000,
       worstInvocationId: "command-2",
-      worstOutputChars: 12_000,
+      worstOutputChars: 24_000,
     });
   });
 
   it("does not rewrite a live warning at terminal completion", () => {
     const live = detectLargeToolOutput({
-      current: buildOutputInvocation(4_000),
+      current: buildOutputInvocation(20_000),
       previousOutputChars: 0,
     })!;
     const incident = mergeLargeToolOutputIncident({ detection: live });
     const terminal = detectLargeToolOutput({
-      current: { ...buildOutputInvocation(4_000), status: "completed" },
+      current: { ...buildOutputInvocation(20_000), status: "completed" },
     })!;
     const completed = mergeLargeToolOutputIncident({
       current: incident.aggregate,
@@ -550,7 +590,7 @@ describe("tool invocation accounting", () => {
   it("reopens a case only when it escalates to critical", () => {
     const warning = mergeLargeToolOutputIncident({
       detection: detectLargeToolOutput({
-        current: buildOutputInvocation(4_000),
+        current: buildOutputInvocation(20_000),
         previousOutputChars: 0,
       })!,
     });
@@ -558,7 +598,7 @@ describe("tool invocation accounting", () => {
       current: warning.aggregate,
       detection: detectLargeToolOutput({
         current: buildOutputInvocation(40_000),
-        previousOutputChars: 4_000,
+        previousOutputChars: 20_000,
       })!,
     });
 

--- a/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
@@ -63,6 +63,36 @@ describe("normalized tool-output replay analyzer", () => {
     ]);
   });
 
+  it("uses the configured large-output threshold for replay findings", () => {
+    const replay = replayWithDetail({
+      displayCommand: "sed -n '1,5000p' build.log",
+      output: "x".repeat(12_000),
+      source: "shell",
+    });
+
+    const defaultAnalysis = analyzeNormalizedToolReplay({
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex",
+      complete: true,
+      pages: [replay],
+      threadId: "thread-default-threshold",
+    });
+    const tunedAnalysis = analyzeNormalizedToolReplay({
+      analyzedAt: 1_800_000_000_000,
+      backend: "codex",
+      complete: true,
+      largeOutputThresholdChars: 10_000,
+      pages: [replay],
+      threadId: "thread-tuned-threshold",
+    });
+
+    expect(defaultAnalysis.invocations[0]?.noisy).toBe(false);
+    expect(tunedAnalysis.invocations[0]).toMatchObject({
+      noisy: true,
+      noisyReason: "broad-file-read",
+    });
+  });
+
   it("attributes inherited normalized replay to a fork with idempotent IDs", () => {
     const inheritedReplay = replayWithDetail({
       displayCommand: "cat inherited-build.log",

--- a/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-replay-analyzer.test.ts
@@ -10,7 +10,9 @@ describe("normalized tool-output replay analyzer", () => {
       complete: true,
       pages: [replayWithDetail({
         displayCommand: "mcp__github__search({\"query\":\"is:open\"})",
-        output: JSON.stringify({ items: Array.from({ length: 600 }, (_, id) => ({ id })) }),
+        output: JSON.stringify({
+          items: Array.from({ length: 2_500 }, (_, id) => ({ id })),
+        }),
         source: "tool",
       })],
       threadId: "thread-mcp",

--- a/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
+++ b/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
@@ -23,7 +23,7 @@ describe("usage spend alerts", () => {
 
   it("alerts independently for active-turn and total-thread spend", () => {
     const alerts = detectUsageSpendAlerts({
-      activeTurnId: "turn-2",
+      activeTurnIds: ["turn-2"],
       backend: "codex",
       now: 1_800_000_000_000,
       policy: POLICY,
@@ -53,9 +53,30 @@ describe("usage spend alerts", () => {
     ]);
   });
 
+  it("evaluates every active turn represented in one usage batch", () => {
+    const alerts = detectUsageSpendAlerts({
+      activeTurnIds: ["turn-1", "turn-2", "turn-1"],
+      backend: "codex",
+      policy: POLICY,
+      pricing: {
+        lines: [
+          usageLine({ turnId: "turn-1", totalCostMicros: 6_000_000 }),
+          usageLine({ turnId: "turn-2", totalCostMicros: 7_000_000 }),
+        ],
+        summaries: [pricingSummary(13_000_000)],
+      },
+      threadId: "thread-1",
+      triggeredAlertIds: new Set(),
+    });
+
+    expect(alerts.map((alert) => alert.kind === "active-turn-spend"
+      ? alert.turnId
+      : alert.kind)).toEqual(["turn-1", "turn-2"]);
+  });
+
   it("ignores disabled, unpriced, historical-summary, and non-USD rows", () => {
     const alerts = detectUsageSpendAlerts({
-      activeTurnId: "turn-2",
+      activeTurnIds: ["turn-2"],
       backend: "codex",
       policy: {
         ...POLICY,

--- a/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
+++ b/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
@@ -1,0 +1,159 @@
+import type {
+  DesktopSpendAlertPolicy,
+  ThreadPricingSummary,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import {
+  detectUsageSpendAlerts,
+  spendThresholdMicros,
+} from "../app-server/usage-spend-alerts";
+
+const POLICY: DesktopSpendAlertPolicy = {
+  activeTurnSpendEnabled: true,
+  activeTurnSpendThresholdUsd: 5,
+  threadSpendEnabled: true,
+  threadSpendThresholdUsd: 25,
+};
+
+describe("usage spend alerts", () => {
+  it("converts dollar thresholds to integer micros", () => {
+    expect(spendThresholdMicros(7.5)).toBe(7_500_000);
+  });
+
+  it("alerts independently for active-turn and total-thread spend", () => {
+    const alerts = detectUsageSpendAlerts({
+      activeTurnId: "turn-2",
+      backend: "codex",
+      now: 1_800_000_000_000,
+      policy: POLICY,
+      pricing: {
+        lines: [
+          usageLine({ turnId: "turn-2", totalCostMicros: 5_250_000 }),
+          usageLine({ turnId: "turn-1", totalCostMicros: 30_000_000 }),
+        ],
+        summaries: [pricingSummary(35_250_000)],
+      },
+      threadId: "thread-1",
+      triggeredAlertIds: new Set(),
+    });
+
+    expect(alerts).toMatchObject([
+      {
+        kind: "active-turn-spend",
+        spendMicros: 5_250_000,
+        thresholdMicros: 5_000_000,
+        turnId: "turn-2",
+      },
+      {
+        kind: "thread-spend",
+        spendMicros: 35_250_000,
+        thresholdMicros: 25_000_000,
+      },
+    ]);
+  });
+
+  it("ignores disabled, unpriced, historical-summary, and non-USD rows", () => {
+    const alerts = detectUsageSpendAlerts({
+      activeTurnId: "turn-2",
+      backend: "codex",
+      policy: {
+        ...POLICY,
+        threadSpendEnabled: false,
+      },
+      pricing: {
+        lines: [
+          usageLine({ priceStatus: "unpriced", totalCostMicros: 20_000_000 }),
+          usageLine({
+            currency: "EUR",
+            totalCostMicros: 20_000_000,
+          }),
+          usageLine({
+            totalCostMicros: 20_000_000,
+            turnUsageAttributed: false,
+          }),
+        ],
+        summaries: [pricingSummary(50_000_000)],
+      },
+      threadId: "thread-1",
+      triggeredAlertIds: new Set(),
+    });
+
+    expect(alerts).toEqual([]);
+  });
+
+  it("does not repeat an alert already emitted for the same threshold", () => {
+    const first = detectUsageSpendAlerts({
+      backend: "codex",
+      policy: POLICY,
+      pricing: {
+        lines: [],
+        summaries: [pricingSummary(30_000_000)],
+      },
+      threadId: "thread-1",
+      triggeredAlertIds: new Set(),
+    });
+    const triggeredAlertIds = new Set(first.map((alert) => alert.alertId));
+
+    expect(detectUsageSpendAlerts({
+      backend: "codex",
+      policy: POLICY,
+      pricing: {
+        lines: [],
+        summaries: [pricingSummary(40_000_000)],
+      },
+      threadId: "thread-1",
+      triggeredAlertIds,
+    })).toEqual([]);
+  });
+});
+
+function usageLine(
+  overrides: Partial<ThreadUsageLineRecord> = {},
+): ThreadUsageLineRecord {
+  return {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 0,
+    createdAt: 1_800_000_000_000,
+    currency: "USD",
+    inputTokens: 0,
+    outputCostMicros: 0,
+    outputTokens: 0,
+    priceStatus: "priced",
+    provider: "openai",
+    reasoningOutputTokens: 0,
+    scope: "turn",
+    source: "live",
+    status: "pending",
+    threadId: "thread-1",
+    totalCostMicros: 0,
+    totalTokens: 0,
+    turnId: "turn-2",
+    turnUsageAttributed: true,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 0,
+    usageLineId: "usage-turn-2",
+    ...overrides,
+  };
+}
+
+function pricingSummary(totalCostMicros: number): ThreadPricingSummary {
+  return {
+    backend: "codex",
+    cachedInputTokens: 0,
+    currency: "USD",
+    inputTokens: 0,
+    outputTokens: 0,
+    pricedUsageLineCount: 1,
+    provider: "openai",
+    reasoningOutputTokens: 0,
+    threadId: "thread-1",
+    totalCostMicros,
+    totalTokens: 0,
+    uncachedInputTokens: 0,
+    unpricedUsageLineCount: 0,
+    updatedAt: 1_800_000_000_000,
+    usageLineCount: 1,
+  };
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -298,8 +298,7 @@ import {
   DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
   TOOL_OUTPUT_CAP_CHARS,
-  TOOL_OUTPUT_WARNING_CHARS,
-  TOOL_OUTPUT_WARNING_INVOCATIONS,
+  toolOutputWarningChars,
   type CancelMonitorDelegationToolArgs,
   type CompleteMonitoringToolArgs,
   type CreateMonitorDelegationToolArgs,
@@ -6884,6 +6883,7 @@ export class DesktopBackendRegistry {
   private readonly resolveCodexFastAllowedFn: () => boolean;
   private readonly resolvePdfAnalysisEnabledFn: () => boolean;
   private readonly resolveToolOutputAlertPolicyFn: () => DesktopToolOutputAlertPolicy;
+  private toolOutputAlertPolicy = DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
   private readonly localFilePrivateStorageRoots: readonly string[];
   private readonly pdfAttachmentStore = new PdfAttachmentStore();
   private readonly pdfToolMcpServer?: AgentToolMcpServerLike;
@@ -7093,6 +7093,14 @@ export class DesktopBackendRegistry {
           return DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
         }
       });
+    this.toolOutputAlertPolicy = this.resolveToolOutputAlertPolicyFn();
+    if (typeof settingsService?.onConfigWritten === "function") {
+      this.unsubscribers.push(
+        settingsService.onConfigWritten(() => {
+          this.toolOutputAlertPolicy = this.resolveToolOutputAlertPolicyFn();
+        }),
+      );
+    }
     const codexCommand = settingsService?.resolveCodexCommandPreference();
     const codexEnv =
       typeof settingsService?.resolveCodexSpawnEnv === "function"
@@ -10753,6 +10761,9 @@ export class DesktopBackendRegistry {
     const analysis = analyzeNormalizedToolReplay({
       backend: request.backend,
       complete,
+      largeOutputThresholdChars: toolOutputWarningChars(
+        this.toolOutputAlertPolicy.repeatedLargeOutputMinimumPercent,
+      ),
       pages,
       threadId: request.threadId,
     });
@@ -22163,8 +22174,13 @@ export class DesktopBackendRegistry {
       return;
     }
     const now = Date.now();
+    const toolOutputAlertPolicy = this.toolOutputAlertPolicy;
+    const largeOutputThresholdChars = toolOutputWarningChars(
+      toolOutputAlertPolicy.repeatedLargeOutputMinimumPercent,
+    );
     const invocation = toolInvocationFromNotification({
       backend: event.backend,
+      largeOutputThresholdChars,
       notification: event.notification,
       now,
     });
@@ -22180,8 +22196,8 @@ export class DesktopBackendRegistry {
       const buffered = this.bufferStreamedToolInvocationDelta(invocation);
       const crossedLargeOutputBoundary =
         (
-          buffered.previousOutputChars < TOOL_OUTPUT_WARNING_CHARS
-          && buffered.current.outputChars >= TOOL_OUTPUT_WARNING_CHARS
+          buffered.previousOutputChars < largeOutputThresholdChars
+          && buffered.current.outputChars >= largeOutputThresholdChars
         )
         || (
           buffered.previousOutputChars < TOOL_OUTPUT_CAP_CHARS
@@ -22191,7 +22207,7 @@ export class DesktopBackendRegistry {
         ? detectLargeToolOutput({
             current: buffered.current,
             now,
-            policy: this.resolveToolOutputAlertPolicyFn(),
+            policy: toolOutputAlertPolicy,
             previousOutputChars: buffered.previousOutputChars,
           })
         : undefined;
@@ -22199,7 +22215,8 @@ export class DesktopBackendRegistry {
         const incident = mergeLargeToolOutputIncident({
           current: this.liveToolOutputIncidents.get(detection.alert.alertId),
           detection,
-          minimumWarningInvocationCount: TOOL_OUTPUT_WARNING_INVOCATIONS,
+          minimumWarningInvocationCount:
+            toolOutputAlertPolicy.repeatedLargeOutputMinimumCalls,
         });
         this.liveToolOutputIncidents.set(
           incident.aggregate.alert.alertId,
@@ -22231,11 +22248,6 @@ export class DesktopBackendRegistry {
     }
     let shouldNotify = event.notification.method === "item/completed";
     const triggeredAlerts: ThreadToolInvocationAlert[] = [];
-    const toolOutputAlertPolicy =
-      invocationWithStreamedOutput.outputChars >= TOOL_OUTPUT_WARNING_CHARS
-      || invocationWithStreamedOutput.category === "polling"
-        ? this.resolveToolOutputAlertPolicyFn()
-        : DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
     const rawLargeOutputDetection = detectLargeToolOutput({
       current: invocationWithStreamedOutput,
       now,
@@ -22247,7 +22259,8 @@ export class DesktopBackendRegistry {
             rawLargeOutputDetection.alert.alertId,
           ),
           detection: rawLargeOutputDetection,
-          minimumWarningInvocationCount: TOOL_OUTPUT_WARNING_INVOCATIONS,
+          minimumWarningInvocationCount:
+            toolOutputAlertPolicy.repeatedLargeOutputMinimumCalls,
         })
       : undefined;
     if (largeOutputIncident) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -114,6 +114,7 @@ import {
   type BackendSummary,
   type DesktopProviderModelDefaults,
   type DesktopProviderThreadModelMigration,
+  type DesktopSpendAlertPolicy,
   type DesktopToolOutputAlertPolicy,
   type CancelQueuedTurnResponse,
   type CheckThreadBranchDriftRequest,
@@ -295,6 +296,7 @@ import {
   DEFAULT_TASK_MONITOR_REASONING_EFFORT,
   DEFAULT_TASK_MONITOR_STARTUP_TIMEOUT_SECONDS,
   DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
+  DESKTOP_SPEND_ALERT_POLICY_DEFAULT,
   DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
   TOOL_OUTPUT_CAP_CHARS,
@@ -463,6 +465,7 @@ import {
   type ToolOutputIncidentAggregate,
 } from "./tool-invocation-accounting";
 import { analyzeNormalizedToolReplay } from "./tool-output-replay-analyzer";
+import { detectUsageSpendAlerts } from "./usage-spend-alerts";
 import {
   ThreadTitleGenerationService,
   type ThreadTitleGenerator,
@@ -6701,6 +6704,7 @@ export class DesktopBackendRegistry {
     string,
     ToolOutputIncidentAggregate
   >();
+  private readonly triggeredSpendAlertIds = new Set<string>();
   private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes every flush and streamed alert boundary so a timer-driven write
@@ -6882,7 +6886,9 @@ export class DesktopBackendRegistry {
   >;
   private readonly resolveCodexFastAllowedFn: () => boolean;
   private readonly resolvePdfAnalysisEnabledFn: () => boolean;
+  private readonly resolveSpendAlertPolicyFn: () => DesktopSpendAlertPolicy;
   private readonly resolveToolOutputAlertPolicyFn: () => DesktopToolOutputAlertPolicy;
+  private spendAlertPolicy = DESKTOP_SPEND_ALERT_POLICY_DEFAULT;
   private toolOutputAlertPolicy = DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
   private readonly localFilePrivateStorageRoots: readonly string[];
   private readonly pdfAttachmentStore = new PdfAttachmentStore();
@@ -6952,6 +6958,7 @@ export class DesktopBackendRegistry {
     >;
     resolveCodexFastAllowed?: () => boolean;
     resolvePdfAnalysisEnabled?: () => boolean;
+    resolveSpendAlertPolicy?: () => DesktopSpendAlertPolicy;
     resolveToolOutputAlertPolicy?: () => DesktopToolOutputAlertPolicy;
     runtimeInstanceId?: string;
     registrySessionId?: string;
@@ -7093,10 +7100,32 @@ export class DesktopBackendRegistry {
           return DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
         }
       });
+    this.resolveSpendAlertPolicyFn =
+      options?.resolveSpendAlertPolicy ??
+      (() => {
+        try {
+          if (settingsService) {
+            return typeof settingsService.resolveSpendAlertPolicy === "function"
+              ? settingsService.resolveSpendAlertPolicy()
+              : DESKTOP_SPEND_ALERT_POLICY_DEFAULT;
+          }
+          return getDesktopSettingsService().resolveSpendAlertPolicy();
+        } catch (error) {
+          backendRegistryLog.warn(
+            "failed to resolve spend alert settings",
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return DESKTOP_SPEND_ALERT_POLICY_DEFAULT;
+        }
+      });
+    this.spendAlertPolicy = this.resolveSpendAlertPolicyFn();
     this.toolOutputAlertPolicy = this.resolveToolOutputAlertPolicyFn();
     if (typeof settingsService?.onConfigWritten === "function") {
       this.unsubscribers.push(
         settingsService.onConfigWritten(() => {
+          this.spendAlertPolicy = this.resolveSpendAlertPolicyFn();
           this.toolOutputAlertPolicy = this.resolveToolOutputAlertPolicyFn();
         }),
       );
@@ -10850,6 +10879,7 @@ export class DesktopBackendRegistry {
   }
 
   private async emitThreadPricingUpdated(params: {
+    activeTurnId?: string;
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<void> {
@@ -10860,6 +10890,17 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: params.threadId,
     });
+    const triggeredSpendAlerts = detectUsageSpendAlerts({
+      ...(params.activeTurnId ? { activeTurnId: params.activeTurnId } : {}),
+      backend: params.backend,
+      policy: this.spendAlertPolicy,
+      pricing,
+      threadId: params.threadId,
+      triggeredAlertIds: this.triggeredSpendAlertIds,
+    });
+    for (const alert of triggeredSpendAlerts) {
+      this.triggeredSpendAlertIds.add(alert.alertId);
+    }
     await this.emit({
       backend: params.backend,
       notification: {
@@ -10867,6 +10908,9 @@ export class DesktopBackendRegistry {
         params: {
           threadId: params.threadId,
           pricing,
+          ...(triggeredSpendAlerts.length > 0
+            ? { triggeredSpendAlerts }
+            : {}),
         },
       },
     });
@@ -20739,6 +20783,9 @@ export class DesktopBackendRegistry {
         return;
       }
       await this.emitThreadPricingUpdated({
+        ...(line.parentThreadId === undefined && line.turnId
+          ? { activeTurnId: line.turnId }
+          : {}),
         backend: event.backend,
         threadId: line.parentThreadId ?? line.threadId,
       });
@@ -20816,10 +20863,17 @@ export class DesktopBackendRegistry {
 
     const pricingTargets = new Map<
       string,
-      { backend: AppServerBackendKind; threadId: string }
+      {
+        activeTurnId?: string;
+        backend: AppServerBackendKind;
+        threadId: string;
+      }
     >();
     for (const { backend, line } of pending) {
       const target = {
+        ...(line.parentThreadId === undefined && line.turnId
+          ? { activeTurnId: line.turnId }
+          : {}),
         backend,
         threadId: line.parentThreadId ?? line.threadId,
       };

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10879,7 +10879,7 @@ export class DesktopBackendRegistry {
   }
 
   private async emitThreadPricingUpdated(params: {
-    activeTurnId?: string;
+    activeTurnIds?: readonly string[];
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<void> {
@@ -10891,7 +10891,7 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
     });
     const triggeredSpendAlerts = detectUsageSpendAlerts({
-      ...(params.activeTurnId ? { activeTurnId: params.activeTurnId } : {}),
+      ...(params.activeTurnIds ? { activeTurnIds: params.activeTurnIds } : {}),
       backend: params.backend,
       policy: this.spendAlertPolicy,
       pricing,
@@ -20784,7 +20784,7 @@ export class DesktopBackendRegistry {
       }
       await this.emitThreadPricingUpdated({
         ...(line.parentThreadId === undefined && line.turnId
-          ? { activeTurnId: line.turnId }
+          ? { activeTurnIds: [line.turnId] }
           : {}),
         backend: event.backend,
         threadId: line.parentThreadId ?? line.threadId,
@@ -20864,29 +20864,35 @@ export class DesktopBackendRegistry {
     const pricingTargets = new Map<
       string,
       {
-        activeTurnId?: string;
+        activeTurnIds: Set<string>;
         backend: AppServerBackendKind;
         threadId: string;
       }
     >();
     for (const { backend, line } of pending) {
-      const target = {
-        ...(line.parentThreadId === undefined && line.turnId
-          ? { activeTurnId: line.turnId }
-          : {}),
+      const threadId = line.parentThreadId ?? line.threadId;
+      const key = JSON.stringify([backend, threadId]);
+      const target = pricingTargets.get(key) ?? {
+        activeTurnIds: new Set<string>(),
         backend,
-        threadId: line.parentThreadId ?? line.threadId,
+        threadId,
       };
-      pricingTargets.set(
-        JSON.stringify([target.backend, target.threadId]),
-        target,
-      );
+      if (line.parentThreadId === undefined && line.turnId) {
+        target.activeTurnIds.add(line.turnId);
+      }
+      pricingTargets.set(key, target);
     }
     for (const target of pricingTargets.values()) {
       try {
         // The notification embeds a fresh store read, so observers can never
         // receive pricing for a usage line that has not committed yet.
-        await this.emitThreadPricingUpdated(target);
+        await this.emitThreadPricingUpdated({
+          ...(target.activeTurnIds.size > 0
+            ? { activeTurnIds: [...target.activeTurnIds] }
+            : {}),
+          backend: target.backend,
+          threadId: target.threadId,
+        });
       } catch (error) {
         backendRegistryLog.warn("live thread pricing update failed", {
           backend: target.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -114,6 +114,7 @@ import {
   type BackendSummary,
   type DesktopProviderModelDefaults,
   type DesktopProviderThreadModelMigration,
+  type DesktopToolOutputAlertPolicy,
   type CancelQueuedTurnResponse,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
@@ -294,7 +295,11 @@ import {
   DEFAULT_TASK_MONITOR_REASONING_EFFORT,
   DEFAULT_TASK_MONITOR_STARTUP_TIMEOUT_SECONDS,
   DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
+  DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
+  TOOL_OUTPUT_CAP_CHARS,
+  TOOL_OUTPUT_WARNING_CHARS,
+  TOOL_OUTPUT_WARNING_INVOCATIONS,
   type CancelMonitorDelegationToolArgs,
   type CompleteMonitoringToolArgs,
   type CreateMonitorDelegationToolArgs,
@@ -6676,7 +6681,8 @@ export class DesktopBackendRegistry {
   /**
    * Full in-memory output totals for active commands. Flush windows clear the
    * sqlite write buffer every 250ms, but warning thresholds must span those
-   * windows or a steady stream of small chunks never reaches 4,000 chars.
+   * windows or a steady stream of small chunks never reaches the configured
+   * large-output boundary.
    */
   private readonly streamedToolInvocationOutputTotals = new Map<
     string,
@@ -6877,6 +6883,7 @@ export class DesktopBackendRegistry {
   >;
   private readonly resolveCodexFastAllowedFn: () => boolean;
   private readonly resolvePdfAnalysisEnabledFn: () => boolean;
+  private readonly resolveToolOutputAlertPolicyFn: () => DesktopToolOutputAlertPolicy;
   private readonly localFilePrivateStorageRoots: readonly string[];
   private readonly pdfAttachmentStore = new PdfAttachmentStore();
   private readonly pdfToolMcpServer?: AgentToolMcpServerLike;
@@ -6945,6 +6952,7 @@ export class DesktopBackendRegistry {
     >;
     resolveCodexFastAllowed?: () => boolean;
     resolvePdfAnalysisEnabled?: () => boolean;
+    resolveToolOutputAlertPolicy?: () => DesktopToolOutputAlertPolicy;
     runtimeInstanceId?: string;
     registrySessionId?: string;
     resolveLiveProfileRuntimeInstanceIds?: () => string[];
@@ -7066,6 +7074,23 @@ export class DesktopBackendRegistry {
             error: error instanceof Error ? error.message : String(error),
           });
           return true;
+        }
+      });
+    this.resolveToolOutputAlertPolicyFn =
+      options?.resolveToolOutputAlertPolicy ??
+      (() => {
+        try {
+          return (
+            settingsService ?? getDesktopSettingsService()
+          ).resolveToolOutputAlertPolicy();
+        } catch (error) {
+          backendRegistryLog.warn(
+            "failed to resolve tool-output alert settings",
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
         }
       });
     const codexCommand = settingsService?.resolveCodexCommandPreference();
@@ -22148,21 +22173,33 @@ export class DesktopBackendRegistry {
     }
 
     if (event.notification.method === "item/commandExecution/outputDelta") {
-      // Streamed output never notifies anyone (`shouldNotify` stays false for
-      // deltas) and never triggers noisy-polling detection (that only looks at
-      // `write_stdin`). Ordinary deltas can wait for the flush timer; a large-
-      // output threshold crossing becomes a durable boundary before its live
-      // alert reaches listeners.
+      // Streamed output never triggers noisy-polling detection (that only
+      // looks at `write_stdin`). Ordinary deltas can wait for the flush timer;
+      // a qualifying repeated-output or cap-hit boundary becomes durable
+      // before its live alert reaches listeners.
       const buffered = this.bufferStreamedToolInvocationDelta(invocation);
-      const detection = detectLargeToolOutput({
-        current: buffered.current,
-        now,
-        previousOutputChars: buffered.previousOutputChars,
-      });
+      const crossedLargeOutputBoundary =
+        (
+          buffered.previousOutputChars < TOOL_OUTPUT_WARNING_CHARS
+          && buffered.current.outputChars >= TOOL_OUTPUT_WARNING_CHARS
+        )
+        || (
+          buffered.previousOutputChars < TOOL_OUTPUT_CAP_CHARS
+          && buffered.current.outputChars >= TOOL_OUTPUT_CAP_CHARS
+        );
+      const detection = crossedLargeOutputBoundary
+        ? detectLargeToolOutput({
+            current: buffered.current,
+            now,
+            policy: this.resolveToolOutputAlertPolicyFn(),
+            previousOutputChars: buffered.previousOutputChars,
+          })
+        : undefined;
       if (detection) {
         const incident = mergeLargeToolOutputIncident({
           current: this.liveToolOutputIncidents.get(detection.alert.alertId),
           detection,
+          minimumWarningInvocationCount: TOOL_OUTPUT_WARNING_INVOCATIONS,
         });
         this.liveToolOutputIncidents.set(
           incident.aggregate.alert.alertId,
@@ -22194,9 +22231,15 @@ export class DesktopBackendRegistry {
     }
     let shouldNotify = event.notification.method === "item/completed";
     const triggeredAlerts: ThreadToolInvocationAlert[] = [];
+    const toolOutputAlertPolicy =
+      invocationWithStreamedOutput.outputChars >= TOOL_OUTPUT_WARNING_CHARS
+      || invocationWithStreamedOutput.category === "polling"
+        ? this.resolveToolOutputAlertPolicyFn()
+        : DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
     const rawLargeOutputDetection = detectLargeToolOutput({
       current: invocationWithStreamedOutput,
       now,
+      policy: toolOutputAlertPolicy,
     });
     const largeOutputIncident = rawLargeOutputDetection
       ? mergeLargeToolOutputIncident({
@@ -22204,6 +22247,7 @@ export class DesktopBackendRegistry {
             rawLargeOutputDetection.alert.alertId,
           ),
           detection: rawLargeOutputDetection,
+          minimumWarningInvocationCount: TOOL_OUTPUT_WARNING_INVOCATIONS,
         })
       : undefined;
     if (largeOutputIncident) {
@@ -22229,7 +22273,8 @@ export class DesktopBackendRegistry {
       ? this.readVolatileDeferredChecks(invocationWithStreamedOutput, now)
       : [];
     const rawPollingDetection =
-      typeof this.overlayStore.readRecentThreadToolInvocations === "function"
+      toolOutputAlertPolicy.repeatedQueuedChecksEnabled
+      && typeof this.overlayStore.readRecentThreadToolInvocations === "function"
       ? detectNoisyPolling({
           current: invocationWithStreamedOutput,
           now,
@@ -22304,7 +22349,9 @@ export class DesktopBackendRegistry {
       ),
     );
     const alertsToPersist = [
-      ...(largeOutputDetection ? [largeOutputDetection.alert] : []),
+      ...(largeOutputDetection && largeOutputIncident?.shouldNotify
+        ? [largeOutputDetection.alert]
+        : []),
       ...(pollingDetection && shouldPersistPollingAlert
         ? [pollingDetection.alert]
         : []),

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -13,6 +13,7 @@ import {
   TOOL_OUTPUT_CAP_CHARS,
   TOOL_OUTPUT_TOKEN_CHAR_RATIO,
   TOOL_OUTPUT_WARNING_CHARS,
+  toolOutputWarningChars,
 } from "@pwragent/shared";
 import { redactCommandText } from "../util/redact-command-text";
 
@@ -159,6 +160,7 @@ export function buildToolInvocationSteeringPrompt(params: {
 
 export function toolInvocationFromNotification(params: {
   backend: AppServerBackendKind;
+  largeOutputThresholdChars?: number;
   notification: AppServerNotification;
   now?: number;
 }): ThreadToolInvocationRecord | undefined {
@@ -243,7 +245,8 @@ export function toolInvocationFromNotification(params: {
     itemType !== "commandExecution"
     && toolName !== "wait"
     && toolName !== "write_stdin"
-    && metrics.outputChars < LARGE_OUTPUT_WARNING_CHARS
+    && metrics.outputChars
+      < (params.largeOutputThresholdChars ?? LARGE_OUTPUT_WARNING_CHARS)
   ) {
     // Function, dynamic, and MCP calls are a much broader stream than the
     // original command accounting surface. Persist only polling signals and
@@ -611,16 +614,19 @@ export function detectLargeToolOutput(params: {
 }): LargeToolOutputDetection | undefined {
   const current = params.current;
   const policy = params.policy ?? DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
+  const warningOutputChars = toolOutputWarningChars(
+    policy.repeatedLargeOutputMinimumPercent,
+  );
   const previousOutputChars = params.previousOutputChars ?? 0;
   const crossedWarning =
-    previousOutputChars < LARGE_OUTPUT_WARNING_CHARS
-    && current.outputChars >= LARGE_OUTPUT_WARNING_CHARS;
+    previousOutputChars < warningOutputChars
+    && current.outputChars >= warningOutputChars;
   const crossedCritical =
     previousOutputChars < LARGE_OUTPUT_CRITICAL_CHARS
     && current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
   const warningEligible =
     policy.repeatedLargeOutputsEnabled
-    && current.outputChars >= LARGE_OUTPUT_WARNING_CHARS;
+    && current.outputChars >= warningOutputChars;
   const criticalEligible =
     policy.outputCapHitsEnabled
     && current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
@@ -639,7 +645,7 @@ export function detectLargeToolOutput(params: {
   const now = params.now ?? current.observedAt;
   const critical = criticalEligible;
   const estimatedCapPercentage = Math.max(
-    50,
+    1,
     Math.round(current.outputChars / LARGE_OUTPUT_CRITICAL_CHARS * 100),
   );
   const message = critical

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -1,6 +1,7 @@
 import type {
   AppServerBackendKind,
   AppServerNotification,
+  DesktopToolOutputAlertPolicy,
   ThreadToolInvocationAlert,
   ThreadToolInvocationCategory,
   ThreadToolInvocationRecord,
@@ -8,6 +9,7 @@ import type {
 } from "@pwragent/shared";
 import {
   buildThreadToolIncidentPrompt,
+  DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   TOOL_OUTPUT_CAP_CHARS,
   TOOL_OUTPUT_TOKEN_CHAR_RATIO,
   TOOL_OUTPUT_WARNING_CHARS,
@@ -71,6 +73,7 @@ export type ToolOutputIncidentAggregate = {
 export function mergeLargeToolOutputIncident(params: {
   current?: ToolOutputIncidentAggregate;
   detection: LargeToolOutputDetection | NoisyPollingDetection;
+  minimumWarningInvocationCount?: number;
 }): {
   aggregate: ToolOutputIncidentAggregate;
   shouldNotify: boolean;
@@ -105,6 +108,9 @@ export function mergeLargeToolOutputIncident(params: {
     : "warning" as const;
   const estimatedOutputTokens = Math.ceil(totalOutputChars / OUTPUT_TOKEN_CHAR_RATIO);
   const caseCount = entries.length;
+  const previousCaseCount = Object.keys(previousCases).length;
+  const minimumWarningInvocationCount =
+    params.minimumWarningInvocationCount ?? 1;
   const subject = incoming.kind === "noisy-polling"
     ? `repeated queued check${caseCount === 1 ? "" : "s"}`
     : `noisy tool-output case${caseCount === 1 ? "" : "s"}`;
@@ -134,7 +140,13 @@ export function mergeLargeToolOutputIncident(params: {
   return {
     aggregate: { alert, cases },
     shouldNotify:
-      newInvocationIds.length > 0 || escalated,
+      severity === "critical"
+        ? newInvocationIds.length > 0 || escalated
+        : caseCount >= minimumWarningInvocationCount
+          && (
+            previousCaseCount < minimumWarningInvocationCount
+            || newInvocationIds.length > 0
+          ),
   };
 }
 
@@ -593,10 +605,12 @@ export function detectNoisyPolling(params: {
 
 export function detectLargeToolOutput(params: {
   current: ThreadToolInvocationRecord;
+  policy?: DesktopToolOutputAlertPolicy;
   previousOutputChars?: number;
   now?: number;
 }): LargeToolOutputDetection | undefined {
   const current = params.current;
+  const policy = params.policy ?? DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT;
   const previousOutputChars = params.previousOutputChars ?? 0;
   const crossedWarning =
     previousOutputChars < LARGE_OUTPUT_WARNING_CHARS
@@ -604,18 +618,28 @@ export function detectLargeToolOutput(params: {
   const crossedCritical =
     previousOutputChars < LARGE_OUTPUT_CRITICAL_CHARS
     && current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
+  const warningEligible =
+    policy.repeatedLargeOutputsEnabled
+    && current.outputChars >= LARGE_OUTPUT_WARNING_CHARS;
+  const criticalEligible =
+    policy.outputCapHitsEnabled
+    && current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
   const terminal = current.status !== "in_progress";
   if (
-    current.outputChars < LARGE_OUTPUT_WARNING_CHARS
-    || (!crossedWarning && !crossedCritical && !terminal)
+    (!warningEligible && !criticalEligible)
+    || (
+      !(policy.repeatedLargeOutputsEnabled && crossedWarning)
+      && !(policy.outputCapHitsEnabled && crossedCritical)
+      && !terminal
+    )
   ) {
     return undefined;
   }
 
   const now = params.now ?? current.observedAt;
-  const critical = current.outputChars >= LARGE_OUTPUT_CRITICAL_CHARS;
+  const critical = criticalEligible;
   const estimatedCapPercentage = Math.max(
-    10,
+    50,
     Math.round(current.outputChars / LARGE_OUTPUT_CRITICAL_CHARS * 100),
   );
   const message = critical

--- a/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
+++ b/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
@@ -7,14 +7,18 @@ import type {
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import {
+  TOOL_OUTPUT_CAP_CHARS,
+  TOOL_OUTPUT_WARNING_CHARS,
+} from "@pwragent/shared";
+import {
   buildToolInvocationSteeringPrompt,
   buildToolOutputMetrics,
   normalizeToolInvocationCommand,
 } from "./tool-invocation-accounting";
 
-export const TOOL_OUTPUT_ANALYZER_VERSION = "1";
-const LARGE_OUTPUT_CHARS = 4_000;
-const CRITICAL_OUTPUT_CHARS = 40_000;
+export const TOOL_OUTPUT_ANALYZER_VERSION = "2";
+const LARGE_OUTPUT_CHARS = TOOL_OUTPUT_WARNING_CHARS;
+const CRITICAL_OUTPUT_CHARS = TOOL_OUTPUT_CAP_CHARS;
 const POLLING_MIN_CASES = 5;
 
 export type ToolOutputReplayAnalysis = {

--- a/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
+++ b/apps/desktop/src/main/app-server/tool-output-replay-analyzer.ts
@@ -16,8 +16,7 @@ import {
   normalizeToolInvocationCommand,
 } from "./tool-invocation-accounting";
 
-export const TOOL_OUTPUT_ANALYZER_VERSION = "2";
-const LARGE_OUTPUT_CHARS = TOOL_OUTPUT_WARNING_CHARS;
+export const TOOL_OUTPUT_ANALYZER_VERSION = "3";
 const CRITICAL_OUTPUT_CHARS = TOOL_OUTPUT_CAP_CHARS;
 const POLLING_MIN_CASES = 5;
 
@@ -30,6 +29,7 @@ export function analyzeNormalizedToolReplay(params: {
   analyzedAt?: number;
   backend: AppServerBackendKind;
   complete: boolean;
+  largeOutputThresholdChars?: number;
   pages: AppServerThreadReplay[];
   threadId: string;
 }): ToolOutputReplayAnalysis {
@@ -76,6 +76,8 @@ export function analyzeNormalizedToolReplay(params: {
         }
         const reason = classifyNoisyReason({
           category,
+          largeOutputThresholdChars:
+            params.largeOutputThresholdChars ?? TOOL_OUTPUT_WARNING_CHARS,
           outputChars: metrics.outputChars,
           outputState,
         });
@@ -192,13 +194,14 @@ function categoryForReplayDetail(
 
 function classifyNoisyReason(params: {
   category: ThreadToolInvocationCategory;
+  largeOutputThresholdChars: number;
   outputChars: number;
   outputState: ThreadToolInvocationRecord["outputState"];
 }): string | undefined {
   if (params.outputChars >= CRITICAL_OUTPUT_CHARS) {
     return "large-output-critical";
   }
-  if (params.outputChars < LARGE_OUTPUT_CHARS) {
+  if (params.outputChars < params.largeOutputThresholdChars) {
     return undefined;
   }
   if (params.category === "file-io") return "broad-file-read";

--- a/apps/desktop/src/main/app-server/usage-spend-alerts.ts
+++ b/apps/desktop/src/main/app-server/usage-spend-alerts.ts
@@ -12,7 +12,7 @@ export function spendThresholdMicros(thresholdUsd: number): number {
 }
 
 export function detectUsageSpendAlerts(params: {
-  activeTurnId?: string;
+  activeTurnIds?: readonly string[];
   backend: string;
   policy: DesktopSpendAlertPolicy;
   pricing: {
@@ -26,44 +26,46 @@ export function detectUsageSpendAlerts(params: {
   const alerts: ThreadSpendAlert[] = [];
   const now = params.now ?? Date.now();
 
-  if (params.policy.activeTurnSpendEnabled && params.activeTurnId) {
+  if (params.policy.activeTurnSpendEnabled) {
     const thresholdMicros = spendThresholdMicros(
       params.policy.activeTurnSpendThresholdUsd,
     );
-    const alertId = [
-      "spend-alert",
-      "active-turn",
-      params.backend,
-      params.threadId,
-      params.activeTurnId,
-      thresholdMicros,
-    ].join(":");
-    const spendMicros = params.pricing.lines.reduce(
-      (total, line) =>
-        line.threadId === params.threadId
-        && line.turnId === params.activeTurnId
-        && line.scope === "turn"
-        && line.turnUsageAttributed !== false
-        && line.priceStatus === "priced"
-        && line.currency.toUpperCase() === "USD"
-          ? total + line.totalCostMicros
-          : total,
-      0,
-    );
-    if (
-      spendMicros >= thresholdMicros
-      && !params.triggeredAlertIds.has(alertId)
-    ) {
-      alerts.push({
-        alertId,
-        createdAt: now,
-        currency: "USD",
-        kind: "active-turn-spend",
-        spendMicros,
-        threadId: params.threadId,
+    for (const activeTurnId of new Set(params.activeTurnIds ?? [])) {
+      const alertId = [
+        "spend-alert",
+        "active-turn",
+        params.backend,
+        params.threadId,
+        activeTurnId,
         thresholdMicros,
-        turnId: params.activeTurnId,
-      });
+      ].join(":");
+      const spendMicros = params.pricing.lines.reduce(
+        (total, line) =>
+          line.threadId === params.threadId
+          && line.turnId === activeTurnId
+          && line.scope === "turn"
+          && line.turnUsageAttributed !== false
+          && line.priceStatus === "priced"
+          && line.currency.toUpperCase() === "USD"
+            ? total + line.totalCostMicros
+            : total,
+        0,
+      );
+      if (
+        spendMicros >= thresholdMicros
+        && !params.triggeredAlertIds.has(alertId)
+      ) {
+        alerts.push({
+          alertId,
+          createdAt: now,
+          currency: "USD",
+          kind: "active-turn-spend",
+          spendMicros,
+          threadId: params.threadId,
+          thresholdMicros,
+          turnId: activeTurnId,
+        });
+      }
     }
   }
 

--- a/apps/desktop/src/main/app-server/usage-spend-alerts.ts
+++ b/apps/desktop/src/main/app-server/usage-spend-alerts.ts
@@ -1,0 +1,105 @@
+import type {
+  DesktopSpendAlertPolicy,
+  ThreadPricingSummary,
+  ThreadSpendAlert,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+
+const USD_MICROS = 1_000_000;
+
+export function spendThresholdMicros(thresholdUsd: number): number {
+  return Math.round(thresholdUsd * USD_MICROS);
+}
+
+export function detectUsageSpendAlerts(params: {
+  activeTurnId?: string;
+  backend: string;
+  policy: DesktopSpendAlertPolicy;
+  pricing: {
+    lines: readonly ThreadUsageLineRecord[];
+    summaries: readonly ThreadPricingSummary[];
+  };
+  threadId: string;
+  triggeredAlertIds: ReadonlySet<string>;
+  now?: number;
+}): ThreadSpendAlert[] {
+  const alerts: ThreadSpendAlert[] = [];
+  const now = params.now ?? Date.now();
+
+  if (params.policy.activeTurnSpendEnabled && params.activeTurnId) {
+    const thresholdMicros = spendThresholdMicros(
+      params.policy.activeTurnSpendThresholdUsd,
+    );
+    const alertId = [
+      "spend-alert",
+      "active-turn",
+      params.backend,
+      params.threadId,
+      params.activeTurnId,
+      thresholdMicros,
+    ].join(":");
+    const spendMicros = params.pricing.lines.reduce(
+      (total, line) =>
+        line.threadId === params.threadId
+        && line.turnId === params.activeTurnId
+        && line.scope === "turn"
+        && line.turnUsageAttributed !== false
+        && line.priceStatus === "priced"
+        && line.currency.toUpperCase() === "USD"
+          ? total + line.totalCostMicros
+          : total,
+      0,
+    );
+    if (
+      spendMicros >= thresholdMicros
+      && !params.triggeredAlertIds.has(alertId)
+    ) {
+      alerts.push({
+        alertId,
+        createdAt: now,
+        currency: "USD",
+        kind: "active-turn-spend",
+        spendMicros,
+        threadId: params.threadId,
+        thresholdMicros,
+        turnId: params.activeTurnId,
+      });
+    }
+  }
+
+  if (params.policy.threadSpendEnabled) {
+    const thresholdMicros = spendThresholdMicros(
+      params.policy.threadSpendThresholdUsd,
+    );
+    const alertId = [
+      "spend-alert",
+      "thread",
+      params.backend,
+      params.threadId,
+      thresholdMicros,
+    ].join(":");
+    const spendMicros = params.pricing.summaries.reduce(
+      (total, summary) =>
+        summary.currency.toUpperCase() === "USD"
+          ? total + summary.totalCostMicros
+          : total,
+      0,
+    );
+    if (
+      spendMicros >= thresholdMicros
+      && !params.triggeredAlertIds.has(alertId)
+    ) {
+      alerts.push({
+        alertId,
+        createdAt: now,
+        currency: "USD",
+        kind: "thread-spend",
+        spendMicros,
+        threadId: params.threadId,
+        thresholdMicros,
+      });
+    }
+  }
+
+  return alerts;
+}

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -658,6 +658,22 @@ export function desktopSettingsPatchToEdits(
     );
   }
   if (
+    patch.general?.toolOutputAlerts?.repeatedLargeOutputMinimumCalls !== undefined
+  ) {
+    set(
+      ["general", "tool_output_alerts", "repeated_large_output_minimum_calls"],
+      patch.general.toolOutputAlerts.repeatedLargeOutputMinimumCalls,
+    );
+  }
+  if (
+    patch.general?.toolOutputAlerts?.repeatedLargeOutputMinimumPercent !== undefined
+  ) {
+    set(
+      ["general", "tool_output_alerts", "repeated_large_output_minimum_percent"],
+      patch.general.toolOutputAlerts.repeatedLargeOutputMinimumPercent,
+    );
+  }
+  if (
     patch.general?.toolOutputAlerts?.repeatedQueuedChecksEnabled !== undefined
   ) {
     set(
@@ -1629,6 +1645,12 @@ function normalizeDesktopConfig(
         ),
         repeatedLargeOutputsEnabled: readBoolean(
           generalToolOutputAlerts?.repeated_large_outputs_enabled,
+        ),
+        repeatedLargeOutputMinimumCalls: readNumber(
+          generalToolOutputAlerts?.repeated_large_output_minimum_calls,
+        ),
+        repeatedLargeOutputMinimumPercent: readNumber(
+          generalToolOutputAlerts?.repeated_large_output_minimum_percent,
         ),
         repeatedQueuedChecksEnabled: readBoolean(
           generalToolOutputAlerts?.repeated_queued_checks_enabled,

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -25,6 +25,7 @@ import type {
   DesktopProviderThreadModelMigration,
   DesktopSettingsConfigPatch,
   DesktopTextSize,
+  DesktopToolOutputAlertPolicy,
   DesktopUpdateChannel,
   DesktopUpdateTrain,
   DesktopWorktreeStorageLocation,
@@ -99,6 +100,7 @@ export type DesktopSettingsConfig = {
     hotCpuProfilingCaptureHeapSnapshot?: boolean;
     hotCpuProfilingHeapSnapshotLimit?: number;
     notificationsEnabled?: boolean;
+    toolOutputAlerts?: Partial<DesktopToolOutputAlertPolicy>;
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;
@@ -640,6 +642,28 @@ export function desktopSettingsPatchToEdits(
   }
   if (patch.general?.notificationsEnabled !== undefined) {
     set(["general", "notifications_enabled"], patch.general.notificationsEnabled);
+  }
+  if (patch.general?.toolOutputAlerts?.outputCapHitsEnabled !== undefined) {
+    set(
+      ["general", "tool_output_alerts", "output_cap_hits_enabled"],
+      patch.general.toolOutputAlerts.outputCapHitsEnabled,
+    );
+  }
+  if (
+    patch.general?.toolOutputAlerts?.repeatedLargeOutputsEnabled !== undefined
+  ) {
+    set(
+      ["general", "tool_output_alerts", "repeated_large_outputs_enabled"],
+      patch.general.toolOutputAlerts.repeatedLargeOutputsEnabled,
+    );
+  }
+  if (
+    patch.general?.toolOutputAlerts?.repeatedQueuedChecksEnabled !== undefined
+  ) {
+    set(
+      ["general", "tool_output_alerts", "repeated_queued_checks_enabled"],
+      patch.general.toolOutputAlerts.repeatedQueuedChecksEnabled,
+    );
   }
 
   if (patch.experimental?.diffCondensation?.enabled !== undefined) {
@@ -1542,6 +1566,7 @@ function normalizeDesktopConfig(
 ): DesktopSettingsConfig {
   const general = tables["general"];
   const generalAppearance = tables["general.appearance"];
+  const generalToolOutputAlerts = tables["general.tool_output_alerts"];
   const generalMessagingAck = tables["general.messaging_acknowledgment"];
   const onboarding = tables["onboarding"];
   const experimental = tables["experimental"];
@@ -1598,6 +1623,17 @@ function normalizeDesktopConfig(
         general?.hot_cpu_profiling_heap_snapshot_limit,
       ),
       notificationsEnabled: readBoolean(general?.notifications_enabled),
+      toolOutputAlerts: {
+        outputCapHitsEnabled: readBoolean(
+          generalToolOutputAlerts?.output_cap_hits_enabled,
+        ),
+        repeatedLargeOutputsEnabled: readBoolean(
+          generalToolOutputAlerts?.repeated_large_outputs_enabled,
+        ),
+        repeatedQueuedChecksEnabled: readBoolean(
+          generalToolOutputAlerts?.repeated_queued_checks_enabled,
+        ),
+      },
       appearance: {
         theme: readAppearanceTheme(generalAppearance?.theme),
         density: readAppearanceDensity(generalAppearance?.density),
@@ -1926,6 +1962,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const attentionPromoteOnTurnEnd = config.general?.attentionPromoteOnTurnEnd;
   const pdfAnalysisEnabled = config.general?.pdfAnalysisEnabled;
   const notificationsEnabled = config.general?.notificationsEnabled;
+  const toolOutputAlerts = config.general?.toolOutputAlerts;
+  const toolOutputAlertsDefined =
+    toolOutputAlerts && hasDefinedValue(toolOutputAlerts);
   const appearance = config.general?.appearance;
   const appearanceDefined = appearance && hasDefinedValue(appearance);
   const codexProfileModel = config.general?.codexProfileModel;
@@ -1942,6 +1981,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     attentionPromoteOnTurnEnd !== undefined ||
     pdfAnalysisEnabled !== undefined ||
     notificationsEnabled !== undefined ||
+    toolOutputAlertsDefined ||
     appearanceDefined ||
     codexProfileModel !== undefined ||
     messagingAcknowledgment !== undefined
@@ -1983,6 +2023,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     }
     if (notificationsEnabled !== undefined) {
       pruned.general.notificationsEnabled = notificationsEnabled;
+    }
+    if (toolOutputAlertsDefined) {
+      pruned.general.toolOutputAlerts = toolOutputAlerts;
     }
     if (appearanceDefined) {
       pruned.general.appearance = appearance;

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -24,6 +24,7 @@ import type {
   DesktopProviderModelDefaults,
   DesktopProviderThreadModelMigration,
   DesktopSettingsConfigPatch,
+  DesktopSpendAlertPolicy,
   DesktopTextSize,
   DesktopToolOutputAlertPolicy,
   DesktopUpdateChannel,
@@ -101,6 +102,7 @@ export type DesktopSettingsConfig = {
     hotCpuProfilingHeapSnapshotLimit?: number;
     notificationsEnabled?: boolean;
     toolOutputAlerts?: Partial<DesktopToolOutputAlertPolicy>;
+    spendAlerts?: Partial<DesktopSpendAlertPolicy>;
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;
@@ -679,6 +681,30 @@ export function desktopSettingsPatchToEdits(
     set(
       ["general", "tool_output_alerts", "repeated_queued_checks_enabled"],
       patch.general.toolOutputAlerts.repeatedQueuedChecksEnabled,
+    );
+  }
+  if (patch.general?.spendAlerts?.activeTurnSpendEnabled !== undefined) {
+    set(
+      ["general", "spend_alerts", "active_turn_spend_enabled"],
+      patch.general.spendAlerts.activeTurnSpendEnabled,
+    );
+  }
+  if (patch.general?.spendAlerts?.activeTurnSpendThresholdUsd !== undefined) {
+    set(
+      ["general", "spend_alerts", "active_turn_spend_threshold_usd"],
+      patch.general.spendAlerts.activeTurnSpendThresholdUsd,
+    );
+  }
+  if (patch.general?.spendAlerts?.threadSpendEnabled !== undefined) {
+    set(
+      ["general", "spend_alerts", "thread_spend_enabled"],
+      patch.general.spendAlerts.threadSpendEnabled,
+    );
+  }
+  if (patch.general?.spendAlerts?.threadSpendThresholdUsd !== undefined) {
+    set(
+      ["general", "spend_alerts", "thread_spend_threshold_usd"],
+      patch.general.spendAlerts.threadSpendThresholdUsd,
     );
   }
 
@@ -1583,6 +1609,7 @@ function normalizeDesktopConfig(
   const general = tables["general"];
   const generalAppearance = tables["general.appearance"];
   const generalToolOutputAlerts = tables["general.tool_output_alerts"];
+  const generalSpendAlerts = tables["general.spend_alerts"];
   const generalMessagingAck = tables["general.messaging_acknowledgment"];
   const onboarding = tables["onboarding"];
   const experimental = tables["experimental"];
@@ -1654,6 +1681,20 @@ function normalizeDesktopConfig(
         ),
         repeatedQueuedChecksEnabled: readBoolean(
           generalToolOutputAlerts?.repeated_queued_checks_enabled,
+        ),
+      },
+      spendAlerts: {
+        activeTurnSpendEnabled: readBoolean(
+          generalSpendAlerts?.active_turn_spend_enabled,
+        ),
+        activeTurnSpendThresholdUsd: readNumber(
+          generalSpendAlerts?.active_turn_spend_threshold_usd,
+        ),
+        threadSpendEnabled: readBoolean(
+          generalSpendAlerts?.thread_spend_enabled,
+        ),
+        threadSpendThresholdUsd: readNumber(
+          generalSpendAlerts?.thread_spend_threshold_usd,
         ),
       },
       appearance: {
@@ -1987,6 +2028,8 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const toolOutputAlerts = config.general?.toolOutputAlerts;
   const toolOutputAlertsDefined =
     toolOutputAlerts && hasDefinedValue(toolOutputAlerts);
+  const spendAlerts = config.general?.spendAlerts;
+  const spendAlertsDefined = spendAlerts && hasDefinedValue(spendAlerts);
   const appearance = config.general?.appearance;
   const appearanceDefined = appearance && hasDefinedValue(appearance);
   const codexProfileModel = config.general?.codexProfileModel;
@@ -2004,6 +2047,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     pdfAnalysisEnabled !== undefined ||
     notificationsEnabled !== undefined ||
     toolOutputAlertsDefined ||
+    spendAlertsDefined ||
     appearanceDefined ||
     codexProfileModel !== undefined ||
     messagingAcknowledgment !== undefined
@@ -2048,6 +2092,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     }
     if (toolOutputAlertsDefined) {
       pruned.general.toolOutputAlerts = toolOutputAlerts;
+    }
+    if (spendAlertsDefined) {
+      pruned.general.spendAlerts = spendAlerts;
     }
     if (appearanceDefined) {
       pruned.general.appearance = appearance;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -57,8 +57,12 @@ import {
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
   MAX_PR_AUTO_DISPATCH_BUDGET_CAPACITY,
   MAX_PR_AUTO_DISPATCH_BUDGET_REFILL_PER_MINUTE,
+  MAX_REPEATED_LARGE_OUTPUT_CALLS,
+  MAX_REPEATED_LARGE_OUTPUT_PERCENT,
   MIN_PR_AUTO_DISPATCH_BUDGET_CAPACITY,
   MIN_PR_AUTO_DISPATCH_BUDGET_REFILL_PER_MINUTE,
+  MIN_REPEATED_LARGE_OUTPUT_CALLS,
+  MIN_REPEATED_LARGE_OUTPUT_PERCENT,
 } from "@pwragent/shared";
 import {
   SLACK_CHANNEL_AUTHORIZATION_MODE_DEFAULT,
@@ -655,6 +659,18 @@ export class DesktopSettingsService {
           repeatedLargeOutputsEnabled: this.resolveConfigBoolean(
             config.general?.toolOutputAlerts?.repeatedLargeOutputsEnabled,
             DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputsEnabled,
+          ),
+          repeatedLargeOutputMinimumCalls: this.resolveBoundedConfigInteger(
+            config.general?.toolOutputAlerts?.repeatedLargeOutputMinimumCalls,
+            DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputMinimumCalls,
+            MIN_REPEATED_LARGE_OUTPUT_CALLS,
+            MAX_REPEATED_LARGE_OUTPUT_CALLS,
+          ),
+          repeatedLargeOutputMinimumPercent: this.resolveBoundedConfigInteger(
+            config.general?.toolOutputAlerts?.repeatedLargeOutputMinimumPercent,
+            DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputMinimumPercent,
+            MIN_REPEATED_LARGE_OUTPUT_PERCENT,
+            MAX_REPEATED_LARGE_OUTPUT_PERCENT,
           ),
           repeatedQueuedChecksEnabled: this.resolveConfigBoolean(
             config.general?.toolOutputAlerts?.repeatedQueuedChecksEnabled,
@@ -1310,6 +1326,18 @@ export class DesktopSettingsService {
       repeatedLargeOutputsEnabled: this.resolveConfigBoolean(
         config?.repeatedLargeOutputsEnabled,
         DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputsEnabled,
+      ).value,
+      repeatedLargeOutputMinimumCalls: this.resolveBoundedConfigInteger(
+        config?.repeatedLargeOutputMinimumCalls,
+        DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputMinimumCalls,
+        MIN_REPEATED_LARGE_OUTPUT_CALLS,
+        MAX_REPEATED_LARGE_OUTPUT_CALLS,
+      ).value,
+      repeatedLargeOutputMinimumPercent: this.resolveBoundedConfigInteger(
+        config?.repeatedLargeOutputMinimumPercent,
+        DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputMinimumPercent,
+        MIN_REPEATED_LARGE_OUTPUT_PERCENT,
+        MAX_REPEATED_LARGE_OUTPUT_PERCENT,
       ).value,
       repeatedQueuedChecksEnabled: this.resolveConfigBoolean(
         config?.repeatedQueuedChecksEnabled,
@@ -2400,6 +2428,22 @@ export class DesktopSettingsService {
     return {
       value: configValue ?? defaultValue,
       source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveBoundedConfigInteger(
+    configValue: number | undefined,
+    defaultValue: number,
+    minValue: number,
+    maxValue: number,
+  ): DesktopSettingsValue<number> {
+    const normalized =
+      configValue !== undefined && Number.isFinite(configValue)
+        ? Math.min(maxValue, Math.max(minValue, Math.round(configValue)))
+        : undefined;
+    return {
+      value: normalized ?? defaultValue,
+      source: normalized === undefined ? "default" : "config",
     };
   }
 

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -2,6 +2,7 @@ import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
   DesktopTextSize,
+  DesktopSpendAlertPolicy,
   DesktopToolOutputAlertPolicy,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
@@ -43,6 +44,7 @@ import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
   DESKTOP_TEXT_SIZE_DEFAULT,
+  DESKTOP_SPEND_ALERT_POLICY_DEFAULT,
   DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
@@ -59,10 +61,12 @@ import {
   MAX_PR_AUTO_DISPATCH_BUDGET_REFILL_PER_MINUTE,
   MAX_REPEATED_LARGE_OUTPUT_CALLS,
   MAX_REPEATED_LARGE_OUTPUT_PERCENT,
+  MAX_SPEND_ALERT_THRESHOLD_USD,
   MIN_PR_AUTO_DISPATCH_BUDGET_CAPACITY,
   MIN_PR_AUTO_DISPATCH_BUDGET_REFILL_PER_MINUTE,
   MIN_REPEATED_LARGE_OUTPUT_CALLS,
   MIN_REPEATED_LARGE_OUTPUT_PERCENT,
+  MIN_SPEND_ALERT_THRESHOLD_USD,
 } from "@pwragent/shared";
 import {
   SLACK_CHANNEL_AUTHORIZATION_MODE_DEFAULT,
@@ -675,6 +679,28 @@ export class DesktopSettingsService {
           repeatedQueuedChecksEnabled: this.resolveConfigBoolean(
             config.general?.toolOutputAlerts?.repeatedQueuedChecksEnabled,
             DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedQueuedChecksEnabled,
+          ),
+        },
+        spendAlerts: {
+          activeTurnSpendEnabled: this.resolveConfigBoolean(
+            config.general?.spendAlerts?.activeTurnSpendEnabled,
+            DESKTOP_SPEND_ALERT_POLICY_DEFAULT.activeTurnSpendEnabled,
+          ),
+          activeTurnSpendThresholdUsd: this.resolveBoundedConfigAmount(
+            config.general?.spendAlerts?.activeTurnSpendThresholdUsd,
+            DESKTOP_SPEND_ALERT_POLICY_DEFAULT.activeTurnSpendThresholdUsd,
+            MIN_SPEND_ALERT_THRESHOLD_USD,
+            MAX_SPEND_ALERT_THRESHOLD_USD,
+          ),
+          threadSpendEnabled: this.resolveConfigBoolean(
+            config.general?.spendAlerts?.threadSpendEnabled,
+            DESKTOP_SPEND_ALERT_POLICY_DEFAULT.threadSpendEnabled,
+          ),
+          threadSpendThresholdUsd: this.resolveBoundedConfigAmount(
+            config.general?.spendAlerts?.threadSpendThresholdUsd,
+            DESKTOP_SPEND_ALERT_POLICY_DEFAULT.threadSpendThresholdUsd,
+            MIN_SPEND_ALERT_THRESHOLD_USD,
+            MAX_SPEND_ALERT_THRESHOLD_USD,
           ),
         },
         appearance: {
@@ -1342,6 +1368,32 @@ export class DesktopSettingsService {
       repeatedQueuedChecksEnabled: this.resolveConfigBoolean(
         config?.repeatedQueuedChecksEnabled,
         DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedQueuedChecksEnabled,
+      ).value,
+    };
+  }
+
+  resolveSpendAlertPolicy(): DesktopSpendAlertPolicy {
+    const config = this.readConfig().config.general?.spendAlerts;
+    return {
+      activeTurnSpendEnabled: this.resolveConfigBoolean(
+        config?.activeTurnSpendEnabled,
+        DESKTOP_SPEND_ALERT_POLICY_DEFAULT.activeTurnSpendEnabled,
+      ).value,
+      activeTurnSpendThresholdUsd: this.resolveBoundedConfigAmount(
+        config?.activeTurnSpendThresholdUsd,
+        DESKTOP_SPEND_ALERT_POLICY_DEFAULT.activeTurnSpendThresholdUsd,
+        MIN_SPEND_ALERT_THRESHOLD_USD,
+        MAX_SPEND_ALERT_THRESHOLD_USD,
+      ).value,
+      threadSpendEnabled: this.resolveConfigBoolean(
+        config?.threadSpendEnabled,
+        DESKTOP_SPEND_ALERT_POLICY_DEFAULT.threadSpendEnabled,
+      ).value,
+      threadSpendThresholdUsd: this.resolveBoundedConfigAmount(
+        config?.threadSpendThresholdUsd,
+        DESKTOP_SPEND_ALERT_POLICY_DEFAULT.threadSpendThresholdUsd,
+        MIN_SPEND_ALERT_THRESHOLD_USD,
+        MAX_SPEND_ALERT_THRESHOLD_USD,
       ).value,
     };
   }
@@ -2440,6 +2492,25 @@ export class DesktopSettingsService {
     const normalized =
       configValue !== undefined && Number.isFinite(configValue)
         ? Math.min(maxValue, Math.max(minValue, Math.round(configValue)))
+        : undefined;
+    return {
+      value: normalized ?? defaultValue,
+      source: normalized === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveBoundedConfigAmount(
+    configValue: number | undefined,
+    defaultValue: number,
+    minValue: number,
+    maxValue: number,
+  ): DesktopSettingsValue<number> {
+    const normalized =
+      configValue !== undefined && Number.isFinite(configValue)
+        ? Math.min(
+            maxValue,
+            Math.max(minValue, Math.round(configValue * 100) / 100),
+          )
         : undefined;
     return {
       value: normalized ?? defaultValue,

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -2,6 +2,7 @@ import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
   DesktopTextSize,
+  DesktopToolOutputAlertPolicy,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
@@ -42,6 +43,7 @@ import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
   DESKTOP_TEXT_SIZE_DEFAULT,
+  DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
   DESKTOP_FEDERATION_MODE_DEFAULT,
@@ -645,6 +647,20 @@ export class DesktopSettingsService {
           config.general?.notificationsEnabled,
           false,
         ),
+        toolOutputAlerts: {
+          outputCapHitsEnabled: this.resolveConfigBoolean(
+            config.general?.toolOutputAlerts?.outputCapHitsEnabled,
+            DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.outputCapHitsEnabled,
+          ),
+          repeatedLargeOutputsEnabled: this.resolveConfigBoolean(
+            config.general?.toolOutputAlerts?.repeatedLargeOutputsEnabled,
+            DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputsEnabled,
+          ),
+          repeatedQueuedChecksEnabled: this.resolveConfigBoolean(
+            config.general?.toolOutputAlerts?.repeatedQueuedChecksEnabled,
+            DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedQueuedChecksEnabled,
+          ),
+        },
         appearance: {
           theme: this.resolveAppearanceTheme(
             config.general?.appearance?.theme,
@@ -1282,6 +1298,24 @@ export class DesktopSettingsService {
       this.readConfig().config.general?.notificationsEnabled,
       false,
     ).value;
+  }
+
+  resolveToolOutputAlertPolicy(): DesktopToolOutputAlertPolicy {
+    const config = this.readConfig().config.general?.toolOutputAlerts;
+    return {
+      outputCapHitsEnabled: this.resolveConfigBoolean(
+        config?.outputCapHitsEnabled,
+        DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.outputCapHitsEnabled,
+      ).value,
+      repeatedLargeOutputsEnabled: this.resolveConfigBoolean(
+        config?.repeatedLargeOutputsEnabled,
+        DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedLargeOutputsEnabled,
+      ).value,
+      repeatedQueuedChecksEnabled: this.resolveConfigBoolean(
+        config?.repeatedQueuedChecksEnabled,
+        DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT.repeatedQueuedChecksEnabled,
+      ).value,
+    };
   }
 
   resolveCodexDefaultModeRequestUserInput(): boolean {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -30,6 +30,7 @@ import {
   type ThreadToolAccounting,
   type ThreadToolIncidentNoticeState,
   type ThreadToolInvocationAlert,
+  type ThreadSpendAlert,
   type ThreadUsageLineRecord,
   type SetThreadToolIncidentNoticeRequest,
   resolveToolIncidentVisibility,
@@ -113,6 +114,7 @@ import { buildGithubPrAuthenticationNotice } from "./features/notifications/gith
 import {
   buildToolAccountingNotice,
 } from "./features/notifications/tool-accounting-notice";
+import { buildSpendAlertNotice } from "./features/notifications/spend-alert-notice";
 import {
   buildThreadIncidentSummary,
   threadIncidentNoticeId,
@@ -679,6 +681,44 @@ function DesktopAppShell(props: {
       const instanceId = event.federationTarget?.scope === "remote"
         ? event.federationTarget.instanceId
         : undefined;
+      if (event.notification.method === "thread/pricing/updated") {
+        const params = event.notification.params;
+        const spendAlerts = params.triggeredSpendAlerts as
+          | ThreadSpendAlert[]
+          | undefined;
+        if (spendAlerts?.length) {
+          const matchingThread = backendErrorThreadsRef.current.find(
+            (thread) =>
+              thread.source === event.backend
+              && thread.id === params.threadId
+              && federationTargetsEqual(
+                thread.federation?.ref.target,
+                event.federationTarget,
+              ),
+          );
+          const threadLink = matchingThread
+            ? {
+                backend: matchingThread.source,
+                inThreadList: true,
+                ...(instanceId ? { instanceId } : {}),
+                threadId: matchingThread.id,
+                title: matchingThread.title,
+                titleSource: matchingThread.titleSource,
+                gitBranch: matchingThread.gitBranch,
+                linkedDirectories: matchingThread.linkedDirectories,
+              }
+            : undefined;
+          for (const alert of spendAlerts) {
+            dispatchAppNotice({
+              type: "show",
+              notice: buildSpendAlertNotice({
+                alert,
+                ...(threadLink ? { threadLink } : {}),
+              }),
+            });
+          }
+        }
+      }
       if (event.notification.method === "thread/toolAccounting/updated") {
         const params = event.notification.params as {
           threadId: string;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import {
   buildThreadIdentityKey,
   DEFAULT_BACKGROUND_PR_POLLING,
   DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
+  DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   isRemoteFederationTarget,
   parseThreadIdentityKey,
   type AppServerBackendKind,
@@ -34,6 +35,7 @@ import {
   type ThreadUsageLineRecord,
   type SetThreadToolIncidentNoticeRequest,
   resolveToolIncidentVisibility,
+  toolOutputWarningChars,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { useThreadJump } from "./features/navigation/useThreadJump";
@@ -364,6 +366,12 @@ function DesktopAppShell(props: {
     readonly ThreadUsageLineRecord[]
   >());
   const showIncidentCostRef = useRef(false);
+  const largeOutputThresholdCharsRef = useRef(toolOutputWarningChars(
+    props.settings.snapshot?.general.toolOutputAlerts
+      ?.repeatedLargeOutputMinimumPercent.value
+      ?? DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT
+        .repeatedLargeOutputMinimumPercent,
+  ));
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
@@ -760,6 +768,7 @@ function DesktopAppShell(props: {
           ...(incidentState?.firstWarningAt !== undefined
             ? { firstWarningAt: incidentState.firstWarningAt }
             : {}),
+          largeOutputThresholdChars: largeOutputThresholdCharsRef.current,
           threadId: params.threadId,
           usageLines: threadUsageLinesRef.current.get(
             buildThreadIdentityKey(event.backend, params.threadId),
@@ -1197,6 +1206,14 @@ function DesktopAppShell(props: {
           ?.value ?? false)
       );
   }, [settings.snapshot?.experimental]);
+  useEffect(() => {
+    largeOutputThresholdCharsRef.current = toolOutputWarningChars(
+      settings.snapshot?.general.toolOutputAlerts
+        ?.repeatedLargeOutputMinimumPercent.value
+        ?? DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT
+          .repeatedLargeOutputMinimumPercent,
+    );
+  }, [settings.snapshot?.general.toolOutputAlerts]);
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1235,6 +1235,11 @@ describe("App", () => {
           value: false,
           source: "default",
         },
+        toolOutputAlerts: {
+          outputCapHitsEnabled: { value: true, source: "default" },
+          repeatedLargeOutputsEnabled: { value: true, source: "default" },
+          repeatedQueuedChecksEnabled: { value: true, source: "default" },
+        },
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1242,6 +1242,12 @@ describe("App", () => {
           repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
           repeatedQueuedChecksEnabled: { value: true, source: "default" },
         },
+        spendAlerts: {
+          activeTurnSpendEnabled: { value: true, source: "default" },
+          activeTurnSpendThresholdUsd: { value: 5, source: "default" },
+          threadSpendEnabled: { value: true, source: "default" },
+          threadSpendThresholdUsd: { value: 25, source: "default" },
+        },
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1238,6 +1238,8 @@ describe("App", () => {
         toolOutputAlerts: {
           outputCapHitsEnabled: { value: true, source: "default" },
           repeatedLargeOutputsEnabled: { value: true, source: "default" },
+          repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
+          repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
           repeatedQueuedChecksEnabled: { value: true, source: "default" },
         },
         appearance: {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/spend-alert-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/spend-alert-notice.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildSpendAlertNotice } from "../spend-alert-notice";
+
+describe("spend alert notice", () => {
+  it("describes active-turn spend against its configured threshold", () => {
+    const notice = buildSpendAlertNotice({
+      alert: {
+        alertId: "spend-alert:active-turn:codex:thread-1:turn-2:5000000",
+        createdAt: 1_800_000_000_000,
+        currency: "USD",
+        kind: "active-turn-spend",
+        spendMicros: 5_250_000,
+        threadId: "thread-1",
+        thresholdMicros: 5_000_000,
+        turnId: "turn-2",
+      },
+    });
+
+    expect(notice).toMatchObject({
+      autoDismiss: false,
+      message: expect.stringContaining("$5.25"),
+      title: "Active turn spend threshold reached",
+      tone: "warning",
+    });
+    expect(notice.message).toContain("$5.00 threshold");
+  });
+
+  it("describes total thread spend", () => {
+    const notice = buildSpendAlertNotice({
+      alert: {
+        alertId: "spend-alert:thread:codex:thread-1:25000000",
+        createdAt: 1_800_000_000_000,
+        currency: "USD",
+        kind: "thread-spend",
+        spendMicros: 31_000_000,
+        threadId: "thread-1",
+        thresholdMicros: 25_000_000,
+      },
+    });
+
+    expect(notice).toMatchObject({
+      message: expect.stringContaining("$31.00"),
+      title: "Thread spend threshold reached",
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -110,6 +110,25 @@ describe("buildThreadIncidentSummary", () => {
       threadId: "thread-1",
     })).toBeUndefined();
   });
+
+  it("folds incidents using the configured large-output threshold", () => {
+    const records = accounting([
+      invocation({ noisy: false, outputChars: 24_000 }),
+    ]);
+
+    expect(buildThreadIncidentSummary({
+      accounting: records,
+      backend: "codex",
+      largeOutputThresholdChars: 30_000,
+      threadId: "thread-1",
+    })).toBeUndefined();
+    expect(buildThreadIncidentSummary({
+      accounting: records,
+      backend: "codex",
+      largeOutputThresholdChars: 10_000,
+      threadId: "thread-1",
+    })?.flaggedInvocationCount).toBe(1);
+  });
 });
 
 describe("resolveToolIncidentVisibility", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/spend-alert-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/spend-alert-notice.ts
@@ -1,0 +1,34 @@
+import type { ThreadSpendAlert } from "@pwragent/shared";
+import type { ResolvedThreadLink } from "../../lib/thread-links";
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export function buildSpendAlertNotice(params: {
+  alert: ThreadSpendAlert;
+  threadLink?: ResolvedThreadLink;
+}): AppNoticeToastNotice {
+  const alert = params.alert;
+  const spend = formatUsdMicros(alert.spendMicros);
+  const threshold = formatUsdMicros(alert.thresholdMicros);
+  const activeTurn = alert.kind === "active-turn-spend";
+  return {
+    autoDismiss: false,
+    id: alert.alertId,
+    message: activeTurn
+      ? `This active turn has reached ${spend} in estimated list-price spend, crossing the configured ${threshold} threshold.`
+      : `This thread has reached ${spend} in estimated list-price spend, crossing the configured ${threshold} threshold.`,
+    ...(params.threadLink ? { threadLink: params.threadLink } : {}),
+    title: activeTurn
+      ? "Active turn spend threshold reached"
+      : "Thread spend threshold reached",
+    tone: "warning",
+  };
+}
+
+function formatUsdMicros(micros: number): string {
+  return (micros / 1_000_000).toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}

--- a/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-incident-summary.ts
@@ -69,6 +69,7 @@ export function buildThreadIncidentSummary(params: {
   backend: string;
   /** Persisted baseline. Survives restart so the cost window does not reset. */
   firstWarningAt?: number;
+  largeOutputThresholdChars?: number;
   threadId: string;
   usageLines?: readonly ThreadUsageLineRecord[];
 }): ThreadIncidentSummary | undefined {
@@ -76,7 +77,9 @@ export function buildThreadIncidentSummary(params: {
   /* Same predicate the explorer uses: a card that counted only rows the
      detectors happened to mark would under-report exactly the threads whose
      history predates them. */
-  const flagged = invocations.filter(isFlaggedToolInvocation);
+  const flagged = invocations.filter((invocation) =>
+    isFlaggedToolInvocation(invocation, params.largeOutputThresholdChars)
+  );
   if (flagged.length === 0) return undefined;
 
   const observedFirst = flagged.reduce(

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import type {
   DesktopSettingsSnapshot,
-  DesktopToolOutputAlertPolicy,
   DesktopUpdateChannel,
   DesktopUpdateTrain,
 } from "@pwragent/shared";
@@ -198,9 +197,6 @@ export function GeneralSettings(props: {
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
   onUpdateTrainChange: (value: DesktopUpdateTrain) => Promise<void>;
   onNotificationsEnabledChange: (value: boolean) => Promise<void>;
-  onToolOutputAlertsChange: (
-    patch: Partial<DesktopToolOutputAlertPolicy>,
-  ) => Promise<void>;
   onClearMessagingAcknowledgment: () => Promise<void>;
 }) {
   const [releaseVersions, setReleaseVersions] = useState<
@@ -225,7 +221,6 @@ export function GeneralSettings(props: {
     props.snapshot.general.attentionPromoteOnTurnEnd;
   const pdfAnalysisEnabled = props.snapshot.general.pdfAnalysisEnabled;
   const notificationsEnabled = props.snapshot.general.notificationsEnabled;
-  const toolOutputAlerts = props.snapshot.general.toolOutputAlerts;
   const updateChannel = props.snapshot.updates.channel;
   const updateTrain = props.snapshot.updates.train;
   const messagingAcknowledgment =
@@ -421,66 +416,6 @@ export function GeneralSettings(props: {
                 label="Move a thread to the top when its turn finishes"
                 onChange={(next) => {
                   void props.onAttentionPromoteOnTurnEndChange(next);
-                }}
-              />
-            }
-          />
-        </div>
-      </SettingsSection>
-
-      <SettingsSection
-        eyebrow="General"
-        title="Tool-use alerts"
-        chip={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
-      >
-        <div className="settings-fields">
-          <SettingsField
-            label="Tool output reaches the cap"
-            sub="Alert immediately when one tool call reaches the model-visible output cap and is truncated."
-            source={sourceBadge(toolOutputAlerts.outputCapHitsEnabled)}
-            control={
-              <SettingsSwitch
-                checked={toolOutputAlerts.outputCapHitsEnabled.value}
-                disabled={props.saving}
-                label="Tool output reaches the cap"
-                onChange={(next) => {
-                  void props.onToolOutputAlertsChange({
-                    outputCapHitsEnabled: next,
-                  });
-                }}
-              />
-            }
-          />
-          <SettingsField
-            label="Repeated large tool outputs"
-            sub="Alert after five tool calls in one turn each produce at least 50% of the model-visible output cap."
-            source={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
-            control={
-              <SettingsSwitch
-                checked={toolOutputAlerts.repeatedLargeOutputsEnabled.value}
-                disabled={props.saving}
-                label="Repeated large tool outputs"
-                onChange={(next) => {
-                  void props.onToolOutputAlertsChange({
-                    repeatedLargeOutputsEnabled: next,
-                  });
-                }}
-              />
-            }
-          />
-          <SettingsField
-            label="Repeated queued checks"
-            sub="Alert when repeated wait or polling calls keep waking the model and replaying the turn context."
-            source={sourceBadge(toolOutputAlerts.repeatedQueuedChecksEnabled)}
-            control={
-              <SettingsSwitch
-                checked={toolOutputAlerts.repeatedQueuedChecksEnabled.value}
-                disabled={props.saving}
-                label="Repeated queued checks"
-                onChange={(next) => {
-                  void props.onToolOutputAlertsChange({
-                    repeatedQueuedChecksEnabled: next,
-                  });
                 }}
               />
             }

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type {
   DesktopSettingsSnapshot,
+  DesktopToolOutputAlertPolicy,
   DesktopUpdateChannel,
   DesktopUpdateTrain,
 } from "@pwragent/shared";
@@ -197,6 +198,9 @@ export function GeneralSettings(props: {
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
   onUpdateTrainChange: (value: DesktopUpdateTrain) => Promise<void>;
   onNotificationsEnabledChange: (value: boolean) => Promise<void>;
+  onToolOutputAlertsChange: (
+    patch: Partial<DesktopToolOutputAlertPolicy>,
+  ) => Promise<void>;
   onClearMessagingAcknowledgment: () => Promise<void>;
 }) {
   const [releaseVersions, setReleaseVersions] = useState<
@@ -221,6 +225,7 @@ export function GeneralSettings(props: {
     props.snapshot.general.attentionPromoteOnTurnEnd;
   const pdfAnalysisEnabled = props.snapshot.general.pdfAnalysisEnabled;
   const notificationsEnabled = props.snapshot.general.notificationsEnabled;
+  const toolOutputAlerts = props.snapshot.general.toolOutputAlerts;
   const updateChannel = props.snapshot.updates.channel;
   const updateTrain = props.snapshot.updates.train;
   const messagingAcknowledgment =
@@ -416,6 +421,66 @@ export function GeneralSettings(props: {
                 label="Move a thread to the top when its turn finishes"
                 onChange={(next) => {
                   void props.onAttentionPromoteOnTurnEndChange(next);
+                }}
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="General"
+        title="Tool-use alerts"
+        chip={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Tool output reaches the cap"
+            sub="Alert immediately when one tool call reaches the model-visible output cap and is truncated."
+            source={sourceBadge(toolOutputAlerts.outputCapHitsEnabled)}
+            control={
+              <SettingsSwitch
+                checked={toolOutputAlerts.outputCapHitsEnabled.value}
+                disabled={props.saving}
+                label="Tool output reaches the cap"
+                onChange={(next) => {
+                  void props.onToolOutputAlertsChange({
+                    outputCapHitsEnabled: next,
+                  });
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Repeated large tool outputs"
+            sub="Alert after five tool calls in one turn each produce at least 50% of the model-visible output cap."
+            source={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
+            control={
+              <SettingsSwitch
+                checked={toolOutputAlerts.repeatedLargeOutputsEnabled.value}
+                disabled={props.saving}
+                label="Repeated large tool outputs"
+                onChange={(next) => {
+                  void props.onToolOutputAlertsChange({
+                    repeatedLargeOutputsEnabled: next,
+                  });
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Repeated queued checks"
+            sub="Alert when repeated wait or polling calls keep waking the model and replaying the turn context."
+            source={sourceBadge(toolOutputAlerts.repeatedQueuedChecksEnabled)}
+            control={
+              <SettingsSwitch
+                checked={toolOutputAlerts.repeatedQueuedChecksEnabled.value}
+                disabled={props.saving}
+                label="Repeated queued checks"
+                onChange={(next) => {
+                  void props.onToolOutputAlertsChange({
+                    repeatedQueuedChecksEnabled: next,
+                  });
                 }}
               />
             }

--- a/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
@@ -1,12 +1,15 @@
 import type {
   DesktopSettingsSnapshot,
+  DesktopSpendAlertPolicy,
   DesktopToolOutputAlertPolicy,
 } from "@pwragent/shared";
 import {
   MAX_REPEATED_LARGE_OUTPUT_CALLS,
   MAX_REPEATED_LARGE_OUTPUT_PERCENT,
+  MAX_SPEND_ALERT_THRESHOLD_USD,
   MIN_REPEATED_LARGE_OUTPUT_CALLS,
   MIN_REPEATED_LARGE_OUTPUT_PERCENT,
+  MIN_SPEND_ALERT_THRESHOLD_USD,
 } from "@pwragent/shared";
 import { useEffect, useState } from "react";
 import {
@@ -39,6 +42,9 @@ export function PricingSettings(props: {
   onThreadPricingSummaryChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayUsdChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayCodexCreditsChange: (enabled: boolean) => Promise<void>;
+  onSpendAlertsChange: (
+    patch: Partial<DesktopSpendAlertPolicy>,
+  ) => Promise<void>;
   onToolOutputAlertsChange: (
     patch: Partial<DesktopToolOutputAlertPolicy>,
   ) => Promise<void>;
@@ -53,6 +59,7 @@ export function PricingSettings(props: {
     props.snapshot.experimental.threadPricingDisplayCodexCredits ??
     DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS;
   const toolOutputAlerts = props.snapshot.general.toolOutputAlerts;
+  const spendAlerts = props.snapshot.general.spendAlerts;
   const displayControlsDisabled = props.saving || !threadPricingSummary.value;
   const repeatedLargeOutputDescription =
     `Alert after ${toolOutputAlerts.repeatedLargeOutputMinimumCalls.value.toLocaleString()} tool calls in one turn each produce at least ${toolOutputAlerts.repeatedLargeOutputMinimumPercent.value.toLocaleString()}% of the model-visible output cap.`;
@@ -142,6 +149,76 @@ export function PricingSettings(props: {
         chip={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
       >
         <div className="settings-fields">
+          <SettingsField
+            label="Active turn spend"
+            sub={`Alert when one active turn reaches $${spendAlerts.activeTurnSpendThresholdUsd.value.toFixed(2)} in estimated list-price spend.`}
+            source={sourceBadge(spendAlerts.activeTurnSpendEnabled)}
+            control={
+              <SettingsSwitch
+                checked={spendAlerts.activeTurnSpendEnabled.value}
+                disabled={props.saving}
+                label="Active turn spend"
+                onChange={(next) => {
+                  void props.onSpendAlertsChange({
+                    activeTurnSpendEnabled: next,
+                  });
+                }}
+              />
+            }
+          />
+          <AlertNumberField
+            decimals={2}
+            disabled={
+              props.saving || !spendAlerts.activeTurnSpendEnabled.value
+            }
+            label="Active turn spend threshold"
+            max={MAX_SPEND_ALERT_THRESHOLD_USD}
+            min={MIN_SPEND_ALERT_THRESHOLD_USD}
+            source={sourceBadge(spendAlerts.activeTurnSpendThresholdUsd)}
+            step={0.01}
+            sub="Estimated list-price spend allowed for one active turn before the alert is raised."
+            suffix="USD"
+            value={spendAlerts.activeTurnSpendThresholdUsd.value}
+            onSave={(next) => {
+              void props.onSpendAlertsChange({
+                activeTurnSpendThresholdUsd: next,
+              });
+            }}
+          />
+          <SettingsField
+            label="Total thread spend"
+            sub={`Alert when a thread reaches $${spendAlerts.threadSpendThresholdUsd.value.toFixed(2)} in estimated list-price spend.`}
+            source={sourceBadge(spendAlerts.threadSpendEnabled)}
+            control={
+              <SettingsSwitch
+                checked={spendAlerts.threadSpendEnabled.value}
+                disabled={props.saving}
+                label="Total thread spend"
+                onChange={(next) => {
+                  void props.onSpendAlertsChange({
+                    threadSpendEnabled: next,
+                  });
+                }}
+              />
+            }
+          />
+          <AlertNumberField
+            decimals={2}
+            disabled={props.saving || !spendAlerts.threadSpendEnabled.value}
+            label="Total thread spend threshold"
+            max={MAX_SPEND_ALERT_THRESHOLD_USD}
+            min={MIN_SPEND_ALERT_THRESHOLD_USD}
+            source={sourceBadge(spendAlerts.threadSpendThresholdUsd)}
+            step={0.01}
+            sub="Estimated list-price spend allowed across the thread before the alert is raised."
+            suffix="USD"
+            value={spendAlerts.threadSpendThresholdUsd.value}
+            onSave={(next) => {
+              void props.onSpendAlertsChange({
+                threadSpendThresholdUsd: next,
+              });
+            }}
+          />
           <SettingsField
             label="Tool output reaches the cap"
             sub="Alert immediately when one tool call reaches the model-visible output cap and is truncated."
@@ -240,11 +317,13 @@ export function PricingSettings(props: {
 }
 
 function AlertNumberField(props: {
+  decimals?: number;
   disabled?: boolean;
   label: string;
   max: number;
   min: number;
   source: string;
+  step?: number;
   sub: string;
   suffix: string;
   value: number;
@@ -269,6 +348,7 @@ function AlertNumberField(props: {
             disabled={props.disabled}
             max={props.max}
             min={props.min}
+            step={props.step}
             type="number"
             value={value}
             onBlur={() => {
@@ -277,8 +357,11 @@ function AlertNumberField(props: {
                 setValue(String(props.value));
                 return;
               }
+              const normalized = props.decimals === undefined
+                ? Math.trunc(parsed)
+                : Number(parsed.toFixed(props.decimals));
               const clamped = Math.min(
-                Math.max(Math.trunc(parsed), props.min),
+                Math.max(normalized, props.min),
                 props.max,
               );
               setValue(String(clamped));

--- a/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
@@ -3,6 +3,13 @@ import type {
   DesktopToolOutputAlertPolicy,
 } from "@pwragent/shared";
 import {
+  MAX_REPEATED_LARGE_OUTPUT_CALLS,
+  MAX_REPEATED_LARGE_OUTPUT_PERCENT,
+  MIN_REPEATED_LARGE_OUTPUT_CALLS,
+  MIN_REPEATED_LARGE_OUTPUT_PERCENT,
+} from "@pwragent/shared";
+import { useEffect, useState } from "react";
+import {
   SettingsField,
   SettingsPanelHead,
   SettingsSection,
@@ -47,6 +54,8 @@ export function PricingSettings(props: {
     DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS;
   const toolOutputAlerts = props.snapshot.general.toolOutputAlerts;
   const displayControlsDisabled = props.saving || !threadPricingSummary.value;
+  const repeatedLargeOutputDescription =
+    `Alert after ${toolOutputAlerts.repeatedLargeOutputMinimumCalls.value.toLocaleString()} tool calls in one turn each produce at least ${toolOutputAlerts.repeatedLargeOutputMinimumPercent.value.toLocaleString()}% of the model-visible output cap.`;
 
   return (
     <SettingsSectionStack paneId="pricing" aria-label="Usage and pricing settings">
@@ -152,7 +161,7 @@ export function PricingSettings(props: {
           />
           <SettingsField
             label="Repeated large tool outputs"
-            sub="Alert after five tool calls in one turn each produce at least 50% of the model-visible output cap."
+            sub={repeatedLargeOutputDescription}
             source={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
             control={
               <SettingsSwitch
@@ -166,6 +175,46 @@ export function PricingSettings(props: {
                 }}
               />
             }
+          />
+          <AlertNumberField
+            disabled={
+              props.saving
+              || !toolOutputAlerts.repeatedLargeOutputsEnabled.value
+            }
+            label="Calls per turn"
+            max={MAX_REPEATED_LARGE_OUTPUT_CALLS}
+            min={MIN_REPEATED_LARGE_OUTPUT_CALLS}
+            source={sourceBadge(
+              toolOutputAlerts.repeatedLargeOutputMinimumCalls,
+            )}
+            sub="Number of qualifying tool calls required before the alert is raised."
+            suffix="calls"
+            value={toolOutputAlerts.repeatedLargeOutputMinimumCalls.value}
+            onSave={(next) => {
+              void props.onToolOutputAlertsChange({
+                repeatedLargeOutputMinimumCalls: next,
+              });
+            }}
+          />
+          <AlertNumberField
+            disabled={
+              props.saving
+              || !toolOutputAlerts.repeatedLargeOutputsEnabled.value
+            }
+            label="Output size threshold"
+            max={MAX_REPEATED_LARGE_OUTPUT_PERCENT}
+            min={MIN_REPEATED_LARGE_OUTPUT_PERCENT}
+            source={sourceBadge(
+              toolOutputAlerts.repeatedLargeOutputMinimumPercent,
+            )}
+            sub="Each qualifying call must produce at least this share of the model-visible output cap."
+            suffix="% of cap"
+            value={toolOutputAlerts.repeatedLargeOutputMinimumPercent.value}
+            onSave={(next) => {
+              void props.onToolOutputAlertsChange({
+                repeatedLargeOutputMinimumPercent: next,
+              });
+            }}
           />
           <SettingsField
             label="Repeated queued checks"
@@ -187,5 +236,61 @@ export function PricingSettings(props: {
         </div>
       </SettingsSection>
     </SettingsSectionStack>
+  );
+}
+
+function AlertNumberField(props: {
+  disabled?: boolean;
+  label: string;
+  max: number;
+  min: number;
+  source: string;
+  sub: string;
+  suffix: string;
+  value: number;
+  onSave: (value: number) => void;
+}) {
+  const [value, setValue] = useState(String(props.value));
+
+  useEffect(() => {
+    setValue(String(props.value));
+  }, [props.value]);
+
+  return (
+    <SettingsField
+      label={props.label}
+      sub={props.sub}
+      source={props.source}
+      control={
+        <span className="settings-number">
+          <input
+            aria-label={props.label}
+            className="settings-input settings-input--inline"
+            disabled={props.disabled}
+            max={props.max}
+            min={props.min}
+            type="number"
+            value={value}
+            onBlur={() => {
+              const parsed = Number(value);
+              if (!Number.isFinite(parsed)) {
+                setValue(String(props.value));
+                return;
+              }
+              const clamped = Math.min(
+                Math.max(Math.trunc(parsed), props.min),
+                props.max,
+              );
+              setValue(String(clamped));
+              if (clamped !== props.value) {
+                props.onSave(clamped);
+              }
+            }}
+            onChange={(event) => setValue(event.currentTarget.value)}
+          />
+          <span className="settings-source">{props.suffix}</span>
+        </span>
+      }
+    />
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
@@ -1,4 +1,7 @@
-import type { DesktopSettingsSnapshot } from "@pwragent/shared";
+import type {
+  DesktopSettingsSnapshot,
+  DesktopToolOutputAlertPolicy,
+} from "@pwragent/shared";
 import {
   SettingsField,
   SettingsPanelHead,
@@ -29,6 +32,9 @@ export function PricingSettings(props: {
   onThreadPricingSummaryChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayUsdChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayCodexCreditsChange: (enabled: boolean) => Promise<void>;
+  onToolOutputAlertsChange: (
+    patch: Partial<DesktopToolOutputAlertPolicy>,
+  ) => Promise<void>;
 }) {
   const threadPricingSummary =
     props.snapshot.experimental.threadPricingSummary ??
@@ -39,6 +45,7 @@ export function PricingSettings(props: {
   const threadPricingDisplayCodexCredits =
     props.snapshot.experimental.threadPricingDisplayCodexCredits ??
     DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS;
+  const toolOutputAlerts = props.snapshot.general.toolOutputAlerts;
   const displayControlsDisabled = props.saving || !threadPricingSummary.value;
 
   return (
@@ -46,7 +53,7 @@ export function PricingSettings(props: {
       <SettingsPanelHead
         eyebrow="Pricing"
         title="Usage & pricing"
-        help="Control how estimated thread usage costs are shown."
+        help="Control how thread usage costs are shown and which usage patterns raise alerts."
       />
 
       <SettingsSection
@@ -114,6 +121,67 @@ export function PricingSettings(props: {
                   Codex Credits
                 </button>
               </div>
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Usage"
+        title="Alerts"
+        description="Choose which costly or lossy tool-use patterns should interrupt you."
+        chip={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Tool output reaches the cap"
+            sub="Alert immediately when one tool call reaches the model-visible output cap and is truncated."
+            source={sourceBadge(toolOutputAlerts.outputCapHitsEnabled)}
+            control={
+              <SettingsSwitch
+                checked={toolOutputAlerts.outputCapHitsEnabled.value}
+                disabled={props.saving}
+                label="Tool output reaches the cap"
+                onChange={(next) => {
+                  void props.onToolOutputAlertsChange({
+                    outputCapHitsEnabled: next,
+                  });
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Repeated large tool outputs"
+            sub="Alert after five tool calls in one turn each produce at least 50% of the model-visible output cap."
+            source={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
+            control={
+              <SettingsSwitch
+                checked={toolOutputAlerts.repeatedLargeOutputsEnabled.value}
+                disabled={props.saving}
+                label="Repeated large tool outputs"
+                onChange={(next) => {
+                  void props.onToolOutputAlertsChange({
+                    repeatedLargeOutputsEnabled: next,
+                  });
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Repeated queued checks"
+            sub="Alert when repeated wait or polling calls keep waking the model and replaying the turn context."
+            source={sourceBadge(toolOutputAlerts.repeatedQueuedChecksEnabled)}
+            control={
+              <SettingsSwitch
+                checked={toolOutputAlerts.repeatedQueuedChecksEnabled.value}
+                disabled={props.saving}
+                label="Repeated queued checks"
+                onChange={(next) => {
+                  void props.onToolOutputAlertsChange({
+                    repeatedQueuedChecksEnabled: next,
+                  });
+                }}
+              />
             }
           />
         </div>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -421,11 +421,6 @@ function SettingsSectionBody(props: {
             general: { notificationsEnabled },
           });
         }}
-        onToolOutputAlertsChange={async (toolOutputAlerts) => {
-          await props.settings.writeConfig({
-            general: { toolOutputAlerts },
-          });
-        }}
         onClearMessagingAcknowledgment={async () => {
           await props.settings.writeConfig({
             general: { messagingAcknowledgment: null },
@@ -506,6 +501,11 @@ function SettingsSectionBody(props: {
         onThreadPricingDisplayCodexCreditsChange={async (enabled: boolean) => {
           await props.settings.writeConfig({
             experimental: { threadPricingDisplayCodexCredits: enabled },
+          });
+        }}
+        onToolOutputAlertsChange={async (toolOutputAlerts) => {
+          await props.settings.writeConfig({
+            general: { toolOutputAlerts },
           });
         }}
       />

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -508,6 +508,11 @@ function SettingsSectionBody(props: {
             general: { toolOutputAlerts },
           });
         }}
+        onSpendAlertsChange={async (spendAlerts) => {
+          await props.settings.writeConfig({
+            general: { spendAlerts },
+          });
+        }}
       />
     );
   }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -421,6 +421,11 @@ function SettingsSectionBody(props: {
             general: { notificationsEnabled },
           });
         }}
+        onToolOutputAlertsChange={async (toolOutputAlerts) => {
+          await props.settings.writeConfig({
+            general: { toolOutputAlerts },
+          });
+        }}
         onClearMessagingAcknowledgment={async () => {
           await props.settings.writeConfig({
             general: { messagingAcknowledgment: null },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -129,6 +129,11 @@ function createSnapshot(
         value: false,
         source: "default",
       },
+      toolOutputAlerts: {
+        outputCapHitsEnabled: { value: true, source: "default" },
+        repeatedLargeOutputsEnabled: { value: true, source: "default" },
+        repeatedQueuedChecksEnabled: { value: true, source: "default" },
+      },
       appearance: {
         theme: { value: "system", source: "default" },
         density: { value: "mission-control", source: "default" },
@@ -834,6 +839,22 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         general: {
           notificationsEnabled: true,
+        },
+      });
+    });
+
+    expect(
+      screen.getByRole("switch", { name: "Repeated large tool outputs" }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Repeated large tool outputs" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          toolOutputAlerts: {
+            repeatedLargeOutputsEnabled: false,
+          },
         },
       });
     });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -843,22 +843,6 @@ describe("SettingsScreen", () => {
       });
     });
 
-    expect(
-      screen.getByRole("switch", { name: "Repeated large tool outputs" }),
-    ).toHaveAttribute("aria-checked", "true");
-    fireEvent.click(
-      screen.getByRole("switch", { name: "Repeated large tool outputs" }),
-    );
-    await waitFor(() => {
-      expect(settings.writeConfig).toHaveBeenCalledWith({
-        general: {
-          toolOutputAlerts: {
-            repeatedLargeOutputsEnabled: false,
-          },
-        },
-      });
-    });
-
     expect(await screen.findByText("v1.0.0-beta.7")).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: /Stable/ })).toHaveAttribute(
       "aria-checked",
@@ -951,6 +935,24 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByRole("heading", { name: "Usage & pricing" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Alerts" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Repeated large tool outputs" }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Repeated large tool outputs" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          toolOutputAlerts: {
+            repeatedLargeOutputsEnabled: false,
+          },
+        },
+      });
+    });
     fireEvent.click(
       screen.getByRole("switch", {
         name: "Show thread pricing",

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -136,6 +136,12 @@ function createSnapshot(
         repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
         repeatedQueuedChecksEnabled: { value: true, source: "default" },
       },
+      spendAlerts: {
+        activeTurnSpendEnabled: { value: true, source: "default" },
+        activeTurnSpendThresholdUsd: { value: 5, source: "default" },
+        threadSpendEnabled: { value: true, source: "default" },
+        threadSpendThresholdUsd: { value: 25, source: "default" },
+      },
       appearance: {
         theme: { value: "system", source: "default" },
         density: { value: "mission-control", source: "default" },
@@ -943,6 +949,38 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByRole("switch", { name: "Repeated large tool outputs" }),
     ).toHaveAttribute("aria-checked", "true");
+    fireEvent.change(
+      screen.getByRole("spinbutton", {
+        name: "Active turn spend threshold",
+      }),
+      { target: { value: "7.50" } },
+    );
+    fireEvent.blur(
+      screen.getByRole("spinbutton", {
+        name: "Active turn spend threshold",
+      }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          spendAlerts: {
+            activeTurnSpendThresholdUsd: 7.5,
+          },
+        },
+      });
+    });
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Total thread spend" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          spendAlerts: {
+            threadSpendEnabled: false,
+          },
+        },
+      });
+    });
     fireEvent.change(screen.getByRole("spinbutton", { name: "Calls per turn" }), {
       target: { value: "7" },
     });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -132,6 +132,8 @@ function createSnapshot(
       toolOutputAlerts: {
         outputCapHitsEnabled: { value: true, source: "default" },
         repeatedLargeOutputsEnabled: { value: true, source: "default" },
+        repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
+        repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
         repeatedQueuedChecksEnabled: { value: true, source: "default" },
       },
       appearance: {
@@ -941,6 +943,35 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByRole("switch", { name: "Repeated large tool outputs" }),
     ).toHaveAttribute("aria-checked", "true");
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Calls per turn" }), {
+      target: { value: "7" },
+    });
+    fireEvent.blur(screen.getByRole("spinbutton", { name: "Calls per turn" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          toolOutputAlerts: {
+            repeatedLargeOutputMinimumCalls: 7,
+          },
+        },
+      });
+    });
+    fireEvent.change(
+      screen.getByRole("spinbutton", { name: "Output size threshold" }),
+      { target: { value: "65" } },
+    );
+    fireEvent.blur(
+      screen.getByRole("spinbutton", { name: "Output size threshold" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          toolOutputAlerts: {
+            repeatedLargeOutputMinimumPercent: 65,
+          },
+        },
+      });
+    });
     fireEvent.click(
       screen.getByRole("switch", { name: "Repeated large tool outputs" }),
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -11,11 +11,13 @@ import type {
 } from "@pwragent/shared";
 import {
   buildThreadToolIncidentPrompt,
+  DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   isFlaggedToolInvocation,
-  TOOL_OUTPUT_WARNING_CHARS,
+  toolOutputWarningChars,
 } from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { useDesktopApi } from "../../lib/desktop-api";
+import { useDesktopSettings } from "../settings/useDesktopSettings";
 import { ThreadChip } from "./ThreadChip";
 import { detailMatchesInvocationItem } from "./tool-call-details";
 import type {
@@ -49,6 +51,7 @@ const HISTORY_PAGE_LIMIT = 100;
 
 export function ToolOutputIncidentExplorerWindow() {
   const desktopApi = useDesktopApi();
+  const settings = useDesktopSettings(desktopApi);
   const [route, setRoute] = useState(readIncidentRoute);
   const [accounting, setAccounting] = useState<ThreadToolAccounting>();
   const [latest, setLatest] = useState<AppServerReadThreadResponse>();
@@ -122,18 +125,30 @@ export function ToolOutputIncidentExplorerWindow() {
     () => accounting?.invocations ?? [],
     [accounting?.invocations],
   );
-  const flagged = useMemo(
-    () => allInvocations.filter(isFlaggedToolInvocation),
-    [allInvocations],
+  const largeOutputThresholdChars = toolOutputWarningChars(
+    settings.snapshot?.general.toolOutputAlerts
+      ?.repeatedLargeOutputMinimumPercent.value
+      ?? DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT
+        .repeatedLargeOutputMinimumPercent,
   );
-  const summary = useMemo(() => summarizeIncidents(allInvocations), [allInvocations]);
+  const flagged = useMemo(
+    () => allInvocations.filter((invocation) =>
+      isFlaggedToolInvocation(invocation, largeOutputThresholdChars)
+    ),
+    [allInvocations, largeOutputThresholdChars],
+  );
+  const summary = useMemo(
+    () => summarizeIncidents(allInvocations, { largeOutputThresholdChars }),
+    [allInvocations, largeOutputThresholdChars],
+  );
   const usageLines = latest?.pricing?.lines;
   const turnStrip = useMemo(
     () => buildTurnCostStrip(allInvocations, {
+      largeOutputThresholdChars,
       scope: turnScope,
       ...(usageLines ? { usageLines } : {}),
     }),
-    [allInvocations, turnScope, usageLines],
+    [allInvocations, largeOutputThresholdChars, turnScope, usageLines],
   );
   const currency = usageLines?.[0]?.currency;
   const composition = useMemo(() => buildCategoryComposition(flagged), [flagged]);
@@ -524,7 +539,7 @@ export function ToolOutputIncidentExplorerWindow() {
                 ? "No findings match these filters."
                 : allInvocations.length === 0
                   ? "No tool calls are recorded for this thread yet."
-                  : `None of this thread's ${allInvocations.length.toLocaleString()} recorded tool calls returned more than ${TOOL_OUTPUT_WARNING_CHARS.toLocaleString()} characters.`}
+                  : `None of this thread's ${allInvocations.length.toLocaleString()} recorded tool calls returned at least ${largeOutputThresholdChars.toLocaleString()} characters.`}
             </p>
           ) : null}
         </aside>
@@ -1145,4 +1160,3 @@ function filterOutputLines(output: string | undefined, query: string) {
 function formatTimestamp(timestamp: number): string {
   return new Date(timestamp).toLocaleString();
 }
-

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -38,9 +38,31 @@ describe("summarizeIncidents", () => {
   it("reports a zero share rather than dividing by zero on an empty thread", () => {
     expect(summarizeIncidents([]).share).toBe(0);
   });
+
+  it("uses the configured output threshold for historical rows", () => {
+    const records = [invocation({ noisy: false, outputChars: 24_000 })];
+
+    expect(summarizeIncidents(records, {
+      largeOutputThresholdChars: 30_000,
+    }).caseCount).toBe(0);
+    expect(summarizeIncidents(records, {
+      largeOutputThresholdChars: 10_000,
+    }).caseCount).toBe(1);
+  });
 });
 
 describe("buildTurnCostStrip", () => {
+  it("uses the configured output threshold for flagged turn scope", () => {
+    const records = [invocation({ noisy: false, outputChars: 24_000 })];
+
+    expect(buildTurnCostStrip(records, {
+      largeOutputThresholdChars: 30_000,
+    }).rows).toHaveLength(0);
+    expect(buildTurnCostStrip(records, {
+      largeOutputThresholdChars: 10_000,
+    }).rows).toHaveLength(1);
+  });
+
   it("counts every call in a turn, not only the flagged ones", () => {
     /* The round-trip driver: a turn of quiet calls still replays the whole
        accumulated context once per call, so a strip built from flagged rows

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -279,8 +279,11 @@ export function repeatCountFor(
 
 export function summarizeIncidents(
   invocations: ThreadToolInvocationRecord[],
+  options?: { largeOutputThresholdChars?: number },
 ): IncidentSummary {
-  const flagged = invocations.filter(isFlaggedToolInvocation);
+  const flagged = invocations.filter((invocation) =>
+    isFlaggedToolInvocation(invocation, options?.largeOutputThresholdChars)
+  );
   const turnKeys = new Set(flagged.map((invocation) => invocation.turnId ?? ""));
   const totalTokens = sumTokens(invocations);
   const incidentTokens = sumTokens(flagged);
@@ -303,6 +306,7 @@ export function summarizeIncidents(
 export function buildTurnCostStrip(
   invocations: ThreadToolInvocationRecord[],
   options?: {
+    largeOutputThresholdChars?: number;
     limit?: number;
     scope?: TurnStripScope;
     usageLines?: readonly ThreadUsageLineRecord[];
@@ -337,7 +341,14 @@ export function buildTurnCostStrip(
     row.callCount += 1;
     row.estimatedOutputTokens += invocation.estimatedOutputTokens;
     row.firstObservedAt = Math.min(row.firstObservedAt, invocation.observedAt);
-    if (isFlaggedToolInvocation(invocation)) row.flaggedCallCount += 1;
+    if (
+      isFlaggedToolInvocation(
+        invocation,
+        options?.largeOutputThresholdChars,
+      )
+    ) {
+      row.flaggedCallCount += 1;
+    }
     if (isOverOutputCap(invocation.outputChars)) row.overCapCount += 1;
     groups.set(key, row);
   }

--- a/packages/shared/src/__tests__/tool-output-incidents.test.ts
+++ b/packages/shared/src/__tests__/tool-output-incidents.test.ts
@@ -7,7 +7,7 @@ describe("isFlaggedToolInvocation", () => {
        row. Trusting the flag alone showed an empty explorer next to a fully
        populated turn strip — 575 oversized calls in one real thread, none of
        them listed. */
-    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 17_771 }))
+    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 20_000 }))
       .toBe(true);
   });
 
@@ -19,7 +19,7 @@ describe("isFlaggedToolInvocation", () => {
   });
 
   it("leaves an ordinary small result alone", () => {
-    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 3_999 }))
+    expect(isFlaggedToolInvocation({ noisy: false, outputChars: 19_999 }))
       .toBe(false);
   });
 });

--- a/packages/shared/src/__tests__/tool-output-incidents.test.ts
+++ b/packages/shared/src/__tests__/tool-output-incidents.test.ts
@@ -22,4 +22,11 @@ describe("isFlaggedToolInvocation", () => {
     expect(isFlaggedToolInvocation({ noisy: false, outputChars: 19_999 }))
       .toBe(false);
   });
+
+  it("uses the operator's effective large-output threshold", () => {
+    const invocation = { noisy: false, outputChars: 24_000 };
+
+    expect(isFlaggedToolInvocation(invocation, 30_000)).toBe(false);
+    expect(isFlaggedToolInvocation(invocation, 10_000)).toBe(true);
+  });
 });

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -69,6 +69,8 @@ describe("desktop settings contracts", () => {
         toolOutputAlerts: {
           outputCapHitsEnabled: { value: true, source: "default" },
           repeatedLargeOutputsEnabled: { value: true, source: "default" },
+          repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
+          repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
           repeatedQueuedChecksEnabled: { value: true, source: "default" },
         },
         appearance: {

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -73,6 +73,12 @@ describe("desktop settings contracts", () => {
           repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
           repeatedQueuedChecksEnabled: { value: true, source: "default" },
         },
+        spendAlerts: {
+          activeTurnSpendEnabled: { value: true, source: "default" },
+          activeTurnSpendThresholdUsd: { value: 5, source: "default" },
+          threadSpendEnabled: { value: true, source: "default" },
+          threadSpendThresholdUsd: { value: 25, source: "default" },
+        },
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -66,6 +66,11 @@ describe("desktop settings contracts", () => {
           value: false,
           source: "default",
         },
+        toolOutputAlerts: {
+          outputCapHitsEnabled: { value: true, source: "default" },
+          repeatedLargeOutputsEnabled: { value: true, source: "default" },
+          repeatedQueuedChecksEnabled: { value: true, source: "default" },
+        },
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -16,7 +16,11 @@ import type {
   ThreadPrAutoDispatchEventKind,
   ThreadPrAutoDispatchPending,
 } from "./navigation";
-import type { ThreadPricingSummary, ThreadUsageLineRecord } from "../token-usage-pricing";
+import type {
+  ThreadPricingSummary,
+  ThreadSpendAlert,
+  ThreadUsageLineRecord,
+} from "../token-usage-pricing";
 import type { ThreadToolIncidentNoticeState } from "./tool-output-incidents";
 
 export type AppServerBuiltinBackendKind = "codex";
@@ -1374,6 +1378,7 @@ export type AppServerNotification =
           lines: ThreadUsageLineRecord[];
           summaries: ThreadPricingSummary[];
         };
+        triggeredSpendAlerts?: ThreadSpendAlert[];
       };
     }
   | {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -152,6 +152,24 @@ export const DESKTOP_TEXT_SIZES = [
 export type DesktopTextSize = (typeof DESKTOP_TEXT_SIZES)[number];
 export const DESKTOP_TEXT_SIZE_DEFAULT: DesktopTextSize = "md";
 
+export type DesktopToolOutputAlertPolicy = {
+  outputCapHitsEnabled: boolean;
+  repeatedLargeOutputsEnabled: boolean;
+  repeatedQueuedChecksEnabled: boolean;
+};
+
+/**
+ * Tool-output alerts stay on by default, but the large-output warning is
+ * deliberately a repeated-pattern signal rather than a one-call tripwire.
+ * The detector owns that threshold; these flags let operators choose which
+ * classes of signal should interrupt them.
+ */
+export const DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT: DesktopToolOutputAlertPolicy = {
+  outputCapHitsEnabled: true,
+  repeatedLargeOutputsEnabled: true,
+  repeatedQueuedChecksEnabled: true,
+};
+
 export const DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELLS = [
   "auto",
   "pwsh",
@@ -474,6 +492,11 @@ export type DesktopGeneralSettingsSnapshot = {
   hotCpuProfilingCaptureHeapSnapshot: DesktopSettingsValue<boolean>;
   hotCpuProfilingHeapSnapshotLimit: DesktopSettingsValue<number>;
   notificationsEnabled: DesktopSettingsValue<boolean>;
+  toolOutputAlerts: {
+    outputCapHitsEnabled: DesktopSettingsValue<boolean>;
+    repeatedLargeOutputsEnabled: DesktopSettingsValue<boolean>;
+    repeatedQueuedChecksEnabled: DesktopSettingsValue<boolean>;
+  };
   appearance: DesktopAppearanceSnapshot;
   codexProfileModel: DesktopSettingsValue<DesktopCodexProfileModel>;
   messagingAcknowledgment: DesktopSettingsValue<DesktopMessagingAcknowledgment | null>;
@@ -989,6 +1012,7 @@ export type DesktopSettingsConfigPatch = {
     hotCpuProfilingCaptureHeapSnapshot?: boolean;
     hotCpuProfilingHeapSnapshotLimit?: number;
     notificationsEnabled?: boolean;
+    toolOutputAlerts?: Partial<DesktopToolOutputAlertPolicy>;
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -183,6 +183,23 @@ export const DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT: DesktopToolOutputAlertPol
   repeatedQueuedChecksEnabled: true,
 };
 
+export type DesktopSpendAlertPolicy = {
+  activeTurnSpendEnabled: boolean;
+  activeTurnSpendThresholdUsd: number;
+  threadSpendEnabled: boolean;
+  threadSpendThresholdUsd: number;
+};
+
+export const MIN_SPEND_ALERT_THRESHOLD_USD = 0.01;
+export const MAX_SPEND_ALERT_THRESHOLD_USD = 10_000;
+
+export const DESKTOP_SPEND_ALERT_POLICY_DEFAULT: DesktopSpendAlertPolicy = {
+  activeTurnSpendEnabled: true,
+  activeTurnSpendThresholdUsd: 5,
+  threadSpendEnabled: true,
+  threadSpendThresholdUsd: 25,
+};
+
 export const DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELLS = [
   "auto",
   "pwsh",
@@ -511,6 +528,12 @@ export type DesktopGeneralSettingsSnapshot = {
     repeatedLargeOutputMinimumCalls: DesktopSettingsValue<number>;
     repeatedLargeOutputMinimumPercent: DesktopSettingsValue<number>;
     repeatedQueuedChecksEnabled: DesktopSettingsValue<boolean>;
+  };
+  spendAlerts: {
+    activeTurnSpendEnabled: DesktopSettingsValue<boolean>;
+    activeTurnSpendThresholdUsd: DesktopSettingsValue<number>;
+    threadSpendEnabled: DesktopSettingsValue<boolean>;
+    threadSpendThresholdUsd: DesktopSettingsValue<number>;
   };
   appearance: DesktopAppearanceSnapshot;
   codexProfileModel: DesktopSettingsValue<DesktopCodexProfileModel>;
@@ -1028,6 +1051,7 @@ export type DesktopSettingsConfigPatch = {
     hotCpuProfilingHeapSnapshotLimit?: number;
     notificationsEnabled?: boolean;
     toolOutputAlerts?: Partial<DesktopToolOutputAlertPolicy>;
+    spendAlerts?: Partial<DesktopSpendAlertPolicy>;
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1,5 +1,9 @@
 import type { MessagingToolUpdateMode } from "./messaging";
 import type { FederationTarget } from "./federation";
+import {
+  TOOL_OUTPUT_WARNING_INVOCATIONS,
+  TOOL_OUTPUT_WARNING_PERCENT,
+} from "./tool-output-incidents";
 
 export const DESKTOP_CHAT_REPLY_COMPOSERS = [
   "tiptap-wysiwyg-markdown-chips",
@@ -155,18 +159,27 @@ export const DESKTOP_TEXT_SIZE_DEFAULT: DesktopTextSize = "md";
 export type DesktopToolOutputAlertPolicy = {
   outputCapHitsEnabled: boolean;
   repeatedLargeOutputsEnabled: boolean;
+  repeatedLargeOutputMinimumCalls: number;
+  repeatedLargeOutputMinimumPercent: number;
   repeatedQueuedChecksEnabled: boolean;
 };
+
+export const MIN_REPEATED_LARGE_OUTPUT_CALLS = 2;
+export const MAX_REPEATED_LARGE_OUTPUT_CALLS = 100;
+export const MIN_REPEATED_LARGE_OUTPUT_PERCENT = 1;
+export const MAX_REPEATED_LARGE_OUTPUT_PERCENT = 100;
 
 /**
  * Tool-output alerts stay on by default, but the large-output warning is
  * deliberately a repeated-pattern signal rather than a one-call tripwire.
- * The detector owns that threshold; these flags let operators choose which
- * classes of signal should interrupt them.
+ * Operators can independently select the qualifying output size and how many
+ * calls in one turn must reach it before the warning interrupts them.
  */
 export const DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT: DesktopToolOutputAlertPolicy = {
   outputCapHitsEnabled: true,
   repeatedLargeOutputsEnabled: true,
+  repeatedLargeOutputMinimumCalls: TOOL_OUTPUT_WARNING_INVOCATIONS,
+  repeatedLargeOutputMinimumPercent: TOOL_OUTPUT_WARNING_PERCENT,
   repeatedQueuedChecksEnabled: true,
 };
 
@@ -495,6 +508,8 @@ export type DesktopGeneralSettingsSnapshot = {
   toolOutputAlerts: {
     outputCapHitsEnabled: DesktopSettingsValue<boolean>;
     repeatedLargeOutputsEnabled: DesktopSettingsValue<boolean>;
+    repeatedLargeOutputMinimumCalls: DesktopSettingsValue<number>;
+    repeatedLargeOutputMinimumPercent: DesktopSettingsValue<number>;
     repeatedQueuedChecksEnabled: DesktopSettingsValue<boolean>;
   };
   appearance: DesktopAppearanceSnapshot;

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -26,10 +26,18 @@ export const TOOL_OUTPUT_TOKEN_CHAR_RATIO = 4;
 export const TOOL_OUTPUT_CAP_CHARS = 40_000;
 
 /** A large-output case starts at half of the observed model-visible cap. */
-export const TOOL_OUTPUT_WARNING_CHARS = TOOL_OUTPUT_CAP_CHARS / 2;
+export const TOOL_OUTPUT_WARNING_PERCENT = 50;
+export const TOOL_OUTPUT_WARNING_CHARS = toolOutputWarningChars(
+  TOOL_OUTPUT_WARNING_PERCENT,
+);
 
 /** Repeated large output becomes alert-worthy at this many calls in one turn. */
 export const TOOL_OUTPUT_WARNING_INVOCATIONS = 5;
+
+/** Translate an operator-facing percentage into the detector's character cap. */
+export function toolOutputWarningChars(percent: number): number {
+  return Math.ceil(TOOL_OUTPUT_CAP_CHARS * percent / 100);
+}
 
 /** Fraction of the observed output cap this invocation consumed. Uncapped. */
 export function toolOutputCapShare(outputChars: number): number {

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -59,8 +59,9 @@ export function toolOutputCapShare(outputChars: number): number {
  */
 export function isFlaggedToolInvocation(
   invocation: Pick<ThreadToolInvocationRecord, "noisy" | "outputChars">,
+  largeOutputThresholdChars = TOOL_OUTPUT_WARNING_CHARS,
 ): boolean {
-  return invocation.noisy || invocation.outputChars >= TOOL_OUTPUT_WARNING_CHARS;
+  return invocation.noisy || invocation.outputChars >= largeOutputThresholdChars;
 }
 
 /**

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -25,8 +25,11 @@ export const TOOL_OUTPUT_TOKEN_CHAR_RATIO = 4;
  */
 export const TOOL_OUTPUT_CAP_CHARS = 40_000;
 
-/** Output at or above this is large enough to be worth flagging on its own. */
-export const TOOL_OUTPUT_WARNING_CHARS = 4_000;
+/** A large-output case starts at half of the observed model-visible cap. */
+export const TOOL_OUTPUT_WARNING_CHARS = TOOL_OUTPUT_CAP_CHARS / 2;
+
+/** Repeated large output becomes alert-worthy at this many calls in one turn. */
+export const TOOL_OUTPUT_WARNING_INVOCATIONS = 5;
 
 /** Fraction of the observed output cap this invocation consumed. Uncapped. */
 export function toolOutputCapShare(outputChars: number): number {

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -125,6 +125,17 @@ export type ThreadPricingSummary = {
   usageLineCount: number;
 };
 
+export type ThreadSpendAlert = {
+  alertId: string;
+  createdAt: number;
+  currency: "USD";
+  kind: "active-turn-spend" | "thread-spend";
+  spendMicros: number;
+  threadId: string;
+  thresholdMicros: number;
+  turnId?: string;
+};
+
 export type TokenUsagePricingCatalogRate = {
   cachedInputMicrosPerMillion: number;
   cachedInputUsdPerMillion: number;


### PR DESCRIPTION
## What changed

- raises the default large-output case threshold from 10% to 50% of the observed model-visible cap
- waits for five qualifying tool calls in the same turn before surfacing the warning
- makes both values editable in Settings → Usage & Pricing → Alerts, with bounded calls-per-turn and percent-of-cap controls
- adds configurable estimated list-price alerts for active-turn spend (default $5.00) and total thread spend (default $25.00)
- keeps independent switches for cap hits, repeated large outputs, repeated queued checks, active-turn spend, and thread spend
- keeps a single cap hit as an immediate critical alert
- applies configured output-size thresholds to live streaming, replay analysis, incident summaries, and explorer filtering
- evaluates spend thresholds from the existing pricing snapshot, retains every distinct active turn in a coalesced pricing batch, emits each configured threshold once, and shows a durable warning linked to the affected thread

## Why

The previous 4,000-character threshold fired on routine skill reads, so the incident notice appeared on nearly every turn. The new 5-call / 50% defaults target repeated replay amplification while operators can tune them for their own workloads instead of accepting hard-coded values.

The same settings surface now covers monetary limits, so operators can choose both which usage patterns interrupt them and the amounts that constitute excessive spend.

## Impact

Existing profiles inherit all five triggers as enabled. Repeated-output alerts default to five calls at 50% of the model-visible cap. Spend alerts use estimated USD list price and default to $5.00 per active turn and $25.00 per thread; both amounts support cents and are bounded from $0.01 to $10,000.

Settings are stored under `[general.tool_output_alerts]` and `[general.spend_alerts]` and apply live after a settings write. Spend detection reuses the pricing update path: it adds no timer and no sqlite write.

Ordinary streamed output still measures 2 sqlite commits / 2 statements / 2 rows for the 500-delta budget scenario, down from 3 / 5 / 5 before this branch; the alert boundary remains one commit.

## Validation

- `pnpm test` — 570 files, 8,193 passed, 5 skipped
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `pnpm licenses:check`
- `git diff --check`

