### PR TITLE
fix(desktop): prewarm the Windows Job wrapper (backport to 1.0)

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -77,6 +77,7 @@ const mainLogErrorMock = vi.fn();
 const initializeAppStateMock = vi.fn();
 const disposeAppStateMock = vi.fn();
 const isAppStateInitializedMock = vi.fn();
+const prewarmWindowsJobWrapperMock = vi.fn<() => Promise<void>>();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const messagingLeaseStartMock = vi.fn<() => Promise<void>>();
 const messagingLeaseShutdownSyncMock = vi.fn();
@@ -191,6 +192,14 @@ vi.mock("electron", () => ({
 vi.mock("../window", () => ({
   createMainWindow: createMainWindowMock,
   syncHotCpuProfilersFromSettings: vi.fn(),
+}));
+
+// Unmocked, this launches a real PowerShell host and a real cmd.exe on Windows
+// for every `await import("../index")` below -- `vi.resetModules()` clears the
+// prewarm's memo between tests, so the launches are per import, not per worker,
+// and nothing here awaits or owns them.
+vi.mock("../windows-job-wrapper", () => ({
+  prewarmWindowsJobWrapper: prewarmWindowsJobWrapperMock,
 }));
 
 vi.mock("../app-menu-bridge", () => ({
@@ -527,6 +536,8 @@ describe("bootstrapApp", () => {
     disposeAppStateMock.mockReset();
     isAppStateInitializedMock.mockReset();
     isAppStateInitializedMock.mockReturnValue(true);
+    prewarmWindowsJobWrapperMock.mockReset();
+    prewarmWindowsJobWrapperMock.mockResolvedValue();
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
     messagingLeaseStartMock.mockReset();
@@ -627,6 +638,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
+    expect(prewarmWindowsJobWrapperMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
       onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   formatWindowsJobStartupTelemetry,
   formatWindowsJobStartupTimeout,
+  prewarmWindowsJobWrapper,
   readWindowsJobStartupTelemetry,
   startWindowsJobReadyPoll,
   type WindowsJobStartupTimeout,
@@ -410,4 +411,59 @@ describe("wrapCommandInWindowsJob", () => {
     },
     30_000,
   );
+});
+
+describe("prewarmWindowsJobWrapper", () => {
+  // The prewarm exists to move a cold start, so it must never become a failure
+  // path of its own: a machine without `SystemRoot`, a PowerShell that will not
+  // launch, and a healthy Windows host all have to settle the same way.
+  it(
+    "shares one best-effort attempt across callers",
+    async () => {
+      const attempt = prewarmWindowsJobWrapper();
+
+      expect(prewarmWindowsJobWrapper()).toBe(attempt);
+      await expect(attempt).resolves.toBeUndefined();
+    },
+    60_000,
+  );
+
+  // Startup discards this promise with `void`, and a rejection before the main
+  // window appears is reported as a fatal boot failure. A host that cannot hand
+  // out a temp directory must therefore cost a cold launch, not a startup that
+  // refuses to continue.
+  it("settles when the wrapper cannot create its state directory", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "win32",
+    });
+    vi.stubEnv("SystemRoot", String.raw`C:\Windows`);
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        default: actual,
+        mkdtempSync: () => {
+          throw new Error("no writable temp directory");
+        },
+      };
+    });
+
+    try {
+      const { prewarmWindowsJobWrapper: prewarmWithBrokenTemp } =
+        await import("../windows-job-wrapper");
+
+      await expect(prewarmWithBrokenTemp()).resolves.toBeUndefined();
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
+      vi.unstubAllEnvs();
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: originalPlatform,
+      });
+    }
+  });
 });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -111,6 +111,7 @@ import {
   isAppStateInitialized,
   recordBootDecision,
 } from "./state/app-state";
+import { prewarmWindowsJobWrapper } from "./windows-job-wrapper";
 import { createMainWindow, syncHotCpuProfilersFromSettings } from "./window";
 import { subscribersForChannel } from "./window-channels";
 import { requestOpenNewThread } from "./window-open-new-thread";
