### PR TITLE
perf(desktop): stop re-rendering the star map composer on every delta

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useEffect,
   useMemo,
@@ -78,6 +79,23 @@ type DragState = {
 };
 
 /**
+ * The composer, behind a memo boundary.
+ *
+ * The card re-renders once per streamed delta — Codex emits fixed 8 KiB
+ * chunks at roughly 444 a second — because that is what the transcript is
+ * for. The composer's own state almost never moves during a turn, so
+ * dragging it through the same renders is pure waste, multiplied by every
+ * card the map has open.
+ *
+ * The boundary lives here rather than inside `CompactComposer` because it
+ * only pays off while this host keeps the props it passes referentially
+ * stable, and those two facts should be reviewable together. Everything
+ * below that feeds it is memoized or ref-read for exactly that reason.
+ * `star-map-chat-card-render-cost.test.tsx` pins the result.
+ */
+const MemoizedCompactComposer = memo(CompactComposer);
+
+/**
  * One chat card, anchored in the star map.
  *
  * The card owns its own thread session rather than borrowing App's single
@@ -111,6 +129,13 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
     thread,
   });
+  // The session is a fresh object literal on every render of a hook that
+  // re-renders per streamed delta, so any callback that closes over it
+  // rebinds at streaming rate. `send` reads three of its members and needs
+  // them current at call time, not at bind time — which is what a ref gives
+  // — so it reads through here and depends on scalars instead.
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
 
   // Cap what actually mounts. Same window the full thread view uses, so a
   // card over a long thread holds tens of entries rather than thousands.
@@ -126,8 +151,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     threadKey: buildThreadIdentityKey(thread.source, thread.id),
   });
 
-  const federationTarget =
-    thread.federation?.ref.target ?? readRendererFederationTarget();
+  // `readRendererFederationTarget` mints a fresh object per call, so in a
+  // federation window an unmemoized read would rebind every callback that
+  // routes through it on each render.
+  const threadFederationTarget = thread.federation?.ref.target;
+  const federationTarget = useMemo(
+    () => threadFederationTarget ?? readRendererFederationTarget(),
+    [threadFederationTarget],
+  );
 
   // The context satellite is a sibling rendered by the screen, so the session
   // data its panels need has to be published rather than passed down.
@@ -327,7 +358,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       setSendError(undefined);
       setSendNotice(undefined);
 
-      if (session.threadBusy) {
+      if (sessionRef.current.threadBusy) {
         if (!desktopApi?.steerTurn) {
           setSendError("This thread is busy and steering is unavailable.");
           return false;
@@ -344,7 +375,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           );
           return false;
         }
-        const optimisticId = session.addOptimisticUserMessage(text);
+        const optimisticId = sessionRef.current.addOptimisticUserMessage(text);
         try {
           const response = await desktopApi.steerTurn({
             backend: thread.source,
@@ -363,7 +394,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           );
           return true;
         } catch (error) {
-          session.removeOptimisticMessage(optimisticId);
+          sessionRef.current.removeOptimisticMessage(optimisticId);
           setSendError(
             error instanceof Error
               ? error.message
@@ -374,7 +405,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       }
 
       if (!desktopApi?.startTurn) return false;
-      const optimisticId = session.addOptimisticUserMessage(text);
+      const optimisticId = sessionRef.current.addOptimisticUserMessage(text);
       try {
         await desktopApi.startTurn({
           backend: thread.source,
@@ -384,7 +415,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         });
         return true;
       } catch (error) {
-        session.removeOptimisticMessage(optimisticId);
+        sessionRef.current.removeOptimisticMessage(optimisticId);
         setSendError(
           error instanceof Error
             ? error.message
@@ -393,7 +424,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         return false;
       }
     },
-    [activeTurnId, cardKey, desktopApi, federationTarget, session, thread],
+    [
+      activeTurnId,
+      cardKey,
+      desktopApi,
+      federationTarget,
+      thread.id,
+      thread.source,
+    ],
   );
 
   const interrupt = useCallback(async () => {
@@ -410,7 +448,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         error instanceof Error ? error.message : "Could not interrupt the turn.",
       );
     }
-  }, [activeTurnId, desktopApi, federationTarget, thread]);
+  }, [activeTurnId, desktopApi, federationTarget, thread.id, thread.source]);
+
+  // The composer takes a plain `() => void`; an inline arrow here would be
+  // a fresh prop on every render and would defeat the memo boundary on its
+  // own.
+  const onInterrupt = useCallback(() => {
+    void interrupt();
+  }, [interrupt]);
 
   /**
    * Everything the card can do with only a thread summary and the desktop
@@ -604,13 +649,13 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         </p>
       ) : undefined}
 
-      <CompactComposer
+      <MemoizedCompactComposer
         busy={session.threadBusy}
         canSteer={canSteer}
         executionMode={thread.executionMode}
         mentionSources={mentionSources}
         model={thread.model}
-        onInterrupt={() => void interrupt()}
+        onInterrupt={onInterrupt}
         onSend={send}
         reasoningEffort={thread.reasoningEffort}
         secondaryActions={secondaryActions}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
@@ -1,0 +1,249 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+
+/**
+ * Counting stand-ins for the card's two children.
+ *
+ * Both delegate to the real component, so this measures the card as it
+ * actually ships rather than a skeleton of it. The mocks stay plain
+ * function components on purpose: the memo that makes this test pass lives
+ * in `StarMapChatCard`, over the imported child, so dropping it there makes
+ * the counts climb again. Re-memoizing in this file would keep the spec
+ * green over an unmemoized card, which is the one thing it must not do.
+ */
+vi.mock("../../composer/CompactComposer", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../composer/CompactComposer")>();
+  return { ...actual, CompactComposer: vi.fn(actual.CompactComposer) };
+});
+vi.mock("../../thread-detail/TranscriptList", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../thread-detail/TranscriptList")>();
+  return { ...actual, TranscriptList: vi.fn(actual.TranscriptList) };
+});
+
+import { CompactComposer } from "../../composer/CompactComposer";
+import { TranscriptList } from "../../thread-detail/TranscriptList";
+import { StarMapChatCard } from "../StarMapChatCard";
+import { resetComposerMentionSourcesCache } from "../../composer/useComposerMentionSources";
+
+const RECT = { left: 40, top: 40, width: 420, height: 520 };
+
+function localThread(
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id: "t-local",
+    title: "Local work",
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 1,
+    ...overrides,
+  } as unknown as NavigationThreadSummary;
+}
+
+/**
+ * The card has more than one agent-event subscriber — the thread session
+ * and the lazy skill list — so a fake that remembers only the last listener
+ * to register silently measures nothing.
+ */
+function streamingApi(overrides: Partial<DesktopApi> = {}): {
+  desktopApi: DesktopApi;
+  emitDelta: (index: number) => void;
+} {
+  const listeners: Array<(event: unknown) => void> = [];
+  const desktopApi = {
+    readThread: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t-local",
+      threadStatus: "active",
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: { supportsPagination: false, hasPreviousPage: false },
+      },
+    })),
+    startTurn: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t-local",
+      turnId: "turn-live",
+    })),
+    onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
+      listeners.push(listener);
+      return () => undefined;
+    }),
+    ...overrides,
+  } as unknown as DesktopApi;
+
+  const emitDelta = (index: number): void => {
+    const event = {
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "t-local",
+          turnId: "turn-live",
+          itemId: "item-live",
+          delta: `chunk-${index} `,
+        },
+      },
+    };
+    for (const listener of listeners) listener(event);
+  };
+
+  return { desktopApi, emitDelta };
+}
+
+function renderCard(desktopApi: DesktopApi, onOpenFull = () => undefined) {
+  return render(
+    <StarMapChatCard
+      cardKey="card-1"
+      desktopApi={desktopApi}
+      onClose={() => undefined}
+      onOpenFull={onOpenFull}
+      onRaise={() => undefined}
+      onRectChange={() => undefined}
+      rect={RECT}
+      thread={localThread()}
+      scale={1}
+      bounds={{ width: 4000, height: 3000 }}
+      onToggleContext={() => undefined}
+      onToggleTerminal={() => undefined}
+      zIndex={40}
+    />
+  );
+}
+
+/**
+ * Let the initial `readThread` land before anything is streamed. Hydration
+ * rewrites the session wholesale, so a delta emitted into the gap has its
+ * turn id thrown away — a race in the harness, not in the card.
+ */
+async function settleInitialRead(desktopApi: DesktopApi): Promise<void> {
+  await waitFor(() => {
+    expect(desktopApi.readThread).toHaveBeenCalled();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+const composerRenders = (): number => vi.mocked(CompactComposer).mock.calls.length;
+const transcriptRenders = (): number => vi.mocked(TranscriptList).mock.calls.length;
+
+/**
+ * Codex streams fixed 8 KiB deltas at roughly 444 a second, and every one of
+ * them lands in the card's thread session. The transcript re-rendering at
+ * that rate is the point of the surface; the composer re-rendering with it
+ * is pure waste, multiplied by however many cards the map has open.
+ */
+describe("StarMapChatCard streaming render cost", () => {
+  beforeEach(() => {
+    vi.mocked(CompactComposer).mockClear();
+    vi.mocked(TranscriptList).mockClear();
+    resetComposerMentionSourcesCache();
+  });
+
+  it("does not re-render the composer for streamed deltas", async () => {
+    const { desktopApi, emitDelta } = streamingApi();
+    renderCard(desktopApi);
+    await screen.findByRole("textbox", { name: "Message Local work" });
+    await settleInitialRead(desktopApi);
+
+    const composerBaseline = composerRenders();
+    const transcriptBaseline = transcriptRenders();
+    const deltas = 20;
+    for (let index = 0; index < deltas; index += 1) {
+      act(() => {
+        emitDelta(index);
+      });
+    }
+
+    // Proves the harness actually drove the card: without this a fake that
+    // dropped its listener would report a perfect composer score.
+    expect(transcriptRenders() - transcriptBaseline).toBeGreaterThanOrEqual(
+      deltas,
+    );
+    expect(composerRenders() - composerBaseline).toBe(0);
+  });
+
+  it("still steers the turn it hydrated onto", async () => {
+    // The memo boundary's real hazard is a composer left holding a stale
+    // `send`. The turn id lands with the thread read, which resolves after
+    // first paint, so a composer frozen at mount would steer at nothing and
+    // the card would report that it cannot identify the running turn.
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t-local",
+      turnId: "turn-live",
+      disposition: "steered" as const,
+    }));
+    const { desktopApi, emitDelta } = streamingApi({
+      readThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t-local",
+        threadStatus: "active",
+        replay: {
+          entries: [
+            {
+              type: "message",
+              id: "m-live",
+              role: "assistant",
+              text: "working on it",
+              parts: [{ type: "text", text: "working on it" }],
+              createdAt: 1,
+              turn: { id: "turn-live", status: "in_progress" },
+            },
+          ],
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+        },
+      })),
+      steerTurn,
+    } as unknown as Partial<DesktopApi>);
+    renderCard(desktopApi);
+    const input = await screen.findByRole("textbox", {
+      name: "Message Local work",
+    });
+    await settleInitialRead(desktopApi);
+    for (let index = 0; index < 5; index += 1) {
+      act(() => {
+        emitDelta(index);
+      });
+    }
+
+    await screen.findByRole("button", { name: "Steer" });
+    fireEvent.change(input, { target: { value: "and check the logs" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedTurnId: "turn-live" }),
+      );
+    });
+  });
+
+  it("keeps the kebab actions wired through the stream", async () => {
+    const onOpenFull = vi.fn();
+    const { desktopApi, emitDelta } = streamingApi();
+    renderCard(desktopApi, onOpenFull);
+    await screen.findByRole("textbox", { name: "Message Local work" });
+    await settleInitialRead(desktopApi);
+    for (let index = 0; index < 5; index += 1) {
+      act(() => {
+        emitDelta(index);
+      });
+    }
+
+    fireEvent.click(await screen.findByRole("button", { name: "More actions" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Open in full view" }),
+    );
+
+    expect(onOpenFull).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
@@ -55,7 +55,7 @@ function streamingApi(overrides: Partial<DesktopApi> = {}): {
   desktopApi: DesktopApi;
   emitDelta: (index: number) => void;
 } {
-  const listeners: Array<(event: unknown) => void> = [];
+  const listeners = new Set<(event: unknown) => void>();
   const desktopApi = {
     readThread: vi.fn(async () => ({
       backend: "codex",
@@ -72,9 +72,16 @@ function streamingApi(overrides: Partial<DesktopApi> = {}): {
       threadId: "t-local",
       turnId: "turn-live",
     })),
+    // The teardown has to actually remove the listener. `useThreadSkills`
+    // re-subscribes whenever its thread target changes, so a no-op
+    // unsubscribe leaves the old listener in place and every later delta is
+    // delivered more than once — which would quietly turn the transcript
+    // guard below into a trivially true assertion.
     onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
-      listeners.push(listener);
-      return () => undefined;
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
     }),
     ...overrides,
   } as unknown as DesktopApi;
@@ -92,7 +99,7 @@ function streamingApi(overrides: Partial<DesktopApi> = {}): {
         },
       },
     };
-    for (const listener of listeners) listener(event);
+    for (const listener of [...listeners]) listener(event);
   };
 
   return { desktopApi, emitDelta };
@@ -227,23 +234,59 @@ describe("StarMapChatCard streaming render cost", () => {
     });
   });
 
