### PR TITLE
fix(desktop): sync mounted remote auto-fix state

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -10243,6 +10243,138 @@ describe("useThreadNavigation", () => {
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("applies PR auto-dispatch events to the matching mounted remote thread", async () => {
+    const firstOwner = {
+      scope: "remote" as const,
+      instanceId: "first-owner",
+    };
+    const secondOwner = {
+      scope: "remote" as const,
+      instanceId: "second-owner",
+    };
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const pending = (fingerprint: string) => ({
+      fingerprint,
+      prKey: "github.com/pwrdrvr/PwrAgent#1105",
+      prNumber: 1105,
+      prUrl: "https://github.com/pwrdrvr/PwrAgent/pull/1105",
+      headSha: "a".repeat(40),
+      eventKinds: ["ci-failure" as const],
+      createdAt: 1_000,
+      scheduledAt: 31_000,
+    });
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "shared-thread-id",
+          title: "Local thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          prAutoDispatchEnabled: true,
+          prAutoDispatchPending: pending("local-pending"),
+          inbox: { inInbox: false },
+        },
+        {
+          id: "shared-thread-id",
+          title: "First remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          prAutoDispatchEnabled: true,
+          prAutoDispatchPending: pending("first-owner-pending"),
+          inbox: { inInbox: false },
+          federation: {
+            ref: {
+              backend: "codex" as const,
+              target: firstOwner,
+              threadId: "shared-thread-id",
+            },
+          },
+        },
+        {
+          id: "shared-thread-id",
+          title: "Second remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          prAutoDispatchEnabled: true,
+          prAutoDispatchPending: pending("second-owner-pending"),
+          inbox: { inInbox: false },
+          federation: {
+            ref: {
+              backend: "codex" as const,
+              target: secondOwner,
+              threadId: "shared-thread-id",
+            },
+          },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => listeners.delete(callback);
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(3);
+    });
+
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          federationTarget: firstOwner,
+          notification: {
+            method: "thread/prAutoDispatch/updated",
+            params: { threadId: "shared-thread-id", enabled: false },
+          },
+        });
+        listener({
+          backend: "codex",
+          federationTarget: firstOwner,
+          notification: {
+            method: "thread/prAutoDispatch/pendingUpdated",
+            params: { threadId: "shared-thread-id", pending: null },
+          },
+        });
+      }
+    });
+
+    const localThread = result.current.threads.find(
+      (thread) => !thread.federation,
+    );
+    const firstRemoteThread = result.current.threads.find(
+      (thread) => thread.federation?.ref.target.instanceId === "first-owner",
+    );
+    const secondRemoteThread = result.current.threads.find(
+      (thread) => thread.federation?.ref.target.instanceId === "second-owner",
+    );
+    expect(firstRemoteThread?.prAutoDispatchEnabled).toBe(false);
+    expect(firstRemoteThread?.prAutoDispatchPending).toBeUndefined();
+    expect(localThread?.prAutoDispatchEnabled).toBe(true);
+    expect(localThread?.prAutoDispatchPending?.fingerprint).toBe("local-pending");
+    expect(secondRemoteThread?.prAutoDispatchEnabled).toBe(true);
+    expect(secondRemoteThread?.prAutoDispatchPending?.fingerprint).toBe(
+      "second-owner-pending",
+    );
+  });
+
   it("reconciles a primary workspace repository resolved after an earlier refresh", async () => {
     const snapshotState: { primaryGitRepository?: string } = {};
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -10291,6 +10291,7 @@ describe("useThreadNavigation", () => {
           prAutoDispatchPending: pending("first-owner-pending"),
           inbox: { inInbox: false },
           federation: {
+            instanceLabel: "First owner",
             ref: {
               backend: "codex" as const,
               target: firstOwner,
@@ -10308,6 +10309,7 @@ describe("useThreadNavigation", () => {
           prAutoDispatchPending: pending("second-owner-pending"),
           inbox: { inInbox: false },
           federation: {
+            instanceLabel: "Second owner",
             ref: {
               backend: "codex" as const,
               target: secondOwner,
@@ -10360,10 +10362,14 @@ describe("useThreadNavigation", () => {
       (thread) => !thread.federation,
     );
     const firstRemoteThread = result.current.threads.find(
-      (thread) => thread.federation?.ref.target.instanceId === "first-owner",
+      (thread) =>
+        thread.federation?.ref.target.scope === "remote"
+        && thread.federation.ref.target.instanceId === "first-owner",
     );
     const secondRemoteThread = result.current.threads.find(
-      (thread) => thread.federation?.ref.target.instanceId === "second-owner",
+      (thread) =>
+        thread.federation?.ref.target.scope === "remote"
+        && thread.federation.ref.target.instanceId === "second-owner",
     );
     expect(firstRemoteThread?.prAutoDispatchEnabled).toBe(false);
     expect(firstRemoteThread?.prAutoDispatchPending).toBeUndefined();

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2134,6 +2134,7 @@ function applyThreadPrAutoDispatchUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     enabled: boolean;
   },
@@ -2143,7 +2144,14 @@ function applyThreadPrAutoDispatchUpdate(
   }
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (thread.source !== params.backend || thread.id !== params.threadId) {
+    if (
+      thread.source !== params.backend
+      || thread.id !== params.threadId
+      || !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
     changed = true;
@@ -2156,6 +2164,7 @@ function applyThreadPrAutoDispatchPendingUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     pending: NavigationThreadSummary["prAutoDispatchPending"];
   },
@@ -2163,7 +2172,14 @@ function applyThreadPrAutoDispatchPendingUpdate(
   if (!snapshot) return snapshot;
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (thread.source !== params.backend || thread.id !== params.threadId) {
+    if (
+      thread.source !== params.backend
+      || thread.id !== params.threadId
+      || !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
     changed = true;
@@ -3833,6 +3849,8 @@ export function useThreadNavigation(
         && (method === "pullRequest/status/updated"
           || method === "thread/pullRequests/updated"
           || method === "thread/reactions/updated"
+          || method === "thread/prAutoDispatch/pendingUpdated"
+          || method === "thread/prAutoDispatch/updated"
           || method === "thread/status/changed"
           || method === "turn/cancelled"
           || method === "turn/completed"
@@ -4348,11 +4366,12 @@ export function useThreadNavigation(
           ...current,
           response: applyThreadPrAutoDispatchUpdate(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             ...params,
           }),
         }));
         setOptimisticThread((current) =>
-          current?.source === event.backend && current.id === params.threadId
+          current && agentEventMatchesThread(event, current, params.threadId)
             ? { ...current, prAutoDispatchEnabled: params.enabled }
             : current
         );
@@ -4369,12 +4388,13 @@ export function useThreadNavigation(
           ...current,
           response: applyThreadPrAutoDispatchPendingUpdate(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId: params.threadId,
             pending,
           }),
         }));
         setOptimisticThread((current) =>
-          current?.source === event.backend && current.id === params.threadId
+          current && agentEventMatchesThread(event, current, params.threadId)
             ? { ...current, prAutoDispatchPending: pending }
             : current
         );
@@ -7783,7 +7803,8 @@ export function useThreadNavigation(
       }
       setSetThreadModelSettingsError(undefined);
       setOptimisticThread((current) =>
-        current && current.id === thread.id && current.source === thread.source
+        current
+        && threadSummaryIdentityKey(current) === threadSummaryIdentityKey(thread)
           ? { ...current, prAutoDispatchEnabled: enabled }
           : current
       );
@@ -7791,6 +7812,7 @@ export function useThreadNavigation(
         ...current,
         response: applyThreadPrAutoDispatchUpdate(current.response, {
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target,
           threadId: thread.id,
           enabled,
         }),


### PR DESCRIPTION
## Summary

- I allow mounted remote thread PR auto-fix state events through the main-window federation filter.
- I scope auto-fix preference and pending-state updates to the event's federation origin so same-ID threads owned locally or by another peer remain unchanged.
- I added a regression test that reproduced the stale Cancel and Send now state before the fix.

## Verification

- I confirmed the new focused regression test failed before the fix and passed afterward.
- I ran all 133 `useThreadNavigation` tests.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` and confirmed it completed with no errors; existing warnings remain.
- I ran `pnpm lint:boundaries`.

## Notes

- The remote cancellation RPC already reached the thread-owning instance. The bug was that the local main window dropped the owner's `thread/prAutoDispatch/pendingUpdated` event and ignored the successful RPC response, leaving the scheduled banner and sidebar state stale.
