### PR TITLE
fix(desktop): recover a Codex whose version probe times out

### DIFF
--- a/apps/desktop/e2e/codex-slow-version-probe.spec.ts
+++ b/apps/desktop/e2e/codex-slow-version-probe.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * A Codex that answers `--version` slowly must still be the Codex we launch.
+ *
+ * `@pwrdrvr/codex-discovery` probes `--version` with a hard 2s `execFile`
+ * timeout on every platform. A probe that blows that budget is not reported
+ * as "slow" — the candidate simply comes back with no version, and a version
+ * is required for protocol-compatibility gating, so the desktop demotes it.
+ * What the operator sees next depends only on what else is installed:
+ *
+ * - nothing else: Codex reads as missing, and since nothing retries, the app
+ *   stays that way until a manual Settings refresh;
+ * - something else: selection quietly falls through to it, so an explicitly
+ *   configured `[models.codex] path` is replaced by a different Codex.
+ *
+ * Neither is hypothetical. The invocation is a process chain, and on the
+ * Windows lab guest `codex.cmd` answers in ~1.5s warm (`cmd.exe -> node ->
+ * shim`) against that 2s ceiling — which is what made
+ * `windows-codex-discovery.spec.ts` fail on a cold guest with ZERO app-server
+ * launches, at any poll budget.
+ *
+ * The 3s case here is that failure made deterministic and portable: no slow
+ * machine required, and it fails on any platform without the re-probe in
+ * `CodexDiscoveryCoordinator.reprobeUnreadVersions`. The 0s case is the guard
+ * on the other side — the healthy path must still issue exactly ONE
+ * `--version`, which is the coalescing #1720 introduced.
+ *
+ * If the shared probe budget ever grows past 3s this stops exercising the
+ * timeout (it would pass on the first probe) rather than failing falsely;
+ * raise the delay here if that happens.
+ */
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+import {
+  FAKE_CODEX_VERSION,
+  findFakeCodexRequests,
+  readFakeCodexProtocolLog,
+  writeFakeCodexExecutable,
+} from "./fixtures/fake-agent-executables";
+
+/**
+ * Point the app at the fake through `PWRDRVR_CODEX_COMMAND` rather than a
+ * seeded `config.toml`.
+ *
+ * Two reasons, and both matter. It reaches the app process directly, so the
+ * spec does not depend on the launched app resolving the same PwrAgent root
+ * the harness seeded — `resolvePwragentRoot` falls back to `os.homedir()`,
+ * which reads `USERPROFILE` on Windows while the harness overrides `HOME`.
+ * And it is the highest-priority source, so this stays a real test on a
+ * developer machine that already has a working Codex installed: without the
+ * re-probe, a timed-out env command loses to that install.
+ */
+const CODEX_COMMAND_ENV = "PWRDRVR_CODEX_COMMAND";
+
+/**
+ * The slow case spends 2s letting the shared probe time out and 3s answering
+ * the re-probe before the app-server can even start, so it needs more than
+ * the 30s default to leave the assertions room on a loaded CI guest. That is
+ * delay this spec creates on purpose, not slack for an unexplained wait.
+ */
+test.setTimeout(60_000);
+
+/** Comfortably past the shared 2s `--version` timeout. */
+const SLOW_VERSION_PROBE_MS = 3_000;
+
+async function readInvocationArgs(invocationLogPath: string): Promise<string[]> {
+  try {
+    return (await readFile(invocationLogPath, "utf8"))
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+for (const versionDelayMs of [0, SLOW_VERSION_PROBE_MS]) {
+  test(`configured codex launches with a ${versionDelayMs}ms version probe`, async () => {
+    let invocationLogPath = "";
+    let protocolLogPath = "";
+    const launchEnv: Record<string, string | undefined> = {};
+    const app = await launchElectronApp({
+      requiresReplayDriver: false,
+      env: launchEnv,
+      preLaunchHook: async (homeRoot) => {
+        const binDir = path.join(homeRoot, "codex-bin");
+        await mkdir(binDir, { recursive: true });
+        const implPath = path.join(binDir, "codex-impl.js");
+        const wrapperPath = path.join(binDir, "codex-probe.js");
+        invocationLogPath = path.join(binDir, "invocations.log");
+        protocolLogPath = path.join(binDir, "protocol.jsonl");
+        await writeFakeCodexExecutable({
+          targetPath: implPath,
+          protocolLogPath,
+          launchMarkerPath: path.join(binDir, "app-server.launched"),
+        });
+        // Delegates everything except `--version` to the shared fake, so the
+        // app-server half of the protocol stays identical to every other spec.
+        const wrapperBody = [
+          `const fs = require("node:fs");`,
+          `try {`,
+          `  fs.appendFileSync(${JSON.stringify(invocationLogPath)},`,
+          `    Date.now() + " " + process.argv.slice(2).join(" ") + "\\n");`,
+          `} catch {}`,
+          `if (process.argv.includes("--version")) {`,
+          `  setTimeout(() => {`,
+          `    process.stdout.write("codex-cli ${FAKE_CODEX_VERSION}\\n");`,
+          `    process.exit(0);`,
+          `  }, ${versionDelayMs});`,
+          `} else {`,
+          `  require(${JSON.stringify(implPath)});`,
+          `}`,
+          "",
+        ];
+
+        // Windows cannot run a shebang script, and the shim chain is the whole
+        // reason the 2s budget is tight there, so give each platform the shape
+        // an operator would actually have: a `.cmd` shim on Windows, a
+        // shebang'd executable elsewhere.
+        let codexPath: string;
+        if (process.platform === "win32") {
+          await writeFile(wrapperPath, wrapperBody.join("\n"), "utf8");
+          codexPath = path.join(binDir, "codex.cmd");
+          await writeFile(
+            codexPath,
+            [
+              "@echo off",
+              `"${process.execPath}" "${wrapperPath}" %*`,
+              "",
+            ].join("\r\n"),
+            "utf8",
+          );
+        } else {
+          codexPath = path.join(binDir, "codex");
+          await writeFile(
+            codexPath,
+            ["#!/usr/bin/env node", ...wrapperBody].join("\n"),
+            "utf8",
+          );
+          await chmod(codexPath, 0o755);
+        }
+        launchEnv[CODEX_COMMAND_ENV] = codexPath;
+      },
+    });
+
+    try {
+      await expect
+        .poll(
+          async () => {
+            const log = await readFakeCodexProtocolLog(protocolLogPath);
+            return findFakeCodexRequests(log, "__launch__").length;
+          },
+          {
+            // Covers the deliberate stall: the shared probe's 2s timeout, then
+            // the re-probe answering at `versionDelayMs`, then the spawn.
+            message:
+              "the configured Codex should reach app-server despite a slow --version probe",
+            timeout: 25_000,
+          },
+        )
+        .toBe(1);
+
+      // The healthy path must not pay for the recovery path. A second probe
+      // here would be the duplicate spawn #1720 removed.
+      const versionProbes = (await readInvocationArgs(invocationLogPath))
+        .filter((args) => args.includes("--version"));
+      expect(versionProbes).toHaveLength(versionDelayMs === 0 ? 1 : 2);
+    } finally {
+      await app.close();
+    }
+  });
+}

--- a/apps/desktop/e2e/windows-codex-discovery.spec.ts
+++ b/apps/desktop/e2e/windows-codex-discovery.spec.ts
@@ -13,6 +13,30 @@ test.skip(
   "This regression exercises native Windows shim discovery and launch.",
 );
 
+/**
+ * How long the app gets to reach its first Codex app-server spawn.
+ *
+ * Playwright's 5s `expect.poll` default is not enough, and the reason is a
+ * bounded piece of app behavior rather than machine slowness. Measured on the
+ * PwrSuiteLab Windows guest, warm, this whole window is 323-579ms across five
+ * runs — but the first `--version` probe belongs to `@pwrdrvr/codex-discovery`
+ * and carries a hard 2s timeout, and a `cmd.exe -> node -> codex.cmd` chain
+ * measures ~1.5s warm on that guest. When the guest is cold that probe blows
+ * its budget, and `CodexDiscoveryCoordinator` then spends a second,
+ * desktop-owned probe recovering it before the transport can spawn anything.
+ *
+ * So the cold budget is one 2s timeout + one re-probe + the spawn, and this
+ * covers it with margin while still failing well inside the 30s test timeout.
+ *
+ * Do NOT read this as "the guest is slow, give it longer". A cold guest used
+ * to fail here with ZERO launches at ANY budget: the timed-out probe left no
+ * validated candidate, `resolve()` threw `CodexCliNotInstalledError`, and
+ * nothing retried. That is fixed on the discovery path, not here —
+ * `e2e/codex-slow-version-probe.spec.ts` is what pins it. This constant only
+ * pays for the recovery the app now performs.
+ */
+const CODEX_APP_SERVER_LAUNCH_TIMEOUT_MS = 15_000;
+
 function envKey(name: string): string {
   return Object.keys(process.env).find(
     (candidate) => candidate.toLowerCase() === name.toLowerCase(),
@@ -81,7 +105,7 @@ test("PATH discovery launches one version probe and starts a real thread", async
     await expect.poll(async () => {
       const log = await readFakeCodexProtocolLog(protocolLogPath);
       return findFakeCodexRequests(log, "__launch__").length;
-    }).toBe(1);
+    }, { timeout: CODEX_APP_SERVER_LAUNCH_TIMEOUT_MS }).toBe(1);
 
     await app.window.getByRole("button", { name: "New thread" }).click();
     const prompt = app.window.getByRole("textbox", { name: "New thread" });
@@ -94,11 +118,17 @@ test("PATH discovery launches one version probe and starts a real thread", async
     }).toBeGreaterThanOrEqual(1);
     await expect.poll(async () => {
       const invocations = await readInvocationArgs(invocationLogPath);
-      return {
-        appServer: invocations.filter((args) => args.includes("app-server")).length,
-        version: invocations.filter((args) => args.includes("--version")).length,
-      };
-    }).toEqual({ appServer: 1, version: 1 });
+      return invocations.filter((args) => args.includes("app-server")).length;
+    }).toBe(1);
+    // One `--version` is the coalescing #1720 introduced, and a cold guest may
+    // add exactly one more: the shared 2s probe times out and the coordinator
+    // re-probes to recover it. Anything beyond that is the per-consumer probe
+    // stampede coming back. The exact-one guard for the healthy path lives in
+    // `codex-slow-version-probe.spec.ts`, where it is deterministic.
+    const versionProbes = (await readInvocationArgs(invocationLogPath))
+      .filter((args) => args.includes("--version"));
+    expect(versionProbes.length).toBeGreaterThanOrEqual(1);
+    expect(versionProbes.length).toBeLessThanOrEqual(2);
   } finally {
     await app.close();
   }
