### PR TITLE
feat(desktop): fly the Star Map to a thread picked with ⌘K

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -40,6 +40,14 @@ type SidebarSearchPopupProps = {
    */
   onJumpToRemoteThread?: (thread: NavigationThreadSummary) => void;
   onClose: () => void;
+  /**
+   * What picking a result does here, for the dialog's accessible name and
+   * the field's own label. The Star Map opens the same palette to fly its
+   * camera to a card rather than to scroll a list, and "Jump to thread"
+   * would describe an action that surface does not have.
+   */
+  label?: string;
+  placeholder?: string;
 };
 
 /**
@@ -59,6 +67,7 @@ type SidebarSearchPopupProps = {
  * longer needs the sidebar revealed underneath it to be visible at all.
  */
 export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement {
+  const label = props.label ?? "Jump to thread";
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -313,7 +322,7 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
         className="jump-palette__panel"
         role="dialog"
         aria-modal="true"
-        aria-label="Jump to thread"
+        aria-label={label}
         // Bound on the panel, not the field: pressing any non-focusable chrome
         // in here (the footer legend, the padding around the input) moves focus
         // to <body> in Chromium, and a handler on the input alone would leave
@@ -339,14 +348,14 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
           <input
             ref={inputRef}
             className="jump-palette__input"
-            aria-label="Jump to thread"
+            aria-label={label}
             aria-controls={listVisible ? listId : undefined}
             aria-activedescendant={
               listVisible ? rowId(activeIndex) : undefined
             }
             autoComplete="off"
             spellCheck={false}
-            placeholder="Jump to thread, PR #, branch, repo…"
+            placeholder={props.placeholder ?? `${label}, PR #, branch, repo…`}
             value={query}
             onChange={(event) => setQuery(event.target.value)}
           />

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -21,8 +21,14 @@ import {
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { SearchIcon } from "../../icons";
+import {
+  formatPrimaryAccel,
+  matchThreadJumpChord,
+} from "../../lib/keyboard-accel";
 import { useCelestialIcons } from "../../lib/useCelestialIcons";
 import { useFederationHealth } from "../../lib/useFederationHealth";
+import { SidebarSearchPopup } from "../navigation/SidebarSearchPopup";
 import {
   type StarMapSessionKeys,
 } from "./attention";
@@ -110,6 +116,11 @@ import {
   starMapSkyOffset,
   type StarMapView,
 } from "./star-map-view-geometry";
+import {
+  starMapFlightScale,
+  starMapViewFocusedOn,
+} from "./star-map-flight";
+import { useStarMapFlight } from "./useStarMapFlight";
 import { StarMapViewOptions } from "./StarMapViewOptions";
 import { StarMapKeyHint } from "./StarMapKeyHint";
 import { useStarMapCameraKeys } from "./useStarMapCameraKeys";
@@ -186,6 +197,24 @@ const SNAP_THRESHOLD_PX = 6;
  * that clears the selection, rather than a pan the operator abandoned.
  */
 const CANVAS_CLICK_SLOP_PX = 4;
+
+/**
+ * How long a card picked from the ⌘K palette wears its "here it is" ring.
+ * Long enough to find with the eye after the flight lands, short enough
+ * that it does not read as a state the card is now in.
+ */
+const STAR_MAP_LOCATED_MS = 1_600;
+
+/**
+ * How long a pending flight waits for its card to be laid out.
+ *
+ * A summon usually produces geometry on the next render; a remote thread
+ * whose instance has no body on the map never will. Giving up quietly
+ * beats a destination that sits armed until some unrelated snapshot
+ * happens to satisfy it.
+ */
+const STAR_MAP_SUMMON_TIMEOUT_MS = 2_000;
+
 
 const STAR_FIELD = generateStarField(STAR_COUNT);
 
@@ -323,10 +352,52 @@ export function StarMapScreen(props: StarMapScreenProps) {
   // view-local and unsynced: it is a "where am I looking" gesture, not a
   // property of the fleet the way card placement is.
   const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
-  // Thread keys that just bubbled in via intake — they wear the entrance
-  // animation until the timer clears them.
+  // Thread keys that just bubbled in via intake or a ⌘K summon — they wear
+  // the entrance animation until the timer clears them.
   const [enteringThreadKeys, setEnteringThreadKeys] = useState<Set<string>>(
     new Set(),
+  );
+  /**
+   * Play the arrival animation for a card that was not on the map a moment
+   * ago. Shared by intake (a thread that did not exist) and the ⌘K summon
+   * (a thread the lens was not drawing): both are a card appearing where
+   * there was sky, and a card that simply blinks into a cloud reads as a
+   * rendering glitch rather than as an arrival.
+   */
+  const markThreadEntering = useCallback((threadKey: string) => {
+    setEnteringThreadKeys((current) => new Set(current).add(threadKey));
+    window.setTimeout(() => {
+      setEnteringThreadKeys((current) => {
+        const next = new Set(current);
+        next.delete(threadKey);
+        return next;
+      });
+    }, 2_000);
+  }, []);
+  /** Open state of the ⌘K palette. */
+  const [jumpOpen, setJumpOpen] = useState(false);
+  /**
+   * Threads the operator summoned from the ⌘K palette, by identity key.
+   *
+   * A search that flies the camera to a card the map is not drawing lands
+   * on empty sky, and every lens has at least three ways to not draw one: a
+   * filter chip that excludes it, a per-cloud cap that folds it into "+N
+   * more", and a peer feed this window has not caught up with. So a pick
+   * summons the card — the summary rides along so it can be merged into its
+   * instance's cloud even in that last case — and `selectFilteredThreads`
+   * seats it ahead of the caps and outside the chips.
+   *
+   * View-local and unsynced, like the selection and the expanded clouds: it
+   * is "what I went looking for in this window", not a property of the
+   * fleet. It lasts for the life of the window, which is the same lifetime
+   * as the search that produced it.
+   */
+  const [summonedThreads, setSummonedThreads] = useState<
+    ReadonlyMap<string, { instanceId: string; thread: NavigationThreadSummary }>
+  >(new Map());
+  const summonedKeys = useMemo(
+    () => new Set(summonedThreads.keys()),
+    [summonedThreads],
   );
   /**
    * Threads the operator archived from a card whose snapshot has not
@@ -433,6 +504,34 @@ export function StarMapScreen(props: StarMapScreenProps) {
     },
     [paintView],
   );
+  /**
+   * ⌘K flies the camera; the operator's own hands outrank it.
+   *
+   * Same live-view contract as the keyboard camera: the flight paints
+   * frames onto the canvas transform and commits on landing, and every
+   * other writer cancels it before it starts (see `abortFlight`), so two
+   * writers are never integrating against the same ref at once.
+   */
+  const flight = useStarMapFlight({
+    liveViewRef: viewRef,
+    onPaint: paintView,
+    onCommit: commitView,
+  });
+  /**
+   * The card a pick is travelling to, by card key.
+   *
+   * A pick cannot fly on the spot: a summoned card has no geometry until
+   * the lens has laid it out, which is a render away at least. So the pick
+   * records the destination and this effect leaves as soon as the layout
+   * produces a rect for it.
+   */
+  const [pendingFlight, setPendingFlight] = useState<string | undefined>();
+
+  const abortFlight = useCallback(() => {
+    setPendingFlight(undefined);
+    flight.cancel();
+  }, [flight]);
+
   const orbitMode = preferences.layout === "orbit";
   /**
    * Pulled far enough out that cards are unreadable. The map draws named
@@ -570,6 +669,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     if (!shouldStartCanvasPan(event.target)) return;
+    // A hand on the map outranks a flight in progress: the operator gets
+    // the view back where they grabbed it, not where the flight was going.
+    abortFlight();
     // A press on bare sky is also how the operator LEAVES a terminal or a
     // chat composer. The pan's preventDefault below suppresses the
     // browser's default focus change, so without this the shell kept
@@ -819,6 +921,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           ),
           selection: filterSelection,
           sessionKeys: props.sessionKeys,
+          summonedKeys,
         }),
       ),
     );
@@ -826,9 +929,35 @@ export function StarMapScreen(props: StarMapScreenProps) {
       result.set(
         instanceId,
         withoutArchived(
-          selectFilteredThreads({ threads, selection: filterSelection }),
+          selectFilteredThreads({
+            threads,
+            selection: filterSelection,
+            summonedKeys,
+          }),
         ),
       );
+    }
+    // A summoned thread whose owning instance has not published it to this
+    // window yet — a peer whose snapshot is a minute old, or one the
+    // federated search reached but the map never fetched — is merged from
+    // the search result itself. Front of the list, like every other summon,
+    // so the caps cannot fold it away again.
+    for (const summon of summonedThreads.values()) {
+      const key = buildThreadIdentityKey(
+        summon.thread.source,
+        summon.thread.id,
+      );
+      if (archivedThreadKeys.has(key)) continue;
+      const present = result.get(summon.instanceId) ?? [];
+      if (
+        present.some(
+          (thread) =>
+            buildThreadIdentityKey(thread.source, thread.id) === key,
+        )
+      ) {
+        continue;
+      }
+      result.set(summon.instanceId, [summon.thread, ...present]);
     }
     return result;
   }, [
@@ -838,6 +967,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
     props.localThreads,
     props.sessionKeys,
     remote,
+    summonedKeys,
+    summonedThreads,
   ]);
 
   // Release optimistic hides once the thread has left its feed for real,
@@ -945,8 +1076,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
   );
 
   const projects = useMemo(
-    () => groupThreadsByProject(attentionByInstance),
-    [attentionByInstance],
+    () => groupThreadsByProject(attentionByInstance, { summonedKeys }),
+    [attentionByInstance, summonedKeys],
   );
 
   const projectThreadOwners = useMemo(
@@ -1224,6 +1355,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // plain scroll over a chat card belongs to that card's transcript.
       if (!event.ctrlKey && !shouldPanOnWheel(event.target)) return;
       event.preventDefault();
+      abortFlight();
       // Both branches read the LIVE view rather than a `setView` updater's
       // `current`. During a keyboard flight the committed state is frozen at
       // the last landing, so an updater would compute this pinch from a base
@@ -1268,6 +1400,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
   }, [
+    abortFlight,
     commitView,
     topAnchoredView,
     panZoomCanvas.width,
@@ -1322,6 +1455,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * ref as well as re-centring means auto-centring resumes afterwards.
    */
   const resetView = useCallback(() => {
+    // `0` mid-flight has to end the flight, not race it: a landing commits
+    // the flight's destination and would silently undo the reset.
+    abortFlight();
     operatorMovedViewRef.current = false;
     // commitView, not setView: `0` can be pressed mid-flight, and the
     // keyboard camera's next frame reads the live ref. Committing to state
@@ -1335,6 +1471,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }),
     );
   }, [
+    abortFlight,
     commitView,
     topAnchoredView,
     panZoomCanvas.width,
@@ -1344,8 +1481,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
   ]);
 
   const claimView = useCallback(() => {
+    abortFlight();
     operatorMovedViewRef.current = true;
-  }, []);
+  }, [abortFlight]);
 
   /**
    * WASD / arrows fly the camera, `-` and `=` work the zoom, `0` resets.
@@ -1954,6 +2092,206 @@ export function StarMapScreen(props: StarMapScreenProps) {
   projectsModeRef.current = projectsMode;
 
   /**
+   * Card geometry for the projects lens, which seats its cards around
+   * project bodies rather than instance bodies and so appears nowhere in
+   * `cardRects`.
+   *
+   * Kept separate rather than folded into that map because `cardRects` is
+   * the drag/snap/marquee geometry, and cards in this lens deliberately do
+   * not move (a project is not an instance, so there is no arrangement row
+   * to persist an offset to). This is read for one thing only: knowing
+   * where a card the operator asked for is, so the camera can go there.
+   */
+  const projectCardRects = useMemo(() => {
+    const rects = new Map<string, SnapRect>();
+    if (!projectsMode) return rects;
+    const placementByKey = new Map(
+      projectLayout.projects.map((placement) => [placement.key, placement]),
+    );
+    for (const project of projects) {
+      const placement = placementByKey.get(project.key);
+      if (!placement) continue;
+      const visible = project.threads.slice(0, PROJECT_MAX_CARDS_PER_BODY);
+      const slots = cardRingSlots(visible.length, ORBIT_CARD_WIDTH);
+      visible.forEach((thread, index) => {
+        const slot = slots[index];
+        if (!slot) return;
+        const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+        const owner = projectThreadOwners.get(threadKey) ?? localInstanceId;
+        // See `cardRects`: an unmeasured card reports 0, and a zero-height
+        // rect would centre the camera on the card's top edge.
+        const height =
+          cardHeights.get(threadKey) || STAR_MAP_ESTIMATED_CARD_HEIGHT;
+        rects.set(`${owner}::${threadKey}`, {
+          // Ring cards are centred on their slot both ways (`centered`),
+          // unlike the lane and cloud slots that hang from the top.
+          x: placement.x + slot.dx - ORBIT_CARD_WIDTH / 2,
+          y: placement.y + slot.dy - height / 2,
+          width: ORBIT_CARD_WIDTH,
+          height,
+        });
+      });
+    }
+    return rects;
+  }, [
+    cardHeights,
+    localInstanceId,
+    projectLayout,
+    projects,
+    projectThreadOwners,
+    projectsMode,
+  ]);
+
+  /** Where every card the current lens draws sits, by card key. */
+  const flightRects = projectsMode ? projectCardRects : cardRects;
+
+  useEffect(() => {
+    if (!pendingFlight) return;
+    const rect = flightRects.get(pendingFlight);
+    if (!rect) {
+      // The one place a summon cannot reach on its own: a cloud in the
+      // orbit lens caps its cards per PROJECT, and seating the summoned
+      // thread first in the instance's feed only puts it first in its
+      // bucket — a child in a long parent group can still land past the
+      // cap. Unfold that cloud exactly as its "+N more" chip would, and
+      // let the next layout answer with a rect.
+      if (!orbitMode) return;
+      const separator = pendingFlight.indexOf("::");
+      if (separator < 0) return;
+      const instanceId = pendingFlight.slice(0, separator);
+      const threadKey = pendingFlight.slice(separator + 2);
+      const cluster = clusterClouds
+        ?.get(instanceId)
+        ?.clusters.find(
+          (entry) =>
+            entry.visibleCount < entry.threads.length
+            && entry.threads.some(
+              (thread) =>
+                buildThreadIdentityKey(thread.source, thread.id) === threadKey,
+            ),
+        );
+      if (!cluster) return;
+      toggleClusterExpanded(instanceId, cluster.key);
+      return;
+    }
+    setPendingFlight(undefined);
+    // Arriving somewhere is the operator moving the view, so the map stops
+    // re-centring itself on content changes from here on — the same claim a
+    // drag or a camera key makes.
+    operatorMovedViewRef.current = true;
+    flight.flyTo(
+      starMapViewFocusedOn({
+        rect,
+        canvas: panZoomCanvas,
+        viewport: viewportSize,
+        scale: starMapFlightScale(viewRef.current.scale),
+      }),
+    );
+  }, [
+    clusterClouds,
+    flight,
+    flightRects,
+    orbitMode,
+    panZoomCanvas,
+    pendingFlight,
+    toggleClusterExpanded,
+    viewportSize,
+  ]);
+
+  /**
+   * The card a pick just landed on, by thread key. Wears a brief ring so
+   * the answer is visible: the camera centres the card, but "the middle of
+   * the window" is not something the eye reads off a field of forty
+   * identical cards.
+   */
+  const [locatedThreadKey, setLocatedThreadKey] = useState<string>();
+
+  /**
+   * Pick a result: put the card on the map if it is not there, then fly to
+   * it. Both halves matter — a search that only moved the camera would fly
+   * to empty sky whenever a chip, a cap, or a stale peer feed was the
+   * reason the operator could not find the card by eye.
+   */
+  const flyToThread = useCallback(
+    (thread: NavigationThreadSummary) => {
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const target = thread.federation?.ref.target;
+      const instanceId =
+        target && isRemoteFederationTarget(target)
+          ? target.instanceId
+          : localInstanceId;
+      const cardKey = `${instanceId}::${threadKey}`;
+      if (!flightRects.has(cardKey)) {
+        setSummonedThreads((current) => {
+          const next = new Map(current);
+          next.set(threadKey, { instanceId, thread });
+          return next;
+        });
+        markThreadEntering(threadKey);
+      }
+      setLocatedThreadKey(threadKey);
+      window.setTimeout(() => {
+        setLocatedThreadKey((current) =>
+          current === threadKey ? undefined : current,
+        );
+      }, STAR_MAP_LOCATED_MS);
+      setPendingFlight(cardKey);
+      // A destination that never produces a rect must not sit waiting for
+      // one: an unrelated snapshot minutes later would otherwise fly the
+      // map somewhere the operator has long stopped expecting.
+      window.setTimeout(() => {
+        setPendingFlight((current) => (current === cardKey ? undefined : current));
+      }, STAR_MAP_SUMMON_TIMEOUT_MS);
+    },
+    [flightRects, localInstanceId, markThreadEntering],
+  );
+
+  /**
+   * Everything the ⌘K palette can search: this window's own threads and
+   * every peer feed the map has fetched, deduped by identity (a pinned
+   * remote thread appears in both). Archived threads are left out — the map
+   * never draws one, so a hit that could only ever fly to nothing is worse
+   * than no hit. The palette queries connected peers itself on top of this.
+   */
+  const searchThreads = useMemo(() => {
+    // Rebuilt only while the palette is open: its inputs change with every
+    // navigation snapshot, and an index nothing is reading is a pass over
+    // the whole fleet's threads per snapshot for nobody.
+    if (!jumpOpen) return [];
+    const seen = new Set<string>();
+    const rows: NavigationThreadSummary[] = [];
+    const add = (thread: NavigationThreadSummary) => {
+      if (thread.archivedAt !== undefined) return;
+      const key = buildThreadIdentityKey(thread.source, thread.id);
+      if (seen.has(key)) return;
+      seen.add(key);
+      rows.push(thread);
+    };
+    for (const thread of props.localThreads) add(thread);
+    for (const threads of remote.threadsByInstance.values()) {
+      for (const thread of threads) add(thread);
+    }
+    return rows;
+  }, [jumpOpen, props.localThreads, remote]);
+
+  /**
+   * ⌘K opens the palette, and pressing it again backs out of a jump the
+   * operator did not mean to start — the same toggle the main window's
+   * shell owns. Bound on the window rather than the map layer because the
+   * chord has to work from inside a chat card's composer too, which is
+   * exactly where an operator is standing when they want to go elsewhere.
+   */
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!matchThreadJumpChord(event)) return;
+      event.preventDefault();
+      setJumpOpen((open) => !open);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  /**
    * Canvas scale for the overlays drawn inside the transform. Every lens
    * scales now, lanes included, so the live value always applies.
    */
