### PR TITLE
fix(desktop): backport directory density and focus styling

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -12,7 +12,7 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
-import { PinIcon, SmileyIcon } from "../../icons";
+import { MoreVerticalIcon, PinIcon, SmileyIcon } from "../../icons";
 import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
@@ -411,7 +411,7 @@ export function ThreadRow(props: ThreadRowProps) {
             });
           }}
         >
-          ...
+          <MoreVerticalIcon size={14} aria-hidden="true" />
         </button>
       </div>
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -111,6 +111,15 @@ describe("ThreadRow chip flow", () => {
     expect(actionChildren[1]).toHaveClass("thread-row__overflow-button");
   });
 
+  it("uses the vertical menu icon for the overflow action", () => {
+    const { container } = renderRow();
+    const overflow = container.querySelector(".thread-row__overflow-button");
+
+    expect(overflow).not.toBeNull();
+    expect(overflow).not.toHaveTextContent("...");
+    expect(overflow?.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+  });
+
   it("uses span[role=button] for the binding chip (not nested <button>)", () => {
     const { container } = renderRow();
     const bindingChip = container.querySelector(".thread-row__chip--binding");

--- a/apps/desktop/src/renderer/src/icons/MoreVerticalIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/MoreVerticalIcon.tsx
@@ -1,0 +1,11 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function MoreVerticalIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <circle cx="12" cy="5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="19" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -18,6 +18,7 @@ export { InfoIcon } from "./InfoIcon";
 export { LightningIcon } from "./LightningIcon";
 export { MattermostIcon } from "./MattermostIcon";
 export { LineIcon } from "./LineIcon";
+export { MoreVerticalIcon } from "./MoreVerticalIcon";
 export { NewThreadIcon } from "./NewThreadIcon";
 export { PinIcon } from "./PinIcon";
 export { PlanIcon } from "./PlanIcon";

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -222,13 +222,36 @@ describe("Tangerine Terminal theme contract", () => {
           + ".thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--pinned .thread-row__heading,\n"
           + ".thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row--pinned .thread-row__heading",
       ),
-    ).toMatch(/padding-right:\s*44px;/);
+    ).toMatch(/padding-right:\s*46px;/);
     expect(extractRuleBody(css, ".thread-row__actions")).toMatch(
-      /right:\s*9px;[\s\S]*gap:\s*4px;/,
+      /right:\s*11px;[\s\S]*gap:\s*4px;/,
+    );
+    expect(extractRuleBody(css, ".thread-row")).toMatch(
+      /padding:\s*4px 10px;/,
     );
     expect(css).toMatch(
       /(?:^|\n)\.thread-row__overflow-button \{[^}]*width:\s*26px;/,
     );
+    expect(extractRuleBody(css, ".directory-row__summary")).toMatch(
+      /min-height:\s*24px;/,
+    );
+  });
+
+  it("keeps the first directory thread focus ring clear of the sticky header", () => {
+    const rowRing = css.match(
+      /\.thread-row:has\(\.thread-row__open:focus\),[\s\S]*?outline:\s*(?<width>\d+)px\s+solid\s+var\(--focus-ring\);[\s\S]*?outline-offset:\s*(?<offset>\d+)px;/,
+    );
+    const directoryDetails = extractRuleBody(css, ".directory-row__details");
+    const ringWidth = Number(rowRing?.groups?.width);
+    const ringOffset = Number(rowRing?.groups?.offset);
+    const detailsTopPadding = Number(
+      directoryDetails.match(/padding:\s*(?<top>\d+)px\s/)?.groups?.top,
+    );
+
+    expect(ringWidth).toBeGreaterThan(0);
+    expect(ringOffset).toBeGreaterThanOrEqual(0);
+    expect(detailsTopPadding).toBeGreaterThan(ringWidth + ringOffset);
+    expect(css).not.toContain("directory-row__pin-drop-boundary");
   });
 
   it("keeps transcript bottom reserve close to the thinking indicator height", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3332,7 +3332,10 @@ textarea,
   position: absolute;
   /* Follow the user-adjustable title's first-line midpoint. */
   top: round(calc(4px + (var(--sidebar-title-size) * 1.25 + 2px) / 2 - 12px), 1px);
-  right: 9px;
+  /* Align the action cluster with the row's 10px content inset plus its
+     1px border. Keeping it 2px inside made its rounded edge read as if it
+     touched the card's 8px corner. */
+  right: 11px;
   z-index: 3;
   display: flex;
   align-items: center;
@@ -3362,9 +3365,9 @@ textarea,
 }
 
 .thread-row__overflow-button {
+  /* Slightly wider than the square add-reaction button, so the vertical
+     menu mark gets the same visual weight as its neighbour. */
   width: 26px;
-  font-size: 13px;
-  font-weight: 700;
 }
 
 .thread-row__actions .thread-row__chip--add-reaction {
@@ -3390,14 +3393,14 @@ textarea,
 
 /* A long pinned title otherwise docks its in-title unpin control under
    the reaction/kebab cluster when that cluster is revealed. Reserve the
-   cluster's 44px title-lane footprint for every reveal path: pointer,
+   cluster's 46px title-lane footprint for every reveal path: pointer,
    keyboard focus, and the open reaction picker. Short titles do not
    reach this boundary, so their layout remains unchanged. */
 .thread-row-shell:hover .thread-row--pinned .thread-row__heading,
 .thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row--pinned .thread-row__heading,
 .thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--pinned .thread-row__heading,
 .thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row--pinned .thread-row__heading {
-  padding-right: 44px;
+  padding-right: 46px;
 }
 
 .thread-row__pin-button:hover,
@@ -4586,7 +4589,10 @@ textarea,
   /* Lateral inset: 4px on the left sits before the disclosure chevron
      and folder icon; 10px on the right gives the meta block (attention
      count pill) breathing room from the selected-row border. */
-  padding: 4px 10px 4px 4px;
+  /* The 24px minimum height still provides the WCAG target floor. Reducing
+     only the block inset closes the remaining blank band between collapsed
+     directory labels without shrinking that target or its selection state. */
+  padding: 2px 10px 2px 4px;
 }
 
 .directory-row__summary:focus,
