### PR TITLE
fix(desktop): backport the Stable Latest suffix guard (#1764)

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -744,6 +744,56 @@ describe("selectChannelReleases", () => {
     expect(selected.betaPrerelease?.tag_name).toBe("v1.1.0-alpha.7");
   });
 
+  it("does not let a mistagged main-train alpha take stable latest", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    // The GitHub Pre-release flag is set by hand at tag time. If a `main` tag
+    // ships without it, it must still not become the feed every Stable
+    // operator is pushed onto.
+    const releases = [
+      { tag_name: "v1.1.0-alpha.1", prerelease: false, draft: false },
+      { tag_name: "v1.0.2", prerelease: false, draft: false },
+      { tag_name: "v1.0.2-prerelease.2", prerelease: true, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.2");
+    // The same flag is what keeps it out of the Stable prerelease slot, so a
+    // mistag must not leak it there either.
+    expect(selected.stablePrerelease?.tag_name).toBe("v1.0.2");
+  });
+
+  it("does not let a mistagged main-train beta take stable latest", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0-beta.3", prerelease: false, draft: false },
+      { tag_name: "v1.0.2", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.2");
+    expect(selected.stablePrerelease?.tag_name).toBe("v1.0.2");
+  });
+
+  it("still promotes a real suffix-free stable over the current one", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.1.0", prerelease: false, draft: false },
+      { tag_name: "v1.0.2", prerelease: false, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.1.0");
+  });
+
+  it("falls back to a suffixed stable when no suffix-free tag exists", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    // The pre-v1.0.0 world: every stable was a `-beta.N` tag published as
+    // GitHub Latest. Those trains must keep resolving.
+    const releases = [
+      { tag_name: "v1.0.0-beta.50", prerelease: false, draft: false },
+      { tag_name: "v1.0.0-beta.48", prerelease: true, draft: false },
+    ];
+    const selected = selectChannelReleases(releases);
+    expect(selected.stableLatest?.tag_name).toBe("v1.0.0-beta.50");
+  });
+
   it("ignores drafts in both channels", async () => {
     const { selectChannelReleases } = await import("../auto-updater");
     const releases = [

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -439,6 +439,17 @@ function firstPrereleaseId(tag: string | undefined): string | undefined {
   return typeof parsed.pre[0] === "string" ? parsed.pre[0] : undefined;
 }
 
+// Stable Latest is the one slot every Stable operator is pushed onto, so it
+// must not depend on a checkbox a human sets by hand. A `main` tag that
+// shipped without its GitHub Pre-release flag looks exactly like a stable
+// release to `prerelease !== true`; the `-alpha.N` / `-beta.N` /
+// `-prerelease.N` suffix in the tag is the part the release process actually
+// controls, so a suffix-free tag is what qualifies for the slot.
+function isSuffixFreeStableTag(tag: string | undefined): boolean {
+  const parsed = parseSemver(tag);
+  return parsed !== undefined && parsed.pre.length === 0;
+}
+
 function isBetaTrainIdentifier(tag: string | undefined): boolean {
   const id = firstPrereleaseId(tag);
   return id === "alpha" || id === "beta";
@@ -507,7 +518,9 @@ export type SelectedUpdateReleases = {
 };
 
 // Resolve slots by semver identifier and GitHub Latest, not publish order:
-//   - stable latest      → highest GitHub non-prerelease (the 1.0 / normie feed)
+//   - stable latest      → highest suffix-free GitHub non-prerelease (the 1.0
+//                          / normie feed), falling back to the highest GitHub
+//                          non-prerelease when no suffix-free tag exists
 //   - stable prerelease  → max(stable latest, 1.0 `-prerelease` / legacy `-beta`)
 //   - beta latest        → highest `-beta` whose core is ahead of Stable Latest
 //   - beta prerelease    → max(beta latest, highest `-alpha` on a newer core)
@@ -520,9 +533,17 @@ export function selectChannelReleases(
   const byPrecedenceDesc = [...publicReleases].sort((a, b) =>
     compareSemver(b.tag_name, a.tag_name),
   );
-  const stableLatest = byPrecedenceDesc.find(
-    (release) => release.prerelease !== true,
-  );
+  // Two tiers, not one predicate: a suffix-free stable wins outright, so a
+  // mistagged `v1.1.0-alpha.1` cannot take the slot on precedence. The
+  // fallback only matters for a release set with no suffix-free tag at all —
+  // the pre-`v1.0.0` world, where every stable was a `v1.0.0-beta.N` tag
+  // published as GitHub Latest — and preserves the behavior those trains had.
+  const stableLatest =
+    byPrecedenceDesc.find(
+      (release) =>
+        release.prerelease !== true && isSuffixFreeStableTag(release.tag_name),
+    )
+    ?? byPrecedenceDesc.find((release) => release.prerelease !== true);
   const betaLatest = byPrecedenceDesc.find((release) =>
     isBetaLatestRelease(release, stableLatest, publicReleases),
   );

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -107,6 +107,18 @@ it cannot steal `/releases/latest` from the Stable train. Promote a smoked
 alpha by bumping `apps/desktop/package.json` and the CHANGELOG heading to
 the beta version, then tagging that commit. Do not retag the alpha SHA.
 
+**The suffix is load-bearing, not just the GitHub flag.** Stable · Latest
+resolves to the highest *suffix-free* non-prerelease tag, so a tag carrying
+`-alpha.N` / `-beta.N` / `-prerelease.N` can never become the feed every
+Stable operator is pushed onto — even if someone forgets the Pre-release
+checkbox at tag time. A mistagged `main` tag fails **closed**: it lands in no
+slot at all, and the Beta rows in Settings read "Unavailable" until the flag
+is corrected on the GitHub release. That is the symptom to look for after a
+`main` tag if Beta operators report seeing nothing new. The fallback to a
+suffixed tag applies only to a release set with no suffix-free stable at all
+(the pre-`v1.0.0` world, where every stable was a `v1.0.0-beta.N` published as
+GitHub Latest).
+
 ## Cutting a release (CI path — preferred)
 
 ```bash


### PR DESCRIPTION
Backport of https://github.com/pwrdrvr/PwrAgent/pull/1764 to `releases/1.0`.

## Why this matters on 1.0 specifically

`releases/1.0` users *are* the Stable train. Stable · Latest resolved to the
highest release with `prerelease !== true` — a checkbox set by hand at tag
time. A `main` tag published without it looks exactly like a stable release,
and since `v1.1.0-alpha.1` outranks `v1.0.2` on precedence it would take the
Stable Latest slot and get pushed to every 1.0 operator.

`v1.1.0-alpha.1` is prepared on `main` and not yet released, so this wants to
be in a shipped 1.0 build before that tag goes out — the guard only protects
the machines actually running it.

## Fix

Stable Latest now prefers the highest **suffix-free** non-prerelease tag, so a
tag carrying `-alpha.N` / `-beta.N` / `-prerelease.N` can never take the slot
regardless of its GitHub flag. A second tier falls back to the old predicate
only when no suffix-free stable exists at all (the pre-`v1.0.0` world, where
every stable was a `v1.0.0-beta.N` published as GitHub Latest), so the
historical 1.0 trains keep resolving exactly as before.

A mistagged `main` tag now fails closed — it lands in no slot, and the Beta
rows in Settings read "Unavailable" until the flag is corrected. See #1764 for
the full rationale and the measured before/after table against the live
release list.

## Backport notes

`selectChannelReleases` is identical on both branches after #1682, so the
change applies unchanged. Only the runbook needed a context merge. No
behavioral divergence from #1764.

Independent of #1763 — different function, no overlapping lines, merges in
either order.

## Verification

Full workspace suite green on this branch (5614 tests), `typecheck` clean,
`lint:eslint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
