### PR TITLE
fix(desktop): relativize paths in collapsed work phase labels

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -6,9 +6,9 @@ import type {
   DesktopApplicationsSnapshot,
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
-import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ThreadLinkSource } from "../../lib/thread-links";
+import { formatActivityText } from "./activity-path-display";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import {
   isThreadReferenceToolDetail,
@@ -314,59 +314,6 @@ function buildActivityCopyText(entry: AppServerThreadActivityEntry): string {
   return [entry.summary, ...entry.details.map((detail) => detail.label)]
     .filter((text) => text.trim().length > 0)
     .join("\n");
-}
-
-function formatActivityText(
-  text: string,
-  details: AppServerThreadActivityEntry["details"],
-  directoryPaths: string[] | undefined,
-): string {
-  const paths = details
-    .filter((detail): detail is typeof detail & { path: string } => Boolean(detail.path))
-    .map((detail) => ({
-      absolutePath: detail.path,
-      displayPath: formatPathRelativeToDirectories(detail.path, directoryPaths),
-    }))
-    .sort((left, right) => right.absolutePath.length - left.absolutePath.length);
-  let displayText = "";
-  let cursor = 0;
-
-  while (cursor < text.length) {
-    const matchingPath = paths.find(
-      (path) =>
-        text.startsWith(path.absolutePath, cursor)
-        && hasPathTextBoundaries(text, cursor, path.absolutePath.length),
-    );
-    if (matchingPath) {
-      displayText += matchingPath.displayPath;
-      cursor += matchingPath.absolutePath.length;
-      continue;
-    }
-    displayText += text[cursor];
-    cursor += 1;
-  }
-
-  return displayText;
-}
-
-function hasPathTextBoundaries(
-  text: string,
-  start: number,
-  length: number,
-): boolean {
-  const before = text[start - 1];
-  const after = text[start + length];
-  return isPathTextBoundary(before, "before") && isPathTextBoundary(after, "after");
-}
-
-function isPathTextBoundary(
-  character: string | undefined,
-  position: "before" | "after",
-): boolean {
-  if (character === undefined || /[\s`'"()[\]{}<>,;:!?=|]/.test(character)) {
-    return true;
-  }
-  return position === "after" && (character === "/" || character === "\\");
 }
 
 function formatActivityDetailStatus(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -923,6 +923,13 @@ export function TranscriptList(props: TranscriptListProps) {
         : undefined,
     [props.directoryPaths, props.pendingRequest, transcriptEntries],
   );
+  // `directoryPaths` is rebuilt by the caller on every render, so depending on
+  // the array itself would rebuild every group label on every streamed item.
+  const directoryPathsKey = (props.directoryPaths ?? []).join("\n");
+  const stableDirectoryPaths = useMemo(
+    () => (directoryPathsKey ? directoryPathsKey.split("\n") : undefined),
+    [directoryPathsKey],
+  );
   const transcriptRenderItems = useMemo(
     () =>
       buildTranscriptRenderItems({
@@ -932,6 +939,7 @@ export function TranscriptList(props: TranscriptListProps) {
         activeMessageId:
           props.transientMessage?.id ?? props.pendingAssistantMessage?.id,
         alwaysVisibleEntryIds: alwaysVisibleTransientMessageIds,
+        directoryPaths: stableDirectoryPaths,
         now: renderNow,
       }),
     [
@@ -941,6 +949,7 @@ export function TranscriptList(props: TranscriptListProps) {
       props.transientMessage?.id,
       alwaysVisibleTransientMessageIds,
       renderNow,
+      stableDirectoryPaths,
       transcriptEntries,
     ]
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -925,9 +925,11 @@ export function TranscriptList(props: TranscriptListProps) {
   );
   // `directoryPaths` is rebuilt by the caller on every render, so depending on
   // the array itself would rebuild every group label on every streamed item.
-  const directoryPathsKey = (props.directoryPaths ?? []).join("\n");
+  // NUL is the one byte a path cannot contain, so the key round-trips a
+  // directory name that holds a newline.
+  const directoryPathsKey = (props.directoryPaths ?? []).join("\u0000");
   const stableDirectoryPaths = useMemo(
-    () => (directoryPathsKey ? directoryPathsKey.split("\n") : undefined),
+    () => (directoryPathsKey ? directoryPathsKey.split("\u0000") : undefined),
     [directoryPathsKey],
   );
   const transcriptRenderItems = useMemo(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -109,7 +109,9 @@ describe("buildTranscriptRenderItems", () => {
       type: "activity",
       id: `tool-${index}`,
       summary: `Read \`${path}\``,
-      details: [{ id: `detail-${index}`, label: `Read \`${path}\``, path }],
+      details: [
+        { id: `detail-${index}`, kind: "read", label: `Read \`${path}\``, path },
+      ],
       turn,
     }));
 
@@ -138,7 +140,9 @@ describe("buildTranscriptRenderItems", () => {
       type: "activity",
       id: `tool-${index}`,
       summary: `Read \`${path}\``,
-      details: [{ id: `detail-${index}`, label: `Read \`${path}\``, path }],
+      details: [
+        { id: `detail-${index}`, kind: "read", label: `Read \`${path}\``, path },
+      ],
       turn,
     }));
 