@@ -180,7 +210,7 @@ test("npm shim trio discovers and launches through codex.cmd", async () => {
     await expect.poll(async () => {
       const log = await readFakeCodexProtocolLog(protocolLogPath);
       return findFakeCodexRequests(log, "__launch__").length;
-    }).toBe(1);
+    }, { timeout: CODEX_APP_SERVER_LAUNCH_TIMEOUT_MS }).toBe(1);
 
     await app.window.getByRole("button", { name: "New thread" }).click();
     const prompt = app.window.getByRole("textbox", { name: "New thread" });
@@ -193,11 +223,17 @@ test("npm shim trio discovers and launches through codex.cmd", async () => {
     }).toBeGreaterThanOrEqual(1);
     await expect.poll(async () => {
       const invocations = await readInvocationArgs(invocationLogPath);
-      return {
-        appServer: invocations.filter((args) => args.includes("app-server")).length,
-        version: invocations.filter((args) => args.includes("--version")).length,
-      };
-    }).toEqual({ appServer: 1, version: 1 });
+      return invocations.filter((args) => args.includes("app-server")).length;
+    }).toBe(1);
+    // One `--version` is the coalescing #1720 introduced, and a cold guest may
+    // add exactly one more: the shared 2s probe times out and the coordinator
+    // re-probes to recover it. Anything beyond that is the per-consumer probe
+    // stampede coming back. The exact-one guard for the healthy path lives in
+    // `codex-slow-version-probe.spec.ts`, where it is deterministic.
+    const versionProbes = (await readInvocationArgs(invocationLogPath))
+      .filter((args) => args.includes("--version"));
+    expect(versionProbes.length).toBeGreaterThanOrEqual(1);
+    expect(versionProbes.length).toBeLessThanOrEqual(2);
 
     expect(await readInvocationArgs(powerShellLogPath)).toEqual([]);
   } finally {

--- a/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
@@ -38,6 +38,35 @@ function unvalidatedSnapshot(command: string): CodexDiscoverySnapshot {
   };
 }
 
+type VersionProbe = (params: {
+  command: string;
+  env: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  timeoutMs?: number;
+}) => Promise<{ failureReason?: string; version?: string }>;
+
+/**
+ * What the shared scan returns when its 2s `--version` timeout fires: the
+ * command is present and executable, but no version was read, so the desktop
+ * has nothing to gate protocol compatibility on.
+ */
+function timedOutProbeSnapshot(command: string): CodexDiscoverySnapshot {
+  return {
+    candidates: [
+      {
+        command,
+        executable: true,
+        selected: true,
+        source: "path",
+        versionFailureReason:
+          `Command failed: ${command} --version\nterminated by SIGTERM`,
+      },
+    ],
+    selectedCommand: command,
+    selectedSource: "path",
+  };
+}
+
 function deferred<T>(): {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -447,5 +476,138 @@ describe("CodexDiscoveryCoordinator", () => {
       command: "/changed/codex",
     });
     expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  describe("unread version re-probe", () => {
+    it("recovers a command whose shared version probe timed out", async () => {
+      const discover = vi.fn(async () => timedOutProbeSnapshot("/slow/codex"));
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        version: "0.130.0",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover,
+        probeVersion,
+        resolveEnv: async () => ({ PATH: "/bin" }),
+      });
+
+      await expect(coordinator.resolve()).resolves.toMatchObject({
+        command: "/slow/codex",
+        version: "0.130.0",
+      });
+      expect(probeVersion).toHaveBeenCalledOnce();
+      expect(probeVersion.mock.calls[0]?.[0]).toMatchObject({
+        command: "/slow/codex",
+      });
+    });
+
+    it("keeps a configured command that a lower-priority install would have replaced", async () => {
+      // The quiet half of the same failure: the machine HAS another Codex, so
+      // a timed-out probe on `[models.codex] path` does not read as "missing"
+      // — selection just falls through to whatever else is installed, and the
+      // operator's explicit choice is silently ignored.
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        version: "0.130.0",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover: async () => ({
+          candidates: [
+            {
+              command: "/configured/codex",
+              executable: true,
+              selected: false,
+              source: "config" as const,
+              versionFailureReason:
+                "Command failed: /configured/codex --version\n",
+            },
+            {
+              command: "/usr/local/bin/codex",
+              executable: true,
+              selected: true,
+              source: "application" as const,
+              version: "0.146.1",
+            },
+          ],
+          selectedCommand: "/usr/local/bin/codex",
+          selectedSource: "application" as const,
+        }),
+        probeVersion,
+        resolveEnv: async () => ({ PATH: "/bin" }),
+      });
+
+      await expect(coordinator.resolve("/configured/codex")).resolves
+        .toMatchObject({
+          command: "/configured/codex",
+          source: "config",
+          version: "0.130.0",
+        });
+      expect(probeVersion).toHaveBeenCalledOnce();
+    });
+
+    it("re-probes nothing when the shared scan already selected a command", async () => {
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        version: "0.130.0",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover: async () => selectedSnapshot("/fast/codex"),
+        probeVersion,
+        resolveEnv: async () => ({ PATH: "/bin" }),
+      });
+
+      await expect(coordinator.resolve()).resolves.toMatchObject({
+        command: "/fast/codex",
+      });
+      // #1720 coalesced provider probes; a re-probe on the healthy path would
+      // reintroduce exactly the duplicate `--version` spawn it removed.
+      expect(probeVersion).not.toHaveBeenCalled();
+    });
+
+    it("leaves settled failures alone", async () => {
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        version: "0.130.0",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover: async () => ({
+          candidates: [
+            {
+              command: "/absent/codex",
+              executable: false,
+              failureReason: "not_found",
+              selected: false,
+              source: "path" as const,
+            },
+            {
+              command: "/old/codex",
+              executable: false,
+              failureReason: "codex_too_old",
+              selected: false,
+              source: "config" as const,
+              version: "0.100.0",
+            },
+          ],
+        }),
+        probeVersion,
+        resolveEnv: async () => ({ PATH: "/bin" }),
+      });
+
+      const snapshot = await coordinator.discover();
+      expect(snapshot.selectedCommand).toBeUndefined();
+      expect(probeVersion).not.toHaveBeenCalled();
+    });
+
+    it("still reports missing when the re-probe cannot read a version either", async () => {
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        failureReason: "version_not_reported",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover: async () => timedOutProbeSnapshot("/slow/codex"),
+        probeVersion,
+        resolveEnv: async () => ({ PATH: "/bin" }),
+      });
+
+      await expect(coordinator.resolve()).rejects.toThrow(
+        /codex CLI not found/i,
+      );
+      expect(probeVersion).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
@@ -486,6 +486,11 @@ describe("CodexDiscoveryCoordinator", () => {
       }));
       const coordinator = new CodexDiscoveryCoordinator({
         discover,
+        // Pin the platform: these fixtures use POSIX-shaped commands, and the
+        // `windows-desktop-main` CI lane would otherwise resolve
+        // `process.platform` to win32, where `isReprobableCommand` rejects an
+        // extension-less path and nothing is re-probed.
+        platform: "darwin",
         probeVersion,
         resolveEnv: async () => ({ PATH: "/bin" }),
       });
