### PR TITLE
fix(desktop): report default Codex profile path

### DIFF
--- a/apps/desktop/src/main/__tests__/app-metadata.test.ts
+++ b/apps/desktop/src/main/__tests__/app-metadata.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveStartupCodexHome = vi.hoisted(() => vi.fn());
+const resolveDefaultCodexHome = vi.hoisted(() =>
+  vi.fn(() => "/Users/operator/.codex"),
+);
+
+vi.mock("@pwrdrvr/codex-discovery", () => ({ resolveDefaultCodexHome }));
 
 vi.mock("electron", () => ({
   app: {
@@ -61,6 +66,7 @@ describe("app metadata", () => {
 
     const metadata = resolveAppMetadata(4101);
 
+    expect(resolveDefaultCodexHome).not.toHaveBeenCalled();
     expect(resolveStartupCodexHome).toHaveBeenCalledOnce();
     expect(metadata).toMatchObject({
       activeProfileName: "sstk",
@@ -69,5 +75,15 @@ describe("app metadata", () => {
         "/Users/operator/Library/Logs/PwrAgent/profile-sstk.main.log",
       rendererProcessId: 4101,
     });
+  });
+
+  it("reports the system-default Codex home when no named profile is pinned", async () => {
+    resolveStartupCodexHome.mockReturnValue(undefined);
+    const { resolveAppMetadata } = await import("../ipc/app-metadata");
+
+    const metadata = resolveAppMetadata(4101);
+
+    expect(resolveDefaultCodexHome).toHaveBeenCalledOnce();
+    expect(metadata.codexProfilePath).toBe("/Users/operator/.codex");
   });
 });

--- a/apps/desktop/src/main/ipc/app-metadata.ts
+++ b/apps/desktop/src/main/ipc/app-metadata.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { resolveDefaultCodexHome } from "@pwrdrvr/codex-discovery";
 import { app, BrowserWindow, ipcMain } from "electron";
 import {
   APP_CHANGELOG_DOCUMENT_READ_CHANNEL,
@@ -53,7 +54,9 @@ export function resolveAppMetadata(
 ): AppMetadata {
   const activeProfileName = resolveActiveProfileName();
   const logFilePath = getMainLogFilePath();
-  const codexProfilePath = getDesktopSettingsService().resolveStartupCodexHome();
+  const codexProfilePath =
+    getDesktopSettingsService().resolveStartupCodexHome()
+    ?? resolveDefaultCodexHome();
   return {
     applicationName: app.getName(),
     applicationVersion: resolveApplicationVersion(app.getVersion()),
@@ -67,7 +70,7 @@ export function resolveAppMetadata(
     ...(rendererProcessId === undefined ? {} : { rendererProcessId }),
     activeProfileName,
     ...(logFilePath ? { logFilePath } : {}),
-    ...(codexProfilePath ? { codexProfilePath } : {}),
+    codexProfilePath,
   };
 }
 


### PR DESCRIPTION
## Summary

- I report the effective system-default Codex home in app metadata when no named Codex auth profile is pinned, so copied thread info shows the full `~/.codex` disk path instead of `Unavailable`.
- I preserve the already-correct PwrAgent-managed profile path for named profiles such as `~/.codex/profiles/work`.
- I kept the change scoped to diagnostics metadata; Codex child-process environment behavior is unchanged.

## Verification

- I added a regression test that fails before the fix and passes after it.
- `pnpm test apps/desktop/src/main/__tests__/app-metadata.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (zero errors; 35 existing warnings)

## Notes

- The root cause was that `resolveStartupCodexHome()` intentionally returns `undefined` for the system-default profile, and app metadata treated that as an unavailable path instead of resolving the default Codex home.
