### PR TITLE
fix(tests): keep startup tests off the Windows Job wrapper

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -85,6 +85,7 @@ const mainLogErrorMock = vi.fn();
 const initializeAppStateMock = vi.fn();
 const disposeAppStateMock = vi.fn();
 const isAppStateInitializedMock = vi.fn();
+const prewarmWindowsJobWrapperMock = vi.fn<() => Promise<void>>();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const federationRuntimeRestartMock = vi.fn<() => Promise<void>>();
 const disposeDesktopFederationRuntimeMock = vi.fn<() => Promise<void>>();
@@ -266,6 +267,14 @@ vi.mock("electron", () => ({
 vi.mock("../window", () => ({
   createMainWindow: createMainWindowMock,
   syncHotCpuProfilersFromSettings: vi.fn(),
+}));
+
+// Unmocked, this launches a real PowerShell host and a real cmd.exe on Windows
+// for every `await import("../index")` below -- `vi.resetModules()` clears the
+// prewarm's memo between tests, so the launches are per import, not per worker,
+// and nothing here awaits or owns them.
+vi.mock("../windows-job-wrapper", () => ({
+  prewarmWindowsJobWrapper: prewarmWindowsJobWrapperMock,
 }));
 
 vi.mock("../app-menu-bridge", () => ({
@@ -679,6 +688,8 @@ describe("bootstrapApp", () => {
     disposeAppStateMock.mockReset();
     isAppStateInitializedMock.mockReset();
     isAppStateInitializedMock.mockReturnValue(true);
+    prewarmWindowsJobWrapperMock.mockReset();
+    prewarmWindowsJobWrapperMock.mockResolvedValue();
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
     federationRuntimeRestartMock.mockReset();
@@ -818,6 +829,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
+    expect(prewarmWindowsJobWrapperMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
       onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,


### PR DESCRIPTION
## Problem

#1769 added `void prewarmWindowsJobWrapper()` to `bootstrapApp`'s `whenReady` body. `index.test.ts` drives that real startup path and mocks 38 modules — but not `../windows-job-wrapper`. Its `whenReady` mock resolves, so execution reaches the prewarm; the tests that assert `messagingLeaseStartMock` (which runs *after* it) prove the line is reached.

`vi.resetModules()` in `beforeEach` clears the module registry, which resets the prewarm's module-level memo. So the launches are **per import, not per worker**: on Windows that worker starts up to 44 real PowerShell hosts plus their `cmd.exe` targets, none awaited or owned by the test lifecycle.

Two costs:

- Each launch burns 0.7–2.1s of machine time in a test that only checks bootstrap wiring.
- Any launch still in flight when the worker exits never reaches `launch.cleanup()`, leaving a `pwragent-windows-job-*` directory (with its `wrapper.ps1`) in TEMP and an orphan `powershell.exe`/`cmd.exe` behind it.

It is silent by construction — the prewarm is best-effort, unawaited, and logs nothing — so CI stayed green throughout.

## Change

Mock `../windows-job-wrapper` the way the file already handles its other startup dependencies, and assert the startup call once so the wiring stays covered. The assertion is not vacuous: it fails if `void prewarmWindowsJobWrapper()` is removed from `index.ts`.

Found while reviewing the `releases/1.0` backport (#1772), which carries the identical fix.

## Verification

- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries` (no violations)
- `pnpm test apps/desktop/src/main/__tests__/index.test.ts`: 44 passed
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main`: 321 files, 4619 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
