### PR TITLE
perf(desktop): fold edited-file groups incrementally per delta

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -21,6 +21,7 @@ import { TranscriptDiff } from "./TranscriptDiff";
 import { DiffStat } from "../../lib/DiffStat";
 import { EditGroupCommitBadge } from "./EditGroupCommitBadge";
 import {
+  editedFileKey,
   flattenEditedFileGroups,
   type EditedFileGroup,
 } from "./edited-file-groups";
@@ -429,7 +430,7 @@ export function EditedFileList(props: {
   return (
     <ul className="live-work-rail__file-list">
       {props.details.map((detail) => (
-        <li key={detail.id} className="live-work-rail__file-row">
+        <li key={editedFileKey(detail)} className="live-work-rail__file-row">
           <EditedFileRow detail={detail} />
         </li>
       ))}

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -14,6 +14,7 @@ import {
   type EditedFileGroupView,
 } from "./EditedFileGroupList";
 import {
+  editedFileKey,
   summarizeEditedFileGroups,
   type EditedFileGroup,
 } from "./edited-file-groups";
@@ -176,7 +177,7 @@ function ChangedFilesSection(props: {
       <ul className="live-work-rail__file-list live-work-rail__file-list--static">
         {props.entry.details.map((detail) => (
           <li
-            key={detail.id}
+            key={editedFileKey(detail)}
             className="live-work-rail__file-row live-work-rail__file-row--static"
           >
             <span className="live-work-rail__file-path" title={detail.path}>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -82,7 +82,10 @@ import {
   type ContextTabId,
   type EditedFilesDock,
 } from "./context-panels/context-tab";
-import { collectEditedFileGroups } from "./edited-file-groups";
+import {
+  createEditedFileGroupsCollector,
+  type EditedFileGroupsCollector,
+} from "./edited-file-groups";
 import { useEditCommitStates } from "./useEditCommitStates";
 import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
@@ -2363,13 +2366,21 @@ export function ThreadView(props: ThreadViewProps) {
       )
     : -1;
 
+  // One collector per mounted view: `props.transcriptEntries` gets a fresh
+  // array identity on every streamed delta, so the derivation folds each entry
+  // once instead of re-walking the transcript per delta.
+  const editedFileGroupsCollectorRef = useRef<EditedFileGroupsCollector>(
+    undefined,
+  );
+  editedFileGroupsCollectorRef.current ??= createEditedFileGroupsCollector();
+  const editedFileGroupsCollector = editedFileGroupsCollectorRef.current;
   // Accumulated edited files: persisted replay entries + deferred live
   // entries grouped per turn, cleared past a committed turn once the
   // next turn starts. Rehydrates on thread load because the replay
   // already carries per-file diffs and command exit codes.
   const editedFileGroups = useMemo(
     () =>
-      collectEditedFileGroups({
+      editedFileGroupsCollector.collect({
         entries: props.transcriptEntries,
         activeTurnId: props.activeTurnId,
         forkCreatedAt: selectedThread?.forkSourceThreadId
@@ -2378,6 +2389,7 @@ export function ThreadView(props: ThreadViewProps) {
         livePendingEntry: pendingRailActivityEntry,
       }),
     [
+      editedFileGroupsCollector,
       props.transcriptEntries,
       props.activeTurnId,
       selectedThread?.createdAt,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -36,6 +36,61 @@ function groups(count: number): EditedFileGroup[] {
   return Array.from({ length: count }, (_, index) => group(count - index));
 }
 
+/**
+ * A live cumulative turn diff, the way `turn/diff/updated` builds one: detail
+ * ids are positional over the diff's path-ordered sections
+ * (`live-diff-<turn>-<n>`), so editing a file that sorts earlier renumbers
+ * every row behind it.
+ */
+function liveDiffGroup(paths: string[]): EditedFileGroup {
+  return {
+    key: "turn-live",
+    turn: { id: "turn-live" },
+    details: [...paths].sort().map((path, index) => ({
+      id: `live-diff-turn-live-${index + 1}`,
+      kind: "write" as const,
+      label: `Update ${path}`,
+      path,
+      fileDiff: {
+        kind: "update" as const,
+        diff: `diff for ${path}`,
+        additions: 1,
+        removals: 0,
+      },
+    })),
+    summary: `Edited ${paths.length} files`,
+    additions: paths.length,
+    removals: 0,
+    live: true,
+  };
+}
+
+describe("EditedFileGroupList live-diff row stability", () => {
+  it("keeps a file's row mounted when a new file renumbers the diff", () => {
+    const { rerender } = render(
+      <EditedFileGroupList groups={[liveDiffGroup(["src/z.ts"])]} />,
+    );
+
+    const before = screen.getByText("Update src/z.ts");
+    // The operator opened this file's diff; a re-mount would collapse it and
+    // flash the row away mid-turn.
+    const toggle = before.closest("button");
+    fireEvent.click(toggle as HTMLElement);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // The agent now edits a file that sorts first, so src/z.ts moves from
+    // `live-diff-turn-live-1` to `live-diff-turn-live-2`.
+    rerender(
+      <EditedFileGroupList groups={[liveDiffGroup(["src/a.ts", "src/z.ts"])]} />,
+    );
+
+    expect(screen.getByText("Update src/a.ts")).toBeInTheDocument();
+    const after = screen.getByText("Update src/z.ts");
+    expect(after).toBe(before);
+    expect(after.closest("button")).toHaveAttribute("aria-expanded", "true");
+  });
+});
+
 describe("EditedFileGroupList Show more / Show less", () => {
   it("shows the first 3 turn-groups and collapses the rest behind a toggle", () => {
     render(<EditedFileGroupList groups={groups(5)} />);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups-incremental.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups-incremental.test.ts
@@ -283,6 +283,46 @@ describe("createEditedFileGroupsCollector", () => {
     );
   });
 
+  it("recomputes when a refresh replaces the middle of the transcript", () => {
+    // `reconcileRetainedTranscriptTail` splices retained entries (identity
+    // preserved) ahead of freshly read ones, so a refresh can leave the first
+    // and last folded entries pointing at the same objects while replacing
+    // everything between them — including with different content.
+    const transcript = Array.from({ length: 100 }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${Math.floor(index / 4)}`,
+        details: [
+          fileDiffDetail({ path: `/repo/src/file-${index}.ts`, additions: 1 }),
+        ],
+      }),
+    );
+    const collector = createEditedFileGroupsCollector();
+    collector.collect({ entries: transcript });
+
+    // Rewrite the band that actually matters: entries old enough to be
+    // committed (the re-folded tail is the last 32, so the fold committed
+    // through index 67) but still inside one of the rendered turn groups.
+    // Entry 0 and entry 67 keep their identity, so head/tail anchors alone
+    // would report the fold as still valid and serve the pre-refresh counts.
+    const refreshed = transcript.slice(0);
+    for (let index = 60; index < 67; index += 1) {
+      refreshed[index] = activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${Math.floor(index / 4)}`,
+        details: [
+          fileDiffDetail({ path: `/repo/src/file-${index}.ts`, additions: 9 }),
+        ],
+      });
+    }
+
+    expect(collector.collect({ entries: refreshed })).toEqual(
+      collectEditedFileGroups({ entries: refreshed }),
+    );
+  });
+
   it("keeps unchanged groups referentially stable across deltas", () => {
     const transcript = Array.from({ length: 12 }, (_, index) =>
       activityEntry({

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups-incremental.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups-incremental.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+} from "@pwragent/shared";
+import {
+  MAX_RETAINED_TURN_GROUPS,
+  collectEditedFileGroups,
+  createEditedFileGroupsCollector,
+  type EditedFileGroupsInput,
+} from "../edited-file-groups";
+
+/**
+ * The incremental collector must be indistinguishable from a full recompute.
+ * `edited-file-groups.test.ts` is the behavioral contract for the derivation
+ * itself; this file replays streaming-shaped inputs through the collector and
+ * compares every step against `collectEditedFileGroups` on the same input.
+ */
+
+let detailCounter = 0;
+
+function fileDiffDetail(params: {
+  path: string;
+  additions?: number;
+  removals?: number;
+  kind?: "add" | "delete" | "update";
+}): AppServerThreadActivityDetail {
+  detailCounter += 1;
+  const kind = params.kind ?? "update";
+  return {
+    id: `detail-${detailCounter}`,
+    kind: "write",
+    label: `${kind[0].toUpperCase()}${kind.slice(1)} ${params.path.split("/").pop()}`,
+    path: params.path,
+    fileDiff: {
+      kind,
+      diff: `diff for ${params.path} (#${detailCounter})`,
+      additions: params.additions ?? 1,
+      removals: params.removals ?? 0,
+    },
+  };
+}
+
+function activityEntry(params: {
+  id: string;
+  createdAt?: number;
+  turnId?: string;
+  details: AppServerThreadActivityDetail[];
+}): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: params.id,
+    ...(params.createdAt !== undefined ? { createdAt: params.createdAt } : {}),
+    summary: "activity",
+    details: params.details,
+    ...(params.turnId ? { turn: { id: params.turnId } } : {}),
+  };
+}
+
+/**
+ * Replay a transcript one entry at a time, asserting after each delta that the
+ * collector agrees with a from-scratch recompute. `snapshot` builds the array
+ * the caller would hand us for a given length — streaming always produces a
+ * fresh array identity, and some scenarios also re-create entry objects.
+ */
+function expectIncrementalParity(params: {
+  length: number;
+  snapshot: (length: number) => AppServerThreadEntry[];
+  rest?: (length: number) => Omit<EditedFileGroupsInput, "entries">;
+}): void {
+  const collector = createEditedFileGroupsCollector();
+  for (let length = 1; length <= params.length; length += 1) {
+    const rest = params.rest?.(length) ?? {};
+    const incremental = collector.collect({
+      entries: params.snapshot(length),
+      ...rest,
+    });
+    const recomputed = collectEditedFileGroups({
+      entries: params.snapshot(length),
+      ...rest,
+    });
+    expect(incremental, `delta ${length}`).toEqual(recomputed);
+  }
+}
+
+describe("createEditedFileGroupsCollector", () => {
+  it("matches a full recompute while a transcript streams in", () => {
+    const transcript = Array.from({ length: 60 }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${Math.floor(index / 4)}`,
+        details: [
+          fileDiffDetail({
+            path: `/repo/src/file-${index % 3}.ts`,
+            additions: index,
+            removals: index % 2,
+          }),
+        ],
+      }),
+    );
+
+    expectIncrementalParity({
+      length: transcript.length,
+      snapshot: (length) => transcript.slice(0, length),
+    });
+  });
+
+  it("matches a full recompute past the retained turn-group cap", () => {
+    const turnCount = MAX_RETAINED_TURN_GROUPS * 3;
+    const transcript = Array.from({ length: turnCount }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${index}`,
+        details: [fileDiffDetail({ path: `/repo/src/file-${index}.ts` })],
+      }),
+    );
+
+    expectIncrementalParity({
+      length: transcript.length,
+      snapshot: (length) => transcript.slice(0, length),
+    });
+  });
+
+  it("matches a full recompute for stacked add/delete/update on one file", () => {
+    // `mergeFileDiffDetail` is order-sensitive (a delete wins, an add sticks),
+    // so a collector that folds in a different order than a single pass would
+    // diverge here even though counts still add up.
+    const kinds = ["add", "update", "delete", "update", "add"] as const;
+    const transcript = kinds.map((kind, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: "turn-1",
+        details: [fileDiffDetail({ path: "/repo/src/one.ts", kind })],
+      }),
+    );
+
+    expectIncrementalParity({
+      length: transcript.length,
+      snapshot: (length) => transcript.slice(0, length),
+    });
+  });
+
+  it("matches a full recompute when the streaming tail is re-created", () => {
+    const transcript = Array.from({ length: 40 }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${Math.floor(index / 4)}`,
+        details: [fileDiffDetail({ path: `/repo/src/file-${index % 5}.ts` })],
+      }),
+    );
+
+    expectIncrementalParity({
+      length: transcript.length,
+      snapshot: (length) => {
+        const slice = transcript.slice(0, length);
+        // The last few entries arrive as fresh objects every delta, the way
+        // pending entries do as they resolve against the persisted replay.
+        for (let index = Math.max(0, length - 5); index < length; index += 1) {
+          slice[index] = { ...(slice[index] as AppServerThreadActivityEntry) };
+        }
+        return slice;
+      },
+    });
+  });
+
+  it("matches a full recompute across a live cumulative diff overlay", () => {
+    const transcript = Array.from({ length: 12 }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${Math.floor(index / 4)}`,
+        details: [fileDiffDetail({ path: `/repo/src/file-${index % 3}.ts` })],
+      }),
+    );
+
+    expectIncrementalParity({
+      length: transcript.length,
+      snapshot: (length) => transcript.slice(0, length),
+      rest: (length) => ({
+        activeTurnId: "turn-live",
+        livePendingEntry: activityEntry({
+          id: "live-diff-turn-live",
+          createdAt: 5_000 + length,
+          turnId: "turn-live",
+          details: Array.from({ length: (length % 3) + 1 }, (_, fileIndex) =>
+            fileDiffDetail({
+              path: `/repo/src/live-${fileIndex}.ts`,
+              additions: length,
+            }),
+          ),
+        }),
+      }),
+    });
+  });
+
+  it("matches a full recompute when the live turn also has per-item entries", () => {
+    // The live cumulative entry is authoritative for its turn; per-item
+    // entries from the same turn must stay ignored as they stream in.
+    const transcript = [
+      activityEntry({
+        id: "entry-0",
+        createdAt: 1_000,
+        turnId: "turn-1",
+        details: [fileDiffDetail({ path: "/repo/src/a.ts", additions: 100 })],
+      }),
+      activityEntry({
+        id: "live-diff-turn-1",
+        createdAt: 1_001,
+        turnId: "turn-1",
+        details: [fileDiffDetail({ path: "/repo/src/a.ts", additions: 4 })],
+      }),
+      activityEntry({
+        id: "entry-2",
+        createdAt: 1_002,
+        turnId: "turn-1",
+        details: [fileDiffDetail({ path: "/repo/src/b.ts", additions: 7 })],
+      }),
+    ];
+
+    expectIncrementalParity({
+      length: transcript.length,
+      snapshot: (length) => transcript.slice(0, length),
+    });
+  });
+
+  it("matches a full recompute past a fork boundary", () => {
+    const transcript = [
+      ...Array.from({ length: 6 }, (_, index) =>
+        activityEntry({
+          id: `ancestor-${index}`,
+          createdAt: 1_000 + index,
+          turnId: `ancestor-turn-${index}`,
+          details: [fileDiffDetail({ path: `/repo/src/ancestor-${index}.ts` })],
+        }),
+      ),
+      ...Array.from({ length: 6 }, (_, index) =>
+        activityEntry({
+          id: `fork-${index}`,
+          createdAt: 3_000 + index,
+          turnId: `fork-turn-${index}`,
+          details: [fileDiffDetail({ path: `/repo/src/fork-${index}.ts` })],
+        }),
+      ),
+    ];
+
+    expectIncrementalParity({
+      length: transcript.length,
+      snapshot: (length) => transcript.slice(0, length),
+      rest: () => ({ forkCreatedAt: 2_000 }),
+    });
+  });
+
+  it("recomputes when the transcript is replaced wholesale", () => {
+    const original = Array.from({ length: 8 }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${index}`,
+        details: [fileDiffDetail({ path: `/repo/src/file-${index}.ts` })],
+      }),
+    );
+    const collector = createEditedFileGroupsCollector();
+    collector.collect({ entries: original });
+
+    // A fresh read of a different thread: same shape, all-new identities and
+    // different content. Nothing of the previous fold may survive.
+    const replacement = Array.from({ length: 3 }, (_, index) =>
+      activityEntry({
+        id: `other-${index}`,
+        createdAt: 7_000 + index,
+        turnId: `other-turn-${index}`,
+        details: [fileDiffDetail({ path: `/repo/src/other-${index}.ts` })],
+      }),
+    );
+
+    expect(collector.collect({ entries: replacement })).toEqual(
+      collectEditedFileGroups({ entries: replacement }),
+    );
+  });
+
+  it("keeps unchanged groups referentially stable across deltas", () => {
+    const transcript = Array.from({ length: 12 }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${index}`,
+        details: [fileDiffDetail({ path: `/repo/src/file-${index}.ts` })],
+      }),
+    );
+    const collector = createEditedFileGroupsCollector();
+
+    const before = collector.collect({ entries: transcript.slice(0, 6) });
+    const after = collector.collect({ entries: transcript.slice(0, 7) });
+
+    // Only the newest group is new; the settled ones keep their identity so
+    // the rail's rows do not re-render (let alone remount) per delta.
+    expect(after[0]).not.toBe(before[0]);
+    expect(after.slice(1)).toEqual(before);
+    for (const [index, group] of before.entries()) {
+      expect(after[index + 1]).toBe(group);
+    }
+  });
+
+  it("returns the identical array when a delta changes nothing", () => {
+    const transcript = Array.from({ length: 5 }, (_, index) =>
+      activityEntry({
+        id: `entry-${index}`,
+        createdAt: 1_000 + index,
+        turnId: `turn-${index}`,
+        details: [fileDiffDetail({ path: `/repo/src/file-${index}.ts` })],
+      }),
+    );
+    const collector = createEditedFileGroupsCollector();
+
+    const first = collector.collect({ entries: transcript.slice(0) });
+    // A re-render with a fresh array identity over the same entries — every
+    // streamed delta that touches no file does exactly this.
+    const second = collector.collect({ entries: transcript.slice(0) });
+    expect(second).toBe(first);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups-performance.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups-performance.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+} from "@pwragent/shared";
+import { createEditedFileGroupsCollector } from "../edited-file-groups";
+
+/**
+ * Per-delta cost of the edited-file-groups derivation.
+ *
+ * `session.entries` gets a fresh array identity on every streamed transcript
+ * delta, so a derivation that walks the whole transcript costs O(n) per delta
+ * and O(n^2) across a turn. These tests measure the *marginal* cost of one
+ * delta by counting the input the derivation touches — no wall-clock
+ * thresholds, which flake on loaded CI.
+ *
+ * The assertions are ratios (delta at ~5000 entries vs. delta at ~100), so
+ * they hold regardless of machine speed: a full-walk derivation reads ~50x
+ * more at 5000 than at 100, an incremental one reads the same either way.
+ */
+
+type Counters = {
+  /** Index reads of the entries array — "entries visited". */
+  entryReads: number;
+  /** `entry.details` reads — entries inspected at detail level. */
+  detailListReads: number;
+  /** `detail.fileDiff` reads — per-file bucketing/merge work. */
+  fileDiffReads: number;
+};
+
+function createCounters(): Counters {
+  return { entryReads: 0, detailListReads: 0, fileDiffReads: 0 };
+}
+
+function snapshot(counters: Counters): Counters {
+  return { ...counters };
+}
+
+function reset(counters: Counters): void {
+  counters.entryReads = 0;
+  counters.detailListReads = 0;
+  counters.fileDiffReads = 0;
+}
+
+const ARRAY_INDEX = /^\d+$/;
+
+/**
+ * Count what the derivation reads without instrumenting production code: the
+ * entries array is proxied (numeric reads counted) and each entry/detail
+ * exposes counting getters for the fields the derivation consumes.
+ */
+function instrumentEntries(
+  entries: readonly AppServerThreadEntry[],
+  counters: Counters,
+): AppServerThreadEntry[] {
+  return new Proxy(entries as AppServerThreadEntry[], {
+    get(target, property, receiver) {
+      if (typeof property === "string" && ARRAY_INDEX.test(property)) {
+        counters.entryReads += 1;
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}
+
+function instrumentDetail(
+  detail: AppServerThreadActivityDetail,
+  counters: Counters,
+): AppServerThreadActivityDetail {
+  const fileDiff = detail.fileDiff;
+  return {
+    ...detail,
+    get fileDiff() {
+      counters.fileDiffReads += 1;
+      return fileDiff;
+    },
+  };
+}
+
+function instrumentEntry(
+  entry: AppServerThreadActivityEntry,
+  counters: Counters,
+): AppServerThreadActivityEntry {
+  const details = entry.details.map((detail) =>
+    instrumentDetail(detail, counters),
+  );
+  return {
+    ...entry,
+    get details() {
+      counters.detailListReads += 1;
+      return details;
+    },
+  };
+}
+
+/** Entries per turn, so a long transcript carries many turn groups. */
+const ENTRIES_PER_TURN = 5;
+/** Distinct files a turn touches, so repeat edits to a file merge. */
+const FILES_PER_TURN = 3;
+
+function transcriptEntry(
+  index: number,
+  counters: Counters,
+): AppServerThreadActivityEntry {
+  const turnIndex = Math.floor(index / ENTRIES_PER_TURN);
+  const fileIndex = index % FILES_PER_TURN;
+  return instrumentEntry(
+    {
+      type: "activity",
+      id: `entry-${index}`,
+      createdAt: 1_000 + index,
+      summary: "activity",
+      turn: { id: `turn-${turnIndex}` },
+      details: [
+        {
+          id: `detail-${index}`,
+          kind: "write",
+          label: `Update file-${fileIndex}.ts`,
+          path: `/repo/src/file-${turnIndex}-${fileIndex}.ts`,
+          fileDiff: {
+            kind: "update",
+            diff: `@@ -1 +1 @@\n-old ${index}\n+new ${index}`,
+            additions: 1,
+            removals: 1,
+          },
+        },
+      ],
+    },
+    counters,
+  );
+}
+
+function buildTranscript(
+  length: number,
+  counters: Counters,
+): AppServerThreadEntry[] {
+  return Array.from({ length }, (_, index) => transcriptEntry(index, counters));
+}
+
+/**
+ * Cost of the single `collect` call that follows one appended entry, with the
+ * collector already warmed to `length` entries. Streaming hands the derivation
+ * a new array identity every delta, so each call slices a fresh array over the
+ * same entry objects — exactly what `session.entries` does.
+ */
+function measureAppendCost(params: {
+  length: number;
+  /**
+   * Entries at the very end of the transcript that are re-created (new object
+   * identity, same content) on every delta — the churn a streaming tail
+   * produces as pending entries resolve.
+   */
+  churnTail?: number;
+}): Counters {
+  const counters = createCounters();
+  const transcript = buildTranscript(params.length + 1, counters);
+  const churnTail = params.churnTail ?? 0;
+
+  const snapshotAt = (length: number): AppServerThreadEntry[] => {
+    const slice = transcript.slice(0, length);
+    for (let index = Math.max(0, length - churnTail); index < length; index += 1) {
+      slice[index] = instrumentEntry(
+        transcript[index] as AppServerThreadActivityEntry,
+        counters,
+      );
+    }
+    return instrumentEntries(slice, counters);
+  };
+
+  const collector = createEditedFileGroupsCollector();
+  collector.collect({ entries: snapshotAt(params.length) });
+
+  const measured = snapshotAt(params.length + 1);
+  reset(counters);
+  collector.collect({ entries: measured });
+  return snapshot(counters);
+}
+
+describe("edited-file-groups per-delta cost", () => {
+  it("reads a flat amount of the transcript per appended entry", () => {
+    const small = measureAppendCost({ length: 100 });
+    const large = measureAppendCost({ length: 5_000 });
+
+    // A full walk reads ~50x more at 5000 entries than at 100. Incremental
+    // work reads the same either way; allow generous slack for bookkeeping.
+    expect(large.entryReads).toBeLessThanOrEqual(small.entryReads * 2);
+    expect(large.detailListReads).toBeLessThanOrEqual(
+      small.detailListReads * 2,
+    );
+    expect(large.fileDiffReads).toBeLessThanOrEqual(small.fileDiffReads * 2);
+  });
+
+  it("stays flat when the streaming tail is re-created every delta", () => {
+    const small = measureAppendCost({ length: 100, churnTail: 8 });
+    const large = measureAppendCost({ length: 5_000, churnTail: 8 });
+
+    expect(large.entryReads).toBeLessThanOrEqual(small.entryReads * 2);
+    expect(large.detailListReads).toBeLessThanOrEqual(
+      small.detailListReads * 2,
+    );
+    expect(large.fileDiffReads).toBeLessThanOrEqual(small.fileDiffReads * 2);
+  });
+
+  it("keeps a live cumulative diff overlay off the transcript walk", () => {
+    const measureLiveDiffCost = (length: number): Counters => {
+      const counters = createCounters();
+      const transcript = buildTranscript(length, counters);
+
+      const livePendingEntry = (
+        revision: number,
+      ): AppServerThreadActivityEntry =>
+        instrumentEntry(
+          {
+            type: "activity",
+            id: "live-diff-turn-live",
+            createdAt: 9_000 + revision,
+            summary: "activity",
+            turn: { id: "turn-live" },
+            details: [
+              {
+                id: "live-diff-turn-live-1",
+                kind: "write",
+                label: "Update live.ts",
+                path: "/repo/src/live.ts",
+                fileDiff: {
+                  kind: "update",
+                  diff: `@@ -1 +1 @@\n-old\n+new ${revision}`,
+                  additions: revision,
+                  removals: 0,
+                },
+              },
+            ],
+          },
+          counters,
+        );
+
+      const collector = createEditedFileGroupsCollector();
+      collector.collect({
+        entries: instrumentEntries(transcript.slice(0), counters),
+        activeTurnId: "turn-live",
+        livePendingEntry: livePendingEntry(1),
+      });
+
+      // A live-diff delta changes only the overlay — no entry is appended.
+      const measured = instrumentEntries(transcript.slice(0), counters);
+      reset(counters);
+      collector.collect({
+        entries: measured,
+        activeTurnId: "turn-live",
+        livePendingEntry: livePendingEntry(2),
+      });
+      return snapshot(counters);
+    };
+
+    const small = measureLiveDiffCost(200);
+    const large = measureLiveDiffCost(5_000);
+
+    expect(large.entryReads).toBeLessThanOrEqual(small.entryReads * 2);
+    expect(large.detailListReads).toBeLessThanOrEqual(
+      small.detailListReads * 2,
+    );
+    expect(large.fileDiffReads).toBeLessThanOrEqual(small.fileDiffReads * 2);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/useEditCommitStates.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/useEditCommitStates.test.tsx
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { EditedFileGroup } from "../edited-file-groups";
+import { collectEditedFileGroups } from "../edited-file-groups";
+import { useEditCommitStates } from "../useEditCommitStates";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function editedGroup(params: {
+  key: string;
+  paths: string[];
+  /** Bumped per delta to model a group whose diff text keeps growing. */
+  revision?: number;
+}): EditedFileGroup {
+  const revision = params.revision ?? 0;
+  return {
+    key: params.key,
+    turn: { id: params.key },
+    details: params.paths.map((path, index) => ({
+      id: `${params.key}-${index + 1}`,
+      kind: "write",
+      label: `Update ${path}`,
+      path,
+      fileDiff: {
+        kind: "update",
+        diff: `diff for ${path} @${revision}`,
+        additions: revision + 1,
+        removals: 0,
+      },
+    })),
+    summary: `Edited ${params.paths.length} files`,
+    additions: params.paths.length,
+    removals: 0,
+    live: false,
+  };
+}
+
+function renderCommitStates(initialGroups: EditedFileGroup[]) {
+  const resolveEditCommitStates = vi
+    .fn()
+    .mockResolvedValue({ states: {} });
+  const view = renderHook(
+    (groups: EditedFileGroup[]) =>
+      useEditCommitStates({
+        desktopApi: { resolveEditCommitStates },
+        worktreePath: "/repo",
+        groups,
+      }),
+    { initialProps: initialGroups },
+  );
+  return { ...view, resolveEditCommitStates };
+}
+
+/** Run past the hook's resolve debounce. */
+async function flushDebounce(): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(400);
+  });
+}
+
+describe("useEditCommitStates", () => {
+  it("does not re-probe git when a delta rebuilds equivalent groups", async () => {
+    vi.useFakeTimers();
+    const { rerender, resolveEditCommitStates } = renderCommitStates([
+      editedGroup({ key: "turn-1", paths: ["/repo/a.ts"] }),
+    ]);
+    await flushDebounce();
+    expect(resolveEditCommitStates).toHaveBeenCalledTimes(1);
+
+    // Same files, fresh objects — what every streamed delta hands the hook.
+    for (let revision = 1; revision <= 5; revision += 1) {
+      rerender([editedGroup({ key: "turn-1", paths: ["/repo/a.ts"], revision })]);
+      await flushDebounce();
+    }
+    expect(resolveEditCommitStates).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes git when the edited file set changes", async () => {
+    vi.useFakeTimers();
+    const { rerender, resolveEditCommitStates } = renderCommitStates([
+      editedGroup({ key: "turn-1", paths: ["/repo/a.ts"] }),
+    ]);
+    await flushDebounce();
+
+    rerender([
+      editedGroup({ key: "turn-1", paths: ["/repo/a.ts", "/repo/b.ts"] }),
+    ]);
+    await flushDebounce();
+    expect(resolveEditCommitStates).toHaveBeenCalledTimes(2);
+    expect(resolveEditCommitStates.mock.calls[1][0]).toEqual({
+      worktreePath: "/repo",
+      groups: [{ key: "turn-1", paths: ["/repo/a.ts", "/repo/b.ts"] }],
+    });
+
+    // A new turn's group is a change too, even with the same files.
+    rerender([
+      editedGroup({ key: "turn-2", paths: ["/repo/a.ts", "/repo/b.ts"] }),
+    ]);
+    await flushDebounce();
+    expect(resolveEditCommitStates).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not serialize the groups on a streamed delta", () => {
+    // The signature used to be `JSON.stringify` over every group's paths,
+    // which ran on each delta because a live turn hands over a new array.
+    const stringify = vi.spyOn(JSON, "stringify");
+    const groups = collectEditedFileGroups({
+      entries: [
+        {
+          type: "activity",
+          id: "entry-1",
+          createdAt: 1_000,
+          summary: "activity",
+          turn: { id: "turn-1" },
+          details: [
+            {
+              id: "detail-1",
+              kind: "write",
+              label: "Update a.ts",
+              path: "/repo/a.ts",
+              fileDiff: {
+                kind: "update",
+                diff: "diff",
+                additions: 1,
+                removals: 0,
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const { rerender } = renderCommitStates(groups);
+    stringify.mockClear();
+
+    rerender([...groups]);
+    expect(stringify).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -38,6 +38,13 @@ export type EditedFileGroup = {
   removals: number;
   /** True when this group is the in-flight turn's live cumulative diff. */
   live: boolean;
+  /**
+   * Cheap identity of the group's {key + edited paths}, maintained as the
+   * group is built so `useEditCommitStates` can tell a real change from a
+   * re-render without re-serializing every group per delta. Absent on
+   * hand-built groups; use `editGroupFileSetSignature` to read it.
+   */
+  pathsSignature?: string;
 };
 
 /**
@@ -56,6 +63,20 @@ export function editGroupPaths(group: EditedFileGroup): string[] {
 }
 
 /**
+ * Identity of a file within a group: its path, falling back to the detail id
+ * for a detail that carries none. This is what repeat edits merge on — and
+ * what a file row must be keyed by. A live cumulative diff's detail ids are
+ * positional over the diff's path-ordered sections
+ * (`live-diff-<turn>-<n>`, see `extractLiveDiffActivityDetails`), so a newly
+ * edited file that sorts earlier renumbers every row behind it; keying rows on
+ * the id remounts each of them mid-turn, which reads as the panel blinking and
+ * collapses any diff the operator had opened.
+ */
+export function editedFileKey(detail: AppServerThreadActivityDetail): string {
+  return detail.path ?? detail.id;
+}
+
+/**
  * Live cumulative turn diffs (from `turn/diff/updated`) are built with
  * this id prefix — see `buildPendingDiffEntry` in ThreadView. When a
  * turn has one, it is authoritative for that turn (it already folds
@@ -64,13 +85,71 @@ export function editGroupPaths(group: EditedFileGroup): string[] {
  */
 const LIVE_CUMULATIVE_DIFF_ID_PREFIX = "live-diff-";
 
-type TurnBucket = {
+/**
+ * Transcript entries at the tail that are re-folded on every delta instead of
+ * being committed to the persistent fold. Streaming replaces the last few
+ * entries in place — pending items resolve against the persisted replay, and
+ * a refresh can rewrite the tail — so committing them on sight would
+ * invalidate the fold on every delta. Everything older is folded once and
+ * never read again.
+ */
+const REFOLDED_TAIL_ENTRIES = 32;
+
+/**
+ * Turn buckets kept in the fold, beyond which a turn's accumulated details are
+ * released. Only `MAX_RETAINED_TURN_GROUPS` ever render, and turn order only
+ * grows, so a bucket past this margin can never return to the rail — the
+ * margin covers the live overlay's group sorting ahead of every folded one.
+ */
+const RETAINED_TURN_BUCKETS = MAX_RETAINED_TURN_GROUPS + 2;
+
+type FoldedBucket = {
   key: string;
   orderIndex: number;
   turn?: AppServerThreadTurnMetadata;
   detailsByKey: Map<string, AppServerThreadActivityDetail>;
   cumulative?: AppServerThreadActivityEntry;
+  /** Older than the render cap: stops accumulating, never renders again. */
+  dropped: boolean;
+  /** Bumped on every fold into this bucket; keys `cachedGroup`. */
+  version: number;
+  cachedGroup?: EditedFileGroup;
+  cachedGroupVersion?: number;
+};
+
+/**
+ * A bucket's un-committed contributions for one derivation pass: the re-folded
+ * tail entries plus the live cumulative diff overlay.
+ */
+type PendingBucket = {
+  key: string;
+  turn?: AppServerThreadTurnMetadata;
+  /**
+   * Raw details in arrival order, replayed onto the folded map at render time
+   * rather than pre-merged: `mergeFileDiffDetail` is order-sensitive (a delete
+   * wins, an add sticks), so a pre-merged tail would not always agree with a
+   * single pass over the whole transcript.
+   */
+  details: AppServerThreadActivityDetail[];
+  cumulative?: AppServerThreadActivityEntry;
   live: boolean;
+  /** Set when this bucket exists only in the tail / overlay. */
+  orderIndex?: number;
+};
+
+/**
+ * The last group resolved for a bucket that had pending contributions, with
+ * the inputs it was built from. The tail is re-folded every pass, so without
+ * this a settled group would get a fresh identity per delta and churn every
+ * downstream memo — exactly what the fold exists to avoid.
+ */
+type PendingGroupCacheEntry = {
+  version: number;
+  cumulative?: AppServerThreadActivityEntry;
+  details: readonly AppServerThreadActivityDetail[];
+  live: boolean;
+  turn?: AppServerThreadTurnMetadata;
+  group?: EditedFileGroup;
 };
 
 function mergeFileDiffDetail(
@@ -124,6 +203,490 @@ function mergeFileDiffDetail(
   };
 }
 
+/** The timestamp a fork boundary is measured against. */
+function entryBoundaryTime(entry: AppServerThreadEntry): number | undefined {
+  return typeof entry.createdAt === "number"
+    ? entry.createdAt
+    : typeof entry.turn?.completedAt === "number"
+      ? entry.turn.completedAt
+      : entry.turn?.startedAt;
+}
+
+/**
+ * The bucket an entry contributes to, or `undefined` when it contributes
+ * nothing. Shared by the committed fold and the re-folded tail so both classify
+ * entries identically.
+ */
+function classifyEditEntry(entry: AppServerThreadEntry):
+  | {
+      key: string;
+      turn?: AppServerThreadTurnMetadata;
+      entry: AppServerThreadActivityEntry;
+      cumulative: boolean;
+    }
+  | undefined {
+  const turnKey = entry.turn?.id;
+  if (entry.type !== "activity") {
+    return undefined;
+  }
+  if (!entry.details.some((detail) => detail.fileDiff)) {
+    return undefined;
+  }
+  return {
+    key: turnKey ?? `entry:${entry.id}`,
+    turn: entry.turn,
+    entry,
+    cumulative: entry.id.startsWith(LIVE_CUMULATIVE_DIFF_ID_PREFIX),
+  };
+}
+
+/** FNV-1a, for the group file-set signature. */
+function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Cheap identity of a group's {key + edited paths}. `useEditCommitStates`
+ * compares these to decide whether the git probes have to run again; hashing
+ * keeps that comparison independent of how much diff text a group carries, so
+ * a streaming delta doesn't re-serialize every retained group.
+ */
+export function computeEditGroupFileSetSignature(
+  group: Pick<EditedFileGroup, "key" | "details">,
+): string {
+  const paths = new Set<string>();
+  for (const detail of group.details) {
+    const candidate = detail.path?.trim();
+    if (candidate) {
+      paths.add(candidate);
+    }
+  }
+  const joined = [...paths].join("\n");
+  return `${group.key}:${paths.size}:${joined.length}:${hashString(joined).toString(36)}`;
+}
+
+/**
+ * The signature of a group's file set, preferring the one the collector
+ * maintained as the group was built. Hand-built groups (tests, fixtures) fall
+ * back to computing it.
+ */
+export function editGroupFileSetSignature(group: EditedFileGroup): string {
+  return group.pathsSignature ?? computeEditGroupFileSetSignature(group);
+}
+
+/** Params for one edited-file-groups derivation pass. */
+export type EditedFileGroupsInput = {
+  entries: readonly AppServerThreadEntry[];
+  activeTurnId?: string;
+  forkCreatedAt?: number;
+  livePendingEntry?: AppServerThreadActivityEntry;
+};
+
+/**
+ * Stateful driver for the edited-file-groups derivation across a streaming
+ * transcript. Callers keep one collector per mounted thread surface and feed
+ * it every delta; see `createEditedFileGroupsCollector`.
+ */
+export type EditedFileGroupsCollector = {
+  collect(input: EditedFileGroupsInput): EditedFileGroup[];
+};
+
+/**
+ * Incremental driver for `collectEditedFileGroups`.
+ *
+ * `session.entries` gets a fresh array identity on every streamed transcript
+ * delta while its entries stay put, so re-walking it per delta costs O(n) for
+ * an append of one — O(n^2) across a turn, with a fresh result graph (and
+ * stacked diff text) allocated each time. The collector instead folds each
+ * entry exactly once and keeps the per-turn buckets, so an appended entry
+ * costs work proportional to that entry.
+ *
+ * Reuse is validated, not assumed: the fold is kept only while the array still
+ * starts with the same entry object and still carries the same object at the
+ * fold's last committed position. Any wholesale replacement — a fresh read, a
+ * different thread — fails that check and recomputes from scratch. The last
+ * `REFOLDED_TAIL_ENTRIES` are never committed, so ordinary tail churn (pending
+ * entries resolving, a live cumulative diff landing) stays on the fast path.
+ *
+ * Groups keep their object identity while their bucket is unchanged, so a
+ * delta that touches one turn does not churn the other groups' rows.
+ */
+export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
+  let turnOrder: string[] = [];
+  let buckets = new Map<string, FoldedBucket>();
+  /** Entries committed to the fold — the length of the validated prefix. */
+  let foldedCount = 0;
+  let headEntry: AppServerThreadEntry | undefined;
+  let anchorEntry: AppServerThreadEntry | undefined;
+  let foldedForkCreatedAt: number | undefined;
+  let pastForkBoundary = true;
+  /** Highest order index released from the fold; older buckets never render. */
+  let droppedThrough = -1;
+  let pendingGroupCache = new Map<string, PendingGroupCacheEntry>();
+  let lastGroups: EditedFileGroup[] = [];
+
+  const reset = (forkCreatedAt: number | undefined): void => {
+    turnOrder = [];
+    buckets = new Map();
+    foldedCount = 0;
+    headEntry = undefined;
+    anchorEntry = undefined;
+    foldedForkCreatedAt = forkCreatedAt;
+    pastForkBoundary = typeof forkCreatedAt !== "number";
+    droppedThrough = -1;
+    pendingGroupCache = new Map();
+  };
+
+  const ensureBucket = (
+    key: string,
+    turn: AppServerThreadTurnMetadata | undefined,
+  ): FoldedBucket => {
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        orderIndex: turnOrder.length,
+        turn,
+        detailsByKey: new Map(),
+        cumulative: undefined,
+        dropped: false,
+        version: 0,
+      };
+      turnOrder.push(key);
+      buckets.set(key, bucket);
+    } else if (!bucket.turn && turn) {
+      bucket.turn = turn;
+      bucket.version += 1;
+    }
+    return bucket;
+  };
+
+  /** Release turns that can never render again, with their stacked diffs. */
+  const dropStaleBuckets = (): void => {
+    const threshold = turnOrder.length - RETAINED_TURN_BUCKETS;
+    while (droppedThrough < threshold - 1) {
+      droppedThrough += 1;
+      const bucket = buckets.get(turnOrder[droppedThrough]);
+      if (bucket && !bucket.dropped) {
+        bucket.dropped = true;
+        bucket.detailsByKey = new Map();
+        bucket.cumulative = undefined;
+        bucket.cachedGroup = undefined;
+      }
+    }
+  };
+
+  const foldEntry = (entry: AppServerThreadEntry): void => {
+    if (typeof foldedForkCreatedAt === "number" && !pastForkBoundary) {
+      // Forked Codex threads replay ancestor entries before their own turns.
+      // Start the edit history at the fork thread's creation boundary.
+      const entryCreatedAt = entryBoundaryTime(entry);
+      if (
+        typeof entryCreatedAt !== "number"
+        || entryCreatedAt < foldedForkCreatedAt
+      ) {
+        return;
+      }
+      pastForkBoundary = true;
+    }
+
+    const classified = classifyEditEntry(entry);
+    if (!classified) {
+      return;
+    }
+
+    const bucket = ensureBucket(classified.key, classified.turn);
+    if (bucket.dropped) {
+      return;
+    }
+    bucket.version += 1;
+
+    if (classified.cumulative) {
+      bucket.cumulative = classified.entry;
+      return;
+    }
+
+    for (const detail of classified.entry.details) {
+      if (!detail.fileDiff) {
+        continue;
+      }
+      const detailKey = editedFileKey(detail);
+      bucket.detailsByKey.set(
+        detailKey,
+        mergeFileDiffDetail(bucket.detailsByKey.get(detailKey), detail),
+      );
+    }
+  };
+
+  const buildGroup = (params: {
+    key: string;
+    turn?: AppServerThreadTurnMetadata;
+    details: AppServerThreadActivityDetail[];
+    live: boolean;
+  }): EditedFileGroup => {
+    let additions = 0;
+    let removals = 0;
+    for (const detail of params.details) {
+      additions += detail.fileDiff?.additions ?? 0;
+      removals += detail.fileDiff?.removals ?? 0;
+    }
+    return {
+      key: params.key,
+      turn: params.turn,
+      details: params.details,
+      // Count only — the +/- stats render via the shared colored DiffStat
+      // chip in the header (consistent with the thread-row dirty chip),
+      // not as plain comma-separated text.
+      summary: formatChangedFileCount({
+        count: params.details.length,
+        prefix: "Edited",
+      }),
+      additions,
+      removals,
+      live: params.live,
+      pathsSignature: computeEditGroupFileSetSignature({
+        key: params.key,
+        details: params.details,
+      }),
+    };
+  };
+
+  const sameDetails = (
+    left: readonly AppServerThreadActivityDetail[],
+    right: readonly AppServerThreadActivityDetail[],
+  ): boolean =>
+    left.length === right.length
+    && left.every((detail, index) => detail === right[index]);
+
+  /** The rendered group for one bucket, folding in its pending contributions. */
+  const resolveGroup = (
+    bucket: FoldedBucket | undefined,
+    pending: PendingBucket | undefined,
+    nextPendingGroupCache: Map<string, PendingGroupCacheEntry>,
+  ): EditedFileGroup | undefined => {
+    if (!pending && bucket) {
+      if (bucket.dropped) {
+        return undefined;
+      }
+      if (bucket.cachedGroup && bucket.cachedGroupVersion === bucket.version) {
+        return bucket.cachedGroup;
+      }
+    }
+
+    const turn = bucket?.turn ?? pending?.turn;
+    if (pending) {
+      const cached = pendingGroupCache.get(pending.key);
+      if (
+        cached
+        && cached.version === (bucket?.version ?? -1)
+        && cached.cumulative === pending.cumulative
+        && cached.live === pending.live
+        && cached.turn === turn
+        && sameDetails(cached.details, pending.details)
+      ) {
+        nextPendingGroupCache.set(pending.key, cached);
+        return cached.group;
+      }
+    }
+
+    const cumulative = pending?.cumulative ?? bucket?.cumulative;
+    let details: AppServerThreadActivityDetail[];
+    if (cumulative) {
+      details = cumulative.details.filter((detail) => detail.fileDiff);
+    } else {
+      const detailsByKey = pending?.details.length
+        ? new Map(bucket?.detailsByKey)
+        : bucket?.detailsByKey;
+      if (pending?.details.length && detailsByKey) {
+        for (const detail of pending.details) {
+          const detailKey = editedFileKey(detail);
+          detailsByKey.set(
+            detailKey,
+            mergeFileDiffDetail(detailsByKey.get(detailKey), detail),
+          );
+        }
+      }
+      details = detailsByKey ? [...detailsByKey.values()] : [];
+    }
+
+    const group =
+      details.length === 0
+        ? undefined
+        : buildGroup({
+            key: bucket?.key ?? pending?.key ?? "",
+            turn,
+            details,
+            live: pending?.live ?? false,
+          });
+
+    if (pending) {
+      nextPendingGroupCache.set(pending.key, {
+        version: bucket?.version ?? -1,
+        cumulative: pending.cumulative,
+        details: pending.details,
+        live: pending.live,
+        turn,
+        group,
+      });
+    } else if (bucket && group) {
+      bucket.cachedGroup = group;
+      bucket.cachedGroupVersion = bucket.version;
+    }
+    return group;
+  };
+
+  return {
+    collect(input) {
+      const entries = input.entries;
+
+      // The fold is only reusable while the array it was built from still
+      // starts and ends (at the committed boundary) with the same entries.
+      // Both anchors are needed: the tail anchor alone would survive a fresh
+      // read of a different thread that happens to be shorter, and the head
+      // alone would survive a truncation. What the anchors cannot see is an
+      // entry rewritten in the middle of the committed prefix while both ends
+      // hold — but a rewrite reaches the renderer through a fresh read, which
+      // replaces every entry object including the head, and anything within
+      // `REFOLDED_TAIL_ENTRIES` of the end is re-folded regardless. A producer
+      // that splices an older entry in place while preserving the first and
+      // last folded ones would need to invalidate this fold explicitly.
+      const reusable =
+        foldedForkCreatedAt === input.forkCreatedAt
+        && entries.length >= foldedCount
+        && (foldedCount === 0
+          || (entries[0] === headEntry && entries[foldedCount - 1] === anchorEntry));
+      if (!reusable) {
+        reset(input.forkCreatedAt);
+      }
+
+      const commitThrough = Math.max(
+        foldedCount,
+        entries.length - REFOLDED_TAIL_ENTRIES,
+      );
+      for (let index = foldedCount; index < commitThrough; index += 1) {
+        foldEntry(entries[index]);
+      }
+      if (commitThrough > foldedCount) {
+        foldedCount = commitThrough;
+        headEntry = entries[0];
+        anchorEntry = entries[foldedCount - 1];
+        dropStaleBuckets();
+      }
+
+      // Re-folded tail: everything the fold has not committed, plus the live
+      // cumulative diff overlay, held per pass so the fold stays untouched.
+      const pendingByKey = new Map<string, PendingBucket>();
+      const pendingOrder: string[] = [];
+      let tailPastForkBoundary = pastForkBoundary;
+      const ensurePending = (
+        key: string,
+        turn: AppServerThreadTurnMetadata | undefined,
+      ): PendingBucket => {
+        let pending = pendingByKey.get(key);
+        if (!pending) {
+          pending = { key, turn, details: [], live: false };
+          if (!buckets.has(key)) {
+            pending.orderIndex = turnOrder.length + pendingOrder.length;
+            pendingOrder.push(key);
+          }
+          pendingByKey.set(key, pending);
+        } else if (!pending.turn && turn) {
+          pending.turn = turn;
+        }
+        return pending;
+      };
+
+      for (let index = foldedCount; index < entries.length; index += 1) {
+        const entry = entries[index];
+        if (typeof input.forkCreatedAt === "number" && !tailPastForkBoundary) {
+          const entryCreatedAt = entryBoundaryTime(entry);
+          if (
+            typeof entryCreatedAt !== "number"
+            || entryCreatedAt < input.forkCreatedAt
+          ) {
+            continue;
+          }
+          tailPastForkBoundary = true;
+        }
+
+        const classified = classifyEditEntry(entry);
+        if (!classified) {
+          continue;
+        }
+        if (buckets.get(classified.key)?.dropped) {
+          continue;
+        }
+        const pending = ensurePending(classified.key, classified.turn);
+        if (classified.cumulative) {
+          pending.cumulative = classified.entry;
+          pending.details = [];
+          continue;
+        }
+        for (const detail of classified.entry.details) {
+          if (detail.fileDiff) {
+            pending.details.push(detail);
+          }
+        }
+      }
+
+      if (input.livePendingEntry) {
+        const key =
+          input.livePendingEntry.turn?.id ?? input.activeTurnId ?? "live-turn";
+        const pending = ensurePending(key, input.livePendingEntry.turn);
+        pending.cumulative = input.livePendingEntry;
+        pending.details = [];
+        pending.live = true;
+      }
+
+      // Newest-first, bounded so an uncommitted thread can't grow the rail
+      // (and its stacked diffs) without limit. The live/active turn sorts
+      // newest, so it is always kept.
+      const groups: EditedFileGroup[] = [];
+      const nextPendingGroupCache = new Map<string, PendingGroupCacheEntry>();
+      for (
+        let index = turnOrder.length + pendingOrder.length - 1;
+        index >= 0 && groups.length < MAX_RETAINED_TURN_GROUPS;
+        index -= 1
+      ) {
+        const key =
+          index < turnOrder.length
+            ? turnOrder[index]
+            : pendingOrder[index - turnOrder.length];
+        const bucket = buckets.get(key);
+        if (bucket?.dropped) {
+          // Order indexes only grow, so nothing older can render either.
+          break;
+        }
+        const group = resolveGroup(
+          bucket,
+          pendingByKey.get(key),
+          nextPendingGroupCache,
+        );
+        if (group) {
+          groups.push(group);
+        }
+      }
+      pendingGroupCache = nextPendingGroupCache;
+
+      // Hand back the previous array when nothing moved, so a delta that
+      // changes no edit does not invalidate a single downstream memo.
+      if (
+        groups.length === lastGroups.length
+        && groups.every((group, index) => group === lastGroups[index])
+      ) {
+        return lastGroups;
+      }
+      lastGroups = groups;
+      return groups;
+    },
+  };
+}
+
 /**
  * Walk transcript entries (persisted replay + deferred live entries, in
  * order) and build the accumulated edited-file groups:
@@ -135,144 +698,15 @@ function mergeFileDiffDetail(
  *   as the newest group while a turn is streaming.
  *
  * Returns groups newest-first, capped at `MAX_RETAINED_TURN_GROUPS`.
+ *
+ * One-shot: every call re-walks the whole transcript. A surface that
+ * re-derives per streamed delta wants `createEditedFileGroupsCollector`,
+ * which folds each entry once.
  */
-export function collectEditedFileGroups(params: {
-  entries: readonly AppServerThreadEntry[];
-  activeTurnId?: string;
-  forkCreatedAt?: number;
-  livePendingEntry?: AppServerThreadActivityEntry;
-}): EditedFileGroup[] {
-  const turnOrder: string[] = [];
-  const orderIndexByKey = new Map<string, number>();
-  const buckets = new Map<string, TurnBucket>();
-  const forkCreatedAt = params.forkCreatedAt;
-  let pastForkBoundary = typeof forkCreatedAt !== "number";
-
-  const ensureTurnIndex = (key: string): number => {
-    let index = orderIndexByKey.get(key);
-    if (index === undefined) {
-      index = turnOrder.length;
-      turnOrder.push(key);
-      orderIndexByKey.set(key, index);
-    }
-    return index;
-  };
-
-  const ensureBucket = (
-    key: string,
-    turn: AppServerThreadTurnMetadata | undefined,
-  ): TurnBucket => {
-    const orderIndex = ensureTurnIndex(key);
-    let bucket = buckets.get(key);
-    if (!bucket) {
-      bucket = {
-        key,
-        orderIndex,
-        turn,
-        detailsByKey: new Map(),
-        live: false,
-      };
-      buckets.set(key, bucket);
-    } else if (!bucket.turn && turn) {
-      bucket.turn = turn;
-    }
-    return bucket;
-  };
-
-  for (const entry of params.entries) {
-    if (typeof forkCreatedAt === "number" && !pastForkBoundary) {
-      // Forked Codex threads replay ancestor entries before their own turns.
-      // Start the edit history at the fork thread's creation boundary.
-      const entryCreatedAt =
-        typeof entry.createdAt === "number"
-          ? entry.createdAt
-          : typeof entry.turn?.completedAt === "number"
-            ? entry.turn.completedAt
-            : entry.turn?.startedAt;
-      if (
-        typeof entryCreatedAt !== "number" ||
-        entryCreatedAt < forkCreatedAt
-      ) {
-        continue;
-      }
-      pastForkBoundary = true;
-    }
-
-    const turnKey = entry.turn?.id;
-    if (entry.type !== "activity") {
-      continue;
-    }
-
-    const hasFileDiff = entry.details.some((detail) => detail.fileDiff);
-    if (!hasFileDiff) {
-      continue;
-    }
-
-    const key = turnKey ?? `entry:${entry.id}`;
-    const bucket = ensureBucket(key, entry.turn);
-
-    if (entry.id.startsWith(LIVE_CUMULATIVE_DIFF_ID_PREFIX)) {
-      bucket.cumulative = entry;
-      continue;
-    }
-
-    for (const detail of entry.details) {
-      if (!detail.fileDiff) {
-        continue;
-      }
-      const detailKey = detail.path ?? detail.id;
-      bucket.detailsByKey.set(
-        detailKey,
-        mergeFileDiffDetail(bucket.detailsByKey.get(detailKey), detail),
-      );
-    }
-  }
-
-  if (params.livePendingEntry) {
-    const key =
-      params.livePendingEntry.turn?.id ?? params.activeTurnId ?? "live-turn";
-    const bucket = ensureBucket(key, params.livePendingEntry.turn);
-    bucket.cumulative = params.livePendingEntry;
-    bucket.live = true;
-  }
-
-  const groups: EditedFileGroup[] = [];
-  for (const bucket of [...buckets.values()].sort(
-    (left, right) => left.orderIndex - right.orderIndex,
-  )) {
-    const details = bucket.cumulative
-      ? bucket.cumulative.details.filter((detail) => detail.fileDiff)
-      : [...bucket.detailsByKey.values()];
-    if (details.length === 0) {
-      continue;
-    }
-
-    const additions = details.reduce(
-      (total, detail) => total + (detail.fileDiff?.additions ?? 0),
-      0,
-    );
-    const removals = details.reduce(
-      (total, detail) => total + (detail.fileDiff?.removals ?? 0),
-      0,
-    );
-    groups.push({
-      key: bucket.key,
-      turn: bucket.turn,
-      details,
-      // Count only — the +/- stats render via the shared colored DiffStat
-      // chip in the header (consistent with the thread-row dirty chip),
-      // not as plain comma-separated text.
-      summary: formatChangedFileCount({ count: details.length, prefix: "Edited" }),
-      additions,
-      removals,
-      live: bucket.live,
-    });
-  }
-
-  // Newest-first, then bound retention so an uncommitted thread can't grow the
-  // rail (and its stacked diffs) without limit. The live/active turn sorts
-  // newest, so it is always kept.
-  return groups.reverse().slice(0, MAX_RETAINED_TURN_GROUPS);
+export function collectEditedFileGroups(
+  params: EditedFileGroupsInput,
+): EditedFileGroup[] {
+  return createEditedFileGroupsCollector().collect(params);
 }
 
 /**
@@ -286,7 +720,7 @@ export function flattenEditedFileGroups(
   const detailsByKey = new Map<string, AppServerThreadActivityDetail>();
   for (const group of [...groups].reverse()) {
     for (const detail of group.details) {
-      const detailKey = detail.path ?? detail.id;
+      const detailKey = editedFileKey(detail);
       detailsByKey.set(
         detailKey,
         mergeFileDiffDetail(detailsByKey.get(detailKey), detail),

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -96,6 +96,16 @@ const LIVE_CUMULATIVE_DIFF_ID_PREFIX = "live-diff-";
 const REFOLDED_TAIL_ENTRIES = 32;
 
 /**
+ * Positions sampled across the committed prefix to detect that the array was
+ * rebuilt underneath the fold. Head and tail alone are not enough:
+ * `reconcileRetainedTranscriptTail` splices retained entries (identity
+ * preserved) ahead of freshly read ones, so a refresh can leave both ends
+ * pointing at the same objects while replacing the middle. Sampling is
+ * bounded, so validation stays O(1) per delta.
+ */
+const PREFIX_ANCHOR_SAMPLES = 16;
+
+/**
  * Turn buckets kept in the fold, beyond which a turn's accumulated details are
  * released. Only `MAX_RETAINED_TURN_GROUPS` ever render, and turn order only
  * grows, so a bucket past this margin can never return to the rail — the
@@ -105,7 +115,6 @@ const RETAINED_TURN_BUCKETS = MAX_RETAINED_TURN_GROUPS + 2;
 
 type FoldedBucket = {
   key: string;
-  orderIndex: number;
   turn?: AppServerThreadTurnMetadata;
   detailsByKey: Map<string, AppServerThreadActivityDetail>;
   cumulative?: AppServerThreadActivityEntry;
@@ -133,8 +142,6 @@ type PendingBucket = {
   details: AppServerThreadActivityDetail[];
   cumulative?: AppServerThreadActivityEntry;
   live: boolean;
-  /** Set when this bucket exists only in the tail / overlay. */
-  orderIndex?: number;
 };
 
 /**
@@ -321,8 +328,8 @@ export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
   let buckets = new Map<string, FoldedBucket>();
   /** Entries committed to the fold — the length of the validated prefix. */
   let foldedCount = 0;
-  let headEntry: AppServerThreadEntry | undefined;
-  let anchorEntry: AppServerThreadEntry | undefined;
+  /** Sampled {index, entry} pairs proving the committed prefix is unchanged. */
+  let prefixAnchors: Array<{ index: number; entry: AppServerThreadEntry }> = [];
   let foldedForkCreatedAt: number | undefined;
   let pastForkBoundary = true;
   /** Highest order index released from the fold; older buckets never render. */
@@ -334,8 +341,7 @@ export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
     turnOrder = [];
     buckets = new Map();
     foldedCount = 0;
-    headEntry = undefined;
-    anchorEntry = undefined;
+    prefixAnchors = [];
     foldedForkCreatedAt = forkCreatedAt;
     pastForkBoundary = typeof forkCreatedAt !== "number";
     droppedThrough = -1;
@@ -350,7 +356,6 @@ export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
     if (!bucket) {
       bucket = {
         key,
-        orderIndex: turnOrder.length,
         turn,
         detailsByKey: new Map(),
         cumulative: undefined,
@@ -380,6 +385,25 @@ export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
       }
     }
   };
+
+  /** Re-sample the anchors after the committed prefix grows. */
+  const captureAnchors = (entries: readonly AppServerThreadEntry[]): void => {
+    prefixAnchors = [];
+    if (foldedCount === 0) {
+      return;
+    }
+    const step = Math.max(1, Math.floor(foldedCount / PREFIX_ANCHOR_SAMPLES));
+    for (let index = 0; index < foldedCount; index += step) {
+      prefixAnchors.push({ index, entry: entries[index] });
+    }
+    const last = foldedCount - 1;
+    if (prefixAnchors[prefixAnchors.length - 1]?.index !== last) {
+      prefixAnchors.push({ index: last, entry: entries[last] });
+    }
+  };
+
+  const anchorsHold = (entries: readonly AppServerThreadEntry[]): boolean =>
+    prefixAnchors.every((anchor) => entries[anchor.index] === anchor.entry);
 
   const foldEntry = (entry: AppServerThreadEntry): void => {
     if (typeof foldedForkCreatedAt === "number" && !pastForkBoundary) {
@@ -545,21 +569,17 @@ export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
       const entries = input.entries;
 
       // The fold is only reusable while the array it was built from still
-      // starts and ends (at the committed boundary) with the same entries.
-      // Both anchors are needed: the tail anchor alone would survive a fresh
-      // read of a different thread that happens to be shorter, and the head
-      // alone would survive a truncation. What the anchors cannot see is an
-      // entry rewritten in the middle of the committed prefix while both ends
-      // hold — but a rewrite reaches the renderer through a fresh read, which
-      // replaces every entry object including the head, and anything within
-      // `REFOLDED_TAIL_ENTRIES` of the end is re-folded regardless. A producer
-      // that splices an older entry in place while preserving the first and
-      // last folded ones would need to invalidate this fold explicitly.
+      // carries the same entry objects at every sampled position, so any
+      // rebuild of the transcript — a fresh read, a page refresh, a different
+      // thread — recomputes instead of serving a stale bucket. Sampling covers
+      // bulk replacement, which is the shape every producer here actually
+      // produces; a surgical rewrite of a single unsampled entry older than
+      // `REFOLDED_TAIL_ENTRIES` would still be missed, and needs an explicit
+      // invalidation rather than a wider sample.
       const reusable =
         foldedForkCreatedAt === input.forkCreatedAt
         && entries.length >= foldedCount
-        && (foldedCount === 0
-          || (entries[0] === headEntry && entries[foldedCount - 1] === anchorEntry));
+        && anchorsHold(entries);
       if (!reusable) {
         reset(input.forkCreatedAt);
       }
@@ -573,8 +593,7 @@ export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
       }
       if (commitThrough > foldedCount) {
         foldedCount = commitThrough;
-        headEntry = entries[0];
-        anchorEntry = entries[foldedCount - 1];
+        captureAnchors(entries);
         dropStaleBuckets();
       }
 
@@ -590,8 +609,9 @@ export function createEditedFileGroupsCollector(): EditedFileGroupsCollector {
         let pending = pendingByKey.get(key);
         if (!pending) {
           pending = { key, turn, details: [], live: false };
-          if (!buckets.has(key)) {
-            pending.orderIndex = turnOrder.length + pendingOrder.length;
+          // A dropped bucket counts as absent: its folded position `break`s the
+          // render walk, so a pending contribution parked there would vanish.
+          if (!buckets.has(key) || buckets.get(key)?.dropped) {
             pendingOrder.push(key);
           }
           pendingByKey.set(key, pending);

--- a/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
@@ -1,7 +1,34 @@
 import { useEffect, useMemo, useState } from "react";
 import type { EditGroupCommitState } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { editGroupPaths, type EditedFileGroup } from "./edited-file-groups";
+import {
+  editGroupFileSetSignature,
+  editGroupPaths,
+  type EditedFileGroup,
+} from "./edited-file-groups";
+
+/**
+ * Per-group resolve input, cached by group identity. The collector keeps a
+ * group's identity while its bucket is unchanged, so a streamed delta rebuilds
+ * only the live turn's entry instead of every retained group's path list.
+ */
+const resolveInputByGroup = new WeakMap<
+  EditedFileGroup,
+  { key: string; paths: string[] }
+>();
+
+function toResolveInput(group: EditedFileGroup): {
+  key: string;
+  paths: string[];
+} {
+  const cached = resolveInputByGroup.get(group);
+  if (cached) {
+    return cached;
+  }
+  const input = { key: group.key, paths: editGroupPaths(group) };
+  resolveInputByGroup.set(group, input);
+  return input;
+}
 
 /**
  * Debounce window before resolving. A git-heavy turn pushes a fresh working
@@ -30,14 +57,15 @@ export function useEditCommitStates(params: {
   );
 
   // A stable signature of the {key → paths} inputs so we only re-resolve when
-  // the actual groups/files change, not on every transcript re-render.
-  const groupsInput = useMemo(
-    () => groups.map((group) => ({ key: group.key, paths: editGroupPaths(group) })),
-    [groups],
-  );
+  // the actual groups/files change, not on every transcript re-render. Each
+  // group carries its own file-set signature, maintained as the group is
+  // built, so this stays O(groups) per render — serializing the whole set here
+  // would run on every streamed delta, since a live turn hands us a new array
+  // each time.
+  const groupsInput = useMemo(() => groups.map(toResolveInput), [groups]);
   const groupsSignature = useMemo(
-    () => JSON.stringify(groupsInput),
-    [groupsInput],
+    () => groups.map(editGroupFileSetSignature).join("\u0001"),
+    [groups],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `collectEditedFileGroups` re-walked the whole transcript on every streamed delta. `session.entries` gets a fresh array identity per delta while its entries stay put, so the ThreadView memo recomputed each time: O(n) work for one appended entry, O(n²) across a turn, allocating a fresh result graph and re-concatenating stacked diff text each pass.
- Replaced the one-shot walk with `createEditedFileGroupsCollector`, which folds each entry exactly once into persistent per-turn buckets. `collectEditedFileGroups` remains as a one-shot wrapper, so `edited-file-groups.test.ts` — the behavioral contract — passes **unchanged**.
- Dropped the per-delta `JSON.stringify` in `useEditCommitStates` for a per-group file-set signature maintained as each group is built.
- Fixed the Edits panel blinking while a transcript streams.

## Verification

- Performance tests were written first and confirmed failing against the pre-change behavior (committed briefly as a pass-through shim so the numbers were real):
  ```
  expected 5001 to be less than or equal to 202   ← 50x, the quadratic
  expected 5000 to be less than or equal to 16    ← live-diff delta re-walked everything
  ```
  After: **37 entry reads at 100 entries, 37 at 5000** — identical counters at both sizes, for appends, for a re-created streaming tail, and for a live-diff-only delta.
- `pnpm test apps/desktop/src/renderer` — 3101 tests, 197 files, all passing.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` (no violations).
- No desktop E2E run locally.

## Notes

**How the perf tests measure.** They count what the derivation *reads* rather than wall-clock time (which flakes on loaded CI): the entries array is proxied and entries/details carry counting getters, so there is no production instrumentation. Each test warms a collector to N entries, resets counters, then measures the single call following one appended entry. Assertions are ratios between N=100 and N=5000, so they hold on any machine.

**Reuse is validated, not assumed.** The fold survives only while the array still starts with the same entry object and holds the same object at the committed boundary — a fresh read or a thread switch fails that check and recomputes from scratch. The last 32 entries are never committed, so ordinary streaming tail churn (pending entries resolving, a live cumulative diff landing) stays on the fast path. The one case the anchors cannot see is documented at the check.

**The tail is replayed raw, not pre-merged.** `mergeFileDiffDetail` is not associative — an `add → delete → update` stack resolves to a different `kind` depending on fold order — so pre-merging the tail would silently diverge from a single pass. `edited-file-groups-incremental.test.ts` replays 10 streaming shapes delta-by-delta against a full recompute, including that one, plus the fork boundary, the retention cap, live-diff precedence, and wholesale array replacement.

**The blink was the React key, not the new object identities.** Rows were keyed on `detail.id`, and a live cumulative diff's detail ids are positional over the diff's path-ordered sections (`live-diff-<turn>-<n>`, see `extractLiveDiffActivityDetails`). Editing a file that sorts earlier renumbers every row behind it, so React remounted them all — the reproduction failed with `expected <span> to be <span> // Object.is equality`, and an open diff collapsed with it. Rows now key on the shared `editedFileKey` (path, falling back to id), the same identity repeat edits merge on. Fixed in both `EditedFileGroupList` and `LiveWorkRail`'s static list.

**One premise in the task didn't hold.** There is no Star Map chat-card copy of this derivation in this checkout — `collectEditedFileGroups` has exactly one caller (ThreadView), `StarMapChatCard.tsx` never references edited-file groups, and PR #1779 is not in this history. The fix went into the derivation regardless, so a second surface would get it for free.

**Left alone deliberately.** `flattenEditedFileGroups` (the "All files" view) still re-merges every retained group's stacked diff text per delta when that tab is open. It is bounded by the 10-group retention cap rather than transcript length, so it is not quadratic — worth a separate look if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
