### PR TITLE
fix(desktop): let the star map's terminal card own its chrome

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -1,6 +1,11 @@
 import { lazy, Suspense, useState, type CSSProperties } from "react";
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { InstanceChip } from "../federation/InstanceGlyph";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { isRemoteFederationTarget } from "@pwragent/shared";
 import { ThreadContextPanel } from "../thread-detail/ThreadContextPanel";
@@ -96,12 +101,23 @@ export function StarMapTerminalCard(props: {
   thread: NavigationThreadSummary;
   threadKey: string;
   rect: ChatCardRect;
+  /** Map zoom, so a drag on the grip moves the edge under the pointer. */
+  scale: number;
   zIndex: number;
   onClose: () => void;
   onHeightChange: (height: number) => void;
 }) {
   const thread = props.thread;
   const target = thread.federation?.ref.target ?? readRendererFederationTarget();
+  const remote =
+    target && isRemoteFederationTarget(target)
+      ? {
+          target,
+          instanceId: target.instanceId,
+          instanceLabel: thread.federation?.instanceLabel ?? target.instanceId,
+          celestialIcon: thread.federation?.celestialIcon,
+        }
+      : undefined;
   const primary = thread.linkedDirectories[0];
   const style: CSSProperties = {
     left: `${props.rect.left}px`,
@@ -110,6 +126,47 @@ export function StarMapTerminalCard(props: {
     height: `${props.rect.height}px`,
     zIndex: props.zIndex,
   };
+
+  const onHeightChange = props.onHeightChange;
+  const resizeBy = (delta: number) => {
+    onHeightChange(clampTerminalCardHeight(props.rect.height + delta));
+  };
+
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+
+    const startY = event.clientY;
+    const startHeight = props.rect.height;
+    // The card lives inside the pan/zoom canvas, so a screen pixel is not a
+    // card pixel. Same conversion the host card's own resize grip makes.
+    const zoom = props.scale > 0 ? props.scale : 1;
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const delta = (moveEvent.clientY - startY) / zoom;
+      onHeightChange(clampTerminalCardHeight(startHeight + delta));
+    };
+    const stopResize = () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", stopResize);
+      window.removeEventListener("pointercancel", stopResize);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", stopResize, { once: true });
+    window.addEventListener("pointercancel", stopResize, { once: true });
+  };
+
+  const handleResizeKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      resizeBy(STAR_MAP_TERMINAL_RESIZE_STEP);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      resizeBy(-STAR_MAP_TERMINAL_RESIZE_STEP);
+    }
+  };
+
   return (
     <section
       aria-label={`Terminal: ${thread.title}`}
@@ -118,6 +175,16 @@ export function StarMapTerminalCard(props: {
     >
       <header className="star-map-satellite-card__bar">
         <span className="star-map-satellite-card__title">Terminal</span>
+        {/* The pane's own chip floats over the terminal's top-right corner,
+            which inside a card means over the first line of output. The bar
+            is where a card says whose shell this is. */}
+        {remote ? (
+          <InstanceChip
+            icon={remote.celestialIcon}
+            instanceId={remote.instanceId}
+            label={remote.instanceLabel}
+          />
+        ) : null}
         <button
           aria-label={`Close terminal for ${thread.title}`}
           className="star-map-satellite-card__close"
@@ -133,26 +200,34 @@ export function StarMapTerminalCard(props: {
             desktopApi={props.desktopApi}
             threadKey={props.threadKey}
             cwd={primary?.worktreePath ?? primary?.path}
-            remote={
-              target && isRemoteFederationTarget(target)
-                ? {
-                    target,
-                    instanceId: target.instanceId,
-                    instanceLabel:
-                      thread.federation?.instanceLabel ?? target.instanceId,
-                    celestialIcon: thread.federation?.celestialIcon,
-                  }
-                : undefined
-            }
-            height={props.rect.height - STAR_MAP_SATELLITE_BAR_HEIGHT}
-            onHeightChange={(height) =>
-              props.onHeightChange(height + STAR_MAP_SATELLITE_BAR_HEIGHT)
+            remote={remote}
+            chrome="hosted"
+            height={
+              props.rect.height
+              - STAR_MAP_SATELLITE_BAR_HEIGHT
+              - STAR_MAP_TERMINAL_GRIP_HEIGHT
             }
             onClose={props.onClose}
             onExit={props.onClose}
           />
         </Suspense>
       </div>
+      {/* Bottom edge, not top: the card is pinned under its host, so the
+          bottom is the edge that actually moves when the card grows. The
+          pane's own handle sat under the title bar and grew the card
+          downward when dragged up. */}
+      <div
+        aria-label={`Resize terminal for ${thread.title}`}
+        aria-orientation="horizontal"
+        aria-valuemax={terminalCardMaxHeight()}
+        aria-valuemin={STAR_MAP_TERMINAL_CARD_MIN_HEIGHT}
+        aria-valuenow={Math.round(props.rect.height)}
+        className="star-map-terminal-card__grip"
+        onKeyDown={handleResizeKeyDown}
+        onPointerDown={startResize}
+        role="separator"
+        tabIndex={0}
+      />
     </section>
   );
 }
@@ -160,6 +235,47 @@ export function StarMapTerminalCard(props: {
 /** Title bar height, shared with the terminal's inner height math. */
 export const STAR_MAP_SATELLITE_BAR_HEIGHT = 30;
 
-/** Default rect height for a fresh terminal card, bar included. */
+/** Bottom resize rail, same hit height as the pane's own handle. */
+export const STAR_MAP_TERMINAL_GRIP_HEIGHT = 10;
+
+/** Keyboard resize step, matching the pane's own handle. */
+const STAR_MAP_TERMINAL_RESIZE_STEP = 16;
+
+/** Default rect height for a fresh terminal card, chrome included. */
 export const STAR_MAP_TERMINAL_CARD_HEIGHT =
-  CHAT_CARD_TERMINAL_HEIGHT + STAR_MAP_SATELLITE_BAR_HEIGHT;
+  CHAT_CARD_TERMINAL_HEIGHT
+  + STAR_MAP_SATELLITE_BAR_HEIGHT
+  + STAR_MAP_TERMINAL_GRIP_HEIGHT;
+
+export const STAR_MAP_TERMINAL_CARD_MIN_HEIGHT =
+  140 + STAR_MAP_SATELLITE_BAR_HEIGHT + STAR_MAP_TERMINAL_GRIP_HEIGHT;
+
+const STAR_MAP_TERMINAL_CARD_MAX_HEIGHT =
+  560 + STAR_MAP_SATELLITE_BAR_HEIGHT + STAR_MAP_TERMINAL_GRIP_HEIGHT;
+
+/**
+ * Tallest the card may grow right now. Mirrors the pane's own clamp rather
+ * than importing it: `IntegratedTerminal` is lazily imported here precisely
+ * to keep xterm out of the map's bundle, and a static import for one
+ * function would pull the whole module back in.
+ */
+export function terminalCardMaxHeight(): number {
+  const viewportMax =
+    typeof window === "undefined"
+      ? STAR_MAP_TERMINAL_CARD_MAX_HEIGHT
+      : Math.max(
+          STAR_MAP_TERMINAL_CARD_MIN_HEIGHT,
+          Math.floor(window.innerHeight * 0.68),
+        );
+  return Math.min(STAR_MAP_TERMINAL_CARD_MAX_HEIGHT, viewportMax);
+}
+
+export function clampTerminalCardHeight(value: number): number {
+  if (!Number.isFinite(value)) {
+    return STAR_MAP_TERMINAL_CARD_HEIGHT;
+  }
+  return Math.min(
+    terminalCardMaxHeight(),
+    Math.max(STAR_MAP_TERMINAL_CARD_MIN_HEIGHT, Math.round(value)),
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -271,11 +271,14 @@ export function terminalCardMaxHeight(): number {
 }
 
 export function clampTerminalCardHeight(value: number): number {
-  if (!Number.isFinite(value)) {
-    return STAR_MAP_TERMINAL_CARD_HEIGHT;
-  }
+  // The fallback goes through the same bounds as everything else: a short
+  // window can put the default above the maximum, and a clamp that can
+  // return out of range is worse than useless to its next caller.
+  const requested = Number.isFinite(value)
+    ? Math.round(value)
+    : STAR_MAP_TERMINAL_CARD_HEIGHT;
   return Math.min(
     terminalCardMaxHeight(),
-    Math.max(STAR_MAP_TERMINAL_CARD_MIN_HEIGHT, Math.round(value)),
+    Math.max(STAR_MAP_TERMINAL_CARD_MIN_HEIGHT, requested),
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -3700,6 +3700,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         height:
                           card.terminalHeight ?? STAR_MAP_TERMINAL_CARD_HEIGHT,
                       })}
+                      scale={view.scale}
                       zIndex={cardZ}
                       onClose={() => chatCards.toggleTerminal(card.key)}
                       onHeightChange={(height) =>

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapTerminalCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapTerminalCard.test.tsx
@@ -6,8 +6,10 @@ import {
   clampTerminalCardHeight,
   StarMapTerminalCard,
   STAR_MAP_SATELLITE_BAR_HEIGHT,
+  STAR_MAP_TERMINAL_CARD_HEIGHT,
   STAR_MAP_TERMINAL_CARD_MIN_HEIGHT,
   STAR_MAP_TERMINAL_GRIP_HEIGHT,
+  terminalCardMaxHeight,
 } from "../StarMapSatelliteCards";
 
 // The card lazy-loads the real pane to keep xterm out of the map's bundle;
@@ -132,8 +134,36 @@ describe("StarMapTerminalCard", () => {
 
   it("never shrinks the card below its chrome plus a usable terminal", () => {
     expect(clampTerminalCardHeight(0)).toBe(STAR_MAP_TERMINAL_CARD_MIN_HEIGHT);
-    expect(clampTerminalCardHeight(Number.NaN)).toBeGreaterThan(
-      STAR_MAP_TERMINAL_CARD_MIN_HEIGHT,
-    );
+  });
+
+  // A clamp that can hand back an out-of-range number is worse than useless
+  // to its next caller, so the non-finite fallback takes the bounds too.
+  //
+  // The window has to be SHORT for this to bite: at jsdom's default 768 the
+  // ceiling is 522 and the unclamped fallback of 300 sits under it, so the
+  // assertion would agree with the bug. At 400 the ceiling is 272.
+  it("keeps even its fallback inside the bounds it enforces", () => {
+    const realHeight = window.innerHeight;
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 400,
+    });
+    try {
+      expect(terminalCardMaxHeight()).toBeLessThan(
+        STAR_MAP_TERMINAL_CARD_HEIGHT,
+      );
+      for (const value of [Number.NaN, Number.POSITIVE_INFINITY]) {
+        const clamped = clampTerminalCardHeight(value);
+        expect(clamped).toBeGreaterThanOrEqual(
+          STAR_MAP_TERMINAL_CARD_MIN_HEIGHT,
+        );
+        expect(clamped).toBeLessThanOrEqual(terminalCardMaxHeight());
+      }
+    } finally {
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: realHeight,
+      });
+    }
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapTerminalCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapTerminalCard.test.tsx
@@ -1,0 +1,139 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  clampTerminalCardHeight,
+  StarMapTerminalCard,
+  STAR_MAP_SATELLITE_BAR_HEIGHT,
+  STAR_MAP_TERMINAL_CARD_MIN_HEIGHT,
+  STAR_MAP_TERMINAL_GRIP_HEIGHT,
+} from "../StarMapSatelliteCards";
+
+// The card lazy-loads the real pane to keep xterm out of the map's bundle;
+// nothing here is about the pane's internals, only about the chrome the
+// card puts around it.
+vi.mock("../../thread-detail/IntegratedTerminal", () => ({
+  IntegratedTerminal: (props: { chrome?: string; height: number }) => (
+    <div
+      data-testid="terminal-pane"
+      data-chrome={props.chrome}
+      data-height={props.height}
+    />
+  ),
+}));
+
+const RECT = { left: 40, top: 600, width: 420, height: 300 };
+
+function thread(): NavigationThreadSummary {
+  return {
+    id: "t-local",
+    title: "Local work",
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 1,
+  } as unknown as NavigationThreadSummary;
+}
+
+function renderCard(
+  overrides: { onHeightChange?: (height: number) => void } = {},
+) {
+  return render(
+    <StarMapTerminalCard
+      onClose={() => undefined}
+      onHeightChange={overrides.onHeightChange ?? (() => undefined)}
+      rect={RECT}
+      scale={1}
+      thread={thread()}
+      threadKey="codex:t-local"
+      zIndex={10}
+    />,
+  );
+}
+
+describe("StarMapTerminalCard", () => {
+  it("leaves exactly one close button on the card", async () => {
+    renderCard();
+
+    expect(
+      screen.getAllByRole("button", { name: /close terminal/i }),
+    ).toHaveLength(1);
+    expect(await screen.findByTestId("terminal-pane")).toHaveAttribute(
+      "data-chrome",
+      "hosted",
+    );
+  });
+
+  it("gives the pane the card minus its own chrome", async () => {
+    renderCard();
+
+    expect(await screen.findByTestId("terminal-pane")).toHaveAttribute(
+      "data-height",
+      String(
+        RECT.height
+          - STAR_MAP_SATELLITE_BAR_HEIGHT
+          - STAR_MAP_TERMINAL_GRIP_HEIGHT,
+      ),
+    );
+  });
+
+  // Dragging the bottom edge down grows the card. The pane's own handle sat
+  // under the title bar and grew the card downward when dragged up.
+  it("grows the card when the bottom grip is dragged down", () => {
+    const onHeightChange = vi.fn();
+    renderCard({ onHeightChange });
+
+    const grip = screen.getByRole("separator", { name: /resize terminal/i });
+    fireEvent.pointerDown(grip, { button: 0, clientY: 900 });
+    fireEvent.pointerMove(window, { clientY: 960 });
+
+    expect(onHeightChange).toHaveBeenLastCalledWith(RECT.height + 60);
+
+    fireEvent.pointerUp(window, { clientY: 960 });
+    onHeightChange.mockClear();
+    fireEvent.pointerMove(window, { clientY: 1200 });
+    expect(onHeightChange).not.toHaveBeenCalled();
+  });
+
+  it("converts screen pixels to card pixels at the current zoom", () => {
+    const onHeightChange = vi.fn();
+    render(
+      <StarMapTerminalCard
+        onClose={() => undefined}
+        onHeightChange={onHeightChange}
+        rect={RECT}
+        scale={0.5}
+        thread={thread()}
+        threadKey="codex:t-local"
+        zIndex={10}
+      />,
+    );
+
+    const grip = screen.getByRole("separator", { name: /resize terminal/i });
+    fireEvent.pointerDown(grip, { button: 0, clientY: 900 });
+    fireEvent.pointerMove(window, { clientY: 930 });
+
+    expect(onHeightChange).toHaveBeenLastCalledWith(RECT.height + 60);
+  });
+
+  it("resizes from the keyboard, down to grow", () => {
+    const onHeightChange = vi.fn();
+    renderCard({ onHeightChange });
+
+    const grip = screen.getByRole("separator", { name: /resize terminal/i });
+    fireEvent.keyDown(grip, { key: "ArrowDown" });
+    expect(onHeightChange).toHaveBeenLastCalledWith(RECT.height + 16);
+
+    fireEvent.keyDown(grip, { key: "ArrowUp" });
+    expect(onHeightChange).toHaveBeenLastCalledWith(RECT.height - 16);
+  });
+
+  it("never shrinks the card below its chrome plus a usable terminal", () => {
+    expect(clampTerminalCardHeight(0)).toBe(STAR_MAP_TERMINAL_CARD_MIN_HEIGHT);
+    expect(clampTerminalCardHeight(Number.NaN)).toBeGreaterThan(
+      STAR_MAP_TERMINAL_CARD_MIN_HEIGHT,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
@@ -26,7 +26,16 @@ type IntegratedTerminalProps = {
   remote?: IntegratedTerminalPaneRemote;
   height: number;
   visible?: boolean;
-  onHeightChange: (height: number) => void;
+  /**
+   * Who owns this pane's window chrome. "standalone" (the thread view) means
+   * the pane draws its own close button, resize handle, and remote chip.
+   * "hosted" means a surrounding card already has a title bar and a resize
+   * grip, so the pane draws none of them and is nothing but terminal: a
+   * second close button 3px under the card's, and a panel-colored resize
+   * strip under the card's bar, read as damage rather than as chrome.
+   */
+  chrome?: "standalone" | "hosted";
+  onHeightChange?: (height: number) => void;
   onClose: () => void;
   onExit: () => void;
 };
@@ -38,10 +47,12 @@ export function IntegratedTerminal({
   remote,
   height,
   visible = true,
+  chrome = "standalone",
   onHeightChange,
   onClose,
   onExit,
 }: IntegratedTerminalProps) {
+  const hosted = chrome === "hosted";
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const sessionIdRef = useRef<string | undefined>(undefined);
@@ -232,7 +243,7 @@ export function IntegratedTerminal({
   }, [height, visible]);
 
   const resizeBy = (delta: number) => {
-    onHeightChange(clampTerminalHeight(height + delta));
+    onHeightChange?.(clampTerminalHeight(height + delta));
   };
 
   const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -244,7 +255,7 @@ export function IntegratedTerminal({
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       const delta = startY - moveEvent.clientY;
-      onHeightChange(clampTerminalHeight(startHeight + delta));
+      onHeightChange?.(clampTerminalHeight(startHeight + delta));
     };
     const stopResize = () => {
       window.removeEventListener("pointermove", handlePointerMove);
@@ -297,7 +308,11 @@ export function IntegratedTerminal({
 
   return (
     <section
-      className="integrated-terminal"
+      className={
+        hosted
+          ? "integrated-terminal integrated-terminal--hosted"
+          : "integrated-terminal"
+      }
       aria-label="Integrated terminal"
       hidden={!visible}
       style={
@@ -306,19 +321,21 @@ export function IntegratedTerminal({
         } as CSSProperties
       }
     >
-      <div
-        aria-label="Resize terminal"
-        aria-orientation="horizontal"
-        aria-valuenow={clampTerminalHeight(height)}
-        aria-valuemin={TERMINAL_MIN_HEIGHT}
-        aria-valuemax={TERMINAL_MAX_HEIGHT}
-        className="integrated-terminal__resize-handle"
-        role="separator"
-        tabIndex={0}
-        onKeyDown={handleResizeKeyDown}
-        onPointerDown={startResize}
-      />
-      {remote ? (
+      {hosted ? null : (
+        <div
+          aria-label="Resize terminal"
+          aria-orientation="horizontal"
+          aria-valuenow={clampTerminalHeight(height)}
+          aria-valuemin={TERMINAL_MIN_HEIGHT}
+          aria-valuemax={TERMINAL_MAX_HEIGHT}
+          className="integrated-terminal__resize-handle"
+          role="separator"
+          tabIndex={0}
+          onKeyDown={handleResizeKeyDown}
+          onPointerDown={startResize}
+        />
+      )}
+      {remote && !hosted ? (
         <span className="integrated-terminal__remote">
           <InstanceChip
             icon={remote.celestialIcon}
@@ -327,18 +344,20 @@ export function IntegratedTerminal({
           />
         </span>
       ) : null}
-      <button
-        type="button"
-        className="integrated-terminal__close"
-        aria-label="Close terminal"
-        title="Close terminal"
-        onClick={onClose}
-        onPointerDown={(event) => {
-          event.stopPropagation();
-        }}
-      >
-        ×
-      </button>
+      {hosted ? null : (
+        <button
+          type="button"
+          className="integrated-terminal__close"
+          aria-label="Close terminal"
+          title="Close terminal"
+          onClick={onClose}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+        >
+          ×
+        </button>
+      )}
       <span className="integrated-terminal__status" role="status">
         {status}
       </span>

--- a/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
@@ -239,8 +239,15 @@ export function IntegratedTerminal({
       return;
     }
     fitAndResizeRef.current();
-    terminalRef.current?.focus();
-  }, [height, visible]);
+    // Standalone, the only thing that changes this height is the pane's own
+    // handle, and taking focus back afterwards is the point. Hosted, the
+    // height changes because the CARD's grip moved — pulling focus here put
+    // it in the shell after one keypress, so the operator's next arrow key
+    // went to the PTY instead of resizing.
+    if (!hosted) {
+      terminalRef.current?.focus();
+    }
+  }, [height, hosted, visible]);
 
   const resizeBy = (delta: number) => {
     onHeightChange?.(clampTerminalHeight(height + delta));

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
@@ -380,6 +380,31 @@ describe("IntegratedTerminal", () => {
     expect(screen.queryByLabelText("Resize terminal")).not.toBeInTheDocument();
     expect(screen.queryByText("Peer One")).not.toBeInTheDocument();
   });
+  // The hosting card owns the resize affordance, so a height change must not
+  // pull focus off the card's grip and into the shell.
+  it("keeps focus off the shell when a hosted card resizes it", async () => {
+    const api = terminalApiStub();
+    const view = (height: number) => (
+      <IntegratedTerminal
+        chrome="hosted"
+        desktopApi={api}
+        threadKey="codex:thread-a"
+        cwd="/repo/a"
+        height={height}
+        onClose={() => undefined}
+        onExit={() => undefined}
+      />
+    );
+    const { rerender } = render(view(260));
+
+    await waitFor(() => expect(xtermState.instances).toHaveLength(1));
+    const terminal = xtermState.instances[0]!;
+    terminal.focus.mockClear();
+
+    rerender(view(300));
+
+    expect(terminal.focus).not.toHaveBeenCalled();
+  });
 });
 
 function terminalApiStub(): DesktopApi {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { IntegratedTerminal } from "../IntegratedTerminal";
@@ -333,4 +333,67 @@ describe("IntegratedTerminal", () => {
       });
     });
   });
+
+  it("draws its own close and resize chrome when it is standalone", async () => {
+    render(
+      <IntegratedTerminal
+        desktopApi={terminalApiStub()}
+        threadKey="codex:thread-a"
+        cwd="/repo/a"
+        height={260}
+        onHeightChange={() => undefined}
+        onClose={() => undefined}
+        onExit={() => undefined}
+      />,
+    );
+
+    await waitFor(() => expect(xtermState.instances).toHaveLength(1));
+
+    expect(screen.getByLabelText("Close terminal")).toBeInTheDocument();
+    expect(screen.getByLabelText("Resize terminal")).toBeInTheDocument();
+  });
+
+  // A hosting card supplies a title bar with its own close button and its
+  // own resize grip. Drawing the pane's too put a second close 3px under
+  // the card's and a panel-colored dead band under the bar.
+  it("draws no close, handle, or remote chip when a card hosts it", async () => {
+    render(
+      <IntegratedTerminal
+        chrome="hosted"
+        desktopApi={terminalApiStub()}
+        threadKey="codex:thread-a"
+        cwd="/repo/a"
+        height={260}
+        remote={{
+          target: { instanceId: "peer-1", scope: "remote" },
+          instanceId: "peer-1",
+          instanceLabel: "Peer One",
+        }}
+        onClose={() => undefined}
+        onExit={() => undefined}
+      />,
+    );
+
+    await waitFor(() => expect(xtermState.instances).toHaveLength(1));
+
+    expect(screen.queryByLabelText("Close terminal")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Resize terminal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Peer One")).not.toBeInTheDocument();
+  });
 });
+
+function terminalApiStub(): DesktopApi {
+  return {
+    createIntegratedTerminal: vi.fn(async () => ({
+      sessionId: "session-1",
+      threadKey: "codex:thread-a",
+      cwd: "/repo/a",
+      shell: "/bin/zsh",
+    })),
+    writeIntegratedTerminal: vi.fn(async () => undefined),
+    resizeIntegratedTerminal: vi.fn(async () => undefined),
+    onIntegratedTerminalOutput: vi.fn(() => () => undefined),
+    onIntegratedTerminalExit: vi.fn(() => () => undefined),
+    onIntegratedTerminalError: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -22340,6 +22340,24 @@ a.transcript-message__messaging-origin:focus-visible {
   display: none;
 }
 
+/* Hosted in a card that already owns the chrome (the star map's terminal
+   satellite). The pane draws no close button, no handle, and no margins:
+   it is the terminal and nothing else, sized by the card. The 12px column
+   margins are what kept the black off the card's border — the breathing
+   room they gave moves inside the black as body padding, so the surface
+   runs to the border and the card's radius clips it. */
+.integrated-terminal--hosted {
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
+  max-height: none;
+  margin: 0;
+}
+
+.integrated-terminal--hosted .integrated-terminal__body {
+  padding: 8px 10px;
+}
+
 .integrated-terminal__resize-handle {
   flex: 0 0 10px;
   min-height: 10px;
@@ -29218,6 +29236,50 @@ a.transcript-message__messaging-origin:focus-visible {
   position: relative;
   flex: 1;
   min-height: 0;
+}
+
+/* Same measurements the pane gave its floating chip, now in the bar. */
+.star-map-terminal-card .star-map-satellite-card__bar .chip--instance {
+  height: 20px;
+  padding: 0 6px;
+  font-size: 10px;
+}
+
+/* The terminal fills its card, so the body is the column it stretches in. */
+.star-map-terminal-card .star-map-satellite-card__body {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Bottom-edge resize rail. The pane's own handle lived under the title bar
+   and grew the card downward when dragged upward; this card is pinned under
+   its host, so the edge that moves is the one the operator grabs. */
+.star-map-terminal-card__grip {
+  display: flex;
+  height: 10px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid var(--border-subtle);
+  cursor: ns-resize;
+}
+
+.star-map-terminal-card__grip::after {
+  width: 34px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--border-strong);
+  content: "";
+  transition: background-color 80ms ease;
+}
+
+.star-map-terminal-card__grip:hover::after {
+  background: var(--text-muted);
+}
+
+.star-map-terminal-card__grip:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
 }
 
 /* The rail's own max-width keeps a 32px peek margin in the thread view.


### PR DESCRIPTION
## Summary

- The Star Map's terminal satellite card wrapped a pane that still drew the chrome it needs in the thread view. Result: a second close button 3px under the card's own, a 10px panel-colored dead band under the title bar (the pane's resize handle), and black that stopped 12px short of the border on both sides (the pane's column margins).
- `IntegratedTerminal` gains `chrome="standalone" | "hosted"`. Hosted draws no close button, no resize handle, and no floating instance chip; it fills its box, and the breathing room its margins gave moves inside the black as body padding, so the surface runs to the card's border and the 8px radius clips it. The thread view keeps the standalone chrome unchanged.
- The card takes over what it removed: one close in the bar, the remote instance chip in the bar rather than floating over the first line of output, and a resize grip on the bottom edge.
- Bottom edge, not top: the card is pinned under its host, so the bottom is the edge that moves. The pane's top handle grew the card *downward* when dragged *up*. The new grip also divides its drag delta by the map zoom, which the pane's handle never did.

Design pass (before / tightened / spec): https://claude.ai/design/p/0b297285-de84-4d85-868c-fc4742faf558?file=Terminal+Card+Chrome.dc.html

## Verification

- `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:colors` — clean.
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail apps/desktop/src/renderer/src/features/star-map apps/desktop/src/renderer/src/styles` — 82 files, 1262 tests passing.
- New coverage: `StarMapTerminalCard.test.tsx` (one close button, pane sized to the card minus its chrome, grip drag grows downward, zoom conversion, keyboard resize, clamp floor) and two `IntegratedTerminal` cases pinning standalone-vs-hosted chrome.
- Desktop E2E not run — lab-only in this environment. The a11y spec audits the map but never opens a terminal card, so it exercises none of this.

## Notes

- Reviewer's eye: `STAR_MAP_TERMINAL_CARD_HEIGHT` now includes the grip, so a card restored from a stored `terminalHeight` gives the pane 10px less than before. It re-fits on the next `ResizeObserver` tick.
- `clampTerminalCardHeight` deliberately mirrors the pane's own clamp rather than importing it: `IntegratedTerminal` is lazily imported precisely to keep xterm out of the map's bundle, and a static import for one function would pull the whole module back in.
- The grip is a focusable `role="separator"` with `aria-valuenow/min/max`, same shape as the pane's handle it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
