### PR TITLE
fix(desktop): attribute cross-provider review usage

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20350,6 +20350,98 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("enriches default-model managed review cards from durable usage", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startThreadResult: { threadId: "managed-review-child" },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-parent": {
+          backend: "codex",
+          threadId: "thread-parent",
+        } as ThreadOverlayState,
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      resolveManagedReviewEnabled: () => true,
+    });
+
+    const response = await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    expect(codexClient.lastStartThreadParams?.model).toBeUndefined();
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: response.reviewThreadId,
+        turnId: response.turnId,
+        model: "gpt-5.5",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 200,
+            outputTokens: 50,
+            reasoningOutputTokens: 10,
+          },
+        },
+      },
+    });
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: response.reviewThreadId,
+        turnId: response.turnId,
+        turn: {
+          id: response.turnId,
+          status: "completed",
+          output: [{
+            type: "text",
+            text: JSON.stringify({
+              findings: [],
+              overall_correctness: "patch is correct",
+              overall_explanation: "No blocking findings.",
+              overall_confidence_score: 0.98,
+            }),
+          }],
+        },
+      },
+    });
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(overlay?.subAgents?.[0]?.monitorUsage?.model).toBe("gpt-5.5");
+    expect(
+      overlay?.managedReviewEntries?.map((entry) => entry.reviewer),
+    ).toEqual([
+      { backend: "codex" },
+      { backend: "codex" },
+    ]);
+
+    const hydrated = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(
+      hydrated.replay.entries
+        .filter((entry) => entry.type === "review")
+        .map((entry) => entry.reviewer),
+    ).toEqual([
+      { backend: "codex", model: "gpt-5.5" },
+      { backend: "codex", model: "gpt-5.5" },
+    ]);
+
+    await registry.close();
+  });
+
   it("terminal-gates failed managed reviews and releases the parent thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19089,6 +19089,14 @@ command = "pnpm dev"
     const parentThreadId = "grok-parent-with-codex-review";
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
+      models: [
+        {
+          id: "gpt-5.5",
+          label: "GPT-5.5",
+          current: true,
+          supportsReasoning: true,
+        },
+      ],
       startThreadResult: { threadId: "codex-review-child" },
     });
     const overlayStore = createOverlayStoreMock({
@@ -19128,6 +19136,8 @@ command = "pnpm dev"
       threadId: parentThreadId,
       target: { type: "baseBranch", branch: "origin/main" },
       delivery: "inline",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
     });
     expect(response).toMatchObject({
       backend: acpBackendId,
@@ -19178,6 +19188,36 @@ command = "pnpm dev"
     });
     await expect(approvalResponse).resolves.toEqual({ decision: "accept" });
 
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: response.reviewThreadId,
+        turnId: response.turnId,
+        model: "gpt-5.5",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 200,
+            outputTokens: 50,
+            reasoningOutputTokens: 10,
+          },
+        },
+      },
+    });
+    const pricing = await overlayStore.readThreadPricing({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+    });
+    expect(pricing.lines).toEqual([
+      expect.objectContaining({
+        backend: acpBackendId,
+        model: "gpt-5.5",
+        parentThreadId,
+        reasoningEffort: "high",
+        scope: "monitor",
+      }),
+    ]);
+
     const reviewOutput = JSON.stringify({
       findings: [],
       overall_correctness: "patch is correct",
@@ -19206,6 +19246,8 @@ command = "pnpm dev"
         backend: "codex",
         monitorThreadId: response.reviewThreadId,
         monitorTurnId: response.turnId,
+        preferredModel: "gpt-5.5",
+        preferredReasoningEffort: "high",
         outcome: "success",
         status: "success",
       }),
@@ -19213,9 +19255,19 @@ command = "pnpm dev"
     expect(overlay?.managedReviewEntries).toEqual([
       expect.objectContaining({
         id: `managed-review:${response.turnId}:started`,
+        reviewer: {
+          backend: "codex",
+          model: "gpt-5.5",
+          reasoningEffort: "high",
+        },
       }),
       expect.objectContaining({
         id: `managed-review:${response.turnId}:result`,
+        reviewer: {
+          backend: "codex",
+          model: "gpt-5.5",
+          reasoningEffort: "high",
+        },
         output: expect.objectContaining({
           overall_correctness: "patch is correct",
         }),
@@ -19225,6 +19277,25 @@ command = "pnpm dev"
         }),
       }),
     ]);
