### PR TITLE
fix(desktop): preserve handed-off worktree authority

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10801,7 +10801,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("promotes a handoff overlay after Codex acknowledges the same workspace", async () => {
+  it("retains a handoff overlay after Codex acknowledges the same workspace", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const handoffWorktreePath = "/Users/huntharo/projects/ProjectA/.worktrees/thread-1";
     const worktreeThread: AppServerThreadSummary = {
@@ -10854,13 +10854,107 @@ script = "echo setup"
     ).resolves.toMatchObject({
       extraLinkedDirectories: [
         {
-          id: expectedDir(handoffWorktreePath),
+          id: "pwragent-handoff:codex:thread-1",
           label: "ProjectA",
-          path: expectedDir(projectA),
-          worktreePath: expectedDir(handoffWorktreePath),
+          path: projectA,
+          worktreePath: handoffWorktreePath,
           kind: "worktree",
         },
       ],
+    });
+
+    await registry.close();
+  });
+
+  it("keeps an acknowledged handoff worktree authoritative when native review restores stale local metadata", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const handoffWorktreePath = "/Users/huntharo/.codex/worktrees/thread-1/ProjectA";
+    const handoffDirectory: ThreadOverlayState["extraLinkedDirectories"][number] = {
+      id: "pwragent-handoff:codex:thread-1",
+      label: "ProjectA",
+      path: projectA,
+      worktreePath: handoffWorktreePath,
+      kind: "worktree",
+    };
+    const worktreeThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA worktree",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: handoffWorktreePath,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      linkedDirectories: [
+        {
+          id: projectA,
+          label: "ProjectA",
+          path: projectA,
+          worktreePath: handoffWorktreePath,
+          kind: "worktree",
+        },
+      ],
+    };
+    const localThread: AppServerThreadSummary = {
+      ...worktreeThread,
+      projectKey: projectA,
+      updatedAt: 2_000,
+      linkedDirectories: [
+        {
+          id: projectA,
+          label: "ProjectA",
+          path: projectA,
+          kind: "local",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["review/start"] },
+      threads: [worktreeThread],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [handoffDirectory],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+    });
+
+    expect(codexClient.lastStartReviewParams).toMatchObject({
+      threadId: "thread-1",
+      cwd: handoffWorktreePath,
+    });
+
+    codexClient.setThreads([localThread]);
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+      forceRefresh: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
+        threadId: "thread-1",
+        cwd: handoffWorktreePath,
+      });
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [handoffDirectory],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -804,8 +804,9 @@ type BackendRegistryForkThreadRequest = ForkThreadRequest & {
  *
  * Worktree threads must run from LinkedDirectorySummary.worktreePath; Local
  * threads run from LinkedDirectorySummary.path. A handoff overlay projects the
- * committed workspace change immediately and remains authoritative until Codex
- * reports that same workspace, acknowledging the provider-side synchronization.
+ * committed workspace change immediately. The selected workspace remains
+ * authoritative across provider-side synchronization so a later stale
+ * provider snapshot cannot silently restore the pre-handoff workspace.
  */
 function resolveThreadWorkspaceCwd(
   thread: AppServerThreadSummary | undefined,
@@ -1214,24 +1215,10 @@ function shouldRepairCachedDirectoryRelationship(params: {
   directory: LinkedDirectorySummary;
   overlay: ThreadOverlayState | undefined;
 }): boolean {
-  const handoffDirectory = params.overlay?.extraLinkedDirectories.find(
-    isHandoffDirectory,
-  );
-  if (
-    handoffDirectory
-    && linkedDirectoriesHaveSameWorkspaceIdentity(
-      handoffDirectory,
-      params.directory,
-    )
-  ) {
-    // Matching provider metadata acknowledges the CWD synchronization. Replace
-    // the temporary handoff identity with Codex's normal directory identity.
-    return true;
-  }
-
-  // The handoff overlay is also the durable retry marker. Older PwrAgent
-  // versions can leave one paired with the pre-handoff Codex CWD, so preserve
-  // it until provider metadata explicitly acknowledges the target workspace.
+  // The handoff overlay is both the authoritative workspace selection and the
+  // durable retry marker. Keep it after Codex acknowledges the target: native
+  // review can later restore the thread's original CWD in provider metadata,
+  // and replacing this marker would let that stale snapshot win permanently.
   if (overlayHasHandoffWorkspace(params.overlay)) {
     return false;
   }


### PR DESCRIPTION
## Summary

- I keep PwrAgent's handoff workspace marker authoritative after Codex acknowledges the selected worktree, preventing a later stale provider snapshot from silently restoring the pre-handoff local checkout.
- I added regression coverage for the observed sequence: worktree acknowledgment, native review, then stale local directory metadata.

## Verification

- `PWRAGENT_HOME=/tmp/pwragent-backend-regression-tests pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (535 passed)
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Notes

- The regression came from converting the durable `pwragent-handoff:*` marker into an ordinary cached directory after the first matching Codex snapshot. Native review could later restore the original CWD in provider metadata, which PwrAgent then accepted as authoritative.
- `releases/1.0` does not contain the CWD synchronization or handoff-promotion change that introduced this regression, so this fix does not need a 1.0 backport.
