### PR TITLE
fix(desktop): backport the selected-channel switch back (#1762)

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -410,6 +410,52 @@ describe("auto updater", () => {
     expect(autoUpdaterMock.allowDowngrade).toBe(false);
   });
 
+  it("resets allowDowngrade once a later check resolves to a newer release", async () => {
+    // The flag is global state on the shared autoUpdater singleton, so the
+    // case that matters is clearing it after a switch-back check set it.
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    mockGitHubReleases([
+      githubRelease("v1.1.0-alpha.2", { prerelease: true }),
+      githubRelease("v1.0.2"),
+    ]);
+    checkForUpdatesMock.mockResolvedValue({ updateInfo: { version: "1.0.2" } });
+    autoUpdaterMock.currentVersion = { version: "1.1.0-alpha.2" };
+    const updater = await importAutoUpdater();
+
+    await updater.checkForAppUpdatesNow("manual");
+    expect(autoUpdaterMock.allowDowngrade).toBe(true);
+
+    // The operator switches to Beta, where the alpha is a real update.
+    resolveUpdateTrainMock.mockReturnValue("beta");
+    resolveUpdateChannelMock.mockReturnValue("prerelease");
+    autoUpdaterMock.currentVersion = { version: "1.0.2" };
+    checkForUpdatesMock.mockResolvedValue({
+      updateInfo: { version: "1.1.0-alpha.2" },
+    });
+
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "available",
+      version: "1.1.0-alpha.2",
+    });
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+  });
+
+  it("does not treat an unreadable release tag as a switch back", async () => {
+    // compareSemver sorts a tag it cannot parse below every real version, so
+    // an unreadable tag must not reach the downgrade path and pin the feed.
+    mockGitHubReleases([githubRelease("nightly")]);
+    autoUpdaterMock.currentVersion = { version: "1.0.2" };
+    const updater = await importAutoUpdater();
+
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "no-update",
+      version: "1.0.2",
+    });
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+    expect(setFeedURLMock).not.toHaveBeenCalled();
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+  });
+
   it("reports no update when the selected release matches the running build", async () => {
     mockGitHubReleases([githubRelease("v1.0.0-beta.7")]);
     autoUpdaterMock.currentVersion = { version: "1.0.0-beta.7" };

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -21,6 +21,7 @@ const logWarnMock = vi.fn();
 const fetchMock = vi.fn();
 
 const autoUpdaterMock = {
+  allowDowngrade: false,
   allowPrerelease: false,
   autoDownload: false,
   autoInstallOnAppQuit: false,
@@ -173,6 +174,7 @@ describe("auto updater", () => {
     onConfigWrittenMock.mockClear();
     logInfoMock.mockReset();
     logWarnMock.mockReset();
+    autoUpdaterMock.allowDowngrade = false;
     autoUpdaterMock.allowPrerelease = false;
     autoUpdaterMock.autoDownload = false;
     autoUpdaterMock.autoInstallOnAppQuit = false;
@@ -366,6 +368,122 @@ describe("auto updater", () => {
       version: "1.1.0-beta.2",
     });
     expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
+  });
+
+  it("offers a switch back when the selected release is older than the running build", async () => {
+    // The stranding case: a prerelease auto-update landed a 1.1 alpha on a
+    // machine whose selection resolves to the 1.0 stable train.
+    resolveUpdateTrainMock.mockReturnValue("stable");
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    mockGitHubReleases([
+      githubRelease("v1.1.0-alpha.2", { prerelease: true }),
+      githubRelease("v1.0.2"),
+    ]);
+    checkForUpdatesMock.mockResolvedValue({
+      updateInfo: { version: "1.0.2" },
+    });
+    autoUpdaterMock.currentVersion = { version: "1.1.0-alpha.2" };
+    const updater = await importAutoUpdater();
+
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "available",
+      version: "1.0.2",
+      direction: "downgrade",
+    });
+    expect(autoUpdaterMock.allowDowngrade).toBe(true);
+    expect(setFeedURLMock).toHaveBeenCalledWith({
+      provider: "generic",
+      url: "https://github.com/pwrdrvr/PwrAgent/releases/download/v1.0.2/",
+    });
+    expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves allowDowngrade off when the selected release is newer", async () => {
+    mockGitHubReleases([githubRelease("v1.0.0-beta.8")]);
+    autoUpdaterMock.currentVersion = { version: "1.0.0-beta.7" };
+    const updater = await importAutoUpdater();
+
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "available",
+      version: "1.0.0-beta.8",
+    });
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+  });
+
+  it("reports no update when the selected release matches the running build", async () => {
+    mockGitHubReleases([githubRelease("v1.0.0-beta.7")]);
+    autoUpdaterMock.currentVersion = { version: "1.0.0-beta.7" };
+    const updater = await importAutoUpdater();
+
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "no-update",
+      version: "1.0.0-beta.7",
+    });
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+    expect(setFeedURLMock).not.toHaveBeenCalled();
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+  });
+
+  it("does not offer a switch back on background checks", async () => {
+    mockGitHubReleases([
+      githubRelease("v1.1.0-alpha.2", { prerelease: true }),
+      githubRelease("v1.0.2"),
+    ]);
+    autoUpdaterMock.currentVersion = { version: "1.1.0-alpha.2" };
+    const updater = await importAutoUpdater();
+
+    for (const trigger of ["startup", "periodic"] as const) {
+      await expect(updater.checkForAppUpdatesNow(trigger)).resolves.toEqual({
+        status: "no-update",
+        version: "1.1.0-alpha.2",
+      });
+    }
+    expect(autoUpdaterMock.allowDowngrade).toBe(false);
+    expect(setFeedURLMock).not.toHaveBeenCalled();
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+  });
+
+  it("never auto-installs a downloaded switch back on quit", async () => {
+    mockGitHubReleases([
+      githubRelease("v1.1.0-alpha.2", { prerelease: true }),
+      githubRelease("v1.0.2"),
+    ]);
+    checkForUpdatesMock.mockResolvedValue({
+      updateInfo: { version: "1.0.2" },
+    });
+    autoUpdaterMock.currentVersion = { version: "1.1.0-alpha.2" };
+    const updater = await importAutoUpdater();
+    const requestQuit = vi.fn(async (performQuit: () => void) => {
+      performQuit();
+      return true;
+    });
+
+    updater.initAutoUpdater();
+    updater.registerAppUpdateIpcHandlers({ requestQuit });
+    // Let the startup check settle first; it declines the switch back, so the
+    // manual check below cannot join it as an in-flight result.
+    await vi.waitFor(() =>
+      expect(updater.readAppUpdateStatus()).toEqual({
+        status: "no-update",
+        version: "1.1.0-alpha.2",
+      }),
+    );
+    await updater.checkForAppUpdatesNow("manual");
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.2" });
+
+    expect(updater.readAppUpdateStatus()).toEqual({
+      status: "downloaded",
+      version: "1.0.2",
+      direction: "downgrade",
+    });
+    // The switch back only happens when the operator asks for it.
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false);
+    await expect(ipcHandlers.get("app:install-update")?.()).resolves.toEqual({
+      status: "restarting",
+    });
+    await vi.waitFor(() =>
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledOnce(),
+    );
   });
 
   it("skips electron-updater on Linux package builds", async () => {

--- a/apps/desktop/src/main/__tests__/pwragent-app-management-service.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-app-management-service.test.ts
@@ -152,6 +152,39 @@ describe("PwrAgent app management service", () => {
     });
   });
 
