### PR TITLE
fix(tests): keep unit tests off the network and out of ~/.pwragent

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -757,23 +757,31 @@ replaces it for its own duration, as `auto-updater.test.ts` does. Not covered:
 `http.request` / `https.request` / `net.connect`, which Node's undici `fetch`
 does not route through and nothing here uses directly.
 
-**Loopback goes through.** `localhost`, `127.0.0.0/8`, and `::1` cannot leave
-the machine, so they are not what the guard is for — that is a test talking to
-a server it started, the same category as the spawn guard's `os.tmpdir()`
+**Loopback goes through.** `localhost` (and any `*.localhost`),
+`127.0.0.0/8` — including the `::ffff:127.0.0.1` form a dual-stack socket
+reports — `::1`, and the wildcard bind addresses `0.0.0.0` / `::` cannot leave
+the machine, so they are not what the guard is for: that is a test talking to a
+server it started, the same category as the spawn guard's `os.tmpdir()`
 allowance. `agent-tool-mcp-server.test.ts` drives its MCP server's real HTTP
-surface (auth, CORS, thread binding) exactly this way. The allowance is pinned
-by the self-test, including that a remote host merely *containing* "localhost"
-is still blocked.
+surface (auth, CORS, thread binding) exactly this way. A scheme that opens no
+socket at all — `data:`, `blob:`, `file:` — is allowed for the same reason;
+those have no host to classify, and reading an inline fixture is not egress.
+The allowance is pinned by the self-test, including that a remote host merely
+*containing* "localhost" is still blocked.
 
 The renderer project loads the fetch guard too. It has no `fetch` call site
 today and reaches the network through IPC, but `lint:boundaries` reads imports
 and cannot see a `globalThis.fetch`, and jsdom inherits a live one from Node —
 so this is the only thing here that would catch a renderer reaching a remote
-host directly. (A relative-URL fetch resolves against jsdom's `localhost` and
-is allowed through as loopback; the guard measures egress, not same-origin.)
+host directly. A relative URL is resolved against the document origin before it
+is classified, so a same-origin renderer fetch is allowed through as loopback;
+the guard measures egress, not same-origin. Node has no `location`, so the same
+input there stays unparseable and is treated as escaping.
 
 `__tests__/outbound-fetch-guard.test.ts` is the guard's self-test, in the same
-shape as `agent-cli-spawn-guard.test.ts`.
+shape as `agent-cli-spawn-guard.test.ts`;
+`renderer/src/test/outbound-fetch-guard.test.ts` covers the one case that needs
+a document origin.
 
 ## Sqlite Write-Volume Instrumentation
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -710,6 +710,71 @@ roots:
 `acp-runtime-override-launch.test.ts` is the worked example of the ACP seams,
 and `acp-instance-discovery.test.ts` of plain probe injection.
 
+## No Network and No Operator State in Vitest
+
+Two more suite-wide guards, both pure test infrastructure. Production code has
+no test-awareness and behaves identically either way — the seams are in
+`vitest.workspace.ts`.
+
+**Where.** Both desktop projects set `PWRAGENT_HOME` to
+`<os.tmpdir()>/pwragent-vitest-home-<pid>`. `resolvePwragentRoot` otherwise
+falls back to `~/.pwragent`, and only about a dozen main tests override it
+themselves, so every other test that touches a root-relative path was reading
+and writing the operator's live application state. A plain `pnpm test` really
+did install a ~353 MB Grok runtime into `~/.pwragent/agents/grok/`, and the
+suite still writes a scratch projects directory and `state/image-inputs` —
+those now land in the temp root.
+
+Nothing pre-creates the directory, so a well-behaved run leaves no trace at
+all; anything that appears there is a test writing to the PwrAgent root. The
+pid keeps concurrent runs (several worktrees testing at once is normal) off
+each other's state. A test that needs its own root still wins with `vi.stubEnv`
+or an explicit `env` argument. `__tests__/disposable-pwragent-home.test.ts`
+pins both halves — that each project still declares the redirect, and that the
+value actually reaches a forked worker — so a config edit cannot quietly drop
+it. The one root path it does not cover is `userHomeWorktreesRoot`, which is
+deliberately `os.homedir()`-anchored; no test has ever created it, and
+`git-directory-service` takes an injected `homeDir`.
+
+**Whether.** [`src/test-setup/outbound-fetch-guard.ts`](src/test-setup/outbound-fetch-guard.ts)
+replaces `globalThis.fetch` and fails any test that makes a real outbound
+request. It hooks the global rather than taking an injected `fetch` per caller
+for the same reason the spawn guard hooks a prototype: it is the one chokepoint
+every request funnels through, so it also covers `acp-registry-service`,
+`pwrsnap-connection-service`, and `auto-updater` — none of which were given a
+seam — plus any network path added later. Injection is how you *fix* a failure
+(`fetchLatestCompatibleRelease` honors `options.fetch`, and
+`grok-managed-runtime.test.ts` passes one); it cannot be what enforces the
+rule, because a module with no seam is exactly the case that needs catching.
+
+Like the spawn guard it records **and** throws — every one of these callers
+degrades to a cached value or a logged warning inside its own `try`/`catch`, so
+a bare throw would be swallowed and the test would pass green having attempted
+the request anyway. Unlike the spawn guard's prototype patch, the global is
+routinely replaced by tests, so the guard reinstalls itself on every setup run
+rather than once per worker; a test that drives its own fake HTTP layer
+replaces it for its own duration, as `auto-updater.test.ts` does. Not covered:
+`http.request` / `https.request` / `net.connect`, which Node's undici `fetch`
+does not route through and nothing here uses directly.
+
+**Loopback goes through.** `localhost`, `127.0.0.0/8`, and `::1` cannot leave
+the machine, so they are not what the guard is for — that is a test talking to
+a server it started, the same category as the spawn guard's `os.tmpdir()`
+allowance. `agent-tool-mcp-server.test.ts` drives its MCP server's real HTTP
+surface (auth, CORS, thread binding) exactly this way. The allowance is pinned
+by the self-test, including that a remote host merely *containing* "localhost"
+is still blocked.
+
+The renderer project loads the fetch guard too. It has no `fetch` call site
+today and reaches the network through IPC, but `lint:boundaries` reads imports
+and cannot see a `globalThis.fetch`, and jsdom inherits a live one from Node —
+so this is the only thing here that would catch a renderer reaching a remote
+host directly. (A relative-URL fetch resolves against jsdom's `localhost` and
+is allowed through as loopback; the guard measures egress, not same-origin.)
+
+`__tests__/outbound-fetch-guard.test.ts` is the guard's self-test, in the same
+shape as `agent-cli-spawn-guard.test.ts`.
+
 ## Sqlite Write-Volume Instrumentation
 
 PR #1406 fixed tool accounting running one implicit transaction per streamed

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -20,6 +20,14 @@ import type {
   SetThreadParentRequest,
   ThreadGitWorkingState,
 } from "@pwragent/shared";
