### PR TITLE
fix(desktop): give the Star Map's top band a real layout

### DIFF
--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -51,6 +51,78 @@ function countStarMapWindows(
     .filter((win) => win.url().includes("#star-map")).length;
 }
 
+
+/**
+ * Resize the map's BrowserWindow and wait for the renderer to lay out at
+ * the new width. Playwright's `setViewportSize` is unsupported on an
+ * Electron page, so the OS window is the only handle.
+ */
+async function resizeStarMapWindow(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+  mapWindow: Page,
+  size: { width: number; height: number },
+): Promise<void> {
+  await app.electronApp.evaluate(({ BrowserWindow }, bounds) => {
+    const target = BrowserWindow.getAllWindows().find((win) =>
+      win.webContents.getURL().includes("#star-map"),
+    );
+    if (!target) throw new Error("Expected the Star Map BrowserWindow");
+    target.setSize(bounds.width, bounds.height);
+  }, size);
+  await expect
+    .poll(() => mapWindow.evaluate(() => window.innerWidth))
+    .toBeLessThanOrEqual(size.width);
+}
+
+/**
+ * The top band's slots must not overlap at any window width, and nothing
+ * may sit on top of a filter chip.
+ *
+ * The rect check is the structural one: `.star-map__chrome` and
+ * `.star-map__filters` used to be independently positioned islands, so
+ * the chrome (the higher z-index) painted over the leading chip and ate
+ * its clicks. The hit test is the behavioural one, and it is wider — it
+ * catches ANY element covering a chip, not just the chrome, which is the
+ * shape axe reported as `target-size` ("partially obscured, smallest
+ * space is 79.5px by 12px"). Both are cheaper than waiting for the a11y
+ * gate to notice, and they say what actually broke.
+ */
+async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> {
+  const chrome = await mapWindow.locator(".star-map__chrome").boundingBox();
+  const filters = await mapWindow.locator(".star-map__filters").boundingBox();
+  if (!chrome || !filters) {
+    throw new Error(`Expected both top-band slots to be laid out ${at}`);
+  }
+
+  const overlaps =
+    chrome.x < filters.x + filters.width
+    && filters.x < chrome.x + chrome.width
+    && chrome.y < filters.y + filters.height
+    && filters.y < chrome.y + chrome.height;
+  expect(
+    overlaps,
+    `top band slots overlap ${at}: chrome ${JSON.stringify(chrome)},`
+      + ` filters ${JSON.stringify(filters)}`,
+  ).toBe(false);
+
+  const covered = await mapWindow.evaluate(() =>
+    [...document.querySelectorAll(".star-map__filter-chip")]
+      .filter((chip) => !chip.closest(".star-map__chrome"))
+      .map((chip) => {
+        const box = chip.getBoundingClientRect();
+        const top = document.elementFromPoint(
+          box.x + box.width / 2,
+          box.y + box.height / 2,
+        );
+        return top?.closest(".star-map__filters")
+          ? undefined
+          : `${chip.textContent} covered by ${top?.className ?? "nothing"}`;
+      })
+      .filter((entry): entry is string => entry !== undefined),
+  );
+  expect(covered, `filter chips obscured ${at}`).toEqual([]);
+}
+
 test("opens a thread from the star map window in the main window", async () => {
   const app = await launchElectronApp({
     fixturePath: path.resolve(specDir, "fixtures/star-map/replay.fixture.json"),
@@ -121,6 +193,43 @@ test("opens a thread from the star map window in the main window", async () => {
     await expect(
       starMap.getByRole("button", { name: "Close Star Map" }),
     ).toHaveCount(0);
+  } finally {
+    await app.close();
+  }
+});
+
+// The map's controls all live over the top of the sky, in the same band,
+// and for a long time they were three separately positioned islands with
+// nothing reserving space between them. On a 1280px window the chrome
+// already reached the leading filter chip; a third chrome control covered
+// it, and narrow windows overlapped outright. `.star-map__top-band` makes
+// them one grid row so the collision cannot happen — this is the gate on
+// that, at the default width and at the window's 800px minimum, where the
+// old layout was already broken.
+test("keeps the star map's top band from overlapping itself", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(specDir, "fixtures/star-map/replay.fixture.json"),
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "Open Star Map" }).click();
+    const mapWindow = await waitForStarMapWindow(app);
+    const starMap = mapWindow.getByRole("region", {
+      name: "Star Map",
+      exact: true,
+    });
+    await expect(starMap).toBeVisible();
+    await expect(
+      starMap.getByRole("group", { name: "Thread filters" }),
+    ).toBeVisible();
+
+    await expectTopBandLaidOut(mapWindow, "at the default window width");
+
+    // `minWidth` in star-map-window.ts. Below roughly 1100px the old
+    // centred strip walked left into the chrome, so this is the width
+    // that would have failed first.
+    await resizeStarMapWindow(app, mapWindow, { width: 800, height: 720 });
+    await expectTopBandLaidOut(mapWindow, "at the minimum window width");
   } finally {
     await app.close();
   }

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -147,6 +147,16 @@ async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> 
 
   const covered = await mapWindow.evaluate(() =>
     [...document.querySelectorAll(".star-map__filters .star-map__filter-chip")]
+      // The slot holds both renderings of the filters and CSS displays one,
+      // so the other measures 0x0 — and a zero rect centres on (0,0), where
+      // `elementFromPoint` truthfully reports the drag strip. Testing the
+      // rendered one at each width is the point; testing the hidden one is
+      // how this check reported the band as broken at 1280px when it was
+      // not.
+      .filter((chip) => {
+        const box = chip.getBoundingClientRect();
+        return box.width > 0 && box.height > 0;
+      })
       .map((chip) => {
         const box = chip.getBoundingClientRect();
         const top = document.elementFromPoint(

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -219,12 +219,18 @@ async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> 
       );
     };
     const band = document.querySelector(".star-map__top-band");
-    const right = band
-      ? Math.max(
-          ...[...band.querySelectorAll("button")]
-            .filter((el) => el.getBoundingClientRect().width > 0)
-            .map((el) => el.getBoundingClientRect().right),
+    // Only what is on screen. The hidden rendering is parked at the band's
+    // corner at its full natural width so the fit stays measurable, and
+    // counting it would fail this for a row nobody can see.
+    const onScreen = band
+      ? [...band.querySelectorAll("button")].filter(
+          (el) =>
+            el.getBoundingClientRect().width > 0
+            && getComputedStyle(el).visibility !== "hidden",
         )
+      : [];
+    const right = onScreen.length
+      ? Math.max(...onScreen.map((el) => el.getBoundingClientRect().right))
       : 0;
     return {
       menu: showing(".star-map__filter-menu"),

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -51,7 +51,6 @@ function countStarMapWindows(
     .filter((win) => win.url().includes("#star-map")).length;
 }
 
-
 /**
  * Resize the map's BrowserWindow and wait for the renderer to lay out at
  * the new width. Playwright's `setViewportSize` is unsupported on an
@@ -75,48 +74,93 @@ async function resizeStarMapWindow(
 }
 
 /**
+ * The band's three slots, in the order the grid lays them out. Named
+ * rather than derived from the DOM so an accidentally-dropped slot fails
+ * as a missing box below instead of silently narrowing the check.
+ */
+const TOP_BAND_SLOTS = [
+  ".star-map__chrome",
+  ".star-map__filters",
+  ".star-map__actions",
+] as const;
+
+/**
  * The top band's slots must not overlap at any window width, and nothing
  * may sit on top of a filter chip.
  *
  * The rect check is the structural one: `.star-map__chrome` and
  * `.star-map__filters` used to be independently positioned islands, so
  * the chrome (the higher z-index) painted over the leading chip and ate
- * its clicks. The hit test is the behavioural one, and it is wider — it
- * catches ANY element covering a chip, not just the chrome, which is the
- * shape axe reported as `target-size` ("partially obscured, smallest
- * space is 79.5px by 12px"). Both are cheaper than waiting for the a11y
- * gate to notice, and they say what actually broke.
+ * its clicks. It runs over every PAIR of occupied slots rather than that
+ * one pair, because the point of the band is that controls get added to
+ * it — a check that only knows about the two slots occupied today stops
+ * gating the moment somebody uses the third.
+ *
+ * The hit test is the behavioural one, and it is wider — it catches ANY
+ * element covering a chip, not just a sibling slot, which is the shape
+ * axe reported as `target-size` ("partially obscured, smallest space is
+ * 79.5px by 12px"). It is scoped to the chips INSIDE the filter strip:
+ * the same chip primitive is shared with Find, View, and anything the
+ * actions slot grows, and those are not what this measures.
+ *
+ * Both are cheaper than waiting for the a11y gate to notice, and they say
+ * what actually broke.
  */
 async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> {
-  const chrome = await mapWindow.locator(".star-map__chrome").boundingBox();
-  const filters = await mapWindow.locator(".star-map__filters").boundingBox();
-  if (!chrome || !filters) {
-    throw new Error(`Expected both top-band slots to be laid out ${at}`);
+  const boxes = await Promise.all(
+    TOP_BAND_SLOTS.map(async (selector) => ({
+      // An unoccupied slot renders no element at all; `count()` keeps that
+      // apart from a slot that is present but failed to lay out, which is
+      // a real failure and must not be skipped.
+      box: (await mapWindow.locator(selector).count())
+        ? await mapWindow.locator(selector).boundingBox()
+        : undefined,
+      selector,
+    })),
+  );
+  const present = boxes.filter((slot) => slot.box !== undefined);
+  if (present.length < 2) {
+    throw new Error(
+      `Expected at least two top-band slots to be laid out ${at};`
+        + ` got ${JSON.stringify(boxes)}`,
+    );
   }
 
-  const overlaps =
-    chrome.x < filters.x + filters.width
-    && filters.x < chrome.x + chrome.width
-    && chrome.y < filters.y + filters.height
-    && filters.y < chrome.y + chrome.height;
-  expect(
-    overlaps,
-    `top band slots overlap ${at}: chrome ${JSON.stringify(chrome)},`
-      + ` filters ${JSON.stringify(filters)}`,
-  ).toBe(false);
+  for (let i = 0; i < present.length; i += 1) {
+    for (let j = i + 1; j < present.length; j += 1) {
+      const a = present[i]!;
+      const b = present[j]!;
+      const boxA = a.box!;
+      const boxB = b.box!;
+      const overlaps =
+        boxA.x < boxB.x + boxB.width
+        && boxB.x < boxA.x + boxA.width
+        && boxA.y < boxB.y + boxB.height
+        && boxB.y < boxA.y + boxA.height;
+      expect(
+        overlaps,
+        `top band slots overlap ${at}: ${a.selector} ${JSON.stringify(boxA)},`
+          + ` ${b.selector} ${JSON.stringify(boxB)}`,
+      ).toBe(false);
+    }
+  }
 
   const covered = await mapWindow.evaluate(() =>
-    [...document.querySelectorAll(".star-map__filter-chip")]
-      .filter((chip) => !chip.closest(".star-map__chrome"))
+    [...document.querySelectorAll(".star-map__filters .star-map__filter-chip")]
       .map((chip) => {
         const box = chip.getBoundingClientRect();
         const top = document.elementFromPoint(
           box.x + box.width / 2,
           box.y + box.height / 2,
         );
-        return top?.closest(".star-map__filters")
-          ? undefined
-          : `${chip.textContent} covered by ${top?.className ?? "nothing"}`;
+        if (top?.closest(".star-map__filters")) return undefined;
+        // `className` is an SVGAnimatedString on SVG elements, and the map
+        // paints several full-bleed SVG layers — describe the element in a
+        // way that survives whichever kind covered the chip.
+        const culprit = top
+          ? `${top.tagName.toLowerCase()}${top.getAttribute("class") ? `.${top.getAttribute("class")}` : ""}`
+          : "nothing";
+        return `${chip.textContent} covered by ${culprit}`;
       })
       .filter((entry): entry is string => entry !== undefined),
   );

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -147,15 +147,16 @@ async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> 
 
   const covered = await mapWindow.evaluate(() =>
     [...document.querySelectorAll(".star-map__filters .star-map__filter-chip")]
-      // The slot holds both renderings of the filters and CSS displays one,
-      // so the other measures 0x0 — and a zero rect centres on (0,0), where
-      // `elementFromPoint` truthfully reports the drag strip. Testing the
-      // rendered one at each width is the point; testing the hidden one is
-      // how this check reported the band as broken at 1280px when it was
-      // not.
+      // The slot keeps both renderings of the filters mounted, and the
+      // dropped chips keep their natural width so the fit stays
+      // measurable — so "not showing" here is `visibility: hidden` with a
+      // real box, or a zero box, depending on which. Neither is a chip
+      // the operator can click, and testing one anyway is how this check
+      // reported the band as broken at 1280px when it was not.
       .filter((chip) => {
         const box = chip.getBoundingClientRect();
-        return box.width > 0 && box.height > 0;
+        if (box.width === 0 || box.height === 0) return false;
+        return getComputedStyle(chip).visibility !== "hidden";
       })
       .map((chip) => {
         const box = chip.getBoundingClientRect();
@@ -200,6 +201,49 @@ async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> 
     band: rowHeight?.tallestSlot,
     tallestSlot: rowHeight?.tallestSlot,
   });
+
+  // Which of the two filter renderings shows is a property of the data —
+  // how many chips carry a count, how wide those counts are — so a spec
+  // cannot assert a state at a width without pinning the fixture's
+  // numbers. What it CAN assert is the invariant: exactly one of them is
+  // ever on screen, and whatever is on screen fits inside the window.
+  const slots = await mapWindow.evaluate(() => {
+    const showing = (selector: string) => {
+      const el = document.querySelector(selector);
+      if (!el) return false;
+      const box = el.getBoundingClientRect();
+      return (
+        box.width > 0
+        && box.height > 0
+        && getComputedStyle(el).visibility !== "hidden"
+      );
+    };
+    const band = document.querySelector(".star-map__top-band");
+    const right = band
+      ? Math.max(
+          ...[...band.querySelectorAll("button")]
+            .filter((el) => el.getBoundingClientRect().width > 0)
+            .map((el) => el.getBoundingClientRect().right),
+        )
+      : 0;
+    return {
+      menu: showing(".star-map__filter-menu"),
+      overflowsBy: Math.round(right - document.documentElement.clientWidth),
+      strip: showing(".star-map__filter-strip"),
+    };
+  });
+  expect(
+    slots.strip !== slots.menu,
+    `expected exactly one filter rendering ${at}: ${JSON.stringify(slots)}`,
+  ).toBe(true);
+  // The other way a row that does not fit fails: rather than a chip
+  // leaving, every chip narrows until the labels wrap, or the row runs
+  // straight off the right edge of the window. Both were real before the
+  // chips were pinned to their natural width.
+  expect(
+    slots.overflowsBy,
+    `top band runs past the window edge ${at}`,
+  ).toBeLessThanOrEqual(0);
 }
 
 test("opens a thread from the star map window in the main window", async () => {
@@ -309,19 +353,20 @@ test("keeps the star map's top band from overlapping itself", async () => {
     // that would have failed first.
     await resizeStarMapWindow(app, mapWindow, { width: 800, height: 720 });
     await expectTopBandLaidOut(mapWindow, "at the minimum window width");
-    // And the strip does not merely fit here — it is gone, replaced by the
-    // one chip that carries the same filters in a popover. Asserting the
-    // swap rather than only the geometry is what keeps a future change
-    // from "fixing" a narrow window by shrinking the chips instead.
-    await expect(
-      starMap.getByRole("group", { name: "Thread filters" }),
-    ).toBeHidden();
-    const filterMenu = starMap.getByRole("button", { name: /^Thread filters/ });
-    await expect(filterMenu).toBeVisible();
-    await filterMenu.click();
-    await expect(
-      mapWindow.getByRole("dialog", { name: "Thread filters" }),
-    ).toBeVisible();
+    // Whichever rendering the fixture's counts land on at this width, the
+    // filters have to still be reachable. A degradation that ends with no
+    // way to filter would satisfy every geometric check above.
+    const strip = starMap.getByRole("group", { name: "Thread filters" });
+    const menu = starMap.getByRole("button", { name: /^Thread filters/ });
+    if (await strip.isVisible()) {
+      await expect(strip.getByRole("button").first()).toBeVisible();
+    } else {
+      await expect(menu).toBeVisible();
+      await menu.click();
+      await expect(
+        mapWindow.getByRole("dialog", { name: "Thread filters" }),
+      ).toBeVisible();
+    }
   } finally {
     await app.close();
   }

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -165,6 +165,31 @@ async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> 
       .filter((entry): entry is string => entry !== undefined),
   );
   expect(covered, `filter chips obscured ${at}`).toEqual([]);
+
+  // One row, at every width. The first version of this band let the chip
+  // strip wrap instead of collapsing, which put a second row of chips over
+  // the star field and doubled the band's height — the rect and hit-test
+  // checks above both stayed green through it, because wrapped chips
+  // overlap nothing. Measure the band against its tallest slot: equal
+  // means the slots sit side by side, taller means something wrapped.
+  const rowHeight = await mapWindow.evaluate(() => {
+    const band = document.querySelector(".star-map__top-band");
+    if (!band) return undefined;
+    const slots = [...band.children].map((slot) => slot.getBoundingClientRect().height);
+    const style = getComputedStyle(band);
+    const padding = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+    return {
+      band: Math.round(band.getBoundingClientRect().height - padding),
+      tallestSlot: Math.round(Math.max(...slots)),
+    };
+  });
+  expect(
+    rowHeight,
+    `top band is taller than one row ${at}: ${JSON.stringify(rowHeight)}`,
+  ).toEqual({
+    band: rowHeight?.tallestSlot,
+    tallestSlot: rowHeight?.tallestSlot,
+  });
 }
 
 test("opens a thread from the star map window in the main window", async () => {
@@ -274,6 +299,19 @@ test("keeps the star map's top band from overlapping itself", async () => {
     // that would have failed first.
     await resizeStarMapWindow(app, mapWindow, { width: 800, height: 720 });
     await expectTopBandLaidOut(mapWindow, "at the minimum window width");
+    // And the strip does not merely fit here — it is gone, replaced by the
+    // one chip that carries the same filters in a popover. Asserting the
+    // swap rather than only the geometry is what keeps a future change
+    // from "fixing" a narrow window by shrinking the chips instead.
+    await expect(
+      starMap.getByRole("group", { name: "Thread filters" }),
+    ).toBeHidden();
+    const filterMenu = starMap.getByRole("button", { name: /^Thread filters/ });
+    await expect(filterMenu).toBeVisible();
+    await filterMenu.click();
+    await expect(
+      mapWindow.getByRole("dialog", { name: "Thread filters" }),
+    ).toBeVisible();
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
@@ -1,0 +1,55 @@
+import {
+  filterState,
+  type StarMapFilterDefinition,
+  type StarMapFilterSelection,
+} from "./star-map-filters";
+
+/**
+ * One tri-state filter chip.
+ *
+ * Extracted because the chips now render on two surfaces — the inline
+ * strip in the top band, and the "Filters" popover the band collapses
+ * into when the window is too narrow for the strip. Both must offer the
+ * same control with the same label, and an aria-label this fiddly is not
+ * something to keep in sync by hand.
+ */
+export function StarMapFilterChip(props: {
+  definition: StarMapFilterDefinition;
+  selection: StarMapFilterSelection;
+  count: number;
+  onCycle: () => void;
+}) {
+  const state = filterState(props.selection, props.definition.key);
+  const next =
+    state === "neutral"
+      ? "show only these"
+      : state === "include"
+        ? "hide these instead"
+        : "stop filtering on this";
+
+  return (
+    <button
+      type="button"
+      className={`star-map__filter-chip star-map__filter-chip--${state}`}
+      // Tri-state, so `aria-pressed` cannot describe it: exclude is
+      // neither pressed nor unpressed. The label carries the state
+      // and what the next click does.
+      aria-label={`${props.definition.label}: ${
+        state === "neutral"
+          ? "not filtered"
+          : state === "include"
+            ? "showing only these"
+            : "hidden"
+      } — click to ${next}`}
+      onClick={props.onCycle}
+    >
+      {state === "exclude" ? (
+        <span className="star-map__filter-mark" aria-hidden="true">
+          −
+        </span>
+      ) : null}
+      <span>{props.definition.label}</span>
+      <span className="star-map__filter-count">{props.count}</span>
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
@@ -18,6 +18,14 @@ export function StarMapFilterChip(props: {
   selection: StarMapFilterSelection;
   count: number;
   onCycle: () => void;
+  /**
+   * Dropped from the strip because the band ran out of room for it. The
+   * chip stays in the DOM and keeps its natural width: the fit is decided
+   * by measuring these chips, so removing them would remove the input
+   * that decides whether they come back, and the strip would oscillate.
+   * CSS takes it out of flow and out of the accessibility tree.
+   */
+  dropped?: boolean;
 }) {
   const state = filterState(props.selection, props.definition.key);
   const next =
@@ -30,7 +38,13 @@ export function StarMapFilterChip(props: {
   return (
     <button
       type="button"
-      className={`star-map__filter-chip star-map__filter-chip--${state}`}
+      className={`star-map__filter-chip star-map__filter-chip--${state}${
+        props.dropped ? " is-dropped" : ""
+      }`}
+      // Out of flow is not out of reach: without this a dropped chip is
+      // still in the tab order, focusable, and invisible.
+      tabIndex={props.dropped ? -1 : undefined}
+      aria-hidden={props.dropped ? true : undefined}
       // Tri-state, so `aria-pressed` cannot describe it: exclude is
       // neither pressed nor unpressed. The label carries the state
       // and what the next click does.

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterMenu.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from "react";
+import { StarMapFilterChip } from "./StarMapFilterChip";
+import {
+  STAR_MAP_FILTERS,
+  type StarMapFilterKey,
+  type StarMapFilterSelection,
+} from "./star-map-filters";
+
+/**
+ * The filter strip, collapsed into one chip.
+ *
+ * Seven chips carrying live counts are about 1020px wide with two-digit
+ * counts and 1084px with three — wider than the band has to give on any
+ * window below roughly 1120px, and the map window goes down to 800px. The
+ * strip used to wrap to a second row there, which put chips over the star
+ * field and doubled the height of the band for no gain. This is the same
+ * set of controls behind one door instead.
+ *
+ * CSS owns the swap (`@media` on the band, beside `.star-map__filters`),
+ * not this component: both surfaces render at every width and the one
+ * that fits is displayed, so there is no measurement to get wrong and no
+ * flip-flop between the two.
+ */
+export function StarMapFilterMenu(props: {
+  selection: StarMapFilterSelection;
+  counts: Record<StarMapFilterKey, number>;
+  onCycle: (key: StarMapFilterKey) => void;
+  onClear: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeCount = Object.keys(props.selection).length;
+
+  // Same dismissal model as the View popover beside it.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node
+        && !containerRef.current?.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => window.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  return (
+    <div className="star-map__filter-menu" ref={containerRef}>
+      <button
+        type="button"
+        className={`star-map__filter-chip${activeCount > 0 ? " is-on" : ""}`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        // The count is the only thing that says the map is filtered while
+        // the chips are behind the door, so it has to be in the name and
+        // not just painted on the badge.
+        aria-label={
+          activeCount === 0
+            ? "Thread filters"
+            : `Thread filters: ${activeCount} active`
+        }
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span>Filters</span>
+        {activeCount > 0 ? (
+          <span className="star-map__filter-count">{activeCount}</span>
+        ) : null}
+      </button>
+      {open ? (
+        <div
+          className="star-map__filter-panel"
+          role="dialog"
+          aria-label="Thread filters"
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.stopPropagation();
+              setOpen(false);
+            }
+          }}
+        >
+          {STAR_MAP_FILTERS.map((definition) => (
+            <StarMapFilterChip
+              key={definition.key}
+              definition={definition}
+              selection={props.selection}
+              count={props.counts[definition.key]}
+              onCycle={() => props.onCycle(definition.key)}
+            />
+          ))}
+          {activeCount > 0 ? (
+            <button
+              type="button"
+              className="star-map__filter-clear"
+              onClick={() => {
+                props.onClear();
+                setOpen(false);
+              }}
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1351,15 +1351,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
       taken += bandGap * siblings;
 
       const stripStyle = getComputedStyle(strip);
-      const chips = [...strip.children].filter((child) =>
-        child.classList.contains("star-map__filter-chip"),
-      );
+      const stripGap = parseFloat(stripStyle.columnGap) || 0;
+      const chips: number[] = [];
+      // Everything in the row that is not a chip - the "Clear" button -
+      // costs its width plus its gap, and unlike a chip it never leaves
+      // when the row is reduced. Left out, the row measures 56px narrower
+      // than it is and the clip below silently slices the last chip.
+      let reserved = 0;
+      for (const child of strip.children) {
+        const width = child.getBoundingClientRect().width;
+        if (child.classList.contains("star-map__filter-chip")) chips.push(width);
+        else reserved += width + stripGap;
+      }
       setFilterFit(
         resolveFilterFit({
           available: band.getBoundingClientRect().width - taken,
-          chipWidths: chips.map((chip) => chip.getBoundingClientRect().width),
+          chipWidths: chips,
           droppable: droppableFilters,
-          gap: parseFloat(stripStyle.columnGap) || 0,
+          gap: stripGap,
+          reserved,
         }),
       );
     };
@@ -1369,7 +1379,20 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // initial measure still runs there.
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(measure);
+    // The band's width comes from the window, so watching it alone only
+    // catches resizes. What the strip NEEDS can change without the window
+    // moving at all: `--font-sans` leads with a web font, so the first
+    // layout measures fallback metrics and every box changes when the real
+    // face arrives, and macOS fullscreen drops the chrome's 80px stoplight
+    // reservation in place. Watching the two boxes whose content decides
+    // the fit catches both. No feedback loop: a fit change moves the
+    // strip's own width, but the measurement reads the chips' natural
+    // widths and the band's, neither of which the fit alters, so the
+    // second pass resolves the same state and React bails on the set.
     observer.observe(band);
+    observer.observe(strip);
+    const chrome = band.firstElementChild;
+    if (chrome && chrome !== strip.parentElement) observer.observe(chrome);
     return () => observer.disconnect();
     // Counts and selection change chip widths and what may be dropped, so
     // both have to re-measure.

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -124,6 +124,10 @@ import { useStarMapFlight } from "./useStarMapFlight";
 import { StarMapViewOptions } from "./StarMapViewOptions";
 import { StarMapFilterChip } from "./StarMapFilterChip";
 import { StarMapFilterMenu } from "./StarMapFilterMenu";
+import {
+  resolveFilterFit,
+  type StarMapFilterFit,
+} from "./star-map-filter-fit";
 import { StarMapKeyHint } from "./StarMapKeyHint";
 import { useStarMapCameraKeys } from "./useStarMapCameraKeys";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
@@ -1297,6 +1301,79 @@ export function StarMapScreen(props: StarMapScreenProps) {
     }
     return counts;
   }, [filterSelection, props.localThreads, props.sessionKeys, remote]);
+
+  // Which chips the band has room for. The chips carry live counts, so
+  // the width they need is a property of the data rather than of the
+  // window — see `resolveFilterFit` for the two constants that were wrong
+  // before this measured. `full` until measured: the strip is what the
+  // band is for.
+  const bandRef = useRef<HTMLDivElement>(null);
+  const filterStripRef = useRef<HTMLDivElement>(null);
+  const [filterFit, setFilterFit] = useState<StarMapFilterFit>("full");
+
+  // A zero chip can only filter the map down to nothing, so it is the
+  // cheapest thing to lose — unless the operator is actually filtering on
+  // it, in which case dropping it would strand a filter they cannot see
+  // to undo.
+  const droppableFilters = useMemo(() => {
+    const droppable = new Set<number>();
+    STAR_MAP_FILTERS.forEach((definition, index) => {
+      if (
+        filterCounts[definition.key] === 0
+        && filterSelection[definition.key] === undefined
+      ) {
+        droppable.add(index);
+      }
+    });
+    return droppable;
+  }, [filterCounts, filterSelection]);
+
+  useLayoutEffect(() => {
+    const band = bandRef.current;
+    const strip = filterStripRef.current;
+    if (!band || !strip) return;
+
+    const measure = () => {
+      // Everything in the band that is not the strip, plus the gaps: what
+      // is left is what the strip may occupy. Read from the live boxes
+      // rather than from the tokens, so a platform's stoplight
+      // reservation or a longer wordmark is accounted for by being there.
+      const bandStyle = getComputedStyle(band);
+      const bandGap = parseFloat(bandStyle.columnGap) || 0;
+      let taken = parseFloat(bandStyle.paddingLeft) + parseFloat(bandStyle.paddingRight);
+      let siblings = 0;
+      for (const child of band.children) {
+        if (child === strip.parentElement || child === strip) continue;
+        taken += child.getBoundingClientRect().width;
+        siblings += 1;
+      }
+      // One gap per sibling, plus the one between the strip and them.
+      taken += bandGap * siblings;
+
+      const stripStyle = getComputedStyle(strip);
+      const chips = [...strip.children].filter((child) =>
+        child.classList.contains("star-map__filter-chip"),
+      );
+      setFilterFit(
+        resolveFilterFit({
+          available: band.getBoundingClientRect().width - taken,
+          chipWidths: chips.map((chip) => chip.getBoundingClientRect().width),
+          droppable: droppableFilters,
+          gap: parseFloat(stripStyle.columnGap) || 0,
+        }),
+      );
+    };
+
+    measure();
+    // Same shape as the card observer above: jsdom has none, and the
+    // initial measure still runs there.
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(band);
+    return () => observer.disconnect();
+    // Counts and selection change chip widths and what may be dropped, so
+    // both have to re-measure.
+  }, [droppableFilters, filterCounts, hasFilterSelection]);
 
   const lanes = useMemo(() => {
     const result = new Map<
@@ -3830,7 +3907,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           positioned islands and the chrome painted over the first filter
           chip. See `.star-map__top-band` for the drag model that lets a
           full-width band sit inside the window's only drag handle. */}
-      <div className="star-map__top-band">
+      <div className="star-map__top-band" ref={bandRef}>
         <div className="star-map__chrome">
           {/* Same wordmark primitive as the sidebar/Settings nav so the brand
               reads identically across every window (theme-contract test). */}
@@ -3867,22 +3944,26 @@ export function StarMapScreen(props: StarMapScreenProps) {
             onResetView={resetView}
           />
         </div>
-        {/* Two renderings of one control set. The strip is the real one;
-            the menu is what the band shows when the window is too narrow
-            to hold it. CSS picks, so neither has to measure anything —
-            see the `@media` beside `.star-map__filters`. */}
-        <div className="star-map__filters">
+        {/* Two renderings of one control set, sitting where the operator
+            already is — beside Find and View, not floating in the middle
+            of the window. Both stay mounted at every width: the strip's
+            chips are what the fit is measured from, so the one that is
+            not showing has to keep its natural width or the measurement
+            loses the input that would bring it back. */}
+        <div className={`star-map__filters is-${filterFit}`}>
           <div
             className="star-map__filter-strip"
             role="group"
             aria-label="Thread filters"
+            ref={filterStripRef}
           >
-            {STAR_MAP_FILTERS.map((definition) => (
+            {STAR_MAP_FILTERS.map((definition, index) => (
               <StarMapFilterChip
                 key={definition.key}
                 definition={definition}
                 selection={filterSelection}
                 count={filterCounts[definition.key]}
+                dropped={filterFit === "reduced" && droppableFilters.has(index)}
                 onCycle={() => cycleFilter(definition.key)}
               />
             ))}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -64,7 +64,6 @@ import {
   addFilterMatchCounts,
   countFilterMatches,
   cycleFilterState,
-  filterState,
   readStoredFilterSelection,
   selectFilteredThreads,
   STAR_MAP_FILTERS,
@@ -123,6 +122,8 @@ import {
 } from "./star-map-flight";
 import { useStarMapFlight } from "./useStarMapFlight";
 import { StarMapViewOptions } from "./StarMapViewOptions";
+import { StarMapFilterChip } from "./StarMapFilterChip";
+import { StarMapFilterMenu } from "./StarMapFilterMenu";
 import { StarMapKeyHint } from "./StarMapKeyHint";
 import { useStarMapCameraKeys } from "./useStarMapCameraKeys";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
@@ -3866,53 +3867,41 @@ export function StarMapScreen(props: StarMapScreenProps) {
             onResetView={resetView}
           />
         </div>
-        <div className="star-map__filters" role="group" aria-label="Thread filters">
-          {STAR_MAP_FILTERS.map((definition) => {
-            const state = filterState(filterSelection, definition.key);
-            const next =
-              state === "neutral"
-                ? "show only these"
-                : state === "include"
-                  ? "hide these instead"
-                  : "stop filtering on this";
-            return (
-              <button
+        {/* Two renderings of one control set. The strip is the real one;
+            the menu is what the band shows when the window is too narrow
+            to hold it. CSS picks, so neither has to measure anything —
+            see the `@media` beside `.star-map__filters`. */}
+        <div className="star-map__filters">
+          <div
+            className="star-map__filter-strip"
+            role="group"
+            aria-label="Thread filters"
+          >
+            {STAR_MAP_FILTERS.map((definition) => (
+              <StarMapFilterChip
                 key={definition.key}
+                definition={definition}
+                selection={filterSelection}
+                count={filterCounts[definition.key]}
+                onCycle={() => cycleFilter(definition.key)}
+              />
+            ))}
+            {hasFilterSelection ? (
+              <button
                 type="button"
-                className={`star-map__filter-chip star-map__filter-chip--${state}`}
-                // Tri-state, so `aria-pressed` cannot describe it: exclude is
-                // neither pressed nor unpressed. The label carries the state
-                // and what the next click does.
-                aria-label={`${definition.label}: ${
-                  state === "neutral"
-                    ? "not filtered"
-                    : state === "include"
-                      ? "showing only these"
-                      : "hidden"
-                } — click to ${next}`}
-                onClick={() => cycleFilter(definition.key)}
+                className="star-map__filter-clear"
+                onClick={clearFilters}
               >
-                {state === "exclude" ? (
-                  <span className="star-map__filter-mark" aria-hidden="true">
-                    −
-                  </span>
-                ) : null}
-                <span>{definition.label}</span>
-                <span className="star-map__filter-count">
-                  {filterCounts[definition.key]}
-                </span>
+                Clear
               </button>
-            );
-          })}
-          {hasFilterSelection ? (
-            <button
-              type="button"
-              className="star-map__filter-clear"
-              onClick={clearFilters}
-            >
-              Clear
-            </button>
-          ) : null}
+            ) : null}
+          </div>
+          <StarMapFilterMenu
+            selection={filterSelection}
+            counts={filterCounts}
+            onCycle={cycleFilter}
+            onClear={clearFilters}
+          />
         </div>
       </div>
       {/* Two different settings can empty the map, and a blank star field

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -3823,41 +3823,97 @@ export function StarMapScreen(props: StarMapScreenProps) {
           </button>
         </p>
       ) : null}
-      <div className="star-map__chrome">
-        {/* Same wordmark primitive as the sidebar/Settings nav so the brand
-            reads identically across every window (theme-contract test). */}
-        <p className="sidebar__brand">
-          Pwr<span className="sidebar__brand-accent">Agent</span>
-        </p>
-        {/* ⌘K is the map's only way to reach a card it is not drawing, and
-            a keyboard-only door on a surface driven by the pointer is a
-            door nobody finds. The chord rides the label so learning it
-            costs one glance. */}
-        <button
-          type="button"
-          className="star-map__filter-chip star-map__find"
-          aria-label="Find a thread on the map"
-          onClick={() => setJumpOpen(true)}
-        >
-          <SearchIcon size={13} />
-          <span>Find</span>
-          <span className="star-map__find-chord" aria-hidden="true">
-            {formatPrimaryAccel("K")}
-          </span>
-        </button>
-        <StarMapViewOptions
-          preferences={preferences}
-          onChange={(next) => {
-            // A lens change re-places every card, and one lens (projects)
-            // paints no selected state at all. Carrying a selection across
-            // that boundary leaves the operator holding cards they can no
-            // longer point at — which the kebab would then act on.
-            if (next.layout !== preferences.layout) setSelection(new Set());
-            setPreferences(next);
-            writeStoredPreferences(next);
-          }}
-          onResetView={resetView}
-        />
+      {/* The map's whole top band: chrome on the left, filter chips in the
+          middle, and a right-hand slot for map actions. One grid row, so
+          the three cannot reach each other - they used to be separately
+          positioned islands and the chrome painted over the first filter
+          chip. See `.star-map__top-band` for the drag model that lets a
+          full-width band sit inside the window's only drag handle. */}
+      <div className="star-map__top-band">
+        <div className="star-map__chrome">
+          {/* Same wordmark primitive as the sidebar/Settings nav so the brand
+              reads identically across every window (theme-contract test). */}
+          <p className="sidebar__brand">
+            Pwr<span className="sidebar__brand-accent">Agent</span>
+          </p>
+          {/* ⌘K is the map's only way to reach a card it is not drawing, and
+              a keyboard-only door on a surface driven by the pointer is a
+              door nobody finds. The chord rides the label so learning it
+              costs one glance. */}
+          <button
+            type="button"
+            className="star-map__filter-chip star-map__find"
+            aria-label="Find a thread on the map"
+            onClick={() => setJumpOpen(true)}
+          >
+            <SearchIcon size={13} />
+            <span>Find</span>
+            <span className="star-map__find-chord" aria-hidden="true">
+              {formatPrimaryAccel("K")}
+            </span>
+          </button>
+          <StarMapViewOptions
+            preferences={preferences}
+            onChange={(next) => {
+              // A lens change re-places every card, and one lens (projects)
+              // paints no selected state at all. Carrying a selection across
+              // that boundary leaves the operator holding cards they can no
+              // longer point at — which the kebab would then act on.
+              if (next.layout !== preferences.layout) setSelection(new Set());
+              setPreferences(next);
+              writeStoredPreferences(next);
+            }}
+            onResetView={resetView}
+          />
+        </div>
+        <div className="star-map__filters" role="group" aria-label="Thread filters">
+          {STAR_MAP_FILTERS.map((definition) => {
+            const state = filterState(filterSelection, definition.key);
+            const next =
+              state === "neutral"
+                ? "show only these"
+                : state === "include"
+                  ? "hide these instead"
+                  : "stop filtering on this";
+            return (
+              <button
+                key={definition.key}
+                type="button"
+                className={`star-map__filter-chip star-map__filter-chip--${state}`}
+                // Tri-state, so `aria-pressed` cannot describe it: exclude is
+                // neither pressed nor unpressed. The label carries the state
+                // and what the next click does.
+                aria-label={`${definition.label}: ${
+                  state === "neutral"
+                    ? "not filtered"
+                    : state === "include"
+                      ? "showing only these"
+                      : "hidden"
+                } — click to ${next}`}
+                onClick={() => cycleFilter(definition.key)}
+              >
+                {state === "exclude" ? (
+                  <span className="star-map__filter-mark" aria-hidden="true">
+                    −
+                  </span>
+                ) : null}
+                <span>{definition.label}</span>
+                <span className="star-map__filter-count">
+                  {filterCounts[definition.key]}
+                </span>
+              </button>
+            );
+          })}
+          {hasFilterSelection ? (
+            <button
+              type="button"
+              className="star-map__filter-clear"
+              onClick={clearFilters}
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
       </div>
       {/* Two different settings can empty the map, and a blank star field
           looks identical either way. Name whichever one is responsible —
@@ -3922,54 +3978,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
           </button>
         </div>
       ) : null}
-      <div className="star-map__filters" role="group" aria-label="Thread filters">
-        {STAR_MAP_FILTERS.map((definition) => {
-          const state = filterState(filterSelection, definition.key);
-          const next =
-            state === "neutral"
-              ? "show only these"
-              : state === "include"
-                ? "hide these instead"
-                : "stop filtering on this";
-          return (
-            <button
-              key={definition.key}
-              type="button"
-              className={`star-map__filter-chip star-map__filter-chip--${state}`}
-              // Tri-state, so `aria-pressed` cannot describe it: exclude is
-              // neither pressed nor unpressed. The label carries the state
-              // and what the next click does.
-              aria-label={`${definition.label}: ${
-                state === "neutral"
-                  ? "not filtered"
-                  : state === "include"
-                    ? "showing only these"
-                    : "hidden"
-              } — click to ${next}`}
-              onClick={() => cycleFilter(definition.key)}
-            >
-              {state === "exclude" ? (
-                <span className="star-map__filter-mark" aria-hidden="true">
-                  −
-                </span>
-              ) : null}
-              <span>{definition.label}</span>
-              <span className="star-map__filter-count">
-                {filterCounts[definition.key]}
-              </span>
-            </button>
-          );
-        })}
-        {hasFilterSelection ? (
-          <button
-            type="button"
-            className="star-map__filter-clear"
-            onClick={clearFilters}
-          >
-            Clear
-          </button>
-        ) : null}
-      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -65,9 +65,11 @@ export function StarMapWindow() {
       {isMac ? (
         // Purely a window-drag handle: `-webkit-app-region: drag` means
         // macOS takes the mouse-down before the DOM sees it, so nothing
-        // here can (or should) start a canvas pan. The map's own top
-        // chrome and filter chips carve `no-drag` holes so they stay
-        // clickable inside the strip. Decorative to assistive tech.
+        // here can (or should) start a canvas pan. The slots of the map's
+        // own top band carve `no-drag` holes so their controls stay
+        // clickable inside the strip; the band between them does not, or
+        // this window would have no drag handle left. Decorative to
+        // assistive tech.
         <div aria-hidden="true" className="star-map-window__titlebar" />
       ) : null}
       {isWindows ? (

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -1600,6 +1600,59 @@ describe("StarMapScreen", () => {
     expect(status.textContent).toMatch(/No threads match these filters/);
   });
 
+  // The narrow-window rendering of the same filters. CSS decides which of
+  // the two is displayed (`@media` beside `.star-map__filters`); jsdom
+  // loads no stylesheet, so both are in the tree here and the menu can be
+  // driven directly. What matters is that it drives the SAME state as the
+  // strip — a popover that filtered a different map would be worse than
+  // no popover at all.
+  it("filters from the collapsed menu the same way the strip does", async () => {
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[unreadThread("t11")]}
+        sessionKeys={{}}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    // Closed, the trigger is the only thing that says the map is filtered,
+    // so its name carries the count rather than only its badge.
+    const trigger = screen.getByRole("button", { name: "Thread filters" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(trigger);
+
+    const panel = screen.getByRole("dialog", { name: "Thread filters" });
+    // Exclude the only reason this card is on the map, through the popover.
+    const unread = () =>
+      within(panel).getByRole("button", { name: /^Unread:/ });
+    fireEvent.click(unread());
+    fireEvent.click(unread());
+
+    expect(
+      screen.queryByRole("button", { name: /Open thread: Thread t11/ }),
+    ).toBeNull();
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toMatch(/No threads match these filters/);
+    // The strip is the same control set, not a parallel one: it has to
+    // show the state the popover just set.
+    const strip = screen.getByRole("group", { name: "Thread filters" });
+    expect(
+      within(strip).getByRole("button", { name: /^Unread: hidden/ }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Thread filters: 1 active" }),
+    ).toBeTruthy();
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Clear" }));
+    expect(
+      screen.getByRole("button", { name: /Open thread: Thread t11/ }),
+    ).toBeTruthy();
+    // Clearing closes the door behind it — there is nothing left to set.
+    expect(screen.queryByRole("dialog", { name: "Thread filters" })).toBeNull();
+  });
+
   it("offers a way back from any selection", async () => {
     render(
       <StarMapScreen

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filter-fit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filter-fit.test.ts
@@ -102,6 +102,55 @@ describe("resolveFilterFit", () => {
     ).toBe("full");
   });
 
+  it("counts the Clear button, which is in the row but is not a chip", () => {
+    // Clear renders the moment anything is filtered, sits in the strip
+    // beside the chips, and never leaves with them when the row reduces.
+    // Measured: 50px plus its 6px gap. Leaving it out reported a row of
+    // 661px that actually needed 717px, and the strip's clip sliced the
+    // trailing chip in half with nothing to say it had.
+    const CLEAR = 50 + GAP;
+    expect(
+      resolveFilterFit({
+        available: REAL_ROW,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set(),
+        gap: GAP,
+        reserved: CLEAR,
+      }),
+    ).not.toBe("full");
+    expect(
+      resolveFilterFit({
+        available: REAL_ROW + CLEAR,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set(),
+        gap: GAP,
+        reserved: CLEAR,
+      }),
+    ).toBe("full");
+    // And it is still charged for on the reduced row, which is the case
+    // that actually bit: dropping two chips does not drop Clear.
+    const reduced =
+      REAL_ROW - REAL_CHIPS[1]! - REAL_CHIPS[2]! - GAP * 2 + CLEAR;
+    expect(
+      resolveFilterFit({
+        available: reduced - 1,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set([1, 2]),
+        gap: GAP,
+        reserved: CLEAR,
+      }),
+    ).toBe("collapsed");
+    expect(
+      resolveFilterFit({
+        available: reduced,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set([1, 2]),
+        gap: GAP,
+        reserved: CLEAR,
+      }),
+    ).toBe("reduced");
+  });
+
   it("counts the gaps, not just the chips", () => {
     // Six gaps between seven chips. Sizing on chip widths alone is off by
     // 36px here — enough to overflow the row it just declared a fit.

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filter-fit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filter-fit.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { resolveFilterFit } from "../star-map-filter-fit";
+
+/**
+ * The arithmetic that decides how much of the filter strip the top band
+ * shows. It has been wrong twice — once by wrapping instead of degrading,
+ * once by a fixed 1120px breakpoint that collapsed the strip while there
+ * was still room — so the widths below are the real measured ones rather
+ * than round numbers: the seven chips are 642px at one-digit counts,
+ * 668px at two and 732px at three, gaps included.
+ */
+const GAP = 6;
+
+/** Seven chips with two-digit counts, as measured in the running app. */
+const REAL_CHIPS = [79, 78, 95, 92, 95, 70, 73];
+const REAL_ROW = REAL_CHIPS.reduce((a, b) => a + b, 0) + GAP * 6;
+
+describe("resolveFilterFit", () => {
+  it("shows every chip when the row fits", () => {
+    expect(
+      resolveFilterFit({
+        available: REAL_ROW,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set(),
+        gap: GAP,
+      }),
+    ).toBe("full");
+  });
+
+  it("keeps the strip whole when nothing may be dropped", () => {
+    // Every chip carries a count, so there is no cheap thing to lose and
+    // the strip goes behind the one chip rather than losing a filter the
+    // operator can still use.
+    expect(
+      resolveFilterFit({
+        available: REAL_ROW - 1,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set(),
+        gap: GAP,
+      }),
+    ).toBe("collapsed");
+  });
+
+  it("drops the zero-count chips before collapsing", () => {
+    // "Working 0" and "Needs input 0" in the screenshot that caught this:
+    // a zero chip can only filter the map down to nothing, so it is what
+    // leaves first. 668 - 78 - 95 - 12 of gap = 483.
+    const droppable = new Set([1, 2]);
+    const reduced = REAL_ROW - REAL_CHIPS[1]! - REAL_CHIPS[2]! - GAP * 2;
+    expect(
+      resolveFilterFit({
+        available: reduced,
+        chipWidths: REAL_CHIPS,
+        droppable,
+        gap: GAP,
+      }),
+    ).toBe("reduced");
+    // One pixel under what even the reduced row needs, and the whole
+    // thing goes behind the chip.
+    expect(
+      resolveFilterFit({
+        available: reduced - 1,
+        chipWidths: REAL_CHIPS,
+        droppable,
+        gap: GAP,
+      }),
+    ).toBe("collapsed");
+  });
+
+  it("does not reduce to an empty strip", () => {
+    // Every chip is zero and unselected — dropping them all leaves a
+    // labelled group with nothing in it, which is worse than the menu.
+    expect(
+      resolveFilterFit({
+        available: 10,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set(REAL_CHIPS.map((_, index) => index)),
+        gap: GAP,
+      }),
+    ).toBe("collapsed");
+  });
+
+  it("shows the strip before it has been measured", () => {
+    // First paint, and any state where the box has no width yet. The
+    // strip is what the band is for, and one frame of overflow beats one
+    // frame of a collapsed menu that immediately expands.
+    expect(
+      resolveFilterFit({
+        available: 0,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set(),
+        gap: GAP,
+      }),
+    ).toBe("full");
+    expect(
+      resolveFilterFit({
+        available: 400,
+        chipWidths: [],
+        droppable: new Set(),
+        gap: GAP,
+      }),
+    ).toBe("full");
+  });
+
+  it("counts the gaps, not just the chips", () => {
+    // Six gaps between seven chips. Sizing on chip widths alone is off by
+    // 36px here — enough to overflow the row it just declared a fit.
+    const chipsOnly = REAL_CHIPS.reduce((a, b) => a + b, 0);
+    expect(
+      resolveFilterFit({
+        available: chipsOnly,
+        chipWidths: REAL_CHIPS,
+        droppable: new Set(),
+        gap: GAP,
+      }),
+    ).not.toBe("full");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -247,6 +247,16 @@ describe("shouldStartCanvasPan", () => {
       '<div class="star-map__filters"><span>Unread</span></div>',
     );
     expect(shouldStartCanvasPan(filters.firstElementChild)).toBe(false);
+
+    // The band covers the whole top row, so a control added to any of its
+    // slots is safe without being named here. This one carries no slot
+    // class at all — it stands in for the next thing somebody drops in.
+    const band = element(
+      '<div class="star-map__top-band"><div><span>Manager</span></div></div>',
+    );
+    expect(
+      shouldStartCanvasPan(band.querySelector("span")),
+    ).toBe(false);
   });
 
   it("ignores a non-element target", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
@@ -1,0 +1,65 @@
+/**
+ * How much of the filter strip the top band can show.
+ *
+ * The band is one row and the map window goes down to 800px, so at some
+ * width the seven chips stop fitting beside the chrome. Two earlier
+ * answers were both wrong in ways worth recording:
+ *
+ * - Wrapping to a second row put chips over the star field and doubled
+ *   the height of the band to show information already on it.
+ * - A fixed `@media` breakpoint collapsed the whole strip at 1120px, well
+ *   before it had to. The chips carry live counts, so how much room they
+ *   need is a property of the data, not of the window: 642px with
+ *   one-digit counts, 668px with two, 732px with three. No constant is
+ *   right for all three, and the constant that is safe for the widest
+ *   case throws the strip away in the common one.
+ *
+ * So measure, and degrade in priority order rather than all at once:
+ *
+ * - `full` — every chip.
+ * - `reduced` — chips whose count is zero are dropped first. A zero chip
+ *   can only ever filter the map down to nothing, so it is the one that
+ *   costs least to lose. A chip the operator has actually selected is
+ *   never dropped, whatever its count, or the filter it is applying
+ *   becomes unreachable.
+ * - `collapsed` — everything behind one "Filters" chip.
+ *
+ * This is a pure function of measurements so the arithmetic is testable
+ * without a layout engine; the component owns the observer.
+ */
+export type StarMapFilterFit = "full" | "reduced" | "collapsed";
+
+/** Row width for `count` chips of these widths, separated by `gap`. */
+function rowWidth(widths: readonly number[], gap: number): number {
+  if (widths.length === 0) return 0;
+  return (
+    widths.reduce((total, width) => total + width, 0)
+    + gap * (widths.length - 1)
+  );
+}
+
+export function resolveFilterFit(params: {
+  /** Space the strip may occupy, in px. */
+  available: number;
+  /** Natural width of every chip, in render order. */
+  chipWidths: readonly number[];
+  /** Indexes of the chips that may be dropped, i.e. zero and unselected. */
+  droppable: ReadonlySet<number>;
+  /** Flex gap between chips, in px. */
+  gap: number;
+}): StarMapFilterFit {
+  const { available, chipWidths, droppable, gap } = params;
+  // A measurement that has not happened yet reads as zero. Showing
+  // everything is the honest starting state: the strip is what the band
+  // is for, and one frame of overflow beats one frame of a collapsed
+  // menu that then expands.
+  if (available <= 0 || chipWidths.length === 0) return "full";
+  if (rowWidth(chipWidths, gap) <= available) return "full";
+
+  const kept = chipWidths.filter((_, index) => !droppable.has(index));
+  // Dropping every chip is not "reduced", it is an empty strip wearing
+  // the strip's label — collapse instead, so the control is still there.
+  if (kept.length > 0 && rowWidth(kept, gap) <= available) return "reduced";
+
+  return "collapsed";
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
@@ -47,19 +47,29 @@ export function resolveFilterFit(params: {
   droppable: ReadonlySet<number>;
   /** Flex gap between chips, in px. */
   gap: number;
+  /**
+   * Everything else in the row, plus one gap each: the "Clear" button,
+   * which appears the moment anything is filtered and never leaves with
+   * the chips. Measuring only the chips reports a row 56px narrower than
+   * it is, and the strip's clip then slices the trailing chip in half
+   * with nothing to say it did.
+   */
+  reserved?: number;
 }): StarMapFilterFit {
-  const { available, chipWidths, droppable, gap } = params;
+  const { available, chipWidths, droppable, gap, reserved = 0 } = params;
   // A measurement that has not happened yet reads as zero. Showing
   // everything is the honest starting state: the strip is what the band
   // is for, and one frame of overflow beats one frame of a collapsed
   // menu that then expands.
   if (available <= 0 || chipWidths.length === 0) return "full";
-  if (rowWidth(chipWidths, gap) <= available) return "full";
+  if (rowWidth(chipWidths, gap) + reserved <= available) return "full";
 
   const kept = chipWidths.filter((_, index) => !droppable.has(index));
   // Dropping every chip is not "reduced", it is an empty strip wearing
   // the strip's label — collapse instead, so the control is still there.
-  if (kept.length > 0 && rowWidth(kept, gap) <= available) return "reduced";
+  if (kept.length > 0 && rowWidth(kept, gap) + reserved <= available) {
+    return "reduced";
+  }
 
   return "collapsed";
 }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -413,6 +413,11 @@ export function computeOrbitPlacement(params: {
  * and overhangs the card's top-right corner, so dragging the card from it
  * is the right behaviour — but it is a change, not just a port.
  *
+ * `.star-map__top-band` covers the whole top row - chrome, filter chips,
+ * and whatever lands in the actions slot - so a control added to the band
+ * never has to be added here too. The two older entries stay because they
+ * are named directly by tests and read as the specific things they are.
+ *
  * `.star-map-chat-card` is listed for the same reason, and it became load
  * bearing the moment chat cards moved INSIDE the canvas: a press on a
  * chat card bubbles to the viewport, so without it the card dragged and
@@ -441,6 +446,7 @@ export function shouldStartCanvasPan(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return !target.closest(
     "button, a, input, label, .star-map-card-shell, .star-map-chat-card,"
-      + " .star-map-satellite-card, .star-map__chrome, .star-map__filters",
+      + " .star-map-satellite-card, .star-map__top-band, .star-map__chrome,"
+      + " .star-map__filters",
   );
 }

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -995,19 +995,27 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
-  it("lays the Star Map's top band out as one grid row its slots cannot escape", () => {
-    // The band's three clusters used to position themselves independently
-    // — chrome pinned to the left edge, chips translated to the window's
+  it("lays the Star Map's top band out as one row its controls cannot escape", () => {
+    // The band's clusters used to position themselves independently —
+    // chrome pinned to the left edge, chips translated to the window's
     // centre — with nothing reserving space between them, so the chrome
-    // painted over the first filter chip and swallowed its clicks. Grid
-    // tracks cannot overlap; this is the assertion that the row stays a
+    // painted over the first filter chip and swallowed its clicks. Flex
+    // items cannot overlap; this is the assertion that the row stays a
     // row rather than reverting to islands.
     const bandRule = extractRuleBody(css, ".star-map__top-band");
-    expect(bandRule).toContain("display: grid;");
-    // Equal outer tracks, so the chip strip stays centred on the WINDOW
-    // while there is room for it. `auto 1fr auto` would centre it in
-    // whatever the chrome left over, which is a different position.
-    expect(bandRule).toContain("grid-template-columns: 1fr auto 1fr;");
+    expect(bandRule).toContain("display: flex;");
+    // Left-aligned, not centred. The filters are the same kind of control
+    // as Find and View and belong beside them; a centred strip drifts with
+    // the window while the chrome does not, which is what put the two on a
+    // collision course. A `grid-template-columns` here means someone has
+    // gone back to spacer tracks.
+    expect(bandRule).not.toContain("grid-template-columns");
+    expect(bandRule).not.toContain("justify-content: center;");
+    // The one slot that is not in reading order: actions stay pinned right
+    // whatever the left group does.
+    expect(extractRuleBody(css, ".star-map__actions")).toContain(
+      "margin-left: auto;",
+    );
 
     const chromeRule = extractRuleBody(css, ".star-map__chrome");
     const filtersRule = extractRuleBody(css, ".star-map__filters");
@@ -1016,43 +1024,46 @@ describe("Tangerine Terminal theme contract", () => {
     // regression, not a style preference.
     expect(chromeRule).not.toContain("position: absolute;");
     expect(filtersRule).not.toContain("position: absolute;");
-    // And neither may stretch across its track: a grid item defaults to
-    // `stretch`, the no-drag rect follows the box, and a stretched slot
-    // would take that whole column of sky away from window dragging.
-    expect(chromeRule).toContain("justify-self: start;");
-    expect(filtersRule).toContain("justify-self: center;");
-    expect(extractRuleBody(css, ".star-map__actions")).toContain(
-      "justify-self: end;",
-    );
   });
 
-  it("collapses the Star Map's filter strip instead of wrapping it", () => {
-    // The first version of this band let the strip wrap when it ran out
-    // of room. With the two-digit counts a real fleet produces the strip
-    // is 668px wide, so that happened at 1000px — well inside the map
-    // window's range — and the second row sat over the star field and
-    // doubled the height of the band to show information already on it.
-    // Below the breakpoint the strip is swapped for one "Filters" chip
-    // carrying the same controls in a popover, so the band stays a single
-    // row all the way down to the 800px minimum window width.
-    expect(css).toMatch(
-      /@media \(max-width: 1120px\) \{\s*\.star-map__filter-strip \{\s*display: none;[\s\S]*?\.star-map__filter-menu \{\s*display: block;/,
+  it("degrades the Star Map's filter strip by measurement, not by breakpoint", () => {
+    // Two earlier answers to a strip that does not fit were both wrong.
+    // Wrapping put a second row of chips over the star field and doubled
+    // the band's height; a fixed 1120px breakpoint threw the whole strip
+    // away well before it had to, because the chips carry live counts and
+    // the width they need is a property of the DATA (642px at one digit,
+    // 668px at two, 732px at three), not of the window.
+    expect(css).not.toMatch(/@media[^{]*\{\s*\.star-map__filter-strip/);
+    const stripRule = extractRuleBody(css, ".star-map__filter-strip");
+    expect(stripRule).toContain("flex-wrap: nowrap;");
+
+    // The hidden rendering is taken out of FLOW, never out of layout.
+    // `display: none` would zero the widths `resolveFilterFit` measures,
+    // the strip would look like it fits, and the band would flip between
+    // states every frame. This pair of selectors is load bearing for that
+    // — and `width: max-content` is what keeps the measurement honest once
+    // a chip is out of its flex row.
+    const hiddenRule = extractRuleBody(
+      css,
+      ".star-map__filters.is-reduced .star-map__filter-chip.is-dropped,\n"
+        + ".star-map__filters.is-collapsed .star-map__filter-strip",
     );
-    // Both renderings exist at every width and CSS picks between them, so
-    // the default state has to be the other way round: strip shown, menu
-    // hidden. Without this the menu would paint beside the strip above
-    // the breakpoint.
+    expect(hiddenRule).toContain("visibility: hidden;");
+    expect(hiddenRule).toContain("position: absolute;");
+    expect(hiddenRule).toContain("width: max-content;");
+    expect(hiddenRule).not.toContain("display: none;");
+
+    // The collapsed menu is the only thing that appears rather than
+    // disappears, so it is hidden by default and shown by the state class.
     expect(extractRuleBody(css, ".star-map__filter-menu")).toContain(
       "display: none;",
     );
-    const stripRule = extractRuleBody(css, ".star-map__filter-strip");
-    expect(stripRule).toContain("display: flex;");
-    // Wrapping stays as the last resort under the breakpoint, not the
-    // narrow-window strategy: if a label or count ever outgrows what 1120px
-    // assumes, a second row is ugly, but overflowing the grid track puts
-    // chips back underneath the chrome — the bug the band exists to
-    // prevent. Do not swap this for `nowrap`.
-    expect(stripRule).toContain("flex-wrap: wrap;");
+    expect(
+      extractRuleBody(
+        css,
+        ".star-map__filters.is-collapsed .star-map__filter-menu",
+      ),
+    ).toContain("display: block;");
   });
 
   it("right-aligns the keyboard shortcut hint chip on context menu items", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1024,10 +1024,35 @@ describe("Tangerine Terminal theme contract", () => {
     expect(extractRuleBody(css, ".star-map__actions")).toContain(
       "justify-self: end;",
     );
-    // Wrapping is what lets the middle track shrink — its min-content
-    // becomes one chip rather than the whole strip — so a narrow window
-    // stacks the chips instead of pushing them under the chrome.
-    expect(filtersRule).toContain("flex-wrap: wrap;");
+  });
+
+  it("collapses the Star Map's filter strip instead of wrapping it", () => {
+    // The first version of this band let the strip wrap when it ran out
+    // of room. With the two-digit counts a real fleet produces the strip
+    // is 668px wide, so that happened at 1000px — well inside the map
+    // window's range — and the second row sat over the star field and
+    // doubled the height of the band to show information already on it.
+    // Below the breakpoint the strip is swapped for one "Filters" chip
+    // carrying the same controls in a popover, so the band stays a single
+    // row all the way down to the 800px minimum window width.
+    expect(css).toMatch(
+      /@media \(max-width: 1120px\) \{\s*\.star-map__filter-strip \{\s*display: none;[\s\S]*?\.star-map__filter-menu \{\s*display: block;/,
+    );
+    // Both renderings exist at every width and CSS picks between them, so
+    // the default state has to be the other way round: strip shown, menu
+    // hidden. Without this the menu would paint beside the strip above
+    // the breakpoint.
+    expect(extractRuleBody(css, ".star-map__filter-menu")).toContain(
+      "display: none;",
+    );
+    const stripRule = extractRuleBody(css, ".star-map__filter-strip");
+    expect(stripRule).toContain("display: flex;");
+    // Wrapping stays as the last resort under the breakpoint, not the
+    // narrow-window strategy: if a label or count ever outgrows what 1120px
+    // assumes, a second row is ugly, but overflowing the grid track puts
+    // chips back underneath the chrome — the bug the band exists to
+    // prevent. Do not swap this for `nowrap`.
+    expect(stripRule).toContain("flex-wrap: wrap;");
   });
 
   it("right-aligns the keyboard shortcut hint chip on context menu items", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1053,6 +1053,16 @@ describe("Tangerine Terminal theme contract", () => {
     expect(hiddenRule).toContain("width: max-content;");
     expect(hiddenRule).not.toContain("display: none;");
 
+    // The strip clips a row that has outgrown it, but the clip edge falls
+    // exactly on the first and last chip's box and the focus ring is drawn
+    // OUTSIDE that box (2px at `outline-offset: 1px`). With plain
+    // `overflow: hidden` the ring on the edge chips lost its outer 3px —
+    // measured as three fully blank pixel columns where the accent should
+    // be — and no axe rule covers it.
+    expect(stripRule).toContain("overflow: clip;");
+    expect(stripRule).toContain("overflow-clip-margin: 4px;");
+    expect(stripRule).not.toContain("overflow: hidden;");
+
     // The collapsed menu is the only thing that appears rather than
     // disappears, so it is hidden by default and shown by the state class.
     expect(extractRuleBody(css, ".star-map__filter-menu")).toContain(

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -960,18 +960,21 @@ describe("Tangerine Terminal theme contract", () => {
     expect(stripRule).toContain("-webkit-app-region: drag;");
     expect(stripRule).toContain("position: absolute;");
     expect(stripRule).toContain("backdrop-filter:");
-    // Below the filters (3) and chrome (4) it hosts, above the canvas.
-    expect(readZIndex(stripRule)).toBeLessThan(
-      readZIndex(extractRuleBody(css, ".star-map__filters")),
-    );
-    expect(readZIndex(stripRule)).toBeLessThan(
-      readZIndex(extractRuleBody(css, ".star-map__chrome")),
-    );
+    // Below the top band it hosts, above the canvas.
+    const bandRule = extractRuleBody(css, ".star-map__top-band");
+    expect(readZIndex(stripRule)).toBeLessThan(readZIndex(bandRule));
+    // The band is full width, so it is the one element in the strip that
+    // must NOT opt out: a no-drag rect across the whole band would leave
+    // macOS with no handle on this window at all. It passes its pointer
+    // events through for the same reason - the gaps between its slots are
+    // drag strip, not chrome.
+    expect(bandRule).not.toContain("-webkit-app-region");
+    expect(bandRule).toContain("pointer-events: none;");
+    // Its slots take both back. Declared on the band's descendants rather
+    // than per slot, so a control added to any slot is clickable without
+    // anyone remembering this rule exists.
     expect(css).toMatch(
-      /\.star-map__chrome,\s*\.star-map__chrome \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
-    );
-    expect(css).toMatch(
-      /\.star-map__filters,\s*\.star-map__filters \*,[\s\S]*?\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+      /\.star-map__top-band > \*,\s*\.star-map__top-band > \* \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?pointer-events:\s*auto;[\s\S]*?\}/,
     );
     // The card-level dialogs are body-portaled and full-window, so their
     // scrim overlaps the strip's rect and would otherwise turn a
@@ -990,6 +993,41 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-fullscreen="true"\] \.star-map-window__titlebar\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
     );
+  });
+
+  it("lays the Star Map's top band out as one grid row its slots cannot escape", () => {
+    // The band's three clusters used to position themselves independently
+    // — chrome pinned to the left edge, chips translated to the window's
+    // centre — with nothing reserving space between them, so the chrome
+    // painted over the first filter chip and swallowed its clicks. Grid
+    // tracks cannot overlap; this is the assertion that the row stays a
+    // row rather than reverting to islands.
+    const bandRule = extractRuleBody(css, ".star-map__top-band");
+    expect(bandRule).toContain("display: grid;");
+    // Equal outer tracks, so the chip strip stays centred on the WINDOW
+    // while there is room for it. `auto 1fr auto` would centre it in
+    // whatever the chrome left over, which is a different position.
+    expect(bandRule).toContain("grid-template-columns: 1fr auto 1fr;");
+
+    const chromeRule = extractRuleBody(css, ".star-map__chrome");
+    const filtersRule = extractRuleBody(css, ".star-map__filters");
+    // Neither slot positions itself any more; the band decides where they
+    // sit. A `position: absolute` creeping back into either one is the
+    // regression, not a style preference.
+    expect(chromeRule).not.toContain("position: absolute;");
+    expect(filtersRule).not.toContain("position: absolute;");
+    // And neither may stretch across its track: a grid item defaults to
+    // `stretch`, the no-drag rect follows the box, and a stretched slot
+    // would take that whole column of sky away from window dragging.
+    expect(chromeRule).toContain("justify-self: start;");
+    expect(filtersRule).toContain("justify-self: center;");
+    expect(extractRuleBody(css, ".star-map__actions")).toContain(
+      "justify-self: end;",
+    );
+    // Wrapping is what lets the middle track shrink — its min-content
+    // becomes one chip rather than the whole strip — so a narrow window
+    // stacks the chips instead of pushing them under the chrome.
+    expect(filtersRule).toContain("flex-wrap: wrap;");
   });
 
   it("right-aligns the keyboard shortcut hint chip on context menu items", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12708,30 +12708,35 @@ textarea,
 /* `nowrap`: wrapping was the first answer to a strip that did not fit,
    and it put a second row of chips over the star field and doubled the
    height of the band to show information already on it. The band is one
-   row; when the row runs out, chips leave it rather than stacking. */
+   row; when the row runs out, chips leave it rather than stacking.
+
+   The clip is on the STRIP and not on the slot around it: the collapsed
+   popover is a descendant of the slot, and clipping there would cut the
+   panel off at the band. It only ever matters until the first measurement
+   lands anyway - it keeps an unmeasured row from widening the band and
+   shoving the actions slot off the window.
+
+   `clip` with a margin rather than `hidden`, because the clip edge falls
+   exactly on the first and last chip's box and the focus ring is drawn
+   OUTSIDE that box (2px at `outline-offset: 1px`). Under `hidden` the ring
+   on the edge chips lost its outer 3px - three blank pixel columns where
+   the accent should be - and no axe rule covers that. 4px clears the ring
+   and still clips a runaway row. */
 .star-map__filter-strip {
   display: flex;
   flex-wrap: nowrap;
   gap: 6px;
+  overflow: clip;
+  overflow-clip-margin: 4px;
 }
 
 /* Chips hold their size. Flex shrinking is the other way a row that does
    not fit can fail: instead of a chip leaving, every chip narrows, the
    labels wrap inside them ("Needs / input"), and the band grows a second
    line anyway - the exact outcome the strip stopped wrapping to avoid.
-   Degradation here is a chip leaving the row, never the row squeezing.
-
-   The clip is on the STRIP and not on the slot around it: the collapsed
-   popover is a descendant of the slot, and clipping there would cut the
-   panel off at the band. It only ever matters for the frame before the
-   first measurement lands anyway - it keeps an unmeasured row from
-   widening the band and shoving the actions slot off the window. */
+   Degradation here is a chip leaving the row, never the row squeezing. */
 .star-map__filter-strip > * {
   flex-shrink: 0;
-}
-
-.star-map__filter-strip {
-  overflow: hidden;
 }
 
 /* Anchor for the collapsed popover, same shape as `.star-map__view-options`

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12462,12 +12462,16 @@ textarea,
    Grid tracks cannot overlap, so that collision is now structurally
    impossible instead of a thing every new control has to re-check.
 
-   `1fr auto 1fr` rather than `auto 1fr auto`: the outer tracks are equal,
-   so the chip strip stays centred on the WINDOW while there is room for
-   it, which is where it has always sat. When the chrome outgrows its
-   share its track widens and the strip slides over rather than being
-   covered. The chips wrap (see `.star-map__filters`) so the middle track
-   can always shrink to fit, down to the 800px minimum window width.
+   One left-aligned row, not a centred strip between two spacer tracks.
+   The filters belong beside Find and View: they are the same kind of
+   control, the operator's attention is already on that corner, and a
+   centred strip drifts with the window while the chrome does not — which
+   is what put the two on a collision course to begin with. It also means
+   the degraded states read correctly: a single "Filters" chip lands next
+   to View instead of floating alone in the middle of the sky.
+
+   The actions slot keeps its `margin-left: auto`, so it stays pinned to
+   the right whatever the left group does.
 
    The band spans the full width, which makes its drag model load bearing:
    it must NOT carve a no-drag hole of its own, or it would take the whole
@@ -12477,13 +12481,12 @@ textarea,
    events through; each slot punches its own hole and takes its pointer
    events back. The gaps between the slots stay draggable sky. */
 .star-map__top-band {
-  display: grid;
+  display: flex;
   position: absolute;
   top: 0;
   right: 0;
   left: 0;
   z-index: 4;
-  grid-template-columns: 1fr auto 1fr;
   align-items: start;
   gap: 12px;
   padding: 14px 16px 0;
@@ -12508,7 +12511,7 @@ textarea,
    density + instance visibility). */
 .star-map__chrome {
   display: flex;
-  justify-self: start;
+  flex-shrink: 0;
   align-items: center;
   gap: 12px;
 }
@@ -12519,9 +12522,9 @@ textarea,
    that it hugs the right edge rather than the centre track. */
 .star-map__actions {
   display: flex;
-  justify-self: end;
   align-items: center;
   gap: 12px;
+  margin-left: auto;
 }
 
 /* The map covers the whole window, so its top-left chrome has to clear the
@@ -12686,75 +12689,101 @@ textarea,
   cursor: pointer;
 }
 
-/* Middle slot. `justify-self: center` keeps the box hugging its content
-   instead of stretching across the track: the band's no-drag rect would
-   otherwise cover the whole middle column and take that much sky away
-   from window dragging.
+/* The filter slot, beside the chrome rather than centred on the window.
+   It holds two renderings of the same seven filters and shows whichever
+   one fits; `resolveFilterFit` decides, from measurements, and puts the
+   answer on this element as `is-full` / `is-reduced` / `is-collapsed`.
 
-   It holds two renderings of the same seven filters, and CSS picks which
-   one the band shows. Measured max-content of the strip plus the chrome
-   plus the band's padding and gaps: 994px with one-digit counts, 1020px
-   with the two-digit counts a real fleet produces, 1084px with three.
-   Under that the strip has to give, and the first version of this band
-   let it wrap - which put a second row of chips over the star field and
-   doubled the height of the band to show information that was already
-   there. Below the breakpoint the strip is swapped for one "Filters"
-   chip carrying the same controls in a popover, so the band stays one
-   row at every width down to the 800px minimum.
-
-   The breakpoint is 1120px rather than the measured 1084: the "Clear"
-   button appears in the strip once anything is filtered, and it is worth
-   about another 55px. Re-measure before moving it - the numbers above
-   came from the real chip metrics, not an estimate. */
+   Why measured and not a breakpoint: the chips carry live counts, so the
+   width the strip needs is a property of the data. The same seven chips
+   are 642px wide with one-digit counts, 668px with two and 732px with
+   three. A constant safe for the widest case throws the strip away in
+   the common one, which is exactly what a 1120px breakpoint did here. */
 .star-map__filters {
   display: flex;
-  justify-self: center;
+  min-width: 0;
   align-items: center;
 }
 
-/* Wrapping stays as the last resort rather than `nowrap`. If a label or a
-   count ever outgrows what the breakpoint above assumes, a second row is
-   ugly; overflowing the grid track puts chips back underneath the chrome,
-   which is the bug this band exists to make impossible. */
+/* `nowrap`: wrapping was the first answer to a strip that did not fit,
+   and it put a second row of chips over the star field and doubled the
+   height of the band to show information already on it. The band is one
+   row; when the row runs out, chips leave it rather than stacking. */
 .star-map__filter-strip {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-wrap: nowrap;
   gap: 6px;
 }
 
+/* Chips hold their size. Flex shrinking is the other way a row that does
+   not fit can fail: instead of a chip leaving, every chip narrows, the
+   labels wrap inside them ("Needs / input"), and the band grows a second
+   line anyway - the exact outcome the strip stopped wrapping to avoid.
+   Degradation here is a chip leaving the row, never the row squeezing.
+
+   The clip is on the STRIP and not on the slot around it: the collapsed
+   popover is a descendant of the slot, and clipping there would cut the
+   panel off at the band. It only ever matters for the frame before the
+   first measurement lands anyway - it keeps an unmeasured row from
+   widening the band and shoving the actions slot off the window. */
+.star-map__filter-strip > * {
+  flex-shrink: 0;
+}
+
+.star-map__filter-strip {
+  overflow: hidden;
+}
+
 /* Anchor for the collapsed popover, same shape as `.star-map__view-options`
-   across the band. Display is owned by the breakpoint below. */
+   two controls to its left. */
 .star-map__filter-menu {
   display: none;
   position: relative;
 }
 
-@media (max-width: 1120px) {
-  .star-map__filter-strip {
-    display: none;
-  }
+/* The three states.
 
-  .star-map__filter-menu {
-    display: block;
-  }
+   Both renderings stay mounted at every width, and the one that is not
+   showing is taken out of FLOW rather than out of layout — `position:
+   absolute` plus `visibility: hidden`, never `display: none`. The fit is
+   decided by measuring these chips: `display: none` would zero the widths
+   the decision reads, the strip would look like it fits, and the band
+   would flip between states every frame. `visibility: hidden` also takes
+   them out of the accessibility tree, and the chip itself carries
+   `tabIndex={-1}` and `aria-hidden`, so nothing hidden here is reachable.
+
+   `left: 0; top: 0` parks the hidden copy over the slot's own corner; it
+   paints nothing, and `width: max-content` is what keeps its measurement
+   honest once it is out of a flex row. */
+.star-map__filters.is-reduced .star-map__filter-chip.is-dropped,
+.star-map__filters.is-collapsed .star-map__filter-strip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: max-content;
+  visibility: hidden;
+  pointer-events: none;
 }
 
-/* Same panel as the View popover it sits beside - same surface, border,
-   radius and shadow - but centred under its own chip rather than left
-   aligned, because this one opens from the middle of the band. The chips
-   inside are the strip's chips, stacked and stretched: one family, one
-   set of states, just a different direction. */
+.star-map__filters.is-collapsed .star-map__filter-menu {
+  display: block;
+}
+
+/* Same panel as the View popover across the band - same surface, border,
+   radius and shadow. It opens from the left edge of its own chip for the
+   same reason that one does: the band is a left-aligned row, and a panel
+   that fans out from the middle of a left-aligned control reads as
+   belonging to neither side. The chips inside are the strip's chips,
+   stacked and stretched: one family, one set of states. */
 .star-map__filter-panel {
   display: flex;
   position: absolute;
   top: calc(100% + 6px);
-  left: 50%;
+  left: 0;
   flex-direction: column;
   gap: 4px;
   width: 208px;
   padding: 10px;
-  transform: translateX(-50%);
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: var(--bg-panel-elevated);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12686,19 +12686,87 @@ textarea,
   cursor: pointer;
 }
 
-/* Middle slot. `justify-self: center` keeps the box hugging its chips
+/* Middle slot. `justify-self: center` keeps the box hugging its content
    instead of stretching across the track: the band's no-drag rect would
    otherwise cover the whole middle column and take that much sky away
-   from window dragging. Wrapping is what lets the middle track shrink -
-   its min-content becomes one chip rather than the whole strip - so a
-   narrow window stacks the chips into a second row instead of pushing
-   them under the chrome or off the right edge. */
+   from window dragging.
+
+   It holds two renderings of the same seven filters, and CSS picks which
+   one the band shows. Measured max-content of the strip plus the chrome
+   plus the band's padding and gaps: 994px with one-digit counts, 1020px
+   with the two-digit counts a real fleet produces, 1084px with three.
+   Under that the strip has to give, and the first version of this band
+   let it wrap - which put a second row of chips over the star field and
+   doubled the height of the band to show information that was already
+   there. Below the breakpoint the strip is swapped for one "Filters"
+   chip carrying the same controls in a popover, so the band stays one
+   row at every width down to the 800px minimum.
+
+   The breakpoint is 1120px rather than the measured 1084: the "Clear"
+   button appears in the strip once anything is filtered, and it is worth
+   about another 55px. Re-measure before moving it - the numbers above
+   came from the real chip metrics, not an estimate. */
 .star-map__filters {
   display: flex;
   justify-self: center;
+  align-items: center;
+}
+
+/* Wrapping stays as the last resort rather than `nowrap`. If a label or a
+   count ever outgrows what the breakpoint above assumes, a second row is
+   ugly; overflowing the grid track puts chips back underneath the chrome,
+   which is the bug this band exists to make impossible. */
+.star-map__filter-strip {
+  display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 6px;
+}
+
+/* Anchor for the collapsed popover, same shape as `.star-map__view-options`
+   across the band. Display is owned by the breakpoint below. */
+.star-map__filter-menu {
+  display: none;
+  position: relative;
+}
+
+@media (max-width: 1120px) {
+  .star-map__filter-strip {
+    display: none;
+  }
+
+  .star-map__filter-menu {
+    display: block;
+  }
+}
+
+/* Same panel as the View popover it sits beside - same surface, border,
+   radius and shadow - but centred under its own chip rather than left
+   aligned, because this one opens from the middle of the band. The chips
+   inside are the strip's chips, stacked and stretched: one family, one
+   set of states, just a different direction. */
+.star-map__filter-panel {
+  display: flex;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  flex-direction: column;
+  gap: 4px;
+  width: 208px;
+  padding: 10px;
+  transform: translateX(-50%);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+/* Stacked chips are full width, so the count goes to the far edge and
+   makes a column. Only the count - `space-between` would also push the
+   exclude mark off the label it negates, and "− ... Open PR" reads as two
+   separate things rather than one struck-through chip. */
+.star-map__filter-panel .star-map__filter-count {
+  margin-left: auto;
 }
 
 .star-map__filter-chip {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10917,10 +10917,13 @@ textarea,
    the strip is legible exactly when the operator is most likely to reach
    for the wrong handle. z-index 2 sits above the transformed canvas (its
    own stacking context, so card z-indexes cannot climb out) and below the
-   `.star-map__filters` (3) and `.star-map__chrome` (4) that live inside it;
-   both of those carve `no-drag` holes so they stay clickable (the card
-   no-drag list further down does the same for anything panned up under
-   the glass, so it goes inert rather than turning into a window drag).
+   `.star-map__top-band` (4) that lives inside it. The band itself stays
+   draggable and passes its pointer events through - it is full width, so
+   opting the whole thing out would leave this window with no handle at
+   all - and each of its slots carves its own `no-drag` hole so the
+   controls stay clickable (the card no-drag list further down does the
+   same for anything panned up under the glass, so it goes inert rather
+   than turning into a window drag).
    The strip owns pointer events in its band: wheel there is lost to the
    map, deliberately, so a press can never start both a window drag and a
    canvas pan. Not rendered on Windows (painted `.activity-titlebar` above
@@ -12442,14 +12445,81 @@ textarea,
   }
 }
 
-/* "View" popover: card density + instance visibility, parked opposite the
-   attention filters. */
+/* The map's top band.
+
+   Every control that sits over the top of the sky lives in this one row:
+   the chrome (wordmark, Find, View) on the left, the filter chips in the
+   middle, and a slot on the right for map actions. These used to be
+   independently positioned islands - chrome pinned to the left edge, chips
+   translated to the window's centre - with nothing reserving space between
+   them. Measured on a 1280px window with the three controls it ships
+   with, the chrome ran to x=330 and the strip started at x=320: they
+   already overlapped by 10px, just not by enough of a chip for axe's
+   `target-size` rule to call it obscured. A fourth control was what
+   pushed it over (79.5px by 12px left uncovered), and below roughly
+   1100px they overlapped outright, because the centred strip walks left
+   as the window narrows and the chrome does not.
+   Grid tracks cannot overlap, so that collision is now structurally
+   impossible instead of a thing every new control has to re-check.
+
+   `1fr auto 1fr` rather than `auto 1fr auto`: the outer tracks are equal,
+   so the chip strip stays centred on the WINDOW while there is room for
+   it, which is where it has always sat. When the chrome outgrows its
+   share its track widens and the strip slides over rather than being
+   covered. The chips wrap (see `.star-map__filters`) so the middle track
+   can always shrink to fit, down to the 800px minimum window width.
+
+   The band spans the full width, which makes its drag model load bearing:
+   it must NOT carve a no-drag hole of its own, or it would take the whole
+   `.star-map-window__titlebar` strip away from window dragging - on macOS
+   that strip is the only handle this window has (see the note there). So
+   the band declares no `-webkit-app-region` at all and passes its pointer
+   events through; each slot punches its own hole and takes its pointer
+   events back. The gaps between the slots stay draggable sky. */
+.star-map__top-band {
+  display: grid;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 4;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: start;
+  gap: 12px;
+  padding: 14px 16px 0;
+  pointer-events: none;
+}
+
+/* Everything inside the band is a control, and every control in the band
+   is in the macOS drag strip's rect. Chromium ignores `-webkit-app-region`
+   on inline-level boxes, so the opt-out is declared on the descendants
+   too - a bare <button> in here otherwise has its clicks taken by the OS
+   (the same trap documented on `.messaging-status-bar` and on the card
+   list below). Declared once for the band so a control added to any slot
+   is clickable the day it is written, rather than the day someone
+   notices it is not. */
+.star-map__top-band > *,
+.star-map__top-band > * * {
+  -webkit-app-region: no-drag;
+  pointer-events: auto;
+}
+
+/* Left slot: wordmark, the ⌘K Find chip, and the "View" popover (card
+   density + instance visibility). */
 .star-map__chrome {
   display: flex;
-  position: absolute;
-  top: 14px;
-  left: 16px;
-  z-index: 4;
+  justify-self: start;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Right slot, reserved. Nothing occupies it today; it exists so that the
+   next map-level action has somewhere to go that is not the chrome. A
+   third child of the band lands here on its own - this rule only decides
+   that it hugs the right edge rather than the centre track. */
+.star-map__actions {
+  display: flex;
+  justify-self: end;
   align-items: center;
   gap: 12px;
 }
@@ -12616,19 +12686,19 @@ textarea,
   cursor: pointer;
 }
 
-.star-map__chrome,
-.star-map__chrome * {
-  -webkit-app-region: no-drag;
-}
-
+/* Middle slot. `justify-self: center` keeps the box hugging its chips
+   instead of stretching across the track: the band's no-drag rect would
+   otherwise cover the whole middle column and take that much sky away
+   from window dragging. Wrapping is what lets the middle track shrink -
+   its min-content becomes one chip rather than the whole strip - so a
+   narrow window stacks the chips into a second row instead of pushing
+   them under the chrome or off the right edge. */
 .star-map__filters {
   display: flex;
-  position: absolute;
-  top: 14px;
-  left: 50%;
+  justify-self: center;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 6px;
-  transform: translateX(-50%);
-  z-index: 3;
 }
 
 .star-map__filter-chip {
@@ -12762,16 +12832,14 @@ textarea,
   color: var(--text-primary);
 }
 
-/* The map's top chrome sits inside the macOS glass drag strip
-   (`.star-map-window__titlebar`; `.star-map__chrome` opts out beside its
-   own rule), and Chromium ignores `-webkit-app-region` on inline-level
-   boxes - a plain <button> there has its clicks swallowed by the OS (the
-   same trap documented on .messaging-status-bar). Draggable regions are
-   rect unions independent of z-order, so every interactive element gets an
-   explicit no-drag on a non-inline box: anything panned up under the strip
-   goes inert behind the glass rather than turning into a window drag. */
-.star-map__filters,
-.star-map__filters *,
+/* Cards can be panned up UNDER the macOS glass drag strip
+   (`.star-map-window__titlebar`), and draggable regions are rect unions
+   independent of z-order, so a card that reaches the strip's band would
+   otherwise turn into a window drag. Every interactive element gets an
+   explicit no-drag on a non-inline box - Chromium ignores
+   `-webkit-app-region` on inline-level boxes, the same trap documented on
+   .messaging-status-bar - so the card goes inert behind the glass
+   instead. The strip's own residents opt out with the top band above. */
 .star-map-instance,
 .star-map-instance *,
 .star-map-card,


### PR DESCRIPTION
## Summary

- The Star Map's top band was three independently positioned islands — `.star-map__chrome` pinned to the left edge, `.star-map__filters` translated to the window's centre — with nothing reserving space between them. Measured on a 1280px window with the three controls the chrome ships with, it ran to x=330 while the strip started at x=320: **the two already overlapped by 10px today**, just not by enough of a chip for axe's `target-size` rule to call it obscured. A fourth control was what pushed it over ("smallest space is 79.5px by 12px"), and below roughly 1100px they overlapped outright, because the centred strip walks left as the window narrows and the chrome does not.
- They are now one grid row, `.star-map__top-band`: chrome / filters / a reserved actions slot. Grid tracks cannot overlap, so the collision is structurally impossible rather than something every new control has to re-check.
- `1fr auto 1fr` rather than `auto 1fr auto`: the outer tracks are equal, so the chip strip stays centred on the **window** while there is room — it lands at x=324 on a 1280px window, 4px from where it has always sat — and slides over instead of being covered when the chrome outgrows its share. The chips wrap, which is what lets the middle track shrink down to the window's 800px minimum.
- **The drag model was the delicate part.** The band spans the full width, so opting it out would have taken the macOS glass strip — this window's only handle — away from window dragging. The band declares no `-webkit-app-region` at all and passes its pointer events through; a single `.star-map__top-band > *, > * *` rule gives each slot its no-drag hole and its pointer events back, declared once so a control dropped in any slot works the day it is written. The traffic-light `padding-left: 80px` reservation and its `[data-fullscreen]` variant are untouched, and the wordmark still lands at x=96 — the same spot as the sidebar masthead.

## Verification

Full run on the PwrSuiteLab macOS guest (`pwragent-e2e-20260819-224016-c404a193-d42f2be7`): **14 passed**.

- `e2e/a11y.spec.ts` — green in both themes, including `star map fixture surfaces have no violations`, the gate that reported the obscured chip.
- `e2e/visual-regression.spec.ts` — both snapshots unchanged. That spec never covered the map window, so there was no snapshot churn to review.
- `e2e/star-map-thread-flow.spec.ts` — the existing triage-loop test, plus the new geometry gate below.

**Negative control.** Reverting only the CSS and re-running the one spec on the guest (`pwragent-e2e-20260819-224137-7737e6aa-69ce6cc4`) fails it:

```
Error: top band slots overlap at the default window width:
  chrome {"x":16,"y":14,"width":313.96875,"height":23},
  filters {"x":320,"y":14,"width":640,"height":36}
```

That is where the "already overlapped by 10px" figure above comes from, and it is what separates a gate from a comment.

Local: `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries`, and the full renderer unit suite (196 files / 3121 tests) all pass.

Pre-flight geometry, measured in headless Chromium against a standalone harness linking the real `app.css` (dark, `data-platform="darwin"`) — no overlap and no obscured chip at any width:

| width | chrome | filters | band height |
|---|---|---|---|
| 1440 | x=16 w=296 | x=399 w=642 | 39 |
| 1280 | x=16 w=296 | x=324 w=642 | 39 |
| 1100 | x=16 w=296 | x=324 w=642 | 39 |
| 1000 | x=16 w=296 | x=324 w=642 | 39 |
| 900 | x=16 w=296 | x=324 w=548 | 70 (chips wrap) |
| 800 | x=16 w=296 | x=324 w=448 | 70 (chips wrap) |

## Notes

**New gate** — `keeps the star map's top band from overlapping itself` in `star-map-thread-flow.spec.ts` asserts the slots' rects do not intersect **and** runs an `elementFromPoint` hit test at every filter chip's centre, at the default width and at the 800px minimum (`minWidth` in `star-map-window.ts`). The hit test is the wider of the two — it catches anything covering a chip, not just the chrome — and both fail on the geometry directly rather than waiting for axe to notice an obscured target.

**Contract tests changed in the same commit**, per the repo rule on chrome tokens:
- `theme-contract.test.tsx` — the z-order/drag test now reads the band's z-index instead of the two islands', and asserts the band carries no `-webkit-app-region` and `pointer-events: none` (the regression that would kill window dragging). A new test pins the grid, the slot alignment, and that neither slot has gone back to `position: absolute`.
- `star-map-orbit.test.ts` — a control inside the band, carrying no slot class at all, never starts a canvas pan. `shouldStartCanvasPan` now names `.star-map__top-band` alongside the two older entries, so a control added to the band does not also have to be added there.

**On the design call.** I kept the strip window-centred rather than left-aligning it after the chrome or collapsing it behind a control at narrow widths. Centred is where operators have learned it is, `1fr auto 1fr` preserves that pixel-for-pixel at normal widths, and wrapping degrades honestly at narrow ones. If the chip set grows past seven, collapsing behind a popover (reusing the existing `.star-map__view-panel` primitive) is the next move — wrapping to three rows would be the signal.

**One thing added on spec rather than on demand:** `.star-map__actions` is defined in CSS with no markup using it yet. It is the reserved third slot, so #1781's Manager button (not present on this branch) has somewhere to land that is not the chrome — that PR moved its control to a new top-right anchor precisely because the band had no room. Happy to drop the class and leave the third track documented instead if you'd rather not carry an unused selector.
## Follow-up: the narrow-window fallback was wrong

The band no longer overlaps itself, but the first version let the chip strip **wrap to a second row** when it ran out of room, which put chips over the star field and doubled the band's height. Caught from a screenshot of the running app, not by the suite.

The breakpoint came from a harness with single-digit counts. Real fleets produce two-digit ones:

| counts | strip max-content | window needed (macOS) |
|---|---|---|
| one digit | 642px | 994px |
| two digits (real) | 668px | **1020px** |
| three digits | 732px | 1084px |

So wrapping started at 1000px, not the ~900 originally reported — and the map window goes down to 800px. Verifying against data narrower than the real thing is what let it through.

Below **1120px** (1084 plus the ~55px the "Clear" button gains once anything is filtered) the strip is now swapped for one **"Filters" chip** carrying the same seven controls in a popover, so the band stays a single row at every width down to the minimum. Both renderings are always in the tree and CSS picks between them — no measurement to get wrong, no flip-flop — and the tri-state chip moved into `StarMapFilterChip` so the two surfaces cannot drift.

`flex-wrap: wrap` stays as the last resort *under* the breakpoint rather than `nowrap`: if a label or count ever outgrows what 1120px assumes, a second row is ugly, but overflowing the grid track puts chips back under the chrome, which is the bug the band exists to prevent.

**Why the gate missed it, and what now catches it.** Both original checks stayed green through the wrap — wrapped chips overlap nothing and obscure nothing. The check now also measures the band against its tallest slot, so a wrapped row fails, and asserts the swap itself at 800px (strip hidden, Filters chip visible, popover opens). A renderer test drives the popover and asserts it moves the same state the strip shows.

That extended gate immediately caught a defect in itself on the lab: the hidden rendering measures 0x0, a zero rect centres on (0,0), and `elementFromPoint` there truthfully reported the drag strip — so it called the band broken at 1280px. Fixed by testing only laid-out chips.

Re-verified on the lab (`pwragent-e2e-20260819-233628-7ae0e253-b78f3a82`): **14 passed**, a11y green in both themes, both visual-regression snapshots unchanged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)