### PR TITLE
fix(desktop): trim redundant work in the Access Control wire measurement

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/AccessControlSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AccessControlSettings.tsx
@@ -352,14 +352,25 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
         ? current
         : { w: cb.width, h: cb.height },
     );
+    // One rect per element, not per edge: a role's box is otherwise re-read
+    // once for every permission it grants, and this runs on every resize
+    // notification.
+    const rects = new Map<HTMLElement, DOMRect>();
+    const rectOf = (el: HTMLElement): DOMRect => {
+      const cached = rects.get(el);
+      if (cached) return cached;
+      const measured = el.getBoundingClientRect();
+      rects.set(el, measured);
+      return measured;
+    };
     const right = (el: HTMLElement | null) => {
       if (!el) return null;
-      const r = el.getBoundingClientRect();
+      const r = rectOf(el);
       return { x: r.right - cb.left, y: r.top + r.height / 2 - cb.top };
     };
     const left = (el: HTMLElement | null) => {
       if (!el) return null;
-      const r = el.getBoundingClientRect();
+      const r = rectOf(el);
       return { x: r.left - cb.left, y: r.top + r.height / 2 - cb.top };
     };
     const path = (a: { x: number; y: number } | null, b: { x: number; y: number } | null) => {
@@ -687,6 +698,7 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
               {subjects.map((known) => {
                 const key = subjectKey(known.subject);
                 const attached = rolesForSubjectKey(key);
+                const sub = `${platformLabel(known.subject.platform)} · ${subjectSub(known.subject)}`;
                 return (
                   <div
                     key={key}
@@ -704,11 +716,8 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
                         {subjectLabel(known.subject, known.displayName)}
                         {known.bucket ? <span className="rbac-node__badge is-danger">bucket</span> : null}
                       </div>
-                      <div
-                        className="rbac-node__sub"
-                        title={`${platformLabel(known.subject.platform)} · ${subjectSub(known.subject)}`}
-                      >
-                        {platformLabel(known.subject.platform)} · {subjectSub(known.subject)}
+                      <div className="rbac-node__sub" title={sub}>
+                        {sub}
                       </div>
                       <div className="rbac-node__roles">
                         {roles.map((role) => {
@@ -771,7 +780,7 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
                     {role.danger ? <Alert /> : <Lock />}
                   </span>
                   <div className="rbac-node__main">
-                    <div className="rbac-node__name" title={role.name}>{role.name}</div>
+                    <div className="rbac-node__name">{role.name}</div>
                     <div
                       className="rbac-node__sub"
                       style={{ fontFamily: "var(--font-sans)" }}
@@ -831,7 +840,7 @@ export function AccessControlSettings(props: { desktopApi: DesktopApi }) {
                       {perm.danger === "high" ? <Alert /> : perm.danger === "med" ? <Eye /> : <Check />}
                     </span>
                     <div className="rbac-node__main">
-                      <div className="rbac-node__name" title={perm.label}>{perm.label}</div>
+                      <div className="rbac-node__name">{perm.label}</div>
                       <div
                         className="rbac-node__sub"
                         style={{ fontFamily: "var(--font-sans)" }}


### PR DESCRIPTION
## Summary

- Follow-ups from the `/code-review` pass on #1784, which was squash-merged before these landed. No behavior change to the layout fix itself.
- **Rect caching.** `measure()` called `getBoundingClientRect()` once per graph *edge* instead of once per element, so a role's box was re-read for every permission it grants — roughly 120 reads per measurement pass on the seeded policy (5 built-in roles over a 20-permission catalog, Admin holding all 20), repeated on every `ResizeObserver` notification while a window resize is dragged. One rect per element per pass cuts that to ~26.
- **Redundant tooltips.** #1784 changed `.rbac-node__name` to `flex-wrap: wrap` with `overflow-wrap: break-word`, so role and permission names are never clipped — the `title` attributes there only repeated fully visible text, and on the permissions column the native tooltip popped over the component's own `PermTooltip` that the same hover opens. Removed from the names; kept on the descriptions, which still clamp at three lines.
- **Duplication.** The actor sub-line expression was written twice, once in the `title` and once in the rendered children, so the two could drift. Bound to one `const`.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — passes on the post-merge main.
- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/AccessControlSettings.test.tsx` — 6/6 pass. The wider settings suite (11 files, 162 tests) passed twice on this change before rebasing onto the merged main.
- `eslint` on the changed file reports only the pre-existing `toggleSelect` unused-arg warning.

## Notes

- The review also flagged that `sameWires` compares only `id` and `d`, ignoring the `danger` flag. I did not change it: `danger` is derived from the permission set via `roleIsDangerous`, so any flip also adds or removes a role→permission wire, which the id comparison already catches. Reported here rather than silently "hardened" so a reviewer can disagree.
- No correctness bugs were found in #1784's diff — the observer/measure lifecycle was checked for stale refs, re-entrancy, and the mount transitions through the `loading` early return and the policy-load-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)