@@ -2545,6 +2883,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               hasUnsentDraft={props.draftThreadKeys?.[threadKey] === true}
               riseDelayMs={index * 45}
               entering={enteringThreadKeys.has(threadKey)}
+              located={locatedThreadKey === threadKey}
               instanceIcon={celestialIcons.iconFor(
                 position.instanceId === localInstanceId
                   ? undefined
@@ -2763,6 +3102,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
       tabIndex={-1}
       onKeyDown={(event) => {
         if (event.key === "Escape") {
+          // The ⌘K palette portals into this subtree, so its own Escape
+          // bubbles here through the React tree. Closing a palette is not
+          // also a request to drop the cards the operator gathered.
+          if (jumpOpen) return;
           event.stopPropagation();
           // Escape unwinds the selection; with nothing left to drop it
           // deliberately does nothing. The map lives in its own OS window
@@ -3040,6 +3383,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         hasUnsentDraft={
                           props.draftThreadKeys?.[threadKey] === true
                         }
+                        entering={enteringThreadKeys.has(threadKey)}
+                        located={locatedThreadKey === threadKey}
                         instanceIcon={celestialIcons.iconFor(
                           owner === localInstanceId ? undefined : owner,
                         )}
@@ -3173,24 +3518,33 @@ export function StarMapScreen(props: StarMapScreenProps) {
             })}
         </div>
       </div>
+      {jumpOpen ? (
+        // The same palette the main window's ⌘K opens, doing the same job
+        // for a different surface: there it scrolls a list to a row, here
+        // it flies the camera to a card. Reused rather than rebuilt so the
+        // matching rules, the peer search, and the keyboard model stay one
+        // implementation — an operator who learns to type "#1771" in one
+        // window should not find it means something else in the other.
+        <SidebarSearchPopup
+          threads={searchThreads}
+          label="Fly to thread"
+          placeholder="Fly to thread, PR #, branch, repo…"
+          onJumpToThread={flyToThread}
+          onClose={() => setJumpOpen(false)}
+        />
+      ) : null}
       {intakeTarget ? (
         <IntakeDialog
           desktopApi={props.desktopApi}
           target={intakeTarget}
           onClose={() => setIntakeTarget(undefined)}
           onCreated={(created) => {
-            const threadKey = buildThreadIdentityKey(
-              created.backend as NavigationThreadSummary["source"],
-              created.threadId,
+            markThreadEntering(
+              buildThreadIdentityKey(
+                created.backend as NavigationThreadSummary["source"],
+                created.threadId,
+              ),
             );
-            setEnteringThreadKeys((current) => new Set(current).add(threadKey));
-            window.setTimeout(() => {
-              setEnteringThreadKeys((current) => {
-                const next = new Set(current);
-                next.delete(threadKey);
-                return next;
-              });
-            }, 2_000);
             if (created.instanceId === localInstanceId) {
               props.onRefreshLocalThreads?.();
             } else {
@@ -3217,6 +3571,22 @@ export function StarMapScreen(props: StarMapScreenProps) {
         <p className="sidebar__brand">
           Pwr<span className="sidebar__brand-accent">Agent</span>
         </p>
+        {/* ⌘K is the map's only way to reach a card it is not drawing, and
+            a keyboard-only door on a surface driven by the pointer is a
+            door nobody finds. The chord rides the label so learning it
+            costs one glance. */}
+        <button
+          type="button"
+          className="star-map__filter-chip star-map__find"
+          aria-label="Find a thread on the map"
+          onClick={() => setJumpOpen(true)}
+        >
+          <SearchIcon size={13} />
+          <span>Find</span>
+          <span className="star-map__find-chord" aria-hidden="true">
+            {formatPrimaryAccel("K")}
+          </span>
+        </button>
         <StarMapViewOptions
           preferences={preferences}
           onChange={(next) => {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -216,6 +216,43 @@ const STAR_MAP_LOCATED_MS = 1_600;
 const STAR_MAP_SUMMON_TIMEOUT_MS = 2_000;
 
 
+/**
+ * Which instance owns a thread: the peer that stamped it, or this one.
+ *
+ * Resolved on demand rather than captured, because `localInstanceId` is
+ * the placeholder `"local"` until federation health lands — anything that
+ * remembers the answer from before that moment is pointing at a cloud
+ * that no longer exists.
+ */
+function threadOwnerInstanceId(
+  thread: NavigationThreadSummary,
+  localInstanceId: string,
+): string {
+  const target = thread.federation?.ref.target;
+  return target && isRemoteFederationTarget(target)
+    ? target.instanceId
+    : localInstanceId;
+}
+
+/**
+ * A thread's card geometry, whichever instance is showing it.
+ *
+ * Card keys are `instanceId::threadKey` and the instance half moves under
+ * us (see `threadOwnerInstanceId`), so the lookup matches on the thread
+ * half — the same suffix match `openThread` and the chat tethers use. A
+ * thread is only ever drawn once: the local cloud takes locally-owned
+ * threads only, so a pinned remote row cannot double up.
+ */
+function rectForThreadKey(
+  rects: ReadonlyMap<string, SnapRect>,
+  threadKey: string,
+): SnapRect | undefined {
+  for (const [key, rect] of rects) {
+    if (key.endsWith(`::${threadKey}`)) return rect;
+  }
+  return undefined;
+}
+
 const STAR_FIELD = generateStarField(STAR_COUNT);
 
 /**
@@ -387,13 +424,20 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * instance's cloud even in that last case — and `selectFilteredThreads`
    * seats it ahead of the caps and outside the chips.
    *
+   * Deliberately the SUMMARY alone, with no instance id captured beside it:
+   * the local instance's durable id only arrives with federation health,
+   * and a pick made before it lands would file the card under the
+   * placeholder `"local"` cloud, which stops existing the moment health
+   * arrives. See the selection-drop effect below for the same hazard. The
+   * owning instance is resolved where the merge happens instead.
+   *
    * View-local and unsynced, like the selection and the expanded clouds: it
    * is "what I went looking for in this window", not a property of the
    * fleet. It lasts for the life of the window, which is the same lifetime
    * as the search that produced it.
    */
   const [summonedThreads, setSummonedThreads] = useState<
-    ReadonlyMap<string, { instanceId: string; thread: NavigationThreadSummary }>
+    ReadonlyMap<string, NavigationThreadSummary>
   >(new Map());
   const summonedKeys = useMemo(
     () => new Set(summonedThreads.keys()),
@@ -518,12 +562,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
     onCommit: commitView,
   });
   /**
-   * The card a pick is travelling to, by card key.
+   * The thread a pick is travelling to, by identity key.
    *
    * A pick cannot fly on the spot: a summoned card has no geometry until
    * the lens has laid it out, which is a render away at least. So the pick
-   * records the destination and this effect leaves as soon as the layout
-   * produces a rect for it.
+   * records the destination and the effect below leaves as soon as the
+   * layout produces a rect for it.
+   *
+   * The THREAD key, not the card key: a card key names its owning instance,
+   * and the local instance's id changes from `"local"` to its durable value
+   * when federation health lands. Rects are matched by suffix instead — the
+   * same thing `openThread` and the chat tethers already do, and for the
+   * same reason.
    */
   const [pendingFlight, setPendingFlight] = useState<string | undefined>();
 
@@ -943,12 +993,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // the search result itself. Front of the list, like every other summon,
     // so the caps cannot fold it away again.
     for (const summon of summonedThreads.values()) {
-      const key = buildThreadIdentityKey(
-        summon.thread.source,
-        summon.thread.id,
-      );
+      const key = buildThreadIdentityKey(summon.source, summon.id);
       if (archivedThreadKeys.has(key)) continue;
-      const present = result.get(summon.instanceId) ?? [];
+      const instanceId = threadOwnerInstanceId(summon, localInstanceId);
+      const present = result.get(instanceId) ?? [];
       if (
         present.some(
           (thread) =>
@@ -957,7 +1005,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       ) {
         continue;
       }
-      result.set(summon.instanceId, [summon.thread, ...present]);
+      result.set(instanceId, [summon, ...present]);
     }
     return result;
   }, [
@@ -2147,7 +2195,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   useEffect(() => {
     if (!pendingFlight) return;
-    const rect = flightRects.get(pendingFlight);
+    const rect = rectForThreadKey(flightRects, pendingFlight);
     if (!rect) {
       // The one place a summon cannot reach on its own: a cloud in the
       // orbit lens caps its cards per PROJECT, and seating the summoned
@@ -2155,23 +2203,22 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // bucket — a child in a long parent group can still land past the
       // cap. Unfold that cloud exactly as its "+N more" chip would, and
       // let the next layout answer with a rect.
-      if (!orbitMode) return;
-      const separator = pendingFlight.indexOf("::");
-      if (separator < 0) return;
-      const instanceId = pendingFlight.slice(0, separator);
-      const threadKey = pendingFlight.slice(separator + 2);
-      const cluster = clusterClouds
-        ?.get(instanceId)
-        ?.clusters.find(
+      if (!orbitMode || !clusterClouds) return;
+      for (const [instanceId, cloud] of clusterClouds) {
+        const cluster = cloud.clusters.find(
           (entry) =>
             entry.visibleCount < entry.threads.length
             && entry.threads.some(
               (thread) =>
-                buildThreadIdentityKey(thread.source, thread.id) === threadKey,
+                buildThreadIdentityKey(thread.source, thread.id)
+                === pendingFlight,
             ),
         );
-      if (!cluster) return;
-      toggleClusterExpanded(instanceId, cluster.key);
+        if (cluster) {
+          toggleClusterExpanded(instanceId, cluster.key);
+          return;
+        }
+      }
       return;
     }
     setPendingFlight(undefined);
@@ -2182,20 +2229,26 @@ export function StarMapScreen(props: StarMapScreenProps) {
     flight.flyTo(
       starMapViewFocusedOn({
         rect,
-        canvas: panZoomCanvas,
-        viewport: viewportSize,
+        canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+        viewport: { width: viewportSize.width, height: viewportSize.height },
         scale: starMapFlightScale(viewRef.current.scale),
       }),
     );
+    // Canvas and viewport enter as their measurements rather than as the
+    // objects holding them: `panZoomCanvas` is rebuilt every render in the
+    // radial lenses, and an effect keyed on its identity would re-run on
+    // every streamed update. Same shape as the wheel listener above.
   }, [
     clusterClouds,
     flight,
     flightRects,
     orbitMode,
-    panZoomCanvas,
+    panZoomCanvas.width,
+    panZoomCanvas.height,
     pendingFlight,
     toggleClusterExpanded,
-    viewportSize,
+    viewportSize.width,
+    viewportSize.height,
   ]);
 
   /**
@@ -2215,16 +2268,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const flyToThread = useCallback(
     (thread: NavigationThreadSummary) => {
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-      const target = thread.federation?.ref.target;
-      const instanceId =
-        target && isRemoteFederationTarget(target)
-          ? target.instanceId
-          : localInstanceId;
-      const cardKey = `${instanceId}::${threadKey}`;
-      if (!flightRects.has(cardKey)) {
+      if (!rectForThreadKey(flightRects, threadKey)) {
         setSummonedThreads((current) => {
           const next = new Map(current);
-          next.set(threadKey, { instanceId, thread });
+          next.set(threadKey, thread);
           return next;
         });
         markThreadEntering(threadKey);
@@ -2235,15 +2282,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
           current === threadKey ? undefined : current,
         );
       }, STAR_MAP_LOCATED_MS);
-      setPendingFlight(cardKey);
+      setPendingFlight(threadKey);
       // A destination that never produces a rect must not sit waiting for
       // one: an unrelated snapshot minutes later would otherwise fly the
       // map somewhere the operator has long stopped expecting.
       window.setTimeout(() => {
-        setPendingFlight((current) => (current === cardKey ? undefined : current));
+        setPendingFlight((current) =>
+          current === threadKey ? undefined : current,
+        );
       }, STAR_MAP_SUMMON_TIMEOUT_MS);
     },
-    [flightRects, localInstanceId, markThreadEntering],
+    [flightRects, markThreadEntering],
   );
 
   /**

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -76,6 +76,13 @@ export function StarMapThreadCard(props: {
   /** This thread has a chat card open on the map, tethered to this card. */
   chatting?: boolean;
   /**
+   * The operator just picked this card out of the ⌘K palette and the camera
+   * flew here. Wears a brief ring: the flight centres the card, and the
+   * middle of the window is not something the eye picks out of a field of
+   * identical cards on its own.
+   */
+  located?: boolean;
+  /**
    * Add or remove this card from the selection. Deliberately outside
    * `drag`: amending a selection has to work before the durable instance
    * id lands, which is the one thing that gates dragging.
@@ -141,7 +148,7 @@ export function StarMapThreadCard(props: {
         props.entering ? " star-map-card-shell--entering" : ""
       }${props.selected ? " star-map-card-shell--selected" : ""}${
         props.chatting ? " star-map-card-shell--chatting" : ""
-      }`}
+      }${props.located ? " star-map-card-shell--located" : ""}`}
       style={style}
       data-thread-key={threadKey}
       data-card-key={props.cardKey}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filters.test.ts
@@ -230,3 +230,56 @@ describe("countFilterMatches", () => {
     expect(counts.pinned).toBe(1);
   });
 });
+
+describe("selectFilteredThreads summons", () => {
+  it("keeps a summoned thread the chips would have hidden", () => {
+    // The operator asked for this one by name in the ⌘K palette. The
+    // camera is about to fly to its card, so the lens has to draw one.
+    expect(
+      selectFilteredThreads({
+        selection: { unread: "include" },
+        threads: [unread, withPr],
+        summonedKeys: new Set(["codex:pr"]),
+      }).map((entry) => entry.id),
+    ).toEqual(["pr", "unread"]);
+  });
+
+  it("outranks an explicit exclude on the same thread", () => {
+    // "Hide open PRs" is a standing chip; "take me to this thread" is an
+    // instruction about one card, issued later.
+    expect(
+      selectFilteredThreads({
+        selection: { pr: "exclude" },
+        threads: [unread, withPr],
+        summonedKeys: new Set(["codex:pr"]),
+      }).map((entry) => entry.id),
+    ).toEqual(["pr", "unread"]);
+  });
+
+  it("seats a summoned thread ahead of pins, so no cap can fold it away", () => {
+    // Every lens caps its cards and renders the first N; a summoned card
+    // that lands past the cap is a flight to empty sky.
+    expect(
+      selectFilteredThreads({
+        selection: {},
+        threads: [pinned, unread, withPr],
+        summonedKeys: new Set(["codex:pr"]),
+      }).map((entry) => entry.id),
+    ).toEqual(["pr", "pinned", "unread"]);
+  });
+
+  it("still refuses an archived thread", () => {
+    // The map never draws one, so summoning it would place a card the
+    // operator cannot act on.
+    const archived = thread("archived", {
+      archivedAt: 10,
+    } as Partial<NavigationThreadSummary>);
+    expect(
+      selectFilteredThreads({
+        selection: {},
+        threads: [archived],
+        summonedKeys: new Set(["codex:archived"]),
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-flight.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-flight.test.ts
@@ -7,7 +7,11 @@ import {
   starMapViewFocusedOn,
   STAR_MAP_FLIGHT_SCALE,
 } from "../star-map-flight";
-import { MAX_ZOOM, MIN_ZOOM } from "../star-map-view-geometry";
+import {
+  MAX_ZOOM,
+  MIN_ZOOM,
+  MIN_VISIBLE_FRACTION,
+} from "../star-map-view-geometry";
 
 const VIEWPORT = { width: 1280, height: 800 };
 
@@ -36,17 +40,28 @@ describe("starMapViewFocusedOn", () => {
     expect(view.y + 1550 * 2).toBeCloseTo(VIEWPORT.height / 2);
   });
 
-  it("clamps a card at the canvas edge back into reach", () => {
-    // Centring this card would leave the canvas almost entirely off-screen;
-    // the shared clamp is what keeps a strip of it grabbable.
+  it("keeps the canvas reachable when the rect is outside it", () => {
+    // Deliberately out of bounds, because a card INSIDE the canvas can
+    // never reach the clamp: centring one leaves at least
+    // `viewport/2 - canvas` of overlap, which is always more than the
+    // strip the clamp guarantees. The bound is a rail for the case where
+    // a rect and the canvas extent disagree — a lens whose canvas shrank
+    // under a rect measured against the previous one — and this pins that
+    // the flight goes through it rather than flying the map out of reach.
+    const canvas = { width: 6000, height: 4000 };
     const view = starMapViewFocusedOn({
-      rect: { x: 0, y: 0, width: 200, height: 100 },
-      canvas: { width: 6000, height: 4000 },
+      rect: { x: 12_000, y: 9_000, width: 200, height: 100 },
+      canvas,
       viewport: VIEWPORT,
       scale: 1,
     });
-    expect(view.x).toBeLessThanOrEqual(VIEWPORT.width * 0.85);
-    expect(view.y).toBeLessThanOrEqual(VIEWPORT.height * 0.85);
+    // Un-clamped this would be 640 - 12100 = -11460, 400 - 9050 = -8650:
+    // the canvas entirely off the left and top of the window.
+    expect(view.x).toBe(MIN_VISIBLE_FRACTION * VIEWPORT.width - canvas.width);
+    expect(view.y).toBe(MIN_VISIBLE_FRACTION * VIEWPORT.height - canvas.height);
+    // Which is to say: a strip of canvas is still on screen to grab.
+    expect(view.x + canvas.width).toBeGreaterThan(0);
+    expect(view.y + canvas.height).toBeGreaterThan(0);
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-flight.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-flight.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  easeStarMapFlight,
+  interpolateStarMapView,
+  starMapFlightIsNoop,
+  starMapFlightScale,
+  starMapViewFocusedOn,
+  STAR_MAP_FLIGHT_SCALE,
+} from "../star-map-flight";
+import { MAX_ZOOM, MIN_ZOOM } from "../star-map-view-geometry";
+
+const VIEWPORT = { width: 1280, height: 800 };
+
+describe("starMapViewFocusedOn", () => {
+  it("puts the middle of the card in the middle of the window", () => {
+    const view = starMapViewFocusedOn({
+      rect: { x: 2000, y: 1500, width: 200, height: 100 },
+      canvas: { width: 6000, height: 4000 },
+      viewport: VIEWPORT,
+      scale: 1,
+    });
+    // Screen position of the card's centre = view.x + centre * scale.
+    expect(view.x + 2100).toBeCloseTo(VIEWPORT.width / 2);
+    expect(view.y + 1550).toBeCloseTo(VIEWPORT.height / 2);
+    expect(view.scale).toBe(1);
+  });
+
+  it("centres in canvas units, so the zoom scales the travel", () => {
+    const view = starMapViewFocusedOn({
+      rect: { x: 2000, y: 1500, width: 200, height: 100 },
+      canvas: { width: 6000, height: 4000 },
+      viewport: VIEWPORT,
+      scale: 2,
+    });
+    expect(view.x + 2100 * 2).toBeCloseTo(VIEWPORT.width / 2);
+    expect(view.y + 1550 * 2).toBeCloseTo(VIEWPORT.height / 2);
+  });
+
+  it("clamps a card at the canvas edge back into reach", () => {
+    // Centring this card would leave the canvas almost entirely off-screen;
+    // the shared clamp is what keeps a strip of it grabbable.
+    const view = starMapViewFocusedOn({
+      rect: { x: 0, y: 0, width: 200, height: 100 },
+      canvas: { width: 6000, height: 4000 },
+      viewport: VIEWPORT,
+      scale: 1,
+    });
+    expect(view.x).toBeLessThanOrEqual(VIEWPORT.width * 0.85);
+    expect(view.y).toBeLessThanOrEqual(VIEWPORT.height * 0.85);
+  });
+});
+
+describe("starMapFlightScale", () => {
+  it("zooms in when the operator is too far out to read a card", () => {
+    // Below STAR_MAP_OVERVIEW_ZOOM the map draws no cards at all, so a
+    // flight that kept this zoom would centre on empty sky.
+    expect(starMapFlightScale(0.2)).toBe(STAR_MAP_FLIGHT_SCALE);
+  });
+
+  it("keeps a zoom the operator already flew in to", () => {
+    expect(starMapFlightScale(1.8)).toBe(1.8);
+  });
+
+  it("stays inside the zoom range whatever it is handed", () => {
+    expect(starMapFlightScale(99)).toBe(MAX_ZOOM);
+    expect(starMapFlightScale(0)).toBe(STAR_MAP_FLIGHT_SCALE);
+    expect(starMapFlightScale(Number.NaN)).toBe(STAR_MAP_FLIGHT_SCALE);
+    expect(starMapFlightScale(MIN_ZOOM)).toBeGreaterThanOrEqual(MIN_ZOOM);
+  });
+});
+
+describe("interpolateStarMapView", () => {
+  const from = { x: 0, y: 0, scale: 0.25 };
+  const to = { x: -400, y: -200, scale: 1 };
+
+  it("starts at the origin and ends at the destination", () => {
+    expect(interpolateStarMapView(from, to, 0)).toEqual(from);
+    const landed = interpolateStarMapView(from, to, 1);
+    expect(landed.x).toBeCloseTo(to.x);
+    expect(landed.y).toBeCloseTo(to.y);
+    expect(landed.scale).toBeCloseTo(to.scale);
+  });
+
+  it("moves zoom geometrically, so the halfway frame is the geometric mean", () => {
+    // Halfway through the EASING, not halfway through time: 0.5 is the
+    // ease's own fixed point.
+    const middle = interpolateStarMapView(from, to, 0.5);
+    expect(middle.scale).toBeCloseTo(Math.sqrt(from.scale * to.scale));
+  });
+
+  it("never leaves the segment it was given", () => {
+    for (const progress of [0.1, 0.3, 0.7, 0.9]) {
+      const frame = interpolateStarMapView(from, to, progress);
+      expect(frame.x).toBeLessThanOrEqual(0);
+      expect(frame.x).toBeGreaterThanOrEqual(to.x);
+      expect(frame.scale).toBeGreaterThanOrEqual(from.scale);
+      expect(frame.scale).toBeLessThanOrEqual(to.scale);
+    }
+  });
+});
+
+describe("easeStarMapFlight", () => {
+  it("is pinned at both ends and clamps out-of-range progress", () => {
+    expect(easeStarMapFlight(0)).toBe(0);
+    expect(easeStarMapFlight(1)).toBe(1);
+    expect(easeStarMapFlight(-1)).toBe(0);
+    expect(easeStarMapFlight(2)).toBe(1);
+  });
+
+  it("accelerates away and settles rather than tracking time linearly", () => {
+    expect(easeStarMapFlight(0.25)).toBeLessThan(0.25);
+    expect(easeStarMapFlight(0.5)).toBeCloseTo(0.5);
+    expect(easeStarMapFlight(0.75)).toBeGreaterThan(0.75);
+  });
+});
+
+describe("starMapFlightIsNoop", () => {
+  it("declines to animate a pick that is already centred", () => {
+    const view = { x: -100, y: -50, scale: 1 };
+    expect(starMapFlightIsNoop(view, { ...view })).toBe(true);
+    expect(starMapFlightIsNoop(view, { ...view, x: -100.2 })).toBe(true);
+  });
+
+  it("animates anything the operator would actually see", () => {
+    const view = { x: -100, y: -50, scale: 1 };
+    expect(starMapFlightIsNoop(view, { ...view, x: -140 })).toBe(false);
+    expect(starMapFlightIsNoop(view, { ...view, scale: 1.4 })).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-jump.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-jump.test.tsx
@@ -1,0 +1,293 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { STAR_MAP_ESTIMATED_CARD_HEIGHT } from "../star-map-layout";
+import { StarMapScreen } from "../StarMapScreen";
+
+/** The viewport the screen assumes until a real measurement arrives. */
+const VIEWPORT = { width: 1280, height: 800 };
+
+function px(value: string | undefined): number {
+  return Number.parseFloat(value ?? "0");
+}
+
+/**
+ * ⌘K on the map: find a thread by name, and go to it.
+ *
+ * The map is the one surface where "the card is somewhere off to the left,
+ * three clouds over" is a real answer, so the palette's job here is not to
+ * scroll a list — it is to summon the card if the lens is not drawing one
+ * and then fly the camera to it. Both halves are asserted; the geometry the
+ * flight lands on is `star-map-flight.test.ts`.
+ */
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  };
+}
+
+function thread(
+  id: string,
+  title: string,
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id,
+    title,
+    titleSource: "generated",
+    linkedDirectories: [
+      {
+        id: "dir-1",
+        label: "PwrSnap",
+        path: "/tmp/pwrsnap",
+        kind: "worktree",
+      },
+    ],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+    ...overrides,
+  } as unknown as NavigationThreadSummary;
+}
+
+/** A thread that matches no attention chip: seen, idle, no PR, nothing to push. */
+function quietThread(id: string, title: string): NavigationThreadSummary {
+  return thread(id, title, {
+    inbox: { inInbox: false },
+  } as Partial<NavigationThreadSummary>);
+}
+
+function renderMap(threads: NavigationThreadSummary[]) {
+  return render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={threads}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+}
+
+async function openPalette(): Promise<void> {
+  fireEvent.keyDown(window, { key: "k", metaKey: true });
+  await screen.findByRole("dialog", { name: "Fly to thread" });
+}
+
+function search(query: string): void {
+  fireEvent.change(screen.getByRole("textbox", { name: "Fly to thread" }), {
+    target: { value: query },
+  });
+}
+
+/**
+ * Pick a palette row. Scoped to the dialog: a thread already on the map
+ * also has a card button carrying its title, and an unscoped query would
+ * resolve to two elements — or worse, to the card, which is not what a
+ * search result click is.
+ */
+async function pickResult(title: RegExp): Promise<void> {
+  const palette = screen.getByRole("dialog", { name: "Fly to thread" });
+  fireEvent.click(await within(palette).findByRole("button", { name: title }));
+}
+
+describe("Star Map ⌘K", () => {
+  beforeEach(() => {
+    // The flight animates over half a second of animation frames; under
+    // reduced motion it lands in one commit, which is the state these
+    // assertions are about. jsdom answers every media query with `false`.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        onchange: null,
+        dispatchEvent: () => false,
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  it("opens on ⌘K and closes on a second press", async () => {
+    renderMap([thread("t1", "Windows job wrapper")]);
+    await openPalette();
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Fly to thread" }),
+      ).toBeNull();
+    });
+  });
+
+  it("flies the camera to the card the operator picked", async () => {
+    const { container } = renderMap([
+      thread("t1", "Windows job wrapper"),
+      thread("t2", "Release notarization"),
+    ]);
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-card")).not.toBeNull();
+    });
+    const canvas = container.querySelector<HTMLElement>(".star-map__canvas");
+    const before = canvas?.style.transform;
+
+    await openPalette();
+    search("notarization");
+    await pickResult(/Release notarization/);
+
+    await waitFor(() => {
+      expect(canvas?.style.transform).not.toBe(before);
+    });
+    // The card is where the LAYOUT put it — the flight does not move cards,
+    // so measuring the destination off the card's own position is measuring
+    // the transform against something the feature did not choose.
+    const shell = container.querySelector<HTMLElement>(
+      '[data-thread-key="codex:t2"]',
+    );
+    const cloud = shell?.closest<HTMLElement>(".star-map__cloud");
+    // Cards are centred on their slot horizontally (`marginLeft: -w/2`) and
+    // hang from it vertically, so the middle of the card is half an
+    // (unmeasured, therefore estimated) card down.
+    const centerX = px(cloud?.style.left) + px(shell?.style.left);
+    const centerY =
+      px(cloud?.style.top)
+      + px(shell?.style.top)
+      + STAR_MAP_ESTIMATED_CARD_HEIGHT / 2;
+    // Landing zoom is the readable one: below it the map stops drawing
+    // cards, so an arrival at overview zoom would centre on empty sky.
+    expect(canvas?.style.transform).toBe(
+      `translate(${VIEWPORT.width / 2 - centerX}px, ${
+        VIEWPORT.height / 2 - centerY
+      }px) scale(1)`,
+    );
+    // And the card says it is the one that was asked for.
+    await waitFor(() => {
+      expect(
+        container.querySelector(".star-map-card-shell--located"),
+      ).not.toBeNull();
+    });
+  });
+
+  it("plops a card onto the map when the filters were hiding its thread", async () => {
+    // "Unread only" is a chip the operator set; the thread they then go
+    // looking for by name is a seen one, so the lens is drawing no card for
+    // it at all. A flight alone would land on sky.
+    window.localStorage.setItem(
+      "pwragent.starMap.filterSelection",
+      JSON.stringify({ unread: "include" }),
+    );
+    const { container } = renderMap([
+      thread("t1", "Windows job wrapper"),
+      quietThread("t2", "Release notarization"),
+    ]);
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-card")).not.toBeNull();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Open thread: Release notarization" }),
+    ).toBeNull();
+
+    await openPalette();
+    search("notarization");
+    await pickResult(/Release notarization/);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", {
+          name: "Open thread: Release notarization",
+        }),
+      ).not.toBeNull();
+    });
+    // The chip itself is untouched: this is one card the operator asked for
+    // by name, not a filter that quietly stopped applying.
+    expect(
+      screen.getByRole("button", { name: /^Unread: showing only these/ }),
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Open thread: Windows job wrapper" }),
+    ).not.toBeNull();
+  });
+
+  it("keeps the summoned card on the map after the flight", async () => {
+    window.localStorage.setItem(
+      "pwragent.starMap.filterSelection",
+      JSON.stringify({ unread: "include" }),
+    );
+    const { container, rerender } = renderMap([
+      thread("t1", "Windows job wrapper"),
+      quietThread("t2", "Release notarization"),
+    ]);
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-card")).not.toBeNull();
+    });
+
+    await openPalette();
+    search("notarization");
+    await pickResult(/Release notarization/);
+    await screen.findByRole("button", {
+      name: "Open thread: Release notarization",
+    });
+
+    // A later navigation snapshot must not take the card away again — the
+    // summon is what keeps it, not the render that happened to follow it.
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[
+          thread("t1", "Windows job wrapper"),
+          quietThread("t2", "Release notarization"),
+          thread("t3", "Composer PR chips"),
+        ]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", {
+          name: "Open thread: Release notarization",
+        }),
+      ).not.toBeNull();
+    });
+  });
+
+  it("offers the palette to the pointer as well as the keyboard", async () => {
+    renderMap([thread("t1", "Windows job wrapper")]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Find a thread on the map" }),
+    );
+    await screen.findByRole("dialog", { name: "Fly to thread" });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-jump.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-jump.test.tsx
@@ -283,6 +283,72 @@ describe("Star Map ⌘K", () => {
     });
   });
 
