### PR TITLE
fix(desktop): preserve directory thread focus outline

### DIFF
--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8df1f979ed894eb6ef68fb2b5406d99f42d383778687074eabf1eb11171c1279
-size 128662
+oid sha256:beb409ed8756af645a1ba5219188021021508db4c628dd4fb648b27ba2c596c6
+size 128216

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:beb409ed8756af645a1ba5219188021021508db4c628dd4fb648b27ba2c596c6
-size 128216
+oid sha256:8df1f979ed894eb6ef68fb2b5406d99f42d383778687074eabf1eb11171c1279
+size 128662

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -782,8 +782,9 @@ describe("Tangerine Terminal theme contract", () => {
   // exactly where a brand token drifts unnoticed: nothing else renders these
   // rings, so a wrong token or offset ships looking plausible. Both must name
   // `--focus-ring` — the semantic token, `var(--accent)` in both themes — and
-  // each keeps its own offset: 2px on the sidebar row, 1px on the star-map
-  // card, whose cards shingle so a wider ring bleeds onto the neighbour.
+  // each keeps its own offset: -2px on the sidebar row keeps the whole ring
+  // inside the card's paint bounds (outside top edges can disappear at 1x),
+  // while 1px on the star-map card preserves that surface's shingled design.
   // Changing either is a design decision; change this test in the same commit
   // so it is reviewed rather than accidental.
   it("draws both card focus rings from the focus-ring token at their own offsets", () => {
@@ -797,7 +798,7 @@ describe("Tangerine Terminal theme contract", () => {
       ".thread-row:has(.thread-row__open:focus)",
     );
     expect(rowRing).toContain("outline: 2px solid var(--focus-ring);");
-    expect(rowRing).toContain("outline-offset: 2px;");
+    expect(rowRing).toContain("outline-offset: -2px;");
 
     const cardRing = extractRuleBody(
       css,
@@ -811,33 +812,6 @@ describe("Tangerine Terminal theme contract", () => {
     // for `.thread-row`: that class is still worn by a real `<button>` on
     // directory summaries, so a focus rule naming it is legitimate there.)
     expect(css).not.toMatch(/\.star-map-card:focus-visible\s*\{/);
-  });
-
-  it("keeps the first directory thread's focus ring clear of the sticky header", () => {
-    // The header deliberately paints above rows that scroll underneath it.
-    // A focused first row therefore needs more top clearance than the ring's
-    // full outside reach (outline width + outline offset). Equality is not
-    // enough at 1x: fractional row positions can hand the shared boundary
-    // pixel to the sticky header, erasing the ring's horizontal top run while
-    // leaving its sides and bottom intact.
-    const rowRing = extractRuleBody(
-      css,
-      ".thread-row:has(.thread-row__open:focus)",
-    );
-    const directoryDetails = extractRuleBody(css, ".directory-row__details");
-    const ringWidth = Number(
-      rowRing.match(/outline:\s*(?<width>\d+)px\s+solid/)?.groups?.width,
-    );
-    const ringOffset = Number(
-      rowRing.match(/outline-offset:\s*(?<offset>\d+)px/)?.groups?.offset,
-    );
-    const detailsTopPadding = Number(
-      directoryDetails.match(/padding:\s*(?<top>\d+)px\s/)?.groups?.top,
-    );
-
-    expect(ringWidth).toBeGreaterThan(0);
-    expect(ringOffset).toBeGreaterThanOrEqual(0);
-    expect(detailsTopPadding).toBeGreaterThan(ringWidth + ringOffset);
   });
 
   // The three focusable controls in the Star Map "View" popover: the chip that

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -813,6 +813,33 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toMatch(/\.star-map-card:focus-visible\s*\{/);
   });
 
+  it("keeps the first directory thread's focus ring clear of the sticky header", () => {
+    // The header deliberately paints above rows that scroll underneath it.
+    // A focused first row therefore needs more top clearance than the ring's
+    // full outside reach (outline width + outline offset). Equality is not
+    // enough at 1x: fractional row positions can hand the shared boundary
+    // pixel to the sticky header, erasing the ring's horizontal top run while
+    // leaving its sides and bottom intact.
+    const rowRing = extractRuleBody(
+      css,
+      ".thread-row:has(.thread-row__open:focus)",
+    );
+    const directoryDetails = extractRuleBody(css, ".directory-row__details");
+    const ringWidth = Number(
+      rowRing.match(/outline:\s*(?<width>\d+)px\s+solid/)?.groups?.width,
+    );
+    const ringOffset = Number(
+      rowRing.match(/outline-offset:\s*(?<offset>\d+)px/)?.groups?.offset,
+    );
+    const detailsTopPadding = Number(
+      directoryDetails.match(/padding:\s*(?<top>\d+)px\s/)?.groups?.top,
+    );
+
+    expect(ringWidth).toBeGreaterThan(0);
+    expect(ringOffset).toBeGreaterThanOrEqual(0);
+    expect(detailsTopPadding).toBeGreaterThan(ringWidth + ringOffset);
+  });
+
   // The three focusable controls in the Star Map "View" popover: the chip that
   // opens it, each button of the layout switch, and the "Reset view" action.
   // They are ordinary `<button>`s, so they are tab-reachable whether or not

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -782,9 +782,8 @@ describe("Tangerine Terminal theme contract", () => {
   // exactly where a brand token drifts unnoticed: nothing else renders these
   // rings, so a wrong token or offset ships looking plausible. Both must name
   // `--focus-ring` — the semantic token, `var(--accent)` in both themes — and
-  // each keeps its own offset: -2px on the sidebar row keeps the whole ring
-  // inside the card's paint bounds (outside top edges can disappear at 1x),
-  // while 1px on the star-map card preserves that surface's shingled design.
+  // each keeps its own offset: 2px on the sidebar row, 1px on the star-map
+  // card, whose cards shingle so a wider ring bleeds onto the neighbour.
   // Changing either is a design decision; change this test in the same commit
   // so it is reviewed rather than accidental.
   it("draws both card focus rings from the focus-ring token at their own offsets", () => {
@@ -798,7 +797,7 @@ describe("Tangerine Terminal theme contract", () => {
       ".thread-row:has(.thread-row__open:focus)",
     );
     expect(rowRing).toContain("outline: 2px solid var(--focus-ring);");
-    expect(rowRing).toContain("outline-offset: -2px;");
+    expect(rowRing).toContain("outline-offset: 2px;");
 
     const cardRing = extractRuleBody(
       css,
@@ -812,6 +811,42 @@ describe("Tangerine Terminal theme contract", () => {
     // for `.thread-row`: that class is still worn by a real `<button>` on
     // directory summaries, so a focus rule naming it is legitimate there.)
     expect(css).not.toMatch(/\.star-map-card:focus-visible\s*\{/);
+  });
+
+  it("does not pull an unpinned first directory thread under the sticky header", () => {
+    // An empty pinned lane still renders its zero-height append target before
+    // the first unpinned row. Its ordinary -2px margins cancel the 2px flex
+    // gaps on both sides, but at :first-child there is no leading gap. Letting
+    // that start margin survive reduced the row's 4px nominal clearance to
+    // 2px, so the z-index 5 header covered the focus ring's 4px outside reach.
+    const rowRing = extractRuleBody(
+      css,
+      ".thread-row:has(.thread-row__open:focus)",
+    );
+    const directoryDetails = extractRuleBody(css, ".directory-row__details");
+    const pinDropBoundary = extractRuleBody(
+      css,
+      ".directory-row__pin-drop-boundary",
+    );
+    const leadingPinDropBoundary = extractRuleBody(
+      css,
+      ".directory-row__pin-drop-boundary:first-child",
+    );
+    const ringWidth = Number(
+      rowRing.match(/outline:\s*(?<width>\d+)px\s+solid/)?.groups?.width,
+    );
+    const ringOffset = Number(
+      rowRing.match(/outline-offset:\s*(?<offset>\d+)px/)?.groups?.offset,
+    );
+    const detailsTopPadding = Number(
+      directoryDetails.match(/padding:\s*(?<top>\d+)px\s/)?.groups?.top,
+    );
+
+    expect(ringWidth).toBeGreaterThan(0);
+    expect(ringOffset).toBeGreaterThanOrEqual(0);
+    expect(detailsTopPadding).toBeGreaterThanOrEqual(ringWidth + ringOffset);
+    expect(pinDropBoundary).toContain("margin-block: -2px;");
+    expect(leadingPinDropBoundary).toContain("margin-block-start: 0;");
   });
 
   // The three focusable controls in the Star Map "View" popover: the chip that

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6081,9 +6081,16 @@ textarea,
      row rhythm: 4px here + the next `.directory-row`'s 2px top pad =
      6px, the same band the thread cards keep between each other
      (`.directory-list` zeroes the sidebar-list gap, so the row pad is
-     the only other term). Top 8 → 4 for the mirror seam under the
-     sticky header. */
-  padding: 4px 0 4px 0;
+     the only other term).
+
+     Top is 6px: a focused thread's 2px outline at a 2px offset reaches 4px
+     outside the card, while the sticky header deliberately paints above
+     scrolling rows at z-index 5. Matching that reach with the old 4px pad
+     left both on the same subpixel boundary; at 1x, rows on the losing phase
+     handed that boundary to the header, erasing the focus ring's horizontal
+     top run. Two pixels of real clearance keep the ring intact without lifting
+     rows over the sticky header when they genuinely scroll underneath it. */
+  padding: 6px 0 4px 0;
 }
 
 .directory-row__threads {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4656,15 +4656,12 @@ textarea,
 
 .thread-row:has(.thread-row__open:focus) {
   outline: 2px solid var(--focus-ring);
-  /* Keep the ring inside the card's paint bounds. Packaged Electron at
-     devicePixelRatio 1 can drop the horizontal top run of an outside
-     outline for some row geometries while leaving the other three sides
-     intact. Live DevTools probes ruled out the sticky header: another 4px
-     of clearance and a z-index above the header both left the top missing,
-     while the same 2px ring rendered completely at this inset. */
-  outline-offset: -2px;
-  /* `.is-selected` lifts itself to z-index 1 so its border survives
-     neighbouring hover fills. The focused card is the one being acted on,
+  outline-offset: 2px;
+  /* The ring paints 4px outside the card (2px width @ 2px offset), into
+     the inter-row gap. `.is-selected` lifts itself to z-index 1 so its
+     border survives neighbouring hover fills — which also buried THIS
+     ring's edge whenever the previously selected card sat directly
+     below the focused one. The focused card is the one being acted on,
      so it wins the stack. */
   z-index: 2;
 }
@@ -6111,6 +6108,17 @@ textarea,
      and starting a drag never moves the source row under the held card.
      (Keep paired with the `.sidebar-list` gap — both densities share 2px.) */
   margin-block: -2px;
+}
+
+/* With no pinned threads the append target is the list's first child. There
+   is no preceding 2px flex gap to cancel in that position, so the shared
+   negative start margin pulled the first unpinned row 2px toward the sticky
+   header. That left only 2px for a focus outline that reaches 4px outside the
+   card, allowing the z-index 5 header to erase its horizontal top run. Keep
+   the end cancellation for the real following gap, but do not invent a gap
+   above a zero-height first child. */
+.directory-row__pin-drop-boundary:first-child {
+  margin-block-start: 0;
 }
 
 .directory-row__pin-drop-slot {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4656,12 +4656,15 @@ textarea,
 
 .thread-row:has(.thread-row__open:focus) {
   outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
-  /* The ring paints 4px outside the card (2px width @ 2px offset), into
-     the inter-row gap. `.is-selected` lifts itself to z-index 1 so its
-     border survives neighbouring hover fills — which also buried THIS
-     ring's edge whenever the previously selected card sat directly
-     below the focused one. The focused card is the one being acted on,
+  /* Keep the ring inside the card's paint bounds. Packaged Electron at
+     devicePixelRatio 1 can drop the horizontal top run of an outside
+     outline for some row geometries while leaving the other three sides
+     intact. Live DevTools probes ruled out the sticky header: another 4px
+     of clearance and a z-index above the header both left the top missing,
+     while the same 2px ring rendered completely at this inset. */
+  outline-offset: -2px;
+  /* `.is-selected` lifts itself to z-index 1 so its border survives
+     neighbouring hover fills. The focused card is the one being acted on,
      so it wins the stack. */
   z-index: 2;
 }
@@ -6081,16 +6084,9 @@ textarea,
      row rhythm: 4px here + the next `.directory-row`'s 2px top pad =
      6px, the same band the thread cards keep between each other
      (`.directory-list` zeroes the sidebar-list gap, so the row pad is
-     the only other term).
-
-     Top is 6px: a focused thread's 2px outline at a 2px offset reaches 4px
-     outside the card, while the sticky header deliberately paints above
-     scrolling rows at z-index 5. Matching that reach with the old 4px pad
-     left both on the same subpixel boundary; at 1x, rows on the losing phase
-     handed that boundary to the header, erasing the focus ring's horizontal
-     top run. Two pixels of real clearance keep the ring intact without lifting
-     rows over the sticky header when they genuinely scroll underneath it. */
-  padding: 6px 0 4px 0;
+     the only other term). Top 8 → 4 for the mirror seam under the
+     sticky header. */
+  padding: 4px 0 4px 0;
 }
 
 .directory-row__threads {


### PR DESCRIPTION
## Summary

- preserve the existing 2 px outside focus ring
- stop the zero-height pin-drop target from pulling a first unpinned row toward its sticky directory header
- lock the first-child margin contract and restore the unchanged focus-ring visual golden

## Root cause

The affected rows are the first **unpinned** threads in their directories. PwrAgent still renders the pinned-lane append target before them: a zero-height `.directory-row__pin-drop-boundary` with `margin-block: -2px` to cancel the normal 2 px flex gaps around that target.

When the append target is the list first child, there is no preceding flex gap to cancel. Its leading negative margin therefore over-cancels by 2 px and pulls the first unpinned card toward the sticky directory header. The header paints at z-index 5; the focused card paints a 2 px outline at a 2 px offset, reaching 4 px outside the card.

That is why the issue is selective:

- unpinned first rows such as Sign GrokBuild releases and Non-blocking saves with Arc snapshots pass through the leading drop target and lose 2 px of clearance
- pinned first rows such as Migrate agent-kit to ACP SDK render before the drop target and retain the full clearance

The scoped fix keeps the shared `margin-block: -2px` behavior, but resets `margin-block-start` to zero only when the drop target is `:first-child`.

## Live verification

The supported DevTools UI was opened on the already-running `localhost:5174` renderer (PID 73529, DPR 1, light theme).

For Sign GrokBuild releases before the scoped override:

- boundary start margin: -2 px
- row-to-header clearance: 2 px
- focus-outline outside reach: 4 px
- result: sticky header erased the horizontal top run

With `.directory-row__pin-drop-boundary:first-child { margin-block-start: 0; }` applied temporarily:

- boundary start margin: 0 px
- row-to-header clearance: 4 px
- outline outer edge: exactly the header bottom
- result: all four outline sides rendered completely

The temporary rule and probes were removed, DevTools was closed, and the original thread was restored.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` (69 passed)
- `pnpm lint:eslint` (no errors; existing warnings only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `git diff --check`