-  it("keeps the kebab actions wired through the stream", async () => {
+  it("closes the kebab's compaction door once the stream makes it busy", async () => {
+    // The kebab is where a frozen composer does real damage. Compaction
+    // rewrites history, so `secondaryActions` gates it on `threadBusy`; a
+    // card still rendering the pre-turn array would leave that door open
+    // mid-turn. Asserting on an action whose props never change — "Open in
+    // full view" — would pass against a composer that had stopped
+    // re-rendering entirely, so the disabled state is the real assertion.
     const onOpenFull = vi.fn();
-    const { desktopApi, emitDelta } = streamingApi();
+    const { desktopApi, emitDelta } = streamingApi({
+      compactThread: vi.fn(async () => undefined),
+      // Idle at mount, so the gate has somewhere to move from. The shared
+      // fake hydrates as already-running.
+      readThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t-local",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+        },
+      })),
+    } as unknown as Partial<DesktopApi>);
     renderCard(desktopApi, onOpenFull);
     await screen.findByRole("textbox", { name: "Message Local work" });
     await settleInitialRead(desktopApi);
+
+    fireEvent.click(await screen.findByRole("button", { name: "More actions" }));
+    const compact = (await screen.findByRole("menuitem", {
+      name: "Compact thread",
+    })) as HTMLButtonElement;
+    expect(compact.disabled).toBe(false);
+
     for (let index = 0; index < 5; index += 1) {
       act(() => {
         emitDelta(index);
       });
     }
 
-    fireEvent.click(await screen.findByRole("button", { name: "More actions" }));
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Open in full view" }),
-    );
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("menuitem", {
+            name: "Compact thread",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true);
+    });
+    expect(desktopApi.compactThread).not.toHaveBeenCalled();
 
