### PR TITLE
test(desktop): stop vitest spawning real agent CLIs

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -670,6 +670,46 @@ The desktop app sits at the **top** of the dependency hierarchy and may import a
 
 Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.
 
+## No Real Agent CLIs in Vitest
+
+The `desktop-main` project loads
+[`src/main/__tests__/setup/agent-cli-spawn-guard.ts`](src/main/__tests__/setup/agent-cli-spawn-guard.ts)
+as a setup file. It fails any test that spawns a `codex` / `gemini` / `grok` /
+`kimi` / `qwen` executable from outside the OS temp dir.
+
+It exists because **sandboxing `PATH` does not sandbox discovery**. The ACP kit
+also scans well-known `$HOME` bin dirs (`~/.local/bin`, `~/.bun/bin`, every
+installed nvm node bin) and each strategy's absolute fallback candidates
+(`~/.kimi-code/bin/kimi`, `~/.grok/bin/grok`); Codex discovery probes its own
+install locations, including the `codex` inside ChatGPT.app. Before #1740 the
+suite ran ~169 real agent processes per run and asserted against whatever
+versions the developer had installed.
+
+**CI cannot catch this on its own.** CI machines have none of those binaries, so
+the probe fails, discovery finds nothing, and the assertions still pass — the
+tests take a different code path locally than on CI. The guard makes both the
+same failure.
+
+The hook is `ChildProcess.prototype.spawn`, not the `child_process` exports:
+it is the one chokepoint every async spawn path funnels through, and a
+prototype patch survives however a module imported `child_process` — including
+externally bundled dependencies vitest never transforms, which `vi.mock` cannot
+reach. It records **and** throws; the recording is what fails the test, because
+discovery probes run inside `try/catch` and swallow a bare throw. Sync spawns
+(`spawnSync` / `execFileSync`) are not covered — all agent discovery is async.
+
+Fix a failure by injecting the seam, never by widening the guard's allowed
+roots:
+
+| Surface | Seam |
+|---|---|
+| ACP discovery | `listExecutables` + `fallbackRootDir` (+ `bundledGrokCommand: null`) to confine candidates to the fixture, or inject `discover` / `readVersionOutput` |
+| Codex discovery | inject `codexDiscoveryCoordinator`, or `vi.mock("@pwrdrvr/codex-discovery")` via [`__tests__/helpers/codex-discovery-stub.ts`](src/main/__tests__/helpers/codex-discovery-stub.ts) |
+| Anything else | `vi.mock` the discovery module, as `settings-ipc` and `backend-registry` already do |
+
+`acp-runtime-override-launch.test.ts` is the worked example of the ACP seams,
+and `acp-instance-discovery.test.ts` of plain probe injection.
+
 ## Sqlite Write-Volume Instrumentation
 
 PR #1406 fixed tool accounting running one implicit transaction per streamed

--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -81,7 +81,10 @@ describe("discoverAcpAgentInstances", () => {
       group("kimi", [instance("/Users/me/.kimi-code/bin/kimi", "fallback", "0.11.0")]),
     ]);
 
