### PR TITLE
fix(desktop): keep the Access Control graph inside the settings panel

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/AccessControlSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AccessControlSettings.tsx
@@ -36,6 +36,28 @@ type HoverTarget =
   | { kind: "perm"; id: MessagingPermissionId }
   | null;
 
+type Wires = {
+  actorRole: Array<{ id: string; d: string; key: string; roleId: string; danger: boolean }>;
+  rolePerm: Array<{ id: string; d: string; roleId: string; permId: string; danger: boolean }>;
+  reject: Array<{ id: string; d: string; key: string }>;
+};
+
+const EMPTY_WIRES: Wires = { actorRole: [], rolePerm: [], reject: [] };
+
+// Measurement runs on every layout change, so bail out of the state update
+// whenever the geometry is unchanged; otherwise the observer loops.
+function sameWires(a: Wires, b: Wires): boolean {
+  const sameList = (
+    x: ReadonlyArray<{ id: string; d: string }>,
+    y: ReadonlyArray<{ id: string; d: string }>,
+  ) => x.length === y.length && x.every((it, i) => it.id === y[i].id && it.d === y[i].d);
+  return (
+    sameList(a.actorRole, b.actorRole)
+    && sameList(a.rolePerm, b.rolePerm)
+    && sameList(a.reject, b.reject)
+  );
+}
+
 function subjectKey(subject: RbacSubject): string {
   if (subject.kind === "actor") {
     return `${subject.platform}:actor:${subject.actorId}`;
@@ -310,43 +332,44 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
 
   // ---- SVG connector wires ----
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const colsRef = useRef<HTMLDivElement | null>(null);
   const actorRefs = useRef<Record<string, HTMLElement | null>>({});
   const roleRefs = useRef<Record<string, HTMLElement | null>>({});
   const permRefs = useRef<Record<string, HTMLElement | null>>({});
   const rejectRef = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState({ w: 0, h: 0 });
+  const [wires, setWires] = useState<Wires>(EMPTY_WIRES);
 
-  useLayoutEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const update = () => {
-      const r = el.getBoundingClientRect();
-      setSize({ w: r.width, h: r.height });
-    };
-    update();
-    // ResizeObserver is absent under jsdom; the initial measure is enough there.
-    if (typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [subjects.length, policy?.roles.length]);
-
-  const wires = useMemo(() => {
+  // Measure after the DOM is committed, never during render: the card
+  // positions the wires attach to are only correct once the browser has laid
+  // out the commit that produced them.
+  const measure = useCallback(() => {
     const container = containerRef.current;
-    if (!container) return { actorRole: [], rolePerm: [], reject: [] as Array<{ id: string; d: string; key: string }> };
+    if (!container) return;
     const cb = container.getBoundingClientRect();
-    const right = (el: HTMLElement | null) =>
-      el ? { x: el.getBoundingClientRect().right - cb.left, y: el.getBoundingClientRect().top + el.getBoundingClientRect().height / 2 - cb.top } : null;
-    const left = (el: HTMLElement | null) =>
-      el ? { x: el.getBoundingClientRect().left - cb.left, y: el.getBoundingClientRect().top + el.getBoundingClientRect().height / 2 - cb.top } : null;
+    setSize((current) =>
+      current.w === cb.width && current.h === cb.height
+        ? current
+        : { w: cb.width, h: cb.height },
+    );
+    const right = (el: HTMLElement | null) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.right - cb.left, y: r.top + r.height / 2 - cb.top };
+    };
+    const left = (el: HTMLElement | null) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.left - cb.left, y: r.top + r.height / 2 - cb.top };
+    };
     const path = (a: { x: number; y: number } | null, b: { x: number; y: number } | null) => {
       if (!a || !b) return "";
       const dx = Math.max(40, (b.x - a.x) * 0.5);
       return `M ${a.x} ${a.y} C ${a.x + dx} ${a.y}, ${b.x - dx} ${b.y}, ${b.x} ${b.y}`;
     };
-    const actorRole: Array<{ id: string; d: string; key: string; roleId: string; danger: boolean }> = [];
-    const rolePerm: Array<{ id: string; d: string; roleId: string; permId: string; danger: boolean }> = [];
-    const reject: Array<{ id: string; d: string; key: string }> = [];
+    const actorRole: Wires["actorRole"] = [];
+    const rolePerm: Wires["rolePerm"] = [];
+    const reject: Wires["reject"] = [];
     for (const known of subjects) {
       const key = subjectKey(known.subject);
       const aEl = actorRefs.current[key];
@@ -385,8 +408,39 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
         }
       }
     }