+import { resolvePwragentRoot } from "../profile";
+
+// `resolveScratchProjectsRoots` anchors the first two workspace roots at the
+// PwrAgent root, which vitest redirects to a disposable directory; only the
+// legacy `.pwragnt` root stays anchored at the real home. Reading the root the
+// same way production does keeps these assertions about *which* roots are
+// scanned rather than about where the suite happens to be pointed.
+const PWRAGENT_ROOT = resolvePwragentRoot();
 
 const mockAppServerLog = vi.hoisted(() => ({
   debug: vi.fn(),
@@ -2099,8 +2107,8 @@ describe("app server ipc", () => {
         expect.objectContaining({ source: "acp:grok", id: "thread-1" }),
       ],
       workspaceRoots: [
-        path.join(os.homedir(), ".pwragent", "profiles", "default", "projects"),
-        path.join(os.homedir(), ".pwragent", "projects"),
+        path.join(PWRAGENT_ROOT, "profiles", "default", "projects"),
+        path.join(PWRAGENT_ROOT, "projects"),
         path.join(os.homedir(), ".pwragnt", "projects"),
       ],
     });
@@ -3346,8 +3354,8 @@ describe("app server ipc", () => {
         expect.objectContaining({ source: "acp:grok", id: "thread-1" }),
       ],
       workspaceRoots: [
-        path.join(os.homedir(), ".pwragent", "profiles", "default", "projects"),
-        path.join(os.homedir(), ".pwragent", "projects"),
+        path.join(PWRAGENT_ROOT, "profiles", "default", "projects"),
+        path.join(PWRAGENT_ROOT, "projects"),
         path.join(os.homedir(), ".pwragnt", "projects"),
       ],
     });
@@ -3596,8 +3604,8 @@ describe("app server ipc", () => {
         }),
       ],
       workspaceRoots: [
-        path.join(os.homedir(), ".pwragent", "profiles", "default", "projects"),
-        path.join(os.homedir(), ".pwragent", "projects"),
+        path.join(PWRAGENT_ROOT, "profiles", "default", "projects"),
+        path.join(PWRAGENT_ROOT, "projects"),
         path.join(os.homedir(), ".pwragnt", "projects"),
       ],
     });

--- a/apps/desktop/src/main/__tests__/disposable-pwragent-home.test.ts
+++ b/apps/desktop/src/main/__tests__/disposable-pwragent-home.test.ts
@@ -1,0 +1,82 @@
+// Pins the `PWRAGENT_HOME` redirect in `vitest.workspace.ts`.
+//
+// Without it, `resolvePwragentRoot` falls back to `~/.pwragent` and every test
+// that touches a root-relative path reads and writes the operator's live
+// application state — their `config.toml`, their `state.db`, their installed
+// agent runtimes. Only about a dozen main tests override the root themselves,
+// so the protection is a property of the config, not of the tests, and a
+// one-line config edit could remove it silently. These assertions are what
+// makes that edit fail.
+//
+// Two halves, and both are needed: the declared config value proves the
+// redirect is still written down for each desktop project, and the runtime
+// value proves it actually reached a forked worker.
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import workspaceConfig from "../../../../../vitest.workspace";
+import { isPathWithin } from "../../shared/path-within";
+import { PWRAGENT_HOME_ENV, resolvePwragentRoot } from "../profile";
+
+const GUARDED_PROJECTS = ["desktop-main", "desktop-renderer"];
+
+type ConfiguredProject = {
+  test?: { env?: Record<string, string>; name?: string };
+};
+
+describe("disposable PWRAGENT_HOME", () => {
+  it("points this worker's PwrAgent root at a disposable directory", () => {
+    const configured = process.env[PWRAGENT_HOME_ENV];
+
+    expect(configured).toBeTruthy();
+    expect(isDisposable(configured ?? "")).toBe(true);
+  });
+
+  it("keeps resolvePwragentRoot away from the operator's home", () => {
+    const resolved = resolvePwragentRoot();
+
+    expect(isDisposable(resolved)).toBe(true);
+    expect(resolved).not.toBe(path.join(os.homedir(), ".pwragent"));
+  });
+
+  // A test that needs its own root still gets it: the seeded value is a
+  // default, and both `vi.stubEnv` and an explicit `env` argument win over it.
+  it("stays overridable by a test that brings its own root", () => {
+    const ownRoot = path.join(os.tmpdir(), "pwragent-own-root");
+
+    expect(resolvePwragentRoot({ env: { [PWRAGENT_HOME_ENV]: ownRoot } })).toBe(
+      ownRoot,
+    );
+  });
+
+  it.each(GUARDED_PROJECTS)(
+    "declares a disposable root for the %s project",
+    (name) => {
+      const project = findProject(name);
+
+      expect(project?.test?.env?.[PWRAGENT_HOME_ENV]).toBeTruthy();
+      expect(isDisposable(project?.test?.env?.[PWRAGENT_HOME_ENV] ?? "")).toBe(
+        true,
+      );
+    },
+  );
+});
+
+function findProject(name: string): ConfiguredProject | undefined {
+  const projects = (workspaceConfig.test?.projects ?? []) as unknown[];
+  return projects.find(
+    (project): project is ConfiguredProject =>
+      typeof project === "object"
+      && project !== null
+      && (project as ConfiguredProject).test?.name === name,
+  );
+}
+
+/**
+ * Disposable means "under the OS temp dir". No realpath dance is needed here,
+ * unlike in the spawn guard: both the declared and the runtime value are built
+ * from `os.tmpdir()` in this same process, so they share its spelling.
+ */
+function isDisposable(target: string): boolean {
+  return target.length > 0 && isPathWithin(os.tmpdir(), path.resolve(target));
+}

