### PR TITLE
fix(desktop): prewarm the Windows Job wrapper

### DIFF
--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   formatWindowsJobStartupTelemetry,
+  prewarmWindowsJobWrapper,
   formatWindowsJobStartupTimeout,
   readWindowsJobStartupTelemetry,
   startWindowsJobReadyPoll,
@@ -450,5 +451,21 @@ describe("wrapCommandInWindowsJob", () => {
       }
     },
     30_000,
+  );
+});
+
+describe("prewarmWindowsJobWrapper", () => {
+  // The prewarm exists to move a cold start, so it must never become a failure
+  // path of its own: a machine without `SystemRoot`, a PowerShell that will not
+  // launch, and a healthy Windows host all have to settle the same way.
+  it(
+    "shares one best-effort attempt across callers",
+    async () => {
+      const attempt = prewarmWindowsJobWrapper();
+
+      expect(prewarmWindowsJobWrapper()).toBe(attempt);
+      await expect(attempt).resolves.toBeUndefined();
+    },
+    60_000,
   );
 });

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -6,8 +6,8 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   formatWindowsJobStartupTelemetry,
-  prewarmWindowsJobWrapper,
   formatWindowsJobStartupTimeout,
+  prewarmWindowsJobWrapper,
   readWindowsJobStartupTelemetry,
   startWindowsJobReadyPoll,
   type WindowsJobStartupTimeout,
@@ -468,4 +468,43 @@ describe("prewarmWindowsJobWrapper", () => {
     },
     60_000,
   );
+
+  // Startup discards this promise with `void`, and a rejection before the main
+  // window appears is reported as a fatal boot failure. A host that cannot hand
+  // out a temp directory must therefore cost a cold launch, not a startup that
+  // refuses to continue.
+  it("settles when the wrapper cannot create its state directory", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "win32",
+    });
+    vi.stubEnv("SystemRoot", String.raw`C:\Windows`);
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        default: actual,
+        mkdtempSync: () => {
+          throw new Error("no writable temp directory");
+        },
+      };
+    });
+
+    try {
+      const { prewarmWindowsJobWrapper: prewarmWithBrokenTemp } =
+        await import("../windows-job-wrapper");
+
+      await expect(prewarmWithBrokenTemp()).resolves.toBeUndefined();
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
+      vi.unstubAllEnvs();
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: originalPlatform,
+      });
+    }
+  });
 });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -151,6 +151,7 @@ import {
   isAppStateInitialized,
   recordBootDecision,
 } from "./state/app-state";
+import { prewarmWindowsJobWrapper } from "./windows-job-wrapper";
 import { createMainWindow, syncHotCpuProfilersFromSettings } from "./window";
 import { subscribersForChannel } from "./window-channels";
 import { requestOpenNewThread } from "./window-open-new-thread";
@@ -1290,6 +1291,11 @@ export function bootstrapApp(): void {
         error: error instanceof Error ? error.message : String(error),
       });
     });
