### PR TITLE
fix(release): always publish GitHub Releases as Pre-release

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -39,14 +39,20 @@ Read these files before changing release metadata:
 - Desktop Settings expose two axes: **channel** (Stable or Beta) and
   **track** (Latest or Prerelease). Encode those slots in the tag suffix
   so GitHub `/releases/latest` stays on the Stable Latest train:
-  - Stable Latest: `v1.0.5` (no suffix; GitHub Latest)
+  - Stable Latest: `v1.0.5` (no suffix; GitHub Latest after promotion)
   - Stable Prerelease: `v1.0.6-prerelease.1` (GitHub Pre-release)
   - Beta Latest: `v1.1.0-beta.3` (GitHub Pre-release; smoke-checked `main`)
   - Beta Prerelease: `v1.1.0-alpha.7` (GitHub Pre-release; may not install)
 - Keep `-prerelease.N` for Stable RCs. Do not reuse `-beta` for 1.0 RCs;
   `-beta` is the Beta Latest identifier.
+- CI publishes every release as a GitHub `Pre-release`, whatever the tag
+  suffix. A suffix-free tag left at `prerelease: true` lands in Stable
+  Prerelease, so Stable Latest keeps serving the previous stable release until
+  an operator promotes the new one. Promotion is the documented final step of
+  a release; see "Promote To Latest" below.
 - `main` tags with a prerelease suffix must stay GitHub Pre-release so they
-  never steal `/releases/latest` from the Stable train.
+  never steal `/releases/latest` from the Stable train. Never promote a
+  suffixed tag.
 - To promote a smoked alpha to beta, bump `apps/desktop/package.json` and
   add a CHANGELOG heading from `X.Y.Z-alpha.N` to `X.Y.Z-beta.M`, commit,
   and tag that commit. The tree can otherwise match the alpha. Do not add
@@ -316,12 +322,14 @@ link to the latest release without knowing the current version. Do not remove
 or replace it with an arch-suffixed DMG.
 
 The workflow replaces electron-builder's empty/default release notes after
-release assets are published. Prerelease-tagged versions such as
-`v1.0.0-beta.41` must be born as GitHub `Pre-release`; stable versions such as
-`v1.0.0` must be born as normal releases so they can become Latest. GitHub
-excludes pre-release entries from `/releases/latest`, which also excludes them
-from `https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg`
-and the default Electron updater feed.
+release assets are published. Every release is born as a GitHub `Pre-release`,
+including a suffix-free stable tag such as `v1.0.0`; the publish step passes
+`--prerelease` unconditionally and fails the job if GitHub did not honor it.
+GitHub excludes pre-release entries from `/releases/latest`, which also excludes
+them from
+`https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg`
+and the default Electron updater feed. Promotion to Latest is a separate
+operator action, not part of the workflow.
 
 This release-note publication is required, not cosmetic. Electron-builder may
 leave the body empty or duplicate the tag name. If the workflow release-notes
@@ -337,10 +345,7 @@ gh release edit v<version> \
   --notes-file .local/release/v<version>/RELEASE_NOTES.md
 ```
 
-Only use `gh release edit --prerelease` as a corrective fallback if a
-prerelease-tagged version was not born as `Pre-release`.
-
-Verify the final release body before calling the release complete:
+Verify the final release body before calling the publish step complete:
 
 ```bash
 gh release view v<version> --json name,body,isPrerelease \