@@ -4744,7 +4750,11 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px 0 10px 0;
+  /* Match the denser 4px seam below an expanded directory. The 1.0 list has
+     no zero-height pin append target, so keep a 6px top guard: a thread row's
+     2px focus outline at a 2px offset reaches 4px outside the card, leaving
+     2px clear of the sticky directory header. */
+  padding: 6px 0 4px 0;
 }
 
 .directory-row__threads {
@@ -4766,8 +4776,10 @@ textarea,
   background: transparent;
   font-family: inherit;
   cursor: pointer;
-  margin-top: 4px;
-  margin-bottom: 2px;
+  /* The shared divider already contributes 2px above and below. With this
+     branch's ordinary 2px list gap on both sides, that yields symmetric 4px
+     bands around the DIRECTORY THREADS label. A zero-height pin append target
+     would cancel that leading gap; this renderer does not render one. */
 }
 
 .directory-row__thread-divider:hover:not(:disabled) {


### PR DESCRIPTION
## Summary

- backport the applicable directory/thread-list density refinements from [#1669](https://github.com/pwrdrvr/PwrAgent/pull/1669)
- apply the [#1719](https://github.com/pwrdrvr/PwrAgent/pull/1719) focus-outline fix with a release-specific spacing guard
- align the thread-row action cluster and replace its horizontal ellipsis with the standard vertical menu icon

## 1.0 adaptation

`releases/1.0` does not include main's #1429 zero-height pin append target, so it cannot use #1719's `.directory-row__pin-drop-boundary:first-child` selector directly.

This backport keeps the tighter 4px seam beneath expanded directories, retains 6px above their first thread, and locks the resulting 2px clearance beyond the focus ring's 4px outside reach. Its normal 2px list gap also produces symmetric 4px bands around the directory-thread divider without importing main-only append-target or reorder behavior.

The main-only per-directory activity-count arrangement from #1669 is likewise absent from the 1.0 renderer and is intentionally not introduced.

## Migration audit

No database migrations, schema, SQL, SQLite, or persistence files changed.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx` (179 passed)
- `pnpm --filter @pwragent/desktop test:e2e e2e/directory-launchpad-workspace.spec.ts` (14 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 135 existing warnings)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `git diff --check`
