### PR TITLE
fix(messaging): compact bursty tool updates

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -780,14 +780,23 @@ describe("AcpBackendAdapter", () => {
     transport.emitSessionUpdate(session.sessionId, {
       session_update: "tool_call_update",
       tool_call_id: "turn-1:tool-1",
-      title: "pnpm build",
       status: "completed",
       content: { type: "text", text: "Build succeeded" },
     });
 
-    expect(
-      events.filter((event) => event.notification.method === "item/completed"),
-    ).toHaveLength(1);
+    const completedToolEvents = events.filter(
+      (event) => event.notification.method === "item/completed",
+    );
+    expect(completedToolEvents).toHaveLength(1);
+    expect(completedToolEvents[0]).toMatchObject({
+      notification: {
+        params: {
+          item: {
+            command: "pnpm build",
+          },
+        },
+      },
+    });
 
     transport.emitSessionUpdate(session.sessionId, {
       sessionUpdate: "turn_completed",

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -225,6 +225,53 @@ describe("acpToolUpdateNotifications", () => {
     expect(resolver.drainDeferredTerminalUpdates(context)).toEqual([]);
   });
 
+  it("emits a rich Grok web-search terminal without waiting for turn completion", () => {
+    const resolver = new AcpLiveToolUpdateResolver();
+    const context = {
+      backendId: "acp:grok",
+      threadId: "session-1",
+      turnId: "turn-1",
+    };
+    const resolved = resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "ws_grok-search-1",
+        status: "completed",
+        title: "Web search:",
+        rawOutput: {
+          action: {
+            type: "search",
+            query: "Grok ACP tool completion",
+            sources: [
+              { type: "url", url: "https://docs.x.ai/developers" },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(resolved).toBeDefined();
+    expect(resolver.drainDeferredTerminalUpdates(context)).toEqual([]);
+    expect(acpToolUpdateNotifications({
+      threadId: context.threadId,
+      turnId: context.turnId,
+      update: resolved!,
+    })).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "ws_grok-search-1",
+            type: "webSearch",
+            status: "completed",
+            arguments: { query: "Grok ACP tool completion" },
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("keeps malformed ACP calls distinct when the provider omits an item id", () => {
     const resolver = new AcpLiveToolUpdateResolver();
     const context = {

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -84,7 +84,7 @@ describe("acpToolUpdateNotifications", () => {
     ]);
   });
 
-  it("does not resurrect an ACP tool when its start arrives after completion", () => {
+  it("enriches an ACP terminal tool when its start arrives late without resurrecting it", () => {
     const resolver = new AcpLiveToolUpdateResolver();
     const context = {
       backendId: "acp:grok",
@@ -99,17 +99,130 @@ describe("acpToolUpdateNotifications", () => {
         toolCallId: "out-of-order-1",
         status: "completed",
       },
-    })).toBeDefined();
-    expect(resolver.resolve({
+    })).toBeUndefined();
+    const enrichedTerminal = resolver.resolve({
       ...context,
       update: {
         sessionUpdate: "tool_call",
         toolCallId: "out-of-order-1",
         kind: "read",
         title: "Read config.toml",
+        rawInput: { path: "/repo/config.toml" },
         status: "in_progress",
       },
+    });
+    expect(enrichedTerminal).toMatchObject({
+      kind: "read",
+      status: "completed",
+      title: "Read config.toml",
+    });
+    expect(acpToolUpdateNotifications({
+      threadId: context.threadId,
+      turnId: context.turnId,
+      update: enrichedTerminal!,
+    })).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "out-of-order-1",
+            status: "completed",
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("keeps ACP terminal metadata and output for follow-up terminal updates", () => {
+    const resolver = new AcpLiveToolUpdateResolver();
+    const context = {
+      backendId: "acp:grok",
+      threadId: "session-1",
+      turnId: "turn-1",
+    };
+
+    expect(resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "grok-read-1",
+        kind: "read",
+        title: "Read config.toml",
+        rawInput: { path: "/repo/config.toml" },
+        status: "in_progress",
+      },
+    })).toBeDefined();
+    expect(resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "grok-read-1",
+        kind: "tool",
+        title: "tool",
+        status: "completed",
+      },
+    })).toMatchObject({
+      kind: "read",
+      title: "Read config.toml",
+      status: "completed",
+    });
+
+    const enrichedCompletion = resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "grok-read-1",
+        status: "completed",
+        content: { type: "text", text: "Read 42 lines" },
+      },
+    });
+    expect(enrichedCompletion).toMatchObject({
+      kind: "read",
+      title: "Read config.toml",
+      status: "completed",
+      content: { type: "text", text: "Read 42 lines" },
+    });
+    expect(acpToolUpdateNotifications({
+      threadId: context.threadId,
+      turnId: context.turnId,
+      update: enrichedCompletion!,
+    })).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            command: "Read config.toml",
+            data: { output: "Read 42 lines" },
+            status: "completed",
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("holds an uncorrelated sparse ACP terminal only until its turn completes", () => {
+    const resolver = new AcpLiveToolUpdateResolver();
+    const context = {
+      backendId: "acp:grok",
+      threadId: "session-1",
+      turnId: "turn-1",
+    };
+
+    expect(resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "sparse-terminal-1",
+        status: "Completed",
+      },
     })).toBeUndefined();
+    expect(resolver.drainDeferredTerminalUpdates(context)).toEqual([
+      expect.objectContaining({
+        toolCallId: "sparse-terminal-1",
+        status: "Completed",
+      }),
+    ]);
+    expect(resolver.drainDeferredTerminalUpdates(context)).toEqual([]);
   });
 
   it("keeps malformed ACP calls distinct when the provider omits an item id", () => {

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -1,10 +1,137 @@
 import { describe, expect, it } from "vitest";
 import {
+  AcpLiveToolUpdateResolver,
   acpToolUpdateNotifications,
   acpTurnCompletedUsageNotification,
 } from "../acp/acp-live-notifications";
 
 describe("acpToolUpdateNotifications", () => {
+  it("uses an explicit diagnostic when an ACP terminal update lacks tool metadata", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "sparse-tool-1",
+        status: "completed",
+      },
+    });
+
+    expect(notifications[0]).toMatchObject({
+      method: "item/completed",
+      params: {
+        item: {
+          command: "Tool details unavailable",
+          status: "completed",
+        },
+      },
+    });
+  });
+
+  it("retains a Grok-shaped call's metadata for its sparse terminal update", () => {
+    const resolver = new AcpLiveToolUpdateResolver();
+    const context = {
+      backendId: "acp:grok",
+      threadId: "session-1",
+      turnId: "turn-1",
+    };
+    const started = resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "call-grok-read-1",
+        kind: "read",
+        title: "read_file",
+        rawInput: { path: "/repo/docs/working-updates.md" },
+        status: "in_progress",
+      },
+    });
+    const completed = resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call-grok-read-1",
+        status: "Completed",
+      },
+    });
+
+    expect(started).toBeDefined();
+    expect(completed).toEqual(expect.objectContaining({
+      kind: "read",
+      status: "Completed",
+      title: "read_file",
+    }));
+    expect(acpToolUpdateNotifications({
+      threadId: context.threadId,
+      turnId: context.turnId,
+      update: completed!,
+    })).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            commandActions: [
+              {
+                type: "read",
+                path: "/repo/docs/working-updates.md",
+                name: "read_file",
+              },
+            ],
+            status: "completed",
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("does not resurrect an ACP tool when its start arrives after completion", () => {
+    const resolver = new AcpLiveToolUpdateResolver();
+    const context = {
+      backendId: "acp:grok",
+      threadId: "session-1",
+      turnId: "turn-1",
+    };
+
+    expect(resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "out-of-order-1",
+        status: "completed",
+      },
+    })).toBeDefined();
+    expect(resolver.resolve({
+      ...context,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "out-of-order-1",
+        kind: "read",
+        title: "Read config.toml",
+        status: "in_progress",
+      },
+    })).toBeUndefined();
+  });
+
+  it("keeps malformed ACP calls distinct when the provider omits an item id", () => {
+    const resolver = new AcpLiveToolUpdateResolver();
+    const context = {
+      backendId: "acp:grok",
+      threadId: "session-1",
+      turnId: "turn-1",
+    };
+    const first = resolver.resolve({
+      ...context,
+      update: { sessionUpdate: "tool_call_update", status: "completed" },
+    });
+    const second = resolver.resolve({
+      ...context,
+      update: { sessionUpdate: "tool_call_update", status: "completed" },
+    });
+
+    expect(first?.itemId).toBe("pwragent:anonymous-acp-tool:1");
+    expect(second?.itemId).toBe("pwragent:anonymous-acp-tool:2");
+  });
+
   it("maps ACP tool calls to live item notifications", () => {
     const notifications = acpToolUpdateNotifications({
       threadId: "session-1",

--- a/apps/desktop/src/main/__tests__/messaging-tool-activity.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-activity.test.ts
@@ -187,6 +187,18 @@ describe("messaging tool activity", () => {
     expect(activity?.title).toBe("Read file");
   });
 
+  it("replaces generic provider placeholders with an explicit diagnostic", () => {
+    const activity = summarizeToolActivityFromBackendEvent(
+      buildCompletedItem({
+        id: "sparse-tool-1",
+        type: "commandExecution",
+        command: "tool",
+      }),
+    );
+
+    expect(formatToolActivityLine(activity!)).toBe("Tool details unavailable");
+  });
+
   it("redacts token-like web search query fragments from titles", () => {
     const directQuery = summarizeToolActivityFromBackendEvent(
       buildCompletedItem({

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-policy.test.ts
@@ -62,6 +62,35 @@ describe("MessagingToolUpdatePolicy", () => {
     ]);
   });
 
+  it("sends one timely noisy batch, then retains later work for the terminal flush", () => {
+    const timers: Array<() => void> = [];
+    const onBatchReady = vi.fn();
+    const policy = new MessagingToolUpdatePolicy({
+      now: () => 1000,
+      onBatchReady,
+      setTimer: (callback) => {
+        timers.push(callback);
+        return setTimeout(() => undefined, 1);
+      },
+    });
+
+    processTitles(policy, "show_less", ["first"]);
+    timers.shift()?.();
+    expect(onBatchReady).toHaveBeenCalledWith(expect.objectContaining({
+      activities: [expect.objectContaining({ title: "first" })],
+      kind: "batch",
+    }));
+
+    processTitles(policy, "show_less", ["second"]);
+    expect(timers).toEqual([]);
+    expect(policy.flush()).toEqual([
+      expect.objectContaining({
+        activities: [expect.objectContaining({ title: "second" })],
+        kind: "batch",
+      }),
+    ]);
+  });
+
   it("delivers every Show All update immediately", () => {
     const policy = new MessagingToolUpdatePolicy({ now: () => 1000 });
 

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
@@ -64,6 +64,45 @@ describe("tool-update renderer prose handling", () => {
     );
   });
 
+  it("groups repeated tool activity into compact named counts", () => {
+    const intent = buildToolUpdateBatchMessageIntent({
+      activities: [
+        tool("t1", "Read config.toml"),
+        tool("t2", "Read config.toml"),
+        tool("t3", "Searched messaging"),
+        tool("t4", "Read config.toml"),
+      ],
+      bindingId: "b1",
+      createdAt: 1,
+      id: "compact-burst",
+    });
+
+    const part = intent.parts[0];
+    expect("text" in part ? part.text : "").toBe(
+      "Tool updates: ran 4 tools\n- 3 × Read config.toml\n- Searched messaging",
+    );
+  });
+
+  it("bounds heterogeneous bursts and calls out sparse provider metadata", () => {
+    const intent = buildToolUpdateBatchMessageIntent({
+      activities: [
+        tool("t1", "tool"),
+        ...["one", "two", "three", "four", "five", "six"].map((title, index) =>
+          tool(`t${index + 2}`, title)
+        ),
+      ],
+      bindingId: "b1",
+      createdAt: 1,
+      id: "heterogeneous-burst",
+    });
+
+    const part = intent.parts[0];
+    const text = "text" in part ? part.text : "";
+    expect(text).toContain("Tool details unavailable");
+    expect(text).toContain("- 2 other tool updates");
+    expect(text).not.toContain("\n- tool");
+  });
+
   it("renders a mixed prose+tool batch as assistant with prose above the tool summary", () => {
     const intent = buildToolUpdateBatchMessageIntent({
       activities: [

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -1,4 +1,7 @@
-import type { AppServerNotification } from "@pwragent/shared";
+import {
+  TOOL_DETAILS_UNAVAILABLE_LABEL,
+  type AppServerNotification,
+} from "@pwragent/shared";
 import { readAcpContentText, readAcpTopicTitle } from "./acp-session-normalizer";
 import {
   isGenericShellToolTitle,
@@ -16,6 +19,106 @@ import {
   type AcpTokenUsage,
   type AcpUsageEnvelope,
 } from "./acp-usage.js";
+
+/**
+ * ACP frequently sends the useful title/input in `tool_call`, then reports
+ * completion as a sparse `tool_call_update` containing only the id and status.
+ * Keep that provider-shaped lifecycle at the ACP boundary so every downstream
+ * consumer receives one normalized item with the best metadata seen so far.
+ *
+ * This is presentation state only. Raw ACP updates still go to the replay
+ * normalizer/rollout store unchanged, which keeps the transcript inspectable.
+ */
+export class AcpLiveToolUpdateResolver {
+  private readonly activeUpdates = new Map<string, Record<string, unknown>>();
+  private anonymousToolSequence = 0;
+  private readonly terminalUpdateKeys = new Set<string>();
+
+  resolve(params: {
+    backendId: string;
+    threadId: string;
+    turnId?: string;
+    update: Record<string, unknown>;
+  }): Record<string, unknown> | undefined {
+    const kind = readKind(params.update);
+    if (kind !== "tool_call" && kind !== "tool_call_update") {
+      return params.update;
+    }
+
+    const toolCallId = readAcpToolCallId(params.update);
+    if (!toolCallId) {
+      // A provider omitted the only stable lifecycle key. Preserve each live
+      // observation rather than collapsing different malformed calls onto the
+      // same "tool" row; the durable raw update remains the inspectable source
+      // of truth after this process exits.
+      this.anonymousToolSequence += 1;
+      return {
+        ...params.update,
+        itemId: `pwragent:anonymous-acp-tool:${this.anonymousToolSequence}`,
+      };
+    }
+
+    const key = [
+      params.backendId,
+      params.threadId,
+      params.turnId ?? "no-turn",
+      toolCallId,
+    ].join("\0");
+    if (this.terminalUpdateKeys.has(key)) {
+      // Terminal events win over a delayed start. We still retain the raw
+      // update, but never resurrect a completed tool as an in-progress row.
+      return undefined;
+    }
+
+    const resolved = mergeAcpLiveToolUpdates(
+      this.activeUpdates.get(key),
+      params.update,
+    );
+    if (isTerminalToolStatus(resolved.status)) {
+      this.activeUpdates.delete(key);
+      this.rememberTerminalUpdateKey(key);
+    } else {
+      this.activeUpdates.set(key, resolved);
+    }
+    return resolved;
+  }
+
+  clearTurn(params: {
+    backendId: string;
+    threadId: string;
+    turnId: string;
+  }): void {
+    const prefix = [params.backendId, params.threadId, params.turnId].join("\0");
+    for (const key of this.activeUpdates.keys()) {
+      if (key.startsWith(`${prefix}\0`)) {
+        this.activeUpdates.delete(key);
+      }
+    }
+    for (const key of this.terminalUpdateKeys) {
+      if (key.startsWith(`${prefix}\0`)) {
+        this.terminalUpdateKeys.delete(key);
+      }
+    }
+  }
+
+  clear(): void {
+    this.activeUpdates.clear();
+    this.terminalUpdateKeys.clear();
+  }
+
+  private rememberTerminalUpdateKey(key: string): void {
+    this.terminalUpdateKeys.add(key);
+    // A terminal event normally clears at turn completion. Keep a bounded
+    // tombstone set as a defensive fallback for a provider that omits it.
+    while (this.terminalUpdateKeys.size > 512) {
+      const oldest = this.terminalUpdateKeys.values().next().value;
+      if (oldest === undefined) {
+        return;
+      }
+      this.terminalUpdateKeys.delete(oldest);
+    }
+  }
+}
 
 export function acpToolUpdateNotifications(params: {
   threadId: string;
@@ -136,12 +239,14 @@ function liveItemForAcpToolUpdate(
     readString(update, "command") ??
     readString(update, "name") ??
     readFirstLocationPath(update) ??
-    toolKind;
+    (isGenericAcpToolKind(toolKind)
+      ? TOOL_DETAILS_UNAVAILABLE_LABEL
+      : toolKind);
   if (!id && !title) {
     return undefined;
   }
 
-  const path = readString(update, "path") ?? readFirstLocationPath(update);
+  const path = readAcpToolPath(update);
   const status = normalizeAcpToolStatus(readString(update, "status"));
   const output = readAcpToolOutput(update);
   const webSearch = readAcpWebSearch(update);
@@ -228,12 +333,17 @@ function acpCommandActions(params: {
 }
 
 function normalizeAcpToolStatus(status: string | undefined): string {
-  return status === "completed" ||
-    status === "failed" ||
-    status === "cancelled" ||
-    status === "in_progress"
-    ? status
+  const normalized = status?.toLowerCase();
+  return normalized === "completed" ||
+    normalized === "failed" ||
+    normalized === "cancelled" ||
+    normalized === "in_progress"
+    ? normalized
     : "in_progress";
+}
+
+function isGenericAcpToolKind(value: string): boolean {
+  return /^(?:other|tool|unknown)$/i.test(value.trim());
 }
 
 function isTerminalToolStatus(status: unknown): boolean {
@@ -261,12 +371,63 @@ function readKind(update: Record<string, unknown>): string {
   );
 }
 
+function readAcpToolCallId(
+  update: Record<string, unknown>,
+): string | undefined {
+  return (
+    readString(update, "toolCallId") ??
+    readString(update, "tool_call_id") ??
+    readString(update, "id") ??
+    readString(update, "itemId") ??
+    readString(update, "item_id")
+  );
+}
+
+function readAcpToolPath(
+  update: Record<string, unknown>,
+): string | undefined {
+  const rawInput = readRecord(update.rawInput);
+  return (
+    readString(update, "path") ??
+    readString(rawInput ?? {}, "path") ??
+    readString(rawInput ?? {}, "file") ??
+    readString(rawInput ?? {}, "filePath") ??
+    readString(rawInput ?? {}, "file_path") ??
+    readFirstLocationPath(update)
+  );
+}
+
+function mergeAcpLiveToolUpdates(
+  previous: Record<string, unknown> | undefined,
+  update: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!previous) {
+    return update;
+  }
+
+  const merged = { ...previous, ...update };
+  for (const key of ["_meta", "rawInput", "rawOutput"] as const) {
+    const previousRecord = readRecord(previous[key]);
+    const updateRecord = readRecord(update[key]);
+    if (previousRecord && updateRecord) {
+      merged[key] = { ...previousRecord, ...updateRecord };
+    }
+  }
+  return merged;
+}
+
 function readString(
   record: Record<string, unknown>,
   key: string,
 ): string | undefined {
   const value = record[key];
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }
 
 function readFirstLocationPath(record: Record<string, unknown>): string | undefined {

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -397,6 +397,9 @@ function isTerminalToolStatus(status: unknown): boolean {
 
 function hasMeaningfulAcpToolMetadata(update: Record<string, unknown>): boolean {
   const item = liveItemForAcpToolUpdate(update);
+  if (readString(item ?? {}, "type") === "webSearch") {
+    return true;
+  }
   const command = item ? readString(item, "command") : undefined;
   return Boolean(command && !isGenericAcpToolMetadata(command));
 }

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -32,7 +32,8 @@ import {
 export class AcpLiveToolUpdateResolver {
   private readonly activeUpdates = new Map<string, Record<string, unknown>>();
   private anonymousToolSequence = 0;
-  private readonly terminalUpdateKeys = new Set<string>();
+  private readonly deferredTerminalUpdateKeys = new Set<string>();
+  private readonly terminalUpdates = new Map<string, Record<string, unknown>>();
 
   resolve(params: {
     backendId: string;
@@ -64,23 +65,57 @@ export class AcpLiveToolUpdateResolver {
       params.turnId ?? "no-turn",
       toolCallId,
     ].join("\0");
-    if (this.terminalUpdateKeys.has(key)) {
-      // Terminal events win over a delayed start. We still retain the raw
-      // update, but never resurrect a completed tool as an in-progress row.
-      return undefined;
-    }
-
+    const terminal = this.terminalUpdates.get(key);
     const resolved = mergeAcpLiveToolUpdates(
-      this.activeUpdates.get(key),
+      this.activeUpdates.get(key) ?? terminal,
       params.update,
     );
+    if (terminal) {
+      // Once the provider has made a call terminal, a delayed start can still
+      // enrich its title/input, but must never turn the existing row back into
+      // an in-progress operation.
+      resolved.status = normalizeAcpToolStatus(readString(terminal, "status"));
+    }
     if (isTerminalToolStatus(resolved.status)) {
       this.activeUpdates.delete(key);
-      this.rememberTerminalUpdateKey(key);
+      this.rememberTerminalUpdate(key, resolved);
+
+      const isMeaningful = hasMeaningfulAcpToolMetadata(resolved);
+      if (!terminal && !isMeaningful) {
+        // A sparse terminal can arrive before its rich `tool_call`. Hold the
+        // generic completion until that call arrives or the turn ends, rather
+        // than sending a generic update that delivery dedupe cannot correct.
+        this.deferredTerminalUpdateKeys.add(key);
+        return undefined;
+      }
+      if (this.deferredTerminalUpdateKeys.has(key) && !isMeaningful) {
+        return undefined;
+      }
+      this.deferredTerminalUpdateKeys.delete(key);
     } else {
       this.activeUpdates.set(key, resolved);
     }
     return resolved;
+  }
+
+  drainDeferredTerminalUpdates(params: {
+    backendId: string;
+    threadId: string;
+    turnId: string;
+  }): Record<string, unknown>[] {
+    const prefix = [params.backendId, params.threadId, params.turnId].join("\0");
+    const updates: Record<string, unknown>[] = [];
+    for (const key of this.deferredTerminalUpdateKeys) {
+      if (!key.startsWith(`${prefix}\0`)) {
+        continue;
+      }
+      const update = this.terminalUpdates.get(key);
+      if (update) {
+        updates.push(update);
+      }
+      this.deferredTerminalUpdateKeys.delete(key);
+    }
+    return updates;
   }
 
   clearTurn(params: {
@@ -94,28 +129,36 @@ export class AcpLiveToolUpdateResolver {
         this.activeUpdates.delete(key);
       }
     }
-    for (const key of this.terminalUpdateKeys) {
+    for (const key of this.deferredTerminalUpdateKeys) {
       if (key.startsWith(`${prefix}\0`)) {
-        this.terminalUpdateKeys.delete(key);
+        this.deferredTerminalUpdateKeys.delete(key);
+      }
+    }
+    for (const key of this.terminalUpdates.keys()) {
+      if (key.startsWith(`${prefix}\0`)) {
+        this.terminalUpdates.delete(key);
       }
     }
   }
 
   clear(): void {
     this.activeUpdates.clear();
-    this.terminalUpdateKeys.clear();
+    this.deferredTerminalUpdateKeys.clear();
+    this.terminalUpdates.clear();
   }
 
-  private rememberTerminalUpdateKey(key: string): void {
-    this.terminalUpdateKeys.add(key);
+  private rememberTerminalUpdate(key: string, update: Record<string, unknown>): void {
+    this.terminalUpdates.delete(key);
+    this.terminalUpdates.set(key, update);
     // A terminal event normally clears at turn completion. Keep a bounded
-    // tombstone set as a defensive fallback for a provider that omits it.
-    while (this.terminalUpdateKeys.size > 512) {
-      const oldest = this.terminalUpdateKeys.values().next().value;
-      if (oldest === undefined) {
+    // cache as a defensive fallback for a provider that omits it.
+    while (this.terminalUpdates.size > 512) {
+      const oldest = this.terminalUpdates.keys().next().value;
+      if (typeof oldest !== "string") {
         return;
       }
-      this.terminalUpdateKeys.delete(oldest);
+      this.terminalUpdates.delete(oldest);
+      this.deferredTerminalUpdateKeys.delete(oldest);
     }
   }
 }
@@ -347,7 +390,21 @@ function isGenericAcpToolKind(value: string): boolean {
 }
 
 function isTerminalToolStatus(status: unknown): boolean {
-  return status === "completed" || status === "failed" || status === "cancelled";
+  return typeof status === "string" && ["completed", "failed", "cancelled"].includes(
+    status.toLowerCase(),
+  );
+}
+
+function hasMeaningfulAcpToolMetadata(update: Record<string, unknown>): boolean {
+  const item = liveItemForAcpToolUpdate(update);
+  const command = item ? readString(item, "command") : undefined;
+  return Boolean(command && !isGenericAcpToolMetadata(command));
+}
+
+function isGenericAcpToolMetadata(value: string): boolean {
+  return /^(?:tool|tool call|tool_call|tool call update|tool_call_update|unknown|other|tool details unavailable)$/i.test(
+    value.trim(),
+  );
 }
 
 function readAcpToolOutput(record: Record<string, unknown>): string | undefined {
@@ -406,6 +463,19 @@ function mergeAcpLiveToolUpdates(
   }
 
   const merged = { ...previous, ...update };
+  for (const key of ["kind", "title", "name", "command"] as const) {
+    const previousValue = readString(previous, key);
+    const updateValue = readString(update, key);
+    if (
+      previousValue
+      && (!updateValue
+        || (key === "kind"
+          ? isGenericAcpToolKind(updateValue)
+          : isGenericAcpToolMetadata(updateValue)))
+    ) {
+      merged[key] = previousValue;
+    }
+  }
   for (const key of ["_meta", "rawInput", "rawOutput"] as const) {
     const previousRecord = readRecord(previous[key]);
     const updateRecord = readRecord(update[key]);

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -2204,6 +2204,25 @@ export class AcpBackendAdapter {
               this.shouldEmitLiveToolNotification(agent.backendId, notification),
             )
           : [];
+        const deferredTerminalToolNotifications =
+          updateKind === "turn_finished" && turnId && !fromSessionLoad
+            ? this.liveToolUpdateResolver
+                .drainDeferredTerminalUpdates({
+                  backendId: agent.backendId,
+                  threadId: sessionId,
+                  turnId,
+                })
+                .flatMap((deferredUpdate) =>
+                  acpToolUpdateNotifications({
+                    threadId: sessionId,
+                    turnId,
+                    update: deferredUpdate,
+                  }),
+                )
+                .filter((notification) =>
+                  this.shouldEmitLiveToolNotification(agent.backendId, notification),
+                )
+            : [];
         if (title) {
           await this.emit({
             backend: agent.backendId,
@@ -2291,7 +2310,10 @@ export class AcpBackendAdapter {
             });
           }
         }
-        for (const notification of toolNotifications) {
+        for (const notification of [
+          ...toolNotifications,
+          ...deferredTerminalToolNotifications,
+        ]) {
           await this.emit({
             backend: agent.backendId,
             notification,

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -53,6 +53,7 @@ import {
   readDesktopSettingsConfigSafe,
 } from "../settings/desktop-config";
 import {
+  AcpLiveToolUpdateResolver,
   acpToolUpdateNotifications,
   acpUsageNotification,
 } from "../acp/acp-live-notifications";
@@ -961,6 +962,7 @@ export class AcpBackendAdapter {
     AcpBackendId,
     Promise<AcpRuntimeClient>
   >();
+  private readonly liveToolUpdateResolver = new AcpLiveToolUpdateResolver();
   private readonly liveNotificationFingerprints = new Map<string, string>();
   private readonly providerStatuses = new Map<AcpBackendId, AcpProviderStatus>();
   private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
@@ -1942,6 +1944,7 @@ export class AcpBackendAdapter {
     this.acpClients.clear();
     this.retainedAcpClients.clear();
     this.acpClientResolutions.clear();
+    this.liveToolUpdateResolver.clear();
     this.liveNotificationFingerprints.clear();
     this.providerStatuses.clear();
     this.providerStatusRefreshAttempts.clear();
@@ -2184,15 +2187,23 @@ export class AcpBackendAdapter {
           updateKind === "agent_message_chunk"
             ? readAcpUpdateText(update)
             : undefined;
-        const toolNotifications = fromSessionLoad
-          ? []
-          : acpToolUpdateNotifications({
+        const resolvedToolUpdate = fromSessionLoad
+          ? undefined
+          : this.liveToolUpdateResolver.resolve({
+              backendId: agent.backendId,
               threadId: sessionId,
               turnId,
               update,
+            });
+        const toolNotifications = resolvedToolUpdate
+          ? acpToolUpdateNotifications({
+              threadId: sessionId,
+              turnId,
+              update: resolvedToolUpdate,
             }).filter((notification) =>
               this.shouldEmitLiveToolNotification(agent.backendId, notification),
-            );
+            )
+          : [];
         if (title) {
           await this.emit({
             backend: agent.backendId,
@@ -2301,6 +2312,11 @@ export class AcpBackendAdapter {
             threadId: sessionId,
             turnId,
           });
+          this.liveToolUpdateResolver.clearTurn({
+            backendId: agent.backendId,
+            threadId: sessionId,
+            turnId,
+          });
           const outputText = readAcpUpdateText(update);
           await this.emit({
             backend: agent.backendId,
@@ -2336,6 +2352,11 @@ export class AcpBackendAdapter {
         this.liveTurnUsage.delete(
           [agent.backendId, sessionId, turnId].join(":"),
         );
+        this.liveToolUpdateResolver.clearTurn({
+          backendId: agent.backendId,
+          threadId: sessionId,
+          turnId,
+        });
         await this.emit({
           backend: agent.backendId,
           notification: {

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -2,6 +2,7 @@ import type {
   AppServerToolRequestUserInputNotification,
   NavigationSnapshot,
 } from "@pwragent/shared";
+import { coalesceToolActivityBurst } from "@pwragent/shared";
 import type {
   MessagingActivityIntent,
   MessagingConfirmationIntent,
@@ -147,10 +148,26 @@ export function buildToolUpdateBatchMessageIntent(params: {
   const segments: string[] = proseActivities.map((activity) => activity.title);
   if (toolActivities.length > 0) {
     const count = toolActivities.length;
+    const groupedActivities = coalesceToolActivityBurst(
+      toolActivities.map((activity) => ({
+        activity,
+        label: formatToolActivityLine(activity),
+        status: activity.status,
+      })),
+    );
+    const visibleGroups = groupedActivities.slice(0, 5);
+    const omittedToolCount = groupedActivities
+      .slice(5)
+      .reduce((total, group) => total + group.count, 0);
     segments.push(
       [
         `Tool updates: ran ${count} tool${count === 1 ? "" : "s"}`,
-        ...toolActivities.map((activity) => `- ${formatToolActivityLine(activity)}`),
+        ...visibleGroups.map((group) =>
+          `- ${group.count === 1 ? group.label : `${group.count} × ${group.label}`}`
+        ),
+        ...(omittedToolCount > 0
+          ? [`- ${omittedToolCount} other tool update${omittedToolCount === 1 ? "" : "s"}`]
+          : []),
       ].join("\n"),
     );
   }

--- a/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import {
   formatSearchCommandActionLabel,
+  normalizeToolActivityBurstLabel,
   type AgentEvent,
 } from "@pwragent/shared";
 import {
@@ -110,10 +111,10 @@ export function summarizeToolActivityFromBackendEvent(
 export function formatToolActivityLine(activity: MessagingToolActivity): string {
   return [
     activity.status === "failed"
-      ? `Failed: ${activity.title}`
+      ? `Failed: ${normalizeToolActivityBurstLabel(activity.title)}`
       : activity.status === "cancelled"
-        ? `Cancelled: ${activity.title}`
-        : activity.title,
+        ? `Cancelled: ${normalizeToolActivityBurstLabel(activity.title)}`
+        : normalizeToolActivityBurstLabel(activity.title),
     activity.durationMs !== undefined
       ? ` (${formatToolActivityDuration(activity.durationMs)})`
       : "",

--- a/apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts
@@ -10,6 +10,7 @@ export type MessagingToolUpdatePolicyDelivery = {
 };
 
 type PolicyState = {
+  batchDeliveryCount: number;
   bindingId: string;
   individualCount: number;
   mode: MessagingToolUpdateMode;
@@ -176,6 +177,7 @@ export class MessagingToolUpdatePolicy {
     let state = this.states.get(key);
     if (!state) {
       state = {
+        batchDeliveryCount: 0,
         bindingId: params.bindingId,
         individualCount: 0,
         mode: params.mode,
@@ -205,7 +207,13 @@ export class MessagingToolUpdatePolicy {
   }
 
   private scheduleFlush(state: PolicyState, policy: ModePolicy): void {
-    if (!policy.windowMs || state.timer) {
+    // The delivery window is a progress signal, not a periodic transcript
+    // mirror. Once a noisy turn has received one timely batch, retain later
+    // activity for the terminal flush. This keeps long-running ACP/Codex
+    // bursts from producing a fresh card or message every window while still
+    // honoring Show All's explicit per-event behavior and preserving the full
+    // trace in the desktop transcript.
+    if (!policy.windowMs || state.timer || state.batchDeliveryCount > 0) {
       return;
     }
 
@@ -244,6 +252,8 @@ export class MessagingToolUpdatePolicy {
     if (activities.length === 0) {
       return undefined;
     }
+
+    state.batchDeliveryCount += 1;
 
     return {
       activities,

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -52,6 +52,7 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
           className="transcript-work-phase-group__toggle"
           aria-controls={hiddenRegionId}
           aria-expanded={props.expanded}
+          aria-label={workPhaseGroupToggleLabel(props.label)}
           onClick={props.onToggle}
         >
           <span className="transcript-work-phase-group__chevron" aria-hidden="true" />
@@ -95,6 +96,13 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
 });
 
 TranscriptWorkPhaseGroup.displayName = "TranscriptWorkPhaseGroup";
+
+function workPhaseGroupToggleLabel(label: string): string {
+  // The visible work summary can include individual tool labels. Keeping those
+  // out of the parent disclosure's accessible name prevents it from colliding
+  // with the nested activity controls when the group is expanded.
+  return label.split(":", 1)[0] ?? label;
+}
 
 function TranscriptWorkPhaseGroupLabel(props: {
   activeStartedAt?: number;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx
@@ -51,6 +51,24 @@ describe("transcript disclosure chevron placement", () => {
     expect((toggle as HTMLElement).textContent).toContain("3 previous messages");
   });
 
+  it("keeps individual tool labels out of a work group toggle's accessible name", () => {
+    render(
+      <TranscriptWorkPhaseGroup
+        collapsible
+        expanded={false}
+        label="Worked for 8m 44s · 2 tool updates: Explored 1 item, Searched docs"
+        entries={[]}
+        skills={[]}
+        onToggle={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", {
+      name: "Worked for 8m 44s · 2 tool updates",
+    })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Explored 1 item/i })).toBeNull();
+  });
+
   it("does not repeat a single tool label before its command output", () => {
     render(
       <TranscriptActivity

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -75,6 +75,30 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
+  it("labels a dense collapsed work phase with compact tool groups", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const activities: AppServerThreadActivityEntry[] = [
+      "Read config.toml",
+      "Read config.toml",
+      "Searched messaging",
+    ].map((summary, index) => ({
+      type: "activity",
+      id: `tool-${index}`,
+      summary,
+      details: [],
+      turn,
+    }));
+
+    expect(buildTranscriptRenderItems({ entries: activities })).toEqual([
+      expect.objectContaining({
+        type: "workPhaseGroup",
+        entries: activities,
+        label:
+          "Worked for 1m 10s · 3 tool updates: 2 × Read config.toml, Searched messaging",
+      }),
+    ]);
+  });
+
   it("uses completed turn metadata when live entries have mixed turn status", () => {
     const inProgressTurn = {
       id: "turn-1",

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -5,6 +5,7 @@ import type {
   AppServerThreadPlanEntry,
   AppServerThreadTurnMetadata,
 } from "@pwragent/shared";
+import { coalesceToolActivityBurst } from "@pwragent/shared";
 
 export type TranscriptRenderItem =
   | {
@@ -175,7 +176,7 @@ function buildCompletedGroups(
       label: hasWork
         ? repeatedWorkTurn
           ? "More work"
-          : workGroupLabel(turn)
+          : workGroupLabel(turn, currentEntries)
         : previousMessagesLabel(currentEntries.filter(isAssistantCommentaryMessage).length),
     });
     if (hasWork) {
@@ -399,20 +400,47 @@ function readCompletedTurn(
     );
 }
 
-function workGroupLabel(turn: AppServerThreadTurnMetadata): string {
-  if (typeof turn.durationMs === "number" && turn.durationMs > 60_000) {
-    return `Worked for ${formatElapsedMs(turn.durationMs)}`;
+function workGroupLabel(
+  turn: AppServerThreadTurnMetadata,
+  entries: AppServerThreadEntry[],
+): string {
+  const base = typeof turn.durationMs === "number" && turn.durationMs > 60_000
+    ? `Worked for ${formatElapsedMs(turn.durationMs)}`
+    : typeof turn.startedAt === "number"
+      && typeof turn.completedAt === "number"
+      && turn.completedAt > turn.startedAt + 60_000
+      ? `Worked for ${formatElapsedMs(turn.completedAt - turn.startedAt)}`
+      : "Previous work";
+  const toolEntries = entries.filter(
+    (entry): entry is AppServerThreadActivityEntry => entry.type === "activity",
+  );
+  if (toolEntries.length < 2) {
+    return base;
   }
 
-  if (
-    typeof turn.startedAt === "number" &&
-    typeof turn.completedAt === "number" &&
-    turn.completedAt > turn.startedAt + 60_000
-  ) {
-    return `Worked for ${formatElapsedMs(turn.completedAt - turn.startedAt)}`;
-  }
-
-  return "Previous work";
+  const groups = coalesceToolActivityBurst(
+    toolEntries.map((entry) => ({
+      entry,
+      label: entry.summary,
+      status: entry.status,
+    })),
+  );
+  const visibleGroups = groups.slice(0, 3);
+  const omittedToolCount = groups
+    .slice(3)
+    .reduce((total, group) => total + group.count, 0);
+  const summary = visibleGroups
+    .map((group) =>
+      group.count === 1 ? group.label : `${group.count} × ${group.label}`
+    )
+    .join(", ");
+  return `${base} · ${toolEntries.length} tool update${
+    toolEntries.length === 1 ? "" : "s"
+  }: ${summary}${
+    omittedToolCount > 0
+      ? `, ${omittedToolCount} other tool update${omittedToolCount === 1 ? "" : "s"}`
+      : ""
+  }`;
 }
 
 function previousMessagesLabel(count: number): string {

--- a/packages/shared/src/__tests__/tool-activity-burst.test.ts
+++ b/packages/shared/src/__tests__/tool-activity-burst.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  coalesceToolActivityBurst,
+  TOOL_DETAILS_UNAVAILABLE_LABEL,
+} from "../tool-activity-burst";
+
+describe("coalesceToolActivityBurst", () => {
+  it("groups repeated labels without losing the original items", () => {
+    const items = [
+      { id: "one", label: "Read config.toml", status: "completed" },
+      { id: "two", label: "Read config.toml", status: "completed" },
+      { id: "three", label: "Searched messaging", status: "completed" },
+    ];
+
+    expect(coalesceToolActivityBurst(items)).toEqual([
+      { count: 2, items: items.slice(0, 2), label: "Read config.toml" },
+      { count: 1, items: [items[2]], label: "Searched messaging" },
+    ]);
+  });
+
+  it("keeps failed retries separate from successful calls", () => {
+    const groups = coalesceToolActivityBurst([
+      { label: "Ran focused tests", status: "completed" },
+      { label: "Ran focused tests", status: "failed" },
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.items[0]?.status)).toEqual([
+      "completed",
+      "failed",
+    ]);
+  });
+
+  it("replaces sparse provider placeholders with an explicit diagnostic", () => {
+    expect(coalesceToolActivityBurst([
+      { label: "tool", status: "completed" },
+      { label: "", status: "completed" },
+    ])).toEqual([
+      {
+        count: 2,
+        items: [
+          { label: "tool", status: "completed" },
+          { label: "", status: "completed" },
+        ],
+        label: TOOL_DETAILS_UNAVAILABLE_LABEL,
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -48,5 +48,6 @@ export * from "./thread-jump-match";
 export * from "./thread-pins";
 export * from "./thread-terminal";
 export * from "./thread-titles";
+export * from "./tool-activity-burst";
 export * from "./token-usage-pricing";
 export * from "./worktree-paths";

--- a/packages/shared/src/tool-activity-burst.ts
+++ b/packages/shared/src/tool-activity-burst.ts
@@ -1,0 +1,56 @@
+/**
+ * Compact a burst of otherwise-lossless tool activities for a summary surface.
+ *
+ * Callers retain and render `items` when the operator expands the surrounding
+ * transcript section. This helper only determines the compact label and count
+ * shown before that expansion, so it deliberately never drops an item.
+ */
+export type ToolActivityBurstItem = {
+  label: string;
+  status?: string;
+};
+
+export type ToolActivityBurstGroup<T extends ToolActivityBurstItem> = {
+  count: number;
+  items: T[];
+  label: string;
+};
+
+const UNINFORMATIVE_TOOL_ACTIVITY_LABELS = new Set([
+  "command",
+  "ran command",
+  "tool",
+  "unknown",
+  "used tool",
+]);
+
+export const TOOL_DETAILS_UNAVAILABLE_LABEL = "Tool details unavailable";
+
+export function normalizeToolActivityBurstLabel(label: string | undefined): string {
+  const normalized = label?.replace(/\s+/g, " ").trim() ?? "";
+  return !normalized
+    || UNINFORMATIVE_TOOL_ACTIVITY_LABELS.has(normalized.toLowerCase())
+    ? TOOL_DETAILS_UNAVAILABLE_LABEL
+    : normalized;
+}
+
+export function coalesceToolActivityBurst<T extends ToolActivityBurstItem>(
+  items: readonly T[],
+): ToolActivityBurstGroup<T>[] {
+  const groups = new Map<string, ToolActivityBurstGroup<T>>();
+  for (const item of items) {
+    const label = normalizeToolActivityBurstLabel(item.label);
+    // A failed retry is semantically distinct from a successful invocation of
+    // the same tool. Keeping statuses separate prevents a concise summary from
+    // disguising failures or cancellation.
+    const key = `${item.status ?? ""}\0${label}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.items.push(item);
+      continue;
+    }
+    groups.set(key, { count: 1, items: [item], label });
+  }
+  return [...groups.values()];
+}


### PR DESCRIPTION
## Summary
- Preserve ACP tool-call identity through sparse terminal updates, including Grok-shaped notifications.
- Keep terminal tool state attached to its original call ID: later terminal output and late metadata can enrich it without reviving it as in-progress.
- Defer a truly uncorrelated sparse terminal until its turn completes, so messaging never dedupes an unfixable generic `tool` card ahead of a rich call.
- Coalesce repeated tool activity into named count summaries for messaging and compact completed work-phase labels in the desktop transcript.
- Limit each noisy working-update interval to one timed batch, then include later activity in the terminal summary; Show all remains per-event.

## Root cause
Coalescing already happened in PwrAgent at the messaging delivery boundary, not upstream in Codex. ACP normalization had two gaps: sparse completion notifications lost earlier tool metadata, and a tombstone dropped later terminal detail or a late rich start after the first terminal state.

## User-visible behavior
A burst can now read `Tool updates: ran 13 tools` followed by `- 12 × Read config.toml` and `- Searched messaging`, rather than many `- tool` lines. A late Grok `tool_call` now completes the same tool row instead of creating a generic or resurrected in-progress row. The desktop completed work-phase disclosure retains every individual activity and detail when expanded.

## Validation
- Focused ACP lifecycle, Codex-shaped messaging, policy, renderer, and transcript tests (138 passing)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 35 pre-existing warnings)
- `pnpm lint:boundaries`
- `git diff --check`