### PR TITLE
fix(desktop): route federated sub-agent transcripts

### DIFF
--- a/apps/desktop/src/main/__tests__/subagent-transcript-window.test.ts
+++ b/apps/desktop/src/main/__tests__/subagent-transcript-window.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const windows: Array<{
+    isDestroyed: ReturnType<typeof vi.fn>;
+    loadFile: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    webContents: { id: number };
+  }> = [];
+  const BrowserWindow = vi.fn(function BrowserWindowMock(
+    this: unknown,
+    _options: unknown,
+  ) {
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      loadFile: vi.fn(async () => undefined),
+      on: vi.fn(),
+      webContents: { id: windows.length + 1 },
+    };
+    windows.push(window);
+    return window;
+  });
+  return {
+    applyWindowSecurityHardening: vi.fn(),
+    BrowserWindow,
+    registerWindowChannels: vi.fn(),
+    windows,
+  };
+});
+
+vi.mock("electron", () => ({ BrowserWindow: mocks.BrowserWindow }));
+vi.mock("../log", () => ({
+  getMainLogger: () => ({ debug: vi.fn() }),
+}));
+vi.mock("../window", () => ({
+  applyWindowSecurityHardening: mocks.applyWindowSecurityHardening,
+  getPreloadPath: () => "/preload.js",
+  getRendererEntry: () => ({ kind: "file", value: "/renderer.html" }),
+}));
+vi.mock("../window-channels", () => ({
+  WINDOW_KIND_SUB_AGENT_TRANSCRIPT: "sub-agent-transcript",
+  registerWindowChannels: mocks.registerWindowChannels,
+}));
+vi.mock("../settings/appearance-bootstrap", () => ({
+  readBootstrapAppearance: () => ({ theme: "dark" }),
+  themedWindowAdditionalArguments: () => ["--appearance=dark"],
+}));
+vi.mock("../native-appearance", () => ({
+  themedWindowBackgroundColor: () => "#000000",
+}));
+vi.mock("../auxiliary-window-chrome", () => ({
+  auxiliaryWindowChromeOptions: () => ({ frame: true }),
+  hideAuxiliaryWindowMenuBar: vi.fn(),
+  registerAuxiliaryWindowTitle: vi.fn(),
+  showAndFocusAuxiliaryWindow: vi.fn(),
+  showAuxiliaryWindowWhenReady: vi.fn(),
+}));
+vi.mock("../window-placement", () => ({
+  placementForSourceDisplay: () => ({ x: 10, y: 20 }),
+  positionWindowForSourceDisplay: vi.fn(),
+}));
+
+describe("sub-agent transcript window", () => {
+  beforeEach(() => {
+    mocks.BrowserWindow.mockClear();
+    mocks.windows.length = 0;
+    mocks.applyWindowSecurityHardening.mockClear();
+    mocks.registerWindowChannels.mockClear();
+  });
+
+  it("routes a peer child to its owner without colliding with a local child id", async () => {
+    const { showSubAgentTranscriptWindow } = await import(
+      "../subagent-transcript-window"
+    );
+    showSubAgentTranscriptWindow({
+      backend: "codex",
+      threadId: "child-1",
+      title: "Local child",
+    });
+    showSubAgentTranscriptWindow({
+      backend: "codex",
+      federationTarget: { instanceId: "peer-instance", scope: "remote" },
+      threadId: "child-1",
+      title: "Peer child",
+    });
+
+    expect(mocks.BrowserWindow).toHaveBeenCalledTimes(2);
+    expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
+      "/renderer.html",
+      { hash: "sub-agent/codex/child-1/Local%20child" },
+    );
+    expect(mocks.windows[1]?.loadFile).toHaveBeenCalledWith(
+      "/renderer.html",
+      { hash: "sub-agent/codex/child-1/Peer%20child/peer-instance" },
+    );
+  });
+});

--- a/apps/desktop/src/main/subagent-transcript-window.ts
+++ b/apps/desktop/src/main/subagent-transcript-window.ts
@@ -57,7 +57,10 @@ export function showSubAgentTranscriptWindow(
     throw new Error("Sub-agent transcript requires a thread id.");
   }
   const title = request.title.trim() || "Sub-agent transcript";
