### PR TITLE
fix(desktop): launch Windows Codex through its .cmd shim

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-windows-launch.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-windows-launch.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  isWindowsSpawnableCommand,
+  resolveWindowsCodexLaunchCommand,
+  resolveWindowsCodexSibling,
+} from "../codex-windows-launch";
+
+const NVM = "C:\\nvm4w\\nodejs";
+
+function existsIn(files: string[]): (candidate: string) => boolean {
+  const lower = new Set(files.map((file) => file.toLowerCase()));
+  return (candidate) => lower.has(candidate.toLowerCase());
+}
+
+describe("resolveWindowsCodexSibling", () => {
+  it("maps the extensionless npm sh shim to its .cmd sibling", () => {
+    expect(
+      resolveWindowsCodexSibling({
+        command: `${NVM}\\codex`,
+        exists: existsIn([`${NVM}\\codex.cmd`]),
+      }),
+    ).toBe(`${NVM}\\codex.cmd`);
+  });
+
+  it("maps a PowerShell shim to its .cmd sibling", () => {
+    expect(
+      resolveWindowsCodexSibling({
+        command: `${NVM}\\codex.ps1`,
+        exists: existsIn([`${NVM}\\codex.cmd`, `${NVM}\\codex.ps1`]),
+      }),
+    ).toBe(`${NVM}\\codex.cmd`);
+  });
+
+  it("prefers a real .exe over the .cmd shim", () => {
+    expect(
+      resolveWindowsCodexSibling({
+        command: `${NVM}\\codex.ps1`,
+        exists: existsIn([`${NVM}\\codex.cmd`, `${NVM}\\codex.exe`]),
+      }),
+    ).toBe(`${NVM}\\codex.exe`);
+  });
+
+  it("leaves an already-spawnable command alone", () => {
+    expect(
+      resolveWindowsCodexSibling({
+        command: `${NVM}\\codex.cmd`,
+        exists: existsIn([`${NVM}\\codex.cmd`]),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not guess siblings for a bare command name", () => {
+    // Resolution is relative to cwd for a bare name, which would silently
+    // launch whatever sits in the working directory.
+    expect(
+      resolveWindowsCodexSibling({
+        command: "codex",
+        exists: () => true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no sibling exists", () => {
+    expect(
+      resolveWindowsCodexSibling({
+        command: `${NVM}\\codex.ps1`,
+        exists: existsIn([`${NVM}\\codex.ps1`]),
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("isWindowsSpawnableCommand", () => {
+  it("rejects .ps1 and accepts the launchable extensions", () => {
+    expect(isWindowsSpawnableCommand("codex.ps1")).toBe(false);
+    expect(isWindowsSpawnableCommand("codex")).toBe(false);
+    expect(isWindowsSpawnableCommand("codex.cmd")).toBe(true);
+    expect(isWindowsSpawnableCommand("codex.EXE")).toBe(true);
+  });
+});
+
+describe("resolveWindowsCodexLaunchCommand", () => {
+  it("redirects a .ps1 launch to the .cmd sibling on win32", () => {
+    expect(
+      resolveWindowsCodexLaunchCommand({
+        command: `${NVM}\\codex.ps1`,
+        exists: existsIn([`${NVM}\\codex.cmd`]),
+        platform: "win32",
+      }),
+    ).toBe(`${NVM}\\codex.cmd`);
+  });
+
+  it("never rewrites off Windows", () => {
+    expect(
+      resolveWindowsCodexLaunchCommand({
+        command: "/usr/local/bin/codex",
+        exists: () => true,
+        platform: "darwin",
+      }),
+    ).toBe("/usr/local/bin/codex");
+  });
+
+  it("passes a .ps1 through unchanged when nothing else is installed", () => {
+    // Better to fail loudly at spawn than to invent a path that is not there.
+    expect(
+      resolveWindowsCodexLaunchCommand({
+        command: `${NVM}\\codex.ps1`,
+        exists: () => false,
+        platform: "win32",
+      }),
+    ).toBe(`${NVM}\\codex.ps1`);
+  });
+});

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -337,4 +337,64 @@ describe("StdioJsonRpcTransport", () => {
 
     await transport.close();
   });
+
+  // A PowerShell shim cannot host the app-server: npm's codex.ps1 branches on
+  // `$MyInvocation.ExpectingInput`, and the transport holds stdin open as a
+  // pipe, so it takes the `$input | & node …` branch and the `initialize`
+  // handshake never returns. Verified on the Windows lab guest: powershell
+  // times out, codex.cmd answers in ~1.5s.
+  it("launches a resolved Windows PowerShell shim through its .cmd sibling", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const command = "C:\\nvm4w\\nodejs\\codex.ps1";
+    const sibling = "C:\\nvm4w\\nodejs\\codex.cmd";
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      args: ["--feature", "value & whoami"],
+      commandExists: (candidate) => candidate === sibling,
+      env: {
+        PATH: "C:\\nvm4w\\nodejs",
+        SystemRoot: "C:\\Windows",
+      },
+      platform: "win32",
+      resolveCommand: async () => ({
+        command,
+        source: "path",
+        version: "0.144.0",
+      }),
+    });
+
+    await transport.connect();
+
+    const [spawnedCommand, spawnedArgs] = spawnMock.mock.calls[0] ?? [];
+    expect(spawnedCommand).toMatch(/cmd\.exe$/i);
+    expect(spawnedArgs?.join(" ")).toContain("codex.cmd");
+    expect(spawnedArgs?.join(" ")).not.toContain("powershell");
+
+    await transport.close();
+  });
+
+  it("keeps a PowerShell shim when no spawnable sibling is installed", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const command = "C:\\nvm4w\\nodejs\\codex.ps1";
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      commandExists: () => false,
+      env: { PATH: "C:\\nvm4w\\nodejs" },
+      platform: "win32",
+      resolveCommand: async () => ({
+        command,
+        source: "path",
+        version: "0.144.0",
+      }),
+    });
+
+    await transport.connect();
+
+    // Failing loudly at spawn beats inventing a path that is not installed.
+    expect(spawnMock.mock.calls[0]?.[0]).toBe(command);
+
+    await transport.close();
+  });
 });

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -15,6 +15,7 @@ import {
   resolveCodexCommand,
   type ResolvedCodexCommandCandidate,
 } from "@pwrdrvr/codex-discovery";
+import { resolveWindowsCodexLaunchCommand } from "../codex-windows-launch";
 
 const codexTransportLog = getMainLogger("pwragent:codex-transport");
 
@@ -40,6 +41,8 @@ export type StdioJsonRpcTransportOptions = {
   }) => Promise<ResolvedCodexCommandCandidate>;
   resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
   platform?: NodeJS.Platform;
+  /** Test seam for the Windows shim-sibling lookup. */
+  commandExists?: (candidate: string) => boolean;
 };
 
 export { compareCodexCliVersions };
@@ -128,8 +131,17 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     });
     this.assertCurrentGeneration(generation);
     const childEnv = buildPwrAgentChildProcessEnv(commandEnv);
+    // A `.ps1` can still reach us from config or a stale cache, and routing a
+    // long-lived stdio JSON-RPC server through PowerShell never completes the
+    // `initialize` handshake. Swap it for the sibling Windows can start.
     const invocation = createCommandInvocation({
-      command: command.command,
+      command: resolveWindowsCodexLaunchCommand({
+        command: command.command,
+        ...(this.options.commandExists
+          ? { exists: this.options.commandExists }
+          : {}),
+        ...(this.options.platform ? { platform: this.options.platform } : {}),
+      }),
       args: ["app-server", ...args],
       env: childEnv,
       platform: this.options.platform,

--- a/apps/desktop/src/main/codex-windows-launch.ts
+++ b/apps/desktop/src/main/codex-windows-launch.ts
@@ -108,7 +108,12 @@ export async function runCodexOneShot(
   return await new Promise((resolve, reject) => {
     const child = execFile(command, args, options, (error, stdout, stderr) => {
       if (error) {
-        reject(error);
+        // execFile's message is the invocation, which on Windows is the
+        // cmd.exe wrapper plus `^` escapes — ~90 characters of boilerplate
+        // that crowds out the child's own diagnostic in any clipped surface.
+        // Carry stdout/stderr on the error the way promisify(execFile) does
+        // so a caller can report what the command actually said.
+        reject(Object.assign(error, { stderr, stdout }));
         return;
       }
       resolve({ stderr, stdout });

--- a/apps/desktop/src/main/codex-windows-launch.ts
+++ b/apps/desktop/src/main/codex-windows-launch.ts
@@ -1,0 +1,122 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Extensions Windows can start directly, or through the cmd.exe wrapper that
+ * `createCommandInvocation` already builds for `.cmd`/`.bat`.
+ *
+ * `.ps1` is deliberately absent. npm writes three shims next to each other
+ * (`codex`, `codex.cmd`, `codex.ps1`) and only the first two are usable here:
+ *
+ * - the extensionless shim is an sh script, unusable on Windows;
+ * - the `.ps1` shim branches on `$MyInvocation.ExpectingInput`, and a
+ *   long-lived JSON-RPC child is spawned with stdin as an open pipe, which
+ *   makes that branch `$input | & node …`. Routing a bidirectional stdio
+ *   server through PowerShell's object pipeline never completes the
+ *   `initialize` handshake — verified on the Windows lab guest, where the
+ *   PowerShell launch times out while `codex.cmd` answers in ~1.5s and the
+ *   native `codex.exe` in ~0.3s. A one-shot `--version` probe survives it
+ *   only because that path closes stdin, taking the other branch.
+ *
+ * So `.ps1` is a discovery signal, never a launch target.
+ */
+const WINDOWS_SPAWNABLE_EXTENSIONS = [".exe", ".com", ".cmd", ".bat"];
+
+type CodexCommandRunner = (
+  command: string,
+  args: string[],
+  options: {
+    env: NodeJS.ProcessEnv;
+    timeout: number;
+    windowsHide: boolean;
+    windowsVerbatimArguments?: boolean;
+  },
+) => Promise<{ stderr?: string | Buffer; stdout?: string | Buffer }>;
+
+export function isWindowsSpawnableCommand(command: string): boolean {
+  return WINDOWS_SPAWNABLE_EXTENSIONS.includes(
+    path.win32.extname(command).toLowerCase(),
+  );
+}
+
+function defaultExists(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Given `…\codex` or `…\codex.ps1`, find the sibling Windows can actually
+ * start (`…\codex.exe`, then `…\codex.cmd`). Returns undefined when the
+ * command is already spawnable, is not an absolute path, or has no sibling.
+ */
+export function resolveWindowsCodexSibling(params: {
+  command: string;
+  exists?: (candidate: string) => boolean;
+}): string | undefined {
+  const exists = params.exists ?? defaultExists;
+  const trimmed = params.command.trim();
+  if (!trimmed || !path.win32.isAbsolute(trimmed)) {
+    return undefined;
+  }
+  const normalized = path.win32.normalize(trimmed);
+  if (isWindowsSpawnableCommand(normalized)) {
+    return undefined;
+  }
+  const extension = path.win32.extname(normalized);
+  const base = extension
+    ? normalized.slice(0, normalized.length - extension.length)
+    : normalized;
+  if (!base) {
+    return undefined;
+  }
+  return WINDOWS_SPAWNABLE_EXTENSIONS.map((candidate) => `${base}${candidate}`)
+    .find(exists);
+}
+
+/**
+ * Last line of defence on the launch path: a command that reached us from
+ * config, `PWRDRVR_CODEX_COMMAND`, or a stale cache may still be a `.ps1`.
+ * Swap it for its spawnable sibling rather than starting a server that can
+ * never answer.
+ */
+export function resolveWindowsCodexLaunchCommand(params: {
+  command: string;
+  exists?: (candidate: string) => boolean;
+  platform?: NodeJS.Platform;
+}): string {
+  const platform = params.platform ?? process.platform;
+  if (platform !== "win32") {
+    return params.command;
+  }
+  return (
+    resolveWindowsCodexSibling({
+      command: params.command,
+      ...(params.exists ? { exists: params.exists } : {}),
+    }) ?? params.command
+  );
+}
+
+export async function runCodexOneShot(
+  command: string,
+  args: string[],
+  options: Parameters<CodexCommandRunner>[2],
+): Promise<{ stderr?: string | Buffer; stdout?: string | Buffer }> {
+  return await new Promise((resolve, reject) => {
+    const child = execFile(command, args, options, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve({ stderr, stdout });
+    });
+    // A `--version` probe reads to EOF and never writes, so close stdin.
+    if (child.stdin) {
+      child.stdin.on("error", () => undefined);
+      child.stdin.end();
+    }
+  });
+}

--- a/apps/desktop/src/main/credential-tester/credential-tester.ts
+++ b/apps/desktop/src/main/credential-tester/credential-tester.ts
@@ -147,7 +147,7 @@ export class CredentialTester {
         status: "failed",
         testedAt: Date.now(),
         durationMs: Date.now() - startedAt,
-        errorMessage: clipError(error),
+        errorMessage: clipError(preferChildDiagnostic(error)),
       };
     }
     this.lastResults.set(kind, result);
@@ -341,7 +341,7 @@ export class CredentialTester {
         testedAt: Date.now(),
         durationMs: Date.now() - probeStart,
         account: command,
-        errorMessage: clipError(error),
+        errorMessage: clipError(preferChildDiagnostic(error)),
       };
     }
   }
@@ -386,6 +386,19 @@ function unset(
 function clipString(value: string): string {
   if (value.length <= ERROR_MESSAGE_LIMIT) return value;
   return `${value.slice(0, ERROR_MESSAGE_LIMIT - 1)}…`;
+}
+
+/**
+ * Prefer what the child printed over the invocation that ran it. On Windows a
+ * Codex probe goes through the cmd.exe wrapper, so `error.message` opens with
+ * ~90 characters of `cmd.exe /d /s /c "^…^"` before anything useful, and the
+ * clip below would otherwise spend the whole budget on it.
+ */
+function preferChildDiagnostic(error: unknown): unknown {
+  const stderr = (error as { stderr?: unknown } | undefined)?.stderr
+    ?.toString?.()
+    .trim();
+  return stderr ? stderr : error;
 }
 
 function clipError(error: unknown): string {

--- a/apps/desktop/src/main/credential-tester/credential-tester.ts
+++ b/apps/desktop/src/main/credential-tester/credential-tester.ts
@@ -1,5 +1,3 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import type { MessagingCredentialValidationResult } from "@pwragent/messaging-interface";
 import type {
   SettingsCredentialTestKind,
@@ -13,8 +11,11 @@ import {
   compareCodexCliVersions,
   MINIMUM_CODEX_CLI_VERSION,
 } from "@pwrdrvr/codex-discovery";
-
-const execFileAsync = promisify(execFile);
+import { createCommandInvocation } from "@pwrdrvr/agent-transport";
+import {
+  resolveWindowsCodexLaunchCommand,
+  runCodexOneShot,
+} from "../codex-windows-launch";
 
 const log = getMainLogger("pwragent:credential-tester");
 
@@ -398,10 +399,24 @@ function clipError(error: unknown): string {
 async function defaultRunCodexVersion(
   command: string,
 ): Promise<{ stdout: string; stderr: string }> {
-  const { stdout, stderr } = await execFileAsync(command, ["--version"], {
-    env: buildPwrAgentChildProcessEnv(process.env),
-    timeout: DEFAULT_PROBE_TIMEOUT_MS,
+  const env = buildPwrAgentChildProcessEnv(process.env);
+  // Probe the command that would actually be launched, so a `.ps1` in config
+  // cannot report Connected while the app-server launch resolves elsewhere.
+  const invocation = createCommandInvocation({
+    command: resolveWindowsCodexLaunchCommand({ command }),
+    args: ["--version"],
+    env,
   });
+  const { stdout, stderr } = await runCodexOneShot(
+    invocation.command,
+    invocation.args,
+    {
+      env,
+      timeout: DEFAULT_PROBE_TIMEOUT_MS,
+      windowsHide: true,
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    },
+  );
   return {
     stdout: stdout?.toString?.() ?? "",
     stderr: stderr?.toString?.() ?? "",

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -101,6 +101,7 @@ import type {
   AcpRegistrySnapshot,
 } from "../acp/acp-registry-types";
 import { getAppStateDb, getAppStateMode } from "../state/app-state";
+import { resolveWindowsCodexLaunchCommand } from "../codex-windows-launch";
 import {
   normalizeProfileName,
   resolveActiveProfileDir,
@@ -760,7 +761,12 @@ async function resolveCodexCommandForProfileWorkflow(
   if (!command) {
     throw new Error("No Codex command is configured or discoverable.");
   }
-  return command;
+  // Codex login and auth-status spawn this command the same way the transport
+  // and the credential tester do, so they need the same Windows shim redirect.
+  // Without it a `.ps1` reaching us from a stale cache launches threads fine
+  // while onboarding login fails, which is the split this redirect exists to
+  // prevent.
+  return resolveWindowsCodexLaunchCommand({ command });
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/settings/GitSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GitSettings.tsx
@@ -15,6 +15,7 @@ import {
   type DesktopSettingsSnapshot,
   type GhStatus,
 } from "@pwragent/shared";
+import { isValidatedDiscoveryCandidate } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { copyText } from "../../lib/copy-text";
 import {
@@ -29,6 +30,10 @@ import {
 } from "./SettingsPathRow";
 import { SettingsSwitch } from "./SettingsSwitch";
 import { sourceBadge } from "./settings-fields";
+import {
+  commandDiscoveryFailureDetail as sharedCommandDiscoveryFailureDetail,
+  describeCommandDiscoveryFailure as describeSharedCommandDiscoveryFailure,
+} from "./command-discovery-failure";
 
 const DEFAULT_BACKGROUND_PR_POLLING_VALUE = {
   value: DEFAULT_BACKGROUND_PR_POLLING,
@@ -861,6 +866,10 @@ function GitCandidateRow(props: {
   return (
     <SettingsPathRow
       title={candidate.command}
+      path={commandDiscoveryFailureDetail(
+        candidate.failureReason ?? candidate.versionFailureReason,
+      )}
+      pathIsDetail
       chips={chips}
       selected={candidate.selected}
       disabled
@@ -875,15 +884,19 @@ function GhCandidateRow(props: {
 }) {
   const candidate = props.candidate;
   const unavailableLabel = describeCommandDiscoveryFailure(candidate.failureReason);
+  // `executable` comes from fs.access(X_OK), which succeeds for any existing
+  // file on Windows, so an sh shim scores true. Gate on the same predicate
+  // the main process selects with.
+  const usable = isValidatedDiscoveryCandidate(candidate);
   const chips: SettingsPathRowChip[] = [
     { label: candidate.source, tone: "muted" },
   ];
-  if (candidate.executable) {
+  if (usable) {
+    // Only a real version belongs in the version slot. Routing a failure
+    // label through here produced rows reading "Launch failed" next to
+    // "Available"; the reason now rides the detail line instead.
     chips.push({
-      label:
-        candidate.version
-        ?? describeCommandDiscoveryFailure(candidate.versionFailureReason)
-        ?? "version unknown",
+      label: candidate.version ?? "version unknown",
       tone: candidate.version ? "muted" : "err",
     });
   } else {
@@ -892,7 +905,7 @@ function GhCandidateRow(props: {
       tone: "err",
     });
   }
-  if (candidate.executable && !candidate.selected) {
+  if (usable && !candidate.selected) {
     chips.push({
       label: "Available",
       tone: "muted",
@@ -902,10 +915,14 @@ function GhCandidateRow(props: {
   return (
     <SettingsPathRow
       title={candidate.command}
+      path={commandDiscoveryFailureDetail(
+        candidate.failureReason ?? candidate.versionFailureReason,
+      )}
+      pathIsDetail
       chips={chips}
       selected={candidate.selected}
-      disabled={props.disabled || !candidate.executable}
-      onUse={candidate.executable ? () => props.onUse(candidate.command) : undefined}
+      disabled={props.disabled || !usable}
+      onUse={usable ? () => props.onUse(candidate.command) : undefined}
     />
   );
 }
@@ -938,13 +955,16 @@ function describeGitCandidateSource(
   return source;
 }
 
+function describeXcodeLicenseFailure(reason: string): string | undefined {
+  return isXcodeLicenseFailure(reason) ? "Xcode license" : undefined;
+}
+
 function describeCommandDiscoveryFailure(reason?: string): string | undefined {
-  if (!reason) return undefined;
-  if (reason === "not_found") return "Missing";
-  if (reason === "not_executable") return "Not executable";
-  if (reason === "version_not_reported") return "Version unknown";
-  if (isXcodeLicenseFailure(reason)) return "Xcode license";
-  return reason;
+  return describeSharedCommandDiscoveryFailure(reason, describeXcodeLicenseFailure);
+}
+
+function commandDiscoveryFailureDetail(reason?: string): string | undefined {
+  return sharedCommandDiscoveryFailureDetail(reason, describeXcodeLicenseFailure);
 }
 
 function isXcodeLicenseCandidate(

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { isValidatedDiscoveryCandidate } from "@pwragent/shared";
 import type {
   BackendModelOption,
   BackendSummary,
@@ -29,8 +30,10 @@ import {
 } from "./CodexAuthProfileSelect";
 import { AcpAgentsSettings } from "./AcpAgentsSettings";
 import { SettingsSwitch } from "./SettingsSwitch";
-
-type CodexPathMode = "auto" | "specified";
+import {
+  commandDiscoveryFailureDetail,
+  describeCommandDiscoveryFailure,
+} from "./command-discovery-failure";
 
 const UNSPECIFIED_SOURCE_MODEL_KEY = "\0unspecified";
 
@@ -105,9 +108,6 @@ export function ModelsSettings(props: {
   onManagedGrokBuildsChange?: (enabled: boolean) => Promise<boolean>;
 }) {
   const [codexPath, setCodexPath] = useState(props.snapshot.models.codex.path.value);
-  const [codexMode, setCodexMode] = useState<CodexPathMode>(
-    props.snapshot.models.codex.path.value.trim() ? "specified" : "auto",
-  );
   const [backends, setBackends] = useState<BackendSummary[]>(
     props.cachedBackends ?? [],
   );
@@ -115,8 +115,24 @@ export function ModelsSettings(props: {
   const [refreshingCatalog, setRefreshingCatalog] = useState(false);
   const codex = props.snapshot.models.codex;
   const envForced = codex.path.source === "env";
+  // Automatic sources, plus any fixed candidate that failed. An operator who
+  // pins a path needs to see why it was rejected — filtering config/env rows
+  // out unconditionally hid the failure reason from the only person who could
+  // act on it, including the "PowerShell shim" diagnostic, which is only ever
+  // emitted for a path someone typed.
+  // Automatic sources always list. A fixed (env/config) row lists when it
+  // failed, so the operator can see why the path they pinned was rejected,
+  // and when it is the current selection, so there is a "Using" row to point
+  // at. Gate on the same predicate the row and the main process use: keying
+  // on `failureReason` alone missed the most common rejection shape, which
+  // upstream reports as executable:true with the reason in
+  // `versionFailureReason`.
   const autoCandidates = codex.discovery.candidates.filter(
-    (candidate) => candidate.source === "path" || candidate.source === "application",
+    (candidate) =>
+      candidate.source === "path"
+      || candidate.source === "application"
+      || candidate.selected
+      || !isValidatedDiscoveryCandidate(candidate),
   );
   // Per-field source pill text — shows where the effective value
   // comes from (config / env override / default). Used on both the
@@ -130,7 +146,6 @@ export function ModelsSettings(props: {
 
   useEffect(() => {
     setCodexPath(codex.path.value);
-    setCodexMode(codex.path.value.trim() || envForced ? "specified" : "auto");
   }, [codex.path.value, envForced]);
 
   useEffect(() => {
@@ -186,6 +201,14 @@ export function ModelsSettings(props: {
   }, [props.desktopApi]);
 
   const saveCodexPath = (path: string): void => {
+    // Skip a no-op write. Without this, blur alone flips `saving` true
+    // synchronously, which disables the button being clicked before mouseup
+    // and Chromium then dispatches no click at all — so clicking Use while
+    // focus is in this field silently does nothing. It also stops a plain
+    // tab-through from rewriting config.toml and re-running discovery.
+    if (path.trim() === codex.path.value.trim()) {
+      return;
+    }
     void props.onSaveCodexPath(path.trim());
   };
 
@@ -215,68 +238,68 @@ export function ModelsSettings(props: {
       <SettingsSection eyebrow="Models" title="Codex">
         <div className="settings-fields">
           <SettingsField
-            label="Codex selection"
-            sub="Pick the Codex binary to invoke for new threads."
+            label="Codex path"
+            sub="Absolute path to the Codex binary. Leave blank to use auto discovery."
             source={codexSource}
             control={
-              <div
-                className="settings-segmented"
-                role="radiogroup"
-                aria-label="Codex selection mode"
-              >
-                <button
-                  aria-checked={codexMode === "auto" && !envForced}
-                  className={`settings-segmented__button${
-                    codexMode === "auto" && !envForced ? " is-active" : ""
-                  }`}
-                  disabled={props.saving || envForced}
-                  role="radio"
-                  type="button"
-                  onClick={() => {
-                    setCodexMode("auto");
-                    setCodexPath("");
-                    saveCodexPath("");
-                  }}
-                >
-                  Auto Discovery - Use Newest
-                </button>
-                <button
-                  aria-checked={codexMode === "specified" || envForced}
-                  className={`settings-segmented__button${
-                    codexMode === "specified" || envForced ? " is-active" : ""
-                  }`}
-                  disabled={props.saving || envForced}
-                  role="radio"
-                  type="button"
-                  onClick={() => setCodexMode("specified")}
-                >
-                  Specified Path
-                </button>
-              </div>
-            }
-          />
-
-          {codexMode === "specified" || envForced ? (
-            <SettingsField
-              label="Codex path"
-              sub="Absolute path to the Codex binary to invoke."
-              control={
+              <>
                 <input
                   aria-label="Codex path"
                   className="settings-input"
                   disabled={props.saving || envForced}
-                  placeholder="Path to codex"
+                  placeholder="Auto discovery"
                   value={codexPath}
+                  // Blur still commits. Requiring Enter or the button meant
+                  // clicking Test, switching fields, or closing Settings threw
+                  // the typed path away with no feedback, and the effect that
+                  // syncs from the snapshot then reset the box.
                   onBlur={() => saveCodexPath(codexPath)}
                   onChange={(event) => setCodexPath(event.currentTarget.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      saveCodexPath(codexPath);
+                    }
+                  }}
                 />
-              }
-            />
-          ) : null}
+                <div className="settings-inline-actions">
+                  <button
+                    className="button button--primary"
+                    disabled={
+                      props.saving
+                      || envForced
+                      || codexPath.trim() === codex.path.value.trim()
+                    }
+                    type="button"
+                    onClick={() => saveCodexPath(codexPath)}
+                  >
+                    Save path
+                  </button>
+                  <button
+                    className="button button--secondary"
+                    disabled={
+                      props.saving || envForced || !codex.path.value.trim()
+                    }
+                    type="button"
+                    onClick={() => {
+                      setCodexPath("");
+                      saveCodexPath("");
+                    }}
+                  >
+                    Use auto discovery
+                  </button>
+                </div>
+              </>
+            }
+            help={
+              envForced
+                ? "PWRAGENT_CODEX_COMMAND controls this path for the current process."
+                : undefined
+            }
+          />
 
           <SettingsField
             label="Available paths"
-            sub="Detected on this machine. The first listed will be used."
+            sub="Detected on this machine. The newest supported version is used automatically."
             source={codexSource}
             control={
               <div
@@ -292,7 +315,6 @@ export function ModelsSettings(props: {
                       candidate={candidate}
                       disabled={props.saving || envForced}
                       onUse={(command) => {
-                        setCodexMode("specified");
                         setCodexPath(command);
                         saveCodexPath(command);
                       }}
@@ -1354,46 +1376,48 @@ function CodexCandidateRow(props: {
   onUse: (command: string) => void;
 }) {
   const candidate = props.candidate;
-  const unavailableLabel = describeCommandDiscoveryFailure(candidate.failureReason);
-  const status = !candidate.executable
-    ? (unavailableLabel ?? "Not executable")
-    : candidate.selected
-      ? "Using"
-      : "Available";
-  const version =
-    candidate.version
-    ?? describeCommandDiscoveryFailure(candidate.versionFailureReason)
-    ?? unavailableLabel
-    ?? "version unknown";
+  const reason = candidate.failureReason ?? candidate.versionFailureReason;
+
+  // One chip per fact: where it came from, and either its version or the one
+  // reason it cannot be used. The old row emitted the failure twice — once as
+  // the version and again as the status — which is what put `spawn EPERM`
+  // on the same row two ways.
+  // `executable` is not a usability test on Windows: it comes from
+  // fs.access(X_OK), which succeeds for any existing file, so an sh shim
+  // scores true. Gate on the same predicate the main process selects with.
+  const usable = isValidatedDiscoveryCandidate(candidate);
 
   const chips: SettingsPathRowChip[] = [
-    { label: candidate.source, tone: "muted" },
-    { label: version, tone: "muted" },
+    { key: "source", label: candidate.source, tone: "muted" },
   ];
-  if (!candidate.selected) {
+  // A version is worth showing whenever we have one, including on a rejected
+  // candidate — "Codex too old" without a number leaves the operator unable
+  // to tell how far behind they are.
+  if (candidate.version) {
+    chips.push({ key: "version", label: candidate.version, tone: "muted" });
+  }
+  if (usable) {
+    if (!candidate.selected) {
+      chips.push({ key: "status", label: "Available", tone: "muted" });
+    }
+  } else {
     chips.push({
-      label: status,
-      tone: candidate.executable ? "muted" : "err",
+      key: "status",
+      label: describeCommandDiscoveryFailure(reason) ?? "Not executable",
+      tone: "err",
     });
   }
 
   return (
     <SettingsPathRow
       title={candidate.command}
+      path={commandDiscoveryFailureDetail(reason)}
+      pathIsDetail
       chips={chips}
       selected={candidate.selected}
       selectedLabel="Using"
-      disabled={props.disabled || !candidate.executable}
-      onUse={() => props.onUse(candidate.command)}
+      disabled={props.disabled || !usable}
+      onUse={usable ? () => props.onUse(candidate.command) : undefined}
     />
   );
-}
-
-function describeCommandDiscoveryFailure(reason?: string): string | undefined {
-  if (!reason) return undefined;
-  if (reason === "not_found") return "Missing";
-  if (reason === "not_executable") return "Not executable";
-  if (reason === "version_not_reported") return "Version unknown";
-  if (reason === "codex_too_old") return "Codex too old";
-  return reason;
 }

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -249,11 +249,19 @@ export function ModelsSettings(props: {
                   disabled={props.saving || envForced}
                   placeholder="Auto discovery"
                   value={codexPath}
-                  // Blur still commits. Requiring Enter or the button meant
-                  // clicking Test, switching fields, or closing Settings threw
-                  // the typed path away with no feedback, and the effect that
-                  // syncs from the snapshot then reset the box.
-                  onBlur={() => saveCodexPath(codexPath)}
+                  // Blur still commits, so tabbing away or closing Settings
+                  // does not silently discard a typed path. But not when focus
+                  // is moving to a button: writeConfig flips `saving` true
+                  // synchronously, React flushes that before mouseup, and a
+                  // control disabled at mouseup receives no click at all — so
+                  // saving here would swallow the very action being clicked.
+                  // Let the button decide instead.
+                  onBlur={(event) => {
+                    if (event.relatedTarget instanceof HTMLButtonElement) {
+                      return;
+                    }
+                    saveCodexPath(codexPath);
+                  }}
                   onChange={(event) => setCodexPath(event.currentTarget.value)}
                   onKeyDown={(event) => {
                     if (event.key === "Enter") {

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -250,14 +250,15 @@ export function ModelsSettings(props: {
                   placeholder="Auto discovery"
                   value={codexPath}
                   // Blur still commits, so tabbing away or closing Settings
-                  // does not silently discard a typed path. But not when focus
-                  // is moving to a button: writeConfig flips `saving` true
-                  // synchronously, React flushes that before mouseup, and a
-                  // control disabled at mouseup receives no click at all — so
-                  // saving here would swallow the very action being clicked.
-                  // Let the button decide instead.
+                  // does not silently discard a typed path. Path actions settle
+                  // the pending value themselves: saving here would flip
+                  // `saving` before mouseup, disable the action, and swallow
+                  // its click. Unrelated buttons still need the blur commit.
                   onBlur={(event) => {
-                    if (event.relatedTarget instanceof HTMLButtonElement) {
+                    if (
+                      event.relatedTarget instanceof HTMLButtonElement
+                      && event.relatedTarget.closest("[data-codex-path-actions]")
+                    ) {
                       return;
                     }
                     saveCodexPath(codexPath);
@@ -269,7 +270,10 @@ export function ModelsSettings(props: {
                     }
                   }}
                 />
-                <div className="settings-inline-actions">
+                <div
+                  className="settings-inline-actions"
+                  data-codex-path-actions
+                >
                   <button
                     className="button button--primary"
                     disabled={
@@ -313,6 +317,7 @@ export function ModelsSettings(props: {
               <div
                 className="settings-paths"
                 aria-label="Codex discovery"
+                data-codex-path-actions
               >
                 {autoCandidates.length === 0 ? (
                   <p className="settings-empty">No Codex candidates found.</p>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsPathRow.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsPathRow.tsx
@@ -30,6 +30,11 @@ export function SettingsPathRow(props: {
   title?: ReactNode;
   /** Mono secondary path beneath the title. */
   path?: string;
+  /**
+   * Render `path` as wrapping prose rather than a single ellipsized line.
+   * Set it when the value is a failure reason instead of a filesystem path.
+   */
+  pathIsDetail?: boolean;
   /** Right-side status chips (source / version / state). */
   chips?: SettingsPathRowChip[];
   /** Whether this row is the currently-active selection. */
@@ -56,10 +61,24 @@ export function SettingsPathRow(props: {
       ) : null}
       <div className="settings-pathrow__body">
         {props.title ? (
-          <span className="settings-pathrow__title">{props.title}</span>
+          <span
+            className="settings-pathrow__title"
+            // Titles are ellipsized (a Windows MSIX path runs well past the
+            // row), so keep the full value reachable on hover.
+            title={typeof props.title === "string" ? props.title : undefined}
+          >
+            {props.title}
+          </span>
         ) : null}
         {props.path ? (
-          <span className="settings-pathrow__path">{props.path}</span>
+          <span
+            className={`settings-pathrow__path${
+              props.pathIsDetail ? " settings-pathrow__path--detail" : ""
+            }`}
+            title={props.path}
+          >
+            {props.path}
+          </span>
         ) : null}
       </div>
       {props.chips && props.chips.length > 0 ? (

--- a/apps/desktop/src/renderer/src/features/settings/SettingsPathRow.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsPathRow.tsx
@@ -62,9 +62,16 @@ export function SettingsPathRow(props: {
       <div className="settings-pathrow__body">
         {props.title ? (
           <span
-            className="settings-pathrow__title"
-            // Titles are ellipsized (a Windows MSIX path runs well past the
-            // row), so keep the full value reachable on hover.
+            // Truncation is only applied to a plain string, where `title`
+            // below can carry the full value. An element title (the auth
+            // profile rows pass one) composes its own inline layout, and
+            // text-overflow does not apply to an atomic inline-flex box, so
+            // ellipsizing it would hard-cut with nothing to hover.
+            className={`settings-pathrow__title${
+              typeof props.title === "string"
+                ? " settings-pathrow__title--truncate"
+                : ""
+            }`}
             title={typeof props.title === "string" ? props.title : undefined}
           >
             {props.title}
@@ -92,6 +99,9 @@ export function SettingsPathRow(props: {
               <span
                 key={chip.key ?? `${chip.tone ?? "default"}-${index}`}
                 className={`settings-pathrow__chip${toneClass}`}
+                // Chips are width-capped, so a long label (a prerelease
+                // version string) needs the full value reachable on hover.
+                title={typeof chip.label === "string" ? chip.label : undefined}
               >
                 {chip.label}
               </span>

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -683,6 +683,36 @@ describe("SettingsScreen", () => {
     expect(screen.queryByText(/PWRDRVR_CODEX_COMMAND/)).not.toBeInTheDocument();
   });
 
+  it("commits an edited Codex path before an unrelated button action", async () => {
+    const settings = createSettingsState();
+
+    render(
+      <SettingsScreen
+        initialSection="models"
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    const codexPathInput = screen.getByRole("textbox", { name: "Codex path" });
+    const generalButton = screen.getByRole("button", { name: "General" });
+    fireEvent.change(codexPathInput, {
+      target: { value: "C:\\nvm4w\\nodejs\\codex.ps1" },
+    });
+    fireEvent.blur(codexPathInput, { relatedTarget: generalButton });
+    fireEvent.click(generalButton);
+
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        models: {
+          codex: {
+            path: "C:\\nvm4w\\nodejs\\codex.ps1",
+          },
+        },
+      });
+    });
+  });
+
   it("clamps accidental document scroll while mounted", async () => {
     Object.defineProperty(window, "scrollX", {
       configurable: true,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -651,6 +651,38 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("names the active PwrAgent Codex path environment override", () => {
+    const base = createSnapshot();
+    const snapshot = createSnapshot({
+      models: {
+        ...base.models,
+        codex: {
+          ...base.models.codex,
+          path: {
+            value: "C:\\nvm4w\\nodejs\\codex.ps1",
+            source: "env",
+          },
+        },
+      },
+    });
+
+    render(
+      <SettingsScreen
+        initialSection="models"
+        settings={createSettingsState(snapshot)}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Codex path" })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "PWRAGENT_CODEX_COMMAND controls this path for the current process.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/PWRDRVR_CODEX_COMMAND/)).not.toBeInTheDocument();
+  });
+
   it("clamps accidental document scroll while mounted", async () => {
     Object.defineProperty(window, "scrollX", {
       configurable: true,
@@ -1251,9 +1283,21 @@ describe("SettingsScreen", () => {
     // default name (it shows the path the Test button would invoke).
     // Both are correct.
     expect(screen.getAllByText("/usr/local/bin/codex").length).toBeGreaterThanOrEqual(2);
-    expect(
-      screen.getByRole("radio", { name: "Auto Discovery - Use Newest" }),
-    ).toHaveAttribute("aria-checked", "true");
+    const codexPathInput = screen.getByRole("textbox", { name: "Codex path" });
+    expect(codexPathInput).toBeEnabled();
+    fireEvent.change(codexPathInput, {
+      target: { value: "C:\\nvm4w\\nodejs\\codex.ps1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save path" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        models: {
+          codex: {
+            path: "C:\\nvm4w\\nodejs\\codex.ps1",
+          },
+        },
+      });
+    });
     expect(screen.getByText("0.130.0")).toBeInTheDocument();
     // Source pills on the Codex fields show the effective config
     // source (the redundant `Using /path/to/binary` label was
@@ -2866,6 +2910,161 @@ describe("SettingsScreen", () => {
       });
     });
     expect(getGhStatus).toHaveBeenCalledWith({ recheck: true });
+  });
+
+  it("lists a pinned Codex whose version probe failed, and the one in use", async () => {
+    // Upstream's most common rejection is executable:true with the reason in
+    // versionFailureReason and no failureReason. Keying the list on
+    // failureReason hid exactly that row from the operator who pinned it,
+    // and a validated config row had no "Using" entry at all.
+    const snapshot = createSnapshot();
+    snapshot.models.codex.discovery = {
+      selectedCommand: "C:\\nvm4w\\nodejs\\codex.cmd",
+      selectedSource: "config",
+      candidates: [
+        {
+          command: "C:\\nvm4w\\nodejs\\codex.cmd",
+          executable: true,
+          selected: true,
+          source: "config",
+          version: "0.146.0",
+        },
+        {
+          command: "C:\\pinned\\codex.cmd",
+          executable: true,
+          selected: false,
+          source: "env",
+          versionFailureReason: "version_not_reported",
+        },
+      ],
+    };
+
+    render(
+      <SettingsScreen
+        initialSection="models"
+        settings={createSettingsState(snapshot)}
+        onClose={() => undefined}
+      />,
+    );
+
+    const rows = Array.from(
+      document.querySelectorAll(".settings-pathrow"),
+    ).map((row) => row.textContent ?? "");
+    expect(rows.some((row) => row.includes("C:\\pinned\\codex.cmd"))).toBe(true);
+    expect(rows.some((row) => row.includes("C:\\nvm4w\\nodejs\\codex.cmd"))).toBe(
+      true,
+    );
+  });
+
+  it("shows the installed version on a Codex rejected as too old", async () => {
+    // Upstream builds a codex_too_old candidate as executable:false WITH a
+    // version — the rejection is derived from parsing one. Gating the version
+    // chip on usability therefore hid the number on every platform, and
+    // commandDiscoveryFailureDetail returns undefined for a classified reason
+    // so the detail line could not recover it either.
+    const snapshot = createSnapshot();
+    snapshot.models.codex.discovery = {
+      selectedCommand: "",
+      selectedSource: "path",
+      candidates: [
+        {
+          command: "/usr/local/bin/codex",
+          executable: false,
+          failureReason: "codex_too_old",
+          selected: false,
+          source: "path",
+          version: "0.100.0",
+        },
+      ],
+    };
+
+    render(
+      <SettingsScreen
+        initialSection="models"
+        settings={createSettingsState(snapshot)}
+        onClose={() => undefined}
+      />,
+    );
+
+    const chips = Array.from(
+      document.querySelectorAll(".settings-pathrow__chip"),
+    ).map((chip) => chip.textContent ?? "");
+    expect(chips).toContain("0.100.0");
+    expect(chips).toContain("Codex too old");
+
+    // Still unusable: no Use button on a rejected candidate.
+    const row = Array.from(document.querySelectorAll(".settings-pathrow")).find(
+      (candidate) => candidate.textContent?.includes("/usr/local/bin/codex"),
+    )!;
+    expect(within(row as HTMLElement).queryByRole("button")).toBeNull();
+  });
+
+  it("keeps a raw Codex spawn error out of the status chips", async () => {
+    // Regression: a failed Windows probe returns a whole command line as its
+    // reason. The row used to render it as BOTH the version chip and the
+    // status chip; chips are `flex: 0 0 auto`, so the path beside them
+    // collapsed to "C:" and the row overflowed.
+    const rawFailure =
+      "Command failed: C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0"
+      + "\\powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy"
+      + " Bypass -File C:\\nvm4w\\nodejs\\codex.ps1 --version";
+    const snapshot = createSnapshot();
+    snapshot.models.codex.discovery = {
+      selectedCommand: "C:\\nvm4w\\nodejs\\codex.cmd",
+      selectedSource: "path",
+      candidates: [
+        {
+          command: "C:\\nvm4w\\nodejs\\codex.cmd",
+          executable: true,
+          selected: true,
+          source: "path",
+          version: "0.146.0",
+        },
+        {
+          command: "C:\\nvm4w\\nodejs\\codex.ps1",
+          executable: false,
+          selected: false,
+          source: "path",
+          failureReason: rawFailure,
+        },
+        {
+          command:
+            "C:\\Program Files\\WindowsApps\\OpenAI.Codex_26.810.7004.0_x64"
+            + "\\app\\resources\\codex.exe",
+          executable: false,
+          selected: false,
+          source: "application",
+          failureReason: "spawn EPERM",
+        },
+      ],
+    };
+
+    render(
+      <SettingsScreen
+        initialSection="models"
+        settings={createSettingsState(snapshot)}
+        onClose={() => undefined}
+      />,
+    );
+
+    const chips = Array.from(
+      document.querySelectorAll(".settings-pathrow__chip"),
+    ).map((chip) => chip.textContent ?? "");
+    expect(chips).toContain("Launch failed");
+    expect(chips).toContain("Blocked");
+    expect(chips.some((chip) => chip.includes("powershell.exe"))).toBe(false);
+    // "spawn EPERM" previously rendered twice on the same row.
+    expect(chips.filter((chip) => chip === "Blocked")).toHaveLength(1);
+
+    // The full reason stays reachable on the row's mono detail line.
+    expect(screen.getByText(rawFailure)).toBeInTheDocument();
+
+    // An unusable candidate must not offer to become the selection.
+    const rows = Array.from(document.querySelectorAll(".settings-pathrow"));
+    const failingRow = rows.find((row) =>
+      row.textContent?.includes("codex.ps1"),
+    )!;
+    expect(within(failingRow as HTMLElement).queryByRole("button")).toBeNull();
   });
 
   it("shows Git discovery and Xcode license remediation", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/command-discovery-failure.ts
+++ b/apps/desktop/src/renderer/src/features/settings/command-discovery-failure.ts
@@ -1,0 +1,73 @@
+/**
+ * Discovery failure reasons arrive from the main process in two very
+ * different shapes: short classified tokens like `not_found`, and raw spawn
+ * errors that are whole command lines —
+ *
+ *   Command failed: C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe
+ *   -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File …
+ *
+ * `.settings-pathrow__chips` is `flex: 0 0 auto`, so a chip carrying that
+ * second shape does not wrap or ellipsize — it takes the width it wants and
+ * squeezes the sibling path down to "C:". Every caller must therefore render
+ * `describeCommandDiscoveryFailure` in the chip and keep the raw text for
+ * `commandDiscoveryFailureDetail`, which feeds the row's mono detail line.
+ */
+
+const CLASSIFIED_FAILURE_LABELS: Record<string, string> = {
+  codex_too_old: "Codex too old",
+  not_executable: "Not executable",
+  not_found: "Missing",
+  version_not_reported: "Version unknown",
+  // @pwrdrvr/codex-discovery >= 0.4.0 reports a cancelled version probe
+  // distinctly instead of folding it into a raw spawn error, so a slow shim
+  // no longer reads as "not installed".
+  version_probe_aborted: "Probe cancelled",
+  version_probe_timed_out: "Timed out",
+};
+
+function classifiedLabel(reason: string): string | undefined {
+  // Bracket access alone would resolve "constructor" / "toString" through the
+  // prototype and hand a Function to React as a chip label.
+  return Object.hasOwn(CLASSIFIED_FAILURE_LABELS, reason)
+    ? CLASSIFIED_FAILURE_LABELS[reason]
+    : undefined;
+}
+
+/**
+ * Chip-sized label for a discovery failure. Never returns the raw reason.
+ *
+ * `extra` lets a caller add domain-specific tokens (Git's Xcode-license
+ * probe) without every surface learning about them.
+ */
+export function describeCommandDiscoveryFailure(
+  reason?: string,
+  extra?: (reason: string) => string | undefined,
+): string | undefined {
+  if (!reason) return undefined;
+  const classified = classifiedLabel(reason);
+  if (classified) return classified;
+  const domain = extra?.(reason);
+  if (domain) return domain;
+  if (/\b(EPERM|EACCES)\b/.test(reason)) return "Blocked";
+  if (/\bETIMEDOUT\b/.test(reason) || /timed?\s?out/i.test(reason)) {
+    return "Timed out";
+  }
+  if (/\b(ENOENT|ENOTDIR)\b/.test(reason)) return "Missing";
+  return "Launch failed";
+}
+
+/**
+ * The raw reason, but only when it carries information the chip label lost.
+ * A classified token is already fully described by its label, so returning it
+ * here would just repeat the chip on the detail line.
+ */
+export function commandDiscoveryFailureDetail(
+  reason?: string,
+  extra?: (reason: string) => string | undefined,
+): string | undefined {
+  if (!reason) return undefined;
+  if (Object.hasOwn(CLASSIFIED_FAILURE_LABELS, reason) || extra?.(reason)) {
+    return undefined;
+  }
+  return reason;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9725,10 +9725,13 @@ textarea,
 
 .settings-pathrow__title {
   display: block;
+  overflow: hidden;
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 600;
   line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-pathrow__title-line {
@@ -9763,6 +9766,21 @@ textarea,
   white-space: nowrap;
 }
 
+/*
+ * Discovery failure text is prose, not a path: a spawn error is a full command
+ * line, and clipping it to one nowrap line left about 24 of 170 characters
+ * readable, recoverable only by hovering a non-focusable span. Let it wrap to
+ * a couple of lines and stay selectable.
+ */
+.settings-pathrow__path--detail {
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  white-space: normal;
+  user-select: text;
+}
+
 .settings-pathrow.is-selected .settings-pathrow__title {
   color: var(--accent-bright);
 }
@@ -9775,6 +9793,8 @@ textarea,
 }
 
 .settings-pathrow__chip {
+  max-width: 180px;
+  overflow: hidden;
   padding: 3px 7px;
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
@@ -9784,6 +9804,8 @@ textarea,
   font-size: 10px;
   font-weight: 500;
   line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-pathrow__chip--ok {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9725,11 +9725,20 @@ textarea,
 
 .settings-pathrow__title {
   display: block;
-  overflow: hidden;
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 600;
   line-height: 1.2;
+}
+
+/*
+ * Only for a plain-string title, which carries a `title` attribute so the
+ * clipped tail stays reachable. An element title composes its own inline
+ * layout and text-overflow does not apply to it, so truncating there would
+ * hard-cut with no ellipsis and no hover.
+ */
+.settings-pathrow__title--truncate {
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -585,6 +585,30 @@ export type DesktopCodexDiscoveryCandidate = {
   failureReason?: string;
 };
 
+/**
+ * Whether a discovered command is safe to launch.
+ *
+ * `executable` alone is not that test. Discovery derives it from
+ * `fs.access(X_OK)`, which succeeds for any existing file on Windows, so an
+ * npm sh shim scores `true` while being unstartable. Selection in the main
+ * process and the Use affordance in Settings must agree on this, so the
+ * predicate lives beside the type both sides already import rather than being
+ * hand-copied into each.
+ */
+export function isValidatedDiscoveryCandidate(candidate: {
+  executable: boolean;
+  failureReason?: string;
+  version?: string;
+  versionFailureReason?: string;
+}): boolean {
+  return (
+    candidate.executable
+    && Boolean(candidate.version)
+    && !candidate.failureReason
+    && !candidate.versionFailureReason
+  );
+}
+
 export type DesktopCodexDiscoverySnapshot = {
   selectedCommand?: string;
   selectedSource?: DesktopCodexCandidateSource;


### PR DESCRIPTION
## Summary

- launch a Windows Codex through the sibling Windows can actually start (`codex.exe`, then `codex.cmd`) instead of the `.ps1` shim
- apply that at **all four** Codex spawn sites, so Settings, the app-server, the connection test, and Codex login agree on one command
- stop rendering raw spawn errors as status chips, which made the Codex panel unreadable
- make the Codex path field directly editable again, with explicit Save / Use auto discovery

## Why the `.ps1` cannot host the app-server

npm installs three shims side by side — `codex` (sh), `codex.cmd`, `codex.ps1`. The `.ps1` branches on `$MyInvocation.ExpectingInput`. A one-shot `--version` closes stdin and takes the direct branch, so it probes clean; the app-server holds stdin open as a pipe and takes `$input | & node …`, routing a bidirectional JSON-RPC stream through PowerShell's object pipeline.

Measured on a Windows guest, spawning `app-server` with stdin open and sending `initialize`:

| launch surface | result |
|---|---|
| `powershell -File codex.ps1` | **timeout after 15s** |
| `cmd.exe /c codex.cmd` | handshake OK in 1583ms |
| native vendor `codex.exe` | handshake OK in 303ms |

That is exactly the split an operator reports as "connection test says Connected, but starting a thread times out on `initialize`".

The fourth spawn site is easy to miss: `resolveCodexCommandForProfileWorkflow` backs Codex login and auth-status. Guard three of four and threads launch while onboarding fails — the same confusing asymmetry, one layer up.

## Settings

Discovery failures arrive as short tokens (`not_found`) or as raw spawn errors that are whole command lines. Both were rendered as chips, and `.settings-pathrow__chips` is `flex: 0 0 auto` — so one command-line-length label took the width it wanted and squeezed the path beside it down to `C:`. Failures now classify to chip-sized labels with the raw text on a wrapping detail line, shared with the Git and gh rows, which carried their own copy of the same flaw.

Two related corrections:

- **`executable` is not a usability test.** Discovery derives it from `fs.access(X_OK)`, which succeeds for any existing file on Windows, so an sh shim scored `true` and Settings offered a **Use** button that wrote an unlaunchable command into config. The Codex and gh rows now gate on `isValidatedDiscoveryCandidate` in `@pwragent/shared` — beside the type both sides already import, since the renderer cannot import from `src/main`.
- **The path field is editable again.** A segmented control previously hid path entry entirely, leaving no manual escape hatch on exactly the machines where discovery was failing.

## Upstream landed while this was in review

`@pwrdrvr/codex-discovery` moved `^0.1.6` → `^0.4.0` on main (#1752), and it carries **both** fixes this branch was originally compensating for:

- `buildPathCommandNames` no longer tries the bare name first — on win32 an extensionless command now expands to PATHEXT variants only, so the scan never stops on npm's sh shim. Automatic discovery reaches `codex.cmd` on its own.
- The version probe timeout is configurable (default now 10s, was a hardcoded 2s) and a cancelled probe reports `version_probe_timed_out` / `version_probe_aborted` instead of folding into a raw spawn error. A slow shim no longer reads as "not installed".

So the downstream discovery module that an earlier revision of this work carried is **not needed and is not here**. The renderer classifier learned the two new reasons upstream now emits.

What still belongs downstream, and is what this PR is:

- **The launch redirect.** Upstream never sees PwrAgent's persisted `config.toml` or the coordinator cache, so a `.ps1` can still arrive from either. `resolveWindowsCodexLaunchCommand` guards all four spawn sites.
- **The usability gate.** `pathIsExecutable` is win32-aware in 0.4.0, but `executable` is still `accessExecutable || versionResult.ran`, so a candidate whose version probe failed still scores `true`. `isValidatedDiscoveryCandidate` keeps Settings from offering a **Use** button on one.
- **The Settings work**, which was never upstream's concern.

## Validation

- `pnpm lint:eslint` (0 errors), `lint:boundaries`, `lint:colors`
- 112 tests across the affected suites
- The Windows lab guest confirmed the handshake table above against a real Codex 0.146.0

Note `pnpm typecheck` currently reports 16 pre-existing errors on `main` in `acp-instance-discovery.test.ts`, untouched by this branch — zero in the files changed here.