--- a/apps/desktop/src/main/__tests__/outbound-fetch-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/outbound-fetch-guard.test.ts
@@ -1,0 +1,161 @@
+// Self-test for the suite-wide guard in `../../test-setup/outbound-fetch-guard.ts`.
+//
+// The guard is loaded as a setup file for both desktop projects, so it is
+// already active here. These tests deliberately trip it and then drain its
+// record before the guard's own `afterEach` reads it — otherwise the
+// deliberate attempt would fail the test that made it on purpose.
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ATTEMPTS = Symbol.for("pwragent.outboundFetchGuard.attempts");
+
+type Attempt = { method: string; url: string };
+
+afterEach(() => {
+  drainAttempts();
+});
+
+describe("outbound fetch guard", () => {
+  it("blocks a string URL and names it", async () => {
+    const error = await captureFetchError(() =>
+      fetch("https://api.github.com/repos/pwrdrvr/grok-build/releases"),
+    );
+
+    expect(error.message).toContain(
+      "GET https://api.github.com/repos/pwrdrvr/grok-build/releases",
+    );
+    expect(drainAttempts()).toEqual([
+      {
+        method: "GET",
+        url: "https://api.github.com/repos/pwrdrvr/grok-build/releases",
+      },
+    ]);
+  });
+
+  it("names the URL and method behind a Request object", async () => {
+    const error = await captureFetchError(() =>
+      fetch(new Request("https://example.test/upload", { method: "POST" })),
+    );
+
+    expect(error.message).toContain("POST https://example.test/upload");
+    expect(drainAttempts()).toEqual([
+      { method: "POST", url: "https://example.test/upload" },
+    ]);
+  });
+
+  // The recording, not the throw, is what fails a test: every caller this guard
+  // protects wraps its request in a `try`/`catch` that degrades to a cached
+  // value or a logged warning.
+  it("records an attempt even when the caller swallows the throw", async () => {
+    await swallow(() => fetch("https://example.test/swallowed"));
+
+    expect(drainAttempts()).toEqual([
+      { method: "GET", url: "https://example.test/swallowed" },
+    ]);
+  });
+
+  // Loopback is not egress. `agent-tool-mcp-server.test.ts` depends on this to
+  // drive its own MCP server's real HTTP surface, so the allowance is pinned
+  // here rather than left to be rediscovered by a suite-wide failure.
+  it("lets a request through to a server the test started on loopback", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "text/plain" });
+      response.end("loopback");
+    });
+    const url = await listenOnLoopback(server);
+
+    try {
+      await expect((await fetch(url)).text()).resolves.toBe("loopback");
+      expect(drainAttempts()).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it.each(["http://127.0.0.1:9/x", "http://[::1]:9/x", "http://localhost:9/x"])(
+    "treats %s as loopback rather than egress",
+    async (url) => {
+      // Nothing is listening on port 9, so the request fails at connect — the
+      // point is that it reached the socket instead of the guard.
+      await swallow(() => fetch(url));
+
+      expect(drainAttempts()).toEqual([]);
+    },
+  );
+
+  it("still blocks a remote host that merely mentions localhost", async () => {
+    const error = await captureFetchError(() =>
+      fetch("https://localhost.attacker.test/x"),
+    );
+
+    expect(error.message).toContain("https://localhost.attacker.test/x");
+    expect(drainAttempts()).toHaveLength(1);
+  });
+
+  // The shape `auto-updater.test.ts` uses: a test that drives its own fake HTTP
+  // layer replaces the global for its own duration and puts back what it found.
+  it("lets a test install its own fetch and restore the guard afterwards", async () => {
+    const guarded = globalThis.fetch;
+    const stub = (async () => new Response("ok")) as typeof globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: stub,
+      writable: true,
+    });
+
+    try {
+      await expect((await fetch("https://example.test/stubbed")).text())
+        .resolves.toBe("ok");
+      expect(drainAttempts()).toEqual([]);
+    } finally {
+      Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        value: guarded,
+        writable: true,
+      });
+    }
+
+    const error = await captureFetchError(() => fetch("https://example.test/after"));
+    expect(error.message).toContain("https://example.test/after");
+    expect(drainAttempts()).toHaveLength(1);
+  });
+});
+
+/**
+ * The guard throws from the call itself rather than returning a rejected
+ * promise, so the throw arrives synchronously and `.rejects` would never see
+ * it. Awaiting inside `try` catches both shapes.
+ */
+async function captureFetchError(request: () => Promise<unknown>): Promise<Error> {
+  try {
+    await request();
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error("expected the guard to block this request");
+}
+
+async function swallow(request: () => Promise<unknown>): Promise<void> {
+  try {
+    await request();
+  } catch {
+    // Exactly what `ensureManagedGrokRuntime` does with a failed release check.
+  }
+}
+
+async function listenOnLoopback(server: Server): Promise<string> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("expected a bound TCP address");
+  }
+  return `http://127.0.0.1:${address.port}/`;
+}
+
+/** Consumes the guard's record so its own `afterEach` sees a clean slate. */
+function drainAttempts(): Attempt[] {
+  const recorded = (globalThis as Record<symbol, unknown>)[ATTEMPTS] as
+    | Attempt[]
+    | undefined;
+  return recorded?.splice(0) ?? [];
+}

