### PR TITLE
fix(desktop): start in the workspace composer

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -818,6 +818,7 @@ const subscribeToAgentEvent = createEventSubscriptionMultiplexer<AgentEvent>(
 
 const desktopApi = Object.freeze({
   ping: () => "pong",
+  replayFixtureActive: Boolean(process.env.PWRAGENT_REPLAY_FIXTURE_PATH),
   // Clipboard writes go through the main process: the sandboxed preload's
   // `electron` module does not expose `clipboard`.
   copyText: async (text: string): Promise<void> => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1713,6 +1713,7 @@ function DesktopAppShell(props: {
       onboarding?.completed.value !== true
       || onboarding?.completedSource?.value !== "wizard"
       || onboardingOpen !== null
+      || Boolean(readRendererFederationTarget())
       || !navigation.loaded
       || workspaceLaunchpadExists
       || postOnboardingWorkspaceOpenStartedRef.current

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import {
   DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   isRemoteFederationTarget,
   parseThreadIdentityKey,
+  resolveNewThreadBackend,
   type AppServerBackendKind,
   type DesktopBootInfo,
   type DesktopCodexProfileModel,
@@ -319,7 +320,9 @@ function DesktopAppShell(props: {
     "auto" | "replay" | null
   >(null);
   const [autoOpenSeen, setAutoOpenSeen] = useState(false);
-  const postOnboardingWorkspaceOpenStartedRef = useRef(false);
+  const startupLandingStateRef = useRef<
+    "pending" | "onboarding-opened" | "complete"
+  >("pending");
   // Boot info is fetched once on mount and is stable across the
   // renderer's lifetime (the main process recorded it before this
   // window opened — see `recordBootDecision` in app-state.ts). The
@@ -1220,6 +1223,10 @@ function DesktopAppShell(props: {
     federationTarget: activeFederationTarget,
     suspended: !peerConnectivity.connected,
   });
+  const startupBackend = useMemo(
+    () => resolveNewThreadBackend(backendSummaries.backends),
+    [backendSummaries.backends],
+  );
   const refreshAcpAgents = backendSummaries.refreshAcpAgents;
   const refreshSelectedAcpProvider = useCallback(
     async (
@@ -1705,35 +1712,44 @@ function DesktopAppShell(props: {
     settings.snapshot?.onboarding?.completed.value,
   ]);
   useEffect(() => {
-    const onboarding = settings.snapshot?.onboarding;
-    const workspaceLaunchpadExists = navigation.directories.some(
-      (directory) => directory.kind === "workspace",
-    );
     if (
-      onboarding?.completed.value !== true
-      || onboarding?.completedSource?.value !== "wizard"
+      settings.snapshot?.onboarding?.completed.value !== true
       || onboardingOpen !== null
       || Boolean(readRendererFederationTarget())
       || !navigation.loaded
-      || workspaceLaunchpadExists
-      || postOnboardingWorkspaceOpenStartedRef.current
+      || !backendSummaries.loaded
+      || !desktopApi?.listBackends
+      || startupLandingStateRef.current === "complete"
     ) {
       return;
     }
 
-    // The wizard's real profile may be this window or a freshly spawned one.
-    // Its first directory-less launchpad is therefore the durable signal that
-    // the post-wizard landing has not happened yet. Opening it persists that
-    // launchpad, so later app launches keep the operator's normal selection.
-    postOnboardingWorkspaceOpenStartedRef.current = true;
+    if (!startupBackend) {
+      // A discovery failure is not proof that the profile has no configured
+      // provider. Let a later refresh make the startup decision instead of
+      // sending the operator through setup because of a transient outage.
+      if (backendSummaries.error) {
+        return;
+      }
+      if (startupLandingStateRef.current === "pending") {
+        startupLandingStateRef.current = "onboarding-opened";
+        setOnboardingOpen("replay");
+      }
+      return;
+    }
+
+    startupLandingStateRef.current = "complete";
     setMainView("thread");
-    void openWorkspaceLaunchpad();
+    void openWorkspaceLaunchpad(startupBackend.kind);
   }, [
-    navigation.directories,
+    backendSummaries.error,
+    backendSummaries.loaded,
+    desktopApi,
     navigation.loaded,
     onboardingOpen,
     openWorkspaceLaunchpad,
-    settings.snapshot?.onboarding,
+    settings.snapshot?.onboarding?.completed.value,
+    startupBackend,
   ]);
   const loadThreadDetail = threadViewReady && mainView === "thread";
   const session = useThreadSessionState({

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1716,6 +1716,7 @@ function DesktopAppShell(props: {
       settings.snapshot?.onboarding?.completed.value !== true
       || onboardingOpen !== null
       || Boolean(readRendererFederationTarget())
+      || desktopApi?.replayFixtureActive === true
       || !navigation.loaded
       || !backendSummaries.loaded
       || !desktopApi?.listBackends

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -319,6 +319,7 @@ function DesktopAppShell(props: {
     "auto" | "replay" | null
   >(null);
   const [autoOpenSeen, setAutoOpenSeen] = useState(false);
+  const postOnboardingWorkspaceOpenStartedRef = useRef(false);
   // Boot info is fetched once on mount and is stable across the
   // renderer's lifetime (the main process recorded it before this
   // window opened — see `recordBootDecision` in app-state.ts). The
@@ -1263,6 +1264,7 @@ function DesktopAppShell(props: {
   }, [mainView, navigation.selectedLaunchpad, navigation.selectedThreadKey]);
   const showThread = navigation.showThread;
   const selectDirectoryLaunchpad = navigation.selectDirectoryLaunchpad;
+  const openWorkspaceLaunchpad = navigation.openWorkspaceLaunchpad;
   const queueMessageLinkRequest = useCallback((request: {
     backend: AppServerBackendKind;
     messageId?: string;
@@ -1701,6 +1703,36 @@ function DesktopAppShell(props: {
     autoOpenSeen,
     onboardingOpen,
     settings.snapshot?.onboarding?.completed.value,
+  ]);
+  useEffect(() => {
+    const onboarding = settings.snapshot?.onboarding;
+    const workspaceLaunchpadExists = navigation.directories.some(
+      (directory) => directory.kind === "workspace",
+    );
+    if (
+      onboarding?.completed.value !== true
+      || onboarding?.completedSource?.value !== "wizard"
+      || onboardingOpen !== null
+      || !navigation.loaded
+      || workspaceLaunchpadExists
+      || postOnboardingWorkspaceOpenStartedRef.current
+    ) {
+      return;
+    }
+
+    // The wizard's real profile may be this window or a freshly spawned one.
+    // Its first directory-less launchpad is therefore the durable signal that
+    // the post-wizard landing has not happened yet. Opening it persists that
+    // launchpad, so later app launches keep the operator's normal selection.
+    postOnboardingWorkspaceOpenStartedRef.current = true;
+    setMainView("thread");
+    void openWorkspaceLaunchpad();
+  }, [
+    navigation.directories,
+    navigation.loaded,
+    onboardingOpen,
+    openWorkspaceLaunchpad,
+    settings.snapshot?.onboarding,
   ]);
   const loadThreadDetail = threadViewReady && mainView === "thread";
   const session = useThreadSessionState({

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -2631,6 +2631,105 @@ describe("App", () => {
     expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves replay fixture navigation instead of opening the startup composer", async () => {
+    const ensureDirectoryLaunchpad = vi.fn();
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        replayFixtureActive: true,
+        readSettings: async () => ({
+          snapshot: {
+            general: {
+              appearance: {
+                theme: { value: "system", source: "default" },
+                density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
+                transcriptTextSize: { value: "md", source: "default" },
+              },
+            },
+            onboarding: {
+              completed: { value: true, source: "config" },
+              completedSource: { value: "migrated", source: "default" },
+            },
+            imageUploads: {
+              pastedImageMaxPatches: { value: 1536, source: "default" },
+            },
+            experimental: {
+              fullAccessRiskWarningDismissed: {
+                value: false,
+                source: "default",
+              },
+            },
+          } as DesktopSettingsSnapshot,
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex" as const,
+              source: "codex" as const,
+              label: "Codex",
+              available: true,
+              methods: ["thread/start", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                renameThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: true,
+                transcriptPagination: true,
+                toolUse: true,
+                approvalRequests: true,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [],
+            },
+          ],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:thread-replay"],
+          threads: [
+            {
+              id: "thread-replay",
+              title: "Existing replay thread",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread" as const,
+              },
+              updatedAt: 1,
+            },
+          ],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        ensureDirectoryLaunchpad,
+        onAgentEvent: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("button", { name: "Existing replay thread" }),
+    ).toBeInTheDocument();
+    await flushReactUpdates();
+    expect(screen.queryByRole("textbox", { name: "New thread" })).not.toBeInTheDocument();
+    expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
+  });
+
   it("reopens onboarding on startup when no backend can create a thread", async () => {
     const ensureDirectoryLaunchpad = vi.fn();
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -2511,6 +2511,90 @@ describe("App", () => {
     });
   });
 
+  it("opens a directory-less composer after the wizard completes", async () => {
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "workspace:new-thread",
+        directoryKind: "workspace" as const,
+        directoryLabel: "Workspaces",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        workMode: "local" as const,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        readSettings: async () => ({
+          snapshot: {
+            general: {
+              appearance: {
+                theme: { value: "system", source: "default" },
+                density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
+                transcriptTextSize: { value: "md", source: "default" },
+              },
+            },
+            onboarding: {
+              completed: { value: true, source: "config" },
+              completedSource: { value: "wizard", source: "config" },
+            },
+            imageUploads: {
+              pastedImageMaxPatches: { value: 1536, source: "default" },
+            },
+            experimental: {
+              fullAccessRiskWarningDismissed: {
+                value: false,
+                source: "default",
+              },
+            },
+          } as DesktopSettingsSnapshot,
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        ensureDirectoryLaunchpad,
+        onAgentEvent: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("textbox", { name: "New thread" }),
+    ).toBeInTheDocument();
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: undefined,
+      preferredBackend: undefined,
+    });
+    await flushReactUpdates();
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+  });
+
   it("routes the new-thread menu push into the existing launchpad flow", async () => {
     let openNewThreadListener: (() => void) | undefined;
     const ensureDirectoryLaunchpad = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -2511,13 +2511,13 @@ describe("App", () => {
     });
   });
 
-  it("opens a directory-less composer after the wizard completes", async () => {
+  it("opens a directory-less composer on startup with a usable ACP backend", async () => {
     const ensureDirectoryLaunchpad = vi.fn(async () => ({
       launchpad: {
         directoryKey: "workspace:new-thread",
         directoryKind: "workspace" as const,
         directoryLabel: "Workspaces",
-        backend: "codex" as const,
+        backend: "acp:grok" as const,
         executionMode: "default" as const,
         prompt: "",
         workMode: "local" as const,
@@ -2545,7 +2545,7 @@ describe("App", () => {
             },
             onboarding: {
               completed: { value: true, source: "config" },
-              completedSource: { value: "wizard", source: "config" },
+              completedSource: { value: "migrated", source: "default" },
             },
             imageUploads: {
               pastedImageMaxPatches: { value: 1536, source: "default" },
@@ -2557,6 +2557,126 @@ describe("App", () => {
               },
             },
           } as DesktopSettingsSnapshot,
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "acp:grok" as const,
+              source: "acp" as const,
+              label: "Grok",
+              available: true,
+              methods: ["thread/start", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                renameThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: true,
+                transcriptPagination: false,
+                toolUse: true,
+                approvalRequests: true,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [],
+            },
+          ],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:thread-existing"],
+          threads: [
+            {
+              id: "thread-existing",
+              title: "Existing thread",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread" as const,
+              },
+              updatedAt: 1,
+            },
+          ],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        ensureDirectoryLaunchpad,
+        onAgentEvent: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("textbox", { name: "New thread" }),
+    ).toBeInTheDocument();
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: undefined,
+      preferredBackend: "acp:grok",
+    });
+    await flushReactUpdates();
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+  });
+
+  it("reopens onboarding on startup when no backend can create a thread", async () => {
+    const ensureDirectoryLaunchpad = vi.fn();
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        readSettings: async () => ({
+          snapshot: {
+            general: {
+              appearance: {
+                theme: { value: "system", source: "default" },
+                density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
+                transcriptTextSize: { value: "md", source: "default" },
+              },
+              codexProfileModel: { value: "shared", source: "default" },
+            },
+            onboarding: {
+              completed: { value: true, source: "config" },
+              completedSource: { value: "migrated", source: "default" },
+            },
+            imageUploads: {
+              pastedImageMaxPatches: { value: 1536, source: "default" },
+            },
+            models: {
+              codex: {
+                path: { value: "", source: "default" },
+                profile: { value: "", source: "default" },
+                discovery: {
+                  selectedCommand: undefined,
+                  candidates: [],
+                },
+                profiles: {
+                  profileRoot: "/home/example/.codex/profiles",
+                  effectiveCodexHome: "/home/example/.codex",
+                  profiles: [],
+                },
+              },
+            },
+            experimental: {
+              fullAccessRiskWarningDismissed: {
+                value: false,
+                source: "default",
+              },
+            },
+          } as unknown as DesktopSettingsSnapshot,
         }),
         listBackends: async () => ({
           fetchedAt: Date.now(),
@@ -2582,17 +2702,9 @@ describe("App", () => {
     render(<App />);
 
     expect(
-      await screen.findByRole("textbox", { name: "New thread" }),
+      await screen.findByRole("heading", { name: /A few short choices/i }),
     ).toBeInTheDocument();
-    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
-      directoryKey: "workspace:new-thread",
-      directoryKind: "workspace",
-      directoryLabel: "Workspaces",
-      directoryPath: undefined,
-      preferredBackend: undefined,
-    });
-    await flushReactUpdates();
-    expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+    expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
   });
 
   it("routes the new-thread menu push into the existing launchpad flow", async () => {
@@ -2642,10 +2754,9 @@ describe("App", () => {
             },
           } as DesktopSettingsSnapshot,
         }),
-        listBackends: async () => ({
-          fetchedAt: Date.now(),
-          backends: [],
-        }),
+        listBackends: async () => {
+          throw new Error("Backend discovery is temporarily unavailable.");
+        },
         getNavigationSnapshot: async () => ({
           backend: "all" as const,
           fetchedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -8,6 +8,29 @@ import {
 } from "../useBackendSummaries";
 
 describe("useBackendSummaries", () => {
+  it("distinguishes pending discovery from a completed empty result", async () => {
+    let resolveBackends!: (value: {
+      fetchedAt: number;
+      backends: [];
+    }) => void;
+    const listBackends = vi.fn<NonNullable<DesktopApi["listBackends"]>>(
+      async () => await new Promise((resolve) => {
+        resolveBackends = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useBackendSummaries({ listBackends }));
+
+    expect(result.current.loaded).toBe(false);
+
+    await act(async () => {
+      resolveBackends({ fetchedAt: 1, backends: [] });
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+  });
+
   it("refreshes cached ACP models only when explicitly requested", async () => {
     const listAcpAgents = vi
       .fn<NonNullable<DesktopApi["listAcpAgents"]>>()

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -427,6 +427,7 @@ import type {
 } from "../../../shared/app-metadata";
 
 export type DesktopApi = {
+  replayFixtureActive?: boolean;
   copyText?: (text: string) => Promise<void>;
   copyRichText?: (payload: { text: string; html: string }) => Promise<void>;
   readPwrSnapConnectionStatus?: (

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -6,6 +6,7 @@ import { federationTargetsEqual } from "./federated-thread-events";
 type BackendSummaryData = {
   backends: BackendSummary[];
   error?: string;
+  loaded: boolean;
 };
 
 type BackendSummaryState = BackendSummaryData & {
@@ -27,7 +28,8 @@ export function useBackendSummaries(
   const federationTarget = options.federationTarget;
   const suspended = options.suspended ?? false;
   const [state, setState] = useState<BackendSummaryData>({
-    backends: []
+    backends: [],
+    loaded: false,
   });
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -40,7 +42,8 @@ export function useBackendSummaries(
     if (!enabled) {
       setState({
         backends: [],
-        error: undefined
+        error: undefined,
+        loaded: false,
       });
       return [];
     }
@@ -52,7 +55,8 @@ export function useBackendSummaries(
     if (!desktopApi?.listBackends) {
       setState({
         backends: [],
-        error: undefined
+        error: undefined,
+        loaded: true,
       });
       return [];
     }
@@ -64,7 +68,8 @@ export function useBackendSummaries(
       });
       setState({
         backends: response.backends,
-        error: undefined
+        error: undefined,
+        loaded: true,
       });
       return response.backends;
     } catch (error) {
@@ -76,7 +81,8 @@ export function useBackendSummaries(
       }
       setState({
         backends: [],
-        error: error instanceof Error ? error.message : String(error)
+        error: error instanceof Error ? error.message : String(error),
+        loaded: true,
       });
       return [];
     }


### PR DESCRIPTION
## Summary

- I start each primary-window launch in the directory-less Workspaces composer when a usable Codex or ACP backend is available, even when existing threads are present.
- I select the actual usable startup backend, including ACP-only profiles.
- I reopen onboarding after backend discovery successfully finds no provider capable of creating a thread, while treating discovery errors as transient.
- I expose backend-discovery completion separately from an empty result and cover the startup branches with red-first renderer tests.

## Verification

- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx` (45 passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check origin/main...HEAD`

## Notes

- This removes the consumable workspace-launchpad row as a startup marker, resolving the review finding that materializing a thread could retrigger the old post-onboarding condition.
