### PR TITLE
chore(deps): ignore better-sqlite3 13.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,14 @@ updates:
       - dependency-name: "@electron/*"
         update-types:
           - "version-update:semver-major"
+      # better-sqlite3 13 is the N-API rewrite: it drops prebuild-install and
+      # Electron-tagged GitHub assets. Desktop postinstall still fetches an
+      # Electron prebuild into electron-native/, so 13.x needs a planned native
+      # pipeline migration rather than a Dependabot bump. 12.x minor/patch
+      # updates stay in desktop-runtime-minor-patch.
+      - dependency-name: "better-sqlite3"
+        versions:
+          - "13.x"
       # node-fetch is kept at v2 for grammY's current Node runtime shim. The
       # latest grammY release still depends on node-fetch v2 and its CommonJS
       # entrypoint; v3 is ESM-only and should be handled as a planned Telegram


### PR DESCRIPTION
## Summary

Stop Dependabot from opening `better-sqlite3` 13.x PRs until the desktop native pipeline is rewritten for the N-API release.

#1644 (`12.11.1` → `13.0.2`) cannot land as a lockfile-only bump: v13 drops `prebuild-install` and Electron-tagged GitHub assets, while `rebuild-native-for-electron.mjs` still fetches `--runtime=electron --target=41.10.3` into `electron-native/`. CI on that PR is red on every install job.

This ignore is version-scoped to `13.x` only. 12.x minor/patch updates stay in the existing `desktop-runtime-minor-patch` group.

A matching `@dependabot ignore this major version` comment on #1644 closes the open PR immediately. This YAML change is the in-repo record so the skip survives a recreated PR.

## Test plan

- [ ] Confirm #1644 closes after the Dependabot ignore comment
- [ ] Next weekly Dependabot run does not reopen a 13.x bump
- [ ] 12.x `better-sqlite3` minor/patch PRs can still open in `desktop-runtime-minor-patch`