### PR TITLE
fix(desktop): dismiss tooltips when anchors change

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   type ComponentType,
@@ -10,7 +9,6 @@ import {
   type MouseEvent,
   type PointerEvent,
 } from "react";
-import { createPortal } from "react-dom";
 import type {
   BackendSummary,
   AppServerThreadEntry,
@@ -39,6 +37,7 @@ import {
 } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { resolveThreadWorkingStatePath } from "../../lib/thread-working-state-path";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { ThreadAutomationsPanel } from "../automations/ThreadAutomationsPanel";
 import { ThreadInfoPanel } from "./context-panels/ThreadInfoPanel";
 import { ProviderStatusPanel } from "./context-panels/ProviderStatusPanel";
@@ -164,7 +163,6 @@ const RAIL_MAX_WIDTH = 560;
 
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const railRef = useRef<HTMLElement>(null);
-  const tooltipRef = useRef<HTMLDivElement>(null);
   const [revealed, setRevealed] = useState(false);
   // A modal portaled to document.body is outside the rail in DOM and pointer
   // geometry, but remains part of the same interaction. Keep the panel
@@ -175,14 +173,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   // `--context-rail-effective` custom property. No local copy → no desync.
   const railWidth = props.width ?? 380;
   const [resizing, setResizing] = useState(false);
-  const [tooltip, setTooltip] = useState<{
-    left?: number;
-    text: string;
-    targetBottom: number;
-    targetCenter: number;
-    targetTop: number;
-    top?: number;
-  }>();
+  const railTooltip = useViewportTooltip({ className: "context-rail__tooltip" });
   const pinned = props.pinned;
   const open = pinned || revealed || portaledInteractionOpen;
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -456,34 +447,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     revealed,
   ]);
 
-  useLayoutEffect(() => {
-    if (!tooltip || tooltip.left !== undefined) {
-      return;
-    }
-
-    const tooltipElement = tooltipRef.current;
-    if (!tooltipElement) {
-      return;
-    }
-
-    const tooltipRect = tooltipElement.getBoundingClientRect();
-    const viewportPadding = 12;
-    const left = Math.min(
-      window.innerWidth - tooltipRect.width - viewportPadding,
-      Math.max(viewportPadding, tooltip.targetCenter - tooltipRect.width / 2)
-    );
-    const top =
-      tooltip.targetTop - tooltipRect.height - 10 >= viewportPadding
-        ? tooltip.targetTop - 10
-        : tooltip.targetBottom + tooltipRect.height + 10;
-
-    setTooltip({
-      ...tooltip,
-      left,
-      top,
-    });
-  }, [tooltip]);
-
   const selectTab = (tab: ContextTabId): void => {
     props.onActiveTabChange(tab);
     if (!pinned) {
@@ -621,23 +584,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         </div>
       </div>
 
-      {tooltip && typeof document !== "undefined"
-        ? createPortal(
-            <div
-              ref={tooltipRef}
-              className="context-rail__tooltip"
-              role="tooltip"
-              style={{
-                left: tooltip.left,
-                top: tooltip.top,
-                visibility: tooltip.left === undefined ? "hidden" : undefined,
-              }}
-            >
-              {tooltip.text}
-            </div>,
-            document.body
-          )
-        : null}
+      {railTooltip.tooltipNode}
     </aside>
   );
 
@@ -840,16 +787,13 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     maxLength?: number,
     copyHint = true
   ): void {
-    const rect = event.currentTarget.getBoundingClientRect();
-    setTooltip({
-      text: buildRailTooltipText(path, maxLength, copyHint),
-      targetBottom: rect.bottom,
-      targetCenter: rect.left + rect.width / 2,
-      targetTop: rect.top,
-    });
+    railTooltip.show(
+      event.currentTarget,
+      buildRailTooltipText(path, maxLength, copyHint),
+    );
   }
 
   function hideRailTooltip(): void {
-    setTooltip(undefined);
+    railTooltip.hide();
   }
 }

