### PR TITLE
fix(desktop): repair cached turn cost attribution

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -21243,6 +21243,160 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("derives consecutive Codex turns in arrival order when overlay reads overlap", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlay: ThreadOverlayState = {
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      model: "gpt-5.5",
+      serviceTier: "standard",
+    };
+    const baseOverlayStore = createOverlayStoreMock({
+      overlays: { "codex:thread-1": overlay },
+    });
+    let releaseFirstOverlay!: () => void;
+    const firstOverlay = new Promise<ThreadOverlayState>((resolve) => {
+      releaseFirstOverlay = () => resolve(overlay);
+    });
+    const getThreadOverlayState = vi.fn()
+      .mockImplementationOnce(() => firstOverlay)
+      .mockResolvedValue(overlay);
+    const overlayStore = {
+      ...baseOverlayStore,
+      getThreadOverlayState,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+    const usage = (params: {
+      inputTokens: number;
+      lastInputTokens: number;
+      turnId: string;
+    }): AppServerNotification => ({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: params.turnId,
+        tokenUsage: {
+          last: {
+            inputTokens: params.lastInputTokens,
+            cachedInputTokens: 0,
+            outputTokens: 0,
+            reasoningOutputTokens: 0,
+            totalTokens: params.lastInputTokens,
+          },
+          total: {
+            inputTokens: params.inputTokens,
+            cachedInputTokens: 0,
+            outputTokens: 0,
+            reasoningOutputTokens: 0,
+            totalTokens: params.inputTokens,
+          },
+        },
+      },
+    });
+
+    const turn1 = codexClient.emit(usage({
+      inputTokens: 1_000,
+      lastInputTokens: 100,
+      turnId: "turn-1",
+    }));
+    await vi.waitFor(() => expect(getThreadOverlayState).toHaveBeenCalledTimes(1));
+    const turn2 = codexClient.emit(usage({
+      inputTokens: 3_000,
+      lastInputTokens: 200,
+      turnId: "turn-2",
+    }));
+    await vi.waitFor(() =>
+      expect(getThreadOverlayState.mock.calls.length).toBeGreaterThanOrEqual(2),
+    );
+    releaseFirstOverlay();
+    await Promise.all([turn1, turn2]);
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(
+      pricing.lines.find((line) => line.turnId === "turn-2")?.inputTokens,
+    ).toBe(2_000);
+
+    await registry.close();
+  });
+
+  it("does not regress Codex cumulative usage on a late older-turn snapshot", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.5",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+    const emitUsage = async (params: {
+      inputTokens: number;
+      lastInputTokens: number;
+      turnId: string;
+    }) => {
+      await codexClient.emit({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: params.turnId,
+          tokenUsage: {
+            last: {
+              inputTokens: params.lastInputTokens,
+              cachedInputTokens: 0,
+              outputTokens: 0,
+              reasoningOutputTokens: 0,
+              totalTokens: params.lastInputTokens,
+            },
+            total: {
+              inputTokens: params.inputTokens,
+              cachedInputTokens: 0,
+              outputTokens: 0,
+              reasoningOutputTokens: 0,
+              totalTokens: params.inputTokens,
+            },
+          },
+        },
+      });
+    };
+
+    await emitUsage({ inputTokens: 1_000, lastInputTokens: 100, turnId: "turn-1" });
+    await emitUsage({ inputTokens: 3_000, lastInputTokens: 200, turnId: "turn-2" });
+    // A reconnect can re-emit turn 1 after turn 2. Its larger arrival sequence
+    // must not make the lower cumulative total the new high-water mark.
+    await emitUsage({ inputTokens: 1_000, lastInputTokens: 100, turnId: "turn-1" });
+    await emitUsage({ inputTokens: 6_000, lastInputTokens: 300, turnId: "turn-3" });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(
+      pricing.lines.find((line) => line.turnId === "turn-3")?.inputTokens,
+    ).toBe(3_000);
+
+    await registry.close();
+  });
+
   it("persists Qwen turn usage as an unpriced card when no catalog rate exists", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -21149,6 +21149,100 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("attributes a late Codex usage snapshot from the preceding cumulative total", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+
+    // Codex can emit the previous turn's final cumulative snapshot only when
+    // the thread is resumed. Preserve it as the next turn's opening balance.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          last: {
+            inputTokens: 171_318,
+            cachedInputTokens: 169_728,
+            outputTokens: 100,
+            reasoningOutputTokens: 0,
+            totalTokens: 171_418,
+          },
+          total: {
+            inputTokens: 49_575_456,
+            cachedInputTokens: 47_800_576,
+            outputTokens: 118_122,
+            reasoningOutputTokens: 46_342,
+            totalTokens: 49_693_578,
+          },
+        },
+      },
+    });
+
+    // Only one snapshot arrives for turn 2. `last` is merely its final
+    // cache-hot model request; total - turn 1 is the complete turn usage.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-2",
+        tokenUsage: {
+          last: {
+            inputTokens: 228_834,
+            cachedInputTokens: 227_840,
+            outputTokens: 141,
+            reasoningOutputTokens: 0,
+            totalTokens: 228_975,
+          },
+          total: {
+            inputTokens: 59_830_359,
+            cachedInputTokens: 57_795_328,
+            outputTokens: 128_478,
+            reasoningOutputTokens: 49_365,
+            totalTokens: 59_958_837,
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const turn2 = pricing.lines.find((line) => line.turnId === "turn-2");
+
+    expect(turn2).toMatchObject({
+      cachedInputTokens: 9_994_752,
+      inputTokens: 10_254_903,
+      outputTokens: 10_356,
+      reasoningOutputTokens: 3_023,
+      totalCostMicros: 6_699_501,
+      totalTokens: 10_265_259,
+      turnUsageAttributed: true,
+      uncachedInputTokens: 260_151,
+    });
+
+    await registry.close();
+  });
+
   it("persists Qwen turn usage as an unpriced card when no catalog rate exists", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -1173,6 +1173,129 @@ describe("StateDb", () => {
     });
   });
 
