### PR TITLE
feat(desktop): rename and mark-unread on star map card kebabs

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapRenameDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapRenameDialog.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Rename one thread from its card kebab.
+ *
+ * The title is not edited in place on the card: a card is a drag handle
+ * before it is anything else, and a text box that starts a drag on
+ * pointerdown cannot be typed into. So the rename happens in the same
+ * small centered panel the [+] intake uses, and shares its shell styles
+ * for that reason.
+ */
+export function StarMapRenameDialog(props: {
+  currentTitle: string;
+  onCancel: () => void;
+  onSubmit: (name: string) => void;
+}) {
+  const [draft, setDraft] = useState(props.currentTitle);
+  const [validationError, setValidationError] = useState<string>();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Selected, not just focused: the operator opened this to replace a
+  // generated title far more often than to append to one.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const submit = () => {
+    const name = draft.trim();
+    if (name.length === 0) {
+      setValidationError("Thread name cannot be blank.");
+      return;
+    }
+    props.onSubmit(name);
+  };
+
+  return createPortal(
+    <div
+      className="star-map-rename"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Rename ${props.currentTitle}`}
+      // Portaled to the body, but React events still travel the component
+      // tree: without this the map layer's Escape would also see the key
+      // and clear the selection behind the dialog.
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          props.onCancel();
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="star-map-rename__backdrop"
+        aria-label="Cancel rename"
+        tabIndex={-1}
+        onClick={props.onCancel}
+      />
+      <div className="star-map-rename__panel">
+        <div className="star-map-rename__header">
+          <span className="star-map-rename__title">Rename Thread</span>
+          <button
+            type="button"
+            className="star-map-rename__close"
+            aria-label="Close"
+            onClick={props.onCancel}
+          >
+            ✕
+          </button>
+        </div>
+        <input
+          ref={inputRef}
+          className="star-map-rename__input"
+          aria-label="Thread name"
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setValidationError(undefined);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              submit();
+            }
+          }}
+        />
+        <div className="star-map-rename__footer">
+          <span
+            className={`star-map-rename__status${
+              validationError ? " is-failed" : ""
+            }`}
+            role="status"
+          >
+            {validationError ?? ""}
+          </span>
+          <button
+            type="button"
+            className="button button--ghost"
+            onClick={props.onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="button button--secondary"
+            disabled={draft.trim().length === 0}
+            onClick={submit}
+          >
+            Rename
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -324,6 +324,16 @@ type StarMapCardTarget = {
 };
 
 /**
+ * A title the operator changed from a card, before any feed has echoed it.
+ * Both halves are needed: `applied` is what the card shows, and `previous`
+ * is what the release watches for — see `renamedTitles`.
+ */
+type StarMapOptimisticTitle = {
+  applied: string;
+  previous: string;
+};
+
+/**
  * What one card's menu acts on: every target, and the subset an unread
  * action applies to. Resolved together because both are answers to the
  * same question — which cards is this menu about — and splitting them
@@ -459,14 +469,20 @@ export function StarMapScreen(props: StarMapScreenProps) {
     new Set(),
   );
   /**
-   * Titles the operator just changed, held until the owning feed reports
-   * them. Same reasoning as `archivedThreadKeys`: a peer's feed refreshes
-   * on its own cadence, and a card still wearing its old title reads as a
-   * rename that quietly failed. Dropped on failure; released once the feed
-   * agrees.
+   * Titles the operator just changed, held until a feed moves off the one
+   * the rename replaced. Same reasoning as `archivedThreadKeys`: a peer's
+   * feed refreshes on its own cadence, and a card still wearing its old
+   * title reads as a rename that quietly failed. Dropped on failure.
+   *
+   * `previous` is what makes the release safe. Releasing on "the feed
+   * reports MY title" would pin the card forever the moment anything else
+   * renamed the same thread — another window, or the backend retitling it
+   * — because the feed would then report a third title this window never
+   * matches against. Holding the replaced title instead means any move off
+   * it, to my name or to someone else's, hands the card back to the feed.
    */
   const [renamedTitles, setRenamedTitles] = useState<
-    ReadonlyMap<string, string>
+    ReadonlyMap<string, StarMapOptimisticTitle>
   >(() => new Map());
   const [remoteRefreshNonce, setRemoteRefreshNonce] = useState(0);
   // Cards vary in height with their chip rows, so lanes stack from real
@@ -977,12 +993,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
             );
       if (renamedTitles.size === 0) return kept;
       return kept.map((thread) => {
-        const title = renamedTitles.get(
+        const edit = renamedTitles.get(
           buildThreadIdentityKey(thread.source, thread.id),
         );
-        return title === undefined || title === thread.title
+        return edit === undefined || edit.applied === thread.title
           ? thread
-          : { ...thread, title };
+          : { ...thread, title: edit.applied };
       });
     };
     const result = new Map<string, NavigationThreadSummary[]>();
@@ -1038,11 +1054,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // Merged in after `withLocalEdits`, so the optimistic title has to
       // be applied here too — the same reason the archive check above is
       // repeated rather than inherited.
-      const renamed = renamedTitles.get(key);
+      const edit = renamedTitles.get(key);
       result.set(instanceId, [
-        renamed === undefined || renamed === summon.title
+        edit === undefined || edit.applied === summon.title
           ? summon
-          : { ...summon, title: renamed },
+          : { ...summon, title: edit.applied },
         ...present,
       ]);
     }
@@ -1082,12 +1098,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // shrinks" intent explicit and cannot loop through its own setState.
   }, [archivedThreadKeys.size, props.localThreads, remote]);
 
-  // Release an optimistic title once its feed reports the same one — or
-  // once the thread is gone, so a card that never comes back cannot pin a
-  // title on whatever later reuses its key.
+  // Release an optimistic title once a source has moved off the title the
+  // rename replaced — to this window's name, to someone else's, or to
+  // nothing at all when the thread is gone, so a card that never comes
+  // back cannot pin a title on whatever later reuses its key.
   useEffect(() => {
     if (renamedTitles.size === 0) return;
+    // Summons FIRST, so a feed that carries the same thread overwrites
+    // them. A summoned card can be the only source there is — a peer
+    // thread the federated search reached and this window has never
+    // fetched — and reading only the feeds would release its title
+    // immediately, undoing the rename on the very next render.
     const titleByKey = new Map<string, string>();
+    for (const [key, summon] of summonedThreads) {
+      titleByKey.set(key, summon.title);
+    }
     for (const thread of props.localThreads) {
       titleByKey.set(
         buildThreadIdentityKey(thread.source, thread.id),
@@ -1104,11 +1129,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
     }
     setRenamedTitles((current) => {
       const kept = [...current].filter(
-        ([key, title]) => titleByKey.has(key) && titleByKey.get(key) !== title,
+        ([key, edit]) => titleByKey.get(key) === edit.previous,
       );
       return kept.length === current.size ? current : new Map(kept);
     });
-  }, [props.localThreads, remote, renamedTitles.size]);
+    // On the map itself rather than its `.size`, unlike the archive
+    // release above: a second rename of the same card changes an entry
+    // without changing the count, and this effect reads the entries.
+  }, [props.localThreads, remote, renamedTitles, summonedThreads]);
 
   /**
    * Orbit-lens project clouds: each instance's threads grouped by project,
@@ -3734,7 +3762,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
             // its card now: the owning feed refreshes on its own cadence,
             // and a card still showing the old title is indistinguishable
             // from a rename that did not happen.
-            setRenamedTitles((current) => new Map(current).set(threadKey, name));
+            setRenamedTitles((current) => {
+              // A second rename before the first one landed keeps the
+              // ORIGINAL `previous`: `target.thread.title` is this
+              // window's own optimistic title by then, and no feed will
+              // ever report it back.
+              const previous =
+                current.get(threadKey)?.previous ?? target.thread.title;
+              return new Map(current).set(threadKey, {
+                applied: name,
+                previous,
+              });
+            });
             runOnCardTargets({
               describeFailure: () => "Could not rename that thread",
               run: (entry) =>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -101,6 +101,7 @@ import {
 import type { StarMapCardMenuAction } from "./StarMapCardMenu";
 import { useStarMapChatCards } from "./useStarMapChatCards";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
+import { StarMapRenameDialog } from "./StarMapRenameDialog";
 import {
   readStoredPreferences,
   writeStoredPreferences,
@@ -385,6 +386,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const viewportSizeRef = useRef(viewportSize);
   const [intakeTarget, setIntakeTarget] = useState<IntakeDialogTarget>();
+  // The card whose title the rename dialog is editing. The whole target,
+  // not just an id: the rename call needs the owning instance to route
+  // and to refresh, exactly like every other card action.
+  const [renameTarget, setRenameTarget] = useState<StarMapCardTarget>();
   // Which instance the operator is focused on. Selection is deliberately
   // view-local and unsynced: it is a "where am I looking" gesture, not a
   // property of the fleet the way card placement is.
@@ -453,6 +458,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [archivedThreadKeys, setArchivedThreadKeys] = useState<Set<string>>(
     new Set(),
   );
+  /**
+   * Titles the operator just changed, held until the owning feed reports
+   * them. Same reasoning as `archivedThreadKeys`: a peer's feed refreshes
+   * on its own cadence, and a card still wearing its old title reads as a
+   * rename that quietly failed. Dropped on failure; released once the feed
+   * agrees.
+   */
+  const [renamedTitles, setRenamedTitles] = useState<
+    ReadonlyMap<string, string>
+  >(() => new Map());
   const [remoteRefreshNonce, setRemoteRefreshNonce] = useState(0);
   // Cards vary in height with their chip rows, so lanes stack from real
   // measurements - a fixed pitch clipped tall cards mid-glyph.
@@ -946,15 +961,30 @@ export function StarMapScreen(props: StarMapScreenProps) {
   );
 
   const attentionByInstance = useMemo(() => {
-    const withoutArchived = (threads: NavigationThreadSummary[]) =>
-      archivedThreadKeys.size === 0
-        ? threads
-        : threads.filter(
-            (thread) =>
-              !archivedThreadKeys.has(
-                buildThreadIdentityKey(thread.source, thread.id),
-              ),
-          );
+    // One pass for both optimistic edits a card can be carrying: the
+    // archive that hid it, and the rename its feed has not echoed yet.
+    // Threads are rebuilt only while an edit is outstanding, so the
+    // ordinary case keeps the identities the feed handed over.
+    const withLocalEdits = (threads: NavigationThreadSummary[]) => {
+      const kept =
+        archivedThreadKeys.size === 0
+          ? threads
+          : threads.filter(
+              (thread) =>
+                !archivedThreadKeys.has(
+                  buildThreadIdentityKey(thread.source, thread.id),
+                ),
+            );
+      if (renamedTitles.size === 0) return kept;
+      return kept.map((thread) => {
+        const title = renamedTitles.get(
+          buildThreadIdentityKey(thread.source, thread.id),
+        );
+        return title === undefined || title === thread.title
+          ? thread
+          : { ...thread, title };
+      });
+    };
     const result = new Map<string, NavigationThreadSummary[]>();
     // The main-window snapshot also carries viewer-side pinned REMOTE
     // threads (Cmd+K unification). Those render under their owning
@@ -962,7 +992,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // locally-owned threads only, or pinned remote cards would double up.
     result.set(
       localInstanceId,
-      withoutArchived(
+      withLocalEdits(
         selectFilteredThreads({
           threads: props.localThreads.filter(
             (thread) =>
@@ -978,7 +1008,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     for (const [instanceId, threads] of remote.threadsByInstance) {
       result.set(
         instanceId,
-        withoutArchived(
+        withLocalEdits(
           selectFilteredThreads({
             threads,
             selection: filterSelection,
@@ -1005,7 +1035,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
       ) {
         continue;
       }
-      result.set(instanceId, [summon, ...present]);
+      // Merged in after `withLocalEdits`, so the optimistic title has to
+      // be applied here too — the same reason the archive check above is
+      // repeated rather than inherited.
+      const renamed = renamedTitles.get(key);
+      result.set(instanceId, [
+        renamed === undefined || renamed === summon.title
+          ? summon
+          : { ...summon, title: renamed },
+        ...present,
+      ]);
     }
     return result;
   }, [
@@ -1015,6 +1054,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     props.localThreads,
     props.sessionKeys,
     remote,
+    renamedTitles,
     summonedKeys,
     summonedThreads,
   ]);
@@ -1041,6 +1081,34 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // stable dep too — but size makes the "runs when the set grows or
     // shrinks" intent explicit and cannot loop through its own setState.
   }, [archivedThreadKeys.size, props.localThreads, remote]);
+
+  // Release an optimistic title once its feed reports the same one — or
+  // once the thread is gone, so a card that never comes back cannot pin a
+  // title on whatever later reuses its key.
+  useEffect(() => {
+    if (renamedTitles.size === 0) return;
+    const titleByKey = new Map<string, string>();
+    for (const thread of props.localThreads) {
+      titleByKey.set(
+        buildThreadIdentityKey(thread.source, thread.id),
+        thread.title,
+      );
+    }
+    for (const threads of remote.threadsByInstance.values()) {
+      for (const thread of threads) {
+        titleByKey.set(
+          buildThreadIdentityKey(thread.source, thread.id),
+          thread.title,
+        );
+      }
+    }
+    setRenamedTitles((current) => {
+      const kept = [...current].filter(
+        ([key, title]) => titleByKey.has(key) && titleByKey.get(key) !== title,
+      );
+      return kept.length === current.size ? current : new Map(kept);
+    });
+  }, [props.localThreads, remote, renamedTitles.size]);
 
   /**
    * Orbit-lens project clouds: each instance's threads grouped by project,
@@ -1913,6 +1981,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
           onSelect: () => openThreadFully(thread),
         },
       ];
+      if (desktopApi?.renameThread) {
+        actions.push({
+          key: "rename",
+          // Single-target like "Open in full view", and for the same kind
+          // of reason: one name across five cards is not a rename, it is
+          // five threads the operator can no longer tell apart.
+          label: "Rename thread…",
+          onSelect: () => setRenameTarget({ instanceId, thread }),
+        });
+      }
       // The unread subset, not the whole selection: an already-seen card
       // has nothing to mark, and the count says so. Same shape as the
       // thread list's `bulkArchivableThreads`.
@@ -1939,6 +2017,45 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   threadId: target.thread.id,
                 }),
               targets: unseenTargets,
+            });
+          },
+        });
+      }
+      // The mirror of the entry above, over the complement of that subset:
+      // a card already showing its cookie has nothing to mark unread. A
+      // thread with no `updatedAt` is skipped because unread is expressed
+      // by moving the seen watermark behind it, and there is nothing to
+      // move it behind.
+      const seenTargets = targets.all.filter(
+        (target) =>
+          !target.thread.inbox.inInbox && target.thread.updatedAt !== undefined,
+      );
+      if (desktopApi?.markThreadSeen && seenTargets.length > 0) {
+        actions.push({
+          key: "mark-unread",
+          label:
+            seenTargets.length > 1
+              ? `Mark ${seenTargets.length} threads as unread`
+              : "Mark as unread",
+          onSelect: () => {
+            runOnCardTargets({
+              describeFailure: (failed, total) =>
+                total === 1
+                  ? "Could not mark that thread unread"
+                  : `Could not mark ${failed} of ${total} threads unread`,
+              run: (target) =>
+                desktopApi.markThreadSeen?.({
+                  backend: target.thread.source,
+                  federationTarget:
+                    target.thread.federation?.ref.target
+                    ?? readRendererFederationTarget(),
+                  threadId: target.thread.id,
+                  // One tick behind the thread's own timestamp: the same
+                  // watermark the thread list writes, so both surfaces
+                  // mean the same thing by "unread".
+                  seenUpdatedAt: Math.max(0, (target.thread.updatedAt ?? 0) - 1),
+                }),
+              targets: seenTargets,
             });
           },
         });
@@ -3599,6 +3716,50 @@ export function StarMapScreen(props: StarMapScreenProps) {
             } else {
               setRemoteRefreshNonce((nonce) => nonce + 1);
             }
+          }}
+        />
+      ) : null}
+      {renameTarget ? (
+        <StarMapRenameDialog
+          currentTitle={renameTarget.thread.title}
+          onCancel={() => setRenameTarget(undefined)}
+          onSubmit={(name) => {
+            const target = renameTarget;
+            setRenameTarget(undefined);
+            const threadKey = buildThreadIdentityKey(
+              target.thread.source,
+              target.thread.id,
+            );
+            // Wear the new title NOW, for the same reason Archive hides
+            // its card now: the owning feed refreshes on its own cadence,
+            // and a card still showing the old title is indistinguishable
+            // from a rename that did not happen.
+            setRenamedTitles((current) => new Map(current).set(threadKey, name));
+            runOnCardTargets({
+              describeFailure: () => "Could not rename that thread",
+              run: (entry) =>
+                desktopApi
+                  ?.renameThread?.({
+                    backend: entry.thread.source,
+                    federationTarget:
+                      entry.thread.federation?.ref.target
+                      ?? readRendererFederationTarget(),
+                    name,
+                    threadId: entry.thread.id,
+                  })
+                  .catch((error: unknown) => {
+                    // The old title is the true one again.
+                    setRenamedTitles((current) => {
+                      if (!current.has(threadKey)) return current;
+                      const next = new Map(current);
+                      next.delete(threadKey);
+                      return next;
+                    });
+                    // Rethrown so the run still reports the failure.
+                    throw error;
+                  }),
+              targets: [target],
+            });
           }}
         />
       ) : null}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -1151,6 +1151,147 @@ describe("StarMapScreen", () => {
     expect(archiveThread).not.toHaveBeenCalled();
   });
 
+  it("renames a thread from the card kebab and wears the new title at once", async () => {
+    const renameThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t1",
+      renamedAt: 1,
+    }));
+    const onRefreshLocalThreads = vi.fn();
+    render(
+      <StarMapScreen
+        desktopApi={{ ...buildDesktopApi(), renameThread } as unknown as DesktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+        onRefreshLocalThreads={onRefreshLocalThreads}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename thread…" }));
+
+    const input = screen.getByLabelText("Thread name") as HTMLInputElement;
+    // Seeded with the current title, so a small correction does not mean
+    // retyping the whole name.
+    expect(input.value).toBe("Thread t1");
+    fireEvent.change(input, { target: { value: "  Star chart cleanup  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+    await waitFor(() => {
+      expect(renameThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          name: "Star chart cleanup",
+          threadId: "t1",
+        }),
+      );
+    });
+    // The props still carry the old title — the card must not wait for the
+    // feed to catch up before it shows the rename.
+    expect(
+      screen.getByRole("button", { name: "Open thread: Star chart cleanup" }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(onRefreshLocalThreads).toHaveBeenCalled();
+    });
+  });
+
+  it("puts the old title back when a rename is refused", async () => {
+    const renameThread = vi.fn(async () => {
+      throw new Error("peer is offline");
+    });
+    render(
+      <StarMapScreen
+        desktopApi={{ ...buildDesktopApi(), renameThread } as unknown as DesktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename thread…" }));
+    fireEvent.change(screen.getByLabelText("Thread name"), {
+      target: { value: "Star chart cleanup" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/peer is offline/);
+    expect(
+      screen.getByRole("button", { name: "Open thread: Thread t1" }),
+    ).toBeTruthy();
+  });
+
+  it("marks a seen thread unread from the card kebab", async () => {
+    const markThreadSeen = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t1",
+      seenAt: 5,
+    }));
+    render(
+      <StarMapScreen
+        desktopApi={
+          { ...buildDesktopApi(), markThreadSeen } as unknown as DesktopApi
+        }
+        localThreads={[
+          {
+            ...unreadThread("t1"),
+            inbox: { inInbox: false },
+          } as NavigationThreadSummary,
+        ]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    // A seen card has nothing to mark seen, and the reverse entry is the
+    // one that applies.
+    expect(screen.queryByRole("menuitem", { name: "Mark as seen" })).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Mark as unread" }));
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "t1",
+          // One tick behind the thread's own `updatedAt`, the same
+          // watermark the thread list writes.
+          seenUpdatedAt: 99,
+        }),
+      );
+    });
+  });
+
   it("groups threads under project suns and swaps the project chip for the instance", async () => {
     window.localStorage.setItem(
       "pwragent.starMap.viewPreferences",

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -1242,6 +1242,75 @@ describe("StarMapScreen", () => {
     ).toBeTruthy();
   });
 
+  it("hands the title back to the feed when someone else renames the thread", async () => {
+    // The optimistic title is released by the feed moving OFF the title
+    // the rename replaced — not by it reporting this window's name. A
+    // second window renaming the same thread reports a title this one
+    // never asked for, and watching for our own would pin the card to a
+    // name nothing agrees with for the life of the window.
+    const renameThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t1",
+      renamedAt: 1,
+    }));
+    const desktopApi = {
+      ...buildDesktopApi(),
+      renameThread,
+    } as unknown as DesktopApi;
+    const { rerender } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename thread…" }));
+    fireEvent.change(screen.getByLabelText("Thread name"), {
+      target: { value: "Star chart cleanup" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+    await waitFor(() => {
+      expect(renameThread).toHaveBeenCalled();
+    });
+    expect(
+      screen.getByRole("button", { name: "Open thread: Star chart cleanup" }),
+    ).toBeTruthy();
+
+    rerender(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[
+          { ...unreadThread("t1"), title: "Renamed from the sidebar" },
+        ]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "Open thread: Renamed from the sidebar",
+        }),
+      ).toBeTruthy();
+    });
+  });
+
   it("marks a seen thread unread from the card kebab", async () => {
     const markThreadSeen = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -973,11 +973,13 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /\.star-map__filters,\s*\.star-map__filters \*,[\s\S]*?\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
     );
-    // The intake dialog is body-portaled and full-window, so its scrim
-    // overlaps the strip's rect and would otherwise turn a dismiss-click
-    // near the top into a window drag.
+    // The card-level dialogs are body-portaled and full-window, so their
+    // scrim overlaps the strip's rect and would otherwise turn a
+    // dismiss-click near the top into a window drag. Both are named here:
+    // a second dialog that forgets the punch-out fails the same way the
+    // first one would have.
     expect(css).toMatch(
-      /\.star-map-intake,\s*\.star-map-intake \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+      /\.star-map-intake,\s*\.star-map-intake \*,\s*\.star-map-rename,\s*\.star-map-rename \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
     );
     // The edge brightens whenever the sky moves under it — pointer pan and
     // keyboard flight alike — and the strip disappears in fullscreen, where

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11431,8 +11431,11 @@ textarea,
   border-style: dashed;
 }
 
-/* AI intake dialog: a small centered chat panel over the map. */
-.star-map-intake {
+/* AI intake dialog: a small centered chat panel over the map. The rename
+   dialog is the same shell — one panel shape for every card-level modal on
+   the map, so a second one cannot drift from the first. */
+.star-map-intake,
+.star-map-rename {
   position: fixed;
   inset: 0;
   z-index: 140;
@@ -11447,11 +11450,14 @@ textarea,
    dismissing the dialog. Punching out the whole overlay is fine — a modal
    is the one time the window has no business moving. */
 .star-map-intake,
-.star-map-intake * {
+.star-map-intake *,
+.star-map-rename,
+.star-map-rename * {
   -webkit-app-region: no-drag;
 }
 
-.star-map-intake__backdrop {
+.star-map-intake__backdrop,
+.star-map-rename__backdrop {
   position: absolute;
   inset: 0;
   border: none;
@@ -11459,7 +11465,8 @@ textarea,
   cursor: default;
 }
 
-.star-map-intake__panel {
+.star-map-intake__panel,
+.star-map-rename__panel {
   display: flex;
   position: relative;
   flex-direction: column;
@@ -11472,14 +11479,16 @@ textarea,
   box-shadow: var(--shadow-popover);
 }
 
-.star-map-intake__header {
+.star-map-intake__header,
+.star-map-rename__header {
   display: flex;
   align-items: center;
   gap: 8px;
   color: var(--text-primary);
 }
 
-.star-map-intake__target {
+.star-map-intake__target,
+.star-map-rename__title {
   flex: 1;
   overflow: hidden;
   font-size: 13px;
@@ -11488,7 +11497,8 @@ textarea,
   white-space: nowrap;
 }
 
-.star-map-intake__close {
+.star-map-intake__close,
+.star-map-rename__close {
   border: none;
   padding: 2px 6px;
   border-radius: 6px;
@@ -11497,12 +11507,14 @@ textarea,
   cursor: pointer;
 }
 
-.star-map-intake__close:hover {
+.star-map-intake__close:hover,
+.star-map-rename__close:hover {
   background: var(--bg-row-active);
   color: var(--text-primary);
 }
 
-.star-map-intake__input {
+.star-map-intake__input,
+.star-map-rename__input {
   width: 100%;
   padding: 8px 10px;
   border: 1px solid var(--border-subtle);
@@ -11514,7 +11526,8 @@ textarea,
   resize: vertical;
 }
 
-.star-map-intake__input:focus-visible {
+.star-map-intake__input:focus-visible,
+.star-map-rename__input:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
@@ -11559,13 +11572,15 @@ textarea,
   font-size: 11px;
 }
 
-.star-map-intake__footer {
+.star-map-intake__footer,
+.star-map-rename__footer {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.star-map-intake__status {
+.star-map-intake__status,
+.star-map-rename__status {
   flex: 1;
   overflow: hidden;
   color: var(--text-muted);
@@ -11574,7 +11589,8 @@ textarea,
   white-space: nowrap;
 }
 
-.star-map-intake__status.is-failed {
+.star-map-intake__status.is-failed,
+.star-map-rename__status.is-failed {
   color: var(--danger-text);
 }
 


### PR DESCRIPTION
## Summary

- Adds **Rename thread…** to the star map's per-card kebab. The menu could open, mark seen, reset position, and archive, but a thread carrying a generated title could only be renamed by leaving the map for the thread list.
- Adds **Mark as unread**, the mirror of the existing mark-seen entry over the complement subset. It moves the seen watermark to `updatedAt - 1` — the same watermark the thread list writes, so both surfaces mean the same thing by "unread".
- New `StarMapRenameDialog` shares the `[+]` intake dialog's shell styles rather than adding a second panel shape; the CSS rules take both selectors so one cannot drift from the other.

Menu is now: Open in full view · Rename thread… · Mark as seen · Mark as unread · Reset position · Archive thread.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/star-map apps/desktop/src/renderer/src/styles` — 520/520 across 33 files, including 3 new cases: rename + optimistic title, refusal revert, mark-unread watermark.
- `pnpm typecheck`, `pnpm lint:eslint` (no new warnings), `pnpm lint:colors`, `pnpm lint:boundaries` — all clean.
- Not driven in a running app: behavior is unit-covered, and the dialog's visual shell is the intake dialog's existing rules.

## Notes

Three decisions a reviewer should weigh:

- **Rename is single-target even when the kebab is opened on a multi-card selection**, unlike Archive and the mark entries. It follows the rule "Open in full view" already follows: one name across five cards is not a rename, it is five threads the operator can no longer tell apart.
- **The card wears the new title immediately**, for the same reason Archive hides its card immediately — the owning feed refreshes on its own cadence, and a card still showing the old title is indistinguishable from a rename that failed. Reverted on refusal (with the reason in the existing card-error strip), released once the feed reports the new title itself. The optimistic hide and the optimistic title share one pass over the thread list, and threads are only rebuilt while an edit is outstanding.
- **`theme-contract.test.tsx` is updated in the same commit.** It pins the exact selector list for the title-bar drag punch-out, and a body-portaled dialog missing from that list turns a dismiss-click near the top of the window into a window drag. Both dialogs are now named in the assertion.

Actions deliberately left out, and why: Pin / Move Up / Move Down (the map has no pin ordering to move within), Fork and Sub-thread (both need a worktree choice the map has no surface for), Unbind messaging, and Unlink from Parent — the orbit lens already detaches by dragging a card out of its cluster, though the lanes lens has no affordance for it. Happy to add any of these; Unlink is the strongest candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