-  const windowKey = buildThreadIdentityKey(request.backend, threadId);
+  const ownerKey = request.federationTarget?.scope === "remote"
+    ? request.federationTarget.instanceId
+    : "local";
+  const windowKey = `${ownerKey}:${buildThreadIdentityKey(request.backend, threadId)}`;
   const current = transcriptWindows.get(windowKey);
   if (current && !current.isDestroyed()) {
     positionWindowForSourceDisplay(current, source);
@@ -102,6 +105,9 @@ export function showSubAgentTranscriptWindow(
     encodeURIComponent(request.backend),
     encodeURIComponent(threadId),
     encodeURIComponent(title.slice(0, SUB_AGENT_TRANSCRIPT_HASH_TITLE_MAX_LENGTH)),
+    ...(request.federationTarget?.scope === "remote"
+      ? [encodeURIComponent(request.federationTarget.instanceId)]
+      : []),
   ].join("/");
   const rendererEntry = getRendererEntry();
   if (rendererEntry.kind === "url") {

--- a/apps/desktop/src/renderer/src/features/navigation/NativeSubAgentsDisclosure.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/NativeSubAgentsDisclosure.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { SubAgentsIcon } from "../../icons";
 import { useDesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 
 type NativeSubAgentsDisclosureProps = {
   compact?: boolean;
@@ -85,6 +86,9 @@ export function NativeSubAgentsDisclosure(props: NativeSubAgentsDisclosureProps)
                   }
                   void openSubAgentTranscriptWindow({
                     backend: "codex",
+                    federationTarget:
+                      props.thread.federation?.ref.target
+                      ?? readRendererFederationTarget(),
                     threadId: subAgent.threadId,
                     title: label,
                   });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1137,6 +1137,15 @@ describe("Sidebar", () => {
       ...sharedThread,
       id: "thread-native-parent",
       title: "Coordinate the launch",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "pwr_remote" },
+          threadId: "thread-native-parent",
+        },
+        instanceLabel: "Remote fixture",
+        peerStatus: "connected",
+      },
       codexNativeSubAgents: [
         {
           threadId: "thread-native-worker",
@@ -1203,6 +1212,10 @@ describe("Sidebar", () => {
     );
     expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
       backend: "codex",
+      federationTarget: {
+        scope: "remote",
+        instanceId: "pwr_remote",
+      },
       threadId: "thread-native-worker-child",
       title: "link-checker",
     });

--- a/apps/desktop/src/renderer/src/features/thread-detail/SubAgentTranscriptWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/SubAgentTranscriptWindow.tsx
@@ -4,6 +4,8 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadEntry,
   AppServerThreadMessage,
+  FederationInstanceId,
+  FederationTarget,
 } from "@pwragent/shared";
 import { CloseIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
@@ -15,6 +17,7 @@ const LIVE_TRANSCRIPT_REFRESH_MS = 2_000;
 
 type SubAgentTranscriptTarget = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: string;
   title: string;
 };
@@ -36,7 +39,11 @@ type LoadState = {
 export function SubAgentTranscriptWindow() {
   const desktopApi = useDesktopApi();
   const target = useMemo(() => subAgentTranscriptTargetFromHash(), []);
-  const targetKey = target ? `${target.backend}:${target.threadId}` : undefined;
+  const targetKey = target
+    ? `${target.federationTarget?.scope === "remote"
+      ? target.federationTarget.instanceId
+      : "local"}:${target.backend}:${target.threadId}`
+    : undefined;
   const [state, setState] = useState<LoadState>({
     loading: Boolean(target),
     loadingMore: false,
@@ -68,6 +75,9 @@ export function SubAgentTranscriptWindow() {
       try {
         const response = await reader({
           backend: target.backend,
+          ...(target.federationTarget
+            ? { federationTarget: target.federationTarget }
+            : {}),
           threadId: target.threadId,
           limit: THREAD_HISTORY_PAGE_LIMIT,
           viewOnly: true,
@@ -110,6 +120,9 @@ export function SubAgentTranscriptWindow() {
     try {
       const olderResponse = await reader({
         backend: target.backend,
+        ...(target.federationTarget
+          ? { federationTarget: target.federationTarget }
+          : {}),
         threadId: target.threadId,
         before: cursor,
         limit: THREAD_HISTORY_PAGE_LIMIT,
@@ -206,6 +219,14 @@ export function SubAgentTranscriptWindow() {
             pagination={state.response?.replay.pagination}
             parentThreadId={target?.threadId}
             threadId={targetKey}
+            threadLinkSource={
+              target?.federationTarget?.scope === "remote"
+                ? {
+                    backend: target.backend,
+                    instanceId: target.federationTarget.instanceId,
+                  }
+                : undefined
+            }
             onLoadOlder={loadOlder}
           />
         </main>
@@ -280,7 +301,8 @@ function mergeOlderTranscriptResponse(params: {
 
 function subAgentTranscriptTargetFromHash(): SubAgentTranscriptTarget | undefined {
   const hash = window.location.hash.replace(/^#/, "");
-  const [kind, backendPart, threadIdPart, titlePart] = hash.split("/");
+  const [kind, backendPart, threadIdPart, titlePart, instanceIdPart] =
+    hash.split("/");
   if (
     kind !== "sub-agent" ||
     !backendPart ||
@@ -294,10 +316,25 @@ function subAgentTranscriptTargetFromHash(): SubAgentTranscriptTarget | undefine
     const backend = decodeURIComponent(backendPart);
     const threadId = decodeURIComponent(threadIdPart).trim();
     const title = decodeURIComponent(titlePart).trim();
+    const instanceId = instanceIdPart
+      ? decodeURIComponent(instanceIdPart).trim()
+      : "";
     if (!isAppServerBackendKind(backend) || !threadId || !title) {
       return undefined;
     }
-    return { backend, threadId, title };
+    return {
+      backend,
+      ...(instanceId
+        ? {
+            federationTarget: {
+              scope: "remote" as const,
+              instanceId: instanceId as FederationInstanceId,
+            },
+          }
+        : {}),
+      threadId,
+      title,
+    };
   } catch {
     return undefined;
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -38,6 +38,7 @@ import {
   type IconProps,
 } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import { resolveThreadWorkingStatePath } from "../../lib/thread-working-state-path";
 import { ThreadAutomationsPanel } from "../automations/ThreadAutomationsPanel";
 import { ThreadInfoPanel } from "./context-panels/ThreadInfoPanel";
@@ -751,8 +752,11 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             threadReasoningEffort={props.thread.reasoningEffort}
           />
         );
-      case "tool-calls":
+      case "tool-calls": {
         if (!props.thread) return null;
+        const toolCallsFederationTarget =
+          props.thread.federation?.ref.target
+          ?? readRendererFederationTarget();
         return (
           <ToolCallsPanel
             entries={props.toolCallEntries}
@@ -761,9 +765,18 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             onOpenIncidentExplorer={props.onOpenToolOutputIncidentExplorer}
             onRequestInvocationDetails={props.onRequestToolCallDetails}
             onScrollToTurn={props.onScrollToTurn}
+            threadLinkSource={
+              toolCallsFederationTarget?.scope === "remote"
+                ? {
+                    backend: props.thread.source,
+                    instanceId: toolCallsFederationTarget.instanceId,
+                  }
+                : undefined
+            }
             toolAccounting={props.toolAccounting}
           />
         );
+      }
       case "actions":
         if (!props.thread) return null;
         return (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
@@ -37,7 +37,12 @@ const PREVIEW_CHARACTER_LIMIT = 3_000;
 
 export function TranscriptCommandOutput(props: TranscriptCommandOutputProps) {
   if (props.detail.command?.subAgent) {
-    return <TranscriptSubAgentCall detail={props.detail} />;
+    return (
+      <TranscriptSubAgentCall
+        detail={props.detail}
+        threadLinkSource={props.threadLinkSource}
+      />
+    );
   }
 
   return <GenericTranscriptCommandOutput {...props} />;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -257,6 +257,14 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
               ?? props.message.origin.sourceThread?.backend
               ?? "codex"
             }
+            federationTarget={
+              props.threadLinkSource
+                ? {
+                    scope: "remote",
+                    instanceId: props.threadLinkSource.instanceId,
+                  }
+                : readRendererFederationTarget()
+            }
             parentThreadId={props.parentThreadId}
             subAgent={monitorSubAgent}
             onClose={() => setMonitorDetailsOpen(false)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
@@ -5,9 +5,11 @@ import type {
 } from "@pwragent/shared";
 import { copyText } from "../../lib/copy-text";
 import { useDesktopApi } from "../../lib/desktop-api";
+import type { ThreadLinkSource } from "../../lib/thread-links";
 
 type TranscriptSubAgentCallProps = {
   detail: AppServerThreadActivityDetail;
+  threadLinkSource?: ThreadLinkSource;
 };
 
 /**
@@ -71,6 +73,14 @@ export function TranscriptSubAgentCall(props: TranscriptSubAgentCallProps) {
                   onClick={() => {
                     void openSubAgentTranscriptWindow({
                       backend: call.backend,
+                      ...(props.threadLinkSource
+                        ? {
+                            federationTarget: {
+                              scope: "remote" as const,
+                              instanceId: props.threadLinkSource.instanceId,
+                            },
+                          }
+                        : {}),
                       threadId: agent.threadId,
                       title: agentLabel,
                     });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/SubAgentTranscriptWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/SubAgentTranscriptWindow.test.tsx
@@ -54,4 +54,39 @@ describe("SubAgentTranscriptWindow", () => {
     expect(screen.getByRole("heading", { name: "Bacon" })).toBeInTheDocument();
     expect(screen.getByText("The child transcript is available.")).toBeInTheDocument();
   });
+
+  it("reads a federated native child from the instance that owns it", async () => {
+    const readThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: 123,
+      threadId: "019ea380-6595-7cf0-8519-58dca9762bfb",
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }));
+    (window as Window & { pwragent?: unknown }).pwragent = { readThread };
+    window.location.hash =
+      "#sub-agent/codex/019ea380-6595-7cf0-8519-58dca9762bfb/Epicurus/pwr_remote";
+
+    render(<SubAgentTranscriptWindow />);
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledWith({
+        backend: "codex",
+        federationTarget: {
+          scope: "remote",
+          instanceId: "pwr_remote",
+        },
+        threadId: "019ea380-6595-7cf0-8519-58dca9762bfb",
+        limit: THREAD_HISTORY_PAGE_LIMIT,
+        viewOnly: true,
+      });
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -67,6 +67,10 @@ describe("TranscriptCommandOutput", () => {
     };
     render(
       <TranscriptCommandOutput
+        threadLinkSource={{
+          backend: "codex",
+          instanceId: "pwr_remote",
+        }}
         detail={{
           id: "agent-wait-1",
           kind: "command",
@@ -109,6 +113,10 @@ describe("TranscriptCommandOutput", () => {
 
     expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
       backend: "codex",
+      federationTarget: {
+        scope: "remote",
+        instanceId: "pwr_remote",
+      },
       threadId: "019fb3d1-28e0-7a30-b964-e93d7a1f3435",
       title: "Kieregaard",
     });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import type { AppServerBackendKind, ThreadSubAgentSummary } from "@pwragent/shared";
+import type {
+  AppServerBackendKind,
+  FederationTarget,
+  ThreadSubAgentSummary,
+} from "@pwragent/shared";
 import { CloseIcon } from "../../../icons";
 import { formatBackendLabel } from "../../../lib/backend-label";
 import { copyText } from "../../../lib/copy-text";
@@ -22,6 +26,7 @@ import { isCodexNativeSubAgent, subAgentOriginLabel } from "./subagent-kind";
 
 type SubAgentDetailsModalProps = {
   defaultBackend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   parentThreadId: string;
   pricingDisplayOptions?: PricingDisplayOptions;
   subAgent: ThreadSubAgentSummary;
@@ -197,6 +202,9 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
                 onClick={() => {
                   void openSubAgentTranscriptWindow({
                     backend: subAgent.backend ?? props.defaultBackend,
+                    ...(props.federationTarget
+                      ? { federationTarget: props.federationTarget }
+                      : {}),
                     threadId: transcriptThreadId,
                     title: subAgent.agentName ?? subAgent.task,
                   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -4,6 +4,7 @@ import type {
   ThreadSubAgentSummary,
 } from "@pwragent/shared";
 import { formatBackendLabel } from "../../../lib/backend-label";
+import { readRendererFederationTarget } from "../../../lib/federation-window";
 import { useSubAgents } from "./useSubAgents";
 import {
   formatSubAgentUsageSummary,
@@ -225,6 +226,10 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
       {detailsFor ? (
         <SubAgentDetailsModal
           defaultBackend={props.thread.source}
+          federationTarget={
+            props.thread.federation?.ref.target
+            ?? readRendererFederationTarget()
+          }
           parentThreadId={props.thread.id}
           pricingDisplayOptions={props.pricingDisplayOptions}
           subAgent={detailsFor}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -6,6 +6,7 @@ import type {
   ThreadToolInvocationRecord,
   ThreadToolInvocationSummary,
 } from "@pwragent/shared";
+import type { ThreadLinkSource } from "../../../lib/thread-links";
 import { TranscriptCommandOutput } from "../TranscriptCommandOutput";
 import { detailMatchesInvocationItem } from "../tool-call-details";
 import { formatTokenCount } from "./subagent-format";
@@ -22,6 +23,7 @@ type ToolCallsPanelProps = {
   onOpenIncidentExplorer?: () => void;
   onRequestInvocationDetails?: (invocation: ThreadToolInvocationRecord) => void;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
+  threadLinkSource?: ThreadLinkSource;
   toolAccounting?: ThreadToolAccounting;
 };
 
@@ -180,6 +182,7 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
                       onExpandedInvocationChange={setExpandedInvocation}
                       onRequestInvocationDetails={props.onRequestInvocationDetails}
                       onScrollToTurn={props.onScrollToTurn}
+                      threadLinkSource={props.threadLinkSource}
                       totalCount={summary.invocationCount}
                     />
                   ) : null}
@@ -201,6 +204,7 @@ function ToolInvocationList(props: {
   onExpandedInvocationChange: (invocationId: string | undefined) => void;
   onRequestInvocationDetails?: (invocation: ThreadToolInvocationRecord) => void;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
+  threadLinkSource?: ThreadLinkSource;
   totalCount: number;
 }) {
   if (props.invocations.length === 0) {
@@ -272,7 +276,10 @@ function ToolInvocationList(props: {
               {expanded ? (
                 <div className="tool-call-instance__detail">
                   {transcriptDetail ? (
-                    <TranscriptCommandOutput detail={transcriptDetail} />
+                    <TranscriptCommandOutput
+                      detail={transcriptDetail}
+                      threadLinkSource={props.threadLinkSource}
+                    />
                   ) : (
                     <p
                       className="tool-call-instance__detail-status"

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
@@ -5,7 +5,9 @@ import type { ThreadSubAgentSummary } from "@pwragent/shared";
 import { SubAgentDetailsModal } from "../SubAgentDetailsModal";
 
 afterEach(() => {
+  delete (window as Window & { pwragent?: unknown }).pwragent;
   cleanup();
+  vi.restoreAllMocks();
 });
 
 const LONG_TASK = [
@@ -132,5 +134,37 @@ describe("SubAgentDetailsModal", () => {
     expect(screen.getByText("Failed")).toBeInTheDocument();
     expect(screen.getByText("OpenAI")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.6-luna · medium")).toBeInTheDocument();
+  });
+
+  it("opens a native child transcript on the instance that owns it", () => {
+    const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true as const }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      openSubAgentTranscriptWindow,
+    };
+    render(
+      <SubAgentDetailsModal
+        defaultBackend="codex"
+        federationTarget={{ scope: "remote", instanceId: "pwr_remote" }}
+        parentThreadId="parent-thread"
+        subAgent={{
+          ...subAgent,
+          agentName: "Epicurus",
+          monitorId: "codex-native:monitor-1",
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open transcript" }));
+
+    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
+      backend: "codex",
+      federationTarget: {
+        scope: "remote",
+        instanceId: "pwr_remote",
+      },
+      threadId: "monitor-thread",
+      title: "Epicurus",
+    });
   });
 });

--- a/packages/shared/src/contracts/subagent-transcript.ts
+++ b/packages/shared/src/contracts/subagent-transcript.ts
@@ -1,3 +1,4 @@
+import type { FederationTarget } from "./federation";
 import type { AppServerBackendKind } from "./normalized-app-server";
 
 /**
@@ -10,6 +11,12 @@ import type { AppServerBackendKind } from "./normalized-app-server";
  */
 export type OpenSubAgentTranscriptWindowRequest = {
   backend: AppServerBackendKind;
+  /**
+   * The instance that owns the parent and its native child. Without this, a
+   * federation viewer asks its local backend to read a child loaded only on
+   * the peer that spawned it.
+   */
+  federationTarget?: FederationTarget;
   threadId: string;
   title: string;
 };


### PR DESCRIPTION
## Summary

- I carry the owning Federation target from remote parent threads into every native sub-agent transcript opener.
- I preserve that target in the auxiliary-window route and use it for initial, refresh, pagination, and nested transcript reads.
- I scope transcript windows by owner instance so identical child IDs on local and remote backends cannot collide.
- I added regression coverage for sidebar, transcript, context-panel, auxiliary-window, and direct viewer paths.

## Verification

- I ran 234 focused Vitest tests across the six affected suites.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` with zero errors; the existing 35 warnings remain unchanged.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- The root cause was that the parent thread retained its remote `federationTarget`, but the sub-agent transcript request contained only backend, child thread ID, and title. The auxiliary viewer therefore asked the local Codex App Server to read a child loaded only on the peer and received `thread not loaded`.