+  it("repairs a late Codex turn snapshot from its fresh cumulative opening balance", () => {
+    const dbPath = path.join(tempDir, "codex-turn-usage-repair-state.db");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    const insert = stateDb.raw.prepare(
+      `INSERT INTO thread_usage_lines (
+         usage_line_id, provider, backend, thread_id, turn_id, source,
+         source_item_id, scope, status, created_at, completed_at, model,
+         reasoning_effort, service_tier, fast_mode, turn_usage_attributed,
+         settings_source, settings_confidence, input_tokens, cached_input_tokens,
+         uncached_input_tokens, output_tokens, reasoning_output_tokens,
+         total_tokens, cumulative_input_tokens, cumulative_cached_input_tokens,
+         cumulative_uncached_input_tokens, cumulative_output_tokens,
+         cumulative_reasoning_output_tokens, cumulative_total_tokens,
+         price_status, currency, pricing_catalog_id, pricing_catalog_version,
+         pricing_rate_id, uncached_input_cost_micros,
+         cached_input_cost_micros, output_cost_micros, total_cost_micros,
+         updated_at
+       ) VALUES (
+         @usageLineId, 'openai', 'codex', 'thread-1', @turnId, 'live',
+         'thread-token-usage', 'turn', 'pending', @createdAt, @completedAt,
+         'gpt-5.6-sol', 'high', 'standard', 0, 1, 'thread-overlay',
+         'fallback', @inputTokens, @cachedInputTokens, @uncachedInputTokens,
+         @outputTokens, @reasoningOutputTokens, @totalTokens,
+         @cumulativeInputTokens, @cumulativeCachedInputTokens,
+         @cumulativeUncachedInputTokens, @cumulativeOutputTokens,
+         @cumulativeReasoningOutputTokens, @cumulativeTotalTokens, 'priced',
+         'USD', 'openai-api', '2026-07-09',
+         'openai:2026-07-09:gpt-5.6-sol:standard',
+         @uncachedInputCostMicros, @cachedInputCostMicros,
+         @outputCostMicros, @totalCostMicros, @updatedAt
+       )`,
+    );
+    const turn2StartedAt = Date.UTC(2026, 7, 8, 18, 18, 22);
+    insert.run({
+      cachedInputCostMicros: 84_864,
+      cachedInputTokens: 169_728,
+      completedAt: Date.UTC(2026, 6, 27, 2, 53, 2),
+      createdAt: Date.UTC(2026, 6, 27, 2, 48, 53),
+      cumulativeCachedInputTokens: 47_800_576,
+      cumulativeInputTokens: 49_575_456,
+      cumulativeOutputTokens: 118_122,
+      cumulativeReasoningOutputTokens: 46_342,
+      cumulativeTotalTokens: 49_693_578,
+      cumulativeUncachedInputTokens: 1_774_880,
+      inputTokens: 171_318,
+      outputCostMicros: 3_000,
+      outputTokens: 100,
+      reasoningOutputTokens: 0,
+      totalCostMicros: 95_814,
+      totalTokens: 171_418,
+      turnId: "turn-1",
+      uncachedInputCostMicros: 7_950,
+      uncachedInputTokens: 1_590,
+      updatedAt: turn2StartedAt - 19_000,
+      usageLineId: "line-turn-1",
+    });
+    insert.run({
+      cachedInputCostMicros: 113_920,
+      cachedInputTokens: 227_840,
+      completedAt: Date.UTC(2026, 7, 8, 18, 24, 28),
+      createdAt: turn2StartedAt,
+      cumulativeCachedInputTokens: 57_795_328,
+      cumulativeInputTokens: 59_830_359,
+      cumulativeOutputTokens: 128_478,
+      cumulativeReasoningOutputTokens: 49_365,
+      cumulativeTotalTokens: 59_958_837,
+      cumulativeUncachedInputTokens: 2_035_031,
+      inputTokens: 228_834,
+      outputCostMicros: 4_230,
+      outputTokens: 141,
+      reasoningOutputTokens: 0,
+      totalCostMicros: 123_120,
+      totalTokens: 228_975,
+      turnId: "turn-2",
+      uncachedInputCostMicros: 4_970,
+      uncachedInputTokens: 994,
+      updatedAt: Date.UTC(2026, 7, 8, 20, 52, 27),
+      usageLineId: "line-turn-2",
+    });
+
+    stateDb.raw.pragma("user_version = 51");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+
+    expect(
+      stateDb.raw
+        .prepare(
+          `SELECT
+             input_tokens,
+             cached_input_tokens,
+             uncached_input_tokens,
+             output_tokens,
+             reasoning_output_tokens,
+             total_tokens,
+             total_cost_micros
+           FROM thread_usage_lines
+           WHERE usage_line_id = 'line-turn-2'`,
+        )
+        .get(),
+    ).toEqual({
+      cached_input_tokens: 9_994_752,
+      input_tokens: 10_254_903,
+      output_tokens: 10_356,
+      reasoning_output_tokens: 3_023,
+      total_cost_micros: 6_699_501,
+      total_tokens: 10_265_259,
+      uncached_input_tokens: 260_151,
+    });
+    expect(
+      stateDb.raw
+        .prepare(
+          `SELECT input_tokens, total_cost_micros
+           FROM thread_pricing_summaries
+           WHERE backend = 'codex' AND thread_id = 'thread-1'`,
+        )
+        .get(),
+    ).toEqual({
+      input_tokens: 10_426_221,
+      total_cost_micros: 6_795_315,
+    });
+  });
+
   it("migrates legacy Grok pricing without billing fork baselines", () => {
     stateDb.close();
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6502,10 +6502,30 @@ type PendingLiveThreadUsageLine = {
 
 type LiveThreadUsageEmitWork = {
   backend: AppServerBackendKind;
+  derivationFinished: boolean;
+  derivationKey: string;
+  derivationTail: Promise<void>;
   observationSequence: number;
+  precedingDerivation: Promise<void>;
+  settleDerivation: () => void;
   settled: Promise<void>;
   settle: () => void;
   threadId: string;
+};
+
+type DerivedLiveThreadTokenUsage = {
+  // Whether turnTokenUsage is a real measurement of this turn — a per-turn
+  // delta or a per-request "last" snapshot — vs a fallback to a whole-thread
+  // total we could not decompose.
+  attributed: boolean;
+  cumulativeTokenUsage?: TaskMonitorTokenUsageBreakdown;
+  turnTokenUsage: TaskMonitorTokenUsageBreakdown | unknown;
+  /**
+   * The `total - latest` baseline, set only on the call that first seeds it
+   * for a `(thread, turn)`. For a fork's first observed turn this equals the
+   * context copied in at the fork point.
+   */
+  seededBaselineTokenUsage?: TaskMonitorTokenUsageBreakdown;
 };
 
 function isCodexInvalidIdRecoveryCooldownActive(
@@ -6750,6 +6770,14 @@ export class DesktopBackendRegistry {
    * an exact arrival-ordered durability barrier.
    */
   private readonly liveThreadUsageEmitWork = new Set<LiveThreadUsageEmitWork>();
+  // Registered synchronously at notification arrival, before the async event
+  // pipeline can reorder overlay reads. Each thread's derivation waits for the
+  // preceding arrival to publish its cumulative snapshot, while unrelated
+  // threads remain fully concurrent.
+  private readonly liveThreadUsageDerivationTails = new Map<
+    string,
+    Promise<void>
+  >();
   private pendingLiveThreadUsageTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes timer, terminal, retry, and shutdown drains. A caller awaiting
@@ -20499,22 +20527,7 @@ export class DesktopBackendRegistry {
     threadId: string;
     tokenUsage: unknown;
     turnId?: string;
-  }): {
-    // Whether turnTokenUsage is a real measurement of this turn — a per-turn
-    // delta or a per-request "last" snapshot — vs a fallback to a whole-thread
-    // total we couldn't decompose. Carried onto the persisted row so the
-    // renderer classifies summaries by fact, not a token-count guess.
-    attributed: boolean;
-    cumulativeTokenUsage?: TaskMonitorTokenUsageBreakdown;
-    turnTokenUsage: TaskMonitorTokenUsageBreakdown | unknown;
-    /**
-     * The `total − latest` baseline, set only on the call that first seeds it
-     * for a `(thread, turn)`. For a fork's first observed turn this equals the
-     * context copied in at the fork point, which pricing captures as the
-     * inherited (never re-billed) fork baseline.
-     */
-    seededBaselineTokenUsage?: TaskMonitorTokenUsageBreakdown;
-  } {
+  }): DerivedLiveThreadTokenUsage {
     const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
     if (!records) {
       return { attributed: false, turnTokenUsage: params.tokenUsage };
@@ -20576,7 +20589,13 @@ export class DesktopBackendRegistry {
       && observationSequence !== undefined
       && (
         !priorCumulative
-        || observationSequence > priorCumulative.observationSequence
+        || (
+          observationSequence > priorCumulative.observationSequence
+          && canSubtractTaskMonitorTokenUsage(
+            records.totalUsage,
+            priorCumulative.usage,
+          )
+        )
       )
     ) {
       this.liveCodexThreadCumulativeUsage.set(cumulativeKey, {
@@ -20776,13 +20795,28 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
   ): LiveThreadUsageEmitWork {
+    const derivationKey = [backend, threadId].join(":");
+    const precedingDerivation =
+      this.liveThreadUsageDerivationTails.get(derivationKey)
+      ?? Promise.resolve();
+    let settleDerivation!: () => void;
+    const derivationSettled = new Promise<void>((resolve) => {
+      settleDerivation = resolve;
+    });
+    const derivationTail = precedingDerivation.then(() => derivationSettled);
+    this.liveThreadUsageDerivationTails.set(derivationKey, derivationTail);
     let settle!: () => void;
     const settled = new Promise<void>((resolve) => {
       settle = resolve;
     });
     const work = {
       backend,
+      derivationFinished: false,
+      derivationKey,
+      derivationTail,
       observationSequence: ++this.liveThreadUsageObservationSequence,
+      precedingDerivation,
+      settleDerivation,
       settled,
       settle,
       threadId,
@@ -20791,9 +20825,30 @@ export class DesktopBackendRegistry {
     return work;
   }
 
+  private finishLiveThreadUsageDerivation(
+    work: LiveThreadUsageEmitWork,
+  ): void {
+    if (work.derivationFinished) {
+      return;
+    }
+    work.derivationFinished = true;
+    work.settleDerivation();
+    void work.derivationTail.then(() => {
+      if (
+        this.liveThreadUsageDerivationTails.get(work.derivationKey)
+        === work.derivationTail
+      ) {
+        this.liveThreadUsageDerivationTails.delete(work.derivationKey);
+      }
+    });
+  }
+
   private finishLiveThreadUsageEmitWork(
     work: LiveThreadUsageEmitWork,
   ): void {
+    // If an earlier pipeline stage failed before recordLiveThreadUsage, release
+    // this arrival's derivation slot so later usage cannot deadlock behind it.
+    this.finishLiveThreadUsageDerivation(work);
     if (!this.liveThreadUsageEmitWork.delete(work)) {
       return;
     }
@@ -20816,45 +20871,76 @@ export class DesktopBackendRegistry {
 
   private async recordLiveThreadUsage(
     event: AgentEvent,
-    observationSequence?: number,
+    work?: LiveThreadUsageEmitWork,
   ): Promise<void> {
     const notification = event.notification;
     if (
       notification.method !== "thread/tokenUsage/updated"
-      || observationSequence === undefined
+      || !work
     ) {
       return;
     }
     const threadId = notification.params.threadId;
     if (!threadId) {
+      this.finishLiveThreadUsageDerivation(work);
       return;
     }
-    if (event.backend === "codex" && this.codexNativeSubAgentParents.has(threadId)) {
-      return;
-    }
-    if (
-      Array.from(this.taskMonitorDelegations.values()).some(
-        (record) =>
-          record.backend === event.backend && record.monitorThreadId === threadId,
-      )
-      || this.completedTaskMonitorsByThread.has(
-        taskMonitorThreadKey(event.backend, threadId),
-      )
-    ) {
-      return;
-    }
-    if (notification.params.turnId) {
-      const reviewKey = buildReviewSubAgentKey(
-        event.backend,
-        threadId,
-        notification.params.turnId,
-      );
+    await work.precedingDerivation;
+    let derivedUsage: DerivedLiveThreadTokenUsage | undefined;
+    let observedReplays: ObservedContextReplayTally | undefined;
+    try {
       if (
-        this.activeReviewSubAgents.has(reviewKey) ||
-        this.reviewSubAgentsByReviewTurn.has(reviewKey)
+        event.backend === "codex"
+        && this.codexNativeSubAgentParents.has(threadId)
       ) {
         return;
       }
+      if (
+        Array.from(this.taskMonitorDelegations.values()).some(
+          (record) =>
+            record.backend === event.backend && record.monitorThreadId === threadId,
+        )
+        || this.completedTaskMonitorsByThread.has(
+          taskMonitorThreadKey(event.backend, threadId),
+        )
+      ) {
+        return;
+      }
+      if (notification.params.turnId) {
+        const reviewKey = buildReviewSubAgentKey(
+          event.backend,
+          threadId,
+          notification.params.turnId,
+        );
+        if (
+          this.activeReviewSubAgents.has(reviewKey)
+          || this.reviewSubAgentsByReviewTurn.has(reviewKey)
+        ) {
+          return;
+        }
+      }
+
+      const tokenUsage = notification.params.tokenUsage;
+      derivedUsage = this.deriveLiveThreadTokenUsage({
+        backend: event.backend,
+        observationSequence: work.observationSequence,
+        threadId,
+        tokenUsage,
+        turnId: notification.params.turnId ?? undefined,
+      });
+      observedReplays = this.observeLiveThreadContextReplay({
+        backend: event.backend,
+        threadId,
+        tokenUsage,
+        turnId: notification.params.turnId ?? undefined,
+      });
+    } finally {
+      // Publish the cumulative cursor before any overlay or sqlite await lets
+      // a later arrival overtake this derivation.
+      this.finishLiveThreadUsageDerivation(work);
+    }
+    if (!derivedUsage) {
+      return;
     }
 
     const overlay = await this.overlayStore.getThreadOverlayState({
@@ -20882,19 +20968,6 @@ export class DesktopBackendRegistry {
         "effort",
       ]) ??
       overlay?.reasoningEffort;
-    const derivedUsage = this.deriveLiveThreadTokenUsage({
-      backend: event.backend,
-      observationSequence,
-      threadId,
-      tokenUsage,
-      turnId: notification.params.turnId ?? undefined,
-    });
-    const observedReplays = this.observeLiveThreadContextReplay({
-      backend: event.backend,
-      threadId,
-      tokenUsage,
-      turnId: notification.params.turnId ?? undefined,
-    });
     const usageTiming = resolveLiveThreadUsageTiming({
       overlay,
       turnId: notification.params.turnId ?? undefined,
@@ -20949,7 +21022,7 @@ export class DesktopBackendRegistry {
         this.bufferLiveThreadUsageLine({
           backend: event.backend,
           line,
-          observationSequence,
+          observationSequence: work.observationSequence,
         });
         return;
       }
@@ -31372,7 +31445,7 @@ export class DesktopBackendRegistry {
 
     await this.recordLiveThreadUsage(
       event,
-      liveThreadUsageWork?.observationSequence,
+      liveThreadUsageWork,
     );
     await this.recordToolInvocationAccounting(event);
     this.forgetCompletedTurnReplayObservations(event);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3765,6 +3765,37 @@ function subtractTaskMonitorTokenUsage(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function canSubtractTaskMonitorTokenUsage(
+  total: TaskMonitorTokenUsageBreakdown,
+  baseline: TaskMonitorTokenUsageBreakdown,
+): boolean {
+  let compared = false;
+  for (const key of [
+    "cachedInputTokens",
+    "inputTokens",
+    "uncachedInputTokens",
+    "outputTokens",
+    "reasoningOutputTokens",
+    "totalTokens",
+  ] as const) {
+    const totalValue = total[key];
+    const baselineValue = baseline[key];
+    if (
+      typeof totalValue !== "number"
+      || !Number.isFinite(totalValue)
+      || typeof baselineValue !== "number"
+      || !Number.isFinite(baselineValue)
+    ) {
+      continue;
+    }
+    compared = true;
+    if (totalValue < baselineValue) {
+      return false;
+    }
+  }
+  return compared;
+}
+
 function normalizeTaskMonitorPricingTokens(
   tokens: TaskMonitorTokenUsageBreakdown,
 ): Required<TaskMonitorTokenUsageBreakdown> {
@@ -6675,6 +6706,18 @@ export class DesktopBackendRegistry {
   private readonly liveThreadUsageBaselines = new Map<
     string,
     TaskMonitorTokenUsageBreakdown
+  >();
+  // Codex `total` usage is cumulative for the thread, while `last` is only the
+  // latest upstream model request. Keep the preceding turn's cumulative high-
+  // water mark so a snapshot first observed after a long multi-request turn
+  // is attributed as `total - preceding total`, not mistaken for `last`.
+  private readonly liveCodexThreadCumulativeUsage = new Map<
+    string,
+    {
+      observationSequence: number;
+      turnId: string;
+      usage: TaskMonitorTokenUsageBreakdown;
+    }
   >();
   // Per-turn tally of observed context replays (key: backend:threadId:turnId).
   private readonly liveThreadReplayObservations = new Map<
@@ -20452,6 +20495,7 @@ export class DesktopBackendRegistry {
 
   private deriveLiveThreadTokenUsage(params: {
     backend: AppServerBackendKind;
+    observationSequence?: number;
     threadId: string;
     tokenUsage: unknown;
     turnId?: string;
@@ -20495,6 +20539,26 @@ export class DesktopBackendRegistry {
     ].join(":");
     let baseline = this.liveThreadUsageBaselines.get(key);
     let seededBaselineTokenUsage: TaskMonitorTokenUsageBreakdown | undefined;
+    const cumulativeKey = [params.backend, params.threadId].join(":");
+    const observationSequence = params.observationSequence;
+    const priorCumulative =
+      params.backend === "codex" && observationSequence !== undefined
+        ? this.liveCodexThreadCumulativeUsage.get(cumulativeKey)
+        : undefined;
+    if (
+      !baseline
+      && priorCumulative
+      && priorCumulative.turnId !== params.turnId
+      && observationSequence !== undefined
+      && priorCumulative.observationSequence < observationSequence
+      && canSubtractTaskMonitorTokenUsage(
+        records.totalUsage,
+        priorCumulative.usage,
+      )
+    ) {
+      baseline = priorCumulative.usage;
+      this.liveThreadUsageBaselines.set(key, baseline);
+    }
     if (!baseline && records.latestUsage) {
       baseline = subtractTaskMonitorTokenUsage(
         records.totalUsage,
@@ -20504,6 +20568,22 @@ export class DesktopBackendRegistry {
         this.liveThreadUsageBaselines.set(key, baseline);
         seededBaselineTokenUsage = baseline;
       }
+    }
+
+    if (
+      params.backend === "codex"
+      && params.turnId
+      && observationSequence !== undefined
+      && (
+        !priorCumulative
+        || observationSequence > priorCumulative.observationSequence
+      )
+    ) {
+      this.liveCodexThreadCumulativeUsage.set(cumulativeKey, {
+        observationSequence,
+        turnId: params.turnId,
+        usage: records.totalUsage,
+      });
     }
 
     const turnTokenUsage = baseline
@@ -20804,6 +20884,7 @@ export class DesktopBackendRegistry {
       overlay?.reasoningEffort;
     const derivedUsage = this.deriveLiveThreadTokenUsage({
       backend: event.backend,
+      observationSequence,
       threadId,
       tokenUsage,
       turnId: notification.params.turnId ?? undefined,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 51;
+export const CURRENT_STATE_DB_USER_VERSION = 52;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -1494,6 +1494,12 @@ LEFT JOIN federation_peers
     if ((db.pragma("user_version", { simple: true }) as number) < 51) {
       db.transaction(() => {
         ensureThreadToolIncidentExplorerSchema(db);
+        db.pragma("user_version = 51");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 52) {
+      db.transaction(() => {
+        repairCodexTurnUsageFromCumulativeSnapshots(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -2670,6 +2676,212 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
   }
 
   rebuildThreadPricingSummaries(db, now);
+}
+
+const CODEX_OPENING_USAGE_SNAPSHOT_MAX_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * Repair the late-snapshot failure that priced only Codex `last` usage as a
+ * whole turn. A preceding row is authoritative only when its cumulative total
+ * was refreshed immediately before the next turn began; older snapshots may
+ * hide unobserved turns and are deliberately left alone.
+ */
+function repairCodexTurnUsageFromCumulativeSnapshots(
+  db: BetterSqlite3.Database,
+): void {
+  if (
+    !tableExists(db, "thread_usage_lines")
+    || !tableExists(db, "thread_pricing_summaries")
+    || !tableColumnExists(
+      db,
+      "thread_usage_lines",
+      "cumulative_input_tokens",
+    )
+  ) {
+    return;
+  }
+
+  type CumulativeUsageRow = {
+    cached_input_tokens: number;
+    created_at: number;
+    cumulative_cached_input_tokens: number | null;
+    cumulative_input_tokens: number | null;
+    cumulative_output_tokens: number | null;
+    cumulative_reasoning_output_tokens: number | null;
+    cumulative_total_tokens: number | null;
+    currency: string;
+    fast_mode: number | null;
+    input_tokens: number;
+    model: string | null;
+    output_tokens: number;
+    reasoning_output_tokens: number;
+    service_tier: string | null;
+    thread_id: string;
+    total_tokens: number;
+    updated_at: number;
+    usage_line_id: string;
+  };
+  const rows = db
+    .prepare(
+      `SELECT
+         usage_line_id,
+         thread_id,
+         created_at,
+         updated_at,
+         model,
+         service_tier,
+         fast_mode,
+         currency,
+         input_tokens,
+         cached_input_tokens,
+         output_tokens,
+         reasoning_output_tokens,
+         total_tokens,
+         cumulative_input_tokens,
+         cumulative_cached_input_tokens,
+         cumulative_output_tokens,
+         cumulative_reasoning_output_tokens,
+         cumulative_total_tokens
+       FROM thread_usage_lines
+       WHERE backend = 'codex'
+         AND provider = 'openai'
+         AND source = 'live'
+         AND scope = 'turn'
+         AND status != 'superseded'
+         AND cumulative_input_tokens IS NOT NULL
+       ORDER BY thread_id ASC, created_at ASC, usage_line_id ASC`,
+    )
+    .all() as CumulativeUsageRow[];
+  const updateLine = db.prepare(
+    `UPDATE thread_usage_lines
+     SET
+       input_tokens = @inputTokens,
+       cached_input_tokens = @cachedInputTokens,
+       uncached_input_tokens = @uncachedInputTokens,
+       output_tokens = @outputTokens,
+       reasoning_output_tokens = @reasoningOutputTokens,
+       total_tokens = @totalTokens,
+       price_status = @priceStatus,
+       price_unavailable_reason = @priceUnavailableReason,
+       currency = @currency,
+       pricing_catalog_id = @pricingCatalogId,
+       pricing_catalog_version = @pricingCatalogVersion,
+       pricing_rate_id = @pricingRateId,
+       uncached_input_cost_micros = @uncachedInputCostMicros,
+       cached_input_cost_micros = @cachedInputCostMicros,
+       output_cost_micros = @outputCostMicros,
+       total_cost_micros = @totalCostMicros,
+       updated_at = @updatedAt
+     WHERE usage_line_id = @usageLineId`,
+  );
+
+  let prior: CumulativeUsageRow | undefined;
+  let repairedCount = 0;
+  const now = Date.now();
+  for (const row of rows) {
+    if (prior?.thread_id !== row.thread_id) {
+      prior = row;
+      continue;
+    }
+
+    const openingSnapshotAge = row.created_at - prior.updated_at;
+    const cumulativePairs = [
+      [row.cumulative_input_tokens, prior.cumulative_input_tokens],
+      [row.cumulative_cached_input_tokens, prior.cumulative_cached_input_tokens],
+      [row.cumulative_output_tokens, prior.cumulative_output_tokens],
+      [
+        row.cumulative_reasoning_output_tokens,
+        prior.cumulative_reasoning_output_tokens,
+      ],
+      [row.cumulative_total_tokens, prior.cumulative_total_tokens],
+    ] as const;
+    const hasExactOpeningSnapshot =
+      openingSnapshotAge >= 0
+      && openingSnapshotAge <= CODEX_OPENING_USAGE_SNAPSHOT_MAX_AGE_MS
+      && cumulativePairs.every(
+        ([current, previous]) =>
+          current !== null
+          && previous !== null
+          && current >= previous,
+      );
+    if (!hasExactOpeningSnapshot) {
+      prior = row;
+      continue;
+    }
+
+    const inputTokens =
+      row.cumulative_input_tokens! - prior.cumulative_input_tokens!;
+    const cachedInputTokens =
+      row.cumulative_cached_input_tokens!
+      - prior.cumulative_cached_input_tokens!;
+    const outputTokens =
+      row.cumulative_output_tokens! - prior.cumulative_output_tokens!;
+    const reasoningOutputTokens =
+      row.cumulative_reasoning_output_tokens!
+      - prior.cumulative_reasoning_output_tokens!;
+    const totalTokens =
+      row.cumulative_total_tokens! - prior.cumulative_total_tokens!;
+    const wasUndercounted =
+      inputTokens > row.input_tokens
+      || cachedInputTokens > row.cached_input_tokens
+      || outputTokens > row.output_tokens
+      || reasoningOutputTokens > row.reasoning_output_tokens
+      || totalTokens > row.total_tokens;
+    if (!wasUndercounted) {
+      prior = row;
+      continue;
+    }
+
+    const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+    const cost = estimateTokenUsageCost({
+      at: row.created_at,
+      cachedInputTokens,
+      fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
+      model: row.model ?? undefined,
+      outputTokens,
+      reasoningOutputTokens,
+      serviceTier: row.service_tier ?? undefined,
+      uncachedInputTokens,
+    });
+    const pricingServiceTier = resolveOpenAiPricingServiceTier({
+      fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
+      serviceTier: row.service_tier ?? undefined,
+    });
+    const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | null =
+      cost
+        ? null
+        : !row.model
+          ? "missing-model"
+          : pricingServiceTier === undefined
+            ? "unsupported-service-tier"
+            : "missing-rate";
+    updateLine.run({
+      cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
+      cachedInputTokens,
+      currency: cost?.currency ?? row.currency,
+      inputTokens,
+      outputCostMicros: cost?.outputCostMicros ?? 0,
+      outputTokens,
+      priceStatus: cost ? "priced" : "unpriced",
+      priceUnavailableReason,
+      pricingCatalogId: cost?.catalogId ?? null,
+      pricingCatalogVersion: cost?.catalogVersion ?? null,
+      pricingRateId: cost?.rateId ?? null,
+      reasoningOutputTokens,
+      totalCostMicros: cost?.totalCostMicros ?? 0,
+      totalTokens,
+      uncachedInputCostMicros: cost?.uncachedInputCostMicros ?? 0,
+      uncachedInputTokens,
+      updatedAt: now,
+      usageLineId: row.usage_line_id,
+    });
+    repairedCount += 1;
+    prior = row;
+  }
+
+  if (repairedCount > 0) {
+    rebuildThreadPricingSummaries(db, now);
+  }
 }
 
 function rebuildThreadPricingSummaries(db: BetterSqlite3.Database, updatedAt: number): void {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -736,7 +736,7 @@ function TurnStrip(props: {
             ? strip.rankedBy === "billed"
               ? "Costliest turns · by billed cost"
               : "Costliest turns · by output × round trips"
-            : "Cost by turn"}
+            : "Tool-output estimate · billed cost"}
         </p>
         <div
           aria-label="Turn scope"
@@ -759,7 +759,7 @@ function TurnStrip(props: {
           </button>
         </div>
         <p className="incident-explorer__turns-legend">
-          <span className="incident-explorer__turns-key" data-kind="tokens" /> output tokens
+          <span className="incident-explorer__turns-key" data-kind="tokens" /> estimated tool-output tokens
           {" · "}
           <span className="incident-explorer__turns-key" data-kind="trips" /> round trips
         </p>
@@ -785,8 +785,11 @@ function TurnStrip(props: {
               style={{ width: `${scaleWidth(row.estimatedOutputTokens, props.strip.maxTokens)}%` }}
             />
           </span>
-          <span className="incident-explorer__turn-number">
-            {formatCompactTokens(row.estimatedOutputTokens)} tok
+          <span
+            className="incident-explorer__turn-number"
+            title={`${formatCompactTokens(row.estimatedOutputTokens)} estimated tool-output tokens; this is not provider-billed usage`}
+          >
+            {formatCompactTokens(row.estimatedOutputTokens)} est.
           </span>
           <span aria-hidden="true" className="incident-explorer__turn-trips">
             <i style={{ width: `${scaleWidth(row.callCount, props.strip.maxCallCount)}%` }} />
@@ -795,7 +798,12 @@ function TurnStrip(props: {
             {row.callCount.toLocaleString()} {row.callCount === 1 ? "call" : "calls"}
           </span>
           {props.showCost ? (
-            <span className="incident-explorer__turn-cost">
+            <span
+              className="incident-explorer__turn-cost"
+              title={row.costMicros !== undefined
+                ? `Billed cost from provider-reported usage: ${formatMicrosCurrency(row.costMicros, props.currency)}`
+                : undefined}
+            >
               {row.costMicros !== undefined
                 ? formatMicrosCurrency(row.costMicros, props.currency)
                 : "—"}
@@ -851,10 +859,10 @@ function TurnTimeline(props: {
           const description = [
             row.label,
             formatTurnWhen(row.firstObservedAt, props.now),
-            `${formatCompactTokens(row.estimatedOutputTokens)} tok`,
+            `${formatCompactTokens(row.estimatedOutputTokens)} estimated tool-output tokens`,
             `${row.callCount.toLocaleString()} ${row.callCount === 1 ? "call" : "calls"}`,
             ...(row.costMicros !== undefined
-              ? [formatMicrosCurrency(row.costMicros, props.currency)]
+              ? [`billed cost ${formatMicrosCurrency(row.costMicros, props.currency)}`]
               : []),
           ].join(" · ");
           return (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -213,6 +213,36 @@ describe("ToolOutputIncidentExplorerWindow", () => {
       .toHaveTextContent("3 calls");
     expect(within(turns).getByRole("button", { name: /Turn 2/ }))
       .toHaveTextContent("1 call");
+    expect(within(turns).getByTitle(
+      "5.1k estimated tool-output tokens; this is not provider-billed usage",
+    )).toHaveTextContent("5.1k est.");
+  });
+
+  it("labels the hover price as billed rather than treating tool output as usage", async () => {
+    const response = buildMultiTurnResponse();
+    response.pricing = {
+      lines: [{
+        createdAt: 1,
+        currency: "USD",
+        threadId: "thread-1",
+        totalCostMicros: 123_120,
+        turnId: "turn-1",
+      }] as never,
+      summaries: [],
+    };
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const timeline = await screen.findByRole("group", {
+      name: "Tool cost per turn, in order",
+    });
+    expect(within(timeline).getAllByRole("button")[0]).toHaveAttribute(
+      "title",
+      expect.stringContaining("5.1k estimated tool-output tokens · 3 calls · billed cost $0.12"),
+    );
+    expect(screen.getByTitle("Billed cost from provider-reported usage: $0.12"))
+      .toHaveTextContent("$0.12");
   });
 
   it("widens the turn strip from flagged turns to every turn with tool calls", async () => {
@@ -253,7 +283,10 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     const columns = within(timeline).getAllByRole("button");
     expect(columns).toHaveLength(2);
     /* Hover text carries the numbers the bars encode. */
-    expect(columns[0]).toHaveAttribute("title", expect.stringMatching(/Turn 1 .*3 calls/));
+    expect(columns[0]).toHaveAttribute(
+      "title",
+      expect.stringMatching(/Turn 1 .*estimated tool-output tokens.*3 calls/),
+    );
 
     fireEvent.click(columns[1]!);
     const cases = screen.getByLabelText("Incident cases");

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts
@@ -490,8 +490,20 @@ describe("turn cost", () => {
       ],
       {
         usageLines: [
-          { createdAt: 1, currency: "USD", totalCostMicros: 1_500_000, turnId: "turn-a" },
-          { createdAt: 2, currency: "USD", totalCostMicros: 900_000, turnId: "turn-a" },
+          {
+            createdAt: 1,
+            currency: "USD",
+            threadId: "thread-1",
+            totalCostMicros: 1_500_000,
+            turnId: "turn-a",
+          },
+          {
+            createdAt: 2,
+            currency: "USD",
+            threadId: "thread-1",
+            totalCostMicros: 900_000,
+            turnId: "turn-a",
+          },
         ] as never,
       },
     );
@@ -501,6 +513,42 @@ describe("turn cost", () => {
     /* A turn the ledger has not priced reports nothing rather than zero. */
     expect(strip.rows.find((row) => row.key === "turn-b")?.costMicros)
       .toBeUndefined();
+  });
+
+  it("does not add a child thread's matching turn id to the parent cost", () => {
+    /* A tool row is scoped to its own thread. Turn ids are normally UUIDs,
+       but the join must not rely on that implementation detail: a child or
+       another backend can reuse a short turn id such as "turn-1". */
+    const strip = buildTurnCostStrip(
+      [
+        invocation({
+          estimatedOutputTokens: 170_730,
+          threadId: "parent-thread",
+          turnId: "turn-1",
+        }),
+      ],
+      {
+        usageLines: [
+          {
+            createdAt: 1,
+            currency: "USD",
+            threadId: "parent-thread",
+            totalCostMicros: 123_120,
+            turnId: "turn-1",
+          },
+          {
+            createdAt: 2,
+            currency: "USD",
+            parentThreadId: "parent-thread",
+            threadId: "sub-agent-thread",
+            totalCostMicros: 500_000,
+            turnId: "turn-1",
+          },
+        ] as never,
+      },
+    );
+
+    expect(strip.rows[0]?.costMicros).toBe(123_120);
   });
 
   it("formats money to a fixed two places so the column aligns", () => {
@@ -565,9 +613,27 @@ describe("turn strip scope and ranking", () => {
       {
         limit: 2,
         usageLines: [
-          { createdAt: 1, currency: "USD", totalCostMicros: 900_000, turnId: "turn-tokens" },
-          { createdAt: 2, currency: "USD", totalCostMicros: 5_000_000, turnId: "turn-dollars" },
-          { createdAt: 3, currency: "USD", totalCostMicros: 100_000, turnId: "turn-cheap" },
+          {
+            createdAt: 1,
+            currency: "USD",
+            threadId: "thread-1",
+            totalCostMicros: 900_000,
+            turnId: "turn-tokens",
+          },
+          {
+            createdAt: 2,
+            currency: "USD",
+            threadId: "thread-1",
+            totalCostMicros: 5_000_000,
+            turnId: "turn-dollars",
+          },
+          {
+            createdAt: 3,
+            currency: "USD",
+            threadId: "thread-1",
+            totalCostMicros: 100_000,
+            turnId: "turn-cheap",
+          },
         ] as never,
       },
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-output-incident-insights.ts
@@ -63,6 +63,8 @@ export type TurnCostRow = {
   label: string;
   /** Calls that reached the harness's output cap, where output is truncated. */
   overCapCount: number;
+  /** Owning thread for the ledger join; never infer it from a turn id alone. */
+  threadId: string;
   turnId?: string;
 };
 
@@ -314,16 +316,20 @@ export function buildTurnCostStrip(
 ): TurnCostStrip {
   const limit = options?.limit ?? DEFAULT_TURN_ROW_LIMIT;
   const scope = options?.scope ?? "flagged";
-  /* Billed cost per turn, joined by turn id. The ledger is the authority on
-     money; the token bar is an estimate from character counts, so the two are
-     reported side by side rather than one derived from the other. */
-  const costByTurn = new Map<string, number>();
+  /* Billed cost per thread and turn. The ledger is the authority on money;
+     the token bar is an estimate from character counts, so the two are
+     reported side by side rather than one derived from the other. A turn id
+     alone is not a safe join key: child threads and other backends can emit
+     short, repeated ids such as "turn-1". */
+  const costByThread = new Map<string, Map<string, number>>();
   for (const line of options?.usageLines ?? []) {
     if (!line.turnId) continue;
-    costByTurn.set(
+    const byTurn = costByThread.get(line.threadId) ?? new Map<string, number>();
+    byTurn.set(
       line.turnId,
-      (costByTurn.get(line.turnId) ?? 0) + line.totalCostMicros,
+      (byTurn.get(line.turnId) ?? 0) + line.totalCostMicros,
     );
+    costByThread.set(line.threadId, byTurn);
   }
   const groups = new Map<string, TurnCostRow>();
   for (const invocation of invocations) {
@@ -336,6 +342,7 @@ export function buildTurnCostStrip(
       key,
       label: "",
       overCapCount: 0,
+      threadId: invocation.threadId,
       ...(invocation.turnId ? { turnId: invocation.turnId } : {}),
     };
     row.callCount += 1;
@@ -354,7 +361,9 @@ export function buildTurnCostStrip(
   }
 
   for (const row of groups.values()) {
-    const cost = row.turnId ? costByTurn.get(row.turnId) : undefined;
+    const cost = row.turnId
+      ? costByThread.get(row.threadId)?.get(row.turnId)
+      : undefined;
     if (cost !== undefined) row.costMicros = cost;
   }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15621,7 +15621,7 @@ a.transcript-message__messaging-origin:focus-visible {
   background: color-mix(in srgb, var(--text-secondary) 66%, transparent);
 }
 
-/* Cost by turn. The solid bar is output volume; the tick rail is round trips.
+/* Tool output and billed cost by turn. The solid bar is output volume; the tick rail is round trips.
    They are deliberately different marks because they are different problems:
    a turn heavy on ticks and light on bar is a polling loop, and the fix for
    it has nothing to do with filtering output. */


### PR DESCRIPTION
## Root cause

Codex reports total as cumulative thread usage and last as only the latest upstream model request. For the investigated turn, PwrAgent observed the preceding cumulative snapshot 19 seconds before the turn started, then observed the next cumulative snapshot when the thread resumed. The existing first-observation logic nevertheless seeded the turn baseline as total minus last, so it discarded every earlier request and priced only the final cache-hot request.

Production evidence for Turn 15:

- persisted row: 228,834 input tokens, 227,840 cached, $0.123120
- cumulative delta from the fresh opening snapshot: 10,254,903 input tokens, 9,994,752 cached, 260,151 uncached, 10,356 output, and 3,023 reasoning
- corrected cost at the persisted GPT-5.6 Sol rate: $6.699501

The turn was not a sub-agent. A separate unsafe renderer join by turn ID alone could mix parent and child rows, but it did not cause this incident.

## Fix

- Preserve the preceding Codex cumulative high-water mark and use it as the opening balance for the next turn.
- Serialize cumulative usage derivation per thread in notification-arrival order, before asynchronous overlay reads can reorder consecutive turns.
- Reject late cumulative snapshots that regress any token counter, so reconnect duplicates cannot replace the high-water mark.
- Keep total minus last only as the cold-start and fork fallback when no preceding snapshot exists.
- Add a version-52 one-time repair for historical Codex rows when the preceding cumulative snapshot was refreshed within five minutes before the turn began.
- Scope incident-explorer cost joins by thread ID and turn ID.
- Label character-derived tool-output estimates separately from provider-billed usage.

## Write budget

The historical repair runs in one migration transaction per upgraded profile. It adds no command, turn, item, stream, or timer writes; steady-state cost is zero commits per day.

## Validation

- 773 focused main and renderer tests
- regression test reproducing the exact $0.123120 versus $6.699501 failure
- regressions for overlapping cross-turn notifications and late stale cumulative snapshots
- migration verified against a backup of the affected profile database
- typecheck
- ESLint, with pre-existing warnings only
- dependency-boundary lint
- Codex-storage boundary lint