--- a/apps/desktop/src/main/__tests__/outbound-fetch-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/outbound-fetch-guard.test.ts
@@ -72,16 +72,31 @@ describe("outbound fetch guard", () => {
     }
   });
 
-  it.each(["http://127.0.0.1:9/x", "http://[::1]:9/x", "http://localhost:9/x"])(
-    "treats %s as loopback rather than egress",
-    async (url) => {
-      // Nothing is listening on port 9, so the request fails at connect — the
-      // point is that it reached the socket instead of the guard.
-      await swallow(() => fetch(url));
+  it.each([
+    "http://127.0.0.1:9/x",
+    "http://[::1]:9/x",
+    "http://localhost:9/x",
+    // The dual-stack spelling of IPv4 loopback, and the wildcard bind
+    // addresses a test's own server reports when it listens on all interfaces.
+    "http://[::ffff:127.0.0.1]:9/x",
+    "http://0.0.0.0:9/x",
+    "http://[::]:9/x",
+  ])("treats %s as loopback rather than egress", async (url) => {
+    // Nothing is listening on port 9, so the request fails at connect — the
+    // point is that it reached the socket instead of the guard.
+    await swallow(() => fetch(url));
 
-      expect(drainAttempts()).toEqual([]);
-    },
-  );
+    expect(drainAttempts()).toEqual([]);
+  });
+
+  // A scheme that opens no socket is not egress and has no host to classify.
+  it("lets a data URL through instead of counting it as a request", async () => {
+    await expect((await fetch("data:text/plain,inline")).text()).resolves.toBe(
+      "inline",
+    );
+
+    expect(drainAttempts()).toEqual([]);
+  });
 
   it("still blocks a remote host that merely mentions localhost", async () => {
     const error = await captureFetchError(() =>

--- a/apps/desktop/src/renderer/src/test/outbound-fetch-guard.test.ts
+++ b/apps/desktop/src/renderer/src/test/outbound-fetch-guard.test.ts
@@ -1,0 +1,50 @@
+// The renderer half of the guard in `../../../test-setup/outbound-fetch-guard.ts`.
+//
+// The main-process self-test (`src/main/__tests__/outbound-fetch-guard.test.ts`)
+// covers everything that does not depend on a document origin. This file covers
+// the one thing it cannot: under jsdom a relative URL is a same-origin request
+// against `localhost`, not an unparseable one, and the guard measures egress
+// rather than same-origin.
+import { afterEach, describe, expect, it } from "vitest";
+
+const ATTEMPTS = Symbol.for("pwragent.outboundFetchGuard.attempts");
+
+type Attempt = { method: string; url: string };
+
+afterEach(() => {
+  drainAttempts();
+});
+
+describe("outbound fetch guard under jsdom", () => {
+  it("does not count a same-origin relative URL as egress", async () => {
+    // The request still fails — undici will not resolve a relative URL against
+    // jsdom's location — but it fails past the guard rather than at it.
+    await swallow(() => fetch("/api/threads"));
+
+    expect(drainAttempts()).toEqual([]);
+  });
+
+  it("still blocks a remote host reached from the renderer", async () => {
+    await swallow(() => fetch("https://api.github.com/repos/pwrdrvr/PwrAgent"));
+
+    expect(drainAttempts()).toEqual([
+      { method: "GET", url: "https://api.github.com/repos/pwrdrvr/PwrAgent" },
+    ]);
+  });
+});
+
+async function swallow(request: () => Promise<unknown>): Promise<void> {
+  try {
+    await request();
+  } catch {
+    // The callers this guard protects all degrade inside their own catch.
+  }
+}
+
+/** Consumes the guard's record so its own `afterEach` sees a clean slate. */
+function drainAttempts(): Attempt[] {
+  const recorded = (globalThis as Record<symbol, unknown>)[ATTEMPTS] as
+    | Attempt[]
+    | undefined;
+  return recorded?.splice(0) ?? [];
+}

--- a/apps/desktop/src/test-setup/outbound-fetch-guard.ts
+++ b/apps/desktop/src/test-setup/outbound-fetch-guard.ts
@@ -1,0 +1,171 @@
+// Fails any test that makes a real outbound HTTP request.
+//
+// The suites reach several live network paths with no test-mode gate of their
+// own: `ensureManagedGrokRuntime` asks the GitHub releases API what to install
+// and then downloads a ~353 MB Grok runtime, `acp-registry-service` and
+// `pwrsnap-connection-service` call their own endpoints, and `auto-updater`
+// polls GitHub for releases. Only `managedGrok.enabled` gates the first, and
+// two live callers pass it: `resolveManagedGrokCommand` in ACP discovery and
+// the `refreshLocal` branch of the settings IPC.
+//
+// The spawn guard already catches the *probe* that follows an install, so the
+// end state before this guard was a full download into the developer's home
+// directory and then a spawn-guard failure. Failing at the request keeps the
+// bytes off the disk in the first place, and keeps a run reproducible on a
+// machine with no network at all.
+//
+// The hook is `globalThis.fetch` rather than an injected `fetch` option on each
+// caller, for the same reason the spawn guard hooks a prototype: it is the one
+// chokepoint every request funnels through, so it covers modules that were
+// never given a seam and any network path added later. Injection is how you
+// *fix* a failure here — `fetchLatestCompatibleRelease` already honors
+// `options.fetch`, and `grok-managed-runtime.test.ts` passes one — but it
+// cannot be what enforces the rule, because a module with no seam is exactly
+// the case that needs catching.
+//
+// It records **and** throws. The throw alone is not enough: every one of these
+// callers runs inside a `try`/`catch` that degrades to a cached value or a
+// logged warning, so a bare throw would be swallowed and the test would pass
+// green having attempted the request anyway. The recorded attempt is what fails
+// the test below.
+//
+// Loopback is allowed through, because it is not egress: a request to
+// `localhost` / `127.0.0.0/8` / `::1` reaches a server the test itself started.
+// See `isLoopback` below.
+//
+// Not covered: `http.request` / `https.request` / `net.connect` and Electron's
+// `net` module. Node's `fetch` is undici and does not route through them, and
+// nothing in these suites uses them directly, so the narrower hook is the one
+// that earns its keep.
+//
+// Fix a failure by keeping the request out of the test, never by calling
+// through to the real `fetch`:
+//   - Managed Grok runtime: pass `options.fetch`, as
+//     `grok-managed-runtime.test.ts` does — or, for a test that only wants
+//     discovery, leave `managedGrok.enabled` off or inject
+//     `resolveManagedGrokCommand`.
+//   - Anything else: inject the module's own fetch seam, or `vi.mock` it.
+// A test that legitimately drives a fake HTTP layer replaces `globalThis.fetch`
+// for its own duration, as `auto-updater.test.ts` does; this file reinstalls
+// the guard for the next test file either way.
+import { afterAll, afterEach } from "vitest";
+
+type Attempt = { method: string; url: string };
+
+const INSTALLED = Symbol.for("pwragent.outboundFetchGuard.installed");
+const ATTEMPTS = Symbol.for("pwragent.outboundFetchGuard.attempts");
+const NATIVE = Symbol.for("pwragent.outboundFetchGuard.native");
+
+type GuardGlobal = typeof globalThis & {
+  [INSTALLED]?: typeof globalThis.fetch;
+  [ATTEMPTS]?: Attempt[];
+  [NATIVE]?: typeof globalThis.fetch;
+};
+
+const guardGlobal = globalThis as GuardGlobal;
+const attempts: Attempt[] = (guardGlobal[ATTEMPTS] ??= []);
+// Captured on the first install only. A reinstall sees whatever the previous
+// test file left behind, which may be that file's mock — passing loopback
+// traffic to a stale mock would be worse than blocking it.
+const nativeFetch: typeof globalThis.fetch = (guardGlobal[NATIVE] ??=
+  guardGlobal.fetch);
+
+// Setup files re-run for every test file in a worker. Unlike the spawn guard's
+// prototype patch, `globalThis.fetch` is a plain writable property that tests
+// routinely replace, so re-asserting the guard here is what makes it the
+// baseline each file starts from rather than a one-shot install a single
+// unrestored mock could retire for the rest of the worker. The identity check
+// keeps a re-run from wrapping the guard in itself.
+if (guardGlobal[INSTALLED] !== guardGlobal.fetch) {
+  const guardedFetch = function guardedFetch(
+    input: Parameters<typeof globalThis.fetch>[0],
+    init?: Parameters<typeof globalThis.fetch>[1],
+  ): Promise<Response> {
+    const attempt = describeRequest(input, init);
+    if (isLoopback(attempt.url)) {
+      return nativeFetch(input, init);
+    }
+    attempts.push(attempt);
+    throw new Error(describeAttempt(attempt));
+  } as typeof globalThis.fetch;
+  Object.defineProperty(guardGlobal, "fetch", {
+    configurable: true,
+    value: guardedFetch,
+    writable: true,
+  });
+  guardGlobal[INSTALLED] = guardedFetch;
+}
+
+afterEach(() => {
+  reportRecordedAttempts("This test");
+});
+
+// `afterEach` cannot see a request issued from `afterAll`, nor one from an
+// async path that settles after the final test — and a swallowed throw leaves
+// nothing else to notice it.
+afterAll(() => {
+  reportRecordedAttempts("This test file, after its last test,");
+});
+
+function reportRecordedAttempts(subject: string): void {
+  const observed = attempts.splice(0);
+  if (observed.length > 0) {
+    throw new Error(
+      [
+        `${subject} attempted ${observed.length} real outbound HTTP request(s):`,
+        ...observed.map((attempt) => `  ${describeAttempt(attempt)}`),
+        "Serve the request from the test instead — see the remedies in",
+        "apps/desktop/src/test-setup/outbound-fetch-guard.ts.",
+      ].join("\n"),
+    );
+  }
+}
+
+/**
+ * `fetch` takes a string, a `URL`, or a `Request`, and a `Request` carries its
+ * own method. Read both shapes so the failure names the URL that was actually
+ * attempted rather than `[object Request]`.
+ */
+function describeRequest(
+  input: Parameters<typeof globalThis.fetch>[0],
+  init: Parameters<typeof globalThis.fetch>[1],
+): Attempt {
+  if (typeof input === "object" && input !== null && "url" in input) {
+    const request = input as Request;
+    return { method: init?.method ?? request.method, url: request.url };
+  }
+  return { method: init?.method ?? "GET", url: String(input) };
+}
+
+function describeAttempt(attempt: Attempt): string {
+  return `${attempt.method.toUpperCase()} ${attempt.url}`;
+}
+
+/**
+ * A request to loopback cannot leave the machine, so it is not the thing this
+ * guard exists to stop — it is a test talking to a server the test itself
+ * started, the same category as the spawn guard's `os.tmpdir()` allowance.
+ * `agent-tool-mcp-server.test.ts` drives its MCP server's real HTTP surface
+ * (auth, CORS, thread binding) this way, and there is no version of that test
+ * worth having that does not.
+ *
+ * An unparseable URL is treated as escaping: nothing here can prove where it
+ * would go.
+ */
+function isLoopback(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  // Node reports IPv6 hosts in their bracketed form.
+  const address = host.replace(/^\[|\]$/g, "");
+  return (
+    address === "localhost"
+    || address.endsWith(".localhost")
+    || address === "::1"
+    || address === "0.0.0.0"
+    || /^127(\.\d{1,3}){3}$/.test(address)
+  );
+}

--- a/apps/desktop/src/test-setup/outbound-fetch-guard.ts
+++ b/apps/desktop/src/test-setup/outbound-fetch-guard.ts
@@ -31,7 +31,8 @@
 //
 // Loopback is allowed through, because it is not egress: a request to
 // `localhost` / `127.0.0.0/8` / `::1` reaches a server the test itself started.
-// See `isLoopback` below.
+// So is a scheme that never opens a socket at all (`data:`, `blob:`, `file:`).
+// See `staysOnThisMachine` below.
 //
 // Not covered: `http.request` / `https.request` / `net.connect` and Electron's
 // `net` module. Node's `fetch` is undici and does not route through them, and
@@ -82,7 +83,7 @@ if (guardGlobal[INSTALLED] !== guardGlobal.fetch) {
     init?: Parameters<typeof globalThis.fetch>[1],
   ): Promise<Response> {
     const attempt = describeRequest(input, init);
-    if (isLoopback(attempt.url)) {
+    if (staysOnThisMachine(attempt.url)) {
       return nativeFetch(input, init);
     }
     attempts.push(attempt);
@@ -142,30 +143,63 @@ function describeAttempt(attempt: Attempt): string {
 }
 
 /**
- * A request to loopback cannot leave the machine, so it is not the thing this
- * guard exists to stop — it is a test talking to a server the test itself
- * started, the same category as the spawn guard's `os.tmpdir()` allowance.
- * `agent-tool-mcp-server.test.ts` drives its MCP server's real HTTP surface
- * (auth, CORS, thread binding) this way, and there is no version of that test
- * worth having that does not.
+ * A request that cannot leave the machine is not the thing this guard exists to
+ * stop. Two shapes qualify:
+ *
+ *   - Loopback — a test talking to a server the test itself started, the same
+ *     category as the spawn guard's `os.tmpdir()` allowance.
+ *     `agent-tool-mcp-server.test.ts` drives its MCP server's real HTTP surface
+ *     (auth, CORS, thread binding) this way, and there is no version of that
+ *     test worth having that does not.
+ *   - A scheme that opens no socket at all — `data:`, `blob:`, `file:`. Those
+ *     have no host to classify, and reading an inline fixture is not egress.
  *
  * An unparseable URL is treated as escaping: nothing here can prove where it
  * would go.
  */
-function isLoopback(url: string): boolean {
-  let host: string;
-  try {
-    host = new URL(url).hostname.toLowerCase();
-  } catch {
+function staysOnThisMachine(url: string): boolean {
+  const parsed = parseRequestUrl(url);
+  if (parsed === null) {
     return false;
   }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return true;
+  }
+  return isLoopbackHost(parsed.hostname.toLowerCase());
+}
+
+/**
+ * jsdom gives the renderer a document origin, so a relative URL there is a
+ * same-origin request against `localhost` rather than an unparseable one — the
+ * guard measures egress, not same-origin. Node has no `location`, and undici
+ * rejects a relative URL outright, so the same input there stays in the
+ * "cannot prove where it goes" case alongside a malformed URL.
+ */
+function parseRequestUrl(url: string): URL | null {
+  try {
+    return new URL(url, globalThis.location?.href);
+  } catch {
+    return null;
+  }
+}
+
+function isLoopbackHost(host: string): boolean {
   // Node reports IPv6 hosts in their bracketed form.
   const address = host.replace(/^\[|\]$/g, "");
   return (
     address === "localhost"
     || address.endsWith(".localhost")
-    || address === "::1"
+    // The wildcard bind addresses: a client that connects to one reaches a
+    // local listener, so a test addressing its own `0.0.0.0`/`::` server is
+    // still talking to itself.
     || address === "0.0.0.0"
+    || address === "::"
+    || address === "::1"
+    // A dual-stack socket reports IPv4 loopback as `::ffff:127.0.0.1`, which
+    // the URL parser normalizes to its hex form — `::ffff:7f00:1` for
+    // `127.0.0.1`. The first group is `7f` plus the second octet, so the whole
+    // of `127.0.0.0/8` is `7f00`–`7fff`.
+    || /^::ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/.test(address)
     || /^127(\.\d{1,3}){3}$/.test(address)
   );
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 // Windows CI runners are markedly slower at spawning child processes (git.exe,
@@ -5,6 +7,27 @@ import { defineConfig } from "vitest/config";
 // Give Windows more headroom; POSIX keeps the standard timeout.
 const TEST_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 5_000;
 const HOOK_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 10_000;
+
+// Where the desktop suites resolve the PwrAgent root to. `resolvePwragentRoot`
+// falls back to `~/.pwragent` — the operator's live application state — and
+// only about a dozen main tests override it themselves, so every other test
+// that reaches a root-relative path reads and writes the real thing. That is
+// not hypothetical: `ensureManagedGrokRuntime` installed a ~353 MB Grok runtime
+// into `~/.pwragent/agents/grok/` from a plain `pnpm test`.
+//
+// Nothing pre-creates this directory. A run where the suites behave leaves no
+// trace at all; a run that writes leaves the evidence in the OS temp dir under
+// an obvious name instead of in the operator's home. The pid keeps concurrent
+// runs (several worktrees testing at once is normal here) off each other's
+// state, and is stable for the whole run because the config is evaluated once
+// in the vitest host process.
+//
+// A test that needs its own root still overrides this with `vi.stubEnv` or an
+// explicit `env` argument, both of which win over the value seeded here.
+const DISPOSABLE_PWRAGENT_HOME = path.join(
+  os.tmpdir(),
+  `pwragent-vitest-home-${process.pid}`,
+);
 
 export default defineConfig({
   test: {
@@ -34,6 +57,7 @@ export default defineConfig({
           testTimeout: TEST_TIMEOUT_MS,
           hookTimeout: HOOK_TIMEOUT_MS,
           environment: "node",
+          env: { PWRAGENT_HOME: DISPOSABLE_PWRAGENT_HOME },
           include: [
             "scripts/**/*.test.mjs",
             ".agents/skills/codex-rollout-forensics/tests/**/*.test.mjs",
@@ -50,6 +74,9 @@ export default defineConfig({
             // Fails a test that probes an agent CLI installed on the machine
             // running the suite instead of its own fixtures.
             "apps/desktop/src/main/__tests__/setup/agent-cli-spawn-guard.ts",
+            // Fails a test that makes a real outbound HTTP request — the step
+            // that runs *before* the probe the guard above catches.
+            "apps/desktop/src/test-setup/outbound-fetch-guard.ts",
           ],
           // Inline @pwrdrvr/codex-discovery so vitest transforms it. Without
           // this, the kit's bundled `import { spawn } from "child_process"`
@@ -65,8 +92,16 @@ export default defineConfig({
           globals: true,
           testTimeout: TEST_TIMEOUT_MS,
           environment: "jsdom",
+          env: { PWRAGENT_HOME: DISPOSABLE_PWRAGENT_HOME },
           include: ["apps/desktop/src/renderer/src/**/*.test.{ts,tsx}"],
-          setupFiles: ["apps/desktop/src/renderer/src/test/setup.ts"]
+          // The renderer reaches the network through IPC, so it has no `fetch`
+          // call site today — but `lint:boundaries` reads imports and cannot
+          // see a `globalThis.fetch`, and jsdom inherits a live one from Node,
+          // so the guard covers a violation nothing else here would catch.
+          setupFiles: [
+            "apps/desktop/src/test-setup/outbound-fetch-guard.ts",
+            "apps/desktop/src/renderer/src/test/setup.ts",
+          ]
         }
       }
     ]


### PR DESCRIPTION
Two suite-wide guards, both pure test infrastructure. **Production code is unchanged** and carries no test-awareness (no `process.env.VITEST` checks) — the seams are in `vitest.workspace.ts`.

## Where — redirect the PwrAgent root

Both desktop vitest projects now set `PWRAGENT_HOME` to `<os.tmpdir()>/pwragent-vitest-home-<pid>`.

`resolvePwragentRoot` otherwise falls back to `~/.pwragent`, and only about a dozen main tests override it themselves, so every other test that touched a root-relative path read and wrote the operator's live application state. That is not hypothetical: a plain `pnpm test` installed a ~353 MB Grok runtime into `~/.pwragent/agents/grok/`. The suite also writes a scratch projects directory and `state/image-inputs`, which now land in the temp root.

Details worth knowing:

- **Nothing pre-creates the directory.** A run where the suites behave leaves no trace at all; anything that appears there is a test writing to the PwrAgent root.
- **The pid is the vitest host's**, verified shared across forked workers (host `77266`, workers `77283`/`77284`), so the config is evaluated once and serialized. It keeps concurrent runs — several worktrees testing at once is normal here — off each other's state.
- **Per-test overrides still win.** `vi.stubEnv` and explicit `env` arguments both take precedence, so the ~13 tests that bring their own root are unaffected.
- Playwright E2E config is untouched.

`apps/desktop/src/main/__tests__/disposable-pwragent-home.test.ts` pins both halves — that each project still *declares* the redirect, and that the value actually *reaches a forked worker* — so a config edit cannot silently remove the protection. Verified falsifiable: removing the `desktop-main` line fails 3 of its 5 assertions.

## Whether — stop the fetch

`apps/desktop/src/test-setup/outbound-fetch-guard.ts` replaces `globalThis.fetch` and fails any test that makes a real outbound request, naming the attempted URL.

**Why the global rather than an injected `fetch` per caller.** Injection would only cover `grok-managed-runtime`, which already honors `options.fetch`. `acp-registry-service`, `pwrsnap-connection-service`, and `auto-updater` have no seam at all — and a module with no seam is exactly the case that needs catching. Hooking the one chokepoint also covers any network path added later. Injection stays the way to *fix* a failure; it cannot be what *enforces* the rule.

**It records as well as throws.** `ensureManagedGrokRuntimeInner` catches everything and logs `managed_grok_runtime_update_failed`; every other caller degrades to a cached value the same way. A bare throw would be swallowed and the test would pass green having attempted the request anyway. The recorded attempt is what fails the test, in `afterEach` and `afterAll` — same design as the spawn guard, for the same reason.

**It reinstalls per setup run**, unlike the spawn guard's one-shot prototype patch, because `globalThis.fetch` is a plain writable property that tests routinely replace (`auto-updater.test.ts` does). That makes the guard the baseline each test file starts from rather than something a single unrestored mock could retire for the rest of the worker.

**Loopback goes through.** `localhost`, `127.0.0.0/8`, and `::1` cannot leave the machine, so a test driving a server it started is not what this guards against — the same category as the spawn guard's `os.tmpdir()` allowance. This was found the honest way: the first full run tripped the guard three times in `agent-tool-mcp-server.test.ts`, which exercises its MCP server's real HTTP surface (auth, CORS, thread binding) over `http://127.0.0.1:<port>/mcp`. The real `fetch` is captured on first install only, so a reinstall cannot route loopback traffic into a stale mock. The self-test pins the allowance, including that a remote host merely *containing* "localhost" is still blocked.

**The renderer project gets it too.** The renderer has no `fetch` call site today and reaches the network through IPC, but `lint:boundaries` reads imports and cannot see a `globalThis.fetch`, and jsdom inherits a live one from Node (verified). So this is the only thing here that would catch a renderer reaching a remote host directly.

Not covered: `http.request` / `https.request` / `net.connect`. Node's undici `fetch` does not route through them and nothing in these suites uses them directly.

## Verification

| Check | Result |
|---|---|
| `pnpm typecheck` | ✅ |
| `pnpm lint:eslint` | ✅ 0 errors (35 pre-existing warnings) |
| `pnpm lint:boundaries` | ✅ |
| Guard self-tests + managed-Grok callers + `auto-updater` + spawn-guard self-test | ✅ 95 tests |

### Two things still outstanding — please finish these on a quieter machine

**1. No clean full-suite green.** The dev machine hit load averages of 240–270 on 8 cores (a VMware Fusion VM, a live PwrAgent dev Electron app, and other agent sessions running `vitest` concurrently). The full run showed 204 failures, essentially all `Test timed out in 5000ms`.

To separate contention from breakage I stashed this branch and ran the four heaviest failing files on clean `main`:

- clean `main`: **112 failed** / 56 passed (168)
- this branch: **94 failed** / 74 passed (168)

Same files, same timeout pattern, and `main` fared worse — so the failures are environmental. But that is a comparison, not a green run. **A full `pnpm test` on an idle machine is still needed.**

**2. The mtime acid test is inconclusive.** A live PwrAgent dev Electron app was running against the real `~/.pwragent`, and other sessions were running *unguarded* vitest throughout, so both write to the operator's root independently of this branch.

What could be established:

- `installedAt` in `~/.pwragent/agents/grok/managed-release.json` stayed at `2026-08-17T13:43:35` while `checkedAt` kept moving — the churn is TTL re-checks from unguarded runs, which corroborates the original report rather than implicating this branch.
- `~/.pwragent/profiles/default/config.toml` did not move across the full run.
- The disposable root *did* receive real writes (`profiles/default/projects/…`, `state/image-inputs`) that previously went to the operator's home.

**To finish:** with no other vitest running and the PwrAgent dev app closed, record `stat` mtimes of `~/.pwragent/agents/grok/managed-release.json` and `~/.pwragent/profiles/default/config.toml`, run `pnpm test`, and confirm neither moves.

## Known residual gaps (deliberately not addressed)

- **`userHomeWorktreesRoot`** (`apps/desktop/src/main/settings/desktop-config.ts`) is deliberately `os.homedir()`-anchored and ignores `PWRAGENT_HOME`. Changing it is a production behavior change, so it was left alone. `~/.pwragent/worktrees` has never been created, and `git-directory-service` takes an injected `homeDir`, so the gap is theoretical. Documented in `apps/desktop/AGENTS.md`.
- **The `messaging` vitest project has no fetch guard.** `mattermost-callback-server.test.ts` and `line-adapter.test.ts` legitimately `fetch` their own local servers, so that project needs its own assessment rather than a copy of this setup file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