+    // Windows only, and a no-op everywhere else. The first Job-wrapped command
+    // on a machine pays a cold PowerShell host launch and a helper compile that
+    // has measured in the tens of seconds; without this the bill lands on the
+    // operator's first worktree archive.
+    void prewarmWindowsJobWrapper();
     const messagingRuntime = getDesktopMessagingRuntime((options) =>
       loadDesktopMessagingConfigFromSettings(
         getDesktopSettingsService(),

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -764,50 +764,51 @@ let windowsJobWrapperPrewarm: Promise<void> | undefined;
  * and active-process drain a real command takes. Nothing about the ownership
  * boundary changes -- this only decides when its cold start happens.
  *
- * Best effort by construction. A failure means the next real launch is cold
- * again, which is exactly today's behavior, so no caller needs to handle it.
- * Repeat calls share the first call's promise.
+ * Best effort by construction: this never rejects. A failure means the next
+ * real launch is cold again, which is exactly today's behavior, so no caller
+ * needs to handle it. Repeat calls share the first call's promise.
  */
-export function prewarmWindowsJobWrapper(
-  options: { env?: NodeJS.ProcessEnv } = {},
-): Promise<void> {
-  windowsJobWrapperPrewarm ??= runWindowsJobWrapperPrewarm(
-    options.env ?? process.env,
-  );
+export function prewarmWindowsJobWrapper(): Promise<void> {
+  windowsJobWrapperPrewarm ??= runWindowsJobWrapperPrewarm();
   return windowsJobWrapperPrewarm;
 }
 
-async function runWindowsJobWrapperPrewarm(
-  env: NodeJS.ProcessEnv,
-): Promise<void> {
-  if (process.platform !== "win32") {
-    return;
-  }
-
-  // `CreateProcess` is given the executable directly and performs no path
-  // search, so a prewarm without an absolute target would only prove that the
-  // wrapper reports a launch failure quickly.
-  const systemRoot = readSystemRoot(env);
-  if (!systemRoot) {
-    return;
-  }
-
-  const launch = wrapCommandInWindowsJob({
-    args: ["/c", "exit", "0"],
-    command: path.win32.join(systemRoot, "System32", "cmd.exe"),
-    env,
-  });
+async function runWindowsJobWrapperPrewarm(): Promise<void> {
+  // Every failure mode settles the same way: warming is an optimization, so the
+  // whole attempt is inside one `catch`. Startup discards this promise with
+  // `void` and boot treats a stray rejection as a fatal boot failure, so a
+  // temp directory PwrAgent could not create -- or one it could not delete
+  // afterwards -- must never reach the operator as a startup error.
   try {
-    await execFile(launch.command, launch.args, {
-      encoding: "utf8",
-      env: launch.env,
-      // A hung prewarm host would otherwise outlive the app. The timeout kills
-      // PowerShell, which closes the Job and takes the target with it.
-      timeout: WINDOWS_JOB_PREWARM_TIMEOUT_MS,
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    // `CreateProcess` is given the executable directly and performs no path
+    // search, so a prewarm without an absolute target would only prove that the
+    // wrapper reports a launch failure quickly.
+    const systemRoot = readSystemRoot(process.env);
+    if (!systemRoot) {
+      return;
+    }
+
+    const launch = wrapCommandInWindowsJob({
+      args: ["/c", "exit", "0"],
+      command: path.win32.join(systemRoot, "System32", "cmd.exe"),
+      env: process.env,
     });
+    try {
+      await execFile(launch.command, launch.args, {
+        encoding: "utf8",
+        env: launch.env,
+        // A hung prewarm host would otherwise outlive the app. The timeout
+        // kills PowerShell, which closes the Job and takes the target with it.
+        timeout: WINDOWS_JOB_PREWARM_TIMEOUT_MS,
+      });
+    } finally {
+      launch.cleanup();
+    }
   } catch {
-    // Warming is an optimization; the next real launch still owns its own tree.
-  } finally {
-    launch.cleanup();
+    // The next real launch is cold again, which is exactly today's behavior.
   }
 }

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -1,3 +1,4 @@
+import { execFile as execFileCallback } from "node:child_process";
 import {
   existsSync,
   mkdtempSync,
@@ -7,6 +8,9 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
 
 const EXECUTABLE_ENV = "PWRAGENT_JOB_WRAPPER_EXECUTABLE";
 const ARGUMENTS_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENTS";
@@ -650,6 +654,13 @@ export function startWindowsJobReadyPoll(params: {
   return { cancel };
 }
 
+/** Windows environment names are case-insensitive; `SystemRoot` is the norm. */
+function readSystemRoot(env: NodeJS.ProcessEnv): string | undefined {
+  return Object.entries(env).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+}
+
 function encodeArgument(value: string): string {
   return Buffer.from(value, "utf8").toString("base64");
 }
@@ -676,9 +687,7 @@ export function wrapCommandInWindowsJob(params: {
     encoding: "utf8",
     mode: 0o600,
   });
-  const systemRoot = Object.entries(params.env).find(
-    ([key]) => key.toUpperCase() === "SYSTEMROOT",
-  )?.[1];
+  const systemRoot = readSystemRoot(params.env);
   const powershell = systemRoot
     ? path.win32.join(
         systemRoot,
@@ -729,4 +738,76 @@ export function wrapCommandInWindowsJob(params: {
     startupStartedAt,
     startupStatusFilePath,
   };
+}
+
+/**
+ * A prewarm has nothing to own, so it only needs to outlast a cold host launch.
+ */
+const WINDOWS_JOB_PREWARM_TIMEOUT_MS = 60_000;
+
+let windowsJobWrapperPrewarm: Promise<void> | undefined;
+
+/**
+ * Pay the machine's Job-wrapper cold start once, off the critical path.
+ *
+ * The first wrapped command on a Windows machine pages in the PowerShell host,
+ * the .NET Framework it loads, and the compiler `Add-Type` shells out to; every
+ * wrapper after it reuses the same warm images. Hosted `windows-latest` runners
+ * have journaled `powershell-started@16761ms` and a 7.09s helper compile for
+ * that first launch against 0.7-2.1s for the ones that follow, and PwrAgent
+ * charges the whole difference to whichever command happens to be first --
+ * today an operator's first worktree archive, and in CI the one desktop-main
+ * test that archives a real worktree.
+ *
+ * The cost belongs to the machine rather than to that command, so pay it here
+ * with a real wrapped no-op: the same suspended launch, Job assignment, resume,
+ * and active-process drain a real command takes. Nothing about the ownership
+ * boundary changes -- this only decides when its cold start happens.
+ *
+ * Best effort by construction. A failure means the next real launch is cold
+ * again, which is exactly today's behavior, so no caller needs to handle it.
+ * Repeat calls share the first call's promise.
+ */
+export function prewarmWindowsJobWrapper(
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<void> {
+  windowsJobWrapperPrewarm ??= runWindowsJobWrapperPrewarm(
+    options.env ?? process.env,
+  );
+  return windowsJobWrapperPrewarm;
+}
+
+async function runWindowsJobWrapperPrewarm(
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  // `CreateProcess` is given the executable directly and performs no path
+  // search, so a prewarm without an absolute target would only prove that the
+  // wrapper reports a launch failure quickly.
+  const systemRoot = readSystemRoot(env);
+  if (!systemRoot) {
+    return;
+  }
+
+  const launch = wrapCommandInWindowsJob({
+    args: ["/c", "exit", "0"],
+    command: path.win32.join(systemRoot, "System32", "cmd.exe"),
+    env,
+  });
+  try {
+    await execFile(launch.command, launch.args, {
+      encoding: "utf8",
+      env: launch.env,
+      // A hung prewarm host would otherwise outlive the app. The timeout kills
+      // PowerShell, which closes the Job and takes the target with it.
+      timeout: WINDOWS_JOB_PREWARM_TIMEOUT_MS,
+    });
+  } catch {
+    // Warming is an optimization; the next real launch still owns its own tree.
+  } finally {
+    launch.cleanup();
+  }
 }

--- a/apps/desktop/src/test-setup/windows-job-wrapper-prewarm.ts
+++ b/apps/desktop/src/test-setup/windows-job-wrapper-prewarm.ts
@@ -1,0 +1,21 @@
+// Pay the Windows Job wrapper's machine-level cold start once per run, before
+// any test file starts, exactly as the desktop app pays it once at startup.
+//
+// The wrapper owns `git worktree remove` on Windows (see
+// `apps/desktop/src/main/windows-job-wrapper.ts`). Its first launch on a
+// machine pages in the PowerShell host and compiles the C# Job runner, which
+// hosted `windows-latest` runners have journaled at up to 16.7s and 7.1s
+// respectively; every launch after it costs 0.7-2.1s. Whichever test reached
+// the wrapper first was charged that difference, which put
+// `backend-registry.test.ts`'s real-worktree archive at 10-21s against the
+// 30-second Windows contract and intermittently over it.
+//
+// This warms the machine, not the assertion: every test still runs the real
+// wrapper, with the same suspended launch, Job assignment, resume, and
+// active-process drain. It adds no retry, no timeout headroom, and no
+// serialization.
+import { prewarmWindowsJobWrapper } from "../main/windows-job-wrapper";
+
+export default async function setup(): Promise<void> {
+  await prewarmWindowsJobWrapper();
+}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -67,6 +67,10 @@ export default defineConfig({
             "apps/desktop/src/preload/__tests__/**/*.test.ts",
             "apps/desktop/src/shared/__tests__/**/*.test.ts"
           ],
+          // Windows only in effect: warms the Job-object wrapper that owns
+          // `git worktree remove` so its one-time PowerShell + helper-compile
+          // cold start is not billed to whichever test reaches it first.
+          globalSetup: ["apps/desktop/src/test-setup/windows-job-wrapper-prewarm.ts"],
           setupFiles: [
             // Inert unless PWRAGENT_DEV_SQLITE_WRITE_METRICS is set; see
             // `pnpm test:sqlite-writes`.


### PR DESCRIPTION
## Summary

- pay the Windows Job wrapper's machine-level cold start once, off the critical path
- prewarm at desktop startup (Windows only; a no-op everywhere else)
- prewarm once per `desktop-main` Vitest run through a `globalSetup`, before any test file starts
- leave the ownership boundary itself untouched: same suspended launch, Job assignment, resume, and active-process drain

## Root cause

`Windows desktop-main` fails intermittently on `backend-registry.test.ts > removes a real Git worktree and unregisters it from the source repo when archiving a thread` with `Test timed out in 30000ms`. It is pre-existing and not caused by any single PR:

- main @ ef327996f — [run 32182140447, job 95857563421](https://github.com/pwrdrvr/PwrAgent/actions/runs/32182140447/job/95857563421)
- PR #1768 (unrelated auto-updater change) — [run 32214754713, job 95954113423](https://github.com/pwrdrvr/PwrAgent/actions/runs/32214754713/job/95954113423)

It never hangs. It runs 10-21 seconds against the 30-second Windows contract and intermittently crosses it:

| Windows job | archive test | wrapper unit tests, same job |
| --- | --- | --- |
| 95791053385 ✅ | 10.1s | 0.64s / 0.93s |
| 95579756950 ✅ | 11.9s | 0.87s / 1.66s |
| 95883190450 ✅ | 14.9s | 0.62s / 0.84s |
| 95560940568 ✅ | 17.7s | 0.64s / 0.99s |
| 95942607663 ✅ | 20.7s | 0.75s / 1.12s |
| 95857563421 ❌ | >30s | 0.55s / 0.82s |
| 95954113423 ❌ | >30s | 0.47s / 1.12s |

Real Git is not the cost. A structurally identical real-repository test in the same file (`pwragent-registry-drift-local-`, six real `git` spawns) runs in **410ms** on the same runner, so the failing test's ~15 spawns account for about a second. The remaining 9-20 seconds is one call: `WorktreeArchiveService.archive` runs `git worktree remove --force` with `ownProcessTree: true` (#1488), which routes through the Job-object wrapper — a fresh Windows PowerShell 5.1 host that compiles the C# Job runner at runtime with `Add-Type`.

That first launch is the expensive one, and #1301 already measured it on hosted runners:

```
wrapper-created@0ms -> powershell-started@16761ms -> helper-compile-started@16869ms
```

> 19 successful hosted-runner samples put the first real Job-wrapped action at 4.4-14.1 seconds, while immediately subsequent wrappers took 0.7-2.1 seconds.

The archive test is the only `desktop-main` test that reaches the wrapper cold: `windows-job-wrapper.test.ts` always runs after it and sees the warm 0.5-1.7s path in every job above, failing runs included. So the cold start — which belongs to the machine — was being billed to one test's 30-second budget, and to an operator's first worktree archive on Windows.

## Fix

`prewarmWindowsJobWrapper()` launches one real wrapped no-op (`cmd.exe /c exit 0`) through the existing wrapper, which pages in the PowerShell host, the .NET Framework it loads, and the compiler `Add-Type` shells out to. It is memoized per process, best-effort by construction (a failure just leaves the next real launch cold, which is today's behavior), and bounded by a timeout that closes the Job and takes the target with it.

- `apps/desktop/src/main/index.ts` calls it at startup, fire-and-forget.
- `vitest.workspace.ts` runs it as a `desktop-main` `globalSetup`, so it completes before any test file — and therefore before any worker — starts.

This warms the machine, not the assertion. Every test still runs the real wrapper with the real Job semantics. No retry, no added timeout headroom, no worker reduction, no serialization, and no change to the suspended-launch → assign → resume → drain sequence.

## Validation

- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries` (no violations)
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main`: 321 files, 4607 passed
- No Windows machine reproduction: the flake is specific to hosted-runner cold start (#1301 measured 267-533ms PowerShell starts on the lab VM, which would not reproduce it), so this PR's own `Windows desktop-main` job is the validating surface. Worth re-running a few times to watch the archive test's reported duration drop from 10-21s toward the warm path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