+  it("keeps the switch-back direction on the reported update status", async () => {
+    // Without this the agent describes a move back down onto the operator's
+    // selected channel as an ordinary update to a lower version.
+    checkForAppUpdatesNowMock.mockResolvedValue({
+      status: "available",
+      version: "1.0.2",
+      direction: "downgrade",
+    });
+    const { createPwrAgentAppManagementHandler } = await import(
+      "../agent-tools/pwragent-app-management-service"
+    );
+    const handler = createPwrAgentAppManagementHandler({ startedAt: 1_000 });
+
+    await expect(
+      handler({
+        operation: "manage_pwragent",
+        context: {},
+        args: { action: "upgrade_check" },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        result: {
+          status: "check_completed",
+          check: { status: "available", version: "1.0.2", direction: "downgrade" },
+        },
+        update: {
+          status: { status: "available", version: "1.0.2", direction: "downgrade" },
+        },
+      },
+    });
+  });
+
   it("uses update install when restarting with a downloaded update", async () => {
     readAppUpdateStatusMock.mockReturnValue({
       status: "downloaded",

--- a/apps/desktop/src/main/agent-tools/pwragent-app-management-service.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-app-management-service.ts
@@ -208,14 +208,23 @@ function toToolUpdateStatus(
     case "skipped":
       return { status: "skipped", reason: status.reason };
     case "no-update":
+      return { status: "no-update", version: status.version };
+    // `direction` has to survive the conversion, or the tool reports a switch
+    // back onto the operator's selected channel as an ordinary update and the
+    // agent describes a move backwards as forward progress.
     case "available":
     case "downloaded":
-      return { status: status.status, version: status.version };
+      return {
+        status: status.status,
+        version: status.version,
+        ...(status.direction ? { direction: status.direction } : {}),
+      };
     case "downloading":
       return {
         status: "downloading",
         version: status.version,
         ...(status.percent !== undefined ? { percent: status.percent } : {}),
+        ...(status.direction ? { direction: status.direction } : {}),
       };
     case "error":
       return { status: "error", message: status.message };

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -339,7 +339,13 @@ export async function checkForAppUpdatesNow(
       }
       const selectedVersion = release.tag_name.replace(/^v/i, "");
       const selectedOrder = compareSemver(selectedVersion, currentVersion);
-      if (selectedOrder === 0) {
+      // `compareSemver` sorts a tag it cannot parse below every real version,
+      // so an unreadable tag looks identical to a deliberate downgrade. The
+      // `<= 0` guard this replaced declined both; keep declining the tag we
+      // cannot read rather than pointing the update feed at it.
+      const selectedIsOlder =
+        selectedOrder < 0 && parseSemver(selectedVersion) !== undefined;
+      if (selectedOrder <= 0 && !selectedIsOlder) {
         const result = { status: "no-update", version: currentVersion } as const;
         setUpdateStatusUnlessDownloaded(result);
         log.info("skipping app update check; selected release is not newer", {
@@ -355,7 +361,7 @@ export async function checkForAppUpdatesNow(
       // operator is on a build their own channel no longer serves — the
       // stranding this branch exists to undo. Offer the switch back rather
       // than reporting "up to date" on a version they did not pick.
-      if (selectedOrder < 0) {
+      if (selectedIsOlder) {
         if (!downgradeOfferAllowed(trigger)) {
           const result = {
             status: "no-update",

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -10,6 +10,7 @@ import {
 } from "../shared/ipc";
 import type {
   AppUpdateCheckResult,
+  AppUpdateDirection,
   AppUpdateInstallResult,
   AppUpdateReleaseInfo,
   AppUpdateReleaseVersions,
@@ -110,17 +111,56 @@ function currentUpdateSelectionKey(): UpdateSelectionKey {
   return updateSelectionKey(currentUpdateTrain(), currentUpdateChannel());
 }
 
+// `allowDowngrade` is the posture that lets an operator move *back* onto the
+// channel they picked after ending up on a newer build than that channel
+// serves. It stays alongside `allowPrerelease` so both halves of the feed
+// posture are set — and logged — in one greppable place.
 function configureAutoUpdaterChannel(
   updateChannel: DesktopUpdateChannel = currentUpdateChannel(),
   updateTrain: DesktopUpdateTrain = currentUpdateTrain(),
+  options: { allowDowngrade?: boolean } = {},
 ): void {
   autoUpdater.allowPrerelease =
     updateTrain === "beta" || updateChannel === "prerelease";
+  autoUpdater.allowDowngrade = options.allowDowngrade === true;
   log.info("configured auto-update channel", {
+    allowDowngrade: autoUpdater.allowDowngrade,
     allowPrerelease: autoUpdater.allowPrerelease,
     updateChannel,
     updateTrain,
   });
+}
+
+// Direction is derived from the running version rather than threaded through
+// every call site, so the electron-updater event handlers — which only learn a
+// version string — classify a build the same way the check flow does.
+function updateDirectionForVersion(
+  version: string | undefined,
+): AppUpdateDirection | undefined {
+  const currentVersion = autoUpdater.currentVersion?.version;
+  // Both sides must parse. A placeholder such as the "unknown" the download
+  // progress handler can carry sorts below every real version in
+  // `compareSemver`, and must not be read as a downgrade.
+  if (!parseSemver(version) || !parseSemver(currentVersion)) {
+    return undefined;
+  }
+  return compareSemver(version, currentVersion) < 0 ? "downgrade" : undefined;
+}
+
+function withDirection<T extends { version: string }>(
+  result: T,
+): T & { direction?: AppUpdateDirection } {
+  const direction = updateDirectionForVersion(result.version);
+  return direction ? { ...result, direction } : result;
+}
+
+// Only an operator-initiated check may offer a downgrade. A background poll
+// that nagged someone back down every hour would fight an operator who
+// deliberately installed a newer build and left their channel alone; the
+// Settings "Check for updates" button, the app menu item, and the app
+// management tool are all explicit asks.
+function downgradeOfferAllowed(trigger: UpdateCheckTrigger): boolean {
+  return trigger === "manual" || trigger === "menu";
 }
 
 function configureAutoUpdaterFeedForRelease(release: GitHubRelease): void {
@@ -188,13 +228,22 @@ function downloadedUpdateMatchesChannel(
   if (heldDownloadedUpdate?.selection !== updateSelection) {
     return undefined;
   }
-  return { status: "downloaded", version: heldDownloadedUpdate.version };
+  return withDirection({
+    status: "downloaded" as const,
+    version: heldDownloadedUpdate.version,
+  });
 }
 
 function syncAutoInstallOnAppQuit(updateSelection: UpdateSelectionKey): void {
+  const eligibleDownload = downloadedUpdateMatchesChannel(updateSelection);
+  if (eligibleDownload?.direction === "downgrade") {
+    // Moving back down a channel is never something to do behind the
+    // operator's back on the next quit. It waits for the explicit restart.
+    autoUpdater.autoInstallOnAppQuit = false;
+    return;
+  }
   autoUpdater.autoInstallOnAppQuit =
-    downloadedUpdateMatchesChannel(updateSelection) !== undefined
-    || heldDownloadedUpdate === undefined;
+    eligibleDownload !== undefined || heldDownloadedUpdate === undefined;
 }
 
 function reconcileDownloadedUpdateEligibility(
@@ -233,8 +282,10 @@ function recordPendingDownloadChannel(
   pendingDownloadChannelsByVersion.set(version, updateSelection);
 }
 
+type UpdateCheckTrigger = "startup" | "periodic" | "manual" | "menu";
+
 export async function checkForAppUpdatesNow(
-  trigger: "startup" | "periodic" | "manual" | "menu" = "manual",
+  trigger: UpdateCheckTrigger = "manual",
 ): Promise<AppUpdateCheckResult> {
   if (!productionUpdatesEnabled()) {
     const result = developmentUpdateCheckResult();
@@ -287,7 +338,8 @@ export async function checkForAppUpdatesNow(
         return result;
       }
       const selectedVersion = release.tag_name.replace(/^v/i, "");
-      if (compareSemver(selectedVersion, currentVersion) <= 0) {
+      const selectedOrder = compareSemver(selectedVersion, currentVersion);
+      if (selectedOrder === 0) {
         const result = { status: "no-update", version: currentVersion } as const;
         setUpdateStatusUnlessDownloaded(result);
         log.info("skipping app update check; selected release is not newer", {
@@ -298,6 +350,37 @@ export async function checkForAppUpdatesNow(
           updateTrain,
         });
         return result;
+      }
+      // A selection that resolves *older* than the running build means the
+      // operator is on a build their own channel no longer serves — the
+      // stranding this branch exists to undo. Offer the switch back rather
+      // than reporting "up to date" on a version they did not pick.
+      if (selectedOrder < 0) {
+        if (!downgradeOfferAllowed(trigger)) {
+          const result = {
+            status: "no-update",
+            version: currentVersion,
+          } as const;
+          setUpdateStatusUnlessDownloaded(result);
+          log.info("skipping background downgrade offer; selection is older", {
+            currentVersion,
+            selectedRelease: release.tag_name,
+            trigger,
+            updateChannel,
+            updateTrain,
+          });
+          return result;
+        }
+        configureAutoUpdaterChannel(updateChannel, updateTrain, {
+          allowDowngrade: true,
+        });
+        log.info("offering a switch back to the selected channel", {
+          currentVersion,
+          selectedRelease: release.tag_name,
+          trigger,
+          updateChannel,
+          updateTrain,
+        });
       }
       configureAutoUpdaterFeedForRelease(release);
       updateCheckChannelInFlight = updateSelection;
@@ -318,7 +401,10 @@ export async function checkForAppUpdatesNow(
       if (result.updateInfo.version === currentVersion) {
         return { status: "no-update", version: currentVersion };
       }
-      return { status: "available", version: result.updateInfo.version };
+      return withDirection({
+        status: "available" as const,
+        version: result.updateInfo.version,
+      });
     } catch (err) {
       const result = {
         status: "error",
@@ -727,7 +813,9 @@ export function initAutoUpdater(): void {
   autoUpdater.on("update-available", (info) => {
     log.info("update-available", { version: info.version });
     recordPendingDownloadChannel(info.version, updateCheckChannelInFlight);
-    setUpdateStatus({ status: "available", version: info.version });
+    setUpdateStatus(
+      withDirection({ status: "available" as const, version: info.version }),
+    );
   });
   autoUpdater.on("update-not-available", (info) => {
     log.info("update-not-available", { version: info.version });
@@ -743,11 +831,13 @@ export function initAutoUpdater(): void {
       updateStatus.status === "available" || updateStatus.status === "downloading"
         ? updateStatus.version
         : "unknown";
-    setUpdateStatus({
-      status: "downloading",
-      version,
-      percent: Math.round(progress.percent),
-    });
+    setUpdateStatus(
+      withDirection({
+        status: "downloading" as const,
+        version,
+        percent: Math.round(progress.percent),
+      }),
+    );
   });
   autoUpdater.on("update-downloaded", (info) => {
     log.info("update-downloaded", { version: info.version });

--- a/apps/desktop/src/renderer/src/features/settings/AboutSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AboutSettings.tsx
@@ -286,13 +286,17 @@ function UpdateResultStatus({ result }: { result: AppUpdateCheckResult }) {
   if (result.status === "downloaded") {
     return (
       <p className="settings-empty">
-        Update ready: v{result.version}. Restart to install.
+        {result.direction === "downgrade"
+          ? `Switch ready: v${result.version}. Restart to switch.`
+          : `Update ready: v${result.version}. Restart to install.`}
       </p>
     );
   }
   return (
     <p className="settings-empty">
-      Update available: v{result.version}. Downloading in the background.
+      {result.direction === "downgrade"
+        ? `Switch to v${result.version}. Downloading in the background.`
+        : `Update available: v${result.version}. Downloading in the background.`}
     </p>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -225,9 +225,13 @@ function updateResultText(result: AppUpdateCheckResult): string {
     return `You're up to date (v${result.version}).`;
   }
   if (result.status === "downloaded") {
-    return `Update ready: v${result.version}. Restart to install.`;
+    return result.direction === "downgrade"
+      ? `Switch ready: v${result.version}. Restart to switch.`
+      : `Update ready: v${result.version}. Restart to install.`;
   }
-  return `Update available: v${result.version}. Downloading in the background.`;
+  return result.direction === "downgrade"
+    ? `Switch to v${result.version}. Downloading in the background.`
+    : `Update available: v${result.version}. Downloading in the background.`;
 }
 
 function formatHotCpuStartDelay(delayMs: DesktopHotCpuProfileStartDelayMs): string {
@@ -444,6 +448,14 @@ export function GeneralSettings(props: {
   const checkForUpdates = props.desktopApi?.checkForAppUpdates;
   const downloadedVersion =
     updateStatus.status === "downloaded" ? updateStatus.version : undefined;
+  // A resolved selection that is older than the running build is a switch back
+  // onto the operator's own channel, not an update.
+  const downloadedIsSwitchBack =
+    updateStatus.status === "downloaded"
+    && updateStatus.direction === "downgrade";
+  const restartActionLabel = downloadedIsSwitchBack
+    ? "Restart to Switch"
+    : "Restart to Update";
   const handleCheckForUpdate = async () => {
     if (!checkForUpdates) {
       return;
@@ -727,7 +739,7 @@ export function GeneralSettings(props: {
                 {downloadedVersion ? (
                   <div className="settings-update-channel__restart">
                     <button
-                      aria-label={`Restart to Update (${downloadedVersion})`}
+                      aria-label={`${restartActionLabel} (${downloadedVersion})`}
                       className="button button--primary settings-update-channel__restart-button"
                       type="button"
                       disabled={
@@ -737,7 +749,7 @@ export function GeneralSettings(props: {
                         void handleRestartUpdate();
                       }}
                     >
-                      <span>Restart to Update</span>
+                      <span>{restartActionLabel}</span>
                       <span className="settings-update-channel__restart-version">
                         ({downloadedVersion})
                       </span>

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -3922,6 +3922,64 @@ describe("SettingsScreen", () => {
     expect(settings.replaceSecret).not.toHaveBeenCalled();
   });
 
+  it("offers a switch back when the downloaded release is older than the running build", async () => {
+    const settings = createSettingsState(
+      createSnapshot({
+        updates: {
+          channel: { value: "latest", source: "config" },
+          train: { value: "stable", source: "config" },
+        },
+      }),
+    );
+    const desktopApi = {
+      checkForAppUpdates: vi.fn(async () => ({
+        status: "available" as const,
+        version: "1.0.2",
+        direction: "downgrade" as const,
+      })),
+      readAppUpdateReleaseVersions: vi.fn(async () => ({
+        fetchedAt: 1,
+        stable: {
+          latest: { version: "v1.0.2" },
+          prerelease: { version: "v1.0.2" },
+        },
+        beta: {
+          latest: { version: "v1.1.0-alpha.2" },
+          prerelease: { version: "v1.1.0-alpha.2" },
+        },
+      })),
+      readAppUpdateStatus: vi.fn(async () => ({
+        status: "downloaded" as const,
+        version: "1.0.2",
+        direction: "downgrade" as const,
+      })),
+      installAppUpdate: vi.fn(async () => ({ status: "restarting" as const })),
+    };
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Restart to Switch (1.0.2)",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Restart to Update (1.0.2)" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Check for Update" }));
+    await waitFor(() => {
+      expect(desktopApi.checkForAppUpdates).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByText(/Switch to v1.0.2/)).toBeInTheDocument();
+  });
+
   it("shows a restart action when the selected channel version is already downloaded", async () => {
     const settings = createSettingsState(
       createSnapshot({

--- a/apps/desktop/src/renderer/src/features/update/AppUpdateBanner.tsx
+++ b/apps/desktop/src/renderer/src/features/update/AppUpdateBanner.tsx
@@ -31,6 +31,11 @@ export function AppUpdateBanner(props: { desktopApi?: DesktopApi }) {
 
   const version =
     updateStatus.status === "downloaded" ? updateStatus.version : undefined;
+  // A downgrade is the operator moving back onto the channel they picked, not
+  // an update landing on them, so it gets its own wording.
+  const switchingBack =
+    updateStatus.status === "downloaded"
+    && updateStatus.direction === "downgrade";
 
   useEffect(() => {
     if (!version || dismissedVersion === version) {
@@ -61,9 +66,13 @@ export function AppUpdateBanner(props: { desktopApi?: DesktopApi }) {
   return (
     <aside className="app-update-banner" role="status" aria-live="polite">
       <div className="app-update-banner__content">
-        <p className="app-update-banner__eyebrow">Update ready</p>
+        <p className="app-update-banner__eyebrow">
+          {switchingBack ? "Switch ready" : "Update ready"}
+        </p>
         <p className="app-update-banner__message">
-          Restart to update to v{version}.
+          {switchingBack
+            ? `Restart to switch to v${version}.`
+            : `Restart to update to v${version}.`}
         </p>
         {restartError ? (
           <p className="app-update-banner__error">{restartError}</p>
@@ -84,7 +93,11 @@ export function AppUpdateBanner(props: { desktopApi?: DesktopApi }) {
           className="button button--ghost app-update-banner__dismiss"
           type="button"
           disabled={restarting}
-          aria-label="Dismiss update notification"
+          aria-label={
+            switchingBack
+              ? "Dismiss channel switch notification"
+              : "Dismiss update notification"
+          }
           onClick={() => setDismissedVersion(version)}
         >
           Dismiss

--- a/apps/desktop/src/renderer/src/features/update/__tests__/AppUpdateBanner.test.tsx
+++ b/apps/desktop/src/renderer/src/features/update/__tests__/AppUpdateBanner.test.tsx
@@ -43,6 +43,20 @@ describe("AppUpdateBanner", () => {
     expect(screen.getByRole("button", { name: "Restart" })).toBeEnabled();
   });
 
+  it("names a downgrade as a channel switch rather than an update", async () => {
+    renderBanner({
+      status: "downloaded",
+      version: "1.0.2",
+      direction: "downgrade",
+    });
+
+    expect(
+      await screen.findByText("Restart to switch to v1.0.2."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Switch ready")).toBeInTheDocument();
+    expect(screen.queryByText(/Restart to update/)).not.toBeInTheDocument();
+  });
+
   it("stays hidden before the update is ready to install", async () => {
     renderBanner({ status: "available", version: "1.2.3" });
 

--- a/apps/desktop/src/shared/app-metadata.ts
+++ b/apps/desktop/src/shared/app-metadata.ts
@@ -56,22 +56,36 @@ export type AppLogEntry = {
   line: string;
 };
 
+/**
+ * Direction of an offered build relative to the running one. `"downgrade"`
+ * means the release resolved for the operator's own channel/track selection
+ * is *older* than what is running — a deliberate switch back onto the chosen
+ * channel, not an update. Absent means the normal forward case; a surface
+ * that ignores the field keeps its existing "update" wording.
+ */
+export type AppUpdateDirection = "downgrade";
+
 export type AppUpdateCheckResult =
   | { status: "skipped"; reason: string }
   | { status: "error"; message: string }
   | { status: "checking" }
   | { status: "no-update"; version: string }
-  | { status: "downloaded"; version: string }
-  | { status: "available"; version: string };
+  | { status: "downloaded"; version: string; direction?: AppUpdateDirection }
+  | { status: "available"; version: string; direction?: AppUpdateDirection };
 
 export type AppUpdateStatus =
   | { status: "idle" }
   | { status: "skipped"; reason: string }
   | { status: "checking" }
   | { status: "no-update"; version: string }
-  | { status: "available"; version: string }
-  | { status: "downloading"; version: string; percent?: number }
-  | { status: "downloaded"; version: string }
+  | { status: "available"; version: string; direction?: AppUpdateDirection }
+  | {
+      status: "downloading";
+      version: string;
+      percent?: number;
+      direction?: AppUpdateDirection;
+    }
+  | { status: "downloaded"; version: string; direction?: AppUpdateDirection }
   | { status: "error"; message: string };
 
 export type AppUpdateInstallResult =

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -375,6 +375,30 @@ The "Check for updates" button in **Settings → About** invokes
 `autoUpdater.checkForUpdates()` — useful for verifying the feed is reachable
 without waiting for the auto-check on next launch.
 
+### Switching back to a channel that is behind the running build
+
+An operator can end up running a build that is newer than the channel they
+have selected — the usual route is a prerelease auto-update landing a `main`
+alpha on a machine whose selection later resolves to the Stable train. That
+build serves no forward update on the selected channel, so the app treats the
+older selected release as a **switch back** rather than "no update":
+
+- The check sets `autoUpdater.allowDowngrade = true` for that check only,
+  points the feed at the selected release, and downloads it. Every check that
+  resolves to a newer release sets `allowDowngrade` back to `false`.
+- The offer is made only for an operator-initiated check — the Settings
+  "Check for Update" button, the app menu **Check for Updates**, or the app
+  management tool. Startup and hourly background checks still report
+  "You're up to date" so an operator who deliberately installed a newer build
+  is not asked to move back down on every poll. Tell an operator who is
+  stranded to press "Check for Update" after selecting their channel.
+- A downloaded switch back never installs on quit. `autoInstallOnAppQuit`
+  stays `false` for it, so it applies only when the operator presses
+  **Restart to Switch**.
+- Surfaces say "Switch to v1.0.2" and "Restart to Switch" instead of the
+  update wording, because the operator is moving onto the channel they picked.
+- A selected release equal to the running version is still "no update".
+
 Phase 2 distribution channel migration removes the token requirement entirely.
 See [desktop-distribution-phase-2-runbook.md](desktop-distribution-phase-2-runbook.md).
 

--- a/packages/shared/src/contracts/app-tools.ts
+++ b/packages/shared/src/contracts/app-tools.ts
@@ -41,14 +41,34 @@ export type PwrAgentAppToolArgs<
   TOperation extends PwrAgentAppOperationName = PwrAgentAppOperationName,
 > = PwrAgentAppToolArgsByOperation[TOperation];
 
+/**
+ * `"downgrade"` means the offered build is *older* than the running one: the
+ * release resolved for the operator's own channel selection, which they can
+ * only reach by moving back down. Absent means the normal forward case.
+ */
+export type PwrAgentUpdateToolDirection = "downgrade";
+
 export type PwrAgentUpdateToolStatus =
   | { status: "idle" }
   | { status: "skipped"; reason: string }
   | { status: "checking" }
   | { status: "no-update"; version: string }
-  | { status: "available"; version: string }
-  | { status: "downloading"; version: string; percent?: number }
-  | { status: "downloaded"; version: string }
+  | {
+      status: "available";
+      version: string;
+      direction?: PwrAgentUpdateToolDirection;
+    }
+  | {
+      status: "downloading";
+      version: string;
+      percent?: number;
+      direction?: PwrAgentUpdateToolDirection;
+    }
+  | {
+      status: "downloaded";
+      version: string;
+      direction?: PwrAgentUpdateToolDirection;
+    }
   | { status: "error"; message: string };
 
 export type PwrAgentAppRuntimeStatus = {


### PR DESCRIPTION
Backport of https://github.com/pwrdrvr/PwrAgent/pull/1762 to `releases/1.0`,
mirroring the #1673 / #1682 pairing.

## Why this matters on 1.0 specifically

A `releases/1.0` user is the one who gets stranded. Publishing
`v1.1.0-alpha.1` from `main` puts a build newer than the Stable train in
front of anyone with Prerelease on; once they are on it, their own
Stable/Latest selection resolves to `v1.0.2`, the app reports "You're up to
date (v1.1.0-alpha.1)", and there is no in-app way back. This has to be in a
shipped 1.0 build before that alpha goes out, since the fix only helps if it
is running on the machine that got stranded.

## Fix

Two things blocked the downgrade and both had to change together: the
`compareSemver(selectedVersion, currentVersion) <= 0` guard in
`checkForAppUpdatesNow` returned `no-update` for anything not strictly newer,
and `allowDowngrade` was never set anywhere in `apps/desktop/src`, so
electron-updater would have refused the install even without the guard.

A selection that resolves **older** than the running build is now treated as a
deliberate switch back onto the channel the operator picked:
`autoUpdater.allowDowngrade` is set alongside `allowPrerelease` (and logged on
the same line), the feed is pointed at that release, and the normal download
path runs. Equal versions are still `no-update`, and any check resolving to a
newer release sets `allowDowngrade` back to `false`.

The offer is made only for operator-initiated checks (`manual` / `menu`), and
a downloaded switch back never installs on quit — `autoInstallOnAppQuit` stays
`false` for it. Surfaces say "Switch to v1.0.2" / "Restart to Switch" via a
new optional `direction` field on the update result.

See #1762 for the full rationale, including why the trigger policy is
"operator-initiated only" rather than "when the selection changed".

## Backport notes

`apps/desktop/src/main/auto-updater.ts`, its test,
`apps/desktop/src/shared/app-metadata.ts`, and `AppUpdateBanner.tsx` are byte
identical on `main` and `releases/1.0` after #1682, so the fix applies
unchanged. Only `GeneralSettings.tsx` needed a context merge (the two branches
have diverged around that file, not in the update section itself). No
behavioral divergence from #1762.

## Verification

Full workspace suite green on this branch (428 files / 5617 tests),
`typecheck` clean, `lint:eslint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
