### PR TITLE
docs: route Windows lab work correctly

### DIFF
--- a/.agents/skills/macos-vm-e2e-lab/SKILL.md
+++ b/.agents/skills/macos-vm-e2e-lab/SKILL.md
@@ -6,14 +6,19 @@ description: >-
   network-isolated self-hosted GitHub Actions lane for macOS/ARM64 E2E and
   visual-regression coverage. Use when a user mentions Tart, a local macOS VM,
   self-hosted macOS runners, E2E windows stealing focus, or PwrAgent visual
-  goldens.
-compatibility: >-
-  Apple Silicon Mac host with Homebrew, Tart, and an authenticated gh CLI.
-  Plan for about 80 GB free disk. The first softnet sudoers rule and the GitHub
-  Actions external-contributor setting require a human operator.
+  goldens. Do not use for Windows VM probes or Windows E2E.
 ---
 
 # PwrAgent macOS VM E2E lab
+
+This skill is macOS-only. For Windows work, read
+`.agents/skills/use-windows-vm-lab/SKILL.md` in the operator-selected
+PwrSuiteLab checkout.
+
+Use an Apple Silicon Mac host with Homebrew, Tart, and an authenticated `gh`
+CLI. Plan for approximately 80 GB of free disk. A human operator must configure
+the first softnet sudoers rule and the GitHub Actions external-contributor
+setting.
 
 ## What this provides
 
@@ -88,6 +93,17 @@ workspace/directory tools, PwrAgent Federation tools, or MCP resources to find
 an existing local PwrSuiteLab checkout; do not assume a pathname or clone,
 install, or provision it as part of a baseline update. If no checkout is
 discoverable, ask the operator for the appropriate lab pointer.
+
+After resolving the checkout, test its ignored configuration directly:
+
+```bash
+test -f "$suite_lab_root/local-config/macos-tart.sh"
+```
+
+Do not infer its absence from `rg --files`, `git ls-files`, or another
+worktree. Do not read, print, or copy the config. If the exact default is
+absent, ask for an existing config path only and set `PWRLAB_MACOS_CONFIG_FILE`
+for that invocation.
 
 ```bash
 suite_lab_root="<PwrSuiteLab checkout discovered with tools/MCP>"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,14 @@
 - Both commands build `apps/desktop/out/` before Playwright starts.
 - Before headed desktop E2E, ask the operator whether an off-desktop lab is available.
 - If a lab is available, ask for its repository or skill.
+- For PwrSuiteLab Windows probes or headed E2E, read
+  `.agents/skills/use-windows-vm-lab/SKILL.md` in the attached lab checkout.
+  Do not use the macOS VM skill for Windows work.
+- Use the attached primary PwrSuiteLab checkout for its controllers. Check an
+  expected ignored config with an exact filesystem test. `rg --files`,
+  `git ls-files`, and other worktrees do not prove that config is absent.
+- Do not read or print lab configuration. If the exact default is absent, ask
+  the operator for an existing config path only.
 - Review the current ownership and readiness constraints before you change:
   - Windows Git or Bash process launch and shutdown.
   - Vitest process isolation.


### PR DESCRIPTION
## What changed

- route PwrSuiteLab Windows probes and headed E2E to the lab checkout's Windows skill
- warn that ignored lab config must be checked with an exact filesystem test
- make the existing macOS VM skill explicitly reject Windows work
- move the macOS skill's compatibility note into valid skill body content

## Why

A Windows investigation loaded the macOS VM skill and then concluded that an
ignored operator config was missing. Git-aware searches and disposable
worktrees do not represent checkout-local private configuration.

## Impact

PwrAgent threads attach the operator-selected primary lab checkout and load the
correct Windows procedure without reading or copying private config.

## Validation

- skill `quick_validate.py`
- `git diff --check`
