### PR TITLE
fix(desktop): launch remote threads in current window

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -384,13 +384,17 @@ function DesktopAppShell(props: {
   });
   const newThreadFederationTargets = useMemo(
     () =>
-      desktopApi?.openFederationWindow
+      desktopApi?.getNavigationSnapshot && desktopApi?.ensureDirectoryLaunchpad
         ? buildFederationThreadTargets(
             liveFederationHealth,
             readRendererFederationTarget()?.instanceId,
           )
         : [],
-    [desktopApi?.openFederationWindow, liveFederationHealth],
+    [
+      desktopApi?.ensureDirectoryLaunchpad,
+      desktopApi?.getNavigationSnapshot,
+      liveFederationHealth,
+    ],
   );
   useEffect(() => {
     return desktopApi?.onWindowFocus?.(() => {
@@ -1149,11 +1153,16 @@ function DesktopAppShell(props: {
   });
   const selectedThreadFederationTarget =
     navigation.selectedThread?.federation?.ref.target;
+  const selectedLaunchpadFederationTarget =
+    navigation.selectedLaunchpad?.federationTarget;
   const navigationFederationTarget = navigation.federationTarget;
   const remoteApplicationInstanceId =
     selectedThreadFederationTarget
     && isRemoteFederationTarget(selectedThreadFederationTarget)
       ? selectedThreadFederationTarget.instanceId
+      : selectedLaunchpadFederationTarget
+        && isRemoteFederationTarget(selectedLaunchpadFederationTarget)
+        ? selectedLaunchpadFederationTarget.instanceId
       : navigationFederationTarget
         && isRemoteFederationTarget(navigationFederationTarget)
         ? navigationFederationTarget.instanceId
@@ -1250,7 +1259,17 @@ function DesktopAppShell(props: {
     if (mainView === "search") {
       return { view: "search" };
     }
-    if (mainView === "thread" && navigation.selectedLaunchpad) {
+    if (
+      mainView === "thread"
+      && navigation.selectedLaunchpad
+      // This short-lived session owns a peer's directories and cannot be
+      // restored by the local directory-key history entry. Its materialized
+      // thread is tracked normally once it is mounted below.
+      && (
+        !navigation.selectedLaunchpad.federationTarget
+        || !isRemoteFederationTarget(navigation.selectedLaunchpad.federationTarget)
+      )
+    ) {
       return {
         view: "launchpad",
         directoryKey: navigation.selectedLaunchpad.directoryKey,
@@ -1745,20 +1764,11 @@ function DesktopAppShell(props: {
   const createThreadOnFederationTarget = async (
     instanceId: string,
   ): Promise<void> => {
-    try {
-      await desktopApi?.openFederationWindow?.({
-        target: { scope: "remote", instanceId },
-        initialLaunchpad: true,
-      });
-    } catch (error) {
-      showAppNotice({
-        id: `new-thread-federation-target:${instanceId}`,
-        title: "Could not open new thread",
-        message: error instanceof Error ? error.message : String(error),
-        tone: "error",
-        transientSlot: "new-thread-federation-target",
-      });
-    }
+    setMainView("thread");
+    await navigation.openFederatedWorkspaceLaunchpad({
+      scope: "remote",
+      instanceId,
+    });
   };
   const mastheadActions = {
     addingProjectDirectory: navigation.pickingDirectory,
@@ -1891,7 +1901,7 @@ function DesktopAppShell(props: {
     selectedThread: navigation.selectedThread,
     threads: navigation.threads,
     suppressBranchDriftDialog: mainView === "settings",
-    directories: navigation.directories,
+    directories: navigation.launchpadDirectories,
     fullAccessRiskWarningDismissed:
       settings.snapshot?.experimental.fullAccessRiskWarningDismissed.value ?? false,
     backgroundPrPollingEnabled:
@@ -1907,9 +1917,22 @@ function DesktopAppShell(props: {
     pickDirectoryError: navigation.pickDirectoryError,
     pickingDirectory: navigation.pickingDirectory,
     onSelectDirectoryFromPicker: (directory) => {
+      const federationTarget = navigation.selectedLaunchpad?.federationTarget;
+      if (federationTarget && isRemoteFederationTarget(federationTarget)) {
+        void navigation.openFederatedDirectoryLaunchpad(
+          federationTarget,
+          directory,
+        );
+        return;
+      }
       void navigation.openDirectoryLaunchpad(directory);
     },
     onSelectNoDirectoryFromPicker: () => {
+      const federationTarget = navigation.selectedLaunchpad?.federationTarget;
+      if (federationTarget && isRemoteFederationTarget(federationTarget)) {
+        void navigation.openFederatedWorkspaceLaunchpad(federationTarget);
+        return;
+      }
       void navigation.openWorkspaceLaunchpad();
     },
     onPickAndRegisterDirectory: () => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -14,9 +14,10 @@ import type {
   CreateScheduledThreadActionRequest,
   DesktopPwrAgentProfileSummary,
   DesktopSettingsSnapshot,
+  EnsureDirectoryLaunchpadRequest,
   FederationPeerSummary,
+  FederationTarget,
   NavigationSnapshot,
-  OpenFederationWindowRequest,
   StartTurnRequest,
   StartTurnResponse,
 } from "@pwragent/shared";
@@ -320,11 +321,65 @@ describe("App", () => {
 
   it("starts a new thread on a selected federation machine and profile", async () => {
     const federationListeners = new Set<(event: AgentEvent) => void>();
-    const openFederationWindow = vi.fn(async (request: OpenFederationWindowRequest) => ({
-      opened: true,
-      target: request.target,
-      windowId: 7,
-    }));
+    const remoteTarget = { scope: "remote" as const, instanceId: "studio-work" };
+    const remoteWorkspace = {
+      key: "workspace:new-thread",
+      kind: "workspace" as const,
+      label: "Workspaces",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    };
+    const remoteProject = {
+      key: "directory:/Users/harold/src/PwrAgent",
+      kind: "directory" as const,
+      label: "PwrAgent",
+      path: "/Users/harold/src/PwrAgent",
+      threadKeys: [],
+      needsAttentionCount: 0,
+      latestUpdatedAt: 1,
+    };
+    const getNavigationSnapshot = vi.fn(
+      async (request?: { federationTarget?: FederationTarget }) => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [],
+        directories: request?.federationTarget
+          ? [remoteWorkspace, remoteProject]
+          : [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+        ...(request?.federationTarget
+          ? { federationTarget: request.federationTarget }
+          : {}),
+      }),
+    );
+    const ensureDirectoryLaunchpad = vi.fn(
+      async (request: EnsureDirectoryLaunchpadRequest) => ({
+        launchpad: {
+          directoryKey: request.directoryKey,
+          directoryKind: request.directoryKind,
+          directoryLabel: request.directoryLabel,
+          directoryPath: request.directoryPath,
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          prompt: "",
+          workMode: "local" as const,
+          ...(request.federationTarget
+            ? { federationTarget: request.federationTarget }
+            : {}),
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        defaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      }),
+    );
     let peers: FederationPeerSummary[] = [
       {
         id: "studio-work",
@@ -333,7 +388,6 @@ describe("App", () => {
         role: "client" as const,
         status: "connected" as const,
         capabilities: [
-          "remote_window",
           "thread_navigation",
           "environment_actions",
         ] as const,
@@ -360,25 +414,14 @@ describe("App", () => {
     Object.defineProperty(window, "pwragent", {
       configurable: true,
       value: {
-        getNavigationSnapshot: async () => ({
-          backend: "all" as const,
-          fetchedAt: Date.now(),
-          unchanged: false,
-          inboxThreadKeys: [],
-          threads: [],
-          directories: [],
-          launchpadDefaults: {
-            backend: "codex" as const,
-            executionMode: "default" as const,
-          },
-        }),
+        getNavigationSnapshot,
+        ensureDirectoryLaunchpad,
         listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
         onAgentEvent: (listener: (event: AgentEvent) => void) => {
           federationListeners.add(listener);
           return () => federationListeners.delete(listener);
         },
         onWindowFocus: () => () => undefined,
-        openFederationWindow,
         readFederationHealth,
       },
     });
@@ -398,11 +441,37 @@ describe("App", () => {
       name: "Studio Mac / work",
     }));
 
-    expect(openFederationWindow).toHaveBeenCalledWith({
-      target: { scope: "remote", instanceId: "studio-work" },
-      initialLaunchpad: true,
-    });
+    await waitFor(() => expect(getNavigationSnapshot).toHaveBeenCalledWith({
+      federationTarget: remoteTarget,
+    }));
+    await waitFor(() => expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: undefined,
+      federationTarget: remoteTarget,
+      preferredBackend: undefined,
+    }));
+    expect(await screen.findByRole("textbox", { name: "New thread" }))
+      .toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: "Choose a project" }));
+    expect(await screen.findByRole("option", { name: /PwrAgent/ }))
+      .toBeInTheDocument();
+    fireEvent.click(screen.getByRole("option", { name: /PwrAgent/ }));
+
+    await waitFor(() => expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: remoteProject.key,
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/harold/src/PwrAgent",
+      federationTarget: remoteTarget,
+      preferredBackend: undefined,
+    }));
+    expect(screen.getByRole("button", { name: "Project: PwrAgent" }))
+      .toBeInTheDocument();
+
+    const healthReadCount = readFederationHealth.mock.calls.length;
     peers = [
       {
         id: "laptop-default",
@@ -410,7 +479,6 @@ describe("App", () => {
         role: "client" as const,
         status: "connected" as const,
         capabilities: [
-          "remote_window",
           "thread_navigation",
           "environment_actions",
         ] as const,
@@ -430,7 +498,9 @@ describe("App", () => {
         });
       }
     });
-    await waitFor(() => expect(readFederationHealth).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(readFederationHealth.mock.calls.length).toBeGreaterThan(healthReadCount);
+    });
 
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
     expect(await screen.findByRole("menuitem", {
@@ -484,6 +554,23 @@ describe("App", () => {
     Object.defineProperty(window, "pwragent", {
       configurable: true,
       value: {
+        ensureDirectoryLaunchpad: async () => ({
+          launchpad: {
+            directoryKey: "workspace:new-thread",
+            directoryKind: "workspace" as const,
+            directoryLabel: "Workspaces",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            prompt: "",
+            workMode: "local" as const,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          defaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
         getNavigationSnapshot: async () => ({
           backend: "all" as const,
           fetchedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
@@ -6,7 +6,6 @@ import type {
 import { buildFederationThreadTargets } from "../federation-thread-targets";
 
 const ALL_CAPABILITIES: FederationCapability[] = [
-  "remote_window",
   "thread_navigation",
   "environment_actions",
 ];
@@ -73,12 +72,26 @@ describe("buildFederationThreadTargets", () => {
         peer({
           id: "a",
           label: "Attic Mini",
-          capabilities: ["remote_window", "thread_navigation"],
+          capabilities: ["thread_navigation"],
         }),
       ]),
     );
 
     expect(targets[0]?.availability).toBe("unsupported");
+  });
+
+  it("does not require remote-viewer capability for a mounted launchpad", () => {
+    const targets = buildFederationThreadTargets(
+      health([
+        peer({
+          id: "a",
+          label: "Attic Mini",
+          capabilities: ["thread_navigation", "environment_actions"],
+        }),
+      ]),
+    );
+
+    expect(targets[0]?.availability).toBe("available");
   });
 
   it("drops revoked peers, which are dead entries rather than offline ones", () => {

--- a/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
@@ -6,12 +6,12 @@ import {
 
 /**
  * Capabilities a peer must advertise before this window can start a thread on
- * it. `remote_window` opens the scoped window, `thread_navigation` lets that
- * window reach its own launchpad, and `environment_actions` covers the
- * environment/script work the launchpad runs once composition begins.
+ * it. `thread_navigation` supplies the peer-owned project picker, and
+ * `environment_actions` covers the environment/script work the launchpad runs
+ * once composition begins. A remote viewer window is deliberately not part of
+ * this flow: the resulting remote thread is mounted in the current window.
  */
 const REQUIRED_TARGET_CAPABILITIES: readonly FederationCapability[] = [
-  "remote_window",
   "thread_navigation",
   "environment_actions",
 ];

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2890,7 +2890,9 @@ export function Composer(props: ComposerProps) {
   const threadLinks = useThreadLinks();
   const rendererFederationTarget = readRendererFederationTarget();
   const filesystemFederationTarget =
-    props.thread?.federation?.ref.target ?? rendererFederationTarget;
+    props.thread?.federation?.ref.target
+    ?? props.launchpad?.federationTarget
+    ?? rendererFederationTarget;
   const filesystemAuthorityKey = filesystemFederationTarget?.scope === "remote"
     ? `remote:${filesystemFederationTarget.instanceId}`
     : "local";

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1514,10 +1514,8 @@ describe("Composer", () => {
   });
 
   it("does not offer the controller's disk picker in a remote launchpad", () => {
-    (window as unknown as {
-      __pwragentFederationTarget?: unknown;
-    }).__pwragentFederationTarget = {
-      scope: "remote",
+    const federationTarget = {
+      scope: "remote" as const,
       instanceId: "remote-instance",
     };
     const onPickAndRegisterDirectory = vi.fn();
@@ -1544,6 +1542,7 @@ describe("Composer", () => {
           executionMode: "default",
           prompt: "",
           workMode: "local",
+          federationTarget,
           createdAt: 1,
           updatedAt: 1,
         }}
@@ -1565,14 +1564,11 @@ describe("Composer", () => {
     expect(onPickAndRegisterDirectory).not.toHaveBeenCalled();
   });
 
-  it("routes remote recent files to the owner and disables every native add path", async () => {
+  it("routes mounted remote launchpad files to the owner and disables native add paths", async () => {
     const federationTarget = {
       scope: "remote" as const,
       instanceId: "remote-instance",
     };
-    (window as unknown as {
-      __pwragentFederationTarget?: unknown;
-    }).__pwragentFederationTarget = federationTarget;
     const listRecentFileReferences = vi.fn(async () => ({
       files: [{ label: "owner.md", path: "/owner/notes/owner.md" }],
     }));
@@ -1585,7 +1581,6 @@ describe("Composer", () => {
       label: "viewer",
       path: "/viewer/project",
     }));
-    const onPickAndAttachDirectoryToThread = vi.fn();
 
     render(
       <Composer
@@ -1605,37 +1600,21 @@ describe("Composer", () => {
           needsAttentionCount: 0,
         }]}
         disabled={false}
-        onPickAndAttachDirectoryToThread={onPickAndAttachDirectoryToThread}
         onPickDirectoryForReference={onPickDirectoryForReference}
         skills={[]}
-        thread={{
-          id: "thread-1",
-          title: "Remote thread",
-          titleSource: "explicit",
-          source: "codex",
+        launchpad={{
+          directoryKey: "workspace:new-thread",
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          backend: "codex",
           executionMode: "default",
-          federation: {
-            ref: {
-              backend: "codex",
-              target: federationTarget,
-              threadId: "thread-1",
-            },
-            instanceLabel: "Remote",
-            peerStatus: "connected",
-          },
-          linkedDirectories: [],
-          inbox: { inInbox: false },
+          prompt: "",
+          workMode: "local",
+          federationTarget,
+          createdAt: 1,
+          updatedAt: 1,
         }}
       />,
-    );
-
-    const existingThreadAdd = screen.getByRole("button", {
-      name: "Add directory",
-    });
-    expect(existingThreadAdd).toBeDisabled();
-    expect(existingThreadAdd).toHaveAttribute(
-      "title",
-      REMOTE_NATIVE_PICKER_TOOLTIP,
     );
 
     fireEvent.change(screen.getByLabelText("Reply"), {
@@ -1675,7 +1654,6 @@ describe("Composer", () => {
     });
     expect(pickFileFromDisk).not.toHaveBeenCalled();
     expect(onPickDirectoryForReference).not.toHaveBeenCalled();
-    expect(onPickAndAttachDirectoryToThread).not.toHaveBeenCalled();
   });
 
   it("clears recent files when filesystem authority changes and the new read fails", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@pwragent/shared";
 import type {
   AgentEvent,
+  FederationRemoteTarget,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   NavigationSnapshot,
@@ -4933,6 +4934,117 @@ describe("useThreadNavigation", () => {
           target: federationTarget,
         },
       },
+    });
+  });
+
+  it("keeps the newest remote launchpad request selected", async () => {
+    const firstTarget = { scope: "remote" as const, instanceId: "first-owner" };
+    const secondTarget = { scope: "remote" as const, instanceId: "second-owner" };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const firstEnsure = createDeferred<{
+      defaults: NavigationLaunchpadDefaults;
+      launchpad: NavigationLaunchpadDraft;
+    }>();
+    const secondEnsure = createDeferred<{
+      defaults: NavigationLaunchpadDefaults;
+      launchpad: NavigationLaunchpadDraft;
+    }>();
+    const makeSnapshot = (target: FederationRemoteTarget): NavigationSnapshot => ({
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [{
+        key: "workspace:new-thread",
+        kind: "workspace",
+        label: "Workspaces",
+        threadKeys: [],
+        needsAttentionCount: 0,
+      }],
+      launchpadDefaults: defaults,
+      federationTarget: target,
+    });
+    const launchpadResponse = (target: FederationRemoteTarget) => ({
+      launchpad: {
+        directoryKey: "workspace:new-thread",
+        directoryKind: "workspace" as const,
+        directoryLabel: "Workspaces",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: target.instanceId,
+        workMode: "local" as const,
+        federationTarget: target,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      defaults,
+    });
+    const getNavigationSnapshot: NonNullable<DesktopApi["getNavigationSnapshot"]> = vi.fn(
+      async (request) => {
+        const target = request?.federationTarget;
+        if (!target || target.scope !== "remote") {
+          return {
+            backend: "all" as const,
+            fetchedAt: 1,
+            unchanged: false,
+            inboxThreadKeys: [],
+            threads: [],
+            directories: [],
+            launchpadDefaults: defaults,
+          };
+        }
+        return makeSnapshot(target);
+      },
+    );
+    const ensureDirectoryLaunchpad: NonNullable<
+      DesktopApi["ensureDirectoryLaunchpad"]
+    > = vi.fn((request) => request.federationTarget?.scope === "remote"
+      && request.federationTarget.instanceId === firstTarget.instanceId
+      ? firstEnsure.promise
+      : secondEnsure.promise);
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      void result.current.openFederatedWorkspaceLaunchpad(firstTarget);
+    });
+    await waitFor(() => expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ federationTarget: firstTarget }),
+    ));
+
+    act(() => {
+      void result.current.openFederatedWorkspaceLaunchpad(secondTarget);
+    });
+    await waitFor(() => expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ federationTarget: secondTarget }),
+    ));
+
+    await act(async () => {
+      secondEnsure.resolve(launchpadResponse(secondTarget));
+      await secondEnsure.promise;
+    });
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      federationTarget: secondTarget,
+      prompt: secondTarget.instanceId,
+    });
+
+    await act(async () => {
+      firstEnsure.resolve(launchpadResponse(firstTarget));
+      await firstEnsure.promise;
+    });
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      federationTarget: secondTarget,
+      prompt: secondTarget.instanceId,
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -4792,6 +4792,150 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedLaunchpad).toBeUndefined();
   });
 
+  it("creates a mounted remote thread from a peer-populated launchpad", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const workspace = {
+      key: "workspace:new-thread",
+      kind: "workspace" as const,
+      label: "Workspaces",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    };
+    const project = {
+      key: "directory:/remote/PwrAgent",
+      kind: "directory" as const,
+      label: "PwrAgent",
+      path: "/remote/PwrAgent",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const remoteSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 2,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [workspace, project],
+      launchpadDefaults: defaults,
+      federationTarget,
+    };
+    const localSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: defaults,
+    };
+    const getNavigationSnapshot: NonNullable<DesktopApi["getNavigationSnapshot"]> = vi.fn(
+      async (request) => request?.federationTarget ? remoteSnapshot : localSnapshot,
+    );
+    const ensureDirectoryLaunchpad: NonNullable<
+      DesktopApi["ensureDirectoryLaunchpad"]
+    > = vi.fn(async (request) => ({
+      launchpad: {
+        directoryKey: request.directoryKey,
+        directoryKind: request.directoryKind,
+        directoryLabel: request.directoryLabel,
+        directoryPath: request.directoryPath,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "Start a remote thread",
+        workMode: "local" as const,
+        federationTarget: request.federationTarget,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults,
+    }));
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "remote-thread-new",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    }));
+    const resetDirectoryLaunchpad = vi.fn(async () => ({
+      directoryKey: project.key,
+      defaults,
+    }));
+    const addRemoteThreadPin = vi.fn(async (request: Parameters<
+      NonNullable<DesktopApi["addRemoteThreadPin"]>
+    >[0]) => ({
+      pin: {
+        ref: request.ref,
+        instanceLabel: request.instanceLabel ?? federationTarget.instanceId,
+        pinnedVia: "explicit" as const,
+        addedAt: 1,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      addRemoteThreadPin,
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+      resetDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.openFederatedWorkspaceLaunchpad(federationTarget);
+    });
+
+    expect(getNavigationSnapshot).toHaveBeenCalledWith({ federationTarget });
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      directoryKey: workspace.key,
+      federationTarget,
+    });
+    expect(result.current.launchpadDirectories).toEqual(expect.arrayContaining([
+      expect.objectContaining(project),
+    ]));
+
+    await act(async () => {
+      await result.current.openFederatedDirectoryLaunchpad(federationTarget, project);
+    });
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      directoryKey: project.key,
+      federationTarget,
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(project.key);
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: project.key,
+        federationTarget,
+      }),
+    );
+    expect(addRemoteThreadPin).toHaveBeenCalledWith(expect.objectContaining({
+      ref: {
+        backend: "codex",
+        target: federationTarget,
+        threadId: "remote-thread-new",
+      },
+    }));
+    expect(result.current.selectedThread).toMatchObject({
+      id: "remote-thread-new",
+      federation: {
+        ref: {
+          target: federationTarget,
+        },
+      },
+    });
+  });
+
   it("scopes a remote optimistic thread before its owner snapshot arrives", async () => {
     const federationTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -8,6 +8,7 @@ import type {
   AppServerTurnInputItem,
   ArchiveThreadCleanupResult,
   CodexThreadEnvironmentRuntime,
+  FederationRemoteTarget,
   FederationTarget,
   HandoffThreadWorkspaceRequest,
   LinkedDirectorySummary,
@@ -102,6 +103,7 @@ export type CreatingThreadState = {
 
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
+const FEDERATED_LAUNCHPAD_SELECTION_PREFIX = "federated-launchpad:";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60_000;
 const NAVIGATION_BACKGROUND_REFRESH_IDLE_AFTER_MS = 30 * 60_000;
 const NAVIGATION_FOCUS_REFRESH_MIN_INTERVAL_MS = 60_000;
@@ -179,6 +181,13 @@ type NavigationRefreshOptions = {
   refreshMode?: "active-recent" | "full";
 };
 
+type FederatedLaunchpadSession = {
+  directories: NavigationDirectorySummary[];
+  directory: NavigationDirectorySummary;
+  launchpad: NavigationLaunchpadDraft;
+  target: FederationRemoteTarget;
+};
+
 type ThreadStatusObservation = {
   sequence: number;
   threadStatus: AppServerThreadStatus;
@@ -200,6 +209,16 @@ type PrChipLocationIndex = {
 
 function buildLaunchpadSelectionKey(directoryKey: string): string {
   return `launchpad:${directoryKey}`;
+}
+
+function buildFederatedLaunchpadSelectionKey(
+  target: FederationRemoteTarget,
+): string {
+  return `${FEDERATED_LAUNCHPAD_SELECTION_PREFIX}${target.instanceId}`;
+}
+
+function isFederatedLaunchpadSelectionKey(selectionKey?: string): boolean {
+  return selectionKey?.startsWith(FEDERATED_LAUNCHPAD_SELECTION_PREFIX) === true;
 }
 
 function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | undefined {
@@ -2812,13 +2831,24 @@ export function useThreadNavigation(
   ) => Promise<void>;
   /** Directory the New Thread button resolves to by default, or undefined for the directory-less workspace. */
   newThreadDirectoryLabel?: string;
+  /** Directories available to the project picker for the active launchpad. */
+  launchpadDirectories: NavigationDirectorySummary[];
   openDirectoryLaunchpad: (
     directory: NavigationDirectorySummary,
     preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
+  /** Open a project launchpad addressed to a remote federation instance. */
+  openFederatedDirectoryLaunchpad: (
+    target: FederationRemoteTarget,
+    directory: NavigationDirectorySummary,
+  ) => Promise<void>;
   /** Switch the composer to the directory-less ("workspace") launchpad. */
   openWorkspaceLaunchpad: (
     preferredBackend?: AppServerBackendKind
+  ) => Promise<void>;
+  /** Open a directory-free launchpad and populate its picker from a peer. */
+  openFederatedWorkspaceLaunchpad: (
+    target: FederationRemoteTarget,
   ) => Promise<void>;
   /** Project-directory picker (issue #223): OS dialog → validate → seed launchpad → focus it. */
   pickAndRegisterDirectory: (
@@ -3017,6 +3047,9 @@ export function useThreadNavigation(
   const [localLaunchpads, setLocalLaunchpads] = useState<
     Record<string, NavigationLaunchpadDraft>
   >({});
+  const [federatedLaunchpad, setFederatedLaunchpad] = useState<
+    FederatedLaunchpadSession
+  >();
   const [createThreadError, setCreateThreadError] = useState<string>();
   const [launchpadError, setLaunchpadError] = useState<string>();
   const [archiveThreadError, setArchiveThreadError] = useState<string>();
@@ -4705,8 +4738,21 @@ export function useThreadNavigation(
     [threads],
   );
 
+  const activeFederatedLaunchpad =
+    federatedLaunchpad
+    && selectedItemKey === buildFederatedLaunchpadSelectionKey(
+      federatedLaunchpad.target,
+    )
+      ? federatedLaunchpad
+      : undefined;
+  const launchpadDirectories = activeFederatedLaunchpad?.directories ?? directories;
+
   const selectedThreadKey = useMemo(() => {
-    if (selectedItemKey && !getDirectoryKeyFromLaunchpadSelection(selectedItemKey)) {
+    if (
+      selectedItemKey
+      && !getDirectoryKeyFromLaunchpadSelection(selectedItemKey)
+      && !isFederatedLaunchpadSelectionKey(selectedItemKey)
+    ) {
       return selectedItemKey;
     }
 
@@ -4725,6 +4771,10 @@ export function useThreadNavigation(
   );
 
   const selectedDirectory = useMemo(() => {
+    if (activeFederatedLaunchpad) {
+      return activeFederatedLaunchpad.directory;
+    }
+
     const launchpadDirectoryKey = getDirectoryKeyFromLaunchpadSelection(selectedItemKey);
     if (launchpadDirectoryKey) {
       return directories.find((directory) => directory.key === launchpadDirectoryKey);
@@ -4737,8 +4787,12 @@ export function useThreadNavigation(
     return directories.find((directory) =>
       directory.threadKeys.includes(selectedThreadKey)
     );
-  }, [directories, selectedItemKey, selectedThreadKey]);
+  }, [activeFederatedLaunchpad, directories, selectedItemKey, selectedThreadKey]);
   const selectedLaunchpad = useMemo(() => {
+    if (activeFederatedLaunchpad) {
+      return activeFederatedLaunchpad.launchpad;
+    }
+
     const launchpadDirectoryKey = getDirectoryKeyFromLaunchpadSelection(selectedItemKey);
     if (!launchpadDirectoryKey) {
       return undefined;
@@ -4746,7 +4800,7 @@ export function useThreadNavigation(
 
     return directories.find((directory) => directory.key === launchpadDirectoryKey)
       ?.launchpad;
-  }, [directories, selectedItemKey]);
+  }, [activeFederatedLaunchpad, directories, selectedItemKey]);
 
   // The directory label the New Thread button would resolve to with its
   // default (context-aware) behavior, or undefined when that resolves to the
@@ -4756,11 +4810,11 @@ export function useThreadNavigation(
   const newThreadDirectoryLabel = useMemo(() => {
     const target = resolveCreateThreadTargetDirectory({
       directories,
-      selectedDirectory,
+      selectedDirectory: activeFederatedLaunchpad ? undefined : selectedDirectory,
       selectedThreadKey,
     });
     return target.directoryKind === "directory" ? target.directoryLabel : undefined;
-  }, [directories, selectedDirectory, selectedThreadKey]);
+  }, [activeFederatedLaunchpad, directories, selectedDirectory, selectedThreadKey]);
   // The thread card to render as the orange "composing" source while a
   // sub-thread launchpad is open. Plain new-thread launchpads have no source.
   const composerSourceThreadKey = useMemo(() => {
@@ -5118,7 +5172,9 @@ export function useThreadNavigation(
       try {
         const targetDirectory = resolveCreateThreadTargetDirectory({
           directories,
-          selectedDirectory,
+          selectedDirectory: activeFederatedLaunchpad
+            ? undefined
+            : selectedDirectory,
           selectedThreadKey,
           forceWorkspace: options?.forceWorkspace,
         });
@@ -5198,7 +5254,9 @@ export function useThreadNavigation(
       } finally {
         const targetDirectory = resolveCreateThreadTargetDirectory({
           directories,
-          selectedDirectory,
+          selectedDirectory: activeFederatedLaunchpad
+            ? undefined
+            : selectedDirectory,
           selectedThreadKey,
           forceWorkspace: options?.forceWorkspace,
         });
@@ -5210,6 +5268,7 @@ export function useThreadNavigation(
       desktopApi,
       directories,
       refresh,
+      activeFederatedLaunchpad,
       selectedDirectory,
       selectedThreadKey,
       takePendingDirectoryGitStatus,
@@ -5676,6 +5735,108 @@ export function useThreadNavigation(
     ],
   );
 
+  const openFederatedDirectoryLaunchpad = useCallback(
+    async (
+      target: FederationRemoteTarget,
+      directory: NavigationDirectorySummary,
+      remoteDirectories?: NavigationDirectorySummary[],
+    ): Promise<void> => {
+      if (!desktopApi?.ensureDirectoryLaunchpad) {
+        setLaunchpadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
+        return;
+      }
+
+      setLaunchpadError(undefined);
+      setCreateThreadError(undefined);
+      setArchiveThreadError(undefined);
+      setSetThreadExecutionModeError(undefined);
+      setSetThreadModelSettingsError(undefined);
+
+      try {
+        const response = await desktopApi.ensureDirectoryLaunchpad({
+          federationTarget: target,
+          directoryKey: directory.key,
+          directoryKind: directory.kind,
+          directoryLabel: directory.label,
+          directoryPath: directory.path,
+          ...(directory.gitStatus ? { gitStatus: directory.gitStatus } : {}),
+          currentBranch: directory.gitStatus?.currentBranch,
+          preferredBackend: directory.launchpad?.backend,
+        });
+        const launchpad = {
+          ...response.launchpad,
+          federationTarget: target,
+        };
+        const sourceDirectories = remoteDirectories
+          ?? (
+            federatedLaunchpad
+            && federationTargetsEqual(federatedLaunchpad.target, target)
+              ? federatedLaunchpad.directories
+              : [directory]
+          );
+        const directoriesWithLaunchpad = upsertLaunchpadDirectory(
+          sourceDirectories,
+          launchpad,
+          {
+            ...(response.gitStatus !== undefined
+              ? { gitStatus: response.gitStatus }
+              : {}),
+          },
+        );
+        const launchpadDirectory = directoriesWithLaunchpad.find(
+          (candidate) => candidate.key === launchpad.directoryKey,
+        );
+        if (!launchpadDirectory) {
+          throw new Error("Could not resolve the remote launchpad directory.");
+        }
+
+        setFederatedLaunchpad({
+          directories: directoriesWithLaunchpad,
+          directory: launchpadDirectory,
+          launchpad,
+          target,
+        });
+        setSelectedItemKey(buildFederatedLaunchpadSelectionKey(target));
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [desktopApi, federatedLaunchpad],
+  );
+
+  const openFederatedWorkspaceLaunchpad = useCallback(
+    async (target: FederationRemoteTarget): Promise<void> => {
+      if (!desktopApi?.getNavigationSnapshot) {
+        setLaunchpadError("Desktop bridge is missing navigation snapshot support.");
+        return;
+      }
+
+      setLaunchpadError(undefined);
+      try {
+        const snapshot = await desktopApi.getNavigationSnapshot({
+          federationTarget: target,
+        });
+        const workspaceDirectory = snapshot.directories.find(
+          (directory) => directory.kind === "workspace",
+        ) ?? {
+          key: ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY,
+          kind: "workspace" as const,
+          label: ROOT_NEW_THREAD_WORKSPACE_LABEL,
+          threadKeys: [],
+          needsAttentionCount: 0,
+        };
+        await openFederatedDirectoryLaunchpad(
+          target,
+          workspaceDirectory,
+          snapshot.directories,
+        );
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [desktopApi, openFederatedDirectoryLaunchpad],
+  );
+
   const openDirectoryLaunchpad = useCallback(
     async (
       directory: NavigationDirectorySummary,
@@ -6027,9 +6188,75 @@ export function useThreadNavigation(
       }
 
       setLaunchpadError(undefined);
+      const federatedSelection =
+        activeFederatedLaunchpad
+        && activeFederatedLaunchpad.launchpad.directoryKey === directoryKey
+          ? activeFederatedLaunchpad
+          : undefined;
+      const launchpadUpdateKey = federatedSelection
+        ? `${federatedSelection.target.instanceId}:${directoryKey}`
+        : directoryKey;
       const revision =
-        (launchpadUpdateRevisionRef.current.get(directoryKey) ?? 0) + 1;
-      launchpadUpdateRevisionRef.current.set(directoryKey, revision);
+        (launchpadUpdateRevisionRef.current.get(launchpadUpdateKey) ?? 0) + 1;
+      launchpadUpdateRevisionRef.current.set(launchpadUpdateKey, revision);
+
+      if (federatedSelection) {
+        const applyFederatedPatch = (
+          launchpad: NavigationLaunchpadDraft,
+        ): NavigationLaunchpadDraft => ({
+          ...applyNavigationLaunchpadProviderSettingsPatch<NavigationLaunchpadDraft>(
+            launchpad,
+            patch,
+          ),
+          directoryKey,
+          federationTarget: federatedSelection.target,
+          updatedAt: Date.now(),
+        });
+        setFederatedLaunchpad((current) =>
+          current
+          && federationTargetsEqual(current.target, federatedSelection.target)
+          && current.launchpad.directoryKey === directoryKey
+            ? {
+                ...current,
+                launchpad: applyFederatedPatch(current.launchpad),
+              }
+            : current,
+        );
+
+        try {
+          const response = await desktopApi.updateDirectoryLaunchpad({
+            directoryKey,
+            patch,
+            stickySettingsChanged: options?.stickySettingsChanged,
+          });
+          if (launchpadUpdateRevisionRef.current.get(launchpadUpdateKey) !== revision) {
+            return;
+          }
+          setFederatedLaunchpad((current) =>
+            current
+            && federationTargetsEqual(current.target, federatedSelection.target)
+            && current.launchpad.directoryKey === directoryKey
+              ? {
+                  ...current,
+                  launchpad: {
+                    ...mergeLaunchpadUpdateResponse(
+                      current.launchpad,
+                      response.launchpad,
+                      patch,
+                    ),
+                    federationTarget: federatedSelection.target,
+                  },
+                }
+              : current,
+          );
+        } catch (error) {
+          if (launchpadUpdateRevisionRef.current.get(launchpadUpdateKey) !== revision) {
+            return;
+          }
+          setLaunchpadError(error instanceof Error ? error.message : String(error));
+        }
+        return;
+      }
 
       setState((current) => {
         const currentResponse = current.response;
@@ -6091,7 +6318,7 @@ export function useThreadNavigation(
           patch,
           stickySettingsChanged: options?.stickySettingsChanged,
         });
-        if (launchpadUpdateRevisionRef.current.get(directoryKey) !== revision) {
+        if (launchpadUpdateRevisionRef.current.get(launchpadUpdateKey) !== revision) {
           return;
         }
         setLocalLaunchpads((current) =>
@@ -6145,13 +6372,13 @@ export function useThreadNavigation(
           );
         }
       } catch (error) {
-        if (launchpadUpdateRevisionRef.current.get(directoryKey) !== revision) {
+        if (launchpadUpdateRevisionRef.current.get(launchpadUpdateKey) !== revision) {
           return;
         }
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, isRendererFederationWindow]
+    [activeFederatedLaunchpad, desktopApi, isRendererFederationWindow]
   );
 
   const resetDirectoryLaunchpad = useCallback(
@@ -6164,6 +6391,21 @@ export function useThreadNavigation(
       setLaunchpadError(undefined);
 
       try {
+        if (
+          activeFederatedLaunchpad
+          && activeFederatedLaunchpad.launchpad.directoryKey === directoryKey
+        ) {
+          await desktopApi.resetDirectoryLaunchpad({ directoryKey });
+          setFederatedLaunchpad(undefined);
+          setSelectedItemKey((current) =>
+            current === buildFederatedLaunchpadSelectionKey(
+              activeFederatedLaunchpad.target,
+            )
+              ? undefined
+              : current,
+          );
+          return;
+        }
         const response = await desktopApi.resetDirectoryLaunchpad({ directoryKey });
         setLocalLaunchpads((current) => {
           if (!current[directoryKey]) {
@@ -6205,7 +6447,14 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, directories, optimisticThread, state.response, threads]
+    [
+      activeFederatedLaunchpad,
+      desktopApi,
+      directories,
+      optimisticThread,
+      state.response,
+      threads,
+    ]
   );
 
   /**
@@ -6300,8 +6549,14 @@ export function useThreadNavigation(
         return;
       }
 
-      const directory = directories.find((candidate) => candidate.key === directoryKey);
-      const launchpad = directory?.launchpad;
+      const federatedSelection =
+        activeFederatedLaunchpad
+        && activeFederatedLaunchpad.launchpad.directoryKey === directoryKey
+          ? activeFederatedLaunchpad
+          : undefined;
+      const directory = federatedSelection?.directory
+        ?? directories.find((candidate) => candidate.key === directoryKey);
+      const launchpad = federatedSelection?.launchpad ?? directory?.launchpad;
       if (!launchpad) {
         setLaunchpadError(`No launchpad found for ${directoryKey}.`);
         return;
@@ -6312,7 +6567,9 @@ export function useThreadNavigation(
       // The draft carries the group root (sub-threading a child re-parents to
       // the root); prefer it over the key-parsed source so the new thread links
       // to the root and renders one level deep.
-      const launchpadSelectionKey = buildLaunchpadSelectionKey(directoryKey);
+      const launchpadSelectionKey = federatedSelection
+        ? buildFederatedLaunchpadSelectionKey(federatedSelection.target)
+        : buildLaunchpadSelectionKey(directoryKey);
       const selectionKeyAtMaterializationStart = selectedItemKeyRef.current;
       const materializeParentThreadId =
         parentThreadId ??
@@ -6481,14 +6738,24 @@ export function useThreadNavigation(
           subthreadOrderTarget,
         );
       }
-      setLocalLaunchpads((current) => {
-        if (!current[directoryKey]) {
-          return current;
-        }
-        const next = { ...current };
-        delete next[directoryKey];
-        return next;
-      });
+      if (federatedSelection) {
+        setFederatedLaunchpad((current) =>
+          current
+          && federationTargetsEqual(current.target, federatedSelection.target)
+          && current.launchpad.directoryKey === directoryKey
+            ? undefined
+            : current,
+        );
+      } else {
+        setLocalLaunchpads((current) => {
+          if (!current[directoryKey]) {
+            return current;
+          }
+          const next = { ...current };
+          delete next[directoryKey];
+          return next;
+        });
+      }
       const shouldSelectMaterializedThread =
         selectionKeyAtMaterializationStart !== launchpadSelectionKey ||
         selectedItemKeyRef.current === launchpadSelectionKey;
@@ -6536,16 +6803,18 @@ export function useThreadNavigation(
           }
         }
       }
-      setState((current) => ({
-        ...current,
-        response: current.response
-          ? applyLaunchpadReset(
-              current.response,
-              directoryKey,
-              current.response.launchpadDefaults
-            )
-          : current.response,
-      }));
+      if (!federatedSelection) {
+        setState((current) => ({
+          ...current,
+          response: current.response
+            ? applyLaunchpadReset(
+                current.response,
+                directoryKey,
+                current.response.launchpadDefaults
+              )
+            : current.response,
+        }));
+      }
       try {
         await refresh(
           shouldSelectMaterializedThread ? nextThreadKey : undefined,
@@ -6557,7 +6826,13 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, directories, insertSubthreadBelowSource, refresh]
+    [
+      activeFederatedLaunchpad,
+      desktopApi,
+      directories,
+      insertSubthreadBelowSource,
+      refresh,
+    ]
   );
 
   /**
@@ -6566,6 +6841,39 @@ export function useThreadNavigation(
    * selection to the source card the user invoked it from.
    */
   const discardLaunchpad = useCallback((directoryKey: string): boolean => {
+    if (
+      activeFederatedLaunchpad
+      && activeFederatedLaunchpad.launchpad.directoryKey === directoryKey
+    ) {
+      const isRegisteredDirectory =
+        activeFederatedLaunchpad.launchpad.registeredAt !== undefined;
+      setFederatedLaunchpad(undefined);
+      setSelectedItemKey((current) =>
+        current === buildFederatedLaunchpadSelectionKey(
+          activeFederatedLaunchpad.target,
+        )
+          ? undefined
+          : current,
+      );
+
+      const handleDiscardError = (error: unknown): void => {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+      };
+      if (isRegisteredDirectory) {
+        void desktopApi
+          ?.updateDirectoryLaunchpad?.({
+            directoryKey,
+            patch: { prompt: "", imageAttachments: [], editorDocument: undefined },
+          })
+          .catch(handleDiscardError);
+      } else {
+        void desktopApi
+          ?.resetDirectoryLaunchpad?.({ directoryKey })
+          .catch(handleDiscardError);
+      }
+      return false;
+    }
+
     // Read from the merged `directories` memo, not the raw snapshot: the
     // main-process snapshot deliberately omits sub-thread launchpads, so after
     // an authoritative refresh they exist only in `localLaunchpads`. Sourcing
@@ -6631,7 +6939,7 @@ export function useThreadNavigation(
         .catch(handleDiscardError);
     }
     return restoresSourceThread;
-  }, [desktopApi, directories]);
+  }, [activeFederatedLaunchpad, desktopApi, directories]);
 
   const archiveThread = useCallback(
     async (
@@ -7840,7 +8148,8 @@ export function useThreadNavigation(
     creatingThread,
     directories,
     error: state.error,
-    federationTarget: state.response?.federationTarget,
+    federationTarget:
+      activeFederatedLaunchpad?.target ?? state.response?.federationTarget,
     inboxThreads,
     recentThreads,
     launchpadError,
@@ -7855,8 +8164,11 @@ export function useThreadNavigation(
     refresh: refreshNavigation,
     materializeDirectoryLaunchpad,
     newThreadDirectoryLabel,
+    launchpadDirectories,
     openDirectoryLaunchpad,
+    openFederatedDirectoryLaunchpad,
     openWorkspaceLaunchpad,
+    openFederatedWorkspaceLaunchpad,
     pickAndRegisterDirectory,
     addProjectDirectory,
     pickAndAttachDirectoryToSelectedThread,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3050,6 +3050,10 @@ export function useThreadNavigation(
   const [federatedLaunchpad, setFederatedLaunchpad] = useState<
     FederatedLaunchpadSession
   >();
+  // A peer snapshot and the subsequent launchpad ensure both cross the
+  // network. Keep only the most recent launch intent so a slow prior peer or
+  // project selection cannot replace the launchpad the operator just chose.
+  const federatedLaunchpadOpenRevisionRef = useRef(0);
   const [createThreadError, setCreateThreadError] = useState<string>();
   const [launchpadError, setLaunchpadError] = useState<string>();
   const [archiveThreadError, setArchiveThreadError] = useState<string>();
@@ -5740,9 +5744,14 @@ export function useThreadNavigation(
       target: FederationRemoteTarget,
       directory: NavigationDirectorySummary,
       remoteDirectories?: NavigationDirectorySummary[],
+      requestRevision?: number,
     ): Promise<void> => {
+      const openRevision =
+        requestRevision ?? ++federatedLaunchpadOpenRevisionRef.current;
       if (!desktopApi?.ensureDirectoryLaunchpad) {
-        setLaunchpadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
+        if (federatedLaunchpadOpenRevisionRef.current === openRevision) {
+          setLaunchpadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
+        }
         return;
       }
 
@@ -5763,6 +5772,9 @@ export function useThreadNavigation(
           currentBranch: directory.gitStatus?.currentBranch,
           preferredBackend: directory.launchpad?.backend,
         });
+        if (federatedLaunchpadOpenRevisionRef.current !== openRevision) {
+          return;
+        }
         const launchpad = {
           ...response.launchpad,
           federationTarget: target,
@@ -5798,7 +5810,9 @@ export function useThreadNavigation(
         });
         setSelectedItemKey(buildFederatedLaunchpadSelectionKey(target));
       } catch (error) {
-        setLaunchpadError(error instanceof Error ? error.message : String(error));
+        if (federatedLaunchpadOpenRevisionRef.current === openRevision) {
+          setLaunchpadError(error instanceof Error ? error.message : String(error));
+        }
       }
     },
     [desktopApi, federatedLaunchpad],
@@ -5806,8 +5820,11 @@ export function useThreadNavigation(
 
   const openFederatedWorkspaceLaunchpad = useCallback(
     async (target: FederationRemoteTarget): Promise<void> => {
+      const openRevision = ++federatedLaunchpadOpenRevisionRef.current;
       if (!desktopApi?.getNavigationSnapshot) {
-        setLaunchpadError("Desktop bridge is missing navigation snapshot support.");
+        if (federatedLaunchpadOpenRevisionRef.current === openRevision) {
+          setLaunchpadError("Desktop bridge is missing navigation snapshot support.");
+        }
         return;
       }
 
@@ -5816,6 +5833,9 @@ export function useThreadNavigation(
         const snapshot = await desktopApi.getNavigationSnapshot({
           federationTarget: target,
         });
+        if (federatedLaunchpadOpenRevisionRef.current !== openRevision) {
+          return;
+        }
         const workspaceDirectory = snapshot.directories.find(
           (directory) => directory.kind === "workspace",
         ) ?? {
@@ -5829,9 +5849,12 @@ export function useThreadNavigation(
           target,
           workspaceDirectory,
           snapshot.directories,
+          openRevision,
         );
       } catch (error) {
-        setLaunchpadError(error instanceof Error ? error.message : String(error));
+        if (federatedLaunchpadOpenRevisionRef.current === openRevision) {
+          setLaunchpadError(error instanceof Error ? error.message : String(error));
+        }
       }
     },
     [desktopApi, openFederatedDirectoryLaunchpad],

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -64,11 +64,14 @@ export function useThreadSkills(params: {
     // the `/` menu instead of falling back to PwrAgent's own commands alone.
     if (launchpad) {
       const cwds = launchpad.directoryPath?.trim() ? [launchpad.directoryPath.trim()] : [];
+      const targetKey = launchpad.federationTarget?.scope === "remote"
+        ? `${launchpad.federationTarget.instanceId}:`
+        : "";
       return {
         backend: launchpad.backend,
         cwds,
-        federationTarget: undefined,
-        key: `launchpad:${launchpad.backend}:${launchpad.directoryKey}`,
+        federationTarget: launchpad.federationTarget,
+        key: `launchpad:${launchpad.backend}:${targetKey}${launchpad.directoryKey}`,
         threadId: undefined,
       };
     }


### PR DESCRIPTION
## Summary
- replace the New Thread remote-viewer route with a current-window, directory-free federated launchpad
- populate its project picker from the selected peer and mount the materialized remote thread in the local list
- allow peers that provide navigation and environment actions without requiring remote-window capability

## Validation
- pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
- pnpm typecheck
- pnpm lint:boundaries
- pnpm lint (passes; existing non-blocking ESLint warnings only)