@@ -164,7 +168,9 @@ describe("buildTranscriptRenderItems", () => {
       type: "activity",
       id: `tool-${index}`,
       summary: `Read \`${path}\``,
-      details: [{ id: `detail-${index}`, label: `Read \`${path}\``, path }],
+      details: [
+        { id: `detail-${index}`, kind: "read", label: `Read \`${path}\``, path },
+      ],
       turn,
     }));
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -99,6 +99,83 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
+  it("relativizes absolute paths in a collapsed work phase label", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const root = "/Users/dev/.pwragent/worktrees/ab12/PwrAgnt";
+    const activities: AppServerThreadActivityEntry[] = [
+      `${root}/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx`,
+      `${root}/packages/messaging/providers/slack/src/validate-credentials.ts`,
+    ].map((path, index) => ({
+      type: "activity",
+      id: `tool-${index}`,
+      summary: `Read \`${path}\``,
+      details: [{ id: `detail-${index}`, label: `Read \`${path}\``, path }],
+      turn,
+    }));
+
+    expect(
+      buildTranscriptRenderItems({
+        entries: activities,
+        directoryPaths: [root],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        type: "workPhaseGroup",
+        entries: activities,
+        label:
+          "Worked for 1m 10s · 2 tool updates: "
+          + "Read `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx`, "
+          + "Read `packages/messaging/providers/slack/src/validate-credentials.ts`",
+      }),
+    ]);
+  });
+
+  it("coalesces repeated reads of one file after relativizing", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const root = "/Users/dev/.pwragent/worktrees/ab12/PwrAgnt";
+    const path = `${root}/apps/desktop/src/main/messaging/messaging-config.ts`;
+    const activities: AppServerThreadActivityEntry[] = [0, 1].map((index) => ({
+      type: "activity",
+      id: `tool-${index}`,
+      summary: `Read \`${path}\``,
+      details: [{ id: `detail-${index}`, label: `Read \`${path}\``, path }],
+      turn,
+    }));
+
+    expect(
+      buildTranscriptRenderItems({
+        entries: activities,
+        directoryPaths: [root],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        type: "workPhaseGroup",
+        label:
+          "Worked for 1m 10s · 2 tool updates: "
+          + "2 × Read `apps/desktop/src/main/messaging/messaging-config.ts`",
+      }),
+    ]);
+  });
+
+  it("leaves a work phase label alone when no directories are linked", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const path = "/Users/dev/PwrAgnt/apps/desktop/src/main/messaging/messaging-config.ts";
+    const activities: AppServerThreadActivityEntry[] = [0, 1].map((index) => ({
+      type: "activity",
+      id: `tool-${index}`,
+      summary: `Read \`${path}\``,
+      details: [{ id: `detail-${index}`, label: `Read \`${path}\``, path }],
+      turn,
+    }));
+
+    expect(buildTranscriptRenderItems({ entries: activities })).toEqual([
+      expect.objectContaining({
+        type: "workPhaseGroup",
+        label: `Worked for 1m 10s · 2 tool updates: 2 × Read \`${path}\``,
+      }),
+    ]);
+  });
+
   it("uses completed turn metadata when live entries have mixed turn status", () => {
     const inProgressTurn = {
       id: "turn-1",

--- a/apps/desktop/src/renderer/src/features/thread-detail/activity-path-display.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/activity-path-display.ts
@@ -15,8 +15,16 @@ export function formatActivityText(
   details: AppServerThreadActivityEntry["details"],
   directoryPaths: string[] | undefined,
 ): string {
-  const paths = details
-    .filter((detail): detail is typeof detail & { path: string } => Boolean(detail.path))
+  const pathDetails = details.filter(
+    (detail): detail is typeof detail & { path: string } => Boolean(detail.path),
+  );
+  // Most entries — commands, searches, plan updates — carry no path at all.
+  // Work phase labels run this over every tool entry of a turn on each
+  // transcript rebuild, so those entries should not pay for the scan below.
+  if (pathDetails.length === 0) {
+    return text;
+  }
+  const paths = pathDetails
     .map((detail) => ({
       absolutePath: detail.path,
       displayPath: formatPathRelativeToDirectories(detail.path, directoryPaths),

--- a/apps/desktop/src/renderer/src/features/thread-detail/activity-path-display.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/activity-path-display.ts
@@ -1,0 +1,64 @@
+import type { AppServerThreadActivityEntry } from "@pwragent/shared";
+import { formatPathRelativeToDirectories } from "@pwragent/shared";
+
+/**
+ * Rewrite absolute paths inside an activity label to directory-relative form.
+ *
+ * Backends disagree on how much of a path belongs in a tool label: Codex sends
+ * a basename, while ACP agents forward the agent's own title verbatim, which
+ * for Grok is the absolute path the model passed to the tool. The entry's
+ * details carry the same path in `detail.path`, so the absolute spans in the
+ * label can be located exactly instead of guessed at.
+ */
+export function formatActivityText(
+  text: string,
+  details: AppServerThreadActivityEntry["details"],
+  directoryPaths: string[] | undefined,
+): string {
+  const paths = details
+    .filter((detail): detail is typeof detail & { path: string } => Boolean(detail.path))
+    .map((detail) => ({
+      absolutePath: detail.path,
+      displayPath: formatPathRelativeToDirectories(detail.path, directoryPaths),
+    }))
+    .sort((left, right) => right.absolutePath.length - left.absolutePath.length);
+  let displayText = "";
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const matchingPath = paths.find(
+      (path) =>
+        text.startsWith(path.absolutePath, cursor)
+        && hasPathTextBoundaries(text, cursor, path.absolutePath.length),
+    );
+    if (matchingPath) {
+      displayText += matchingPath.displayPath;
+      cursor += matchingPath.absolutePath.length;
+      continue;
+    }
+    displayText += text[cursor];
+    cursor += 1;
+  }
+
+  return displayText;
+}
+
+function hasPathTextBoundaries(
+  text: string,
+  start: number,
+  length: number,
+): boolean {
+  const before = text[start - 1];
+  const after = text[start + length];
+  return isPathTextBoundary(before, "before") && isPathTextBoundary(after, "after");
+}
+
+function isPathTextBoundary(
+  character: string | undefined,
+  position: "before" | "after",
+): boolean {
+  if (character === undefined || /[\s`'"()[\]{}<>,;:!?=|]/.test(character)) {
+    return true;
+  }
+  return position === "after" && (character === "/" || character === "\\");
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -6,6 +6,7 @@ import type {
   AppServerThreadTurnMetadata,
 } from "@pwragent/shared";
 import { coalesceToolActivityBurst } from "@pwragent/shared";
+import { formatActivityText } from "./activity-path-display";
 
 export type TranscriptRenderItem =
   | {
@@ -29,6 +30,7 @@ export function buildTranscriptRenderItems(params: {
   activeTurnStartedAt?: number;
   activeMessageId?: string;
   alwaysVisibleEntryIds?: ReadonlySet<string>;
+  directoryPaths?: string[];
   now?: number;
 }): TranscriptRenderItem[] {
   const activeTurnId =
@@ -44,6 +46,7 @@ export function buildTranscriptRenderItems(params: {
       params.entries,
       activeTurnId,
       params.alwaysVisibleEntryIds,
+      params.directoryPaths,
     );
     const activeGroups = buildActiveWorkGroups(
       params.entries,
@@ -64,6 +67,7 @@ export function buildTranscriptRenderItems(params: {
     params.entries,
     undefined,
     params.alwaysVisibleEntryIds,
+    params.directoryPaths,
   );
   if (completedGroups.length > 0) {
     return renderWithGroups(params.entries, completedGroups);
@@ -142,6 +146,7 @@ function buildCompletedGroups(
   entries: AppServerThreadEntry[],
   excludeTurnId?: string,
   alwaysVisibleEntryIds?: ReadonlySet<string>,
+  directoryPaths?: string[],
 ): RenderGroup[] {
   const groups: RenderGroup[] = [];
   const groupIds = new Set<string>();
@@ -176,7 +181,7 @@ function buildCompletedGroups(
       label: hasWork
         ? repeatedWorkTurn
           ? "More work"
-          : workGroupLabel(turn, currentEntries)
+          : workGroupLabel(turn, currentEntries, directoryPaths)
         : previousMessagesLabel(currentEntries.filter(isAssistantCommentaryMessage).length),
     });
     if (hasWork) {
@@ -403,6 +408,7 @@ function readCompletedTurn(
 function workGroupLabel(
   turn: AppServerThreadTurnMetadata,
   entries: AppServerThreadEntry[],
+  directoryPaths: string[] | undefined,
 ): string {
   const base = typeof turn.durationMs === "number" && turn.durationMs > 60_000
     ? `Worked for ${formatElapsedMs(turn.durationMs)}`
@@ -421,7 +427,10 @@ function workGroupLabel(
   const groups = coalesceToolActivityBurst(
     toolEntries.map((entry) => ({
       entry,
-      label: entry.summary,
+      // Backends that forward an agent's own tool title can put an absolute
+      // path here. The rows inside the group already display these relative to
+      // the thread's directories, so the group label has to match them.
+      label: formatActivityText(entry.summary, entry.details, directoryPaths),
       status: entry.status,
     })),
   );


### PR DESCRIPTION
## Summary

- The collapsed work-phase header rendered absolute paths (`Read `/Users/huntharo/.pwragent/worktrees/.../MessagingSettings.tsx``) while the activity rows inside the same group showed short directory-relative paths. Two renderers, one formatting step: `TranscriptActivity` ran the label through `formatActivityText`, but `workGroupLabel` in `transcript-render-items.ts` used the raw `entry.summary`, and `buildTranscriptRenderItems` was never given `directoryPaths` at all.
- Only ACP threads exposed it. Codex builds its own label with a basename (`thread-activity.ts:94`), while `acp-session-normalizer.ts:1292` forwards the agent's own ACP title verbatim — and Grok's upstream title is `format!("Read `{}`", read_file.path)` with whatever absolute path the model passed. Nothing to fix on the Grok side; the ACP `locations[].path` it sends is exactly what makes the row-level relativization work.
- Lifted `formatActivityText` (plus its two boundary helpers) out of `TranscriptActivity.tsx` into a new `activity-path-display.ts`, moved verbatim, and threaded `directoryPaths` through `buildTranscriptRenderItems` → `buildCompletedGroups` → `workGroupLabel`.
- Each summary is now formatted **before** `coalesceToolActivityBurst`, so repeated reads of one file collapse into ``2 × Read `apps/…` `` on the display text instead of staying separate.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail` — 46 files, 700 tests pass.
- 3 new cases in `transcript-render-items.test.ts`. Confirmed the two positive ones **fail** against the old `label: entry.summary` and pass with the fix; the third pins the no-linked-directories case so absolute paths still pass through untouched.
- `pnpm lint:eslint` — 0 errors. `pnpm lint:boundaries` — clean (1506 modules). `pnpm typecheck` — clean.

## Notes

- `pnpm typecheck` is clean. An earlier revision of this description claimed a pre-existing typecheck failure in `apps/desktop/src/main/acp/acp-instance-discovery.ts`; that was a stale local `node_modules` (`@pwrdrvr/agent-acp@0.13.1` against a lockfile pinning `0.15.0`), not a repo problem. Nothing there needs fixing.
- `ThreadView` calls `threadDirectoryPaths(selectedThread!)` inline, so `props.directoryPaths` is a fresh array every render. Adding it to the render-items `useMemo` directly would rebuild every group label on every streamed item, so the memo keys on the joined string and reconstructs a stable array. The neighbouring `pendingApprovalContext` memo has the same dep issue today — cheap and usually short-circuited on `pendingRequest`, so it was left alone.
- The label still lists up to three tool groups plus an "N other tool updates" remainder. That reads fine with relative paths; collapsing to basenames or dropping the enumeration entirely is a separate design call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

