### PR TITLE
fix(desktop): quiet the startup log (backport to 1.0)

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1462,6 +1462,20 @@ describe("app server ipc", () => {
       prs: [passingPr],
     });
     expect(detectPullRequestsForThread).toHaveBeenCalledOnce();
+    // Thread two's overlay observes the older PR and loses to the registry.
+    // That drop is aggregated into one debug line — never an info line per PR,
+    // which would bury the startup log once a profile tracks many PRs.
+    expect(mockAppServerLog.debug).toHaveBeenCalledWith(
+      "pr status observations ignored as stale",
+      expect.objectContaining({
+        staleCount: 1,
+        prKeys: ["github.com/openai/codex#727"],
+      }),
+    );
+    expect(mockAppServerLog.info).not.toHaveBeenCalledWith(
+      "pr status observation ignored",
+      expect.anything(),
+    );
   });
 
   it("hydrates canonical PR state from persisted cache without scheduled GitHub refresh", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -35,6 +35,7 @@ import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
 import { DesktopSettingsService } from "../settings/desktop-settings-service";
 
 const messagingLog = vi.hoisted(() => ({
+  debug: vi.fn(),
   error: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -111,6 +111,8 @@ function currentUpdateSelectionKey(): UpdateSelectionKey {
   return updateSelectionKey(currentUpdateTrain(), currentUpdateChannel());
 }
 
+let lastLoggedUpdatePosture: string | null = null;
+
 // `allowDowngrade` is the posture that lets an operator move *back* onto the
 // channel they picked after ending up on a newer build than that channel
 // serves. It stays alongside `allowPrerelease` so both halves of the feed
@@ -123,6 +125,15 @@ function configureAutoUpdaterChannel(
   autoUpdater.allowPrerelease =
     updateTrain === "beta" || updateChannel === "prerelease";
   autoUpdater.allowDowngrade = options.allowDowngrade === true;
+  // Startup configures the channel and then every check reconfigures it, so
+  // report the posture when it changes rather than once per update check. Both
+  // halves are keyed: flipping `allowDowngrade` alone is a real posture change.
+  const posture = `${updateSelectionKey(updateTrain, updateChannel)}:${autoUpdater.allowDowngrade}`;
+  if (posture === lastLoggedUpdatePosture) {
+    return;
+  }
+
+  lastLoggedUpdatePosture = posture;
   log.info("configured auto-update channel", {
     allowDowngrade: autoUpdater.allowDowngrade,
     allowPrerelease: autoUpdater.allowPrerelease,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -388,13 +388,16 @@ function describePayloadShape(payload: unknown): {
   return { payloadType: typeof payload };
 }
 
-/** Methods already reported by `logUnhandledCodexMessage`, warned about once. */
-const reportedUnknownNotificationMethods = new Set<string>();
-
 function logUnhandledCodexMessage(params: {
   kind: "notification" | "request";
   method: string;
   payload: unknown;
+  /**
+   * Methods this client has already warned about. Owned by the client rather
+   * than the module so a reconnect re-warns once, and so one test's unknown
+   * method cannot downgrade the next test's warning to a debug line.
+   */
+  reportedNotificationMethods: Set<string>;
 }): void {
   if (params.kind === "request") {
     codexClientLog.error("unhandled inbound codex request", {
@@ -415,8 +418,8 @@ function logUnhandledCodexMessage(params: {
   // A method we do not model is worth one warning, not one per delivery: Codex
   // pushes some of these (remoteControl/status/changed) on every connect, and
   // repeats add nothing once the shape has been recorded.
-  const alreadyReported = reportedUnknownNotificationMethods.has(params.method);
-  reportedUnknownNotificationMethods.add(params.method);
+  const alreadyReported = params.reportedNotificationMethods.has(params.method);
+  params.reportedNotificationMethods.add(params.method);
   const details = {
     method: params.method,
     ...describePayloadShape(params.payload),
@@ -5795,6 +5798,9 @@ export class CodexAppServerClient {
     StructuredRecordPredicate
   >();
 
+  /** Unknown notification methods already warned about on this connection. */
+  private readonly reportedUnknownNotificationMethods = new Set<string>();
+
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
       new StdioJsonRpcTransport({
@@ -5824,6 +5830,7 @@ export class CodexAppServerClient {
           kind: "notification",
           method,
           payload: params,
+          reportedNotificationMethods: this.reportedUnknownNotificationMethods,
         });
       }
       if (method === "skills/changed") {
@@ -5872,6 +5879,7 @@ export class CodexAppServerClient {
           kind: "request",
           method,
           payload: params,
+          reportedNotificationMethods: this.reportedUnknownNotificationMethods,
         });
         throw new Error(`No desktop request handler registered for ${method}`);
       }
@@ -5881,6 +5889,7 @@ export class CodexAppServerClient {
           kind: "request",
           method,
           payload: params,
+          reportedNotificationMethods: this.reportedUnknownNotificationMethods,
         });
       }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -388,6 +388,9 @@ function describePayloadShape(payload: unknown): {
   return { payloadType: typeof payload };
 }
 
+/** Methods already reported by `logUnhandledCodexMessage`, warned about once. */
+const reportedUnknownNotificationMethods = new Set<string>();
+
 function logUnhandledCodexMessage(params: {
   kind: "notification" | "request";
   method: string;
@@ -409,11 +412,22 @@ function logUnhandledCodexMessage(params: {
     return;
   }
 
-  codexClientLog.warn("unknown codex notification", {
+  // A method we do not model is worth one warning, not one per delivery: Codex
+  // pushes some of these (remoteControl/status/changed) on every connect, and
+  // repeats add nothing once the shape has been recorded.
+  const alreadyReported = reportedUnknownNotificationMethods.has(params.method);
+  reportedUnknownNotificationMethods.add(params.method);
+  const details = {
     method: params.method,
     ...describePayloadShape(params.payload),
     payload: params.payload,
-  });
+  };
+  if (alreadyReported) {
+    codexClientLog.debug("unknown codex notification", details);
+    return;
+  }
+
+  codexClientLog.warn("unknown codex notification", details);
 }
 
 function logSkillsChangedNotification(params: {
@@ -6438,16 +6452,20 @@ export class CodexAppServerClient {
       const parsedResult = parseConsumedCodexModelListResponse(result);
       const models = extractGeneratedModelOptions(parsedResult);
       codexClientLog.info("model/list", {
-        rawModels: summarizeGeneratedModelList(parsedResult),
         normalizedModelIds: models.map((model) => model.id),
+      });
+      codexClientLog.debug("model/list raw models", {
+        rawModels: summarizeGeneratedModelList(parsedResult),
       });
       return models;
     }
 
     const models = extractModelOptions(result);
     codexClientLog.info("model/list", {
-      rawModels: summarizeRawModelList(result),
       normalizedModelIds: models.map((model) => model.id),
+    });
+    codexClientLog.debug("model/list raw models", {
+      rawModels: summarizeRawModelList(result),
     });
 
     return models;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -911,6 +911,15 @@ export function bootstrapApp(): void {
           assertUnreachableProfileBootDecision(bootDecision);
       }
     })();
+    // Every log file needs the build it came from. The preload records the
+    // same versions per window, but that is debug detail; this line is the one
+    // an operator reads at the top of a support log.
+    mainLog.info("app starting", {
+      appVersion: app.getVersion(),
+      electron: process.versions.electron ?? "unknown",
+      platform: process.platform,
+      arch: process.arch,
+    });
     logBootDecision(bootDecision);
     // Stash the boot decision so the renderer can read it via
     // `getBootInfo` IPC once the wizard mounts. Specifically the

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -815,6 +815,9 @@ function prLogIds(prs: PrSummary[]): string[] {
   return prs.map((pr) => getPrStatusKey(pr));
 }
 
+/** Bounded sample of PR keys carried by the stale-observation debug line. */
+const STALE_PR_OBSERVATION_LOG_SAMPLE = 5;
+
 function userPrRefreshLogPayload(params: {
   backend: AppServerBackendKind;
   branch: string;
@@ -2941,19 +2944,12 @@ class DesktopAppServerService {
   private rememberPrStatuses(prs: PrSummary[], fetchedAt: number): PrSummary[] {
     const changedPrs: PrSummary[] = [];
     const transitions: PrStatusTransition[] = [];
+    const staleKeys: string[] = [];
     for (const candidate of prs.map(normalizePrSummary)) {
       const key = getPrStatusKey(candidate);
       const current = this.prStatusRegistry.get(key);
       if (current && current.fetchedAt > fetchedAt) {
-        appServerLog.info("pr status observation ignored", {
-          prKey: key,
-          observedAt: fetchedAt,
-          currentObservedAt: current.fetchedAt,
-          observedCheckState: candidate.checkState,
-          currentCheckState: current.pr.checkState,
-          observedLifecycleState: candidate.lifecycleState,
-          currentLifecycleState: current.pr.lifecycleState,
-        });
+        staleKeys.push(key);
         continue;
       }
       const pr = preserveKnownPrHoverMetadata(current?.pr, candidate);
@@ -2972,6 +2968,17 @@ class DesktopAppServerService {
         ...current,
         pr,
         fetchedAt,
+      });
+    }
+    if (staleKeys.length > 0) {
+      // Losing to a newer registry entry is ordinary bookkeeping: cache loads
+      // and overlay seeds observe at timestamp 0, so every known PR reports one.
+      // A single bounded debug line keeps the detail reachable through
+      // Help -> Logs without burying the startup log under a line per PR.
+      appServerLog.debug("pr status observations ignored as stale", {
+        observedAt: fetchedAt,
+        staleCount: staleKeys.length,
+        prKeys: staleKeys.slice(0, STALE_PR_OBSERVATION_LOG_SAMPLE),
       });
     }
     if (transitions.length > 0) {

--- a/apps/desktop/src/main/ipc/preload-log.ts
+++ b/apps/desktop/src/main/ipc/preload-log.ts
@@ -9,7 +9,7 @@ import {
   type StartupProfileEventSource,
 } from "../diagnostics/startup-profile-events";
 
-type PreloadLogLevel = "error" | "info" | "warn";
+type PreloadLogLevel = "debug" | "error" | "info" | "warn";
 
 type PreloadLogRequest = {
   details?: unknown;

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -1162,7 +1162,9 @@ function buildChannelConfig(params: {
 
   if (!enabled) {
     if (logStartupEligibility) {
-      log.info(`${channel}: disabled in settings — skipping`, {
+      // Every channel the operator never turned on reports here, so a disabled
+      // channel is debug detail; the startup log only states what did start.
+      log.debug(`${channel}: disabled in settings — skipping`, {
         channel,
       });
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -492,7 +492,7 @@ import type {
 } from "../shared/app-metadata";
 
 function recordPreloadLog(
-  level: "info" | "warn",
+  level: "debug" | "info" | "warn",
   message: string,
   details?: unknown,
 ): void {
@@ -566,7 +566,7 @@ async function invokeWithStartupProfileTiming<T>(
   }
 }
 
-recordPreloadLog("info", "start", {
+recordPreloadLog("debug", "start", {
   contextIsolated: process.contextIsolated,
   platform: process.platform,
   electron: process.versions.electron
@@ -1754,7 +1754,7 @@ if (process.contextIsolated) {
     "__pwragentLogFilePath",
     bootstrapLogFilePath,
   );
-  recordPreloadLog("info", "exposed context bridge", {
+  recordPreloadLog("debug", "exposed context bridge", {
     keyCount: Object.keys(desktopApi).length
   });
 } else {


### PR DESCRIPTION
Backport of #1766 to `releases/1.0`.

## Problem

Startup wrote several hundred `pr status observation ignored` info lines before the app finished booting. Every cache load and navigation-overlay seed reconciles at observation timestamp `0`, so every PR already in the registry loses the comparison and logs a line. On `1.0` this is worse than on `main`: the log has no source gate, so every reconciliation path emits it.

## Change

`rememberPrStatuses` collects the stale keys and emits one bounded debug line per reconciliation instead of one info line per PR. Same treatment for the other repeat offenders visible in a single boot:

| Line | Before | After |
|---|---|---|
| `pr status observation ignored` | info, one per PR (hundreds) | one aggregated debug line per reconciliation |
| `model/list rawModels=[…]` | info, full catalog dump per connect | info keeps normalized ids; raw summary at debug |
| `unknown codex notification` | warn on every delivery (Codex pushes `remoteControl/status/changed` on each connect) | warn once per method, debug thereafter |
| `<channel>: disabled in settings — skipping` | info × every channel not enabled | debug |
| `configured auto-update channel` | info on startup *and* every check | info only when the selection changes |
| preload `start` / `exposed context bridge` | info × every window | debug |

Nothing is lost: every demoted line is still collected when debug collection is on (Help → Logs). Since the preload lines carried the Electron version, main now logs one `app starting` line with app version, Electron, platform, and arch.

## Differences from #1766

Mechanically identical except where `1.0` differs:

- `rememberPrStatuses` on `1.0` has no `source` parameter, so the debug line omits that field.
- The `main` regression test lives in a block of PR-observation tests `1.0` does not have. The equivalent assertion is attached here to the existing "serves the same canonical PR state across different thread overlays" test, which already drives an overlay that loses to a newer registry entry.

## Verification

- `pnpm test` — 428 files, 5610 passed
- `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)