### PR TITLE
refactor(desktop): make ACP machine discovery an explicit, required seam

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3949,8 +3949,8 @@ function createTestAcpBackendAdapter(
     & Partial<Pick<AcpBackendAdapterOptions, "discoverLocalAcpAgents">>,
 ): AcpBackendAdapter {
   return new AcpBackendAdapter({
-    discoverLocalAcpAgents: async () => [],
     ...options,
+    discoverLocalAcpAgents: options.discoverLocalAcpAgents ?? (async () => []),
   });
 }
 

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -631,6 +631,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -738,6 +739,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -884,6 +886,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1007,6 +1010,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1174,6 +1178,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1247,6 +1252,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1341,6 +1347,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1525,6 +1532,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1685,6 +1693,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1838,6 +1847,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1945,6 +1955,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -2041,6 +2052,7 @@ describe("AcpBackendAdapter", () => {
         onNotification: (listener) => transport.onNotification(listener),
         onRequest: (listener) => transport.onRequest(listener),
       }),
+      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -2142,6 +2154,7 @@ describe("AcpBackendAdapter", () => {
         onNotification: (listener) => transport.onNotification(listener),
         onRequest: (listener) => transport.onRequest(listener),
       }),
+      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -2701,6 +2714,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -2822,6 +2836,7 @@ describe("AcpBackendAdapter", () => {
             threadStatus: "idle",
           })),
         }) as never,
+      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -2968,6 +2983,7 @@ describe("AcpBackendAdapter", () => {
           dispose: vi.fn(async () => undefined),
           refreshSession: vi.fn(async () => undefined),
         }) as never,
+      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -3113,6 +3129,7 @@ describe("AcpBackendAdapter", () => {
           })),
           refreshSession: vi.fn(async () => undefined),
         }) as never,
+      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -3237,6 +3254,7 @@ describe("AcpBackendAdapter", () => {
           dispose: vi.fn(async () => undefined),
           refreshSession: vi.fn(async () => undefined),
         }) as never,
+      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3938,8 +3938,15 @@ describe("AcpBackendAdapter", () => {
   });
 });
 
+/**
+ * `discoverLocalAcpAgents` is required on the adapter so no caller inherits
+ * machine-wide discovery by omission; it stays optional here so this helper can
+ * keep supplying the inert default a test wants by default.
+ */
 function createTestAcpBackendAdapter(
-  options: AcpBackendAdapterOptions,
+  options:
+    Omit<AcpBackendAdapterOptions, "discoverLocalAcpAgents">
+    & Partial<Pick<AcpBackendAdapterOptions, "discoverLocalAcpAgents">>,
 ): AcpBackendAdapter {
   return new AcpBackendAdapter({
     discoverLocalAcpAgents: async () => [],

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -631,7 +631,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -739,7 +738,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -886,7 +884,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1010,7 +1007,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1178,7 +1174,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1252,7 +1247,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1347,7 +1341,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1532,7 +1525,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1693,7 +1685,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1847,7 +1838,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -1955,7 +1945,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -2052,7 +2041,6 @@ describe("AcpBackendAdapter", () => {
         onNotification: (listener) => transport.onNotification(listener),
         onRequest: (listener) => transport.onRequest(listener),
       }),
-      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -2154,7 +2142,6 @@ describe("AcpBackendAdapter", () => {
         onNotification: (listener) => transport.onNotification(listener),
         onRequest: (listener) => transport.onRequest(listener),
       }),
-      discoverLocalAcpAgents: async () => [],
       emit: async (event) => {
         events.push(event);
       },
@@ -2714,7 +2701,6 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       createAcpTransport: () => transport,
-      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -2836,7 +2822,6 @@ describe("AcpBackendAdapter", () => {
             threadStatus: "idle",
           })),
         }) as never,
-      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -2983,7 +2968,6 @@ describe("AcpBackendAdapter", () => {
           dispose: vi.fn(async () => undefined),
           refreshSession: vi.fn(async () => undefined),
         }) as never,
-      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -3129,7 +3113,6 @@ describe("AcpBackendAdapter", () => {
           })),
           refreshSession: vi.fn(async () => undefined),
         }) as never,
-      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
@@ -3254,7 +3237,6 @@ describe("AcpBackendAdapter", () => {
           dispose: vi.fn(async () => undefined),
           refreshSession: vi.fn(async () => undefined),
         }) as never,
-      discoverLocalAcpAgents: async () => [],
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -154,6 +154,63 @@ export type AcpTransportFactory = (
 ) => AcpJsonRpcTransport;
 export type LocalAcpDiscovery = () => Promise<AcpInstalledAgentRecord[]>;
 
