### PR TITLE
fix(desktop): keep suffixed tags out of the Stable Latest slot

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -744,6 +744,56 @@ describe("selectChannelReleases", () => {
     expect(selected.betaPrerelease?.tag_name).toBe("v1.1.0-alpha.7");
   });
 
+  it("does not let a mistagged main-train alpha take stable latest", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    // The GitHub Pre-release flag is set by hand at tag time. If a `main` tag
+    // ships without it, it must still not become the feed every Stable
+    // operator is pushed onto.
+    const releases = [
+      { tag_name: "v1.1.0-alpha.1", prerelease: false, draft: false },
+      { tag_name: "v1.0.2", prerelease: false, draft: false },
+      { tag_name: "v1.0.2-prerelease.2", prerelease: true, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.2");
+    // The same flag is what keeps it out of the Stable prerelease slot, so a
+    // mistag must not leak it there either.
+    expect(selected.stablePrerelease?.tag_name).toBe("v1.0.2");
+  });
+
+  it("does not let a mistagged main-train beta take stable latest", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0-beta.3", prerelease: false, draft: false },
+      { tag_name: "v1.0.2", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.2");
+    expect(selected.stablePrerelease?.tag_name).toBe("v1.0.2");
+  });
+
+  it("still promotes a real suffix-free stable over the current one", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0", prerelease: false, draft: false },
+      { tag_name: "v1.0.2", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.1.0");
+  });
+
+  it("falls back to a suffixed stable when no suffix-free tag exists", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    // The pre-v1.0.0 world: every stable was a `-beta.N` tag published as
+    // GitHub Latest. Those trains must keep resolving.
+    const releases = [
+      { tag_name: "v1.0.0-beta.50", prerelease: false, draft: false },
+      { tag_name: "v1.0.0-beta.48", prerelease: true, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.0-beta.50");
+  });
+
   it("ignores drafts in both channels", async () => {
     const { selectChannelReleases } = await import("../auto-updater");
     const releases = [

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -439,6 +439,17 @@ function firstPrereleaseId(tag: string | undefined): string | undefined {
   return typeof parsed.pre[0] === "string" ? parsed.pre[0] : undefined;
 }
 
+// Stable Latest is the one slot every Stable operator is pushed onto, so it
+// must not depend on a checkbox a human sets by hand. A `main` tag that
+// shipped without its GitHub Pre-release flag looks exactly like a stable
+// release to `prerelease !== true`; the `-alpha.N` / `-beta.N` /
+// `-prerelease.N` suffix in the tag is the part the release process actually
+// controls, so a suffix-free tag is what qualifies for the slot.
+function isSuffixFreeStableTag(tag: string | undefined): boolean {
+  const parsed = parseSemver(tag);
+  return parsed !== undefined && parsed.pre.length === 0;
+}
+
 function isBetaTrainIdentifier(tag: string | undefined): boolean {
   const id = firstPrereleaseId(tag);
   return id === "alpha" || id === "beta";
@@ -507,7 +518,9 @@ export type SelectedUpdateReleases = {
 };
 
 // Resolve slots by semver identifier and GitHub Latest, not publish order:
-//   - stable latest      → highest GitHub non-prerelease (the 1.0 / normie feed)
+//   - stable latest      → highest suffix-free GitHub non-prerelease (the 1.0
+//                          / normie feed), falling back to the highest GitHub
+//                          non-prerelease when no suffix-free tag exists
 //   - stable prerelease  → max(stable latest, 1.0 `-prerelease` / legacy `-beta`)
 //   - beta latest        → highest `-beta` whose core is ahead of Stable Latest
 //   - beta prerelease    → max(beta latest, highest `-alpha` on a newer core)
@@ -520,9 +533,17 @@ export function selectChannelReleases(
   const byPrecedenceDesc = [...publicReleases].sort((a, b) =>
     compareSemver(b.tag_name, a.tag_name),
   );
-  const stableLatest = byPrecedenceDesc.find(
-    (release) => release.prerelease !== true,
-  );
+  // Two tiers, not one predicate: a suffix-free stable wins outright, so a
+  // mistagged `v1.1.0-alpha.1` cannot take the slot on precedence. The
+  // fallback only matters for a release set with no suffix-free tag at all —
+  // the pre-`v1.0.0` world, where every stable was a `v1.0.0-beta.N` tag
+  // published as GitHub Latest — and preserves the behavior those trains had.
+  const stableLatest =
+    byPrecedenceDesc.find(
+      (release) =>
+        release.prerelease !== true && isSuffixFreeStableTag(release.tag_name),
+    )
+    ?? byPrecedenceDesc.find((release) => release.prerelease !== true);
   const betaLatest = byPrecedenceDesc.find((release) =>
     isBetaLatestRelease(release, stableLatest, publicReleases),
   );

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -105,6 +105,18 @@ it cannot steal `/releases/latest` from the Stable train. Promote a smoked
 alpha by bumping `apps/desktop/package.json` and the CHANGELOG heading to
 the beta version, then tagging that commit. Do not retag the alpha SHA.
 
+**The suffix is load-bearing, not just the GitHub flag.** Stable · Latest
+resolves to the highest *suffix-free* non-prerelease tag, so a tag carrying
+`-alpha.N` / `-beta.N` / `-prerelease.N` can never become the feed every
+Stable operator is pushed onto — even if someone forgets the Pre-release
+checkbox at tag time. A mistagged `main` tag fails **closed**: it lands in no
+slot at all, and the Beta rows in Settings read "Unavailable" until the flag
+is corrected on the GitHub release. That is the symptom to look for after a
+`main` tag if Beta operators report seeing nothing new. The fallback to a
+suffixed tag applies only to a release set with no suffix-free stable at all
+(the pre-`v1.0.0` world, where every stable was a `v1.0.0-beta.N` published as
+GitHub Latest).
+
 ## Cutting a release (CI path — preferred)
 
 ```bash


### PR DESCRIPTION
## Problem

Stable · Latest resolved to the highest release with `prerelease !== true`:

```ts
const stableLatest = byPrecedenceDesc.find((release) => release.prerelease !== true);
```

That flag is a checkbox a human sets by hand at tag time. A `main` tag
published without it looks exactly like a stable release, and because
`v1.1.0-alpha.1` outranks `v1.0.2` on precedence it would take Stable Latest
and get pushed to **every Stable operator**.

The runbook already requires that "every `main` tag with a prerelease suffix
must stay a GitHub Pre-release" — but nothing enforced it. And the flag
demonstrably does get set by hand: `v1.0.0-beta.40`, `-beta.47`, `-beta.49`,
and `-beta.50` in the live release list all carry `prerelease=false`. That was
correct when `1.0.0-beta` *was* the stable train, but it shows the failure mode
is one checkbox away.

This came up while confirming that #1762's premise held — that a Stable-track
user already ignores main-train alphas. They do, but only because of the flag.

## Fix

Stable Latest now prefers the highest **suffix-free** non-prerelease tag. The
`-alpha.N` / `-beta.N` / `-prerelease.N` suffix is the part the release process
actually controls, so a suffixed tag can no longer become the feed every Stable
operator follows regardless of how it was flagged.

Two tiers rather than one predicate:

```ts
const stableLatest =
  byPrecedenceDesc.find(
    (release) => release.prerelease !== true && isSuffixFreeStableTag(release.tag_name),
  )
  ?? byPrecedenceDesc.find((release) => release.prerelease !== true);
```

The fallback fires only for a release set with **no** suffix-free stable at all
— the pre-`v1.0.0` world, where every stable was a `v1.0.0-beta.N` published as
GitHub Latest. Those trains keep resolving exactly as before, which is why the
existing `selectChannelReleases` coverage is unchanged.

Only Stable Latest changed. `stablePrerelease`, `betaLatest`, `betaPrerelease`,
and `releaseForSelection` are untouched.

## Behavior, measured against the live release list

Real `repos/pwrdrvr/PwrAgent/releases?per_page=30` output, plus one
hypothetical tag per scenario:

| Scenario | Stable · Latest | Stable · Prerelease | Beta · Prerelease |
|---|---|---|---|
| live today | `v1.0.2` | `v1.0.2` | — |
| `+ v1.1.0-alpha.1`, correctly flagged | `v1.0.2` | `v1.0.2` | `v1.1.0-alpha.1` |
| `+ v1.1.0-alpha.1` **mistagged** | `v1.0.2` | `v1.0.2` | — |
| `+ v1.1.0-beta.3` **mistagged** | `v1.0.2` | `v1.0.2` | — |
| `+ v1.1.0-prerelease.1` **mistagged** | `v1.0.2` | `v1.0.2` | — |
| `+ real v1.1.0 promotion` | `v1.1.0` | `v1.1.0` | — |

Before this change, every **mistagged** row read `v1.1.0-…` in both Stable
columns.

**A mistag now fails closed rather than open.** It lands in no slot at all: the
suffix keeps it out of Stable Latest, and `prerelease !== true` already kept it
out of Stable Prerelease and off the Beta train. Settings shows "Unavailable"
for the Beta rows until the flag is corrected on the GitHub release — that is
the symptom to look for if Beta operators report seeing nothing new after a
`main` tag. Documented in the runbook alongside the tag-suffix table.

## Tests

Four cases added to the existing `selectChannelReleases` block: mistagged alpha
can't take Stable Latest (and doesn't leak into Stable Prerelease), same for a
mistagged beta, a real suffix-free `v1.1.0` still promotes, and a release set of
only suffixed stables still resolves via the fallback.

Full workspace suite green (587 files / 8440 tests), `typecheck` clean,
`lint:eslint` 0 errors.

## Notes

- Independent of #1762 / #1763 — different function, no overlapping lines,
  merges in either order. That pair is the way *back out* for someone already
  stranded on a newer build; this is what stops one more way of getting there.
- `selectChannelReleases` is shared with PwrSnap. The same hardening should
  land there.

A backport to `releases/1.0` follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
