### PR TITLE
fix(desktop): align the Updates control row to one height and type size

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -566,36 +566,38 @@ export function GeneralSettings(props: {
             source={sourceBadge(updateChannel)}
             control={
               <div className="settings-update-channel">
-                <div
-                  className="settings-segmented"
-                  role="radiogroup"
-                  aria-label="Update track"
-                >
-                  {UPDATE_CHANNEL_OPTIONS.map((option) => (
-                    <button
-                      key={option.value}
-                      aria-checked={updateChannel.value === option.value}
-                      className={`settings-segmented__button settings-segmented__button--stacked${
-                        updateChannel.value === option.value ? " is-active" : ""
-                      }`}
-                      disabled={props.saving}
-                      role="radio"
-                      type="button"
-                      onClick={() => {
-                        void props.onUpdateChannelChange(option.value);
-                      }}
-                    >
-                      <span>{option.label}</span>
-                      <span className="settings-segmented__meta">
-                        {releaseVersionText(
-                          releaseVersions?.[updateTrain.value]?.[option.value],
-                        )}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-                {downloadedVersion ? (
-                  <div className="settings-update-channel__restart">
+                <div className="settings-update-channel__controls">
+                  <div
+                    className="settings-segmented"
+                    role="radiogroup"
+                    aria-label="Update track"
+                  >
+                    {UPDATE_CHANNEL_OPTIONS.map((option) => (
+                      <button
+                        key={option.value}
+                        aria-checked={updateChannel.value === option.value}
+                        className={`settings-segmented__button settings-segmented__button--stacked${
+                          updateChannel.value === option.value
+                            ? " is-active"
+                            : ""
+                        }`}
+                        disabled={props.saving}
+                        role="radio"
+                        type="button"
+                        onClick={() => {
+                          void props.onUpdateChannelChange(option.value);
+                        }}
+                      >
+                        <span>{option.label}</span>
+                        <span className="settings-segmented__meta">
+                          {releaseVersionText(
+                            releaseVersions?.[updateTrain.value]?.[option.value],
+                          )}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  {downloadedVersion ? (
                     <button
                       aria-label={`${restartActionLabel} (${downloadedVersion})`}
                       className="button button--primary settings-update-channel__restart-button"
@@ -612,29 +614,31 @@ export function GeneralSettings(props: {
                         ({downloadedVersion})
                       </span>
                     </button>
-                    <span className="settings-update-channel__downloaded">
-                      Downloaded version: {downloadedVersion}
-                    </span>
-                    {updateRestartError ? (
-                      <span
-                        className="settings-update-channel__result settings-update-channel__result--error"
-                        role="alert"
-                      >
-                        {updateRestartError}
-                      </span>
-                    ) : null}
-                  </div>
+                  ) : null}
+                  <button
+                    className="button button--secondary settings-update-channel__button"
+                    type="button"
+                    disabled={!checkForUpdates || props.saving || updateChecking}
+                    onClick={() => {
+                      void handleCheckForUpdate();
+                    }}
+                  >
+                    {updateChecking ? "Checking..." : "Check for Update"}
+                  </button>
+                </div>
+                {downloadedVersion ? (
+                  <span className="settings-update-channel__downloaded">
+                    Downloaded version: {downloadedVersion}
+                  </span>
                 ) : null}
-                <button
-                  className="button button--secondary settings-update-channel__button"
-                  type="button"
-                  disabled={!checkForUpdates || props.saving || updateChecking}
-                  onClick={() => {
-                    void handleCheckForUpdate();
-                  }}
-                >
-                  {updateChecking ? "Checking..." : "Check for Update"}
-                </button>
+                {downloadedVersion && updateRestartError ? (
+                  <span
+                    className="settings-update-channel__result settings-update-channel__result--error"
+                    role="alert"
+                  >
+                    {updateRestartError}
+                  </span>
+                ) : null}
               </div>
             }
           />

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -627,17 +627,19 @@ export function GeneralSettings(props: {
                   </button>
                 </div>
                 {downloadedVersion ? (
-                  <span className="settings-update-channel__downloaded">
-                    Downloaded version: {downloadedVersion}
-                  </span>
-                ) : null}
-                {downloadedVersion && updateRestartError ? (
-                  <span
-                    className="settings-update-channel__result settings-update-channel__result--error"
-                    role="alert"
-                  >
-                    {updateRestartError}
-                  </span>
+                  <>
+                    <span className="settings-update-channel__downloaded">
+                      Downloaded version: {downloadedVersion}
+                    </span>
+                    {updateRestartError ? (
+                      <span
+                        className="settings-update-channel__result settings-update-channel__result--error"
+                        role="alert"
+                      >
+                        {updateRestartError}
+                      </span>
+                    ) : null}
+                  </>
                 ) : null}
               </div>
             }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8412,10 +8412,15 @@ textarea,
 
 /* Match the segmented control's label register (12px/650). Without this the
    two buttons fall back to the browser-default inherited size and read a
-   full step larger than the chiclets beside them. */
+   full step larger than the chiclets beside them.
+
+   Do NOT reintroduce `min-height: 0` here. `stretch` already sizes these to
+   the segmented control on a shared line, so the override bought nothing
+   there — but once the row wraps and a button lands on a line alone it has
+   nothing to stretch against, and the override collapsed it to a 16px
+   sliver. The `.button` base floor of 34px is what catches that case. */
 .settings-update-channel__button,
 .settings-update-channel__restart-button {
-  min-height: 0;
   font-size: 12px;
   font-weight: 650;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8393,32 +8393,42 @@ textarea,
 
 .settings-update-channel {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+/* The three controls (track segmented, Restart, Check) read as one row of
+   equal-height chiclets. `stretch` sizes both buttons to the segmented
+   control, which is the tallest because its options are two-line. Status
+   text is a SIBLING of this row, never a member of it — as a member its
+   own height fed back into `stretch` and inflated the buttons. */
+.settings-update-channel__controls {
+  display: flex;
   flex-wrap: wrap;
   align-items: stretch;
   gap: 8px;
 }
 
-.settings-update-channel__button {
+/* Match the segmented control's label register (12px/650). Without this the
+   two buttons fall back to the browser-default inherited size and read a
+   full step larger than the chiclets beside them. */
+.settings-update-channel__button,
+.settings-update-channel__restart-button {
   min-height: 0;
-}
-
-.settings-update-channel__restart {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 5px;
+  font-size: 12px;
+  font-weight: 650;
 }
 
 .settings-update-channel__restart-button {
   display: inline-flex;
-  min-height: 0;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
   gap: 3px;
   padding-top: 6px;
   padding-bottom: 6px;
-  line-height: 1.1;
+  line-height: 1.15;
 }
 
 .settings-update-channel__restart-version,


### PR DESCRIPTION
## Problem

The Settings → General → **Updates** row rendered three controls at three different heights, three different bottom edges, and two different type sizes.


Measured against the real stylesheet rather than by eye:

| Control | Height | Bottom edge | Font size |
|---|---|---|---|
| Latest / Prerelease segmented | 53.9px | 77.9 | 12px |
| Restart to Update | 46.1px | 70.1 | **16px** |
| Check for Update | **63.1px** | 87.1 | **16px** |

Three causes:

1. **`Downloaded version: <v>` was a member of the flex row.** The row is `align-items: stretch`, so the caption's height fed back into the row and inflated *Check for Update* to 63px — a single-line text button taller than the two-line segmented control beside it.
2. **The restart button sat inside its own column wrapper**, so it sized itself independently of the row and landed 8px short of everything else.
3. **`.button` sets no `font-size`**, so both buttons inherited the browser default 16px against the segmented control's 12px labels. This is the "browser-default buttons" anti-pattern the [style guide](docs/design/desktop-style-guide.md) calls out.

## Fix

`GeneralSettings.tsx` — the caption and the restart error are now siblings *below* the control row rather than members of it, and the three controls are direct children of a new `settings-update-channel__controls` row. `stretch` now equalizes them against the segmented control (the tallest, and the one that should set the row height) instead of against a caption.

`app.css` — both buttons take the segmented control's 12px/650 register.

After: all three controls measure **53.9px with a shared top and bottom edge**, at a uniform 12px.

## Not included

The base `.button` 16px inheritance is app-wide. Only `.messaging-route-row__actions` (11px) and `.composer__actions` (13px) override it today, so essentially every other `.button` in the app still renders at the browser default. Fixing that properly touches ~125 call sites across surfaces this PR does not exercise, so it is left for a separate change.

## Verification

- `settings-screen.test.tsx` — 73 passed (the `getByText("Downloaded version: …")` assertion survives the DOM restructure)
- `theme-contract.test.tsx` — 70 passed
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`
- Geometry above measured by rendering the real `app.css` against the real markup, before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

