### PR TITLE
fix(release): cache GitHub releases in main and back off when rate limited

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -681,9 +681,12 @@ describe("auto updater", () => {
     fetchMock.mockResolvedValue(rateLimitedResponse(resetAt));
     await vi.advanceTimersByTimeAsync(updater.APP_UPDATE_RELEASE_CACHE_TTL_MS + 1);
 
-    // One request discovers the limit; later reads must not spend another.
-    await updater.readAppUpdateReleaseVersions();
+    // One request discovers the limit; that read already degrades to the
+    // cached list, and later reads must not spend another request.
+    const discovering = await updater.readAppUpdateReleaseVersions();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(discovering.stable.latest.version).toBe("v1.0.0-beta.8");
+    expect(discovering.stable.latest.unavailableReason).toBeUndefined();
 
     const stale = await updater.readAppUpdateReleaseVersions();
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -35,6 +35,7 @@ const autoUpdaterMock = {
 };
 
 vi.mock("electron", () => ({
+  app: { isPackaged: false },
   BrowserWindow: {
     getAllWindows: vi.fn(() => [
       {
@@ -169,6 +170,7 @@ function createDeferred<T>(): {
 
 describe("auto updater", () => {
   const originalNodeEnv = process.env.NODE_ENV;
+  const originalE2e = process.env.PWRAGENT_E2E;
   const originalPlatform = process.platform;
   const originalFetch = globalThis.fetch;
 
@@ -222,6 +224,11 @@ describe("auto updater", () => {
   afterEach(() => {
     vi.useRealTimers();
     process.env.NODE_ENV = originalNodeEnv;
+    if (originalE2e === undefined) {
+      delete process.env.PWRAGENT_E2E;
+    } else {
+      process.env.PWRAGENT_E2E = originalE2e;
+    }
     Object.defineProperty(globalThis, "fetch", {
       configurable: true,
       value: originalFetch,
@@ -682,6 +689,62 @@ describe("auto updater", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(stale.stable.latest.version).toBe("v1.0.0-beta.8");
     expect(stale.stable.latest.unavailableReason).toBeUndefined();
+  });
+
+  it("makes no update requests during an E2E run", async () => {
+    process.env.PWRAGENT_E2E = "1";
+    const updater = await importAutoUpdater();
+
+    updater.initAutoUpdater();
+    const result = await updater.checkForAppUpdatesNow("startup");
+    await vi.advanceTimersByTimeAsync(updater.APP_UPDATE_CHECK_INTERVAL_MS);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+    expect(result.status).toBe("skipped");
+  });
+
+  it("serves the E2E release read without reaching GitHub", async () => {
+    process.env.PWRAGENT_E2E = "1";
+    const updater = await importAutoUpdater();
+
+    updater.registerAppUpdateIpcHandlers();
+    const versions = (await ipcHandlers.get("app:read-update-releases")?.()) as
+      | { stable: { latest: { unavailableReason?: string } } }
+      | undefined;
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(versions?.stable.latest.unavailableReason).toBe(
+      "Update checks are disabled.",
+    );
+  });
+
+  it("still backs off when the rate-limit reset header is already past", async () => {
+    const updater = await importAutoUpdater();
+    // A local clock running ahead of GitHub reports the reset in the past.
+    fetchMock.mockResolvedValue(rateLimitedResponse(Date.now() - 60_000));
+
+    await updater.readAppUpdateReleaseVersions();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const second = await updater.readAppUpdateReleaseVersions();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.stable.latest.unavailableReason).toMatch(
+      /GitHub rate limit reached/,
+    );
+  });
+
+  it("treats a backwards clock jump as a stale cache", async () => {
+    const updater = await importAutoUpdater();
+
+    await updater.readAppUpdateReleaseVersions();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(Date.now() - 2 * 60 * 60 * 1_000);
+    await updater.readAppUpdateReleaseVersions();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("resumes requesting after the rate-limit window passes", async () => {

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -116,11 +116,44 @@ function githubRelease(
   };
 }
 
+function githubResponse(
+  body: unknown,
+  options: { headers?: Record<string, string>; status?: number } = {},
+) {
+  const status = options.status ?? 200;
+  const headers = new Headers(options.headers ?? {});
+  return {
+    headers,
+    json: async () => body,
+    ok: status >= 200 && status < 300,
+    status,
+  };
+}
+
 function mockGitHubReleases(releases = [githubRelease("v1.0.0-beta.8")]): void {
-  fetchMock.mockResolvedValue({
-    ok: true,
-    json: async () => releases,
-  });
+  fetchMock.mockResolvedValue(
+    githubResponse(releases, { headers: { etag: 'W/"releases"' } }),
+  );
+}
+
+function rateLimitedResponse(resetAtMs: number) {
+  return githubResponse(
+    { message: "API rate limit exceeded" },
+    {
+      headers: {
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": String(Math.floor(resetAtMs / 1_000)),
+      },
+      status: 403,
+    },
+  );
+}
+
+function requestHeader(callIndex: number, name: string): string | undefined {
+  const init = fetchMock.mock.calls[callIndex]?.[1] as
+    | { headers?: Record<string, string> }
+    | undefined;
+  return init?.headers?.[name];
 }
 
 function createDeferred<T>(): {
@@ -570,6 +603,101 @@ describe("auto updater", () => {
 
     await install?.();
     expect(markUpdateInstallInProgressMock).not.toHaveBeenCalled();
+  });
+
+  it("serves renderer release reads from the main-process cache", async () => {
+    const updater = await importAutoUpdater();
+
+    const first = await updater.readAppUpdateReleaseVersions();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const second = await updater.readAppUpdateReleaseVersions();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.fetchedAt).toBe(first.fetchedAt);
+    expect(second.stable.latest.version).toBe("v1.0.0-beta.8");
+  });
+
+  it("shares one request between concurrent release readers", async () => {
+    const updater = await importAutoUpdater();
+
+    const [versions, release] = await Promise.all([
+      updater.readAppUpdateReleaseVersions(),
+      updater.checkForAppUpdatesNow("periodic"),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(versions.stable.latest.version).toBe("v1.0.0-beta.8");
+    expect(release.status).not.toBe("error");
+  });
+
+  it("refetches once the cache entry expires", async () => {
+    const updater = await importAutoUpdater();
+
+    await updater.readAppUpdateReleaseVersions();
+    await vi.advanceTimersByTimeAsync(updater.APP_UPDATE_RELEASE_CACHE_TTL_MS + 1);
+    await updater.readAppUpdateReleaseVersions();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("revalidates conditionally and keeps the cached list on 304", async () => {
+    const updater = await importAutoUpdater();
+
+    await updater.readAppUpdateReleaseVersions();
+    fetchMock.mockResolvedValueOnce(githubResponse(undefined, { status: 304 }));
+
+    const result = await updater.checkForAppUpdatesNow("manual");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestHeader(1, "If-None-Match")).toBe('W/"releases"');
+    expect(result.status).not.toBe("error");
+  });
+
+  it("reports the rate-limit reset time instead of a bare 403", async () => {
+    const updater = await importAutoUpdater();
+    const resetAt = Date.now() + 30 * 60 * 1_000;
+    fetchMock.mockResolvedValue(rateLimitedResponse(resetAt));
+
+    const versions = await updater.readAppUpdateReleaseVersions();
+
+    expect(versions.stable.latest.unavailableReason).toMatch(
+      /GitHub rate limit reached\. Update checks resume at /,
+    );
+    expect(versions.stable.latest.unavailableReason).not.toMatch(/403/);
+  });
+
+  it("stops requesting while rate limited and serves the last good list", async () => {
+    const updater = await importAutoUpdater();
+
+    await updater.readAppUpdateReleaseVersions();
+    const resetAt = Date.now() + 30 * 60 * 1_000;
+    fetchMock.mockResolvedValue(rateLimitedResponse(resetAt));
+    await vi.advanceTimersByTimeAsync(updater.APP_UPDATE_RELEASE_CACHE_TTL_MS + 1);
+
+    // One request discovers the limit; later reads must not spend another.
+    await updater.readAppUpdateReleaseVersions();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const stale = await updater.readAppUpdateReleaseVersions();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(stale.stable.latest.version).toBe("v1.0.0-beta.8");
+    expect(stale.stable.latest.unavailableReason).toBeUndefined();
+  });
+
+  it("resumes requesting after the rate-limit window passes", async () => {
+    const updater = await importAutoUpdater();
+    const resetAt = Date.now() + 30 * 60 * 1_000;
+    fetchMock.mockResolvedValue(rateLimitedResponse(resetAt));
+
+    await updater.readAppUpdateReleaseVersions();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(31 * 60 * 1_000);
+    mockGitHubReleases();
+    const recovered = await updater.readAppUpdateReleaseVersions();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(recovered.stable.latest.version).toBe("v1.0.0-beta.8");
   });
 
   it("does not install a downloaded update when quit confirmation is cancelled", async () => {

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from "electron";
+import { app, BrowserWindow, ipcMain } from "electron";
 import electronUpdater from "electron-updater";
 const { autoUpdater } = electronUpdater;
 import {
@@ -151,8 +151,17 @@ function configureAutoUpdaterFeedForRelease(release: GitHubRelease): void {
   log.info("configured auto-update feed for GitHub release", { tag });
 }
 
+// E2E launches the app with NODE_ENV=production, which would otherwise arm the
+// startup check, the hourly timer, and the Settings release read against the
+// live GitHub API. Every spinup would spend requests from the 60-per-hour
+// anonymous budget shared by the whole runner IP, and the release list would
+// make the UI depend on what happens to be published.
+function e2eUpdateChecksDisabled(): boolean {
+  return process.env.PWRAGENT_E2E === "1" && !app.isPackaged;
+}
+
 function productionUpdatesEnabled(): boolean {
-  return process.env.NODE_ENV === "production";
+  return process.env.NODE_ENV === "production" && !e2eUpdateChecksDisabled();
 }
 
 function developmentUpdateCheckResult(): AppUpdateCheckResult {
@@ -639,24 +648,26 @@ function rateLimitedError(resetAt: number): Error {
   return new Error(`GitHub rate limit reached. Update checks resume at ${resumesAt}.`);
 }
 
-function releaseRequestError(response: Response): Error {
+/**
+ * The reset instant to back off until, or undefined when the failure is not a
+ * rate limit. A reset that is not in the future cannot be trusted — a skewed
+ * local clock would otherwise leave the backoff permanently disarmed — so it
+ * falls back to a fixed window.
+ */
+function rateLimitResetFromResponse(response: Response): number | undefined {
   const status = response.status;
   const rateLimited =
     (status === 403 || status === 429)
     && readResponseHeader(response, "x-ratelimit-remaining") === "0";
   if (!rateLimited) {
-    return new Error(`GitHub releases request failed with ${status}`);
+    return undefined;
   }
-  const resetSeconds = Number(readResponseHeader(response, "x-ratelimit-reset"));
-  rateLimitResetAt =
-    Number.isFinite(resetSeconds) && resetSeconds > 0
-      ? resetSeconds * 1_000
-      : Date.now() + RATE_LIMIT_FALLBACK_BACKOFF_MS;
-  log.warn("GitHub release rate limit reached", {
-    resetAt: new Date(rateLimitResetAt).toISOString(),
-    status,
-  });
-  return rateLimitedError(rateLimitResetAt);
+  const now = Date.now();
+  const resetAt =
+    Number(readResponseHeader(response, "x-ratelimit-reset")) * 1_000;
+  return Number.isFinite(resetAt) && resetAt > now
+    ? resetAt
+    : now + RATE_LIMIT_FALLBACK_BACKOFF_MS;
 }
 
 async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
@@ -673,7 +684,18 @@ async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
       return releaseCache.releases;
     }
     if (!response.ok) {
-      throw releaseRequestError(response);
+      const resetAt = rateLimitResetFromResponse(response);
+      if (resetAt === undefined) {
+        throw new Error(
+          `GitHub releases request failed with ${response.status}`,
+        );
+      }
+      rateLimitResetAt = resetAt;
+      log.warn("GitHub release rate limit reached", {
+        resetAt: new Date(resetAt).toISOString(),
+        status: response.status,
+      });
+      throw rateLimitedError(resetAt);
     }
     const payload = await response.json();
     const releases = Array.isArray(payload)
@@ -702,7 +724,15 @@ async function readGitHubReleases(
   maxAgeMs = APP_UPDATE_RELEASE_CACHE_TTL_MS,
 ): Promise<GitHubRelease[]> {
   const now = Date.now();
-  if (releaseCache && now - releaseCache.fetchedAt < maxAgeMs) {
+  const cacheAgeMs = releaseCache ? now - releaseCache.fetchedAt : undefined;
+  // A negative age means the wall clock moved backwards. Treat that entry as
+  // stale rather than fresh for the size of the jump.
+  if (
+    releaseCache
+    && cacheAgeMs !== undefined
+    && cacheAgeMs >= 0
+    && cacheAgeMs < maxAgeMs
+  ) {
     return releaseCache.releases;
   }
   if (rateLimitResetAt !== undefined && now < rateLimitResetAt) {
@@ -735,6 +765,14 @@ async function readAppUpdateReleaseForChannel(
 }
 
 export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVersions> {
+  if (e2eUpdateChecksDisabled()) {
+    const unavailable = { unavailableReason: "Update checks are disabled." };
+    return {
+      fetchedAt: Date.now(),
+      stable: { latest: unavailable, prerelease: unavailable },
+      beta: { latest: unavailable, prerelease: unavailable },
+    };
+  }
   try {
     const releases = await readGitHubReleases();
     const selected = selectAppUpdateReleases(releases);

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -32,6 +32,12 @@ const GITHUB_RELEASES_URL =
   "https://api.github.com/repos/pwrdrvr/PwrAgent/releases?per_page=30";
 const RELEASE_FETCH_TIMEOUT_MS = 5_000;
 export const APP_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1_000;
+// The GitHub REST API allows 60 anonymous requests per hour per IP, shared by
+// every process on the machine. The renderer reads release versions on every
+// Settings mount, so main caches the release list and serves those reads from
+// memory instead of spending a request each time.
+export const APP_UPDATE_RELEASE_CACHE_TTL_MS = 15 * 60 * 1_000;
+const RATE_LIMIT_FALLBACK_BACKOFF_MS = 15 * 60 * 1_000;
 
 let initialized = false;
 let updateStatus: AppUpdateStatus = { status: "idle" };
@@ -44,6 +50,16 @@ let heldDownloadedUpdate:
   | { selection: UpdateSelectionKey; version: string }
   | undefined;
 const pendingDownloadChannelsByVersion = new Map<string, UpdateSelectionKey>();
+
+type ReleaseCacheEntry = {
+  releases: GitHubRelease[];
+  etag?: string;
+  fetchedAt: number;
+};
+
+let releaseCache: ReleaseCacheEntry | undefined;
+let releaseFetchInFlight: Promise<GitHubRelease[]> | undefined;
+let rateLimitResetAt: number | undefined;
 
 type GitHubRelease = {
   assets?: GitHubReleaseAsset[];
@@ -274,6 +290,7 @@ export async function checkForAppUpdatesNow(
       const release = await readAppUpdateReleaseForChannel(
         updateChannel,
         updateTrain,
+        trigger === "manual" || trigger === "menu" ? 0 : undefined,
       );
       const currentVersion = autoUpdater.currentVersion?.version ?? "unknown";
       if (!release?.tag_name) {
@@ -595,57 +612,134 @@ function releaseForSelection(
     : selected.stableLatest;
 }
 
-function githubReleaseHeaders(): HeadersInit {
+function githubReleaseHeaders(etag?: string): HeadersInit {
   const token = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim();
   return {
     Accept: "application/vnd.github+json",
     "User-Agent": "PwrAgent",
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    // A conditional request that answers 304 is not charged against the
+    // GitHub rate limit, so revalidation stays free while nothing ships.
+    ...(etag ? { "If-None-Match": etag } : {}),
   };
 }
 
-async function fetchGitHubReleases(signal?: AbortSignal): Promise<GitHubRelease[]> {
-  const response = await fetch(GITHUB_RELEASES_URL, {
-    headers: githubReleaseHeaders(),
-    ...(signal ? { signal } : {}),
-  });
-  if (!response.ok) {
-    throw new Error(`GitHub releases request failed with ${response.status}`);
-  }
-  const payload = await response.json();
-  return Array.isArray(payload)
-    ? payload.filter((release): release is GitHubRelease =>
-        typeof release === "object" && release !== null,
-      )
-    : [];
+function readResponseHeader(
+  response: Response,
+  name: string,
+): string | undefined {
+  return response.headers?.get?.(name) ?? undefined;
 }
 
-async function readAppUpdateReleaseForChannel(
-  updateChannel: DesktopUpdateChannel,
-  updateTrain: DesktopUpdateTrain,
-): Promise<GitHubRelease | undefined> {
+function rateLimitedError(resetAt: number): Error {
+  const resumesAt = new Date(resetAt).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return new Error(`GitHub rate limit reached. Update checks resume at ${resumesAt}.`);
+}
+
+function releaseRequestError(response: Response): Error {
+  const status = response.status;
+  const rateLimited =
+    (status === 403 || status === 429)
+    && readResponseHeader(response, "x-ratelimit-remaining") === "0";
+  if (!rateLimited) {
+    return new Error(`GitHub releases request failed with ${status}`);
+  }
+  const resetSeconds = Number(readResponseHeader(response, "x-ratelimit-reset"));
+  rateLimitResetAt =
+    Number.isFinite(resetSeconds) && resetSeconds > 0
+      ? resetSeconds * 1_000
+      : Date.now() + RATE_LIMIT_FALLBACK_BACKOFF_MS;
+  log.warn("GitHub release rate limit reached", {
+    resetAt: new Date(rateLimitResetAt).toISOString(),
+    status,
+  });
+  return rateLimitedError(rateLimitResetAt);
+}
+
+async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), RELEASE_FETCH_TIMEOUT_MS);
   try {
-    const releases = await fetchGitHubReleases(controller.signal);
-    return releaseForSelection(
-      selectAppUpdateReleases(releases),
-      updateChannel,
-      updateTrain,
-    );
+    const response = await fetch(GITHUB_RELEASES_URL, {
+      headers: githubReleaseHeaders(releaseCache?.etag),
+      signal: controller.signal,
+    });
+    if (response.status === 304 && releaseCache) {
+      releaseCache = { ...releaseCache, fetchedAt: Date.now() };
+      rateLimitResetAt = undefined;
+      return releaseCache.releases;
+    }
+    if (!response.ok) {
+      throw releaseRequestError(response);
+    }
+    const payload = await response.json();
+    const releases = Array.isArray(payload)
+      ? payload.filter((release): release is GitHubRelease =>
+          typeof release === "object" && release !== null,
+        )
+      : [];
+    releaseCache = {
+      etag: readResponseHeader(response, "etag"),
+      fetchedAt: Date.now(),
+      releases,
+    };
+    rateLimitResetAt = undefined;
+    return releases;
   } finally {
     clearTimeout(timeout);
   }
 }
 
+/**
+ * Single owner of the GitHub release list. Every caller in main goes through
+ * this cache, and the renderer only ever reads it over IPC, so a Settings
+ * mount costs no network request.
+ */
+async function readGitHubReleases(
+  maxAgeMs = APP_UPDATE_RELEASE_CACHE_TTL_MS,
+): Promise<GitHubRelease[]> {
+  const now = Date.now();
+  if (releaseCache && now - releaseCache.fetchedAt < maxAgeMs) {
+    return releaseCache.releases;
+  }
+  if (rateLimitResetAt !== undefined && now < rateLimitResetAt) {
+    // Spending a request that GitHub will reject only deepens the hole. Serve
+    // the last good list when we have one.
+    if (releaseCache) {
+      return releaseCache.releases;
+    }
+    throw rateLimitedError(rateLimitResetAt);
+  }
+  if (!releaseFetchInFlight) {
+    releaseFetchInFlight = fetchGitHubReleases().finally(() => {
+      releaseFetchInFlight = undefined;
+    });
+  }
+  return await releaseFetchInFlight;
+}
+
+async function readAppUpdateReleaseForChannel(
+  updateChannel: DesktopUpdateChannel,
+  updateTrain: DesktopUpdateTrain,
+  maxAgeMs?: number,
+): Promise<GitHubRelease | undefined> {
+  const releases = await readGitHubReleases(maxAgeMs);
+  return releaseForSelection(
+    selectAppUpdateReleases(releases),
+    updateChannel,
+    updateTrain,
+  );
+}
+
 export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVersions> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), RELEASE_FETCH_TIMEOUT_MS);
   try {
-    const releases = await fetchGitHubReleases(controller.signal);
+    const releases = await readGitHubReleases();
     const selected = selectAppUpdateReleases(releases);
     return {
-      fetchedAt: Date.now(),
+      fetchedAt: releaseCache?.fetchedAt ?? Date.now(),
       stable: {
         latest: releaseInfoFromGitHubRelease(
           selected.stableLatest,
@@ -675,8 +769,6 @@ export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVe
       stable: { latest: unavailable, prerelease: unavailable },
       beta: { latest: unavailable, prerelease: unavailable },
     };
-  } finally {
-    clearTimeout(timeout);
   }
 }
 

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -748,7 +748,20 @@ async function readGitHubReleases(
       releaseFetchInFlight = undefined;
     });
   }
-  return await releaseFetchInFlight;
+  try {
+    return await releaseFetchInFlight;
+  } catch (err) {
+    // The request that discovers the limit degrades the same way every later
+    // one does: last good list first, error only when there is none.
+    if (
+      releaseCache
+      && rateLimitResetAt !== undefined
+      && Date.now() < rateLimitResetAt
+    ) {
+      return releaseCache.releases;
+    }
+    throw err;
+  }
 }
 
 async function readAppUpdateReleaseForChannel(

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -277,10 +277,16 @@ export function GeneralSettings(props: {
       setUpdateResult(result);
       setUpdateStatus(result);
       // The check refreshed the main-process release cache, so this read is
-      // served from memory and clears any stale Unavailable slot labels.
-      const versions = await props.desktopApi?.readAppUpdateReleaseVersions?.();
-      if (versions) {
-        setReleaseVersions(versions);
+      // served from memory and clears any stale Unavailable slot labels. It is
+      // cosmetic: failing it must not overwrite the check result above.
+      try {
+        const versions =
+          await props.desktopApi?.readAppUpdateReleaseVersions?.();
+        if (versions) {
+          setReleaseVersions(versions);
+        }
+      } catch {
+        // Keep the check result the operator just asked for.
       }
     } catch (err) {
       setUpdateResult({

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -276,6 +276,12 @@ export function GeneralSettings(props: {
       const result = await checkForUpdates();
       setUpdateResult(result);
       setUpdateStatus(result);
+      // The check refreshed the main-process release cache, so this read is
+      // served from memory and clears any stale Unavailable slot labels.
+      const versions = await props.desktopApi?.readAppUpdateReleaseVersions?.();
+      if (versions) {
+        setReleaseVersions(versions);
+      }
     } catch (err) {
       setUpdateResult({
         status: "error",


### PR DESCRIPTION
## Summary

Settings → General reported `Update check failed: GitHub releases request failed with 403`, with all four channel slots stuck on `Unavailable`. The 403 is not an auth failure — it is GitHub's anonymous REST rate limit (60 requests/hour, per IP, shared by every process on the machine). Reproduced on the affected machine: `x-ratelimit-limit: 60`, `x-ratelimit-remaining: 0`, `x-ratelimit-used: 60`.

The app spent that budget faster than it needed to. `GeneralSettings` fetched the release list on **every mount** of the panel, `Check for Update` spent another request, and the hourly periodic check spent one more per running instance — none of it cached, and none of it conditional.

Main now owns a single cached release list:

- **One cache, one reader.** `releaseCache` holds releases + etag + `fetchedAt` with a 15-minute TTL, and every main-process caller goes through `readGitHubReleases(maxAgeMs)`. Concurrent readers share the in-flight promise instead of each issuing a request.
- **The renderer never requests directly.** It reads the cache over IPC, so opening Settings costs no network request. `readAppUpdateReleaseVersions` now reports the cache's real `fetchedAt` rather than `Date.now()`.
- **Conditional revalidation.** Requests send `If-None-Match` from the stored etag. GitHub does not charge a 304 against the rate limit, so a manual check — which deliberately bypasses the TTL — is nearly free when nothing shipped.
- **Backoff on rate limit.** A 403/429 carrying `x-ratelimit-remaining: 0` records `x-ratelimit-reset`, suppresses further requests until it passes, and serves the last good list when one is cached.
- **Better message.** `GitHub rate limit reached. Update checks resume at 10:30 PM.` instead of a raw status code that reads like an auth problem.

A successful manual check also refreshes the four slot labels from the just-revalidated cache, so they stop showing a stale `Unavailable`.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/auto-updater.test.ts` — 39 passed, including 7 new tests: cached read issues no second request, concurrent readers share one request, TTL expiry refetches, 304 keeps the cached list and sends `If-None-Match`, rate limit yields the friendly message, rate limit suppresses further requests while serving the stale list, and requests resume after the reset window.
- Ran the other suites that import `auto-updater` (`index`, `outbound-fetch-guard`, `pwragent-app-management-service`) — 100 passed across 4 files.
- `pnpm --filter @pwragent/desktop typecheck` — clean.
- `pnpm lint:eslint` — 0 errors (35 pre-existing warnings, none in the changed files).

## Notes

- The download feed is unaffected. `configureAutoUpdaterFeedForRelease` uses `provider: "generic"` against `github.com/.../releases/download/<tag>/`, which is not the rate-limited REST API. Only the release-metadata call needed caching.
- `GH_TOKEN`/`GITHUB_TOKEN` still lift the limit to 5,000/hour when present, but a Dock/Finder launch inherits no shell environment, so packaged builds are anonymous in practice. Caching is the fix that actually applies to shipped installs.
- Existing test response mocks were bare `{ ok, json }` objects; they now carry `status` and real `Headers` so the etag and rate-limit paths are exercised rather than silently skipped.
- Follow-up under discussion: proxying the metadata call through a Cloudflare Worker on `pwragent.ai` (the domain is already on Cloudflare nameservers) with a server-side token, `stale-if-error`, and a trimmed payload — one shared endpoint could serve PwrAgent, PwrSnap, and PwrGit. Not in this PR.
- The same bug likely exists in PwrGit and PwrSnap; ports are queued separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
