### PR TITLE
docs: simplify repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - Treat plans as decision records. Do not use them as implementation scripts.
 - Follow the active plan unless the user changes the scope.
 - Treat brainstorms, plans, and solutions as historical records.
+  - The record directories are `docs/brainstorms/`, `docs/plans/`, and `docs/solutions/`.
   - Do not delete or rewrite a record without explicit user authorization.
   - You may update the plan that the current branch implements.
   - Limit updates to progress, dependencies, and resolved implementation questions.
@@ -34,7 +35,7 @@
 - Keep model-visible command output bounded.
 - Tool output becomes thread context. Later turns can replay that output.
 - For broad discovery, start with `rg -l` or `rg --count-matches`.
-- Exclude tests from discovery unless tests are in scope.
+- Exclude `__tests__` from discovery unless tests are in scope.
 - After discovery, inspect only the files and line ranges that you need.
 - Use `rg -n -C` only with a selected file or a small file set.
 - Use the minimum context that supports the next decision.
@@ -151,7 +152,7 @@
 - The renderer also uses the classic React Hooks rules.
 - The ESLint configuration has no style rules.
 - Fix all ESLint errors.
-- Existing `no-explicit-any`, `exhaustive-deps`, and intentional patterns can produce warnings.
+- ESLint sets existing `no-explicit-any`, `exhaustive-deps`, and intentional patterns to `warn`.
 - CI blocks errors. CI does not block warnings.
 - Do not add style or whitespace rules to ESLint.
 - Do not use `eslint --fix` to format code.
@@ -162,7 +163,7 @@
 - Format code by hand.
 - Prettier is not a dependency.
 - The repository has no `.prettierrc`, `format` script, or CI formatting step.
-- Never run `npx prettier` or `prettier --write` on repository files.
+- Never run `npx prettier`, `npx prettier --write`, or `prettier --write` on repository files.
 - Without a local dependency, `npx` downloads Prettier and uses its default configuration.
 - Those defaults conflict with the hand-maintained repository style.
 - The defaults also reformat unchanged code.
@@ -203,7 +204,7 @@
 
 - Use Conventional Commit-style PR titles: `type(scope): short description`.
 - Select the scope that matches the changed area:
-  - Use `messaging` for adapters and messaging integrations.
+  - Use `messaging` for Telegram, Discord, adapters, and messaging integrations.
   - Use `desktop` for the desktop application.
   - Use `agent-core` for coding-agent backends and ACP integration.
   - Use `release` for packaging, signing, notarization, distribution, and automatic updates.
@@ -245,6 +246,7 @@
 
 These variables are for development only.
 
+- A build is packaged when `app.isPackaged === true`.
 - Production operators must not set these variables.
 - A packaged build ignores each variable.
 - If a packaged build finds one, startup writes a `mainLog.error` entry.
@@ -262,7 +264,7 @@ These variables are for development only.
 
 - Skip all `safeStorage` operations.
 - The wizard silently discards secrets that the operator enters.
-- Secret indicators on the Settings screen report `unavailable`.
+- Secret pills on the Settings screen report `unavailable`.
 - Use this workaround only for unsigned development builds on macOS.
 - Those builds can show a `Keychain Not Found` dialog because they have no stable signing identity.
 - Signed release builds do not have this problem.
@@ -383,7 +385,7 @@ Canonical primitives and the tokens they read:
   - Draft storage is machine-wide, but each window reads it only during mount.
   - A second window does not update its Draft chips until it restarts.
   - Launchpad composer text has no thread row.
-  - Therefore, the lens label refers to replies.
+  - Therefore, the lens label uses `replies`.
   - Its empty state is `No unsent replies.`
 
 ### Inbox, Recents, and Directories
@@ -438,6 +440,7 @@ Canonical primitives and the tokens they read:
 Never weaken the dependency boundary rules.
 
 - `.dependency-cruiser.cjs` defines the layered architecture.
+- `dependency-cruiser` reads this configuration.
 - Do not add an exception or allowlist to that file.
 - Do not add a `severity: "ignore"` override.
 - Do not import from a package above the current package layer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ These variables are for development only.
 - Do not put scaffold narration in the user interface.
 - Do not put placeholder implementation text in the user interface.
 
-### Reuse existing chrome — copy tokens, don't pick new ones
+### Reuse existing chrome tokens
 
 Before you build new window chrome, open `apps/desktop/src/renderer/src/styles/app.css`.
 
@@ -435,28 +435,55 @@ Canonical primitives and the tokens they read:
 
 ## Dependency Boundary Enforcement
 
-**DO NOT, under any circumstances, loosen the dependency boundary rules.**
+Never weaken the dependency boundary rules.
 
-This repository enforces a strict layered dependency architecture via
-`dependency-cruiser` (`.dependency-cruiser.cjs`). These rules are load-bearing:
+- `.dependency-cruiser.cjs` defines the layered architecture.
+- Do not add an exception or allowlist to that file.
+- Do not add a `severity: "ignore"` override.
+- Do not import from a package above the current package layer.
+- Do not introduce a circular dependency.
+- Do not move code to bypass a boundary.
+- Do not restructure code to bypass a boundary.
+- If a boundary blocks a change, redesign the change.
 
-- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
-- **DO NOT** add imports from packages above a package's layer in the dependency hierarchy
-- **DO NOT** introduce circular dependencies between any modules
-- **DO NOT** move or restructure code to circumvent boundary rules
-- If a rule blocks your change, the change is architecturally wrong — redesign it
+Use this dependency order from lowest to highest:
 
-The dependency hierarchy (bottom to top):
-- **Leaves** (import nothing internal): `packages/shared`
-- **Mid-tier**: `packages/messaging/interface` (→ shared only), `packages/messaging/providers/*` (→ messaging/interface only)
-- **Top**: `apps/desktop` (→ any package)
+- `packages/shared` imports no internal package.
+- `packages/messaging/interface` imports only `packages/shared`.
+- `packages/messaging/providers/*` imports only `packages/messaging/interface`.
+- `apps/desktop` can import any package.
 
-Additional renderer constraint: `apps/desktop/src/renderer/` may only import `@pwragent/shared`. All other package access crosses the IPC bridge via the main process.
+The renderer has an additional boundary.
 
-Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation. Run it locally before pushing.
+- `apps/desktop/src/renderer/` can import only `@pwragent/shared` directly.
+- Access every other package through the main-process IPC bridge.
+- Run `pnpm lint:boundaries` before you push.
+- CI fails for every boundary violation.
 
 ## App-Specific Guidance
 
-- Additional desktop-app instructions live in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
-- Messaging package boundary instructions live in [packages/messaging/AGENTS.md](packages/messaging/AGENTS.md). Review them before adding messaging integrations, changing messaging provider code, or deciding where messaging calls and workflow logic should live.
-- For messaging architecture (separation of concerns between interface, providers, and desktop orchestration; data-flow diagrams; the capability-profile system; callback delivery models; file map), read [docs/messaging-architecture.md](docs/messaging-architecture.md). For the formal per-adapter contract, [docs/messaging-adapter-contract.md](docs/messaging-adapter-contract.md). For a hands-on walkthrough when adding a new provider, [docs/messaging-adding-a-provider.md](docs/messaging-adding-a-provider.md). For operator setup, the command surface, and Cloudflare-Tunnel / Tailscale-Funnel deployment for HTTP-callback providers, [docs/messaging-platform-integration.md](docs/messaging-platform-integration.md). For the messaging RBAC capability layer (permission catalog, built-in roles, enforcement surfaces, audit), [docs/messaging-rbac.md](docs/messaging-rbac.md).
+- Before desktop application work, read [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
+- Before messaging package work, read [packages/messaging/AGENTS.md](packages/messaging/AGENTS.md).
+- Read the messaging package guidance before you:
+  - Add a messaging integration.
+  - Change messaging provider code.
+  - Select the owner of messaging calls or workflow logic.
+- Read [messaging-architecture.md](docs/messaging-architecture.md) for:
+  - Package responsibilities.
+  - Data flow.
+  - Capability profiles.
+  - Callback delivery models.
+  - The messaging file map.
+- Read [messaging-adapter-contract.md](docs/messaging-adapter-contract.md) for the formal adapter contract.
+- Read [messaging-adding-a-provider.md](docs/messaging-adding-a-provider.md) before you add a provider.
+- Read [messaging-platform-integration.md](docs/messaging-platform-integration.md) for:
+  - Operator setup.
+  - Messaging commands.
+  - Cloudflare Tunnel deployment.
+  - Tailscale Funnel deployment.
+  - HTTP callback providers.
+- Read [messaging-rbac.md](docs/messaging-rbac.md) for:
+  - The permission catalog.
+  - Built-in roles.
+  - Enforcement points.
+  - Audit behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,38 +221,86 @@
 - Do not change the first-party license without an explicit PwrDrvr LLC policy change.
 - Do not remove license disclosures without an explicit PwrDrvr LLC policy change.
 
-## Runtime Config
+## Runtime Configuration
 
-- All desktop config and state lives under `~/.pwragent/` (the "PwrAgent root").
-- Override the root with `PWRAGENT_HOME=/path/to/root` for isolated E2E or dev-profile use.
-- Select a named profile with `PWRAGENT_PROFILE=<name>` (defaults to `default`).
-- Per-profile layout: `~/.pwragent/profiles/<name>/config.toml` (settings), `~/.pwragent/profiles/<name>/state/state.db` (sqlite).
-- Before making a backwards-incompatible TOML config shape change, read [docs/config-file-evolution.md](docs/config-file-evolution.md) and follow its read-fallback, lazy-conversion, legacy-comment, and dual-write rules.
-- Removed env vars (no longer honored): `PWRAGNT_STATE_ROOT`, `PWRAGNT_CONFIG_PATH`.
-- Multiple instances can share the same profile DB safely (sqlite WAL mode); no lockfile needed.
+- Store all desktop configuration and state under `~/.pwragent/`.
+- This directory is the **PwrAgent root**.
+- For isolated E2E or development work, override the root with `PWRAGENT_HOME=/path/to/root`.
+- Select a named profile with `PWRAGENT_PROFILE=<name>`.
+- If the variable is not set, use the `default` profile.
+- Store profile settings in `~/.pwragent/profiles/<name>/config.toml`.
+- Store profile state in `~/.pwragent/profiles/<name>/state/state.db`.
+- Before an incompatible TOML shape change, read [config-file-evolution.md](docs/config-file-evolution.md).
+- Apply all of these configuration evolution rules:
+  - Read fallback.
+  - Lazy conversion.
+  - Legacy comment.
+  - Dual write.
+- Do not use `PWRAGNT_STATE_ROOT` or `PWRAGNT_CONFIG_PATH`.
+- The application does not read those removed variables.
+- Multiple instances can safely share one profile database through SQLite WAL mode.
+- Do not add a lock file for this database.
 
 ### Dev-only env vars
 
-These are **dev-only escape hatches**. They are silently ignored in packaged production builds (`app.isPackaged === true`); production operators MUST NOT set them. Each is rejected at startup with a `mainLog.error` line if it appears alongside a packaged build, then treated as unset.
+These variables are for development only.
 
-- `PWRAGENT_PROFILE_AUTO_CREATE=1` — Bypass the onboarding wizard's "set up profile" prompt for missing-named-profile boots. Used by E2E fixtures and replay harnesses that need a profile dir materialized without operator interaction. Production launches MUST go through the wizard so an operator never gets a silently-created profile mapped to a Codex auth profile they didn't ask for (see issue #524).
-- `PWRAGENT_DEV_DISABLE_SECRET_STORAGE=1` — Skip `safeStorage` operations entirely. Wizard typed secrets are SILENTLY DROPPED; settings-screen secret pills report "unavailable." Workaround for unsigned dev Electron builds on macOS that surface a confusing "Keychain Not Found" dialog because the binary lacks a stable code-signed identity (signed release builds don't have this problem). Operator re-enters secrets in Settings → Models on a real build afterwards.
-- `PWRAGENT_DEV_SQLITE_WRITE_METRICS=1` — Count sqlite write volume (commits, write statements, rows, WAL growth, per table) for the process. Wraps the database in `StateDb.open` after schema setup. Paired with `PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE=<path>`, which appends one JSON line of totals per source. See "Sqlite Write-Volume Instrumentation" in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
+- Production operators must not set these variables.
+- A packaged build ignores each variable.
+- If a packaged build finds one, startup writes a `mainLog.error` entry.
+- The packaged build then treats the variable as unset.
+
+`PWRAGENT_PROFILE_AUTO_CREATE=1`
+
+- Skip the onboarding prompt when a named profile does not exist.
+- Use this variable for E2E fixtures and replay harnesses that need a profile directory.
+- Production launches must use the onboarding wizard.
+- The wizard prevents an unrequested mapping to a Codex authentication profile.
+- Issue #524 explains this requirement.
+
+`PWRAGENT_DEV_DISABLE_SECRET_STORAGE=1`
+
+- Skip all `safeStorage` operations.
+- The wizard silently discards secrets that the operator enters.
+- Secret indicators on the Settings screen report `unavailable`.
+- Use this workaround only for unsigned development builds on macOS.
+- Those builds can show a `Keychain Not Found` dialog because they have no stable signing identity.
+- Signed release builds do not have this problem.
+- After development, enter the secrets again in **Settings → Models** on a signed build.
+
+`PWRAGENT_DEV_SQLITE_WRITE_METRICS=1`
+
+- Count process-level SQLite commits, statements, rows, WAL growth, and table activity.
+- `StateDb.open` installs the metrics wrapper after schema setup.
+- Set `PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE=<path>` to select an output file.
+- The metrics file gets one JSON line of totals for each source.
+- Read "Sqlite Write-Volume Instrumentation" in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
 
 ## Frontend and Desktop UI
 
-- For renderer UI work, follow the desktop style guide before inventing local styling.
-- For colors, tokens, and visual theme decisions, follow the UI theme guide before adding local CSS.
-- Favor thread-first information hierarchy over generic dashboard layout.
-- Do not ship scaffold narration or placeholder implementation copy in user-facing UI.
+- Before renderer UI work, read the [desktop style guide](docs/design/desktop-style-guide.md).
+- Before color or theme work, read the [UI theme guide](docs/UI-THEME.md).
+- Use existing theme tokens before you add local CSS.
+- Prefer a thread-first information hierarchy to a generic dashboard layout.
+- Do not put scaffold narration in the user interface.
+- Do not put placeholder implementation text in the user interface.
 
 ### Reuse existing chrome — copy tokens, don't pick new ones
 
-When you build new chrome (a title bar strip, a brand mark, a breadcrumb,
-an eyebrow, a path/app row), open `apps/desktop/src/renderer/src/styles/app.css`
-and copy the token references from the existing primitive that solves the
-same problem. Don't pick a new token because it "looks similar" — the brand
-across windows must read identically.
+Before you build new window chrome, open `apps/desktop/src/renderer/src/styles/app.css`.
+
+- Find the existing primitive that has the same function.
+- Copy its token references.
+- Do not select a different token because it looks similar.
+- Keep brand presentation identical in all windows.
+
+This rule applies to these elements:
+
+- Title-bar strips.
+- Brand marks.
+- Breadcrumbs.
+- Eyebrows.
+- Path or application rows.
 
 Canonical primitives and the tokens they read:
 
@@ -263,13 +311,12 @@ Canonical primitives and the tokens they read:
 | `.settings-titlebar__*` (Settings right-pane) | n/a | n/a | `--accent` | `--text-muted` | `--text-primary` |
 | `.activity-titlebar__*` (Activity window) | `--text-primary` | `--accent` | `--accent` | `--text-muted` | `--text-primary` |
 
-`apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
-locks the brand-accent + breadcrumb token contract across these primitives.
-A test fails if anyone (you, a future PR) picks a different accent token
-for a brand mark or drifts the Activity titlebar breadcrumb away from the
-Settings titlebar. **If you need to deliberately change a chrome token,
-change the test in the same commit** so the intent is reviewed, not
-accidental.
+`apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` enforces this token contract.
+
+- The test compares brand accent tokens across the listed primitives.
+- The test also compares Activity and Settings breadcrumb tokens.
+- If you intentionally change a chrome token, change the test in the same commit.
+- This paired change makes the design decision visible during review.
 
 ## Current Product Direction
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,32 +138,47 @@
 
 ## Code Formatting & Linting
 
-**There is a linter (ESLint) but no autoformatter — and that split is
-deliberate. Run ESLint; hand-format; never run Prettier.**
+- Use ESLint only as a correctness linter.
+- Run `pnpm lint:eslint`.
+- The CI `Lint` job also runs these checks:
+  - `lint:sql`.
+  - `lint:codex-storage`.
+  - `lint:colors`.
+  - `licenses:check`.
+  - `typecheck`.
+  - `lint:boundaries`.
+- [`eslint.config.mjs`](eslint.config.mjs) enables the recommended TypeScript ESLint rules.
+- The renderer also uses the classic React Hooks rules.
+- The ESLint configuration has no style rules.
+- Fix all ESLint errors.
+- Existing `no-explicit-any`, `exhaustive-deps`, and intentional patterns can produce warnings.
+- CI blocks errors. CI does not block warnings.
+- Do not add style or whitespace rules to ESLint.
+- Do not use `eslint --fix` to format code.
 
-- **ESLint is adopted — as a correctness linter, not a formatter.** Run
-  `pnpm lint:eslint` (CI's `Lint` job runs it too, alongside `lint:sql`,
-  `lint:codex-storage`, `lint:colors`, `licenses:check`, `typecheck`, and
-  `lint:boundaries`). The config is [`eslint.config.mjs`](eslint.config.mjs):
-  typescript-eslint recommended + classic react-hooks (scoped to the renderer),
-  **no stylistic rules**. Fix the errors it reports. A block of pre-existing
-  findings (`no-explicit-any`, `exhaustive-deps`, and intentional patterns) is
-  set to `warn` as a burn-down baseline — CI blocks on errors, not warnings.
-  Do NOT add stylistic/whitespace rules and do NOT run `eslint --fix` to
-  reformat code: formatting is not ESLint's job here.
-- **Prettier is deliberately absent.** No dependency, no `.prettierrc`, no
-  `format` script, no CI formatting step. **Never run `npx prettier` or
-  `prettier --write` on repo files.** Because no config is committed, `npx`
-  downloads Prettier and applies its built-in defaults, which fight this repo's
-  hand-maintained house style and reformat large spans of untouched code. On
-  PR #934 a single `npx prettier --write` on one file rewrote ~90 unrelated
-  lines around a 3-line change, bloating the diff and muddying `git blame`. A
-  full-tree Prettier reformat was evaluated (it touched ~77% of files) and
-  declined; don't reintroduce it ad hoc.
-- **Match the surrounding code by hand.** The house style (verify against
-  neighbors, don't assume): double quotes, 2-space indent, semicolons, trailing
-  commas on multi-line literals, and **leading binary operators** on wrapped
-  expressions — the operator starts the continuation line:
+### Formatting
+
+- The repository intentionally has no automatic formatter.
+- Format code by hand.
+- Prettier is not a dependency.
+- The repository has no `.prettierrc`, `format` script, or CI formatting step.
+- Never run `npx prettier` or `prettier --write` on repository files.
+- Without a local dependency, `npx` downloads Prettier and uses its default configuration.
+- Those defaults conflict with the hand-maintained repository style.
+- The defaults also reformat unchanged code.
+- In PR #934, Prettier changed approximately 90 unrelated lines around a three-line change.
+- Those changes made the diff larger and reduced the value of `git blame`.
+- A full repository test changed approximately 77% of files.
+- The project rejected that full repository reformat.
+- Do not introduce an isolated Prettier reformat.
+- Inspect adjacent code before you format new code.
+- Use these local style rules:
+  - Double quotes.
+  - Two-space indentation.
+  - Semicolons.
+  - Trailing commas in multiline literals.
+  - Leading binary operators in wrapped expressions.
+- Put a wrapped binary operator at the start of the continuation line:
 
   ```ts
   const ok =
@@ -172,38 +187,39 @@ deliberate. Run ESLint; hand-format; never run Prettier.**
     || isDigit(char);
   ```
 
-  Prettier's default flips these to trailing operators; there are 500+ leading-
-  operator lines in the tree, so a default run is pure churn. Format new code to
-  look like its neighbors.
-- Keep diffs scoped to your actual change. If a file is already inconsistent,
-  leave the untouched lines alone rather than "tidying" them.
+- Prettier puts these operators at the end of the prior line.
+- The repository contains more than 500 leading-operator lines.
+- Make new code match adjacent code.
+- Keep each diff limited to the requested change.
+- If a file has unrelated inconsistencies, do not change those lines.
 
 ## Agent Instruction Files
 
-- Keep a sibling `CLAUDE.md` symlink next to every `AGENTS.md`, pointing at that `AGENTS.md`, so Codex and Claude read the same local guidance.
+- Put a `CLAUDE.md` symlink next to each `AGENTS.md` file.
+- Point each symlink to its sibling `AGENTS.md` file.
+- This structure gives Codex and Claude the same local guidance.
 
 ## Pull Requests
 
 - Use Conventional Commit-style PR titles: `type(scope): short description`.
-- Prefer scopes that match the project area being changed:
-  - `messaging` for Telegram, Discord, adapters, and messaging integrations.
-  - `desktop` for the desktop app itself.
-  - `agent-core` for coding-agent backend and ACP integration changes.
-  - `release` for packaging, signing, notarization, distribution, and auto-update pipeline.
-  - `docs` for documentation changes.
-  - `tests` for test coverage, fixtures, and test infrastructure.
+- Select the scope that matches the changed area:
+  - Use `messaging` for adapters and messaging integrations.
+  - Use `desktop` for the desktop application.
+  - Use `agent-core` for coding-agent backends and ACP integration.
+  - Use `release` for packaging, signing, notarization, distribution, and automatic updates.
+  - Use `docs` for documentation.
+  - Use `tests` for test coverage, fixtures, and test infrastructure.
 
 ## Release / Distribution
 
-- The desktop release pipeline (Mac, signing, notarization, auto-update) is
-  documented in [docs/desktop-release-runbook.md](docs/desktop-release-runbook.md).
-- The Phase 1 → Phase 2 distribution channel migration runbook lives at
-  [docs/desktop-distribution-phase-2-runbook.md](docs/desktop-distribution-phase-2-runbook.md).
-- PwrAgent is MIT-licensed, owned by PwrDrvr LLC. Treat the repo-root
-  `LICENSE`, package `license: "MIT"` declarations, and third-party license
-  aggregation as load-bearing release metadata. Do not introduce a different
-  first-party license or remove license disclosures without an explicit policy
-  change from PwrDrvr LLC.
+- Read the [desktop release runbook](docs/desktop-release-runbook.md) for release procedures.
+- The runbook covers packaging, signing, notarization, publishing, and automatic updates.
+- PwrAgent uses the MIT license. PwrDrvr LLC owns the project.
+- Preserve the repository `LICENSE` file.
+- Preserve each package `license: "MIT"` declaration.
+- Preserve the third-party license report.
+- Do not change the first-party license without an explicit PwrDrvr LLC policy change.
+- Do not remove license disclosures without an explicit PwrDrvr LLC policy change.
 
 ## Runtime Config
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,87 +2,139 @@
 
 ## Source of Truth
 
-- Product requirements live in `docs/brainstorms/`
-- Implementation plans live in `docs/plans/`
-- UI theme tokens and visual language live in [docs/UI-THEME.md](docs/UI-THEME.md)
-- Desktop UI direction lives in [docs/design/desktop-style-guide.md](docs/design/desktop-style-guide.md)
-- The PwrAgent v2 design source bundle (HTML/CSS/JSX prototypes + chat transcripts) lives in [docs/design/pwragent-v2/](docs/design/pwragent-v2/) — see [docs/design/pwragent-v2/SOURCE.md](docs/design/pwragent-v2/SOURCE.md) for provenance and the "reference, not copy verbatim" policy
-- The operator-facing site at <https://docs.pwragent.ai> lives in its own repo at [pwrdrvr/docs.pwragent.ai](https://github.com/pwrdrvr/docs.pwragent.ai) (split out from this repo on 2026-05-25). Edit there for per-platform setup walkthroughs, streaming/webhook explainers, and Settings → Messaging reference content. Contributor-facing messaging docs stay in [docs/messaging-*.md](docs/).
+- Product requirements are in `docs/brainstorms/`.
+- Implementation plans are in `docs/plans/`.
+- UI theme tokens and visual rules are in [docs/UI-THEME.md](docs/UI-THEME.md).
+- Desktop UI direction is in [docs/design/desktop-style-guide.md](docs/design/desktop-style-guide.md).
+- PwrAgent v2 design references are in [docs/design/pwragent-v2/](docs/design/pwragent-v2/).
+  - The bundle contains HTML, CSS, and JSX prototypes.
+  - [SOURCE.md](docs/design/pwragent-v2/SOURCE.md) gives the source history and usage policy.
+  - Use the bundle as a reference. Do not copy it exactly.
+- Operator documentation is in [pwrdrvr/docs.pwragent.ai](https://github.com/pwrdrvr/docs.pwragent.ai).
+  - Put platform setup, streaming, webhook, and Settings reference content there.
+  - Keep contributor messaging documentation in [this repository](docs/).
 
 ## Workflow
 
-- Treat plan documents as decision artifacts, not implementation scripts.
-- Keep changes aligned with the current active plan unless the user explicitly changes scope.
-- Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories. **Don't rewrite plan / brainstorm / solution files that weren't created on your current branch either** — they are point-in-time decision artifacts, a historical record of what was decided when. The one exception: the plan file your current branch is executing is fair game for in-flight updates (progress checkboxes, deferred-to-implementation answers resolved as you work). The root [`.rgignore`](.rgignore) skips all three directories from default `rg` searches; override per-search with `rg --no-ignore` (or `rg -u`) when you actually want to grep them. Full rules in [`docs/plans/AGENTS.md`](docs/plans/AGENTS.md).
-- GitHub Actions labels that intentionally trigger workflow behavior are
-  documented in [.github/workflows/README.md](.github/workflows/README.md).
-  Check that list before adding or using a CI-triggering PR label.
-- Exclude `apps/desktop/.local/protocol-captures/` from broad searches by default. Only search it when the task is specifically about captured E2E protocol snippets.
-- **Keep model-visible command output bounded.** Tool output is part of the
-  thread context and can be replayed on later turns, so do not use a broad,
-  context-heavy search as a first read. For discovery, start with
-  `rg -l`/`rg --count-matches` (and exclude `__tests__` unless tests are in
-  scope); then inspect only the named files and line ranges needed for the
-  next decision. Use `rg -n -C` only for a selected file or small file set,
-  with the minimum useful context. `sed` has no ignore-file setting: it reads
-  only the explicit path and range, so keep those operands specific.
-- Do not chain content-producing reads/searches with `&&`: their combined
-  stdout is sent as one tool result. For a deliberately broad scan, redirect
-  full stdout/stderr to an ignored `.local/` log and return only the exact
-  command, exit state, matching-file/count summary, failures or warnings, and
-  a bounded tail or targeted fields needed for the next decision. Truncation
-  is not a safe output budget.
-- Never read Codex-owned storage files directly from PwrAgent code. Treat
-  Codex session JSONL files, rollout files, and Codex sqlite databases as
-  private implementation details; use the Codex App Server protocol instead.
-  PwrAgent-owned files under `~/.pwragent/` and repo-local test fixtures are
-  fine when the feature explicitly owns them. CI enforces common cases with
-  `pnpm lint:codex-storage`; do not bypass that check by renaming variables or
-  shelling out. The sole exception is
-  `apps/desktop/src/main/codex-app-server/invalid-response-message-id-recovery.ts`,
-  which PwrDrvr LLC explicitly authorizes to repair only protocol-identified
-  rollouts after the exact Responses API invalid message-ID-prefix failure.
-  That module must remain backup-first, atomic, thread-validated, and limited
-  to removing invalid `id` fields from response items whose type is `message`.
-- Use the project-local [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when seeding or refreshing desktop replay fixtures from live captured sessions.
-- For reliable desktop E2E runs, prefer `pnpm test:desktop-e2e` from the repo root. The package-level `pnpm --filter @pwragent/desktop test:e2e` path is also safe now because it builds `apps/desktop/out/` before launching Playwright.
-- **An operator may have a lab available for off-desktop Windows or macOS E2E
-  testing.** Ask the operator for a pointer to the appropriate lab repository
-  or skill before running headed desktop E2E.
-- Before changing Windows Git/Bash process launch or shutdown, Vitest process
-  isolation, queue/composer lifecycle tests, or lazy-renderer readiness, read
-  [Windows Vitest stability: process ownership and lifecycle truth](docs/solutions/2026-08-06-windows-vitest-process-isolation.md).
-  Git-for-Windows launcher handoffs, non-atomic descendant cleanup, and
-  optimistic renderer synchronization have all caused expensive Windows-only
-  flakes; retries, wider timeouts, fewer workers, and serial lanes are not
-  substitutes for evidence-backed ownership and readiness fixes.
-- The macOS CI lane uses the selected-repository **PwrDrvr macOS**
-  organization runner group, shared only with PwrSnap. Do not add a
-  repository-scoped runner or widen access to the rest of the organization.
-- For manual screenshots of the branch-drift dialog, run `pnpm --filter @pwragent/desktop inspect:e2e:branch-drift`; it opens a replay-backed Electron fixture and waits until you close the app.
-- To regenerate the README screenshots under `docs/assets/screenshots/`, run `pnpm --filter @pwragent/desktop screenshot:readme`. The full walkthrough (spec, fixtures, state-seeding helpers, native capture utilities) lives in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md) under "Capturing README Screenshots". macOS Screen Recording permission is required for whichever terminal/IDE runs the spec.
-- When focusing root Vitest runs through `pnpm test`, pass file paths or filters directly, for example `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`. Do not insert a standalone `--` before the focus args; `pnpm test -- apps/...` makes Vitest run the full workspace suite.
-- **Any new sqlite write that fires per command, per turn, per item, per
-  streamed event, or on a timer must be measured before it ships, and pinned
-  by a checked-in write budget** that fails the suite when it moves. Do the arithmetic out loud: writes/second × commit
-  cost × how long a real session runs → MB/day. Sqlite commits are the unit,
-  not statements — each implicit transaction flushes its dirty pages plus every
-  index the row moved (~4 KB/page, and a timestamp column in an index moves on
-  every write). Two calibration points: tool accounting once wrote per streamed
-  8 KiB chunk, costing 3,693 commits and 58 MB of WAL for one `find /`
-  (PR #1406); the former 10-second runtime lease heartbeats cost 720 commits
-  and 2.7 MB/hour per running instance, about 65 MB/day. PID-owned runtime
-  leases now cost zero sqlite commits while idle. **If the projection looks excessive, say so to the
-  user rather than shipping it quietly — the right answer is often that the
-  design constraint has to change** (batch into one transaction, debounce
-  behind a flush window, accumulate in memory and persist on a boundary, or
-  not persist at all), and that is their call to make. Budgets live in
-  `apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json`; wrap the
-  feature (not its setup) in `measureSqliteWrites` and record with
-  `UPDATE_SQLITE_WRITE_BUDGETS=1`, so a write-cost change lands as a reviewable
-  line in the diff instead of never surfacing. Survey a whole run with
-  `pnpm test:sqlite-writes`. See "Sqlite Write-Volume Instrumentation" in
-  [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
+- Treat plans as decision records. Do not use them as implementation scripts.
+- Follow the active plan unless the user changes the scope.
+- Treat brainstorms, plans, and solutions as historical records.
+  - Do not delete or rewrite a record without explicit user authorization.
+  - You may update the plan that the current branch implements.
+  - Limit updates to progress, dependencies, and resolved implementation questions.
+  - Read [the historical-document rules](docs/plans/AGENTS.md) before you change these files.
+- Default `rg` searches exclude brainstorms, plans, and solutions through [`.rgignore`](.rgignore).
+  - Use `rg --no-ignore` or `rg -u` only when you need these records.
+- Read the [workflow label list](.github/workflows/README.md) before you use a CI-triggering label.
+- Exclude `apps/desktop/.local/protocol-captures/` from broad searches.
+  - Search that directory only for captured E2E protocol work.
+
+### Command output
+
+- Keep model-visible command output bounded.
+- Tool output becomes thread context. Later turns can replay that output.
+- For broad discovery, start with `rg -l` or `rg --count-matches`.
+- Exclude tests from discovery unless tests are in scope.
+- After discovery, inspect only the files and line ranges that you need.
+- Use `rg -n -C` only with a selected file or a small file set.
+- Use the minimum context that supports the next decision.
+- Give `sed` an explicit file and line range. `sed` does not use an ignore file.
+- Do not combine content-producing reads and searches with `&&`.
+- The shell sends their combined standard output as one tool result.
+- For an intentionally broad scan:
+  1. Redirect all output to an ignored `.local/` log.
+  2. Report the exact command and its exit state.
+  3. Report matching file counts and result counts.
+  4. Report failures and warnings.
+  5. Return only a bounded tail or the fields needed for the next decision.
+- Do not use tool-result truncation as an output budget.
+
+### Codex data boundary
+
+- PwrAgent code must not read Codex-owned storage files.
+- Treat Codex session JSONL, rollout files, and SQLite databases as private implementation details.
+- Use the Codex App Server protocol for Codex data.
+- A feature may read PwrAgent-owned files under `~/.pwragent/`.
+- A test may read repository-local fixtures that the test owns.
+- CI enforces common violations with `pnpm lint:codex-storage`.
+- Do not bypass this check through variable renames or shell commands.
+- One module has explicit PwrDrvr LLC authorization for a narrow repair:
+  `apps/desktop/src/main/codex-app-server/invalid-response-message-id-recovery.ts`.
+  - Repair only rollouts identified by the protocol.
+  - Repair only the Responses API invalid message-ID-prefix failure.
+  - Create a backup before the repair.
+  - Make the repair atomic.
+  - Validate the thread before the repair.
+  - Remove only invalid `id` fields from response items with type `message`.
+
+### Desktop test operations
+
+- Use the [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) for live captured sessions.
+- Run desktop E2E from the repository root with `pnpm test:desktop-e2e`.
+- The package command `pnpm --filter @pwragent/desktop test:e2e` is also safe.
+- Both commands build `apps/desktop/out/` before Playwright starts.
+- Before headed desktop E2E, ask the operator whether an off-desktop lab is available.
+- If a lab is available, ask for its repository or skill.
+- Read the [Windows Vitest stability guidance](docs/solutions/2026-08-06-windows-vitest-process-isolation.md) before you change:
+  - Windows Git or Bash process launch and shutdown.
+  - Vitest process isolation.
+  - Queue or composer lifecycle tests.
+  - Lazy renderer readiness.
+- Git-for-Windows launcher handoffs have caused expensive Windows-only failures.
+- Non-atomic descendant cleanup has caused expensive Windows-only failures.
+- Optimistic renderer synchronization has caused expensive Windows-only failures.
+- Do not substitute retries, longer timeouts, fewer workers, or serial lanes for an ownership fix.
+- Do not substitute those workarounds for an evidence-based readiness fix.
+- The macOS CI lane uses the selected-repository **PwrDrvr macOS** runner group.
+- Only PwrAgent and PwrSnap share this group.
+- Do not add a repository-scoped runner.
+- Do not give the full organization access to this group.
+- For branch-drift dialog screenshots, run `pnpm --filter @pwragent/desktop inspect:e2e:branch-drift`.
+- This command opens a replay-backed Electron fixture.
+- Close the application to end the command.
+- For README screenshots, run `pnpm --filter @pwragent/desktop screenshot:readme`.
+- The README screenshot command writes files under `docs/assets/screenshots/`.
+- Read "Capturing README Screenshots" in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md) for the complete procedure.
+- That procedure identifies the specification, fixtures, state helpers, and native capture tools.
+- The terminal or IDE that runs the screenshot test needs macOS Screen Recording permission.
+- To focus root Vitest, pass file paths or filters directly to `pnpm test`.
+- For example, run `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`.
+- Do not put a standalone `--` before the focus arguments.
+- The command `pnpm test -- apps/...` runs the full workspace suite.
+
+### SQLite write budgets
+
+- Measure a new SQLite write if it runs at any of these frequencies:
+  - Per command.
+  - Per turn.
+  - Per item.
+  - Per streamed event.
+  - On a timer.
+- Add a checked-in write budget that fails when the write count changes.
+- Calculate the write cost as writes per second × commit cost × session duration.
+- Report the projected cost in MB per day.
+- Count SQLite commits, not statements.
+- Each implicit transaction flushes dirty pages and all changed index pages.
+- A SQLite page is approximately 4 KB.
+- An indexed timestamp can move one index entry during each write.
+- Use these calibration results:
+  - PR #1406 wrote once for each streamed 8 KiB chunk.
+  - One `find /` caused 3,693 commits and 58 MB of WAL.
+  - Former 10-second runtime lease heartbeats caused 720 commits each hour.
+  - Those heartbeats wrote 2.7 MB each hour for each running instance.
+  - That rate was approximately 65 MB each day.
+  - PID-owned runtime leases now make no SQLite commits while idle.
+- If the projection is excessive, report it to the user.
+- Do not quietly ship an excessive projection.
+- Ask the user to select a different design constraint.
+- Possible designs include one transaction, a flush window, or boundary-based persistence.
+- The correct design can also be no persistence.
+- Write budgets are in `apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json`.
+- Wrap the feature, not its setup, with `measureSqliteWrites`.
+- Record a budget with `UPDATE_SQLITE_WRITE_BUDGETS=1`.
+- Keep each write-cost change visible as one reviewable diff line.
+- Survey a full run with `pnpm test:sqlite-writes`.
+- Read "Sqlite Write-Volume Instrumentation" in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
 
 ## Code Formatting & Linting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,82 +320,118 @@ Canonical primitives and the tokens they read:
 
 ## Current Product Direction
 
+### Thread model and lenses
+
 - Threads are first-class and may exist without a directory.
-- Attention, Drafts, Inbox, Recents, and Directories share the thread lens
-  switch. The tabs are icon-only; the lens name lives in `aria-label` and the
-  tooltip.
-- Attention is the work-queue lens: threads with a live turn or waiting to be
-  reviewed. Its tab is two indicators with counts
-  (scanner + in-progress, cookie + unread) rather than an icon, and each goes
-  grey at zero so the tab reads as "nothing running, nothing unread" without
-  being opened. A zero is shown, never hidden — a vanishing count makes an
-  idle tab look like a broken one.
-- **Attention orders by turn, not by activity.** Every other lens is a pure
-  sort over `updatedAt` / `createdAt`; this one is not, because `updatedAt`
-  moves on every streamed item, sub-agent invocation, and tool result, and a
-  queue that re-sorts under the pointer while two turns run is unusable. Each
-  member holds a rank minted when its turn *starts* and left alone for the rest
-  of that turn, so a thread moves at most twice per turn no matter how loud the
-  turn is. The second move is the one exception, and it is a setting:
-  `general.attention_promote_on_turn_end` (default on) gives a finished turn one
-  last trip to the top so freshly completed work surfaces for review. That
-  covers a turn this window watched run *and* one it only learned about
-  afterwards — a messaging- or peer-driven turn can start and finish inside a
-  single poll interval, so an idle member whose `updatedAt` advanced counts as a
-  finished turn too. A live turn can never take that path, which is what keeps
-  it from becoming a back door to update-driven churn. Ranks are
-  a monotonic counter, not a clock — no `Date.now()` in a render path and no
-  ties to break — and they are scoped to current lens membership, so a thread
-  that leaves and returns is fresh activity and re-enters at the top. The
-  reducer and the reasoning live in
-  [attention-order.ts](apps/desktop/src/renderer/src/features/navigation/attention-order.ts).
-- Drafts is the second state lens: threads holding unsent composer text, in
-  recent-activity order. A draft belongs to whoever typed it — it is stored in
-  that machine's `composer_draft_latest` table, re-hydrated on the next launch,
-  and deliberately **never federated**. A viewer that half-writes a reply to a
-  peer's thread sees its own "Draft" chip on that row; the owning instance does
-  not, because publishing an operator's unsent text to another machine is not
-  something the affordance is worth. Threads carry the chip in every lens, not
-  only this one. Two limits are deliberate rather than bugs: the storage is
-  machine-wide but each window reads it once at mount, so a second open window
-  does not light up until it restarts; and launchpad (new-thread) composer text
-  has no thread row, so the lens says "replies" and its empty state says "No
-  unsent replies."
-- Inbox is the default browsing lens: all threads in recent-activity order.
-- Recents shows all threads in thread-creation order so active threads do not
-  jump around.
-- Inbox and Recents are **pure sort orders** — they do not float pinned threads
-  into a section. A pinned thread appears in its natural position by
-  updated/created time. Pin *ordering* (drag, the ⌘⇧↑/↓ shortcut, and the
-  context menu's Move Up / Move Down) is offered only in Directories, the one
-  lens where pin order is visible.
-- Directories keep pinned threads first within each directory, then sort
-  unpinned threads by thread creation time.
-- Unread state remains available as the orange cookie marker on thread rows
-  wherever they appear.
-- **Unread clears on focus everywhere except the Attention lens.** There,
-  focusing a thread deliberately leaves the cookie in place and only a reply
-  clears it (the composer reports sends and steers via
-  `onUserRepliedToThread`, which routes to `markThreadsSeen`). The rule is
-  scoped to that lens rather than global on purpose: a global "only a reply
-  clears unread" would stop every lens's unread count draining on its own, so
-  a thread you read and decide not to answer would sit unread until you
-  explicitly marked it read. Scoping it keeps ordinary browsing unchanged and
-  confines the work-queue semantics to the surface that asked for them. The
-  `retainedUnreadThread` mechanism is skipped in this lens for the same
-  reason — it exists to release (clear) a thread on the way out.
-- The exemption belongs to the **lens, not the thread**: leaving Attention
-  while an unread thread stays selected marks it seen, because the operator is
-  now browsing rather than working a queue. Carrying "never auto-clear" out
-  with the thread would leak a rule nobody asked for into every other lens.
-  Both halves are pinned by tests in `useThreadNavigation.test.tsx`.
-- Reply reporting is **acceptance-gated**, not intent-gated: the composer
-  calls `onUserRepliedToThread` only after `startTurn` / `steerTurn` resolves,
-  and `useQueuedTurnRelease` does the same when it drains a turn the operator
-  queued earlier. Reporting before the await would drop a thread out of the
-  queue for a message that never left the machine — the exact loss this lens
-  exists to prevent.
-- A thread may be associated with multiple linked Git directories.
+- Attention, Drafts, Inbox, Recents, and Directories use one thread lens switch.
+- Each lens tab contains only an icon or status indicators.
+- Put the lens name in the `aria-label` and tooltip.
+- A thread can have links to multiple Git directories.
+
+### Attention lens
+
+- Use Attention as the work queue.
+- Include threads with a live turn.
+- Include threads that wait for review.
+- Use two count indicators instead of a tab icon:
+  - A scanner for turns in progress.
+  - An orange cookie for unread threads.
+- Show zero for each empty count.
+- Make an indicator grey when its count is zero.
+- Do not hide a zero indicator. A missing indicator makes an idle tab appear broken.
+
+### Attention order
+
+- Order Attention by turn, not by activity.
+- All other lenses use a pure `updatedAt` or `createdAt` sort.
+- Do not use `updatedAt` to order Attention.
+- `updatedAt` changes for each streamed item, subagent call, and tool result.
+- Activity ordering would move queue items while the operator uses the queue.
+- Give each Attention member a rank when its turn starts.
+- Keep that rank for the complete turn.
+- A thread can move at most twice during one turn.
+- The optional second move occurs when the turn ends.
+- `general.attention_promote_on_turn_end` controls that move and defaults to on.
+- When enabled, move a finished turn to the top for review.
+- Apply this promotion to a turn that the current window observed.
+- Also apply it to a turn that starts and finishes between polls.
+- Messaging and peer-driven turns can use this case.
+- For that case, treat an idle member with a newer `updatedAt` as a finished turn.
+- Never use this detection path for a live turn.
+- Use a monotonic counter for ranks. Do not use a clock.
+- Do not call `Date.now()` from the render path.
+- Do not create rank ties.
+- Scope ranks to current Attention membership.
+- If a thread leaves and returns, give it a new rank at the top.
+- The reducer and design rationale are in [attention-order.ts](apps/desktop/src/renderer/src/features/navigation/attention-order.ts).
+
+### Drafts lens
+
+- Drafts is the second state lens.
+- Use Drafts for threads that contain unsent composer text.
+- Sort Drafts by recent activity.
+- Store a draft on the machine where the operator writes it.
+- Store the latest draft in `composer_draft_latest`.
+- Restore that draft during the next application launch.
+- Never federate draft text.
+- A viewer can draft a reply to a thread from a peer instance.
+- Show the Draft chip only to that viewer.
+- Do not show that draft to the instance that owns the thread.
+- This rule prevents publication of an operator's unsent text.
+- Show the Draft chip in every lens.
+- The current implementation has two intentional limits:
+  - Draft storage is machine-wide, but each window reads it only during mount.
+  - A second window does not update its Draft chips until it restarts.
+  - Launchpad composer text has no thread row.
+  - Therefore, the lens label refers to replies.
+  - Its empty state is `No unsent replies.`
+
+### Inbox, Recents, and Directories
+
+- Use Inbox as the default browsing lens.
+- Sort Inbox by recent activity.
+- Show all threads in Inbox.
+- Sort Recents by thread creation time.
+- Show all threads in Recents.
+- This creation-time order prevents active threads from moving.
+- Keep Inbox and Recents as pure sort orders.
+- Do not create a pinned section in those lenses.
+- In Inbox, show each pinned thread at its normal `updatedAt` position.
+- In Recents, show each pinned thread at its normal `createdAt` position.
+- Offer visible pin ordering only in Directories.
+- The pin-order controls are:
+  - Drag.
+  - The `⌘⇧↑` and `⌘⇧↓` shortcuts.
+  - **Move Up** and **Move Down** in the context menu.
+- Within each directory, show pinned threads first.
+- Sort unpinned directory threads by thread creation time.
+
+### Unread behavior
+
+- Show unread state as an orange cookie on thread rows in every lens.
+- In all lenses except Attention, clear unread state when the thread gets focus.
+- In Attention, keep unread state when the thread gets focus.
+- In Attention, clear unread state only after the operator sends a reply.
+- The composer reports accepted sends and steers through `onUserRepliedToThread`.
+- That callback calls `markThreadsSeen`.
+- Do not apply reply-only clearing to other lenses.
+- A global rule would leave read threads unread when the operator does not reply.
+- Keep normal focus-based clearing in ordinary browsing lenses.
+- Skip `retainedUnreadThread` in Attention.
+- That mechanism normally clears a retained thread when the operator leaves it.
+- Apply the exemption to the Attention lens, not to a thread.
+- If the operator leaves Attention, clear the selected thread's unread state.
+- This rule applies when the selected thread remains selected in the next lens.
+- Tests in `useThreadNavigation.test.tsx` enforce both parts of this transition.
+
+### Reply acceptance
+
+- Report a reply only after the backend accepts it.
+- Do not report a reply when the operator only attempts it.
+- Call `onUserRepliedToThread` only after `startTurn` or `steerTurn` resolves.
+- Apply the same rule when `useQueuedTurnRelease` sends a queued turn.
+- If the send fails, keep the thread in Attention.
+- Early reporting would remove a thread for a message that never left the machine.
 
 ## Dependency Boundary Enforcement
 


### PR DESCRIPTION
## Summary

- I rewrote the root `AGENTS.md` toward an ASD-STE100-inspired structure without removing active requirements.
- I split compound rules into short sentences, ordered steps, and vertical lists so each point remains explicit.
- I audited referenced files, commands, environment variables, UI contracts, and product invariants against the current repository.
- I removed the obsolete Phase 1 → Phase 2 distribution migration reference because the repository now publishes publicly.

## Verification

- I verified that no prose sentence exceeds 20 words with a repository-local structural audit.
- I verified that the file contains no contractions from the audited contraction list.
- I verified that every local Markdown link resolves.
- I ran `git diff --check`.
- I verified the SSH signature on all six commits.
- I compared technical terms and numeric calibration points with the prior file.

## Notes

- I am not claiming formal ASD-STE100 compliance because the repository does not yet use the controlled dictionary.
- The file grew from 311 to 492 lines because lists replaced dense paragraphs.
- The file size changed from 23,884 to 23,888 bytes, so the rewrite adds structure rather than substantial content.
- A separate child thread is evaluating an MIT-compatible lint workflow.
