### PR TITLE
fix(desktop): stop serving vendor Grok update notices on PwrAgent builds

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -2489,6 +2489,72 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("drops a cached vendor update status once a PwrAgent build is the runtime", async () => {
+    const launchDescriptor = {
+      backendId: "acp:grok" as AcpBackendId,
+      registryId: "grok",
+      distributionKind: "local" as const,
+      command: "/pwragent/agents/grok/versions/latest/grok",
+      args: ["agent", "stdio"],
+      env: { GROK_INSTALLER: "pwragent" },
+    };
+    // Same runtime as the discovery result, so the merge carries cached fields
+    // forward — except the vendor update status, which belongs to the vendor
+    // binary that was active when the check ran.
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId: "acp:grok",
+      registryId: "grok",
+      name: "Grok",
+      version: "1.0.4-pwragent.2",
+      activeCommand: launchDescriptor.command,
+      launchDescriptor,
+      update: {
+        status: "available",
+        checkedAt: 1000,
+        currentVersion: "1.0.3",
+        latestVersion: "1.0.5",
+      },
+      updateCommand: "/Users/me/.grok/bin/grok",
+    };
+    const upsertInstalledAgent = vi.fn((record: AcpInstalledAgentRecord) => {
+      stored = record;
+    });
+    const adapter = createTestAcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      checkGrokCliUpdate: vi.fn(),
+      discoverLocalAcpAgents: async () => [
+        {
+          ...buildInstalledAgent(),
+          backendId: "acp:grok" as AcpBackendId,
+          registryId: "grok",
+          name: "Grok",
+          version: "1.0.4-pwragent.2",
+          activeCommand: launchDescriptor.command,
+          launchDescriptor,
+        },
+      ],
+      emit: async () => undefined,
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    const [agent] = await adapter.listAvailableAgents();
+
+    expect(agent?.update).toBeUndefined();
+    expect(agent?.updateCommand).toBeUndefined();
+    expect(upsertInstalledAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ backendId: "acp:grok" }),
+    );
+    expect(stored.update).toBeUndefined();
+    await adapter.close();
+  });
+
   it.each([
     {
       change: "selected command",

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -931,6 +931,86 @@ describe("settings ipc", () => {
     }
   });
 
+  it("never serves a vendor Grok update status for a PwrAgent build", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState("bootstrap");
+    try {
+      // A vendor update status left in the durable record from a session where
+      // ~/.grok/bin/grok was the runtime, now that a PwrAgent build is active.
+      new AcpAgentStore(getAppStateDb()).upsertInstalledAgent({
+        backendId: "acp:grok",
+        registryId: "grok",
+        name: "Grok",
+        version: "1.0.4-pwragent.2",
+        distributionKind: "local",
+        distributionSource: "grok agent stdio",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-grok-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        activeCommand: "/pwragent/agents/grok/versions/latest/grok",
+        launchDescriptor: {
+          backendId: "acp:grok",
+          registryId: "grok",
+          distributionKind: "local",
+          command: "/pwragent/agents/grok/versions/latest/grok",
+          args: ["agent", "stdio"],
+          env: { GROK_INSTALLER: "pwragent", NO_COLOR: "1" },
+        },
+        update: {
+          status: "available",
+          checkedAt: 1000,
+          currentVersion: "1.0.3",
+          latestVersion: "1.0.5",
+        },
+        updateCommand: "/Users/me/.grok/bin/grok",
+      });
+      registerSettingsIpcHandlers(service);
+
+      // `refresh: false` serves the durable record without a discovery pass —
+      // the read path the update notice uses, and where the stale vendor
+      // status used to reach the renderer.
+      const response = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: false },
+      )) as
+        | {
+            entries?: Array<{
+              registryId: string;
+              pwrAgentManagedRuntime?: boolean;
+              update?: unknown;
+            }>;
+          }
+        | undefined;
+      const grok = response?.entries?.find(
+        (entry) => entry.registryId === "grok",
+      );
+      expect(grok).toMatchObject({ pwrAgentManagedRuntime: true });
+      expect(grok?.update).toBeUndefined();
+    } finally {
+      disposeAppState();
+    }
+  });
+
   it("persists legacy Kimi diagnostics without probing or retaining models", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "pwragent-settings-ipc-"),

