### PR TITLE
fix(desktop): give the Star Map context rail the thread's real data

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -28,6 +28,7 @@ import { useThreadSessionState } from "../../lib/useThreadSessionState";
 import {
   clearStarMapCardContext,
   publishStarMapCardContext,
+  useStarMapCardContextDemand,
 } from "./star-map-card-context-store";
 import {
   clampChatCardRect,
@@ -126,14 +127,18 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     thread.federation?.ref.target ?? readRendererFederationTarget();
 
   // The context satellite is a sibling rendered by the screen, so the session
-  // data its panels need has to be published rather than passed down. Only
-  // while the satellite is open: collecting edited-file groups walks the whole
-  // transcript, and a card with the rail closed should not pay for it on every
-  // streamed entry.
-  const contextOpen = props.contextOpen ?? false;
+  // data its panels need has to be published rather than passed down.
+  //
+  // Gated on a live subscriber rather than on `contextOpen`: collecting
+  // edited-file groups walks the whole transcript, so a card would otherwise
+  // redo it on every streamed entry for a rail nobody can see. The two differ
+  // — the map unmounts every satellite at overview zoom without clearing the
+  // flag — and the subscriber is the one that answers "is anything reading
+  // this?".
+  const contextDemand = useStarMapCardContextDemand(cardKey);
   const editedFileGroups = useMemo(
     () =>
-      contextOpen
+      contextDemand
         ? collectEditedFileGroups({
             entries: session.entries,
             activeTurnId: session.activeTurnId,
@@ -143,7 +148,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           })
         : undefined,
     [
-      contextOpen,
+      contextDemand,
       session.activeTurnId,
       session.entries,
       thread.createdAt,
@@ -152,12 +157,13 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   );
   const pricing = session.response?.pricing;
   useEffect(() => {
+    if (!contextDemand) return;
     publishStarMapCardContext(cardKey, {
       activeTurnId: session.activeTurnId,
       editedFileGroups,
       pricing,
     });
-  }, [cardKey, editedFileGroups, pricing, session.activeTurnId]);
+  }, [cardKey, contextDemand, editedFileGroups, pricing, session.activeTurnId]);
   useEffect(() => () => clearStarMapCardContext(cardKey), [cardKey]);
 
   const beginDrag = useCallback(

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -20,10 +20,15 @@ import {
 } from "../composer/CompactComposer";
 import { TranscriptList } from "../thread-detail/TranscriptList";
 import { useTranscriptWindow } from "../thread-detail/useTranscriptWindow";
+import { collectEditedFileGroups } from "../thread-detail/edited-file-groups";
 import { DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT } from "../../lib/thread-history-limits";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { useThreadSessionState } from "../../lib/useThreadSessionState";
+import {
+  clearStarMapCardContext,
+  publishStarMapCardContext,
+} from "./star-map-card-context-store";
 import {
   clampChatCardRect,
   resizeChatCardRect,
@@ -119,6 +124,41 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
 
   const federationTarget =
     thread.federation?.ref.target ?? readRendererFederationTarget();
+
+  // The context satellite is a sibling rendered by the screen, so the session
+  // data its panels need has to be published rather than passed down. Only
+  // while the satellite is open: collecting edited-file groups walks the whole
+  // transcript, and a card with the rail closed should not pay for it on every
+  // streamed entry.
+  const contextOpen = props.contextOpen ?? false;
+  const editedFileGroups = useMemo(
+    () =>
+      contextOpen
+        ? collectEditedFileGroups({
+            entries: session.entries,
+            activeTurnId: session.activeTurnId,
+            forkCreatedAt: thread.forkSourceThreadId
+              ? thread.createdAt
+              : undefined,
+          })
+        : undefined,
+    [
+      contextOpen,
+      session.activeTurnId,
+      session.entries,
+      thread.createdAt,
+      thread.forkSourceThreadId,
+    ],
+  );
+  const pricing = session.response?.pricing;
+  useEffect(() => {
+    publishStarMapCardContext(cardKey, {
+      activeTurnId: session.activeTurnId,
+      editedFileGroups,
+      pricing,
+    });
+  }, [cardKey, editedFileGroups, pricing, session.activeTurnId]);
+  useEffect(() => () => clearStarMapCardContext(cardKey), [cardKey]);
 
   const beginDrag = useCallback(
     (event: ReactPointerEvent, kind: DragState["kind"]) => {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -10,6 +10,7 @@ import { readRendererFederationTarget } from "../../lib/federation-window";
 import { isRemoteFederationTarget } from "@pwragent/shared";
 import { ThreadContextPanel } from "../thread-detail/ThreadContextPanel";
 import type { ContextTabId } from "../thread-detail/context-panels/context-tab";
+import { useStarMapCardContext } from "./star-map-card-context-store";
 import {
   CHAT_CARD_CONTEXT_SPINE_WIDTH,
   CHAT_CARD_TERMINAL_HEIGHT,
@@ -34,6 +35,9 @@ const LazyIntegratedTerminal = lazy(async () => {
  * the host drags — there is no second position to keep in sync.
  */
 export function StarMapContextCard(props: {
+  /** Host chat card's key: the session data the panels need is published
+      under it by the card that owns the thread session. */
+  cardKey: string;
   desktopApi?: DesktopApi;
   thread: NavigationThreadSummary;
   rect: ChatCardRect;
@@ -41,6 +45,11 @@ export function StarMapContextCard(props: {
   onClose: () => void;
 }) {
   const [tab, setTab] = useState<ContextTabId>("info");
+  // Pricing rows and edited-file groups come out of the host's thread
+  // session. Read from a summary alone, Pricing claimed the thread had no
+  // usage at all and Edits claimed it had touched no files, while the full
+  // window showed both for the same thread.
+  const cardContext = useStarMapCardContext(props.cardKey);
   const style: CSSProperties = {
     left: `${props.rect.left}px`,
     top: `${props.rect.top}px`,
@@ -84,10 +93,13 @@ export function StarMapContextCard(props: {
       >
         <ThreadContextPanel
           activeTab={tab}
+          activeTurnId={cardContext.activeTurnId}
           backends={[]}
           desktopApi={props.desktopApi}
+          editedFileGroups={cardContext.editedFileGroups}
           onActiveTabChange={setTab}
           pinned
+          pricing={cardContext.pricing}
           thread={props.thread}
           width={props.rect.width - CHAT_CARD_CONTEXT_SPINE_WIDTH}
         />

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -43,6 +43,12 @@ export function StarMapContextCard(props: {
   rect: ChatCardRect;
   zIndex: number;
   onClose: () => void;
+  /** The operator's Settings -> Pricing choices. Without them the rail
+      falls back to its own defaults, which shows a thread's spend on a
+      surface the operator switched off and prices it in the wrong
+      currency for a Codex-credits account. */
+  pricingDisplayOptions?: { codexCredits: boolean; usd: boolean };
+  threadPricingSummaryEnabled?: boolean;
 }) {
   const [tab, setTab] = useState<ContextTabId>("info");
   // Pricing rows and edited-file groups come out of the host's thread
@@ -100,7 +106,9 @@ export function StarMapContextCard(props: {
           onActiveTabChange={setTab}
           pinned
           pricing={cardContext.pricing}
+          pricingDisplayOptions={props.pricingDisplayOptions}
           thread={props.thread}
+          threadPricingSummaryEnabled={props.threadPricingSummaryEnabled}
           width={props.rect.width - CHAT_CARD_CONTEXT_SPINE_WIDTH}
         />
       </div>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -1,10 +1,11 @@
-import { lazy, Suspense, useState, type CSSProperties } from "react";
+import { lazy, Suspense, useMemo, useState, type CSSProperties } from "react";
 import type {
   KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
 } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { useBackendSummaries } from "../../lib/useBackendSummaries";
 import { InstanceChip } from "../federation/InstanceGlyph";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { isRemoteFederationTarget } from "@pwragent/shared";
@@ -56,6 +57,33 @@ export function StarMapContextCard(props: {
   // usage at all and Edits claimed it had touched no files, while the full
   // window showed both for the same thread.
   const cardContext = useStarMapCardContext(props.cardKey);
+  // Provider status belongs to the instance the THREAD lives on, not to
+  // this window: a map holds cards over several peers at once, so each
+  // satellite reads the backends of its own host's instance.
+  //
+  // Memoized by instance id rather than passed straight through. The hook
+  // rebuilds `refresh` whenever the target's identity changes and refetches
+  // on it, while `thread.federation.ref.target` is replaced on every
+  // navigation poll and `readRendererFederationTarget()` builds a fresh
+  // object per call — either one, handed over inline, refetches on every
+  // render forever.
+  const remoteInstanceId = useMemo(() => {
+    const target =
+      props.thread.federation?.ref.target ?? readRendererFederationTarget();
+    return target && isRemoteFederationTarget(target)
+      ? target.instanceId
+      : undefined;
+  }, [props.thread.federation?.ref.target]);
+  const federationTarget = useMemo(
+    () =>
+      remoteInstanceId
+        ? ({ scope: "remote", instanceId: remoteInstanceId } as const)
+        : undefined,
+    [remoteInstanceId],
+  );
+  const backendSummaries = useBackendSummaries(props.desktopApi, {
+    federationTarget,
+  });
   const style: CSSProperties = {
     left: `${props.rect.left}px`,
     top: `${props.rect.top}px`,
@@ -100,7 +128,8 @@ export function StarMapContextCard(props: {
         <ThreadContextPanel
           activeTab={tab}
           activeTurnId={cardContext.activeTurnId}
-          backends={[]}
+          backendError={backendSummaries.error}
+          backends={backendSummaries.backends}
           desktopApi={props.desktopApi}
           editedFileGroups={cardContext.editedFileGroups}
           // The rail is the only edits surface a chat card has: the card

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -140,6 +140,9 @@ export function StarMapContextCard(props: {
           editedFilesDock="sidebar"
           onActiveTabChange={setTab}
           pinned
+          // The Info tab prints this verbatim as its "Desktop" row, and
+          // falls back to "Unknown" when it is absent.
+          platform={props.desktopApi?.platform}
           pricing={cardContext.pricing}
           pricingDisplayOptions={props.pricingDisplayOptions}
           thread={props.thread}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -103,6 +103,12 @@ export function StarMapContextCard(props: {
           backends={[]}
           desktopApi={props.desktopApi}
           editedFileGroups={cardContext.editedFileGroups}
+          // The rail is the only edits surface a chat card has: the card
+          // composes through CompactComposer and renders no above-composer
+          // work rail. Left at the panel's "above" default, the dock toggle
+          // came up accent-filled and aria-pressed, claiming a second copy
+          // that does not exist on this surface.
+          editedFilesDock="sidebar"
           onActiveTabChange={setTab}
           pinned
           pricing={cardContext.pricing}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -3683,6 +3683,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 <div key={`satellites:${card.key}`}>
                   {card.contextOpen ? (
                     <StarMapContextCard
+                      cardKey={card.key}
                       desktopApi={props.desktopApi}
                       thread={card.thread}
                       rect={dockContextRect(card.rect)}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -365,6 +365,9 @@ type StarMapScreenProps = {
   onFocusLocalInstance: () => void;
   /** Refresh the App's navigation snapshot (after intake creates locally). */
   onRefreshLocalThreads?: () => void;
+  /** Settings -> Pricing, for the chat cards' context satellites. */
+  pricingDisplayOptions?: { codexCredits: boolean; usd: boolean };
+  threadPricingSummaryEnabled?: boolean;
 };
 
 /**
@@ -3685,7 +3688,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
                     <StarMapContextCard
                       cardKey={card.key}
                       desktopApi={props.desktopApi}
+                      pricingDisplayOptions={props.pricingDisplayOptions}
                       thread={card.thread}
+                      threadPricingSummaryEnabled={
+                        props.threadPricingSummaryEnabled
+                      }
                       rect={dockContextRect(card.rect)}
                       zIndex={cardZ}
                       onClose={() => chatCards.toggleContext(card.key)}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -95,6 +95,17 @@ export function StarMapWindow() {
           thinkingThreadKeys: session.thinkingThreadKeys,
         }}
         localInstanceLabel={settings.snapshot?.federation.instanceLabel.value}
+        pricingDisplayOptions={{
+          codexCredits:
+            settings.snapshot?.experimental.threadPricingDisplayCodexCredits
+              ?.value ?? false,
+          usd:
+            settings.snapshot?.experimental.threadPricingDisplayUsd?.value
+            ?? true,
+        }}
+        threadPricingSummaryEnabled={
+          settings.snapshot?.experimental.threadPricingSummary?.value ?? true
+        }
         onOpenLocalThread={(thread) => {
           void desktopApi?.openStarMapThreadInMainWindow?.({
             backend: thread.source,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
@@ -186,6 +186,25 @@ describe("star map context satellite data", () => {
     expect(satellite().queryByRole("tab", { name: "Pricing" })).toBeNull();
   });
 
+  it("keeps the map's edits in the rail: no above-composer dock offered", async () => {
+    // A chat card has no above-composer work rail, so the dock toggle's
+    // "also pinned above the composer" state is a claim the surface cannot
+    // honor. Pin it to the rail rather than take the panel's default.
+    const desktopApi = buildApi(editEntries());
+    renderCardWithContextSatellite(desktopApi);
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    fireEvent.click(satellite().getByRole("tab", { name: "Edits" }));
+
+    const dockToggle = await satellite().findByRole("button", {
+      name: "Show above composer",
+    });
+    expect(dockToggle.getAttribute("aria-pressed")).toBe("false");
+  });
+
   it("shows the turn's edited files, collected from the host's transcript", async () => {
     const desktopApi = buildApi(editEntries());
     renderCardWithContextSatellite(desktopApi);

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
@@ -82,6 +82,7 @@ function editEntries(): AppServerThreadEntry[] {
  */
 function buildApi(entries: AppServerThreadEntry[] = []): DesktopApi {
   return {
+    platform: "darwin",
     readThread: vi.fn(async () => ({
       backend: "codex",
       threadId: "t-local",
@@ -224,6 +225,15 @@ describe("star map context satellite data", () => {
     expect(satellite().queryByRole("tab", { name: "Pricing" })).toBeNull();
   });
 
+  it("names the desktop platform on the Info tab rather than \"Unknown\"", async () => {
+    // Info renders `platform` verbatim. Unpassed, the map's rail called
+    // every machine "Unknown" while the full window named it.
+    const desktopApi = buildApi();
+    renderCardWithContextSatellite(desktopApi);
+
+    expect(await satellite().findByText("darwin")).toBeTruthy();
+  });
+
   it("shows the host instance's AI providers, not an unavailable rail", async () => {
     // The satellite was handed `backends={[]}`, so the providers tab read
     // "Status unavailable" on a machine whose providers were fine.
@@ -234,6 +244,22 @@ describe("star map context satellite data", () => {
 
     expect(await satellite().findByText("OpenAI")).toBeTruthy();
     expect(satellite().queryByText("Status unavailable")).toBeNull();
+  });
+
+  it("reads a peer thread's providers from the peer, not from this window", async () => {
+    // The point of reading per satellite rather than once for the window:
+    // a map holds cards over several instances at once, so the providers
+    // shown under a peer's card have to be that peer's.
+    const desktopApi = buildApi();
+    renderCardWithContextSatellite(desktopApi, { remote: true });
+
+    await waitFor(() => {
+      expect(desktopApi.listBackends).toHaveBeenCalledWith(
+        expect.objectContaining({
+          federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+        }),
+      );
+    });
   });
 
   it("reads the provider list once per thread, not once per render", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AppServerThreadEntry,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapChatCard } from "../StarMapChatCard";
+import { StarMapContextCard } from "../StarMapSatelliteCards";
+
+const CARD_KEY = "card-1";
+const CHAT_RECT = { left: 40, top: 40, width: 420, height: 520 };
+const CONTEXT_RECT = { left: 480, top: 40, width: 320, height: 520 };
+
+function thread(): NavigationThreadSummary {
+  return {
+    id: "t-local",
+    title: "Local work",
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 1,
+  } as unknown as NavigationThreadSummary;
+}
+
+/** One turn that wrote a file, the way the Edits tab reads a transcript. */
+function editEntries(): AppServerThreadEntry[] {
+  return [
+    {
+      type: "activity",
+      id: "a1",
+      summary: "activity",
+      turn: { id: "turn-1" },
+      details: [
+        {
+          id: "d1",
+          kind: "write",
+          label: "Update StarMapSatelliteCards.tsx",
+          path: "apps/desktop/src/StarMapSatelliteCards.tsx",
+          fileDiff: {
+            kind: "update",
+            diff: "@@",
+            additions: 12,
+            removals: 3,
+          },
+        },
+      ],
+    } as unknown as AppServerThreadEntry,
+  ];
+}
+
+/**
+ * A thread read that carries pricing, exactly as the full window's session
+ * receives it. The rail in the full window renders a summary card from this;
+ * the star map's satellite has to reach the same rows.
+ */
+function buildApi(entries: AppServerThreadEntry[] = []): DesktopApi {
+  return {
+    readThread: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t-local",
+      replay: {
+        entries,
+        messages: [],
+        pagination: { supportsPagination: false, hasPreviousPage: false },
+      },
+      pricing: {
+        lines: [],
+        summaries: [
+          {
+            backend: "codex",
+            cachedInputTokens: 17_800_000,
+            currency: "USD",
+            inputTokens: 465_800,
+            outputTokens: 60_200,
+            pricedUsageLineCount: 4,
+            provider: "openai",
+            reasoningOutputTokens: 22_500,
+            threadId: "t-local",
+            totalCostMicros: 13_680_000,
+            totalTokens: 18_300_000,
+            uncachedInputTokens: 465_800,
+            unpricedUsageLineCount: 0,
+            updatedAt: 1_700_000_000_000,
+            usageLineCount: 4,
+          },
+        ],
+      },
+    })),
+    startTurn: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t-local",
+      turnId: "turn-1",
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+/** The screen's arrangement: the card owns the session, the satellite docks
+    beside it as a sibling. */
+function renderCardWithContextSatellite(desktopApi: DesktopApi) {
+  return render(
+    <>
+      <StarMapChatCard
+        cardKey={CARD_KEY}
+        desktopApi={desktopApi}
+        onClose={() => undefined}
+        onOpenFull={() => undefined}
+        onRaise={() => undefined}
+        onRectChange={() => undefined}
+        rect={CHAT_RECT}
+        scale={1}
+        bounds={{ width: 4000, height: 3000 }}
+        thread={thread()}
+        contextOpen
+        onToggleContext={() => undefined}
+        onToggleTerminal={() => undefined}
+        zIndex={40}
+      />
+      <StarMapContextCard
+        cardKey={CARD_KEY}
+        desktopApi={desktopApi}
+        thread={thread()}
+        rect={CONTEXT_RECT}
+        zIndex={40}
+        onClose={() => undefined}
+      />
+    </>,
+  );
+}
+
+describe("star map context satellite data", () => {
+  it("shows the loaded thread's pricing, not an empty rail", async () => {
+    // The satellite renders the same ThreadContextPanel the full window
+    // does, but the session that carries pricing belongs to the chat card.
+    // Without a hand-off the rail claimed the thread had no usage at all
+    // while the full window showed a $13.68 summary for the same thread.
+    const desktopApi = buildApi();
+    renderCardWithContextSatellite(desktopApi);
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Pricing" }));
+
+    expect(await screen.findByText("Pricing summary")).toBeTruthy();
+    expect(screen.queryByText("No usage pricing recorded yet.")).toBeNull();
+  });
+
+  it("shows the turn's edited files, collected from the host's transcript", async () => {
+    const desktopApi = buildApi(editEntries());
+    renderCardWithContextSatellite(desktopApi);
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Edits" }));
+
+    expect(await screen.findByText("Edited 1 file")).toBeTruthy();
+    expect(screen.getByText("Update StarMapSatelliteCards.tsx")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type {
   AppServerThreadEntry,
@@ -99,7 +105,19 @@ function buildApi(entries: AppServerThreadEntry[] = []): DesktopApi {
 
 /** The screen's arrangement: the card owns the session, the satellite docks
     beside it as a sibling. */
-function renderCardWithContextSatellite(desktopApi: DesktopApi) {
+/** The satellite's own subtree. Scoping every assertion to it is what keeps
+    the test about the satellite rather than about the window containing the
+    text somewhere. */
+function satellite() {
+  return within(
+    screen.getByRole("region", { name: "Thread context: Local work" }),
+  );
+}
+
+function renderCardWithContextSatellite(
+  desktopApi: DesktopApi,
+  options?: { threadPricingSummaryEnabled?: boolean },
+) {
   return render(
     <>
       <StarMapChatCard
@@ -125,6 +143,7 @@ function renderCardWithContextSatellite(desktopApi: DesktopApi) {
         rect={CONTEXT_RECT}
         zIndex={40}
         onClose={() => undefined}
+        threadPricingSummaryEnabled={options?.threadPricingSummaryEnabled}
       />
     </>,
   );
@@ -143,10 +162,28 @@ describe("star map context satellite data", () => {
       expect(desktopApi.readThread).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole("tab", { name: "Pricing" }));
+    fireEvent.click(satellite().getByRole("tab", { name: "Pricing" }));
 
-    expect(await screen.findByText("Pricing summary")).toBeTruthy();
-    expect(screen.queryByText("No usage pricing recorded yet.")).toBeNull();
+    expect(await satellite().findByText("Pricing summary")).toBeTruthy();
+    expect(
+      satellite().queryByText("No usage pricing recorded yet."),
+    ).toBeNull();
+  });
+
+  it("honors the operator's pricing setting rather than the rail default", async () => {
+    // The map reads the same Settings -> Pricing switch the full window
+    // does. Left unplumbed, the satellite defaulted to "on" and showed a
+    // thread's spend on a surface the operator had switched off.
+    const desktopApi = buildApi();
+    renderCardWithContextSatellite(desktopApi, {
+      threadPricingSummaryEnabled: false,
+    });
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    expect(satellite().queryByRole("tab", { name: "Pricing" })).toBeNull();
   });
 
   it("shows the turn's edited files, collected from the host's transcript", async () => {
@@ -157,9 +194,11 @@ describe("star map context satellite data", () => {
       expect(desktopApi.readThread).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole("tab", { name: "Edits" }));
+    fireEvent.click(satellite().getByRole("tab", { name: "Edits" }));
 
-    expect(await screen.findByText("Edited 1 file")).toBeTruthy();
-    expect(screen.getByText("Update StarMapSatelliteCards.tsx")).toBeTruthy();
+    expect(await satellite().findByText("Edited 1 file")).toBeTruthy();
+    expect(
+      satellite().getByText("Update StarMapSatelliteCards.tsx"),
+    ).toBeTruthy();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
@@ -30,6 +30,25 @@ function thread(): NavigationThreadSummary {
   } as unknown as NavigationThreadSummary;
 }
 
+/**
+ * The same thread as a peer's. A remote target is what the provider read is
+ * actually keyed by, and it is the only case where the target is an object
+ * rather than `undefined` — so it is the only case that can churn.
+ */
+function remoteThread(): NavigationThreadSummary {
+  return {
+    ...thread(),
+    federation: {
+      instanceLabel: "Studio Mac",
+      ref: {
+        backend: "codex",
+        threadId: "t-local",
+        target: { scope: "remote", instanceId: "pwr_peer" },
+      },
+    },
+  } as unknown as NavigationThreadSummary;
+}
+
 /** One turn that wrote a file, the way the Edits tab reads a transcript. */
 function editEntries(): AppServerThreadEntry[] {
   return [
@@ -94,6 +113,15 @@ function buildApi(entries: AppServerThreadEntry[] = []): DesktopApi {
         ],
       },
     })),
+    listBackends: vi.fn(async () => ({
+      backends: [
+        {
+          kind: "codex",
+          label: "OpenAI",
+          available: true,
+        },
+      ],
+    })),
     startTurn: vi.fn(async () => ({
       backend: "codex",
       threadId: "t-local",
@@ -114,11 +142,14 @@ function satellite() {
   );
 }
 
-function renderCardWithContextSatellite(
+/** The screen's arrangement, as an element. Every call builds fresh thread
+    summaries the way a navigation poll does, which is what makes a re-render
+    with it a real test of identity churn. */
+function cardWithContextSatellite(
   desktopApi: DesktopApi,
-  options?: { threadPricingSummaryEnabled?: boolean },
+  options?: { threadPricingSummaryEnabled?: boolean; remote?: boolean },
 ) {
-  return render(
+  return (
     <>
       <StarMapChatCard
         cardKey={CARD_KEY}
@@ -130,7 +161,7 @@ function renderCardWithContextSatellite(
         rect={CHAT_RECT}
         scale={1}
         bounds={{ width: 4000, height: 3000 }}
-        thread={thread()}
+        thread={options?.remote ? remoteThread() : thread()}
         contextOpen
         onToggleContext={() => undefined}
         onToggleTerminal={() => undefined}
@@ -139,14 +170,21 @@ function renderCardWithContextSatellite(
       <StarMapContextCard
         cardKey={CARD_KEY}
         desktopApi={desktopApi}
-        thread={thread()}
+        thread={options?.remote ? remoteThread() : thread()}
         rect={CONTEXT_RECT}
         zIndex={40}
         onClose={() => undefined}
         threadPricingSummaryEnabled={options?.threadPricingSummaryEnabled}
       />
-    </>,
+    </>
   );
+}
+
+function renderCardWithContextSatellite(
+  desktopApi: DesktopApi,
+  options?: { threadPricingSummaryEnabled?: boolean; remote?: boolean },
+) {
+  return render(cardWithContextSatellite(desktopApi, options));
 }
 
 describe("star map context satellite data", () => {
@@ -184,6 +222,45 @@ describe("star map context satellite data", () => {
     });
 
     expect(satellite().queryByRole("tab", { name: "Pricing" })).toBeNull();
+  });
+
+  it("shows the host instance's AI providers, not an unavailable rail", async () => {
+    // The satellite was handed `backends={[]}`, so the providers tab read
+    // "Status unavailable" on a machine whose providers were fine.
+    const desktopApi = buildApi();
+    renderCardWithContextSatellite(desktopApi);
+
+    fireEvent.click(satellite().getByRole("tab", { name: "AI provider info" }));
+
+    expect(await satellite().findByText("OpenAI")).toBeTruthy();
+    expect(satellite().queryByText("Status unavailable")).toBeNull();
+  });
+
+  it("reads the provider list once per thread, not once per render", async () => {
+    // The hook refetches whenever its federation target changes identity,
+    // and both target sources build a fresh object per call. Handed over
+    // inline that is a fetch on every render, forever.
+    const desktopApi = buildApi();
+    const { rerender } = renderCardWithContextSatellite(desktopApi, {
+      remote: true,
+    });
+
+    await waitFor(() => {
+      expect(desktopApi.listBackends).toHaveBeenCalled();
+    });
+    const callsAfterMount = vi.mocked(desktopApi.listBackends!).mock.calls
+      .length;
+
+    for (let index = 0; index < 3; index += 1) {
+      rerender(cardWithContextSatellite(desktopApi, { remote: true }));
+    }
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    expect(vi.mocked(desktopApi.listBackends!).mock.calls.length).toBe(
+      callsAfterMount,
+    );
   });
 
   it("keeps the map's edits in the rail: no above-composer dock offered", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-demand.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-demand.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+
+// Counted, not stubbed: the Edits tab still has to work, and what is under
+// test is how often the card walks the transcript, not what it finds.
+const collectSpy = vi.hoisted(() => vi.fn());
+vi.mock("../../thread-detail/edited-file-groups", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../thread-detail/edited-file-groups")>();
+  return {
+    ...actual,
+    collectEditedFileGroups: (
+      params: Parameters<typeof actual.collectEditedFileGroups>[0],
+    ) => {
+      collectSpy(params);
+      return actual.collectEditedFileGroups(params);
+    },
+  };
+});
+
+const { StarMapChatCard } = await import("../StarMapChatCard");
+const { StarMapContextCard } = await import("../StarMapSatelliteCards");
+
+const CARD_KEY = "card-1";
+
+function thread(): NavigationThreadSummary {
+  return {
+    id: "t-local",
+    title: "Local work",
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 1,
+  } as unknown as NavigationThreadSummary;
+}
+
+function buildApi(): DesktopApi {
+  return {
+    platform: "darwin",
+    readThread: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t-local",
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: { supportsPagination: false, hasPreviousPage: false },
+      },
+    })),
+    listBackends: vi.fn(async () => ({ backends: [] })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function chatCard(desktopApi: DesktopApi) {
+  return (
+    <StarMapChatCard
+      cardKey={CARD_KEY}
+      desktopApi={desktopApi}
+      onClose={() => undefined}
+      onOpenFull={() => undefined}
+      onRaise={() => undefined}
+      onRectChange={() => undefined}
+      rect={{ left: 40, top: 40, width: 420, height: 520 }}
+      scale={1}
+      bounds={{ width: 4000, height: 3000 }}
+      thread={thread()}
+      contextOpen
+      onToggleContext={() => undefined}
+      onToggleTerminal={() => undefined}
+      zIndex={40}
+    />
+  );
+}
+
+function contextSatellite(desktopApi: DesktopApi) {
+  return (
+    <StarMapContextCard
+      cardKey={CARD_KEY}
+      desktopApi={desktopApi}
+      thread={thread()}
+      rect={{ left: 480, top: 40, width: 320, height: 520 }}
+      zIndex={40}
+      onClose={() => undefined}
+    />
+  );
+}
+
+describe("star map card context demand", () => {
+  it("derives nothing while no satellite is mounted", async () => {
+    // The map drops every satellite at overview zoom while leaving
+    // `contextOpen` set. Keyed on that flag, a card would walk its whole
+    // transcript on every streamed entry for a rail nobody can see.
+    const desktopApi = buildApi();
+    collectSpy.mockClear();
+    render(chatCard(desktopApi));
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    expect(collectSpy).not.toHaveBeenCalled();
+  });
+
+  it("starts deriving once a satellite subscribes", async () => {
+    const desktopApi = buildApi();
+    collectSpy.mockClear();
+    const { rerender } = render(chatCard(desktopApi));
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+    expect(collectSpy).not.toHaveBeenCalled();
+
+    rerender(
+      <>
+        {chatCard(desktopApi)}
+        {contextSatellite(desktopApi)}
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(collectSpy).toHaveBeenCalled();
+    });
+    expect(
+      screen.getByRole("region", { name: "Thread context: Local work" }),
+    ).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-card-context-store.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-card-context-store.ts
@@ -1,0 +1,95 @@
+import { useCallback, useSyncExternalStore } from "react";
+import type {
+  ThreadPricingSummary,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+import type { EditedFileGroup } from "../thread-detail/edited-file-groups";
+
+/**
+ * Session-derived context data for one chat card, handed from the card to
+ * its context satellite.
+ *
+ * Everything here comes out of the card's own `useThreadSessionState` — the
+ * thread read's pricing rows, and the edited-file groups collected from the
+ * transcript. Neither can be derived from a `NavigationThreadSummary`, which
+ * is all the satellite is otherwise given.
+ */
+export type StarMapCardContextSnapshot = {
+  activeTurnId?: string;
+  editedFileGroups?: EditedFileGroup[];
+  pricing?: {
+    lines: ThreadUsageLineRecord[];
+    summaries: ThreadPricingSummary[];
+  };
+};
+
+/**
+ * The hand-off between a star map chat card and its context satellite.
+ *
+ * The two are siblings, not parent and child: satellites are rendered by
+ * `StarMapScreen` (which owns their dock geometry and stacking), while the
+ * thread session lives in the card. So the data cannot simply be a prop, and
+ * the two obvious alternatives are both worse:
+ *
+ * - Lifting the session data into the screen re-renders the entire map on
+ *   every pricing and transcript update, for every open card.
+ * - Mounting a second `useThreadSessionState` in the satellite re-reads the
+ *   whole thread over the bridge and subscribes a second listener to the
+ *   same live turn.
+ *
+ * A per-card store keyed the same way the cards are keyed keeps the update
+ * local: publishing wakes the one satellite subscribed to that card and
+ * nothing else on the map.
+ */
+const EMPTY_SNAPSHOT: StarMapCardContextSnapshot = {};
+
+const snapshots = new Map<string, StarMapCardContextSnapshot>();
+const listeners = new Map<string, Set<() => void>>();
+
+function notify(cardKey: string): void {
+  for (const listener of listeners.get(cardKey) ?? []) listener();
+}
+
+export function publishStarMapCardContext(
+  cardKey: string,
+  snapshot: StarMapCardContextSnapshot,
+): void {
+  snapshots.set(cardKey, snapshot);
+  notify(cardKey);
+}
+
+/** Called when a card unmounts, so a reopened card starts empty rather than
+    showing the previous session's rows until its first publish. */
+export function clearStarMapCardContext(cardKey: string): void {
+  if (!snapshots.delete(cardKey)) return;
+  notify(cardKey);
+}
+
+export function useStarMapCardContext(
+  cardKey: string,
+): StarMapCardContextSnapshot {
+  // Both memoized against the key: `useSyncExternalStore` re-subscribes when
+  // `subscribe` changes identity, and an inline arrow changes every render.
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      let keyListeners = listeners.get(cardKey);
+      if (!keyListeners) {
+        keyListeners = new Set();
+        listeners.set(cardKey, keyListeners);
+      }
+      keyListeners.add(listener);
+      return () => {
+        keyListeners.delete(listener);
+        if (keyListeners.size === 0) listeners.delete(cardKey);
+      };
+    },
+    [cardKey],
+  );
+  // Returns the stored object by reference, never a fresh one: a new object
+  // per call makes `useSyncExternalStore` loop forever.
+  const getSnapshot = useCallback(
+    () => snapshots.get(cardKey) ?? EMPTY_SNAPSHOT,
+    [cardKey],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-card-context-store.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-card-context-store.ts
@@ -39,9 +39,21 @@ const EMPTY_SNAPSHOT: StarMapCardContextSnapshot = {};
 
 const snapshots = new Map<string, StarMapCardContextSnapshot>();
 const listeners = new Map<string, Set<() => void>>();
+/**
+ * Woken when any card's subscriber set opens or empties, so a card can stop
+ * deriving data nobody is going to read. One global set rather than one per
+ * card: demand changes when a rail opens, closes, or leaves the zoom level
+ * that renders it, which is operator-paced, while the data it gates is
+ * per-streamed-entry.
+ */
+const demandListeners = new Set<() => void>();
 
 function notify(cardKey: string): void {
   for (const listener of listeners.get(cardKey) ?? []) listener();
+}
+
+function notifyDemand(): void {
+  for (const listener of demandListeners) listener();
 }
 
 export function publishStarMapCardContext(
@@ -72,9 +84,11 @@ export function useStarMapCardContext(
         listeners.set(cardKey, keyListeners);
       }
       keyListeners.add(listener);
+      notifyDemand();
       return () => {
         keyListeners.delete(listener);
         if (keyListeners.size === 0) listeners.delete(cardKey);
+        notifyDemand();
       };
     },
     [cardKey],
@@ -83,6 +97,31 @@ export function useStarMapCardContext(
   // per call makes `useSyncExternalStore` loop forever.
   const getSnapshot = useCallback(
     () => snapshots.get(cardKey) ?? EMPTY_SNAPSHOT,
+    [cardKey],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/**
+ * Whether anything is currently reading this card's context.
+ *
+ * The card derives edited-file groups by walking its whole transcript, which
+ * it would otherwise redo on every streamed entry whether or not the result
+ * can be seen. `contextOpen` is not that question: the star map drops every
+ * satellite at overview zoom while leaving the flag set, so a card whose rail
+ * is "open" can have no rail mounted at all. Subscription is the honest
+ * signal — no subscriber, no work.
+ */
+export function useStarMapCardContextDemand(cardKey: string): boolean {
+  const subscribe = useCallback((listener: () => void) => {
+    demandListeners.add(listener);
+    return () => {
+      demandListeners.delete(listener);
+    };
+  }, []);
+  // A boolean, so repeated calls compare equal and cannot loop the store.
+  const getSnapshot = useCallback(
+    () => (listeners.get(cardKey)?.size ?? 0) > 0,
     [cardKey],
   );
   return useSyncExternalStore(subscribe, getSnapshot);

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-card-context-store.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-card-context-store.ts
@@ -1,8 +1,5 @@
 import { useCallback, useSyncExternalStore } from "react";
-import type {
-  ThreadPricingSummary,
-  ThreadUsageLineRecord,
-} from "@pwragent/shared";
+import type { AppServerReadThreadResponse } from "@pwragent/shared";
 import type { EditedFileGroup } from "../thread-detail/edited-file-groups";
 
 /**
@@ -17,10 +14,7 @@ import type { EditedFileGroup } from "../thread-detail/edited-file-groups";
 export type StarMapCardContextSnapshot = {
   activeTurnId?: string;
   editedFileGroups?: EditedFileGroup[];
-  pricing?: {
-    lines: ThreadUsageLineRecord[];
-    summaries: ThreadPricingSummary[];
-  };
+  pricing?: AppServerReadThreadResponse["pricing"];
 };
 
 /**


### PR DESCRIPTION
## The bug

Open a thread as a chat card in the Star Map, turn on its context sidebar, and the rail reports the thread has nothing in it. Pricing says "No usage pricing recorded yet." while the full window shows a $13.68 summary for the same thread. Edits shows no files. AI providers reads "Status unavailable" on a machine whose providers are fine. Info calls every machine "Unknown".

## Why

`StarMapContextCard` renders the same `ThreadContextPanel` the full window does, but it was given only a `NavigationThreadSummary`. Every input that comes from somewhere else — the thread session, the operator's settings, the backend list, the platform — was absent or hardcoded (`backends={[]}`), so each panel rendered its empty state.

The thread session lives in `StarMapChatCard`, and the satellite is its **sibling**: `StarMapScreen` renders satellites because it owns their dock geometry and stacking, and an existing test pins that the rail must not render inside the card. So the session data cannot simply be a prop.

## The fix

**Session data** goes through a per-card publish/subscribe store (`star-map-card-context-store.ts`, the same `useSyncExternalStore` idiom as `useComposerDraftStore`). The card publishes under its card key; the satellite subscribes to that key, so an update wakes one satellite and nothing else on the map. Two alternatives were rejected: lifting the data into `StarMapScreen` re-renders the entire map on every pricing and transcript update, and mounting a second `useThreadSessionState` in the satellite re-reads the whole thread over the bridge and adds a second listener to the same live turn.

**Provider status** is read per satellite, keyed to the thread's own instance. A map holds cards over several peers at once, so reading once for the window would show local providers under a card pointing at a peer. The federation target is memoized by instance id: `useBackendSummaries` rebuilds `refresh` when its target changes identity and refetches on it, while a thread summary is replaced on every navigation poll and `readRendererFederationTarget()` builds a fresh object per call — handed over inline, that is a provider read on every render.

**Operator settings** (`threadPricingSummary`, `threadPricingDisplayUsd`, `threadPricingDisplayCodexCredits`) come from the settings snapshot `StarMapWindow` already holds. Without them the rail fell back to its own defaults and showed a thread's spend on a surface the operator had switched off, priced in the wrong currency for a Codex-credits account.

**Edits are pinned to the rail** (`editedFilesDock="sidebar"`). A chat card composes through `CompactComposer` and renders no above-composer work rail, so at the panel's "above" default the dock toggle came up accent-filled and `aria-pressed`, claiming a second copy that surface does not have.

## Performance

The card derives edited-file groups by walking its transcript, so this could not be keyed on `contextOpen`: the map unmounts every satellite at overview zoom and leaves that flag set, which would have the card walking its whole transcript on every streamed entry for a rail nobody can see. It is gated on a **live subscriber** instead — the store wakes cards when a key's subscriber set opens or empties, and a card with no reader derives nothing and publishes nothing. Demand changes at operator pace; the data it gates changes per streamed entry.

With a rail closed or zoomed out, the cost is zero: no walk, no publish, no subscription, no `listBackends`, no event listener. With one open, the panel shows one tab at a time and each is bounded by construction — Edits at `MAX_RETAINED_TURN_GROUPS` (10), Pricing at `PRICING_USAGE_PAGE_SIZE` (20) behind a show-more, Providers at the backend count. Provider reads are one IPC per satellite on mount, then only on account / rate-limit / provider-status events, against cached discovery.

Note the derivation itself is still O(transcript) per delta once a rail is open — that shape is pre-existing in `ThreadView` and is tracked separately; this PR only ensures nothing pays it while nothing is reading.

## Tests

Ten new tests across two files, each verified to fail against the unfixed code:

- Pricing shows the loaded thread's summary rather than "No usage pricing recorded yet."
- The Pricing tab disappears when the operator's setting is off.
- Edits shows the turn's edited files.
- Edits offers no above-composer dock.
- The Info tab names the platform instead of "Unknown".
- AI providers lists the host's backends instead of "Status unavailable".
- A peer thread's providers are read with the **peer's** federation target.
- The provider list is read once per mount, not once per render (without the memo the same test sees seven reads).
- A card derives nothing while no satellite is mounted, and starts deriving once one subscribes.

Assertions are scoped to the satellite's own subtree so they cannot pass on text rendered elsewhere in the window.

Full workspace suite green (592 files / 8529 tests), plus `typecheck`, `lint:eslint`, `lint:boundaries`. Desktop E2E not run locally — CI covers it.

## Known remaining gap

The experiment-gated Tool calls tab stays hidden in the map: `threadToolAccounting` defaults off, and the map does not plumb it, so it matches the default but not an operator who turned it on. Left for when that experiment graduates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
