### PR TITLE
fix(desktop): stop claiming a thread's directory was deleted

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10493,10 +10493,9 @@ script = "echo setup"
         },
       ],
     });
-    const enrichThreadDirectories = vi.fn(
-      async (threads: AppServerThreadSummary[]) =>
-        threads.map((thread) => ({ ...thread, linkedDirectories: [] })),
-    );
+    // No implementation: the assertion below is that this is never invoked,
+    // so any body would be unreachable.
+    const enrichThreadDirectories = vi.fn();
     Object.assign(codexClient, { enrichThreadDirectories });
     const overlayStore = createOverlayStoreMock({
       overlays: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10472,6 +10472,89 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("skips Codex directory backfill when the overlay owns a handoff workspace", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    // The provider still reports the pre-handoff worktree. That directory was
+    // removed when the workspace moved to a freshly hashed worktree, so
+    // enrichment resolves nothing from it and reports no linked directories.
+    const staleWorktreePath = "/Users/huntharo/.codex/worktrees/mse9d2vb/ProjectA";
+    const handoffWorktreePath = "/Users/huntharo/.codex/worktrees/msf1iq9n/ProjectA";
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "ProjectA worktree",
+          titleSource: "explicit",
+          source: "codex",
+          projectKey: staleWorktreePath,
+          createdAt: 1_000,
+          updatedAt: 1_000,
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const enrichThreadDirectories = vi.fn(
+      async (threads: AppServerThreadSummary[]) =>
+        threads.map((thread) => ({ ...thread, linkedDirectories: [] })),
+    );
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [
+            {
+              id: "pwragent-handoff:codex:thread-1",
+              label: "ProjectA",
+              path: projectA,
+              worktreePath: handoffWorktreePath,
+              kind: "worktree",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    // The handoff overlay is the authoritative workspace selection, so the
+    // repair gate refuses this thread no matter what enrichment returns.
+    // Enriching it anyway cannot change stored state; it only spends a probe
+    // on a removed path and logs a missing-relationship warning for a thread
+    // whose directory the overlay already records correctly.
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [
+        expect.objectContaining({
+          id: "pwragent-handoff:codex:thread-1",
+          worktreePath: handoffWorktreePath,
+        }),
+      ],
+    });
+
+    // Skipping backfill must not disturb the workspace sync that carries the
+    // handoff to the provider — that is what migrates the stale projectKey.
+    await vi.waitFor(() => {
+      expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
+        threadId: "thread-1",
+        cwd: handoffWorktreePath,
+      });
+    });
+
+    await registry.close();
+  });
+
   it("keeps aggregate list cache sensitive to Codex directory backfill", async () => {
     const worktreePath = "/Users/huntharo/.codex/worktrees/wt1/ProjectA";
     const codexClient = new MockBackendClient({
@@ -10784,7 +10867,12 @@ script = "echo setup"
       callerReason: "startup-prewarm",
     });
 
-    expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
+    // This used to enrich and then discard the result at the repair gate. The
+    // gate refuses every handoff-overlay thread, so the candidate filter now
+    // skips the probe outright — same guarantee below, without spending a git
+    // probe on the provider's stale worktree or logging a missing-relationship
+    // warning when that worktree has since been removed.
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
     await vi.waitFor(() => {
       expect(codexClient.lastUpdateThreadWorkspaceParams).toEqual({
         threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
@@ -285,4 +285,55 @@ describe("createThreadDirectoryEnricher", () => {
       linkedDirectories: [],
     });
   });
+
+  it("does not cache a miss, so a directory created later resolves immediately", async () => {
+    const projectPath = "/Users/huntharo/.pwragent/profiles/default/projects";
+    let directoryExists = false;
+    vi.doMock("node:fs/promises", () => ({
+      // The scratch projects root is created lazily by the first thread that
+      // needs it, so the first probe legitimately misses.
+      access: vi.fn(async () => {
+        if (!directoryExists) {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+      }),
+      readFile: vi.fn(async () => {
+        throw Object.assign(new Error("EISDIR"), { code: "EISDIR" });
+      }),
+    }));
+    vi.doMock("node:child_process", () => ({
+      // Not a git repository, so the probe fails and the enricher falls back
+      // to describing the directory itself.
+      execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, done: (
+        error: Error | null,
+        result?: { stdout: string; stderr: string },
+      ) => void) => {
+        done(new Error("not a git repository"));
+      }),
+    }));
+
+    const { createThreadDirectoryEnricher } = await import(
+      "../app-server/thread-directory-enricher"
+    );
+    const enricher = createThreadDirectoryEnricher({ cacheTtlMs: 60_000 });
+
+    await expect(enricher(projectPath)).resolves.toEqual({
+      linkedDirectories: [],
+    });
+
+    directoryExists = true;
+
+    // A cached miss would serve the empty result for the full 60s TTL and keep
+    // the thread reading as unlinked long after the directory appeared.
+    await expect(enricher(projectPath)).resolves.toEqual({
+      linkedDirectories: [
+        {
+          id: expectedDir(projectPath),
+          path: expectedDir(projectPath),
+          label: "projects",
+          kind: "local",
+        },
+      ],
+    });
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -20607,6 +20607,17 @@ export class DesktopBackendRegistry {
       ) {
         return false;
       }
+      // A handoff overlay is the authoritative workspace selection, so a
+      // relationship derived from the provider's projectKey can never be
+      // persisted — `shouldRepairCachedDirectoryRelationship` refuses every
+      // thread whose overlay carries one. Enriching it anyway is guaranteed
+      // wasted work, and when the provider still reports a pre-handoff
+      // worktree that has since been removed, enrichment resolves nothing and
+      // the miss below logs a phantom "no worktree relationship" warning for a
+      // thread whose directory is already correct in the overlay.
+      if (overlayHasHandoffWorkspace(params.overlaysByThreadId[thread.id])) {
+        return false;
+      }
       const projectKey = thread.projectKey?.trim();
       if (!isLikelyToolManagedWorktreePath(projectKey)) {
         return false;

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -323,12 +323,18 @@ export function createThreadDirectoryEnricher(params?: {
     const inFlight = loadThreadDirectoryEnrichment(normalizedKey)
       .then((value) => {
         // A miss is deliberately left uncached, matching the ACP worktree
-        // resolver. `loadThreadDirectoryEnrichment` yields no directories
-        // only when the path does not exist — every other outcome, including
-        // a git probe that fails or times out, still returns one. Absence is
-        // transient: a scratch project root and a worktree are both created
-        // moments after a thread first refers to them. Caching it pins the
-        // thread to "no linked project" for the rest of the TTL after the
+        // resolver (`resolveAcpLinkedDirectories` persists only a directory
+        // it actually resolved). `loadThreadDirectoryEnrichment` yields no
+        // directories only when `access()` on the path fails — every other
+        // outcome, including a git probe that fails or times out, still
+        // returns one. Note what that does and does not prove: `access()`
+        // also fails for a path that is merely unreachable right now (denied
+        // permissions, an unmounted or stalled network volume), so a miss
+        // means "unresolved", not "deleted" — the same distinction the thread
+        // header's copy draws. Retrying is worth it because the common causes
+        // are transient: a scratch project root and a worktree are both
+        // created moments after a thread first refers to them. Caching pins
+        // the thread to "no linked project" for the rest of the TTL after the
         // directory appears, which is long enough on a slow machine to show
         // a workspace warning for a directory that exists by the time anyone
         // reads it. Recomputing costs one `access()` and never spawns git.

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -322,6 +322,20 @@ export function createThreadDirectoryEnricher(params?: {
 
     const inFlight = loadThreadDirectoryEnrichment(normalizedKey)
       .then((value) => {
+        // A miss is deliberately left uncached, matching the ACP worktree
+        // resolver. `loadThreadDirectoryEnrichment` yields no directories
+        // only when the path does not exist — every other outcome, including
+        // a git probe that fails or times out, still returns one. Absence is
+        // transient: a scratch project root and a worktree are both created
+        // moments after a thread first refers to them. Caching it pins the
+        // thread to "no linked project" for the rest of the TTL after the
+        // directory appears, which is long enough on a slow machine to show
+        // a workspace warning for a directory that exists by the time anyone
+        // reads it. Recomputing costs one `access()` and never spawns git.
+        if (value.linkedDirectories.length === 0) {
+          cache.delete(normalizedKey);
+          return value;
+        }
         cache.set(normalizedKey, {
           expiresAt: Date.now() + cacheTtlMs,
           value,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -365,7 +365,11 @@ export function ThreadHeader(props: ThreadHeaderProps) {
         </div>
       </div>
       {unlinkedPath ? (
-        <p className="thread-header__warning" role="alert">
+        // `role="status"` (polite), not `alert`: this reports an unresolved
+        // link, not a failure, and it is derived state that re-announces on
+        // every thread selection. Matches the branch-drift banner right
+        // below, which shares this class and is the more urgent of the two.
+        <p className="thread-header__warning" role="status">
           This thread's recorded working directory is not linked to a project:{" "}
           <code>{unlinkedPath}</code>
         </p>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -94,7 +94,17 @@ type ThreadHeaderProps = {
   };
 };
 
-function missingDirectoryPath(thread: NavigationThreadSummary): string | undefined {
+/**
+ * The thread records a working directory the backend reported, but nothing
+ * resolved it to a linked project. Deliberately NOT an "it was deleted" test:
+ * the renderer never stats a path, and an empty `linkedDirectories` has
+ * several causes besides absence — a cwd that is not a git checkout, a git
+ * probe that failed or timed out, or a backend that reports no cwd at all.
+ * Absence is only one of them, so the copy this drives must stay limited to
+ * what is actually known here. Do not reword it back into a claim about the
+ * directory no longer existing without a real absence signal on the summary.
+ */
+function unlinkedWorkspacePath(thread: NavigationThreadSummary): string | undefined {
   const projectKey = thread.projectKey?.trim();
   if (!projectKey || thread.linkedDirectories.length > 0) {
     return undefined;
@@ -104,7 +114,7 @@ function missingDirectoryPath(thread: NavigationThreadSummary): string | undefin
 }
 
 export function ThreadHeader(props: ThreadHeaderProps) {
-  const missingPath = missingDirectoryPath(props.thread);
+  const unlinkedPath = unlinkedWorkspacePath(props.thread);
   const projectLabel = props.projectLabel?.trim();
   const branchDrifted = isBranchDrifted(
     props.thread.gitBranch,
@@ -354,10 +364,10 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           />
         </div>
       </div>
-      {missingPath ? (
+      {unlinkedPath ? (
         <p className="thread-header__warning" role="alert">
-          This thread is linked to a directory that no longer exists:{" "}
-          <code>{missingPath}</code>
+          This thread's recorded working directory is not linked to a project:{" "}
+          <code>{unlinkedPath}</code>
         </p>
       ) : null}
       {branchDrifted ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2782,7 +2782,9 @@ describe("ThreadView", () => {
     // that is not a git checkout and for a git probe that failed, so the copy
     // must not claim the directory was deleted. A false positive shipped for
     // exactly that reason: the banner named an existing directory.
-    expect(screen.getByRole("alert")).toHaveTextContent(
+    // Polite, not assertive: an unresolved link is not a failure, and this
+    // banner re-renders on every thread selection.
+    expect(screen.getByRole("status")).toHaveTextContent(
       "This thread's recorded working directory is not linked to a project: /Users/example/.codex/worktrees/tree-epsilon/catalog-portal"
     );
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2777,11 +2777,16 @@ describe("ThreadView", () => {
       />
     );
 
+    // The predicate behind this banner is "projectKey set, linkedDirectories
+    // empty" — it never stats the path. An empty list also happens for a cwd
+    // that is not a git checkout and for a git probe that failed, so the copy
+    // must not claim the directory was deleted. A false positive shipped for
+    // exactly that reason: the banner named an existing directory.
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "This thread is linked to a directory that no longer exists: /Users/example/.codex/worktrees/tree-epsilon/catalog-portal"
+      "This thread's recorded working directory is not linked to a project: /Users/example/.codex/worktrees/tree-epsilon/catalog-portal"
     );
 
-    expect(screen.getByText("Recorded working directory is no longer available.")).toBeInTheDocument();
+    expect(screen.getByText("Recorded working directory is not linked to a project.")).toBeInTheDocument();
     expect(screen.getByText("catalog-portal")).toBeInTheDocument();
 
     fireEvent.click(

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -250,13 +250,16 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
               <dl className="linked-project__facts">
                 <div>
                   <dt>Kind</dt>
-                  <dd>Missing directory</dd>
+                  <dd>Unlinked directory</dd>
                 </div>
               </dl>
             </li>
           </ul>
+          {/* Nothing here stats the path: an empty `linkedDirectories` means
+              no project was resolved, which is not the same as the directory
+              being gone. Keep this limited to what the summary proves. */}
           <p className="context-empty">
-            Recorded working directory is no longer available.
+            Recorded working directory is not linked to a project.
           </p>
         </>
       ) : (


### PR DESCRIPTION
## Problem

The thread header warned:

> This thread is linked to a directory that no longer exists: `<path>`

from a predicate that never touched the filesystem. It only tested "has a `projectKey` and an empty `linkedDirectories`" (`ThreadHeader.tsx:97`). Observed in the wild naming `/Users/huntharo/.pwragent/profiles/default/projects` — a directory that exists on disk.

## Root cause of the false positive

That path is the **scratch projects root** (`resolveScratchProjectsRoot`), created lazily by `fs.mkdir` in `createScratchProjectDirectory`. So at render time the directory genuinely did not exist yet: this was a *transient true positive that went stale*, not a pure false positive.

What made it readable rather than a sub-millisecond blip is that `createThreadDirectoryEnricher` **cached the miss for its full 5s TTL**. Once it saw "not there" it kept answering "not there" for five seconds after the directory appeared.

`loadThreadDirectoryEnrichment` returns an empty list in exactly two cases — no `projectKey`, or `pathExists` false (`thread-directory-enricher.ts:216-223`). Every other outcome, including a git probe that fails or times out, still returns one directory. That is what makes the empty list a *timing* signal rather than an absence signal.

## Changes

**1. Copy** — `ThreadHeader` and `LinkedProjectsPanel` both made the same unchecked claim. Both now describe the condition actually tested. `missingDirectoryPath` → `unlinkedWorkspacePath`, with a comment listing the other ways the list goes empty so the absence claim is not reintroduced without a real signal on the summary.

**2. Negative caching** — misses are no longer cached. This matches the ACP worktree resolver, which already leaves a miss uncached deliberately (`backend-registry.ts:9141`: *"A miss is deliberately left uncached so a transient failure is retried cheaply"*). The Codex enricher was doing the opposite.

**3. Backfill seam** — `backfillMissingCodexDirectoryRelationships` selected threads whose overlay already owns a handoff workspace. `shouldRepairCachedDirectoryRelationship` refuses every such thread on its first line, so enrichment could never persist anything; it only spent a git probe on the provider's pre-handoff worktree and, once that worktree was removed, logged a phantom warning for a thread whose directory the overlay already recorded correctly.

### Evidence for change 3

From the originating session log:

```
(pwragent:backend-registry) Codex directory enrichment did not produce a worktree
  repository relationship callerReason=messaging-navigation-snapshot
  threadId=019fcb64-3115-7d53-b284-73517c3022ce
  projectKey=/Users/huntharo/.codex/worktrees/mse9d2vb/PwrSuiteLab
  linkedDirectories=[]
  overlayExtraLinkedDirectories=[{"kind":"worktree","label":"PwrSuiteLab",
    "path":"/Users/huntharo/pwrdrvr/PwrSuiteLab",
    "worktreePath":"/Users/huntharo/.codex/worktrees/msf1iq9n/PwrSuiteLab"}]
```

Two different worktree hashes: `projectKey` is `mse9d2vb`, the overlay's `worktreePath` is `msf1iq9n`. On-disk check at the time: `mse9d2vb` **missing**, `msf1iq9n` and `/Users/huntharo/pwrdrvr/PwrSuiteLab` both present. The worktree was recreated under a new hash; the overlay followed, the provider's `projectKey` did not.

That single logged `extraLinkedDirectories` element is provably the handoff directory: the same session logged `pending Codex workspace CWD synchronization failed ... workspaceCwd=.../msf1iq9n/PwrSuiteLab` for the same `threadId`, and `schedulePendingCodexWorkspaceCwdSyncs` only fires when `extraLinkedDirectories.find(isHandoffDirectory)` matches, taking `workspaceCwd` from that entry.

## Deliberate test updates

Two existing assertions changed rather than being deleted:

- `thread-view.test.tsx:2781` — the banner text, with a comment recording why the old wording was wrong.
- `backend-registry.test.ts` "does not backfill stale Codex worktree metadata over a legacy handoff overlay" — its `enrichThreadDirectories` call count was incidental to the guarantee in its name (the overlay is not overwritten). That guarantee still holds; the probe is now skipped rather than spent and discarded.

## For a reviewer on another machine

Exact commands, no full-suite run needed:

```bash
pnpm typecheck
pnpm lint:eslint
pnpm test apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "handoff overlay"
pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "backfill"
```

Expected: 8/8, 66/66, 4 passed, 6 passed. `lint:eslint` reports 0 errors and 35 pre-existing warnings, none in touched files.

**To confirm each new test actually catches its regression**, revert one guard and re-run:

- Delete the `if (value.linkedDirectories.length === 0) { cache.delete(...); return value; }` block in `thread-directory-enricher.ts` → "does not cache a miss, so a directory created later resolves immediately" fails with `expected { linkedDirectories: [] } to deeply equal { linkedDirectories: [ {…} ] }`.
- Delete the `if (overlayHasHandoffWorkspace(...)) return false;` block in `backend-registry.ts` → "skips Codex directory backfill when the overlay owns a handoff workspace" fails on `expect(enrichThreadDirectories).not.toHaveBeenCalled()`.

Both were verified this way before commit.

### Risk surface

- **Negative caching** is the widest-reaching change: it affects every Codex thread listing. The added cost is bounded to one `access()` per missing path per call — `loadThreadDirectoryEnrichment` returns before the git block on a miss, so **no additional git process is ever spawned**. Concurrent callers still share the in-flight promise, so there is no thundering herd; only post-resolution lookups re-probe.
- **Copy** is renderer-only, no behavior change.
- **Backfill** strictly removes work. It cannot persist anything that was not already refused downstream by `shouldRepairCachedDirectoryRelationship`.

### Machine note on local test noise — do not chase this

CI on this PR is **fully green**, including the whole-workspace `Test` job and `Windows desktop-main`. On the authoring machine (2018 Intel MBP, heavily loaded) `backend-registry.test.ts` fails **13 tests on a clean, unmodified `main`**, with the count swinging 2/5/13/24 run to run — all real-git tests timing out at 5001ms. None are directory tests, none are related to this change, and none reproduce in CI. A reviewer on healthy hardware should expect a clean run; if you see these timeouts, it is your machine, not this PR. (Worth its own issue — the same slow-hardware sensitivity is what surfaced the user-visible bug this PR fixes.)

## Not fixed here

The Codex workspace CWD sync that would migrate the stale `projectKey` fails with `-32600 "thread not found"` and retries unbounded on every navigation snapshot.

An early hypothesis was a missing `thread/resume` before `thread/settings/update`. That does **not** hold up: `updateThreadWorkspace` matches four sibling thread-record methods that also never resume — `archiveThread` (8578), `restoreThread` (8593), `renameThread` (8608), `updateThreadMetadata` (8622). The three methods that do resume-then-mutate (`interruptTurn`, `compactThread`, `steerTurn`) are all turn-scoped and all treat resume as best-effort (`.catch(() => undefined)`), which is inconsistent with resume being what makes a thread reachable. `setThreadPermissions` is not a counterexample — it issues *only* `thread/resume`, with settings in the payload, so resume is its mutation rather than a priming step.

`setThreadPermissions` accepting `cwd` (and `buildThreadResumePayloads` setting `base.cwd` at 6431-6432) is a genuine third option, but that payload also carries `model`/`approvalPolicy`/`sandbox`/`serviceTier`/`reasoningEffort` conditionally — sending `threadId` + `cwd` alone omits them, and whether Codex reads an omitted field as *unchanged* or *reset to default* is the same open question with a worse failure mode. Wants a live repro before anyone picks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