@@ -530,6 +535,11 @@ describe("CodexDiscoveryCoordinator", () => {
           selectedCommand: "/usr/local/bin/codex",
           selectedSource: "application" as const,
         }),
+        // Pin the platform: these fixtures use POSIX-shaped commands, and the
+        // `windows-desktop-main` CI lane would otherwise resolve
+        // `process.platform` to win32, where `isReprobableCommand` rejects an
+        // extension-less path and nothing is re-probed.
+        platform: "darwin",
         probeVersion,
         resolveEnv: async () => ({ PATH: "/bin" }),
       });
@@ -549,6 +559,11 @@ describe("CodexDiscoveryCoordinator", () => {
       }));
       const coordinator = new CodexDiscoveryCoordinator({
         discover: async () => selectedSnapshot("/fast/codex"),
+        // Pin the platform: these fixtures use POSIX-shaped commands, and the
+        // `windows-desktop-main` CI lane would otherwise resolve
+        // `process.platform` to win32, where `isReprobableCommand` rejects an
+        // extension-less path and nothing is re-probed.
+        platform: "darwin",
         probeVersion,
         resolveEnv: async () => ({ PATH: "/bin" }),
       });
@@ -559,6 +574,116 @@ describe("CodexDiscoveryCoordinator", () => {
       // #1720 coalesced provider probes; a re-probe on the healthy path would
       // reintroduce exactly the duplicate `--version` spawn it removed.
       expect(probeVersion).not.toHaveBeenCalled();
+    });
+
+    it("does not probe a candidate that carries no probe failure at all", async () => {
+      // `__tests__/helpers/codex-discovery-stub.ts` emits exactly this shape —
+      // `executable: false`, no version, no reason — for an explicitly
+      // requested command. Treating that as retryable made the coordinator
+      // escape the documented seam and spawn a real `codex --version` out of
+      // desktop-settings-service.test.ts and messaging-config.test.ts, which
+      // `agent-cli-spawn-guard` only failed to catch because a Windows-shaped
+      // fixture path defeats its POSIX `path.basename` check.
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        version: "0.130.0",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover: async () => ({
+          candidates: [
+            {
+              command: "codex-env",
+              executable: false,
+              selected: false,
+              source: "env" as const,
+            },
+          ],
+        }),
+        // Pin the platform: these fixtures use POSIX-shaped commands, and the
+        // `windows-desktop-main` CI lane would otherwise resolve
+        // `process.platform` to win32, where `isReprobableCommand` rejects an
+        // extension-less path and nothing is re-probed.
+        platform: "darwin",
+        probeVersion,
+        resolveEnv: async () => ({ PATH: "/bin" }),
+      });
+
+      const snapshot = await coordinator.discover();
+      expect(snapshot.selectedCommand).toBeUndefined();
+      expect(probeVersion).not.toHaveBeenCalled();
+    });
+
+    it("skips a Windows command Windows cannot start, and keeps its shim", async () => {
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        version: "0.146.0",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover: async () => ({
+          candidates: [
+            // npm's extensionless sh shim. Upstream calls it `executable`
+            // because `fs.access(X_OK)` succeeds for any file on Windows.
+            {
+              command: "C:\\npm\\codex",
+              executable: true,
+              selected: false,
+              source: "path" as const,
+              versionFailureReason: "spawn C:\\npm\\codex ENOEXEC",
+            },
+            {
+              command: "C:\\npm\\codex.cmd",
+              executable: true,
+              selected: false,
+              source: "path" as const,
+              versionFailureReason: "Command failed\nterminated by SIGTERM",
+            },
+          ],
+        }),
+        discoverWindows: async () => [],
+        platform: "win32",
+        probeVersion,
+        resolveEnv: async () => ({ Path: "C:\\npm" }),
+      });
+
+      await expect(coordinator.resolve()).resolves.toMatchObject({
+        command: "C:\\npm\\codex.cmd",
+        version: "0.146.0",
+      });
+      expect(probeVersion).toHaveBeenCalledOnce();
+      expect(probeVersion.mock.calls[0]?.[0]).toMatchObject({
+        command: "C:\\npm\\codex.cmd",
+      });
+    });
+
+    it("probes one binary once when its rows differ only in case", async () => {
+      const probeVersion = vi.fn<VersionProbe>(async () => ({
+        version: "0.146.0",
+      }));
+      const coordinator = new CodexDiscoveryCoordinator({
+        discover: async () => ({
+          candidates: [
+            {
+              command: "C:\\npm\\codex.cmd",
+              executable: true,
+              selected: false,
+              source: "application" as const,
+              versionFailureReason: "Command failed\nterminated by SIGTERM",
+            },
+            {
+              command: "C:\\npm\\codex.CMD",
+              executable: true,
+              selected: false,
+              source: "path" as const,
+              versionFailureReason: "Command failed\nterminated by SIGTERM",
+            },
+          ],
+        }),
+        discoverWindows: async () => [],
+        platform: "win32",
+        probeVersion,
+        resolveEnv: async () => ({ Path: "C:\\npm" }),
+      });
+
+      await coordinator.discover();
+      expect(probeVersion).toHaveBeenCalledOnce();
     });
 
     it("leaves settled failures alone", async () => {
@@ -585,6 +710,11 @@ describe("CodexDiscoveryCoordinator", () => {
             },
           ],
         }),
+        // Pin the platform: these fixtures use POSIX-shaped commands, and the
+        // `windows-desktop-main` CI lane would otherwise resolve
+        // `process.platform` to win32, where `isReprobableCommand` rejects an
+        // extension-less path and nothing is re-probed.
+        platform: "darwin",
         probeVersion,
         resolveEnv: async () => ({ PATH: "/bin" }),
       });
@@ -600,6 +730,11 @@ describe("CodexDiscoveryCoordinator", () => {
       }));
       const coordinator = new CodexDiscoveryCoordinator({
         discover: async () => timedOutProbeSnapshot("/slow/codex"),
+        // Pin the platform: these fixtures use POSIX-shaped commands, and the
+        // `windows-desktop-main` CI lane would otherwise resolve
+        // `process.platform` to win32, where `isReprobableCommand` rejects an
+        // extension-less path and nothing is re-probed.
+        platform: "darwin",
         probeVersion,
         resolveEnv: async () => ({ PATH: "/bin" }),
       });

