### PR TITLE
feat(desktop): give the Star Map chat card working mentions

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -8,7 +8,10 @@ import {
 } from "react";
 import type { ThreadExecutionMode } from "@pwragent/shared";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
-import type { ComposerSkillToken } from "./ComposerInputTypes";
+import {
+  useComposerMentions,
+  type ComposerMentionSources,
+} from "./useComposerMentions";
 
 export type CompactComposerAction = {
   disabled?: boolean;
@@ -27,6 +30,12 @@ export type CompactComposerProps = {
   canSteer?: boolean;
   disabled?: boolean;
   executionMode?: ThreadExecutionMode;
+  /**
+   * Populations the `$` / `@` / `#` popovers pick from. Optional on
+   * purpose: a host that supplies nothing keeps the trigger characters as
+   * literal prose, so adopting this component never requires them.
+   */
+  mentionSources?: ComposerMentionSources;
   /** Thread's current model, shown as ambient state rather than a control. */
   model?: string;
   onInterrupt?: () => void;
@@ -48,13 +57,6 @@ const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
 };
 
 /**
- * Module-level so the identity is stable: the Tiptap input re-syncs its
- * document whenever this prop changes identity, and a fresh `[]` on every
- * render would make that run on every keystroke.
- */
-const NO_SKILL_TOKENS: ComposerSkillToken[] = [];
-
-/**
  * Composer for surfaces with no vertical budget — currently the star map's
  * floating chat cards.
  *
@@ -73,9 +75,10 @@ const NO_SKILL_TOKENS: ComposerSkillToken[] = [];
  * rather than hydrating it on focus, which would cost a click and a caret
  * every time the operator moved between cards.
  *
- * Mentions are the one thing left out: `$skill`, `@file`, and `#thread`
- * need the backend list and directory index the card does not have, so no
- * skill tokens are ever supplied and the trigger characters stay literal.
+ * Mentions come from `useComposerMentions`, driven by whatever populations
+ * the host can honestly supply through `mentionSources`. Nothing about the
+ * pickers is re-implemented here: the triggers, ranking, token minting and
+ * markdown serialization are the same modules the full composer calls.
  *
  * Two moves buy back the height: secondary actions consolidate under a
  * single kebab, and model / reasoning effort render as right-aligned
@@ -83,7 +86,7 @@ const NO_SKILL_TOKENS: ComposerSkillToken[] = [];
  * state to be aware of, not controls to reach for.
  */
 export function CompactComposer(props: CompactComposerProps) {
-  const [draft, setDraft] = useState("");
+  const mentions = useComposerMentions({ sources: props.mentionSources });
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const { onSend } = props;
@@ -100,21 +103,28 @@ export function CompactComposer(props: CompactComposerProps) {
     .join(" · ");
 
   const send = useCallback(async () => {
-    const text = draft.trim();
+    // The serialized text, not the plain draft: a mention chip is
+    // zero-width until this splices its markdown back in.
+    const text = mentions.text.trim();
     if (!text) return;
     // Clear optimistically so the input frees up immediately, then put the
-    // text back if the send turned out to fail.
-    setDraft("");
+    // draft back — chips and all — if the send turned out to fail.
+    const previous = mentions.snapshot;
+    mentions.clear();
     const delivered = await onSend(text);
     if (delivered === false) {
-      setDraft((current) => (current.length > 0 ? current : text));
+      mentions.restore(previous);
     }
-  }, [draft, onSend]);
+  }, [mentions, onSend]);
 
-  // The editor forwards only the keys it does not claim itself: Enter
-  // without Shift or Alt (both of which insert a newline), and the arrows.
+  // The editor forwards the keys it does not claim itself: Enter without
+  // Shift or Alt (both of which insert a newline), the arrows, and anything
+  // it has no binding for — Escape and Tab among them.
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      // An open mention popover claims the arrows, Enter, Tab, and Escape
+      // before the send path sees them.
+      if (mentions.handleKeyDown(event)) return;
       if (event.key !== "Enter" || event.metaKey || event.ctrlKey) return;
       // The button checks this too. A disabled `<textarea>` used to swallow
       // the keydown for us; the editor only stops taking new text, and still
@@ -123,7 +133,7 @@ export function CompactComposer(props: CompactComposerProps) {
       event.preventDefault();
       void send();
     },
-    [props.disabled, send],
+    [mentions, props.disabled, send],
   );
 
   // Click-away and Escape close the kebab. Without this the menu survives