+    // And the actions that do not change still fire.
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Open in full view" }),
+    );
     expect(onOpenFull).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What

`useThreadSessionState` updates state on every streamed delta — Codex emits fixed 8 KiB deltas at roughly 444/second — so `StarMapChatCard` re-renders at streaming rate. `TranscriptList` re-rendering is correct; that is what changed. `CompactComposer` re-rendering with it is pure waste, and it multiplies by every card open on a busy map.

Measured by mocking each child with `vi.fn(actual.Component)` and counting calls while emitting `item/agentMessage/delta`:

| child | before | after |
|---|---|---|
| `CompactComposer` | 1 render / delta | **0** |
| `TranscriptList` | 1.5 renders / delta | unchanged (correct) |

This is **pre-existing, not a regression** — the same numbers hold at `2f1b53d8e`, before #1782. The mention work #1782 added (~2 µs/render) is under 1% of a render, so this is about eliminating the renders, not about anything that PR added.

## Why `React.memo` alone would not have worked

The card handed the composer two props that changed identity every render:

1. `onInterrupt={() => void interrupt()}` — a fresh inline arrow.
2. `onSend={send}` — `send`'s dep array contained `session`, and `useThreadSessionState` returns a bare object literal with no `useMemo`, so it is a new object on every render.

A third, only visible in a federation window: `federationTarget` was computed inline as `thread.federation?.ref.target ?? readRendererFederationTarget()`, and `readRendererFederationTarget` mints a fresh object per call. That rebound both `send` and `secondaryActions` every render for any thread without its own federation ref.

