### PR TITLE
fix(desktop): quiet the startup log

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4370,17 +4370,24 @@ describe("app server ipc", () => {
       });
 
       resolveFetches[0]?.([stalePr]);
+      // The losing observation is dropped quietly: one aggregated debug line,
+      // never a per-PR info line, so a boot that reconciles hundreds of cached
+      // PRs does not bury the log.
       await vi.waitFor(() => {
-        expect(mockAppServerLog.info).toHaveBeenCalledWith(
-          "pr status observation ignored",
+        expect(mockAppServerLog.debug).toHaveBeenCalledWith(
+          "pr status observations ignored as stale",
           expect.objectContaining({
-            currentObservedAt: 4_000_001,
             observedAt: 4_000_000,
-            prKey: "github.com/pwrdrvr/pwragent#847",
+            staleCount: 1,
+            prKeys: ["github.com/pwrdrvr/pwragent#847"],
             source: "thread-lookup:user",
           }),
         );
       });
+      expect(mockAppServerLog.info).not.toHaveBeenCalledWith(
+        "pr status observation ignored",
+        expect.anything(),
+      );
       expect(setThreadPullRequests).toHaveBeenCalledWith(
         expect.objectContaining({
           threadId: "thread-request-order-0",

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -48,6 +48,7 @@ vi.mock("@pwrdrvr/codex-discovery", async (importOriginal) => {
 });
 
 const messagingLog = vi.hoisted(() => ({
+  debug: vi.fn(),
   error: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -111,6 +111,8 @@ function currentUpdateSelectionKey(): UpdateSelectionKey {
   return updateSelectionKey(currentUpdateTrain(), currentUpdateChannel());
 }
 
+let lastLoggedUpdatePosture: string | null = null;
+
 // `allowDowngrade` is the posture that lets an operator move *back* onto the
 // channel they picked after ending up on a newer build than that channel
 // serves. It stays alongside `allowPrerelease` so both halves of the feed
@@ -123,6 +125,15 @@ function configureAutoUpdaterChannel(
   autoUpdater.allowPrerelease =
     updateTrain === "beta" || updateChannel === "prerelease";
   autoUpdater.allowDowngrade = options.allowDowngrade === true;
+  // Startup configures the channel and then every check reconfigures it, so
+  // report the posture when it changes rather than once per update check. Both
+  // halves are keyed: flipping `allowDowngrade` alone is a real posture change.
+  const posture = `${updateSelectionKey(updateTrain, updateChannel)}:${autoUpdater.allowDowngrade}`;
+  if (posture === lastLoggedUpdatePosture) {
+    return;
+  }
+
+  lastLoggedUpdatePosture = posture;
   log.info("configured auto-update channel", {
     allowDowngrade: autoUpdater.allowDowngrade,
     allowPrerelease: autoUpdater.allowPrerelease,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -467,13 +467,16 @@ function describePayloadShape(payload: unknown): {
   return { payloadType: typeof payload };
 }
 
-/** Methods already reported by `logUnhandledCodexMessage`, warned about once. */
-const reportedUnknownNotificationMethods = new Set<string>();
-
 function logUnhandledCodexMessage(params: {
   kind: "notification" | "request";
   method: string;
   payload: unknown;
+  /**
+   * Methods this client has already warned about. Owned by the client rather
+   * than the module so a reconnect re-warns once, and so one test's unknown
+   * method cannot downgrade the next test's warning to a debug line.
+   */
+  reportedNotificationMethods: Set<string>;
 }): void {
   if (params.kind === "request") {
     codexClientLog.error("unhandled inbound codex request", {
@@ -494,8 +497,8 @@ function logUnhandledCodexMessage(params: {
   // A method we do not model is worth one warning, not one per delivery: Codex
   // pushes some of these (remoteControl/status/changed) on every connect, and
   // repeats add nothing once the shape has been recorded.
-  const alreadyReported = reportedUnknownNotificationMethods.has(params.method);
-  reportedUnknownNotificationMethods.add(params.method);
+  const alreadyReported = params.reportedNotificationMethods.has(params.method);
+  params.reportedNotificationMethods.add(params.method);
   const details = {
     method: params.method,
     ...describePayloadShape(params.payload),
@@ -6966,6 +6969,9 @@ export class CodexAppServerClient {
     StructuredRecordPredicate
   >();
 
+  /** Unknown notification methods already warned about on this connection. */
+  private readonly reportedUnknownNotificationMethods = new Set<string>();
+
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
       new StdioJsonRpcTransport({
@@ -6995,6 +7001,7 @@ export class CodexAppServerClient {
           kind: "notification",
           method,
           payload: params,
+          reportedNotificationMethods: this.reportedUnknownNotificationMethods,
         });
       }
       if (method === "skills/changed") {
@@ -7067,6 +7074,7 @@ export class CodexAppServerClient {
           kind: "request",
           method,
           payload: params,
+          reportedNotificationMethods: this.reportedUnknownNotificationMethods,
         });
         throw new Error(`No desktop request handler registered for ${method}`);
       }
@@ -7076,6 +7084,7 @@ export class CodexAppServerClient {
           kind: "request",
           method,
           payload: params,
+          reportedNotificationMethods: this.reportedUnknownNotificationMethods,
         });
       }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -467,6 +467,9 @@ function describePayloadShape(payload: unknown): {
   return { payloadType: typeof payload };
 }
 
+/** Methods already reported by `logUnhandledCodexMessage`, warned about once. */
+const reportedUnknownNotificationMethods = new Set<string>();
+
 function logUnhandledCodexMessage(params: {
   kind: "notification" | "request";
   method: string;
@@ -488,11 +491,22 @@ function logUnhandledCodexMessage(params: {
     return;
   }
 
-  codexClientLog.warn("unknown codex notification", {
+  // A method we do not model is worth one warning, not one per delivery: Codex
+  // pushes some of these (remoteControl/status/changed) on every connect, and
+  // repeats add nothing once the shape has been recorded.
+  const alreadyReported = reportedUnknownNotificationMethods.has(params.method);
+  reportedUnknownNotificationMethods.add(params.method);
+  const details = {
     method: params.method,
     ...describePayloadShape(params.payload),
     payload: params.payload,
-  });
+  };
+  if (alreadyReported) {
+    codexClientLog.debug("unknown codex notification", details);
+    return;
+  }
+
+  codexClientLog.warn("unknown codex notification", details);
 }
 
 function logSkillsChangedNotification(params: {
@@ -7889,16 +7903,20 @@ export class CodexAppServerClient {
       const parsedResult = parseConsumedCodexModelListResponse(result);
       const models = extractGeneratedModelOptions(parsedResult);
       codexClientLog.info("model/list", {
-        rawModels: summarizeGeneratedModelList(parsedResult),
         normalizedModelIds: models.map((model) => model.id),
+      });
+      codexClientLog.debug("model/list raw models", {
+        rawModels: summarizeGeneratedModelList(parsedResult),
       });
       return models;
     }
 
     const models = extractModelOptions(result);
     codexClientLog.info("model/list", {
-      rawModels: summarizeRawModelList(result),
       normalizedModelIds: models.map((model) => model.id),
+    });
+    codexClientLog.debug("model/list raw models", {
+      rawModels: summarizeRawModelList(result),
     });
 
     return models;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1143,6 +1143,15 @@ export function bootstrapApp(): void {
           assertUnreachableProfileBootDecision(bootDecision);
       }
     })();
+    // Every log file needs the build it came from. The preload records the
+    // same versions per window, but that is debug detail; this line is the one
+    // an operator reads at the top of a support log.
+    mainLog.info("app starting", {
+      appVersion: app.getVersion(),
+      electron: process.versions.electron ?? "unknown",
+      platform: process.platform,
+      arch: process.arch,
+    });
     logBootDecision(bootDecision);
     // Stash the boot decision so the renderer can read it via
     // `getBootInfo` IPC once the wizard mounts. Specifically the

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1298,6 +1298,9 @@ function prLogIds(prs: PrSummary[]): string[] {
   return prs.map((pr) => getPrStatusKey(pr));
 }
 
+/** Bounded sample of PR keys carried by the stale-observation debug line. */
+const STALE_PR_OBSERVATION_LOG_SAMPLE = 5;
+
 function prLogStatuses(prs: PrSummary[]): Record<string, unknown>[] {
   return prs.map((pr) => {
     const normalized = normalizePrSummary(pr);
@@ -4616,20 +4619,12 @@ class DesktopAppServerService {
   ): PrSummary[] {
     const changedPrs: PrSummary[] = [];
     const transitions: PrStatusTransition[] = [];
+    const staleKeys: string[] = [];
     for (const pr of prs.map(normalizePrSummary)) {
       const key = getPrStatusKey(pr);
       const current = this.prStatusRegistry.get(key);
       if (current && current.fetchedAt > fetchedAt) {
-        if (source === "background-poll" || source.startsWith("thread-lookup:")) {
-          appServerLog.info("pr status observation ignored", {
-            prKey: key,
-            source,
-            observedAt: fetchedAt,
-            currentObservedAt: current.fetchedAt,
-            observedStatus: prLogStatuses([pr])[0],
-            currentStatus: prLogStatuses([current.pr])[0],
-          });
-        }
+        staleKeys.push(key);
         continue;
       }
       if (!current || !prSummariesEqual([current.pr], [pr])) {
@@ -4649,6 +4644,18 @@ class DesktopAppServerService {
         fetchedAt,
       });
       this.applyPrStatusToAttachments(pr);
+    }
+    if (staleKeys.length > 0) {
+      // Losing to a newer registry entry is ordinary bookkeeping: cache loads
+      // and overlay seeds observe at timestamp 0, so every known PR reports one.
+      // A single bounded debug line keeps the detail reachable through
+      // Help -> Logs without burying the startup log under a line per PR.
+      appServerLog.debug("pr status observations ignored as stale", {
+        source,
+        observedAt: fetchedAt,
+        staleCount: staleKeys.length,
+        prKeys: staleKeys.slice(0, STALE_PR_OBSERVATION_LOG_SAMPLE),
+      });
     }
     if (transitions.length > 0) {
       this.emitPrStatusTransitions(transitions, { observedAt: fetchedAt, source });

--- a/apps/desktop/src/main/ipc/preload-log.ts
+++ b/apps/desktop/src/main/ipc/preload-log.ts
@@ -9,7 +9,7 @@ import {
   type StartupProfileEventSource,
 } from "../diagnostics/startup-profile-events";
 
-type PreloadLogLevel = "error" | "info" | "warn";
+type PreloadLogLevel = "debug" | "error" | "info" | "warn";
 
 type PreloadLogRequest = {
   details?: unknown;

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -1178,7 +1178,9 @@ function buildChannelConfig(params: {
 
   if (!enabled) {
     if (logStartupEligibility) {
-      log.info(`${channel}: disabled in settings — skipping`, {
+      // Every channel the operator never turned on reports here, so a disabled
+      // channel is debug detail; the startup log only states what did start.
+      log.debug(`${channel}: disabled in settings — skipping`, {
         channel,
       });
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -719,7 +719,7 @@ import type {
 } from "../shared/app-metadata";
 
 function recordPreloadLog(
-  level: "info" | "warn",
+  level: "debug" | "info" | "warn",
   message: string,
   details?: unknown,
 ): void {
@@ -793,7 +793,7 @@ async function invokeWithStartupProfileTiming<T>(
   }
 }
 
-recordPreloadLog("info", "start", {
+recordPreloadLog("debug", "start", {
   contextIsolated: process.contextIsolated,
   platform: process.platform,
   electron: process.versions.electron
@@ -2412,7 +2412,7 @@ if (process.contextIsolated) {
     "__pwragentFederationLabel",
     bootstrapFederationLabel,
   );
-  recordPreloadLog("info", "exposed context bridge", {
+  recordPreloadLog("debug", "exposed context bridge", {
     keyCount: Object.keys(desktopApi).length
   });
 } else {


### PR DESCRIPTION
## Problem

Startup wrote several hundred `pr status observation ignored` info lines before the app finished booting. Every cache load and navigation-overlay seed reconciles at observation timestamp `0`, so every PR already in the registry loses the comparison and logs a line. The detail — a stale read losing to a newer entry — is bookkeeping nobody acts on, and it buried everything else in the log.

## Change

`rememberPrStatuses` now collects the stale keys and emits one bounded debug line per reconciliation instead of one info line per PR.

Same treatment for the other repeat offenders visible in a single boot:

| Line | Before | After |
|---|---|---|
| `pr status observation ignored` | info, one per PR (hundreds) | one aggregated debug line per reconciliation |
| `model/list rawModels=[…]` | info, full catalog dump per connect | info keeps normalized ids; raw summary at debug |
| `unknown codex notification` | warn on every delivery (Codex pushes `remoteControl/status/changed` on each connect) | warn once per method, debug thereafter |
| `<channel>: disabled in settings — skipping` | info × every channel not enabled | debug |
| `configured auto-update channel` | info on startup *and* every check | info only when the selection changes |
| preload `start` / `exposed context bridge` | info × every window | debug |

Nothing is lost: every demoted line is still collected when debug collection is on (Help → Logs). Since the preload lines carried the Electron version, main now logs one `app starting` line with app version, Electron, platform, and arch — the line an operator reads at the top of a support log.

## Verification

- `pnpm test` — 587 files, 8436 passed
- `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries` clean
- `app-server-ipc.test.ts` covered the old per-PR info line; it now asserts the aggregated debug line and that the info line is gone.

A backport to `releases/1.0` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)