### PR TITLE
fix(desktop): route thread-action failures to the notice stack

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -109,6 +109,11 @@ import {
   appNoticeReducer,
   INITIAL_APP_NOTICE_STATE,
 } from "./features/notifications/app-notice-state";
+import {
+  resolveThreadActionErrorNotice,
+  threadActionErrorNoticeId,
+  type ThreadActionErrorKind,
+} from "./features/notifications/thread-action-error-notice";
 import { buildPrAutoDispatchBudgetNotice } from "./features/notifications/pr-auto-dispatch-budget-notice";
 import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNotices";
 import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
@@ -343,6 +348,30 @@ function DesktopAppShell(props: {
   }, []);
   const dismissAppNotice = useCallback((id: string): void => {
     dispatchAppNotice({ type: "dismiss", id });
+  }, []);
+  /* Thread create / rename / archive failures. The originating control is
+     always gone by the time these resolve — the rename dialog closes on
+     submit, the context menu closes on click, and a failed create has no
+     thread to point at — so they land in the durable stack rather than a
+     static slot. An empty message means the producer cleared it. */
+  const handleThreadActionError = useCallback((event: {
+    kind: ThreadActionErrorKind;
+    message?: string;
+  }): void => {
+    if (!event.message) {
+      dispatchAppNotice({
+        type: "dismiss",
+        id: threadActionErrorNoticeId(event.kind),
+      });
+      return;
+    }
+    dispatchAppNotice({
+      type: "show",
+      notice: resolveThreadActionErrorNotice({
+        kind: event.kind,
+        message: event.message,
+      }),
+    });
   }, []);
   const [githubPrSamlEvents, setGithubPrSamlEvents] =
     useState<GithubPrSamlEnforcementEvent[]>([]);