--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -49,6 +49,7 @@ function DelayedTooltipFixture() {
       <div data-testid="sidebar-scroll-region">
         <button
           type="button"
+          aria-describedby={tooltip.visible ? tooltip.tooltipId : undefined}
           onMouseEnter={(event) =>
             tooltip.showAfterDelay(event.currentTarget, "Branch details")
           }
@@ -57,6 +58,37 @@ function DelayedTooltipFixture() {
           agent/delay-tooltip
         </button>
       </div>
+      {tooltip.tooltipNode}
+    </div>
+  );
+}
+
+function AnchorLifecycleFixture(props: {
+  anchorKey?: string;
+  anchorLabel?: string;
+  anchorTop?: number;
+  showAnchor?: boolean;
+  unrelatedLabel?: string;
+}) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+
+  return (
+    <div>
+      <div data-testid="anchor-layout" data-anchor-top={props.anchorTop ?? 80}>
+        {props.showAnchor === false ? null : (
+          <button
+            key={props.anchorKey ?? "anchor"}
+            type="button"
+            onMouseEnter={(event) =>
+              tooltip.show(event.currentTarget, "Branch details")
+            }
+            onMouseLeave={tooltip.hide}
+          >
+            {props.anchorLabel ?? "agent/lifecycle-tooltip"}
+          </button>
+        )}
+      </div>
+      <div data-testid="unrelated-update">{props.unrelatedLabel ?? "Idle"}</div>
       {tooltip.tooltipNode}
     </div>
   );
