### PR TITLE
fix(desktop): color composer PR chips with the PR's real status

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -119,7 +119,16 @@ import {
   canChangeExistingThreadAgentDesignation,
   createDesktopAgentThread,
 } from "../../lib/agent-thread";
-import { parsePullRequestUrl } from "../../lib/pull-request-links";
+import {
+  parsePullRequestUrl,
+  resolveLivePullRequest,
+  usePullRequestLinks,
+  type PullRequestLinkContextValue,
+} from "../../lib/pull-request-links";
+import {
+  prChipModifierClasses,
+  resolvePrChipPresentation,
+} from "../pr-status/pr-chip-state";
 import {
   resolveThreadHref,
   resolveThreadIdText,
@@ -1525,6 +1534,14 @@ function createComposerPullRequestToken(
     shortDescription: `${pullRequest.org}/${pullRequest.repo}`,
     id: `${pullRequest.url}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
     index,
+    // Every PR chip in the composer is minted here — picker, pasted URL, and
+    // draft rehydration — so this is the one place the chip's status can be
+    // read off the summary. A summary that carries no status at all resolves
+    // to the same "unknown" gray the chip renders without it, so a PR nothing
+    // has observed is not dressed up as a state we know.
+    prChipModifiers: prChipModifierClasses(
+      resolvePrChipPresentation(pullRequest),
+    ),
   };
 }
 
@@ -1773,6 +1790,7 @@ function hydrateComposerDraft(
   canonicalDraft: string,
   skills: AppServerSkillSummary[],
   threadLinks: ThreadLinkContextValue | undefined,
+  pullRequestLinks: PullRequestLinkContextValue | undefined,
 ): {
   draft: string;
   skillTokens: ComposerSkillToken[];
@@ -1837,8 +1855,15 @@ function hydrateComposerDraft(
     } else {
       const pullRequest = parsePullRequestUrl(href);
       if (pullRequest) {
+        // The parsed summary knows the repo and the number and nothing else.
+        // Upgrading it through the live store before minting the token is what
+        // gives a restored draft the same colored chip the sidebar shows; an
+        // unseen PR falls back to the parsed summary and stays gray.
         skillTokens.push(
-          createComposerPullRequestToken(pullRequest, draft.length),
+          createComposerPullRequestToken(
+            resolveLivePullRequest(pullRequest, pullRequestLinks),
+            draft.length,
+          ),
         );
       } else {
         draft += match[0];
@@ -2888,6 +2913,7 @@ function CopyableComposerError(props: {
 
 export function Composer(props: ComposerProps) {
   const threadLinks = useThreadLinks();
+  const pullRequestLinks = usePullRequestLinks();
   const rendererFederationTarget = readRendererFederationTarget();
   const filesystemFederationTarget =
     props.thread?.federation?.ref.target
@@ -2947,6 +2973,7 @@ export function Composer(props: ComposerProps) {
           props.launchpad.prompt ?? "",
           props.skills,
           threadLinks,
+          pullRequestLinks,
         );
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
@@ -3270,8 +3297,14 @@ export function Composer(props: ComposerProps) {
     [draft, skillTokens]
   );
   const canonicalReferenceTokens = useMemo(
-    () => hydrateComposerDraft(canonicalDraft, props.skills, threadLinks).skillTokens,
-    [canonicalDraft, props.skills, threadLinks],
+    () =>
+      hydrateComposerDraft(
+        canonicalDraft,
+        props.skills,
+        threadLinks,
+        pullRequestLinks,
+      ).skillTokens,
+    [canonicalDraft, props.skills, pullRequestLinks, threadLinks],
   );
   const explicitReferencePaths = useMemo(
     () =>
@@ -3647,7 +3680,12 @@ export function Composer(props: ComposerProps) {
   const setComposerDraftFromCanonical = (nextDraft: string): void => {
     deletedSkillTokenHistoryRef.current = [];
     setEditorDocument(undefined);
-    const hydrated = hydrateComposerDraft(nextDraft, props.skills, threadLinks);
+    const hydrated = hydrateComposerDraft(
+      nextDraft,
+      props.skills,
+      threadLinks,
+      pullRequestLinks,
+    );
     setDraft(hydrated.draft);
     setSkillTokens(hydrated.skillTokens);
   };
@@ -4947,6 +4985,7 @@ export function Composer(props: ComposerProps) {
         props.launchpad?.prompt ?? "",
         props.skills,
         threadLinks,
+        pullRequestLinks,
       );
       const parkedTargetDraft = savedTargetDraft ?? {
         draft: hydratedTargetDraft.draft,
@@ -5123,7 +5162,12 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     deletedSkillTokenHistoryRef.current = [];
     if (skillTokens.length === 0 && draft.includes("](")) {
-      const hydrated = hydrateComposerDraft(draft, props.skills, threadLinks);
+      const hydrated = hydrateComposerDraft(
+        draft,
+        props.skills,
+        threadLinks,
+        pullRequestLinks,
+      );
       if (hydrated.skillTokens.length > 0) {
         // The paste update retained a rich document without mention nodes.
         // Let the controlled editor rebuild it from the hydrated tokens so
@@ -6172,6 +6216,7 @@ export function Composer(props: ComposerProps) {
       textDraft,
       props.skills,
       threadLinks,
+      pullRequestLinks,
     ).skillTokens;
     const localReferenceTokens = [
       ...fileSkillTokens,

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -24,6 +24,15 @@ export type ComposerSkillToken = AppServerSkillSummary & {
   id: string;
   index: number;
   kind?: "directory" | "file" | "pull-request" | "thread";
+  /**
+   * Pull-request chips only: the `pr-chip--*` modifiers the sidebar chip would
+   * render for this PR, resolved when the token was minted. The composer draws
+   * its chips through Tiptap DOM specs, which cannot mount `PrChip`, so the
+   * status has to travel with the token or the chip renders permanently gray.
+   * Absent only on a chip restored from an editor document saved before chips
+   * carried their status; those keep rendering the gray "unknown" dot.
+   */
+  prChipModifiers?: string[];
 };
 
 export type ComposerInputChangeMetadata = {

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -41,6 +41,7 @@ import {
   threadCopyTargets,
   type ThreadChipMenuLink,
 } from "../chrome/ThreadChipContextMenu";
+import { readPrChipModifierClasses } from "../pr-status/pr-chip-state";
 import type {
   ComposerInputChangeMetadata,
   ComposerInputHandle,
@@ -139,6 +140,18 @@ const SkillMention = Mention.extend({
         default: null,
         parseHTML: (element) => element.getAttribute("data-mention-kind"),
       },
+      // Pull-request chips only. The dot color is a fact about the PR, and
+      // Tiptap's DOM specs cannot mount `PrChip` to look it up, so the
+      // `pr-chip--*` modifiers `resolvePrChipPresentation` produced when the
+      // chip was minted ride on the node. They round-trip through the chip's
+      // own `class`, so a copy/paste of a chip keeps its color.
+      prChipModifiers: {
+        default: null,
+        parseHTML: (element) => {
+          const modifiers = readPrChipModifierClasses(element.className);
+          return modifiers.length > 0 ? modifiers : null;
+        },
+      },
     };
   },
 }).configure({
@@ -197,10 +210,20 @@ const SkillMention = Mention.extend({
     if (node.attrs.kind === "pull-request") {
       const label = String(node.attrs.name ?? "pull request");
       const path = typeof node.attrs.path === "string" ? node.attrs.path : "";
+      // A chip minted before any status was known keeps the gray dot; that is
+      // the honest reading of "we have never seen this PR", not a default.
+      const modifiers = readMentionPrChipModifiers(node.attrs) ?? [
+        "pr-chip--unknown",
+      ];
       return [
         "span",
         {
-          class: "pr-chip pr-chip--unknown composer-pr-chip composer-tiptap-input__mention",
+          class: [
+            "pr-chip",
+            ...modifiers,
+            "composer-pr-chip",
+            "composer-tiptap-input__mention",
+          ].join(" "),
           "data-type": "mention",
           "data-mention-kind": "pull-request",
           "data-composer-skill-token-id": String(node.attrs.id ?? ""),
@@ -212,6 +235,12 @@ const SkillMention = Mention.extend({
         },
         ["span", { class: "pr-chip__dot", "aria-hidden": "true" }],
         ["span", { class: "pr-chip__label" }, label],
+        // Same affordance the sidebar chip renders under a draft PR. Without
+        // it `pr-chip--draft` only lifts the label and the chip reads as
+        // misaligned rather than as a draft.
+        ...(modifiers.includes("pr-chip--draft")
+          ? [["span", { class: "pr-chip__draft-bar", "aria-hidden": "true" }]]
+          : []),
       ];
     }
     if (node.attrs.kind === "directory" || node.attrs.kind === "file") {
@@ -826,14 +855,7 @@ function buildTiptapContent(
     content.push(...splitTextContent(value.slice(cursor, index)));
     content.push({
       type: "mention",
-      attrs: {
-        id: skill.id,
-        name: skill.name,
-        path: skill.path ?? null,
-        description: skill.description ?? null,
-        shortDescription: skill.shortDescription ?? null,
-        kind: skill.kind ?? null,
-      },
+      attrs: getSkillMentionAttrs(skill),
     });
     cursor = index;
   });
@@ -1000,6 +1022,7 @@ function mentionAttrsToSkill(
     || attrs.kind === "thread"
       ? attrs.kind
       : undefined;
+  const prChipModifiers = readMentionPrChipModifiers(attrs);
   return {
     id: typeof attrs.id === "string" ? attrs.id : `${name}:${index}`,
     index,
@@ -1012,6 +1035,7 @@ function mentionAttrsToSkill(
         ? attrs.shortDescription
         : undefined,
     ...(kind ? { kind } : {}),
+    ...(prChipModifiers ? { prChipModifiers } : {}),
   };
 }
 
@@ -1898,7 +1922,22 @@ function getSkillMentionAttrs(skill: ComposerSkillToken): Record<string, unknown
     description: skill.description ?? null,
     shortDescription: skill.shortDescription ?? null,
     kind: skill.kind ?? null,
+    prChipModifiers: skill.prChipModifiers ?? null,
   };
+}
+
+/** The stored `pr-chip--*` modifiers on a mention node, when it has any. */
+function readMentionPrChipModifiers(
+  attrs: Record<string, unknown>,
+): string[] | undefined {
+  if (!Array.isArray(attrs.prChipModifiers)) {
+    return undefined;
+  }
+  const modifiers = attrs.prChipModifiers.filter(
+    (entry): entry is string =>
+      typeof entry === "string" && entry.startsWith("pr-chip--"),
+  );
+  return modifiers.length > 0 ? modifiers : undefined;
 }
 
 function getContentSignature(params: {
@@ -1912,6 +1951,11 @@ function getContentSignature(params: {
       kind: token.kind,
       name: token.name,
       path: token.path,
+      // A re-hydrated draft mints its PR chips from the live status, so the
+      // same `#123` at the same offset can come back a different color. That
+      // is a content change — without it the rebuilt document compares equal
+      // to the rendered one and the dot keeps the status it was minted with.
+      prChipModifiers: token.prChipModifiers,
     })),
   });
 }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../../lib/agent-thread";
 import { normalizeImageFile } from "../../../lib/image-normalization";
 import { FEDERATED_THREAD_SEARCH_DEBOUNCE_MS } from "../../../lib/useFederatedThreadSearch";