@@ -150,16 +160,24 @@ export function CompactComposer(props: CompactComposerProps) {
     <div className="compact-composer">
       <div className="compact-composer__field">
         <ComposerTiptapInput
+          ref={mentions.inputRef}
+          ariaActiveDescendant={mentions.activeOptionId}
+          ariaControls={mentions.listboxId}
+          ariaExpanded={mentions.open}
           disabled={props.disabled}
           id={inputId}
           label={`Message ${props.threadTitle}`}
           markdownConversion
-          onChange={(value) => setDraft(value)}
+          onChange={mentions.handleChange}
           onKeyDown={onKeyDown}
           placeholder={props.placeholder ?? "Reply…"}
-          skillTokens={NO_SKILL_TOKENS}
-          value={draft}
+          skillTokens={mentions.skillTokens}
+          value={mentions.draft}
         />
+        {/* Inside the field, not portalled to the body: on the star map
+            that is what keeps the list within `.star-map-chat-card`, the
+            selector every camera-gesture guard tests against. */}
+        {mentions.popover}
         {ambient ? (
           // Ambient, not interactive: the label belongs to the input, so
           // screen readers reach it through the field rather than as a
@@ -222,7 +240,7 @@ export function CompactComposer(props: CompactComposerProps) {
           className="compact-composer__send"
           disabled={
             props.disabled
-            || draft.trim().length === 0
+            || mentions.text.trim().length === 0
             || (props.busy && props.canSteer === false)
           }
           onClick={() => void send()}

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -86,7 +86,10 @@ const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
  * state to be aware of, not controls to reach for.
  */
 export function CompactComposer(props: CompactComposerProps) {
-  const mentions = useComposerMentions({ sources: props.mentionSources });
+  const mentions = useComposerMentions({
+    disabled: props.disabled,
+    sources: props.mentionSources,
+  });
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const { onSend } = props;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -47,7 +47,6 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
-  buildPullRequestStatusKey,
   buildThreadIdentityKey,
   buildThreadMarkdownLink,
   buildThreadUrl,
@@ -58,7 +57,6 @@ import {
   normalizeGitOriginUrl,
   parseThreadUrl,
   readCodexEnvironmentActionRuns,
-  threadHasExactPrNumberMatch,
 } from "@pwragent/shared";
 import {
   BranchIcon,
@@ -104,8 +102,8 @@ import {
 } from "../../lib/directory-references";
 import { expandTildePath } from "../../lib/tildify-path";
 import {
-  collapseHashReferenceWhitespace,
-  filterHashReferenceCandidates,
+  buildHashReferenceOptions,
+  describeHashReferenceThread,
   findHashReferenceTrigger,
   formatHashReferenceThreadLabel,
   formatHashReferenceThreadTooltip,
@@ -158,6 +156,19 @@ import {
   type ComposerInputHandle,
   type ComposerSkillToken,
 } from "./ComposerInputTypes";
+import {
+  adjustSkillTokenIndexesForTextChange,
+  createComposerDirectoryToken,
+  createComposerFileToken,
+  createComposerPullRequestToken,
+  createComposerSkillToken,
+  createComposerThreadToken,
+  filterSkillAutocompleteCandidates,
+  getComposerSkillTokensSignature,
+  resolveThreadSummaryReference,
+  serializeDraftWithSkillTokens,
+} from "./composer-mention-tokens";
+import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
 import { ProjectPicker } from "./ProjectPicker";
 import {
@@ -1401,167 +1412,6 @@ function reviewSubmissionKey(command: {
  * populations ($ skills, / commands, @ directories) keep the leading-run
  * highlight so the emphasis always sits on what was typed.
  */
-function HighlightedAutocompleteLabel(props: {
-  label: string;
-  matchAnywhere?: boolean;
-  query: string;
-}) {
-  const matchIndex = !props.query
-    ? -1
-    : props.matchAnywhere
-      ? props.label.toLowerCase().indexOf(props.query.toLowerCase())
-      : props.label.toLowerCase().startsWith(props.query.toLowerCase())
-        ? 0
-        : -1;
-  if (matchIndex < 0) {
-    return <span>{props.label}</span>;
-  }
-
-  return (
-    <span>
-      {props.label.slice(0, matchIndex)}
-      <span className="composer__autocomplete-match">
-        {props.label.slice(matchIndex, matchIndex + props.query.length)}
-      </span>
-      {props.label.slice(matchIndex + props.query.length)}
-    </span>
-  );
-}
-
-function describeHashReferenceThread(
-  thread: NavigationThreadSummary,
-  query: string,
-): string {
-  const parts: string[] = [];
-  const pullRequest = threadHasExactPrNumberMatch(thread, query)
-    ? (thread.prs ?? []).find(
-        (candidate) => candidate.number === Number(query.trim()),
-      )
-    : (thread.prs ?? [])[0];
-  if (pullRequest) {
-    parts.push(`#${pullRequest.number}`);
-  }
-  if (thread.gitBranch) {
-    parts.push(thread.gitBranch);
-  }
-  const directory = (thread.linkedDirectories ?? [])[0];
-  if (directory?.label) {
-    parts.push(directory.label);
-  }
-  if (parts.length > 0) {
-    return parts.join(" · ");
-  }
-  // The id is the last-resort disambiguator between same-named threads. A
-  // thread with no title is already showing that same id as its label, so
-  // repeating it here would just print the uuid twice.
-  return collapseHashReferenceWhitespace(thread.title) ? thread.id : "";
-}
-
-function createComposerSkillToken(
-  skill: AppServerSkillSummary,
-  index: number,
-): ComposerSkillToken {
-  return {
-    ...skill,
-    id: `${skill.path ?? skill.name}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
-    index,
-  };
-}
-
-function createComposerDirectoryToken(
-  directory: Pick<NavigationDirectorySummary, "label" | "path">,
-  index: number,
-): ComposerSkillToken {
-  return {
-    kind: "directory",
-    name: directory.label,
-    path: directory.path,
-    id: `${directory.path ?? directory.label}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
-    index,
-  };
-}
-
-// Exported for the `@`-popover / picker surfaces that mint file-reference
-// chips; the drop/paste tray uses the pill list instead of chips.
-export function createComposerFileToken(
-  file: { label: string; path: string },
-  index: number,
-): ComposerSkillToken {
-  return {
-    kind: "file",
-    name: file.label,
-    path: file.path,
-    id: `${file.path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
-    index,
-  };
-}
-
-function createComposerThreadToken(
-  thread: ResolvedThreadLink,
-  index: number,
-): ComposerSkillToken {
-  const path = buildThreadUrl({
-    backend: thread.backend,
-    ...(thread.instanceId ? { instanceId: thread.instanceId } : {}),
-    threadId: thread.threadId,
-  });
-  return {
-    kind: "thread",
-    // Every thread chip is minted here — picker, pasted url, and the draft
-    // rehydrate that rebuilds tokens from the live thread summary rather
-    // than from the saved link text. Formatting at the choke point is what
-    // makes the clamp survive a restore, and it makes the round trip
-    // converge: `format` of an already-formatted title is itself.
-    name: formatHashReferenceThreadLabel({
-      id: thread.threadId,
-      title: thread.title,
-    }),
-    path,
-    id: `${path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
-    index,
-  };
-}
-
-function createComposerPullRequestToken(
-  pullRequest: PrSummary,
-  index: number,
-): ComposerSkillToken {
-  return {
-    kind: "pull-request",
-    name: `#${pullRequest.number}`,
-    path: pullRequest.url,
-    description: pullRequest.title,
-    shortDescription: `${pullRequest.org}/${pullRequest.repo}`,
-    id: `${pullRequest.url}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
-    index,
-    // Every PR chip in the composer is minted here — picker, pasted URL, and
-    // draft rehydration — so this is the one place the chip's status can be
-    // read off the summary. A summary that carries no status at all resolves
-    // to the same "unknown" gray the chip renders without it, so a PR nothing
-    // has observed is not dressed up as a state we know.
-    prChipModifiers: prChipModifierClasses(
-      resolvePrChipPresentation(pullRequest),
-    ),
-  };
-}
-
-function resolveThreadSummaryReference(
-  thread: NavigationThreadSummary,
-): ResolvedThreadLink {
-  const federationTarget = thread.federation?.ref.target;
-  return {
-    backend: thread.source,
-    ...(federationTarget && isRemoteFederationTarget(federationTarget)
-      ? { instanceId: federationTarget.instanceId }
-      : {}),
-    threadId: thread.id,
-    title: thread.title,
-    titleSource: thread.titleSource,
-    gitBranch: thread.gitBranch,
-    linkedDirectories: thread.linkedDirectories,
-  };
-}
-
 /**
  * Append path-only file references to outgoing text as one
  * `[@label](~/path)` line per file, separated from the typed draft by a
@@ -1721,71 +1571,6 @@ function mergeDerivedLocalFileInputs(
   return merged;
 }
 
-function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): string {
-  return JSON.stringify(
-    skillTokens.map((token) => ({
-      id: token.id,
-      index: token.index,
-      kind: token.kind,
-      name: token.name,
-      path: token.path,
-    })),
-  );
-}
-
-function clampSkillTokenIndex(index: number, draft: string): number {
-  return Math.max(0, Math.min(index, draft.length));
-}
-
-function serializeDraftWithSkillTokens(
-  draft: string,
-  skillTokens: ComposerSkillToken[],
-): string {
-  if (skillTokens.length === 0) {
-    return draft;
-  }
-
-  const sortedTokens = [...skillTokens].sort((left, right) => {
-    if (left.index !== right.index) {
-      return left.index - right.index;
-    }
-    return left.id.localeCompare(right.id);
-  });
-
-  let output = "";
-  let cursor = 0;
-  for (const token of sortedTokens) {
-    const index = clampSkillTokenIndex(token.index, draft);
-    output += draft.slice(cursor, index);
-    // Directory- and file-reference chips serialize to `[@label](~/path)`
-    // markdown — the parens bound the path so adjacent text can't glue
-    // onto it, the transcript renders it back as a chip, and
-    // hydrateComposerDraft rebuilds the token from a prompt-only restore.
-    // Skills keep their `[$name](path)` markdown.
-    if (token.kind === "directory" || token.kind === "file") {
-      output += buildDirectoryReferenceMarkdown({
-        label: token.name,
-        path: token.path ?? "",
-      });
-    } else if (token.kind === "thread") {
-      const ref = parseThreadUrl(token.path ?? "");
-      output += ref
-        ? buildThreadMarkdownLink({ ...ref, title: token.name })
-        : token.path ?? token.name;
-    } else if (token.kind === "pull-request") {
-      output += token.path
-        ? `[${token.name}](${token.path})`
-        : token.name;
-    } else {
-      output += buildSkillMentionMarkdown(token);
-    }
-    cursor = index;
-  }
-
-  output += draft.slice(cursor);
-  return output;
-}
-
 function hydrateComposerDraft(
   canonicalDraft: string,
   skills: AppServerSkillSummary[],
@@ -1874,92 +1659,6 @@ function hydrateComposerDraft(
   hydrateSkillAndDirectoryParts(canonicalDraft.slice(cursor));
 
   return { draft, skillTokens };
-}
-
-function adjustSkillTokenIndexesForTextChange(params: {
-  currentDraft: string;
-  nextDraft: string;
-  skillTokens: ComposerSkillToken[];
-}): ComposerSkillToken[] {
-  const { currentDraft, nextDraft, skillTokens } = params;
-  if (currentDraft === nextDraft || skillTokens.length === 0) {
-    return skillTokens;
-  }
-
-  let prefixLength = 0;
-  while (
-    prefixLength < currentDraft.length &&
-    prefixLength < nextDraft.length &&
-    currentDraft[prefixLength] === nextDraft[prefixLength]
-  ) {
-    prefixLength += 1;
-  }
-
-  let suffixLength = 0;
-  while (
-    suffixLength < currentDraft.length - prefixLength &&
-    suffixLength < nextDraft.length - prefixLength &&
-    currentDraft[currentDraft.length - 1 - suffixLength] ===
-      nextDraft[nextDraft.length - 1 - suffixLength]
-  ) {
-    suffixLength += 1;
-  }
-
-  const currentChangedEnd = currentDraft.length - suffixLength;
-  const nextChangedEnd = nextDraft.length - suffixLength;
-  const delta = nextChangedEnd - currentChangedEnd;
-
-  return skillTokens.map((token) => {
-    if (token.index <= prefixLength) {
-      return token;
-    }
-
-    if (token.index >= currentChangedEnd) {
-      return {
-        ...token,
-        index: clampSkillTokenIndex(token.index + delta, nextDraft),
-      };
-    }
-
-    return {
-      ...token,
-      index: clampSkillTokenIndex(prefixLength, nextDraft),
-    };
-  });
-}
-
-function rankSkillAutocompleteMatch(
-  skill: AppServerSkillSummary,
-  normalizedQuery: string,
-): number | undefined {
-  if (!normalizedQuery) {
-    return 0;
-  }
-
-  const name = skill.name.toLowerCase();
-  const shortDescription = skill.shortDescription?.toLowerCase() ?? "";
-  const description = skill.description?.toLowerCase() ?? "";
-
-  if (name === normalizedQuery) {
-    return 0;
-  }
-  if (name.startsWith(`${normalizedQuery}:`)) {
-    return 1;
-  }
-  if (name.startsWith(normalizedQuery)) {
-    return 2;
-  }
-  if (name.includes(normalizedQuery)) {
-    return 3;
-  }
-  if (shortDescription.includes(normalizedQuery)) {
-    return 4;
-  }
-  if (description.includes(normalizedQuery)) {
-    return 5;
-  }
-
-  return undefined;
 }
 
 function ComposerThreadOptionsMenu(props: {
@@ -4565,26 +4264,7 @@ export function Composer(props: ComposerProps) {
       return [];
     }
 
-    const normalizedQuery = trigger.query.trim().toLowerCase();
-    return props.skills
-      .map((skill, index) => ({
-        index,
-        score: skill.path
-          ? rankSkillAutocompleteMatch(skill, normalizedQuery)
-          : undefined,
-        skill,
-      }))
-      .filter(
-        (match): match is { index: number; score: number; skill: AppServerSkillSummary } =>
-          match.score !== undefined
-      )
-      .sort((left, right) => {
-        if (left.score !== right.score) {
-          return left.score - right.score;
-        }
-        return left.index - right.index;
-      })
-      .map((match) => match.skill);
+    return filterSkillAutocompleteCandidates(props.skills, trigger.query);
   }, [props.skills, trigger]);
   const slashCommandSuggestions = useMemo(() => {
     const commands =
@@ -4632,65 +4312,14 @@ export function Composer(props: ComposerProps) {
     if (!hashReferenceTrigger) {
       return [];
     }
-    // Referencing the thread you are writing in tells the agent nothing it
-    // does not already have, and on a bare `#` the current thread is the
-    // most recently updated one — so it would otherwise take the first row.
-    const currentThreadKey = props.thread
-      ? buildThreadIdentityKey(props.thread.source, props.thread.id)
-      : undefined;
-    const isCurrentThread = (thread: NavigationThreadSummary): boolean =>
-      currentThreadKey !== undefined
-      && buildThreadIdentityKey(thread.source, thread.id) === currentThreadKey;
-    const localCandidates = filterHashReferenceCandidates(
-      (props.threads ?? []).filter((thread) => !isCurrentThread(thread)),
-      hashReferenceTrigger.query,
-    );
-    const localThreadKeys = new Set(
-      (props.threads ?? []).map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id),
-      ),
-    );
-    const remoteCandidates = filterHashReferenceCandidates(
-      federatedHashSearchResults.filter(
-        (thread) =>
-          thread.federation?.ref.target.scope === "remote"
-          && !isCurrentThread(thread)
-          && !localThreadKeys.has(
-            buildThreadIdentityKey(thread.source, thread.id),
-          ),
-      ),
-      hashReferenceTrigger.query,
-    );
-    const localPullRequestKeys = new Set(
-      localCandidates.pullRequests.map(buildPullRequestStatusKey),
-    );
-    return [
-      ...localCandidates.threads.map((thread) => ({
-        kind: "thread" as const,
-        remote: false,
-        thread,
-      })),
-      ...localCandidates.pullRequests.map((pullRequest) => ({
-        kind: "pull-request" as const,
-        pullRequest,
-        remote: false,
-      })),
-      ...remoteCandidates.threads.map((thread) => ({
-        kind: "thread" as const,
-        remote: true,
-        thread,
-      })),
-      ...remoteCandidates.pullRequests
-        .filter(
-          (pullRequest) =>
-            !localPullRequestKeys.has(buildPullRequestStatusKey(pullRequest)),
-        )
-        .map((pullRequest) => ({
-          kind: "pull-request" as const,
-          pullRequest,
-          remote: true,
-        })),
-    ];
+    return buildHashReferenceOptions({
+      currentThreadKey: props.thread
+        ? buildThreadIdentityKey(props.thread.source, props.thread.id)
+        : undefined,
+      localThreads: props.threads ?? [],
+      query: hashReferenceTrigger.query,
+      remoteThreads: federatedHashSearchResults,
+    });
   }, [
     federatedHashSearchResults,
     hashReferenceTrigger,

--- a/apps/desktop/src/renderer/src/features/composer/HighlightedAutocompleteLabel.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/HighlightedAutocompleteLabel.tsx
@@ -1,0 +1,35 @@
+/**
+ * The matched run of an autocomplete row's label, marked up so the operator
+ * can see why a row is in the list.
+ *
+ * Its own module because more than one composer surface renders
+ * autocomplete rows, and a second copy would be free to drift on which
+ * span carries `.composer__autocomplete-match` — the one thing every
+ * surface's highlight styling hangs off.
+ */
+export function HighlightedAutocompleteLabel(props: {
+  label: string;
+  matchAnywhere?: boolean;
+  query: string;
+}) {
+  const matchIndex = !props.query
+    ? -1
+    : props.matchAnywhere
+      ? props.label.toLowerCase().indexOf(props.query.toLowerCase())
+      : props.label.toLowerCase().startsWith(props.query.toLowerCase())
+        ? 0
+        : -1;
+  if (matchIndex < 0) {
+    return <span>{props.label}</span>;
+  }
+
+  return (
+    <span>
+      {props.label.slice(0, matchIndex)}
+      <span className="composer__autocomplete-match">
+        {props.label.slice(matchIndex, matchIndex + props.query.length)}
+      </span>
+      {props.label.slice(matchIndex + props.query.length)}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -1,5 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type {
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { CompactComposer } from "../CompactComposer";
 
 function renderComposer(overrides: Partial<Parameters<typeof CompactComposer>[0]> = {}) {
@@ -198,6 +202,246 @@ describe("CompactComposer markdown", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
     await waitFor(() => {
       expect(onSend).toHaveBeenCalledWith("```sh\npnpm lint\n```");
+    });
+  });
+
+  describe("mentions", () => {
+    const SKILLS = [
+      { name: "deploy", path: "/skills/deploy.md", shortDescription: "Ship it" },
+      { name: "debug", path: "/skills/debug.md" },
+    ];
+    function thread(
+      overrides: Partial<NavigationThreadSummary>,
+    ): NavigationThreadSummary {
+      return {
+        titleSource: "generated",
+        source: "codex",
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+        updatedAt: 1,
+        ...overrides,
+      } as NavigationThreadSummary;
+    }
+
+    function openPicker(value: string) {
+      const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+      fireEvent.change(input, { target: { value } });
+      return input;
+    }
+
+    it("leaves every trigger literal when no sources are supplied", () => {
+      // The default has to stay exactly what it was before mentions
+      // existed: `CompactComposer` is shared, and a host that knows
+      // nothing about `mentionSources` must not start opening pickers.
+      const { onSend } = renderComposer();
+      const input = openPicker("ask $deploy about @app and #42");
+      expect(screen.queryByRole("listbox")).toBeNull();
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith("ask $deploy about @app and #42");
+    });
+
+    it("opens the skill picker on $ and serializes the chip as markdown", () => {
+      const { container, onSend } = renderComposer({
+        mentionSources: { skills: SKILLS },
+      });
+      const input = openPicker("run $dep");
+      const options = screen.getAllByRole("option");
+      expect(options.map((option) => option.textContent)).toEqual([
+        "$deployShip it",
+      ]);
+
+      fireEvent.click(options[0]!);
+      // The chip is zero-width in the plain draft, so the rendered mention
+      // node is the only evidence it landed as a chip and not as text.
+      expect(
+        container.querySelector(".composer-tiptap-input__mention")?.textContent,
+      ).toBe("$deploy");
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith("run [$deploy](/skills/deploy.md)");
+    });
+
+    it("opens the directory picker on @ and serializes a tilde link", () => {
+      const { onSend } = renderComposer({
+        mentionSources: {
+          directories: [
+            {
+              key: "d-app",
+              kind: "directory",
+              label: "app",
+              path: "/dev/app",
+            } as NavigationDirectorySummary,
+          ],
+        },
+      });
+      const input = openPicker("look in @ap");
+      fireEvent.click(screen.getByRole("option"));
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith("look in [@app](/dev/app)");
+    });
+
+    it("offers threads on # and serializes the thread url", () => {
+      const { onSend } = renderComposer({
+        mentionSources: {
+          threads: [thread({ id: "t-42", title: "Ship the release" })],
+        },
+      });
+      const input = openPicker("see #Ship");
+      fireEvent.click(screen.getByRole("option"));
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith(
+        "see [Ship the release](pwragent://thread/t-42?backend=codex)",
+      );
+    });
+
+    it("offers a pull request on a numeric # and keeps its url", () => {
+      const { onSend } = renderComposer({
+        mentionSources: {
+          threads: [
+            thread({
+              id: "t-42",
+              title: "Ship the release",
+              prs: [
+                {
+                  provider: "github.com",
+                  state: "passing",
+                  number: 118,
+                  org: "pwrdrvr",
+                  repo: "PwrAgnt",
+                  title: "Fix the thing",
+                  url: "https://github.com/pwrdrvr/PwrAgnt/pull/118",
+                },
+              ],
+            }),
+          ],
+        },
+      });
+      const input = openPicker("about #118");
+      const pullRequest = screen
+        .getAllByRole("option")
+        .find((option) => option.textContent?.startsWith("#118"));
+      fireEvent.click(pullRequest!);
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith(
+        "about [#118](https://github.com/pwrdrvr/PwrAgnt/pull/118)",
+      );
+    });
+
+    it("keeps a trigger with no matches as literal text", () => {
+      const { onSend } = renderComposer({
+        mentionSources: { skills: SKILLS },
+      });
+      const input = openPicker("run $nothinghere");
+      expect(screen.queryByRole("listbox")).toBeNull();
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith("run $nothinghere");
+    });
+
+    it("gives arrows and Enter to the picker before the send path", () => {
+      const { onSend } = renderComposer({
+        mentionSources: { skills: SKILLS },
+      });
+      const input = openPicker("run $de");
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "Enter" });
+      // Enter committed the second row instead of sending the draft.
+      expect(onSend).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith("run [$debug](/skills/debug.md)");
+    });
+
+    it("hands Enter back to the send path once Escape closes the picker", () => {
+      const { onSend } = renderComposer({
+        mentionSources: { skills: SKILLS },
+      });
+      const input = openPicker("run $dep");
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(screen.queryByRole("listbox")).toBeNull();
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith("run $dep");
+    });
+
+    it("points the editor at the open listbox and its active row", () => {
+      renderComposer({ mentionSources: { skills: SKILLS } });
+      const input = openPicker("run $de");
+      const listbox = screen.getByRole("listbox");
+      expect(input.getAttribute("aria-controls")).toBe(listbox.id);
+      expect(input.getAttribute("aria-activedescendant")).toBe(
+        screen.getAllByRole("option")[0]!.id,
+      );
+    });
+
+    it("asks the host to load a population when a trigger opens", () => {
+      // Lazy on purpose: a card the operator only reads must not pay for a
+      // skill list or a navigation snapshot it never shows.
+      const ensureSkillsLoaded = vi.fn();
+      const ensureNavigationLoaded = vi.fn();
+      renderComposer({
+        mentionSources: { ensureNavigationLoaded, ensureSkillsLoaded },
+      });
+      expect(ensureSkillsLoaded).not.toHaveBeenCalled();
+      expect(ensureNavigationLoaded).not.toHaveBeenCalled();
+
+      openPicker("run $de");
+      expect(ensureSkillsLoaded).toHaveBeenCalled();
+      expect(ensureNavigationLoaded).not.toHaveBeenCalled();
+
+      openPicker("look in @ap");
+      expect(ensureNavigationLoaded).toHaveBeenCalled();
+    });
+
+    it("keeps two chips at their own offsets in one draft", async () => {
+      // Where the index math breaks if it breaks: a chip is zero-width in
+      // the plain draft, so the second insert has to shift nothing and the
+      // serializer has to splice both back at the right offsets.
+      const { onSend } = renderComposer({
+        mentionSources: {
+          directories: [
+            {
+              key: "d-app",
+              kind: "directory",
+              label: "app",
+              path: "/dev/app",
+            } as NavigationDirectorySummary,
+          ],
+          skills: SKILLS,
+        },
+      });
+      const input = openPicker("run $dep");
+      fireEvent.click(screen.getByRole("option"));
+
+      // Paste, not `change`: the test-only value setter replaces the whole
+      // document and would drop the chip already in it.
+      pasteMarkdown(input, "over @ap");
+      fireEvent.click(await screen.findByRole("option"));
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith(
+        "run [$deploy](/skills/deploy.md) over [@app](/dev/app)",
+      );
+    });
+
+    it("puts a bounced send back with its chips intact", async () => {
+      const onSend = vi.fn(async () => false);
+      const { container } = render(
+        <CompactComposer
+          mentionSources={{ skills: SKILLS }}
+          onSend={onSend}
+          threadTitle="Thread t1"
+        />,
+      );
+      const input = openPicker("run $dep");
+      fireEvent.click(screen.getByRole("option"));
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(
+          container.querySelector(".composer-tiptap-input__mention")?.textContent,
+        ).toBe("$deploy");
+      });
     });
   });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -364,6 +364,82 @@ describe("CompactComposer markdown", () => {
       expect(onSend).toHaveBeenCalledWith("run $dep");
     });
 
+    it("reopens for the same query later in the same message", () => {
+      // Dismissing one `$dep` must not retire every later `$dep`. Keyed on
+      // the query alone, Escape poisoned that word for the rest of the
+      // message and the picker silently refused to open again.
+      const { onSend } = renderComposer({ mentionSources: { skills: SKILLS } });
+      const input = openPicker("run $dep");
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(screen.queryByRole("listbox")).toBeNull();
+
+      fireEvent.change(input, { target: { value: "run $dep and $dep" } });
+      expect(screen.getByRole("listbox")).toBeTruthy();
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("reopens after backspacing over a dismissed trigger and retyping", () => {
+      const { onSend } = renderComposer({ mentionSources: { skills: SKILLS } });
+      const input = openPicker("run $dep");
+      fireEvent.keyDown(input, { key: "Escape" });
+
+      // Same offsets as the dismissed trigger, so only retiring the
+      // dismissal when the trigger moves gets this right.
+      fireEvent.change(input, { target: { value: "run $de" } });
+      fireEvent.change(input, { target: { value: "run $dep" } });
+      expect(screen.getByRole("listbox")).toBeTruthy();
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("still closes on Escape once focus has left the editor", () => {
+      // The popover deliberately survives a blur, so the editor's key
+      // handler is out of the loop — without a window-scope listener the
+      // list sits over the card's transcript with no way to dismiss it.
+      renderComposer({ mentionSources: { skills: SKILLS } });
+      openPicker("run $dep");
+      expect(screen.getByRole("listbox")).toBeTruthy();
+
+      fireEvent.keyDown(document.body, { key: "Escape" });
+      expect(screen.queryByRole("listbox")).toBeNull();
+    });
+
+    it("does not open a picker on a disabled composer", () => {
+      // A disabled composer still forwards keys from a field focused
+      // before it was disabled, so an un-gated popover would let Enter
+      // commit a chip into a composer that is refusing new text.
+      renderComposer({ disabled: true, mentionSources: { skills: SKILLS } });
+      const input = screen.getByRole("textbox", {
+        name: "Message Thread t1",
+      });
+      fireEvent.change(input, { target: { value: "run $dep" } });
+      expect(screen.queryByRole("listbox")).toBeNull();
+    });
+
+    it("keeps a consumed Escape from reaching the host", () => {
+      // The star map layer's Escape handler sits on an ancestor and clears
+      // the operator's gathered card selection. Closing a popover is not
+      // also a request to drop that selection.
+      const onKeyDown = vi.fn();
+      render(
+        <div onKeyDown={onKeyDown}>
+          <CompactComposer
+            mentionSources={{ skills: SKILLS }}
+            onSend={vi.fn()}
+            threadTitle="Thread t1"
+          />
+        </div>,
+      );
+      const input = screen.getByRole("textbox", {
+        name: "Message Thread t1",
+      });
+      fireEvent.change(input, { target: { value: "run $dep" } });
+      onKeyDown.mockClear();
+
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(screen.queryByRole("listbox")).toBeNull();
+      expect(onKeyDown).not.toHaveBeenCalled();
+    });
+
     it("points the editor at the open listbox and its active row", () => {
       renderComposer({ mentionSources: { skills: SKILLS } });
       const input = openPicker("run $de");

--- a/apps/desktop/src/renderer/src/features/composer/composer-mention-tokens.ts
+++ b/apps/desktop/src/renderer/src/features/composer/composer-mention-tokens.ts
@@ -1,0 +1,329 @@
+import type {
+  AppServerSkillSummary,
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+  PrSummary,
+} from "@pwragent/shared";
+import {
+  buildThreadMarkdownLink,
+  buildThreadUrl,
+  isRemoteFederationTarget,
+  parseThreadUrl,
+} from "@pwragent/shared";
+import { buildDirectoryReferenceMarkdown } from "../../lib/directory-references";
+import { formatHashReferenceThreadLabel } from "../../lib/hash-references";
+import { buildSkillMentionMarkdown } from "../../lib/skill-mentions";
+import type { ResolvedThreadLink } from "../../lib/thread-links";
+import {
+  prChipModifierClasses,
+  resolvePrChipPresentation,
+} from "../pr-status/pr-chip-state";
+import type { ComposerSkillToken } from "./ComposerInputTypes";
+
+/**
+ * Mention-token plumbing shared by every composer surface.
+ *
+ * These are the pure halves of the full composer's mention machinery:
+ * minting a token for each chip kind, keeping token offsets aligned as the
+ * plain draft changes around them, and splicing the tokens back into
+ * markdown for the outgoing text. `Composer.tsx` owned all of it while it
+ * was the only surface with mentions; the star map's `CompactComposer` is
+ * the second, and duplicating any of this would let the two surfaces
+ * serialize the same chip differently.
+ *
+ * Everything here is a pure function over a draft and its tokens. The
+ * stateful parts — which popover is open, where the caret goes after an
+ * insert — stay with the surface that owns the editor.
+ */
+
+export function createComposerSkillToken(
+  skill: AppServerSkillSummary,
+  index: number,
+): ComposerSkillToken {
+  return {
+    ...skill,
+    id: `${skill.path ?? skill.name}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
+export function createComposerDirectoryToken(
+  directory: Pick<NavigationDirectorySummary, "label" | "path">,
+  index: number,
+): ComposerSkillToken {
+  return {
+    kind: "directory",
+    name: directory.label,
+    path: directory.path,
+    id: `${directory.path ?? directory.label}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
+// Exported for the `@`-popover / picker surfaces that mint file-reference
+// chips; the drop/paste tray uses the pill list instead of chips.
+export function createComposerFileToken(
+  file: { label: string; path: string },
+  index: number,
+): ComposerSkillToken {
+  return {
+    kind: "file",
+    name: file.label,
+    path: file.path,
+    id: `${file.path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
+export function createComposerThreadToken(
+  thread: ResolvedThreadLink,
+  index: number,
+): ComposerSkillToken {
+  const path = buildThreadUrl({
+    backend: thread.backend,
+    ...(thread.instanceId ? { instanceId: thread.instanceId } : {}),
+    threadId: thread.threadId,
+  });
+  return {
+    kind: "thread",
+    // Every thread chip is minted here — picker, pasted url, and the draft
+    // rehydrate that rebuilds tokens from the live thread summary rather
+    // than from the saved link text. Formatting at the choke point is what
+    // makes the clamp survive a restore, and it makes the round trip
+    // converge: `format` of an already-formatted title is itself.
+    name: formatHashReferenceThreadLabel({
+      id: thread.threadId,
+      title: thread.title,
+    }),
+    path,
+    id: `${path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
+export function createComposerPullRequestToken(
+  pullRequest: PrSummary,
+  index: number,
+): ComposerSkillToken {
+  return {
+    kind: "pull-request",
+    name: `#${pullRequest.number}`,
+    path: pullRequest.url,
+    description: pullRequest.title,
+    shortDescription: `${pullRequest.org}/${pullRequest.repo}`,
+    id: `${pullRequest.url}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+    // Every PR chip in the composer is minted here — picker, pasted URL, and
+    // draft rehydration — so this is the one place the chip's status can be
+    // read off the summary. A summary that carries no status at all resolves
+    // to the same "unknown" gray the chip renders without it, so a PR nothing
+    // has observed is not dressed up as a state we know.
+    prChipModifiers: prChipModifierClasses(
+      resolvePrChipPresentation(pullRequest),
+    ),
+  };
+}
+
+export function resolveThreadSummaryReference(
+  thread: NavigationThreadSummary,
+): ResolvedThreadLink {
+  const federationTarget = thread.federation?.ref.target;
+  return {
+    backend: thread.source,
+    ...(federationTarget && isRemoteFederationTarget(federationTarget)
+      ? { instanceId: federationTarget.instanceId }
+      : {}),
+    threadId: thread.id,
+    title: thread.title,
+    titleSource: thread.titleSource,
+    gitBranch: thread.gitBranch,
+    linkedDirectories: thread.linkedDirectories,
+  };
+}
+
+export function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): string {
+  return JSON.stringify(
+    skillTokens.map((token) => ({
+      id: token.id,
+      index: token.index,
+      kind: token.kind,
+      name: token.name,
+      path: token.path,
+    })),
+  );
+}
+
+export function clampSkillTokenIndex(index: number, draft: string): number {
+  return Math.max(0, Math.min(index, draft.length));
+}
+
+export function serializeDraftWithSkillTokens(
+  draft: string,
+  skillTokens: ComposerSkillToken[],
+): string {
+  if (skillTokens.length === 0) {
+    return draft;
+  }
+
+  const sortedTokens = [...skillTokens].sort((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  let output = "";
+  let cursor = 0;
+  for (const token of sortedTokens) {
+    const index = clampSkillTokenIndex(token.index, draft);
+    output += draft.slice(cursor, index);
+    // Directory- and file-reference chips serialize to `[@label](~/path)`
+    // markdown — the parens bound the path so adjacent text can't glue
+    // onto it, the transcript renders it back as a chip, and
+    // hydrateComposerDraft rebuilds the token from a prompt-only restore.
+    // Skills keep their `[$name](path)` markdown.
+    if (token.kind === "directory" || token.kind === "file") {
+      output += buildDirectoryReferenceMarkdown({
+        label: token.name,
+        path: token.path ?? "",
+      });
+    } else if (token.kind === "thread") {
+      const ref = parseThreadUrl(token.path ?? "");
+      output += ref
+        ? buildThreadMarkdownLink({ ...ref, title: token.name })
+        : token.path ?? token.name;
+    } else if (token.kind === "pull-request") {
+      output += token.path
+        ? `[${token.name}](${token.path})`
+        : token.name;
+    } else {
+      output += buildSkillMentionMarkdown(token);
+    }
+    cursor = index;
+  }
+
+  output += draft.slice(cursor);
+  return output;
+}
+
+export function adjustSkillTokenIndexesForTextChange(params: {
+  currentDraft: string;
+  nextDraft: string;
+  skillTokens: ComposerSkillToken[];
+}): ComposerSkillToken[] {
+  const { currentDraft, nextDraft, skillTokens } = params;
+  if (currentDraft === nextDraft || skillTokens.length === 0) {
+    return skillTokens;
+  }
+
+  let prefixLength = 0;
+  while (
+    prefixLength < currentDraft.length &&
+    prefixLength < nextDraft.length &&
+    currentDraft[prefixLength] === nextDraft[prefixLength]
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < currentDraft.length - prefixLength &&
+    suffixLength < nextDraft.length - prefixLength &&
+    currentDraft[currentDraft.length - 1 - suffixLength] ===
+      nextDraft[nextDraft.length - 1 - suffixLength]
+  ) {
+    suffixLength += 1;
+  }
+
+  const currentChangedEnd = currentDraft.length - suffixLength;
+  const nextChangedEnd = nextDraft.length - suffixLength;
+  const delta = nextChangedEnd - currentChangedEnd;
+
+  return skillTokens.map((token) => {
+    if (token.index <= prefixLength) {
+      return token;
+    }
+
+    if (token.index >= currentChangedEnd) {
+      return {
+        ...token,
+        index: clampSkillTokenIndex(token.index + delta, nextDraft),
+      };
+    }
+
+    return {
+      ...token,
+      index: clampSkillTokenIndex(prefixLength, nextDraft),
+    };
+  });
+}
+
+export function rankSkillAutocompleteMatch(
+  skill: AppServerSkillSummary,
+  normalizedQuery: string,
+): number | undefined {
+  if (!normalizedQuery) {
+    return 0;
+  }
+
+  const name = skill.name.toLowerCase();
+  const shortDescription = skill.shortDescription?.toLowerCase() ?? "";
+  const description = skill.description?.toLowerCase() ?? "";
+
+  if (name === normalizedQuery) {
+    return 0;
+  }
+  if (name.startsWith(`${normalizedQuery}:`)) {
+    return 1;
+  }
+  if (name.startsWith(normalizedQuery)) {
+    return 2;
+  }
+  if (name.includes(normalizedQuery)) {
+    return 3;
+  }
+  if (shortDescription.includes(normalizedQuery)) {
+    return 4;
+  }
+  if (description.includes(normalizedQuery)) {
+    return 5;
+  }
+
+  return undefined;
+}
+
+/**
+ * The `$` autocomplete's candidate list: skills that rank against the
+ * query, best rank first, ties broken by the source order so the same
+ * query always produces the same list.
+ *
+ * Skills without a `path` are skipped — a mention chip serializes to
+ * `[$name](path)`, and there is nothing to point at without one.
+ */
+export function filterSkillAutocompleteCandidates(
+  skills: readonly AppServerSkillSummary[],
+  query: string,
+): AppServerSkillSummary[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  return skills
+    .map((skill, index) => ({
+      index,
+      score: skill.path
+        ? rankSkillAutocompleteMatch(skill, normalizedQuery)
+        : undefined,
+      skill,
+    }))
+    .filter(
+      (
+        match,
+      ): match is { index: number; score: number; skill: AppServerSkillSummary } =>
+        match.score !== undefined,
+    )
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return left.score - right.score;
+      }
+      return left.index - right.index;
+    })
+    .map((match) => match.skill);
+}

--- a/apps/desktop/src/renderer/src/features/composer/useComposerMentionSources.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerMentionSources.ts
@@ -110,6 +110,11 @@ export function useComposerMentionSources(params: {
   }, []);
 
   const ensureLoaded = useCallback((): void => {
+    // Both guards are load-bearing, and not only against redundant work: a
+    // host builds its sources object from the population this returns, so a
+    // completed load changes that object's identity and re-runs whatever
+    // effect asked for the load. Unguarded, that is a fetch loop rather
+    // than a one-shot.
     if (inFlight || Date.now() - cachedAt < NAVIGATION_STALE_MS) {
       return;
     }

--- a/apps/desktop/src/renderer/src/features/composer/useComposerMentionSources.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerMentionSources.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+/**
+ * How long a fetched population stays good enough for an autocomplete.
+ *
+ * The popover is not a view of the thread list — it is a picker, and a
+ * thread created in the last few seconds is not worth a bridge round trip
+ * per keystroke. Long enough that one composing burst reuses a single
+ * fetch, short enough that a card opened minutes later sees a list the
+ * operator recognizes.
+ */
+const NAVIGATION_STALE_MS = 10_000;
+
+type NavigationPopulation = {
+  directories: readonly NavigationDirectorySummary[];
+  threads: readonly NavigationThreadSummary[];
+};
+
+const EMPTY_POPULATION: NavigationPopulation = {
+  directories: [],
+  threads: [],
+};
+
+/**
+ * Module-level, not per hook instance: the star map can have a dozen chat
+ * cards open, every one of them able to open an `@` or `#` popover, and
+ * every one of them wants the same local snapshot. A per-card fetch would
+ * turn one operator typing `@` into N identical bridge calls.
+ */
+let cachedPopulation: NavigationPopulation | undefined;
+let cachedAt = 0;
+let inFlight: Promise<void> | undefined;
+const subscribers = new Set<(population: NavigationPopulation) => void>();
+
+/** Test seam: drop the shared cache so specs do not leak into each other. */
+export function resetComposerMentionSourcesCache(): void {
+  cachedPopulation = undefined;
+  cachedAt = 0;
+  inFlight = undefined;
+}
+
+async function loadPopulation(desktopApi: DesktopApi | undefined): Promise<void> {
+  const getNavigationSnapshot = desktopApi?.getNavigationSnapshot;
+  if (!getNavigationSnapshot) {
+    return;
+  }
+
+  try {
+    const snapshot = await getNavigationSnapshot();
+    cachedPopulation = {
+      directories: snapshot.directories,
+      threads: snapshot.threads,
+    };
+    cachedAt = Date.now();
+    for (const subscriber of subscribers) {
+      subscriber(cachedPopulation);
+    }
+  } catch {
+    // A failed load leaves the popover with whatever it already had. An
+    // autocomplete that cannot reach the bridge should offer nothing and
+    // let the trigger stay literal, not raise an error over a transcript.
+  }
+}
+
+/**
+ * The tracked directories and local threads a compact composer's `@` and
+ * `#` popovers pick from.
+ *
+ * Deliberately lazy and deliberately shared. Lazy because a chat card that
+ * never types a trigger should cost nothing beyond its transcript; shared
+ * because several cards are open at once and they all want one snapshot.
+ * `ensureLoaded` is what a popover calls when it opens — the hook itself
+ * fetches nothing on mount.
+ *
+ * Skills are NOT served from here. They are scoped to a thread's linked
+ * directories, so two cards genuinely have different skill lists and
+ * `useThreadSkills` already owns that per-thread fetch and its
+ * `skills/changed` invalidation.
+ */
+export function useComposerMentionSources(params: {
+  desktopApi?: DesktopApi;
+}): {
+  directories: readonly NavigationDirectorySummary[];
+  ensureLoaded: () => void;
+  threads: readonly NavigationThreadSummary[];
+} {
+  const { desktopApi } = params;
+  const [population, setPopulation] = useState<NavigationPopulation>(
+    () => cachedPopulation ?? EMPTY_POPULATION,
+  );
+
+  useEffect(() => {
+    const subscriber = (next: NavigationPopulation): void => {
+      setPopulation(next);
+    };
+    subscribers.add(subscriber);
+    // A card mounted after another already loaded starts from the cache
+    // rather than waiting for the next `ensureLoaded`.
+    if (cachedPopulation) {
+      setPopulation(cachedPopulation);
+    }
+    return () => {
+      subscribers.delete(subscriber);
+    };
+  }, []);
+
+  const ensureLoaded = useCallback((): void => {
+    if (inFlight || Date.now() - cachedAt < NAVIGATION_STALE_MS) {
+      return;
+    }
+    inFlight = loadPopulation(desktopApi).finally(() => {
+      inFlight = undefined;
+    });
+  }, [desktopApi]);
+
+  return {
+    directories: population.directories,
+    ensureLoaded,
+    threads: population.threads,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
@@ -1,0 +1,657 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { flushSync } from "react-dom";
+import type {
+  AppServerSkillSummary,
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { FolderIcon, PullRequestIcon, ThreadIcon } from "../../icons";
+import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  buildDirectoryReferenceInsertText,
+  filterDirectoryReferenceCandidates,
+  findDirectoryReferenceTrigger,
+} from "../../lib/directory-references";
+import {
+  buildHashReferenceOptions,
+  describeHashReferenceThread,
+  findHashReferenceTrigger,
+  formatHashReferenceThreadLabel,
+  formatHashReferenceThreadTooltip,
+  hashReferenceAnchorKey,
+  HASH_ANCHOR_COLD_QUERY_LENGTH,
+} from "../../lib/hash-references";
+import { buildSkillTooltip, findSkillTrigger } from "../../lib/skill-mentions";
+import {
+  FEDERATED_THREAD_SEARCH_LIMIT,
+  useFederatedThreadSearch,
+} from "../../lib/useFederatedThreadSearch";
+import type {
+  ComposerInputHandle,
+  ComposerSkillToken,
+} from "./ComposerInputTypes";
+import {
+  adjustSkillTokenIndexesForTextChange,
+  createComposerDirectoryToken,
+  createComposerPullRequestToken,
+  createComposerSkillToken,
+  createComposerThreadToken,
+  filterSkillAutocompleteCandidates,
+  getComposerSkillTokensSignature,
+  resolveThreadSummaryReference,
+  serializeDraftWithSkillTokens,
+} from "./composer-mention-tokens";
+import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
+
+/**
+ * The populations a compact composer's mention popovers pick from.
+ *
+ * Every field is optional and an absent one simply retires its trigger
+ * character back to prose — a host that supplies nothing gets exactly the
+ * literal `$`/`@`/`#` behaviour the compact composer had before mentions
+ * existed. That is deliberate: `CompactComposer` is shared, and a required
+ * source would be a breaking change for the next surface that adopts it.
+ *
+ * Populations are values, not fetches: the host decides where they come
+ * from and how they are cached. The two `ensure*` callbacks are how a
+ * popover says "I am open now" so a host can load lazily instead of paying
+ * for a list the operator may never ask for.
+ */
+export type ComposerMentionSources = {
+  /**
+   * Identity key of the thread being written in. Never offered as a `#`
+   * candidate — referencing the current thread tells the agent nothing it
+   * does not already have.
+   */
+  currentThreadKey?: string;
+  /** Tracked directories behind `@`. */
+  directories?: readonly NavigationDirectorySummary[];
+  /** Called when `@` or `#` opens a popover. */
+  ensureNavigationLoaded?: () => void;
+  /** Called when `$` opens a popover. */
+  ensureSkillsLoaded?: () => void;
+  /**
+   * Peer thread search behind `#`. Omitted leaves `#` local-only; the
+   * shared hook otherwise falls back to this window's own bridge.
+   */
+  searchRemoteThreads?: DesktopApi["jumpSearchRemoteThreads"];
+  /** Skills behind `$`. Thread-scoped, so the host owns this fetch. */
+  skills?: readonly AppServerSkillSummary[];
+  /** Local threads (and, through them, pull requests) behind `#`. */
+  threads?: readonly NavigationThreadSummary[];
+};
+
+/** A draft and its chips, together — the pair a failed send must restore. */
+export type ComposerMentionDraft = {
+  draft: string;
+  skillTokens: ComposerSkillToken[];
+};
+
+export type ComposerMentions = {
+  /** `aria-activedescendant` for the editor while a popover is open. */
+  activeOptionId?: string;
+  clear: () => void;
+  /** The plain draft; mention chips are zero-width in it. */
+  draft: string;
+  handleChange: (value: string, skillTokens?: ComposerSkillToken[]) => void;
+  /** Returns whether the popover consumed the key. */
+  handleKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => boolean;
+  inputRef: RefObject<ComposerInputHandle | null>;
+  /** `aria-controls` for the editor while a popover is open. */
+  listboxId?: string;
+  open: boolean;
+  popover: ReactNode;
+  /** Put a failed send's draft back, unless the operator has typed since. */
+  restore: (snapshot: ComposerMentionDraft) => void;
+  /**
+   * Stable between renders unless a token actually changed: the editor
+   * re-syncs its whole document whenever this prop changes identity.
+   */
+  skillTokens: ComposerSkillToken[];
+  snapshot: ComposerMentionDraft;
+  /** Outgoing text: the draft with every chip spliced back as markdown. */
+  text: string;
+};
+
+type MentionKind = "directories" | "hash" | "skills";
+
+const NO_DIRECTORIES: readonly NavigationDirectorySummary[] = [];
+const NO_SKILLS: readonly AppServerSkillSummary[] = [];
+const NO_THREADS: readonly NavigationThreadSummary[] = [];
+
+/**
+ * Mention autocomplete for a compact composer.
+ *
+ * The full composer's popovers are woven through a 12,000-line component
+ * that also owns queued turns, review mode, attachments, and draft
+ * recovery. This is the same behaviour with none of that: the trigger
+ * detection, candidate ranking, token minting, and markdown serialization
+ * are all the shared modules the full composer calls, and what lives here
+ * is only the part that is genuinely about *this* surface — which popover
+ * is open, which row is highlighted, and where the caret lands after an
+ * insert.
+ *
+ * The hook owns the draft as well as the tokens because an insert has to
+ * move both at once: a mention chip is zero-width in the plain draft, so a
+ * token whose index is applied a render later than the text it sits in
+ * would splice its markdown at the wrong offset.
+ *
+ * The popover renders *inside* the host's field rather than through a
+ * portal. On the star map that is what keeps it inside `.star-map-chat-card`,
+ * which is the selector every camera-gesture guard tests against —
+ * `isStarMapTypingTarget`, `shouldPanOnWheel`, `shouldStartCanvasPan`. A
+ * body portal would sit outside all three and arrow keys over an open list
+ * would fly the camera.
+ */
+export function useComposerMentions(params: {
+  sources?: ComposerMentionSources;
+}): ComposerMentions {
+  const { sources } = params;
+  const inputRef = useRef<ComposerInputHandle | null>(null);
+  const listboxId = useId();
+  // One state, not two: an insert has to move the draft and its tokens in
+  // the same commit, and a bounced send has to put both back or neither.
+  const [content, setContent] = useState<ComposerMentionDraft>(() => ({
+    draft: "",
+    skillTokens: [],
+  }));
+  const { draft, skillTokens } = content;
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [dismissedKey, setDismissedKey] = useState<string | undefined>(
+    undefined,
+  );
+  /**
+   * `#` anchors that have run long with nothing to show. Unlike `$` and
+   * `@`, a `#` query spans spaces, so nothing else retires it and a `#`
+   * mid-sentence would keep the picker armed — and the peer search
+   * re-firing — for the rest of the line.
+   */
+  const [coldHashAnchors, setColdHashAnchors] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  /**
+   * The stale echo an in-flight programmatic insert is expected to produce.
+   *
+   * `ComposerTiptapInput` re-emits its still-pre-insert content through
+   * `onChange` when the editability sync runs, which lands after the
+   * `flushSync` below has already committed the new draft. Swallowing that
+   * one echo is what stops the two sides ping-ponging the insert away.
+   */
+  const pendingProgrammaticChangeRef = useRef<
+    { staleDraft: string; staleSkillTokensSignature: string } | undefined
+  >(undefined);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const skills = sources?.skills ?? NO_SKILLS;
+  const directories = sources?.directories ?? NO_DIRECTORIES;
+  const threads = sources?.threads ?? NO_THREADS;
+
+  // Read live from the editor rather than from tracked state: the caret
+  // moves on clicks and arrow keys that never produce an `onChange`, and a
+  // trigger resolved against a stale caret opens the wrong popover.
+  const selectionStart = Math.min(
+    inputRef.current?.selectionStart ?? draft.length,
+    draft.length,
+  );
+  const skillTrigger = findSkillTrigger(draft, selectionStart);
+  const directoryTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
+  const rawHashTrigger = findHashReferenceTrigger(draft, selectionStart);
+  const hashTrigger =
+    rawHashTrigger
+    && !coldHashAnchors.has(hashReferenceAnchorKey(rawHashTrigger.query))
+      ? rawHashTrigger
+      : undefined;
+
+  const skillQuery = skillTrigger?.query;
+  const directoryQuery = directoryTrigger?.query;
+  const hashQuery = hashTrigger?.query;
+
+  // Opt-in, and gated on the query as well as the callback: the shared
+  // search hook otherwise resolves this window's own bridge, which would
+  // have a host that supplies no sources at all firing a federated search
+  // the first time someone typed `#` in a sentence.
+  const remoteSearch = sources?.searchRemoteThreads;
+  const {
+    available: remoteSearchAvailable,
+    loading: remoteSearchLoading,
+    results: remoteThreads,
+    settledQuery: remoteSettledQuery,
+  } = useFederatedThreadSearch({
+    query: remoteSearch ? (hashQuery ?? "") : "",
+    limit: FEDERATED_THREAD_SEARCH_LIMIT,
+    search: remoteSearch,
+  });
+
+  const skillOptions = useMemo(
+    () =>
+      skillQuery === undefined
+        ? []
+        : filterSkillAutocompleteCandidates(skills, skillQuery),
+    [skillQuery, skills],
+  );
+  const directoryOptions = useMemo(
+    () =>
+      directoryQuery === undefined
+        ? []
+        : filterDirectoryReferenceCandidates([...directories], directoryQuery),
+    [directories, directoryQuery],
+  );
+  const hashOptions = useMemo(
+    () =>
+      hashQuery === undefined
+        ? []
+        : buildHashReferenceOptions({
+            currentThreadKey: sources?.currentThreadKey,
+            localThreads: threads,
+            query: hashQuery,
+            remoteThreads,
+          }),
+    [hashQuery, remoteThreads, sources?.currentThreadKey, threads],
+  );
+
+  // Same precedence the full composer uses. A trigger with no candidates
+  // yields to the next one rather than holding an empty popover open.
+  const kind: MentionKind | undefined =
+    skillTrigger && skillOptions.length > 0
+      ? "skills"
+      : directoryTrigger && directoryOptions.length > 0
+        ? "directories"
+        : hashTrigger && hashOptions.length > 0
+          ? "hash"
+          : undefined;
+  const query =
+    kind === "skills"
+      ? (skillQuery ?? "")
+      : kind === "directories"
+        ? (directoryQuery ?? "")
+        : (hashQuery ?? "");
+  const optionCount =
+    kind === "skills"
+      ? skillOptions.length
+      : kind === "directories"
+        ? directoryOptions.length
+        : kind === "hash"
+          ? hashOptions.length
+          : 0;
+  // Escape retires one popover, identified by what it was offering. Any
+  // edit moves the query and re-arms it, which is what makes Escape read
+  // as "not this one" rather than "no more mentions in this message".
+  const dismissKey = kind ? `${kind}:${query}` : undefined;
+  const open = Boolean(kind) && dismissKey !== dismissedKey;
+  const activeOption = Math.min(activeIndex, Math.max(optionCount - 1, 0));
+
+  const skillsTriggered = Boolean(skillTrigger);
+  const navigationTriggered = Boolean(directoryTrigger || rawHashTrigger);
+  const ensureSkillsLoaded = sources?.ensureSkillsLoaded;
+  const ensureNavigationLoaded = sources?.ensureNavigationLoaded;
+  // Keyed on the trigger existing, NOT on there being candidates: an empty
+  // population is exactly the state a load is supposed to fix.
+  useEffect(() => {
+    if (skillsTriggered) ensureSkillsLoaded?.();
+  }, [ensureSkillsLoaded, skillsTriggered]);
+  useEffect(() => {
+    if (navigationTriggered) ensureNavigationLoaded?.();
+  }, [ensureNavigationLoaded, navigationTriggered]);
+
+  // Have the peers answered about *this* query? `loading` is set inside the
+  // search hook's effect, so for one commit after a keystroke it still
+  // reads `false` while holding the previous query's results.
+  const remoteSearchSettled =
+    !remoteSearch
+    || !remoteSearchAvailable
+    || (!remoteSearchLoading
+      && remoteSettledQuery === (rawHashTrigger?.query ?? "").trim());
+  const rawHashQuery = rawHashTrigger?.query;
+  useEffect(() => {
+    if (
+      rawHashQuery === undefined
+      || rawHashQuery.length < HASH_ANCHOR_COLD_QUERY_LENGTH
+      || !remoteSearchSettled
+      || hashOptions.length > 0
+    ) {
+      return;
+    }
+    const key = hashReferenceAnchorKey(rawHashQuery);
+    setColdHashAnchors((current) =>
+      current.has(key) ? current : new Set(current).add(key),
+    );
+  }, [hashOptions.length, rawHashQuery, remoteSearchSettled]);
+
+  // Cold anchors belong to one composing session: a run that matched
+  // nothing must not suppress `#` in the next message.
+  useEffect(() => {
+    if (draft.trim().length > 0) return;
+    setColdHashAnchors((current) => (current.size === 0 ? current : new Set()));
+  }, [draft]);
+
+  // The highlight belongs to one query. Resetting it here rather than in
+  // `handleChange` is deliberate: the editor re-emits unchanged content on
+  // caret moves, and resetting there sent every arrow key straight back to
+  // the first row.
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [dismissKey]);
+
+  useEffect(() => {
+    if (!open) return;
+    // Optional call, not decoration: jsdom does not implement it, so an
+    // unguarded call takes down every renderer test that opens a popover.
+    optionRefs.current[activeOption]?.scrollIntoView?.({ block: "nearest" });
+  }, [activeOption, open]);
+
+  const handleChange = (
+    nextDraft: string,
+    nextSkillTokens?: ComposerSkillToken[],
+  ): void => {
+    const pending = pendingProgrammaticChangeRef.current;
+    if (pending && nextSkillTokens) {
+      if (
+        nextDraft === pending.staleDraft
+        && getComposerSkillTokensSignature(nextSkillTokens)
+          === pending.staleSkillTokensSignature
+      ) {
+        return;
+      }
+      pendingProgrammaticChangeRef.current = undefined;
+    }
+    // Bail on an unchanged emit rather than committing an equal-but-new
+    // object. The editor re-emits its current content on transactions that
+    // changed nothing the composer cares about — a caret move is enough —
+    // and each of those would otherwise hand `ComposerTiptapInput` a fresh
+    // `skillTokens` identity and make it re-sync its whole document.
+    setContent((current) => {
+      const tokens = nextSkillTokens ?? current.skillTokens;
+      if (
+        current.draft === nextDraft
+        && (tokens === current.skillTokens
+          || getComposerSkillTokensSignature(tokens)
+            === getComposerSkillTokensSignature(current.skillTokens))
+      ) {
+        return current;
+      }
+      return { draft: nextDraft, skillTokens: tokens };
+    });
+  };
+
+  /**
+   * Replace an autocomplete trigger with a mention chip.
+   *
+   * The chip is zero-width in the plain draft, so the trigger text is
+   * removed and a token minted at that offset instead. Always leave one
+   * space after the chip — including at the end of the draft — and park
+   * the caret after it, so typing straight on cannot glue onto the chip's
+   * serialized markdown.
+   */
+  const insertToken = (
+    trigger: { end: number; start: number },
+    createToken: (index: number) => ComposerSkillToken,
+  ): void => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    const caret = Math.min(input.selectionStart ?? draft.length, draft.length);
+    const selectionEnd = Math.min(input.selectionEnd ?? caret, draft.length);
+    const before = draft.slice(0, trigger.start);
+    const after = draft.slice(Math.max(trigger.end, selectionEnd));
+    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
+    const nextDraft = `${before}${nextAfter}`;
+    const tokenIndex = before.length;
+    const nextSelection = tokenIndex + 1;
+    const nextSkillTokens = [
+      ...adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens,
+      }),
+      createToken(tokenIndex),
+    ];
+
+    pendingProgrammaticChangeRef.current = {
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    flushSync(() => {
+      setContent({ draft: nextDraft, skillTokens: nextSkillTokens });
+      setActiveIndex(0);
+    });
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
+  };
+
+  const commit = (index: number): void => {
+    if (kind === "skills" && skillTrigger) {
+      const skill = skillOptions[index] ?? skillOptions[0];
+      if (skill) {
+        insertToken(skillTrigger, (at) => createComposerSkillToken(skill, at));
+      }
+      return;
+    }
+    if (kind === "directories" && directoryTrigger) {
+      const directory = directoryOptions[index] ?? directoryOptions[0];
+      if (directory?.path) {
+        insertToken(directoryTrigger, (at) =>
+          createComposerDirectoryToken(directory, at),
+        );
+      }
+      return;
+    }
+    if (kind === "hash" && hashTrigger) {
+      const option = hashOptions[index] ?? hashOptions[0];
+      if (!option) return;
+      insertToken(hashTrigger, (at) =>
+        option.kind === "thread"
+          ? createComposerThreadToken(
+              resolveThreadSummaryReference(option.thread),
+              at,
+            )
+          : createComposerPullRequestToken(option.pullRequest, at),
+      );
+    }
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>): boolean => {
+    if (!open || optionCount === 0 || event.defaultPrevented) return false;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex(Math.min(activeOption + 1, optionCount - 1));
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex(Math.max(activeOption - 1, 0));
+      return true;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setDismissedKey(dismissKey);
+      return true;
+    }
+    if (
+      (event.key === "Enter" && !event.shiftKey && !event.altKey)
+      || (event.key === "Tab" && !event.shiftKey)
+    ) {
+      event.preventDefault();
+      commit(activeOption);
+      return true;
+    }
+    return false;
+  };
+
+  const optionId = (index: number): string => `${listboxId}-option-${index}`;
+
+  const renderOption = (index: number, content: ReactNode, extra?: {
+    title?: string;
+  }): ReactNode => (
+    <button
+      aria-selected={index === activeOption}
+      className={`compact-composer__mention-option${
+        index === activeOption ? " is-active" : ""
+      }`}
+      id={optionId(index)}
+      key={optionId(index)}
+      ref={(node) => {
+        optionRefs.current[index] = node;
+      }}
+      role="option"
+      tabIndex={-1}
+      title={extra?.title}
+      type="button"
+      // `mousedown` default would blur the editor before the click lands,
+      // and the trigger offsets are resolved against a live caret.
+      onMouseDown={(event) => {
+        event.preventDefault();
+        commit(index);
+      }}
+      onClick={() => commit(index)}
+    >
+      {content}
+    </button>
+  );
+
+  let options: ReactNode = null;
+  let label = "";
+  if (kind === "skills") {
+    label = "Skills";
+    options = skillOptions.map((skill, index) =>
+      renderOption(
+        index,
+        <>
+          <span className="compact-composer__mention-title">
+            <HighlightedAutocompleteLabel
+              label={`$${skill.name}`}
+              query={query ? `$${query}` : "$"}
+            />
+          </span>
+          <span className="compact-composer__mention-meta">
+            {skill.shortDescription || skill.description || skill.path}
+          </span>
+        </>,
+        { title: buildSkillTooltip(skill) || undefined },
+      ),
+    );
+  } else if (kind === "directories") {
+    label = "Directories";
+    options = directoryOptions.map((directory, index) =>
+      renderOption(
+        index,
+        <>
+          <span className="compact-composer__mention-title">
+            <FolderIcon size={12} aria-hidden="true" />
+            <HighlightedAutocompleteLabel
+              label={directory.label}
+              query={query}
+            />
+          </span>
+          <span className="compact-composer__mention-meta">
+            {buildDirectoryReferenceInsertText(directory)}
+          </span>
+        </>,
+      ),
+    );
+  } else if (kind === "hash") {
+    label = "Threads and pull requests";
+    options = hashOptions.map((option, index) => {
+      if (option.kind === "thread") {
+        const thread = option.thread;
+        const meta = describeHashReferenceThread(thread, query);
+        return renderOption(
+          index,
+          <>
+            <span className="compact-composer__mention-title">
+              <ThreadIcon size={12} aria-hidden="true" />
+              <HighlightedAutocompleteLabel
+                label={`#${formatHashReferenceThreadLabel(thread).replace(/^#/, "")}`}
+                matchAnywhere
+                query={query.trim()}
+              />
+            </span>
+            {/* The full composer separates peer rows with an "Other
+                instances" divider and an instance chip. Two rows fit in a
+                card's popover, so the instance rides in the meta line
+                instead of spending one of them on a heading. */}
+            <span className="compact-composer__mention-meta">
+              {option.remote && thread.federation?.instanceLabel
+                ? `${thread.federation.instanceLabel}${meta ? ` · ${meta}` : ""}`
+                : meta}
+            </span>
+          </>,
+          { title: formatHashReferenceThreadTooltip(thread) },
+        );
+      }
+      const pullRequest = option.pullRequest;
+      return renderOption(
+        index,
+        <>
+          <span className="compact-composer__mention-title">
+            <PullRequestIcon size={12} aria-hidden="true" />
+            <HighlightedAutocompleteLabel
+              label={`#${pullRequest.number}`}
+              matchAnywhere
+              query={query.trim()}
+            />
+          </span>
+          <span className="compact-composer__mention-meta">
+            {`${pullRequest.org}/${pullRequest.repo} · ${pullRequest.title}`}
+          </span>
+        </>,
+        { title: pullRequest.title },
+      );
+    });
+  }
+
+  // Rebuilt every render, so a shrinking list cannot leave a scroll target
+  // pointing at a row that is gone.
+  optionRefs.current.length = optionCount;
+
+  const popover = open ? (
+    <div
+      aria-label={label}
+      className="compact-composer__mention-list"
+      id={listboxId}
+      role="listbox"
+    >
+      {options}
+    </div>
+  ) : null;
+
+  return {
+    activeOptionId: open ? optionId(activeOption) : undefined,
+    clear: () => {
+      pendingProgrammaticChangeRef.current = undefined;
+      setContent({ draft: "", skillTokens: [] });
+      setActiveIndex(0);
+      setDismissedKey(undefined);
+    },
+    draft,
+    handleChange,
+    handleKeyDown,
+    inputRef,
+    listboxId: open ? listboxId : undefined,
+    open,
+    popover,
+    restore: (previous) => {
+      // Only if the operator has not started something new in the meantime;
+      // their fresh text outranks a bounced message.
+      setContent((current) =>
+        current.draft.length > 0 || current.skillTokens.length > 0
+          ? current
+          : previous,
+      );
+    },
+    skillTokens,
+    snapshot: content,
+    text: serializeDraftWithSkillTokens(draft, skillTokens),
+  };
+}

--- a/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
@@ -153,6 +153,13 @@ const NO_THREADS: readonly NavigationThreadSummary[] = [];
  * would fly the camera.
  */
 export function useComposerMentions(params: {
+  /**
+   * Mirrors the host's own disabled state. A disabled composer still
+   * forwards keys from a field that was focused before it was disabled, so
+   * without this a popover stays live and Enter commits a chip into a
+   * composer that is refusing new text.
+   */
+  disabled?: boolean;
   sources?: ComposerMentionSources;
 }): ComposerMentions {
   const { sources } = params;
@@ -282,11 +289,29 @@ export function useComposerMentions(params: {
         : kind === "hash"
           ? hashOptions.length
           : 0;
-  // Escape retires one popover, identified by what it was offering. Any
-  // edit moves the query and re-arms it, which is what makes Escape read
-  // as "not this one" rather than "no more mentions in this message".
-  const dismissKey = kind ? `${kind}:${query}` : undefined;
-  const open = Boolean(kind) && dismissKey !== dismissedKey;
+  const activeTrigger =
+    kind === "skills"
+      ? skillTrigger
+      : kind === "directories"
+        ? directoryTrigger
+        : kind === "hash"
+          ? hashTrigger
+          : undefined;
+  /**
+   * Identity of the popover Escape retires: its kind, the trigger's
+   * position, and the query.
+   *
+   * The offsets are not decoration. Keyed on the query alone, dismissing
+   * `$dep` once would suppress every later `$dep` in the same message —
+   * and, with the retirement below, a backspace-and-retype of the same
+   * word too. The full composer keys its `dismissedAutocompleteKey` the
+   * same way for the same reason.
+   */
+  const dismissKey = activeTrigger
+    ? `${kind}:${activeTrigger.start}:${activeTrigger.end}:${query}`
+    : undefined;
+  const open =
+    Boolean(kind) && !params.disabled && dismissKey !== dismissedKey;
   const activeOption = Math.min(activeIndex, Math.max(optionCount - 1, 0));
 
   const skillsTriggered = Boolean(skillTrigger);
@@ -333,6 +358,14 @@ export function useComposerMentions(params: {
     setColdHashAnchors((current) => (current.size === 0 ? current : new Set()));
   }, [draft]);
 
+  // A dismissal belongs to the trigger it was made against. Without this
+  // it outlives that trigger and silently suppresses a later popover the
+  // operator never dismissed.
+  useEffect(() => {
+    if (!dismissedKey) return;
+    if (!dismissKey || dismissKey !== dismissedKey) setDismissedKey(undefined);
+  }, [dismissKey, dismissedKey]);
+
   // The highlight belongs to one query. Resetting it here rather than in
   // `handleChange` is deliberate: the editor re-emits unchanged content on
   // caret moves, and resetting there sent every arrow key straight back to
@@ -340,6 +373,23 @@ export function useComposerMentions(params: {
   useEffect(() => {
     setActiveIndex(0);
   }, [dismissKey]);
+
+  // The popover deliberately survives a blur — clicking into the card's
+  // transcript to check something should not throw away a half-typed
+  // mention. But the editor's key handler is then out of the loop, so
+  // without a window-scope listener Escape stops closing the popover and
+  // it sits over the transcript with no way out but editing the draft.
+  useEffect(() => {
+    if (!open) return;
+    const dismissOnEscape = (event: globalThis.KeyboardEvent): void => {
+      // Already handled by the editor path, which prevents the default.
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      event.preventDefault();
+      setDismissedKey(dismissKey);
+    };
+    window.addEventListener("keydown", dismissOnEscape);
+    return () => window.removeEventListener("keydown", dismissOnEscape);
+  }, [dismissKey, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -475,6 +525,10 @@ export function useComposerMentions(params: {
     }
     if (event.key === "Escape") {
       event.preventDefault();
+      // Stop here as well: the star map layer's own Escape handler sits on
+      // an ancestor and clears the operator's gathered card selection.
+      // Closing a popover is not also a request to drop that selection.
+      event.stopPropagation();
       setDismissedKey(dismissKey);
       return true;
     }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -18,6 +18,8 @@ import {
   CompactComposer,
   type CompactComposerAction,
 } from "../composer/CompactComposer";
+import { useComposerMentionSources } from "../composer/useComposerMentionSources";
+import type { ComposerMentionSources } from "../composer/useComposerMentions";
 import { TranscriptList } from "../thread-detail/TranscriptList";
 import { useTranscriptWindow } from "../thread-detail/useTranscriptWindow";
 import { collectEditedFileGroups } from "../thread-detail/edited-file-groups";
@@ -25,6 +27,7 @@ import { DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT } from "../../lib/thread-hist
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { useThreadSessionState } from "../../lib/useThreadSessionState";
+import { useThreadSkills } from "../../lib/useThreadSkills";
 import {
   clearStarMapCardContext,
   publishStarMapCardContext,
@@ -165,6 +168,47 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     });
   }, [cardKey, contextDemand, editedFileGroups, pricing, session.activeTurnId]);
   useEffect(() => () => clearStarMapCardContext(cardKey), [cardKey]);
+
+  /**
+   * What the card can honestly offer the composer's mention pickers.
+   *
+   * Skills are thread-scoped — they come from this thread's linked
+   * directories — so they use the same per-thread hook the full thread view
+   * does, lazily: nothing is fetched until the operator types `$`.
+   * Directories and threads are one local snapshot shared by every open
+   * card. Both loads are triggered by the popover opening, so a card the
+   * operator only reads costs neither.
+   *
+   * `#` also reaches peers, through the same federated search the sidebar's
+   * jump uses. That matters more here than anywhere: a card on a star map
+   * is usually open *because* of another instance.
+   */
+  const threadSkills = useThreadSkills({ desktopApi, thread });
+  const navigationSources = useComposerMentionSources({ desktopApi });
+  const ensureSkillsLoaded = threadSkills.ensureLoaded;
+  const mentionSources = useMemo<ComposerMentionSources>(
+    () => ({
+      currentThreadKey: buildThreadIdentityKey(thread.source, thread.id),
+      directories: navigationSources.directories,
+      ensureNavigationLoaded: navigationSources.ensureLoaded,
+      ensureSkillsLoaded: () => {
+        void ensureSkillsLoaded();
+      },
+      searchRemoteThreads: desktopApi?.jumpSearchRemoteThreads,
+      skills: threadSkills.skills,
+      threads: navigationSources.threads,
+    }),
+    [
+      desktopApi,
+      ensureSkillsLoaded,
+      navigationSources.directories,
+      navigationSources.ensureLoaded,
+      navigationSources.threads,
+      threadSkills.skills,
+      thread.id,
+      thread.source,
+    ],
+  );
 
   const beginDrag = useCallback(
     (event: ReactPointerEvent, kind: DragState["kind"]) => {
@@ -564,6 +608,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         busy={session.threadBusy}
         canSteer={canSteer}
         executionMode={thread.executionMode}
+        mentionSources={mentionSources}
         model={thread.model}
         onInterrupt={() => void interrupt()}
         onSend={send}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -647,6 +647,22 @@ describe("StarMapChatCard mentions", () => {
     });
   });
 
+  it("settles a whole picker session on one snapshot fetch", async () => {
+    // Load-bearing, and not only for caching: the sources memo changes
+    // identity when the fetch lands, which re-runs the effect that asked
+    // for it. Without the cache's staleness guard that is a fetch loop,
+    // and it would run at typing speed rather than showing up as an error.
+    const desktopApi = mentionApi();
+    renderCard({ desktopApi, thread: localThread() });
+    await screen.findByRole("button", { name: "Send" });
+
+    for (const value of ["look in @", "look in @a", "look in @ap"]) {
+      fireEvent.change(composer(), { target: { value } });
+      await screen.findByRole("option");
+    }
+    expect(desktopApi.getNavigationSnapshot).toHaveBeenCalledTimes(1);
+  });
+
   it("never offers the thread the card is already on", async () => {
     // On a bare `#` the current thread would otherwise take the first row,
     // and referencing it tells the agent nothing it does not have.

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,8 +1,11 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapChatCard } from "../StarMapChatCard";
+import { resetComposerMentionSourcesCache } from "../../composer/useComposerMentionSources";
+import { isStarMapTypingTarget } from "../star-map-keyboard";
+import { shouldPanOnWheel, shouldStartCanvasPan } from "../star-map-orbit";
 import {
   DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
   DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
@@ -511,10 +514,16 @@ describe("StarMapChatCard steering a live turn", () => {
   it("drops the landing notice once that turn is over", async () => {
     // The notice describes a turn. Left alone it would sit on an idle card
     // for hours still claiming something is in flight.
-    let emit: ((event: unknown) => void) | undefined;
+    // The card has more than one agent-event subscriber (the thread
+    // session and the lazy skill list), so the fake has to fan out rather
+    // than remember the last listener to register.
+    const listeners: Array<(event: unknown) => void> = [];
+    const emit = (event: unknown): void => {
+      for (const listener of listeners) listener(event);
+    };
     const desktopApi = busyApi({
       onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
-        emit = listener;
+        listeners.push(listener);
         return () => undefined;
       }),
     } as unknown as Partial<DesktopApi>);
@@ -526,7 +535,7 @@ describe("StarMapChatCard steering a live turn", () => {
     ).toBeTruthy();
 
     act(() => {
-      emit?.({
+      emit({
         backend: "codex",
         notification: {
           method: "turn/completed",
@@ -552,5 +561,121 @@ describe("StarMapChatCard steering a live turn", () => {
     await waitFor(() => {
       expect(steer.disabled).toBe(true);
     });
+  });
+});
+
+describe("StarMapChatCard mentions", () => {
+  beforeEach(() => {
+    // The directory/thread population is cached across cards on purpose;
+    // that cache must not leak between specs.
+    resetComposerMentionSourcesCache();
+  });
+
+  const SNAPSHOT = {
+    directories: [
+      {
+        key: "d-app",
+        kind: "repo",
+        label: "app",
+        latestUpdatedAt: 2,
+        path: "/Users/dev/app",
+      },
+    ],
+    threads: [
+      localThread(),
+      localThread({ id: "t-other", title: "Rewrite the parser" }),
+    ],
+  };
+
+  function mentionApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
+    return buildApi({
+      getNavigationSnapshot: vi.fn(async () => SNAPSHOT),
+      listSkills: vi.fn(async () => ({
+        backend: "codex",
+        fetchedAt: 1,
+        data: [
+          {
+            cwd: "/Users/dev/app",
+            skills: [{ name: "deploy", path: "/skills/deploy.md" }],
+          },
+        ],
+      })),
+      ...overrides,
+    } as unknown as Partial<DesktopApi>);
+  }
+
+  function composer() {
+    return screen.getByRole("textbox", { name: "Message Local work" });
+  }
+
+  it("loads skills only once the operator types $", async () => {
+    // A card the operator only reads must not pay for a skill list.
+    const desktopApi = mentionApi();
+    renderCard({ desktopApi, thread: localThread() });
+    await screen.findByRole("button", { name: "Send" });
+    expect(desktopApi.listSkills).not.toHaveBeenCalled();
+
+    fireEvent.change(composer(), { target: { value: "run $dep" } });
+    await waitFor(() => {
+      expect(desktopApi.listSkills).toHaveBeenCalled();
+    });
+    expect(
+      (await screen.findByRole("option")).textContent,
+    ).toContain("$deploy");
+  });
+
+  it("offers tracked directories on @ and links them as markdown", async () => {
+    const desktopApi = mentionApi();
+    renderCard({ desktopApi, thread: localThread() });
+    await screen.findByRole("button", { name: "Send" });
+    expect(desktopApi.getNavigationSnapshot).not.toHaveBeenCalled();
+
+    fireEvent.change(composer(), { target: { value: "check @ap" } });
+    const option = await screen.findByRole("option");
+    expect(option.textContent).toContain("app");
+
+    fireEvent.click(option);
+    fireEvent.keyDown(composer(), { key: "Enter" });
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [
+            { type: "text", text: "check [@app](/Users/dev/app)" },
+          ],
+        }),
+      );
+    });
+  });
+
+  it("never offers the thread the card is already on", async () => {
+    // On a bare `#` the current thread would otherwise take the first row,
+    // and referencing it tells the agent nothing it does not have.
+    const desktopApi = mentionApi();
+    renderCard({ desktopApi, thread: localThread() });
+    await screen.findByRole("button", { name: "Send" });
+
+    fireEvent.change(composer(), { target: { value: "see #" } });
+    const options = await screen.findAllByRole("option");
+    const labels = options.map((option) => option.textContent ?? "");
+    expect(labels.some((label) => label.includes("Rewrite the parser"))).toBe(
+      true,
+    );
+    expect(labels.some((label) => label.includes("Local work"))).toBe(false);
+  });
+
+  it("keeps an open picker inside the card's gesture guards", async () => {
+    // The popover renders in the card rather than through a body portal
+    // precisely so these three selectors still cover it. A portalled list
+    // would send arrow keys and wheel events straight to the camera.
+    const desktopApi = mentionApi();
+    renderCard({ desktopApi, thread: localThread() });
+    await screen.findByRole("button", { name: "Send" });
+
+    fireEvent.change(composer(), { target: { value: "check @ap" } });
+    const option = await screen.findByRole("option");
+    expect(option.closest(".star-map-chat-card")).not.toBeNull();
+    expect(isStarMapTypingTarget(option)).toBe(true);
+    expect(shouldPanOnWheel(option)).toBe(false);
+    expect(shouldStartCanvasPan(option)).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
 import {
+  buildHashReferenceOptions,
   collapseHashReferenceWhitespace,
   filterHashReferenceCandidates,
   findHashReferenceTrigger,
@@ -196,5 +197,77 @@ describe("filterHashReferenceCandidates", () => {
       "https://github.com/pwrdrvr/PwrAgent/pull/123",
       "https://github.com/pwrdrvr/PwrSnap/pull/123",
     ]);
+  });
+});
+
+describe("buildHashReferenceOptions", () => {
+  function remote(
+    id: string,
+    title: string,
+    instanceId = "pwr_peer",
+  ): NavigationThreadSummary {
+    return thread(id, title, {
+      federation: {
+        instanceLabel: "Studio Mac",
+        ref: {
+          backend: "codex",
+          threadId: id,
+          target: { scope: "remote", instanceId },
+        },
+      },
+    } as Partial<NavigationThreadSummary>);
+  }
+
+  it("lists local rows before peer rows", () => {
+    const options = buildHashReferenceOptions({
+      localThreads: [thread("t-1", "Parser rewrite")],
+      query: "parser",
+      remoteThreads: [remote("t-2", "Parser cleanup")],
+    });
+    expect(
+      options.map((option) =>
+        option.kind === "thread"
+          ? [option.thread.id, option.remote]
+          : [option.pullRequest.url, option.remote],
+      ),
+    ).toEqual([
+      ["t-1", false],
+      ["t-2", true],
+    ]);
+  });
+
+  it("drops the thread being written in", () => {
+    const options = buildHashReferenceOptions({
+      currentThreadKey: "codex:t-1",
+      localThreads: [thread("t-1", "Parser rewrite"), thread("t-2", "Parser fix")],
+      query: "parser",
+    });
+    expect(options.map((option) => option.kind === "thread" && option.thread.id))
+      .toEqual(["t-2"]);
+  });
+
+  it("drops a peer row the local snapshot already carries", () => {
+    // A pinned peer thread appears in both populations; offering it twice
+    // is the kind of duplicate an operator reads as two different threads.
+    const options = buildHashReferenceOptions({
+      localThreads: [remote("t-2", "Parser cleanup")],
+      query: "parser",
+      remoteThreads: [remote("t-2", "Parser cleanup")],
+    });
+    expect(options).toHaveLength(1);
+    expect(options[0]!.remote).toBe(false);
+  });
+
+  it("drops a peer pull request a local thread already offers", () => {
+    const shared = pullRequest(123);
+    const options = buildHashReferenceOptions({
+      localThreads: [thread("t-1", "Local", { prs: [shared] })],
+      query: "123",
+      remoteThreads: [remote("t-2", "Remote")],
+    });
+    const pullRequests = options.filter(
+      (option) => option.kind === "pull-request",
+    );
+    expect(pullRequests).toHaveLength(1);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/hash-references.ts
+++ b/apps/desktop/src/renderer/src/lib/hash-references.ts
@@ -1,5 +1,6 @@
 import {
   buildPullRequestStatusKey,
+  buildThreadIdentityKey,
   threadHasExactPrNumberMatch,
   threadMatchesQuery,
   type NavigationThreadSummary,
@@ -218,6 +219,131 @@ export function filterHashReferenceCandidates(
       })
       .slice(0, PULL_REQUEST_CANDIDATE_LIMIT),
   };
+}
+
+/**
+ * The secondary line under a `#` thread row: the details that tell two
+ * similarly-titled threads apart — a PR number (the one the query matched,
+ * when it matched one), the branch, the first linked directory.
+ */
+export function describeHashReferenceThread(
+  thread: NavigationThreadSummary,
+  query: string,
+): string {
+  const parts: string[] = [];
+  const pullRequest = threadHasExactPrNumberMatch(thread, query)
+    ? (thread.prs ?? []).find(
+        (candidate) => candidate.number === Number(query.trim()),
+      )
+    : (thread.prs ?? [])[0];
+  if (pullRequest) {
+    parts.push(`#${pullRequest.number}`);
+  }
+  if (thread.gitBranch) {
+    parts.push(thread.gitBranch);
+  }
+  const directory = (thread.linkedDirectories ?? [])[0];
+  if (directory?.label) {
+    parts.push(directory.label);
+  }
+  if (parts.length > 0) {
+    return parts.join(" · ");
+  }
+  // The id is the last-resort disambiguator between same-named threads. A
+  // thread with no title is already showing that same id as its label, so
+  // repeating it here would just print the uuid twice.
+  return collapseHashReferenceWhitespace(thread.title) ? thread.id : "";
+}
+
+/**
+ * One row in the `#` popover: a thread or a pull request, and whether it
+ * came from a peer rather than this instance's own navigation snapshot.
+ */
+export type HashReferenceOption =
+  | {
+      kind: "thread";
+      remote: boolean;
+      thread: NavigationThreadSummary;
+    }
+  | {
+      kind: "pull-request";
+      pullRequest: PrSummary;
+      remote: boolean;
+    };
+
+/**
+ * Assemble the `#` popover's rows from the local thread population and
+ * whatever a federated search turned up, local rows first.
+ *
+ * Shared by every composer surface so the two never disagree about what a
+ * `#` offers. Three things are filtered out, in this order:
+ *   - the thread being written in — referencing it tells the agent nothing
+ *     it does not already have, and on a bare `#` it is the most recently
+ *     updated thread, so it would otherwise take the first row;
+ *   - remote threads the local snapshot already carries, which would
+ *     otherwise appear twice once a peer answers;
+ *   - remote pull requests already offered by a local thread.
+ */
+export function buildHashReferenceOptions(params: {
+  currentThreadKey?: string;
+  localThreads: readonly NavigationThreadSummary[];
+  query: string;
+  remoteThreads?: readonly NavigationThreadSummary[];
+}): HashReferenceOption[] {
+  const { currentThreadKey, localThreads, query } = params;
+  const isCurrentThread = (thread: NavigationThreadSummary): boolean =>
+    currentThreadKey !== undefined
+    && buildThreadIdentityKey(thread.source, thread.id) === currentThreadKey;
+  const localCandidates = filterHashReferenceCandidates(
+    localThreads.filter((thread) => !isCurrentThread(thread)),
+    query,
+  );
+  const localThreadKeys = new Set(
+    localThreads.map((thread) =>
+      buildThreadIdentityKey(thread.source, thread.id),
+    ),
+  );
+  const remoteCandidates = filterHashReferenceCandidates(
+    (params.remoteThreads ?? []).filter(
+      (thread) =>
+        thread.federation?.ref.target.scope === "remote"
+        && !isCurrentThread(thread)
+        && !localThreadKeys.has(
+          buildThreadIdentityKey(thread.source, thread.id),
+        ),
+    ),
+    query,
+  );
+  const localPullRequestKeys = new Set(
+    localCandidates.pullRequests.map(buildPullRequestStatusKey),
+  );
+  return [
+    ...localCandidates.threads.map((thread) => ({
+      kind: "thread" as const,
+      remote: false,
+      thread,
+    })),
+    ...localCandidates.pullRequests.map((pullRequest) => ({
+      kind: "pull-request" as const,
+      pullRequest,
+      remote: false,
+    })),
+    ...remoteCandidates.threads.map((thread) => ({
+      kind: "thread" as const,
+      remote: true,
+      thread,
+    })),
+    ...remoteCandidates.pullRequests
+      .filter(
+        (pullRequest) =>
+          !localPullRequestKeys.has(buildPullRequestStatusKey(pullRequest)),
+      )
+      .map((pullRequest) => ({
+        kind: "pull-request" as const,
+        pullRequest,
+        remote: true,
+      })),
+  ];
 }
 
 function threadTitleMatchRank(title: string, query: string): number {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12984,6 +12984,84 @@ textarea,
   pointer-events: none;
 }
 
+/* Mention autocomplete (`$` skills, `@` directories, `#` threads and PRs).
+
+   Anchored to the field and opening upward, the same shape as the kebab's
+   menu two rules down — a floating card has nothing below the composer to
+   open into. It renders inside the card rather than through a body portal
+   so it stays under `.star-map-chat-card`, which is the ancestor every
+   star-map gesture guard tests for; a portalled list would take arrow keys
+   and wheel events straight to the camera.
+
+   `.star-map-chat-card` clips its children, so the list is capped short
+   enough to open over the transcript rather than out of the card. The
+   highlight is the shared popover language (`--accent-soft` tint, no
+   selection border), just at the card's smaller type scale. */
+.compact-composer__mention-list {
+  display: flex;
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 3;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 168px;
+  padding: 4px;
+  overflow-y: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.compact-composer__mention-option {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding: 5px 7px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.compact-composer__mention-option:hover,
+.compact-composer__mention-option.is-active {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.compact-composer__mention-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* One line, clipped: a thread title or a skill description is free text
+   and an unbounded row would be the only row the operator can see. */
+.compact-composer__mention-meta {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 10px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.compact-composer__mention-meta:empty {
+  display: none;
+}
+
 .compact-composer__controls {
   display: flex;
   flex: 0 0 auto;

--- a/apps/desktop/src/renderer/src/test/setup.ts
+++ b/apps/desktop/src/renderer/src/test/setup.ts
@@ -1,5 +1,29 @@
 import { afterEach } from "vitest";
 
+/**
+ * jsdom implements `getClientRects` on Element but not on Range, and
+ * ProseMirror asks a Range for its rects whenever it scrolls a selection
+ * into view — which `editor.commands.focus()` does by default.
+ *
+ * Synchronous tests never notice: the composer schedules its post-insert
+ * focus in a `requestAnimationFrame`, and teardown destroys the editor
+ * before the frame runs. The moment a test awaits anything after inserting
+ * a mention chip, that frame fires while the editor is still mounted and
+ * the missing method surfaces as an unhandled `TypeError` that fails the
+ * whole run rather than any one test.
+ *
+ * Empty rects are the honest answer here: jsdom does no layout, so there
+ * is no geometry to report and ProseMirror's scroll is correctly a no-op.
+ */
+if (typeof Range.prototype.getClientRects !== "function") {
+  Range.prototype.getClientRects = function getClientRects() {
+    return Object.assign([], { item: () => null }) as unknown as DOMRectList;
+  };
+  Range.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    return new DOMRect(0, 0, 0, 0);
+  };
+}
+
 const originalConsoleError = console.error.bind(console);
 
 afterEach(() => {


### PR DESCRIPTION
Follow-up to #1780. That PR swapped the Star Map chat card's composer to the shared markdown editor and deliberately left mentions out — `CompactComposer` passed a module-level empty token array, so `$`, `@`, and `#` typed through as literal text.

This wires them up.

## What the card can honestly resolve

All three trigger characters, and every chip kind they produce in the full composer:

| Trigger | Source | Notes |
|---|---|---|
| `$skill` | `desktopApi.listSkills` via `useThreadSkills` | Thread-scoped — the skill list comes from the thread's linked directories, so two cards genuinely differ. Fetched on the first `$`, not on mount. |
| `@directory` | local navigation snapshot | Shared module-level cache: a dozen open cards make one fetch, not twelve. |
| `#thread` | navigation snapshot + `jumpSearchRemoteThreads` | Peer threads included — a card on a star map is usually open *because* of another instance. |
| `#123` | `thread.prs` off the same snapshot | Chip carries the PR's real status, same as the sidebar. |

**Left out: `@file` chips.** Not a scope call — `kind: "file"` was never a trigger-driven kind. In the full composer the `@` popover lists only tracked directories; file chips come from drag/drop, paste, and the native file dialog. So the card offers everything typing can reach.

## Structure

Two commits. The first is a pure extraction with no behaviour change — the mention plumbing that lived in `Composer.tsx` (12k lines) moves to modules a second surface can call:

- `composer-mention-tokens.ts` — token minting per chip kind, the index adjustment that keeps zero-width tokens aligned as the plain draft changes around them, and the markdown serializer. Verbatim move.
- `buildHashReferenceOptions` in `lib/hash-references.ts` — the local/peer merge and dedupe that was inline in Composer's `#` memo, now with its own unit tests.
- `HighlightedAutocompleteLabel.tsx` — its own module now that two surfaces render autocomplete rows.

The second adds `useComposerMentions` (which popover is open, which row is highlighted, where the caret lands) and `useComposerMentionSources` (the shared, lazy population). `CompactComposer` grew 17 lines and re-implements nothing.

`mentionSources` is **optional**. A host that supplies nothing keeps today's literal-text behaviour, so this is not a breaking change for future adopters — there's a test pinning that.

## Popover placement and the camera guards

The list renders **inside the card**, not portalled to `document.body`. That is what keeps it under `.star-map-chat-card` — the selector `isStarMapTypingTarget`, `shouldPanOnWheel`, and `shouldStartCanvasPan` all test for. A portalled list would sit outside all three and arrow keys or a wheel over an open popover would fly the camera. A test asserts all three guards directly against a rendered option.

No z-layer changes were needed and `star-map-z-layers.test.ts` is untouched: the popover uses the same in-card `position: absolute` / open-upward shape as the existing kebab menu, so it never leaves `.star-map-chat-card`'s stacking context. `.star-map-chat-card` clips its children, so the list is capped short enough to open over the transcript rather than out of the card.

## Behaviour notes

- Precedence and keyboard match the full composer: `$` → `@` → `#`, arrows clamp, Enter/Tab commit, Escape retires one popover, a trigger with no candidates yields to the next.
- Cold `#` anchors are carried over — `#` queries span spaces, so nothing else retires them and a `#` mid-sentence would otherwise keep the picker armed and the peer search re-firing for the rest of the line.
- Federated `#` search is **opt-in via `searchRemoteThreads`**, not the shared hook's implicit bridge fallback, so a source-less host can't fire a network search by typing `#`.
- A bounced send restores the draft *and its chips*, unless the operator has started something new.

## One test-infrastructure change

`Range.getClientRects` is stubbed in the renderer test setup. jsdom does not implement it, and ProseMirror asks a Range for its rects whenever `editor.commands.focus()` scrolls a selection into view — which the post-insert frame does. Synchronous tests never notice because teardown destroys the editor first; the moment a test awaits anything after inserting a chip, that frame fires while mounted and the missing method surfaces as an unhandled `TypeError` that fails the whole run rather than any one test. Empty rects are the honest answer: jsdom does no layout, so ProseMirror's scroll is correctly a no-op.

`ComposerTiptapInput.tsx` is unchanged, as expected.

## Tests

`CompactComposer.test.tsx` (+12) covers each trigger opening its picker, selection inserting a chip, the chip's markdown in the text handed to `onSend`, a no-match trigger staying literal, two chips at their own offsets in one draft, Escape handing Enter back to the send path, the ARIA wiring, lazy loading, and the source-less default. `StarMapChatCard.test.tsx` (+4) covers lazy `listSkills`, `@` reaching `startTurn` as markdown, the current thread never being offered by `#`, and the three gesture guards. `hash-references.test.ts` (+4) covers the extracted merge/dedupe.

One pre-existing test needed a harness fix: it captured a single `onAgentEvent` listener, and the card now has two subscribers, so the fake fans out instead.

## Verification

```
pnpm test apps/desktop/src/renderer   # 193 files, 3093 tests
pnpm typecheck
pnpm lint:eslint                      # 0 errors (44 pre-existing warnings)
pnpm lint:colors
pnpm lint:boundaries
```

All green, and the renderer suite was run repeatedly to confirm the run is stable.

**Not verified:** desktop E2E is not run on this machine, so nothing here was exercised in a real Electron window. Specifically unverified by automation: the popover's actual geometry inside the pan/zoom canvas at non-1.0 scale, and live federated `#` results from a real peer (the wiring is tested, the round trip is not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)