### PR TITLE
feat(desktop): highlight the linked thread card while a thread link is hovered

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -19,6 +19,7 @@ import {
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { useThreadLinkHoverTarget } from "../../lib/thread-links";
 import { isNativeDragInteractionActive } from "../../lib/native-drag-interaction";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { PrChip } from "../pr-status/PrChip";
@@ -139,6 +140,10 @@ export function ThreadRow(props: ThreadRowProps) {
     : threadKey === props.selectedThreadKey;
   const active = threadKey === props.selectedThreadKey;
   const isComposerSource = threadKey === props.composerSourceThreadKey;
+  // A thread link elsewhere in the window (a provenance chip in the
+  // transcript, the title-bar thread link) is being hovered and points at
+  // this card. Wears the composer-source accent fill for the duration.
+  const isLinkTarget = useThreadLinkHoverTarget(threadKey);
   // A remote-owned row whose peer isn't currently connected renders dimmed:
   // the data shown is the last-known snapshot, not live.
   const isRemoteOffline = Boolean(
@@ -301,7 +306,9 @@ export function ThreadRow(props: ThreadRowProps) {
           isPinnedRow ? " thread-row--pinned" : ""
         }${selected ? " is-selected" : ""}${
           isComposerSource ? " is-composer-source" : ""
-        }${isRemoteOffline ? " is-remote-offline" : ""}`}
+        }${isLinkTarget ? " is-link-target" : ""}${
+          isRemoteOffline ? " is-remote-offline" : ""
+        }`}
         // The open-thread BUTTON's rect is only the title band (see
         // `.thread-row__open` in app.css for why a card-sized button
         // rect broke axe target-size and Playwright row clicks). The

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -1,12 +1,10 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type MouseEvent,
-} from "react";
+import { useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
 import { PopoutIcon, ThreadIcon } from "../../icons";
-import { useLiveThreadLink, useThreadLinks } from "../../lib/thread-links";
+import {
+  useLiveThreadLink,
+  useThreadLinkHoverSource,
+  useThreadLinks,
+} from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import {
@@ -53,34 +51,13 @@ export function ThreadChip(props: ThreadChipProps) {
     ? `Open this thread in the remote viewer window for ${remoteInstanceLabel}`
     : undefined;
 
-  // While the pointer (or focus) rests on the chip, the sidebar card it points
-  // at lights up in the same solid-accent style as a sub-thread composer's
-  // source card — the link and its target read as one thing. Only rows already
-  // on screen respond; nothing scrolls until the chip is activated.
-  const hoveringRef = useRef(false);
-  const threadLinksRef = useRef(threadLinks);
-  threadLinksRef.current = threadLinks;
-  const showTarget = (element: HTMLSpanElement): void => {
-    tooltipController.show(element, tooltip);
-    hoveringRef.current = true;
-    threadLinks?.setHoverTarget(link);
-  };
-  const hideTarget = (): void => {
-    tooltipController.hide();
-    hoveringRef.current = false;
-    threadLinks?.setHoverTarget(undefined);
-  };
-  // A chip can unmount under the pointer (its message re-renders, the
-  // transcript navigates away) without ever seeing mouseleave. Release the
-  // highlight then, but only if this chip is the one holding it.
-  useEffect(
-    () => () => {
-      if (hoveringRef.current) {
-        threadLinksRef.current?.setHoverTarget(undefined);
-      }
-    },
-    [],
-  );
+  // While the pointer (or keyboard focus) rests on the link, the sidebar card
+  // it points at lights up in the same solid-accent style as a sub-thread
+  // composer's source card — the link and its target read as one thing. Only
+  // rows already on screen respond; nothing scrolls until the chip is
+  // activated. Wired on the group so a remote link's pop-out button counts as
+  // the same link: sliding from the chip onto it must not drop the highlight.
+  const hoverSource = useThreadLinkHoverSource(link);
 
   // role="button" span rather than a real <button>: the chip renders inside
   // markdown that may already sit within a clickable surface, and a nested
@@ -90,14 +67,27 @@ export function ThreadChip(props: ThreadChipProps) {
   ): void => {
     event.preventDefault();
     event.stopPropagation();
-    hideTarget();
+    tooltipController.hide();
+    hoverSource.hide();
     event.currentTarget.blur();
     props.onOpen(link);
   };
 
   return (
     <>
-      <span className="thread-chip-group">
+      <span
+        className="thread-chip-group"
+        onBlur={(event) => {
+          // Focus moving between the chip and its pop-out stays in the group.
+          if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            return;
+          }
+          hoverSource.hide();
+        }}
+        onFocus={(event) => hoverSource.showFromFocus(event.target as Element)}
+        onMouseEnter={hoverSource.show}
+        onMouseLeave={hoverSource.hide}
+      >
         <span
           aria-label={`Open thread ${label}`}
           aria-haspopup="menu"
@@ -106,13 +96,13 @@ export function ThreadChip(props: ThreadChipProps) {
           draggable={false}
           role="button"
           tabIndex={0}
-          onBlur={hideTarget}
+          onBlur={tooltipController.hide}
           onClick={handleActivate}
           onContextMenu={(event) => {
             event.preventDefault();
             event.stopPropagation();
             window.getSelection()?.removeAllRanges();
-            hideTarget();
+            tooltipController.hide();
             const rect = event.currentTarget.getBoundingClientRect();
             contextMenuInvokerRef.current = event.currentTarget;
             setContextMenuPosition({
@@ -122,14 +112,14 @@ export function ThreadChip(props: ThreadChipProps) {
             });
           }}
           onDragStart={(event) => event.preventDefault()}
-          onFocus={(event) => showTarget(event.currentTarget)}
+          onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === " ") {
               handleActivate(event);
             }
           }}
-          onMouseEnter={(event) => showTarget(event.currentTarget)}
-          onMouseLeave={hideTarget}
+          onMouseEnter={(event) => tooltipController.show(event.currentTarget, tooltip)}
+          onMouseLeave={tooltipController.hide}
         >
           <ThreadIcon className="thread-chip__icon" size={12} />
           <span className="thread-chip__label">#{label.replace(/^#/, "")}</span>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -68,7 +68,7 @@ export function ThreadChip(props: ThreadChipProps) {
     event.preventDefault();
     event.stopPropagation();
     tooltipController.hide();
-    hoverSource.hide();
+    hoverSource.release();
     event.currentTarget.blur();
     props.onOpen(link);
   };
@@ -82,11 +82,11 @@ export function ThreadChip(props: ThreadChipProps) {
           if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
             return;
           }
-          hoverSource.hide();
+          hoverSource.hideFromFocus();
         }}
         onFocus={(event) => hoverSource.showFromFocus(event.target as Element)}
-        onMouseEnter={hoverSource.show}
-        onMouseLeave={hoverSource.hide}
+        onMouseEnter={hoverSource.showFromPointer}
+        onMouseLeave={hoverSource.hideFromPointer}
       >
         <span
           aria-label={`Open thread ${label}`}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -1,4 +1,10 @@
