### PR TITLE
fix(desktop): honor current tool-output alert settings

### DIFF
--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -129,6 +129,28 @@ describe("buildThreadIncidentSummary", () => {
       threadId: "thread-1",
     })?.flaggedInvocationCount).toBe(1);
   });
+
+  it("does not carry size flags minted under an older lower threshold", () => {
+    const summary = buildThreadIncidentSummary({
+      accounting: accounting([
+        invocation({
+          invocationId: "old-default-case",
+          noisyReason: "large-output",
+          outputChars: 8_000,
+        }),
+        invocation({
+          invocationId: "current-default-case",
+          noisyReason: "large-output",
+          outputChars: 24_000,
+        }),
+      ]),
+      backend: "codex",
+      largeOutputThresholdChars: 20_000,
+      threadId: "thread-1",
+    });
+
+    expect(summary?.flaggedInvocationCount).toBe(1);
+  });
 });
 
 describe("resolveToolIncidentVisibility", () => {

--- a/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
@@ -221,7 +221,7 @@ export function PricingSettings(props: {
           />
           <SettingsField
             label="Tool output reaches the cap"
-            sub="Alert immediately when one tool call reaches the model-visible output cap and is truncated."
+            sub="Alert immediately when one tool call reaches the model-visible output cap and is truncated. This trigger does not use the calls-per-turn setting."
             source={sourceBadge(toolOutputAlerts.outputCapHitsEnabled)}
             control={
               <SettingsSwitch
@@ -264,7 +264,7 @@ export function PricingSettings(props: {
             source={sourceBadge(
               toolOutputAlerts.repeatedLargeOutputMinimumCalls,
             )}
-            sub="Number of qualifying tool calls required before the alert is raised."
+            sub="Number of qualifying calls required for Repeated large tool outputs. Cap-hit alerts remain immediate."
             suffix="calls"
             value={toolOutputAlerts.repeatedLargeOutputMinimumCalls.value}
             onSave={(next) => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -949,6 +949,12 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByRole("switch", { name: "Repeated large tool outputs" }),
     ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByText(/This trigger does not use the calls-per-turn setting/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cap-hit alerts remain immediate/),
+    ).toBeInTheDocument();
     fireEvent.change(
       screen.getByRole("spinbutton", {
         name: "Active turn spend threshold",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -197,8 +197,8 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     const cases = await screen.findByLabelText("Incident cases");
     const rows = within(cases).getAllByRole("button", { name: /chars/ });
     expect(rows[0]).toHaveAttribute("title", expect.stringContaining("wide-scan"));
-    expect(rows[0]).toHaveTextContent("50% of cap");
-    expect(rows[1]).toHaveTextContent("15% of cap");
+    expect(rows[0]).toHaveTextContent("75% of cap");
+    expect(rows[1]).toHaveTextContent("60% of cap");
   });
 
   it("reports round trips per turn, counting calls that were never flagged", async () => {
@@ -317,7 +317,7 @@ function buildResponse(
     ...buildInvocation(),
     invocationId: `invocation-${index + 1}`,
     itemId: `item-${index + 1}`,
-    outputChars: 8_000 + index * 1_000,
+    outputChars: 24_000 + index * 1_000,
   }));
   return {
     backend: "codex",
@@ -374,12 +374,12 @@ function buildMultiTurnResponse(): AppServerReadThreadResponse {
     {
       ...base,
       category: "shell",
-      estimatedOutputTokens: 5_000,
+      estimatedOutputTokens: 7_500,
       invocationId: "invocation-wide",
       itemId: "item-wide",
       normalizedCommand: "rg --files wide-scan",
       observedAt: 1_800_000_000_000,
-      outputChars: 20_000,
+      outputChars: 30_000,
       turnId: "turn-1",
     },
     {
@@ -409,12 +409,12 @@ function buildMultiTurnResponse(): AppServerReadThreadResponse {
     {
       ...base,
       category: "build-test",
-      estimatedOutputTokens: 1_500,
+      estimatedOutputTokens: 6_000,
       invocationId: "invocation-tests",
       itemId: "item-tests",
       normalizedCommand: "pnpm test",
       observedAt: 1_800_000_003_000,
-      outputChars: 6_000,
+      outputChars: 24_000,
       turnId: "turn-2",
     },
   ];
@@ -438,7 +438,7 @@ function buildInvocation(): ThreadToolInvocationRecord {
     category: "build-test",
     debugLines: 0,
     errorLines: 1,
-    estimatedOutputTokens: 2_000,
+    estimatedOutputTokens: 6_000,
     infoLines: 0,
     invocationId: "invocation-1",
     itemId: "item-1",
@@ -446,7 +446,7 @@ function buildInvocation(): ThreadToolInvocationRecord {
     noisyReason: "verbose-build-test",
     normalizedCommand: "pnpm test",
     observedAt: 1_800_000_000_000,
-    outputChars: 8_000,
+    outputChars: 24_000,
     outputLines: 200,
     outputState: "available",
     outputTruncated: false,

--- a/packages/shared/src/__tests__/tool-output-incidents.test.ts
+++ b/packages/shared/src/__tests__/tool-output-incidents.test.ts
@@ -1,3 +1,4 @@
+import type { ThreadToolInvocationRecord } from "../contracts/normalized-app-server";
 import { describe, expect, it } from "vitest";
 import { isFlaggedToolInvocation } from "../contracts/tool-output-incidents";
 
@@ -28,5 +29,34 @@ describe("isFlaggedToolInvocation", () => {
 
     expect(isFlaggedToolInvocation(invocation, 30_000)).toBe(false);
     expect(isFlaggedToolInvocation(invocation, 10_000)).toBe(true);
+  });
+
+  it("re-evaluates size-derived flags against the operator's current threshold", () => {
+    /* This row was marked under the original 10%-of-cap default. Raising the
+       setting to 50% must stop counting it as a case; otherwise the saved
+       flag makes the threshold control ineffective for existing threads. */
+    const invocation: Pick<
+      ThreadToolInvocationRecord,
+      "noisy" | "noisyReason" | "outputChars"
+    > = {
+      noisy: true,
+      noisyReason: "large-output",
+      outputChars: 8_000,
+    };
+
+    expect(isFlaggedToolInvocation(invocation, 20_000)).toBe(false);
+  });
+
+  it("preserves pattern-derived flags below the size threshold", () => {
+    const invocation: Pick<
+      ThreadToolInvocationRecord,
+      "noisy" | "noisyReason" | "outputChars"
+    > = {
+      noisy: true,
+      noisyReason: "repeat-polling-output",
+      outputChars: 200,
+    };
+
+    expect(isFlaggedToolInvocation(invocation, 20_000)).toBe(true);
   });
 });

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -34,6 +34,19 @@ export const TOOL_OUTPUT_WARNING_CHARS = toolOutputWarningChars(
 /** Repeated large output becomes alert-worthy at this many calls in one turn. */
 export const TOOL_OUTPUT_WARNING_INVOCATIONS = 5;
 
+/* These reasons are conclusions drawn from one invocation's output size.
+   Unlike pattern-derived flags such as repeated polling, they can be
+   re-evaluated when the operator changes the effective size threshold. */
+const SIZE_DERIVED_TOOL_OUTPUT_REASONS = new Set([
+  "broad-file-read",
+  "broad-mcp-result",
+  "broad-search",
+  "large-output",
+  "large-output-critical",
+  "large-truncated-output",
+  "verbose-build-test",
+]);
+
 /** Translate an operator-facing percentage into the detector's character cap. */
 export function toolOutputWarningChars(percent: number): number {
   return Math.ceil(TOOL_OUTPUT_CAP_CHARS * percent / 100);
@@ -54,14 +67,25 @@ export function toolOutputCapShare(outputChars: number): number {
  * populated turn strip. The size test is re-derivable from a row we already
  * have, so derive it rather than trusting when the row was written.
  *
- * The flag still matters and is ORed in, because polling is a pattern across
- * invocations: no single row carries enough to reconstruct it.
+ * The flag still matters for patterns such as repeated polling: no single row
+ * carries enough to reconstruct why a small result was part of the incident.
+ * A size-derived flag is different. It records the threshold that was active
+ * when the row was written, so trusting it forever would make a later, higher
+ * operator threshold ineffective for existing threads. Re-derive those flags
+ * from the stored output size and preserve only pattern-derived/legacy flags.
  */
 export function isFlaggedToolInvocation(
-  invocation: Pick<ThreadToolInvocationRecord, "noisy" | "outputChars">,
+  invocation: Pick<
+    ThreadToolInvocationRecord,
+    "noisy" | "noisyReason" | "outputChars"
+  >,
   largeOutputThresholdChars = TOOL_OUTPUT_WARNING_CHARS,
 ): boolean {
-  return invocation.noisy || invocation.outputChars >= largeOutputThresholdChars;
+  const sizeDerivedFlag = invocation.noisyReason !== undefined
+    && SIZE_DERIVED_TOOL_OUTPUT_REASONS.has(invocation.noisyReason);
+  const patternOrLegacyFlag = invocation.noisy && !sizeDerivedFlag;
+  return patternOrLegacyFlag
+    || invocation.outputChars >= largeOutputThresholdChars;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Re-evaluate stored size-derived tool-output flags against the operator's current output-size threshold instead of treating the threshold active at record time as permanent.
- Preserve pattern-derived flags such as repeated polling, where one row cannot reconstruct why the call belongs to an incident.
- Clarify in Usage & Pricing that cap-hit alerts are immediate and independent of the repeated-output calls-per-turn setting.

## Verification

- I first added regression tests that failed with the real stale-flag behavior: an 8,000-character call marked under the old 10%-of-cap default continued to count after the effective threshold became 50%.
- `pnpm test packages/shared/src/__tests__/tool-output-incidents.test.ts apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/tool-output-incident-insights.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx` (154 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Notes

- For thread `01a00be1-715c-7e13-ab64-b41e341c2762`, the current 50%-of-cap setting classifies 36 calls, not the 99 shown by the stale notice. The thread still contains 16 calls at or above the cap, so it remains eligible while **Tool output reaches the cap** is On. Turning that switch Off suppresses that independent immediate trigger; the updated copy now says so explicitly.
- No config or sqlite schema change is required. Existing rows are reclassified at read/render time, so the fix applies immediately to already-recorded threads.
