### PR TITLE
fix(desktop): coalesce launchpad transcript messages

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3342,6 +3342,68 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("replaces a launchpad placeholder with its authoritative retained live user entry", async () => {
+    const launchpadText =
+      "https://github.com/pwrdrvr/PwrSnap/pull/407 - Update the TanStack Virtual lockfile.";
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+    const officialEntry: AppServerThreadMessageEntry = {
+      type: "message",
+      id: "item-1",
+      role: "user",
+      text: launchpadText,
+      createdAt: 2_000,
+      turn: {
+        id: "turn-1",
+        status: "in_progress",
+        startedAt: 2_000,
+      },
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
+          optimisticUserMessage: {
+            text: launchpadText,
+            createdAt: 1_000,
+          },
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([
+        expect.objectContaining({
+          id: "optimistic-launchpad-codex:thread-1",
+          role: "user",
+          text: launchpadText,
+        }),
+      ]);
+    });
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry(officialEntry);
+    });
+
+    expect(result.current.entries).toEqual([officialEntry]);
+  });
+
   it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {
     const readThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3342,11 +3342,17 @@ describe("useThreadSessionState", () => {
     );
   });
 
-  it("replaces a launchpad placeholder with its authoritative retained live user entry", async () => {
+  it("replaces a launchpad placeholder when its user-message item completes", async () => {
     const launchpadText =
       "https://github.com/pwrdrvr/PwrSnap/pull/407 - Update the TanStack Virtual lockfile.";
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
     const desktopApi: DesktopApi = {
-      onAgentEvent: () => () => undefined,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
       readThread: async ({ backend, threadId }) => ({
         backend: backend ?? "codex",
         fetchedAt: Date.now(),
@@ -3360,18 +3366,6 @@ describe("useThreadSessionState", () => {
           },
         },
       }),
-    };
-    const officialEntry: AppServerThreadMessageEntry = {
-      type: "message",
-      id: "item-1",
-      role: "user",
-      text: launchpadText,
-      createdAt: 2_000,
-      turn: {
-        id: "turn-1",
-        status: "in_progress",
-        startedAt: 2_000,
-      },
     };
     const { result } = renderHook(() =>
       useThreadSessionState({
@@ -3403,34 +3397,49 @@ describe("useThreadSessionState", () => {
     });
 
     act(() => {
-      result.current.upsertLiveTranscriptEntry(officialEntry);
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "item-1",
+              type: "userMessage",
+              text: launchpadText,
+            },
+          },
+        },
+      });
     });
 
-    expect(result.current.entries).toEqual([officialEntry]);
+    expect(result.current.entries).toEqual([
+      expect.objectContaining({
+        id: "item-1",
+        role: "user",
+        text: launchpadText,
+        turn: expect.objectContaining({ id: "turn-1" }),
+      }),
+    ]);
   });
 