--- a/apps/desktop/src/main/__tests__/codex-version-probe.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-version-probe.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_VERSION_PATTERN,
+  classifyProbeFailure,
+  probeCodexVersion,
+} from "../codex-version-probe";
+
+describe("CODEX_VERSION_PATTERN", () => {
+  it("reads the version off Codex's own banner", () => {
+    for (const [output, expected] of [
+      ["codex-cli 0.146.0\n", "0.146.0"],
+      ["codex 0.130.0\n", "0.130.0"],
+      ["codex-cli 0.128.0-alpha.1\n", "0.128.0-alpha.1"],
+      ["codex/1.2.3\n", "1.2.3"],
+    ] as const) {
+      expect(output.match(CODEX_VERSION_PATTERN)?.[1]).toBe(expected);
+    }
+  });
+
+  it("still finds a banner printed behind a warning line", () => {
+    // node/npm deprecation notices routinely land on stdout before the banner,
+    // so the line anchor must not be a whole-output anchor.
+    const output = "(node:1) DeprecationWarning: fs.R_OK is deprecated\ncodex-cli 0.146.0\n";
+    expect(output.match(CODEX_VERSION_PATTERN)?.[1]).toBe("0.146.0");
+  });
+
+  it("refuses a version that is only part of a filesystem path", () => {
+    // `/` is in the separator class so `codex/1.2.3` works, which without the
+    // line anchor also accepted the Homebrew Cellar layout out of any error
+    // message — the recovery path marks a candidate launchable on that value,
+    // and automatic candidates are ranked by version descending, so a
+    // fabricated version can outrank a genuine install.
+    for (const output of [
+      "Error: cannot find module /opt/homebrew/Cellar/codex/0.146.0/lib/x",
+      "  at /usr/lib/node_modules/@openai/codex/0.9.0/bin/x.js:1:1",
+    ]) {
+      expect(output.match(CODEX_VERSION_PATTERN)).toBeNull();
+    }
+  });
+});
+
+describe("probeCodexVersion", () => {
+  it("reports the version its runner printed", async () => {
+    await expect(
+      probeCodexVersion({
+        command: "/fake/codex",
+        env: {},
+        runner: async () => ({ stdout: "codex-cli 0.146.0\n" }),
+      }),
+    ).resolves.toEqual({ version: "0.146.0" });
+  });
+
+  it("reports version_not_reported when the command answered unparseably", async () => {
+    await expect(
+      probeCodexVersion({
+        command: "/fake/codex",
+        env: {},
+        runner: async () => ({ stdout: "some other tool 1.2.3\n" }),
+      }),
+    ).resolves.toEqual({ failureReason: "version_not_reported" });
+  });
+
+  it("never throws, so one bad candidate cannot poison a batch", async () => {
+    await expect(
+      probeCodexVersion({
+        command: "/fake/codex",
+        env: {},
+        runner: async () => {
+          throw Object.assign(new Error("boom"), { code: "ENOENT" });
+        },
+      }),
+    ).resolves.toEqual({ failureReason: "not_found" });
+  });
+});
+
+describe("classifyProbeFailure", () => {
+  it("separates a killed probe from a missing command", () => {
+    expect(
+      classifyProbeFailure(
+        Object.assign(new Error("killed"), { killed: true, signal: "SIGTERM" }),
+      ),
+    ).toBe("version_probe_timed_out");
+    expect(
+      classifyProbeFailure(Object.assign(new Error("nope"), { code: "ENOENT" })),
+    ).toBe("not_found");
+    expect(classifyProbeFailure(new Error("exit 49"))).toBe("exit 49");
+  });
+});

