### PR TITLE
fix(desktop): collapse fallback workspace launchpads

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -6950,6 +6950,104 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("rebases a loading fallback launchpad onto the remote workspace without duplicating it", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "owner-mini",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const initialSnapshot = createDeferred<NavigationSnapshot>();
+    const workspaceKey = "workspace:/Users/test/.pwragent/profiles/default/projects";
+    const canonicalSnapshot: NavigationSnapshot = {
+      backend: "all",
+      federationTarget,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [{
+        key: workspaceKey,
+        kind: "workspace",
+        label: "Workspaces",
+        path: "/Users/test/.pwragent/profiles/default/projects",
+        threadKeys: ["codex:scratch-thread"],
+        needsAttentionCount: 1,
+        pinnedRank: "6144",
+      }],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const fallbackLaunchpad: NavigationLaunchpadDraft = {
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: fallbackLaunchpad,
+      defaults: canonicalSnapshot.launchpadDefaults,
+    }));
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockReturnValueOnce(initialSnapshot.promise)
+      .mockResolvedValue(canonicalSnapshot);
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    let create!: Promise<void>;
+    act(() => {
+      create = result.current.createThread(undefined, "default", {
+        forceWorkspace: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+        federationTarget,
+        directoryKey: "workspace:new-thread",
+        directoryKind: "workspace",
+        directoryLabel: "Workspaces",
+        directoryPath: undefined,
+        preferredBackend: undefined,
+      });
+    });
+
+    await act(async () => {
+      initialSnapshot.resolve(canonicalSnapshot);
+      await create;
+    });
+
+    await waitFor(() => {
+      expect(result.current.directories).toHaveLength(1);
+      expect(result.current.directories[0]).toMatchObject({
+        key: workspaceKey,
+        path: "/Users/test/.pwragent/profiles/default/projects",
+        threadKeys: ["codex:scratch-thread"],
+        needsAttentionCount: 1,
+        pinnedRank: "6144",
+        launchpad: {
+          directoryKey: workspaceKey,
+          directoryPath: "/Users/test/.pwragent/profiles/default/projects",
+        },
+      });
+      expect(result.current.selectedItemKey).toBe(`launchpad:${workspaceKey}`);
+      expect(result.current.selectedDirectory?.key).toBe(workspaceKey);
+    });
+  });
+
   it("creates a new thread in the selected thread's project directory", async () => {
     const directoryKey = "directory:/Users/test/PwrAgent";
     const ensureDirectoryLaunchpad = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -6950,7 +6950,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("rebases a loading fallback launchpad onto the remote workspace without duplicating it", async () => {
+  it("rebases a loading fallback launchpad without duplicating it or losing viewer input", async () => {
     const federationTarget = {
       scope: "remote" as const,
       instanceId: "owner-mini",
@@ -6975,6 +6975,19 @@ describe("useThreadNavigation", () => {
         threadKeys: ["codex:scratch-thread"],
         needsAttentionCount: 1,
         pinnedRank: "6144",
+        launchpad: {
+          directoryKey: workspaceKey,
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          directoryPath: "/Users/test/.pwragent/profiles/default/projects",
+          backend: "codex",
+          executionMode: "default",
+          model: "owner-model",
+          prompt: "Owner snapshot draft",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        },
       }],
       launchpadDefaults: {
         backend: "codex",
@@ -6987,7 +7000,8 @@ describe("useThreadNavigation", () => {
       directoryLabel: "Workspaces",
       backend: "codex",
       executionMode: "default",
-      prompt: "",
+      model: "viewer-model",
+      prompt: "Viewer unsent draft",
       workMode: "local",
       createdAt: 1,
       updatedAt: 2,
@@ -7041,6 +7055,8 @@ describe("useThreadNavigation", () => {
         launchpad: {
           directoryKey: workspaceKey,
           directoryPath: "/Users/test/.pwragent/profiles/default/projects",
+          model: "viewer-model",
+          prompt: "Viewer unsent draft",
         },
       });
       expect(result.current.selectedItemKey).toBe(`launchpad:${workspaceKey}`);

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -4773,8 +4773,8 @@ export function useThreadNavigation(
       delete next[ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY];
       const canonicalLaunchpad =
         current[canonicalWorkspace.key]
-        ?? canonicalWorkspace.launchpad
-        ?? fallbackLaunchpad;
+        ?? fallbackLaunchpad
+        ?? canonicalWorkspace.launchpad;
       next[canonicalWorkspace.key] = {
         ...canonicalLaunchpad,
         directoryKey: canonicalWorkspace.key,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -355,9 +355,23 @@ function upsertLaunchpadDirectory(
   },
 ): NavigationSnapshot["directories"] {
   let foundDirectory = false;
-  const existingDirectory = directories.find(
+  const exactDirectory = directories.find(
     (directory) => directory.key === launchpad.directoryKey,
   );
+  // A viewer can open a directory-less draft before its first owner snapshot
+  // arrives. Once the path-backed workspace appears, the temporary
+  // `workspace:new-thread` key is an alias for that row, not another project.
+  const canonicalWorkspaceDirectory =
+    launchpad.directoryKind === "workspace"
+    && launchpad.directoryKey === ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY
+      ? directories.find(
+          (directory) =>
+            directory.kind === "workspace"
+            && directory.key !== ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY
+            && Boolean(directory.path),
+        )
+      : undefined;
+  const existingDirectory = canonicalWorkspaceDirectory ?? exactDirectory;
   const displayLabel = options?.preserveExistingDirectoryAuthority
     && existingDirectory
     ? existingDirectory.label
@@ -382,8 +396,10 @@ function upsertLaunchpadDirectory(
       : launchpad.branchName;
   const normalizedLaunchpad = {
     ...launchpad,
-    ...(options?.preserveExistingDirectoryAuthority && existingDirectory
+    ...((options?.preserveExistingDirectoryAuthority || canonicalWorkspaceDirectory)
+      && existingDirectory
       ? {
+          directoryKey: existingDirectory.key,
           directoryKind: existingDirectory.kind,
           directoryLabel: existingDirectory.label,
           directoryPath: existingDirectory.path,
@@ -401,9 +417,25 @@ function upsertLaunchpadDirectory(
   const inheritedGitStatus = hasGitStatusOverride
     ? options.gitStatus ?? undefined
     : sourceDirectory?.gitStatus;
-  const nextDirectories = directories.map((directory) => {
+  const fallbackWorkspaceDirectory =
+    normalizedLaunchpad.directoryKind === "workspace"
+    && normalizedLaunchpad.directoryKey !== ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY
+      ? directories.find(
+          (directory) =>
+            directory.kind === "workspace"
+            && directory.key === ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY,
+        )
+      : undefined;
+  const nextDirectories = directories.flatMap((directory) => {
+    if (
+      fallbackWorkspaceDirectory
+      && directory.key === fallbackWorkspaceDirectory.key
+    ) {
+      return [];
+    }
+
     if (directory.key !== normalizedLaunchpad.directoryKey) {
-      return directory;
+      return [directory];
     }
 
     foundDirectory = true;
@@ -414,6 +446,22 @@ function upsertLaunchpadDirectory(
       path: normalizedLaunchpad.directoryPath ?? directory.path,
       launchpad: normalizedLaunchpad,
     };
+    if (fallbackWorkspaceDirectory) {
+      next.threadKeys = [
+        ...new Set([
+          ...directory.threadKeys,
+          ...fallbackWorkspaceDirectory.threadKeys,
+        ]),
+      ];
+      next.needsAttentionCount = Math.max(
+        directory.needsAttentionCount,
+        fallbackWorkspaceDirectory.needsAttentionCount,
+      );
+      next.latestUpdatedAt = Math.max(
+        directory.latestUpdatedAt ?? 0,
+        fallbackWorkspaceDirectory.latestUpdatedAt ?? 0,
+      ) || undefined;
+    }
     if (hasGitStatusOverride) {
       if (inheritedGitStatus) {
         next.gitStatus = inheritedGitStatus;
@@ -423,7 +471,7 @@ function upsertLaunchpadDirectory(
     } else if (!directory.gitStatus && inheritedGitStatus) {
       next.gitStatus = inheritedGitStatus;
     }
-    return next;
+    return [next];
   });
 
   return sortNavigationDirectories(
@@ -432,12 +480,14 @@ function upsertLaunchpadDirectory(
       : [
           ...nextDirectories,
           {
+            ...(fallbackWorkspaceDirectory ?? {}),
             key: normalizedLaunchpad.directoryKey,
             kind: normalizedLaunchpad.directoryKind,
             label: displayLabel,
             path: normalizedLaunchpad.directoryPath,
-            threadKeys: [],
-            needsAttentionCount: 0,
+            threadKeys: fallbackWorkspaceDirectory?.threadKeys ?? [],
+            needsAttentionCount:
+              fallbackWorkspaceDirectory?.needsAttentionCount ?? 0,
             ...(inheritedGitStatus
               ? { gitStatus: inheritedGitStatus }
               : {}),
@@ -4698,6 +4748,49 @@ export function useThreadNavigation(
       rendererFederationTarget,
     ]
   );
+
+  useEffect(() => {
+    // Move the renderer-local fallback draft and its selection onto the
+    // authoritative workspace key. Keeping the alias in localLaunchpads would
+    // reintroduce it after every snapshot refresh.
+    const canonicalWorkspace = state.response?.directories.find(
+      (directory) =>
+        directory.kind === "workspace"
+        && directory.key !== ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY
+        && Boolean(directory.path),
+    );
+    if (!canonicalWorkspace) {
+      return;
+    }
+
+    setLocalLaunchpads((current) => {
+      const fallbackLaunchpad = current[ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY];
+      if (!fallbackLaunchpad) {
+        return current;
+      }
+
+      const next = { ...current };
+      delete next[ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY];
+      const canonicalLaunchpad =
+        current[canonicalWorkspace.key]
+        ?? canonicalWorkspace.launchpad
+        ?? fallbackLaunchpad;
+      next[canonicalWorkspace.key] = {
+        ...canonicalLaunchpad,
+        directoryKey: canonicalWorkspace.key,
+        directoryKind: "workspace",
+        directoryLabel: canonicalWorkspace.label,
+        directoryPath: canonicalWorkspace.path,
+      };
+      return next;
+    });
+
+    setSelectedItemKey((current) =>
+      current === buildLaunchpadSelectionKey(ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY)
+        ? buildLaunchpadSelectionKey(canonicalWorkspace.key)
+        : current
+    );
+  }, [state.response?.directories]);
 
   const inboxThreads = threads;
   const recentThreads = useMemo(


### PR DESCRIPTION
## Summary

- I rebase a pathless `workspace:new-thread` launchpad onto the canonical path-backed workspace when the owner snapshot arrives.
- I preserve the canonical workspace path, pinned rank, thread membership, attention count, and selection while removing the duplicate renderer-local alias.
- I added a remote-viewer regression test for opening a directory-less draft while the initial owner snapshot is still loading.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (132 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)

## Notes

- The duplicate was not a second filesystem directory. A remote viewer could optimistically add the fallback launchpad before learning the canonical workspace key, and `localLaunchpads` then reintroduced both rows after each snapshot refresh.
- This change does not modify or migrate profile database state.
