### PR TITLE
feat(desktop): parallax the Star Map sky behind the map

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
 } from "react";
 import {
   buildThreadIdentityKey,
@@ -105,6 +106,7 @@ import {
   MIN_ZOOM,
   overviewChromeScale,
   placeStarMapView,
+  starMapSkyOffset,
   type StarMapView,
 } from "./star-map-view-geometry";
 import { StarMapViewOptions } from "./StarMapViewOptions";
@@ -191,28 +193,47 @@ const STAR_FIELD = generateStarField(STAR_COUNT);
  *
  * The map re-renders whenever active-thread state advances. Keeping the 130
  * circles behind a memo boundary means React does not reconcile a decorative
- * subtree on every streamed update. The stars intentionally stay still: 130
- * independent SVG opacity animations kept Chromium painting continuously even
- * when the operator was not touching the map.
+ * subtree on every streamed update. The stars intentionally do not twinkle:
+ * 130 independent SVG opacity animations kept Chromium painting continuously
+ * even when the operator was not touching the map.
+ *
+ * The field is one viewport-sized tile drawn four times, 2×2, and the whole
+ * sky is what `paintView` slides for the parallax — the map moves, and the
+ * stars follow it a fraction of the way. Tiling is what makes that safe:
+ * wrapped to one tile (`starMapSkyOffset`), the sky covers the window at
+ * every offset, so no pan can ever drag a bare edge into view. Only the
+ * parent's `paintView` writes the offset, through the ref, so this subtree
+ * still never re-renders for a view change.
  */
-const StarMapSky = memo(function StarMapSky() {
+const StarMapSky = memo(function StarMapSky(props: {
+  ref: RefObject<SVGSVGElement | null>;
+}) {
   return (
     <svg
+      ref={props.ref}
       className="star-map__sky"
-      viewBox="0 0 100 100"
+      viewBox="0 0 200 200"
       preserveAspectRatio="none"
       aria-hidden="true"
     >
-      {STAR_FIELD.map((star, index) => (
-        <circle
-          key={index}
-          className="star-map__star"
-          cx={star.x}
-          cy={star.y}
-          r={star.radius * 0.08}
-          fillOpacity={star.opacity}
-        />
-      ))}
+      <defs>
+        <g id="star-map-sky-tile">
+          {STAR_FIELD.map((star, index) => (
+            <circle
+              key={index}
+              className="star-map__star"
+              cx={star.x}
+              cy={star.y}
+              r={star.radius * 0.08}
+              fillOpacity={star.opacity}
+            />
+          ))}
+        </g>
+      </defs>
+      <use href="#star-map-sky-tile" x={0} y={0} />
+      <use href="#star-map-sky-tile" x={100} y={0} />
+      <use href="#star-map-sky-tile" x={0} y={100} />
+      <use href="#star-map-sky-tile" x={100} y={100} />
     </svg>
   );
 });
@@ -272,6 +293,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const layerRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
+  const skyRef = useRef<SVGSVGElement>(null);
   const { health } = useFederationHealth({ desktopApi: props.desktopApi });
   const celestialIcons = useCelestialIcons({ desktopApi: props.desktopApi });
   const [filterSelection, setFilterSelection] =
@@ -280,6 +302,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
     width: number;
     height: number;
   }>({ width: 1280, height: 800 });
+  /**
+   * The viewport size as `paintView` sees it. The sky's parallax wraps to
+   * the viewport, and `paintView` runs on gesture frames outside React, so
+   * it reads the measurement from a ref rather than closing over state and
+   * changing identity — and every gesture's captured copy of it — on resize.
+   */
+  const viewportSizeRef = useRef(viewportSize);
   const [intakeTarget, setIntakeTarget] = useState<IntakeDialogTarget>();
   // Which instance the operator is focused on. Selection is deliberately
   // view-local and unsynced: it is a "where am I looking" gesture, not a
@@ -364,6 +393,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
       canvas.style.transform =
         `translate(${next.x}px, ${next.y}px) scale(${next.scale})`;
     }
+    // The sky follows a fraction of the way behind the canvas. Written as
+    // custom properties rather than a transform so the stylesheet owns the
+    // transform and reduced motion can pin the sky in CSS alone.
+    const sky = skyRef.current;
+    if (sky) {
+      const offset = starMapSkyOffset({
+        view: next,
+        viewport: viewportSizeRef.current,
+      });
+      sky.style.setProperty("--star-map-sky-x", `${offset.x}px`);
+      sky.style.setProperty("--star-map-sky-y", `${offset.y}px`);
+    }
   }, []);
 
   /**
@@ -430,6 +471,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
     observer.observe(element);
     return () => observer.disconnect();
   }, []);
+
+  // A resize changes the tile the sky's parallax wraps to. Re-painting the
+  // live view re-wraps the offset against the new size before the frame
+  // shows; a stale wrap from a wider window can leave the sky short of the
+  // window's right or bottom edge.
+  useLayoutEffect(() => {
+    viewportSizeRef.current = viewportSize;
+    paintView(viewRef.current);
+  }, [paintView, viewportSize]);
 
   // Card height changes are driven by the browser's layout observer rather
   // than a synchronous offsetHeight sweep after every render. Active threads
@@ -2719,7 +2769,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         className="star-map__viewport"
         onPointerDown={startCanvasPan}
       >
-        <StarMapSky />
+        <StarMapSky ref={skyRef} />
         <div
           ref={canvasRef}
           // Every lens is now a transformed canvas sized to its content —

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2,6 +2,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -208,6 +209,13 @@ const STAR_FIELD = generateStarField(STAR_COUNT);
 const StarMapSky = memo(function StarMapSky(props: {
   ref: RefObject<SVGSVGElement | null>;
 }) {
+  // SVG ids are document-wide, and `<use>` resolves against the document:
+  // a second map in the same document would otherwise borrow — or, once
+  // the first unmounted, lose — this one's tile. React's id is wrapped in
+  // punctuation that is legal in an `id` but not worth trusting in a
+  // fragment reference, so only its alphanumerics are kept.
+  const tileId = `star-map-sky-tile-${useId().replace(/[^a-zA-Z0-9]/g, "")}`;
+  const tileHref = `#${tileId}`;
   return (
     <svg
       ref={props.ref}
@@ -217,7 +225,7 @@ const StarMapSky = memo(function StarMapSky(props: {
       aria-hidden="true"
     >
       <defs>
-        <g id="star-map-sky-tile">
+        <g id={tileId}>
           {STAR_FIELD.map((star, index) => (
             <circle
               key={index}
@@ -230,10 +238,10 @@ const StarMapSky = memo(function StarMapSky(props: {
           ))}
         </g>
       </defs>
-      <use href="#star-map-sky-tile" x={0} y={0} />
-      <use href="#star-map-sky-tile" x={100} y={0} />
-      <use href="#star-map-sky-tile" x={0} y={100} />
-      <use href="#star-map-sky-tile" x={100} y={100} />
+      <use href={tileHref} x={0} y={0} />
+      <use href={tileHref} x={100} y={0} />
+      <use href={tileHref} x={0} y={100} />
+      <use href={tileHref} x={100} y={100} />
     </svg>
   );
 });
@@ -307,6 +315,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * the viewport, and `paintView` runs on gesture frames outside React, so
    * it reads the measurement from a ref rather than closing over state and
    * changing identity — and every gesture's captured copy of it — on resize.
+   * Written by the measure below, in the same call that sets the state.
    */
   const viewportSizeRef = useRef(viewportSize);
   const [intakeTarget, setIntakeTarget] = useState<IntakeDialogTarget>();