-    return { actorRole, rolePerm, reject };
-  }, [size.w, size.h, subjects, policy, rolesForSubjectKey]);
+    const next: Wires = { actorRole, rolePerm, reject };
+    setWires((current) => (sameWires(current, next) ? current : next));
+  }, [subjects, policy, rolesForSubjectKey]);
+
+  useLayoutEffect(() => {
+    measure();
+    // ResizeObserver is absent under jsdom; the initial measure is enough there.
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => measure());
+    if (containerRef.current) ro.observe(containerRef.current);
+    const cols = colsRef.current;
+    if (cols) {
+      ro.observe(cols);
+      // The columns share the row's width, so a redistribution between them
+      // moves the cards without changing the graph box. Watch each column.
+      for (const col of Array.from(cols.children)) ro.observe(col);
+    }
+    return () => ro.disconnect();
+  }, [measure]);
+
+  useEffect(() => {
+    // Web fonts land after the last commit and change text metrics, which
+    // reflows the columns with no resize of anything we observe above.
+    const fonts = (document as Document & { fonts?: { ready: Promise<unknown> } }).fonts;
+    if (!fonts?.ready) return;
+    let cancelled = false;
+    void fonts.ready.then(() => {
+      if (!cancelled) measure();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [measure]);
 
   const wireActive = (which: "ar" | "rp" | "rj", info: { key?: string; roleId?: string; permId?: string }): boolean => {
     if (!trace) return false;
@@ -622,9 +676,9 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
           ))}
         </svg>
 
-        <div className="rbac-graph__cols">
+        <div className="rbac-graph__cols" ref={colsRef}>
           {/* ACTORS */}
-          <div>
+          <div className="rbac-col">
             <div className="rbac-col__head">
               <span className="rbac-col__eyebrow">Actors</span>
               <span className="rbac-col__count">{subjects.length}</span>
@@ -650,7 +704,10 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
                         {subjectLabel(known.subject, known.displayName)}
                         {known.bucket ? <span className="rbac-node__badge is-danger">bucket</span> : null}
                       </div>
-                      <div className="rbac-node__sub">
+                      <div
+                        className="rbac-node__sub"
+                        title={`${platformLabel(known.subject.platform)} · ${subjectSub(known.subject)}`}
+                      >
                         {platformLabel(known.subject.platform)} · {subjectSub(known.subject)}
                       </div>
                       <div className="rbac-node__roles">
@@ -690,7 +747,7 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
           </div>
 
           {/* ROLES */}
-          <div>
+          <div className="rbac-col">
             <div className="rbac-col__head">
               <span className="rbac-col__eyebrow">PwrAgent · Roles (additive)</span>
               <span className="rbac-col__count">{roles.length}</span>
@@ -714,8 +771,12 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
                     {role.danger ? <Alert /> : <Lock />}
                   </span>
                   <div className="rbac-node__main">
-                    <div className="rbac-node__name">{role.name}</div>
-                    <div className="rbac-node__sub" style={{ fontFamily: "var(--font-sans)" }}>
+                    <div className="rbac-node__name" title={role.name}>{role.name}</div>
+                    <div
+                      className="rbac-node__sub"
+                      style={{ fontFamily: "var(--font-sans)" }}
+                      title={role.description ?? `${role.permissions.length} permissions`}
+                    >
                       {role.description ?? `${role.permissions.length} permissions`}
                     </div>
                   </div>
@@ -743,7 +804,7 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
           </div>
 
           {/* PERMISSIONS */}
-          <div>
+          <div className="rbac-col">
             <div className="rbac-col__head">
               <span className="rbac-col__eyebrow">Permissions</span>
               <span className="rbac-col__count">{catalog.length}</span>
@@ -770,8 +831,12 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
                       {perm.danger === "high" ? <Alert /> : perm.danger === "med" ? <Eye /> : <Check />}
                     </span>
                     <div className="rbac-node__main">
-                      <div className="rbac-node__name">{perm.label}</div>
-                      <div className="rbac-node__sub" style={{ fontFamily: "var(--font-sans)" }}>
+                      <div className="rbac-node__name" title={perm.label}>{perm.label}</div>
+                      <div
+                        className="rbac-node__sub"
+                        style={{ fontFamily: "var(--font-sans)" }}
+                        title={perm.description}
+                      >
                         {perm.description}
                       </div>
                     </div>

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -28713,9 +28713,18 @@ a.transcript-message__messaging-origin:focus-visible {
 .rbac-graph__cols {
   position: relative;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 120px;
+  /* minmax(0, 1fr), not 1fr: the auto minimum is the column's min-content
+     width, which the card descriptions push far past the panel width. That
+     overflowed the third column out of a container that cannot scroll. */
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  /* The gap is wire room, so it scales with the window instead of pinning
+     120px of empty space while the cards starve. */
+  column-gap: clamp(36px, 4.5vw, 96px);
+  row-gap: 0;
   z-index: 2;
+}
+.rbac-col {
+  min-width: 0;
 }
 .rbac-graph__svg {
   position: absolute;
@@ -28787,6 +28796,7 @@ a.transcript-message__messaging-origin:focus-visible {
   position: relative;
   display: flex;
   align-items: center;
+  min-width: 0;
   gap: 10px;
   padding: 10px 12px;
   border: 1px solid var(--border-subtle);
@@ -28795,6 +28805,9 @@ a.transcript-message__messaging-origin:focus-visible {
   cursor: pointer;
   text-align: left;
   width: 100%;
+  /* Clip rather than spill: the badge and count pills do not shrink, so a very
+     narrow panel would otherwise push them outside the card border. */
+  overflow: hidden;
   transition: border-color 140ms ease, background 140ms ease;
 }
 .rbac-node:hover {
@@ -28855,14 +28868,24 @@ a.transcript-message__messaging-origin:focus-visible {
 .rbac-node__name {
   font: 600 12.5px/1.2 var(--font-sans);
   color: var(--text-primary);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  display: flex; align-items: center; gap: 6px;
+  /* Wraps instead of clipping: the badge and count pills are fixed width, so
+     a nowrap name loses its tail on a narrow panel with no ellipsis — a flex
+     container does not apply text-overflow to its anonymous text run. */
+  display: flex; align-items: center; flex-wrap: wrap; gap: 4px 6px;
+  overflow-wrap: break-word;
 }
 .rbac-node__sub {
   font: 500 11px/1.3 var(--font-mono);
   color: var(--text-muted);
   margin-top: 2px;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  /* Wrap and clamp to three lines, with the full text on the element's
+     title. A nowrap sub-line makes the whole column's min-content width the
+     full description, which is what overflowed the grid. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  overflow-wrap: anywhere;
 }
 .rbac-node__badge {
   font: 600 9px/1 var(--font-sans);


### PR DESCRIPTION
## Summary

- Enabling Access Control rendered a broken screen: the permissions column sat off-screen with no way to scroll or zoom to it, and the connector wires floated free of the cards they were supposed to join.
- **Overflow.** `.rbac-graph__cols` sized its three columns with `1fr`, whose auto minimum is the column's *min-content* width. `.rbac-node__sub` was `white-space: nowrap`, so each column's min-content was the full width of its longest card description (~600px). The grid grew past the settings panel and `.rbac-graph { overflow: hidden }` clipped the third column with nothing to scroll. Fixed with `repeat(3, minmax(0, 1fr))` plus `min-width: 0` on the new `.rbac-col` wrappers.
- **Cards too wide.** Descriptions now wrap and clamp to three lines instead of one nowrap line, with the full text on a `title` tooltip. Card names wrap rather than being cut without an ellipsis — a flex container does not apply `text-overflow` to its anonymous text run, which is why `Power User + To` lost its tail with no `…`.
- **Gap.** `120px` → `clamp(36px, 4.5vw, 96px)`, so wire room scales with the window instead of eating 120px twice while the cards starve.
- **Detached wires.** The paths were computed in a `useMemo` during render, and the only `ResizeObserver` watched the graph container, whose size never changes. When the columns redistributed after the commit (web fonts changing text metrics) the cards moved and the paths did not, leaving a constant offset at both ends. Measurement now runs in a layout effect after the DOM is committed, observes the container, the column row, **and each column**, and re-measures on `document.fonts.ready`. The state update is skipped when the geometry is unchanged so the observer cannot loop.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — passes.
- `pnpm lint:colors` — passes. `eslint` on the changed file reports only a pre-existing warning (`toggleSelect`'s unused `current`).
- `pnpm test apps/desktop/src/renderer/src/features/settings apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — 12 files, 232 tests pass.
- Layout measured in a browser harness built from the real extracted RBAC CSS: zero horizontal overflow at panel widths 560/640/700/760/840/980/1200, no card spilling its column at any of them, and at 840px the columns come out 238px each. After the observer fires, the wire endpoint x-coordinate matches the card edge exactly (230 vs 230).

## Notes

- Not launched in the Electron app — the harness reproduced the graph markup against the real CSS rather than driving the desktop build. Worth a quick look in dev at your actual window size.
- Below roughly a 700px panel the cards are cramped but intact: names wrap to 2–3 lines rather than clipping. A container query that dropped the `BUILT-IN`/`DANGER` badges to their own row at narrow widths was tried and backed out — the flex re-wrap squeezed labels to one character per line, which was worse. It is not in this diff.
- The main window's 960px minimum leaves roughly a 680px content pane, which is inside the range verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)