`mentionSources` and `secondaryActions` were confirmed stable rather than assumed — their `useMemo` deps bottom out in `useState` values and `useCallback`s that do not move during a turn (`useComposerMentionSources` serves `population.directories` / `.threads` straight from state; `useThreadSkills`'s `ensureLoaded` and `skills` are memoized on the thread target).

## Changes

- `send` reads `threadBusy`, `addOptimisticUserMessage`, and `removeOptimisticMessage` through a `sessionRef` updated each render, and depends on scalars (`thread.id` / `thread.source`) instead of whole objects. This also makes it read the value **current at call time** rather than at bind time, which is what a send path wants. The file already uses this pattern for `rectRef`.
- `onInterrupt` hoisted into a stable `useCallback`.
- `federationTarget` memoized on `thread.federation?.ref.target`.
- `interrupt` narrowed to the scalars it reads.
- The composer wrapped in `React.memo`.

### Narrow fix, not the wide one

I did **not** memoize `useThreadSessionState`'s return value. That would help `ThreadView` too, but every consumer's dep arrays would need auditing against a suddenly-stable object, and this PR would stop being reviewable as a perf change. Flagging it as a follow-up worth considering on its own.

The memo boundary lives at the call site in `StarMapChatCard` rather than inside `CompactComposer`, because it only pays off while this host keeps those props referentially stable — the two facts should be reviewable in one file. `CompactComposer` has one host today.

### Siblings, checked as asked

- `StarMapTerminalCard` does not subscribe to the card-context store, so it never re-renders per delta.
- `StarMapContextCard` does subscribe, but the card only publishes when something is actually reading (`useStarMapCardContextDemand`), and when it does publish the satellite's data genuinely changed. No comparable waste.
- The card header is inline JSX, so it re-renders with the card. Left alone: extracting it behind a memo means stabilizing seven handler props for a subtree of ~15 static elements and a small inline SVG, which is a materially larger diff than its share of the cost justifies. Flagging rather than silently expanding scope.

## Tests

New `star-map-chat-card-render-cost.test.tsx`:

- Pins **composer renders per delta at 0** after first paint.
- Asserts the transcript count climbed by at least the delta count first — without that, a fake `onAgentEvent` that dropped its listener would report a perfect composer score. The fake collects listeners into an array and fans out, because the card has two subscribers (thread session and lazy skill list).
- Covers the stale-memo failure modes the change could introduce: the composer still steers the turn it hydrated onto (the turn id arrives with the async thread read, *after* first paint), and the kebab actions still fire after a stream.

Mutation-checked: replacing the boundary with `memo(CompactComposer, () => true)` fails the steer test, and dropping the memo entirely fails the render-count test. The counting mocks stay plain function components so they observe the shipped memo rather than one the spec created.

Verified green: `pnpm test apps/desktop/src/renderer` (197 files / 3123 tests), `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries`.

**Not verified:** desktop E2E — not run on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)