@@ -348,7 +353,41 @@ gh release view v<version> --json name,body,isPrerelease \
 ```
 
 The `bodyLength` must be greater than zero and the title/body must match the
-approved changelog entry.
+approved changelog entry. `isPrerelease` must be `true` at this point — that is
+the expected published state for every tag, not a failure signal. If it reads
+`false`, the publish step's own assertion should already have failed the job;
+investigate before going further.
+
+## Promote To Latest
+
+Promotion is the final step of a stable release and is always an explicit
+operator action. Do not promote without the user asking for it.
+
+Promote only a suffix-free tag, and only once all of these hold:
+
+- Every platform asset the tag should carry is attached to the release.
+- The updater metadata (`latest-mac.yml`, `latest.yml`, `latest-linux*.yml`)
+  is attached and names the published version.
+- The release body carries the matching `CHANGELOG.md` entry.
+- The build has been smoke-checked on at least one machine.
+
+```bash
+gh release edit v<version> --repo pwrdrvr/PwrAgent --latest --prerelease=false
+```
+
+No retag is needed. Clearing the flag moves a suffix-free tag from Stable
+Prerelease into Stable Latest.
+
+Never run this on a suffixed tag such as `v1.1.0-beta.3`. `--latest` repoints
+`/releases/latest/download/`, so it would hand the website a beta build while
+leaving the app's Stable Latest slot on the previous stable — the updater
+requires a candidate to be both suffix-free and non-prerelease.
+
+To undo a premature promotion, restore the flag:
+
+```bash
+gh release edit v<version> --repo pwrdrvr/PwrAgent --prerelease
+```
 
 ## Local Fallback
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,18 +385,17 @@ jobs:
             exit 1
           fi
 
+          # Every CI-published release is born as a GitHub Pre-release, even when
+          # the tag has no prerelease suffix. Promotion to Latest is a separate
+          # operator action after assets, updater metadata, and smoke checks pass.
           release_args=(
             "$RELEASE_TAG"
             --repo pwrdrvr/PwrAgent
             --verify-tag
+            --prerelease
             --title "$RELEASE_TAG"
             --notes-file "$notes"
           )
-          if [[ "$RELEASE_TAG" == *-* ]]; then
-            release_args+=(--prerelease)
-          else
-            release_args+=(--latest)
-          fi
 
           gh release create "${release_args[@]}" \
             mac-dist/* \
@@ -404,6 +403,15 @@ jobs:
             windows-dist/*.exe.blockmap \
             linux-dist/*.deb \
             linux-dist/SHA256SUMS
+
+          is_prerelease="$(gh release view "$RELEASE_TAG" \
+            --repo pwrdrvr/PwrAgent \
+            --json isPrerelease \
+            --jq '.isPrerelease')"
+          if [ "$is_prerelease" != "true" ]; then
+            echo "::error::Release $RELEASE_TAG was not created as a GitHub Pre-release." >&2
+            exit 1
+          fi
 
       - name: Upload assembled release artifacts (debug retention)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -96,10 +96,16 @@ Desktop Settings let operators pick a **channel** (Stable or Beta) and a
 
 | Settings slot | Tag | GitHub flag |
 |---|---|---|
-| Stable · Latest | `v1.0.5` | Latest |
+| Stable · Latest | `v1.0.5` | Latest (after promotion) |
 | Stable · Prerelease | `v1.0.6-prerelease.1` | Pre-release |
 | Beta · Latest | `v1.1.0-beta.3` | Pre-release |
 | Beta · Prerelease | `v1.1.0-alpha.7` | Pre-release |
+
+CI publishes **every** release as a GitHub `Pre-release`, including a
+suffix-free stable tag. A suffix-free tag left at `prerelease: true` lands in
+Stable · Prerelease, so Stable · Latest keeps serving the previous stable
+release until an operator promotes the new one. See
+[Promoting a release to Latest](#promoting-a-release-to-latest).
 
 Use `-prerelease.N` for Stable RCs. Use `-alpha.N` / `-beta.N` on `main`.
 Every `main` tag with a prerelease suffix must stay a GitHub Pre-release so
@@ -177,9 +183,10 @@ seven job definitions (the Linux package job fans out across two architectures):
    step.
 6. `Publish release assets`, which waits for successful macOS signing, both
    Linux packages, and the signed Windows installer. Only then does it create
-   the GitHub Release (as `Pre-release` for prerelease tags and normal/Latest
-   for stable tags), upload every platform's assets, and generate Linux
-   `SHA256SUMS`.
+   the GitHub Release — always as a `Pre-release`, whatever the tag suffix —
+   upload every platform's assets, and generate Linux `SHA256SUMS`. The step
+   then reads the release back and fails the job if GitHub did not record
+   `isPrerelease: true`.
 7. `Publish release notes`, which waits for successful all-platform asset
    publishing, extracts the matching `CHANGELOG.md` section, updates the
    GitHub Release body, and fails the workflow if the body still reads back as
@@ -201,9 +208,10 @@ The macOS environment-gated signing job:
 1. Verifies the prepared artifact SHA-256 from the build job output.
 2. Decodes `APPLE_API_KEY_BASE64` from the env to a temp `.p8` file.
 3. Patches the staged electron-builder GitHub `releaseType` from the desktop
-   package version: versions with a prerelease suffix such as `-beta.41` are
-   born as GitHub `Pre-release`, while stable versions are born as normal
-   releases.
+   package version. This rewrites the staged config only; the job packages with
+   `--publish never` and never creates a GitHub Release. The `Pre-release` flag
+   on the published release comes from `Publish release assets`, which always
+   passes `--prerelease`.
 4. Runs `electron-builder --mac --universal --publish never` from the
    downloaded artifact, without invoking `pnpm install`, `npx`, or dependency
    lifecycle scripts. `electron-builder` signs every
@@ -245,11 +253,12 @@ approval gate: after approval, continue watching the run through `Publish
 release notes`, then verify the final GitHub Release body is non-empty. If a
 monitor or handoff stops at an approval gate, resume after approval rather than
 treating the release as done.
-Prerelease-tagged versions such as `v1.0.0-beta.41` must be born as GitHub
-`Pre-release`, not edited afterward. Stable versions such as `v1.0.0` are born
-as normal releases so they can become Latest. GitHub excludes pre-release
-entries from `/releases/latest`, `PwrAgent.dmg`, and the default Electron
-updater feed.
+Every CI-published release is born as a GitHub `Pre-release`, including a
+suffix-free stable tag such as `v1.0.0`. Promotion to Latest is a separate
+operator action taken after the assets, updater metadata, and smoke checks are
+validated. GitHub excludes pre-release entries from `/releases/latest`,
+`PwrAgent.dmg`, and the default Electron updater feed, so a freshly published
+release reaches no Stable operator until that promotion.
 
 If the automated release-notes job fails or GitHub temporarily rejects the
 release edit, use this manual fallback after confirming the notes file contains
@@ -294,6 +303,43 @@ cd "$tmpdir"
 gh release download v1.0.0-beta.4 --repo pwrdrvr/PwrAgent --pattern "*arm64.dmg"
 mv PwrAgent-*-arm64.dmg PwrAgent.dmg
 gh release upload v1.0.0-beta.4 PwrAgent.dmg --repo pwrdrvr/PwrAgent --clobber
+```
+
+---
+
+## Promoting a release to Latest
+
+CI publishes every release as a GitHub `Pre-release`, so a freshly published
+build reaches nobody on Stable · Latest and serves nothing from
+`/releases/latest/download/`. Promotion is a deliberate operator action taken
+after the release is validated.
+
+Promote only once all of these hold:
+
+- Every platform asset the tag should carry is attached to the release.
+- The updater metadata (`latest-mac.yml`, `latest.yml`, `latest-linux*.yml`)
+  is attached and names the published version.
+- The release body carries the matching `CHANGELOG.md` entry.
+- The build has been smoke-checked on at least one machine.
+
+```bash
+gh release edit v<version> --repo pwrdrvr/PwrAgent --latest --prerelease=false
+```
+
+No retag is needed. Clearing the flag on a suffix-free tag moves it from
+Stable · Prerelease into Stable · Latest.
+
+**Promote suffix-free tags only.** `--latest` also repoints
+`/releases/latest/download/`, so promoting a suffixed tag such as
+`v1.1.0-beta.3` would hand the website a beta build while leaving the app's
+Stable · Latest slot on the previous stable — `selectChannelReleases` requires
+a candidate to be both suffix-free and non-prerelease. Leave suffixed tags as
+pre-releases.
+
+To undo a premature promotion, restore the flag:
+
+```bash
+gh release edit v<version> --repo pwrdrvr/PwrAgent --prerelease
 ```
 
 ---

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -384,7 +384,8 @@ for (const expected of [
   "gh release create",
   "--verify-tag",
   "--prerelease",
-  "--latest",
+  "isPrerelease",
+  "was not created as a GitHub Pre-release",
   "windows-dist/*.exe",
   "windows-dist/*.exe.blockmap",
 ]) {
@@ -400,6 +401,22 @@ assertWorkflowJobExcludesText(
   ".github/workflows/release.yml",
   "publish-release-assets",
   "windows-dist/* \\",
+);
+// Every release is published as a GitHub Pre-release. Promotion to Latest is a
+// deliberate operator action after the assets and smoke checks are validated,
+// so CI must never pass --latest.
+assertWorkflowJobExcludesText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "publish-release-assets",
+  "--latest",
+);
+assertWorkflowJobOrdersText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "publish-release-assets",
+  "gh release create",
+  "was not created as a GitHub Pre-release",
 );
 assertWorkflowJobContainsText(
   releaseWorkflow,
@@ -501,7 +518,8 @@ for (const expected of [
   "PwrAgent-linux-x64.deb",
   "PwrAgent-linux-arm64.deb",
   "SHA256SUMS",
-  "born as GitHub `Pre-release`",
+  "born as a GitHub `Pre-release`",
+  "--latest --prerelease=false",
 ]) {
   if (!desktopReleaseRunbook.includes(expected)) {
     fail(`docs/desktop-release-runbook.md must contain ${JSON.stringify(expected)}`);


### PR DESCRIPTION
PwrAgent was the outlier across the three PwrDrvr desktop apps. PwrSnap and PwrGit both pass `--prerelease` unconditionally and then assert `isPrerelease` on readback. PwrAgent derived the flag from the tag suffix:

```bash
if [[ "$RELEASE_TAG" == *-* ]]; then
  release_args+=(--prerelease)
else
  release_args+=(--latest)
fi
```

So a suffix-free tag such as `v1.0.3` was born as GitHub Latest — instantly the Stable·Latest update feed pushed to every operator, and the target of `releases/latest/download/PwrAgent.dmg` for the website, before anyone had smoke-checked the build.

## What changed

- **`.github/workflows/release.yml`** — `--prerelease` moves into the `release_args` array unconditionally alongside `--verify-tag`; the suffix conditional is gone. After `gh release create`, the step reads the release back and fails the job with `::error::Release $RELEASE_TAG was not created as a GitHub Pre-release.` if GitHub did not honor the flag. Asset lists, notes extraction, `--verify-tag`, and the separate release-notes job are untouched.
- **`docs/desktop-release-runbook.md`** — documented the old birth behavior in three places; now states the sibling policy and adds a **Promoting a release to Latest** section with the promotion command and its preconditions.
- **`.agents/skills/release/SKILL.md`** — same correction. `gh release edit --prerelease` was framed as a corrective fallback; promotion is now the documented final step. The verification block treats `isPrerelease: true` as the expected published state rather than a failure signal.
- **`scripts/check-desktop-release-metadata.mjs`** — see below.

## Why this is safe now

The Stable·Latest suffix guard (#1764 on `main`, #1765 on `releases/1.0`) made this possible. `selectChannelReleases` requires a slot candidate to be **both** suffix-free **and** `prerelease !== true`:

```ts
const stableLatest =
  byPrecedenceDesc.find((release) =>
    release.prerelease !== true && isSuffixFreeStableTag(release.tag_name))
  ?? byPrecedenceDesc.find((release) => release.prerelease !== true);
```

A suffix-free tag left at `prerelease: true` therefore lands in **Stable·Prerelease**, and Stable·Latest keeps serving the previous stable release until an operator flips the flag. Promotion needs no retag:

```bash
gh release edit v<version> --repo pwrdrvr/PwrAgent --latest --prerelease=false
```

## One change beyond the brief

`scripts/check-desktop-release-metadata.mjs` (run by `pnpm release:check`, twice inside the release workflow) asserted the publish job **contains** `--latest`, and asserted the runbook contains the exact string ``born as GitHub `Pre-release` ``. Both assertions encoded the old policy, so the change was a hard `release:check` failure without touching this file. It now pins the new policy in both directions:

- publish job must contain `--prerelease`, `isPrerelease`, and the error string
- publish job must **not** contain `--latest` (`assertWorkflowJobExcludesText`)
- `gh release create` must be ordered before the readback assertion
- runbook must document the promotion command

Verified the negative guard fires: swapping `--prerelease` back to `--latest` produces both `must contain "--prerelease"` and `must not contain "--latest"`.

Companion PR for `main`: https://github.com/pwrdrvr/PwrAgent/pull/1774

## Verification

- `pnpm release:check` passes on both branches; confirmed it failed before the validator update.
- `pnpm lint:eslint` — exit 0 (35 pre-existing warnings, 0 errors). None of the four changed files fall under its `packages/**` / `apps/*/src/**` TS globs.
- `node --check` on the validator.
- No YAML/actions linter exists in the repo; `release:check` is the workflow-content gate.
- Untouched: `apps/desktop/package.json`, `CHANGELOG.md`, asset lists (each branch keeps its own), and the release-notes job.

## Note for follow-up (not changed here)

`configureStageGithubReleaseType` in `apps/desktop/scripts/release.mjs` still derives an electron-builder `releaseType` from the version suffix. It is inert — that job packages with `--publish never` and never creates a release — but it is now the only place left that encodes suffix-implies-prerelease. Left alone as out of scope; the runbook now explains that it rewrites staged config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
