### PR TITLE
fix(desktop): reconcile native sub-agent accounting

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -37680,9 +37680,10 @@ script = "printf setup"
         },
       ],
     });
+    const overlayStore = createOverlayStoreMock({ executionMode: "default" });
     const registry = new DesktopBackendRegistry({
       codexClient,
-      overlayStore: createOverlayStoreMock({ executionMode: "default" }),
+      overlayStore,
     });
 
     const threads = await registry.listThreads({ backend: "codex" });
@@ -37722,6 +37723,184 @@ script = "printf setup"
     ]);
     expect(codexClient.listNativeSubAgentThreadsCallCount).toBe(1);
     expect(codexClient.lastListNativeSubAgentThreadsParams).toEqual({});
+    expect(
+      (
+        await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-parent",
+        })
+      )?.subAgents,
+    ).toEqual([
+      expect.objectContaining({
+        monitorId: "codex-native:thread-worker-b",
+        monitorThreadId: "thread-worker-b",
+        agentName: "release-reviewer",
+        status: "success",
+      }),
+      expect.objectContaining({
+        monitorId: "codex-native:thread-worker-a-child",
+        monitorThreadId: "thread-worker-a-child",
+        agentName: "link-checker",
+        status: "running",
+      }),
+      expect.objectContaining({
+        monitorId: "codex-native:thread-worker-a",
+        monitorThreadId: "thread-worker-a",
+        agentName: "release-writer",
+        status: "success",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("backfills native Codex cards and pricing from durable child turn usage", async () => {
+    const nativeThreadId = "thread-epicurus";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "thread-parent",
+          title: "Investigate the regression",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+          updatedAt: 100,
+        },
+      ],
+      nativeSubAgentThreads: [
+        {
+          id: nativeThreadId,
+          title: "Audit settings discovery calls",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+          createdAt: 20,
+          updatedAt: 40,
+          threadStatus: "idle",
+          codexNativeSubAgent: {
+            parentThreadId: "thread-parent",
+            depth: 1,
+            agentNickname: "Epicurus",
+          },
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock();
+    await overlayStore.upsertThreadUsageLine({
+      line: {
+        usageLineId: "codex:thread-parent:turn-parent:live-token-usage",
+        backend: "codex",
+        provider: "openai",
+        threadId: "thread-parent",
+        turnId: "turn-parent",
+        source: "live",
+        scope: "turn",
+        status: "finalized",
+        createdAt: 25,
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        fastMode: false,
+        settingsSource: "event",
+        settingsConfidence: "exact",
+        inputTokens: 1_000,
+        cachedInputTokens: 800,
+        uncachedInputTokens: 200,
+        outputTokens: 50,
+        reasoningOutputTokens: 10,
+        totalTokens: 1_060,
+        priceStatus: "priced",
+        currency: "USD",
+        uncachedInputCostMicros: 0,
+        cachedInputCostMicros: 0,
+        outputCostMicros: 0,
+        totalCostMicros: 0,
+      },
+    });
+    await overlayStore.persistThreadUsageActivity({
+      backend: "codex",
+      threadId: nativeThreadId,
+      activity: {
+        type: "activity",
+        id: "live-turn-usage-turn-epicurus",
+        createdAt: 35,
+        summary:
+          "Turn usage: 106,640 uncached in · 2,811,136 cached · 11,224 out (4,269 reasoning)",
+        status: "completed",
+        details: [],
+        turn: {
+          id: "turn-epicurus",
+          status: "completed",
+          completedAt: 35,
+        },
+      },
+    });
+    const upsertThreadSubAgent = vi.spyOn(
+      overlayStore,
+      "upsertThreadSubAgent",
+    );
+    const upsertThreadUsageLine = vi.spyOn(
+      overlayStore,
+      "upsertThreadUsageLine",
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+
+    await registry.listThreads({ backend: "codex" });
+    await registry.listThreads({ backend: "codex", forceRefresh: true });
+
+    const parentOverlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(parentOverlay?.subAgents).toHaveLength(1);
+    expect(parentOverlay?.subAgents?.[0]).toMatchObject({
+      monitorId: `codex-native:${nativeThreadId}`,
+      monitorThreadId: nativeThreadId,
+      monitorTurnId: "turn-epicurus",
+      agentName: "Epicurus",
+      task: "Audit settings discovery calls",
+      status: "success",
+      outcome: "success",
+      preferredModel: "gpt-5.6-sol",
+      preferredReasoningEffort: "high",
+      preferredFastMode: false,
+      monitorUsage: {
+        tokenUsage: {
+          cachedInputTokens: 2_811_136,
+          inputTokens: 2_917_776,
+          outputTokens: 11_224,
+          reasoningOutputTokens: 4_269,
+          uncachedInputTokens: 106_640,
+        },
+      },
+    });
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(pricing.lines).toHaveLength(2);
+    const nativePricing = pricing.lines.find(
+      (line) => line.sourceItemId === `codex-native:${nativeThreadId}`,
+    );
+    expect(nativePricing).toMatchObject({
+      parentThreadId: "thread-parent",
+      threadId: nativeThreadId,
+      turnId: "turn-epicurus",
+      source: "monitor",
+      scope: "monitor",
+      status: "finalized",
+      model: "gpt-5.6-sol",
+      cachedInputTokens: 2_811_136,
+      uncachedInputTokens: 106_640,
+      outputTokens: 11_224,
+      reasoningOutputTokens: 4_269,
+    });
+    expect(nativePricing?.totalCostMicros).toBeGreaterThan(0);
+    expect(upsertThreadSubAgent).toHaveBeenCalledTimes(1);
+    expect(upsertThreadUsageLine).toHaveBeenCalledTimes(1);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -37905,6 +37905,116 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("repairs missing native Codex pricing from an existing card usage snapshot", async () => {
+    const nativeThreadId = "thread-epicurus";
+    const monitorId = `codex-native:${nativeThreadId}`;
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "thread-parent",
+          title: "Investigate the regression",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+          updatedAt: 100,
+        },
+      ],
+      nativeSubAgentThreads: [
+        {
+          id: nativeThreadId,
+          title: "Audit settings discovery calls",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+          createdAt: 20,
+          updatedAt: 40,
+          threadStatus: "idle",
+          codexNativeSubAgent: {
+            parentThreadId: "thread-parent",
+            depth: 1,
+            agentNickname: "Epicurus",
+          },
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock();
+    await overlayStore.upsertThreadSubAgent({
+      backend: "codex",
+      threadId: "thread-parent",
+      subAgent: {
+        monitorId,
+        task: "Audit settings discovery calls",
+        status: "success",
+        createdAt: 20,
+        updatedAt: 40,
+        backend: "codex",
+        monitorThreadId: nativeThreadId,
+        monitorTurnId: "turn-epicurus",
+        agentName: "Epicurus",
+        preferredModel: "gpt-5.6-sol",
+        preferredReasoningEffort: "high",
+        preferredFastMode: false,
+        outcome: "success",
+        completedAt: 35,
+        monitorUsage: {
+          model: "gpt-5.6-sol",
+          fastMode: false,
+          summary:
+            "106,640 uncached in · 2,811,136 cached · 11,224 out (4,269 reasoning)",
+          tokenUsage: {
+            cachedInputTokens: 2_811_136,
+            inputTokens: 2_917_776,
+            outputTokens: 11_224,
+            reasoningOutputTokens: 4_269,
+            totalTokens: 2_933_269,
+            uncachedInputTokens: 106_640,
+          },
+        },
+      },
+    });
+    const upsertThreadSubAgent = vi.spyOn(
+      overlayStore,
+      "upsertThreadSubAgent",
+    );
+    const upsertThreadUsageLine = vi.spyOn(
+      overlayStore,
+      "upsertThreadUsageLine",
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+
+    await registry.listThreads({ backend: "codex" });
+    await registry.listThreads({ backend: "codex", forceRefresh: true });
+
+    expect(upsertThreadSubAgent).not.toHaveBeenCalled();
+    expect(upsertThreadUsageLine).toHaveBeenCalledTimes(1);
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      parentThreadId: "thread-parent",
+      threadId: nativeThreadId,
+      turnId: "turn-epicurus",
+      source: "monitor",
+      sourceItemId: monitorId,
+      scope: "monitor",
+      status: "finalized",
+      model: "gpt-5.6-sol",
+      cachedInputTokens: 2_811_136,
+      uncachedInputTokens: 106_640,
+      outputTokens: 11_224,
+      reasoningOutputTokens: 4_269,
+    });
+    expect(pricing.lines[0]?.totalCostMicros).toBeGreaterThan(0);
+
+    await registry.close();
+  });
+
   it("snapshots and removes linked worktrees when archiving a thread", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -90,6 +90,13 @@
     "rowsChanged": 30,
     "statements": 30
   },
+  "native-subagent-discovery-backfill": {
+    "commits": 2,
+    "note": "one missing native child pricing row and parent sub-agent card discovered from the thread list",
+    "observedWalBytes": 82400,
+    "rowsChanged": 4,
+    "statements": 4
+  },
   "runtime-lease-dead-owner-takeover": {
     "commits": 5,
     "note": "observe one dead owner, wait one minute, replace both runtime leases",

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -97,6 +97,13 @@
     "rowsChanged": 4,
     "statements": 4
   },
+  "native-subagent-pricing-repair": {
+    "commits": 1,
+    "note": "one missing native child pricing row repaired from its existing parent sub-agent card",
+    "observedWalBytes": 65920,
+    "rowsChanged": 3,
+    "statements": 3
+  },
   "runtime-lease-dead-owner-takeover": {
     "commits": 5,
     "note": "observe one dead owner, wait one minute, replace both runtime leases",

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type {
   AgentEvent,
   AppServerThreadReplay,
+  AppServerThreadSummary,
   TaskMonitorUsageSnapshot,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
@@ -304,6 +305,85 @@ describe("sqlite write metrics", () => {
     ]);
 
     await registry.close();
+  });
+
+  it("backfills one discovered native sub-agent in two boundary writes", async () => {
+    const nativeThreadId = "thread-epicurus";
+    await store.persistThreadUsageActivity({
+      backend: "codex",
+      threadId: nativeThreadId,
+      activity: {
+        type: "activity",
+        id: "live-turn-usage-turn-epicurus",
+        createdAt: 1_800_000_000_000,
+        summary:
+          "Turn usage: 106,640 uncached in · 2,811,136 cached · 11,224 out (4,269 reasoning)",
+        status: "completed",
+        details: [],
+        turn: {
+          id: "turn-epicurus",
+          status: "completed",
+          completedAt: 1_800_000_000_000,
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient({
+        threads: [
+          {
+            id: "thread-parent",
+            title: "Investigate the regression",
+            titleSource: "explicit",
+            linkedDirectories: [],
+            source: "codex",
+            updatedAt: 1_800_000_000_000,
+            model: "gpt-5.6-sol",
+          },
+        ],
+        nativeSubAgentThreads: [
+          {
+            id: nativeThreadId,
+            title: "Audit settings discovery calls",
+            titleSource: "explicit",
+            linkedDirectories: [],
+            source: "codex",
+            createdAt: 1_799_999_900_000,
+            updatedAt: 1_800_000_000_000,
+            threadStatus: "idle",
+            codexNativeSubAgent: {
+              parentThreadId: "thread-parent",
+              agentNickname: "Epicurus",
+            },
+          },
+        ],
+      }),
+      overlayStore: store as never,
+    });
+
+    try {
+      const { writes } = await measureSqliteWrites(async () => {
+        await registry.listThreads({ backend: "codex" });
+      });
+      expectSqliteWriteBudget({
+        // The repair happens once per native child: one parent pricing row and
+        // one parent overlay card. At 100 repaired children/day, the measured
+        // WAL projects to only a few MB/day and later snapshots write nothing.
+        note:
+          "one missing native child pricing row and parent sub-agent card discovered from the thread list",
+        scenario: "native-subagent-discovery-backfill",
+        writes,
+      });
+
+      const repeated = await measureSqliteWrites(async () => {
+        await registry.listThreads({
+          backend: "codex",
+          forceRefresh: true,
+        });
+      });
+      expect(repeated.writes.commits).toBe(0);
+    } finally {
+      await registry.close();
+    }
   });
 
   it("holds five deferred checks and their first alert to one commit", async () => {
@@ -1753,13 +1833,20 @@ function buildUnpricedGrokUsageLine(index: number): ThreadUsageLineRecord {
   });
 
 function createStubBackendClient(options?: {
+  nativeSubAgentThreads?: AppServerThreadSummary[];
   replay?: AppServerThreadReplay;
+  threads?: AppServerThreadSummary[];
 }) {
   return {
     close: async () => {},
     getInitializeResult: async () => ({
-      methods: options?.replay ? ["thread/read"] : [],
+      methods: [
+        ...(options?.replay ? ["thread/read"] : []),
+        ...(options?.threads ? ["thread/list"] : []),
+      ],
     }),
+    listNativeSubAgentThreads: async () => options?.nativeSubAgentThreads ?? [],
+    listThreads: async () => options?.threads ?? [],
     onNotification: () => () => {},
     onPendingRequest: () => () => {},
     readThread: async () =>

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -386,6 +386,97 @@ describe("sqlite write metrics", () => {
     }
   });
 
+  it("repairs missing native sub-agent pricing in one boundary write", async () => {
+    const nativeThreadId = "thread-epicurus-partial";
+    await store.upsertThreadSubAgent({
+      backend: "codex",
+      threadId: "thread-parent-partial",
+      subAgent: {
+        monitorId: `codex-native:${nativeThreadId}`,
+        task: "Audit partial pricing persistence",
+        status: "success",
+        createdAt: 1_799_999_900_000,
+        updatedAt: 1_800_000_000_000,
+        backend: "codex",
+        monitorThreadId: nativeThreadId,
+        monitorTurnId: "turn-epicurus-partial",
+        agentName: "Epicurus",
+        preferredModel: "gpt-5.6-sol",
+        preferredReasoningEffort: "high",
+        preferredFastMode: false,
+        outcome: "success",
+        completedAt: 1_800_000_000_000,
+        monitorUsage: {
+          model: "gpt-5.6-sol",
+          fastMode: false,
+          summary:
+            "106,640 uncached in · 2,811,136 cached · 11,224 out (4,269 reasoning)",
+          tokenUsage: {
+            cachedInputTokens: 2_811_136,
+            inputTokens: 2_917_776,
+            outputTokens: 11_224,
+            reasoningOutputTokens: 4_269,
+            totalTokens: 2_933_269,
+            uncachedInputTokens: 106_640,
+          },
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient({
+        threads: [
+          {
+            id: "thread-parent-partial",
+            title: "Investigate the partial write",
+            titleSource: "explicit",
+            linkedDirectories: [],
+            source: "codex",
+            updatedAt: 1_800_000_000_000,
+          },
+        ],
+        nativeSubAgentThreads: [
+          {
+            id: nativeThreadId,
+            title: "Audit partial pricing persistence",
+            titleSource: "explicit",
+            linkedDirectories: [],
+            source: "codex",
+            createdAt: 1_799_999_900_000,
+            updatedAt: 1_800_000_000_000,
+            threadStatus: "idle",
+            codexNativeSubAgent: {
+              parentThreadId: "thread-parent-partial",
+              agentNickname: "Epicurus",
+            },
+          },
+        ],
+      }),
+      overlayStore: store as never,
+    });
+
+    try {
+      const { writes } = await measureSqliteWrites(async () => {
+        await registry.listThreads({ backend: "codex" });
+      });
+      expectSqliteWriteBudget({
+        note:
+          "one missing native child pricing row repaired from its existing parent sub-agent card",
+        scenario: "native-subagent-pricing-repair",
+        writes,
+      });
+
+      const repeated = await measureSqliteWrites(async () => {
+        await registry.listThreads({
+          backend: "codex",
+          forceRefresh: true,
+        });
+      });
+      expect(repeated.writes.commits).toBe(0);
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("holds five deferred checks and their first alert to one commit", async () => {
     vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -20312,8 +20312,26 @@ export class DesktopBackendRegistry {
     );
 
     for (const parent of params.parentThreads) {
+      let parentPricingLines: ThreadUsageLineRecord[] = [];
       let parentPricingSettings: ThreadUsageLineRecord | undefined;
-      let parentPricingSettingsLoaded = false;
+      let parentPricingLoaded = false;
+      const readParentPricingLines = async (): Promise<ThreadUsageLineRecord[]> => {
+        if (
+          !parentPricingLoaded
+          && typeof this.overlayStore.readThreadPricing === "function"
+        ) {
+          parentPricingLoaded = true;
+          const pricing = await this.overlayStore.readThreadPricing({
+            backend: "codex",
+            threadId: parent.id,
+          });
+          parentPricingLines = pricing.lines;
+          parentPricingSettings = pricing.lines.find(
+            (line) => line.threadId === parent.id && Boolean(line.model),
+          );
+        }
+        return parentPricingLines;
+      };
       for (const discovered of parent.codexNativeSubAgents ?? []) {
         const nativeThread = nativeThreadsById.get(discovered.threadId);
         if (!nativeThread) {
@@ -20327,6 +20345,8 @@ export class DesktopBackendRegistry {
         let preferredModel =
           nativeThread.model
           ?? existing?.preferredModel
+          ?? existing?.monitorUsage?.model
+          ?? existing?.monitorUsage?.cost?.model
           ?? parent.model;
         let preferredReasoningEffort =
           nativeThread.reasoningEffort
@@ -20335,12 +20355,15 @@ export class DesktopBackendRegistry {
         let preferredFastMode =
           nativeThread.fastMode
           ?? existing?.preferredFastMode
+          ?? existing?.monitorUsage?.fastMode
           ?? parent.fastMode;
-        let serviceTier = nativeThread.serviceTier ?? parent.serviceTier;
+        let serviceTier =
+          nativeThread.serviceTier
+          ?? existing?.monitorUsage?.serviceTier
+          ?? parent.serviceTier;
         const childOverlay = params.overlaysByThreadId[nativeThread.id];
         const hasPersistedTurnUsage = Boolean(
-          !existing?.monitorUsage
-          && childOverlay?.immutableUsageActivities?.some(
+          childOverlay?.immutableUsageActivities?.some(
             (activity) =>
               activity.status === "completed"
               && (
@@ -20359,29 +20382,53 @@ export class DesktopBackendRegistry {
           )
           && typeof this.overlayStore.readThreadPricing === "function"
         ) {
-          if (!parentPricingSettingsLoaded) {
-            parentPricingSettingsLoaded = true;
-            const pricing = await this.overlayStore.readThreadPricing({
-              backend: "codex",
-              threadId: parent.id,
-            });
-            parentPricingSettings = pricing.lines.find(
-              (line) => line.threadId === parent.id && Boolean(line.model),
-            );
-          }
+          await readParentPricingLines();
           preferredModel ??= parentPricingSettings?.model;
           preferredReasoningEffort ??= parentPricingSettings?.reasoningEffort;
           preferredFastMode ??= parentPricingSettings?.fastMode;
           serviceTier ??= parentPricingSettings?.serviceTier;
         }
+        const persistedUsageBackfill = buildPersistedCodexNativeUsageBackfill({
+          fastMode: preferredFastMode,
+          model: preferredModel,
+          overlay: childOverlay,
+          serviceTier,
+        });
         const usageBackfill = existing?.monitorUsage
           ? undefined
-          : buildPersistedCodexNativeUsageBackfill({
+          : persistedUsageBackfill;
+        const monitorTurnId =
+          existing?.monitorTurnId
+          ?? persistedUsageBackfill?.monitorTurnId;
+        const pricingUsage =
+          existing?.monitorUsage
+          ?? persistedUsageBackfill?.usage;
+        const pricingLine = pricingUsage
+          ? buildTaskMonitorUsageLine({
+              backend: "codex",
               fastMode: preferredFastMode,
               model: preferredModel,
-              overlay: childOverlay,
+              monitorId,
+              monitorThreadId: nativeThread.id,
+              monitorTurnId,
+              parentThreadId: parent.id,
+              reasoningEffort: preferredReasoningEffort,
               serviceTier,
-            });
+              source: "monitor",
+              usage: pricingUsage,
+            })
+          : undefined;
+        const needsPricingWrite = pricingLine
+          ? usageBackfill
+            ? true
+            : typeof this.overlayStore.readThreadPricing === "function"
+              && !(await readParentPricingLines()).some(
+                (line) =>
+                  line.sourceItemId === monitorId
+                  && line.threadId === nativeThread.id
+                  && line.scope === "monitor",
+              )
+          : false;
         const discoveredStatus =
           nativeThread.threadStatus === "active"
             ? "running"
@@ -20419,14 +20466,11 @@ export class DesktopBackendRegistry {
             !codexNativeSubAgentIsTerminal(existing.status)
             && status !== existing.status
           );
-        if (!needsCardWrite) {
+        if (!needsCardWrite && !needsPricingWrite) {
           continue;
         }
 
         try {
-          const monitorTurnId =
-            existing?.monitorTurnId
-            ?? usageBackfill?.monitorTurnId;
           const subAgent: ThreadSubAgentSummary = {
             monitorId,
             task:
@@ -20465,33 +20509,23 @@ export class DesktopBackendRegistry {
             ...(usageBackfill ? { monitorUsage: usageBackfill.usage } : {}),
           };
 
-          // Persist pricing first. If the process exits between these two
-          // one-time writes, the still-missing card makes the next discovery
-          // retry the same stable usage-line id instead of stranding pricing.
-          if (usageBackfill && this.overlayStore.upsertThreadUsageLine) {
-            const line = buildTaskMonitorUsageLine({
-              backend: "codex",
-              fastMode: preferredFastMode,
-              model: preferredModel,
-              monitorId,
-              monitorThreadId: nativeThread.id,
-              monitorTurnId,
-              parentThreadId: parent.id,
-              reasoningEffort: preferredReasoningEffort,
-              serviceTier,
-              source: "monitor",
-              usage: usageBackfill.usage,
-            });
-            logUnpricedThreadUsageLine(line);
-            await this.overlayStore.upsertThreadUsageLine({ line });
+          // Pricing and the card are independently repairable. Persist pricing
+          // first for a missing card, while an already-present card can supply
+          // its durable usage snapshot if a prior pricing write failed.
+          if (needsPricingWrite && pricingLine) {
+            logUnpricedThreadUsageLine(pricingLine);
+            await this.overlayStore.upsertThreadUsageLine({ line: pricingLine });
+            parentPricingLines.push(pricingLine);
           }
 
-          params.overlaysByThreadId[parent.id] =
-            await this.overlayStore.upsertThreadSubAgent({
-              backend: "codex",
-              threadId: parent.id,
-              subAgent,
-            });
+          if (needsCardWrite) {
+            params.overlaysByThreadId[parent.id] =
+              await this.overlayStore.upsertThreadSubAgent({
+                backend: "codex",
+                threadId: parent.id,
+                subAgent,
+              });
+          }
           if (!codexNativeSubAgentIsTerminal(status)) {
             this.scheduleCodexNativeSubAgentReconciliation({
               delayMs: CODEX_NATIVE_SUBAGENT_INITIAL_STATUS_DELAY_MS,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3629,6 +3629,128 @@ function buildTaskMonitorUsageSnapshot(params: {
   };
 }
 
+type PersistedCodexNativeUsageBackfill = {
+  completedAt?: number;
+  monitorTurnId?: string;
+  usage: TaskMonitorUsageSnapshot;
+};
+
+function readFormattedTokenCount(
+  value: string,
+  pattern: RegExp,
+): number | undefined {
+  const match = value.match(pattern);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  const parsed = Number(match[1].replaceAll(",", ""));
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Final turn usage is persisted as transcript metadata even when PwrAgent did
+ * not observe the native spawn event that would have created a parent card.
+ * The activity summary is PwrAgent-owned, deterministic copy; reading it here
+ * lets thread-list discovery repair both the card and its parent pricing row.
+ */
+function buildPersistedCodexNativeUsageBackfill(params: {
+  fastMode?: boolean;
+  model?: string;
+  overlay?: ThreadOverlayState;
+  serviceTier?: string;
+}): PersistedCodexNativeUsageBackfill | undefined {
+  const activities = (params.overlay?.immutableUsageActivities ?? []).filter(
+    (activity) =>
+      activity.status === "completed"
+      && (
+        activity.id.startsWith("live-turn-usage-")
+        || activity.summary.startsWith("Turn usage:")
+      ),
+  );
+  if (activities.length === 0) {
+    return undefined;
+  }
+
+  const seenTurnIds = new Set<string>();
+  let cachedInputTokens = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let reasoningOutputTokens = 0;
+  let completedAt: number | undefined;
+  let monitorTurnId: string | undefined;
+  let observed = false;
+
+  for (const activity of activities) {
+    const turnId = activity.turn?.id;
+    if (turnId && seenTurnIds.has(turnId)) {
+      continue;
+    }
+    if (turnId) {
+      seenTurnIds.add(turnId);
+    }
+
+    const line = activity.usageLine;
+    const uncached = line?.uncachedInputTokens ?? readFormattedTokenCount(
+      activity.summary,
+      /([\d,]+)\s+uncached in/i,
+    );
+    const cached = line?.cachedInputTokens ?? readFormattedTokenCount(
+      activity.summary,
+      /([\d,]+)\s+cached/i,
+    );
+    const output = line?.outputTokens ?? readFormattedTokenCount(
+      activity.summary,
+      /([\d,]+)\s+out/i,
+    );
+    const reasoning = line?.reasoningOutputTokens ?? readFormattedTokenCount(
+      activity.summary,
+      /\(([\d,]+)\s+reasoning\)/i,
+    ) ?? 0;
+    if (uncached === undefined || cached === undefined || output === undefined) {
+      continue;
+    }
+
+    observed = true;
+    cachedInputTokens += cached;
+    inputTokens += uncached + cached;
+    outputTokens += output;
+    reasoningOutputTokens += reasoning;
+    const activityCompletedAt = activity.turn?.completedAt ?? activity.createdAt;
+    if (
+      typeof activityCompletedAt === "number"
+      && (completedAt === undefined || activityCompletedAt >= completedAt)
+    ) {
+      completedAt = activityCompletedAt;
+      monitorTurnId = turnId ?? monitorTurnId;
+    }
+  }
+
+  if (!observed) {
+    return undefined;
+  }
+  const usage = buildTaskMonitorUsageSnapshot({
+    fastMode: params.fastMode,
+    model: params.model,
+    serviceTier: params.serviceTier,
+    tokenUsage: {
+      total: {
+        cachedInputTokens,
+        inputTokens,
+        outputTokens,
+        reasoningOutputTokens,
+        totalTokens: inputTokens + outputTokens + reasoningOutputTokens,
+      },
+    },
+  });
+  return usage
+    ? {
+        usage,
+        ...(completedAt !== undefined ? { completedAt } : {}),
+        ...(monitorTurnId ? { monitorTurnId } : {}),
+      }
+    : undefined;
+}
+
 function normalizeTaskMonitorTokenUsage(
   tokenUsage: unknown,
 ): TaskMonitorTokenUsageBreakdown | undefined {
@@ -20070,16 +20192,20 @@ export class DesktopBackendRegistry {
             return [];
           })
         : [];
-    for (const thread of nativeSubAgentThreads) {
-      const parentThreadId = thread.codexNativeSubAgent?.parentThreadId.trim();
-      if (parentThreadId && parentThreadId !== thread.id) {
-        this.codexNativeSubAgentParents.set(thread.id, parentThreadId);
-      }
-    }
-    const allThreads = groupCodexNativeSubAgents({
+    const groupedThreads = groupCodexNativeSubAgents({
       nativeThreads: nativeSubAgentThreads,
       parentThreads: defaultThreads,
-    }).map((thread) => ({
+    });
+    // The sidebar deliberately flattens nested native workers below their
+    // nearest ordinary thread. Keep accounting and the right-rail cards on
+    // that same visible owner instead of writing them to a hidden worker's
+    // overlay.
+    for (const parent of groupedThreads) {
+      for (const subAgent of parent.codexNativeSubAgents ?? []) {
+        this.codexNativeSubAgentParents.set(subAgent.threadId, parent.id);
+      }
+    }
+    const allThreads = groupedThreads.map((thread) => ({
       ...thread,
       executionMode: "default" as const,
     }));
@@ -20091,7 +20217,17 @@ export class DesktopBackendRegistry {
 
     const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
       backend: "codex",
-      threadIds: threadsWithPending.map((thread) => thread.id),
+      threadIds: [
+        ...new Set([
+          ...threadsWithPending.map((thread) => thread.id),
+          ...nativeSubAgentThreads.map((thread) => thread.id),
+        ]),
+      ],
+    });
+    await this.reconcileDiscoveredCodexNativeSubAgents({
+      nativeThreads: nativeSubAgentThreads,
+      overlaysByThreadId,
+      parentThreads: threadsWithPending,
     });
     const visibleThreads = threadsWithPending.filter(
       (thread) => overlaysByThreadId[thread.id]?.archiveTombstonedAt === undefined,
@@ -20161,6 +20297,220 @@ export class DesktopBackendRegistry {
     return filteredThreads.sort(
       (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
     );
+  }
+
+  private async reconcileDiscoveredCodexNativeSubAgents(params: {
+    nativeThreads: AppServerThreadSummary[];
+    overlaysByThreadId: Record<string, ThreadOverlayState | undefined>;
+    parentThreads: AppServerThreadSummary[];
+  }): Promise<void> {
+    if (params.nativeThreads.length === 0) {
+      return;
+    }
+    const nativeThreadsById = new Map(
+      params.nativeThreads.map((thread) => [thread.id, thread]),
+    );
+
+    for (const parent of params.parentThreads) {
+      let parentPricingSettings: ThreadUsageLineRecord | undefined;
+      let parentPricingSettingsLoaded = false;
+      for (const discovered of parent.codexNativeSubAgents ?? []) {
+        const nativeThread = nativeThreadsById.get(discovered.threadId);
+        if (!nativeThread) {
+          continue;
+        }
+        const monitorId = codexNativeSubAgentId(nativeThread.id);
+        const parentOverlay = params.overlaysByThreadId[parent.id];
+        const existing = parentOverlay?.subAgents?.find(
+          (subAgent) => subAgent.monitorId === monitorId,
+        );
+        let preferredModel =
+          nativeThread.model
+          ?? existing?.preferredModel
+          ?? parent.model;
+        let preferredReasoningEffort =
+          nativeThread.reasoningEffort
+          ?? existing?.preferredReasoningEffort
+          ?? parent.reasoningEffort;
+        let preferredFastMode =
+          nativeThread.fastMode
+          ?? existing?.preferredFastMode
+          ?? parent.fastMode;
+        let serviceTier = nativeThread.serviceTier ?? parent.serviceTier;
+        const childOverlay = params.overlaysByThreadId[nativeThread.id];
+        const hasPersistedTurnUsage = Boolean(
+          !existing?.monitorUsage
+          && childOverlay?.immutableUsageActivities?.some(
+            (activity) =>
+              activity.status === "completed"
+              && (
+                activity.id.startsWith("live-turn-usage-")
+                || activity.summary.startsWith("Turn usage:")
+              ),
+          ),
+        );
+        if (
+          hasPersistedTurnUsage
+          && (
+            !preferredModel
+            || !preferredReasoningEffort
+            || preferredFastMode === undefined
+            || !serviceTier
+          )
+          && typeof this.overlayStore.readThreadPricing === "function"
+        ) {
+          if (!parentPricingSettingsLoaded) {
+            parentPricingSettingsLoaded = true;
+            const pricing = await this.overlayStore.readThreadPricing({
+              backend: "codex",
+              threadId: parent.id,
+            });
+            parentPricingSettings = pricing.lines.find(
+              (line) => line.threadId === parent.id && Boolean(line.model),
+            );
+          }
+          preferredModel ??= parentPricingSettings?.model;
+          preferredReasoningEffort ??= parentPricingSettings?.reasoningEffort;
+          preferredFastMode ??= parentPricingSettings?.fastMode;
+          serviceTier ??= parentPricingSettings?.serviceTier;
+        }
+        const usageBackfill = existing?.monitorUsage
+          ? undefined
+          : buildPersistedCodexNativeUsageBackfill({
+              fastMode: preferredFastMode,
+              model: preferredModel,
+              overlay: childOverlay,
+              serviceTier,
+            });
+        const discoveredStatus =
+          nativeThread.threadStatus === "active"
+            ? "running"
+            : nativeThread.threadStatus === "idle" || usageBackfill
+              ? "success"
+              : existing?.status ?? "running";
+        const status =
+          existing && codexNativeSubAgentIsTerminal(existing.status)
+            ? existing.status
+            : discoveredStatus;
+        const agentName =
+          nativeThread.codexNativeSubAgent?.agentNickname
+          ?? existing?.agentName;
+        const completedAt =
+          status === "success"
+            ? existing?.completedAt
+              ?? usageBackfill?.completedAt
+              ?? nativeThread.updatedAt
+              ?? Date.now()
+            : existing?.completedAt;
+        const needsCardWrite =
+          !existing
+          || Boolean(usageBackfill)
+          || Boolean(agentName && !existing.agentName)
+          || Boolean(preferredModel && !existing.preferredModel)
+          || Boolean(
+            preferredReasoningEffort
+            && !existing.preferredReasoningEffort,
+          )
+          || Boolean(
+            preferredFastMode !== undefined
+            && existing.preferredFastMode === undefined,
+          )
+          || (
+            !codexNativeSubAgentIsTerminal(existing.status)
+            && status !== existing.status
+          );
+        if (!needsCardWrite) {
+          continue;
+        }
+
+        try {
+          const monitorTurnId =
+            existing?.monitorTurnId
+            ?? usageBackfill?.monitorTurnId;
+          const subAgent: ThreadSubAgentSummary = {
+            monitorId,
+            task:
+              existing?.task
+              ?? nativeThread.title,
+            status,
+            createdAt:
+              existing?.createdAt
+              ?? nativeThread.createdAt
+              ?? nativeThread.updatedAt
+              ?? Date.now(),
+            updatedAt: Math.max(
+              existing?.updatedAt ?? 0,
+              nativeThread.updatedAt ?? 0,
+              usageBackfill?.completedAt ?? 0,
+              Date.now(),
+            ),
+            ownerRuntimeInstanceId:
+              existing?.ownerRuntimeInstanceId ?? this.runtimeInstanceId,
+            ownerRegistrySessionId:
+              existing?.ownerRegistrySessionId ?? this.registrySessionId,
+            backend: "codex",
+            monitorThreadId: nativeThread.id,
+            lastMessage:
+              existing?.lastMessage
+              ?? (status === "success"
+                ? "Codex native sub-agent completed."
+                : "Discovered from Codex native thread metadata."),
+            ...(agentName ? { agentName } : {}),
+            ...(preferredModel ? { preferredModel } : {}),
+            ...(preferredReasoningEffort ? { preferredReasoningEffort } : {}),
+            ...(preferredFastMode !== undefined ? { preferredFastMode } : {}),
+            ...(monitorTurnId ? { monitorTurnId } : {}),
+            ...(status === "success" ? { outcome: "success" as const } : {}),
+            ...(completedAt !== undefined ? { completedAt } : {}),
+            ...(usageBackfill ? { monitorUsage: usageBackfill.usage } : {}),
+          };
+
+          // Persist pricing first. If the process exits between these two
+          // one-time writes, the still-missing card makes the next discovery
+          // retry the same stable usage-line id instead of stranding pricing.
+          if (usageBackfill && this.overlayStore.upsertThreadUsageLine) {
+            const line = buildTaskMonitorUsageLine({
+              backend: "codex",
+              fastMode: preferredFastMode,
+              model: preferredModel,
+              monitorId,
+              monitorThreadId: nativeThread.id,
+              monitorTurnId,
+              parentThreadId: parent.id,
+              reasoningEffort: preferredReasoningEffort,
+              serviceTier,
+              source: "monitor",
+              usage: usageBackfill.usage,
+            });
+            logUnpricedThreadUsageLine(line);
+            await this.overlayStore.upsertThreadUsageLine({ line });
+          }
+
+          params.overlaysByThreadId[parent.id] =
+            await this.overlayStore.upsertThreadSubAgent({
+              backend: "codex",
+              threadId: parent.id,
+              subAgent,
+            });
+          if (!codexNativeSubAgentIsTerminal(status)) {
+            this.scheduleCodexNativeSubAgentReconciliation({
+              delayMs: CODEX_NATIVE_SUBAGENT_INITIAL_STATUS_DELAY_MS,
+              parentThreadId: parent.id,
+              receiverThreadId: nativeThread.id,
+            });
+          }
+        } catch (error) {
+          backendRegistryLog.warn(
+            "native Codex sub-agent discovery reconciliation failed",
+            {
+              error: error instanceof Error ? error.message : String(error),
+              parentThreadId: parent.id,
+              receiverThreadId: nativeThread.id,
+            },
+          );
+        }
+      }
+    }
   }
 
   private async reconcileCodexDirectoryRelationshipsFromSource(params: {


### PR DESCRIPTION
## Summary

- reconcile native Codex children discovered through thread/list into durable parent sub-agent cards
- restore persisted child turn usage into the parent pricing ledger, with parent runtime settings as a fallback when Codex omits child model metadata
- flatten nested native-child accounting onto the same visible ordinary parent used by the sidebar
- add regression coverage and an exact SQLite write budget

## Root cause

The sidebar discovers native Codex workers directly from thread/list, while the Sub-agents rail and pricing surfaces read persisted ThreadSubAgentSummary records. If PwrAgent missed the original live spawn_agent event, the child remained visible on the left but never entered the card or accounting pipeline.

## Impact

Existing affected native children are repaired on navigation refresh when durable turn usage is available. The repair performs two one-time SQLite commits (pricing + card); later refreshes write nothing.

## Validation

- pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts (565 tests)
- pnpm typecheck
- pnpm lint:eslint
- pnpm lint:boundaries
- git diff --check