+import { PullRequestLinkProvider } from "../../../lib/pull-request-links";
 import { ThreadLinkProvider } from "../../../lib/thread-links";
 import { Composer } from "../Composer";
 import { REMOTE_NATIVE_PICKER_TOOLTIP } from "../native-picker-boundary";
@@ -2988,6 +2989,140 @@ describe("Composer", () => {
         ],
       });
     });
+  });
+
+  it("gives a picked pull-request chip the status color the thread list shows", async () => {
+    const pullRequest = {
+      provider: "github.com" as const,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      number: 13268,
+      state: "unknown" as const,
+      checkState: "passing" as const,
+      lifecycleState: "open" as const,
+      title: "Ship channel-style thread references",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/13268",
+    };
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const pullRequestThread: NavigationThreadSummary = {
+      id: "thread-pr-13268",
+      title: "Implement hash references",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      prs: [pullRequest],
+    };
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(async () => ({
+            backend: "codex" as const,
+            threadId: currentThread.id,
+            turnId: "turn-1",
+          })),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, pullRequestThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "See #13268" } });
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    fireEvent.click(
+      within(listbox).getByRole("option", { name: /pwrdrvr\/PwrAgent#13268/ }),
+    );
+
+    const chip = await waitFor(() =>
+      within(textbox).getByText("#13268").closest("[data-mention-kind]"),
+    );
+    expect(chip).toHaveClass("pr-chip--passing");
+    expect(chip).not.toHaveClass("pr-chip--unknown");
+  });
+
+  it("colors a restored pull-request chip from the live pull request status", async () => {
+    const url = "https://github.com/pwrdrvr/PwrAgent/pull/13268";
+    const pullRequest = {
+      provider: "github.com" as const,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      number: 13268,
+      state: "unknown" as const,
+      checkState: "failing" as const,
+      lifecycleState: "open" as const,
+      reviewState: "draft" as const,
+      title: "Ship channel-style thread references",
+      url,
+    };
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      prs: [pullRequest],
+    };
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: `look at [#13268](${url})`,
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    render(
+      <PullRequestLinkProvider
+        activeThread={currentThread}
+        threads={[currentThread]}
+      >
+        <Composer
+          backends={[backendSummary("codex")]}
+          directory={{
+            key: "directory:/repo",
+            kind: "directory",
+            label: "Repo",
+            path: "/repo",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          }}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={async () => undefined}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+          threads={[currentThread]}
+        />
+      </PullRequestLinkProvider>,
+    );
+
+    const richInput = screen.getByTestId("composer-tiptap-input");
+    const chip = await waitFor(() =>
+      within(richInput).getByText("#13268").closest("[data-mention-kind]"),
+    );
+    expect(chip).toHaveClass("pr-chip--failing");
+    expect(chip).toHaveClass("pr-chip--draft");
+    expect(chip).not.toHaveClass("pr-chip--unknown");
   });
 
   it("rebuilds a GitLab merge request chip from a prompt-only launchpad restore", async () => {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -10,10 +10,9 @@ import { CloseIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { PrChipContextMenu } from "./PrChipContextMenu";
 import {
+  prChipModifierClasses,
   prStatusLabel,
-  resolveCheckState,
-  resolveChipState,
-  resolveLifecycleState,
+  resolvePrChipPresentation,
 } from "./pr-chip-state";
 import { PrStatusCard } from "./PrStatusCard";
 
@@ -53,7 +52,10 @@ export function PrChip(props: PrChipProps) {
   const label = props.showRepoPrefix
     ? `${pr.org}/${pr.repo}#${pr.number}`
     : `#${pr.number}`;
-  const chipState = resolveChipState(pr);
+  const presentation = resolvePrChipPresentation(pr, {
+    withStatusPills: props.withStatusPills,
+  });
+  const chipState = presentation.chipState;
   const status = prStatusLabel(pr);
   // Creating this element is not rendering it: it stays an inert object until
   // `show` hands it to the portal on hover/focus, so a sidebar full of chips
@@ -103,30 +105,12 @@ export function PrChip(props: PrChipProps) {
     );
   }, [cardKey, pr, props.withStatusPills, tooltipVisible, updateTooltip]);
 
-  // Draft and merge-conflict ride ALONGSIDE the check-state dot color rather
-  // than replacing it: an OPEN draft keeps its real status color and gains a
-  // separate affordance bar, and a conflict recolors the dot red (see the
-  // `.pr-chip--draft` / `.pr-chip--conflicting` rules in app.css). Both only
-  // apply while the PR is open — a merged/closed chip owns its own dot color —
-  // and only when the chip is standalone; next to status pills the dot defers
-  // to them so it never disagrees with the "Checks …" pill.
-  const isOpen = resolveLifecycleState(pr) === "open";
-  const surfaceAffordances = isOpen && !props.withStatusPills;
-  const isDraft = surfaceAffordances && pr.reviewState === "draft";
-  const isConflicting = surfaceAffordances && pr.mergeState === "conflicting";
-  const hasFailingChecksStillRunning =
-    isOpen
-    && resolveCheckState(pr) === "failing"
-    && pr.checksStillRunning === true;
-  const className = [
-    "pr-chip",
-    `pr-chip--${chipState}`,
-    hasFailingChecksStillRunning ? "pr-chip--checks-running" : "",
-    isDraft ? "pr-chip--draft" : "",
-    isConflicting ? "pr-chip--conflicting" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  // `resolvePrChipPresentation` owns the draft / conflict / checks-running
+  // rules, including the "defer to the sibling status pills" case, so the
+  // composer's Tiptap-rendered chip reaches the same classes from the same
+  // reading of the PR.
+  const isDraft = presentation.isDraft;
+  const className = ["pr-chip", ...prChipModifierClasses(presentation)].join(" ");
 
   // role="button" span (not a real <button>) so the chip is legal HTML
   // inside the row's main <button>. stopPropagation prevents the row's

--- a/apps/desktop/src/renderer/src/features/pr-status/pr-chip-state.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/pr-chip-state.ts
@@ -54,6 +54,72 @@ function normalizeLegacyCheckState(
   return "unknown";
 }
 
+/**
+ * Everything the chip's classes say about a PR, resolved once.
+ *
+ * The composer renders its PR chips through Tiptap's DOM specs, which cannot
+ * mount `PrChip` and never see a `PrSummary` again after the chip is minted.
+ * Deriving both surfaces from this one function is what keeps a composer chip
+ * the same color as the sidebar chip for the same PR.
+ */
+export type PrChipPresentation = {
+  chipState: PrChipDotState;
+  hasFailingChecksStillRunning: boolean;
+  isConflicting: boolean;
+  isDraft: boolean;
+};
+
+export function resolvePrChipPresentation(
+  pr: PrSummary,
+  options?: {
+    /**
+     * The chip sits next to explicit status pills (the Pull Requests card), so
+     * draft + merge conflict belong to those pills and are dropped here.
+     */
+    withStatusPills?: boolean;
+  },
+): PrChipPresentation {
+  // Draft and merge-conflict ride ALONGSIDE the check-state dot color rather
+  // than replacing it: an OPEN draft keeps its real status color and gains a
+  // separate affordance bar, and a conflict recolors the dot red (see the
+  // `.pr-chip--draft` / `.pr-chip--conflicting` rules in app.css). Both only
+  // apply while the PR is open — a merged/closed chip owns its own dot color.
+  const isOpen = resolveLifecycleState(pr) === "open";
+  const surfaceAffordances = isOpen && !options?.withStatusPills;
+  return {
+    chipState: resolveChipState(pr),
+    hasFailingChecksStillRunning:
+      isOpen
+      && resolveCheckState(pr) === "failing"
+      && pr.checksStillRunning === true,
+    isConflicting: surfaceAffordances && pr.mergeState === "conflicting",
+    isDraft: surfaceAffordances && pr.reviewState === "draft",
+  };
+}
+
+/**
+ * The `pr-chip--*` modifiers for a presentation, WITHOUT the base `pr-chip`
+ * class. Kept separate so the composer can store the modifiers on its mention
+ * node and still compose them with its own chip classes.
+ */
+export function prChipModifierClasses(
+  presentation: PrChipPresentation,
+): string[] {
+  return [
+    `pr-chip--${presentation.chipState}`,
+    presentation.hasFailingChecksStillRunning ? "pr-chip--checks-running" : "",
+    presentation.isDraft ? "pr-chip--draft" : "",
+    presentation.isConflicting ? "pr-chip--conflicting" : "",
+  ].filter(Boolean);
+}
+
+/** The modifiers a `pr-chip` element already carries, in stored order. */
+export function readPrChipModifierClasses(className: string): string[] {
+  return className
+    .split(/\s+/)
+    .filter((entry) => entry.startsWith("pr-chip--"));
+}
+
 /** Whether the PR carries no status signal at all — a fresh attachment. */
 export function isPrStatusUnknown(pr: PrSummary): boolean {
   return (

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -14,7 +14,7 @@ import {
   type ReactNode,
 } from "react";
 
-type PullRequestLinkContextValue = {
+export type PullRequestLinkContextValue = {
   getSnapshot: (fallback: PrSummary) => PrSummary;
   getNumberSnapshot: (number: number) => PrSummary | undefined;
   resolve: (href: string) => PrSummary | undefined;
@@ -372,6 +372,18 @@ export function useLivePullRequestNumber(number: number): PrSummary | undefined 
     getSnapshot,
     () => undefined,
   );
+}
+
+/**
+ * The live status for a parsed PR, for callers outside a component that already
+ * hold the context value (draft hydration). `useLivePullRequest` is the hook
+ * form and stays the right choice inside a chip.
+ */
+export function resolveLivePullRequest(
+  pr: PrSummary,
+  links: PullRequestLinkContextValue | undefined,
+): PrSummary {
+  return links?.getSnapshot(pr) ?? pr;
 }
 
 export function resolvePullRequestHref(


### PR DESCRIPTION
## Problem

Typing `#13268` in the composer and picking the PR off the list produces a chip with a **gray** dot, while the very same PR shows **green** in the thread list one pane away.

The picker hands `createComposerPullRequestToken` a live `PrSummary`, but the token kept only the label and URL — and `ComposerTiptapInput`'s mention `renderHTML` hardcoded `pr-chip--unknown`. Every composer PR chip was gray, always.

## Fix

Tiptap draws composer mentions through DOM specs and cannot mount `PrChip`, so the status has to travel with the mention node.

- `pr-chip-state.ts` — the module that already exists so the chip and its hover card can't drift — gains `resolvePrChipPresentation` + `prChipModifierClasses`. `PrChip` now reads its classes from them instead of computing them inline, so both surfaces reach the same `pr-chip--*` set from the same reading of a `PrSummary` (including the "defer to the sibling status pills" case).
- `createComposerPullRequestToken` is the one place composer PR chips are minted — picker, pasted URL, and draft rehydration — so it resolves the modifiers there and stores them on the token / mention node. They round-trip through the chip's own `class`, so copy/paste keeps the color.
- Draft hydration upgrades the URL-parsed summary through the live PR store (`resolveLivePullRequest`) before minting, so a restored draft comes back colored rather than gray.
- A PR nothing on this machine has observed still resolves to the gray unknown dot — that stays the honest reading, not a default.
- The composer chip renders the draft bar when the PR is a draft, so `pr-chip--draft`'s 1px lift reads as the affordance it is instead of a misaligned label.

The status is a snapshot taken when the chip is minted. It refreshes on every rehydrate (thread switch, draft restore, paste); `getContentSignature` carries the modifiers so a rehydrate that returns a different color actually repaints.

## Tests

Two new cases in `composer.test.tsx`, both verified failing on `main` and passing here:

- `gives a picked pull-request chip the status color the thread list shows` — picks a passing PR out of the hash-reference list, asserts the chip is `pr-chip--passing` and not `pr-chip--unknown`.
- `colors a restored pull-request chip from the live pull request status` — restores `[#13268](url)` from a launchpad prompt inside a `PullRequestLinkProvider` holding a failing draft PR, asserts `pr-chip--failing` + `pr-chip--draft`.

Full renderer suite: 3030 passed (191 files). `lint:eslint` (0 errors), `lint:boundaries`, `lint:colors`, and `typecheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)