@@ -112,6 +144,23 @@ describe("useViewportTooltip", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
+  it("shows a delayed tooltip when its accessibility relationship is added", async () => {
+    vi.useFakeTimers();
+    render(<DelayedTooltipFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    await act(async () => {
+      vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-describedby",
+      screen.getByRole("tooltip").id,
+    );
+  });
+
   it("cancels a pending tooltip when scrolling moves its anchor", () => {
     vi.useFakeTimers();
     render(<DelayedTooltipFixture />);
@@ -119,6 +168,87 @@ describe("useViewportTooltip", () => {
     fireEvent.mouseEnter(screen.getByRole("button"));
     fireEvent.scroll(screen.getByTestId("sidebar-scroll-region"));
     act(() => vi.advanceTimersByTime(TOOLTIP_HOVER_DELAY_MS));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("closes a tooltip when a refresh removes its anchor", async () => {
+    const { rerender } = render(<AnchorLifecycleFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+
+    rerender(<AnchorLifecycleFixture showAnchor={false} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes a tooltip when React replaces its anchor", async () => {
+    const { rerender } = render(<AnchorLifecycleFixture anchorKey="first" />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(<AnchorLifecycleFixture anchorKey="second" />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes a tooltip when its connected anchor moves", async () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getBoundingClientRect(this: HTMLElement) {
+        if (this.getAttribute("role") === "tooltip") {
+          return rectangle({ width: 240, height: 40 });
+        }
+        if (this.tagName === "BUTTON") {
+          const top = Number(
+            this.closest("[data-anchor-top]")?.getAttribute("data-anchor-top"),
+          );
+          return rectangle({ left: 20, top, width: 160, height: 26 });
+        }
+        return rectangle({});
+      },
+    );
+    vi.stubGlobal("innerWidth", 1200);
+    vi.stubGlobal("innerHeight", 800);
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps a tooltip open through unrelated DOM updates", async () => {
+    const { rerender } = render(<AnchorLifecycleFixture unrelatedLabel="Idle" />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(<AnchorLifecycleFixture unrelatedLabel="Streaming" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+  });
+
+  it("closes a tooltip on Escape", () => {
+    render(<AnchorLifecycleFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("closes a tooltip when the operator clicks elsewhere", () => {
+    render(<AnchorLifecycleFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.pointerDown(screen.getByTestId("unrelated-update"));
 
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -7,6 +7,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TOOLTIP_HOVER_DELAY_MS,
@@ -66,11 +67,19 @@ function DelayedTooltipFixture() {
 function AnchorLifecycleFixture(props: {
   anchorKey?: string;
   anchorLabel?: string;
+  anchorStatus?: string;
   anchorTop?: number;
   showAnchor?: boolean;
+  tooltipContent?: string;
   unrelatedLabel?: string;
 }) {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const tooltipContent = props.tooltipContent ?? "Branch details";
+  const updateTooltip = tooltip.update;
+
+  useEffect(() => {
+    updateTooltip(tooltipContent);
+  }, [tooltipContent, updateTooltip]);
 
   return (
     <div>
@@ -78,9 +87,11 @@ function AnchorLifecycleFixture(props: {
         {props.showAnchor === false ? null : (
           <button
             key={props.anchorKey ?? "anchor"}
+            aria-label={`Branch status: ${props.anchorStatus ?? "pending"}`}
+            className={`branch-status--${props.anchorStatus ?? "pending"}`}
             type="button"
             onMouseEnter={(event) =>
-              tooltip.show(event.currentTarget, "Branch details")
+              tooltip.show(event.currentTarget, tooltipContent)
             }
             onMouseLeave={tooltip.hide}
           >
@@ -233,6 +244,31 @@ describe("useViewportTooltip", () => {
     });
 
     expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+  });
+
+  it("keeps a live tooltip open when its anchor attributes and card content update", async () => {
+    const { rerender } = render(
+      <AnchorLifecycleFixture
+        anchorStatus="pending"
+        tooltipContent="Checks pending"
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(
+      <AnchorLifecycleFixture
+        anchorStatus="success"
+        tooltipContent="Checks passed"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Checks passed");
+    });
+    expect(screen.getByRole("button")).toHaveAccessibleName(
+      "Branch status: success",
+    );
+    expect(screen.getByRole("button")).toHaveClass("branch-status--success");
   });
 
   it("closes a tooltip on Escape", () => {

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -102,6 +102,13 @@ type TooltipState = {
   top?: number;
 };
 
+type TooltipTargetRect = {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+};
+
 type DelayedTooltipContent = ReactNode | (() => ReactNode);
 
 /**
@@ -164,6 +171,7 @@ export function useViewportTooltip(options: {
 } {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const targetRef = useRef<HTMLElement | null>(null);
+  const targetRectRef = useRef<TooltipTargetRect | null>(null);
   const hoverDelayTimerRef = useRef<number | null>(null);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
@@ -175,6 +183,31 @@ export function useViewportTooltip(options: {
     }
     window.clearTimeout(hoverDelayTimerRef.current);
     hoverDelayTimerRef.current = null;
+  }, []);
+
+  const hide = useCallback((): void => {
+    clearHoverDelay();
+    setDelayPending(false);
+    targetRef.current = null;
+    targetRectRef.current = null;
+    setState(undefined);
+  }, [clearHoverDelay]);
+
+  const rememberTarget = useCallback((target: HTMLElement): DOMRect | undefined => {
+    if (!target.isConnected) {
+      targetRef.current = null;
+      targetRectRef.current = null;
+      return undefined;
+    }
+    const rect = target.getBoundingClientRect();
+    targetRef.current = target;
+    targetRectRef.current = {
+      bottom: rect.bottom,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+    };
+    return rect;
   }, []);
 
   // Measure the rendered tooltip and clamp position so it stays in the
@@ -231,18 +264,22 @@ export function useViewportTooltip(options: {
     setDelayPending(false);
     if (isNativeDragInteractionActive()) {
       targetRef.current = null;
+      targetRectRef.current = null;
       setState(undefined);
       return;
     }
-    const rect = target.getBoundingClientRect();
-    targetRef.current = target;
+    const rect = rememberTarget(target);
+    if (!rect) {
+      setState(undefined);
+      return;
+    }
     setState({
       content,
       targetTop: rect.top,
       targetBottom: rect.bottom,
       targetCenter: rect.left + rect.width / 2,
     });
-  }, [clearHoverDelay]);
+  }, [clearHoverDelay, rememberTarget]);
 
   const showAfterDelay = useCallback(
     (target: HTMLElement, content: DelayedTooltipContent): void => {
@@ -250,7 +287,11 @@ export function useViewportTooltip(options: {
         return;
       }
       clearHoverDelay();
-      targetRef.current = target;
+      if (!rememberTarget(target)) {
+        setDelayPending(false);
+        setState(undefined);
+        return;
+      }
       setDelayPending(true);
       hoverDelayTimerRef.current = window.setTimeout(() => {
         hoverDelayTimerRef.current = null;
@@ -258,30 +299,23 @@ export function useViewportTooltip(options: {
         show(target, typeof content === "function" ? content() : content);
       }, TOOLTIP_HOVER_DELAY_MS);
     },
-    [clearHoverDelay, show],
+    [clearHoverDelay, rememberTarget, show],
   );
 
   const update = useCallback((content: ReactNode): void => {
     setState((current) => (current ? { ...current, content } : current));
   }, []);
 
-  const hide = useCallback((): void => {
-    clearHoverDelay();
-    setDelayPending(false);
-    targetRef.current = null;
-    setState(undefined);
-  }, [clearHoverDelay]);
-
   useEffect(() => clearHoverDelay, [clearHoverDelay]);
 
-  // A hover tooltip is armed or shown on pointerenter/focus, but those handlers give
-  // us no dismissal signal when the window loses focus (cmd-tab away leaves
-  // the pointer "over" the chip, so no `mouseleave` fires) or when the list
-  // scrolls underneath the position:fixed portal (the tooltip detaches from
-  // its target and lingers). Tear it down when the viewport or an ancestor of
-  // the target scrolls. A captured scroll from an unrelated pane must not
-  // dismiss it — transcript auto-scrolls otherwise close sidebar tooltips.
-  // Keyed on activity so the measure pass doesn't resubscribe each render.
+  // A portal outlives its anchor unless the hook explicitly notices that the
+  // anchor changed. React does not fire `mouseleave` when a refresh removes or
+  // replaces the hovered element, and moving a keyed row can leave the same
+  // DOM element connected at a new position. Watch the document only while a
+  // tooltip is armed or visible, and dismiss when its anchor disappears,
+  // changes identity/content, or moves from its recorded viewport rectangle.
+  // Unrelated mutations are intentionally ignored when the anchor stays put;
+  // transcript streaming must not close a sidebar tooltip.
   const visible = state !== undefined;
   const active = delayPending || visible;
   useEffect(() => {
@@ -302,12 +336,63 @@ export function useViewportTooltip(options: {
         hide();
       }
     };
+    const targetChanged = (records: MutationRecord[]): boolean => {
+      const target = targetRef.current;
+      const rememberedRect = targetRectRef.current;
+      if (!target || !rememberedRect || !target.isConnected) {
+        return true;
+      }
+      if (
+        records.some((record) => {
+          if (
+            record.type === "attributes"
+            && record.target === target
+            && record.attributeName === "aria-describedby"
+          ) {
+            // Consumers add this relationship when `visible` flips to true.
+            // It describes the tooltip; it is not a changed anchor identity.
+            return false;
+          }
+          return record.target === target || target.contains(record.target);
+        })
+      ) {
+        return true;
+      }
+      const currentRect = target.getBoundingClientRect();
+      return currentRect.top !== rememberedRect.top
+        || currentRect.right !== rememberedRect.right
+        || currentRect.bottom !== rememberedRect.bottom
+        || currentRect.left !== rememberedRect.left;
+    };
+    const mutationObserver = new MutationObserver((records) => {
+      if (targetChanged(records)) {
+        hide();
+      }
+    });
+    mutationObserver.observe(document.body, {
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        hide();
+      }
+    };
     window.addEventListener("blur", hide);
+    window.addEventListener("resize", hide);
     window.addEventListener("scroll", onScroll, { capture: true });
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", hide, { capture: true });
     return () => {
       unsubscribeNativeDrag();
+      mutationObserver.disconnect();
       window.removeEventListener("blur", hide);
+      window.removeEventListener("resize", hide);
       window.removeEventListener("scroll", onScroll, { capture: true });
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", hide, { capture: true });
     };
   }, [active, hide]);
 

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -313,7 +313,9 @@ export function useViewportTooltip(options: {
   // replaces the hovered element, and moving a keyed row can leave the same
   // DOM element connected at a new position. Watch the document only while a
   // tooltip is armed or visible, and dismiss when its anchor disappears,
-  // changes identity/content, or moves from its recorded viewport rectangle.
+  // is replaced, or moves from its recorded viewport rectangle. Attribute and
+  // content updates alone are not replacement: live cards update both their
+  // trigger state and tooltip content while they remain open.
   // Unrelated mutations are intentionally ignored when the anchor stays put;
   // transcript streaming must not close a sidebar tooltip.
   const visible = state !== undefined;
@@ -336,26 +338,10 @@ export function useViewportTooltip(options: {
         hide();
       }
     };
-    const targetChanged = (records: MutationRecord[]): boolean => {
+    const targetChanged = (): boolean => {
       const target = targetRef.current;
       const rememberedRect = targetRectRef.current;
       if (!target || !rememberedRect || !target.isConnected) {
-        return true;
-      }
-      if (
-        records.some((record) => {
-          if (
-            record.type === "attributes"
-            && record.target === target
-            && record.attributeName === "aria-describedby"
-          ) {
-            // Consumers add this relationship when `visible` flips to true.
-            // It describes the tooltip; it is not a changed anchor identity.
-            return false;
-          }
-          return record.target === target || target.contains(record.target);
-        })
-      ) {
         return true;
       }
       const currentRect = target.getBoundingClientRect();
@@ -364,8 +350,8 @@ export function useViewportTooltip(options: {
         || currentRect.bottom !== rememberedRect.bottom
         || currentRect.left !== rememberedRect.left;
     };
-    const mutationObserver = new MutationObserver((records) => {
-      if (targetChanged(records)) {
+    const mutationObserver = new MutationObserver(() => {
+      if (targetChanged()) {
         hide();
       }
     });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -19253,7 +19253,6 @@ a.transcript-message__messaging-origin:focus-visible {
   line-height: 1.45;
   pointer-events: none;
   text-align: left;
-  transform: translateY(-100%);
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
## Summary

- I hardened the shared portal-tooltip lifecycle so a tooltip closes when its anchor is removed, replaced, changed, or moved during a live refresh or list reorder.
- I added Escape, outside pointer-down, window resize, scroll, blur, and native-drag dismissal while preserving tooltips through unrelated DOM updates.
- I migrated the context rail's remaining bespoke portal tooltip to the shared hook, leaving one lifecycle implementation for every portal-rendered tooltip.
- I added regressions for removed, replaced, and moved anchors, accessibility updates, unrelated streaming updates, Escape, and outside clicks.

## Verification

- I ran 160 focused renderer tests covering the tooltip hook, PR chip, thread-row chips, and context rail; all passed.
- I ran `pnpm --filter @pwragent/desktop typecheck`; it passed.
- I ran `pnpm lint:boundaries`; it passed with no dependency violations.
- I ran `pnpm lint:eslint`; it completed with zero errors and the repository's existing warnings.

## Notes

- The root cause was that React can remove or move a hovered DOM anchor without emitting `mouseleave`, while its tooltip portal remains mounted under `document.body`.
- Hover-stable thread-list ordering is intentionally scoped to a separate child thread and PR.
