### PR TITLE
feat(desktop): give the Star Map composer markdown and mid-turn sends

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -1,11 +1,14 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import type { ThreadExecutionMode } from "@pwragent/shared";
+import { ComposerTiptapInput } from "./ComposerTiptapInput";
+import type { ComposerSkillToken } from "./ComposerInputTypes";
 
 export type CompactComposerAction = {
   disabled?: boolean;
@@ -16,6 +19,12 @@ export type CompactComposerAction = {
 
 export type CompactComposerProps = {
   busy?: boolean;
+  /**
+   * Whether a send during a live turn can reach the backend at all. False
+   * disables the primary button while busy rather than letting the operator
+   * fire a send that is guaranteed to bounce.
+   */
+  canSteer?: boolean;
   disabled?: boolean;
   executionMode?: ThreadExecutionMode;
   /** Thread's current model, shown as ambient state rather than a control. */
@@ -39,6 +48,13 @@ const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
 };
 
 /**
+ * Module-level so the identity is stable: the Tiptap input re-syncs its
+ * document whenever this prop changes identity, and a fresh `[]` on every
+ * render would make that run on every keystroke.
+ */
+const NO_SKILL_TOKENS: ComposerSkillToken[] = [];
+
+/**
  * Composer for surfaces with no vertical budget — currently the star map's
  * floating chat cards.
  *
@@ -47,6 +63,19 @@ const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
  * launchpad state, and provider defaults that a floating card has no
  * access to. The two share a contract (send text, stop a running turn),
  * not an implementation.
+ *
+ * It does share the *input*: `ComposerTiptapInput` in markdown mode, the
+ * same editor the full composer types into. A card that renders a fully
+ * formatted transcript but takes replies through a plain textarea teaches
+ * the operator that backticks and fences do not work here, which is the
+ * opposite of true. The editor is not the expensive part of a card — each
+ * one already mounts a whole `TranscriptList` — so cards mount it eagerly
+ * rather than hydrating it on focus, which would cost a click and a caret
+ * every time the operator moved between cards.
+ *
+ * Mentions are the one thing left out: `$skill`, `@file`, and `#thread`
+ * need the backend list and directory index the card does not have, so no
+ * skill tokens are ever supplied and the trigger characters stay literal.
  *
  * Two moves buy back the height: secondary actions consolidate under a
  * single kebab, and model / reasoning effort render as right-aligned
@@ -58,6 +87,9 @@ export function CompactComposer(props: CompactComposerProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const { onSend } = props;
+  // Several cards can be open at once and the editor puts this on a DOM
+  // `id`; a shared literal would give the map duplicate ids.
+  const inputId = `compact-composer-${useId()}`;
 
   const ambient = [
     props.model,
@@ -79,12 +111,13 @@ export function CompactComposer(props: CompactComposerProps) {
     }
   }, [draft, onSend]);
 
+  // The editor forwards only the keys it does not claim itself: Enter
+  // without Shift or Alt (both of which insert a newline), and the arrows.
   const onKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key === "Enter" && !event.shiftKey) {
-        event.preventDefault();
-        void send();
-      }
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Enter" || event.metaKey || event.ctrlKey) return;
+      event.preventDefault();
+      void send();
     },
     [send],
   );
@@ -112,14 +145,15 @@ export function CompactComposer(props: CompactComposerProps) {
   return (
     <div className="compact-composer">
       <div className="compact-composer__field">
-        <textarea
-          aria-label={`Message ${props.threadTitle}`}
-          className="compact-composer__input"
+        <ComposerTiptapInput
           disabled={props.disabled}
-          onChange={(event) => setDraft(event.target.value)}
+          id={inputId}
+          label={`Message ${props.threadTitle}`}
+          markdownConversion
+          onChange={(value) => setDraft(value)}
           onKeyDown={onKeyDown}
           placeholder={props.placeholder ?? "Reply…"}
-          rows={2}
+          skillTokens={NO_SKILL_TOKENS}
           value={draft}
         />
         {ambient ? (
@@ -167,24 +201,31 @@ export function CompactComposer(props: CompactComposerProps) {
           </div>
         ) : null}
 
-        {props.busy ? (
+        {props.busy && props.onInterrupt ? (
           <button
-            className="compact-composer__send"
+            className="compact-composer__stop"
             onClick={props.onInterrupt}
             type="button"
           >
             Stop
           </button>
-        ) : (
-          <button
-            className="compact-composer__send"
-            disabled={props.disabled || draft.trim().length === 0}
-            onClick={() => void send()}
-            type="button"
-          >
-            Send
-          </button>
-        )}
+        ) : null}
+        {/* A live turn used to leave Stop as the only control, which read as
+            "you cannot say anything until this finishes". Sending stays
+            available and becomes a steer; the host reports back whether the
+            backend took it into the running turn or held it for the next. */}
+        <button
+          className="compact-composer__send"
+          disabled={
+            props.disabled
+            || draft.trim().length === 0
+            || (props.busy && props.canSteer === false)
+          }
+          onClick={() => void send()}
+          type="button"
+        >
+          {props.busy ? "Steer" : "Send"}
+        </button>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -116,10 +116,14 @@ export function CompactComposer(props: CompactComposerProps) {
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (event.key !== "Enter" || event.metaKey || event.ctrlKey) return;
+      // The button checks this too. A disabled `<textarea>` used to swallow
+      // the keydown for us; the editor only stops taking new text, and still
+      // forwards Enter from a field that was focused before it was disabled.
+      if (props.disabled) return;
       event.preventDefault();
       void send();
     },
-    [send],
+    [props.disabled, send],
   );
 
   // Click-away and Escape close the kebab. Without this the menu survives

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -52,6 +52,18 @@ describe("CompactComposer", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
+  it("does not send on Enter while disabled", () => {
+    // The button checks `disabled`; the key path has to agree. A disabled
+    // `<textarea>` used to swallow the keydown natively, but the editor only
+    // stops taking new text — a field focused before it was disabled still
+    // forwards Enter.
+    const { onSend } = renderComposer({ disabled: true });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "should not go" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it("shows model, effort, and access mode as one ambient string", () => {
     renderComposer({
       executionMode: "full-access",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -1,13 +1,29 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { CompactComposer } from "../CompactComposer";
 
 function renderComposer(overrides: Partial<Parameters<typeof CompactComposer>[0]> = {}) {
   const onSend = vi.fn();
-  render(
+  const view = render(
     <CompactComposer onSend={onSend} threadTitle="Thread t1" {...overrides} />,
   );
-  return { onSend };
+  return { ...view, onSend };
+}
+
+/**
+ * Paste is how the Tiptap suite drives markdown in: jsdom does not run the
+ * `beforeinput` machinery typing-based input rules need, and the paste rules
+ * exercise the same markdown parser.
+ */
+function pasteMarkdown(input: HTMLElement, text: string): void {
+  fireEvent.paste(input, {
+    clipboardData: {
+      files: [],
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+      items: [],
+      types: ["text/plain"],
+    },
+  });
 }
 
 describe("CompactComposer", () => {
@@ -54,12 +70,41 @@ describe("CompactComposer", () => {
     expect(screen.queryByRole("button", { name: "More actions" })).toBeNull();
   });
 
-  it("swaps Send for Stop while a turn is running", () => {
+  it("offers Steer alongside Stop while a turn is running", () => {
     const onInterrupt = vi.fn();
     renderComposer({ busy: true, onInterrupt });
+    // Stop used to be the only control, which read as "you cannot say
+    // anything until this finishes".
     expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Steer" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Stop" }));
     expect(onInterrupt).toHaveBeenCalledTimes(1);
+  });
+
+  it("steers the typed text into the running turn", async () => {
+    const { onSend } = renderComposer({ busy: true, onInterrupt: vi.fn() });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "also check the logs" } });
+    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith("also check the logs");
+    });
+  });
+
+  it("disables Steer when the running turn cannot take one", () => {
+    renderComposer({ busy: true, canSteer: false, onInterrupt: vi.fn() });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "no route for this" } });
+    // Better a dead button than a send that is guaranteed to bounce.
+    expect(
+      (screen.getByRole("button", { name: "Steer" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("keeps Stop hidden when the host offers no way to interrupt", () => {
+    renderComposer({ busy: true });
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
   });
 
   it("runs a secondary action and closes the menu", () => {
@@ -94,5 +139,53 @@ describe("CompactComposer", () => {
     fireEvent.click(screen.getByRole("button", { name: "More actions" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Compact thread" }));
     expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("CompactComposer markdown", () => {
+  it("formats inline code rather than leaving the backticks literal", async () => {
+    const { container } = renderComposer();
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    pasteMarkdown(input, "Can you deploy `pr-13598-3f3b862d1163`");
+
+    // The card renders a fully formatted transcript; a reply box that
+    // cannot format teaches the operator that markdown does not work here.
+    await waitFor(() => {
+      expect(container.querySelector("code")?.textContent).toBe(
+        "pr-13598-3f3b862d1163",
+      );
+    });
+  });
+
+  it("sends the markdown source, not the rendered text", async () => {
+    const { onSend } = renderComposer();
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    pasteMarkdown(input, "run `pnpm test` first");
+
+    await waitFor(() => {
+      expect(input.textContent).toContain("pnpm test");
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => {
+      // The backend reads markdown, so the backticks have to survive the
+      // trip through the editor.
+      expect(onSend).toHaveBeenCalledWith("run `pnpm test` first");
+    });
+  });
+
+  it("keeps a fenced block intact across the send", async () => {
+    const { onSend } = renderComposer();
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    pasteMarkdown(input, "```sh\npnpm lint\n```");
+
+    await waitFor(() => {
+      expect(input.querySelector("pre code")?.textContent).toContain(
+        "pnpm lint",
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith("```sh\npnpm lint\n```");
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -198,14 +198,27 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     }
   }, [bounds.width, bounds.height, cardKey, onRectChange]);
 
+  // The notice describes a turn ("steered into", "queued for the next"), so
+  // it is only true while that turn runs. Left alone it would sit on an idle
+  // card for hours claiming something is still in flight.
+  const threadBusy = session.threadBusy;
+  useEffect(() => {
+    if (!threadBusy) setSendNotice(undefined);
+  }, [threadBusy]);
+
   const activeTurnId = session.activeTurnId;
   /**
-   * A live turn is steerable when the bridge offers `steerTurn` and we know
-   * which turn to aim at. Backends that cannot steer reject the request, so
-   * this is an optimistic gate, not a capability check — the rejection is
+   * Structural only: whether this bridge can steer at all. Deliberately NOT
+   * "and we know which turn to aim at" — that is a moment-to-moment fact,
+   * and gating the button on it disables the card's only send control in a
+   * state the operator cannot see or get out of. A send that cannot be
+   * aimed yet is reported, not silently unavailable.
+   *
+   * Backends that cannot steer reject the request, so even this is an
+   * optimistic gate rather than a capability check; the rejection is
    * reported rather than swallowed.
    */
-  const canSteer = Boolean(desktopApi?.steerTurn && activeTurnId);
+  const canSteer = Boolean(desktopApi?.steerTurn);
 
   /**
    * Returns whether the turn actually reached the backend. A peer can drop
@@ -224,9 +237,21 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       setSendError(undefined);
       setSendNotice(undefined);
 
-      if (session.threadBusy && activeTurnId) {
+      if (session.threadBusy) {
         if (!desktopApi?.steerTurn) {
           setSendError("This thread is busy and steering is unavailable.");
+          return false;
+        }
+        if (!activeTurnId) {
+          // Do NOT fall through to `startTurn` here. A thread can report
+          // busy before its turn id is hydrated — a peer's or a messaging
+          // adapter's turn does exactly that — and starting a turn in that
+          // window is the second-turn-on-a-running-thread this whole branch
+          // exists to prevent. The id arrives with the next thread read, so
+          // this is worth retrying rather than routing around.
+          setSendError(
+            "Still identifying the running turn — try again in a moment.",
+          );
           return false;
         }
         const optimisticId = session.addOptimisticUserMessage(text);

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -85,6 +85,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const rectRef = useRef(rect);
   rectRef.current = rect;
   const [sendError, setSendError] = useState<string | undefined>(undefined);
+  // Where a mid-turn send actually landed. The operator cannot tell a steer
+  // from a queue by looking at the transcript, and the answer differs by
+  // backend, so the card says which one happened.
+  const [sendNotice, setSendNotice] = useState<string | undefined>(undefined);
   // The card is draggable and clipped; a native `title` fights both, and
   // UI-THEME.md rules it out regardless.
   const titleTooltip = useViewportTooltip({ className: "viewport-tooltip" });
@@ -194,16 +198,67 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     }
   }, [bounds.width, bounds.height, cardKey, onRectChange]);
 
+  const activeTurnId = session.activeTurnId;
+  /**
+   * A live turn is steerable when the bridge offers `steerTurn` and we know
+   * which turn to aim at. Backends that cannot steer reject the request, so
+   * this is an optimistic gate, not a capability check — the rejection is
+   * reported rather than swallowed.
+   */
+  const canSteer = Boolean(desktopApi?.steerTurn && activeTurnId);
+
   /**
    * Returns whether the turn actually reached the backend. A peer can drop
    * mid-send, and when it does the operator must get their text back and
    * the transcript must not keep an optimistic message for a turn that
    * never started.
+   *
+   * While a turn is running this steers instead of starting a new turn.
+   * `steerTurn` reports back whether the backend injected the message into
+   * the running turn or held it for the next one; either way the operator
+   * gets to type during a turn, which starting a second turn would not
+   * allow.
    */
   const send = useCallback(
     async (text: string): Promise<boolean> => {
-      if (!desktopApi?.startTurn) return false;
       setSendError(undefined);
+      setSendNotice(undefined);
+
+      if (session.threadBusy && activeTurnId) {
+        if (!desktopApi?.steerTurn) {
+          setSendError("This thread is busy and steering is unavailable.");
+          return false;
+        }
+        const optimisticId = session.addOptimisticUserMessage(text);
+        try {
+          const response = await desktopApi.steerTurn({
+            backend: thread.source,
+            expectedTurnId: activeTurnId,
+            federationTarget,
+            input: [{ type: "text", text }],
+            // Main dedupes retries by request id, so it has to be fresh per
+            // attempt or a corrected resend would return the first result.
+            requestId: `star-map-chat-card:${cardKey}:${activeTurnId}:${Date.now()}`,
+            threadId: thread.id,
+          });
+          setSendNotice(
+            response.disposition === "queued"
+              ? "Queued for the next turn."
+              : "Steered into the running turn.",
+          );
+          return true;
+        } catch (error) {
+          session.removeOptimisticMessage(optimisticId);
+          setSendError(
+            error instanceof Error
+              ? error.message
+              : "Could not steer that turn.",
+          );
+          return false;
+        }
+      }
+
+      if (!desktopApi?.startTurn) return false;
       const optimisticId = session.addOptimisticUserMessage(text);
       try {
         await desktopApi.startTurn({
@@ -223,10 +278,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         return false;
       }
     },
-    [desktopApi, federationTarget, session, thread],
+    [activeTurnId, cardKey, desktopApi, federationTarget, session, thread],
   );
 
-  const activeTurnId = session.activeTurnId;
   const interrupt = useCallback(async () => {
     if (!desktopApi?.interruptTurn || !activeTurnId) return;
     try {
@@ -429,10 +483,15 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         <p className="star-map-chat-card__error" role="alert">
           {sendError}
         </p>
+      ) : sendNotice ? (
+        <p className="star-map-chat-card__notice" role="status">
+          {sendNotice}
+        </p>
       ) : undefined}
 
       <CompactComposer
         busy={session.threadBusy}
+        canSteer={canSteer}
         executionMode={thread.executionMode}
         model={thread.model}
         onInterrupt={() => void interrupt()}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -15,7 +15,9 @@ const RECT = { left: 40, top: 40, width: 420, height: 520 };
  * card must route both reads and writes to that instance without the
  * thread ever being pinned or merged into the local snapshot.
  */
-function remoteThread(): NavigationThreadSummary {
+function remoteThread(
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
   return {
     id: "t-remote",
     title: "Remote work",
@@ -32,10 +34,13 @@ function remoteThread(): NavigationThreadSummary {
         target: { scope: "remote", instanceId: "pwr_peer" },
       },
     },
+    ...overrides,
   } as unknown as NavigationThreadSummary;
 }
 
-function localThread(): NavigationThreadSummary {
+function localThread(
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
   return {
     id: "t-local",
     title: "Local work",
@@ -44,6 +49,7 @@ function localThread(): NavigationThreadSummary {
     source: "codex",
     inbox: { inInbox: false },
     updatedAt: 1,
+    ...overrides,
   } as unknown as NavigationThreadSummary;
 }
 
@@ -87,12 +93,23 @@ function renderCard(params: {
   );
 }
 
+/**
+ * The composer is a Tiptap editor, not a textarea. It exposes a `value`
+ * setter on its contenteditable node exactly so a controlled-input idiom
+ * still drives it, which is what `fireEvent.change` reaches here.
+ */
 async function typeAndSend(title: string, text: string) {
   const input = screen.getByRole("textbox", { name: `Message ${title}` });
   fireEvent.change(input, { target: { value: text } });
   fireEvent.keyDown(input, { key: "Enter" });
-  return input as HTMLTextAreaElement;
+  return input as HTMLElement & { value: string };
 }
+
+/**
+ * Text queries match the composer's own content, so a draft would satisfy a
+ * "this reached the transcript" assertion on its own.
+ */
+const IGNORE_COMPOSER = ".composer-tiptap-input, .composer-tiptap-input *";
 
 describe("StarMapChatCard transcript loading", () => {
   it("asks for the last few turns rather than the whole thread", async () => {
@@ -209,11 +226,10 @@ describe("StarMapChatCard send failures", () => {
       expect(input.value).toBe("do not lose me");
     });
     // The transcript must not keep a message for a turn that never ran.
-    // The composer is excluded because the restored draft lives there and
-    // text queries match textarea content.
+    // The composer is excluded because the restored draft lives there.
     await waitFor(() => {
       expect(
-        screen.queryByText("do not lose me", { ignore: "textarea" }),
+        screen.queryByText("do not lose me", { ignore: IGNORE_COMPOSER }),
       ).toBeNull();
     });
     expect((await screen.findByRole("alert")).textContent).toMatch(
@@ -230,10 +246,8 @@ describe("StarMapChatCard send failures", () => {
     renderCard({ desktopApi, thread: remoteThread() });
     await typeAndSend("Remote work", "in flight");
 
-    // Ignore the composer: a textarea's content matches text queries, and
-    // the draft would otherwise satisfy this on its own.
     expect(
-      await screen.findByText("in flight", { ignore: "textarea" }),
+      await screen.findByText("in flight", { ignore: IGNORE_COMPOSER }),
     ).toBeTruthy();
   });
 });
@@ -302,5 +316,146 @@ describe("satellite toggles", () => {
     // are the screen's to render; the card only carries the toggles.
     const { container } = renderToggleCard({ contextOpen: true });
     expect(container.querySelector(".context-rail")).toBeNull();
+  });
+});
+
+/**
+ * A card over a running turn. Sending here has to reach the live turn: a
+ * `startTurn` while one is in flight is not a second conversation, it is a
+ * message the operator loses.
+ */
+describe("StarMapChatCard steering a live turn", () => {
+  /**
+   * The session hook takes "is a turn running" from the navigation snapshot
+   * as well as the thread read, and resyncs from the snapshot — so a card is
+   * only busy when both say so.
+   */
+  const BUSY = { threadStatus: "active" } as Partial<NavigationThreadSummary>;
+
+  function busyApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
+    return buildApi({
+      readThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t-local",
+        // A window that opens a thread mid-turn only learns the turn is
+        // running from the hydrated snapshot, and it adopts one only when
+        // the thread itself reports active.
+        threadStatus: "active",
+        replay: {
+          entries: [
+            {
+              type: "message",
+              id: "m-live",
+              role: "assistant",
+              text: "working on it",
+              parts: [{ type: "text", text: "working on it" }],
+              createdAt: 1,
+              turn: { id: "turn-live", status: "in_progress" },
+            },
+          ],
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+        },
+      })),
+      steerTurn: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t-local",
+        turnId: "turn-live",
+        disposition: "steered" as const,
+      })),
+      ...overrides,
+    } as unknown as Partial<DesktopApi>);
+  }
+
+  it("steers the running turn instead of starting a second one", async () => {
+    const desktopApi = busyApi();
+    renderCard({ desktopApi, thread: localThread(BUSY) });
+    await screen.findByRole("button", { name: "Steer" });
+    await typeAndSend("Local work", "also check the logs");
+
+    await waitFor(() => {
+      expect(desktopApi.steerTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          expectedTurnId: "turn-live",
+          input: [{ type: "text", text: "also check the logs" }],
+          threadId: "t-local",
+        }),
+      );
+    });
+    expect(desktopApi.startTurn).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("Steered into the running turn."),
+    ).toBeTruthy();
+  });
+
+  it("says so when the backend held the message for the next turn", async () => {
+    const desktopApi = busyApi({
+      steerTurn: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t-local",
+        turnId: "turn-live",
+        disposition: "queued",
+      })),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: localThread(BUSY) });
+    await screen.findByRole("button", { name: "Steer" });
+    await typeAndSend("Local work", "and then deploy");
+
+    // Steered and queued are both accepted sends that land in different
+    // places, and only the backend knows which happened.
+    expect(await screen.findByText("Queued for the next turn.")).toBeTruthy();
+  });
+
+  it("gives the text back when the backend refuses to steer", async () => {
+    const desktopApi = busyApi({
+      steerTurn: vi.fn(async () => {
+        throw new Error("Selected backend does not support turn/steer");
+      }),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: localThread(BUSY) });
+    await screen.findByRole("button", { name: "Steer" });
+    const input = await typeAndSend("Local work", "do not lose me");
+
+    await waitFor(() => {
+      expect(input.value).toBe("do not lose me");
+    });
+    expect((await screen.findByRole("alert")).textContent).toMatch(
+      /does not support turn\/steer/,
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByText("do not lose me", { ignore: IGNORE_COMPOSER }),
+      ).toBeNull();
+    });
+  });
+
+  it("keeps a peer's steer pointed at that peer", async () => {
+    const desktopApi = busyApi();
+    renderCard({ desktopApi, thread: remoteThread(BUSY) });
+    await screen.findByRole("button", { name: "Steer" });
+    await typeAndSend("Remote work", "over there");
+
+    await waitFor(() => {
+      expect(desktopApi.steerTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+        }),
+      );
+    });
+  });
+
+  it("disables the control when the bridge cannot steer at all", async () => {
+    const desktopApi = busyApi({ steerTurn: undefined });
+    renderCard({ desktopApi, thread: localThread(BUSY) });
+    const steer = (await screen.findByRole("button", {
+      name: "Steer",
+    })) as HTMLButtonElement;
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "no route for this" } });
+
+    await waitFor(() => {
+      expect(steer.disabled).toBe(true);
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -70,11 +70,13 @@ function buildApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
   } as unknown as DesktopApi;
 }
 
-function renderCard(params: {
+type CardParams = {
   desktopApi: DesktopApi;
   thread: NavigationThreadSummary;
-}) {
-  render(
+};
+
+function card(params: CardParams) {
+  return (
     <StarMapChatCard
       cardKey="card-1"
       desktopApi={params.desktopApi}
@@ -89,8 +91,13 @@ function renderCard(params: {
       onToggleContext={() => undefined}
       onToggleTerminal={() => undefined}
       zIndex={40}
-    />,
+    />
   );
+}
+
+function renderCard(params: CardParams) {
+  const view = render(card(params));
+  return view;
 }
 
 /**
@@ -442,6 +449,94 @@ describe("StarMapChatCard steering a live turn", () => {
           federationTarget: { scope: "remote", instanceId: "pwr_peer" },
         }),
       );
+    });
+  });
+
+  it("refuses to start a second turn before the running one is identified", async () => {
+    // A thread reports busy from the navigation snapshot before any turn id
+    // is hydrated — a peer's or a messaging adapter's turn does exactly
+    // this. Starting a turn in that window is the second-turn-on-a-running-
+    // thread the steer path exists to prevent.
+    const desktopApi = busyApi({
+      readThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t-local",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+        },
+      })),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: localThread(BUSY) });
+    const input = await typeAndSend("Local work", "do not double-turn");
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(
+      /Still identifying the running turn/,
+    );
+    expect(desktopApi.startTurn).not.toHaveBeenCalled();
+    expect(desktopApi.steerTurn).not.toHaveBeenCalled();
+    // Nothing reached the backend, so the operator keeps what they typed.
+    await waitFor(() => {
+      expect(input.value).toBe("do not double-turn");
+    });
+  });
+
+  it("leaves the control live so that refusal is reachable", async () => {
+    // Disabling here would hide the state behind a dead button the operator
+    // can neither use nor understand.
+    const desktopApi = busyApi({
+      readThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t-local",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+        },
+      })),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: localThread(BUSY) });
+    const steer = (await screen.findByRole("button", {
+      name: "Steer",
+    })) as HTMLButtonElement;
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "let me through" } });
+
+    await waitFor(() => {
+      expect(steer.disabled).toBe(false);
+    });
+  });
+
+  it("drops the landing notice once that turn is over", async () => {
+    // The notice describes a turn. Left alone it would sit on an idle card
+    // for hours still claiming something is in flight.
+    let emit: ((event: unknown) => void) | undefined;
+    const desktopApi = busyApi({
+      onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
+        emit = listener;
+        return () => undefined;
+      }),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: localThread(BUSY) });
+    await screen.findByRole("button", { name: "Steer" });
+    await typeAndSend("Local work", "also check the logs");
+    expect(
+      await screen.findByText("Steered into the running turn."),
+    ).toBeTruthy();
+
+    act(() => {
+      emit?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: { threadId: "t-local", turnId: "turn-live" },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Steered into the running turn.")).toBeNull();
     });
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12882,6 +12882,17 @@ textarea,
   font-size: 11px;
 }
 
+/* Same slot as the error line, muted: where a mid-turn send landed is
+   information, not a fault. */
+.star-map-chat-card__notice {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 5px 10px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 /* Compact composer: for surfaces with no vertical budget. Secondary
    actions collapse under the kebab and model/effort render as ambient text
    inside the field, so the whole control row stays one line tall. */
@@ -12900,24 +12911,33 @@ textarea,
   flex: 1 1 auto;
 }
 
-.compact-composer__input {
-  display: block;
-  width: 100%;
-  /* Right padding reserves the ambient model/effort strip so typed text
-     never runs underneath it. */
-  padding: 6px 8px 16px;
-  border: 1px solid var(--border-subtle);
+/* The field is the shared markdown editor, re-scaled. The base rule is
+   sized for the full composer (48px floor, 14px text, 12px padding); a
+   floating card cannot spend that, so everything here is a measurement
+   override and nothing here is a color or a border — those stay with the
+   one definition in the base rule. */
+.compact-composer .composer-tiptap-input {
+  min-height: 44px;
+  /* ~5 lines at 12/1.5. Past that the card's transcript is what should
+     give way, and the operator has the full thread view for a long draft. */
+  max-height: 108px;
   border-radius: 6px;
-  background: var(--bg-input);
-  color: var(--text-primary);
-  font: inherit;
   font-size: 12px;
-  resize: none;
+  line-height: 1.5;
 }
 
-.compact-composer__input:focus-visible {
-  border-color: var(--accent-border);
-  outline: none;
+.compact-composer .composer-tiptap-input__editor {
+  min-height: 42px;
+  /* Bottom padding reserves the ambient model/effort strip so typed text
+     never runs underneath it. */
+  padding: 6px 8px 16px;
+}
+
+.compact-composer
+  .composer-tiptap-input.is-empty
+  .composer-tiptap-input__editor::before {
+  top: 6px;
+  left: 8px;
 }
 
 .compact-composer__ambient {
@@ -13012,6 +13032,24 @@ textarea,
   background: transparent;
   color: var(--text-muted);
   cursor: default;
+}
+
+/* Sits beside Send during a live turn, so it reads as the secondary of the
+   two rather than as a second accent button competing with it. */
+.compact-composer__stop {
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.compact-composer__stop:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
 }
 
 /* Bottom-right resize grip. Sized for a comfortable pointer target


### PR DESCRIPTION
Two gaps in the Star Map chat card's composer, both reported from the same screenshot: backticks typed into a card stayed literal, and a live turn offered nothing but **Stop**.

## Markdown

`CompactComposer` used a plain `<textarea>`. The card renders a fully formatted transcript above it, so a reply box that cannot format actively teaches the operator that markdown does not work here — the opposite of true.

It now uses `ComposerTiptapInput` with `markdownConversion`, the same editor the full composer types into. The component was already self-contained: it needs a value, an `onChange`, and a (here always empty) skill-token array, not the backend list or launchpad state the card has no access to.

**On the "hydrate only the focused card" idea** — it isn't needed. Each card already mounts a whole `TranscriptList`; a ProseMirror instance is small next to that, and the number of open cards is operator-driven. Hydrating on focus would cost a click and a caret every time the operator moved between cards, to save something the card is already spending ten times over. Cards mount the editor eagerly.

Mentions are the one thing left out. `$skill`, `@file`, and `#thread` need the backend list and directory index the card does not have, so no skill tokens are ever supplied and those trigger characters stay literal.

## Queue / steer during a live turn

There was no way to tell whether a card could queue or steer, because it could not: `send` only ever called `startTurn`, and the composer hid Send entirely while busy.

A mid-turn send now goes through `steerTurn` against the running turn, with the button labelled **Steer** and **Stop** beside it rather than instead of it. `steerTurn` already resolves to `steered` (injected into the running turn) or `queued` (held for the next one) depending on the backend, so the card reports which one happened — that distinction is not visible in the transcript and only the backend knows it.

This is deliberately not the full composer's queued-turn machinery (durable queue rows, scheduled sends, per-item Steer buttons). The card gets the one behavior that was missing: the operator can type during a turn and have it land somewhere real.

Failures give the text back and surface the reason, same contract as the existing `startTurn` path. When the bridge offers no `steerTurn` at all, the button is disabled rather than firing a send guaranteed to bounce.

## Gesture guards

No new handling needed — `isStarMapTypingTarget` already excludes any `contenteditable`, and both `shouldPanOnWheel` and `shouldStartCanvasPan` already exclude `.star-map-chat-card`.

## Tests

`CompactComposer.test.tsx`: inline code renders as `<code>` and the backticks survive the send; a fenced block round-trips; Steer appears alongside Stop and calls through; Steer is disabled when the host says a steer cannot land; Stop stays hidden with no `onInterrupt`.

`StarMapChatCard.test.tsx`: a busy card steers instead of starting a second turn; a `queued` disposition is reported as such; a refused steer restores the draft, rolls back the optimistic message, and shows the reason; a peer's steer stays pointed at that peer. The existing suite drives the editor through the `value` setter it exposes on its contenteditable node, so `typeAndSend` needed only a type change.

## Verification

- `pnpm test apps/desktop/src/renderer` — 193 files, 3066 tests, all pass
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries` — all pass

Not run: desktop E2E and the a11y gate, which are not run on this machine. The a11y spec audits the Star Map window but never opens a chat card, so the new editor is not in its scope; the identical markup is already audited through the main composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)