@@ -457,6 +466,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
     const measure = () => {
       const rect = element.getBoundingClientRect();
       if (rect.width > 0 && rect.height > 0) {
+        // A resize changes the tile the sky's parallax wraps to. Re-wrapped
+        // here, synchronously in the observer callback, rather than in an
+        // effect off the state below: the observer runs after layout and
+        // before paint, while the state commit lands a frame later, and a
+        // stale wrap from a wider window leaves the sky short of the new
+        // right or bottom edge for that frame.
+        viewportSizeRef.current = { width: rect.width, height: rect.height };
+        paintView(viewRef.current);
         setViewportSize((current) =>
           current.width === rect.width && current.height === rect.height
             ? current
@@ -470,16 +487,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     return () => observer.disconnect();
-  }, []);
-
-  // A resize changes the tile the sky's parallax wraps to. Re-painting the
-  // live view re-wraps the offset against the new size before the frame
-  // shows; a stale wrap from a wider window can leave the sky short of the
-  // window's right or bottom edge.
-  useLayoutEffect(() => {
-    viewportSizeRef.current = viewportSize;
-    paintView(viewRef.current);
-  }, [paintView, viewportSize]);
+  }, [paintView]);
 
   // Card height changes are driven by the browser's layout observer rather
   // than a synchronous offsetHeight sweep after every render. Active threads

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-sky-parallax.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-sky-parallax.test.tsx
@@ -2,15 +2,16 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
-import { STAR_MAP_SKY_PARALLAX } from "../star-map-view-geometry";
+import { starMapSkyOffset } from "../star-map-view-geometry";
 import { StarMapScreen } from "../StarMapScreen";
 
 /**
  * The sky is a parallax layer: it follows the map a fraction of the way,
  * so the map reads as sitting in front of the stars rather than painted on
- * them. These pin the wiring — that the screen actually moves the sky when
- * the operator moves the map, by the geometry's fraction, and through the
- * same live path the canvas uses.
+ * them. These pin the wiring — that the screen writes the sky offset the
+ * geometry prescribes for wherever the canvas is, through the same live
+ * path the canvas uses. The fraction, the wrap, and the zoom-invariance are
+ * the geometry's own tests.
  */
 
 function buildDesktopApi(): DesktopApi {
@@ -57,12 +58,13 @@ function sky(): HTMLElement {
   return element as HTMLElement;
 }
 
-function canvasPosition(): { x: number; y: number } {
-  const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\)/.exec(
+/** The view as the canvas transform currently shows it. */
+function canvasView(): { x: number; y: number; scale: number } {
+  const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(
     canvas().style.transform,
   );
   if (!match) throw new Error(`unparsable transform: ${canvas().style.transform}`);
-  return { x: Number(match[1]), y: Number(match[2]) };
+  return { x: Number(match[1]), y: Number(match[2]), scale: Number(match[3]) };
 }
 
 function skyOffset(): { x: number; y: number } {
@@ -79,16 +81,12 @@ function skyOffset(): { x: number; y: number } {
  */
 const VIEWPORT = { width: 1280, height: 800 };
 
-/**
- * How far the sky moved on one axis, read through the tile wrap: the sky
- * shows the same field at offsets a whole tile apart, so a move that
- * crosses the origin comes back as `delta ± tile` and means the same thing.
- */
-function skyTravel(before: number, after: number, tile: number): number {
-  const delta = (after - before) % tile;
-  if (delta > tile / 2) return delta - tile;
-  if (delta <= -tile / 2) return delta + tile;
-  return delta;
+/** The sky sits exactly where the geometry says it should for the canvas. */
+function expectSkyFollowsCanvas() {
+  const expected = starMapSkyOffset({ view: canvasView(), viewport: VIEWPORT });
+  const actual = skyOffset();
+  expect(actual.x).toBeCloseTo(expected.x, 6);
+  expect(actual.y).toBeCloseTo(expected.y, 6);
 }
 
 /** Drag the canvas by a fixed delta, the way an operator pans. */
@@ -137,43 +135,25 @@ describe("star map sky parallax", () => {
     expect(sky().getAttribute("viewBox")).toBe("0 0 200 200");
   });
 
-  it("moves the sky a fraction of the pan, in the same direction", async () => {
+  it("places the sky for the opening view and moves it with a pan", async () => {
     await renderMap();
-    const canvasBefore = canvasPosition();
+    // Placed on open, before the operator touches anything.
+    expectSkyFollowsCanvas();
+    const before = canvasView();
     const skyBefore = skyOffset();
 
     pan(-320, -180);
 
-    const canvasAfter = canvasPosition();
-    const skyAfter = skyOffset();
-    // Sanity: the pan itself landed.
-    expect(canvasAfter.x).toBeLessThan(canvasBefore.x);
-    expect(canvasAfter.y).toBeLessThan(canvasBefore.y);
-    // The sky followed, but only by the parallax fraction.
-    expect(skyTravel(skyBefore.x, skyAfter.x, VIEWPORT.width)).toBeCloseTo(
-      (canvasAfter.x - canvasBefore.x) * STAR_MAP_SKY_PARALLAX,
-      6,
-    );
-    expect(skyTravel(skyBefore.y, skyAfter.y, VIEWPORT.height)).toBeCloseTo(
-      (canvasAfter.y - canvasBefore.y) * STAR_MAP_SKY_PARALLAX,
-      6,
-    );
-  });
+    // Sanity: the pan itself landed, and the sky did not sit still.
+    const after = canvasView();
+    expect(after.x).toBeLessThan(before.x);
+    expect(after.y).toBeLessThan(before.y);
+    expect(skyOffset()).not.toEqual(skyBefore);
+    expectSkyFollowsCanvas();
 
-  it("keeps the sky's offset inside one tile at rest and after a pan", async () => {
-    await renderMap();
-    for (const move of [
-      [0, 0],
-      [-320, -180],
-      [900, 500],
-    ] as const) {
-      if (move[0] || move[1]) pan(move[0], move[1]);
-      const offset = skyOffset();
-      expect(offset.x).toBeGreaterThan(-VIEWPORT.width);
-      expect(offset.x).toBeLessThanOrEqual(0);
-      expect(offset.y).toBeGreaterThan(-VIEWPORT.height);
-      expect(offset.y).toBeLessThanOrEqual(0);
-    }
+    // A pan back the other way, across the wrap the opening view sits near.
+    pan(900, 500);
+    expectSkyFollowsCanvas();
   });
 
   it("writes the sky offset on the live drag frame, not only on release", async () => {
@@ -187,18 +167,15 @@ describe("star map sky parallax", () => {
         return 1;
       });
     try {
-      const before = skyOffset();
+      const before = canvasView();
       fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
       fireEvent.pointerMove(window, { clientX: 300, clientY: 400 });
       expect(frame).toBeDefined();
       frame!(0);
-      // Mid-drag, before any pointerup and any React commit, the sky has
-      // already followed the canvas.
-      expect(skyTravel(before.x, skyOffset().x, VIEWPORT.width)).toBeCloseTo(
-        -200 * STAR_MAP_SKY_PARALLAX,
-        6,
-      );
-      expect(skyTravel(before.y, skyOffset().y, VIEWPORT.height)).toBeCloseTo(0, 6);
+      // Mid-drag, before any pointerup and any React commit, the canvas has
+      // moved by hand — and the sky has already followed it.
+      expect(canvasView().x).toBeCloseTo(before.x - 200, 6);
+      expectSkyFollowsCanvas();
       fireEvent.pointerUp(window, { clientX: 300, clientY: 400 });
     } finally {
       raf.mockRestore();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-sky-parallax.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-sky-parallax.test.tsx
@@ -1,0 +1,207 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { STAR_MAP_SKY_PARALLAX } from "../star-map-view-geometry";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * The sky is a parallax layer: it follows the map a fraction of the way,
+ * so the map reads as sitting in front of the stars rather than painted on
+ * them. These pin the wiring — that the screen actually moves the sky when
+ * the operator moves the map, by the geometry's fraction, and through the
+ * same live path the canvas uses.
+ */
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function thread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      { id: `${id}-dir`, label: "PwrSnap", path: "/repos/PwrSnap", kind: "local" },
+    ],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+function canvas(): HTMLElement {
+  const element = document.querySelector(".star-map__canvas");
+  if (!element) throw new Error("canvas not found");
+  return element as HTMLElement;
+}
+
+function sky(): HTMLElement {
+  const element = document.querySelector(".star-map__sky");
+  if (!element) throw new Error("sky not found");
+  return element as HTMLElement;
+}
+
+function canvasPosition(): { x: number; y: number } {
+  const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\)/.exec(
+    canvas().style.transform,
+  );
+  if (!match) throw new Error(`unparsable transform: ${canvas().style.transform}`);
+  return { x: Number(match[1]), y: Number(match[2]) };
+}
+
+function skyOffset(): { x: number; y: number } {
+  const style = sky().style;
+  return {
+    x: Number.parseFloat(style.getPropertyValue("--star-map-sky-x")),
+    y: Number.parseFloat(style.getPropertyValue("--star-map-sky-y")),
+  };
+}
+
+/**
+ * jsdom measures every element as 0x0, so the screen keeps its unmeasured
+ * default viewport — which is also the sky's tile.
+ */
+const VIEWPORT = { width: 1280, height: 800 };
+
+/**
+ * How far the sky moved on one axis, read through the tile wrap: the sky
+ * shows the same field at offsets a whole tile apart, so a move that
+ * crosses the origin comes back as `delta ± tile` and means the same thing.
+ */
+function skyTravel(before: number, after: number, tile: number): number {
+  const delta = (after - before) % tile;
+  if (delta > tile / 2) return delta - tile;
+  if (delta <= -tile / 2) return delta + tile;
+  return delta;
+}
+
+/** Drag the canvas by a fixed delta, the way an operator pans. */
+function pan(dx: number, dy: number) {
+  const viewport = document.querySelector(".star-map__viewport");
+  if (!viewport) throw new Error("viewport not found");
+  fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+  fireEvent.pointerMove(window, { clientX: 500 + dx, clientY: 400 + dy });
+  fireEvent.pointerUp(window, { clientX: 500 + dx, clientY: 400 + dy });
+}
+
+async function renderMap() {
+  window.localStorage.setItem(
+    "pwragent.starMap.viewPreferences",
+    JSON.stringify({ layout: "orbit" }),
+  );
+  render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={Array.from({ length: 6 }, (_, index) => thread(`t${index}`))}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: /Open this instance/ }),
+    ).toBeTruthy();
+  });
+}
+
+describe("star map sky parallax", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("tiles the star field so the sky can slide without exposing an edge", async () => {
+    await renderMap();
+    // One field, drawn four times: the tile is a def, and 2×2 uses cover
+    // twice the viewport on each axis.
+    expect(sky().querySelectorAll("defs .star-map__star").length).toBeGreaterThan(0);
+    expect(sky().querySelectorAll("use").length).toBe(4);
+    expect(sky().getAttribute("viewBox")).toBe("0 0 200 200");
+  });
+
+  it("moves the sky a fraction of the pan, in the same direction", async () => {
+    await renderMap();
+    const canvasBefore = canvasPosition();
+    const skyBefore = skyOffset();
+
+    pan(-320, -180);
+
+    const canvasAfter = canvasPosition();
+    const skyAfter = skyOffset();
+    // Sanity: the pan itself landed.
+    expect(canvasAfter.x).toBeLessThan(canvasBefore.x);
+    expect(canvasAfter.y).toBeLessThan(canvasBefore.y);
+    // The sky followed, but only by the parallax fraction.
+    expect(skyTravel(skyBefore.x, skyAfter.x, VIEWPORT.width)).toBeCloseTo(
+      (canvasAfter.x - canvasBefore.x) * STAR_MAP_SKY_PARALLAX,
+      6,
+    );
+    expect(skyTravel(skyBefore.y, skyAfter.y, VIEWPORT.height)).toBeCloseTo(
+      (canvasAfter.y - canvasBefore.y) * STAR_MAP_SKY_PARALLAX,
+      6,
+    );
+  });
+
+  it("keeps the sky's offset inside one tile at rest and after a pan", async () => {
+    await renderMap();
+    for (const move of [
+      [0, 0],
+      [-320, -180],
+      [900, 500],
+    ] as const) {
+      if (move[0] || move[1]) pan(move[0], move[1]);
+      const offset = skyOffset();
+      expect(offset.x).toBeGreaterThan(-VIEWPORT.width);
+      expect(offset.x).toBeLessThanOrEqual(0);
+      expect(offset.y).toBeGreaterThan(-VIEWPORT.height);
+      expect(offset.y).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("writes the sky offset on the live drag frame, not only on release", async () => {
+    await renderMap();
+    const viewport = document.querySelector(".star-map__viewport")!;
+    let frame: FrameRequestCallback | undefined;
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        frame = callback;
+        return 1;
+      });
+    try {
+      const before = skyOffset();
+      fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+      fireEvent.pointerMove(window, { clientX: 300, clientY: 400 });
+      expect(frame).toBeDefined();
+      frame!(0);
+      // Mid-drag, before any pointerup and any React commit, the sky has
+      // already followed the canvas.
+      expect(skyTravel(before.x, skyOffset().x, VIEWPORT.width)).toBeCloseTo(
+        -200 * STAR_MAP_SKY_PARALLAX,
+        6,
+      );
+      expect(skyTravel(before.y, skyOffset().y, VIEWPORT.height)).toBeCloseTo(0, 6);
+      fireEvent.pointerUp(window, { clientX: 300, clientY: 400 });
+    } finally {
+      raf.mockRestore();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
@@ -4,10 +4,12 @@ import {
   MIN_VISIBLE_FRACTION,
   MIN_ZOOM,
   STAR_MAP_OVERVIEW_ZOOM,
+  STAR_MAP_SKY_PARALLAX,
   centerStarMapView,
   clampStarMapView,
   isOverviewZoom,
   overviewChromeScale,
+  starMapSkyOffset,
   type StarMapView,
 } from "../star-map-view-geometry";
 
@@ -145,5 +147,74 @@ describe("overview zoom", () => {
   it("treats a nonsense scale as unzoomed rather than dividing by zero", () => {
     expect(Number.isFinite(overviewChromeScale(0))).toBe(true);
     expect(overviewChromeScale(0)).toBe(1);
+  });
+});
+
+describe("starMapSkyOffset", () => {
+  function sky(view: Partial<StarMapView>, viewport = VIEWPORT) {
+    return starMapSkyOffset({
+      view: { x: 0, y: 0, scale: 1, ...view },
+      viewport,
+    });
+  }
+
+  it("moves the sky a small fraction of the way the map moved", () => {
+    // Subtle by design: the map should read as sitting in front of the
+    // sky, not as dragging it along.
+    expect(STAR_MAP_SKY_PARALLAX).toBeGreaterThan(0);
+    expect(STAR_MAP_SKY_PARALLAX).toBeLessThanOrEqual(0.2);
+    expect(sky({ x: -400, y: -300 })).toEqual({
+      x: -400 * STAR_MAP_SKY_PARALLAX,
+      y: -300 * STAR_MAP_SKY_PARALLAX,
+    });
+  });
+
+  it("does not move for zoom alone", () => {
+    expect(sky({ scale: 0.25 })).toEqual({ x: 0, y: 0 });
+    expect(sky({ x: -400, y: -300, scale: 2 })).toEqual(
+      sky({ x: -400, y: -300, scale: 0.5 }),
+    );
+  });
+
+  it("keeps the offset within one tile so the 2x2 sky always covers the window", () => {
+    // Any legal pan, at any zoom, in either direction, far beyond one tile.
+    for (const x of [-1e6, -25600, -12801, -12800, -1, 0, 1, 640, 12800, 1e6]) {
+      for (const y of [-1e6, -8001, -8000, 0, 800, 8000, 1e6]) {
+        const offset = sky({ x, y });
+        expect(offset.x).toBeGreaterThan(-VIEWPORT.width);
+        expect(offset.x).toBeLessThanOrEqual(0);
+        expect(offset.y).toBeGreaterThan(-VIEWPORT.height);
+        expect(offset.y).toBeLessThanOrEqual(0);
+      }
+    }
+  });
+
+  it("wraps by whole tiles, so the sky it shows is unchanged", () => {
+    // One tile of parallax is one viewport of pan divided by the factor.
+    const tilePan = VIEWPORT.width / STAR_MAP_SKY_PARALLAX;
+    const base = sky({ x: -400 });
+    expect(sky({ x: -400 - tilePan }).x).toBeCloseTo(base.x, 6);
+    expect(sky({ x: -400 + 3 * tilePan }).x).toBeCloseTo(base.x, 6);
+  });
+
+  it("wraps a positive pan below the origin rather than above it", () => {
+    // The sky starts at the window's origin and extends right and down, so
+    // a positive offset would uncover the window's left or top edge.
+    const offset = sky({ x: 500, y: 300 });
+    expect(offset.x).toBe(500 * STAR_MAP_SKY_PARALLAX - VIEWPORT.width);
+    expect(offset.y).toBe(300 * STAR_MAP_SKY_PARALLAX - VIEWPORT.height);
+  });
+
+  it("lands on a plain zero at a tile boundary, never -0", () => {
+    const tilePan = VIEWPORT.width / STAR_MAP_SKY_PARALLAX;
+    expect(Object.is(sky({ x: -tilePan }).x, 0)).toBe(true);
+    expect(Object.is(sky({ x: 0 }).x, 0)).toBe(true);
+  });
+
+  it("stays still against an unmeasured viewport", () => {
+    expect(sky({ x: -400, y: -300 }, { width: 0, height: 0 })).toEqual({
+      x: 0,
+      y: 0,
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -148,6 +148,59 @@ export function clampStarMapView(params: {
 }
 
 /**
+ * How far the sky moves for each pixel the map moves.
+ *
+ * The stars are the far layer of a two-plane parallax: the canvas is what
+ * the operator holds, and the sky drifts a fraction of that behind it, the
+ * way the backdrop of a side-scroller lags the foreground. Small on purpose
+ * — the point is that the map reads as sitting in front of the sky, not
+ * that the sky is going anywhere.
+ */
+export const STAR_MAP_SKY_PARALLAX = 0.1;
+
+/**
+ * Wrap a scroll offset into one tile period, `(-period, 0]`.
+ *
+ * `%` alone leaves a positive result for positive input; shifting that down
+ * a period keeps the sky's origin at or left of the window's, which is what
+ * lets a 2×2 tiling starting at the origin always cover the window.
+ */
+function wrapToTile(offset: number, period: number): number {
+  if (!(period > 0) || !Number.isFinite(offset)) return 0;
+  const wrapped = offset % period;
+  // `-0` from a negative multiple of the period; a plain 0 keeps the value
+  // comparable and the CSS free of `-0px`.
+  if (wrapped === 0) return 0;
+  return wrapped > 0 ? wrapped - period : wrapped;
+}
+
+/**
+ * Where the sky sits for a view, in viewport pixels.
+ *
+ * The sky is drawn as a 2×2 tiling of one viewport-sized star field, so it
+ * can follow the map by any distance and still cover the window: the offset
+ * is wrapped to one tile, and the copy scrolling in on one side is the copy
+ * that left on the other. Only the pan participates — zoom does not scale
+ * distant stars, and the operator's zoom-to-cursor pans are exactly the
+ * camera moves a parallax layer should answer.
+ */
+export function starMapSkyOffset(params: {
+  view: StarMapView;
+  viewport: StarMapViewBox;
+}): { x: number; y: number } {
+  return {
+    x: wrapToTile(
+      params.view.x * STAR_MAP_SKY_PARALLAX,
+      params.viewport.width,
+    ),
+    y: wrapToTile(
+      params.view.y * STAR_MAP_SKY_PARALLAX,
+      params.viewport.height,
+    ),
+  };
+}
+
+/**
  * The view that puts the middle of the canvas in the middle of the window
  * at 1:1. Used to place the map on open, on a lens switch, and by "Reset
  * view".

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -341,6 +341,11 @@ describe("Tangerine Terminal theme contract", () => {
       // lines offset themselves by; both are layout, not theme.
       "automations-header-h",
       "automation-row-h",
+      // Star Map sky parallax offset — registered with `@property` as a
+      // non-inherited length and written per gesture frame by the screen.
+      // Geometry, not theme.
+      "star-map-sky-x",
+      "star-map-sky-y",
     ]);
     const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
       ([, token]) => token

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10863,6 +10863,23 @@ textarea,
   transition: transform 240ms ease, opacity 240ms ease;
 }
 
+/* The sky's parallax offset. Registered so it does NOT inherit: `paintView`
+   rewrites it on every gesture frame, and an inherited custom property
+   would dirty the style of every star under the sky — the tile's circles
+   plus four `<use>` instances of them — before the compositor saw the
+   transform. Non-inherited, the write touches the sky element alone. */
+@property --star-map-sky-x {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@property --star-map-sky-y {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
 /* The sky is a 2×2 tiling of one viewport-sized star field, twice the
    window on each axis, and slides behind the map as a parallax layer.
    `paintView` writes the offset — always within one tile, (-100%, 0] —
@@ -10876,15 +10893,19 @@ textarea,
   height: 200%;
   color: color-mix(in srgb, var(--text-primary) 78%, transparent);
   pointer-events: none;
-  transform: translate(var(--star-map-sky-x, 0px), var(--star-map-sky-y, 0px));
+  transform: translate(var(--star-map-sky-x), var(--star-map-sky-y));
 }
 
-/* Promoted alongside the canvas for the pointer drag only: the parallax is
-   a per-frame transform on a surface four times the window, and a
-   permanently promoted sky is exactly the retained compositor surface the
-   canvas rule (`.star-map__viewport.is-panning .star-map__canvas`) avoids. */
-.star-map__viewport.is-panning .star-map__sky {
-  will-change: transform;
+@media (prefers-reduced-motion: no-preference) {
+  /* Promoted alongside the canvas for the pointer drag only: the parallax
+     is a per-frame transform on a surface four times the window, and a
+     permanently promoted sky is exactly the retained compositor surface the
+     canvas rule (`.star-map__viewport.is-panning .star-map__canvas`)
+     avoids. Not under reduced motion either — the sky is pinned there and
+     a promoted layer would buy nothing. */
+  .star-map__viewport.is-panning .star-map__sky {
+    will-change: transform;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10863,13 +10863,36 @@ textarea,
   transition: transform 240ms ease, opacity 240ms ease;
 }
 
+/* The sky is a 2×2 tiling of one viewport-sized star field, twice the
+   window on each axis, and slides behind the map as a parallax layer.
+   `paintView` writes the offset — always within one tile, (-100%, 0] —
+   as custom properties so the transform stays the stylesheet's to own:
+   reduced motion pins the sky below without fighting an inline style. */
 .star-map__sky {
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  left: 0;
+  top: 0;
+  width: 200%;
+  height: 200%;
   color: color-mix(in srgb, var(--text-primary) 78%, transparent);
   pointer-events: none;
+  transform: translate(var(--star-map-sky-x, 0px), var(--star-map-sky-y, 0px));
+}
+
+/* Promoted alongside the canvas for the pointer drag only: the parallax is
+   a per-frame transform on a surface four times the window, and a
+   permanently promoted sky is exactly the retained compositor surface the
+   canvas rule (`.star-map__viewport.is-panning .star-map__canvas`) avoids. */
+.star-map__viewport.is-panning .star-map__sky {
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Parallax is the textbook vestibular trigger. Pinned, the sky shows the
+     origin tile — the same still field the map had before the effect. */
+  .star-map__sky {
+    transform: none;
+  }
 }
 
 .star-map__star {

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -298,6 +298,11 @@ Avoid:
 - theatrical page entrances
 - decorative parallax or float effects
 
+One exception: the Star Map sky parallaxes behind the map as the operator
+pans it. That is a direct-manipulation depth cue, not decoration — it only
+moves when the map moves, by a tenth as far, and it is pinned under
+`prefers-reduced-motion`. Do not extend it to other surfaces.
+
 ## Copy Rules
 
 PwrAgent UI copy should sound like product UI, not demo narration.


### PR DESCRIPTION
## What

The Star Map sky is now a parallax layer: drag the map and the stars follow a tenth of the way, in the same direction, so the map reads as sitting in front of the sky rather than painted on it. Subtle by design — the strength is the single constant `STAR_MAP_SKY_PARALLAX` (0.1).

## How

- **`star-map-view-geometry.ts`** — `STAR_MAP_SKY_PARALLAX` and a pure `starMapSkyOffset(view, viewport)`. Only the pan participates (zoom does not scale distant stars). The offset is wrapped to one viewport tile, `(-viewport, 0]`, so the sky can follow the map any distance and still cover the window.
- **`StarMapScreen.tsx`** — the sky is one star-field tile in `<defs>` drawn 2×2 with `<use>` (same 130 stars, same seed, still memo'd — it never re-renders for a view change). `paintView` writes the offset as `--star-map-sky-x/y` custom properties alongside the canvas transform, so every mover — pointer drag frames, wheel pan, pinch, keyboard flight, reset — moves the sky through the one existing live path. A resize re-wraps the offset against the new tile so a narrower window cannot uncover a bare edge.
- **`app.css`** — sky is `200%×200%`, its `transform` reads the custom properties, it is promoted (`will-change`) only during `.is-panning` exactly like the canvas, and `prefers-reduced-motion: reduce` pins it (parallax is a vestibular trigger; pinned it shows the same still field as before).

## Reviewer notes

- The offset is written as custom properties rather than an inline `transform` so the stylesheet owns the transform and reduced motion can pin the sky in CSS alone, without `!important`.
- Tiling is what makes an unbounded pan safe: with the offset wrapped to one tile the copy scrolling in on one side is the copy that left on the other, so there is no clamp and no visible seam.
- Verified in a standalone harness with the real star generator and CSS: a 240px drag moved the stars 24px, and with the tile seams placed through the middle of the window there was no visible seam, duplicate cluster, or gap.

## Tests

- New: geometry (fraction, zoom-invariance, wrap-within-tile across huge pans, whole-tile periodicity, `-0` normalization, unmeasured viewport) and a screen test that a real pan moves the sky by exactly the fraction of the canvas move, on the live rAF drag frame as well as on release (`star-map-sky-parallax.test.tsx`).
- All star-map + styles test files pass (517 tests); `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
