### PR TITLE
fix(desktop): keep machine ACP discovery out of registry construction

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4268,6 +4268,46 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  // Machine discovery reads the operator's config, may fetch a GitHub release
+  // list, install a managed Grok build under the PwrAgent root, and then probe
+  // that binary — 5-16s per lookup. A registry test must never reach it, and
+  // must not have to remember to opt out. These two cases pin both directions
+  // of the gate: default off, and still wired when production asks for it.
+  it("does not reach machine ACP discovery without an explicit opt-in", async () => {
+    localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockClear();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+    });
+
+    await registry.listBackends({ includeUnavailable: true });
+
+    expect(
+      localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+    ).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
+  it("reaches machine ACP discovery when the caller opts in", async () => {
+    localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockClear();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+      useMachineAcpDiscovery: true,
+    });
+
+    await registry.listBackends({ includeUnavailable: true });
+
+    expect(
+      localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+    ).toHaveBeenCalled();
+
+    await registry.close();
+  });
+
   it("filters disabled ACP agents before default backend discovery", async () => {
     const tempRoot = await mkdtemp(
       path.join(os.tmpdir(), "pwragent-backend-registry-"),
@@ -4293,6 +4333,10 @@ describe("DesktopBackendRegistry", () => {
       codexClient: new MockBackendClient({}),
       overlayStore: createOverlayStoreMock(),
       acpAgentStore: createAcpAgentStoreMock([]),
+      // This case asserts on what machine discovery is asked for, so it opts in
+      // deliberately. `../acp/acp-instance-discovery` is mocked file-wide, so
+      // opting in here stays inside the process.
+      useMachineAcpDiscovery: true,
     });
 
     try {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -56,6 +56,16 @@ import {
 import { FederationRouter } from "../federation/federation-router";
 import type { FederationGatewayConnection } from "../federation/federation-transport";
 
+// `getDesktopBackendRegistry()` is the one construction that opts into real
+// machine ACP discovery, so a test that reaches the singleton inherits it — the
+// config read, the GitHub release fetch, the managed-Grok install under the
+// PwrAgent root, and the 5-16s probe. Nothing here needs an installed agent, so
+// keep that one call inert and leave the rest of the module real.
+vi.mock("../acp/acp-instance-discovery", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../acp/acp-instance-discovery")>()),
+  discoverLocalAcpAgentRecords: vi.fn(async () => []),
+}));
+
 type RuntimeHarness = {
   router?: FederationRouter;
   receiveEnvelope: (

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -211,6 +211,14 @@ export function createLocalAcpAgentDiscovery(params?: {
   };
 }
 
+/**
+ * Inert discovery: reports no installed ACP agents and touches nothing outside
+ * this process. This is what a `DesktopBackendRegistry` gets unless its caller
+ * opts in to machine discovery, so a registry test that injects no stub fails
+ * by finding no agents rather than by installing a Grok runtime.
+ */
+export const noLocalAcpAgentDiscovery: LocalAcpDiscovery = async () => [];
+
 export type AcpSessionStoreLike =
   Pick<AcpSessionStoreContract, "getSession" | "listSessions"> &
   Partial<Pick<AcpSessionStoreContract, "upsertSession">>;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -325,6 +325,7 @@ import {
   acpAdvertisesRuntimeModeSelector,
   isAcpSessionMissingForProjectError,
   mergeAcpRuntimeState,
+  noLocalAcpAgentDiscovery,
   readKimiYoloExecutionModeFromText,
   withAcpModelRuntimeSelection,
   type AcpBackendAdapterOptions,
@@ -7245,6 +7246,15 @@ export class DesktopBackendRegistry {
     acpAvailableCommandsStore?: AcpAvailableCommandsStoreLike | null;
     acpAvailableCommandProbeBudgetMs?: number;
     discoverLocalAcpAgents?: LocalAcpDiscovery;
+    /**
+     * Opt in to real machine ACP discovery — scanning the operator's machine,
+     * and installing/probing a managed Grok build under the PwrAgent root.
+     * Only `getDesktopBackendRegistry()` sets this. Every other construction
+     * (all of them in tests) gets `noLocalAcpAgentDiscovery` unless it injects
+     * its own `discoverLocalAcpAgents`, so a test cannot reach the machine by
+     * forgetting an option.
+     */
+    useMachineAcpDiscovery?: boolean;
     isAcpAgentEnabled?: (registryId: string) => boolean;
     createAcpClient?: AcpClientFactory;
     agentToolMcpServer?: AgentToolMcpServerLike | null;
@@ -7569,14 +7579,16 @@ export class DesktopBackendRegistry {
       createAcpClient: options?.createAcpClient,
       discoverLocalAcpAgents:
         options?.discoverLocalAcpAgents
-        ?? createLocalAcpAgentDiscovery(
-          settingsService
-            ? {
-                resolveEnv: async () =>
-                  await settingsService.resolveTerminalSpawnEnvAsync(),
-              }
-            : undefined,
-        ),
+        ?? (options?.useMachineAcpDiscovery
+          ? createLocalAcpAgentDiscovery(
+              settingsService
+                ? {
+                    resolveEnv: async () =>
+                      await settingsService.resolveTerminalSpawnEnvAsync(),
+                  }
+                : undefined,
+            )
+          : noLocalAcpAgentDiscovery),
       isAcpAgentEnabled: options?.isAcpAgentEnabled,
       emit: async (event) => {
         this.rememberAcpAvailableCommands(event);
@@ -32792,7 +32804,12 @@ export function getExistingDesktopBackendRegistry(): DesktopBackendRegistry | nu
 
 export function getDesktopBackendRegistry(): DesktopBackendRegistry {
   if (!registry) {
-    registry = new DesktopBackendRegistry();
+    // The one construction that wants the operator's real machine. Every other
+    // `new DesktopBackendRegistry(...)` in the tree is a test, and defaults to
+    // `noLocalAcpAgentDiscovery` — keeping the config read, the GitHub release
+    // fetch, the managed-Grok install, and the 5-16s binary probe out of the
+    // suite even when a test forgets to inject its own discovery stub.
+    registry = new DesktopBackendRegistry({ useMachineAcpDiscovery: true });
   }
 
   return registry;


### PR DESCRIPTION
Stacked on #1739 — targets `agent/isolate-acp-discovery-from-tests`, so review that one first.

## Problem

#1739 made `discoverLocalAcpAgents` a required option on `AcpBackendAdapterOptions`, but `DesktopBackendRegistry` still had to resolve it in its constructor, because the production singleton constructs `new DesktopBackendRegistry()` with no options. Production and tests took the identical path.

So any registry construction could reach `createLocalAcpAgentDiscovery` through any code path that called `listBackends` — which reads the operator's `~/.pwragent` config, may fetch the GitHub release list, installs a managed Grok build under the PwrAgent root, and then probes that binary at 5-16s per lookup. There are 478 registry constructions in tests; 3 injected a stub.

## Fix

Real discovery is now opt-in via `useMachineAcpDiscovery`, set only by `getDesktopBackendRegistry()` — the single construction outside tests. Everything else gets the new inert `noLocalAcpAgentDiscovery`.

The flag deliberately keeps the `settingsService`-derived `resolveEnv` wiring in the constructor instead of moving it to the singleton. That matters: `settingsService` is derived internally as `createsLiveCodexClient ? getDesktopSettingsService() : undefined`, and passing the discovery in at the singleton would have diverged in the replay-fixture path, where `settingsService` is undefined and `resolveEnv` is correctly omitted. **Production behavior is unchanged on every path.**

## One correction to the original framing

`backend-registry.test.ts` — the 456 constructions — already mocked `../acp/acp-instance-discovery` file-wide, so the expensive part could not happen there. The genuinely exposed callers were the three files with no such mock, all now covered without being touched:

| File | Constructions | `acp-instance-discovery` mocked? |
|---|---|---|
| `backend-registry.test.ts` | 456 | yes — already protected |
| `sqlite-write-metrics.test.ts` | 14 | **no** |
| `backend-registry-replay.test.ts` | 4 | **no** |
| `backend-registry-replay-isolation.test.ts` | 4 | **no** |

`federation-runtime.test.ts` reaches the production singleton once and so now constructs real discovery, but never calls `listBackends` or `listAvailableAgents`, and discovery is a lazy closure — nothing runs.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` → 536/536 passed
- `pnpm typecheck` → 0 errors
- `~/.pwragent/agents/grok/managed-release.json` mtime unchanged across three full suite runs
- The guard was confirmed to fail when the gate is removed

Two guard tests pin both directions — default off, and still wired on opt-in. The second is the one that stops this from silently disabling production discovery.

`filters disabled ACP agents before default backend discovery` asserts on the arguments machine discovery receives, so it now opts in explicitly.

## Unrelated flakiness noted

Ten Git handoff tests in this suite are load- and cache-sensitive. On the untouched base commit a warm run still failed 3 of them; a cold first run in a fresh worktree failed 11. All are timeouts, not assertions, and all passed on a warm idle run. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)