@@ -1101,6 +1130,7 @@ function DesktopAppShell(props: {
     enabled: normalAppEnabled,
     lightweightNavigationRefresh:
       settings.snapshot?.experimental.lightweightNavigationRefresh?.value ?? false,
+    onThreadActionError: handleThreadActionError,
     threadViewVisible: mainView === "thread",
   });
   useEffect(() => {
@@ -1888,7 +1918,6 @@ function DesktopAppShell(props: {
     providerModelDefaults: settings.snapshot?.models?.providerDefaults,
     providerThreadMigrations:
       settings.snapshot?.models?.providerThreadMigrations,
-    archiveThreadError: navigation.archiveThreadError,
     clearPendingRequest: session.clearPendingRequest,
     composerDisabled:
       !navigation.selectedThread ||
@@ -2277,8 +2306,6 @@ function DesktopAppShell(props: {
           addingProjectDirectory={navigation.pickingDirectory}
           backends={backendSummaries.backends}
           browseMode={navigation.browseMode}
-          createThreadError={navigation.createThreadError}
-          pickDirectoryError={navigation.pickDirectoryError}
           creatingThread={navigation.creatingThread}
           directories={navigation.directories}
           error={navigation.error}
@@ -2287,12 +2314,9 @@ function DesktopAppShell(props: {
           attentionPromoteOnTurnEnd={
             settings.snapshot?.general.attentionPromoteOnTurnEnd?.value ?? true
           }
-          archiveThreadError={navigation.archiveThreadError}
-          renameThreadError={navigation.renameThreadError}
           runtimeIdentity={runtimeIdentity}
           activeProfile={profiles.activeProfile}
           profiles={profiles.profiles}
-          launchpadError={navigation.launchpadError}
           loaded={navigation.loaded}
           loading={navigation.loading}
           approvalRequestThreadKeys={session.approvalRequestThreadKeys}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -182,8 +182,6 @@ function hydrateHoverStableSidebarSnapshot(
 type SidebarProps = {
   backends: BackendSummary[];
   browseMode: BrowseMode;
-  createThreadError?: string;
-  pickDirectoryError?: string;
   directories: NavigationDirectorySummary[];
   error?: string;
   inboxThreads?: NavigationThreadSummary[];
@@ -201,9 +199,6 @@ type SidebarProps = {
     backend: AppServerBackendKind;
     executionMode: ThreadExecutionMode;
   };
-  launchpadError?: string;
-  archiveThreadError?: string;
-  renameThreadError?: string;
   runtimeIdentity?: RuntimeIdentity;
   activeProfile?: string;
   automationsActive?: boolean;
@@ -1942,17 +1937,13 @@ export function Sidebar(props: SidebarProps) {
         </div>
       ) : null}
 
-      {props.createThreadError ? (
-        <p className="sidebar-error sidebar-error--masthead">{props.createThreadError}</p>
-      ) : props.pickDirectoryError ? (
-        <p className="sidebar-error sidebar-error--masthead">{props.pickDirectoryError}</p>
-      ) : props.launchpadError ? (
-        <p className="sidebar-error sidebar-error--masthead">{props.launchpadError}</p>
-      ) : props.archiveThreadError ? (
-        <p className="sidebar-error sidebar-error--masthead">{props.archiveThreadError}</p>
-      ) : props.renameThreadError ? (
-        <p className="sidebar-error sidebar-error--masthead">{props.renameThreadError}</p>
-      ) : null}
+      {/* The masthead error slot is gone. It rendered five unrelated
+          failures through one `? :` chain, so a stale create error masked a
+          fresh rename error, none of them could be dismissed or timed out,
+          and each one permanently shortened the thread list. Create, rename,
+          and archive failures now go to the durable notice stack; the
+          directory-picker and launchpad failures render at their own
+          controls in the composer, which stay on screen. */}
 
       <section className="sidebar__section sidebar__section--fill" aria-label="Thread browser">
         <div className="lens-switch" role="tablist" aria-label="Thread lenses">

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -340,10 +340,8 @@ describe("Sidebar", () => {
         activeProfile="dev"
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         profiles={[]}
@@ -388,10 +386,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="recents"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={[sharedThread, nextThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-1"
@@ -408,10 +404,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="recents"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={[sharedThread, nextThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-next"
@@ -461,10 +455,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="directories"
-          createThreadError={undefined}
           directories={[directories[0]!, projectBDirectory]}
           inboxThreads={[sharedThread, nextThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-1"
@@ -492,10 +484,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="directories"
-          createThreadError={undefined}
           directories={[directories[0]!, projectBDirectory]}
           inboxThreads={[sharedThread, nextThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-in-projectb"
@@ -557,7 +547,6 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[
           {
             ...collapsedDirectory,
@@ -565,7 +554,6 @@ describe("Sidebar", () => {
           },
         ]}
         inboxThreads={[pinnedThread, parentThread, childThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         revealSelectedThreadRequest={1}
@@ -667,10 +655,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="directories"
-          createThreadError={undefined}
           directories={[directories[0]!, projectBWithoutThread]}
           inboxThreads={[sharedThread, refreshedThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-1"
@@ -696,10 +682,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="directories"
-          createThreadError={undefined}
           directories={[directories[0]!, projectBWithoutThread]}
           inboxThreads={[sharedThread, refreshedThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-after-refresh"
@@ -719,10 +703,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="directories"
-          createThreadError={undefined}
           directories={[directories[0]!, projectBWithThread]}
           inboxThreads={[sharedThread, refreshedThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-after-refresh"
@@ -754,10 +736,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -803,10 +783,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -866,10 +844,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="inbox"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -910,10 +886,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         newThreadDirectoryLabel="PwrAgnt"
@@ -1741,10 +1715,8 @@ describe("Sidebar", () => {
           },
         ]}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -1800,10 +1772,8 @@ describe("Sidebar", () => {
           },
         ]}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -1840,10 +1810,8 @@ describe("Sidebar", () => {
           },
         ]}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -1865,10 +1833,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -1912,7 +1878,6 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[
           {
             ...directories[0],
@@ -1920,7 +1885,6 @@ describe("Sidebar", () => {
           },
         ]}
         inboxThreads={[sharedThread, localThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2004,10 +1968,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[pwrGitDirectory]}
         inboxThreads={[multiDirectoryThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2051,10 +2013,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2089,10 +2049,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[unconfiguredDirectory]}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2141,10 +2099,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={openedOnlyDirectories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2184,10 +2140,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={pendingDirectories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2209,10 +2163,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -2246,10 +2198,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[activeThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2310,10 +2260,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[directory]}
         inboxThreads={[backendActiveThread, locallyThinkingThread, idleThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2364,10 +2312,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         approvalRequestThreadKeys={{ "codex:thread-1": true }}
@@ -2398,10 +2344,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         inputRequestThreadKeys={{ "codex:thread-1": true }}
@@ -2432,10 +2376,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2461,10 +2403,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[updatedSinceSeenThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -2521,10 +2461,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode={browseMode}
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={allThreads}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -2564,9 +2502,7 @@ describe("Sidebar", () => {
       const props = {
         backends,
         browseMode: "attention" as const,
-        createThreadError: undefined,
         directories,
-        launchpadError: undefined,
         loading: false,
         creatingThread: undefined,
         selectedItemKey: undefined,
@@ -2621,10 +2557,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="inbox"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={[idleThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -2678,10 +2612,8 @@ describe("Sidebar", () => {
         const sidebarProps = (threads: typeof allThreads) => ({
           backends,
           browseMode: "inbox" as const,
-          createThreadError: undefined,
           directories,
           inboxThreads: threads,
-          launchpadError: undefined,
           loading: false,
           creatingThread: undefined,
           selectedItemKey: undefined,
@@ -2741,10 +2673,8 @@ describe("Sidebar", () => {
       const remoteSidebarProps = (threads: typeof allThreads) => ({
         backends,
         browseMode: "inbox" as const,
-        createThreadError: undefined,
         directories,
         inboxThreads: threads,
-        launchpadError: undefined,
         loading: false,
         creatingThread: undefined,
         selectedItemKey: undefined,
@@ -2921,10 +2851,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="attention"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={[activeAndUnread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -2948,10 +2876,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="attention"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={[idleThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -3007,10 +2933,8 @@ describe("Sidebar", () => {
       const props = (threads: typeof allThreads) => ({
         backends,
         browseMode: "inbox" as const,
-        createThreadError: undefined,
         directories,
         inboxThreads: threads,
-        launchpadError: undefined,
         loading: false,
         creatingThread: undefined,
         selectedItemKey: undefined,
@@ -3054,10 +2978,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="inbox"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={[activeThread, remoteActive, unreadThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -3106,11 +3028,9 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode={browseMode}
-          createThreadError={undefined}
           directories={directories}
           draftThreadKeys={draftThreadKeys}
           inboxThreads={allThreads}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -3198,14 +3118,12 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="inbox"
-          createThreadError={undefined}
           directories={directories}
           draftThreadKeys={{
             ...draftThreadKeys,
             [`${secondDraftThread.source}:${secondDraftThread.id}`]: true,
           }}
           inboxThreads={[...allThreads, secondDraftThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -3250,10 +3168,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="inbox"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={allThreads}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -3278,10 +3194,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="drafts"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={allThreads}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey={undefined}
@@ -3306,10 +3220,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="inbox"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[updatedSinceSeenThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -3358,11 +3270,9 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[updatedLater, createdLater]}
         recentThreads={[createdLater, updatedLater]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -3391,10 +3301,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -3862,10 +3770,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread, childThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -3918,10 +3824,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread, childThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -3959,10 +3863,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -4029,7 +3931,6 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[
           {
             ...directories[0]!,
@@ -4037,7 +3938,6 @@ describe("Sidebar", () => {
           },
         ]}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-top"
@@ -4090,10 +3990,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -4137,10 +4035,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[directoryWithPinnedThread]}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4197,7 +4093,6 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[
           {
             ...directoryWithPinnedThread,
@@ -4205,7 +4100,6 @@ describe("Sidebar", () => {
           },
         ]}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-updated"
@@ -4276,10 +4170,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[directoryWithManyThreads]}
         inboxThreads={cappedThreads}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-cap-1"
@@ -4338,10 +4230,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[directoryWithManyThreads]}
         inboxThreads={cappedThreads}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         // thread-cap-12 sits in the overflow (beyond the cap of 10).
@@ -4370,10 +4260,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4413,10 +4301,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[directoryWithPinnedThread]}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4464,10 +4350,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4531,10 +4415,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4605,10 +4487,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4676,10 +4556,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4747,7 +4625,6 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[
           {
             ...directories[0]!,
@@ -4759,7 +4636,6 @@ describe("Sidebar", () => {
           },
         ]}
         inboxThreads={[firstPinnedThread, secondPinnedThread, unpinnedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4838,10 +4714,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4901,10 +4775,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[directories[0], projectBDirectory]}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4939,10 +4811,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -4983,10 +4853,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[readThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5014,10 +4882,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="attention"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[updatedSinceSeenThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-updated"
@@ -5043,10 +4909,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[updatedSinceSeenThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-updated"
@@ -5120,10 +4984,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5158,10 +5020,8 @@ describe("Sidebar", () => {
         <Sidebar
           backends={backends}
           browseMode="recents"
-          createThreadError={undefined}
           directories={directories}
           inboxThreads={[sharedThread]}
-          launchpadError={undefined}
           loading={false}
           creatingThread={undefined}
           selectedItemKey="codex:thread-1"
@@ -5200,7 +5060,6 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[
           {
@@ -5216,7 +5075,6 @@ describe("Sidebar", () => {
             ],
           },
         ]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5267,10 +5125,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backendsWithoutArchive}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5296,10 +5152,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5349,10 +5203,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={[...backends, acpBackend]}
         browseMode="recents"
-        createThreadError={undefined}
         directories={[]}
         inboxThreads={[acpThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="acp:gemini:session-1"
@@ -5384,10 +5236,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5417,10 +5267,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5456,10 +5304,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5492,10 +5338,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5529,10 +5373,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5604,10 +5446,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[threadWithBase]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5653,10 +5493,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[pullRequestThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5695,10 +5533,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         runtimeIdentity={{
@@ -5759,10 +5595,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         runtimeIdentity={{
@@ -5789,7 +5623,6 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[
           {
@@ -5797,7 +5630,6 @@ describe("Sidebar", () => {
             observedGitBranch: "main",
           },
         ]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5824,10 +5656,8 @@ describe("Sidebar", () => {
       <Sidebar
         backends={backends}
         browseMode="recents"
-        createThreadError={undefined}
         directories={directories}
         inboxThreads={[sharedThread]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
@@ -5948,10 +5778,8 @@ describe("Sidebar directory pinning", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={directoriesArg}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
@@ -6491,10 +6319,8 @@ describe("Sidebar directory pinning", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[pinnedA, pinnedB]}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={threadKey}
@@ -6534,10 +6360,8 @@ describe("Sidebar directory pinning", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[unpinnedA, pinnedB]}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey={threadKey}
@@ -6579,10 +6403,8 @@ describe("Sidebar directory pinning", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[pinnedA]}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         // selectedItemKey points at the thread inside A so the
@@ -6850,7 +6672,6 @@ describe("Sidebar thread pinning Move items", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[
           pinnedThreadsDirectory([
             "codex:codex-top",
@@ -6859,7 +6680,6 @@ describe("Sidebar thread pinning Move items", () => {
           ]),
         ]}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:codex-top"
@@ -6918,12 +6738,10 @@ describe("Sidebar thread pinning Move items", () => {
       <Sidebar
         backends={backends}
         browseMode="directories"
-        createThreadError={undefined}
         directories={[
           pinnedThreadsDirectory(["codex:thread-top", "codex:thread-bottom"]),
         ]}
         inboxThreads={[]}
-        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-top"

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/thread-action-error-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/thread-action-error-notice.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { appNoticeReducer, INITIAL_APP_NOTICE_STATE } from "../app-notice-state";
+import {
+  resolveThreadActionErrorNotice,
+  threadActionErrorNoticeId,
+} from "../thread-action-error-notice";
+
+describe("resolveThreadActionErrorNotice", () => {
+  it("builds a sticky, copyable notice carrying the backend's message", () => {
+    const notice = resolveThreadActionErrorNotice({
+      kind: "create-thread",
+      message: "Desktop backend registry is closed",
+    });
+
+    expect(notice).toMatchObject({
+      // The failure the sidebar used to pin forever with no way to dismiss
+      // it. Sticky is still right — a create failure the operator never saw
+      // is worse — but it is now dismissible and copyable.
+      autoDismiss: false,
+      copyText: "Desktop backend registry is closed",
+      id: "thread-action-error:create-thread",
+      message: "Desktop backend registry is closed",
+      title: "Could not start thread",
+      tone: "error",
+    });
+  });
+
+  it("titles each action distinctly so a toast says what failed", () => {
+    const titles = (
+      ["archive-thread", "create-thread", "rename-thread"] as const
+    ).map((kind) =>
+      resolveThreadActionErrorNotice({ kind, message: "boom" }).title
+    );
+
+    expect(titles).toEqual([
+      "Archive failed",
+      "Could not start thread",
+      "Rename failed",
+    ]);
+  });
+
+  it("keys each action separately so one failure cannot mask another", () => {
+    // The sidebar slot this replaced rendered five errors through one `? :`
+    // chain, so a stale create error hid a fresh rename error entirely.
+    let state = INITIAL_APP_NOTICE_STATE;
+    for (const kind of ["create-thread", "rename-thread"] as const) {
+      state = appNoticeReducer(state, {
+        type: "show",
+        notice: resolveThreadActionErrorNotice({ kind, message: `${kind} broke` }),
+      });
+    }
+
+    expect(state.durable.map((notice) => notice.id)).toEqual([
+      "thread-action-error:create-thread",
+      "thread-action-error:rename-thread",
+    ]);
+    expect(state.durable.map((notice) => notice.message)).toEqual([
+      "create-thread broke",
+      "rename-thread broke",
+    ]);
+  });
+
+  it("replaces rather than stacks when the same action fails twice", () => {
+    // The hook holds one slot per action, so a second failure supersedes the
+    // first. Two toasts for one slot would leave the stale one unclearable.
+    const first = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "show",
+      notice: resolveThreadActionErrorNotice({
+        kind: "archive-thread",
+        message: "first failure",
+      }),
+    });
+    const second = appNoticeReducer(first, {
+      type: "show",
+      notice: resolveThreadActionErrorNotice({
+        kind: "archive-thread",
+        message: "second failure",
+      }),
+    });
+
+    expect(second.durable).toHaveLength(1);
+    expect(second.durable[0]?.message).toBe("second failure");
+  });
+
+  it("clears through the id the producer publishes when the slot empties", () => {
+    const shown = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "show",
+      notice: resolveThreadActionErrorNotice({
+        kind: "rename-thread",
+        message: "rename failed",
+      }),
+    });
+    const cleared = appNoticeReducer(shown, {
+      type: "dismiss",
+      id: threadActionErrorNoticeId("rename-thread"),
+    });
+
+    expect(shown.durable).toHaveLength(1);
+    expect(cleared.durable).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/thread-action-error-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-action-error-notice.ts
@@ -1,0 +1,57 @@
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+/**
+ * Thread lifecycle actions that can fail *after* the control that started
+ * them is gone from the screen.
+ *
+ * Each of these is fire-and-forget: the rename dialog closes before
+ * `renameThread` resolves, the context menu closes before `archiveThread`
+ * resolves, and a create failure has no thread to anchor to at all. There is
+ * therefore nothing left inline to hang the message on, which is why these
+ * route to the durable toast stack instead of a static slot in the sidebar.
+ *
+ * Failures whose originating control IS still on screen deliberately do NOT
+ * appear here — `pickDirectoryError` renders beside the composer's "Add
+ * directory" button and `launchpadError` renders in the composer footer.
+ */
+export type ThreadActionErrorKind =
+  | "archive-thread"
+  | "create-thread"
+  | "rename-thread";
+
+export type ThreadActionErrorSignal = {
+  kind: ThreadActionErrorKind;
+  message: string;
+};
+
+const THREAD_ACTION_ERROR_TITLES: Record<ThreadActionErrorKind, string> = {
+  "archive-thread": "Archive failed",
+  "create-thread": "Could not start thread",
+  "rename-thread": "Rename failed",
+};
+
+/**
+ * One durable notice per action kind. Re-keying on the thread would be
+ * wrong today: the hook holds a single error slot per action, so a second
+ * failure replaces the first rather than accumulating, and a per-thread id
+ * would strand the earlier toast with no producer left to clear it.
+ */
+export function threadActionErrorNoticeId(kind: ThreadActionErrorKind): string {
+  return `thread-action-error:${kind}`;
+}
+
+export function resolveThreadActionErrorNotice(
+  signal: ThreadActionErrorSignal,
+): AppNoticeToastNotice {
+  return {
+    // Sticky: a backend failure the operator never saw is worse than a
+    // toast they have to dismiss. The producer clears it on the next
+    // attempt, so a successful retry takes it down on its own.
+    autoDismiss: false,
+    copyText: signal.message,
+    id: threadActionErrorNoticeId(signal.kind),
+    message: signal.message,
+    title: THREAD_ACTION_ERROR_TITLES[signal.kind],
+    tone: "error",
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/thread-action-error-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-action-error-notice.ts
@@ -11,12 +11,19 @@ import type { AppNoticeToastNotice } from "./AppNoticeToast";
  * therefore nothing left inline to hang the message on, which is why these
  * route to the durable toast stack instead of a static slot in the sidebar.
  *
+ * The masthead's "Add project directory" entry is here for the same reason:
+ * it lives in the sidebar / title bar, and `pickDirectoryError`'s only inline
+ * surface is the launchpad composer's project picker, which is not mounted
+ * behind it.
+ *
  * Failures whose originating control IS still on screen deliberately do NOT
- * appear here — `pickDirectoryError` renders beside the composer's "Add
- * directory" button, and `launchpadError` renders in the launchpad composer's
- * footer, which is still mounted for every producer except the discard.
+ * appear here — the launchpad composer's own "Add directory" button renders
+ * `pickDirectoryError` beside itself, and `launchpadError` renders in that
+ * composer's footer, which is still mounted for every producer except the
+ * discard.
  */
 export type ThreadActionErrorKind =
+  | "add-directory"
   | "archive-thread"
   | "create-thread"
   | "discard-launchpad"
@@ -28,6 +35,7 @@ export type ThreadActionErrorSignal = {
 };
 
 const THREAD_ACTION_ERROR_TITLES: Record<ThreadActionErrorKind, string> = {
+  "add-directory": "Could not add directory",
   "archive-thread": "Archive failed",
   "create-thread": "Could not start thread",
   "discard-launchpad": "Discard failed",

--- a/apps/desktop/src/renderer/src/features/notifications/thread-action-error-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-action-error-notice.ts
@@ -6,17 +6,20 @@ import type { AppNoticeToastNotice } from "./AppNoticeToast";
  *
  * Each of these is fire-and-forget: the rename dialog closes before
  * `renameThread` resolves, the context menu closes before `archiveThread`
- * resolves, and a create failure has no thread to anchor to at all. There is
+ * resolves, `discardLaunchpad` drops the selection before it persists the
+ * discard, and a create failure has no thread to anchor to at all. There is
  * therefore nothing left inline to hang the message on, which is why these
  * route to the durable toast stack instead of a static slot in the sidebar.
  *
  * Failures whose originating control IS still on screen deliberately do NOT
  * appear here — `pickDirectoryError` renders beside the composer's "Add
- * directory" button and `launchpadError` renders in the composer footer.
+ * directory" button, and `launchpadError` renders in the launchpad composer's
+ * footer, which is still mounted for every producer except the discard.
  */
 export type ThreadActionErrorKind =
   | "archive-thread"
   | "create-thread"
+  | "discard-launchpad"
   | "rename-thread";
 
 export type ThreadActionErrorSignal = {
@@ -27,6 +30,7 @@ export type ThreadActionErrorSignal = {
 const THREAD_ACTION_ERROR_TITLES: Record<ThreadActionErrorKind, string> = {
   "archive-thread": "Archive failed",
   "create-thread": "Could not start thread",
+  "discard-launchpad": "Discard failed",
   "rename-thread": "Rename failed",
 };
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -1,8 +1,7 @@
-import {
-  isBranchDrifted,
-  type BackendSummary,
-  type MessagingChannelKind,
-  type NavigationThreadSummary,
+import type {
+  BackendSummary,
+  MessagingChannelKind,
+  NavigationThreadSummary,
 } from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
@@ -95,31 +94,13 @@ type ThreadHeaderProps = {
 };
 
 /**
- * The thread records a working directory the backend reported, but nothing
- * resolved it to a linked project. Deliberately NOT an "it was deleted" test:
- * the renderer never stats a path, and an empty `linkedDirectories` has
- * several causes besides absence — a cwd that is not a git checkout, a git
- * probe that failed or timed out, or a backend that reports no cwd at all.
- * Absence is only one of them, so the copy this drives must stay limited to
- * what is actually known here. Do not reword it back into a claim about the
- * directory no longer existing without a real absence signal on the summary.
+ * Keep this header's height constant. The context rail is anchored to
+ * `.thread-view__layout`, the header's next sibling, so a conditional row in
+ * here slides the rail's icon strip down the pane. Thread-level warning
+ * banners live in `ThreadWarnings`, inside the chat column, for that reason.
  */
-function unlinkedWorkspacePath(thread: NavigationThreadSummary): string | undefined {
-  const projectKey = thread.projectKey?.trim();
-  if (!projectKey || thread.linkedDirectories.length > 0) {
-    return undefined;
-  }
-
-  return projectKey;
-}
-
 export function ThreadHeader(props: ThreadHeaderProps) {
-  const unlinkedPath = unlinkedWorkspacePath(props.thread);
   const projectLabel = props.projectLabel?.trim();
-  const branchDrifted = isBranchDrifted(
-    props.thread.gitBranch,
-    props.thread.observedGitBranch,
-  );
   // On Windows the AppTitleBar strip owns the layout toggles + masthead
   // actions; rendering them here too would duplicate the control and the
   // ⌘B/⌘⌥B listener.
@@ -364,22 +345,6 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           />
         </div>
       </div>
-      {unlinkedPath ? (
-        // `role="status"` (polite), not `alert`: this reports an unresolved
-        // link, not a failure, and it is derived state that re-announces on
-        // every thread selection. Matches the branch-drift banner right
-        // below, which shares this class and is the more urgent of the two.
-        <p className="thread-header__warning" role="status">
-          This thread's recorded working directory is not linked to a project:{" "}
-          <code>{unlinkedPath}</code>
-        </p>
-      ) : null}
-      {branchDrifted ? (
-        <p className="thread-header__warning" role="status">
-          Branch warning: this thread expects <code>{props.thread.gitBranch}</code>, but the
-          worktree is on <code>{props.thread.observedGitBranch}</code>.
-        </p>
-      ) : null}
     </header>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -88,6 +88,7 @@ import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
 import { ThreadFindBar } from "./ThreadFindBar";
 import { ThreadHeader, type StarMapToggleControls } from "./ThreadHeader";
+import { ThreadWarnings } from "./ThreadWarnings";
 import { ThreadPlaceholderHeader } from "./ThreadPlaceholderHeader";
 import { ImageLightbox } from "./ImageLightbox";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
@@ -893,7 +894,6 @@ export type ThreadViewProps = {
   onProviderSelected?: (
     backend: NavigationLaunchpadDraft["backend"],
   ) => BackendSummary | undefined | Promise<BackendSummary | undefined>;
-  archiveThreadError?: string;
   loading: boolean;
   loadingMore: boolean;
   messageCount: number;
@@ -3413,6 +3413,10 @@ export function ThreadView(props: ThreadViewProps) {
       >
         <div className="thread-view__primary">
           <CelestialWatermark icon={celestialWatermarkIcon} />
+          {/* Inside the chat column, not the header: a conditional row in
+              the header moves `.thread-view__layout`, and the context rail
+              is anchored to it. See `ThreadWarnings`. */}
+          {selectedThread ? <ThreadWarnings thread={selectedThread} /> : null}
           {showSetupFailureChoice && selectedThread && selectedThreadKey ? (
             <EnvironmentSetupFailureChoice
               archiving={setupFailureArchiving}
@@ -3431,7 +3435,13 @@ export function ThreadView(props: ThreadViewProps) {
                 selectedThread.codexEnvironmentRuntime?.environmentName ??
                 "Environment"
               }
-              error={props.archiveThreadError ?? setupFailureContinueError}
+              error={
+                // Archive failures go to the durable notice stack (they can
+                // also originate from a context menu with nothing left on
+                // screen), so this slot reports only the Continue button's
+                // own failure — one surface per error.
+                setupFailureContinueError
+              }
               exitCode={
                 selectedThreadEnvironmentFailurePhase === "setup"
                   ? selectedThread.codexEnvironmentRuntime?.setupExitCode ??

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadWarnings.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadWarnings.tsx
@@ -20,9 +20,9 @@ import {
  * clear the rail because the layout already reserves its gutter.
  *
  * Do not move these back into `<header>`, and do not try to compensate with a
- * hard-coded rail offset — the header has two conditional rows plus a
- * wordmark that relocates here when the sidebar is hidden, so no constant is
- * correct. `thread-view.test.tsx` pins the placement.
+ * hard-coded rail offset — these two rows are conditional and the header also
+ * takes in the sidebar's wordmark when the sidebar is hidden, so no constant
+ * is correct. `thread-view.test.tsx` pins the placement.
  */
 export function ThreadWarnings(props: { thread: NavigationThreadSummary }) {
   const unlinkedPath = unlinkedWorkspacePath(props.thread);

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadWarnings.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadWarnings.tsx
@@ -1,0 +1,77 @@
+import {
+  isBranchDrifted,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
+
+/**
+ * Thread-level warning banners, rendered at the top of the chat column.
+ *
+ * These deliberately do NOT live in `ThreadHeader`. The context rail is
+ * absolutely positioned inside `.thread-view__layout`, which is the header's
+ * NEXT sibling — so anything that changes the header's height moves the top
+ * of the layout, and the rail's icon strip slides down with it. Both rows
+ * here are independently conditional and one of them (branch drift) can
+ * appear from a background poll, which made the rail jump while the operator
+ * was reaching for it.
+ *
+ * Keeping them inside `.thread-view__primary` fixes that at the source: the
+ * header's height is now fixed by `min-height` and its own single row, the
+ * layout's top edge never moves, and the rail stays put. The warnings still
+ * clear the rail because the layout already reserves its gutter.
+ *
+ * Do not move these back into `<header>`, and do not try to compensate with a
+ * hard-coded rail offset — the header has two conditional rows plus a
+ * wordmark that relocates here when the sidebar is hidden, so no constant is
+ * correct. `thread-view.test.tsx` pins the placement.
+ */
+export function ThreadWarnings(props: { thread: NavigationThreadSummary }) {
+  const unlinkedPath = unlinkedWorkspacePath(props.thread);
+  const branchDrifted = isBranchDrifted(
+    props.thread.gitBranch,
+    props.thread.observedGitBranch,
+  );
+
+  if (!unlinkedPath && !branchDrifted) {
+    return null;
+  }
+
+  return (
+    <div className="thread-warnings">
+      {unlinkedPath ? (
+        // `role="status"` (polite), not `alert`: this reports an unresolved
+        // link, not a failure, and it is derived state that re-announces on
+        // every thread selection. Matches the branch-drift banner right
+        // below, which shares this class and is the more urgent of the two.
+        <p className="thread-warning" role="status">
+          This thread's recorded working directory is not linked to a project:{" "}
+          <code>{unlinkedPath}</code>
+        </p>
+      ) : null}
+      {branchDrifted ? (
+        <p className="thread-warning" role="status">
+          Branch warning: this thread expects <code>{props.thread.gitBranch}</code>, but the
+          worktree is on <code>{props.thread.observedGitBranch}</code>.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The thread records a working directory the backend reported, but nothing
+ * resolved it to a linked project. Deliberately NOT an "it was deleted" test:
+ * the renderer never stats a path, and an empty `linkedDirectories` has
+ * several causes besides absence — a cwd that is not a git checkout, a git
+ * probe that failed or timed out, or a backend that reports no cwd at all.
+ * Absence is only one of them, so the copy this drives must stay limited to
+ * what is actually known here. Do not reword it back into a claim about the
+ * directory no longer existing without a real absence signal on the summary.
+ */
+function unlinkedWorkspacePath(thread: NavigationThreadSummary): string | undefined {
+  const projectKey = thread.projectKey?.trim();
+  if (!projectKey || thread.linkedDirectories.length > 0) {
+    return undefined;
+  }
+
+  return projectKey;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2784,9 +2784,18 @@ describe("ThreadView", () => {
     // exactly that reason: the banner named an existing directory.
     // Polite, not assertive: an unresolved link is not a failure, and this
     // banner re-renders on every thread selection.
-    expect(screen.getByRole("status")).toHaveTextContent(
+    const unlinkedWorkspaceWarning = screen.getByRole("status");
+    expect(unlinkedWorkspaceWarning).toHaveTextContent(
       "This thread's recorded working directory is not linked to a project: /Users/example/.codex/worktrees/tree-epsilon/catalog-portal"
     );
+    // The context rail is absolutely positioned inside
+    // `.thread-view__layout`, the header's next sibling, so a conditional
+    // row inside the header slides the rail's icon strip down the pane.
+    // These banners belong to the chat column for that reason.
+    expect(unlinkedWorkspaceWarning.closest(".thread-header")).toBeNull();
+    expect(
+      unlinkedWorkspaceWarning.closest(".thread-view__primary"),
+    ).not.toBeNull();
 
     expect(screen.getByText("Recorded working directory is not linked to a project.")).toBeInTheDocument();
     expect(screen.getByText("catalog-portal")).toBeInTheDocument();
@@ -5408,9 +5417,15 @@ describe("ThreadView", () => {
     });
     expect(updateThreadExpectedBranch).not.toHaveBeenCalled();
     expect(retainThreadBranchDrift).not.toHaveBeenCalled();
-    expect(screen.getByRole("status")).toHaveTextContent(
+    const branchWarning = screen.getByRole("status");
+    expect(branchWarning).toHaveTextContent(
       "Branch warning: this thread expects feature/old, but the worktree is on main.",
     );
+    // Branch drift lands from a background poll, so a header row here would
+    // move the context rail under the operator's cursor. Keep it in the
+    // chat column — see `ThreadWarnings`.
+    expect(branchWarning.closest(".thread-header")).toBeNull();
+    expect(branchWarning.closest(".thread-view__primary")).not.toBeNull();
   });
 
   it("retains branch drift on the remote thread owner", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -22,6 +22,23 @@ import {
 } from "../native-drag-interaction";
 import { useThreadNavigation } from "../useThreadNavigation";
 
+/**
+ * Create / rename / archive failures leave the hook through
+ * `onThreadActionError` instead of a returned string — they render as
+ * durable toasts now, not as a static slot in the sidebar. The hook
+ * republishes the slot on every change, including the clear that each new
+ * attempt performs, so the LAST call for a kind is the current state.
+ */
+function latestThreadActionError(
+  onThreadActionError: ReturnType<typeof vi.fn>,
+  kind: "archive-thread" | "create-thread" | "rename-thread",
+): string | undefined {
+  const calls = onThreadActionError.mock.calls.filter(
+    ([event]) => event?.kind === kind,
+  );
+  return calls.at(-1)?.[0]?.message;
+}
+
 describe("useThreadNavigation", () => {
   beforeEach(() => {
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
@@ -3429,7 +3446,10 @@ describe("useThreadNavigation", () => {
       onAgentEvent: () => () => undefined,
     };
 
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
 
     await waitFor(() => {
       expect(result.current.threads.map((thread) => thread.id)).toEqual([
@@ -3441,7 +3461,7 @@ describe("useThreadNavigation", () => {
       await result.current.archiveThread(result.current.threads[0]!);
     });
 
-    expect(result.current.archiveThreadError).toBeUndefined();
+    expect(latestThreadActionError(onThreadActionError, "archive-thread")).toBeUndefined();
     expect(result.current.archiveThreadNotice).toMatchObject({
       title: "Worktree cleanup skipped",
       message: "Thread archived. The worktree cleanup did not complete.",
@@ -3502,7 +3522,10 @@ describe("useThreadNavigation", () => {
       onAgentEvent: () => () => undefined,
     };
 
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
 
     await waitFor(() => {
       expect(result.current.threads.map((thread) => thread.id)).toEqual([
@@ -3514,7 +3537,7 @@ describe("useThreadNavigation", () => {
       await result.current.archiveThread(result.current.threads[0]!);
     });
 
-    expect(result.current.archiveThreadError).toBeUndefined();
+    expect(latestThreadActionError(onThreadActionError, "archive-thread")).toBeUndefined();
     expect(result.current.archiveThreadNotice).toMatchObject({
       title: "Worktree cleanup skipped",
       message: "Thread archived. The worktree cleanup did not complete.",
@@ -3572,7 +3595,10 @@ describe("useThreadNavigation", () => {
       onAgentEvent: () => () => undefined,
     };
 
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
 
     await waitFor(() => {
       expect(result.current.threads.map((thread) => thread.id)).toEqual([
@@ -3584,7 +3610,7 @@ describe("useThreadNavigation", () => {
       await result.current.archiveThread(result.current.threads[0]!);
     });
 
-    expect(result.current.archiveThreadError).toBeUndefined();
+    expect(latestThreadActionError(onThreadActionError, "archive-thread")).toBeUndefined();
     expect(result.current.archiveThreadNotice).toMatchObject({
       title: "Worktree kept",
       message:
@@ -4200,7 +4226,10 @@ describe("useThreadNavigation", () => {
       onAgentEvent: () => () => undefined,
     };
 
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
 
     await waitFor(() => {
       expect(result.current.selectedThread?.id).toBe("thread-archived");
@@ -4210,7 +4239,7 @@ describe("useThreadNavigation", () => {
       await result.current.archiveThread(result.current.threads[0]!);
     });
 
-    expect(result.current.archiveThreadError).toBe("Archive failed");
+    expect(latestThreadActionError(onThreadActionError, "archive-thread")).toBe("Archive failed");
     expect(result.current.threads.map((thread) => thread.id)).toEqual([
       "thread-archived",
       "thread-fallback",
@@ -7133,6 +7162,94 @@ describe("useThreadNavigation", () => {
     );
   });
 
+  it("publishes a create failure to the notice stack and clears it on retry", async () => {
+    // Regression: `Desktop backend registry is closed` pinned itself in the
+    // sidebar masthead with no dismiss, no timeout, and a permanent layout
+    // cost. It is a durable toast now, and the retry that clears the hook's
+    // slot has to take the toast down with it.
+    let attempt = 0;
+    const ensureDirectoryLaunchpad = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error("Desktop backend registry is closed");
+      }
+      return {
+        launchpad: {
+          directoryKey: "workspace:/Users/test/.pwragent/projects",
+          directoryKind: "workspace" as const,
+          directoryLabel: "Workspaces",
+          directoryPath: "/Users/test/.pwragent/projects",
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          prompt: "",
+          workMode: "local" as const,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        defaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      };
+    });
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "workspace:/Users/test/.pwragent/projects",
+          kind: "workspace" as const,
+          label: "Workspaces",
+          path: "/Users/test/.pwragent/projects",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.label).toBe("Workspaces");
+    });
+
+    await act(async () => {
+      await result.current.createThread();
+    });
+
+    await waitFor(() => {
+      expect(latestThreadActionError(onThreadActionError, "create-thread")).toBe(
+        "Desktop backend registry is closed",
+      );
+    });
+
+    await act(async () => {
+      await result.current.createThread();
+    });
+
+    await waitFor(() => {
+      expect(
+        latestThreadActionError(onThreadActionError, "create-thread"),
+      ).toBeUndefined();
+    });
+  });
+
   it("opens masthead new-thread drafts while the initial navigation snapshot is loading", async () => {
     const initialSnapshot = createDeferred<NavigationSnapshot>();
     const emptySnapshot: NavigationSnapshot = {
@@ -9816,7 +9933,10 @@ describe("useThreadNavigation", () => {
       onAgentEvent: () => () => undefined,
     };
 
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
 
     await waitFor(() => {
       expect(result.current.selectedThread?.title).toBe("First thread");
@@ -9827,7 +9947,7 @@ describe("useThreadNavigation", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.renameThreadError).toBe("rename failed");
+      expect(latestThreadActionError(onThreadActionError, "rename-thread")).toBe("rename failed");
       expect(result.current.selectedThread?.title).toBe("First thread");
     });
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -32,6 +32,7 @@ import { useThreadNavigation } from "../useThreadNavigation";
 function latestThreadActionError(
   onThreadActionError: ReturnType<typeof vi.fn>,
   kind:
+    | "add-directory"
     | "archive-thread"
     | "create-thread"
     | "discard-launchpad"
@@ -8862,6 +8863,70 @@ describe("useThreadNavigation", () => {
         (directory) => directory.key === "directory:/repo/app",
       ),
     ).toBe(true);
+  });
+
+  it("publishes a masthead add-directory rejection to the notice stack", async () => {
+    // "Add project directory" lives in the sidebar / title-bar menu, and
+    // `pickDirectoryError`'s only inline surface is the launchpad composer's
+    // project picker — not mounted behind that menu. Picking a folder that is
+    // not a git repository would otherwise fail silently.
+    const pickDirectoryFromDisk = vi.fn(async () => ({
+      canceled: false as const,
+      path: "/Users/test/not-a-repo",
+    }));
+    const registerDirectoryFromDisk = vi.fn(async () => ({
+      ok: false as const,
+      reason: "not-a-git-repo" as const,
+      message: "/Users/test/not-a-repo is not a git repository.",
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      pickDirectoryFromDisk,
+      registerDirectoryFromDisk,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.addProjectDirectory();
+    });
+
+    expect(latestThreadActionError(onThreadActionError, "add-directory")).toBe(
+      "/Users/test/not-a-repo is not a git repository.",
+    );
+
+    // A later cancel clears the slot, so the notice comes down on its own.
+    pickDirectoryFromDisk.mockResolvedValueOnce({
+      canceled: true,
+    } as unknown as Awaited<ReturnType<typeof pickDirectoryFromDisk>>);
+    await act(async () => {
+      await result.current.addProjectDirectory();
+    });
+
+    expect(
+      latestThreadActionError(onThreadActionError, "add-directory"),
+    ).toBeUndefined();
   });
 
   it("publishes a launchpad discard failure to the notice stack", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -31,7 +31,11 @@ import { useThreadNavigation } from "../useThreadNavigation";
  */
 function latestThreadActionError(
   onThreadActionError: ReturnType<typeof vi.fn>,
-  kind: "archive-thread" | "create-thread" | "rename-thread",
+  kind:
+    | "archive-thread"
+    | "create-thread"
+    | "discard-launchpad"
+    | "rename-thread",
 ): string | undefined {
   const calls = onThreadActionError.mock.calls.filter(
     ([event]) => event?.kind === kind,
@@ -8858,6 +8862,85 @@ describe("useThreadNavigation", () => {
         (directory) => directory.key === "directory:/repo/app",
       ),
     ).toBe(true);
+  });
+
+  it("publishes a launchpad discard failure to the notice stack", async () => {
+    // `discardLaunchpad` drops the selection before it persists the discard,
+    // so the launchpad composer that renders `launchpadError` is already
+    // unmounted when the persistence call rejects. Routing it there would
+    // show the operator nothing while the cancelled draft rehydrates on the
+    // next open.
+    const registeredLaunchpad = {
+      directoryKey: "directory:/repo/app",
+      directoryKind: "directory" as const,
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "local" as const,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "leftover draft",
+      registeredAt: 1_500,
+      settingsTouchedAt: 1_600,
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const updateDirectoryLaunchpad = vi.fn(async () => {
+      throw new Error("Launchpad overlay is read-only");
+    });
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory" as const,
+          label: "app",
+          path: "/repo/app",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2,
+          launchpad: registeredLaunchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      updateDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const onThreadActionError = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { onThreadActionError }),
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.directories.some(
+          (directory) => directory.key === "directory:/repo/app",
+        ),
+      ).toBe(true);
+    });
+
+    await act(async () => {
+      result.current.discardLaunchpad("directory:/repo/app");
+    });
+
+    await waitFor(() => {
+      expect(
+        latestThreadActionError(onThreadActionError, "discard-launchpad"),
+      ).toBe("Launchpad overlay is read-only");
+    });
+    // The launchpad's own inline surface stays empty — one surface per error.
+    expect(result.current.launchpadError).toBeUndefined();
   });
 
   it("removes an empty registered directory and deletes its overlay row", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2846,9 +2846,9 @@ type UseThreadNavigationOptions = {
   lightweightNavigationRefresh?: boolean;
   threadViewVisible?: boolean;
   /**
-   * Publishes create / rename / archive failures to the app's notice stack.
-   * A `message` of `undefined` means the slot cleared — the next attempt
-   * started, or it succeeded — and the notice should come down.
+   * Publishes create / rename / archive / discard failures to the app's
+   * notice stack. A `message` of `undefined` means the slot cleared — the
+   * next attempt started, or it succeeded — and the notice should come down.
    *
    * These actions used to render into a shared static slot at the top of the
    * sidebar, which had no dismiss, no timeout, a fixed priority order that
@@ -3165,6 +3165,22 @@ export function useThreadNavigation(
       message: renameThreadError,
     });
   }, [renameThreadError]);
+  // Discard has no slot of its own. `discardLaunchpad` clears the selection
+  // before it persists the discard, so the launchpad composer that renders
+  // `launchpadError` is already unmounted when the persistence call rejects —
+  // the message would land on a surface nobody is looking at (or, worse, on
+  // the next unrelated launchpad the operator opens). Publish it directly.
+  const publishDiscardLaunchpadError = useCallback((error?: unknown): void => {
+    onThreadActionErrorRef.current?.({
+      kind: "discard-launchpad",
+      message:
+        error === undefined
+          ? undefined
+          : error instanceof Error
+            ? error.message
+            : String(error),
+    });
+  }, []);
   const [updatingThreadExecutionMode, setUpdatingThreadExecutionMode] =
     useState<ThreadExecutionMode>();
   const [setThreadExecutionModeError, setSetThreadExecutionModeError] =
@@ -7016,6 +7032,9 @@ export function useThreadNavigation(
    * selection to the source card the user invoked it from.
    */
   const discardLaunchpad = useCallback((directoryKey: string): boolean => {
+    // A previous discard failure is stale the moment the operator tries
+    // again; clear it so a retry that succeeds takes the toast down.
+    publishDiscardLaunchpadError();
     if (
       activeFederatedLaunchpad
       && activeFederatedLaunchpad.launchpad.directoryKey === directoryKey
@@ -7032,7 +7051,7 @@ export function useThreadNavigation(
       );
 
       const handleDiscardError = (error: unknown): void => {
-        setLaunchpadError(error instanceof Error ? error.message : String(error));
+        publishDiscardLaunchpadError(error);
       };
       if (isRegisteredDirectory) {
         void desktopApi
@@ -7097,7 +7116,7 @@ export function useThreadNavigation(
     // draft on the next open (or after a refresh / restart / in another window).
     // The in-memory reset above only affects this render.
     const handleDiscardError = (error: unknown): void => {
-      setLaunchpadError(error instanceof Error ? error.message : String(error));
+      publishDiscardLaunchpadError(error);
     };
     if (isRegisteredDirectory) {
       // Keep the registered directory (and its remembered sticky settings);
@@ -7114,7 +7133,12 @@ export function useThreadNavigation(
         .catch(handleDiscardError);
     }
     return restoresSourceThread;
-  }, [activeFederatedLaunchpad, desktopApi, directories]);
+  }, [
+    activeFederatedLaunchpad,
+    desktopApi,
+    directories,
+    publishDiscardLaunchpadError,
+  ]);
 
   const archiveThread = useCallback(
     async (

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3181,6 +3181,16 @@ export function useThreadNavigation(
             : String(error),
     });
   }, []);
+  // Same shape for the masthead's "Add project directory" entry. It lives in
+  // the sidebar / title bar, and `pickDirectoryError`'s only inline surface is
+  // the launchpad composer's project picker — not mounted behind that menu, so
+  // a rejected pick ("not a git repository") would land nowhere. The ref
+  // carries what `pickDirectoryForReference` last recorded, since the state
+  // setter cannot be read back inside the same call.
+  const lastPickDirectoryErrorRef = useRef<string>(undefined);
+  const publishAddDirectoryError = useCallback((message?: string): void => {
+    onThreadActionErrorRef.current?.({ kind: "add-directory", message });
+  }, []);
   const [updatingThreadExecutionMode, setUpdatingThreadExecutionMode] =
     useState<ThreadExecutionMode>();
   const [setThreadExecutionModeError, setSetThreadExecutionModeError] =
@@ -6193,6 +6203,11 @@ export function useThreadNavigation(
     [desktopApi, refresh, rendererFederationTarget],
   );
 
+  const recordPickDirectoryError = useCallback((message?: string): void => {
+    lastPickDirectoryErrorRef.current = message;
+    setPickDirectoryError(message);
+  }, []);
+
   const pickDirectoryForReference = useCallback(async (): Promise<
     { label: string; path: string } | undefined
   > => {
@@ -6202,6 +6217,7 @@ export function useThreadNavigation(
     // the caller mints a chip in place instead of moving to the new
     // launchpad. Same cancel-vs-failure split as the sibling: cancel is
     // silent, validation failure surfaces via `pickDirectoryError`.
+    lastPickDirectoryErrorRef.current = undefined;
     if (rendererFederationTarget) {
       return undefined;
     }
@@ -6209,11 +6225,11 @@ export function useThreadNavigation(
       !desktopApi?.pickDirectoryFromDisk ||
       !desktopApi?.registerDirectoryFromDisk
     ) {
-      setPickDirectoryError("Desktop bridge is missing the directory picker.");
+      recordPickDirectoryError("Desktop bridge is missing the directory picker.");
       return undefined;
     }
 
-    setPickDirectoryError(undefined);
+    recordPickDirectoryError(undefined);
     setPickingDirectory(true);
     try {
       const pick = await desktopApi.pickDirectoryFromDisk();
@@ -6224,7 +6240,7 @@ export function useThreadNavigation(
         path: pick.path,
       });
       if (!result.ok) {
-        setPickDirectoryError(result.message);
+        recordPickDirectoryError(result.message);
         return undefined;
       }
       setLocalLaunchpads((current) => ({
@@ -6244,22 +6260,31 @@ export function useThreadNavigation(
         path: result.launchpad.directoryPath ?? pick.path,
       };
     } catch (error) {
-      setPickDirectoryError(
+      recordPickDirectoryError(
         error instanceof Error ? error.message : String(error),
       );
       return undefined;
     } finally {
       setPickingDirectory(false);
     }
-  }, [desktopApi, rendererFederationTarget]);
+  }, [desktopApi, recordPickDirectoryError, rendererFederationTarget]);
 
   const addProjectDirectory = useCallback(async (): Promise<void> => {
     const picked = await pickDirectoryForReference();
+    // Nothing on screen renders `pickDirectoryError` for this entry point,
+    // so publish the outcome to the notice stack. A cancel or a success
+    // records `undefined`, which takes any prior notice down.
+    publishAddDirectoryError(lastPickDirectoryErrorRef.current);
     if (picked) {
       updateBrowseMode("directories");
       await refresh();
     }
-  }, [pickDirectoryForReference, refresh, updateBrowseMode]);
+  }, [
+    pickDirectoryForReference,
+    publishAddDirectoryError,
+    refresh,
+    updateBrowseMode,
+  ]);
 
   const pickAndAttachDirectoryToSelectedThread = useCallback(async (): Promise<void> => {
     if (rendererFederationTarget) {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -47,6 +47,7 @@ import {
   sortSubthreadSummaries,
 } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
+import type { ThreadActionErrorKind } from "../features/notifications/thread-action-error-notice";
 import { fileLabelFromPath } from "./directory-references";
 import {
   readRendererFederationLabel,
@@ -2844,6 +2845,19 @@ type UseThreadNavigationOptions = {
   enabled?: boolean;
   lightweightNavigationRefresh?: boolean;
   threadViewVisible?: boolean;
+  /**
+   * Publishes create / rename / archive failures to the app's notice stack.
+   * A `message` of `undefined` means the slot cleared — the next attempt
+   * started, or it succeeded — and the notice should come down.
+   *
+   * These actions used to render into a shared static slot at the top of the
+   * sidebar, which had no dismiss, no timeout, a fixed priority order that
+   * let one stale error mask the other four, and a permanent layout cost.
+   */
+  onThreadActionError?: (event: {
+    kind: ThreadActionErrorKind;
+    message?: string;
+  }) => void;
 };
 
 export function useThreadNavigation(
@@ -2868,7 +2882,6 @@ export function useThreadNavigation(
     parent: NavigationThreadSummary,
     mode: ThreadWorkspaceMode,
   ) => Promise<void>;
-  createThreadError?: string;
   creatingThread?: CreatingThreadState;
   directories: NavigationDirectorySummary[];
   error?: string;
@@ -2877,11 +2890,9 @@ export function useThreadNavigation(
   inboxThreads: NavigationThreadSummary[];
   recentThreads: NavigationThreadSummary[];
   launchpadError?: string;
-  archiveThreadError?: string;
   archiveThreadNotice?: ArchiveThreadNotice;
   dismissArchiveThreadNotice: () => void;
   worktreeArchiveError?: string;
-  renameThreadError?: string;
   loading: boolean;
   loaded: boolean;
   refreshing: boolean;
@@ -3120,12 +3131,40 @@ export function useThreadNavigation(
   // network. Keep only the most recent launch intent so a slow prior peer or
   // project selection cannot replace the launchpad the operator just chose.
   const federatedLaunchpadOpenRevisionRef = useRef(0);
+  // Create / rename / archive keep their single error slot here — every
+  // producer already clears it when the next attempt starts — but the slot
+  // is now published to the notice stack instead of rendered inline. See
+  // `onThreadActionError`.
   const [createThreadError, setCreateThreadError] = useState<string>();
   const [launchpadError, setLaunchpadError] = useState<string>();
   const [archiveThreadError, setArchiveThreadError] = useState<string>();
   const [archiveThreadNotice, setArchiveThreadNotice] = useState<ArchiveThreadNotice>();
   const [worktreeArchiveError, setWorktreeArchiveError] = useState<string>();
   const [renameThreadError, setRenameThreadError] = useState<string>();
+  // Held in a ref so a caller that rebuilds the callback every render cannot
+  // re-fire the publish effects below on an unchanged message.
+  const onThreadActionErrorRef = useRef(options.onThreadActionError);
+  useEffect(() => {
+    onThreadActionErrorRef.current = options.onThreadActionError;
+  }, [options.onThreadActionError]);
+  useEffect(() => {
+    onThreadActionErrorRef.current?.({
+      kind: "create-thread",
+      message: createThreadError,
+    });
+  }, [createThreadError]);
+  useEffect(() => {
+    onThreadActionErrorRef.current?.({
+      kind: "archive-thread",
+      message: archiveThreadError,
+    });
+  }, [archiveThreadError]);
+  useEffect(() => {
+    onThreadActionErrorRef.current?.({
+      kind: "rename-thread",
+      message: renameThreadError,
+    });
+  }, [renameThreadError]);
   const [updatingThreadExecutionMode, setUpdatingThreadExecutionMode] =
     useState<ThreadExecutionMode>();
   const [setThreadExecutionModeError, setSetThreadExecutionModeError] =
@@ -8282,7 +8321,6 @@ export function useThreadNavigation(
     createSubthread,
     discardLaunchpad,
     forkThread,
-    createThreadError,
     creatingThread,
     directories,
     error: state.error,
@@ -8291,11 +8329,9 @@ export function useThreadNavigation(
     inboxThreads,
     recentThreads,
     launchpadError,
-    archiveThreadError,
     archiveThreadNotice,
     dismissArchiveThreadNotice,
     worktreeArchiveError,
-    renameThreadError,
     loading: state.loading,
     loaded: Boolean(state.response),
     refreshing: state.refreshing,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6350,10 +6350,6 @@ textarea,
   line-height: 1.45;
 }
 
-.sidebar-error--masthead {
-  margin-top: 12px;
-}
-
 .thread-context-menu {
   position: fixed;
   z-index: 50;
@@ -13376,7 +13372,22 @@ textarea,
   background: var(--status-warning);
 }
 
-.thread-header__warning {
+/* Thread-level warning banners. These sit at the top of the chat column
+   (`.thread-view__primary`), NOT in `.thread-header` — a conditional row in
+   the header changes its height, which moves `.thread-view__layout` and
+   drags the absolutely-positioned context rail down with it. The left inset
+   matches the header's 22px so the banner still lines up under the title. */
+.thread-warnings {
+  display: flex;
+  /* `.thread-view__primary` is a flex column whose transcript takes the
+     remaining space, so pin the banners at their content height instead of
+     letting the default `flex-shrink: 1` compress them on a short window. */
+  flex: 0 0 auto;
+  flex-direction: column;
+  padding: 0 22px;
+}
+
+.thread-warning {
   max-width: min(72vw, 760px);
   margin: 10px 0 0;
   padding: 10px 12px;
@@ -13388,7 +13399,7 @@ textarea,
   line-height: 1.45;
 }
 
-.thread-header__warning code {
+.thread-warning code {
   color: var(--accent-bright);
   font-family: var(--font-mono);
   overflow-wrap: anywhere;
@@ -19106,7 +19117,18 @@ a.transcript-message__messaging-origin:focus-visible {
      or squash its toggles/MSG to clear a rail that overlaps the title line.
      `right: 0` lands on the layout's padding edge = the window's right edge;
      the layout's padding-right reserves the gutter so the transcript /
-     composer sit flush against the rail's left border when pinned. */
+     composer sit flush against the rail's left border when pinned.
+
+     This anchor makes the rail's top a function of the header's height, so
+     THE HEADER MUST STAY A FIXED HEIGHT. It used to grow two conditional
+     warning rows, and each one slid the rail's icon strip down the pane —
+     branch drift lands from a background poll, so the strip moved under the
+     operator's cursor. Those banners now render in `.thread-view__primary`
+     (see `.thread-warnings`). Do not add a conditional row to the header,
+     and do not "fix" a future displacement with a constant top offset: the
+     header also relocates the sidebar's wordmark into itself, so no
+     hard-coded height is right. Keep the header one fixed row and the rail
+     cannot move. */
   position: absolute;
   top: 0;
   right: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1501,12 +1501,14 @@ textarea,
      compact title's top at y=18.5 — exactly where the brand sits in
      the sidebar masthead. Result: title, brand, and messaging pills
      all share the same vertical centerline.
-     The header is now a column: a single top row (breadcrumb + chips on
-     the left, layout toggles + MessagingStatusBar on the right) with any
-     directory/branch warnings stacked beneath it. Keeping MSG in the top
-     row — instead of vertically centered against a `__main` that grows
-     when a warning appears — is what keeps the MSG cluster on the
-     titlebar line on macOS (the warnings used to push it down). */
+     The header is a column holding exactly ONE row (breadcrumb + chips on
+     the left, layout toggles + MessagingStatusBar on the right). Keeping MSG
+     in that row — instead of vertically centered against a `__main` that
+     grows — is what keeps the MSG cluster on the titlebar line on macOS.
+     Directory/branch warnings used to stack beneath it here and pushed MSG
+     down; they now render in `.thread-warnings` inside the chat column so
+     this header's height (and therefore the context rail's top) is
+     constant. Do not add a second row here. */
   flex-direction: column;
   align-items: stretch;
   justify-content: flex-start;


### PR DESCRIPTION
Two surfaces rendered backend failures inconsistently. This routes thread-action failures into the existing notice framework and stops the context rail from sliding down the pane.

## Problem 1 — the sidebar masthead error slot

`Sidebar.tsx` rendered five unrelated failures through a single `? :` chain:

```
createThreadError → pickDirectoryError → launchpadError → archiveThreadError → renameThreadError
```

That slot had no dismiss, no timeout, and a permanent layout cost, and the priority chain meant a stale create error **silently masked** a fresh rename error. `Desktop backend registry is closed` (thrown from `backend-registry.ts`) was observed pinned there indefinitely.

The slot is deleted. Each failure now goes to the surface that owns its action:

| Error | Destination | Why |
|---|---|---|
| `createThreadError` | durable toast | no thread exists to anchor to |
| `renameThreadError` | durable toast | the rename dialog closes on submit, *before* `onRenameThread` is awaited — nothing is left on screen |
| `archiveThreadError` | durable toast | the context menu is closed; bulk archive fires N calls into one string slot |
| `pickDirectoryError` | **unchanged** — composer | already renders at the "Add directory" button with `role="alert"` |
| `launchpadError` | **unchanged** — composer | already renders in the composer footer, with a copy button |

The last two were duplicates of a *better* surface. Moving them would have replaced a good inline error with a distant toast, so only the redundant masthead copy is removed. The rule is one consistent one — the control that started the action reports the failure if it still exists; otherwise the durable stack does.

`EnvironmentSetupFailureChoice` stops reading `archiveThreadError` so a single error reports on a single surface; its own Continue failure still renders inline.

Failures leave the hook through a new `onThreadActionError` option rather than returned strings. The hook keeps its single slot per action — every producer already clears it when the next attempt starts — so a successful retry takes the toast down on its own.

## Problem 2 — context-rail layout shift

`.context-rail` is `position: absolute; top: 0; bottom: 0` inside `.thread-view__layout`, which is `ThreadHeader`'s **next sibling**. The header grew two independently-conditional `thread-header__warning` rows, so each one pushed the layout down and the rail's icon strip rode down with it. Branch drift arrives from a background poll, so the strip moved under the operator's cursor.

Worth being explicit about why the fix is not in the rail: **anchoring below the header by any mechanism makes the rail's top a function of header height.** A measured `top: var(--header-height)` moves exactly as much as today's flex anchor does. The rail is stable if and only if the header's height is stable.

So the header is now a fixed height. Both banners moved to `ThreadWarnings.tsx`, rendered at the top of `.thread-view__primary` — which already reserves the rail's gutter, so they clear it for free. No hard-coded offset (none would be right: the header also relocates the sidebar wordmark into itself), and the header keeps its full width when the rail pins, preserving the earlier fix that stopped the panel sliding over the MSG cluster.

`.context-rail` itself is unchanged apart from a comment recording the invariant. `thread-header__warning` → `thread-warning`.

## Verification already run locally

- `pnpm typecheck` — clean
- `pnpm lint:eslint` — **0 errors**
- `pnpm lint:colors` — passed
- `pnpm lint:boundaries` — clean, 1494 modules
- Full renderer suite — **2986 / 2987**

The single failure is `app-shell.test.tsx > starts a new thread on a selected federation machine and profile`. **It is pre-existing** — confirmed by stashing this branch's changes and re-running against the untouched tree. Please don't chase it as a regression from this PR.

Two other failures appeared once in a heavily-loaded parallel run (`surfaces GitHub organization SAML enforcement as a sticky error toast`, `star map … truncates a big cloud at the group cap`). Both pass in isolation with these changes, and both pass in a repeat full run. Treating them as load flakes, but flagging them in case CI disagrees.

## What still needs doing

Handing off — this machine is too loaded to run the heavy lanes.

1. **Desktop E2E** — not run locally. CI covers the Linux, macOS, and Windows lanes automatically; no label is needed (neither `ci:build-preview` nor `ci:windows-package` applies, since nothing here touches packaging).
2. **Visual check of the rail fix** — the one thing tests cannot really assert. Open a thread with branch drift (`pnpm --filter @pwragent/desktop inspect:e2e:branch-drift`) and confirm the rail's icon strip does not move when the banner appears, and that the banner still lines up under the title at the 22px inset.
3. **Light theme** — the banners kept their existing tokens and `lint:colors` passes, but a glance in both themes is cheap.

## Test coverage added

- `thread-action-error-notice.test.ts` — 5 cases, including that two action kinds can no longer mask each other, which was the actual defect in the old slot.
- `useThreadNavigation.test.tsx` — a create failure publishes `Desktop backend registry is closed`, and a successful retry clears it.
- `thread-view.test.tsx` — both banners assert they are **outside** `.thread-header` and inside `.thread-view__primary`, so a future header row fails a test instead of shipping a moving rail.

Existing `archiveThreadError` / `renameThreadError` assertions were converted to the callback rather than deleted. The 174 removed `sidebar.test.tsx` references were all `undefined` boilerplate with no assertion behind them.

## Note for whoever picks this up

A concurrent session is fixing the *false-positive* `missingDirectoryPath` predicate (worktree recreated under a new hash while `projectKey` was never migrated). This PR **moves that function verbatim** from `ThreadHeader.tsx` to `ThreadWarnings.tsx` and renames the CSS class. Its semantics are deliberately untouched here — still `projectKey && !linkedDirectories.length`, no existence check. Expect a textual conflict, not a semantic one.

## Deliberate non-goal

The toasts carry no thread chip. The hook holds one error slot per action with no record of the targeted thread, so adding identity would mean threading companion state through ~27 catch blocks in an 8,000-line hook. The toast carries the backend's message, which is the actionable part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
