### PR TITLE
test(desktop): backport backend test hardening to 1.0

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -13,6 +13,7 @@ import {
   describeInstalledAcpBackend,
   isAcpSessionMissingForProjectError,
   withAcpModelRuntimeSelection,
+  type AcpBackendAdapterOptions,
   type AcpSessionMetadata,
 } from "../app-server/acp-backend-adapter";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
@@ -371,7 +372,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -478,7 +479,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -614,7 +615,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -737,7 +738,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -810,7 +811,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -904,7 +905,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1007,7 +1008,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1128,7 +1129,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1204,7 +1205,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1298,7 +1299,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1385,7 +1386,7 @@ describe("AcpBackendAdapter", () => {
           env: {},
         },
       };
-      const adapter = new AcpBackendAdapter({
+      const adapter = createTestAcpBackendAdapter({
         acpAgentStore: {
           getInstalledAgent: () => agent,
           listInstalledAgents: () => [agent],
@@ -1481,7 +1482,7 @@ describe("AcpBackendAdapter", () => {
       },
     };
     const emit = vi.fn(async () => undefined);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1552,7 +1553,7 @@ describe("AcpBackendAdapter", () => {
     const readProviderStatus = vi.fn(
       async () => await new Promise<never>(() => undefined),
     );
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1608,7 +1609,7 @@ describe("AcpBackendAdapter", () => {
       channel: "stable",
     }));
     const emit = vi.fn(async () => undefined);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => stored,
         listInstalledAgents: () => [stored],
@@ -1693,7 +1694,7 @@ describe("AcpBackendAdapter", () => {
       error: "offline",
     }));
     const emit = vi.fn(async () => undefined);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => stored,
         listInstalledAgents: () => [stored],
@@ -1751,7 +1752,7 @@ describe("AcpBackendAdapter", () => {
       }),
     );
     const emit = vi.fn(async () => undefined);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => stored,
         listInstalledAgents: () => [stored],
@@ -1839,7 +1840,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -1949,7 +1950,7 @@ describe("AcpBackendAdapter", () => {
       threadStatus: "idle" as const,
     };
     const loadSession = vi.fn();
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -2093,7 +2094,7 @@ describe("AcpBackendAdapter", () => {
       },
       threadStatus: "idle" as const,
     }));
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -2222,7 +2223,7 @@ describe("AcpBackendAdapter", () => {
       threadStatus: "idle" as const,
     };
     const loadSession = vi.fn(async () => providerReplay);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -2330,7 +2331,7 @@ describe("AcpBackendAdapter", () => {
       },
       threadStatus: "idle" as const,
     }));
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
         listInstalledAgents: () => [agent],
@@ -2430,7 +2431,7 @@ describe("AcpBackendAdapter", () => {
       .fn()
       .mockReturnValueOnce(firstClient)
       .mockReturnValueOnce(secondClient);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: null,
       captureStores: [],
       createAcpClient: createAcpClient as never,
@@ -2511,7 +2512,7 @@ describe("AcpBackendAdapter", () => {
       ownsSession: () => false,
       supportsSessionLoad: () => true,
     };
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: null,
       captureStores: [],
       createAcpClient: vi
@@ -2577,7 +2578,7 @@ describe("AcpBackendAdapter", () => {
       .fn()
       .mockReturnValueOnce(firstClient)
       .mockReturnValueOnce(secondClient);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => firstAgent,
         listInstalledAgents: () => [firstAgent],
@@ -2666,7 +2667,7 @@ describe("AcpBackendAdapter", () => {
       .fn()
       .mockReturnValueOnce(firstClient)
       .mockReturnValueOnce(secondClient);
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: null,
       captureStores: [],
       createAcpClient: createAcpClient as never,
@@ -2731,7 +2732,7 @@ describe("AcpBackendAdapter", () => {
       return promise;
     });
     const upsertInstalledAgent = vi.fn();
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => undefined,
         listInstalledAgents: () => [],
@@ -2799,7 +2800,7 @@ describe("AcpBackendAdapter", () => {
       return promise;
     });
     const upsertInstalledAgent = vi.fn();
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => undefined,
         listInstalledAgents: () => [],
@@ -2855,7 +2856,7 @@ describe("AcpBackendAdapter", () => {
     const upsertInstalledAgent = vi.fn((record: AcpInstalledAgentRecord) => {
       cached = record;
     });
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => cached,
         listInstalledAgents: () => [cached],
@@ -2919,7 +2920,7 @@ describe("AcpBackendAdapter", () => {
       const agent = buildInstalledAgent();
       const initialize = vi.fn(() => new Promise<void>(() => undefined));
       const dispose = vi.fn(async () => undefined);
-      const adapter = new AcpBackendAdapter({
+      const adapter = createTestAcpBackendAdapter({
         acpAgentStore: {
           getInstalledAgent: () => agent,
           listInstalledAgents: () => [agent],
@@ -2955,7 +2956,7 @@ describe("AcpBackendAdapter", () => {
       | ((agents: AcpInstalledAgentRecord[]) => void)
       | undefined;
     const createAcpClient = vi.fn();
-    const adapter = new AcpBackendAdapter({
+    const adapter = createTestAcpBackendAdapter({
       acpAgentStore: null,
       captureStores: [],
       createAcpClient,
@@ -2976,6 +2977,15 @@ describe("AcpBackendAdapter", () => {
     expect(createAcpClient).not.toHaveBeenCalled();
   });
 });
+
+function createTestAcpBackendAdapter(
+  options: AcpBackendAdapterOptions,
+): AcpBackendAdapter {
+  return new AcpBackendAdapter({
+    discoverLocalAcpAgents: async () => [],
+    ...options,
+  });
+}
 
 function buildInstalledAgent(): AcpInstalledAgentRecord {
   return {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -209,8 +209,7 @@ function createDeferred<T>(): {
 }
 
 async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
-    cwd,
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
     encoding: "utf8",
     maxBuffer: 1024 * 1024 * 10,
   });
@@ -28883,7 +28882,7 @@ script = "printf setup"
 
       await registry.close();
     } finally {
-      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      await rm(root, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary

Backports the test-hardening fixes from [#1730](https://github.com/pwrdrvr/PwrAgent/pull/1730) to `releases/1.0`:

- invoke the backend-registry test Git helper with `git -C <repo> ...`, avoiding a disposable repository as the child-process working directory
- remove cleanup retries only from the real-worktree archive regression, so it verifies immediate Git process handle release
- route the 1.0 ACP adapter tests through a shared factory that defaults `discoverLocalAcpAgents` to an empty async result
- spread test options after that default so every test-specific discovery override remains authoritative

## Manual adaptation

This was adapted manually rather than cherry-picked because both large test files have drifted substantially between `main` and `releases/1.0`.

The source ACP file had 38 adapter-construction replacement sites; the 1.0 file has 30. All 30 release-branch sites now use the shared factory. The eight source-only sites have no corresponding construction sites on 1.0, so this backport does not import their main-only tests or related features.

The backend-registry source hunk also moved from roughly line 39,923 on `main` to roughly line 28,883 on 1.0. The same named real-worktree archive regression exists, so its cleanup semantics were adapted directly. The other 26 retrying cleanup sites remain unchanged.

## Scope

Test-only. The diff contains exactly:

- `apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts`
- `apps/desktop/src/main/__tests__/backend-registry.test.ts`

There are no database migrations, production changes, or unrelated main-only features.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "removes a real Git worktree and unregisters it from the source repo when archiving a thread"` — 1 passed
- `pnpm test apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts` — 43 passed
- `pnpm typecheck` — passed across the workspace
- `pnpm exec eslint apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` — 0 errors; 1 pre-existing `prefer-const` warning
- `pnpm lint:boundaries` — passed, 0 dependency violations
- `git diff --check` — passed
- changed-file and staged-diff audits — exactly the two test files above
