### PR TITLE
feat(desktop): glass drag strip for the full-bleed Star Map window

### DIFF
--- a/apps/desktop/src/main/star-map-window.ts
+++ b/apps/desktop/src/main/star-map-window.ts
@@ -30,6 +30,7 @@ import {
   positionWindowForSourceDisplay,
   type WindowPlacementSource,
 } from "./window-placement";
+import { attachWindowFullscreenSync } from "./window-fullscreen-sync";
 
 const log = getMainLogger("pwragent:star-map-window");
 const STAR_MAP_WINDOW_TITLE = "Federation Star Map";
@@ -95,6 +96,13 @@ export function showStarMapWindow(source: WindowPlacementSource = {}): void {
   hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);
+  // This is the one auxiliary window that can go native-fullscreen, and
+  // macOS hides the stoplights when it does. The renderer reserves their
+  // gutter in `.star-map__chrome` and paints a drag strip across the top
+  // of the sky; both read `<html data-fullscreen>` to stand down, and
+  // that attribute only exists if this window forwards its fullscreen
+  // transitions the way the main window does.
+  attachWindowFullscreenSync(window);
   // The map is a live surface: thread status, star-map arrangement
   // deltas, and federation peer changes all arrive as agent events, so
   // this window subscribes to that push channel (unlike the polling

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2696,7 +2696,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
   return (
     <div
       ref={layerRef}
-      className="star-map"
+      // `is-flying` mirrors the pointer pan's `is-panning` for keyboard
+      // flight, so the window's glass title strip can brighten its edge
+      // whenever the sky is moving under it, whichever hand moves it.
+      className={heldCameraKeys.size > 0 ? "star-map is-flying" : "star-map"}
       role="region"
       aria-label="Star Map"
       tabIndex={-1}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -52,12 +52,24 @@ export function StarMapWindow() {
   // Windows draws its caption buttons in a frameless overlay, so the
   // window needs a painted drag strip the way every other aux window
   // does. macOS keeps the map full-bleed: the map's own top chrome
-  // already reserves the stoplight gutter and the native title-bar band
-  // handles dragging. Linux keeps its normal OS frame.
-  const isWindows = getDesktopApi()?.platform === "win32";
+  // already reserves the stoplight gutter, but `hiddenInset` leaves no
+  // native title-bar band to grab, so a transparent glass strip over the
+  // top of the sky is the window's only drag handle. Linux keeps its
+  // normal OS frame.
+  const platform = getDesktopApi()?.platform;
+  const isWindows = platform === "win32";
+  const isMac = platform === "darwin";
 
   return (
     <div className="star-map-window">
+      {isMac ? (
+        // Purely a window-drag handle: `-webkit-app-region: drag` means
+        // macOS takes the mouse-down before the DOM sees it, so nothing
+        // here can (or should) start a canvas pan. The map's own top
+        // chrome and filter chips carve `no-drag` holes so they stay
+        // clickable inside the strip. Decorative to assistive tech.
+        <div aria-hidden="true" className="star-map-window__titlebar" />
+      ) : null}
       {isWindows ? (
         <header className="activity-titlebar">
           <p className="activity-titlebar__brand">

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
@@ -74,15 +74,17 @@ describe("star map idle performance", () => {
     expect(css).not.toContain(".star-map__link-flow");
   });
 
-  it("promotes the large canvas only while pointer-panning", () => {
+  it("promotes the large canvas only while it is moving", () => {
     const canvasRule = css.match(
       /\.star-map__canvas\.is-transformed\s*\{[\s\S]*?\n\}/,
     )?.[0];
-    const panningRule = css.match(
-      /\.star-map__viewport\.is-panning \.star-map__canvas\.is-transformed\s*\{[\s\S]*?\n\}/,
+    // Pointer pan and keyboard flight both write the transform every
+    // frame; neither promotion may outlive its gesture.
+    const movingRule = css.match(
+      /\.star-map__viewport\.is-panning \.star-map__canvas\.is-transformed,\s*\.star-map\.is-flying \.star-map__canvas\.is-transformed\s*\{[\s\S]*?\n\}/,
     )?.[0];
     expect(canvasRule).not.toContain("will-change");
-    expect(panningRule).toContain("will-change: transform;");
+    expect(movingRule).toContain("will-change: transform;");
   });
 
   it("updates card layout from ResizeObserver without reading offsetHeight", async () => {

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -72,8 +72,9 @@ const unsubscribeAppearance = desktopApi?.onAppearanceChanged?.(
 // Mirror native fullscreen state onto <html data-fullscreen>. macOS hides
 // the traffic-light stoplights in fullscreen, so app.css reads this to
 // drop the reserved stoplight inset that would otherwise leave a dead gap
-// at the left of the masthead. Only the main window ever fires this (aux
-// windows are not fullscreenable); the listener is harmless elsewhere.
+// at the left of the masthead. Fired by the main window and by the Star
+// Map window (the one fullscreenable aux window, which drops its stoplight
+// gutter and drag strip the same way); harmless in the others.
 const unsubscribeFullscreen = desktopApi?.onWindowFullscreen?.(
   (isFullScreen) => {
     if (isFullScreen) {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -943,6 +943,39 @@ describe("Tangerine Terminal theme contract", () => {
     expect(windowRule).toMatch(/z-index:\s*\d+;/);
   });
 
+  it("gives the full-bleed Star Map window a glass drag strip that its top chrome punches through", () => {
+    // macOS `hiddenInset` leaves the map with stoplights but no native
+    // title-bar band, and the sky underneath is a pan handle, so the
+    // transparent strip is the only place the operator can grab the window.
+    // The two clusters that live inside it must opt out, or their pixels
+    // fall back to window-drag hit-testing and swallow the click.
+    const stripRule = extractRuleBody(css, ".star-map-window__titlebar");
+    expect(stripRule).toContain("-webkit-app-region: drag;");
+    expect(stripRule).toContain("position: absolute;");
+    expect(stripRule).toContain("backdrop-filter:");
+    // Below the filters (3) and chrome (4) it hosts, above the canvas.
+    const readZIndex = (rule: string): number =>
+      Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
+    expect(readZIndex(stripRule)).toBeLessThan(
+      readZIndex(extractRuleBody(css, ".star-map__filters")),
+    );
+    expect(readZIndex(stripRule)).toBeLessThan(
+      readZIndex(extractRuleBody(css, ".star-map__chrome")),
+    );
+    expect(css).toMatch(
+      /\.star-map__chrome,\s*\.star-map__chrome \*,\s*\.star-map__filters,\s*\.star-map__filters \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+    );
+    // The edge brightens whenever the sky moves under it — pointer pan and
+    // keyboard flight alike — and the strip disappears in fullscreen, where
+    // there is no window to drag.
+    expect(css).toMatch(
+      /\.star-map-window:has\(\.star-map__viewport\.is-panning\) \.star-map-window__titlebar::before,\s*\.star-map-window:has\(\.star-map\.is-flying\) \.star-map-window__titlebar::before,/,
+    );
+    expect(css).toMatch(
+      /:root\[data-fullscreen="true"\] \.star-map-window__titlebar\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
+    );
+  });
+
   it("right-aligns the keyboard shortcut hint chip on context menu items", () => {
     // The `__shortcut` chip is the discoverability surface for
     // the otherwise-invisible Cmd+(Shift+)Arrow reorder shortcut.

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -57,6 +57,11 @@ function extractRuleBody(source: string, selector: string): string {
   return ruleMatch.groups.body;
 }
 
+/** First `z-index` in a rule body, NaN when the rule declares none. */
+function readZIndex(rule: string): number {
+  return Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
+}
+
 function expandHex(hex: string): string {
   const normalized = hex.replace("#", "");
   if (normalized.length === 3) {
@@ -925,9 +930,6 @@ describe("Tangerine Terminal theme contract", () => {
       css,
       ".app-notice-toast__thread-menu",
     );
-    const readZIndex = (rule: string): number =>
-      Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
-
     expect(readZIndex(toastThreadMenuRule)).toBeGreaterThan(
       readZIndex(toastStackRule),
     );
@@ -954,8 +956,6 @@ describe("Tangerine Terminal theme contract", () => {
     expect(stripRule).toContain("position: absolute;");
     expect(stripRule).toContain("backdrop-filter:");
     // Below the filters (3) and chrome (4) it hosts, above the canvas.
-    const readZIndex = (rule: string): number =>
-      Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
     expect(readZIndex(stripRule)).toBeLessThan(
       readZIndex(extractRuleBody(css, ".star-map__filters")),
     );
@@ -963,13 +963,22 @@ describe("Tangerine Terminal theme contract", () => {
       readZIndex(extractRuleBody(css, ".star-map__chrome")),
     );
     expect(css).toMatch(
-      /\.star-map__chrome,\s*\.star-map__chrome \*,\s*\.star-map__filters,\s*\.star-map__filters \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+      /\.star-map__chrome,\s*\.star-map__chrome \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+    );
+    expect(css).toMatch(
+      /\.star-map__filters,\s*\.star-map__filters \*,[\s\S]*?\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+    );
+    // The intake dialog is body-portaled and full-window, so its scrim
+    // overlaps the strip's rect and would otherwise turn a dismiss-click
+    // near the top into a window drag.
+    expect(css).toMatch(
+      /\.star-map-intake,\s*\.star-map-intake \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
     );
     // The edge brightens whenever the sky moves under it — pointer pan and
     // keyboard flight alike — and the strip disappears in fullscreen, where
     // there is no window to drag.
     expect(css).toMatch(
-      /\.star-map-window:has\(\.star-map__viewport\.is-panning\) \.star-map-window__titlebar::before,\s*\.star-map-window:has\(\.star-map\.is-flying\) \.star-map-window__titlebar::before,/,
+      /\.star-map-window:has\(\.star-map__viewport\.is-panning, \.star-map\.is-flying\)\s*\.star-map-window__titlebar::before,/,
     );
     expect(css).toMatch(
       /:root\[data-fullscreen="true"\] \.star-map-window__titlebar\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10860,9 +10860,14 @@ textarea,
    for the wrong handle. z-index 2 sits above the transformed canvas (its
    own stacking context, so card z-indexes cannot climb out) and below the
    `.star-map__filters` (3) and `.star-map__chrome` (4) that live inside it;
-   both of those carve `no-drag` holes so they stay clickable. Not rendered
-   on Windows (painted `.activity-titlebar` above the map) or Linux (OS
-   frame). */
+   both of those carve `no-drag` holes so they stay clickable (the card
+   no-drag list further down does the same for anything panned up under
+   the glass, so it goes inert rather than turning into a window drag).
+   The strip owns pointer events in its band: wheel there is lost to the
+   map, deliberately, so a press can never start both a window drag and a
+   canvas pan. Not rendered on Windows (painted `.activity-titlebar` above
+   the map) or Linux (OS frame); hidden in fullscreen, which
+   `star-map-window.ts` forwards to `<html data-fullscreen>`. */
 .star-map-window__titlebar {
   position: absolute;
   top: 0;
@@ -10870,20 +10875,14 @@ textarea,
   left: 0;
   z-index: 2;
   height: 52px;
-  background:
-    linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--bg-app) 42%, transparent),
-      color-mix(in srgb, var(--bg-app) 12%, transparent)
-    );
-  -webkit-backdrop-filter: blur(12px) saturate(135%);
   backdrop-filter: blur(12px) saturate(135%);
   -webkit-app-region: drag;
 }
 
-/* Extra tint that fades in while the sky moves. A separate layer because
-   gradients do not interpolate: swapping the background would snap, and
-   an opacity ramp on this sheet cross-fades instead. */
+/* The tint, drawn at its moving strength and dimmed through opacity at
+   rest. A pseudo-element rather than a background on the strip because
+   gradients do not interpolate: swapping backgrounds would snap, and one
+   opacity ramp cross-fades. */
 .star-map-window__titlebar::before {
   content: "";
   position: absolute;
@@ -10891,18 +10890,17 @@ textarea,
   background:
     linear-gradient(
       to bottom,
-      color-mix(in srgb, var(--bg-app) 30%, transparent),
-      color-mix(in srgb, var(--bg-app) 14%, transparent)
+      color-mix(in srgb, var(--bg-app) 60%, transparent),
+      color-mix(in srgb, var(--bg-app) 24%, transparent)
     );
-  opacity: 0;
+  opacity: 0.7;
   transition: opacity 220ms ease;
 }
 
 /* The glass edge. A hairline that fades out toward both ends (so it reads
    as a lit edge, not a ruled border) over a soft shadow that darkens the
-   sky just beneath it, which is what gives the sheet its thickness. Drawn
-   at its moving strength and dimmed through opacity at rest, so the same
-   ramp brightens it. */
+   sky just beneath it, which is what gives the sheet its thickness. Same
+   draw-bright-dim-at-rest ramp as the tint above. */
 .star-map-window__titlebar::after {
   content: "";
   position: absolute;
@@ -10918,15 +10916,15 @@ textarea,
       color-mix(in srgb, var(--text-primary) 36%, transparent) 86%,
       transparent
     );
-  box-shadow: 0 1px 8px color-mix(in srgb, var(--bg-app) 70%, transparent);
+  box-shadow: 0 1px 8px var(--shadow-tint-soft);
   opacity: 0.45;
   transition: opacity 220ms ease;
 }
 
-.star-map-window:has(.star-map__viewport.is-panning) .star-map-window__titlebar::before,
-.star-map-window:has(.star-map.is-flying) .star-map-window__titlebar::before,
-.star-map-window:has(.star-map__viewport.is-panning) .star-map-window__titlebar::after,
-.star-map-window:has(.star-map.is-flying) .star-map-window__titlebar::after {
+.star-map-window:has(.star-map__viewport.is-panning, .star-map.is-flying)
+  .star-map-window__titlebar::before,
+.star-map-window:has(.star-map__viewport.is-panning, .star-map.is-flying)
+  .star-map-window__titlebar::after {
   opacity: 1;
 }
 
@@ -11354,6 +11352,16 @@ textarea,
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* The dialog is body-portaled and full-window, so on macOS its top 52px
+   overlap the glass drag strip's rect. Draggable regions ignore z-order:
+   without this, a click on the scrim up there moves the window instead of
+   dismissing the dialog. Punching out the whole overlay is fine — a modal
+   is the one time the window has no business moving. */
+.star-map-intake,
+.star-map-intake * {
+  -webkit-app-region: no-drag;
 }
 
 .star-map-intake__backdrop {
@@ -12362,7 +12370,8 @@ textarea,
 /* Promote the large canvas only for the direct-manipulation window. Keeping
    the whole off-screen map permanently promoted retains a large compositor
    surface even while the operator is only reading it. */
-.star-map__viewport.is-panning .star-map__canvas.is-transformed {
+.star-map__viewport.is-panning .star-map__canvas.is-transformed,
+.star-map.is-flying .star-map__canvas.is-transformed {
   will-change: transform;
 }
 
@@ -12453,14 +12462,8 @@ textarea,
   cursor: pointer;
 }
 
-/* Both top clusters sit inside the macOS glass drag strip
-   (`.star-map-window__titlebar`). Draggable regions are rect-unions, so
-   every descendant has to opt out or its pixels fall back to window-drag
-   hit-testing and swallow the click. */
 .star-map__chrome,
-.star-map__chrome *,
-.star-map__filters,
-.star-map__filters * {
+.star-map__chrome * {
   -webkit-app-region: no-drag;
 }
 
@@ -12605,12 +12608,14 @@ textarea,
   color: var(--text-primary);
 }
 
-/* The map's top chrome sits inside the macOS title-bar drag band, and
-   Chromium ignores `-webkit-app-region` on inline-level boxes - a plain
-   <button> there has its clicks swallowed by the OS (the same trap
-   documented on .messaging-status-bar). Every interactive element gets an
-   explicit no-drag on a non-inline box; the bare sky stays draggable so
-   the window can still be moved while the map is open. */
+/* The map's top chrome sits inside the macOS glass drag strip
+   (`.star-map-window__titlebar`; `.star-map__chrome` opts out beside its
+   own rule), and Chromium ignores `-webkit-app-region` on inline-level
+   boxes - a plain <button> there has its clicks swallowed by the OS (the
+   same trap documented on .messaging-status-bar). Draggable regions are
+   rect unions independent of z-order, so every interactive element gets an
+   explicit no-drag on a non-inline box: anything panned up under the strip
+   goes inert behind the glass rather than turning into a window drag. */
 .star-map__filters,
 .star-map__filters *,
 .star-map-instance,
@@ -12619,6 +12624,10 @@ textarea,
 .star-map-card *,
 .star-map-load-card,
 .star-map-load-card *,
+.star-map-chat-card,
+.star-map-chat-card *,
+.star-map-satellite-card,
+.star-map-satellite-card *,
 .star-map__cluster-label,
 .star-map__cluster-label *,
 .star-map__cluster-overflow {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10848,6 +10848,94 @@ textarea,
     var(--bg-app);
 }
 
+/* macOS drag handle for the full-bleed map. `hiddenInset` keeps the
+   stoplights but leaves no native title-bar band, and the sky underneath is
+   a pan handle, so this transparent strip is the only place the operator
+   can grab the window. It reads as a sheet of glass laid over the top of
+   the sky: a faint tint plus backdrop blur, finished with a specular
+   hairline along its bottom edge. At rest the hairline alone says "there is
+   a bar here"; while the map moves (pointer pan or WASD flight) the tint
+   and edge both step up, and the blur smears whatever slides underneath, so
+   the strip is legible exactly when the operator is most likely to reach
+   for the wrong handle. z-index 2 sits above the transformed canvas (its
+   own stacking context, so card z-indexes cannot climb out) and below the
+   `.star-map__filters` (3) and `.star-map__chrome` (4) that live inside it;
+   both of those carve `no-drag` holes so they stay clickable. Not rendered
+   on Windows (painted `.activity-titlebar` above the map) or Linux (OS
+   frame). */
+.star-map-window__titlebar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 2;
+  height: 52px;
+  background:
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--bg-app) 42%, transparent),
+      color-mix(in srgb, var(--bg-app) 12%, transparent)
+    );
+  -webkit-backdrop-filter: blur(12px) saturate(135%);
+  backdrop-filter: blur(12px) saturate(135%);
+  -webkit-app-region: drag;
+}
+
+/* Extra tint that fades in while the sky moves. A separate layer because
+   gradients do not interpolate: swapping the background would snap, and
+   an opacity ramp on this sheet cross-fades instead. */
+.star-map-window__titlebar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--bg-app) 30%, transparent),
+      color-mix(in srgb, var(--bg-app) 14%, transparent)
+    );
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+/* The glass edge. A hairline that fades out toward both ends (so it reads
+   as a lit edge, not a ruled border) over a soft shadow that darkens the
+   sky just beneath it, which is what gives the sheet its thickness. Drawn
+   at its moving strength and dimmed through opacity at rest, so the same
+   ramp brightens it. */
+.star-map-window__titlebar::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1px;
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in srgb, var(--text-primary) 36%, transparent) 14%,
+      color-mix(in srgb, var(--text-primary) 36%, transparent) 86%,
+      transparent
+    );
+  box-shadow: 0 1px 8px color-mix(in srgb, var(--bg-app) 70%, transparent);
+  opacity: 0.45;
+  transition: opacity 220ms ease;
+}
+
+.star-map-window:has(.star-map__viewport.is-panning) .star-map-window__titlebar::before,
+.star-map-window:has(.star-map.is-flying) .star-map-window__titlebar::before,
+.star-map-window:has(.star-map__viewport.is-panning) .star-map-window__titlebar::after,
+.star-map-window:has(.star-map.is-flying) .star-map-window__titlebar::after {
+  opacity: 1;
+}
+
+/* Native fullscreen hides the stoplights and a fullscreen window cannot be
+   dragged, so the handle would only be a band of blur over the sky. */
+:root[data-fullscreen="true"] .star-map-window__titlebar {
+  display: none;
+}
+
 .star-map {
   position: relative;
   flex: 1;
@@ -12365,8 +12453,14 @@ textarea,
   cursor: pointer;
 }
 
+/* Both top clusters sit inside the macOS glass drag strip
+   (`.star-map-window__titlebar`). Draggable regions are rect-unions, so
+   every descendant has to opt out or its pixels fall back to window-drag
+   hit-testing and swallow the click. */
 .star-map__chrome,
-.star-map__chrome * {
+.star-map__chrome *,
+.star-map__filters,
+.star-map__filters * {
   -webkit-app-region: no-drag;
 }
 


### PR DESCRIPTION
## Summary

The dedicated Star Map window went full-bleed, and with macOS `titleBarStyle: hiddenInset` there is no native title-bar band left to grab — the sky underneath is a canvas pan handle — so the window could not be moved. This adds a transparent glass drag strip along the top.

## What changed

- **`StarMapWindow.tsx`** — on `darwin` only, renders `.star-map-window__titlebar` over the top of the map. It is purely a window-drag handle: `-webkit-app-region: drag` means macOS takes the mouse-down before the DOM sees it, so grabbing there never starts a canvas pan. Fixes the stale comment that claimed the native band handled dragging.
- **`app.css`** — the strip: 52px, `z-index: 2` (above the transformed canvas — its own stacking context, so cards can't out-stack it — and below the filter chips (3) and View/wordmark chrome (4) that live inside it). Faint `--bg-app` tint + `backdrop-filter: blur(12px) saturate(135%)`, finished with a 1px specular hairline along the bottom edge (`--text-primary`, fading toward both ends) over a soft shadow. At rest the hairline sits at 45% opacity so the bar is legible; while the map moves (`.star-map__viewport.is-panning` for pointer pan, new `.star-map.is-flying` for WASD flight) an extra tint layer and the hairline ramp to full over 220ms via opacity (gradients don't interpolate). Hidden under `[data-fullscreen="true"]`. `.star-map__filters` joins `.star-map__chrome` in the `no-drag` hole rule so the chips stay clickable inside the strip. All colors are token-derived `color-mix`.
- **`StarMapScreen.tsx`** — adds `is-flying` to `.star-map` while camera keys are held so keyboard flight lights the edge too.
- **`theme-contract.test.tsx`** — pins the drag region, backdrop-filter, z-order under chrome/filters, the shared no-drag rule, the pan/fly brightening selectors, and the fullscreen hide.

Not rendered on Windows (the painted `.activity-titlebar` above the map already drags) or Linux (OS frame).

## Reviewer notes

- Wheel-zoom over the top 52px is lost to the strip, same as it already was over the chrome; cards panned up under the strip go behind glass, like content under any title bar.
- The height is a single `height: 52px` — traffic lights end ~30px and the chips ~44px, so the edge lands 8px below the chips. Easy to tune if it feels off.
- Verified: `typecheck`, `lint:colors`, ESLint on touched files, theme-contract + all star-map renderer tests (27 files / 471 tests). Live screenshot of the Electron window was not captured in this session; the look was sanity-checked against a token-matched static mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