+/**
+ * Real local ACP discovery, and the only discovery that reaches outside this
+ * process: it reads the operator's PwrAgent config, scans their machine for
+ * installed CLIs, and may fetch a release listing from GitHub and install a
+ * managed Grok build under the PwrAgent root before probing it.
+ *
+ * `AcpBackendAdapter` never reaches for this on its own — `discoverLocalAcpAgents`
+ * is a required option, so the caller always says which discovery it wants. That
+ * is deliberate: while the adapter defaulted to this factory, any test that
+ * forgot to pass one silently inherited whatever the developer had installed,
+ * and a plain `pnpm test` would download a Grok runtime into `~/.pwragent`
+ * and then spend 5-16s per lookup probing it. Tests inject their own.
+ */
+export function createLocalAcpAgentDiscovery(params?: {
+  resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
+}): LocalAcpDiscovery {
+  return async () => {
+    // Chat-launch discovery runs through the kit's multi-install discovery
+    // (same as the settings path), so the binary that launches is the
+    // resolved active install (override → picked → first) and every agent's
+    // cliPath override is honored — consistent with what Settings shows.
+    // Read + parse the config once for all four agents (override + enabled),
+    // not once per lookup.
+    const config = readDesktopSettingsConfigSafe();
+    const preferences: Record<string, AcpAgentPreference> = {};
+    const enabledRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
+      (registryId) => acpAgentEnabledFor(config, registryId),
+    );
+    for (const registryId of enabledRegistryIds) {
+      const override = acpCliPathOverrideFor(config, registryId);
+      if (override) {
+        preferences[registryId] = { overridePath: override };
+      }
+    }
+    const env = await params?.resolveEnv?.();
+    const records = await discoverLocalAcpAgentRecords({
+      enabledRegistryIds,
+      managedGrok: {
+        enabled:
+          acpAgentEnabledFor(config, "grok")
+          && managedGrokBuildsEnabledForRuntime(
+            config,
+            {
+              env: env ?? process.env,
+              isPackaged: app?.isPackaged === true,
+            },
+          ),
+        checkMode: app?.isPackaged === true ? "ttl" : "once-per-process",
+        requirePlatformSignature: app?.isPackaged === true,
+      },
+      ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
+      ...(env ? { env } : {}),
+    });
+    return records;
+  };
+}
+
 export type AcpSessionStoreLike =
   Pick<AcpSessionStoreContract, "getSession" | "listSessions"> &
   Partial<Pick<AcpSessionStoreContract, "upsertSession">>;