-  it("keeps a duplicate optimistic user message when one retained live entry arrives", async () => {
+  it("keeps a duplicate optimistic user message when the launch item completes", async () => {
     const messageText = "Please update the TanStack Virtual lockfile.";
     let authoritativeEntries: AppServerThreadEntry[] = [];
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
     const desktopApi: DesktopApi = {
-      onAgentEvent: () => () => undefined,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
       readThread: async () => readThreadResponse({
         entries: authoritativeEntries,
         hasPreviousPage: false,
         supportsPagination: false,
       }),
-    };
-    const officialEntry: AppServerThreadMessageEntry = {
-      type: "message",
-      id: "item-1",
-      role: "user",
-      text: messageText,
-      createdAt: 2_000,
-      turn: {
-        id: "turn-1",
-        status: "in_progress",
-        startedAt: 2_000,
-      },
     };
     const { result, rerender } = renderHook(
       ({ updatedAt }) =>
@@ -3456,7 +3465,21 @@ describe("useThreadSessionState", () => {
     let duplicateOptimisticId = "";
     act(() => {
       duplicateOptimisticId = result.current.addOptimisticUserMessage(messageText);
-      result.current.upsertLiveTranscriptEntry(officialEntry);
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "item-1",
+              type: "userMessage",
+              text: messageText,
+            },
+          },
+        },
+      });
     });
 
     const userEntries = result.current.entries.filter(
@@ -3466,7 +3489,11 @@ describe("useThreadSessionState", () => {
     expect(userEntries).toHaveLength(2);
     expect(userEntries).toEqual(
       expect.arrayContaining([
-        officialEntry,
+        expect.objectContaining({
+          id: "item-1",
+          text: messageText,
+          turn: expect.objectContaining({ id: "turn-1" }),
+        }),
         expect.objectContaining({
           id: duplicateOptimisticId,
           text: messageText,
@@ -3474,7 +3501,9 @@ describe("useThreadSessionState", () => {
       ])
     );
 
-    authoritativeEntries = [officialEntry];
+    authoritativeEntries = [
+      userEntries.find((entry) => entry.id === "item-1")!,
+    ];
     rerender({ updatedAt: 3_000 });
 
     await waitFor(() => {
@@ -3490,8 +3519,14 @@ describe("useThreadSessionState", () => {
 
   it("does not reconcile a launchpad placeholder with another turn's identical user message", async () => {
     const messageText = "Please update the TanStack Virtual lockfile.";
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
     const desktopApi: DesktopApi = {
-      onAgentEvent: () => () => undefined,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
       readThread: async ({ backend, threadId }) => ({
         backend: backend ?? "codex",
         fetchedAt: Date.now(),
@@ -3526,28 +3561,33 @@ describe("useThreadSessionState", () => {
 
     await waitForThreadHydration(result);
     act(() => {
-      result.current.upsertLiveTranscriptEntry({
-        type: "message",
-        id: "item-turn-2",
-        role: "user",
-        text: messageText,
-        createdAt: 2_000,
-        turn: {
-          id: "turn-2",
-          status: "in_progress",
-          startedAt: 2_000,
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            item: {
+              id: "item-turn-2",
+              type: "userMessage",
+              text: messageText,
+            },
+          },
         },
       });
     });
 
-    expect(
-      result.current.entries
-        .filter((entry) => entry.type === "message" && entry.role === "user")
-        .map((entry) => entry.id)
-    ).toEqual([
-      "optimistic-launchpad-codex:thread-1",
-      "item-turn-2",
-    ]);
+    const userEntryIds = result.current.entries
+      .filter((entry) => entry.type === "message" && entry.role === "user")
+      .map((entry) => entry.id);
+    expect(userEntryIds).toHaveLength(2);
+    expect(userEntryIds).toEqual(
+      expect.arrayContaining([
+        "optimistic-launchpad-codex:thread-1",
+        "item-turn-2",
+      ])
+    );
   });
 
   it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3404,6 +3404,72 @@ describe("useThreadSessionState", () => {
     expect(result.current.entries).toEqual([officialEntry]);
   });
 
+  it("keeps a duplicate optimistic user message when one retained live entry arrives", async () => {
+    const messageText = "Please update the TanStack Virtual lockfile.";
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+    const officialEntry: AppServerThreadMessageEntry = {
+      type: "message",
+      id: "item-1",
+      role: "user",
+      text: messageText,
+      createdAt: 2_000,
+      turn: {
+        id: "turn-1",
+        status: "in_progress",
+        startedAt: 2_000,
+      },
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
+          optimisticUserMessage: {
+            text: messageText,
+            createdAt: 1_000,
+          },
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+    let duplicateOptimisticId = "";
+    act(() => {
+      duplicateOptimisticId = result.current.addOptimisticUserMessage(messageText);
+      result.current.upsertLiveTranscriptEntry(officialEntry);
+    });
+
+    const userEntries = result.current.entries.filter(
+      (entry): entry is AppServerThreadMessageEntry =>
+        entry.type === "message" && entry.role === "user"
+    );
+    expect(userEntries).toHaveLength(2);
+    expect(userEntries).toEqual(
+      expect.arrayContaining([
+        officialEntry,
+        expect.objectContaining({
+          id: duplicateOptimisticId,
+          text: messageText,
+        }),
+      ])
+    );
+  });
+
   it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {
     const readThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3382,6 +3382,11 @@ describe("useThreadSessionState", () => {
             text: launchpadText,
             createdAt: 1_000,
           },
+          optimisticActiveTurn: {
+            id: "turn-1",
+            statusText: "Thinking",
+            startedAt: 2_000,
+          },
         },
       })
     );
@@ -3406,20 +3411,13 @@ describe("useThreadSessionState", () => {
 
   it("keeps a duplicate optimistic user message when one retained live entry arrives", async () => {
     const messageText = "Please update the TanStack Virtual lockfile.";
+    let authoritativeEntries: AppServerThreadEntry[] = [];
     const desktopApi: DesktopApi = {
       onAgentEvent: () => () => undefined,
-      readThread: async ({ backend, threadId }) => ({
-        backend: backend ?? "codex",
-        fetchedAt: Date.now(),
-        threadId,
-        replay: {
-          entries: [],
-          messages: [],
-          pagination: {
-            supportsPagination: false,
-            hasPreviousPage: false,
-          },
-        },
+      readThread: async () => readThreadResponse({
+        entries: authoritativeEntries,
+        hasPreviousPage: false,
+        supportsPagination: false,
       }),
     };
     const officialEntry: AppServerThreadMessageEntry = {
@@ -3434,17 +3432,24 @@ describe("useThreadSessionState", () => {
         startedAt: 2_000,
       },
     };
-    const { result } = renderHook(() =>
-      useThreadSessionState({
-        desktopApi,
-        thread: {
-          ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
-          optimisticUserMessage: {
-            text: messageText,
-            createdAt: 1_000,
+    const { result, rerender } = renderHook(
+      ({ updatedAt }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: {
+            ...buildThread({ id: "thread-1", updatedAt }),
+            optimisticUserMessage: {
+              text: messageText,
+              createdAt: 1_000,
+            },
+            optimisticActiveTurn: {
+              id: "turn-1",
+              statusText: "Thinking",
+              startedAt: 2_000,
+            },
           },
-        },
-      })
+        }),
+      { initialProps: { updatedAt: 2_000 } },
     );
 
     await waitForThreadHydration(result);
@@ -3468,6 +3473,81 @@ describe("useThreadSessionState", () => {
         }),
       ])
     );
+
+    authoritativeEntries = [officialEntry];
+    rerender({ updatedAt: 3_000 });
+
+    await waitFor(() => {
+      const hydratedUserEntryIds = result.current.entries
+        .filter((entry) => entry.type === "message" && entry.role === "user")
+        .map((entry) => entry.id);
+      expect(hydratedUserEntryIds).toHaveLength(2);
+      expect(hydratedUserEntryIds).toEqual(
+        expect.arrayContaining(["item-1", duplicateOptimisticId])
+      );
+    });
+  });
+
+  it("does not reconcile a launchpad placeholder with another turn's identical user message", async () => {
+    const messageText = "Please update the TanStack Virtual lockfile.";
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
+          optimisticUserMessage: {
+            text: messageText,
+            createdAt: 1_000,
+          },
+          optimisticActiveTurn: {
+            id: "turn-1",
+            statusText: "Thinking",
+            startedAt: 1_000,
+          },
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+    act(() => {
+      result.current.upsertLiveTranscriptEntry({
+        type: "message",
+        id: "item-turn-2",
+        role: "user",
+        text: messageText,
+        createdAt: 2_000,
+        turn: {
+          id: "turn-2",
+          status: "in_progress",
+          startedAt: 2_000,
+        },
+      });
+    });
+
+    expect(
+      result.current.entries
+        .filter((entry) => entry.type === "message" && entry.role === "user")
+        .map((entry) => entry.id)
+    ).toEqual([
+      "optimistic-launchpad-codex:thread-1",
+      "item-turn-2",
+    ]);
   });
 
   it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1249,27 +1249,92 @@ function getThreadHydrationVersion(
   return typeof thread.updatedAt === "number" ? thread.updatedAt : "unknown";
 }
 
+type MessageMatchCandidate = Pick<
+  AppServerThreadMessage,
+  "parts" | "role" | "text"
+>;
+
+type MessageMatchIndex = ReadonlyMap<string, ReadonlySet<number>>;
+
+function messageMatchKey(message: MessageMatchCandidate): string {
+  return JSON.stringify([
+    message.role,
+    normalizeComposerFileReferenceText(message.text),
+  ]);
+}
+
+function messageImageCount(message: MessageMatchCandidate): number {
+  return (message.parts ?? []).filter((part) => part.type === "image").length;
+}
+
+function createMessageMatchIndex(params: {
+  additionalEntries: AppServerThreadEntry[];
+  response?: AppServerReadThreadResponse;
+}): MessageMatchIndex {
+  const imageCountsByMessageKey = new Map<string, Set<number>>();
+  const addMessage = (message: MessageMatchCandidate): void => {
+    const key = messageMatchKey(message);
+    const imageCounts = imageCountsByMessageKey.get(key) ?? new Set<number>();
+    imageCounts.add(messageImageCount(message));
+    imageCountsByMessageKey.set(key, imageCounts);
+  };
+
+  for (const message of params.response?.replay.messages ?? []) {
+    addMessage(message);
+  }
+  for (const entry of params.additionalEntries) {
+    if (entry.type === "message") {
+      addMessage(entry);
+    }
+  }
+
+  return imageCountsByMessageKey;
+}
+
+function hasMatchingMessage(
+  message: AppServerThreadMessageEntry,
+  messageMatchIndex: MessageMatchIndex
+): boolean {
+  const imageCounts = messageMatchIndex.get(messageMatchKey(message));
+  if (!imageCounts) {
+    return false;
+  }
+
+  const imageCount = messageImageCount(message);
+  return imageCount === 0 || imageCounts.has(imageCount);
+}
+
 function pruneOptimisticEntries(
   optimisticEntries: AppServerThreadEntry[],
-  response: AppServerReadThreadResponse | undefined
+  response: AppServerReadThreadResponse | undefined,
+  additionalAuthoritativeEntries: AppServerThreadEntry[] = []
 ): AppServerThreadEntry[] {
-  if (!response) {
+  if (
+    optimisticEntries.length === 0 ||
+    (!response && additionalAuthoritativeEntries.length === 0)
+  ) {
     return optimisticEntries;
   }
 
-  const latestResponseTurnId = latestTranscriptTurnId(response.replay.entries);
-  const latestResponseCreatedAt = latestTranscriptCreatedAt(response.replay.entries);
+  const responseEntries = response?.replay.entries ?? [];
+  const latestResponseTurnId = latestTranscriptTurnId(responseEntries);
+  const latestResponseCreatedAt = latestTranscriptCreatedAt(responseEntries);
+  const hasOptimisticMessages = optimisticEntries.some(
+    (entry) => entry.type === "message"
+  );
+  const messageMatchIndex = hasOptimisticMessages
+    ? createMessageMatchIndex({
+        additionalEntries: additionalAuthoritativeEntries,
+        response,
+      })
+    : undefined;
   return optimisticEntries.filter((entry) => {
     if (entry.type === "message") {
-      return !response.replay.messages.some((message) =>
-        messageMatchesOptimisticEntry(message, entry, {
-          allowImageUrlMismatch: true,
-        })
-      );
+      return !hasMatchingMessage(entry, messageMatchIndex!);
     }
 
     if (entry.type === "review") {
-      return !response.replay.entries.some(
+      return !responseEntries.some(
         (candidate) =>
           candidate.type === "review" &&
           reviewEntriesMatch(candidate, entry)
@@ -1286,14 +1351,14 @@ function pruneOptimisticEntries(
         return false;
       }
 
-      return !response.replay.entries.some(
+      return !responseEntries.some(
         (candidate) =>
           candidate.type === "activity" &&
           activityEntriesMatch(candidate, entry)
       );
     }
 
-    return !response.replay.entries.some((candidate) => candidate.id === entry.id);
+    return !responseEntries.some((candidate) => candidate.id === entry.id);
   });
 }
 
@@ -6516,12 +6581,18 @@ export function useThreadSessionState(params: {
   const visibleOptimisticEntries = useMemo(
     () => {
       const optimisticEntries = selectedSession?.optimisticEntries ?? [];
-      return pruneOptimisticEntries(
-        selectedRetainedLiveEntries.length > 0
-          ? [...optimisticEntries, ...selectedRetainedLiveEntries]
-          : optimisticEntries,
+      const retainedLiveEntries = pruneOptimisticEntries(
+        selectedRetainedLiveEntries,
         selectedSession?.response,
       );
+      const localOptimisticEntries = pruneOptimisticEntries(
+        optimisticEntries,
+        selectedSession?.response,
+        retainedLiveEntries,
+      );
+      return retainedLiveEntries.length > 0
+        ? [...localOptimisticEntries, ...retainedLiveEntries]
+        : localOptimisticEntries;
     },
     [
       selectedRetainedLiveEntries,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1249,114 +1249,29 @@ function getThreadHydrationVersion(
   return typeof thread.updatedAt === "number" ? thread.updatedAt : "unknown";
 }
 
-type MessageMatchCandidate = Pick<
-  AppServerThreadMessage,
-  "parts" | "role" | "text"
->;
-
-type MessageMatchIndex = Map<string, Map<number, number>>;
-
-function messageMatchKey(message: MessageMatchCandidate): string {
-  return JSON.stringify([
-    message.role,
-    normalizeComposerFileReferenceText(message.text),
-  ]);
-}
-
-function messageImageCount(message: MessageMatchCandidate): number {
-  return (message.parts ?? []).filter((part) => part.type === "image").length;
-}
-
-function createMessageMatchIndex(params: {
-  additionalEntries: AppServerThreadEntry[];
-  response?: AppServerReadThreadResponse;
-}): MessageMatchIndex {
-  const availableMessageCountsByKey = new Map<string, Map<number, number>>();
-  const addMessage = (message: MessageMatchCandidate): void => {
-    const key = messageMatchKey(message);
-    const imageCount = messageImageCount(message);
-    const imageCounts = availableMessageCountsByKey.get(key) ?? new Map<number, number>();
-    imageCounts.set(imageCount, (imageCounts.get(imageCount) ?? 0) + 1);
-    availableMessageCountsByKey.set(key, imageCounts);
-  };
-
-  for (const message of params.response?.replay.messages ?? []) {
-    addMessage(message);
-  }
-  for (const entry of params.additionalEntries) {
-    if (entry.type === "message") {
-      addMessage(entry);
-    }
-  }
-
-  return availableMessageCountsByKey;
-}
-
-function consumeMatchingMessage(
-  message: AppServerThreadMessageEntry,
-  messageMatchIndex: MessageMatchIndex
-): boolean {
-  const key = messageMatchKey(message);
-  const imageCounts = messageMatchIndex.get(key);
-  if (!imageCounts) {
-    return false;
-  }
-
-  const imageCount = messageImageCount(message);
-  const matchingImageCount = imageCount === 0
-    ? (imageCounts.has(0) ? 0 : imageCounts.keys().next().value)
-    : imageCount;
-  if (matchingImageCount === undefined) {
-    return false;
-  }
-
-  const availableCount = imageCounts.get(matchingImageCount) ?? 0;
-  if (availableCount === 0) {
-    return false;
-  }
-
-  if (availableCount === 1) {
-    imageCounts.delete(matchingImageCount);
-    if (imageCounts.size === 0) {
-      messageMatchIndex.delete(key);
-    }
-  } else {
-    imageCounts.set(matchingImageCount, availableCount - 1);
-  }
-  return true;
-}
-
 function pruneOptimisticEntries(
   optimisticEntries: AppServerThreadEntry[],
   response: AppServerReadThreadResponse | undefined,
-  additionalAuthoritativeEntries: AppServerThreadEntry[] = []
+  reconciledLaunchpadMessageId?: string
 ): AppServerThreadEntry[] {
-  if (
-    optimisticEntries.length === 0 ||
-    (!response && additionalAuthoritativeEntries.length === 0)
-  ) {
+  if (!response) {
     return optimisticEntries;
   }
 
-  const responseEntries = response?.replay.entries ?? [];
-  const latestResponseTurnId = latestTranscriptTurnId(responseEntries);
-  const latestResponseCreatedAt = latestTranscriptCreatedAt(responseEntries);
-  const hasOptimisticMessages = optimisticEntries.some(
-    (entry) => entry.type === "message"
-  );
-  const messageMatchIndex = hasOptimisticMessages
-    ? createMessageMatchIndex({
-        additionalEntries: additionalAuthoritativeEntries,
-        response,
-      })
-    : undefined;
+  const latestResponseTurnId = latestTranscriptTurnId(response.replay.entries);
+  const latestResponseCreatedAt = latestTranscriptCreatedAt(response.replay.entries);
   return optimisticEntries.filter((entry) => {
     if (entry.type === "message") {
-      return !consumeMatchingMessage(entry, messageMatchIndex!);
+      return !response.replay.messages.some((message) =>
+        message.id !== reconciledLaunchpadMessageId
+        && messageMatchesOptimisticEntry(message, entry, {
+          allowImageUrlMismatch: true,
+        })
+      );
     }
 
     if (entry.type === "review") {
-      return !responseEntries.some(
+      return !response.replay.entries.some(
         (candidate) =>
           candidate.type === "review" &&
           reviewEntriesMatch(candidate, entry)
@@ -1373,14 +1288,14 @@ function pruneOptimisticEntries(
         return false;
       }
 
-      return !responseEntries.some(
+      return !response.replay.entries.some(
         (candidate) =>
           candidate.type === "activity" &&
           activityEntriesMatch(candidate, entry)
       );
     }
 
-    return !responseEntries.some((candidate) => candidate.id === entry.id);
+    return !response.replay.entries.some((candidate) => candidate.id === entry.id);
   });
 }
 
@@ -3251,6 +3166,53 @@ function messageTextMatchesOptimisticEntry(
   return true;
 }
 
+type LaunchpadMessageCandidate = {
+  entry: AppServerThreadMessageEntry;
+  turnId?: string;
+};
+
+function buildLaunchpadMessageCandidate(params: {
+  optimisticActiveTurnId?: string;
+  optimisticUserMessage: NonNullable<
+    NavigationThreadSummary["optimisticUserMessage"]
+  >;
+  threadKey: string;
+}): LaunchpadMessageCandidate {
+  return {
+    entry: {
+      type: "message",
+      id: `optimistic-launchpad-${params.threadKey}`,
+      role: "user",
+      text: params.optimisticUserMessage.text,
+      parts: [
+        ...(params.optimisticUserMessage.text
+          ? [{ type: "text" as const, text: params.optimisticUserMessage.text }]
+          : []),
+        ...(params.optimisticUserMessage.imageParts ?? []),
+      ],
+      createdAt: params.optimisticUserMessage.createdAt ?? Date.now(),
+    },
+    turnId: params.optimisticActiveTurnId,
+  };
+}
+
+function matchesAuthoritativeLaunchpadMessage(
+  message: AppServerThreadMessageEntry,
+  candidate: LaunchpadMessageCandidate
+): boolean {
+  if (
+    candidate.turnId
+    && message.turn?.id
+    && message.turn.id !== candidate.turnId
+  ) {
+    return false;
+  }
+
+  return messageMatchesOptimisticEntry(message, candidate.entry, {
+    allowImageUrlMismatch: true,
+  });
+}
+
 function mergeCompletedUserMessageWithOptimisticEntry(
   message: AppServerThreadMessageEntry,
   optimisticEntries: AppServerThreadEntry[]
@@ -4181,8 +4143,27 @@ export function useThreadSessionState(params: {
   const threadKey = thread
     ? threadSummaryIdentityKey(thread)
     : undefined;
+  const launchpadMessageCandidate = useMemo(() => {
+    if (!threadKey || !thread?.optimisticUserMessage) {
+      return undefined;
+    }
+    return buildLaunchpadMessageCandidate({
+      optimisticActiveTurnId: thread.optimisticActiveTurn?.id,
+      optimisticUserMessage: thread.optimisticUserMessage,
+      threadKey,
+    });
+  }, [
+    thread?.optimisticActiveTurn?.id,
+    thread?.optimisticUserMessage,
+    threadKey,
+  ]);
   const selectedThreadKeyRef = useRef<string | undefined>(undefined);
   const consumedOptimisticActiveTurnKeysRef = useRef<Set<string>>(new Set());
+  const launchpadMessageCandidateRef = useRef<{
+    candidate: LaunchpadMessageCandidate;
+    threadKey: string;
+  } | undefined>(undefined);
+  const reconciledLaunchpadMessageIdsRef = useRef<Record<string, string>>({});
   const lastLiveActivitySignatureRef = useRef<Record<string, string>>({});
   const loadedHistoryIndexesRef = useRef<Record<string, TranscriptHistoryIndex>>({});
   // Avoid copying and rescanning every previously retained live aggregate on
@@ -4196,6 +4177,19 @@ export function useThreadSessionState(params: {
   const [sessions, setSessions] = useState<ThreadSessionState>({});
 
   selectedThreadKeyRef.current = threadKey;
+  if (launchpadMessageCandidateRef.current?.threadKey !== threadKey) {
+    launchpadMessageCandidateRef.current = undefined;
+  }
+  if (
+    threadKey
+    && launchpadMessageCandidate
+    && reconciledLaunchpadMessageIdsRef.current[threadKey] === undefined
+  ) {
+    launchpadMessageCandidateRef.current = {
+      candidate: launchpadMessageCandidate,
+      threadKey,
+    };
+  }
 
   useEffect(() => {
     const retainedThreadKeys = new Set(Object.keys(sessions));
@@ -4207,6 +4201,15 @@ export function useThreadSessionState(params: {
     for (const retainedThreadKey of Object.keys(retainedLiveEntriesRef.current)) {
       if (!retainedThreadKeys.has(retainedThreadKey)) {
         delete retainedLiveEntriesRef.current[retainedThreadKey];
+      }
+    }
+    for (
+      const reconciledThreadKey of Object.keys(
+        reconciledLaunchpadMessageIdsRef.current,
+      )
+    ) {
+      if (!retainedThreadKeys.has(reconciledThreadKey)) {
+        delete reconciledLaunchpadMessageIdsRef.current[reconciledThreadKey];
       }
     }
   }, [sessions]);
@@ -4556,7 +4559,8 @@ export function useThreadSessionState(params: {
               + (didPruneRetainedLiveEntries ? 1 : 0),
             optimisticEntries: pruneOptimisticEntries(
               current.optimisticEntries,
-              responseWithRetainedTail
+              responseWithRetainedTail,
+              reconciledLaunchpadMessageIdsRef.current[targetThreadKey],
             ),
             pendingAssistantMessage: shouldClearStaleThinking
               ? undefined
@@ -4675,28 +4679,25 @@ export function useThreadSessionState(params: {
       }
     }
 
-    const optimisticUserMessage = thread.optimisticUserMessage;
-    if (optimisticUserMessage) {
-      const optimisticEntry: AppServerThreadMessageEntry = {
-        type: "message",
-        id: `optimistic-launchpad-${threadKey}`,
-        role: "user",
-        text: optimisticUserMessage.text,
-        parts: [
-          ...(optimisticUserMessage.text
-            ? [{ type: "text" as const, text: optimisticUserMessage.text }]
-            : []),
-          ...(optimisticUserMessage.imageParts ?? []),
-        ],
-        createdAt: optimisticUserMessage.createdAt ?? Date.now(),
-      };
-
+    if (
+      launchpadMessageCandidate
+      && reconciledLaunchpadMessageIdsRef.current[threadKey] === undefined
+    ) {
+      const optimisticEntry = launchpadMessageCandidate.entry;
       updateSession(threadKey, (current) => {
-        const persistedMessageExists = current.response?.replay.messages.some((message) =>
-          messageMatchesOptimisticEntry(message, optimisticEntry, {
-            allowImageUrlMismatch: true,
-          })
+        const persistedMessage = current.response?.replay.entries.find(
+          (entry): entry is AppServerThreadMessageEntry =>
+            entry.type === "message"
+            && matchesAuthoritativeLaunchpadMessage(
+              entry,
+              launchpadMessageCandidate,
+            )
         );
+        const persistedMessageExists = persistedMessage !== undefined;
+        if (persistedMessage) {
+          reconciledLaunchpadMessageIdsRef.current[threadKey] =
+            persistedMessage.id;
+        }
         const persistedTextMessageExists = current.response?.replay.messages.some(
           (message) => messageTextMatchesOptimisticEntry(message, optimisticEntry)
         );
@@ -4890,7 +4891,15 @@ export function useThreadSessionState(params: {
     }
 
     void loadLatest(thread);
-  }, [initialHistoryLimit, loadLatest, sessions, thread, threadKey, updateSession]);
+  }, [
+    initialHistoryLimit,
+    launchpadMessageCandidate,
+    loadLatest,
+    sessions,
+    thread,
+    threadKey,
+    updateSession,
+  ]);
 
   useEffect(() => {
     if (!thread || !threadKey) {
@@ -6347,24 +6356,71 @@ export function useThreadSessionState(params: {
         return;
       }
 
+      const launchpadMessageCandidate =
+        launchpadMessageCandidateRef.current?.threadKey === threadKey
+          ? launchpadMessageCandidateRef.current.candidate
+          : undefined;
+      let matchingLaunchpadMessageCandidate: LaunchpadMessageCandidate | undefined;
+      let retainedEntry = entry;
+      if (
+        entry.type === "message"
+        && entry.role === "user"
+        && launchpadMessageCandidate !== undefined
+        && reconciledLaunchpadMessageIdsRef.current[threadKey] === undefined
+        && matchesAuthoritativeLaunchpadMessage(
+          entry,
+          launchpadMessageCandidate,
+        )
+      ) {
+        matchingLaunchpadMessageCandidate = launchpadMessageCandidate;
+        retainedEntry = mergeCompletedUserMessageWithOptimisticEntry(
+          entry,
+          [launchpadMessageCandidate.entry],
+        );
+      }
+      if (matchingLaunchpadMessageCandidate) {
+        reconciledLaunchpadMessageIdsRef.current[threadKey] = retainedEntry.id;
+      }
+
       const retainedLiveEntryStore =
         retainedLiveEntriesRef.current[threadKey]
         ?? new Map<string, AppServerThreadEntry>();
       retainedLiveEntriesRef.current[threadKey] = retainedLiveEntryStore;
-      const entryId = entry.id;
-      if (retainedLiveEntryStore.get(entryId) === entry) {
+      const entryId = retainedEntry.id;
+      const retainedEntryUnchanged =
+        retainedLiveEntryStore.get(entryId) === retainedEntry;
+      if (retainedEntryUnchanged && !matchingLaunchpadMessageCandidate) {
         return;
       }
-      retainedLiveEntryStore.set(entryId, entry);
+      if (!retainedEntryUnchanged) {
+        retainedLiveEntryStore.set(entryId, retainedEntry);
+      }
 
-      updateSession(threadKey, (current) => ({
-        ...current,
-        expectOwnUpdate: true,
-        interacted: true,
-        lastTouchedAt: Date.now(),
-        retainedLiveEntryCount: retainedLiveEntryStore.size,
-        retainedLiveEntryVersion: current.retainedLiveEntryVersion + 1,
-      }));
+      updateSession(threadKey, (current) => {
+        const optimisticEntries = matchingLaunchpadMessageCandidate
+          ? current.optimisticEntries.filter(
+              (optimisticEntry) =>
+                optimisticEntry.id !== matchingLaunchpadMessageCandidate.entry.id
+            )
+          : current.optimisticEntries;
+        if (
+          retainedEntryUnchanged
+          && optimisticEntries === current.optimisticEntries
+        ) {
+          return current;
+        }
+        return {
+          ...current,
+          expectOwnUpdate: true,
+          interacted: true,
+          lastTouchedAt: Date.now(),
+          optimisticEntries,
+          retainedLiveEntryCount: retainedLiveEntryStore.size,
+          retainedLiveEntryVersion:
+            current.retainedLiveEntryVersion
+            + (retainedEntryUnchanged ? 0 : 1),
+        };
+      });
     },
     [threadKey, updateSession]
   );
@@ -6600,26 +6656,23 @@ export function useThreadSessionState(params: {
     }
     return [...(retainedLiveEntriesRef.current[threadKey]?.values() ?? [])];
   }, [selectedRetainedLiveEntryVersion, threadKey]);
+  const visibleLocalOptimisticEntries = useMemo(
+    () => pruneOptimisticEntries(
+      selectedSession?.optimisticEntries ?? [],
+      selectedSession?.response,
+      threadKey
+        ? reconciledLaunchpadMessageIdsRef.current[threadKey]
+        : undefined,
+    ),
+    [selectedSession?.optimisticEntries, selectedSession?.response, threadKey],
+  );
   const visibleOptimisticEntries = useMemo(
-    () => {
-      const optimisticEntries = selectedSession?.optimisticEntries ?? [];
-      const retainedLiveEntries = pruneOptimisticEntries(
-        selectedRetainedLiveEntries,
-        selectedSession?.response,
-      );
-      const localOptimisticEntries = pruneOptimisticEntries(
-        optimisticEntries,
-        selectedSession?.response,
-        retainedLiveEntries,
-      );
-      return retainedLiveEntries.length > 0
-        ? [...localOptimisticEntries, ...retainedLiveEntries]
-        : localOptimisticEntries;
-    },
+    () => selectedRetainedLiveEntries.length > 0
+      ? [...visibleLocalOptimisticEntries, ...selectedRetainedLiveEntries]
+      : visibleLocalOptimisticEntries,
     [
       selectedRetainedLiveEntries,
-      selectedSession?.optimisticEntries,
-      selectedSession?.response,
+      visibleLocalOptimisticEntries,
     ],
   );
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1252,7 +1252,8 @@ function getThreadHydrationVersion(
 function pruneOptimisticEntries(
   optimisticEntries: AppServerThreadEntry[],
   response: AppServerReadThreadResponse | undefined,
-  reconciledLaunchpadMessageId?: string
+  reconciledLaunchpadMessageId?: string,
+  launchpadMessageCandidate?: LaunchpadMessageCandidate,
 ): AppServerThreadEntry[] {
   if (!response) {
     return optimisticEntries;
@@ -1262,6 +1263,19 @@ function pruneOptimisticEntries(
   const latestResponseCreatedAt = latestTranscriptCreatedAt(response.replay.entries);
   return optimisticEntries.filter((entry) => {
     if (entry.type === "message") {
+      const isLaunchpadPlaceholder =
+        entry.id === launchpadMessageCandidate?.entry.id;
+      if (isLaunchpadPlaceholder && launchpadMessageCandidate) {
+        return !response.replay.entries.some(
+          (candidate) =>
+            candidate.type === "message"
+            && candidate.id !== reconciledLaunchpadMessageId
+            && matchesAuthoritativeLaunchpadMessage(
+              candidate,
+              launchpadMessageCandidate,
+            )
+        );
+      }
       return !response.replay.messages.some((message) =>
         message.id !== reconciledLaunchpadMessageId
         && messageMatchesOptimisticEntry(message, entry, {
@@ -4561,6 +4575,9 @@ export function useThreadSessionState(params: {
               current.optimisticEntries,
               responseWithRetainedTail,
               reconciledLaunchpadMessageIdsRef.current[targetThreadKey],
+              launchpadMessageCandidateRef.current?.threadKey === targetThreadKey
+                ? launchpadMessageCandidateRef.current.candidate
+                : undefined,
             ),
             pendingAssistantMessage: shouldClearStaleThinking
               ? undefined
@@ -5390,14 +5407,37 @@ export function useThreadSessionState(params: {
             event.notification.params
           );
           if (userMessageEntry) {
+            const launchpadMessageCandidate =
+              launchpadMessageCandidateRef.current?.threadKey === targetThreadKey
+                ? launchpadMessageCandidateRef.current.candidate
+                : undefined;
+            const unreconciledLaunchpadMessageCandidate =
+              reconciledLaunchpadMessageIdsRef.current[targetThreadKey]
+                === undefined
+                ? launchpadMessageCandidate
+                : undefined;
+            const reconcilesLaunchpadMessage = Boolean(
+              unreconciledLaunchpadMessageCandidate
+              && matchesAuthoritativeLaunchpadMessage(
+                userMessageEntry,
+                unreconciledLaunchpadMessageCandidate,
+              )
+            );
             const completedUserMessageEntry =
               mergeCompletedUserMessageWithPromotedOptimisticEntry(
                 mergeCompletedUserMessageWithOptimisticEntry(
                   userMessageEntry,
-                  current.optimisticEntries
+                  reconcilesLaunchpadMessage
+                    && unreconciledLaunchpadMessageCandidate
+                    ? [unreconciledLaunchpadMessageCandidate.entry]
+                    : current.optimisticEntries
                 ),
                 current.response
               );
+            if (reconcilesLaunchpadMessage) {
+              reconciledLaunchpadMessageIdsRef.current[targetThreadKey] =
+                completedUserMessageEntry.id;
+            }
             const nextResponse = appendMessageEntries(
               removePromotedOptimisticUserMessage(
                 current.response,
@@ -5415,11 +5455,22 @@ export function useThreadSessionState(params: {
               expectOwnUpdate: true,
               interacted: true,
               lastTouchedAt: nextLastTouchedAt,
-              optimisticEntries: current.optimisticEntries.filter(
-                (entry) =>
-                  entry.type !== "message" ||
-                  !messageTextMatchesOptimisticEntry(completedUserMessageEntry, entry)
-              ),
+              optimisticEntries:
+                reconcilesLaunchpadMessage
+                  && unreconciledLaunchpadMessageCandidate
+                  ? current.optimisticEntries.filter(
+                      (entry) =>
+                        entry.id !== unreconciledLaunchpadMessageCandidate.entry.id
+                    )
+                  : current.optimisticEntries.filter(
+                      (entry) =>
+                        entry.id === unreconciledLaunchpadMessageCandidate?.entry.id
+                        || entry.type !== "message"
+                        || !messageTextMatchesOptimisticEntry(
+                          completedUserMessageEntry,
+                          entry,
+                        )
+                    ),
               response: nextResponse,
             };
           }
@@ -6356,71 +6407,24 @@ export function useThreadSessionState(params: {
         return;
       }
 
-      const launchpadMessageCandidate =
-        launchpadMessageCandidateRef.current?.threadKey === threadKey
-          ? launchpadMessageCandidateRef.current.candidate
-          : undefined;
-      let matchingLaunchpadMessageCandidate: LaunchpadMessageCandidate | undefined;
-      let retainedEntry = entry;
-      if (
-        entry.type === "message"
-        && entry.role === "user"
-        && launchpadMessageCandidate !== undefined
-        && reconciledLaunchpadMessageIdsRef.current[threadKey] === undefined
-        && matchesAuthoritativeLaunchpadMessage(
-          entry,
-          launchpadMessageCandidate,
-        )
-      ) {
-        matchingLaunchpadMessageCandidate = launchpadMessageCandidate;
-        retainedEntry = mergeCompletedUserMessageWithOptimisticEntry(
-          entry,
-          [launchpadMessageCandidate.entry],
-        );
-      }
-      if (matchingLaunchpadMessageCandidate) {
-        reconciledLaunchpadMessageIdsRef.current[threadKey] = retainedEntry.id;
-      }
-
       const retainedLiveEntryStore =
         retainedLiveEntriesRef.current[threadKey]
         ?? new Map<string, AppServerThreadEntry>();
       retainedLiveEntriesRef.current[threadKey] = retainedLiveEntryStore;
-      const entryId = retainedEntry.id;
-      const retainedEntryUnchanged =
-        retainedLiveEntryStore.get(entryId) === retainedEntry;
-      if (retainedEntryUnchanged && !matchingLaunchpadMessageCandidate) {
+      const entryId = entry.id;
+      if (retainedLiveEntryStore.get(entryId) === entry) {
         return;
       }
-      if (!retainedEntryUnchanged) {
-        retainedLiveEntryStore.set(entryId, retainedEntry);
-      }
+      retainedLiveEntryStore.set(entryId, entry);
 
-      updateSession(threadKey, (current) => {
-        const optimisticEntries = matchingLaunchpadMessageCandidate
-          ? current.optimisticEntries.filter(
-              (optimisticEntry) =>
-                optimisticEntry.id !== matchingLaunchpadMessageCandidate.entry.id
-            )
-          : current.optimisticEntries;
-        if (
-          retainedEntryUnchanged
-          && optimisticEntries === current.optimisticEntries
-        ) {
-          return current;
-        }
-        return {
-          ...current,
-          expectOwnUpdate: true,
-          interacted: true,
-          lastTouchedAt: Date.now(),
-          optimisticEntries,
-          retainedLiveEntryCount: retainedLiveEntryStore.size,
-          retainedLiveEntryVersion:
-            current.retainedLiveEntryVersion
-            + (retainedEntryUnchanged ? 0 : 1),
-        };
-      });
+      updateSession(threadKey, (current) => ({
+        ...current,
+        expectOwnUpdate: true,
+        interacted: true,
+        lastTouchedAt: Date.now(),
+        retainedLiveEntryCount: retainedLiveEntryStore.size,
+        retainedLiveEntryVersion: current.retainedLiveEntryVersion + 1,
+      }));
     },
     [threadKey, updateSession]
   );
@@ -6663,8 +6667,14 @@ export function useThreadSessionState(params: {
       threadKey
         ? reconciledLaunchpadMessageIdsRef.current[threadKey]
         : undefined,
+      launchpadMessageCandidate,
     ),
-    [selectedSession?.optimisticEntries, selectedSession?.response, threadKey],
+    [
+      launchpadMessageCandidate,
+      selectedSession?.optimisticEntries,
+      selectedSession?.response,
+      threadKey,
+    ],
   );
   const visibleOptimisticEntries = useMemo(
     () => selectedRetainedLiveEntries.length > 0

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1254,7 +1254,7 @@ type MessageMatchCandidate = Pick<
   "parts" | "role" | "text"
 >;
 
-type MessageMatchIndex = ReadonlyMap<string, ReadonlySet<number>>;
+type MessageMatchIndex = Map<string, Map<number, number>>;
 
 function messageMatchKey(message: MessageMatchCandidate): string {
   return JSON.stringify([
@@ -1271,12 +1271,13 @@ function createMessageMatchIndex(params: {
   additionalEntries: AppServerThreadEntry[];
   response?: AppServerReadThreadResponse;
 }): MessageMatchIndex {
-  const imageCountsByMessageKey = new Map<string, Set<number>>();
+  const availableMessageCountsByKey = new Map<string, Map<number, number>>();
   const addMessage = (message: MessageMatchCandidate): void => {
     const key = messageMatchKey(message);
-    const imageCounts = imageCountsByMessageKey.get(key) ?? new Set<number>();
-    imageCounts.add(messageImageCount(message));
-    imageCountsByMessageKey.set(key, imageCounts);
+    const imageCount = messageImageCount(message);
+    const imageCounts = availableMessageCountsByKey.get(key) ?? new Map<number, number>();
+    imageCounts.set(imageCount, (imageCounts.get(imageCount) ?? 0) + 1);
+    availableMessageCountsByKey.set(key, imageCounts);
   };
 
   for (const message of params.response?.replay.messages ?? []) {
@@ -1288,20 +1289,41 @@ function createMessageMatchIndex(params: {
     }
   }
 
-  return imageCountsByMessageKey;
+  return availableMessageCountsByKey;
 }
 
-function hasMatchingMessage(
+function consumeMatchingMessage(
   message: AppServerThreadMessageEntry,
   messageMatchIndex: MessageMatchIndex
 ): boolean {
-  const imageCounts = messageMatchIndex.get(messageMatchKey(message));
+  const key = messageMatchKey(message);
+  const imageCounts = messageMatchIndex.get(key);
   if (!imageCounts) {
     return false;
   }
 
   const imageCount = messageImageCount(message);
-  return imageCount === 0 || imageCounts.has(imageCount);
+  const matchingImageCount = imageCount === 0
+    ? (imageCounts.has(0) ? 0 : imageCounts.keys().next().value)
+    : imageCount;
+  if (matchingImageCount === undefined) {
+    return false;
+  }
+
+  const availableCount = imageCounts.get(matchingImageCount) ?? 0;
+  if (availableCount === 0) {
+    return false;
+  }
+
+  if (availableCount === 1) {
+    imageCounts.delete(matchingImageCount);
+    if (imageCounts.size === 0) {
+      messageMatchIndex.delete(key);
+    }
+  } else {
+    imageCounts.set(matchingImageCount, availableCount - 1);
+  }
+  return true;
 }
 
 function pruneOptimisticEntries(
@@ -1330,7 +1352,7 @@ function pruneOptimisticEntries(
     : undefined;
   return optimisticEntries.filter((entry) => {
     if (entry.type === "message") {
-      return !hasMatchingMessage(entry, messageMatchIndex!);
+      return !consumeMatchingMessage(entry, messageMatchIndex!);
     }
 
     if (entry.type === "review") {


### PR DESCRIPTION
## Summary

- Coalesce a launchpad placeholder with its authoritative retained live user entry.
- Preserve the authoritative item ID and turn metadata instead of rendering the prompt twice.
- Index normalized message keys during reconciliation, avoiding a cross-product scan.

## Root cause

The live-transcript performance path retains authoritative live entries outside the session array. When an initial launchpad placeholder and its distinct-ID authoritative user entry arrived before hydration, the renderer merged both into the transcript.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm lint:eslint`
- `pnpm typecheck`
- `pnpm lint:boundaries`