### PR TITLE
fix(desktop): coalesce provider discovery probes

### DIFF
--- a/apps/desktop/e2e/windows-codex-discovery.spec.ts
+++ b/apps/desktop/e2e/windows-codex-discovery.spec.ts
@@ -88,8 +88,13 @@ test("PATH discovery launches one version probe and starts a real thread", async
       const log = await readFakeCodexProtocolLog(protocolLogPath);
       return findFakeCodexRequests(log, "thread/start").length;
     }).toBeGreaterThanOrEqual(1);
-    await expect.poll(async () => await readInvocationArgs(invocationLogPath))
-      .toEqual(["--version", "app-server"]);
+    await expect.poll(async () => {
+      const invocations = await readInvocationArgs(invocationLogPath);
+      return {
+        appServer: invocations.filter((args) => args.includes("app-server")).length,
+        version: invocations.filter((args) => args.includes("--version")).length,
+      };
+    }).toEqual({ appServer: 1, version: 1 });
   } finally {
     await app.close();
   }

--- a/apps/desktop/e2e/windows-codex-discovery.spec.ts
+++ b/apps/desktop/e2e/windows-codex-discovery.spec.ts
@@ -1,0 +1,96 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+import {
+  findFakeCodexRequests,
+  readFakeCodexProtocolLog,
+  writeFakeCodexExecutable,
+} from "./fixtures/fake-agent-executables";
+
+test.skip(
+  process.platform !== "win32",
+  "This regression exercises native Windows .cmd discovery and launch.",
+);
+
+function envKey(name: string): string {
+  return Object.keys(process.env).find(
+    (candidate) => candidate.toLowerCase() === name.toLowerCase(),
+  ) ?? name;
+}
+
+async function readInvocationArgs(invocationLogPath: string): Promise<string[]> {
+  try {
+    return (await readFile(invocationLogPath, "utf8"))
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+test("PATH discovery launches one version probe and starts a real thread", async () => {
+  let invocationLogPath = "";
+  let protocolLogPath = "";
+  const pathKey = envKey("PATH");
+  const pathExtKey = envKey("PATHEXT");
+  const launchEnv: Record<string, string | undefined> = {
+    PWRAGENT_CODEX_COMMAND: undefined,
+  };
+  const app = await launchElectronApp({
+    requiresReplayDriver: false,
+    env: launchEnv,
+    preLaunchHook: async (homeRoot) => {
+      const binDir = path.join(homeRoot, "codex-bin");
+      const scriptPath = path.join(binDir, "codex.js");
+      const commandPath = path.join(binDir, "codex.cmd");
+      invocationLogPath = path.join(binDir, "invocations.log");
+      protocolLogPath = path.join(binDir, "protocol.jsonl");
+      const launchMarkerPath = path.join(binDir, "app-server.launched");
+      await writeFakeCodexExecutable({
+        targetPath: scriptPath,
+        protocolLogPath,
+        launchMarkerPath,
+      });
+      await writeFile(
+        commandPath,
+        [
+          "@echo off",
+          `echo %*>>"${invocationLogPath}"`,
+          `"${process.execPath}" "${scriptPath}" %*`,
+          "",
+        ].join("\r\n"),
+        "utf8",
+      );
+
+      const inheritedPath = process.env[pathKey] ?? "";
+      launchEnv[pathKey] = `${binDir};${inheritedPath}`;
+      launchEnv[pathExtKey] = ".COM;.EXE;.BAT;.CMD";
+    },
+  });
+
+  try {
+    await expect.poll(async () => {
+      const log = await readFakeCodexProtocolLog(protocolLogPath);
+      return findFakeCodexRequests(log, "__launch__").length;
+    }).toBe(1);
+
+    await app.window.getByRole("button", { name: "New thread" }).click();
+    const prompt = app.window.getByRole("textbox", { name: "New thread" });
+    await prompt.fill("Windows Codex discovery works");
+    await app.window.getByRole("button", { name: "Start thread" }).click();
+
+    await expect.poll(async () => {
+      const log = await readFakeCodexProtocolLog(protocolLogPath);
+      return findFakeCodexRequests(log, "thread/start").length;
+    }).toBeGreaterThanOrEqual(1);
+    await expect.poll(async () => await readInvocationArgs(invocationLogPath))
+      .toEqual(["--version", "app-server"]);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
@@ -50,7 +50,7 @@ function deferred<T>(): {
 }
 
 describe("CodexDiscoveryCoordinator", () => {
-  it("prefers a Windows PATHEXT launcher over an extensionless npm shim", async () => {
+  it("delegates Windows PATHEXT resolution to shared Codex discovery", async () => {
     const windowsCommand = "C:\\nvm4w\\nodejs\\codex.CMD";
     const env = {
       Path: "C:\\nvm4w\\nodejs;C:\\Windows\\System32",
@@ -59,7 +59,6 @@ describe("CodexDiscoveryCoordinator", () => {
     const discover = vi.fn(async () => selectedSnapshot(windowsCommand));
     const coordinator = new CodexDiscoveryCoordinator({
       discover,
-      pathExists: async (candidate) => candidate === windowsCommand,
       platform: "win32",
       resolveEnv: async () => env,
     });
@@ -69,7 +68,7 @@ describe("CodexDiscoveryCoordinator", () => {
       version: "0.126.0",
     });
     expect(discover).toHaveBeenCalledWith({
-      configuredCommand: windowsCommand,
+      configuredCommand: undefined,
       env,
       platform: "win32",
     });
@@ -272,14 +271,18 @@ describe("CodexDiscoveryCoordinator", () => {
   });
 
   it("coalesces force refreshes and bypasses a fresh cache entry", async () => {
+    let now = 0;
     const discover = vi.fn()
       .mockResolvedValueOnce(selectedSnapshot("/old/codex"))
       .mockResolvedValueOnce(selectedSnapshot("/forced/codex"));
     const coordinator = new CodexDiscoveryCoordinator({
       discover,
+      forceReuseTtlMs: 5,
+      now: () => now,
       resolveEnv: async () => ({ PATH: "/bin" }),
     });
     await coordinator.discover();
+    now = 5;
 
     const [first, second] = await Promise.all([
       coordinator.discover(undefined, { force: true }),
@@ -288,6 +291,50 @@ describe("CodexDiscoveryCoordinator", () => {
 
     expect(first).toEqual(selectedSnapshot("/forced/codex"));
     expect(second).toEqual(first);
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses a just-finished result for sequential force requests", async () => {
+    let now = 0;
+    const discover = vi.fn(async () => selectedSnapshot("/bin/codex"));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      forceReuseTtlMs: 5_000,
+      now: () => now,
+      resolveEnv: async () => ({ PATH: "/bin" }),
+    });
+
+    const first = await coordinator.discover(undefined, { force: true });
+    now = 4_999;
+    const second = await coordinator.discover(undefined, { force: true });
+
+    expect(second).toEqual(first);
+    expect(discover).toHaveBeenCalledOnce();
+  });
+
+  it("serializes probes for different configured Codex targets", async () => {
+    const firstProbe = deferred<CodexDiscoverySnapshot>();
+    const discover = vi.fn()
+      .mockReturnValueOnce(firstProbe.promise)
+      .mockResolvedValueOnce(selectedSnapshot("/second/codex"));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      resolveEnv: async () => ({ PATH: "/bin" }),
+    });
+
+    const first = coordinator.discover("/first/codex");
+    const second = coordinator.discover("/second/codex");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(discover).toHaveBeenCalledOnce();
+
+    firstProbe.resolve(selectedSnapshot("/first/codex"));
+    await expect(first).resolves.toMatchObject({
+      selectedCommand: "/first/codex",
+    });
+    await expect(second).resolves.toMatchObject({
+      selectedCommand: "/second/codex",
+    });
     expect(discover).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1288,11 +1288,13 @@ describe("settings ipc", () => {
       await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
       expect(probe).toHaveBeenCalledTimes(2);
 
-      // Forced refresh ("Discover new"): re-probe regardless of freshness.
+      // A forced refresh arriving immediately after that probe reuses its
+      // result. "Discover new" may bypass older capability freshness, but it
+      // must not create a rapid-fire sequential launch.
       await handlers
         .get(ACP_AGENTS_LIST_CHANNEL)
         ?.({}, { refresh: true, force: true });
-      expect(probe).toHaveBeenCalledTimes(3);
+      expect(probe).toHaveBeenCalledTimes(2);
     } finally {
       disposeAppState();
     }
@@ -1366,18 +1368,29 @@ describe("settings ipc", () => {
         }),
       );
 
-      // A non-forced caller that arrives during a stronger forced pass must
-      // ride that pass instead of launching the same runtime in parallel.
-      const forced = handler?.({}, { refresh: true, force: true });
+      // Force bypasses an old cache, but a forced caller that arrives while
+      // the same ordinary probe is active must ride that pass instead of
+      // launching the same runtime in parallel.
+      const regular = handler?.({}, { refresh: true });
       await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(1));
       const forcedFollower = handler?.({}, { refresh: true, force: true });
-      const regular = handler?.({}, { refresh: true });
+      const regularFollower = handler?.({}, { refresh: true });
       const targetedForced = handler?.(
         {},
         { refresh: true, force: true, registryIds: ["gemini"] },
       );
       releaseProbe?.();
-      await Promise.all([forced, forcedFollower, regular, targetedForced]);
+      await Promise.all([
+        regular,
+        forcedFollower,
+        regularFollower,
+        targetedForced,
+      ]);
+      expect(probe).toHaveBeenCalledTimes(1);
+
+      // A late duplicate that arrives just after the shared pass completed
+      // reuses that same result instead of starting a sequential second probe.
+      await handler?.({}, { refresh: true, force: true });
       expect(probe).toHaveBeenCalledTimes(1);
 
       // The reverse ordering also coordinates the actual per-provider probe:

--- a/apps/desktop/src/main/codex-discovery-coordinator.ts
+++ b/apps/desktop/src/main/codex-discovery-coordinator.ts
@@ -5,14 +5,12 @@ import {
   type CodexDiscoverySnapshot,
   type ResolvedCodexCommandCandidate,
 } from "@pwrdrvr/codex-discovery";
-import { constants as fsConstants } from "node:fs";
-import { access } from "node:fs/promises";
-import path from "node:path";
 
 export const CODEX_DISCOVERY_SUCCESS_TTL_MS = 5 * 60_000;
 export const CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS = 15_000;
 export const CODEX_DISCOVERY_FAILURE_TTL_MS = 5_000;
 export const CODEX_DISCOVERY_STALE_SUCCESS_TTL_MS = 30 * 60_000;
+export const CODEX_DISCOVERY_FORCE_REUSE_TTL_MS = 5_000;
 
 type DiscoveryOutcome =
   | {
@@ -30,16 +28,15 @@ type DiscoveryCacheEntry = {
 };
 
 type InFlightDiscovery = {
-  forced: boolean;
   promise: Promise<CodexDiscoverySnapshot>;
 };
 
 export type CodexDiscoveryCoordinatorOptions = {
   discover?: typeof discoverCodexCommands;
   failureTtlMs?: number;
+  forceReuseTtlMs?: number;
   notInstalledTtlMs?: number;
   now?: () => number;
-  pathExists?: (candidate: string) => Promise<boolean>;
   platform?: NodeJS.Platform;
   resolveEnv: () => Promise<NodeJS.ProcessEnv>;
   staleSuccessTtlMs?: number;
@@ -63,11 +60,11 @@ export class CodexDiscoveryCoordinator {
   private readonly cache = new Map<string, DiscoveryCacheEntry>();
   private readonly discoverFn: typeof discoverCodexCommands;
   private readonly failureTtlMs: number;
+  private readonly forceReuseTtlMs: number;
   private readonly inFlight = new Map<string, InFlightDiscovery>();
   private readonly notInstalledTtlMs: number;
   private readonly now: () => number;
-  private readonly pathExists: (candidate: string) => Promise<boolean>;
-  private readonly platform: NodeJS.Platform;
+  private probeTail: Promise<void> = Promise.resolve();
   private readonly staleSuccessTtlMs: number;
   private readonly successTtlMs: number;
   private generation = 0;
@@ -76,11 +73,11 @@ export class CodexDiscoveryCoordinator {
     this.discoverFn = options.discover ?? discoverCodexCommands;
     this.failureTtlMs =
       options.failureTtlMs ?? CODEX_DISCOVERY_FAILURE_TTL_MS;
+    this.forceReuseTtlMs =
+      options.forceReuseTtlMs ?? CODEX_DISCOVERY_FORCE_REUSE_TTL_MS;
     this.notInstalledTtlMs =
       options.notInstalledTtlMs ?? CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS;
     this.now = options.now ?? Date.now;
-    this.pathExists = options.pathExists ?? defaultPathExists;
-    this.platform = options.platform ?? process.platform;
     this.staleSuccessTtlMs =
       options.staleSuccessTtlMs ?? CODEX_DISCOVERY_STALE_SUCCESS_TTL_MS;
     this.successTtlMs =
@@ -98,24 +95,24 @@ export class CodexDiscoveryCoordinator {
   ): Promise<CodexDiscoverySnapshot> {
     const key = configuredCommand?.trim() ?? "";
     const active = this.inFlight.get(key);
+    const cached = this.cache.get(key);
 
     if (request.force === true) {
-      if (active?.forced) {
+      // A force request means "do not trust an old cache entry", not "launch
+      // another process even though this exact target just finished or is
+      // already being checked". This closes the sequential half of a renderer
+      // stampede: late arrivals reuse the same main-owned result for five
+      // seconds instead of lining up another `codex --version` child.
+      if (active) {
         return await active.promise;
       }
-      this.invalidate();
-      if (active) {
-        try {
-          await active.promise;
-        } catch {
-          // The forced probe below supersedes the earlier result.
-        }
-        return await this.discover(configuredCommand, request);
+      if (cached && this.now() - cached.cachedAt < this.forceReuseTtlMs) {
+        return this.readOutcome(cached.outcome);
       }
-      return await this.startProbe(key, configuredCommand, true);
+      this.invalidate();
+      return await this.startProbe(key, configuredCommand);
     }
 
-    const cached = this.cache.get(key);
     if (cached && this.isFresh(cached)) {
       return this.readOutcome(cached.outcome);
     }
@@ -133,7 +130,7 @@ export class CodexDiscoveryCoordinator {
       return await active.promise;
     }
 
-    return await this.startProbe(key, configuredCommand, false);
+    return await this.startProbe(key, configuredCommand);
   }
 
   async resolve(
@@ -195,7 +192,6 @@ export class CodexDiscoveryCoordinator {
   private async startProbe(
     key: string,
     configuredCommand: string | undefined,
-    forced: boolean,
   ): Promise<CodexDiscoverySnapshot> {
     const existing = this.inFlight.get(key);
     if (existing) {
@@ -203,8 +199,14 @@ export class CodexDiscoveryCoordinator {
     }
 
     const generation = this.generation;
-    const promise = this.runProbe(configuredCommand, generation);
-    const active: InFlightDiscovery = { forced, promise };
+    const promise = this.probeTail.then(
+      async () => await this.runProbe(configuredCommand, generation),
+    );
+    this.probeTail = promise.then(
+      () => undefined,
+      () => undefined,
+    );
+    const active: InFlightDiscovery = { promise };
     this.inFlight.set(key, active);
     try {
       return await promise;
@@ -221,19 +223,16 @@ export class CodexDiscoveryCoordinator {
   ): Promise<CodexDiscoverySnapshot> {
     try {
       const env = await this.options.resolveEnv();
-      const windowsPathCommand =
-        !configuredCommand && this.platform === "win32"
-          ? await findWindowsCodexPathCommand(env, this.pathExists)
-          : undefined;
+      // @pwrdrvr/codex-discovery resolves PATHEXT shims itself. Do not turn
+      // its Windows PATH result into a configured candidate first: fixed and
+      // automatic candidates are probed separately inside the package, which
+      // would execute the same codex.cmd twice before candidate deduplication.
       const discovered = await this.discoverFn({
-        configuredCommand: configuredCommand ?? windowsPathCommand,
+        configuredCommand,
         env,
         ...(this.options.platform ? { platform: this.options.platform } : {}),
       });
-      const snapshot = normalizeCodexDiscoverySnapshot(
-        discovered,
-        windowsPathCommand,
-      );
+      const snapshot = normalizeCodexDiscoverySnapshot(discovered);
       if (generation === this.generation) {
         this.cache.set(configuredCommand?.trim() ?? "", {
           cachedAt: this.now(),
@@ -253,62 +252,10 @@ export class CodexDiscoveryCoordinator {
   }
 }
 
-async function defaultPathExists(candidate: string): Promise<boolean> {
-  try {
-    await access(candidate, fsConstants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function windowsEnvValue(
-  env: NodeJS.ProcessEnv,
-  name: string,
-): string | undefined {
-  const key = Object.keys(env).find(
-    (candidate) => candidate.toLowerCase() === name.toLowerCase(),
-  );
-  return key ? env[key] : undefined;
-}
-
-async function findWindowsCodexPathCommand(
-  env: NodeJS.ProcessEnv,
-  pathExists: (candidate: string) => Promise<boolean>,
-): Promise<string | undefined> {
-  const pathValue = windowsEnvValue(env, "PATH");
-  if (!pathValue?.trim()) return undefined;
-
-  const rawExtensions = windowsEnvValue(env, "PATHEXT")?.trim()
-    || ".COM;.EXE;.BAT;.CMD";
-  const extensions = rawExtensions
-    .split(";")
-    .map((extension) => extension.trim())
-    .filter(Boolean)
-    .map((extension) => (extension.startsWith(".") ? extension : `.${extension}`));
-
-  for (const rawDirectory of pathValue.split(";")) {
-    const directory = rawDirectory.trim().replace(/^"(.+)"$/, "$1");
-    if (!directory) continue;
-    for (const extension of extensions) {
-      const candidate = path.win32.join(directory, `codex${extension}`);
-      if (await pathExists(candidate)) return candidate;
-    }
-  }
-  return undefined;
-}
-
 function normalizeCodexDiscoverySnapshot(
   snapshot: CodexDiscoverySnapshot,
-  windowsPathCommand?: string,
 ): CodexDiscoverySnapshot {
   const normalizedCandidates = snapshot.candidates.map((candidate) => {
-    const source =
-      windowsPathCommand
-      && candidate.command.toLowerCase() === windowsPathCommand.toLowerCase()
-      && candidate.source === "config"
-        ? "path"
-        : candidate.source;
     if (
       candidate.selected
       && (
@@ -319,7 +266,6 @@ function normalizeCodexDiscoverySnapshot(
     ) {
       return {
         ...candidate,
-        source,
         executable: false,
         selected: false,
         failureReason:
@@ -328,7 +274,7 @@ function normalizeCodexDiscoverySnapshot(
           ?? "version_not_reported",
       };
     }
-    return source === candidate.source ? candidate : { ...candidate, source };
+    return candidate;
   });
   const isValidated = (
     candidate: (typeof normalizedCandidates)[number],

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -130,6 +130,9 @@ async function refreshModelBackendsIfNeeded(params: {
   const acpCliPathChanged = Object.values(
     params.patch?.acpAgents ?? {},
   ).some((agent) => agent?.cliPath !== undefined);
+  if (params.patch?.acpAgents !== undefined) {
+    recentAcpRefreshes.clear();
+  }
   if (
     params.patch?.models?.codex?.path !== undefined
     || acpCliPathChanged
@@ -148,12 +151,12 @@ async function refreshModelBackendsIfNeeded(params: {
 // so without this two passes would launch the same agents in parallel. Pure
 // cache reads (refresh === false) never launch and are not coalesced.
 //
-// We track force strength and provider scope so narrower requests can ride a
-// stronger in-flight superset. When a broader request arrives second, it waits
-// for overlapping providers and refreshes only the remainder. This preserves
-// force semantics without launching the same interactive runtime twice.
+// We track provider scope so narrower requests can ride an in-flight superset.
+// Force bypasses old durable capability freshness; it never justifies launching
+// a second copy of an agent that main is already probing. When a broader
+// request arrives second, it waits for overlapping providers and refreshes only
+// the remainder. A matching late arrival also reuses a result for five seconds.
 type InFlightAcpRefresh = {
-  forced: boolean;
   probeCapabilities: boolean;
   registryIds: ReadonlySet<string>;
   promise: Promise<ListAcpAgentSettingsResponse>;
@@ -161,6 +164,13 @@ type InFlightAcpRefresh = {
 
 const LOCAL_ACP_REGISTRY_IDS = ["gemini", "grok", "kimi", "qwen"] as const;
 const inFlightAcpRefreshes = new Set<InFlightAcpRefresh>();
+const recentAcpRefreshes = new Set<
+  InFlightAcpRefresh & {
+    completedAt: number;
+    response: ListAcpAgentSettingsResponse;
+  }
+>();
+const ACP_REFRESH_REUSE_TTL_MS = 5_000;
 const USER_INITIATED_ACP_PROBE_TIMEOUT_MS = 10 * 60_000;
 
 function acpRefreshRegistryIds(
@@ -190,6 +200,16 @@ function setsOverlap(
   return [...left].some((registryId) => right.has(registryId));
 }
 
+function invalidateRecentAcpRefreshes(
+  registryIds: ReadonlySet<string>,
+): void {
+  for (const recent of recentAcpRefreshes) {
+    if (setsOverlap(recent.registryIds, registryIds)) {
+      recentAcpRefreshes.delete(recent);
+    }
+  }
+}
+
 async function listAcpAgentSettings(
   request: ListAcpAgentSettingsRequest = {},
   service?: DesktopSettingsService,
@@ -197,13 +217,10 @@ async function listAcpAgentSettings(
   if (request.refresh === false) {
     return await listAcpAgentSettingsImpl(request, service);
   }
-  const wantsForce = request.force === true;
   const probeCapabilities = request.probeCapabilities !== false;
   const registryIds = acpRefreshRegistryIds(request);
   const compatible = [...inFlightAcpRefreshes].filter(
-    (active) =>
-      active.probeCapabilities === probeCapabilities
-      && (!wantsForce || active.forced),
+    (active) => active.probeCapabilities === probeCapabilities,
   );
   const superset = compatible.find((active) =>
     setContainsAll(active.registryIds, registryIds),
@@ -215,6 +232,23 @@ async function listAcpAgentSettings(
   const overlapping = compatible.filter((active) =>
     setsOverlap(active.registryIds, registryIds),
   );
+  if (overlapping.length === 0) {
+    const now = Date.now();
+    for (const recent of recentAcpRefreshes) {
+      if (now - recent.completedAt >= ACP_REFRESH_REUSE_TTL_MS) {
+        recentAcpRefreshes.delete(recent);
+      }
+    }
+    const recentMatch = [...recentAcpRefreshes].find(
+      (recent) =>
+        recent.probeCapabilities === probeCapabilities
+        && setContainsAll(recent.registryIds, registryIds)
+        && setContainsAll(registryIds, recent.registryIds),
+    );
+    if (recentMatch) {
+      return recentMatch.response;
+    }
+  }
   const coveredRegistryIds = new Set(
     overlapping.flatMap((active) => [...active.registryIds]),
   );
@@ -231,22 +265,27 @@ async function listAcpAgentSettings(
         service,
       );
     }
-    return await listAcpAgentSettingsImpl(
+    const nextRequest =
       request.registryIds || remainingRegistryIds.length !== registryIds.size
         ? { ...request, registryIds: remainingRegistryIds }
-        : request,
-      service,
-    );
+        : request;
+    invalidateRecentAcpRefreshes(acpRefreshRegistryIds(nextRequest));
+    return await listAcpAgentSettingsImpl(nextRequest, service);
   })();
   const active: InFlightAcpRefresh = {
-    forced: wantsForce,
     probeCapabilities,
     registryIds,
     promise: run,
   };
   inFlightAcpRefreshes.add(active);
   try {
-    return await run;
+    const response = await run;
+    recentAcpRefreshes.add({
+      ...active,
+      completedAt: Date.now(),
+      response,
+    });
+    return response;
   } finally {
     inFlightAcpRefreshes.delete(active);
   }
@@ -1067,6 +1106,7 @@ export function registerSettingsIpcHandlers(
     ) => void | Promise<void>;
   },
 ): void {
+  recentAcpRefreshes.clear();
   ipcMain.removeHandler(ACP_AGENTS_LIST_CHANNEL);
   ipcMain.handle(
     ACP_AGENTS_LIST_CHANNEL,
@@ -1387,6 +1427,7 @@ export function registerSettingsIpcHandlers(
 
 export function disposeSettingsIpcHandlers(): void {
   codexLoginManager.dispose();
+  recentAcpRefreshes.clear();
   ipcMain.removeHandler(ACP_AGENTS_LIST_CHANNEL);
   ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -384,15 +384,15 @@ export function AutomationEditor(props: AutomationEditorProps) {
   }, [props.desktopApi]);
 
   useEffect(() => {
-    const readSettings = props.desktopApi?.readSettings;
-    if (!readSettings) {
+    const desktopApi = props.desktopApi;
+    if (!desktopApi?.readSettings) {
       setEnabledProviders(DEFAULT_INBOUND_PROVIDERS);
       return;
     }
     let cancelled = false;
     void (async () => {
       try {
-        const response = await readDesktopSettingsCoalesced(props.desktopApi);
+        const response = await readDesktopSettingsCoalesced(desktopApi);
         if (cancelled) return;
         setEnabledProviders(readEnabledProviders(response.snapshot));
         setProviderGroups(readProviderGroups(response.snapshot));

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -36,6 +36,7 @@ import {
   validateAutomationScheduleDefinition,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { readDesktopSettingsCoalesced } from "../../lib/settings-read-coordinator";
 import {
   CODEX_AGENT_THREAD_CREATION_NOTE,
   canChangeExistingThreadAgentDesignation,
@@ -391,7 +392,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
     let cancelled = false;
     void (async () => {
       try {
-        const response = await readSettings();
+        const response = await readDesktopSettingsCoalesced(props.desktopApi);
         if (cancelled) return;
         setEnabledProviders(readEnabledProviders(response.snapshot));
         setProviderGroups(readProviderGroups(response.snapshot));

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -19,6 +19,7 @@ import { useFederationPeerConnectivity } from "../../lib/useFederationPeerConnec
 import { SettingsIcon } from "../../icons/SettingsIcon";
 import { useMessagingPlatformStatuses } from "./useMessagingPlatformStatuses";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { readDesktopSettingsCoalesced } from "../../lib/settings-read-coordinator";
 
 const HEALTH_LABEL: Record<MessagingPlatformHealth, string> = {
   enabled: "Enabled",
@@ -168,7 +169,7 @@ export function MessagingStatusBar(props: {
       return;
     }
     let cancelled = false;
-    void desktopApi.readSettings({}).then((response) => {
+    void readDesktopSettingsCoalesced(desktopApi).then((response) => {
       if (!cancelled) setSettingsSnapshot(response.snapshot);
     }).catch(() => {
       // Settings screen owns user-facing errors; keep this controller quiet.
@@ -187,7 +188,7 @@ export function MessagingStatusBar(props: {
       return;
     }
     let cancelled = false;
-    void desktopApi.readSettings({}).then((response) => {
+    void readDesktopSettingsCoalesced(desktopApi).then((response) => {
       if (!cancelled) setSettingsSnapshot(response.snapshot);
     }).catch(() => {
       // Settings screen owns user-facing errors; keep this controller quiet.

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -11,6 +11,11 @@ import type {
 import { DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
+import {
+  invalidateDesktopSettingsRead,
+  readDesktopSettingsCoalesced,
+  rememberDesktopSettingsSnapshot,
+} from "../../lib/settings-read-coordinator";
 
 export type DesktopSettingsState = {
   composerImplementation: DesktopChatReplyComposer;
@@ -36,7 +41,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
 
-  const refresh = useCallback(async (): Promise<void> => {
+  const read = useCallback(async (force = false): Promise<void> => {
     if (!desktopApi?.readSettings) {
       return;
     }
@@ -44,7 +49,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
     setLoading(true);
     setError(undefined);
     try {
-      const response = await desktopApi.readSettings({});
+      const response = await readDesktopSettingsCoalesced(desktopApi, { force });
       setSnapshot(response.snapshot);
     } catch (readError) {
       setError(readError instanceof Error ? readError.message : String(readError));
@@ -53,9 +58,13 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
     }
   }, [desktopApi]);
 
+  const refresh = useCallback(async (): Promise<void> => {
+    await read(true);
+  }, [read]);
+
   useEffect(() => {
-    void refresh();
-  }, [refresh]);
+    void read();
+  }, [read]);
 
   const writeConfig = useCallback(
     async (patch: DesktopSettingsConfigPatch): Promise<boolean> => {
@@ -67,9 +76,11 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
       setSaving(true);
       setError(undefined);
       try {
+        invalidateDesktopSettingsRead(desktopApi);
         const request: WriteDesktopSettingsConfigRequest = { patch };
         const response = await desktopApi.writeSettingsConfig(request);
         setSnapshot(response.snapshot);
+        rememberDesktopSettingsSnapshot(desktopApi, response);
         if (
           patch.models?.codex?.path !== undefined
           || patch.acpAgents !== undefined
@@ -108,6 +119,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
         const request: ReplaceDesktopSettingsSecretRequest = { secret, value };
         const response = await desktopApi.replaceSettingsSecret(request);
         setSnapshot(response.snapshot);
+        rememberDesktopSettingsSnapshot(desktopApi, response);
         return true;
       } catch (writeError) {
         setError(writeError instanceof Error ? writeError.message : String(writeError));
@@ -132,6 +144,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
         const request: ClearDesktopSettingsSecretRequest = { secret };
         const response = await desktopApi.clearSettingsSecret(request);
         setSnapshot(response.snapshot);
+        rememberDesktopSettingsSnapshot(desktopApi, response);
         return true;
       } catch (writeError) {
         setError(writeError instanceof Error ? writeError.message : String(writeError));
@@ -143,9 +156,17 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
     [desktopApi],
   );
 
+  const applySnapshot = useCallback(
+    (nextSnapshot: DesktopSettingsSnapshot): void => {
+      setSnapshot(nextSnapshot);
+      rememberDesktopSettingsSnapshot(desktopApi, { snapshot: nextSnapshot });
+    },
+    [desktopApi],
+  );
+
   return useMemo(
     () => ({
-      applySnapshot: setSnapshot,
+      applySnapshot,
       clearSecret,
       composerImplementation: DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
       error,
@@ -157,6 +178,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
       writeConfig,
     }),
     [
+      applySnapshot,
       clearSecret,
       error,
       loading,

--- a/apps/desktop/src/renderer/src/lib/settings-read-coordinator.test.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-read-coordinator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReadDesktopSettingsResponse } from "@pwragent/shared";
+import type { DesktopApi } from "./desktop-api";
+import { readDesktopSettingsCoalesced } from "./settings-read-coordinator";
+
+function response(fetchedAt: number): ReadDesktopSettingsResponse {
+  return {
+    snapshot: { fetchedAt } as ReadDesktopSettingsResponse["snapshot"],
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("renderer settings read coordinator", () => {
+  it("coalesces concurrent reads from layered renderer consumers", async () => {
+    const pending = deferred<ReadDesktopSettingsResponse>();
+    const readSettings = vi.fn(() => pending.promise);
+    const desktopApi = { readSettings } as DesktopApi;
+
+    const first = readDesktopSettingsCoalesced(desktopApi);
+    const second = readDesktopSettingsCoalesced(desktopApi);
+    expect(readSettings).toHaveBeenCalledOnce();
+
+    pending.resolve(response(1));
+    await expect(first).resolves.toEqual(response(1));
+    await expect(second).resolves.toEqual(response(1));
+  });
+
+  it("reuses a completed read for five seconds but honors a forced refresh", async () => {
+    let now = 0;
+    const readSettings = vi.fn()
+      .mockResolvedValueOnce(response(1))
+      .mockResolvedValueOnce(response(2));
+    const desktopApi = { readSettings } as DesktopApi;
+
+    await expect(
+      readDesktopSettingsCoalesced(desktopApi, { now: () => now }),
+    ).resolves.toEqual(response(1));
+    now = 4_999;
+    await expect(
+      readDesktopSettingsCoalesced(desktopApi, { now: () => now }),
+    ).resolves.toEqual(response(1));
+    expect(readSettings).toHaveBeenCalledOnce();
+
+    await expect(
+      readDesktopSettingsCoalesced(desktopApi, {
+        force: true,
+        now: () => now,
+      }),
+    ).resolves.toEqual(response(2));
+    expect(readSettings).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/settings-read-coordinator.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-read-coordinator.ts
@@ -1,0 +1,77 @@
+import type {
+  ReadDesktopSettingsResponse,
+} from "@pwragent/shared";
+import type { DesktopApi } from "./desktop-api";
+
+export const RENDERER_SETTINGS_READ_REUSE_TTL_MS = 5_000;
+
+type SettingsReadEntry = {
+  completedAt?: number;
+  promise: Promise<ReadDesktopSettingsResponse>;
+};
+
+const readsByApi = new WeakMap<object, SettingsReadEntry>();
+
+/**
+ * Coalesces the renderer's many consumers of the same settings snapshot.
+ *
+ * Electron main remains the only process that discovers or launches provider
+ * executables. This boundary merely prevents layered title bars, StrictMode,
+ * and secondary panels from sending a herd of identical IPC reads to main.
+ */
+export async function readDesktopSettingsCoalesced(
+  desktopApi: DesktopApi,
+  options: { force?: boolean; now?: () => number } = {},
+): Promise<ReadDesktopSettingsResponse> {
+  if (!desktopApi.readSettings) {
+    throw new Error("Settings are unavailable.");
+  }
+  const now = options.now ?? Date.now;
+  const existing = readsByApi.get(desktopApi);
+  if (
+    existing
+    && (
+      existing.completedAt === undefined
+      || (
+        options.force !== true
+        && now() - existing.completedAt < RENDERER_SETTINGS_READ_REUSE_TTL_MS
+      )
+    )
+  ) {
+    return await existing.promise;
+  }
+
+  const entry: SettingsReadEntry = {
+    promise: desktopApi.readSettings({}),
+  };
+  readsByApi.set(desktopApi, entry);
+  try {
+    const response = await entry.promise;
+    entry.completedAt = now();
+    return response;
+  } catch (error) {
+    if (readsByApi.get(desktopApi) === entry) {
+      readsByApi.delete(desktopApi);
+    }
+    throw error;
+  }
+}
+
+export function rememberDesktopSettingsSnapshot(
+  desktopApi: DesktopApi | undefined,
+  response: ReadDesktopSettingsResponse,
+): void {
+  if (!desktopApi) return;
+  readsByApi.set(desktopApi, {
+    completedAt: Date.now(),
+    promise: Promise.resolve(response),
+  });
+}
+
+export function invalidateDesktopSettingsRead(
+  desktopApi: DesktopApi | undefined,
+): void {
+  if (desktopApi) {
+    readsByApi.delete(desktopApi);
+  }
+}


### PR DESCRIPTION
## What changed

- remove PwrAgent's redundant Windows PATHEXT pre-resolution and let `@pwrdrvr/codex-discovery` resolve `codex.cmd` once
- serialize main-process Codex probes across targets, single-flight active requests, and reuse just-finished forced results for five seconds
- give ACP capability refreshes the same in-flight and five-second late-arrival protection
- coalesce renderer settings reads across StrictMode, layered messaging title bars, and Automation Editor consumers
- add a Windows-only headed E2E that uses a real `.cmd` shim and fake Codex app-server, creates a thread, and asserts one version probe

## Root cause

The Windows compatibility code pre-resolved the PATH shim and passed it back to `@pwrdrvr/codex-discovery` as a configured command. The package already performs PATHEXT-aware resolution, so one logical discovery probed the same `codex.cmd` once as a fixed candidate and again as the automatic PATH candidate before package-level candidate deduplication. One bad result could then be shared with both Settings and thread launch by the main-process cache.

This is not a missing package or lockfile backport: `@pwrdrvr/codex-discovery` 0.1.6 and `@pwrdrvr/agent-transport` 0.1.7 are present and their Windows shim invocation works. The duplicate PwrAgent compatibility layer was the regression.

## Validation

- pre-fix PwrSuiteLab Windows run failed with two quoted `--version` invocations for one PATH-discovered `codex.cmd`
- post-fix PwrSuiteLab Windows run passed with one version probe, one app-server launch, a successful real thread start, and healthy Electron shutdown
- 49 focused Vitest tests passed
- desktop TypeScript typecheck passed
- full ESLint passed
- dependency boundaries passed