@@ -189,8 +246,11 @@ export type AcpBackendAdapterOptions = {
   automationInspectionMcpCommand?: string;
   createAcpClient?: AcpClientFactory;
   createAcpTransport?: AcpTransportFactory;
-  discoverLocalAcpAgents?: LocalAcpDiscovery;
-  resolveLocalAcpDiscoveryEnv?: () => Promise<NodeJS.ProcessEnv>;
+  /**
+   * Required so no caller can silently inherit machine-wide discovery.
+   * Production passes `createLocalAcpAgentDiscovery(...)`; tests pass a stub.
+   */
+  discoverLocalAcpAgents: LocalAcpDiscovery;
   isAcpAgentEnabled?: (registryId: string) => boolean;
   checkGrokCliUpdate?: typeof checkGrokCliUpdate | null;
   resolveMcpConnectionServers?: (context: {
@@ -1011,47 +1071,7 @@ export class AcpBackendAdapter {
           (isAppStateInitialized()
             ? new AcpRolloutStore(resolveDefaultAcpRolloutRoot())
             : undefined);
-    this.discoverLocalAcpAgents =
-      options.discoverLocalAcpAgents ??
-      (async () => {
-        // Chat-launch discovery runs through the kit's multi-install discovery
-        // (same as the settings path), so the binary that launches is the
-        // resolved active install (override → picked → first) and every agent's
-        // cliPath override is honored — consistent with what Settings shows.
-        // Read + parse the config once for all four agents (override + enabled),
-        // not once per lookup.
-        const config = readDesktopSettingsConfigSafe();
-        const preferences: Record<string, AcpAgentPreference> = {};
-        const enabledRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
-          (registryId) => acpAgentEnabledFor(config, registryId),
-        );
-        for (const registryId of enabledRegistryIds) {
-          const override = acpCliPathOverrideFor(config, registryId);
-          if (override) {
-            preferences[registryId] = { overridePath: override };
-          }
-        }
-        const env = await options.resolveLocalAcpDiscoveryEnv?.();
-        const records = await discoverLocalAcpAgentRecords({
-          enabledRegistryIds,
-          managedGrok: {
-            enabled:
-              acpAgentEnabledFor(config, "grok")
-              && managedGrokBuildsEnabledForRuntime(
-                config,
-                {
-                  env: env ?? process.env,
-                  isPackaged: app?.isPackaged === true,
-                },
-              ),
-            checkMode: app?.isPackaged === true ? "ttl" : "once-per-process",
-            requirePlatformSignature: app?.isPackaged === true,
-          },
-          ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
-          ...(env ? { env } : {}),
-        });
-        return records;
-      });
+    this.discoverLocalAcpAgents = options.discoverLocalAcpAgents;
     this.isAcpAgentEnabled = options.isAcpAgentEnabled;
     this.createAcpTransport = options.createAcpTransport;
     this.createAcpClient =

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -317,6 +317,7 @@ import {
   acpRuntimeValueLooksPrivileged,
   acpSessionHasConversationHistory,
   acpSessionToThreadSummary,
+  createLocalAcpAgentDiscovery,
   findAcpModelConfigOption,
   findAcpThoughtLevelConfigOption,
   formatAcpRuntimeLabel,
@@ -7457,10 +7458,16 @@ export class DesktopBackendRegistry {
       agentToolMcpServer,
       captureStores: this.captureStores,
       createAcpClient: options?.createAcpClient,
-      discoverLocalAcpAgents: options?.discoverLocalAcpAgents,
-      resolveLocalAcpDiscoveryEnv: settingsService
-        ? async () => await settingsService.resolveTerminalSpawnEnvAsync()
-        : undefined,
+      discoverLocalAcpAgents:
+        options?.discoverLocalAcpAgents
+        ?? createLocalAcpAgentDiscovery(
+          settingsService
+            ? {
+                resolveEnv: async () =>
+                  await settingsService.resolveTerminalSpawnEnvAsync(),
+              }
+            : undefined,
+        ),
       isAcpAgentEnabled: options?.isAcpAgentEnabled,
       emit: async (event) => {
         this.rememberAcpAvailableCommands(event);


### PR DESCRIPTION
> **Rewritten.** This PR opened as a fix for 15 timing out tests in `acp-backend-adapter.test.ts`. #1730 and the `agent-cli-spawn-guard` setup file landed on `main` in the meantime and fixed those. I re-verified: **current `main` is green** for both ACP files (58 passed, 11.2s). What remains here is the enforcement layer, not the bug fix.

## What this adds

`discoverLocalAcpAgents` was **optional** on `AcpBackendAdapterOptions`, and the fallback was real machine discovery: read the operator's `~/.pwragent` config, scan `PATH`, call the GitHub releases API, install a managed Grok build under the PwrAgent root, spawn it to probe.

`main` now defends that by convention — `createTestAcpBackendAdapter` supplies an inert default, and the spawn guard fails a probe of any binary outside `os.tmpdir()`. Both are good. Neither stops a *new* `new AcpBackendAdapter({...})` from omitting the option and silently inheriting the machine.

So:

- **Make `discoverLocalAcpAgents` required.** Omitting it is now a type error rather than an implicit dependency on whatever the developer has installed. `pnpm typecheck` is the guard.
- **Extract `createLocalAcpAgentDiscovery()`** — names the one path allowed to reach the network or the PwrAgent root, and documents what it costs. Body moved verbatim.
- **Drop `resolveLocalAcpDiscoveryEnv`** from the adapter options; it only ever fed that closure and is now a factory param.
- `DesktopBackendRegistry` passes the factory, so **production behavior is unchanged**.
- `createTestAcpBackendAdapter` keeps #1730's inert default; its parameter type makes discovery optional so the default isn't provably overwritten (that combination is what produced the TS2783 on the first revision of this PR).

## Why the seam is worth a type

Measured on a machine that had a managed Grok build installed:

| discovery | cost |
|---|---|
| `managedGrok` disabled | 90ms |
| `managedGrok` enabled, 1st call | 16,440ms |
| 2nd call | 8,791ms |
| 3rd call | 4,726ms |

Against a 5s default `testTimeout`. And the install is self-inflicted: on 2026-08-17 a vitest run wrote `~/.pwragent/agents/grok/managed-release.json` with an `installedAt` matching the run's start second — the suite fetched and installed a 353MB runtime into a home directory. CI never sees any of it, because CI machines have nothing installed for the probe to find.

## Still open (not this PR)

The download capability itself is untouched. `ensureManagedGrokRuntime` has no test-mode guard, `PWRAGENT_HOME` is not set for the unit-test projects, and `apps/desktop/src/main/ipc/settings.ts` reaches the same code behind `refreshLocal`. The spawn guard turns the *probe* into a loud failure, but the fetch and the 353MB install happen before it. Tracked separately.

## Verification

- `pnpm typecheck` clean; `pnpm lint:eslint` 0 errors; `pnpm lint:boundaries` clean.
- `acp-backend-adapter.test.ts` + `acp-runtime-override-launch.test.ts`: 58 passed.
- Merged current `main` into the branch; net diff is 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