+  it("flies to a peer's card without cloning it onto the local cloud", async () => {
+    // A card key names its OWNING instance, and the owner of a search hit
+    // is not always the instance the picker happens to be sitting on: this
+    // thread lives on pwr_remote, so its card is keyed pwr_remote::codex:r1
+    // while the pick knows only the thread. Resolving the card key from the
+    // local instance instead would miss the card that is already on the map
+    // — and then summon a duplicate of it under the local cloud.
+    const desktopApi = {
+      readFederationHealth: vi.fn(async () => ({
+        health: {
+          enabled: true,
+          role: "gateway",
+          status: "listening",
+          instanceId: "pwr_local",
+          localCelestialIcon: "sun",
+          localLabel: "Harold-MBP-M5-Max",
+          localProfileName: "default",
+          peers: [
+            {
+              id: "pwr_remote",
+              label: "Remote",
+              role: "client",
+              status: "connected",
+              capabilities: ["thread_navigation"],
+            },
+          ],
+        },
+      })),
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all",
+        fetchedAt: 1_000,
+        threads: [thread("r1", "Remote work")],
+        inboxThreadKeys: [],
+        directories: [],
+        launchpadDefaults: { backend: "codex", executionMode: "default" },
+      })),
+      onAgentEvent: vi.fn(() => () => undefined),
+    } as unknown as DesktopApi;
+
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[thread("t1", "Windows job wrapper")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await screen.findByRole("button", { name: "Open thread: Remote work" });
+    const canvas = container.querySelector<HTMLElement>(".star-map__canvas");
+    const before = canvas?.style.transform;
+
+    await openPalette();
+    search("Remote work");
+    await pickResult(/Remote work/);
+
+    await waitFor(() => {
+      expect(canvas?.style.transform).not.toBe(before);
+    });
+    // Exactly one card: the peer's, not a summoned copy beside it.
+    expect(
+      screen.getAllByRole("button", { name: "Open thread: Remote work" }),
+    ).toHaveLength(1);
+  });
+
   it("offers the palette to the pointer as well as the keyboard", async () => {
     renderMap([thread("t1", "Windows job wrapper")]);
     fireEvent.click(

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
@@ -415,3 +415,51 @@ describe("gravity seating", () => {
     expect(d.get("solo")!).toBeLessThan(400);
   });
 });
+
+describe("groupThreadsByProject summons", () => {
+  it("seats a summoned thread first, ahead of recency", () => {
+    // A project body seats only its first PROJECT_MAX_CARDS_PER_BODY
+    // threads, and this lens re-sorts its pools by activity — so a card
+    // the operator asked for by name has to be told to come forward here
+    // as well as in `selectFilteredThreads`.
+    const stale = thread({
+      id: "stale",
+      repoPath: "/repo/pwragent",
+      updatedAt: 1,
+    });
+    const busy = thread({
+      id: "busy",
+      repoPath: "/repo/pwragent",
+      updatedAt: 500,
+    });
+    const [project] = groupThreadsByProject(
+      new Map([["pwr_local", [busy, stale]]]),
+      { now: 1_000, summonedKeys: new Set(["codex:stale"]) },
+    );
+    expect(project.threads.map((entry) => entry.id)).toEqual([
+      "stale",
+      "busy",
+    ]);
+  });
+
+  it("leaves the order alone when nothing was summoned", () => {
+    const stale = thread({
+      id: "stale",
+      repoPath: "/repo/pwragent",
+      updatedAt: 1,
+    });
+    const busy = thread({
+      id: "busy",
+      repoPath: "/repo/pwragent",
+      updatedAt: 500,
+    });
+    const [project] = groupThreadsByProject(
+      new Map([["pwr_local", [stale, busy]]]),
+      { now: 1_000 },
+    );
+    expect(project.threads.map((entry) => entry.id)).toEqual([
+      "busy",
+      "stale",
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
@@ -205,9 +205,18 @@ export function selectFilteredThreads(params: {
   /** Identity keys the operator summoned from the ⌘K palette. */
   summonedKeys?: ReadonlySet<string>;
 }): NavigationThreadSummary[] {
+  // Guarded on the set being non-empty, which it is for every snapshot
+  // until the operator uses ⌘K: this runs per comparison inside a sort that
+  // itself runs per instance per navigation snapshot, and building an
+  // identity key for a lookup that cannot match is a string allocation per
+  // card per event for nothing.
+  const summonedKeys =
+    params.summonedKeys && params.summonedKeys.size > 0
+      ? params.summonedKeys
+      : undefined;
   const summoned = (thread: NavigationThreadSummary): boolean =>
-    params.summonedKeys?.has(buildThreadIdentityKey(thread.source, thread.id))
-    === true;
+    summonedKeys !== undefined
+    && summonedKeys.has(buildThreadIdentityKey(thread.source, thread.id));
   return params.threads
     .filter((thread) => thread.archivedAt === undefined)
     .filter(

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
@@ -1,4 +1,8 @@
-import { comparePinnedThreads, type NavigationThreadSummary } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  comparePinnedThreads,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
 import {
   isAgentThread,
   threadAttentionCategories,
@@ -180,24 +184,36 @@ function pinOverridesFilters(
 }
 
 /**
- * Threads to show: pinned threads first in the operator's own pin order,
- * then everything else by recent activity. Archived threads never surface
- * on the map regardless of selection.
+ * Threads to show: summoned threads first, then pinned threads in the
+ * operator's own pin order, then everything else by recent activity.
+ * Archived threads never surface on the map regardless of selection.
  *
  * Pins sort nearest the star deliberately — the slot closest to the body is
  * the one that stays put as the column grows, so a curated thread does not
  * wander as unrelated activity arrives.
+ *
+ * A summoned thread is one the operator named in the ⌘K palette, and it
+ * outranks even a pin twice over: the chips do not get to hide it, and the
+ * slot order puts it inside every per-cloud cap. Both matter for the same
+ * reason — flying the camera to a card that the lens then declines to draw
+ * is the failure the summon exists to prevent.
  */
 export function selectFilteredThreads(params: {
   selection: StarMapFilterSelection;
   sessionKeys?: StarMapSessionKeys;
   threads: readonly NavigationThreadSummary[];
+  /** Identity keys the operator summoned from the ⌘K palette. */
+  summonedKeys?: ReadonlySet<string>;
 }): NavigationThreadSummary[] {
+  const summoned = (thread: NavigationThreadSummary): boolean =>
+    params.summonedKeys?.has(buildThreadIdentityKey(thread.source, thread.id))
+    === true;
   return params.threads
     .filter((thread) => thread.archivedAt === undefined)
     .filter(
       (thread) =>
-        pinOverridesFilters(params.selection, thread)
+        summoned(thread)
+        || pinOverridesFilters(params.selection, thread)
         || threadPassesFilters({
           selection: params.selection,
           sessionKeys: params.sessionKeys,
@@ -205,6 +221,9 @@ export function selectFilteredThreads(params: {
         }),
     )
     .sort((left, right) => {
+      const leftSummoned = summoned(left);
+      const rightSummoned = summoned(right);
+      if (leftSummoned !== rightSummoned) return leftSummoned ? -1 : 1;
       const leftPinned = isPinnedThread(left);
       const rightPinned = isPinnedThread(right);
       if (leftPinned !== rightPinned) return leftPinned ? -1 : 1;

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-flight.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-flight.ts
@@ -1,0 +1,142 @@
+/**
+ * Flying the camera to one card.
+ *
+ * The map is a surface you fly over, and ⌘K is the way to reach a card
+ * you cannot see: the palette names it, and the camera travels to it
+ * rather than teleporting. The travel is the point — a cut would leave
+ * the operator holding a map they no longer recognise, with no idea which
+ * direction the card they picked was in. Watching the sky slide keeps the
+ * spatial memory the whole lens is built on.
+ *
+ * Everything here is pure: the hook owns the timing and the DOM, this owns
+ * the rules. Coordinates are the same ones `clampStarMapView` speaks —
+ * untransformed canvas units for the rect, screen pixels for the view.
+ */
+
+import {
+  clampStarMapView,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  type StarMapView,
+  type StarMapViewBox,
+} from "./star-map-view-geometry";
+
+/** A card's footprint on the untransformed canvas. */
+export type StarMapFlightRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/**
+ * How long one flight takes.
+ *
+ * Long enough to read as travel across the map rather than a jump cut,
+ * short enough that a run of ⌘K picks does not feel like waiting on an
+ * animation. Roughly the length of a window-manager space switch, which
+ * is the same "I moved, not the world" gesture.
+ */
+export const STAR_MAP_FLIGHT_DURATION_MS = 520;
+
+/**
+ * The zoom a flight lands at when the operator is pulled further out.
+ *
+ * Below `STAR_MAP_OVERVIEW_ZOOM` the map draws no cards at all, so a
+ * flight that kept an overview zoom would centre the viewport on empty
+ * sky and call it success. 1:1 is where the map opens and where "Reset
+ * view" puts it, so it is the scale the operator already reads cards at.
+ */
+export const STAR_MAP_FLIGHT_SCALE = 1;
+
+/**
+ * The scale to arrive at: the operator's own zoom whenever it is already
+ * close enough to read a card, and 1:1 when it is not. Deliberately never
+ * zooms OUT — someone who flew in to 2x asked to be there.
+ */
+export function starMapFlightScale(current: number): number {
+  if (!Number.isFinite(current) || current <= 0) return STAR_MAP_FLIGHT_SCALE;
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.max(current, STAR_MAP_FLIGHT_SCALE)));
+}
+
+/**
+ * The view that puts `rect` in the middle of the window at `scale`.
+ *
+ * Clamped through the same `clampStarMapView` as every other
+ * operator-driven write, so a card at the very edge of the canvas lands as
+ * close to centre as the bounds allow rather than dragging the map out of
+ * reach.
+ */
+export function starMapViewFocusedOn(params: {
+  rect: StarMapFlightRect;
+  canvas: StarMapViewBox;
+  viewport: StarMapViewBox;
+  scale: number;
+}): StarMapView {
+  const scale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, params.scale));
+  const centerX = params.rect.x + params.rect.width / 2;
+  const centerY = params.rect.y + params.rect.height / 2;
+  return clampStarMapView({
+    view: {
+      x: params.viewport.width / 2 - centerX * scale,
+      y: params.viewport.height / 2 - centerY * scale,
+      scale,
+    },
+    canvas: params.canvas,
+    viewport: params.viewport,
+  });
+}
+
+/**
+ * Ease-in-out cubic: the map accelerates away, coasts, and settles. A
+ * linear flight starts and stops dead, which reads as a scroll bar being
+ * dragged by someone else rather than as a camera move.
+ */
+export function easeStarMapFlight(progress: number): number {
+  const t = Math.min(1, Math.max(0, progress));
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+/**
+ * One frame of a flight.
+ *
+ * Pan interpolates linearly, zoom geometrically: scale is perceived
+ * multiplicatively, so a linear ramp from 0.3 to 1 spends most of the
+ * flight already zoomed in and then lurches at the end. Same reasoning as
+ * the keyboard camera's octaves-per-second.
+ */
+export function interpolateStarMapView(
+  from: StarMapView,
+  to: StarMapView,
+  progress: number,
+): StarMapView {
+  const eased = easeStarMapFlight(progress);
+  const scale =
+    from.scale > 0 && to.scale > 0
+      ? from.scale * Math.pow(to.scale / from.scale, eased)
+      : to.scale;
+  return {
+    x: from.x + (to.x - from.x) * eased,
+    y: from.y + (to.y - from.y) * eased,
+    scale,
+  };
+}
+
+/**
+ * Whether a flight is worth animating at all.
+ *
+ * A pick whose card is already centred (the operator searched for what
+ * they were looking at) should not shudder the map half a pixel. The
+ * threshold is in screen pixels, and the zoom check is a ratio because
+ * scale is multiplicative.
+ */
+export function starMapFlightIsNoop(
+  from: StarMapView,
+  to: StarMapView,
+): boolean {
+  return (
+    Math.abs(to.x - from.x) < 0.5
+    && Math.abs(to.y - from.y) < 0.5
+    && Math.abs(to.scale / (from.scale || 1) - 1) < 0.001
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
@@ -90,7 +90,18 @@ export function threadProjectLabel(thread: NavigationThreadSummary): string {
  */
 export function groupThreadsByProject(
   threadsByInstance: ReadonlyMap<string, readonly NavigationThreadSummary[]>,
-  params?: { now?: number },
+  params?: {
+    now?: number;
+    /**
+     * Identity keys the operator summoned from the ⌘K palette. A project
+     * body caps how many cards it seats, and recency is the wrong tie-break
+     * for a card that was asked for by name — so summoned threads sort to
+     * the front of their project, inside the cap. The instance lenses get
+     * the same guarantee from `selectFilteredThreads`; this lens re-sorts
+     * its pools, so it has to be told again.
+     */
+    summonedKeys?: ReadonlySet<string>;
+  },
 ): StarMapProject[] {
   const projects = new Map<string, StarMapProject>();
   for (const threads of threadsByInstance.values()) {
@@ -113,10 +124,16 @@ export function groupThreadsByProject(
     }
   }
   const now = params?.now ?? Date.now();
+  const summoned = (thread: NavigationThreadSummary): boolean =>
+    params?.summonedKeys?.has(buildThreadIdentityKey(thread.source, thread.id))
+    === true;
   for (const project of projects.values()) {
-    project.threads.sort(
-      (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
-    );
+    project.threads.sort((left, right) => {
+      const leftSummoned = summoned(left);
+      const rightSummoned = summoned(right);
+      if (leftSummoned !== rightSummoned) return leftSummoned ? -1 : 1;
+      return (right.updatedAt ?? 0) - (left.updatedAt ?? 0);
+    });
     project.lastActivityAt = project.threads.reduce(
       (latest, thread) => Math.max(latest, thread.updatedAt ?? 0),
       0,

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
@@ -124,9 +124,14 @@ export function groupThreadsByProject(
     }
   }
   const now = params?.now ?? Date.now();
+  // Non-empty check first: see the same guard in `selectFilteredThreads`.
+  const summonedKeys =
+    params?.summonedKeys && params.summonedKeys.size > 0
+      ? params.summonedKeys
+      : undefined;
   const summoned = (thread: NavigationThreadSummary): boolean =>
-    params?.summonedKeys?.has(buildThreadIdentityKey(thread.source, thread.id))
-    === true;
+    summonedKeys !== undefined
+    && summonedKeys.has(buildThreadIdentityKey(thread.source, thread.id));
   for (const project of projects.values()) {
     project.threads.sort((left, right) => {
       const leftSummoned = summoned(left);

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+import {
+  interpolateStarMapView,
+  starMapFlightIsNoop,
+  STAR_MAP_FLIGHT_DURATION_MS,
+} from "./star-map-flight";
+import type { StarMapView } from "./star-map-view-geometry";
+
+/**
+ * Whether the operator asked for less movement.
+ *
+ * Read per flight rather than cached: the setting can change while a
+ * window is open, and a flight is cheap to decide about. Guarded because
+ * jsdom (and any host without `matchMedia`) has no media queries at all.
+ */
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fly the map's camera to a view over time.
+ *
+ * The same shape as the keyboard camera and the pointer drag: frames are
+ * painted straight onto the canvas transform through `onPaint`, and only
+ * the landing is committed to React — a `setView` per frame re-renders
+ * every card on the map to move one transform.
+ *
+ * The flight reads its base from the SHARED live view ref at the moment it
+ * starts, and it is the only writer while it runs: anything the operator
+ * does — a drag, a pinch, a camera key, "Reset view" — calls `cancel`
+ * first, so the two never fight over the transform. Under
+ * `prefers-reduced-motion` the flight lands immediately instead of
+ * travelling; the operator still arrives, the sky just does not slide.
+ */
+export function useStarMapFlight(params: {
+  /** Where the view is right now, shared with every other writer. */
+  liveViewRef: RefObject<StarMapView>;
+  /** Move the view for one frame, without telling React. */
+  onPaint: (next: StarMapView) => void;
+  /** Hand the flown-to view back to React on landing. */
+  onCommit: (next: StarMapView) => void;
+}): {
+  flyTo: (target: StarMapView) => void;
+  cancel: () => void;
+} {
+  const callbacksRef = useRef({
+    onPaint: params.onPaint,
+    onCommit: params.onCommit,
+  });
+  useEffect(() => {
+    callbacksRef.current = {
+      onPaint: params.onPaint,
+      onCommit: params.onCommit,
+    };
+  });
+
+  const frameRef = useRef(0);
+  const { liveViewRef } = params;
+
+  const cancel = useCallback(() => {
+    if (!frameRef.current) return;
+    cancelAnimationFrame(frameRef.current);
+    frameRef.current = 0;
+    // The distance already flown is real: commit it, or the next render
+    // snaps the canvas back to wherever the last commit left it.
+    callbacksRef.current.onCommit(liveViewRef.current);
+  }, [liveViewRef]);
+
+  const flyTo = useCallback(
+    (target: StarMapView) => {
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = 0;
+      }
+      const from = liveViewRef.current;
+      if (starMapFlightIsNoop(from, target) || prefersReducedMotion()) {
+        callbacksRef.current.onCommit(target);
+        return;
+      }
+      let start = 0;
+      const step = (now: number) => {
+        // The first frame has no previous timestamp to measure against, so
+        // it is the flight's own zero rather than a guessed elapsed time.
+        if (start === 0) start = now;
+        const progress = Math.min(
+          1,
+          (now - start) / STAR_MAP_FLIGHT_DURATION_MS,
+        );
+        if (progress >= 1) {
+          frameRef.current = 0;
+          callbacksRef.current.onCommit(target);
+          return;
+        }
+        callbacksRef.current.onPaint(
+          interpolateStarMapView(from, target, progress),
+        );
+        frameRef.current = requestAnimationFrame(step);
+      };
+      frameRef.current = requestAnimationFrame(step);
+    },
+    [liveViewRef],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (!frameRef.current) return;
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = 0;
+    };
+  }, []);
+
+  return { flyTo, cancel };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, type RefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type RefObject,
+} from "react";
 import {
   interpolateStarMapView,
   starMapFlightIsNoop,
@@ -116,5 +122,9 @@ export function useStarMapFlight(params: {
     };
   }, []);
 
-  return { flyTo, cancel };
+  // Memoised as one object: consumers put `cancel` in the dependency list
+  // of a `useEffect` that registers a non-passive wheel listener, and a
+  // fresh literal every render would tear that listener down and re-add it
+  // on every streamed update. Same rule as `useStarMapArrangement`.
+  return useMemo(() => ({ flyTo, cancel }), [cancel, flyTo]);
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12371,6 +12371,29 @@ textarea,
   }
 }
 
+/* The answer to a ⌘K pick. The flight centres the card, which is a
+   position, not a marker — a lane of forty identical cards gives the eye
+   nothing to lock onto. One accent pulse says "this one", then gets out of
+   the way rather than leaving a state the card now appears to be in.
+
+   On `.star-map-card` rather than the shell because the shell's animation
+   channel is already spoken for by the rise and the entrance, and a
+   summoned card wears both at once. */
+.star-map-card-shell--located .star-map-card {
+  animation: star-map-card-located 1600ms ease-out;
+}
+
+@keyframes star-map-card-located {
+  0%,
+  60% {
+    border-color: var(--accent-border);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 45%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 2px transparent;
+  }
+}
+
 @media (prefers-reduced-motion: no-preference) {
   @keyframes star-map-card-enter {
     0% {
@@ -12423,6 +12446,19 @@ textarea,
 
 .star-map__view-options {
   position: relative;
+}
+
+/* Reuses the filter chip's shape so the top-left chrome reads as one row
+   of controls; the chord sits inside it the way the sidebar's own search
+   affordance carries its accelerator. */
+.star-map__find {
+  color: var(--text-secondary);
+}
+
+.star-map__find-chord {
+  color: var(--text-muted);
+  font-size: 10px;
+  letter-spacing: 0.04em;
 }
 
 .star-map__view-panel {


### PR DESCRIPTION
## What

⌘K did nothing on the Star Map. It now opens the **same quick-jump palette the main window uses** — same matching rules (title, PR #, branch, repo), same federated peer search, same keyboard model — and picking a result **flies the camera to that thread's card**.

Picking also **summons the card** when the lens is not drawing one. The map has three ways to not draw a thread the operator can name by heart:

1. a filter chip that excludes it,
2. a per-cloud cap that folded it into "+N more",
3. a peer feed this window has not caught up with.

A flight without the summon lands on empty sky in all three cases. So a summoned thread is merged into its instance's cloud from the search result itself, seated ahead of every cap, and exempt from the chips (the chips themselves are untouched — this is one card the operator asked for by name, not a filter that quietly stopped applying). It arrives with the same entrance animation intake uses, and the landing card wears a brief accent ring, because "the middle of the window" is not something the eye picks out of a field of forty identical cards.

A **`Find ⌘K`** chip joins the top-left chrome: a keyboard-only door on a surface driven by the pointer is a door nobody finds.

## How

- `star-map-flight.ts` — pure geometry: the view that centres a card rect (through the shared `clampStarMapView`), the landing zoom (never zooms *out*; raises an overview zoom to 1:1, below which the map draws no cards at all), the ease, and geometric zoom interpolation.
- `useStarMapFlight.ts` — the same contract as the keyboard camera: frames paint straight onto the canvas transform, only the landing commits to React, and every other writer (drag, wheel/pinch, camera keys, "Reset view") cancels it first so two writers never integrate against the live view ref at once. `prefers-reduced-motion` lands immediately instead of travelling.
- `selectFilteredThreads` / `groupThreadsByProject` take `summonedKeys` — keep and seat first.
- Orbit fallback: if a summoned card still has no geometry (a child deep in a long parent group past the per-cloud cap), the pending flight unfolds that cloud exactly as its "+N more" chip would, then leaves.
- `SidebarSearchPopup` gains optional `label` / `placeholder` so it can say "Fly to thread" here; behaviour is unchanged for the sidebar.
- The projects lens seats cards around project bodies, so it appears nowhere in `cardRects` (the drag/snap geometry, which that lens deliberately has none of). It gets a small read-only rect map used for one thing: knowing where the picked card is.

## Testing

- `pnpm test apps/desktop/src/renderer` — 193 files / 3054 tests pass, including two new files:
  - `star-map-flight.test.ts` — the centring, clamping, landing-zoom and interpolation rules.
  - `star-map-jump.test.tsx` — ⌘K opens/toggles, the flight lands with the picked card's centre at the window's centre (asserted against the card's own layout position, which the flight does not move), the summon puts a filtered-out thread's card on the map, it survives the next snapshot, and the pointer has a door too.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors, no new warnings), `pnpm lint:colors`, `pnpm lint:boundaries` all pass.
- Not exercised in a running app on this machine — worth a look in the real window before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)