@@ -1005,6 +1006,11 @@ export function bootstrapApp(): void {
     if (isDevelopment) {
       registerRuntimeIdentityIpcHandlers();
     }
+    // Windows only, and a no-op everywhere else. The first Job-wrapped command
+    // on a machine pays a cold PowerShell host launch and a helper compile that
+    // has measured in the tens of seconds; without this the bill lands on the
+    // operator's first worktree archive.
+    void prewarmWindowsJobWrapper();
     const messagingRuntime = getDesktopMessagingRuntime((options) =>
       loadDesktopMessagingConfigFromSettings(
         getDesktopSettingsService(),

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -1,3 +1,4 @@
+import { execFile as execFileCallback } from "node:child_process";
 import {
   existsSync,
   mkdtempSync,
@@ -7,6 +8,9 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
 
 const EXECUTABLE_ENV = "PWRAGENT_JOB_WRAPPER_EXECUTABLE";
 const ARGUMENTS_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENTS";
@@ -650,6 +654,13 @@ export function startWindowsJobReadyPoll(params: {
   return { cancel };
 }
 
+/** Windows environment names are case-insensitive; `SystemRoot` is the norm. */
+function readSystemRoot(env: NodeJS.ProcessEnv): string | undefined {
+  return Object.entries(env).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+}
+
 function encodeArgument(value: string): string {
   return Buffer.from(value, "utf8").toString("base64");
 }
@@ -676,9 +687,7 @@ export function wrapCommandInWindowsJob(params: {
     encoding: "utf8",
     mode: 0o600,
   });
-  const systemRoot = Object.entries(params.env).find(
-    ([key]) => key.toUpperCase() === "SYSTEMROOT",
-  )?.[1];
+  const systemRoot = readSystemRoot(params.env);
   const powershell = systemRoot
     ? path.win32.join(
         systemRoot,
@@ -729,4 +738,77 @@ export function wrapCommandInWindowsJob(params: {
     startupStartedAt,
     startupStatusFilePath,
   };
+}
+
+/**
+ * A prewarm has nothing to own, so it only needs to outlast a cold host launch.
+ */
+const WINDOWS_JOB_PREWARM_TIMEOUT_MS = 60_000;
+
+let windowsJobWrapperPrewarm: Promise<void> | undefined;
+
+/**
+ * Pay the machine's Job-wrapper cold start once, off the critical path.
+ *
+ * The first wrapped command on a Windows machine pages in the PowerShell host,
+ * the .NET Framework it loads, and the compiler `Add-Type` shells out to; every
+ * wrapper after it reuses the same warm images. Hosted `windows-latest` runners
+ * have journaled `powershell-started@16761ms` and a 7.09s helper compile for
+ * that first launch against 0.7-2.1s for the ones that follow, and PwrAgent
+ * charges the whole difference to whichever command happens to be first --
+ * today an operator's first worktree archive, and in CI the one desktop-main
+ * test that archives a real worktree.
+ *
+ * The cost belongs to the machine rather than to that command, so pay it here
+ * with a real wrapped no-op: the same suspended launch, Job assignment, resume,
+ * and active-process drain a real command takes. Nothing about the ownership
+ * boundary changes -- this only decides when its cold start happens.
+ *
+ * Best effort by construction: this never rejects. A failure means the next
+ * real launch is cold again, which is exactly today's behavior, so no caller
+ * needs to handle it. Repeat calls share the first call's promise.
+ */
+export function prewarmWindowsJobWrapper(): Promise<void> {
+  windowsJobWrapperPrewarm ??= runWindowsJobWrapperPrewarm();
+  return windowsJobWrapperPrewarm;
+}
+
+async function runWindowsJobWrapperPrewarm(): Promise<void> {
+  // Every failure mode settles the same way: warming is an optimization, so the
+  // whole attempt is inside one `catch`. Startup discards this promise with
+  // `void` and boot treats a stray rejection as a fatal boot failure, so a
+  // temp directory PwrAgent could not create -- or one it could not delete
+  // afterwards -- must never reach the operator as a startup error.
+  try {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    // `CreateProcess` is given the executable directly and performs no path
+    // search, so a prewarm without an absolute target would only prove that the
+    // wrapper reports a launch failure quickly.
+    const systemRoot = readSystemRoot(process.env);
+    if (!systemRoot) {
+      return;
+    }
+
+    const launch = wrapCommandInWindowsJob({
+      args: ["/c", "exit", "0"],
+      command: path.win32.join(systemRoot, "System32", "cmd.exe"),
+      env: process.env,
+    });
+    try {
+      await execFile(launch.command, launch.args, {
+        encoding: "utf8",
+        env: launch.env,
+        // A hung prewarm host would otherwise outlive the app. The timeout
+        // kills PowerShell, which closes the Job and takes the target with it.
+        timeout: WINDOWS_JOB_PREWARM_TIMEOUT_MS,
+      });
+    } finally {
+      launch.cleanup();
+    }
+  } catch {
+    // The next real launch is cold again, which is exactly today's behavior.
+  }
 }

--- a/apps/desktop/src/test-setup/windows-job-wrapper-prewarm.ts
+++ b/apps/desktop/src/test-setup/windows-job-wrapper-prewarm.ts
@@ -1,0 +1,21 @@
+// Pay the Windows Job wrapper's machine-level cold start once per run, before
+// any test file starts, exactly as the desktop app pays it once at startup.
+//
+// The wrapper owns `git worktree remove` on Windows (see
+// `apps/desktop/src/main/windows-job-wrapper.ts`). Its first launch on a
+// machine pages in the PowerShell host and compiles the C# Job runner, which
+// hosted `windows-latest` runners have journaled at up to 16.7s and 7.1s
+// respectively; every launch after it costs 0.7-2.1s. Whichever test reached
+// the wrapper first was charged that difference, which put
+// `backend-registry.test.ts`'s real-worktree archive at 10-21s against the
+// 30-second Windows contract and intermittently over it.
+//
+// This warms the machine, not the assertion: every test still runs the real
+// wrapper, with the same suspended launch, Job assignment, resume, and
+// active-process drain. It adds no retry, no timeout headroom, and no
+// serialization.
+import { prewarmWindowsJobWrapper } from "../main/windows-job-wrapper";
+
+export default async function setup(): Promise<void> {
+  await prewarmWindowsJobWrapper();
+}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -59,6 +59,10 @@ export default defineConfig({
             "apps/desktop/src/main/agent-tools/__tests__/**/*.test.ts",
             "apps/desktop/src/shared/__tests__/**/*.test.ts"
           ],
+          // Windows only in effect: warms the Job-object wrapper that owns
+          // `git worktree remove` so its one-time PowerShell + helper-compile
+          // cold start is not billed to whichever test reaches it first.
+          globalSetup: ["apps/desktop/src/test-setup/windows-job-wrapper-prewarm.ts"],
           // Inline @pwrdrvr/codex-discovery so vitest transforms it. Without
           // this, the kit's bundled `import { spawn } from "child_process"`
           // is loaded raw by Node and bypasses the tests'


### PR DESCRIPTION
Backport of #1769 to `releases/1.0`.

## Problem

`Windows desktop-main` fails intermittently on `backend-registry.test.ts > removes a real Git worktree and unregisters it from the source repo when archiving a thread` with `Test timed out in 30000ms`. `1.0` carries the same defect: `worktree-archive-service.ts:199` runs `git worktree remove --force` with `ownProcessTree: true`, and its `windows-job-wrapper.ts` is byte-identical to the `main` version this fixes.

It never hangs. The first Job-wrapped command on a machine pays a cold PowerShell 5.1 host launch plus the C# helper compile `Add-Type` shells out to — journaled at `powershell-started@16761ms` and 7.09s in #1301, against 0.7-2.1s for every wrapper after it. That test is the only `desktop-main` test that reaches the wrapper cold, which put it at 10-21s against the 30-second Windows contract and intermittently over it.

## Change

`prewarmWindowsJobWrapper()` pays that machine-level cold start once, off the critical path: at app startup (fire-and-forget) and once per `desktop-main` Vitest run through a `globalSetup`, using a real wrapped no-op that walks the same suspended launch, Job assignment, resume, and active-process drain. The ownership boundary is untouched — no retry, no timeout headroom, no worker reduction, no serialization.

On `main` this took the archive test from 10-21s to **3.07s** ([job 96079509148](https://github.com/pwrdrvr/PwrAgent/actions/runs/32256520873/job/96079509148)), with the wrapper's own unit tests unchanged at 0.74/0.99s.

## Differences from #1769

Mechanically identical except where `1.0` differs:

- `1.0`'s `desktop-main` project has no `setupFiles` block, so `globalSetup` is attached after `include` rather than above `setupFiles`.
- `1.0`'s `whenReady` has no federation-runtime restart, so `void prewarmWindowsJobWrapper()` sits directly after the `registerRuntimeIdentityIpcHandlers` block — the same position in the startup sequence, before the messaging runtime is constructed.
- `apps/desktop/src/test-setup/` does not exist on `1.0`; the global setup file creates it at the same path `main` uses, so the branches stay convergent.
- `windows-job-wrapper.ts` and its unit-test additions apply unchanged.

## Verification

- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries` (no violations)
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main`: 230 files, 3103 passed
- Windows behavior is validated by this PR's own `Windows desktop-main` job; the flake is specific to hosted-runner cold start, which a lab VM (267-533ms PowerShell starts) does not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
