### PR TITLE
fix(desktop): avoid destroyed explorer window access

### DIFF
--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -177,4 +177,32 @@ describe("tool-output incident explorer window", () => {
       { backend: "acp:grok", threadId: "another-thread" },
     )).toThrow("can only open its own thread");
   });
+
+  it("cleans up after Electron destroys the closed window", async () => {
+    const { showToolOutputIncidentExplorerWindow } = await import(
+      "../tool-output-incident-explorer-window"
+    );
+    const request = {
+      backend: "codex" as const,
+      threadId: "thread-destroyed",
+      title: "Destroyed window",
+    };
+    showToolOutputIncidentExplorerWindow(request);
+    const window = mocks.windows[0]!;
+    const closedHandler = window.on.mock.calls.find(
+      ([event]) => event === "closed",
+    )?.[1] as (() => void) | undefined;
+    expect(closedHandler).toBeDefined();
+
+    Object.defineProperty(window, "webContents", {
+      configurable: true,
+      get: () => {
+        throw new Error("Object has been destroyed");
+      },
+    });
+
+    expect(() => closedHandler?.()).not.toThrow();
+    showToolOutputIncidentExplorerWindow(request);
+    expect(mocks.BrowserWindow).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -125,8 +125,9 @@ export function showToolOutputIncidentExplorerWindow(
   }
   showAuxiliaryWindowWhenReady(window);
   incidentWindows.set(windowKey, window);
+  const webContentsId = window.webContents.id;
   if (source.sourceWindow && !source.sourceWindow.isDestroyed()) {
-    incidentWindowContexts.set(window.webContents.id, {
+    incidentWindowContexts.set(webContentsId, {
       owner: source.sourceWindow.webContents,
       threadKey: windowKey,
     });
@@ -135,7 +136,10 @@ export function showToolOutputIncidentExplorerWindow(
     if (incidentWindows.get(windowKey) === window) {
       incidentWindows.delete(windowKey);
     }
-    incidentWindowContexts.delete(window.webContents.id);
+    // Electron has destroyed the BrowserWindow by the time `closed` fires.
+    // Reading `window.webContents` here throws "Object has been destroyed",
+    // so retain the primitive id while the window is still live.
+    incidentWindowContexts.delete(webContentsId);
     log.debug("tool-output incident explorer closed", { windowKey });
   });
   log.debug("tool-output incident explorer created", { windowKey });


### PR DESCRIPTION
## Summary

- I capture the tool-output incident explorer's web-contents ID while its `BrowserWindow` is still live.
- I use that retained primitive during `closed` cleanup, avoiding access to `window.webContents` after Electron destroys the window.
- I restored the regression test that models Electron's destroyed-window behavior and verifies cleanup remains safe.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts` (4 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing 35-warning baseline remains)
- `pnpm --filter @pwragent/desktop build`
- `git diff --check HEAD^..HEAD`
- I verified the commit has a good SSH signature.

## Notes

- This recovers commit `6f76a316e`, which fixed the shutdown exception in #1676 but was lost when #1676 was reverted and the incident-explorer stack later landed separately.
