### PR TITLE
fix(desktop): backport Windows chrome theme

### DIFF
--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -164,6 +164,10 @@ vi.mock("electron", () => ({
   Menu: {
     buildFromTemplate: buildFromTemplateMock
   },
+  nativeTheme: {
+    shouldUseDarkColors: true,
+    on: vi.fn()
+  },
   shell: {
     openExternal: shellOpenExternalMock
   },

--- a/apps/desktop/src/main/__tests__/native-appearance.test.ts
+++ b/apps/desktop/src/main/__tests__/native-appearance.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronMocks = vi.hoisted(() => ({
+  getAllWindows: vi.fn(),
+  nativeThemeOn: vi.fn(),
+  systemUsesDarkColors: false,
+}));
+
+const appearanceMocks = vi.hoisted(() => ({
+  appearance: {
+    density: "mission-control" as const,
+    sidebarTextSize: "md" as const,
+    theme: "system" as "system" | "dark" | "light",
+    transcriptTextSize: "md" as const,
+  },
+}));
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    getAllWindows: electronMocks.getAllWindows,
+  },
+  nativeTheme: {
+    get shouldUseDarkColors() {
+      return electronMocks.systemUsesDarkColors;
+    },
+    on: electronMocks.nativeThemeOn,
+  },
+}));
+
+vi.mock("../settings/appearance-bootstrap", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../settings/appearance-bootstrap")>(),
+  readBootstrapAppearance: () => appearanceMocks.appearance,
+}));
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+beforeEach(() => {
+  setPlatform("win32");
+  electronMocks.getAllWindows.mockReset();
+  electronMocks.getAllWindows.mockReturnValue([]);
+  electronMocks.nativeThemeOn.mockReset();
+  electronMocks.systemUsesDarkColors = false;
+  appearanceMocks.appearance.theme = "system";
+  vi.resetModules();
+});
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
+describe("native appearance", () => {
+  it("resolves the system theme through Electron for window and title-bar colors", async () => {
+    const {
+      themedTitleBarOverlay,
+      themedWindowBackgroundColor,
+    } = await import("../native-appearance");
+
+    expect(themedWindowBackgroundColor(appearanceMocks.appearance)).toBe(
+      "#fdfcfa",
+    );
+    expect(themedTitleBarOverlay(appearanceMocks.appearance)).toEqual({
+      color: "#f7f4ef",
+      height: 40,
+      symbolColor: "#3a3a3a",
+    });
+
+    electronMocks.systemUsesDarkColors = true;
+
+    expect(themedWindowBackgroundColor(appearanceMocks.appearance)).toBe(
+      "#10151f",
+    );
+    expect(themedTitleBarOverlay(appearanceMocks.appearance)).toEqual({
+      color: "#050505",
+      height: 40,
+      symbolColor: "#c8ccd4",
+    });
+  });
+
+  it("keeps explicit themes independent of the OS appearance", async () => {
+    const { themedTitleBarOverlay } = await import("../native-appearance");
+
+    electronMocks.systemUsesDarkColors = true;
+    appearanceMocks.appearance.theme = "light";
+    expect(themedTitleBarOverlay(appearanceMocks.appearance).color).toBe(
+      "#f7f4ef",
+    );
+
+    electronMocks.systemUsesDarkColors = false;
+    appearanceMocks.appearance.theme = "dark";
+    expect(themedTitleBarOverlay(appearanceMocks.appearance).color).toBe(
+      "#050505",
+    );
+  });
+
+  it("refreshes every overlay when the Windows system appearance changes", async () => {
+    const setTitleBarOverlay = vi.fn();
+    electronMocks.getAllWindows.mockReturnValue([
+      { setTitleBarOverlay },
+      {
+        setTitleBarOverlay: vi.fn(() => {
+          throw new Error("no overlay");
+        }),
+      },
+    ]);
+    const { installWindowsTitleBarAppearanceSync } = await import(
+      "../native-appearance"
+    );
+
+    installWindowsTitleBarAppearanceSync();
+    installWindowsTitleBarAppearanceSync();
+
+    expect(electronMocks.nativeThemeOn).toHaveBeenCalledOnce();
+    expect(electronMocks.nativeThemeOn).toHaveBeenCalledWith(
+      "updated",
+      expect.any(Function),
+    );
+
+    const handleUpdated = electronMocks.nativeThemeOn.mock.calls[0]?.[1] as
+      | (() => void)
+      | undefined;
+    expect(handleUpdated).toBeDefined();
+    handleUpdated?.();
+    expect(setTitleBarOverlay).toHaveBeenLastCalledWith({
+      color: "#f7f4ef",
+      height: 40,
+      symbolColor: "#3a3a3a",
+    });
+
+    electronMocks.systemUsesDarkColors = true;
+    handleUpdated?.();
+    expect(setTitleBarOverlay).toHaveBeenLastCalledWith({
+      color: "#050505",
+      height: 40,
+      symbolColor: "#c8ccd4",
+    });
+  });
+});

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -16,8 +16,8 @@ import {
 import {
   readBootstrapAppearance,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import { themedWindowBackgroundColor } from "./native-appearance";
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,

--- a/apps/desktop/src/main/appearance-broadcast.ts
+++ b/apps/desktop/src/main/appearance-broadcast.ts
@@ -13,7 +13,7 @@
 
 import { BrowserWindow } from "electron";
 import type { BootstrapAppearance } from "./settings/appearance-bootstrap";
-import { themedTitleBarOverlay } from "./settings/appearance-bootstrap";
+import { themedTitleBarOverlay } from "./native-appearance";
 import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
 import { subscribersForChannel } from "./window-channels";
 

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -2,10 +2,8 @@ import type {
   BrowserWindow,
   BrowserWindowConstructorOptions,
 } from "electron";
-import {
-  readBootstrapAppearance,
-  themedTitleBarOverlay,
-} from "./settings/appearance-bootstrap";
+import { readBootstrapAppearance } from "./settings/appearance-bootstrap";
+import { themedTitleBarOverlay } from "./native-appearance";
 
 const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -13,8 +13,8 @@ import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
 import {
   readBootstrapAppearance,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import { themedWindowBackgroundColor } from "./native-appearance";
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -13,8 +13,8 @@ import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
 import {
   readBootstrapAppearance,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import { themedWindowBackgroundColor } from "./native-appearance";
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,

--- a/apps/desktop/src/main/markdown-files-window.ts
+++ b/apps/desktop/src/main/markdown-files-window.ts
@@ -22,8 +22,8 @@ import {
 import {
   readBootstrapAppearance,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import { themedWindowBackgroundColor } from "./native-appearance";
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -13,8 +13,8 @@ import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
 import {
   readBootstrapAppearance,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import { themedWindowBackgroundColor } from "./native-appearance";
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,

--- a/apps/desktop/src/main/native-appearance.ts
+++ b/apps/desktop/src/main/native-appearance.ts
@@ -1,0 +1,88 @@
+import { BrowserWindow, nativeTheme } from "electron";
+import type { BootstrapAppearance } from "./settings/appearance-bootstrap";
+import { readBootstrapAppearance } from "./settings/appearance-bootstrap";
+
+/**
+ * Pre-tinted BrowserWindow `backgroundColor` values. Mirrors the
+ * `--bg` token's resolved value in each theme so the OS-level window
+ * fill matches the renderer's first paint and we don't flash a dark
+ * window before a light renderer (or vice versa). Keep in sync with
+ * the `--bg` values in app.css `:root` and `:root[data-theme="light"]`.
+ */
+export const WINDOW_BG_DARK = "#10151f";
+export const WINDOW_BG_LIGHT = "#fdfcfa";
+
+/**
+ * Title-bar (caption-button strip) background. This MUST match the renderer's
+ * painted title strip — `.app-titlebar`, which fills `var(--bg-sidebar)`, NOT
+ * the page background — so the native min/max/close buttons blend seamlessly
+ * into our chrome instead of sitting on a slightly-off rectangle (most visible
+ * in light theme: pure white behind cream). Keep in sync with `--bg-sidebar`
+ * in app.css (`:root` and `:root[data-theme="light"]`).
+ */
+export const TITLE_BAR_BG_DARK = "#050505";
+export const TITLE_BAR_BG_LIGHT = "#f7f4ef";
+
+// Keep in sync with `--win-titlebar-h` in app.css so the OS caption buttons
+// and the painted menu bar share one line.
+export const TITLE_BAR_OVERLAY_HEIGHT = 40;
+
+function resolvedNativeTheme(
+  appearance: BootstrapAppearance,
+): "dark" | "light" {
+  if (appearance.theme === "dark" || appearance.theme === "light") {
+    return appearance.theme;
+  }
+  return nativeTheme.shouldUseDarkColors ? "dark" : "light";
+}
+
+/** Pick the right `backgroundColor` for an Electron `BrowserWindow`.
+ *  The main process can resolve "system" synchronously through
+ *  `nativeTheme`, matching the renderer's `prefers-color-scheme`. */
+export function themedWindowBackgroundColor(
+  appearance: BootstrapAppearance,
+): string {
+  return resolvedNativeTheme(appearance) === "light"
+    ? WINDOW_BG_LIGHT
+    : WINDOW_BG_DARK;
+}
+
+/**
+ * Window Controls Overlay (Windows) styling for the frameless title bar.
+ * `color` paints behind the OS-drawn caption buttons; `symbolColor` paints
+ * their glyphs; `height` aligns them with the renderer's title bar.
+ */
+export function themedTitleBarOverlay(appearance: BootstrapAppearance): {
+  color: string;
+  symbolColor: string;
+  height: number;
+} {
+  const light = resolvedNativeTheme(appearance) === "light";
+  return {
+    color: light ? TITLE_BAR_BG_LIGHT : TITLE_BAR_BG_DARK,
+    symbolColor: light ? "#3a3a3a" : "#c8ccd4",
+    height: TITLE_BAR_OVERLAY_HEIGHT,
+  };
+}
+
+/** Re-color every overlay-capable window after the OS appearance changes. */
+export function refreshWindowsTitleBarOverlays(): void {
+  if (process.platform !== "win32") return;
+  const overlay = themedTitleBarOverlay(readBootstrapAppearance());
+  for (const window of BrowserWindow.getAllWindows()) {
+    try {
+      window.setTitleBarOverlay(overlay);
+    } catch {
+      // Frameless windows without Window Controls Overlay support are skipped.
+    }
+  }
+}
+
+let systemAppearanceListenerInstalled = false;
+
+/** Install the one process-wide listener that keeps "system" chrome current. */
+export function installWindowsTitleBarAppearanceSync(): void {
+  if (process.platform !== "win32" || systemAppearanceListenerInstalled) return;
+  systemAppearanceListenerInstalled = true;
+  nativeTheme.on("updated", refreshWindowsTitleBarOverlays);
+}

--- a/apps/desktop/src/main/settings/appearance-bootstrap.ts
+++ b/apps/desktop/src/main/settings/appearance-bootstrap.ts
@@ -38,68 +38,6 @@ export type BootstrapAppearance = {
 
 export const BOOTSTRAP_APPEARANCE_ARG_PREFIX = "--pwragent-appearance=";
 
-/**
- * Pre-tinted BrowserWindow `backgroundColor` values. Mirrors the
- * `--bg` token's resolved value in each theme so the OS-level window
- * fill matches the renderer's first paint and we don't flash a dark
- * window before a light renderer (or vice versa). Keep in sync with
- * the `--bg` values in `app.css` `:root` and `:root[data-theme="light"]`.
- */
-export const WINDOW_BG_DARK = "#10151f";
-export const WINDOW_BG_LIGHT = "#fdfcfa";
-
-/** Pick the right `backgroundColor` for an Electron `BrowserWindow`
- *  based on the resolved appearance. "system" falls back to dark
- *  because we can't resolve `prefers-color-scheme` synchronously
- *  at window-creation time — the renderer's inline bootstrap will
- *  flip the data-theme attribute if it resolves light, and the
- *  brief OS-fill mismatch is preferable to blocking on a media query. */
-export function themedWindowBackgroundColor(
-  appearance: BootstrapAppearance,
-): string {
-  return appearance.theme === "light" ? WINDOW_BG_LIGHT : WINDOW_BG_DARK;
-}
-
-/**
- * Title-bar (caption-button strip) background. This MUST match the renderer's
- * painted title strip — `.app-titlebar`, which fills `var(--bg-sidebar)`, NOT
- * the page background — so the native min/max/close buttons blend seamlessly
- * into our chrome instead of sitting on a slightly-off rectangle (most visible
- * in light theme: pure white behind cream). GitHub Desktop does the same: point
- * the overlay at the title-bar color. Keep in sync with `--bg-sidebar` in
- * `app.css` (`:root` and `:root[data-theme="light"]`).
- */
-export const TITLE_BAR_BG_DARK = "#050505";
-export const TITLE_BAR_BG_LIGHT = "#f7f4ef";
-
-/**
- * Window Controls Overlay (Windows) styling for the frameless title bar.
- *
- * `color` is the background behind the OS-drawn min/max/close caption buttons
- * (matched to the painted `.app-titlebar` strip so there's no seam);
- * `symbolColor` is the caption glyph color; `height` sets the caption strip
- * height so the buttons align with the painted menu bar. Re-apply via
- * `window.setTitleBarOverlay(...)` when the theme flips — Electron restyles the
- * existing overlay in place, so NO window recreation is needed. macOS uses
- * `trafficLightPosition` instead; Linux gets a normal frame.
- */
-// Keep in sync with `--win-titlebar-h` in app.css so the OS caption buttons
-// and the painted menu bar share one line.
-export const TITLE_BAR_OVERLAY_HEIGHT = 40;
-
-export function themedTitleBarOverlay(appearance: BootstrapAppearance): {
-  color: string;
-  symbolColor: string;
-  height: number;
-} {
-  const light = appearance.theme === "light";
-  return {
-    color: light ? TITLE_BAR_BG_LIGHT : TITLE_BAR_BG_DARK,
-    symbolColor: light ? "#3a3a3a" : "#c8ccd4",
-    height: TITLE_BAR_OVERLAY_HEIGHT,
-  };
-}
-
 /** Build the `webPreferences.additionalArguments` array that surfaces
  *  the appearance to the preload script. Every BrowserWindow that
  *  loads the renderer needs this — without it, the preload's

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -48,10 +48,13 @@ import {
 } from "../shared/ipc";
 import {
   readBootstrapAppearance,
-  themedTitleBarOverlay,
   themedWindowAdditionalArguments,
-  themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import {
+  installWindowsTitleBarAppearanceSync,
+  themedTitleBarOverlay,
+  themedWindowBackgroundColor,
+} from "./native-appearance";
 import {
   navigationPreferencesAdditionalArguments,
   readBootstrapNavigationPreferences,
@@ -324,6 +327,7 @@ export function createMainWindow(options?: {
     attachWindow: (window: BrowserWindow) => void;
   };
 }): BrowserWindow {
+  installWindowsTitleBarAppearanceSync();
   const preloadPath = getPreloadPath();
   const appearance = readBootstrapAppearance();
   const navigationPreferences = readBootstrapNavigationPreferences();


### PR DESCRIPTION
## Summary

Backports the Windows title-bar appearance fix from #1668 to `releases/1.0`.

- Resolve the `system` appearance through Electron's `nativeTheme` for BrowserWindow backgrounds and Windows caption-button overlays.
- Refresh every overlay-capable 1.0 window when Windows changes between light and dark appearance.
- Preserve explicit light and dark preferences independently of the OS setting.

## 1.0 adaptations

This backport includes the main window plus every matching 1.0 auxiliary surface: Logs, Changelog, License documents, Markdown files, and Messaging Activity.

The source PR's Automation Run, Star Map, and subagent transcript window edits are intentionally omitted because those 1.1-only surfaces do not exist on `releases/1.0`. No Federation code or dependencies were backported. There are no database migrations in this change.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/native-appearance.test.ts apps/desktop/src/main/__tests__/app-bootstrap.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts` — 82 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `pnpm lint:boundaries`

Source: https://github.com/pwrdrvr/PwrAgent/pull/1668