-    const result = await discoverAcpAgentInstances({ discover });
+    const result = await discoverAcpAgentInstances({
+      discover,
+      readVersionOutput: async () => "kimi-code 0.11.0",
+    });
 
     expect(result.get("qwen")).toEqual({
       instances: [
@@ -142,6 +145,7 @@ describe("discoverAcpAgentInstances", () => {
     await discoverAcpAgentInstances({
       discover,
       enabledRegistryIds: ["kimi", "qwen"],
+      readVersionOutput: async () => "kimi-code 0.30.0",
     });
 
     const options = discover.mock.calls[0]?.[0];
@@ -207,6 +211,7 @@ describe("discoverAcpAgentInstances", () => {
     const result = await discoverAcpAgentInstances({
       discover,
       bundledGrokCommand: "/app/resources/agents/grok/grok",
+      readVersionOutput: async () => undefined,
     });
 
     expect(result.get("grok")).toEqual({
@@ -531,6 +536,7 @@ describe("discoverLocalAcpAgentRecords", () => {
       discover,
       bundledGrokCommand: "/app/resources/agents/grok/grok",
       preferences: { grok: { overridePath: "/custom/grok" } },
+      readVersionOutput: async () => undefined,
     });
 
     expect(record?.activeCommand).toBe("/custom/grok");

--- a/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import type { AcpPathExecutableLister } from "@pwrdrvr/agent-acp";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AcpBackendId } from "@pwragent/shared";
+import type { AcpAgentInstance, AcpBackendId } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AcpAgentStore } from "../acp/acp-agent-store";
 import { discoverLocalAcpAgentRecords } from "../acp/acp-instance-discovery";
@@ -64,17 +65,28 @@ describeExecutableAcp("ACP runtime path overrides", () => {
           agentStore,
           sessionStore,
           discover: async () => [
-            await discoverSingleProvider({ env, registryId }),
+            await discoverSingleProvider({ env, registryId, rootDir: tempDir }),
           ],
         });
         await adapter.listAvailableAgents();
         await adapter.close();
         adapter = undefined;
 
+        // The fixture's own version proves discovery resolved the fixture
+        // binary rather than an agent CLI installed on this machine.
         expect(
-          agentStore.getInstalledAgent(`acp:${registryId}` as AcpBackendId)
-            ?.activeCommand,
-        ).toBe(fixture.defaultCommand);
+          agentStore.getInstalledAgent(`acp:${registryId}` as AcpBackendId),
+        ).toMatchObject({
+          activeCommand: fixture.defaultCommand,
+          instances: [
+            {
+              command: fixture.defaultCommand,
+              source: "path",
+              version: "0.1.0-default",
+            },
+          ],
+          version: "0.1.0-default",
+        });
         const persistDiscovered = vi.spyOn(agentStore, "upsertInstalledAgent");
 
         adapter = createAdapter({
@@ -85,6 +97,7 @@ describeExecutableAcp("ACP runtime path overrides", () => {
               env,
               overridePath: fixture.overrideCommand,
               registryId,
+              rootDir: tempDir,
             }),
           ],
         });
@@ -108,18 +121,20 @@ describeExecutableAcp("ACP runtime path overrides", () => {
             args: expectedArgs,
           },
         });
-        expect(persisted?.instances).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              command: fixture.overrideCommand,
-              source: "override",
-            }),
-            expect.objectContaining({
-              command: fixture.defaultCommand,
-              source: "path",
-            }),
-          ]),
-        );
+        // Exact, not `arrayContaining`: an extra instance here means discovery
+        // reached outside the fixture and found a real installation.
+        expect(persisted?.instances).toEqual([
+          {
+            command: fixture.overrideCommand,
+            source: "override",
+            version: "0.2.0-override",
+          },
+          {
+            command: fixture.defaultCommand,
+            source: "path",
+            version: "0.1.0-default",
+          },
+        ]);
 
         const settingsEntry = installedAcpAgentSettingsEntry(
           persisted as AcpInstalledAgentRecord,
@@ -172,8 +187,22 @@ describeExecutableAcp("ACP runtime path overrides", () => {
 
     try {
       agentStore.upsertInstalledAgent(
-        await discoverSingleProvider({ env, registryId: "grok" }),
+        await discoverSingleProvider({
+          env,
+          registryId: "grok",
+          rootDir: tempDir,
+        }),
       );
+      expect(agentStore.getInstalledAgent("acp:grok")).toMatchObject({
+        activeCommand: first.defaultCommand,
+        instances: [
+          {
+            command: first.defaultCommand,
+            source: "path",
+            version: "0.1.0-default",
+          },
+        ],
+      });
       adapter = createAdapter({
         agentStore,
         sessionStore,
@@ -182,6 +211,7 @@ describeExecutableAcp("ACP runtime path overrides", () => {
             env,
             overridePath,
             registryId: "grok",
+            rootDir: tempDir,
           }),
         ],
       });
@@ -248,14 +278,31 @@ function createAdapter(params: {
   });
 }
 
+/**
+ * Runs the real discovery pipeline, confined to `rootDir`.
+ *
+ * An `env.PATH` override alone does NOT sandbox discovery: the kit also probes
+ * well-known `$HOME` bin dirs and each strategy's absolute fallback candidates
+ * (`~/.kimi-code/bin/kimi`, `/opt/homebrew/bin/qwen`, …). Left unconfined this
+ * `execFile`s whichever agent CLIs the developer has installed — hundreds of
+ * real `kimi` / `grok` / `qwen` processes per suite run — and asserts against
+ * their versions instead of the fixture's. `listExecutables` + `fallbackRootDir`
+ * are the seams that keep every candidate inside the fixture; the
+ * agent-cli-spawn guard in `setup/agent-cli-spawn-guard.ts` fails the test if
+ * one escapes anyway.
+ */
 async function discoverSingleProvider(params: {
   env: NodeJS.ProcessEnv;
   overridePath?: string;
   registryId: ProviderCase["registryId"];
+  rootDir: string;
 }): Promise<AcpInstalledAgentRecord> {
   const records = await discoverLocalAcpAgentRecords({
     enabledRegistryIds: [params.registryId],
     env: params.env,
+    bundledGrokCommand: null,
+    fallbackRootDir: params.rootDir,
+    listExecutables: fixtureListExecutables(params.rootDir),
     ...(params.overridePath
       ? { preferences: { [params.registryId]: { overridePath: params.overridePath } } }
       : {}),
@@ -266,7 +313,60 @@ async function discoverSingleProvider(params: {
   if (!record) {
     throw new Error(`Fake ${params.registryId} executable was not discovered`);
   }
+  expectInstancesInside(params.rootDir, record.instances ?? []);
   return record;
+}
+
+/**
+ * `PATH` lister that only ever yields executables under `rootDir`. The kit's
+ * default lister appends the operator's well-known bin dirs to `env.PATH`, and
+ * the fixture `PATH` itself has to carry the Node bin dir so the fixtures'
+ * `#!/usr/bin/env node` shebang resolves — which is exactly where a globally
+ * installed `gemini` or `qwen` lives.
+ */
+function fixtureListExecutables(rootDir: string): AcpPathExecutableLister {
+  return (command, env) => {
+    if (command.includes(path.sep)) {
+      return [];
+    }
+    const found: string[] = [];
+    for (const dir of (env.PATH ?? "").split(path.delimiter)) {
+      const candidate = path.join(dir, command);
+      if (!isInside(rootDir, candidate)) {
+        continue;
+      }
+      try {
+        const stat = statSync(candidate);
+        if (stat.isFile() && (stat.mode & 0o111) !== 0) {
+          found.push(candidate);
+        }
+      } catch {
+        // Not installed in this directory.
+      }
+    }
+    return found;
+  };
+}
+
+function expectInstancesInside(
+  rootDir: string,
+  instances: readonly AcpAgentInstance[],
+): void {
+  for (const instance of instances) {
+    expect(
+      isInside(rootDir, instance.command),
+      `discovered ${instance.command} outside the fixture root ${rootDir}`,
+    ).toBe(true);
+  }
+}
+
+function isInside(rootDir: string, candidate: string): boolean {
+  const relative = path.relative(rootDir, candidate);
+  return (
+    relative.length > 0
+    && !relative.startsWith("..")
+    && !path.isAbsolute(relative)
+  );
 }
 
 function fixtureDiscoveryEnv(

--- a/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
@@ -2,7 +2,7 @@ import type { AcpPathExecutableLister } from "@pwrdrvr/agent-acp";
 import { mkdtempSync, rmSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AcpAgentInstance, AcpBackendId } from "@pwragent/shared";
+import type { AcpBackendId } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AcpAgentStore } from "../acp/acp-agent-store";
 import { discoverLocalAcpAgentRecords } from "../acp/acp-instance-discovery";
@@ -14,6 +14,7 @@ import {
 } from "../acp/testing/executable-acp-agent-fixture";
 import { AcpBackendAdapter } from "../app-server/acp-backend-adapter";
 import { installedAcpAgentSettingsEntry } from "../ipc/settings";
+import { isPathWithin } from "../../shared/path-within";
 import { StateDb } from "../state/state-db";
 
 type ProviderCase = {
@@ -313,7 +314,15 @@ async function discoverSingleProvider(params: {
   if (!record) {
     throw new Error(`Fake ${params.registryId} executable was not discovered`);
   }
-  expectInstancesInside(params.rootDir, record.instances ?? []);
+  // Every bucket, not just `instances`: a real binary that discovery finds but
+  // then classifies as legacy or unverifiable lands in `incompatibleInstances`
+  // / `rejectedInstances`, which is exactly the escape this assertion exists to
+  // catch.
+  expectInstancesInside(params.rootDir, [
+    ...(record.instances ?? []),
+    ...(record.incompatibleInstances ?? []),
+    ...(record.rejectedInstances ?? []),
+  ]);
   return record;
 }
 
@@ -326,13 +335,15 @@ async function discoverSingleProvider(params: {
  */
 function fixtureListExecutables(rootDir: string): AcpPathExecutableLister {
   return (command, env) => {
-    if (command.includes(path.sep)) {
+    // Both separators, matching the kit's own lister: `path.sep` alone would
+    // treat "bin/qwen" as a bare name on Windows and join it onto every dir.
+    if (command.includes("/") || command.includes("\\")) {
       return [];
     }
     const found: string[] = [];
     for (const dir of (env.PATH ?? "").split(path.delimiter)) {
       const candidate = path.join(dir, command);
-      if (!isInside(rootDir, candidate)) {
+      if (!isPathWithin(rootDir, candidate)) {
         continue;
       }
       try {
@@ -350,23 +361,14 @@ function fixtureListExecutables(rootDir: string): AcpPathExecutableLister {
 
 function expectInstancesInside(
   rootDir: string,
-  instances: readonly AcpAgentInstance[],
+  instances: readonly { command: string }[],
 ): void {
   for (const instance of instances) {
     expect(
-      isInside(rootDir, instance.command),
+      isPathWithin(rootDir, instance.command),
       `discovered ${instance.command} outside the fixture root ${rootDir}`,
     ).toBe(true);
   }
-}
-
-function isInside(rootDir: string, candidate: string): boolean {
-  const relative = path.relative(rootDir, candidate);
-  return (
-    relative.length > 0
-    && !relative.startsWith("..")
-    && !path.isAbsolute(relative)
-  );
 }
 
 function fixtureDiscoveryEnv(

--- a/apps/desktop/src/main/__tests__/agent-cli-spawn-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-cli-spawn-guard.test.ts
@@ -1,0 +1,112 @@
+// Self-test for the suite-wide guard in `setup/agent-cli-spawn-guard.ts`.
+//
+// The guard is loaded as a `desktop-main` setup file, so it is already active
+// here. These tests deliberately trip it and then drain its violation record
+// before the guard's own `afterEach` reads it — otherwise the deliberate
+// violation would fail the test that caused it on purpose.
+import { execFile as execFileCallback } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFile = promisify(execFileCallback);
+
+const VIOLATIONS = Symbol.for("pwragent.agentCliSpawnGuard.violations");
+
+const tempDirs: string[] = [];
+
+// Extensionless shebang files are not executable through execFile on Windows,
+// the same constraint `acp-runtime-override-launch.test.ts` documents.
+const describeGuard = process.platform === "win32" ? describe.skip : describe;
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describeGuard("agent CLI spawn guard", () => {
+  it("allows a fixture agent executable inside the temp dir", async () => {
+    const tempDir = makeTempDir();
+    const command = path.join(tempDir, "kimi");
+    writeFileSync(command, "#!/bin/sh\necho fixture\n", "utf8");
+    chmodSync(command, 0o755);
+
+    const result = await execFile(command, []);
+
+    expect(result.stdout.trim()).toBe("fixture");
+    expect(drainViolations()).toEqual([]);
+  });
+
+  it("blocks a temp-dir symlink that resolves outside the temp dir", async () => {
+    // The shape that matters in this domain: `~/.local/bin/grok` is a symlink
+    // to `~/.grok/bin/grok`, so checking the literal path alone would let a
+    // real installation through on a fixture-looking name.
+    const tempDir = makeTempDir();
+    const command = path.join(tempDir, "grok");
+    symlinkSync(process.execPath, command);
+
+    const error = await captureSpawnError(() => execFile(command, ["--version"]));
+
+    expect(error.message).toContain(command);
+    expect(drainViolations().map((violation) => violation.file)).toEqual([
+      command,
+    ]);
+  });
+
+  it("blocks a bare agent command name resolved against the child PATH", async () => {
+    const error = await captureSpawnError(() => execFile("qwen", ["--version"]));
+
+    expect(error.message).toContain("qwen");
+    expect(drainViolations().map((violation) => violation.file)).toEqual([
+      "qwen",
+    ]);
+  });
+
+  it("ignores executables that are not agent CLIs", async () => {
+    const result = await execFile("/bin/echo", ["ok"]);
+
+    expect(result.stdout.trim()).toBe("ok");
+    expect(drainViolations()).toEqual([]);
+  });
+});
+
+/**
+ * The guard throws from inside `ChildProcess.prototype.spawn`. `execFile` has a
+ * custom promisifier that calls through OUTSIDE the promise executor, so that
+ * throw arrives synchronously rather than as a rejection — `.rejects` would
+ * never see it. An `async` caller's own `try`/`catch` still swallows it either
+ * way, which is why the guard records the violation instead of relying on it.
+ */
+async function captureSpawnError(
+  spawn: () => Promise<unknown>,
+): Promise<Error> {
+  try {
+    await spawn();
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error("expected the guard to block this spawn");
+}
+
+/** Consumes the guard's record so its own `afterEach` sees a clean slate. */
+function drainViolations(): { args: string[]; file: string }[] {
+  const recorded = (globalThis as Record<symbol, unknown>)[VIOLATIONS] as
+    | { args: string[]; file: string }[]
+    | undefined;
+  return recorded?.splice(0) ?? [];
+}
+
+function makeTempDir(): string {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-spawn-guard-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -10,6 +10,21 @@ import {
 } from "../settings/desktop-secret-store";
 import { readBootstrapAppearance } from "../settings/appearance-bootstrap";
 
+// `DesktopSettingsService` builds a real `CodexDiscoveryCoordinator` unless the
+// test injects one, and the kit's probe runs `codex --version` against every
+// install location on this machine (ChatGPT.app ships a `codex`). Stub the
+// probe to the shape a machine with no Codex CLI produces, so the suite reads
+// the same here as on CI. Tests that assert on discovery inject their own
+// coordinator and are unaffected.
+vi.mock("@pwrdrvr/codex-discovery", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@pwrdrvr/codex-discovery")>();
+  return {
+    ...actual,
+    discoverCodexCommands: vi.fn(async () => ({ candidates: [] })),
+  };
+});
+
 const tempRoots: string[] = [];
 
 afterEach(() => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -12,17 +12,14 @@ import { readBootstrapAppearance } from "../settings/appearance-bootstrap";
 
 // `DesktopSettingsService` builds a real `CodexDiscoveryCoordinator` unless the
 // test injects one, and the kit's probe runs `codex --version` against every
-// install location on this machine (ChatGPT.app ships a `codex`). Stub the
-// probe to the shape a machine with no Codex CLI produces, so the suite reads
-// the same here as on CI. Tests that assert on discovery inject their own
-// coordinator and are unaffected.
+// install location on this machine. See the stub for what it reproduces.
 vi.mock("@pwrdrvr/codex-discovery", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@pwrdrvr/codex-discovery")>();
-  return {
-    ...actual,
-    discoverCodexCommands: vi.fn(async () => ({ candidates: [] })),
-  };
+  const { stubbedCodexDiscovery } = await import(
+    "./helpers/codex-discovery-stub"
+  );
+  return stubbedCodexDiscovery(
+    await importOriginal<typeof import("@pwrdrvr/codex-discovery")>(),
+  );
 });
 
 const tempRoots: string[] = [];

--- a/apps/desktop/src/main/__tests__/helpers/codex-discovery-stub.ts
+++ b/apps/desktop/src/main/__tests__/helpers/codex-discovery-stub.ts
@@ -1,0 +1,74 @@
+// Shared `@pwrdrvr/codex-discovery` stub for tests that build a real
+// `DesktopSettingsService` without injecting a `codexDiscoveryCoordinator`.
+//
+// The service constructs a real `CodexDiscoveryCoordinator` in that case, whose
+// probe runs `codex --version` against every install location on the machine
+// running the suite (ChatGPT.app ships one). That is both a process storm and a
+// host-dependent result. Use this from a test file's `vi.mock` factory:
+//
+//   vi.mock("@pwrdrvr/codex-discovery", async (importOriginal) => {
+//     const { stubbedCodexDiscovery } = await import(
+//       "./helpers/codex-discovery-stub"
+//     );
+//     return stubbedCodexDiscovery(await importOriginal());
+//   });
+//
+// Tests that assert on discovery inject their own coordinator and are
+// unaffected by this stub.
+//
+// Every import below MUST stay `import type`. A runtime import of
+// `@pwrdrvr/codex-discovery` here deadlocks: the `vi.mock` factory awaits this
+// module, which would re-enter the factory for the module it is mocking. Read
+// runtime values off the `actual` module passed in instead.
+import type {
+  CodexCandidateSource,
+  CodexDiscoverySnapshot,
+} from "@pwrdrvr/codex-discovery";
+
+type CodexDiscoveryModule = {
+  CODEX_COMMAND_ENV: string;
+};
+
+/**
+ * Reproduces what real discovery returns on a machine with no Codex CLI: no
+ * selection, and one non-executable candidate per explicitly requested command.
+ *
+ * The `env` / `config` candidates matter — real `discoverCodexCommands` keeps a
+ * fixed candidate for a command the caller named even when it is not
+ * executable, and only drops the auto-discovered ones. A stub that always
+ * returned `[]` would answer differently from CI for exactly the tests that
+ * write `models.codex.path`.
+ */
+export function stubbedCodexDiscovery<Actual extends CodexDiscoveryModule>(
+  actual: Actual,
+): Actual {
+  return {
+    ...actual,
+    discoverCodexCommands: async (params?: {
+      configuredCommand?: string | undefined;
+      env?: NodeJS.ProcessEnv | undefined;
+    }): Promise<CodexDiscoverySnapshot> => ({
+      candidates: [
+        fixedCandidate(params?.env?.[actual.CODEX_COMMAND_ENV], "env"),
+        fixedCandidate(params?.configuredCommand, "config"),
+      ].filter((candidate) => candidate !== undefined),
+    }),
+  };
+}
+
+function fixedCandidate(
+  command: string | undefined,
+  source: CodexCandidateSource,
+):
+  | {
+      command: string;
+      executable: boolean;
+      selected: boolean;
+      source: CodexCandidateSource;
+    }
+  | undefined {
+  const trimmed = command?.trim();
+  return trimmed
+    ? { command: trimmed, executable: false, selected: false, source }
+    : undefined;
+}

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -37,15 +37,14 @@ import { DesktopSettingsService } from "../settings/desktop-settings-service";
 
 // These tests build a real `DesktopSettingsService`, whose default
 // `CodexDiscoveryCoordinator` runs `codex --version` against every install
-// location on this machine. Stub the probe to the shape a machine with no
-// Codex CLI produces; messaging config has no stake in the result.
+// location on this machine. Messaging config has no stake in the result.
 vi.mock("@pwrdrvr/codex-discovery", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@pwrdrvr/codex-discovery")>();
-  return {
-    ...actual,
-    discoverCodexCommands: vi.fn(async () => ({ candidates: [] })),
-  };
+  const { stubbedCodexDiscovery } = await import(
+    "./helpers/codex-discovery-stub"
+  );
+  return stubbedCodexDiscovery(
+    await importOriginal<typeof import("@pwrdrvr/codex-discovery")>(),
+  );
 });
 
 const messagingLog = vi.hoisted(() => ({

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -35,6 +35,19 @@ import {
 import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
 import { DesktopSettingsService } from "../settings/desktop-settings-service";
 
+// These tests build a real `DesktopSettingsService`, whose default
+// `CodexDiscoveryCoordinator` runs `codex --version` against every install
+// location on this machine. Stub the probe to the shape a machine with no
+// Codex CLI produces; messaging config has no stake in the result.
+vi.mock("@pwrdrvr/codex-discovery", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@pwrdrvr/codex-discovery")>();
+  return {
+    ...actual,
+    discoverCodexCommands: vi.fn(async () => ({ candidates: [] })),
+  };
+});
+
 const messagingLog = vi.hoisted(() => ({
   error: vi.fn(),
   info: vi.fn(),

--- a/apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts
+++ b/apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts
@@ -31,7 +31,8 @@ import { ChildProcess } from "node:child_process";
 import { realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach } from "vitest";
+import { afterAll, afterEach } from "vitest";
+import { isPathWithin } from "../../../shared/path-within";
 
 /** `codex`, `kimi-code`, `grok-absolute-override`, `codex-beta`, … */
 const AGENT_CLI_PATTERN =
@@ -90,18 +91,30 @@ if (guardGlobal[INSTALLED] !== true) {
 }
 
 afterEach(() => {
+  reportRecordedViolations("This test");
+});
+
+// `afterEach` cannot see a spawn from `afterAll`, nor one from an async probe
+// that settles after the final test. The recorded violation would sit in the
+// array unread and the file would exit green, since the throw at the spawn site
+// is swallowed by the probe's own try/catch.
+afterAll(() => {
+  reportRecordedViolations("This test file, after its last test,");
+});
+
+function reportRecordedViolations(subject: string): void {
   const observed = violations.splice(0);
   if (observed.length > 0) {
     throw new Error(
       [
-        `This test spawned ${observed.length} real coding-agent CLI process(es):`,
+        `${subject} spawned ${observed.length} real coding-agent CLI process(es):`,
         ...observed.map((violation) => `  ${describeViolation(violation)}`),
         "Confine discovery to the test's fixtures instead — see the remedies in",
         "apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts.",
       ].join("\n"),
     );
   }
-});
+}
 
 function isForbiddenAgentCli(file: string): boolean {
   if (file.length === 0 || !AGENT_CLI_PATTERN.test(path.basename(file))) {
@@ -112,20 +125,17 @@ function isForbiddenAgentCli(file: string): boolean {
   return path.isAbsolute(file) ? !isInsideAllowedRoot(file) : true;
 }
 
+/**
+ * Resolved, not literal. A symlink under the temp dir pointing at a real
+ * installation would otherwise pass on its raw path alone, and symlinked agent
+ * CLIs are the norm here (`~/.local/bin/grok` → `~/.grok/bin/grok` → the
+ * downloaded binary). `realpathOrSelf` falls back to the literal path when the
+ * file does not exist, which is what the sandboxed-but-absent fallback
+ * candidates (`<fixture>/.kimi-code/bin/kimi`) rely on.
+ */
 function isInsideAllowedRoot(file: string): boolean {
-  const candidates = [file, realpathOrSelf(path.dirname(file))];
-  return ALLOWED_ROOTS.some((root) =>
-    candidates.some((candidate) => isInside(root, candidate)),
-  );
-}
-
-function isInside(root: string, candidate: string): boolean {
-  const relative = path.relative(root, candidate);
-  return (
-    relative.length > 0
-    && !relative.startsWith("..")
-    && !path.isAbsolute(relative)
-  );
+  const resolved = realpathOrSelf(file);
+  return ALLOWED_ROOTS.some((root) => isPathWithin(root, resolved));
 }
 
 function realpathOrSelf(target: string): string {

--- a/apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts
+++ b/apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts
@@ -1,0 +1,141 @@
+// Fails any test that spawns a real coding-agent CLI from the machine running
+// the suite.
+//
+// Agent discovery probes far more than `env.PATH`: the ACP kit also scans
+// well-known `$HOME` bin dirs and each strategy's absolute fallback candidates
+// (`~/.kimi-code/bin/kimi`, `/opt/homebrew/bin/qwen`, …), and Codex discovery
+// probes its own install locations. A test that sandboxes only `PATH` still
+// `execFile`s whatever the developer happens to have installed — hundreds of
+// short-lived `kimi` / `grok` / `qwen` / `codex` processes per run — and then
+// asserts against those versions instead of its fixtures. CI hides all of it,
+// because CI machines have none of those binaries: the probe fails, discovery
+// finds nothing, and the assertions still pass. This guard makes the local
+// behavior and the CI behavior the same failure.
+//
+// The hook is `ChildProcess.prototype.spawn` rather than the `child_process`
+// exports because it is the one chokepoint every async spawn path funnels
+// through (`exec`, `execFile`, `spawn` all reach it), and because a prototype
+// patch survives however a module imported `child_process` — including
+// externally bundled dependencies that vitest never transforms and `vi.mock`
+// therefore cannot reach.
+//
+// Fix a failure by injecting the seam, never by widening `ALLOWED_ROOTS`:
+//   - ACP discovery: pass `listExecutables` + `fallbackRootDir` (and
+//     `bundledGrokCommand: null`) so candidates stay inside the fixture, or
+//     inject `discover` / `readVersionOutput` outright.
+//   - Codex discovery: inject `codexDiscoveryCoordinator`, or stub
+//     `discoverCodexCommands` from `@pwrdrvr/codex-discovery`.
+//   - Everything else: `vi.mock` the discovery module, as `settings-ipc` and
+//     `backend-registry` already do.
+import { ChildProcess } from "node:child_process";
+import { realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach } from "vitest";
+
+/** `codex`, `kimi-code`, `grok-absolute-override`, `codex-beta`, … */
+const AGENT_CLI_PATTERN =
+  /^(claude|codex|gemini|grok|kimi|qwen)(-[\w.-]+)?(\.(exe|cmd|bat))?$/i;
+
+/**
+ * Only the OS temp dir. Every fixture in this suite builds its fake agent
+ * executables under `mkdtemp(os.tmpdir(), …)`, so a spawn from anywhere else
+ * is by definition a binary this suite did not create. Both spellings are kept
+ * because macOS reports `/var/folders/…` while its realpath is
+ * `/private/var/folders/…`.
+ */
+const ALLOWED_ROOTS = [os.tmpdir(), realpathOrSelf(os.tmpdir())];
+
+type SpawnOptions = { args?: string[]; file?: string };
+
+/** `ChildProcess#spawn` is internal to Node and absent from `@types/node`. */
+type SpawnableChildProcess = ChildProcess & {
+  spawn: (options: SpawnOptions) => unknown;
+};
+
+type Violation = { args: string[]; file: string };
+
+const INSTALLED = Symbol.for("pwragent.agentCliSpawnGuard.installed");
+const VIOLATIONS = Symbol.for("pwragent.agentCliSpawnGuard.violations");
+
+type GuardGlobal = typeof globalThis & {
+  [INSTALLED]?: true;
+  [VIOLATIONS]?: Violation[];
+};
+
+const guardGlobal = globalThis as GuardGlobal;
+const violations: Violation[] = (guardGlobal[VIOLATIONS] ??= []);
+
+// Setup files re-run for every test file in a worker, but the builtin
+// prototype is shared across all of them — patch it exactly once.
+if (guardGlobal[INSTALLED] !== true) {
+  guardGlobal[INSTALLED] = true;
+  const prototype = ChildProcess.prototype as SpawnableChildProcess;
+  const original = prototype.spawn;
+  prototype.spawn = function guardedSpawn(
+    this: SpawnableChildProcess,
+    options: SpawnOptions,
+  ) {
+    const file = options?.file ?? "";
+    if (isForbiddenAgentCli(file)) {
+      const violation: Violation = { args: options?.args ?? [], file };
+      violations.push(violation);
+      // Throwing stops the real process from starting. It is not enough on its
+      // own — discovery probes run inside try/catch and would swallow it — so
+      // the recorded violation is what actually fails the test below.
+      throw new Error(describeViolation(violation));
+    }
+    return original.call(this, options);
+  };
+}
+
+afterEach(() => {
+  const observed = violations.splice(0);
+  if (observed.length > 0) {
+    throw new Error(
+      [
+        `This test spawned ${observed.length} real coding-agent CLI process(es):`,
+        ...observed.map((violation) => `  ${describeViolation(violation)}`),
+        "Confine discovery to the test's fixtures instead — see the remedies in",
+        "apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts.",
+      ].join("\n"),
+    );
+  }
+});
+
+function isForbiddenAgentCli(file: string): boolean {
+  if (file.length === 0 || !AGENT_CLI_PATTERN.test(path.basename(file))) {
+    return false;
+  }
+  // A bare command name is resolved by the OS against the child's `PATH`, so
+  // nothing here can prove it stays inside the fixture. Treat it as escaping.
+  return path.isAbsolute(file) ? !isInsideAllowedRoot(file) : true;
+}
+
+function isInsideAllowedRoot(file: string): boolean {
+  const candidates = [file, realpathOrSelf(path.dirname(file))];
+  return ALLOWED_ROOTS.some((root) =>
+    candidates.some((candidate) => isInside(root, candidate)),
+  );
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative.length > 0
+    && !relative.startsWith("..")
+    && !path.isAbsolute(relative)
+  );
+}
+
+function realpathOrSelf(target: string): string {
+  try {
+    return realpathSync(target);
+  } catch {
+    return target;
+  }
+}
+
+function describeViolation(violation: Violation): string {
+  return `${violation.file} ${violation.args.slice(1).join(" ")}`.trim();
+}

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -146,26 +146,9 @@ export async function discoverAcpAgentInstances(
     options?.fallbackRootDir,
   );
 
-  const overrides: Record<string, string> = {};
-  for (const [registryId, pref] of Object.entries(preferences)) {
-    const override = pref.overridePath?.trim();
-    if (override) {
-      overrides[registryId] = override;
-    }
-  }
-
   const discover = options?.discover ?? discoverLocalAcpAgentInstances;
   const [discoveredGroups, managedGrokCommand] = await Promise.all([
-    discover({
-      ...(strategies !== undefined ? { strategies } : {}),
-      ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
-      ...(options?.env ? { env: options.env } : {}),
-      ...(options?.now ? { now: options.now } : {}),
-      ...(options?.listExecutables
-        ? { listExecutables: options.listExecutables }
-        : {}),
-      includeRejectedCandidates: true,
-    }),
+    discover(kitDiscoveryOptions(options, strategies)),
     resolveManagedGrokCommand(options, strategies),
   ]);
   const groups = await withPwrAgentGrok(
@@ -223,26 +206,9 @@ export async function discoverLocalAcpAgentRecords(
     options?.fallbackRootDir,
   );
 
-  const overrides: Record<string, string> = {};
-  for (const [registryId, pref] of Object.entries(preferences)) {
-    const override = pref.overridePath?.trim();
-    if (override) {
-      overrides[registryId] = override;
-    }
-  }
-
   const discover = options?.discover ?? discoverLocalAcpAgentInstances;
   const [discoveredGroups, managedGrokCommand] = await Promise.all([
-    discover({
-      ...(strategies !== undefined ? { strategies } : {}),
-      ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
-      ...(options?.env ? { env: options.env } : {}),
-      ...(options?.now ? { now: options.now } : {}),
-      ...(options?.listExecutables
-        ? { listExecutables: options.listExecutables }
-        : {}),
-      includeRejectedCandidates: true,
-    }),
+    discover(kitDiscoveryOptions(options, strategies)),
     resolveManagedGrokCommand(options, strategies),
   ]);
   const now = options?.now?.() ?? Date.now();
@@ -554,10 +520,38 @@ function rejectedAcpCandidateMessage(
   }
 }
 
+/**
+ * Builds the kit's options for both entry points, so an option added here
+ * reaches the record view and the per-registryId view together instead of
+ * silently diverging between them.
+ */
+function kitDiscoveryOptions(
+  options: DiscoverAcpAgentInstancesOptions | undefined,
+  strategies: readonly AcpAgentStrategy[],
+): LocalAcpDiscoveryOptions {
+  const overrides: Record<string, string> = {};
+  for (const [registryId, pref] of Object.entries(options?.preferences ?? {})) {
+    const override = pref.overridePath?.trim();
+    if (override) {
+      overrides[registryId] = override;
+    }
+  }
+  return {
+    strategies,
+    ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
+    ...(options?.env ? { env: options.env } : {}),
+    ...(options?.now ? { now: options.now } : {}),
+    ...(options?.listExecutables
+      ? { listExecutables: options.listExecutables }
+      : {}),
+    includeRejectedCandidates: true,
+  };
+}
+
 function strategiesForEnabledRegistryIds(
   enabledRegistryIds: readonly string[] | undefined,
   fallbackRootDir: string | undefined,
-): readonly AcpAgentStrategy[] | undefined {
+): readonly AcpAgentStrategy[] {
   let strategies = ACP_DISCOVERY_STRATEGIES;
   if (enabledRegistryIds !== undefined) {
     const enabled = new Set(enabledRegistryIds);

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -13,10 +13,13 @@ import {
   discoverLocalAcpAgentInstances,
   strategyById,
   type AcpAgentStrategy,
+  type AcpPathExecutableLister,
   type DiscoveredAcpAgentGroup,
   type LocalAcpDiscoveryOptions,
 } from "@pwrdrvr/agent-acp";
 import { execFile as execFileCallback } from "node:child_process";
+import { homedir } from "node:os";
+import path from "node:path";
 import { promisify } from "node:util";
 import type {
   AcpAgentInstance,
@@ -109,6 +112,22 @@ export type DiscoverAcpAgentInstancesOptions = {
     checkMode: ManagedGrokCheckMode,
     requirePlatformSignature: boolean,
   ) => Promise<string | undefined>;
+  /**
+   * Injectable `PATH` executable lister (tests), forwarded to the kit. The
+   * kit's default lister enumerates `env.PATH` *plus* well-known `$HOME` bin
+   * dirs (`~/.local/bin`, `~/.bun/bin`, every installed nvm node bin, …), so
+   * an `env.PATH` override alone does not confine discovery to a fixture.
+   */
+  listExecutables?: AcpPathExecutableLister;
+  /**
+   * Root for each strategy's absolute fallback candidates (tests). Every
+   * `$HOME`-relative fallback (`~/.kimi-code/bin/kimi`, `~/.grok/bin/grok`, …)
+   * is rebased under this directory and the system prefixes
+   * (`/opt/homebrew/bin`, `/usr/local/bin`) are dropped, so discovery cannot
+   * version-probe an agent CLI the operator happens to have installed.
+   * Production leaves this undefined and keeps the real fallbacks.
+   */
+  fallbackRootDir?: string;
 };
 
 /**
@@ -122,7 +141,10 @@ export async function discoverAcpAgentInstances(
   options?: DiscoverAcpAgentInstancesOptions,
 ): Promise<Map<string, AcpInstanceDiscovery>> {
   const preferences = options?.preferences ?? {};
-  const strategies = strategiesForEnabledRegistryIds(options?.enabledRegistryIds);
+  const strategies = strategiesForEnabledRegistryIds(
+    options?.enabledRegistryIds,
+    options?.fallbackRootDir,
+  );
 
   const overrides: Record<string, string> = {};
   for (const [registryId, pref] of Object.entries(preferences)) {
@@ -139,6 +161,9 @@ export async function discoverAcpAgentInstances(
       ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
       ...(options?.env ? { env: options.env } : {}),
       ...(options?.now ? { now: options.now } : {}),
+      ...(options?.listExecutables
+        ? { listExecutables: options.listExecutables }
+        : {}),
       includeRejectedCandidates: true,
     }),
     resolveManagedGrokCommand(options, strategies),
@@ -193,7 +218,10 @@ export async function discoverLocalAcpAgentRecords(
   options?: DiscoverAcpAgentInstancesOptions,
 ): Promise<AcpInstalledAgentRecord[]> {
   const preferences = options?.preferences ?? {};
-  const strategies = strategiesForEnabledRegistryIds(options?.enabledRegistryIds);
+  const strategies = strategiesForEnabledRegistryIds(
+    options?.enabledRegistryIds,
+    options?.fallbackRootDir,
+  );
 
   const overrides: Record<string, string> = {};
   for (const [registryId, pref] of Object.entries(preferences)) {
@@ -210,6 +238,9 @@ export async function discoverLocalAcpAgentRecords(
       ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
       ...(options?.env ? { env: options.env } : {}),
       ...(options?.now ? { now: options.now } : {}),
+      ...(options?.listExecutables
+        ? { listExecutables: options.listExecutables }
+        : {}),
       includeRejectedCandidates: true,
     }),
     resolveManagedGrokCommand(options, strategies),
@@ -525,12 +556,47 @@ function rejectedAcpCandidateMessage(
 
 function strategiesForEnabledRegistryIds(
   enabledRegistryIds: readonly string[] | undefined,
+  fallbackRootDir: string | undefined,
 ): readonly AcpAgentStrategy[] | undefined {
-  if (enabledRegistryIds === undefined) {
-    return ACP_DISCOVERY_STRATEGIES;
+  let strategies = ACP_DISCOVERY_STRATEGIES;
+  if (enabledRegistryIds !== undefined) {
+    const enabled = new Set(enabledRegistryIds);
+    strategies = strategies.filter((strategy) => enabled.has(strategy.id));
   }
-  const enabled = new Set(enabledRegistryIds);
-  return ACP_DISCOVERY_STRATEGIES.filter((strategy) => enabled.has(strategy.id));
+  return fallbackRootDir === undefined
+    ? strategies
+    : strategies.map((strategy) =>
+        withRebasedFallbackCommands(strategy, fallbackRootDir),
+      );
+}
+
+/**
+ * Rebases a strategy's `$HOME`-relative fallback candidates under `rootDir`
+ * and drops the absolute system prefixes. See `fallbackRootDir`: this is how a
+ * test confines candidate enumeration to its fixture instead of probing the
+ * operator's real installations.
+ */
+function withRebasedFallbackCommands(
+  strategy: AcpAgentStrategy,
+  rootDir: string,
+): AcpAgentStrategy {
+  const home = homedir();
+  return {
+    ...strategy,
+    discoveryProbe: {
+      ...strategy.discoveryProbe,
+      fallbackCommands: (strategy.discoveryProbe.fallbackCommands ?? []).flatMap(
+        (command) => {
+          const relative = path.relative(home, command);
+          return relative.length === 0
+            || relative.startsWith("..")
+            || path.isAbsolute(relative)
+            ? []
+            : [path.join(rootDir, relative)];
+        },
+      ),
+    },
+  };
 }
 
 async function resolveManagedGrokCommand(

--- a/apps/desktop/src/shared/path-within.ts
+++ b/apps/desktop/src/shared/path-within.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+
+/**
+ * True when `candidate` is a strict descendant of `root`.
+ *
+ * `root` itself is not "within" itself, and neither operand is resolved
+ * against the filesystem — pass realpaths when symlinks must not escape the
+ * boundary.
+ */
+export function isPathWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative.length > 0
+    && !relative.startsWith("..")
+    && !path.isAbsolute(relative)
+  );
+}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -43,9 +43,14 @@ export default defineConfig({
             "apps/desktop/src/preload/__tests__/**/*.test.ts",
             "apps/desktop/src/shared/__tests__/**/*.test.ts"
           ],
-          // Inert unless PWRAGENT_DEV_SQLITE_WRITE_METRICS is set; see
-          // `pnpm test:sqlite-writes`.
-          setupFiles: ["apps/desktop/src/main/state/sqlite-write-metrics-setup.ts"],
+          setupFiles: [
+            // Inert unless PWRAGENT_DEV_SQLITE_WRITE_METRICS is set; see
+            // `pnpm test:sqlite-writes`.
+            "apps/desktop/src/main/state/sqlite-write-metrics-setup.ts",
+            // Fails a test that probes an agent CLI installed on the machine
+            // running the suite instead of its own fixtures.
+            "apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts",
+          ],
           // Inline @pwrdrvr/codex-discovery so vitest transforms it. Without
           // this, the kit's bundled `import { spawn } from "child_process"`
           // is loaded raw by Node and bypasses the tests'


### PR DESCRIPTION
## Summary

- The vitest suite spawned the developer's installed coding-agent CLIs ~169 times per run. CI passes because CI machines have none of those binaries: the probe fails, discovery finds nothing, and the assertions still pass — so the tests take a different code path locally than on CI and assert against whatever versions the developer happens to have.
- `acp-runtime-override-launch.test.ts` sandboxed `PATH`, which is not enough. The ACP kit escapes `env.PATH` two independent ways, and the production code had a seam for neither:
  1. `discoveryDirs()` appends `wellKnownAgentBinDirs(homedir())` to the `PATH` dirs — `~/.local/bin`, `~/.bun/bin`, every installed nvm node bin, `/opt/homebrew/bin`, `/usr/local/bin`.
  2. Each strategy's `discoveryProbe.fallbackCommands` are absolute `$HOME`-relative paths baked in at module load — `~/.kimi-code/bin/kimi`, `~/.grok/bin/grok`, `~/.qwen/bin/qwen`.

  Every surviving candidate is then `execFile`d twice, for `--version` **and** `--help`.
- **Production seam** (`acp-instance-discovery.ts`): two optional test-injection options alongside the file's existing ones (`discover`, `readVersionOutput`, `bundledGrokCommand`) — `listExecutables`, forwarded to the kit, and `fallbackRootDir`, which rebases `$HOME`-relative fallbacks under a root and drops the absolute system prefixes. Production leaves both undefined; behavior is unchanged.
- **Test**: now passes a fixture-confined lister plus `fallbackRootDir` and `bundledGrokCommand: null`, and asserts every discovered command lies under the fixture root. `instances` is now an exact array rather than `arrayContaining`, pinned to the fixture's own `0.1.0-default` / `0.2.0-override` versions — a real installation leaking in fails the test instead of passing it for the wrong reason.
- **Regression guard**: new `__tests__/setup/agent-cli-spawn-guard.ts`, wired as a `desktop-main` setup file (the project had no shared setup module for this before). It hooks `ChildProcess.prototype.spawn` rather than the `child_process` exports — that is the single chokepoint every async spawn path funnels through, and a prototype patch survives however a module imported `child_process`, including externally bundled deps vitest never transforms and `vi.mock` therefore cannot reach. It records **and** throws: recording is what fails the test, because discovery probes run inside `try/catch` and would swallow a bare throw.

### Audit of the rest of the suite

Done by instrumenting every spawn across a full run rather than by grep. Two more offenders of the same class, both fixed here:

| Test | Problem |
|---|---|
| `desktop-settings-service.test.ts`, `messaging-config.test.ts` | 81 real `codex` probes per run from `/Applications/ChatGPT.app/Contents/Resources/codex`. `DesktopSettingsService` builds a real `CodexDiscoveryCoordinator` unless injected, and 1 of 77 constructions injected one. Fixed by stubbing `discoverCodexCommands` to the shape a machine with no Codex CLI produces. |
| `acp-instance-discovery.test.ts` | Four probes of synthetic paths (`/Users/me/…`, `/app/resources/…`) reaching real `execFile`. Fixed by injecting `readVersionOutput`. |

`settings-ipc`, `backend-registry`, `acp-backend-adapter`, and `grok-managed-runtime` were already clean.

## Verification

| Check | Result |
|---|---|
| Real agent-CLI spawns per suite run | **~169 → 0** — all 61 remaining are inside the fixture tmp dir |
| `ps -Ao pid,ppid,etime,comm \| grep -iE 'kimi\|grok\|qwen'` during run | 3 processes, all long-lived and parented by running PwrAgent Electron apps — the legitimate category, none parented by a vitest worker |
| Guard negative test | Removing the seams fails loudly with `/Users/…/.kimi-code/bin/kimi --version`, `/opt/homebrew/bin/grok --version`, … |
| `pnpm test` | 578 files / 8319 tests passing |
| `pnpm lint:eslint` | exit 0, 0 errors |
| e2e/eval in the default test run | 0 of 8322 collected tests — `apps/desktop/e2e/` and `apps/desktop/eval/` match no project's `include` glob, so their real-binary use is fine as-is |

## Notes

- **Pre-existing typecheck errors, not introduced here**: 4 errors in `acp-instance-discovery.ts` (`includeRejectedCandidates` / `rejectedInstances` missing from the installed `@pwrdrvr/agent-acp` types — version skew between the code and the installed kit). Confirmed present on the base commit via `git stash`. Worth a separate look.
- **Unrelated flake observed**: `app-shell.test.tsx > starts a new thread on a selected federation machine and profile` failed in 1 of 3 full runs and passes in isolation. It is in the `desktop-renderer` project, whose config this PR does not touch.
- **Left alone deliberately**: the audit also surfaced 1506 `git`, 1020 `which`, and 164 `gh` spawns. Same non-hermeticity in principle but outside this change's scope; `gh` in particular is not guaranteed on CI and may deserve its own pass.
- The guard covers async spawns only (`ChildProcess.prototype.spawn`). All agent discovery and launch is async, so that is the relevant surface; `spawnSync`/`execFileSync` are not intercepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)