### PR TITLE
fix(desktop): prevent hovered thread rows from resorting

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1361,6 +1361,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       <section
         key={directory.key}
         className="directory-row"
+        data-hover-stable-row="directory"
         onDragOver={
           directoryDragEnabled
             ? (event) => {

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -114,34 +114,66 @@ function hydrateHoverStableSidebarSnapshot(
       thread,
     ]),
   );
+  const frozenDirectoryKeys = new Set(
+    frozen.directories.map((directory) => directory.key),
+  );
+  const frozenThreadKeys = new Set(
+    frozen.threads.map((thread) =>
+      buildThreadIdentityKey(thread.source, thread.id),
+    ),
+  );
 
   return {
-    directories: frozen.directories.map((directory) => {
-      const latestDirectory = latestDirectoriesByKey.get(directory.key);
-      return latestDirectory
-        ? {
-            ...latestDirectory,
-            pinnedRank: directory.pinnedRank,
-            threadKeys: directory.threadKeys,
-          }
-        : directory;
-    }),
-    threads: frozen.threads.map((thread) => {
-      const latestThread = latestThreadsByKey.get(
-        buildThreadIdentityKey(thread.source, thread.id),
-      );
-      return latestThread
-        ? {
-            ...latestThread,
-            createdAt: thread.createdAt,
-            parentThreadBackend: thread.parentThreadBackend,
-            parentThreadId: thread.parentThreadId,
-            parentThreadInstanceId: thread.parentThreadInstanceId,
-            pinnedRank: thread.pinnedRank,
-            subthreadOrder: thread.subthreadOrder,
-          }
-        : thread;
-    }),
+    directories: [
+      ...frozen.directories.map((directory) => {
+        const latestDirectory = latestDirectoriesByKey.get(directory.key);
+        if (!latestDirectory) return directory;
+        const frozenDirectoryThreadKeys = new Set(directory.threadKeys);
+        return {
+          ...latestDirectory,
+          pinnedRank: directory.pinnedRank,
+          threadKeys: [
+            ...directory.threadKeys,
+            ...latestDirectory.threadKeys.filter(
+              (threadKey) => !frozenDirectoryThreadKeys.has(threadKey),
+            ),
+          ],
+        };
+      }),
+      ...latest.directories
+        .filter((directory) => !frozenDirectoryKeys.has(directory.key))
+        .map((directory) => ({ ...directory, pinnedRank: undefined })),
+    ],
+    threads: [
+      ...frozen.threads.map((thread) => {
+        const latestThread = latestThreadsByKey.get(
+          buildThreadIdentityKey(thread.source, thread.id),
+        );
+        return latestThread
+          ? {
+              ...latestThread,
+              createdAt: thread.createdAt,
+              parentThreadBackend: thread.parentThreadBackend,
+              parentThreadId: thread.parentThreadId,
+              parentThreadInstanceId: thread.parentThreadInstanceId,
+              pinnedRank: thread.pinnedRank,
+              subthreadOrder: thread.subthreadOrder,
+            }
+          : thread;
+      }),
+      ...latest.threads
+        .filter((thread) => !frozenThreadKeys.has(
+          buildThreadIdentityKey(thread.source, thread.id),
+        ))
+        .map((thread) => ({
+          ...thread,
+          createdAt: 0,
+          parentThreadBackend: undefined,
+          parentThreadId: undefined,
+          parentThreadInstanceId: undefined,
+          pinnedRank: undefined,
+        })),
+    ],
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -91,6 +91,60 @@ type ThreadContextMenuPosition = {
   anchorTop?: number;
 };
 
+type HoverStableSidebarSnapshot = {
+  directories: NavigationDirectorySummary[];
+  threads: NavigationThreadSummary[];
+};
+
+/**
+ * Refresh row content without accepting structural fields that can move a row
+ * while the pointer is resting on it. Live state such as federation health,
+ * turn status, PRs, and unread markers still reaches the stationary card.
+ */
+function hydrateHoverStableSidebarSnapshot(
+  frozen: HoverStableSidebarSnapshot,
+  latest: HoverStableSidebarSnapshot,
+): HoverStableSidebarSnapshot {
+  const latestDirectoriesByKey = new Map(
+    latest.directories.map((directory) => [directory.key, directory]),
+  );
+  const latestThreadsByKey = new Map(
+    latest.threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread,
+    ]),
+  );
+
+  return {
+    directories: frozen.directories.map((directory) => {
+      const latestDirectory = latestDirectoriesByKey.get(directory.key);
+      return latestDirectory
+        ? {
+            ...latestDirectory,
+            pinnedRank: directory.pinnedRank,
+            threadKeys: directory.threadKeys,
+          }
+        : directory;
+    }),
+    threads: frozen.threads.map((thread) => {
+      const latestThread = latestThreadsByKey.get(
+        buildThreadIdentityKey(thread.source, thread.id),
+      );
+      return latestThread
+        ? {
+            ...latestThread,
+            createdAt: thread.createdAt,
+            parentThreadBackend: thread.parentThreadBackend,
+            parentThreadId: thread.parentThreadId,
+            parentThreadInstanceId: thread.parentThreadInstanceId,
+            pinnedRank: thread.pinnedRank,
+            subthreadOrder: thread.subthreadOrder,
+          }
+        : thread;
+    }),
+  };
+}
+
 type SidebarProps = {
   backends: BackendSummary[];
   browseMode: BrowseMode;
@@ -501,6 +555,7 @@ export function Sidebar(props: SidebarProps) {
           ? props.recentThreads ?? props.threads
           : updatedOrderThreads;
   const hoverStableSnapshot = useHoverStableSnapshot({
+    hydrateFrozenValue: hydrateHoverStableSidebarSnapshot,
     scope: props.browseMode,
     value: {
       directories: props.directories,

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -73,6 +73,7 @@ import {
 import { useAttentionOrderedThreads } from "./attention-order";
 import { DirectoriesList } from "./DirectoriesList";
 import { RecentsList } from "./RecentsList";
+import { useHoverStableSnapshot } from "./useHoverStableSnapshot";
 import {
   formatActiveThreadCount,
   formatLocalActiveThreadCount,
@@ -499,6 +500,16 @@ export function Sidebar(props: SidebarProps) {
         : props.browseMode === "recents"
           ? props.recentThreads ?? props.threads
           : updatedOrderThreads;
+  const hoverStableSnapshot = useHoverStableSnapshot({
+    scope: props.browseMode,
+    value: {
+      directories: props.directories,
+      threads:
+        props.browseMode === "directories" ? props.threads : visibleThreads,
+    },
+  });
+  const renderedDirectories = hoverStableSnapshot.value.directories;
+  const renderedThreads = hoverStableSnapshot.value.threads;
   /**
    * The numbers on the Attention tab. Counted over the very rows the lens
    * renders, not over `props.threads`, so the tab and the list cannot report
@@ -1890,7 +1901,13 @@ export function Sidebar(props: SidebarProps) {
           )}
         </div>
 
-        <div className="sidebar__scroll-region">
+        <div
+          className="sidebar__scroll-region"
+          onPointerCancel={hoverStableSnapshot.onPointerCancel}
+          onPointerLeave={hoverStableSnapshot.onPointerLeave}
+          onPointerOut={hoverStableSnapshot.onPointerOut}
+          onPointerOver={hoverStableSnapshot.onPointerOver}
+        >
           {props.loading ? (
             <p className="sidebar-empty">Loading threads…</p>
           ) : props.error && !props.loaded ? (
@@ -1903,13 +1920,13 @@ export function Sidebar(props: SidebarProps) {
               queuedMessageThreadKeys={props.queuedMessageThreadKeys}
               draftThreadKeys={props.draftThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
-              directories={props.directories}
+              directories={renderedDirectories}
               revealSelectedThreadRequest={directoryRevealRequest}
               selectedItemKey={props.selectedItemKey}
               selectedDirectoryKeys={selectedDirectoryKeys}
               selectedThreadKeys={selectedThreadKeys}
               thinkingThreadKeys={props.thinkingThreadKeys}
-              threads={props.threads}
+              threads={renderedThreads}
               onOpenThreadContextMenu={openThreadContextMenu}
               onOpenLaunchpad={props.onOpenLaunchpad}
               onOpenFederationTargetMenu={
@@ -1947,7 +1964,7 @@ export function Sidebar(props: SidebarProps) {
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : (
-            visibleThreads.length === 0 ? (
+            renderedThreads.length === 0 ? (
               <p className="sidebar-empty">
                 {props.browseMode === "attention"
                   ? "Nothing running, nothing to review."
@@ -1971,7 +1988,7 @@ export function Sidebar(props: SidebarProps) {
                 selectedThreadKey={props.selectedItemKey}
                 selectedThreadKeys={selectedThreadKeys}
                 thinkingThreadKeys={props.thinkingThreadKeys}
-                threads={visibleThreads}
+                threads={renderedThreads}
                 onOpenThreadContextMenu={openThreadContextMenu}
                 onOpenPullRequestContextMenu={openPullRequestContextMenu}
                 onPrefetchPullRequests={props.onPrefetchPullRequests}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -157,6 +157,8 @@ function hydrateHoverStableSidebarSnapshot(
               parentThreadId: thread.parentThreadId,
               parentThreadInstanceId: thread.parentThreadInstanceId,
               pinnedRank: thread.pinnedRank,
+              codexNativeSubAgents: thread.codexNativeSubAgents,
+              subthreadsCollapsed: thread.subthreadsCollapsed,
               subthreadOrder: thread.subthreadOrder,
             }
           : thread;
@@ -1990,6 +1992,7 @@ export function Sidebar(props: SidebarProps) {
 
         <div
           className="sidebar__scroll-region"
+          onClickCapture={hoverStableSnapshot.onClickCapture}
           onPointerCancel={hoverStableSnapshot.onPointerCancel}
           onPointerLeave={hoverStableSnapshot.onPointerLeave}
           onPointerOut={hoverStableSnapshot.onPointerOut}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -257,6 +257,7 @@ export function ThreadRow(props: ThreadRowProps) {
         props.subthreadCount ? " has-subthreads" : ""
       }`}
       draggable={props.draggable}
+      data-hover-stable-row="thread"
       data-thread-pin-key={props.threadPinState ? threadKey : undefined}
       data-thread-pin-state={props.threadPinState}
       role="listitem"

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -287,6 +287,7 @@ export function ThreadRow(props: ThreadRowProps) {
           className={`thread-row__subthread-toggle${
             props.subthreadsCollapsed ? "" : " is-open"
           }`}
+          data-hover-stable-release="subthreads"
           type="button"
           onClick={(event) => {
             event.stopPropagation();

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -67,6 +67,10 @@ function renderSidebar(params: {
   draftThreadKeys?: Record<string, boolean>;
   inboxThreads?: NavigationThreadSummary[];
   onSelectThread?: (thread: NavigationThreadSummary) => void;
+  onSetSubthreadsCollapsed?: (
+    parent: NavigationThreadSummary,
+    collapsed: boolean,
+  ) => Promise<void>;
   recentThreads?: NavigationThreadSummary[];
   selectedItemKey?: string;
   threads: NavigationThreadSummary[];
@@ -86,6 +90,7 @@ function renderSidebar(params: {
       onCreateThread={async () => undefined}
       onOpenLaunchpad={async () => undefined}
       onSelectThread={params.onSelectThread ?? (() => undefined)}
+      onSetSubthreadsCollapsed={params.onSetSubthreadsCollapsed}
     />
   );
 }
@@ -215,6 +220,102 @@ describe("Sidebar hover-stable thread ordering", () => {
       "Alpha thread",
       "Bravo thread",
     ]);
+  });
+
+  it("freezes fields that add or remove subthread rows while hovered", () => {
+    const parent = thread({
+      id: "parent",
+      title: "Parent thread",
+      updatedAt: 3,
+    });
+    const child: NavigationThreadSummary = {
+      ...thread({ id: "child", title: "Child thread", updatedAt: 2 }),
+      parentThreadId: parent.id,
+    };
+    const tail = thread({ id: "tail", title: "Tail thread", updatedAt: 1 });
+    const onSetSubthreadsCollapsed = vi.fn(async () => undefined);
+    const view = render(renderSidebar({
+      browseMode: "inbox",
+      onSetSubthreadsCollapsed,
+      threads: [parent, child, tail],
+    }));
+    const tailRow = screen.getByRole("button", { name: /^Tail thread/ })
+      .closest("[data-hover-stable-row]");
+    if (!(tailRow instanceof HTMLElement)) {
+      throw new Error("Expected the tail thread row");
+    }
+    fireEvent.pointerOver(tailRow, { pointerType: "mouse" });
+
+    const latestParent: NavigationThreadSummary = {
+      ...parent,
+      codexNativeSubAgents: [
+        {
+          threadId: "native-worker",
+          title: "Native worker",
+          depth: 1,
+          agentNickname: "worker",
+          agentRole: "reviewer",
+          threadStatus: "active",
+        },
+      ],
+      subthreadsCollapsed: true,
+    };
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      onSetSubthreadsCollapsed,
+      threads: [latestParent, child, tail],
+    }));
+
+    expect(screen.getByRole("button", { name: "Child thread" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("button", {
+      name: "Collapse sub-threads for Parent thread",
+    })).toBeInTheDocument();
+    expect(screen.queryByText("Sub-agents")).not.toBeInTheDocument();
+
+    leaveThreadBrowser();
+    expect(screen.queryByRole("button", { name: "Child thread" }))
+      .not.toBeInTheDocument();
+    expect(screen.getByRole("button", {
+      name: "Expand sub-threads for Parent thread",
+    })).toBeInTheDocument();
+  });
+
+  it("releases the frozen snapshot for an explicit subthread toggle", () => {
+    const parent = thread({
+      id: "parent",
+      title: "Parent thread",
+      updatedAt: 3,
+    });
+    const child: NavigationThreadSummary = {
+      ...thread({ id: "child", title: "Child thread", updatedAt: 2 }),
+      parentThreadId: parent.id,
+    };
+    const tail = thread({ id: "tail", title: "Tail thread", updatedAt: 1 });
+    const onSetSubthreadsCollapsed = vi.fn(async () => undefined);
+    const view = render(renderSidebar({
+      browseMode: "inbox",
+      onSetSubthreadsCollapsed,
+      threads: [parent, child, tail],
+    }));
+    const collapseButton = screen.getByRole("button", {
+      name: "Collapse sub-threads for Parent thread",
+    });
+    fireEvent.pointerOver(collapseButton, { pointerType: "mouse" });
+    fireEvent.click(collapseButton);
+    expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(parent, true);
+
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      onSetSubthreadsCollapsed,
+      threads: [{ ...parent, subthreadsCollapsed: true }, child, tail],
+    }));
+
+    expect(screen.queryByRole("button", { name: "Child thread" }))
+      .not.toBeInTheDocument();
+    expect(screen.getByRole("button", {
+      name: "Expand sub-threads for Parent thread",
+    })).toBeInTheDocument();
   });
 
   it.each([

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -44,6 +44,12 @@ const bravo = thread({
   title: "Bravo thread",
   updatedAt: 1,
 });
+const charlie = thread({
+  createdAt: 3,
+  id: "charlie",
+  title: "Charlie thread",
+  updatedAt: 3,
+});
 
 const directory: NavigationDirectorySummary = {
   key: "directory:/repo",
@@ -186,6 +192,31 @@ describe("Sidebar hover-stable thread ordering", () => {
     expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
   });
 
+  it("appends newly visible threads until hover ends", () => {
+    const view = render(renderSidebar({
+      browseMode: "inbox",
+      threads: [alpha, bravo],
+    }));
+    hoverFirstThread();
+
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      threads: [charlie, alpha, bravo],
+    }));
+
+    expect(threadTitles()).toEqual([
+      "Alpha thread",
+      "Bravo thread",
+      "Charlie thread",
+    ]);
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual([
+      "Charlie thread",
+      "Alpha thread",
+      "Bravo thread",
+    ]);
+  });
+
   it.each([
     { browseMode: "drafts" as const, label: "Drafts" },
     { browseMode: "recents" as const, label: "Recents" },
@@ -224,15 +255,27 @@ describe("Sidebar hover-stable thread ordering", () => {
     hoverFirstThread();
 
     const pinnedBravo = { ...bravo, pinnedRank: "1024" };
+    const expandedDirectory = {
+      ...directory,
+      threadKeys: ["codex:charlie", ...directory.threadKeys],
+    };
     view.rerender(renderSidebar({
       browseMode: "directories",
-      directories: [directory],
+      directories: [expandedDirectory],
       selectedItemKey: "codex:alpha",
-      threads: [alpha, pinnedBravo],
+      threads: [charlie, alpha, pinnedBravo],
     }));
 
-    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    expect(threadTitles()).toEqual([
+      "Alpha thread",
+      "Bravo thread",
+      "Charlie thread",
+    ]);
     leaveThreadBrowser();
-    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+    expect(threadTitles()).toEqual([
+      "Bravo thread",
+      "Charlie thread",
+      "Alpha thread",
+    ]);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -1,0 +1,216 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { BrowseMode } from "../../../lib/useThreadNavigation";
+import { Sidebar } from "../Sidebar";
+
+function thread(params: {
+  createdAt?: number;
+  id: string;
+  inbox?: NavigationThreadSummary["inbox"];
+  pinnedRank?: string;
+  status?: NavigationThreadSummary["threadStatus"];
+  title: string;
+  updatedAt?: number;
+}): NavigationThreadSummary {
+  return {
+    id: params.id,
+    title: params.title,
+    titleSource: "explicit",
+    source: "codex",
+    executionMode: "default",
+    createdAt: params.createdAt ?? params.updatedAt ?? 1,
+    updatedAt: params.updatedAt ?? 1,
+    inbox: params.inbox ?? { inInbox: true, reason: "new-thread" },
+    linkedDirectories: [],
+    pinnedRank: params.pinnedRank,
+    threadStatus: params.status,
+  };
+}
+
+const alpha = thread({
+  createdAt: 2,
+  id: "alpha",
+  title: "Alpha thread",
+  updatedAt: 2,
+});
+const bravo = thread({
+  createdAt: 1,
+  id: "bravo",
+  title: "Bravo thread",
+  updatedAt: 1,
+});
+
+const directory: NavigationDirectorySummary = {
+  key: "directory:/repo",
+  kind: "directory",
+  label: "Repo",
+  path: "/repo",
+  threadKeys: ["codex:alpha", "codex:bravo"],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 2,
+};
+
+function renderSidebar(params: {
+  browseMode: BrowseMode;
+  directories?: NavigationDirectorySummary[];
+  draftThreadKeys?: Record<string, boolean>;
+  inboxThreads?: NavigationThreadSummary[];
+  onSelectThread?: (thread: NavigationThreadSummary) => void;
+  recentThreads?: NavigationThreadSummary[];
+  selectedItemKey?: string;
+  threads: NavigationThreadSummary[];
+}) {
+  return (
+    <Sidebar
+      backends={[]}
+      browseMode={params.browseMode}
+      directories={params.directories ?? []}
+      draftThreadKeys={params.draftThreadKeys}
+      inboxThreads={params.inboxThreads ?? params.threads}
+      loading={false}
+      recentThreads={params.recentThreads}
+      selectedItemKey={params.selectedItemKey}
+      threads={params.threads}
+      onBrowseModeChange={() => undefined}
+      onCreateThread={async () => undefined}
+      onOpenLaunchpad={async () => undefined}
+      onSelectThread={params.onSelectThread ?? (() => undefined)}
+    />
+  );
+}
+
+function threadTitles(): string[] {
+  const browser = screen.getByRole("region", { name: "Thread browser" });
+  return within(browser)
+    .getAllByRole("listitem")
+    .map((row) => row.querySelector(".thread-row__title")?.textContent ?? "");
+}
+
+function hoverFirstThread(): HTMLElement {
+  const firstRow = screen.getAllByRole("listitem")[0];
+  fireEvent.pointerOver(firstRow, { pointerType: "mouse" });
+  return firstRow;
+}
+
+function leaveThreadBrowser(): void {
+  const scrollRegion = document.querySelector(".sidebar__scroll-region");
+  if (!(scrollRegion instanceof HTMLElement)) {
+    throw new Error("Expected the sidebar scroll region");
+  }
+  fireEvent.pointerLeave(scrollRegion, { pointerType: "mouse" });
+}
+
+describe("Sidebar hover-stable thread ordering", () => {
+  it("keeps an Inbox click aimed at the row that was under the pointer", () => {
+    const onSelectThread = vi.fn<(thread: NavigationThreadSummary) => void>();
+    const initial = [alpha, bravo];
+    const view = render(renderSidebar({
+      browseMode: "inbox",
+      onSelectThread,
+      threads: initial,
+    }));
+    const firstRow = hoverFirstThread();
+
+    const resorted = [bravo, alpha];
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      onSelectThread,
+      threads: resorted,
+    }));
+
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    fireEvent.click(within(firstRow).getByRole("button", { name: /^Alpha thread/ }));
+    expect(onSelectThread).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "alpha" }),
+    );
+
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+  });
+
+  it("defers a legitimate Attention turn-boundary promotion until hover ends", () => {
+    const activeAlpha = { ...alpha, threadStatus: "active" as const };
+    const unreadBravo = {
+      ...bravo,
+      inbox: {
+        inInbox: true,
+        reason: "updated-since-seen" as const,
+        lastSeenUpdatedAt: 0,
+      },
+    };
+    const view = render(renderSidebar({
+      browseMode: "attention",
+      threads: [activeAlpha, unreadBravo],
+    }));
+    hoverFirstThread();
+
+    const startedBravo = {
+      ...unreadBravo,
+      threadStatus: "active" as const,
+      updatedAt: 3,
+    };
+    view.rerender(renderSidebar({
+      browseMode: "attention",
+      threads: [startedBravo, activeAlpha],
+    }));
+
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+  });
+
+  it.each([
+    { browseMode: "drafts" as const, label: "Drafts" },
+    { browseMode: "recents" as const, label: "Recents" },
+  ])("defers a $label resort until hover ends", ({ browseMode }) => {
+    const draftThreadKeys = {
+      "codex:alpha": true,
+      "codex:bravo": true,
+    };
+    const view = render(renderSidebar({
+      browseMode,
+      draftThreadKeys,
+      recentThreads: [alpha, bravo],
+      threads: [alpha, bravo],
+    }));
+    hoverFirstThread();
+
+    view.rerender(renderSidebar({
+      browseMode,
+      draftThreadKeys,
+      recentThreads: [bravo, alpha],
+      threads: [bravo, alpha],
+    }));
+
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+  });
+
+  it("defers a Directories pin promotion until hover ends", () => {
+    const view = render(renderSidebar({
+      browseMode: "directories",
+      directories: [directory],
+      selectedItemKey: "codex:alpha",
+      threads: [alpha, bravo],
+    }));
+    hoverFirstThread();
+
+    const pinnedBravo = { ...bravo, pinnedRank: "1024" };
+    view.rerender(renderSidebar({
+      browseMode: "directories",
+      directories: [directory],
+      selectedItemKey: "codex:alpha",
+      threads: [alpha, pinnedBravo],
+    }));
+
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -116,21 +116,43 @@ describe("Sidebar hover-stable thread ordering", () => {
     }));
     const firstRow = hoverFirstThread();
 
-    const resorted = [bravo, alpha];
+    const offlineAlpha: NavigationThreadSummary = {
+      ...alpha,
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "remote-instance" },
+          threadId: alpha.id,
+        },
+        instanceLabel: "Remote fixture",
+        peerStatus: "disconnected",
+      },
+    };
+    const refreshedBravo = { ...bravo, title: "Bravo thread refreshed" };
+    const resorted = [refreshedBravo, offlineAlpha];
     view.rerender(renderSidebar({
       browseMode: "inbox",
       onSelectThread,
       threads: resorted,
     }));
 
-    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    expect(threadTitles()).toEqual([
+      "Alpha thread",
+      "Bravo thread refreshed",
+    ]);
+    expect(firstRow.querySelector(".thread-row")).toHaveClass(
+      "is-remote-offline",
+    );
     fireEvent.click(within(firstRow).getByRole("button", { name: /^Alpha thread/ }));
     expect(onSelectThread).toHaveBeenCalledWith(
       expect.objectContaining({ id: "alpha" }),
     );
 
     leaveThreadBrowser();
-    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+    expect(threadTitles()).toEqual([
+      "Bravo thread refreshed",
+      "Alpha thread",
+    ]);
   });
 
   it("defers a legitimate Attention turn-boundary promotion until hover ends", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
@@ -1,11 +1,18 @@
 import { useCallback, useReducer, useRef } from "react";
-import type { PointerEventHandler } from "react";
+import type { MouseEventHandler, PointerEventHandler } from "react";
 
 const HOVER_STABLE_ROW_SELECTOR = "[data-hover-stable-row]";
+const HOVER_STABLE_RELEASE_SELECTOR = "[data-hover-stable-release]";
 
 function closestHoverStableRow(target: EventTarget | null): Element | null {
   return target instanceof Element
     ? target.closest(HOVER_STABLE_ROW_SELECTOR)
+    : null;
+}
+
+function closestHoverStableRelease(target: EventTarget | null): Element | null {
+  return target instanceof Element
+    ? target.closest(HOVER_STABLE_RELEASE_SELECTOR)
     : null;
 }
 
@@ -24,6 +31,7 @@ export function useHoverStableSnapshot<T>(params: {
   scope: string;
   value: T;
 }): {
+  onClickCapture: MouseEventHandler<HTMLDivElement>;
   onPointerCancel: PointerEventHandler<HTMLDivElement>;
   onPointerLeave: PointerEventHandler<HTMLDivElement>;
   onPointerOut: PointerEventHandler<HTMLDivElement>;
@@ -78,7 +86,17 @@ export function useHoverStableSnapshot<T>(params: {
     [release],
   );
 
+  const onClickCapture = useCallback<MouseEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (closestHoverStableRelease(event.target)) {
+        release();
+      }
+    },
+    [release],
+  );
+
   return {
+    onClickCapture,
     onPointerCancel: release,
     onPointerLeave: release,
     onPointerOut,

--- a/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
@@ -15,9 +15,12 @@ function closestHoverStableRow(target: EventTarget | null): Element | null {
  * Every lens keeps computing its authoritative order in the parent. This hook
  * only delays when that newest snapshot becomes visible, so an update cannot
  * replace the card under a stationary pointer between pointer-down and click.
- * Leaving the row area reveals the latest snapshot in one render.
+ * A caller can hydrate non-positional fields from the latest value while the
+ * structure is frozen. Leaving the row area reveals the latest snapshot in
+ * one render.
  */
 export function useHoverStableSnapshot<T>(params: {
+  hydrateFrozenValue?: (frozenValue: T, latestValue: T) => T;
   scope: string;
   value: T;
 }): {
@@ -80,6 +83,9 @@ export function useHoverStableSnapshot<T>(params: {
     onPointerLeave: release,
     onPointerOut,
     onPointerOver,
-    value: hoveringRowRef.current ? frozenValueRef.current : params.value,
+    value: hoveringRowRef.current
+      ? params.hydrateFrozenValue?.(frozenValueRef.current, params.value)
+        ?? frozenValueRef.current
+      : params.value,
   };
 }

--- a/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
@@ -1,0 +1,85 @@
+import { useCallback, useReducer, useRef } from "react";
+import type { PointerEventHandler } from "react";
+
+const HOVER_STABLE_ROW_SELECTOR = "[data-hover-stable-row]";
+
+function closestHoverStableRow(target: EventTarget | null): Element | null {
+  return target instanceof Element
+    ? target.closest(HOVER_STABLE_ROW_SELECTOR)
+    : null;
+}
+
+/**
+ * Hold one rendered navigation snapshot while the pointer rests on its rows.
+ *
+ * Every lens keeps computing its authoritative order in the parent. This hook
+ * only delays when that newest snapshot becomes visible, so an update cannot
+ * replace the card under a stationary pointer between pointer-down and click.
+ * Leaving the row area reveals the latest snapshot in one render.
+ */
+export function useHoverStableSnapshot<T>(params: {
+  scope: string;
+  value: T;
+}): {
+  onPointerCancel: PointerEventHandler<HTMLDivElement>;
+  onPointerLeave: PointerEventHandler<HTMLDivElement>;
+  onPointerOut: PointerEventHandler<HTMLDivElement>;
+  onPointerOver: PointerEventHandler<HTMLDivElement>;
+  value: T;
+} {
+  const latestValueRef = useRef(params.value);
+  latestValueRef.current = params.value;
+  const frozenValueRef = useRef(params.value);
+  const hoveringRowRef = useRef(false);
+  const scopeRef = useRef(params.scope);
+  const [, renderLatestValue] = useReducer((revision: number) => revision + 1, 0);
+
+  if (scopeRef.current !== params.scope) {
+    scopeRef.current = params.scope;
+    hoveringRowRef.current = false;
+    frozenValueRef.current = params.value;
+  }
+
+  const release = useCallback(() => {
+    if (!hoveringRowRef.current) return;
+    hoveringRowRef.current = false;
+    renderLatestValue();
+  }, []);
+
+  const onPointerOver = useCallback<PointerEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (
+        event.pointerType === "touch"
+        || !closestHoverStableRow(event.target)
+        || hoveringRowRef.current
+      ) {
+        return;
+      }
+      frozenValueRef.current = latestValueRef.current;
+      hoveringRowRef.current = true;
+    },
+    [],
+  );
+
+  const onPointerOut = useCallback<PointerEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (!hoveringRowRef.current || !closestHoverStableRow(event.target)) {
+        return;
+      }
+      const nextRow = closestHoverStableRow(event.relatedTarget);
+      if (nextRow && event.currentTarget.contains(nextRow)) {
+        return;
+      }
+      release();
+    },
+    [release],
+  );
+
+  return {
+    onPointerCancel: release,
+    onPointerLeave: release,
+    onPointerOut,
+    onPointerOver,
+    value: hoveringRowRef.current ? frozenValueRef.current : params.value,
+  };
+}


### PR DESCRIPTION
## Summary

- I keep the rendered sidebar navigation snapshot stable while the pointer is over a thread or directory row, then reveal the newest snapshot when the pointer leaves.
- I apply the same event-delegated behavior to Attention, Drafts, Inbox, Recents, and Directories without changing any lens's authoritative sort or Attention's turn-rank reducer.
- I added regression coverage for wrong-target Inbox clicks and deferred Attention, Drafts, Recents, and Directories reordering.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/attention-order.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` (158 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (passes with existing non-blocking warnings outside this change)
- `pnpm lint:boundaries`

## Notes

- I made no CSS or visual styling changes; this is pointer interaction and render-timing behavior only.
