### PR TITLE
fix(messaging): identify Slack replies by binding

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2275,7 +2275,9 @@ describe("MessagingController", () => {
     );
     expect(assistantReplies).toHaveLength(1);
     expect(assistantReplies[0]?.bindingId).toMatch(/^default-agent-route:/);
-    expect(assistantReplies[0]).not.toHaveProperty("attribution");
+    expect(assistantReplies[0]).toMatchObject({
+      attribution: { label: "Agent: Topic Agent" },
+    });
   });
 
   async function createSlackPrivateResponseHarness(options?: {
@@ -2452,7 +2454,7 @@ describe("MessagingController", () => {
 
     expect(harness.delivered).toContainEqual(
       expect.objectContaining({
-        attribution: expect.objectContaining({ label: "Signals Agent" }),
+        attribution: expect.objectContaining({ label: "Agent: Signals Agent" }),
         kind: "message",
       }),
     );
@@ -2503,7 +2505,7 @@ describe("MessagingController", () => {
     expect(harness.delivered).toContainEqual(
       expect.objectContaining({
         attribution: expect.objectContaining({
-          label: "AWS incident follow-up",
+          label: "Bound thread: AWS incident follow-up",
         }),
         kind: "message",
       }),
@@ -2585,7 +2587,7 @@ describe("MessagingController", () => {
           }),
         }),
         attribution: {
-          label: "Signals Agent",
+          label: "Agent: Signals Agent",
           hint: "Private Request · Reply in Thread to Respond to this Agent",
         },
         kind: "message",
@@ -2779,7 +2781,7 @@ describe("MessagingController", () => {
     expect(harness.delivered).toContainEqual(
       expect.objectContaining({
         attribution: {
-          label: "Signals Agent",
+          label: "Agent: Signals Agent",
           hint:
             "Private Request · Reply in Thread to Respond to this Agent; Completion Returns to the Original Conversation",
         },
@@ -3043,7 +3045,7 @@ describe("MessagingController", () => {
     ).toEqual([
       expect.objectContaining({
         attribution: expect.objectContaining({
-          label: "Signals Agent",
+          label: "Agent: Signals Agent",
         }),
         parts: [expect.objectContaining({
           text: expect.stringContaining("PRIVATE-CODE"),
@@ -7369,6 +7371,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
     });
     expect(harness.delivered.at(-1)).toMatchObject({
+      attribution: { label: "Bound thread: Thread one" },
       kind: "message",
       role: "assistant",
       parts: [
@@ -14346,6 +14349,7 @@ describe("MessagingController", () => {
 
     expect(harness.delivered).toHaveLength(1);
     expect(harness.delivered.at(-1)).toMatchObject({
+      attribution: { label: "Bound thread: Thread one" },
       kind: "message",
       role: "assistant",
       parts: [
@@ -14486,6 +14490,7 @@ describe("MessagingController", () => {
       (intent) => intent.kind === "stream_update",
     );
     expect(streamUpdates.at(-1)).toMatchObject({
+      attribution: { label: "Bound thread: Thread one" },
       delivery: {
         mode: "update",
         fallback: "fail",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -17768,6 +17768,11 @@ describe("MessagingController", () => {
     expect(proseIndex).toBeGreaterThanOrEqual(0);
     expect(questionnaireIndex).toBeGreaterThanOrEqual(0);
     expect(proseIndex).toBeLessThan(questionnaireIndex);
+    expect(harness.delivered[proseIndex]).toMatchObject({
+      attribution: { label: "Bound thread: Thread one" },
+      kind: "message",
+      role: "assistant",
+    });
   });
 
   it("only flushes setup prose captured under the elicitation's own turn", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -6206,6 +6206,9 @@ export class MessagingController {
       buffer.turnId,
     );
     const now = this.now();
+    const attribution = isFinal
+      ? await this.responseAttributionForBinding(binding)
+      : undefined;
     const intent: MessagingStreamUpdateIntent = {
       id: this.newIntentId(isFinal ? "assistant-stream-final" : "assistant-stream"),
       kind: "stream_update",
@@ -6221,6 +6224,7 @@ export class MessagingController {
           }
         : {}),
       role: "assistant",
+      ...(attribution ? { attribution } : {}),
       markdown: isFinal ? "markdown" : "plain",
       policy: binding.preferences?.streamingResponses ?? "inherit",
       delta: buffer.delta,
@@ -6551,6 +6555,7 @@ export class MessagingController {
     this.logger.debug?.(
       `messaging assistant deliver thread=${binding.threadId} binding=${binding.id} chars=${text.length} images=${messageImages.length} preview="${compactLogPreview(text)}"`,
     );
+    const attribution = await this.responseAttributionForBinding(binding);
 
     await this.deliver(
       {
@@ -6559,6 +6564,7 @@ export class MessagingController {
         bindingId: binding.id,
         createdAt: this.now(),
         role: "assistant",
+        attribution,
         parts: [
           {
             type: "text",
@@ -6603,6 +6609,7 @@ export class MessagingController {
     ) {
       return;
     }
+    const attribution = await this.responseAttributionForBinding(binding);
     await this.deliver(
       {
         id: this.newIntentId("assistant-images"),
@@ -6610,6 +6617,7 @@ export class MessagingController {
         bindingId: binding.id,
         createdAt: this.now(),
         role: "assistant",
+        attribution,
         parts: images,
       },
       binding,
@@ -6753,6 +6761,7 @@ export class MessagingController {
         bindingId: binding.id,
         createdAt: this.now(),
         role: "assistant",
+        attribution: await this.responseAttributionForBinding(binding),
         parts: [
           {
             type: "text",
@@ -16535,7 +16544,7 @@ export class MessagingController {
       ? await this.resolveBoundThreadSummary(sourceBinding)
       : undefined;
     const attributionLabel = sourceBinding
-      ? privateResponseAttributionLabel(sourceBinding, sourceThread)
+      ? responseAttributionLabel(sourceBinding, sourceThread)
       : "PwrAgent Agent";
     const result = await this.deliver(
       {
@@ -17055,6 +17064,17 @@ export class MessagingController {
       });
       return undefined;
     }
+  }
+
+  private async responseAttributionForBinding(
+    binding: MessagingBindingRecord,
+  ): Promise<{ label: string }> {
+    return {
+      label: responseAttributionLabel(
+        binding,
+        await this.resolveBoundThreadSummary(binding),
+      ),
+    };
   }
 
   private async resolveManagedConversationSummary(
@@ -19643,7 +19663,7 @@ function summarizeNavigationThreadForMessaging(
   };
 }
 
-function privateResponseAttributionLabel(
+function responseAttributionLabel(
   binding: MessagingBindingRecord,
   thread: PwrAgentMessagingBoundThreadSummary | undefined,
 ): string {
@@ -19655,7 +19675,9 @@ function privateResponseAttributionLabel(
       : thread?.title;
   const normalized = identity?.replace(/\s+/g, " ").trim();
   if (normalized) {
-    return normalized;
+    return targetKind === "agent_thread"
+      ? `Agent: ${normalized}`
+      : `Bound thread: ${normalized}`;
   }
   return targetKind === "agent_thread"
     ? "PwrAgent Agent"

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -16201,6 +16201,7 @@ export class MessagingController {
         bindingId: binding.id,
         createdAt: this.now(),
         role: "assistant",
+        attribution: await this.responseAttributionForBinding(binding),
         parts: [{ type: "text", text: latest.text, markdown: "markdown" }],
       },
       binding,

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -187,14 +187,16 @@ link syntax or a future structured link part. Platform clients may still apply
 native autolinking to plain text; neutralize that only with a provider-specific
 policy and tests for the concrete platform behavior.
 
-`MessagingMessageIntent.attribution` carries optional source identity and
-secondary delivery context for responses routed away from their bound
-conversation. Providers should render it as restrained secondary context, such
-as a Slack Block Kit context block. Producers omit it for routine replies when
-the destination already identifies the bound thread. For bound Agent threads,
-desktop orchestration uses normalized Agent metadata only; for ordinary bound
-threads it uses the normalized thread title unless its title source is
-`fallback`, then uses `PwrAgent thread`. A missing Agent name must not be
+`MessagingMessageIntent.attribution` and
+`MessagingStreamUpdateIntent.attribution` carry optional source identity and
+secondary delivery context. Providers should render it as restrained secondary
+context, such as a Slack Block Kit context block. Desktop orchestration adds the
+identity to durable assistant replies so a shared conversation still says which
+bound Agent or thread produced each response. For bound Agent threads, it uses
+normalized Agent metadata only; for ordinary bound threads it uses the
+normalized thread title unless its title source is `fallback`. Named identities
+render as `Agent: <name>` or `Bound thread: <title>`; the restrained fallbacks
+remain `PwrAgent Agent` and `PwrAgent thread`. A missing Agent name must not be
 inferred from a derived thread title, prompt text, or `AGENTS.md` content.
 
 Telegram currently uses Bot API long polling, HTML-safe text, inline keyboards,

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -828,23 +828,27 @@ export type MessagingBaseSurfaceIntent = {
   targetSurface?: MessagingSurfaceRef;
 };
 
+export type MessagingResponseAttribution = {
+  label: string;
+  hint?: string;
+};
+
 export type MessagingMessageIntent = MessagingBaseSurfaceIntent & {
   kind: "message";
   /**
-   * Optional source identity and delivery context for a response routed away
-   * from its bound conversation. Routine replies should omit this when their
-   * destination already makes the source identity unambiguous.
+   * Optional bound Agent or thread identity plus secondary delivery context.
    */
-  attribution?: {
-    label: string;
-    hint?: string;
-  };
+  attribution?: MessagingResponseAttribution;
   parts: MessagingContentPart[];
   role?: "assistant" | "user" | "system";
 };
 
 export type MessagingStreamUpdateIntent = MessagingBaseSurfaceIntent & {
   kind: "stream_update";
+  /**
+   * Optional bound Agent or thread identity on the durable streamed response.
+   */
+  attribution?: MessagingResponseAttribution;
   stream: {
     isFinal: boolean;
     key: string;

--- a/packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts
@@ -90,6 +90,42 @@ describe("Slack formatting", () => {
     ]);
   });
 
+  it("renders bound response identity on final streamed replies", () => {
+    const intent: MessagingSurfaceIntent = {
+      id: "streamed-reply",
+      kind: "stream_update",
+      attribution: { label: "Agent: Signals Agent" },
+      createdAt: 1,
+      role: "assistant",
+      markdown: "markdown",
+      stream: {
+        isFinal: true,
+        key: "thread-1:turn-1:item-1",
+        sequence: 2,
+      },
+      text: "Investigation complete.",
+    };
+
+    expect(
+      buildSlackBlocksForIntent({ intent, text: intent.text }),
+    ).toEqual([
+      {
+        type: "markdown",
+        text: "Investigation complete.",
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "plain_text",
+            text: "Agent: Signals Agent",
+            emoji: true,
+          },
+        ],
+      },
+    ]);
+  });
+
   it("clamps remote image alt text to Slack's plain-text limit", () => {
     const alt = "a".repeat(2_500);
     const intent: MessagingSurfaceIntent = {

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -211,7 +211,10 @@ export function buildSlackBlocksForIntent(params: {
     });
   }
 
-  if (params.intent.kind === "message" && params.intent.attribution) {
+  if (
+    (params.intent.kind === "message" || params.intent.kind === "stream_update")
+    && params.intent.attribution
+  ) {
     blocks.push({
       type: "context",
       elements: [


### PR DESCRIPTION
## Summary

- add bound response attribution to routine assistant messages, image-only replies, resume reposts, and final streamed edits
- render explicit Slack context labels as `Agent: <name>` or `Bound thread: <title>`
- keep private-response guidance exclusive to actual private replies
- update the channel-neutral messaging contract and focused coverage

## Why

Slack already supported Block Kit context on channel messages, but PwrAgent only populated attribution for privately routed responses. The contract and a controller test explicitly encoded that routine replies should omit it. That made responses from multiple Agents or bound threads indistinguishable in shared Slack conversations.

## Impact

Every durable PwrAgent assistant reply in Slack now identifies the Agent or bound thread that produced it. Interim prose, tool activity, status surfaces, and working cards remain unchanged.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts packages/messaging/interface/src/__tests__/messaging-contract.test.ts` — 534 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