--- a/apps/desktop/src/main/codex-discovery-coordinator.ts
+++ b/apps/desktop/src/main/codex-discovery-coordinator.ts
@@ -10,10 +10,12 @@ import {
 import {
   discoverWindowsCodexCandidates,
   isValidatedCandidate,
+  isWindowsSpawnableCommand,
 } from "./codex-windows-launch";
 import {
   CODEX_VERSION_PROBE_TIMEOUT_MS,
   probeCodexVersion,
+  type CodexVersionProbeResult,
 } from "./codex-version-probe";
 
 export const CODEX_DISCOVERY_SUCCESS_TTL_MS = 5 * 60_000;
@@ -256,12 +258,16 @@ export class CodexDiscoveryCoordinator {
    * be on the machine. Both are the same event, so the rule is keyed on
    * PRIORITY rather than on "nothing was selected":
    *
-   * - A candidate is re-probed only if no candidate of equal or higher
+   * - A candidate is re-probed only if no candidate of STRICTLY higher
    *   priority already validated (env > config > automatic, matching
-   *   `normalizeCodexDiscoverySnapshot`). A healthy scan therefore
-   *   re-probes nothing, which is what keeps
-   *   `windows-codex-discovery.spec.ts`'s "exactly one version probe"
-   *   assertion — and #1720's coalescing — true.
+   *   `normalizeCodexDiscoverySnapshot`). Same-tier is deliberately included:
+   *   the automatic tier is ordered by version, not by source, so a validated
+   *   Homebrew install does not settle the question for an npm install that
+   *   merely failed to answer. The cost of that is real and worth stating —
+   *   a machine with a working Codex AND a second broken one pays one
+   *   re-probe for the broken one, because "which is newer" cannot be known
+   *   without asking. Only candidates that reported nothing are eligible, so
+   *   a scan where every command answered re-probes nothing.
    * - Only candidates whose version could not be READ are eligible. A
    *   command that is absent (`not_found`), genuinely too old
    *   (`codex_too_old`), or a `.ps1` we refuse to launch is a settled
@@ -281,51 +287,88 @@ export class CodexDiscoveryCoordinator {
           : best,
       Number.POSITIVE_INFINITY,
     );
-    const eligible = snapshot.candidates.filter(
-      (candidate) =>
-        isUnreadVersionCandidate(candidate)
-        && codexCandidateRank(candidate) < bestValidatedRank,
+    const eligible = new Set(
+      snapshot.candidates.filter(
+        (candidate) =>
+          isUnreadVersionCandidate(candidate)
+          // `<=`, not `<`: the automatic tier is ordered by version descending,
+          // not by source, so a validated automatic candidate does not settle
+          // the question for a DIFFERENT automatic candidate that merely failed
+          // to answer. With `<`, a newer npm install whose probe timed out is
+          // never recovered once an older Homebrew install validated, and the
+          // app silently launches the older one — the same wrong-binary harm
+          // this method exists to prevent, one tier down.
+          && codexCandidateRank(candidate) <= bestValidatedRank
+          && isReprobableCommand(candidate.command, context.platform),
+      ),
     );
-    if (eligible.length === 0) {
+    if (eligible.size === 0) {
       return snapshot;
     }
 
     const probe = this.options.probeVersion ?? probeCodexVersion;
-    const reprobed = new Map<
-      string,
-      CodexDiscoverySnapshot["candidates"][number]
-    >();
+    // Probe each distinct command ONCE. Upstream concatenates fixed and auto
+    // candidates without cross-deduping them, so a configured `[models.codex]
+    // path` that also resolves on PATH arrives as two rows sharing one
+    // command; probing per row would spawn the same binary twice, which is the
+    // stampede #1720 removed.
+    // Case-insensitively on Windows, matching `mergeCodexDiscoveryCandidates`
+    // and `stripExtension` in this file. It is the one platform where two rows
+    // for the same binary routinely differ only in case: the hard-coded
+    // install candidate is `…/npm/codex.cmd` while a PATH scan appends the
+    // PATHEXT entry verbatim and yields `…\codex.CMD`.
+    const versions = new Map<string, string>();
+    const probeKey = (command: string): string =>
+      context.platform === "win32" ? command.toLowerCase() : command;
+    const commands = [
+      ...new Map(
+        [...eligible].map((it) => [probeKey(it.command), it.command] as const),
+      ).values(),
+    ];
     await Promise.all(
-      eligible.map(async (candidate) => {
+      commands.map(async (command) => {
+        // Isolate per command: a single rejection must not discard the
+        // versions the other probes recovered, which would leave `runProbe`
+        // caching a hard discovery failure and make recovery strictly worse
+        // than no recovery at all.
         const result = await probe({
-          command: candidate.command,
+          command,
           env: context.env,
           platform: context.platform,
           timeoutMs: CODEX_VERSION_PROBE_TIMEOUT_MS,
-        });
-        if (!result.version) {
-          return;
+        }).catch(() => ({}) as CodexVersionProbeResult);
+        if (result.version) {
+          versions.set(probeKey(command), result.version);
         }
-        const tooOld =
-          compareCodexCliVersions(result.version, MINIMUM_CODEX_CLI_VERSION) < 0;
-        reprobed.set(candidate.command, {
-          command: candidate.command,
-          source: candidate.source,
-          executable: !tooOld,
-          selected: false,
-          version: result.version,
-          ...(tooOld ? { failureReason: "codex_too_old" } : {}),
-        });
       }),
     );
-    if (reprobed.size === 0) {
+    if (versions.size === 0) {
       return snapshot;
     }
     return normalizeCodexDiscoverySnapshot({
       ...snapshot,
-      candidates: snapshot.candidates.map(
-        (candidate) => reprobed.get(candidate.command) ?? candidate,
-      ),
+      // Rewrite only the rows that were actually eligible. Keying the result
+      // by command alone would stamp every row sharing that command with one
+      // arbitrary `source`, so the operator's configured row could be
+      // reclassified as `path` — nondeterministically, by probe race order.
+      candidates: snapshot.candidates.map((candidate) => {
+        const version = eligible.has(candidate)
+          ? versions.get(probeKey(candidate.command))
+          : undefined;
+        if (!version) {
+          return candidate;
+        }
+        const tooOld =
+          compareCodexCliVersions(version, MINIMUM_CODEX_CLI_VERSION) < 0;
+        return {
+          command: candidate.command,
+          source: candidate.source,
+          executable: !tooOld,
+          selected: false,
+          version,
+          ...(tooOld ? { failureReason: "codex_too_old" } : {}),
+        };
+      }),
     });
   }
 
@@ -388,12 +431,28 @@ export class CodexDiscoveryCoordinator {
  * Failure reasons that are a settled answer about a command, not a probe
  * that failed to get one. Re-probing these would only spawn a process to
  * learn what we already know.
+ *
+ * Two of these settle the question even though they came from a probe:
+ *
+ * - `version_not_reported` means the probe RAN TO COMPLETION and printed
+ *   something we could not parse. A longer budget cannot change that, and
+ *   our own pattern is stricter than upstream's, so the re-probe would read
+ *   the same output and reject it again.
+ * - `version_probe_timed_out` is produced only by `classifyProbeFailure`,
+ *   i.e. by a desktop-owned probe that already spent the full
+ *   `CODEX_VERSION_PROBE_TIMEOUT_MS`. Upstream reports its own 2s timeout as
+ *   a raw `execFile` message instead, which stays unsettled and is exactly
+ *   the case worth retrying. Without this entry the Windows path probes one
+ *   command three times — 2s upstream, 10s sibling, 10s here — for a
+ *   guaranteed-identical answer.
  */
 const SETTLED_CODEX_FAILURE_REASONS = new Set([
   "codex_too_old",
   "not_executable",
   "not_found",
   "powershell_shim_unsupported",
+  "version_not_reported",
+  "version_probe_timed_out",
 ]);
 
 /**
@@ -416,15 +475,26 @@ function codexCandidateRank(
 }
 
 /**
- * Whether this candidate's version is unknown *because the probe did not
- * report one* — a timeout, a killed child, an unparseable answer — rather
- * than because the command itself is unusable.
+ * Whether a command is worth spending a process on at all.
  *
- * `version_probe_timed_out` (from `classifyProbeFailure`) is the explicit
- * form of exactly the case this exists for, and is deliberately absent from
- * the settled set. The shared upstream probe reports its own timeout as a raw
- * `execFile` message instead, which lands here the same way: unrecognized
- * means unsettled.
+ * On Windows `fs.access(X_OK)` succeeds for any existing file, so upstream
+ * hands back npm's extensionless sh shim as `executable: true` with only a
+ * raw spawn error to show for it. Re-probing that shim spawns a process that
+ * cannot succeed, and if it somehow did report a version the recovery path
+ * would mark it launchable — reintroducing the unspawnable-shim selection
+ * `codex-windows-launch` exists to prevent.
+ */
+function isReprobableCommand(
+  command: string,
+  platform: NodeJS.Platform,
+): boolean {
+  return platform !== "win32" || isWindowsSpawnableCommand(command);
+}
+
+/**
+ * Whether this candidate's version is unknown *because the probe did not
+ * report one* — a timeout at a budget we can beat, or a killed child — rather
+ * than because the command itself is unusable or already had its answer.
  */
 function isUnreadVersionCandidate(
   candidate: CodexDiscoverySnapshot["candidates"][number],
@@ -432,8 +502,16 @@ function isUnreadVersionCandidate(
   if (candidate.version) {
     return false;
   }
+  // Deliberately NOT gated on `candidate.executable`: the normalizer clears
+  // that flag when it demotes a candidate, and it runs immediately before
+  // this, so every genuinely recoverable candidate arrives with
+  // `executable: false`.
   const reason = candidate.failureReason ?? candidate.versionFailureReason;
-  return reason === undefined || !SETTLED_CODEX_FAILURE_REASONS.has(reason);
+  // A candidate with NO reason at all is not evidence of a probe we can beat.
+  // Upstream always records one, so this shape only comes from a stub or a
+  // future producer — and treating it as retryable made discovery spawn a real
+  // `codex --version` out of tests that had pinned every other seam.
+  return reason !== undefined && !SETTLED_CODEX_FAILURE_REASONS.has(reason);
 }
 
 function normalizeCodexDiscoverySnapshot(

--- a/apps/desktop/src/main/codex-discovery-coordinator.ts
+++ b/apps/desktop/src/main/codex-discovery-coordinator.ts
@@ -11,6 +11,10 @@ import {
   discoverWindowsCodexCandidates,
   isValidatedCandidate,
 } from "./codex-windows-launch";
+import {
+  CODEX_VERSION_PROBE_TIMEOUT_MS,
+  probeCodexVersion,
+} from "./codex-version-probe";
 
 export const CODEX_DISCOVERY_SUCCESS_TTL_MS = 5 * 60_000;
 export const CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS = 15_000;
@@ -45,6 +49,8 @@ export type CodexDiscoveryCoordinatorOptions = {
   notInstalledTtlMs?: number;
   now?: () => number;
   platform?: NodeJS.Platform;
+  /** Test seam for the desktop-owned `--version` re-probe. */
+  probeVersion?: typeof probeCodexVersion;
   resolveEnv: () => Promise<NodeJS.ProcessEnv>;
   staleSuccessTtlMs?: number;
   successTtlMs?: number;
@@ -224,6 +230,105 @@ export class CodexDiscoveryCoordinator {
     }
   }
 
+  /**
+   * Give a command that failed only its `--version` probe one more chance,
+   * on a desktop-owned budget, before we report Codex as missing.
+   *
+   * `@pwrdrvr/codex-discovery` probes with a hard 2s timeout on every
+   * platform. A timed-out probe is not surfaced as "slow" — it yields a
+   * candidate with no version, which `normalizeCodexDiscoverySnapshot`
+   * demotes (a version is required for protocol-compatibility gating), so
+   * the snapshot reads exactly like "no Codex installed" and `resolve()`
+   * throws `CodexCliNotInstalledError`. Nothing else retries: the app then
+   * sits with Codex reported missing until the operator forces a refresh
+   * from Settings.
+   *
+   * That is not hypothetical on a Windows shim chain (`cmd.exe -> node ->
+   * codex.cmd` measures ~1.5s warm on the lab guest, against a 2s ceiling),
+   * and it is not Windows-specific — the timeout is unconditional.
+   * `e2e/codex-slow-version-probe.spec.ts` pins the behavior on any platform.
+   *
+   * "Reported missing" is the visible half on a machine with nothing else
+   * installed. The quieter half shows up when there IS something else: the
+   * timed-out command is demoted, and selection falls through to a
+   * lower-priority candidate — so an operator's explicitly configured
+   * `[models.codex] path` is silently replaced by whatever Codex happens to
+   * be on the machine. Both are the same event, so the rule is keyed on
+   * PRIORITY rather than on "nothing was selected":
+   *
+   * - A candidate is re-probed only if no candidate of equal or higher
+   *   priority already validated (env > config > automatic, matching
+   *   `normalizeCodexDiscoverySnapshot`). A healthy scan therefore
+   *   re-probes nothing, which is what keeps
+   *   `windows-codex-discovery.spec.ts`'s "exactly one version probe"
+   *   assertion — and #1720's coalescing — true.
+   * - Only candidates whose version could not be READ are eligible. A
+   *   command that is absent (`not_found`), genuinely too old
+   *   (`codex_too_old`), or a `.ps1` we refuse to launch is a settled
+   *   answer and is left alone.
+   * - One extra probe per eligible candidate, never a loop.
+   *
+   * The cost lands only on the path that was about to get the answer wrong.
+   */
+  private async reprobeUnreadVersions(
+    snapshot: CodexDiscoverySnapshot,
+    context: { env: NodeJS.ProcessEnv; platform: NodeJS.Platform },
+  ): Promise<CodexDiscoverySnapshot> {
+    const bestValidatedRank = snapshot.candidates.reduce(
+      (best, candidate) =>
+        isValidatedCandidate(candidate)
+          ? Math.min(best, codexCandidateRank(candidate))
+          : best,
+      Number.POSITIVE_INFINITY,
+    );
+    const eligible = snapshot.candidates.filter(
+      (candidate) =>
+        isUnreadVersionCandidate(candidate)
+        && codexCandidateRank(candidate) < bestValidatedRank,
+    );
+    if (eligible.length === 0) {
+      return snapshot;
+    }
+
+    const probe = this.options.probeVersion ?? probeCodexVersion;
+    const reprobed = new Map<
+      string,
+      CodexDiscoverySnapshot["candidates"][number]
+    >();
+    await Promise.all(
+      eligible.map(async (candidate) => {
+        const result = await probe({
+          command: candidate.command,
+          env: context.env,
+          platform: context.platform,
+          timeoutMs: CODEX_VERSION_PROBE_TIMEOUT_MS,
+        });
+        if (!result.version) {
+          return;
+        }
+        const tooOld =
+          compareCodexCliVersions(result.version, MINIMUM_CODEX_CLI_VERSION) < 0;
+        reprobed.set(candidate.command, {
+          command: candidate.command,
+          source: candidate.source,
+          executable: !tooOld,
+          selected: false,
+          version: result.version,
+          ...(tooOld ? { failureReason: "codex_too_old" } : {}),
+        });
+      }),
+    );
+    if (reprobed.size === 0) {
+      return snapshot;
+    }
+    return normalizeCodexDiscoverySnapshot({
+      ...snapshot,
+      candidates: snapshot.candidates.map(
+        (candidate) => reprobed.get(candidate.command) ?? candidate,
+      ),
+    });
+  }
+
   private async runProbe(
     configuredCommand: string | undefined,
     generation: number,
@@ -249,14 +354,17 @@ export class CodexDiscoveryCoordinator {
           env,
         })
         : [];
-      const snapshot = normalizeCodexDiscoverySnapshot({
-        ...discovered,
-        candidates: mergeCodexDiscoveryCandidates(
-          discovered.candidates,
-          windowsCandidates,
-          platform,
-        ),
-      });
+      const snapshot = await this.reprobeUnreadVersions(
+        normalizeCodexDiscoverySnapshot({
+          ...discovered,
+          candidates: mergeCodexDiscoveryCandidates(
+            discovered.candidates,
+            windowsCandidates,
+            platform,
+          ),
+        }),
+        { env, platform },
+      );
       if (generation === this.generation) {
         this.cache.set(configuredCommand?.trim() ?? "", {
           cachedAt: this.now(),
@@ -274,6 +382,58 @@ export class CodexDiscoveryCoordinator {
       throw error;
     }
   }
+}
+
+/**
+ * Failure reasons that are a settled answer about a command, not a probe
+ * that failed to get one. Re-probing these would only spawn a process to
+ * learn what we already know.
+ */
+const SETTLED_CODEX_FAILURE_REASONS = new Set([
+  "codex_too_old",
+  "not_executable",
+  "not_found",
+  "powershell_shim_unsupported",
+]);
+
+/**
+ * Selection priority, matching the fallback order
+ * `normalizeCodexDiscoverySnapshot` applies: a fixed `PWRDRVR_CODEX_COMMAND`
+ * beats a configured `[models.codex] path`, which beats anything found on
+ * PATH or in a known install location. Lower is preferred.
+ */
+function codexCandidateRank(
+  candidate: CodexDiscoverySnapshot["candidates"][number],
+): number {
+  switch (candidate.source) {
+    case "env":
+      return 0;
+    case "config":
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+/**
+ * Whether this candidate's version is unknown *because the probe did not
+ * report one* — a timeout, a killed child, an unparseable answer — rather
+ * than because the command itself is unusable.
+ *
+ * `version_probe_timed_out` (from `classifyProbeFailure`) is the explicit
+ * form of exactly the case this exists for, and is deliberately absent from
+ * the settled set. The shared upstream probe reports its own timeout as a raw
+ * `execFile` message instead, which lands here the same way: unrecognized
+ * means unsettled.
+ */
+function isUnreadVersionCandidate(
+  candidate: CodexDiscoverySnapshot["candidates"][number],
+): boolean {
+  if (candidate.version) {
+    return false;
+  }
+  const reason = candidate.failureReason ?? candidate.versionFailureReason;
+  return reason === undefined || !SETTLED_CODEX_FAILURE_REASONS.has(reason);
 }
 
 function normalizeCodexDiscoverySnapshot(

--- a/apps/desktop/src/main/codex-version-probe.ts
+++ b/apps/desktop/src/main/codex-version-probe.ts
@@ -1,0 +1,132 @@
+import { execFile } from "node:child_process";
+import { createCommandInvocation } from "@pwrdrvr/agent-transport";
+
+/**
+ * Anchored to Codex's own `--version` banner (`codex-cli 0.146.0`).
+ *
+ * A bare `\d+\.\d+\.\d+` matches anything in the combined output — a node
+ * deprecation notice, an npm warning, even a version-shaped directory in an
+ * error message. That was survivable while a junk version only mislabeled a
+ * row, but selection now ranks automatic candidates by version descending, so
+ * an unanchored match can outrank a genuine install and become the launched
+ * command.
+ */
+export const CODEX_VERSION_PATTERN =
+  /\bcodex(?:-cli)?[\s/v]+(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/i;
+
+/**
+ * How long a Codex CLI gets to answer `--version` on a desktop-owned probe.
+ *
+ * `@pwrdrvr/codex-discovery` probes with a hard 2s timeout on every platform.
+ * That is generous for a native binary (`codex.exe` answers in ~0.3s) and
+ * marginal for a shim: on the Windows lab guest `codex.cmd` answers in ~1.5s
+ * even warm, because the invocation is a `cmd.exe -> node -> shim` chain. A
+ * loaded machine blows straight through 2s.
+ *
+ * That matters more than a slow boot, because a timed-out probe is not
+ * reported as "slow" — it is indistinguishable from "no Codex here". The
+ * candidate comes back without a version, `normalizeCodexDiscoverySnapshot`
+ * demotes it (a version is required for protocol-compatibility gating), no
+ * candidate is selected, and `resolve()` throws `CodexCliNotInstalledError`.
+ * Nothing retries, so one slow moment strands the app with Codex reported
+ * missing until the operator forces a refresh from Settings.
+ *
+ * 10s matches the budget the Windows sibling probe already used.
+ */
+export const CODEX_VERSION_PROBE_TIMEOUT_MS = 10_000;
+
+export type CodexCommandRunner = (
+  command: string,
+  args: string[],
+  options: {
+    env: NodeJS.ProcessEnv;
+    timeout: number;
+    windowsHide: boolean;
+    windowsVerbatimArguments?: boolean;
+  },
+) => Promise<{ stderr?: string | Buffer; stdout?: string | Buffer }>;
+
+export type CodexVersionProbeResult = {
+  failureReason?: string;
+  version?: string;
+};
+
+export async function runCodexOneShot(
+  command: string,
+  args: string[],
+  options: Parameters<CodexCommandRunner>[2],
+): Promise<{ stderr?: string | Buffer; stdout?: string | Buffer }> {
+  return await new Promise((resolve, reject) => {
+    const child = execFile(command, args, options, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve({ stderr, stdout });
+    });
+    // A `--version` probe reads to EOF and never writes, so close stdin.
+    if (child.stdin) {
+      child.stdin.on("error", () => undefined);
+      child.stdin.end();
+    }
+  });
+}
+
+/**
+ * Run one `--version` probe and report the version or why it could not be
+ * read. Callers own the interpretation: this does not decide whether a
+ * version is new enough, only whether the command answered.
+ */
+export async function probeCodexVersion(params: {
+  command: string;
+  env: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  runner?: CodexCommandRunner;
+  timeoutMs?: number;
+}): Promise<CodexVersionProbeResult> {
+  const runner = params.runner ?? runCodexOneShot;
+  try {
+    const invocation = createCommandInvocation({
+      command: params.command,
+      args: ["--version"],
+      env: params.env,
+      ...(params.platform ? { platform: params.platform } : {}),
+    });
+    const result = await runner(invocation.command, invocation.args, {
+      env: params.env,
+      timeout: params.timeoutMs ?? CODEX_VERSION_PROBE_TIMEOUT_MS,
+      windowsHide: true,
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    });
+    const output = `${result.stdout?.toString() ?? ""}\n${
+      result.stderr?.toString() ?? ""
+    }`;
+    const version = output.match(CODEX_VERSION_PATTERN)?.[1];
+    return version ? { version } : { failureReason: "version_not_reported" };
+  } catch (error) {
+    return { failureReason: classifyProbeFailure(error) };
+  }
+}
+
+/**
+ * `execFile`'s error shape is not what the obvious `code === "ENOENT"` test
+ * expects here. A `.cmd` probe runs through the cmd.exe wrapper, and cmd.exe
+ * always exists, so `code` arrives as a numeric exit status (49, say) and a
+ * timeout arrives as `code: null` with `killed: true` and `signal: "SIGTERM"`.
+ * Classifying on the errno string alone left `not_found` unreachable and made
+ * every timeout render as a generic launch failure.
+ */
+export function classifyProbeFailure(error: unknown): string {
+  const failure = error as NodeJS.ErrnoException & {
+    killed?: boolean;
+    signal?: string;
+  };
+  if (failure?.killed || failure?.signal === "SIGTERM") {
+    return "version_probe_timed_out";
+  }
+  const code = failure?.code;
+  if (code === "ENOENT" || code === "ENOTDIR") {
+    return "not_found";
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/src/main/codex-version-probe.ts
+++ b/apps/desktop/src/main/codex-version-probe.ts
@@ -10,9 +10,17 @@ import { createCommandInvocation } from "@pwrdrvr/agent-transport";
  * row, but selection now ranks automatic candidates by version descending, so
  * an unanchored match can outrank a genuine install and become the launched
  * command.
+ *
+ * The banner anchor has to be the START OF A LINE, not just a word boundary:
+ * `/` is in the separator class (to accept `codex/1.2.3`), which without the
+ * line anchor also accepts the version out of a PATH fragment — the Homebrew
+ * layout `/opt/homebrew/Cellar/codex/0.146.0/bin` appearing anywhere in
+ * stderr would hand back a fabricated `0.146.0`, and the recovery path marks
+ * a candidate launchable on exactly that value. `m` keeps it working when the
+ * banner sits behind a node/npm warning line.
  */
 export const CODEX_VERSION_PATTERN =
-  /\bcodex(?:-cli)?[\s/v]+(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/i;
+  /^\s*codex(?:-cli)?[\s/v]+(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/im;
 
 /**
  * How long a Codex CLI gets to answer `--version` on a desktop-owned probe.

--- a/apps/desktop/src/main/codex-windows-launch.ts
+++ b/apps/desktop/src/main/codex-windows-launch.ts
@@ -1,27 +1,17 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { createCommandInvocation } from "@pwrdrvr/agent-transport";
 import {
   CODEX_COMMAND_ENV,
   compareCodexCliVersions,
   MINIMUM_CODEX_CLI_VERSION,
   type CodexDiscoveryCandidate,
 } from "@pwrdrvr/codex-discovery";
-
-/**
- * Anchored to Codex's own `--version` banner (`codex-cli 0.146.0`).
- *
- * A bare `\d+\.\d+\.\d+` matches anything in the combined output — a node
- * deprecation notice, an npm warning, even a version-shaped directory in an
- * error message. That was survivable while a junk version only mislabeled a
- * row, but selection now ranks automatic candidates by version descending, so
- * an unanchored match can outrank a genuine install and become the launched
- * command.
- */
-const CODEX_VERSION_PATTERN =
-  /\bcodex(?:-cli)?[\s/v]+(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/i;
-const VERSION_PROBE_TIMEOUT_MS = 10_000;
+import {
+  CODEX_VERSION_PROBE_TIMEOUT_MS,
+  probeCodexVersion,
+  runCodexOneShot,
+  type CodexCommandRunner,
+} from "./codex-version-probe";
 
 const POWERSHELL_SHIM_EXTENSION = ".ps1";
 
@@ -45,17 +35,6 @@ const POWERSHELL_SHIM_EXTENSION = ".ps1";
  * So `.ps1` is a discovery signal, never a launch target.
  */
 const WINDOWS_SPAWNABLE_EXTENSIONS = [".exe", ".com", ".cmd", ".bat"];
-
-type CodexCommandRunner = (
-  command: string,
-  args: string[],
-  options: {
-    env: NodeJS.ProcessEnv;
-    timeout: number;
-    windowsHide: boolean;
-    windowsVerbatimArguments?: boolean;
-  },
-) => Promise<{ stderr?: string | Buffer; stdout?: string | Buffer }>;
 
 function isPowerShellScript(command: string): boolean {
   return path.win32.extname(command).toLowerCase() === POWERSHELL_SHIM_EXTENSION;
@@ -127,94 +106,49 @@ export function resolveWindowsCodexLaunchCommand(params: {
   );
 }
 
-export async function runCodexOneShot(
-  command: string,
-  args: string[],
-  options: Parameters<CodexCommandRunner>[2],
-): Promise<{ stderr?: string | Buffer; stdout?: string | Buffer }> {
-  return await new Promise((resolve, reject) => {
-    const child = execFile(command, args, options, (error, stdout, stderr) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve({ stderr, stdout });
-    });
-    // A `--version` probe reads to EOF and never writes, so close stdin.
-    if (child.stdin) {
-      child.stdin.on("error", () => undefined);
-      child.stdin.end();
-    }
-  });
-}
-
 async function inspectCandidate(params: {
   command: string;
   env: NodeJS.ProcessEnv;
   runner: CodexCommandRunner;
   source: CodexDiscoveryCandidate["source"];
 }): Promise<CodexDiscoveryCandidate> {
-  try {
-    const invocation = createCommandInvocation({
-      command: params.command,
-      args: ["--version"],
-      env: params.env,
-      platform: "win32",
-    });
-    const result = await params.runner(invocation.command, invocation.args, {
-      env: params.env,
-      timeout: VERSION_PROBE_TIMEOUT_MS,
-      windowsHide: true,
-      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-    });
-    const output = `${result.stdout?.toString() ?? ""}\n${
-      result.stderr?.toString() ?? ""
-    }`;
-    const version = output.match(CODEX_VERSION_PATTERN)?.[1];
-    const tooOld =
-      version && compareCodexCliVersions(version, MINIMUM_CODEX_CLI_VERSION) < 0;
-    return {
-      command: params.command,
-      source: params.source,
-      executable: Boolean(version) && !tooOld,
-      selected: false,
-      ...(version
-        ? { version }
-        : { versionFailureReason: "version_not_reported" }),
-      ...(tooOld ? { failureReason: "codex_too_old" } : {}),
-    };
-  } catch (error) {
-    return {
-      command: params.command,
-      source: params.source,
-      executable: false,
-      selected: false,
-      failureReason: classifyProbeFailure(error),
-    };
+  const probe = await probeCodexVersion({
+    command: params.command,
+    env: params.env,
+    platform: "win32",
+    runner: params.runner,
+    timeoutMs: CODEX_VERSION_PROBE_TIMEOUT_MS,
+  });
+  if (!probe.version) {
+    // `version_not_reported` means the command answered but said nothing we
+    // recognize; anything else (including `version_probe_timed_out`) means it
+    // could not be run to completion.
+    return probe.failureReason === "version_not_reported"
+      ? {
+          command: params.command,
+          source: params.source,
+          executable: false,
+          selected: false,
+          versionFailureReason: "version_not_reported",
+        }
+      : {
+          command: params.command,
+          source: params.source,
+          executable: false,
+          selected: false,
+          failureReason: probe.failureReason ?? "version_not_reported",
+        };
   }
-}
-
-/**
- * `execFile`'s error shape is not what the obvious `code === "ENOENT"` test
- * expects here. A `.cmd` probe runs through the cmd.exe wrapper, and cmd.exe
- * always exists, so `code` arrives as a numeric exit status (49, say) and a
- * timeout arrives as `code: null` with `killed: true` and `signal: "SIGTERM"`.
- * Classifying on the errno string alone left `not_found` unreachable and made
- * every timeout render as a generic launch failure.
- */
-function classifyProbeFailure(error: unknown): string {
-  const failure = error as NodeJS.ErrnoException & {
-    killed?: boolean;
-    signal?: string;
+  const tooOld =
+    compareCodexCliVersions(probe.version, MINIMUM_CODEX_CLI_VERSION) < 0;
+  return {
+    command: params.command,
+    source: params.source,
+    executable: !tooOld,
+    selected: false,
+    version: probe.version,
+    ...(tooOld ? { failureReason: "codex_too_old" } : {}),
   };
-  if (failure?.killed || failure?.signal === "SIGTERM") {
-    return "version_probe_timed_out";
-  }
-  const code = failure?.code;
-  if (code === "ENOENT" || code === "ENOTDIR") {
-    return "not_found";
-  }
-  return error instanceof Error ? error.message : String(error);
 }
 
 type SiblingTarget = {

--- a/apps/desktop/src/main/credential-tester/credential-tester.ts
+++ b/apps/desktop/src/main/credential-tester/credential-tester.ts
@@ -12,10 +12,8 @@ import {
   MINIMUM_CODEX_CLI_VERSION,
 } from "@pwrdrvr/codex-discovery";
 import { createCommandInvocation } from "@pwrdrvr/agent-transport";
-import {
-  resolveWindowsCodexLaunchCommand,
-  runCodexOneShot,
-} from "../codex-windows-launch";
+import { resolveWindowsCodexLaunchCommand } from "../codex-windows-launch";
+import { runCodexOneShot } from "../codex-version-probe";
 
 const log = getMainLogger("pwragent:credential-tester");
 

--- a/apps/desktop/src/main/credential-tester/credential-tester.ts
+++ b/apps/desktop/src/main/credential-tester/credential-tester.ts
@@ -13,7 +13,10 @@ import {
 } from "@pwrdrvr/codex-discovery";
 import { createCommandInvocation } from "@pwrdrvr/agent-transport";
 import { resolveWindowsCodexLaunchCommand } from "../codex-windows-launch";
-import { runCodexOneShot } from "../codex-version-probe";
+import {
+  CODEX_VERSION_PATTERN,
+  runCodexOneShot,
+} from "../codex-version-probe";
 
 const log = getMainLogger("pwragent:credential-tester");
 
@@ -302,7 +305,12 @@ export class CredentialTester {
       const durationMs = Date.now() - probeStart;
       const testedAt = Date.now();
       const output = `${stdout}\n${stderr}`;
-      const match = output.match(/\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/);
+      // Share discovery's banner-anchored pattern. An unanchored
+      // `\d+\.\d+\.\d+` here reported "Connected, 18.20.4" off a node
+      // deprecation warning while discovery — now anchored — called the same
+      // binary unusable, leaving the operator with two Settings surfaces
+      // giving opposite answers about one install.
+      const match = output.match(CODEX_VERSION_PATTERN);
       if (match) {
         const version = match[1];
         if (compareCodexCliVersions(version, MINIMUM_CODEX_CLI_VERSION) < 0) {


### PR DESCRIPTION
Stacked on #1734 — `codex-windows-launch.ts` does not exist on `main`, so this
cannot stand alone. **Only the last commit is mine**; the first two belong to
the base branch and will disappear from this diff once that branch is pushed
forward.

## What is wrong

`@pwrdrvr/codex-discovery` probes `--version` with a hard 2s `execFile`
timeout, on every platform. A probe that blows that budget is not reported as
"slow" — the candidate comes back with no version, and a version is required
for protocol-compatibility gating, so `normalizeCodexDiscoverySnapshot` demotes
it. What the operator sees next depends only on what else is installed:

- **nothing else** — Codex reads as missing, and since nothing retries, the app
  stays that way until a manual Settings refresh;
- **something else** — selection quietly falls through to it, so an explicitly
  configured Codex is replaced by a different one.

2s is not generous for a process chain. The note already in
`codex-windows-launch.ts` records `codex.cmd` answering in **~1.5s** on the
Windows lab guest (`cmd.exe -> node -> shim`) against a native `codex.exe` at
~0.3s.

## Evidence

This is what was failing `windows-codex-discovery.spec.ts` on a cold guest. I
instrumented that spec and ran it on the PwrSuiteLab Windows VM:

| | result |
|---|---|
| warm | `__launch__` lands **323–579 ms** after the harness returns (5 runs) |
| cold | **2 of 3 repetitions never launched an app-server at all — with a 60 s poll** |

So the reported "13.1 s cold" failure was never a budget that needed widening.
It would have failed at any budget.

## The fix

`CodexDiscoveryCoordinator` re-probes, once, on a desktop-owned 10s budget, any
candidate whose version could not be **read**. The rule is keyed on selection
priority rather than "nothing was selected", so it covers both faces above: a
candidate is re-probed only when no candidate of equal or higher priority
already validated.

Deliberately narrow:

- settled answers (`not_found`, `codex_too_old`, a `.ps1` we refuse to launch)
  are never re-probed — so a machine with no Codex pays nothing extra;
- a healthy scan re-probes nothing, which keeps #1720's coalescing intact;
- one extra probe per eligible candidate, never a loop.

The `--version` probe moves to a platform-neutral `codex-version-probe` module,
since the failure is not Windows-specific. `codex-windows-launch` keeps its
Windows sibling logic and now shares that probe instead of duplicating it.

## Testing

`e2e/codex-slow-version-probe.spec.ts` pins the behavior deterministically on
any platform (a 3s probe against the 2s ceiling) and needs no slow machine.
**Verified failing without the fix and passing with it**, on macOS and on the
Windows guest.

It drives the fake through `PWRDRVR_CODEX_COMMAND` rather than a seeded
`config.toml`. The env var reaches the app process directly, so the spec does
not depend on the app resolving the same PwrAgent root the harness seeded —
`resolvePwragentRoot` falls back to `os.homedir()`, which reads `USERPROFILE`
on Windows while the harness overrides only `HOME`. Env is also the
highest-priority source, so the slow case stays a real test on a machine that
already has a working Codex installed.

`windows-codex-discovery.spec.ts`'s launch poll gains a documented 15s budget
covering the recovery the app now performs, and its exact-probe-count assertion
becomes a 1–2 range, since a cold guest legitimately probes twice; the
exact-one guard moves to the deterministic spec.

- Windows lab guest: **8/8 passing** across both specs, two repetitions each
- `codex-discovery-coordinator.test.ts` / `codex-windows-launch.test.ts`: 35 passing
- `lint:eslint`, `lint:boundaries`, `lint:codex-storage`, `lint:sql`, `lint:colors`, `typecheck`: clean

### Not addressed here

The 2s timeout is upstream in `@pwrdrvr/codex-discovery`; this is desktop-side
compensation. A configurable or platform-aware budget there would be the real
fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