--- a/apps/desktop/src/main/acp/grok-cli-update.ts
+++ b/apps/desktop/src/main/acp/grok-cli-update.ts
@@ -2,6 +2,7 @@ import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import type { AcpAgentUpdateStatus } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
+import type { AcpInstalledAgentRecord } from "./acp-registry-types.js";
 
 const execFile = promisify(execFileCallback);
 
@@ -23,6 +24,20 @@ type GrokUpdateCheckJson = {
 export type GrokCliUpdateProbe = (
   command: string,
 ) => Promise<{ stdout?: string; stderr?: string }>;
+
+/**
+ * Whether this record's active runtime is a PwrAgent-supplied Grok build
+ * (managed download or app bundle). Discovery stamps `GROK_INSTALLER=pwragent`
+ * on the launch descriptor when the resolved active command is one of those,
+ * and that stamp is the single marker every update-status path keys on: the
+ * vendor updater follows a different channel, so its result must never run
+ * against, decorate, or survive on a PwrAgent-owned runtime.
+ */
+export function isPwrAgentOwnedGrokRuntime(
+  record: Pick<AcpInstalledAgentRecord, "launchDescriptor">,
+): boolean {
+  return record.launchDescriptor?.env?.GROK_INSTALLER === "pwragent";
+}
 
 export function shouldCheckGrokCliUpdate(params: {
   command: string;

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -88,6 +88,7 @@ import {
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
 import {
   checkGrokCliUpdate,
+  isPwrAgentOwnedGrokRuntime,
   preserveGrokUpdateAcknowledgement,
   shouldCheckGrokCliUpdate,
 } from "../acp/grok-cli-update";
@@ -1118,7 +1119,7 @@ export class AcpBackendAdapter {
   private refreshGrokUpdateStatusInBackground(
     agent: AcpInstalledAgentRecord,
   ): void {
-    if (agent.launchDescriptor?.env?.GROK_INSTALLER === "pwragent") {
+    if (isPwrAgentOwnedGrokRuntime(agent)) {
       // Managed and bundled PwrAgent builds follow the verified GitHub release
       // feed. The vendor updater follows a different channel and must not
       // decorate these runtimes with an unrelated update notice.
@@ -1950,10 +1951,18 @@ export class AcpBackendAdapter {
         ...(sameRuntime && cached?.lastDiscoveryError !== undefined
           ? { lastDiscoveryError: cached.lastDiscoveryError }
           : {}),
-        ...(sameRuntime && cached?.update !== undefined
+        // A PwrAgent-supplied Grok build follows the verified GitHub release
+        // feed, so a cached vendor-updater result must not ride along with it.
+        // Dropping it here keeps a status written while a vendor binary was
+        // active from reappearing once the managed build becomes the runtime.
+        ...(sameRuntime
+          && cached?.update !== undefined
+          && !isPwrAgentOwnedGrokRuntime(agent)
           ? { update: cached.update }
           : {}),
-        ...(sameRuntime && cached?.updateCommand !== undefined
+        ...(sameRuntime
+          && cached?.updateCommand !== undefined
+          && !isPwrAgentOwnedGrokRuntime(agent)
           ? { updateCommand: cached.updateCommand }
           : {}),
       };

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -91,6 +91,7 @@ import { discoverLocalAcpAgentRecords } from "../acp/acp-instance-discovery";
 import { discoverAcpRuntimeCapabilities } from "../acp/acp-runtime-discovery";
 import { shouldReprobeAcpCapabilities } from "../acp/acp-capability-freshness";
 import { describeDistributionSource } from "../acp/acp-install-provenance";
+import { isPwrAgentOwnedGrokRuntime } from "../acp/grok-cli-update";
 import { selectAcpDistributionForCurrentPlatform } from "../acp/acp-platform-distribution";
 import { AcpRegistryService } from "../acp/acp-registry-service";
 import type {
@@ -510,8 +511,7 @@ async function listInstalledAndLocalAcpAgents(
           current?.version !== undefined
           && record.version !== undefined
           && current.version !== record.version;
-        const pwrAgentOwnedGrok =
-          record.launchDescriptor?.env?.GROK_INSTALLER === "pwragent";
+        const pwrAgentOwnedGrok = isPwrAgentOwnedGrokRuntime(record);
         const nextRecord = {
           ...record,
           runtimeCapabilities: runtimeVersionChanged
@@ -708,6 +708,11 @@ export function installedAcpAgentSettingsEntry(
   registryAgent?: AcpRegistryAgent,
 ): AcpAgentSettingsEntry {
   const agent = registryAgent ?? record.registryAgent;
+  // Reads without a discovery pass (`refresh: false`) serve the durable record
+  // as-is, so a vendor update status written while a vendor binary was active
+  // would still reach the renderer after the PwrAgent build became the runtime.
+  // Drop it at the boundary: the runtime in effect owns the update story.
+  const pwrAgentOwnedGrok = isPwrAgentOwnedGrokRuntime(record);
   return {
     backendId: record.backendId,
     registryId: record.registryId,
@@ -732,7 +737,8 @@ export function installedAcpAgentSettingsEntry(
     lastDiscoveredAt: record.lastDiscoveredAt,
     lastDiscoveryError: record.lastDiscoveryError,
     runtime: record.runtimeCapabilities,
-    update: record.update,
+    update: pwrAgentOwnedGrok ? undefined : record.update,
+    ...(pwrAgentOwnedGrok ? { pwrAgentManagedRuntime: true } : {}),
     ...(record.instances !== undefined ? { instances: record.instances } : {}),
     ...(record.incompatibleInstances !== undefined
       ? { incompatibleInstances: record.incompatibleInstances }

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -99,6 +99,13 @@ export function buildGrokCliUpdateNotice(params: {
     || !update.latestVersion
     || update.dismissedAt !== undefined
     || (update.snoozedUntil ?? 0) > params.now
+    // The notice is durable (`autoDismiss: false`), so a status that no longer
+    // describes the runtime in effect would sit on screen until the operator
+    // clicked it. Show it only for a vendor install whose installed version
+    // still matches the version the check ran against.
+    || params.entry.pwrAgentManagedRuntime === true
+    || (params.entry.version !== undefined
+      && params.entry.version !== update.currentVersion)
   ) {
     return undefined;
   }

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -7,6 +7,7 @@ import {
 
 function grokEntry(
   update: AcpAgentSettingsEntry["update"],
+  overrides?: Partial<AcpAgentSettingsEntry>,
 ): AcpAgentSettingsEntry {
   return {
     backendId: "acp:grok",
@@ -21,6 +22,7 @@ function grokEntry(
     authStatus: "not-required",
     verificationStatus: "not-applicable",
     update,
+    ...overrides,
   };
 }
 
@@ -88,5 +90,40 @@ describe("buildGrokCliUpdateNotice", () => {
       now: 200,
       ...callbacks,
     })).toBeUndefined();
+  });
+
+  it("hides a vendor update status on a PwrAgent-supplied runtime", () => {
+    const callbacks = {
+      onOpenUpdatePage: vi.fn(),
+      onDismiss: vi.fn(),
+      onSnooze: vi.fn(),
+    };
+    const available = {
+      status: "available" as const,
+      checkedAt: 100,
+      currentVersion: "1.0.3",
+      latestVersion: "1.0.5",
+    };
+
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry(available, {
+        pwrAgentManagedRuntime: true,
+        version: "1.0.4-pwragent.2",
+      }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    // A status left over from a vendor binary that is no longer the runtime:
+    // the notice is durable, so a stale one would never clear itself.
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry(available, { version: "1.0.4-pwragent.2" }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry(available, { version: "1.0.3" }),
+      now: 200,
+      ...callbacks,
+    })).toBeDefined();
   });
 });

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -289,6 +289,10 @@ export type AcpAgentSettingsEntry = {
    *  `probe-timed-out` is retryable; the other reasons are definitive failures. */
   rejectedInstances?: AcpRejectedAgentInstance[];
   activeCommand?: string;
+  /** The active install is a PwrAgent-supplied build (managed download or app
+   *  bundle) rather than a vendor install. Those runtimes follow the verified
+   *  PwrAgent release feed, so vendor update notices never apply to them. */
+  pwrAgentManagedRuntime?: boolean;
   enabled?: boolean;
   preference?: AcpAgentPreference;
 };


### PR DESCRIPTION
## Summary

- The Grok update toast fired with **"Grok 1.0.5 is available; 1.0.3 is installed"** while the active runtime was the PwrAgent build `1.0.4-pwragent.2`. That `1.0.3` can only come from the vendor binary at `~/.grok/bin/grok` — the managed build's own check reports `"currentVersion":"1.0.4-pwragent.2"` — so a vendor-updater result for a runtime that was not in use was being shown, and reached the operator even though Settings correctly showed the PwrAgent build as `Using`.
- The existing `GROK_INSTALLER === "pwragent"` guard only gates *running* the check. Everything downstream trusted the durable record, so a status written during a pass where the managed runtime did not resolve (ACP probe timeout on a fresh download, unreachable release feed at launch) kept being served afterwards:
  - `GrokCliUpdateNotice` reads `listAcpAgents({ refresh: false })` — a pure record read with no discovery pass — so a stale status reached the renderer verbatim.
  - `buildGrokCliUpdateNotice` never compared the status against the runtime in effect, and the toast is `autoDismiss: false`, so a stale one sat on screen until clicked rather than clearing itself.
  - Clearing was one-sided: the settings discovery merge dropped `update` for PwrAgent-owned records, while `mergeAndPersistDiscoveredAgents` in the adapter carried `update`/`updateCommand` forward with no such check.
- Fix, keyed on one shared marker (`isPwrAgentOwnedGrokRuntime`) so every update path reads the runtime the same way:
  - `acp-backend-adapter.ts` no longer carries a cached vendor status onto a PwrAgent-owned runtime.
  - `ipc/settings.ts` drops `update` at the IPC boundary and sets a new `pwrAgentManagedRuntime` flag on the entry, so even a `refresh: false` read cannot hand a vendor status to the renderer.
  - `GrokCliUpdateNotice` suppresses the notice for a PwrAgent runtime, and whenever `update.currentVersion` disagrees with the installed version — the general staleness guard a durable (non-auto-dismissing) toast needs.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/settings-ipc.test.ts` — 20 passed, including a new case asserting the `refresh: false` read serves no vendor status and sets `pwrAgentManagedRuntime` for a PwrAgent-owned record.
- `pnpm test apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts` — 54 passed, including a new merge case. Confirmed it fails without the fix (`expected { status: 'available', …(3) } to be undefined`), so it is not vacuous.
- `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts` — new cases for the PwrAgent runtime and the version-mismatch suppression.
- `pnpm lint:eslint` — 0 errors (35 pre-existing warnings). `pnpm lint:boundaries` — no violations (1505 modules cruised).
- `pnpm typecheck` and `acp-runtime-override-launch.test.ts` fail in this worktree from a stale `@pwrdrvr/agent-transport` in `node_modules` (missing `createCommandInvocation` export). Verified pre-existing by stashing these changes and re-running; none of the errors are in files this PR touches.

## Notes

- **Not addressed here:** the transient that lets a discovery pass select the vendor binary while a managed build exists on disk. This PR makes that harmless to the UI, but if the managed build should hold its slot through a failed ACP probe or an offline release-feed check, that is a separate change in the discovery/activation path.
- `pwrAgentManagedRuntime` is a new optional field on `AcpAgentSettingsEntry`. It is additive and currently read only by the update notice; it is also the natural signal if Settings ever wants to badge the PwrAgent-supplied path.
- Reviewer note on the read-boundary drop: `installedAcpAgentSettingsEntry` is the single record→entry conversion, so dropping there covers every list path without touching persistence. The durable record is still cleaned by the next discovery pass, which keeps discovery the single writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