-import { useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 import { PopoutIcon, ThreadIcon } from "../../icons";
 import { useLiveThreadLink, useThreadLinks } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -47,6 +53,35 @@ export function ThreadChip(props: ThreadChipProps) {
     ? `Open this thread in the remote viewer window for ${remoteInstanceLabel}`
     : undefined;
 
+  // While the pointer (or focus) rests on the chip, the sidebar card it points
+  // at lights up in the same solid-accent style as a sub-thread composer's
+  // source card — the link and its target read as one thing. Only rows already
+  // on screen respond; nothing scrolls until the chip is activated.
+  const hoveringRef = useRef(false);
+  const threadLinksRef = useRef(threadLinks);
+  threadLinksRef.current = threadLinks;
+  const showTarget = (element: HTMLSpanElement): void => {
+    tooltipController.show(element, tooltip);
+    hoveringRef.current = true;
+    threadLinks?.setHoverTarget(link);
+  };
+  const hideTarget = (): void => {
+    tooltipController.hide();
+    hoveringRef.current = false;
+    threadLinks?.setHoverTarget(undefined);
+  };
+  // A chip can unmount under the pointer (its message re-renders, the
+  // transcript navigates away) without ever seeing mouseleave. Release the
+  // highlight then, but only if this chip is the one holding it.
+  useEffect(
+    () => () => {
+      if (hoveringRef.current) {
+        threadLinksRef.current?.setHoverTarget(undefined);
+      }
+    },
+    [],
+  );
+
   // role="button" span rather than a real <button>: the chip renders inside
   // markdown that may already sit within a clickable surface, and a nested
   // <button> is invalid HTML.
@@ -55,7 +90,7 @@ export function ThreadChip(props: ThreadChipProps) {
   ): void => {
     event.preventDefault();
     event.stopPropagation();
-    tooltipController.hide();
+    hideTarget();
     event.currentTarget.blur();
     props.onOpen(link);
   };
@@ -71,13 +106,13 @@ export function ThreadChip(props: ThreadChipProps) {
           draggable={false}
           role="button"
           tabIndex={0}
-          onBlur={tooltipController.hide}
+          onBlur={hideTarget}
           onClick={handleActivate}
           onContextMenu={(event) => {
             event.preventDefault();
             event.stopPropagation();
             window.getSelection()?.removeAllRanges();
-            tooltipController.hide();
+            hideTarget();
             const rect = event.currentTarget.getBoundingClientRect();
             contextMenuInvokerRef.current = event.currentTarget;
             setContextMenuPosition({
@@ -87,14 +122,14 @@ export function ThreadChip(props: ThreadChipProps) {
             });
           }}
           onDragStart={(event) => event.preventDefault()}
-          onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
+          onFocus={(event) => showTarget(event.currentTarget)}
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === " ") {
               handleActivate(event);
             }
           }}
-          onMouseEnter={(event) => tooltipController.show(event.currentTarget, tooltip)}
-          onMouseLeave={tooltipController.hide}
+          onMouseEnter={(event) => showTarget(event.currentTarget)}
+          onMouseLeave={hideTarget}
         >
           <ThreadIcon className="thread-chip__icon" size={12} />
           <span className="thread-chip__label">#{label.replace(/^#/, "")}</span>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -3,11 +3,10 @@ import type {
   MessagingChannelKind,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { useEffect, useRef } from "react";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
-import { useThreadLinks } from "../../lib/thread-links";
+import { useThreadLinkHoverSource } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { TerminalIcon } from "../../icons/TerminalIcon";
 import { HistoryIcon } from "../../icons/HistoryIcon";
@@ -116,33 +115,14 @@ export function ThreadHeader(props: ThreadHeaderProps) {
   // slow, edge-clipping native `title`.
   const terminalTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   // The title is a link back to this thread's sidebar card. While hovered or
-  // focused it lights that card up in the accent fill, the same cue a
-  // transcript thread chip gives its target, so "which row is this?" is
-  // answered before the click scrolls to it.
-  const threadLinks = useThreadLinks();
-  const threadSource = props.thread.source;
-  const threadId = props.thread.id;
-  const titleHoveringRef = useRef(false);
-  const showTitleTarget = (): void => {
-    titleHoveringRef.current = true;
-    threadLinks?.setHoverTarget({ backend: threadSource, threadId });
-  };
-  const hideTitleTarget = (): void => {
-    titleHoveringRef.current = false;
-    threadLinks?.setHoverTarget(undefined);
-  };
-  // The header stays mounted across a thread switch (⌘K, sidebar click while
-  // the pointer rests on the title), and no mouseleave fires for that. Drop
-  // the previous thread's highlight rather than leave its row lit.
-  useEffect(
-    () => () => {
-      if (titleHoveringRef.current) {
-        titleHoveringRef.current = false;
-        threadLinks?.setHoverTarget(undefined);
-      }
-    },
-    [threadLinks, threadSource, threadId],
-  );
+  // keyboard-focused it lights that card up in the accent fill, the same cue
+  // a transcript thread chip gives its target, so "which row is this?" is
+  // answered before the click scrolls to it. The hook follows a thread switch
+  // under a resting pointer and releases on unmount.
+  const titleHover = useThreadLinkHoverSource({
+    backend: props.thread.source,
+    threadId: props.thread.id,
+  });
   const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const rewindTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const workflowBudgetTooltip = useViewportTooltip({ className: "viewport-tooltip" });
@@ -199,11 +179,11 @@ export function ThreadHeader(props: ThreadHeaderProps) {
                     className="thread-header__title-button"
                     title="Show in thread list"
                     type="button"
-                    onBlur={hideTitleTarget}
+                    onBlur={titleHover.hide}
                     onClick={props.onRevealSelectedThreadInList}
-                    onFocus={showTitleTarget}
-                    onMouseEnter={showTitleTarget}
-                    onMouseLeave={hideTitleTarget}
+                    onFocus={(event) => titleHover.showFromFocus(event.currentTarget)}
+                    onMouseEnter={titleHover.show}
+                    onMouseLeave={titleHover.hide}
                   >
                     {props.thread.title}
                   </button>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -3,9 +3,11 @@ import type {
   MessagingChannelKind,
   NavigationThreadSummary,
 } from "@pwragent/shared";
+import { useEffect, useRef } from "react";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
+import { useThreadLinks } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { TerminalIcon } from "../../icons/TerminalIcon";
 import { HistoryIcon } from "../../icons/HistoryIcon";
@@ -113,6 +115,34 @@ export function ThreadHeader(props: ThreadHeaderProps) {
   // sidebar/rail toggles sitting right beside it instead of falling back to the
   // slow, edge-clipping native `title`.
   const terminalTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  // The title is a link back to this thread's sidebar card. While hovered or
+  // focused it lights that card up in the accent fill, the same cue a
+  // transcript thread chip gives its target, so "which row is this?" is
+  // answered before the click scrolls to it.
+  const threadLinks = useThreadLinks();
+  const threadSource = props.thread.source;
+  const threadId = props.thread.id;
+  const titleHoveringRef = useRef(false);
+  const showTitleTarget = (): void => {
+    titleHoveringRef.current = true;
+    threadLinks?.setHoverTarget({ backend: threadSource, threadId });
+  };
+  const hideTitleTarget = (): void => {
+    titleHoveringRef.current = false;
+    threadLinks?.setHoverTarget(undefined);
+  };
+  // The header stays mounted across a thread switch (⌘K, sidebar click while
+  // the pointer rests on the title), and no mouseleave fires for that. Drop
+  // the previous thread's highlight rather than leave its row lit.
+  useEffect(
+    () => () => {
+      if (titleHoveringRef.current) {
+        titleHoveringRef.current = false;
+        threadLinks?.setHoverTarget(undefined);
+      }
+    },
+    [threadLinks, threadSource, threadId],
+  );
   const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const rewindTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const workflowBudgetTooltip = useViewportTooltip({ className: "viewport-tooltip" });
@@ -169,7 +199,11 @@ export function ThreadHeader(props: ThreadHeaderProps) {
                     className="thread-header__title-button"
                     title="Show in thread list"
                     type="button"
+                    onBlur={hideTitleTarget}
                     onClick={props.onRevealSelectedThreadInList}
+                    onFocus={showTitleTarget}
+                    onMouseEnter={showTitleTarget}
+                    onMouseLeave={hideTitleTarget}
                   >
                     {props.thread.title}
                   </button>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -179,11 +179,11 @@ export function ThreadHeader(props: ThreadHeaderProps) {
                     className="thread-header__title-button"
                     title="Show in thread list"
                     type="button"
-                    onBlur={titleHover.hide}
+                    onBlur={titleHover.hideFromFocus}
                     onClick={props.onRevealSelectedThreadInList}
                     onFocus={(event) => titleHover.showFromFocus(event.currentTarget)}
-                    onMouseEnter={titleHover.show}
-                    onMouseLeave={titleHover.hide}
+                    onMouseEnter={titleHover.showFromPointer}
+                    onMouseLeave={titleHover.hideFromPointer}
                   >
                     {props.thread.title}
                   </button>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
@@ -1,0 +1,225 @@
+import "@testing-library/jest-dom/vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadLinkProvider } from "../../../lib/thread-links";
+import { ThreadRow } from "../../navigation/ThreadRow";
+import { ThreadHeader } from "../ThreadHeader";
+import { ThreadMarkdown } from "../ThreadMarkdown";
+
+// Hovering (or focusing) a thread link anywhere in the window lights up the
+// sidebar card it points at, in the same solid-accent treatment a sub-thread
+// composer gives its source card. The link chip and the header title-bar link
+// both write to one hover store on the thread-link context; `ThreadRow` reads
+// it per row. These tests render both ends under one provider, the way the
+// app shell does, and assert on the row's class — the same hook the CSS keys
+// on.
+
+const TARGET_THREAD_ID = "019f5d79-a595-73f2-84d9-a0976762c303";
+const OTHER_THREAD_ID = "019f5d79-a595-73f2-84d9-a0976762c304";
+
+function threadSummary(
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id: TARGET_THREAD_ID,
+    title: "RELATED query deranking issue",
+    titleSource: "generated",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { unread: false },
+    ...overrides,
+  } as NavigationThreadSummary;
+}
+
+const targetThread = threadSummary();
+const otherThread = threadSummary({
+  id: OTHER_THREAD_ID,
+  title: "Unrelated thread",
+});
+
+function rowFor(thread: NavigationThreadSummary) {
+  return (
+    <ThreadRow
+      thread={thread}
+      onOpenContextMenu={vi.fn()}
+      onSelectThread={vi.fn()}
+      onSetReaction={vi.fn(async () => undefined)}
+      onUnbindMessagingBinding={vi.fn(async () => undefined)}
+    />
+  );
+}
+
+function rowElement(title: string): HTMLElement {
+  const row = screen
+    .getByRole("button", { name: new RegExp(`^${title}`) })
+    .closest(".thread-row");
+  if (!(row instanceof HTMLElement)) {
+    throw new Error(`no .thread-row for ${title}`);
+  }
+  return row;
+}
+
+function renderChipAndRows(text: string, threads = [targetThread, otherThread]) {
+  return render(
+    <ThreadLinkProvider onShowThread={vi.fn()} threads={threads}>
+      <ThreadMarkdown text={text} />
+      <div className="sidebar">
+        {threads.map((thread) => (
+          <div key={thread.id}>{rowFor(thread)}</div>
+        ))}
+      </div>
+    </ThreadLinkProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("thread link hover target", () => {
+  it("lights up the linked thread's card while a chip is hovered, and only that card", () => {
+    renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
+    const chip = screen.getByRole("button", {
+      name: "Open thread RELATED query deranking issue",
+    });
+    const targetRow = rowElement("RELATED query deranking issue");
+    const otherRow = rowElement("Unrelated thread");
+
+    expect(targetRow).not.toHaveClass("is-link-target");
+
+    fireEvent.mouseEnter(chip);
+    expect(targetRow).toHaveClass("is-link-target");
+    expect(otherRow).not.toHaveClass("is-link-target");
+
+    fireEvent.mouseLeave(chip);
+    expect(targetRow).not.toHaveClass("is-link-target");
+  });
+
+  it("follows keyboard focus the same way as the pointer", () => {
+    renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
+    const chip = screen.getByRole("button", {
+      name: "Open thread RELATED query deranking issue",
+    });
+    const targetRow = rowElement("RELATED query deranking issue");
+
+    fireEvent.focus(chip);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    fireEvent.blur(chip);
+    expect(targetRow).not.toHaveClass("is-link-target");
+  });
+
+  it("releases the highlight when the chip is activated", () => {
+    renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
+    const chip = screen.getByRole("button", {
+      name: "Open thread RELATED query deranking issue",
+    });
+    const targetRow = rowElement("RELATED query deranking issue");
+
+    fireEvent.mouseEnter(chip);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    fireEvent.click(chip);
+    expect(targetRow).not.toHaveClass("is-link-target");
+  });
+
+  it("releases the highlight when a hovered chip unmounts without a mouseleave", () => {
+    const view = renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
+    const chip = screen.getByRole("button", {
+      name: "Open thread RELATED query deranking issue",
+    });
+    fireEvent.mouseEnter(chip);
+    expect(rowElement("RELATED query deranking issue")).toHaveClass("is-link-target");
+
+    // Same provider, chip gone: the message re-rendered under the pointer.
+    view.rerender(
+      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
+        <ThreadMarkdown text="no link any more" />
+        <div className="sidebar">
+          <div>{rowFor(targetThread)}</div>
+          <div>{rowFor(otherThread)}</div>
+        </div>
+      </ThreadLinkProvider>,
+    );
+
+    expect(rowElement("RELATED query deranking issue")).not.toHaveClass(
+      "is-link-target",
+    );
+  });
+
+  it("lights up the selected thread's card from the title-bar thread link", () => {
+    render(
+      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
+        <ThreadHeader
+          thread={targetThread}
+          onRevealSelectedThreadInList={vi.fn()}
+        />
+        <div className="sidebar">
+          <div>{rowFor(targetThread)}</div>
+          <div>{rowFor(otherThread)}</div>
+        </div>
+      </ThreadLinkProvider>,
+    );
+    const titleLink = screen.getByRole("button", {
+      name: "Show selected thread in thread list",
+    });
+    const targetRow = rowElement("RELATED query deranking issue");
+    const otherRow = rowElement("Unrelated thread");
+
+    fireEvent.mouseEnter(titleLink);
+    expect(targetRow).toHaveClass("is-link-target");
+    expect(otherRow).not.toHaveClass("is-link-target");
+
+    fireEvent.mouseLeave(titleLink);
+    expect(targetRow).not.toHaveClass("is-link-target");
+
+    fireEvent.focus(titleLink);
+    expect(targetRow).toHaveClass("is-link-target");
+    fireEvent.blur(titleLink);
+    expect(targetRow).not.toHaveClass("is-link-target");
+  });
+
+  it("drops the previous thread's highlight when the header switches threads under the pointer", () => {
+    const view = render(
+      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
+        <ThreadHeader thread={targetThread} onRevealSelectedThreadInList={vi.fn()} />
+        <div>{rowFor(targetThread)}</div>
+        <div>{rowFor(otherThread)}</div>
+      </ThreadLinkProvider>,
+    );
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "Show selected thread in thread list" }),
+    );
+    expect(rowElement("RELATED query deranking issue")).toHaveClass("is-link-target");
+
+    view.rerender(
+      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
+        <ThreadHeader thread={otherThread} onRevealSelectedThreadInList={vi.fn()} />
+        <div>{rowFor(targetThread)}</div>
+        <div>{rowFor(otherThread)}</div>
+      </ThreadLinkProvider>,
+    );
+
+    expect(rowElement("RELATED query deranking issue")).not.toHaveClass(
+      "is-link-target",
+    );
+    expect(rowElement("Unrelated thread")).not.toHaveClass("is-link-target");
+  });
+
+  it("is inert outside a ThreadLinkProvider", () => {
+    render(
+      <>
+        <ThreadHeader thread={targetThread} onRevealSelectedThreadInList={vi.fn()} />
+        <div>{rowFor(targetThread)}</div>
+      </>,
+    );
+    const titleLink = screen.getByRole("button", {
+      name: "Show selected thread in thread list",
+    });
+    expect(() => fireEvent.mouseEnter(titleLink)).not.toThrow();
+    expect(rowElement("RELATED query deranking issue")).not.toHaveClass(
+      "is-link-target",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
@@ -1,22 +1,28 @@
 import "@testing-library/jest-dom/vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadLinkProvider } from "../../../lib/thread-links";
 import { ThreadRow } from "../../navigation/ThreadRow";
 import { ThreadHeader } from "../ThreadHeader";
 import { ThreadMarkdown } from "../ThreadMarkdown";
 
-// Hovering (or focusing) a thread link anywhere in the window lights up the
-// sidebar card it points at, in the same solid-accent treatment a sub-thread
-// composer gives its source card. The link chip and the header title-bar link
-// both write to one hover store on the thread-link context; `ThreadRow` reads
-// it per row. These tests render both ends under one provider, the way the
-// app shell does, and assert on the row's class — the same hook the CSS keys
-// on.
+// Hovering (or keyboard-focusing) a thread link anywhere in the window lights
+// up the sidebar card it points at, in the same solid-accent treatment a
+// sub-thread composer gives its source card. The link chip and the header
+// title-bar link both write to one owner-aware hover store on the thread-link
+// context; `ThreadRow` reads it per row. These tests render both ends under
+// one provider, the way the app shell does, and assert on the row's class —
+// the same hook the CSS keys on.
+//
+// Focus is driven with real `.focus()` / `.blur()` rather than
+// `fireEvent.focus`: the highlight only follows *visible* keyboard focus
+// (`:focus-visible`), which jsdom resolves from `document.activeElement`
+// once the focus dispatch has settled.
 
 const TARGET_THREAD_ID = "019f5d79-a595-73f2-84d9-a0976762c303";
 const OTHER_THREAD_ID = "019f5d79-a595-73f2-84d9-a0976762c304";
+const REMOTE_INSTANCE_ID = "instance-remote-1";
 
 function threadSummary(
   overrides: Partial<NavigationThreadSummary> = {},
@@ -37,6 +43,20 @@ const otherThread = threadSummary({
   id: OTHER_THREAD_ID,
   title: "Unrelated thread",
 });
+const remoteThread = threadSummary({
+  federation: {
+    ref: {
+      target: { scope: "remote", instanceId: REMOTE_INSTANCE_ID },
+    },
+    instanceLabel: "Peer",
+  } as NavigationThreadSummary["federation"],
+});
+
+const TARGET_LINK = `[handoff](pwragent://thread/${TARGET_THREAD_ID})`;
+const OTHER_LINK = `[other](pwragent://thread/${OTHER_THREAD_ID})`;
+const CHIP_NAME = "Open thread RELATED query deranking issue";
+const OTHER_CHIP_NAME = "Open thread Unrelated thread";
+const TITLE_LINK_NAME = "Show selected thread in thread list";
 
 function rowFor(thread: NavigationThreadSummary) {
   return (
@@ -60,17 +80,60 @@ function rowElement(title: string): HTMLElement {
   return row;
 }
 
-function renderChipAndRows(text: string, threads = [targetThread, otherThread]) {
-  return render(
+/**
+ * One provider wrapping the link sources under test and a sidebar of rows —
+ * the shape the app shell has. `text` renders transcript chips; `headerThread`
+ * renders the title-bar link for that thread. Rerender with a different
+ * `headerThread` to model a thread switch under a resting pointer.
+ */
+function scene(options: {
+  headerThread?: NavigationThreadSummary;
+  text?: string;
+  threads?: NavigationThreadSummary[];
+}) {
+  const threads = options.threads ?? [targetThread, otherThread];
+  return (
     <ThreadLinkProvider onShowThread={vi.fn()} threads={threads}>
-      <ThreadMarkdown text={text} />
+      {options.headerThread ? (
+        <ThreadHeader
+          thread={options.headerThread}
+          onRevealSelectedThreadInList={vi.fn()}
+        />
+      ) : null}
+      {options.text ? <ThreadMarkdown text={options.text} /> : null}
       <div className="sidebar">
         {threads.map((thread) => (
           <div key={thread.id}>{rowFor(thread)}</div>
         ))}
       </div>
-    </ThreadLinkProvider>,
+    </ThreadLinkProvider>
   );
+}
+
+function renderScene(options: Parameters<typeof scene>[0]) {
+  const view = render(scene(options));
+  return {
+    ...view,
+    rerenderScene: (next: Parameters<typeof scene>[0]) => view.rerender(scene(next)),
+  };
+}
+
+// Keyboard focus: a Tab keystroke followed by the focus move, which is what
+// jsdom's `:focus-visible` emulation (like the browsers') keys on. The
+// highlight reads `:focus-visible` a microtask after focus settles, so the
+// move is awaited inside an async act.
+async function focus(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Tab" });
+    element.focus();
+    await Promise.resolve();
+  });
+}
+
+async function blur(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.blur();
+  });
 }
 
 afterEach(() => {
@@ -79,10 +142,8 @@ afterEach(() => {
 
 describe("thread link hover target", () => {
   it("lights up the linked thread's card while a chip is hovered, and only that card", () => {
-    renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
-    const chip = screen.getByRole("button", {
-      name: "Open thread RELATED query deranking issue",
-    });
+    renderScene({ text: `See ${TARGET_LINK}` });
+    const chip = screen.getByRole("button", { name: CHIP_NAME });
     const targetRow = rowElement("RELATED query deranking issue");
     const otherRow = rowElement("Unrelated thread");
 
@@ -96,25 +157,39 @@ describe("thread link hover target", () => {
     expect(targetRow).not.toHaveClass("is-link-target");
   });
 
-  it("follows keyboard focus the same way as the pointer", () => {
-    renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
-    const chip = screen.getByRole("button", {
-      name: "Open thread RELATED query deranking issue",
-    });
+  it("follows keyboard focus the same way as the pointer", async () => {
+    renderScene({ text: `See ${TARGET_LINK}` });
+    const chip = screen.getByRole("button", { name: CHIP_NAME });
     const targetRow = rowElement("RELATED query deranking issue");
 
-    fireEvent.focus(chip);
+    await focus(chip);
     expect(targetRow).toHaveClass("is-link-target");
 
-    fireEvent.blur(chip);
+    await blur(chip);
     expect(targetRow).not.toHaveClass("is-link-target");
   });
 
-  it("releases the highlight when the chip is activated", () => {
-    renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
-    const chip = screen.getByRole("button", {
-      name: "Open thread RELATED query deranking issue",
+  it("ignores a focus event that is not visible keyboard focus", async () => {
+    // Programmatic focus (a context menu returning focus to its invoker, the
+    // window re-activating with the button still focused) fires `focus`
+    // without `:focus-visible`. Emulate by dispatching without moving
+    // `document.activeElement`.
+    renderScene({ text: `See ${TARGET_LINK}` });
+    const chip = screen.getByRole("button", { name: CHIP_NAME });
+
+    await act(async () => {
+      fireEvent.focus(chip);
+      await Promise.resolve();
     });
+
+    expect(rowElement("RELATED query deranking issue")).not.toHaveClass(
+      "is-link-target",
+    );
+  });
+
+  it("releases the highlight when the chip is activated", () => {
+    renderScene({ text: `See ${TARGET_LINK}` });
+    const chip = screen.getByRole("button", { name: CHIP_NAME });
     const targetRow = rowElement("RELATED query deranking issue");
 
     fireEvent.mouseEnter(chip);
@@ -125,45 +200,89 @@ describe("thread link hover target", () => {
   });
 
   it("releases the highlight when a hovered chip unmounts without a mouseleave", () => {
-    const view = renderChipAndRows(`See [handoff](pwragent://thread/${TARGET_THREAD_ID})`);
-    const chip = screen.getByRole("button", {
-      name: "Open thread RELATED query deranking issue",
-    });
-    fireEvent.mouseEnter(chip);
+    const view = renderScene({ text: `See ${TARGET_LINK}` });
+    fireEvent.mouseEnter(screen.getByRole("button", { name: CHIP_NAME }));
     expect(rowElement("RELATED query deranking issue")).toHaveClass("is-link-target");
 
     // Same provider, chip gone: the message re-rendered under the pointer.
-    view.rerender(
-      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
-        <ThreadMarkdown text="no link any more" />
-        <div className="sidebar">
-          <div>{rowFor(targetThread)}</div>
-          <div>{rowFor(otherThread)}</div>
-        </div>
-      </ThreadLinkProvider>,
-    );
+    view.rerenderScene({ text: "no link any more" });
 
     expect(rowElement("RELATED query deranking issue")).not.toHaveClass(
       "is-link-target",
     );
   });
 
-  it("lights up the selected thread's card from the title-bar thread link", () => {
-    render(
-      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
-        <ThreadHeader
-          thread={targetThread}
-          onRevealSelectedThreadInList={vi.fn()}
-        />
-        <div className="sidebar">
-          <div>{rowFor(targetThread)}</div>
-          <div>{rowFor(otherThread)}</div>
-        </div>
-      </ThreadLinkProvider>,
-    );
-    const titleLink = screen.getByRole("button", {
-      name: "Show selected thread in thread list",
+  it("keeps a focused link's highlight when the pointer crosses and leaves another link", async () => {
+    renderScene({ text: `See ${TARGET_LINK} and ${OTHER_LINK}` });
+    const focusedChip = screen.getByRole("button", { name: CHIP_NAME });
+    const passingChip = screen.getByRole("button", { name: OTHER_CHIP_NAME });
+    const targetRow = rowElement("RELATED query deranking issue");
+    const otherRow = rowElement("Unrelated thread");
+
+    await focus(focusedChip);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    // The most recent link wins while the pointer rests on it…
+    fireEvent.mouseEnter(passingChip);
+    expect(otherRow).toHaveClass("is-link-target");
+    expect(targetRow).not.toHaveClass("is-link-target");
+
+    // …and leaving it hands the highlight back to the link that still holds
+    // focus, rather than wiping the slot.
+    fireEvent.mouseLeave(passingChip);
+    expect(otherRow).not.toHaveClass("is-link-target");
+    expect(targetRow).toHaveClass("is-link-target");
+  });
+
+  it("does not let an unmounting link clear a highlight another link holds", async () => {
+    const view = renderScene({
+      headerThread: otherThread,
+      text: `See ${TARGET_LINK}`,
     });
+    const chip = screen.getByRole("button", { name: CHIP_NAME });
+    const titleLink = screen.getByRole("button", { name: TITLE_LINK_NAME });
+
+    fireEvent.mouseEnter(chip);
+    await focus(titleLink);
+    expect(rowElement("Unrelated thread")).toHaveClass("is-link-target");
+
+    // The hovered chip unmounts (its message re-renders) while the title
+    // still has focus: the title's highlight must survive.
+    view.rerenderScene({ headerThread: otherThread, text: "no link" });
+
+    expect(rowElement("Unrelated thread")).toHaveClass("is-link-target");
+  });
+
+  it("keeps the highlight while the pointer moves onto a remote link's pop-out", async () => {
+    renderScene({
+      text: `See [remote](pwragent://thread/${TARGET_THREAD_ID}?backend=codex&instanceId=${REMOTE_INSTANCE_ID})`,
+      threads: [remoteThread, otherThread],
+    });
+    const chip = screen.getByRole("button", { name: CHIP_NAME });
+    const popout = screen.getByRole("button", { name: "Open remote viewer for Peer" });
+    const targetRow = rowElement("RELATED query deranking issue");
+
+    // Enter the group through the chip; leaving the chip for its sibling
+    // pop-out stays inside the group, so no leave fires on the group.
+    fireEvent.mouseEnter(chip.parentElement!);
+    fireEvent.mouseEnter(chip);
+    expect(targetRow).toHaveClass("is-link-target");
+    fireEvent.mouseLeave(chip);
+    fireEvent.mouseEnter(popout);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    // Tab from chip to pop-out likewise stays lit; blurring out of the group
+    // releases it.
+    await focus(chip);
+    await focus(popout);
+    expect(targetRow).toHaveClass("is-link-target");
+    await blur(popout);
+    expect(targetRow).not.toHaveClass("is-link-target");
+  });
+
+  it("lights up the selected thread's card from the title-bar thread link", async () => {
+    renderScene({ headerThread: targetThread });
+    const titleLink = screen.getByRole("button", { name: TITLE_LINK_NAME });
     const targetRow = rowElement("RELATED query deranking issue");
     const otherRow = rowElement("Unrelated thread");
 
@@ -174,37 +293,48 @@ describe("thread link hover target", () => {
     fireEvent.mouseLeave(titleLink);
     expect(targetRow).not.toHaveClass("is-link-target");
 
-    fireEvent.focus(titleLink);
+    await focus(titleLink);
     expect(targetRow).toHaveClass("is-link-target");
-    fireEvent.blur(titleLink);
+    await blur(titleLink);
     expect(targetRow).not.toHaveClass("is-link-target");
   });
 
-  it("drops the previous thread's highlight when the header switches threads under the pointer", () => {
-    const view = render(
-      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
-        <ThreadHeader thread={targetThread} onRevealSelectedThreadInList={vi.fn()} />
-        <div>{rowFor(targetThread)}</div>
-        <div>{rowFor(otherThread)}</div>
-      </ThreadLinkProvider>,
-    );
-    fireEvent.mouseEnter(
-      screen.getByRole("button", { name: "Show selected thread in thread list" }),
-    );
+  it("follows a thread switch under a resting pointer on the title-bar link", () => {
+    const view = renderScene({ headerThread: targetThread });
+    fireEvent.mouseEnter(screen.getByRole("button", { name: TITLE_LINK_NAME }));
     expect(rowElement("RELATED query deranking issue")).toHaveClass("is-link-target");
 
-    view.rerender(
-      <ThreadLinkProvider onShowThread={vi.fn()} threads={[targetThread, otherThread]}>
-        <ThreadHeader thread={otherThread} onRevealSelectedThreadInList={vi.fn()} />
-        <div>{rowFor(targetThread)}</div>
-        <div>{rowFor(otherThread)}</div>
-      </ThreadLinkProvider>,
-    );
+    // ⌘K / sidebar click while the pointer rests on the title: the header
+    // stays mounted with a new thread, and no mouse event fires. The lit row
+    // must be the one the link now points at.
+    view.rerenderScene({ headerThread: otherThread });
 
     expect(rowElement("RELATED query deranking issue")).not.toHaveClass(
       "is-link-target",
     );
+    expect(rowElement("Unrelated thread")).toHaveClass("is-link-target");
+
+    fireEvent.mouseLeave(screen.getByRole("button", { name: TITLE_LINK_NAME }));
     expect(rowElement("Unrelated thread")).not.toHaveClass("is-link-target");
+  });
+
+  it("keeps the title-bar highlight across a thread-membership change", () => {
+    // The provider's context value is rebuilt whenever the set of threads
+    // changes; the hover store must not be reset by that.
+    const view = renderScene({ headerThread: targetThread });
+    fireEvent.mouseEnter(screen.getByRole("button", { name: TITLE_LINK_NAME }));
+    expect(rowElement("RELATED query deranking issue")).toHaveClass("is-link-target");
+
+    view.rerenderScene({
+      headerThread: targetThread,
+      threads: [
+        targetThread,
+        otherThread,
+        threadSummary({ id: "019f5d79-a595-73f2-84d9-a0976762c305", title: "New arrival" }),
+      ],
+    });
+
+    expect(rowElement("RELATED query deranking issue")).toHaveClass("is-link-target");
   });
 
   it("is inert outside a ThreadLinkProvider", () => {
@@ -214,9 +344,7 @@ describe("thread link hover target", () => {
         <div>{rowFor(targetThread)}</div>
       </>,
     );
-    const titleLink = screen.getByRole("button", {
-      name: "Show selected thread in thread list",
-    });
+    const titleLink = screen.getByRole("button", { name: TITLE_LINK_NAME });
     expect(() => fireEvent.mouseEnter(titleLink)).not.toThrow();
     expect(rowElement("RELATED query deranking issue")).not.toHaveClass(
       "is-link-target",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
@@ -271,12 +271,52 @@ describe("thread link hover target", () => {
     fireEvent.mouseEnter(popout);
     expect(targetRow).toHaveClass("is-link-target");
 
-    // Tab from chip to pop-out likewise stays lit; blurring out of the group
-    // releases it.
+    // Tab from chip to pop-out likewise stays lit; releasing needs BOTH the
+    // focus to leave the group and the pointer to leave it.
     await focus(chip);
     await focus(popout);
     expect(targetRow).toHaveClass("is-link-target");
     await blur(popout);
+    expect(targetRow).toHaveClass("is-link-target");
+    fireEvent.mouseLeave(popout.parentElement!);
+    expect(targetRow).not.toHaveClass("is-link-target");
+  });
+
+  it("keeps a pointer-held highlight when the same link loses focus", async () => {
+    // The pointer and keyboard focus are independent inputs on one link, and
+    // either can outlive the other: Chromium delivers a blur when the window
+    // is deactivated, and a pointer can drift off a Tab-focused link. Neither
+    // ending may darken a row the other input still holds.
+    renderScene({ headerThread: targetThread });
+    const titleLink = screen.getByRole("button", { name: TITLE_LINK_NAME });
+    const targetRow = rowElement("RELATED query deranking issue");
+
+    fireEvent.mouseEnter(titleLink);
+    await focus(titleLink);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    // Focus leaves (window deactivated, Tab onward) — the pointer has not moved.
+    await blur(titleLink);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    fireEvent.mouseLeave(titleLink);
+    expect(targetRow).not.toHaveClass("is-link-target");
+  });
+
+  it("keeps a focus-held highlight when the pointer drifts off the same link", async () => {
+    renderScene({ headerThread: targetThread });
+    const titleLink = screen.getByRole("button", { name: TITLE_LINK_NAME });
+    const targetRow = rowElement("RELATED query deranking issue");
+
+    await focus(titleLink);
+    fireEvent.mouseEnter(titleLink);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    // Pointer wanders off while the link still wears the focus ring.
+    fireEvent.mouseLeave(titleLink);
+    expect(targetRow).toHaveClass("is-link-target");
+
+    await blur(titleLink);
     expect(targetRow).not.toHaveClass("is-link-target");
   });
 

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -49,7 +49,60 @@ export type ThreadLinkContextValue = {
   show: (link: ResolvedThreadLink) => void;
   getSnapshot: (link: ResolvedThreadLink) => ResolvedThreadLink;
   subscribe: (link: ResolvedThreadLink, listener: () => void) => () => void;
+  /**
+   * Marks the thread a hovered or focused link points at, so the matching
+   * sidebar card can light up while the pointer rests on the link. Pass
+   * `undefined` when the pointer leaves. Rows read it through
+   * `useThreadLinkHoverTarget`.
+   */
+  setHoverTarget: (link: ThreadLinkHoverTarget | undefined) => void;
+  getHoverTargetKey: () => string | undefined;
+  subscribeHoverTarget: (listener: () => void) => () => void;
 };
+
+export type ThreadLinkHoverTarget = Pick<ResolvedThreadLink, "backend" | "threadId">;
+
+/**
+ * The key a hovered link is matched against a sidebar card by. Same shape as
+ * the row's own identity key (`buildThreadIdentityKey(source, id)`) and as
+ * `composerSourceThreadKey`, so a link to a pinned remote thread lights up
+ * that row too — the instance is deliberately not part of the match.
+ */
+export function threadLinkHoverKey(link: ThreadLinkHoverTarget): string {
+  return buildThreadIdentityKey(link.backend, link.threadId);
+}
+
+/**
+ * Hover state is a separate store from the metadata store: it changes on
+ * every pointer enter/leave, and only the row it names (plus the one it just
+ * left) should re-render — not the provider, and not the transcript.
+ */
+class ThreadLinkHoverStore {
+  private key: string | undefined;
+  private listeners = new Set<() => void>();
+
+  get(): string | undefined {
+    return this.key;
+  }
+
+  set(link: ThreadLinkHoverTarget | undefined): void {
+    const nextKey = link ? threadLinkHoverKey(link) : undefined;
+    if (nextKey === this.key) {
+      return;
+    }
+    this.key = nextKey;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+}
 
 function threadLinkKey(
   link: Pick<ResolvedThreadLink, "backend" | "instanceId" | "threadId">,
@@ -226,6 +279,25 @@ export function useLiveThreadLink(link: ResolvedThreadLink): ResolvedThreadLink 
   );
 }
 
+/**
+ * Whether a hovered or focused thread link currently points at `threadKey`
+ * (a `buildThreadIdentityKey` value). Subscribes per row, so only the rows
+ * whose answer flips re-render. Always false outside a `ThreadLinkProvider`.
+ */
+export function useThreadLinkHoverTarget(threadKey: string): boolean {
+  const links = useThreadLinks();
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      links?.subscribeHoverTarget(listener) ?? (() => {}),
+    [links],
+  );
+  const getSnapshot = useCallback(
+    () => links?.getHoverTargetKey() === threadKey,
+    [links, threadKey],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+
 export function ThreadLinkProvider(props: {
   children: ReactNode;
   onOpenRemoteViewer?: (request: {
@@ -251,6 +323,11 @@ export function ThreadLinkProvider(props: {
     metadataStoreRef.current = new ThreadLinkMetadataStore(threads);
   }
   const metadataStore = metadataStoreRef.current;
+  const hoverStoreRef = useRef<ThreadLinkHoverStore | null>(null);
+  if (!hoverStoreRef.current) {
+    hoverStoreRef.current = new ThreadLinkHoverStore();
+  }
+  const hoverStore = hoverStoreRef.current;
   const threadsRef = useRef(threads);
   threadsRef.current = threads;
   const metadataKey = threadLinkMetadataKey(threads);
@@ -372,11 +449,20 @@ export function ThreadLinkProvider(props: {
       subscribe(link, listener) {
         return metadataStore.subscribe(link, listener);
       },
+      setHoverTarget(link) {
+        hoverStore.set(link);
+      },
+      getHoverTargetKey() {
+        return hoverStore.get();
+      },
+      subscribeHoverTarget(listener) {
+        return hoverStore.subscribe(listener);
+      },
     };
     // Rebuild only when membership changes; `threadsRef`/`onShowThreadRef`
     // carry the freshest values so no other deps are needed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [membershipKey, metadataStore]);
+  }, [hoverStore, membershipKey, metadataStore]);
 
   return <ThreadLinkContext.Provider value={value}>{props.children}</ThreadLinkContext.Provider>;
 }

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -343,6 +343,8 @@ export function useThreadLinkHoverTarget(threadKey: string): boolean {
  * sidebar card then reads as a stuck highlight. `:focus-visible` is the
  * platform's own answer to "did the user get here by keyboard".
  */
+type HoverSourceOwner = { active: boolean };
+
 function isFocusVisible(element: Element): boolean {
   try {
     return element.matches(":focus-visible");
@@ -358,36 +360,62 @@ function isFocusVisible(element: Element): boolean {
  * in place if `target` changes while the pointer still rests on the link
  * (the title-bar link after a thread switch). Inert outside a provider.
  *
- * Each caller is one owner in the store, so releasing here never darkens a
- * highlight another link still holds.
+ * The pointer and focus are **independent** inputs and register as separate
+ * owners, because either can outlive the other on the same link: a pointer
+ * drifting off a Tab-focused link, or the blur Chromium delivers when the
+ * window is deactivated under a resting pointer. A shared owner would let
+ * whichever input ended first darken the row the other still holds.
+ *
+ * Each owner is distinct in the store, so releasing here never darkens a
+ * highlight another link holds either.
  */
 export function useThreadLinkHoverSource(
   target: ThreadLinkHoverTarget | undefined,
 ): {
-  show: () => void;
-  /** `show`, gated on visible keyboard focus — wire to `onFocus`. */
+  showFromPointer: () => void;
+  hideFromPointer: () => void;
+  /** Gated on visible keyboard focus — wire to `onFocus`. */
   showFromFocus: (element: Element) => void;
-  hide: () => void;
+  hideFromFocus: () => void;
+  /** Drop both inputs at once, for a link that was just activated. */
+  release: () => void;
 } {
   const store = useThreadLinks()?.hoverTarget;
-  // The owner token doubles as the "am I currently showing" flag so the
-  // re-point effect below can tell a resting pointer from an idle link.
-  const ownerRef = useRef<{ active: boolean }>({ active: false });
+  // Each owner token doubles as its own "am I currently showing" flag, so the
+  // re-point effect below can tell a resting input from an idle one.
+  const pointerOwnerRef = useRef<HoverSourceOwner>({ active: false });
+  const focusOwnerRef = useRef<HoverSourceOwner>({ active: false });
   const storeRef = useRef(store);
   storeRef.current = store;
   const targetRef = useRef(target);
   targetRef.current = target;
   const targetKey = target ? threadLinkHoverKey(target) : undefined;
+  const mountedRef = useRef(true);
 
-  const show = useCallback(() => {
-    const owner = ownerRef.current;
+  const showOwner = useCallback((owner: HoverSourceOwner) => {
     owner.active = true;
     const current = targetRef.current;
     if (current) {
       storeRef.current?.set(owner, current);
     }
   }, []);
-  const mountedRef = useRef(true);
+  const hideOwner = useCallback((owner: HoverSourceOwner) => {
+    owner.active = false;
+    storeRef.current?.clear(owner);
+  }, []);
+
+  const showFromPointer = useCallback(
+    () => showOwner(pointerOwnerRef.current),
+    [showOwner],
+  );
+  const hideFromPointer = useCallback(
+    () => hideOwner(pointerOwnerRef.current),
+    [hideOwner],
+  );
+  const hideFromFocus = useCallback(
+    () => hideOwner(focusOwnerRef.current),
+    [hideOwner],
+  );
   const showFromFocus = useCallback(
     (element: Element) => {
       // Read `:focus-visible` once the focus dispatch has settled rather than
@@ -395,45 +423,47 @@ export function useThreadLinkHoverSource(
       // longer matches, and an unmounted source stays silent.
       queueMicrotask(() => {
         if (mountedRef.current && isFocusVisible(element)) {
-          show();
+          showOwner(focusOwnerRef.current);
         }
       });
     },
-    [show],
+    [showOwner],
   );
-  const hide = useCallback(() => {
-    const owner = ownerRef.current;
-    owner.active = false;
-    storeRef.current?.clear(owner);
-  }, []);
+  const release = useCallback(() => {
+    hideOwner(pointerOwnerRef.current);
+    hideOwner(focusOwnerRef.current);
+  }, [hideOwner]);
 
-  // The link's target changed under a resting pointer: follow it, so the row
-  // that is lit is always the one activation would open.
+  // The link's target changed under a resting pointer or focus: follow it, so
+  // the row that is lit is always the one activation would open.
   useEffect(() => {
-    const owner = ownerRef.current;
-    if (!owner.active) {
-      return;
-    }
-    const current = targetRef.current;
-    if (current) {
-      storeRef.current?.set(owner, current);
-    } else {
-      storeRef.current?.clear(owner);
+    for (const owner of [pointerOwnerRef.current, focusOwnerRef.current]) {
+      if (!owner.active) {
+        continue;
+      }
+      const current = targetRef.current;
+      if (current) {
+        storeRef.current?.set(owner, current);
+      } else {
+        storeRef.current?.clear(owner);
+      }
     }
   }, [targetKey]);
 
   // A link can unmount under the pointer (its message re-renders, the
   // transcript navigates away) without ever seeing mouseleave.
   useEffect(() => {
-    const owner = ownerRef.current;
+    const pointerOwner = pointerOwnerRef.current;
+    const focusOwner = focusOwnerRef.current;
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
-      storeRef.current?.clear(owner);
+      storeRef.current?.clear(pointerOwner);
+      storeRef.current?.clear(focusOwner);
     };
   }, []);
 
-  return { show, showFromFocus, hide };
+  return { showFromPointer, hideFromPointer, showFromFocus, hideFromFocus, release };
 }
 
 export function ThreadLinkProvider(props: {

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -13,6 +13,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -50,14 +51,12 @@ export type ThreadLinkContextValue = {
   getSnapshot: (link: ResolvedThreadLink) => ResolvedThreadLink;
   subscribe: (link: ResolvedThreadLink, listener: () => void) => () => void;
   /**
-   * Marks the thread a hovered or focused link points at, so the matching
-   * sidebar card can light up while the pointer rests on the link. Pass
-   * `undefined` when the pointer leaves. Rows read it through
-   * `useThreadLinkHoverTarget`.
+   * Which sidebar card a hovered or focused thread link points at. Sources
+   * (`ThreadChip`, the title-bar link) write it through
+   * `useThreadLinkHoverSource`; rows read it through `useThreadLinkHoverTarget`.
+   * One store instance per provider, stable across membership rebuilds.
    */
-  setHoverTarget: (link: ThreadLinkHoverTarget | undefined) => void;
-  getHoverTargetKey: () => string | undefined;
-  subscribeHoverTarget: (listener: () => void) => () => void;
+  hoverTarget: ThreadLinkHoverStore;
 };
 
 export type ThreadLinkHoverTarget = Pick<ResolvedThreadLink, "backend" | "threadId">;
@@ -68,7 +67,7 @@ export type ThreadLinkHoverTarget = Pick<ResolvedThreadLink, "backend" | "thread
  * `composerSourceThreadKey`, so a link to a pinned remote thread lights up
  * that row too — the instance is deliberately not part of the match.
  */
-export function threadLinkHoverKey(link: ThreadLinkHoverTarget): string {
+function threadLinkHoverKey(link: ThreadLinkHoverTarget): string {
   return buildThreadIdentityKey(link.backend, link.threadId);
 }
 
@@ -76,31 +75,68 @@ export function threadLinkHoverKey(link: ThreadLinkHoverTarget): string {
  * Hover state is a separate store from the metadata store: it changes on
  * every pointer enter/leave, and only the row it names (plus the one it just
  * left) should re-render — not the provider, and not the transcript.
+ * Listeners are partitioned by thread key for that reason.
+ *
+ * Owner-aware: hover and keyboard focus are independent inputs from
+ * different elements, so several sources can hold a target at once (a
+ * Tab-focused chip while the pointer crosses another). Each source registers
+ * under its own owner token; the most recently set owner wins, and clearing
+ * an owner falls back to whoever else still holds one rather than wiping the
+ * slot — a chip's mouseleave never darkens a highlight the focused title link
+ * still owns.
  */
-class ThreadLinkHoverStore {
-  private key: string | undefined;
-  private listeners = new Set<() => void>();
+export class ThreadLinkHoverStore {
+  /** Owner → key, in set order; the last entry is the current target. */
+  private holders = new Map<object, string>();
+  private currentKey: string | undefined;
+  private listeners = new Map<string, Set<() => void>>();
 
   get(): string | undefined {
-    return this.key;
+    return this.currentKey;
   }
 
-  set(link: ThreadLinkHoverTarget | undefined): void {
-    const nextKey = link ? threadLinkHoverKey(link) : undefined;
-    if (nextKey === this.key) {
+  set(owner: object, target: ThreadLinkHoverTarget): void {
+    const key = threadLinkHoverKey(target);
+    // Re-insert so a re-set moves this owner to the most-recent position.
+    this.holders.delete(owner);
+    this.holders.set(owner, key);
+    this.recompute();
+  }
+
+  clear(owner: object): void {
+    if (this.holders.delete(owner)) {
+      this.recompute();
+    }
+  }
+
+  subscribe(key: string, listener: () => void): () => void {
+    const listeners = this.listeners.get(key) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(key, listeners);
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        this.listeners.delete(key);
+      }
+    };
+  }
+
+  private recompute(): void {
+    let nextKey: string | undefined;
+    for (const key of this.holders.values()) {
+      nextKey = key;
+    }
+    if (nextKey === this.currentKey) {
       return;
     }
-    this.key = nextKey;
-    for (const listener of this.listeners) {
-      listener();
+    const previousKey = this.currentKey;
+    this.currentKey = nextKey;
+    for (const key of [previousKey, nextKey]) {
+      if (key === undefined) continue;
+      for (const listener of this.listeners.get(key) ?? []) {
+        listener();
+      }
     }
-  }
-
-  subscribe(listener: () => void): () => void {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
   }
 }
 
@@ -285,17 +321,119 @@ export function useLiveThreadLink(link: ResolvedThreadLink): ResolvedThreadLink 
  * whose answer flips re-render. Always false outside a `ThreadLinkProvider`.
  */
 export function useThreadLinkHoverTarget(threadKey: string): boolean {
-  const links = useThreadLinks();
+  // The store is a stable per-provider instance, so these deps do not churn
+  // when the context value is rebuilt on a membership change.
+  const store = useThreadLinks()?.hoverTarget;
   const subscribe = useCallback(
-    (listener: () => void) =>
-      links?.subscribeHoverTarget(listener) ?? (() => {}),
-    [links],
+    (listener: () => void) => store?.subscribe(threadKey, listener) ?? (() => {}),
+    [store, threadKey],
   );
   const getSnapshot = useCallback(
-    () => links?.getHoverTargetKey() === threadKey,
-    [links, threadKey],
+    () => store?.get() === threadKey,
+    [store, threadKey],
   );
   return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+
+/**
+ * Whether focus on `element` should be treated as visible keyboard focus.
+ * Focus also arrives programmatically (a context menu returning focus to its
+ * invoker, Chromium re-dispatching focus to the active element when the
+ * window is re-activated) with the pointer nowhere near the link; lighting a
+ * sidebar card then reads as a stuck highlight. `:focus-visible` is the
+ * platform's own answer to "did the user get here by keyboard".
+ */
+function isFocusVisible(element: Element): boolean {
+  try {
+    return element.matches(":focus-visible");
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * The write side of the hover-target store, for an element that links to a
+ * thread. Returns handlers to wire to the link's pointer and focus events;
+ * the highlight is released on mouseleave/blur, on unmount, and is re-pointed
+ * in place if `target` changes while the pointer still rests on the link
+ * (the title-bar link after a thread switch). Inert outside a provider.
+ *
+ * Each caller is one owner in the store, so releasing here never darkens a
+ * highlight another link still holds.
+ */
+export function useThreadLinkHoverSource(
+  target: ThreadLinkHoverTarget | undefined,
+): {
+  show: () => void;
+  /** `show`, gated on visible keyboard focus — wire to `onFocus`. */
+  showFromFocus: (element: Element) => void;
+  hide: () => void;
+} {
+  const store = useThreadLinks()?.hoverTarget;
+  // The owner token doubles as the "am I currently showing" flag so the
+  // re-point effect below can tell a resting pointer from an idle link.
+  const ownerRef = useRef<{ active: boolean }>({ active: false });
+  const storeRef = useRef(store);
+  storeRef.current = store;
+  const targetRef = useRef(target);
+  targetRef.current = target;
+  const targetKey = target ? threadLinkHoverKey(target) : undefined;
+
+  const show = useCallback(() => {
+    const owner = ownerRef.current;
+    owner.active = true;
+    const current = targetRef.current;
+    if (current) {
+      storeRef.current?.set(owner, current);
+    }
+  }, []);
+  const mountedRef = useRef(true);
+  const showFromFocus = useCallback(
+    (element: Element) => {
+      // Read `:focus-visible` once the focus dispatch has settled rather than
+      // mid-event: an element that lost focus again in between simply no
+      // longer matches, and an unmounted source stays silent.
+      queueMicrotask(() => {
+        if (mountedRef.current && isFocusVisible(element)) {
+          show();
+        }
+      });
+    },
+    [show],
+  );
+  const hide = useCallback(() => {
+    const owner = ownerRef.current;
+    owner.active = false;
+    storeRef.current?.clear(owner);
+  }, []);
+
+  // The link's target changed under a resting pointer: follow it, so the row
+  // that is lit is always the one activation would open.
+  useEffect(() => {
+    const owner = ownerRef.current;
+    if (!owner.active) {
+      return;
+    }
+    const current = targetRef.current;
+    if (current) {
+      storeRef.current?.set(owner, current);
+    } else {
+      storeRef.current?.clear(owner);
+    }
+  }, [targetKey]);
+
+  // A link can unmount under the pointer (its message re-renders, the
+  // transcript navigates away) without ever seeing mouseleave.
+  useEffect(() => {
+    const owner = ownerRef.current;
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      storeRef.current?.clear(owner);
+    };
+  }, []);
+
+  return { show, showFromFocus, hide };
 }
 
 export function ThreadLinkProvider(props: {
@@ -449,15 +587,7 @@ export function ThreadLinkProvider(props: {
       subscribe(link, listener) {
         return metadataStore.subscribe(link, listener);
       },
-      setHoverTarget(link) {
-        hoverStore.set(link);
-      },
-      getHoverTargetKey() {
-        return hoverStore.get();
-      },
-      subscribeHoverTarget(listener) {
-        return hoverStore.subscribe(listener);
-      },
+      hoverTarget: hoverStore,
     };
     // Rebuild only when membership changes; `threadsRef`/`onShowThreadRef`
     // carry the freshest values so no other deps are needed.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4145,8 +4145,15 @@ textarea,
    foreground flips to the on-accent token and meta chips invert to readable
    pills. Declared after `.thread-row:hover` (equal specificity) so the fill
    survives hover. Clears automatically when the composer materializes, is
-   cancelled, or the user navigates away. */
-.thread-row.is-composer-source {
+   cancelled, or the user navigates away.
+
+   `.is-link-target` is the same treatment on a different trigger: a thread
+   link elsewhere in the window (a transcript provenance chip, the title-bar
+   thread link) is hovered or focused and points at this card. Sharing the
+   rule keeps "the card this points at" one visual idea; it lasts only as
+   long as the pointer rests on the link (see ThreadRow / thread-links). */
+.thread-row.is-composer-source,
+.thread-row.is-link-target {
   border-color: var(--accent);
   background: var(--accent);
   color: var(--accent-on);
@@ -4156,17 +4163,21 @@ textarea,
 }
 
 .thread-row.is-composer-source .thread-row__time,
-.thread-row.is-composer-source .thread-row__summary {
+.thread-row.is-composer-source .thread-row__summary,
+.thread-row.is-link-target .thread-row__time,
+.thread-row.is-link-target .thread-row__summary {
   color: var(--accent-on);
 }
 
-.thread-row.is-composer-source .thread-row__chip {
+.thread-row.is-composer-source .thread-row__chip,
+.thread-row.is-link-target .thread-row__chip {
   border-color: transparent;
   background: var(--accent-on);
   color: var(--accent);
 }
 
-.thread-row.is-composer-source .thread-row__status-cookie {
+.thread-row.is-composer-source .thread-row__status-cookie,
+.thread-row.is-link-target .thread-row__status-cookie {
   border-color: var(--accent-on);
   background: var(--accent-on);
   box-shadow: none;
@@ -4175,7 +4186,8 @@ textarea,
 /* The thinking sweep is an accent-on-accent gradient — invisible on the solid
    accent fill. Recolor it to the on-accent token so a source card that's still
    working stays legible. */
-.thread-row.is-composer-source .thinking-scanner__beam {
+.thread-row.is-composer-source .thinking-scanner__beam,
+.thread-row.is-link-target .thinking-scanner__beam {
   background: linear-gradient(
     90deg,
     color-mix(in srgb, var(--accent-on) 18%, transparent) 0%,


### PR DESCRIPTION
## Summary

Hovering (or keyboard-focusing) a thread link now lights up the sidebar card it points at, in the same solid-accent treatment a sub-thread composer already gives its source card. Applies to:

- transcript **provenance chips** (`AGENT #PR #31 …` message-header chip),
- `pwragent://thread/…` chips inside markdown, tool output, and notices — anything rendered through `ThreadChip`,
- the **title-bar thread link** (“Show selected thread in thread list”).

Only rows already on screen respond; nothing scrolls until the link is activated. The highlight lasts exactly as long as the pointer/focus rests on the link.

## How

- `lib/thread-links.tsx`: a small hover store on the existing thread-link context — `setHoverTarget(link)`, plus a per-row `useThreadLinkHoverTarget(threadKey)` hook backed by `useSyncExternalStore`. It is deliberately **not** React state on the provider: an enter/leave re-renders only the row whose answer flips, not the provider and not the transcript. Match key is `buildThreadIdentityKey(backend, threadId)`, the same key `ThreadRow` and `composerSourceThreadKey` already use.
- `ThreadRow`: adds `.is-link-target` when the hovered link points at it.
- `app.css`: `.is-link-target` is appended to the existing `.is-composer-source` selector lists (fill, time/summary, chips, cookie, thinking beam) — no new tokens or duplicated rules.
- `ThreadChip` / `ThreadHeader`: set the target on mouseenter/focus, clear on mouseleave/blur/activate, and also clear if the element unmounts or the header switches threads under a resting pointer (no mouseleave fires for that).

## Test plan

- [x] New `thread-link-hover-target.test.tsx` (7 tests): chip hover lights only the linked row and clears on leave; focus/blur; activate clears; hovered chip unmount clears; title-bar link hover/focus lights the selected row; header thread switch under the pointer drops the stale highlight; inert outside a `ThreadLinkProvider`.
- [x] Existing `thread-links`, `ThreadHeader`, `thread-row-chips`, `AppNoticeToast`, `theme-contract`, `sidebar` suites pass (302 tests).
- [x] `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`.
- [ ] Not visually verified in a running app — the CSS is the existing composer-source rule set with one more selector, so what you see is the same orange card the sub-thread launchpad shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)