+    expect(
+      events.find((event) =>
+        isCompletedItemType(event, "exitedReviewMode")
+      ),
+    ).toMatchObject({
+      notification: {
+        params: {
+          item: {
+            data: {
+              reviewer: {
+                backend: "codex",
+                model: "gpt-5.5",
+                reasoningEffort: "high",
+              },
+            },
+          },
+        },
+      },
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5146,7 +5146,10 @@ function attachReviewEntryReviewers(params: {
   replay: AppServerThreadReplay;
   subAgents?: ThreadSubAgentSummary[];
 }): AppServerThreadReplay {
-  const reviewerByTurnId = new Map<string, AppServerThreadReviewEntry["reviewer"]>();
+  const reviewerByTurnId = new Map<
+    string,
+    NonNullable<AppServerThreadReviewEntry["reviewer"]>
+  >();
   for (const subAgent of params.subAgents ?? []) {
     if (
       !subAgent.monitorId.startsWith("review:")
@@ -5174,11 +5177,26 @@ function attachReviewEntryReviewers(params: {
 
   let changed = false;
   const entries = params.replay.entries.map((entry) => {
-    if (entry.type !== "review" || entry.reviewer || !entry.turn?.id) {
+    if (entry.type !== "review" || !entry.turn?.id) {
       return entry;
     }
-    const reviewer = reviewerByTurnId.get(entry.turn.id);
-    if (!reviewer) {
+    const durableReviewer = reviewerByTurnId.get(entry.turn.id);
+    if (!durableReviewer) {
+      return entry;
+    }
+    const model = entry.reviewer?.model ?? durableReviewer.model;
+    const reasoningEffort =
+      entry.reviewer?.reasoningEffort ?? durableReviewer.reasoningEffort;
+    const reviewer = {
+      backend: entry.reviewer?.backend ?? durableReviewer.backend,
+      ...(model ? { model } : {}),
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+    };
+    if (
+      entry.reviewer?.backend === reviewer.backend
+      && entry.reviewer?.model === reviewer.model
+      && entry.reviewer?.reasoningEffort === reviewer.reasoningEffort
+    ) {
       return entry;
     }
     changed = true;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2686,6 +2686,7 @@ type ReviewSubAgentRecord = {
   latestUsage?: TaskMonitorUsageSnapshot;
   mode: "managed" | "native";
   model?: string;
+  reasoningEffort?: string;
   /** Backend owning the thread being reviewed. */
   parentBackend: AppServerBackendKind;
   parentThreadId: string;
@@ -3850,6 +3851,7 @@ function buildTaskMonitorUsageLine(params: {
   monitorTurnId?: string;
   observedReplays?: ObservedContextReplayTally;
   parentThreadId: string;
+  reasoningEffort?: string;
   serviceTier?: string;
   source: ThreadUsageLineRecord["source"];
   usage: TaskMonitorUsageSnapshot;
@@ -3921,6 +3923,9 @@ function buildTaskMonitorUsageLine(params: {
     ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
     ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
     ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
+    ...(params.reasoningEffort
+      ? { reasoningEffort: params.reasoningEffort }
+      : {}),
     reasoningOutputTokens,
     scope: "monitor",
     ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
@@ -5117,6 +5122,69 @@ function mergeManagedReviewEntries(params: {
     ...params.replay,
     entries,
   };
+}
+
+function reviewEntryReviewer(
+  record: Pick<
+    ReviewSubAgentRecord,
+    "backend" | "model" | "reasoningEffort"
+  >,
+): NonNullable<AppServerThreadReviewEntry["reviewer"]> {
+  return {
+    backend: record.backend,
+    ...(record.model ? { model: record.model } : {}),
+    ...(record.reasoningEffort ? { reasoningEffort: record.reasoningEffort } : {}),
+  };
+}
+
+/**
+ * Native review entries come from the provider transcript, which does not
+ * carry the reviewer configuration. The durable review sub-agent summary is
+ * the authority for that configuration, including after an app restart.
+ */
+function attachReviewEntryReviewers(params: {
+  replay: AppServerThreadReplay;
+  subAgents?: ThreadSubAgentSummary[];
+}): AppServerThreadReplay {
+  const reviewerByTurnId = new Map<string, AppServerThreadReviewEntry["reviewer"]>();
+  for (const subAgent of params.subAgents ?? []) {
+    if (
+      !subAgent.monitorId.startsWith("review:")
+      || !subAgent.monitorTurnId
+      || !subAgent.backend
+    ) {
+      continue;
+    }
+    const model =
+      subAgent.preferredModel
+      ?? subAgent.monitorUsage?.model
+      ?? subAgent.monitorUsage?.cost?.model;
+    reviewerByTurnId.set(subAgent.monitorTurnId, {
+      backend: subAgent.backend,
+      ...(model ? { model } : {}),
+      ...(subAgent.preferredReasoningEffort
+        ? { reasoningEffort: subAgent.preferredReasoningEffort }
+        : {}),
+    });
+  }
+
+  if (reviewerByTurnId.size === 0) {
+    return params.replay;
+  }
+
+  let changed = false;
+  const entries = params.replay.entries.map((entry) => {
+    if (entry.type !== "review" || entry.reviewer || !entry.turn?.id) {
+      return entry;
+    }
+    const reviewer = reviewerByTurnId.get(entry.turn.id);
+    if (!reviewer) {
+      return entry;
+    }
+    changed = true;
+    return { ...entry, reviewer };
+  });
+  return changed ? { ...params.replay, entries } : params.replay;
 }
 
 function mergeImmutableUsageActivities(params: {
@@ -8982,6 +9050,10 @@ export class DesktopBackendRegistry {
       replayWithTranscriptOverlays,
       messageOrigins,
     );
+    const replayWithReviewers = attachReviewEntryReviewers({
+      replay: replayWithMessageOrigins,
+      subAgents: overlay?.subAgents,
+    });
     const pricing =
       typeof this.overlayStore.readThreadPricing === "function"
         ? await this.overlayStore.readThreadPricing({
@@ -9017,10 +9089,10 @@ export class DesktopBackendRegistry {
       threadId: request.threadId,
       ...(toolAccounting ? { toolAccounting } : {}),
       ...(pendingRequest ? { pendingRequest } : {}),
-      ...(replayWithMessageOrigins.threadStatus
-        ? { threadStatus: replayWithMessageOrigins.threadStatus }
+      ...(replayWithReviewers.threadStatus
+        ? { threadStatus: replayWithReviewers.threadStatus }
         : {}),
-      replay: replayWithMessageOrigins,
+      replay: replayWithReviewers,
     };
   }
 
@@ -10747,6 +10819,10 @@ export class DesktopBackendRegistry {
       replayWithImmutableUsage,
       messageOrigins,
     );
+    const replayWithReviewers = attachReviewEntryReviewers({
+      replay: replayWithMessageOrigins,
+      subAgents: overlay?.subAgents,
+    });
     if (!request.viewOnly && !request.before && shouldAppendTranscriptOverlays) {
       // Hydration supersedes live rows for the same turn in sqlite. Preserve
       // that ordering now that live observations are delayed in memory: first
@@ -10791,10 +10867,10 @@ export class DesktopBackendRegistry {
       pricing,
       ...(toolAccounting ? { toolAccounting } : {}),
       ...(pendingRequest ? { pendingRequest } : {}),
-      ...(replayWithMessageOrigins.threadStatus
-        ? { threadStatus: replayWithMessageOrigins.threadStatus }
+      ...(replayWithReviewers.threadStatus
+        ? { threadStatus: replayWithReviewers.threadStatus }
         : {}),
-      replay: replayWithMessageOrigins,
+      replay: replayWithReviewers,
     };
   }
 
@@ -13397,6 +13473,9 @@ export class DesktopBackendRegistry {
       displayText: reviewTaskLabel(params.target),
       ...(modelSettings.fastMode !== undefined ? { fastMode: modelSettings.fastMode } : {}),
       ...(modelSettings.model ? { model: modelSettings.model } : {}),
+      ...(modelSettings.reasoningEffort
+        ? { reasoningEffort: modelSettings.reasoningEffort }
+        : {}),
       mode: managedMode ? "managed" : "native",
       parentBackend: params.backend,
       parentThreadId: result.threadId,
@@ -13549,6 +13628,7 @@ export class DesktopBackendRegistry {
       review: record.displayText,
       displayText: record.displayText,
       createdAt: startedAt,
+      reviewer: reviewEntryReviewer(record),
       turn: {
         id: record.turnId,
         status: "in_progress",
@@ -13587,6 +13667,7 @@ export class DesktopBackendRegistry {
             type: "enteredReviewMode",
             review: record.displayText,
             createdAt: startedAt,
+            data: { reviewer: entry.reviewer },
           },
         },
       },
@@ -20317,6 +20398,7 @@ export class DesktopBackendRegistry {
             monitorTurnId: reviewRecord.turnId,
             observedReplays,
             parentThreadId: reviewRecord.parentThreadId,
+            reasoningEffort: reviewRecord.reasoningEffort,
             serviceTier,
             source: "monitor",
             usage: usageSnapshot,
@@ -20358,6 +20440,7 @@ export class DesktopBackendRegistry {
             observedReplays,
             parentThreadId:
               completedReviewRecord?.parentThreadId ?? notification.params.threadId,
+            reasoningEffort: completedReviewRecord?.reasoningEffort,
             serviceTier,
             source: "monitor",
             usage: usageSnapshot,
@@ -21914,6 +21997,18 @@ export class DesktopBackendRegistry {
       ownerRegistrySessionId:
         existing?.ownerRegistrySessionId ?? this.registrySessionId,
       backend: record.backend,
+      ...(record.model ?? existing?.preferredModel
+        ? { preferredModel: record.model ?? existing?.preferredModel }
+        : {}),
+      ...(record.reasoningEffort ?? existing?.preferredReasoningEffort
+        ? {
+            preferredReasoningEffort:
+              record.reasoningEffort ?? existing?.preferredReasoningEffort,
+          }
+        : {}),
+      ...(record.fastMode ?? existing?.preferredFastMode
+        ? { preferredFastMode: record.fastMode ?? existing?.preferredFastMode }
+        : {}),
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
       ...(patch.lastMessage ?? existing?.lastMessage
@@ -22053,6 +22148,7 @@ export class DesktopBackendRegistry {
         id: `managed-review:${params.record.turnId}:result`,
         review,
         createdAt: completedAt,
+        reviewer: reviewEntryReviewer(params.record),
         ...(parsed ? { output: parsed } : {}),
         turn: {
           id: params.record.turnId,
@@ -22078,7 +22174,10 @@ export class DesktopBackendRegistry {
               type: "exitedReviewMode",
               review,
               createdAt: completedAt,
-              ...(parsed ? { data: { reviewOutput: parsed } } : {}),
+              data: {
+                ...(parsed ? { reviewOutput: parsed } : {}),
+                reviewer: entry.reviewer,
+              },
             },
           },
         },
@@ -31306,7 +31405,55 @@ export class DesktopBackendRegistry {
     if (liveThreadUsageWork) {
       this.finishLiveThreadUsageEmitWork(liveThreadUsageWork);
     }
+    event = this.withReviewRuntimeMetadata(event);
     await this.emitToListeners(event);
+  }
+
+  /**
+   * Provider transcripts do not attach model settings to review-mode items.
+   * The registry owns that association for the review's lifetime, so include
+   * it in the live item as well as the durable review artifact.
+   */
+  private withReviewRuntimeMetadata(event: AgentEvent): AgentEvent {
+    if (event.notification.method !== "item/completed") {
+      return event;
+    }
+    const params = readRecord(event.notification.params);
+    const threadId = readNonEmptyString(params?.threadId);
+    const turnId = readNonEmptyString(params?.turnId);
+    const item = readRecord(params?.item);
+    const itemType = readNonEmptyString(item?.type);
+    if (
+      !threadId
+      || !turnId
+      || !item
+      || (itemType !== "enteredReviewMode" && itemType !== "exitedReviewMode")
+    ) {
+      return event;
+    }
+    const reviewKey = buildReviewSubAgentKey(event.backend, threadId, turnId);
+    const record =
+      this.activeReviewSubAgents.get(reviewKey)
+      ?? this.reviewSubAgentsByReviewTurn.get(reviewKey);
+    if (!record || readRecord(item.data)?.reviewer) {
+      return event;
+    }
+    return {
+      ...event,
+      notification: {
+        ...event.notification,
+        params: {
+          ...event.notification.params,
+          item: {
+            ...item,
+            data: {
+              ...(readRecord(item.data) ?? {}),
+              reviewer: reviewEntryReviewer(record),
+            },
+          },
+        },
+      },
+    } as AgentEvent;
   }
 
   /**

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -7,6 +7,7 @@ import type {
 import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import { useCallback, useMemo, type MouseEvent } from "react";
 import { normalizeReviewDisplayText } from "../../../../shared/review-command";
+import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ThreadLinkSource } from "../../lib/thread-links";
 import { ThreadMarkdown } from "./ThreadMarkdown";
@@ -170,6 +171,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
       : output?.overall_correctness === "patch is incorrect"
         ? "Patch needs work"
         : undefined;
+  const reviewer = props.entry.reviewer;
 
   return (
     <aside className="transcript-review" role="group" aria-label="Code review">
@@ -216,6 +218,22 @@ export function TranscriptReview(props: TranscriptReviewProps) {
           </span>
           {confidence ? (
             <span className="transcript-review__badge">{confidence}</span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {reviewer ? (
+        <div className="transcript-review__meta" aria-label="Review runtime">
+          <span className="transcript-review__badge">
+            {formatBackendLabel(reviewer.backend)}
+          </span>
+          {reviewer.model ? (
+            <span className="transcript-review__badge">{reviewer.model}</span>
+          ) : null}
+          {reviewer.reasoningEffort ? (
+            <span className="transcript-review__badge">
+              {reviewer.reasoningEffort}
+            </span>
           ) : null}
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -3339,6 +3339,116 @@ describe("ThreadContextPanel", () => {
     expect(children[2]?.textContent).toBe("b6f2bd748");
   });
 
+  it("keeps mixed-provider review usage attributed to its reviewer", () => {
+    const createdAt = 1_800_000_000_000;
+    const summaries: ThreadPricingSummary[] = [
+      {
+        backend: "acp:grok",
+        cachedInputTokens: 200,
+        currency: "USD",
+        inputTokens: 1_000,
+        outputTokens: 50,
+        pricedUsageLineCount: 1,
+        provider: "openai",
+        reasoningOutputTokens: 10,
+        threadId: "thread-1",
+        totalCostMicros: 1_000_000,
+        totalTokens: 1_050,
+        uncachedInputTokens: 800,
+        unpricedUsageLineCount: 0,
+        updatedAt: createdAt,
+        usageLineCount: 1,
+      },
+      {
+        backend: "acp:grok",
+        cachedInputTokens: 400,
+        currency: "USD",
+        inputTokens: 1_500,
+        outputTokens: 100,
+        pricedUsageLineCount: 1,
+        provider: "xai",
+        reasoningOutputTokens: 20,
+        threadId: "thread-1",
+        totalCostMicros: 2_000_000,
+        totalTokens: 1_600,
+        uncachedInputTokens: 1_100,
+        unpricedUsageLineCount: 0,
+        updatedAt: createdAt,
+        usageLineCount: 1,
+      },
+    ];
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        source: "acp:grok",
+        subAgents: [
+          {
+            monitorId: "review:turn-review-1",
+            task: "Review changes against main",
+            status: "success",
+            createdAt,
+            updatedAt: createdAt,
+            backend: "codex",
+            preferredModel: "gpt-5.6-sol",
+            preferredReasoningEffort: "high",
+          },
+        ],
+      },
+      pricing: {
+        lines: [
+          buildMonitorLine({
+            backend: "acp:grok",
+            createdAt,
+            model: undefined,
+            parentThreadId: "thread-1",
+            provider: "openai",
+            reasoningEffort: undefined,
+            sourceItemId: "review:turn-review-1",
+            totalCostMicros: 1_000_000,
+            usageLineId: "openai-review-usage",
+          }),
+          buildMonitorLine({
+            backend: "acp:grok",
+            createdAt: createdAt - 1,
+            parentThreadId: "thread-1",
+            provider: "xai",
+            sourceItemId: "turn-grok-1",
+            totalCostMicros: 2_000_000,
+            usageLineId: "grok-turn-usage",
+          }),
+        ],
+        summaries,
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const summaryCard = screen.getByText("Pricing summary").closest(
+      ".pricing-summary-card",
+    );
+    expect(summaryCard).not.toBeNull();
+    expect(within(summaryCard as HTMLElement).getByText("By provider")).toBeInTheDocument();
+    expect(within(summaryCard as HTMLElement).getByText("OpenAI")).toBeInTheDocument();
+    expect(within(summaryCard as HTMLElement).getByText("xAI")).toBeInTheDocument();
+    expect(
+      within(summaryCard as HTMLElement).getByText("$1.00 · 1 row"),
+    ).toBeInTheDocument();
+    expect(
+      within(summaryCard as HTMLElement).getByText("$2.00 · 1 row"),
+    ).toBeInTheDocument();
+
+    const reviewUsage = screen.getByText("Review usage").closest(
+      ".pricing-usage-row",
+    );
+    expect(reviewUsage).not.toBeNull();
+    expect(within(reviewUsage as HTMLElement).getByText("OpenAI")).toBeInTheDocument();
+    expect(
+      within(reviewUsage as HTMLElement).getByText("gpt-5.6-sol · high"),
+    ).toBeInTheDocument();
+    expect(within(reviewUsage as HTMLElement).queryByText("Grok")).not.toBeInTheDocument();
+  });
+
   it("renders accumulated edit groups on the Edits tab and toggles the dock", () => {
     const groups = collectEditedFileGroups({
       entries: [

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -3437,6 +3437,13 @@ describe("ThreadContextPanel", () => {
     expect(
       within(summaryCard as HTMLElement).getByText("$2.00 · 1 row"),
     ).toBeInTheDocument();
+    const providerDetail = screen.getByText("openai · USD").closest(
+      ".pricing-provider-row",
+    );
+    expect(providerDetail).not.toBeNull();
+    expect(
+      within(providerDetail as HTMLElement).getByText("$1.00 list price · 1 row"),
+    ).toBeInTheDocument();
 
     const reviewUsage = screen.getByText("Review usage").closest(
       ".pricing-usage-row",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
@@ -17,6 +17,11 @@ describe("TranscriptReview", () => {
           id: "review-1",
           review: "The patch has one review issue.",
           displayText: "Review changes against main",
+          reviewer: {
+            backend: "codex",
+            model: "gpt-5.6-sol",
+            reasoningEffort: "high",
+          },
           output: {
             findings: [
               {
@@ -47,6 +52,10 @@ describe("TranscriptReview", () => {
     expect(screen.getByText("Patch needs work")).toBeInTheDocument();
     expect(screen.getByText("1 finding")).toBeInTheDocument();
     expect(screen.getByText("87% confidence")).toBeInTheDocument();
+    const runtime = screen.getByLabelText("Review runtime");
+    expect(runtime).toHaveTextContent("OpenAI");
+    expect(runtime).toHaveTextContent("gpt-5.6-sol");
+    expect(runtime).toHaveTextContent("high");
     expect(screen.getByText("P1")).toBeInTheDocument();
     expect(screen.getByText("P1")).toHaveClass("transcript-review__priority--p1");
     expect(screen.getByText("Hydrate review transcript items")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -173,6 +173,28 @@ export function PricingPanel(props: PricingPanelProps) {
               {summary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
             </p>
           ) : null}
+          {displaySummaries.length > 1 ? (
+            <ul className="context-list context-list--cards pricing-provider-list">
+              {displaySummaries.map((providerSummary) => (
+                <li
+                  key={`${providerSummary.provider}:${providerSummary.currency}`}
+                  className="rail-card pricing-provider-row"
+                >
+                  <p className="rail-card__title">
+                    {providerSummary.provider} · {providerSummary.currency}
+                  </p>
+                  <p className="rail-card__usage">
+                    {formatMoney(
+                      providerSummary.totalCostMicros,
+                      providerSummary.currency,
+                    )}{" "}
+                    list price · {providerSummary.usageLineCount.toLocaleString()} row
+                    {providerSummary.usageLineCount === 1 ? "" : "s"}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </>
       ) : displayLines.length === 0 ? (
         <p className="context-empty">No usage pricing recorded yet.</p>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -149,34 +149,29 @@ export function PricingPanel(props: PricingPanelProps) {
                 />
               ) : null}
             </div>
+            {displaySummaries.length > 1 ? (
+              <div className="rail-summary-card__section">
+                <span className="rail-summary-card__section-title">By provider</span>
+                {displaySummaries.map((providerSummary) => (
+                  <RailSummaryRow
+                    key={`${providerSummary.provider}:${providerSummary.currency}`}
+                    label={formatPricingProviderLabel(providerSummary.provider)}
+                    value={`${formatMoney(
+                      providerSummary.totalCostMicros,
+                      providerSummary.currency,
+                    )} · ${providerSummary.usageLineCount.toLocaleString()} row${
+                      providerSummary.usageLineCount === 1 ? "" : "s"
+                    }`}
+                  />
+                ))}
+              </div>
+            ) : null}
           </div>
           {summary.unpricedUsageLineCount > 0 ? (
             <p className="context-empty context-empty--warning">
               {summary.unpricedUsageLineCount.toLocaleString()} usage row
               {summary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
             </p>
-          ) : null}
-          {displaySummaries.length > 1 ? (
-            <ul className="context-list context-list--cards pricing-provider-list">
-              {displaySummaries.map((providerSummary) => (
-                <li
-                  key={`${providerSummary.provider}:${providerSummary.currency}`}
-                  className="rail-card pricing-provider-row"
-                >
-                  <p className="rail-card__title">
-                    {providerSummary.provider} · {providerSummary.currency}
-                  </p>
-                  <p className="rail-card__usage">
-                    {formatMoney(
-                      providerSummary.totalCostMicros,
-                      providerSummary.currency,
-                    )}{" "}
-                    list price · {providerSummary.usageLineCount.toLocaleString()} row
-                    {providerSummary.usageLineCount === 1 ? "" : "s"}
-                  </p>
-                </li>
-              ))}
-            </ul>
           ) : null}
         </>
       ) : displayLines.length === 0 ? (
@@ -215,6 +210,12 @@ export function PricingPanel(props: PricingPanelProps) {
               ?? (isActive && line.scope !== "monitor"
                 ? props.threadReasoningEffort
                 : undefined);
+            const runtimeLabel = formatUsageLineRuntimeLabel(line, subAgent);
+            const runtimeModel =
+              line.model
+              ?? subAgent?.preferredModel
+              ?? subAgent?.monitorUsage?.model
+              ?? subAgent?.monitorUsage?.cost?.model;
 
             return (
               <li
@@ -230,10 +231,10 @@ export function PricingPanel(props: PricingPanelProps) {
                     ) : null}
                     <p className="rail-card__runtime">
                       <span className="rail-card__provider-chip">
-                        {formatBackendLabel(line.backend as AppServerBackendKind)}
+                        {runtimeLabel}
                       </span>
                       <span className="rail-card__model">
-                        {line.model ?? "Unknown model"}
+                        {runtimeModel ?? "Unknown model"}
                         {reasoningEffort ? ` · ${reasoningEffort}` : ""}
                         {formatServiceTierLabel(line)}
                       </span>
@@ -988,8 +989,11 @@ function formatUsageLineTitle(
   subAgent?: ThreadSubAgentSummary,
 ): string {
   if (line.scope === "monitor") {
-    return subAgent
-      ? subAgentPricingUsageTitle(subAgent)
+    if (subAgent) {
+      return subAgentPricingUsageTitle(subAgent);
+    }
+    return line.sourceItemId?.startsWith("review:")
+      ? "Review usage"
       : "Sub-agent usage";
   }
   if (isForkBaselineLine(line)) {
@@ -1005,6 +1009,34 @@ function formatUsageLineTitle(
     return "Latest request usage";
   }
   return "Turn usage";
+}
+
+function formatUsageLineRuntimeLabel(
+  line: PricingUsageLine,
+  subAgent?: ThreadSubAgentSummary,
+): string {
+  if (subAgent?.backend) {
+    return formatBackendLabel(subAgent.backend);
+  }
+  // Monitor rows are stored under their parent thread backend so its ledger
+  // can aggregate them. Without a loaded sub-agent summary, the pricing
+  // provider is the truthful runtime identity.
+  return line.scope === "monitor"
+    ? formatPricingProviderLabel(line.provider)
+    : formatBackendLabel(line.backend as AppServerBackendKind);
+}
+
+function formatPricingProviderLabel(provider: string): string {
+  switch (provider.toLocaleLowerCase()) {
+    case "openai":
+      return "OpenAI";
+    case "qwen":
+      return "Qwen";
+    case "xai":
+      return "xAI";
+    default:
+      return provider;
+  }
 }
 
 function formatUsageLineCostSuffix(line: PricingUsageLine): string {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -10917,6 +10917,11 @@ describe("useThreadSessionState", () => {
                 type: "exitedReviewMode",
                 review: "No findings. Ready to merge.",
                 data: {
+                  reviewer: {
+                    backend: "codex",
+                    model: "gpt-5.6-sol",
+                    reasoningEffort: "high",
+                  },
                   reviewOutput: {
                     findings: [],
                     overall_correctness: "patch is correct",
@@ -10972,6 +10977,14 @@ describe("useThreadSessionState", () => {
         type: "review",
         review: "Review changes against main",
         displayText: "Review changes against main",
+      });
+      expect(result.current.entries[2]).toMatchObject({
+        type: "review",
+        reviewer: {
+          backend: "codex",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+        },
       });
     });
     expect(result.current.response?.replay.messages).toHaveLength(1);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -23,7 +23,7 @@ import type {
   MessagingConversationKind,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { isCelestialIconId } from "@pwragent/shared";
+import { isAppServerBackendKind, isCelestialIconId } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 import { readRendererFederationTarget } from "./federation-window";
 import {
@@ -3428,6 +3428,7 @@ function reviewEntryFromCompletedItem(params: {
         : "Code review started"
       : undefined;
   const output = normalizeReviewOutput(record.data?.reviewOutput);
+  const reviewer = normalizeReviewer(record.data?.reviewer);
   const turn = buildTurnMetadata({
     fallbackId: typeof params.turnId === "string" ? params.turnId : undefined,
     fallbackStatus:
@@ -3440,11 +3441,38 @@ function reviewEntryFromCompletedItem(params: {
     review: displayText ?? review,
     ...(displayText ? { displayText } : {}),
     ...(output ? { output } : {}),
+    ...(reviewer ? { reviewer } : {}),
     ...(turn ? { turn } : {}),
     createdAt:
       normalizeNotificationTimestamp(record.createdAt) ??
       normalizeNotificationTimestamp(record.created_at) ??
       Date.now(),
+  };
+}
+
+function normalizeReviewer(
+  value: unknown,
+): AppServerThreadReviewEntry["reviewer"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const backend = record.backend;
+  if (typeof backend !== "string" || !isAppServerBackendKind(backend)) {
+    return undefined;
+  }
+  const model =
+    typeof record.model === "string" && record.model.trim()
+      ? record.model.trim()
+      : undefined;
+  const reasoningEffort =
+    typeof record.reasoningEffort === "string" && record.reasoningEffort.trim()
+      ? record.reasoningEffort.trim()
+      : undefined;
+  return {
+    backend,
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
   };
 }
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -664,6 +664,16 @@ export type AppServerThreadReviewEntry = {
   status?: AppServerThreadActivityStatus;
   review: string;
   displayText?: string;
+  /**
+   * The provider runtime that produced this review. Reviews may run on a
+   * different provider than their parent thread, so this belongs to the
+   * review artifact rather than to the thread's ambient settings.
+   */
+  reviewer?: {
+    backend: AppServerBackendKind;
+    model?: string;
+    reasoningEffort?: string;
+  };
   output?: AppServerReviewOutput;
   turn?: AppServerThreadTurnMetadata;
 };


### PR DESCRIPTION
## Summary

- preserve reviewer provider, model, and reasoning effort in managed review usage and transcript metadata
- attribute cross-provider review pricing to the actual reviewer while retaining the parent-thread total
- add an in-summary provider cost breakdown and runtime chips on review responses

## Why

Review usage is stored in the parent thread ledger. The pricing UI treated that ledger backend as the reviewer backend, so an OpenAI review inside a Grok thread appeared as Grok and lacked its runtime details.

## User impact

Mixed-provider threads now have an accurate total plus a provider breakdown. Review pricing rows and transcript cards identify the reviewer consistently, including when it matches the parent provider. New review records retain the runtime settings for future reads.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `git diff --check`