### PR TITLE
fix(desktop): open the Star Map on a cluster instead of the canvas centre

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1525,15 +1525,19 @@ export function StarMapScreen(props: StarMapScreenProps) {
    *
    * `anchorBody` comes off a layout that is recomputed for every streamed
    * update, so its identity churns even when the body has not moved a
-   * pixel. Keying the placement below on the coordinates instead of on the
-   * object is the same rule `panZoomCanvas` follows two lines up, and for
-   * the same reason: an effect keyed on the identity would re-place — and
-   * so re-render the whole map — on every delta.
+   * pixel. Hoisting the two coordinates out and memoising on those is the
+   * same rule `panZoomCanvas` follows two lines up, and for the same
+   * reason: an effect keyed on the identity would re-place — and so
+   * re-render the whole map — on every delta.
    */
+  const anchorX = anchorBody?.x;
+  const anchorY = anchorBody?.y;
   const viewAnchor = useMemo(
-    () => (anchorBody ? { x: anchorBody.x, y: anchorBody.y } : undefined),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [anchorBody?.x, anchorBody?.y],
+    () =>
+      anchorX === undefined || anchorY === undefined
+        ? undefined
+        : { x: anchorX, y: anchorY },
+    [anchorX, anchorY],
   );
 
   // Trackpad: two-finger drag pans, pinch (ctrl+wheel) zooms about the
@@ -1644,14 +1648,29 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   useLayoutEffect(() => {
     if (operatorMovedViewRef.current) return;
-    commitView(
-      placeStarMapView({
-        anchor: viewAnchor,
-        canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
-        viewport: { width: viewportSize.width, height: viewportSize.height },
-        topAnchored: topAnchoredView,
-      }),
-    );
+    const placed = placeStarMapView({
+      anchor: viewAnchor,
+      canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+      viewport: { width: viewportSize.width, height: viewportSize.height },
+      topAnchored: topAnchoredView,
+    });
+    // Most resizes during a load do not move the anchor: a cloud growing
+    // downward changes the canvas height without changing the bounding
+    // box's top-left, so the placement lands exactly where the view
+    // already is. Committing it anyway would hand React a new object and
+    // re-render every card on the map — synchronously, ahead of paint,
+    // once per card measurement. Nothing is skipped by leaving early: the
+    // live ref and the DOM only ever disagree during a gesture, and a
+    // gesture owns the view, which the line above already returned on.
+    const current = viewRef.current;
+    if (
+      placed.x === current.x
+      && placed.y === current.y
+      && placed.scale === current.scale
+    ) {
+      return;
+    }
+    commitView(placed);
   }, [
     commitView,
     topAnchoredView,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1487,6 +1487,55 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const canvasBoundsRef = useRef(panZoomCanvas);
   canvasBoundsRef.current = panZoomCanvas;
 
+  /**
+   * The body the map opens on, in canvas units: this machine's own
+   * cluster, or the galaxy core in the lens that has no instances.
+   *
+   * Opening on a body rather than on the middle of the canvas is what
+   * makes a load sit still. Every lens sizes its canvas to the bounding
+   * box of what it laid out, so the middle of that box moves whenever the
+   * box does — a peer's first snapshot landing, a card measuring taller
+   * than its estimate, a cloud gaining a ring. The map used to re-centre
+   * on each of those, which is why opening it looked like it was flying
+   * itself somewhere: it was, several times, before the fleet had
+   * finished arriving. The home cluster's canvas position moves by the
+   * same amount as the box, so placing the view on it cancels out and the
+   * canvas grows around a map that has not moved.
+   */
+  const anchorBody = useMemo(() => {
+    if (projectsMode) {
+      // Projects pool threads across the fleet, so there is no local body
+      // to hold; the arms converge on the core and seat outward from it.
+      return projectLayout.projects.length > 0 ? projectLayout.core : undefined;
+    }
+    return (
+      bodies.find((body) => body.instanceId === localInstanceId)
+      ?? bodies.find((body) => body.isHub)
+      ?? bodies[0]
+    );
+  }, [
+    bodies,
+    localInstanceId,
+    projectLayout.core,
+    projectLayout.projects.length,
+    projectsMode,
+  ]);
+  /**
+   * The same point, rebuilt only when it actually moves.
+   *
+   * `anchorBody` comes off a layout that is recomputed for every streamed
+   * update, so its identity churns even when the body has not moved a
+   * pixel. Keying the placement below on the coordinates instead of on the
+   * object is the same rule `panZoomCanvas` follows two lines up, and for
+   * the same reason: an effect keyed on the identity would re-place — and
+   * so re-render the whole map — on every delta.
+   */
+  const viewAnchor = useMemo(
+    () => (anchorBody ? { x: anchorBody.x, y: anchorBody.y } : undefined),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [anchorBody?.x, anchorBody?.y],
+  );
+
   // Trackpad: two-finger drag pans, pinch (ctrl+wheel) zooms about the
   // pointer. Registered natively because the listener must not be passive.
   // Sits below panZoomCanvas because the clamp needs the canvas size.
@@ -1556,14 +1605,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
     viewportSize.height,
   ]);
 
-  // A lens switch is a different map, so the view starts centred again.
-  useEffect(() => {
+  // A lens switch is a different map, so the view starts placed again.
+  // A layout effect, and declared above the placement below, because that
+  // is now one too: a passive release would land after the placement had
+  // already read the flag and bailed, leaving the new lens holding the old
+  // lens's pan.
+  useLayoutEffect(() => {
     operatorMovedViewRef.current = false;
   }, [preferences.layout]);
 
   /**
-   * Centre the canvas so the operator does not open onto empty space —
-   * but only while the view is still ours to place.
+   * Hold the map on its home cluster so the operator does not open onto
+   * empty space — but only while the view is still ours to place.
    *
    * The canvas size is an input here, and it changes whenever a cloud's
    * card count changes: archiving a card can drop a ring and resize the
@@ -1571,11 +1624,29 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * thread in one corner of the map threw away the operator's pan and
    * zoom and snapped them back to centre — the map moving under the
    * person using it.
+   *
+   * Ownership answers that for a map the operator has already moved, and
+   * answers nothing for the first seconds of one they have not: a load is
+   * a run of canvas resizes with the view still ours, so this effect
+   * re-ran on each of them and the map visibly toured itself. Anchoring
+   * is the other half — see `viewAnchor`. This still re-runs on every
+   * resize, and that is the point: each run re-places the same body under
+   * the same pixel, so the recompute is what keeps the map still rather
+   * than what moves it.
+   *
+   * A layout effect, not a passive one: the anchor's new canvas position
+   * is in the DOM as soon as React commits it, so a placement that waited
+   * for paint would show one frame of the body in its new place under the
+   * old transform — the content jumping, then the view catching up, once
+   * per snapshot. Re-placing before paint makes the two writes land in the
+   * same frame, which is what "the canvas grew, the map did not move"
+   * actually looks like.
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (operatorMovedViewRef.current) return;
     commitView(
       placeStarMapView({
+        anchor: viewAnchor,
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
         topAnchored: topAnchoredView,
@@ -1586,6 +1657,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
+    viewAnchor,
     viewportSize.width,
     viewportSize.height,
   ]);
@@ -1612,6 +1684,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // React's last-rendered transform still matched, would not even repaint.
     commitView(
       placeStarMapView({
+        anchor: viewAnchor,
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
         topAnchored: topAnchoredView,
@@ -1623,6 +1696,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
+    viewAnchor,
     viewportSize.width,
     viewportSize.height,
   ]);

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-load-drift.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-load-drift.test.tsx
@@ -1,0 +1,270 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  FederationPeerSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * The map must not tour itself while it loads.
+ *
+ * A fleet arrives in pieces: health lands, peers enrol one at a time, each
+ * one's navigation snapshot arrives on its own round trip, and the real
+ * height of every card lands later still as the browser measures it. Every
+ * one of those resizes the canvas — and the canvas was what the opening
+ * view was placed against, so the map re-centred on a moving target over
+ * and over before the fleet had finished arriving. Opening the Star Map
+ * looked like it was flying itself somewhere.
+ *
+ * The rule here: the map opens on the home cluster, and that cluster does
+ * not move on screen while the canvas grows around it.
+ */
+
+const VIEWPORT = { width: 1280, height: 800 };
+
+function peer(id: string): FederationPeerSummary {
+  return {
+    id,
+    label: id,
+    status: "connected",
+    capabilities: ["thread_navigation"],
+  } as unknown as FederationPeerSummary;
+}
+
+type LoadingFleet = {
+  desktopApi: DesktopApi;
+  /** Enrol another peer, the way a real one arrives: health, then event. */
+  announce: (peerId: string) => Promise<void>;
+};
+
+/**
+ * A fleet that arrives over time rather than all at once.
+ *
+ * Peers land through the same path the app uses — a `peerStatus/changed`
+ * notification, then a re-read of health — because that is what makes the
+ * canvas grow in stages, which is the whole subject of these tests.
+ */
+function buildLoadingFleet(
+  threadsByPeer: Map<string, NavigationThreadSummary[]>,
+): LoadingFleet {
+  const peers: FederationPeerSummary[] = [];
+  const listeners = new Set<(event: { notification: { method: string } }) => void>();
+  const desktopApi = {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: true,
+        role: "gateway" as const,
+        status: "listening" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [...peers],
+      },
+    })),
+    getNavigationSnapshot: vi.fn(
+      async (request: { federationTarget: { instanceId: string } }) => ({
+        threads:
+          threadsByPeer.get(request.federationTarget.instanceId) ?? [],
+      }),
+    ),
+    onAgentEvent: vi.fn((listener: (event: { notification: { method: string } }) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+  } as unknown as DesktopApi;
+
+  return {
+    desktopApi,
+    announce: async (peerId: string) => {
+      peers.push(peer(peerId));
+      await act(async () => {
+        for (const listener of listeners) {
+          listener({ notification: { method: "federation/peerStatus/changed" } });
+        }
+        await Promise.resolve();
+      });
+      await settle();
+    },
+  };
+}
+
+function thread(id: string, project: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      {
+        id: `${project}-dir`,
+        label: project,
+        path: `/repos/${project}`,
+        kind: "local",
+      },
+    ],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+function threads(
+  count: number,
+  project: string,
+  prefix: string,
+): NavigationThreadSummary[] {
+  return Array.from({ length: count }, (_, index) =>
+    thread(`${prefix}${index}`, project),
+  );
+}
+
+function parseTransform(raw: string): { x: number; y: number; scale: number } {
+  const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(
+    raw,
+  );
+  if (!match) throw new Error(`unparsable transform: ${raw}`);
+  return { x: Number(match[1]), y: Number(match[2]), scale: Number(match[3]) };
+}
+
+/**
+ * Where the local instance's body lands in the window, in viewport pixels.
+ *
+ * Composed the way the operator sees it: the body's canvas position put
+ * through the canvas transform. Asserting on the transform alone would
+ * agree with the bug — a view chasing a moving anchor and a view holding a
+ * still one both change — and asserting on the body's canvas position
+ * alone would too, since content moving inside a growing canvas is exactly
+ * what is supposed to happen. Only the composition tells them apart.
+ */
+function homeBodyScreenPosition(): { x: number; y: number } {
+  const canvas = document.querySelector(".star-map__canvas") as HTMLElement;
+  if (!canvas) throw new Error("canvas not found");
+  const view = parseTransform(canvas.style.transform);
+  const body = document.querySelector(".star-map-instance--local");
+  const anchor = body?.closest(".star-map__anchor") as HTMLElement | null;
+  if (!anchor) throw new Error("local instance body not on the map");
+  return {
+    x: view.x + Number.parseFloat(anchor.style.left) * view.scale,
+    y: view.y + Number.parseFloat(anchor.style.top) * view.scale,
+  };
+}
+
+/** Let pending snapshots, measurements and placements settle. */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function renderMap(props: {
+  desktopApi: DesktopApi;
+  localThreads: NavigationThreadSummary[];
+}) {
+  return (
+    <StarMapScreen
+      desktopApi={props.desktopApi}
+      localThreads={props.localThreads}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />
+  );
+}
+
+function seedLayout(layout: "lanes" | "orbit" | "projects") {
+  window.localStorage.setItem(
+    "pwragent.starMap.viewPreferences",
+    JSON.stringify({ layout }),
+  );
+}
+
+async function openMap(fleet: LoadingFleet) {
+  const rendered = render(
+    renderMap({ desktopApi: fleet.desktopApi, localThreads: [] }),
+  );
+  await waitFor(() => {
+    expect(
+      screen.getAllByRole("button", { name: /Open this instance/ }).length,
+    ).toBeGreaterThan(0);
+  });
+  await settle();
+  return rendered;
+}
+
+function fleetThreads() {
+  return new Map([
+    ["pwr_a", threads(12, "Alpha", "a")],
+    ["pwr_b", threads(9, "Beta", "b")],
+    ["pwr_c", threads(17, "Gamma", "c")],
+  ]);
+}
+
+describe("star map load drift", () => {
+  // Layout preference is global; leaking it reorders unrelated suites.
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("opens on the home cluster rather than on the middle of the canvas", async () => {
+    seedLayout("orbit");
+    const fleet = buildLoadingFleet(fleetThreads());
+    await openMap(fleet);
+    // One peer is enough to pull the canvas's middle away from the hub:
+    // children seat on a jittered ring, so the bounding box grows further
+    // on one side than the other.
+    await fleet.announce("pwr_a");
+
+    expect(homeBodyScreenPosition()).toEqual({
+      x: VIEWPORT.width / 2,
+      y: VIEWPORT.height / 2,
+    });
+  });
+
+  it("holds the home cluster still while the fleet loads (orbit)", async () => {
+    seedLayout("orbit");
+    const fleet = buildLoadingFleet(fleetThreads());
+    const { rerender } = await openMap(fleet);
+    const opened = homeBodyScreenPosition();
+
+    // Peers enrol one at a time, each answering with its own thread feed.
+    for (const peerId of ["pwr_a", "pwr_b", "pwr_c"]) {
+      await fleet.announce(peerId);
+      expect(homeBodyScreenPosition()).toEqual(opened);
+    }
+
+    // Then this machine's own threads land, which grows its cloud and
+    // pushes every peer further out again.
+    rerender(
+      renderMap({
+        desktopApi: fleet.desktopApi,
+        localThreads: threads(14, "PwrSnap", "l"),
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Open thread: Thread l0/ }),
+      ).toBeTruthy();
+    });
+    await settle();
+
+    expect(homeBodyScreenPosition()).toEqual(opened);
+  });
+
+  it("holds the home cluster still while the fleet loads (lanes)", async () => {
+    seedLayout("lanes");
+    const fleet = buildLoadingFleet(fleetThreads());
+    await openMap(fleet);
+    const opened = homeBodyScreenPosition();
+
+    // Lanes re-order their row around the hub as instances arrive, so each
+    // peer shifts every body's canvas position by half a lane.
+    for (const peerId of ["pwr_a", "pwr_b", "pwr_c"]) {
+      await fleet.announce(peerId);
+      expect(homeBodyScreenPosition()).toEqual(opened);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
@@ -9,6 +9,7 @@ import {
   clampStarMapView,
   isOverviewZoom,
   overviewChromeScale,
+  placeStarMapView,
   starMapSkyOffset,
   type StarMapView,
 } from "../star-map-view-geometry";
@@ -112,6 +113,101 @@ describe("centerStarMapView", () => {
       const centered = centerStarMapView({ canvas, viewport: VIEWPORT });
       expect(clamp(centered, canvas)).toEqual(centered);
     }
+  });
+});
+
+describe("placeStarMapView", () => {
+  /**
+   * The canvas is the bounding box of what a lens laid out, shifted into
+   * positive space, so it grows on whichever side the new content landed
+   * and its middle slides by half of that. An anchor is a body, and it
+   * moves with the box — which is why the anchored view is the one that
+   * holds a loading map still.
+   */
+  const before = {
+    canvas: { width: 900, height: 700 },
+    anchor: { x: 450, y: 350 },
+  };
+  const after = {
+    canvas: { width: 1600, height: 1100 },
+    anchor: { x: 900, y: 620 },
+  };
+
+  /** Where the anchor lands in the window under a placed view. */
+  function anchorOnScreen(step: typeof before) {
+    const view = placeStarMapView({
+      anchor: step.anchor,
+      canvas: step.canvas,
+      viewport: VIEWPORT,
+    });
+    return {
+      x: view.x + step.anchor.x * view.scale,
+      y: view.y + step.anchor.y * view.scale,
+    };
+  }
+
+  it("opens on the anchor rather than on the middle of the canvas", () => {
+    expect(anchorOnScreen(before)).toEqual({
+      x: VIEWPORT.width / 2,
+      y: VIEWPORT.height / 2,
+    });
+  });
+
+  it("leaves the anchor where it was when the canvas grows around it", () => {
+    expect(anchorOnScreen(after)).toEqual(anchorOnScreen(before));
+    // The view itself must move to do that — an unchanged view here would
+    // mean the test was passing on a canvas that never grew.
+    expect(placeStarMapView({ ...after, viewport: VIEWPORT })).not.toEqual(
+      placeStarMapView({ ...before, viewport: VIEWPORT }),
+    );
+  });
+
+  it("centres the canvas when there is no body to open on", () => {
+    // An empty map, before health has landed: no anchor exists yet, and
+    // the middle of the canvas is the only point there is.
+    expect(
+      placeStarMapView({ canvas: CANVAS, viewport: VIEWPORT }),
+    ).toEqual(centerStarMapView({ canvas: CANVAS, viewport: VIEWPORT }));
+  });
+
+  it("keeps a column lens at the top edge, anchor or not", () => {
+    // Lanes bodies sit on a fixed row with their columns growing downward,
+    // so the anchor governs x only; centring its y would open the map
+    // already scrolled past the bodies.
+    const view = placeStarMapView({
+      anchor: { x: 900, y: 620 },
+      canvas: after.canvas,
+      viewport: VIEWPORT,
+      topAnchored: true,
+    });
+    expect(view.y).toBe(0);
+    expect(view.x + 900).toBe(VIEWPORT.width / 2);
+  });
+
+  it("produces a view the clamp accepts unchanged", () => {
+    // Any anchor inside the canvas, including one hard against an edge.
+    for (const anchor of [
+      { x: 0, y: 0 },
+      { x: 450, y: 350 },
+      { x: 900, y: 700 },
+    ]) {
+      const placed = placeStarMapView({
+        anchor,
+        canvas: before.canvas,
+        viewport: VIEWPORT,
+      });
+      expect(clamp(placed, before.canvas)).toEqual(placed);
+    }
+  });
+
+  it("falls back to the canvas centre for a nonsense anchor", () => {
+    expect(
+      placeStarMapView({
+        anchor: { x: Number.NaN, y: 0 },
+        canvas: CANVAS,
+        viewport: VIEWPORT,
+      }),
+    ).toEqual(centerStarMapView({ canvas: CANVAS, viewport: VIEWPORT }));
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -202,8 +202,8 @@ export function starMapSkyOffset(params: {
 
 /**
  * The view that puts the middle of the canvas in the middle of the window
- * at 1:1. Used to place the map on open, on a lens switch, and by "Reset
- * view".
+ * at 1:1. The fallback for `placeStarMapView` when the lens has no body to
+ * open on, and the shape "Reset view" restores through it.
  *
  * This is also the manual half of the content-shrink gap described on
  * clampStarMapView. A rescue that re-placed the view automatically would
@@ -227,27 +227,52 @@ export function centerStarMapView(params: {
 /**
  * Where a lens opens.
  *
- * Radial lenses centre their canvas: content radiates from the middle, so
- * the middle is the interesting part. A column lens anchors to the top
- * instead — its bodies sit on a fixed row and their columns grow downward,
- * so centring a tall canvas would open the map already scrolled past the
- * bodies with nothing but card tails on screen.
+ * `anchor` is a point in canvas units that the map opens on — the home
+ * cluster, not the middle of the canvas. The distinction matters because
+ * the canvas is sized to its content and every lens builds it by taking
+ * the bounding box of what it laid out and shifting it into positive
+ * space. A peer snapshot landing, or a card measuring taller than the
+ * estimate, moves that bounding box, and the middle of the canvas moves
+ * with it — so a view placed on the middle chases the content around for
+ * the whole of a load while nothing the operator cares about holds still.
+ * An anchor is a real body, and it moves with the content it names, so
+ * holding it fixed is what lets the canvas grow around a still map.
  *
- * Clamped, so a top anchor on a canvas that is shorter than the window
- * still lands somewhere legal rather than at a negative offset.
+ * With no anchor — an empty map, before a body exists — the canvas centre
+ * is the only point there is, so that is what it falls back to.
+ *
+ * A column lens anchors to the top on the y axis instead: its bodies sit
+ * on a fixed row and their columns grow downward, so centring their y
+ * would open the map already scrolled past the bodies with nothing but
+ * card tails on screen.
+ *
+ * Clamped, so an anchor near an edge — or a top anchor on a canvas that is
+ * shorter than the window — still lands somewhere legal.
  */
 export function placeStarMapView(params: {
   canvas: StarMapViewBox;
   viewport: StarMapViewBox;
   topAnchored?: boolean;
+  /** Canvas-space point to open on; the canvas centre when absent. */
+  anchor?: { x: number; y: number };
 }): StarMapView {
   const centered = centerStarMapView({
     canvas: params.canvas,
     viewport: params.viewport,
   });
-  if (!params.topAnchored) return centered;
+  const anchored =
+    params.anchor
+    && Number.isFinite(params.anchor.x)
+    && Number.isFinite(params.anchor.y)
+      ? {
+          scale: centered.scale,
+          x: params.viewport.width / 2 - params.anchor.x,
+          y: params.viewport.height / 2 - params.anchor.y,
+        }
+      : centered;
+  if (!params.topAnchored && anchored === centered) return centered;
   return clampStarMapView({
-    view: { ...centered, y: 0 },
+    view: params.topAnchored ? { ...anchored, y: 0 } : anchored,
     canvas: params.canvas,
     viewport: params.viewport,
   });

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -246,8 +246,10 @@ export function centerStarMapView(params: {
  * would open the map already scrolled past the bodies with nothing but
  * card tails on screen.
  *
- * Clamped, so an anchor near an edge — or a top anchor on a canvas that is
- * shorter than the window — still lands somewhere legal.
+ * Always clamped, so an anchor near an edge — or a top anchor on a canvas
+ * that is shorter than the window — still lands somewhere legal. The clamp
+ * is a no-op on a centred view at every canvas size, so the unanchored
+ * result is unchanged by passing through it.
  */
 export function placeStarMapView(params: {
   canvas: StarMapViewBox;
@@ -256,23 +258,24 @@ export function placeStarMapView(params: {
   /** Canvas-space point to open on; the canvas centre when absent. */
   anchor?: { x: number; y: number };
 }): StarMapView {
-  const centered = centerStarMapView({
-    canvas: params.canvas,
-    viewport: params.viewport,
-  });
-  const anchored =
+  const anchor =
     params.anchor
     && Number.isFinite(params.anchor.x)
     && Number.isFinite(params.anchor.y)
-      ? {
-          scale: centered.scale,
-          x: params.viewport.width / 2 - params.anchor.x,
-          y: params.viewport.height / 2 - params.anchor.y,
-        }
-      : centered;
-  if (!params.topAnchored && anchored === centered) return centered;
+      ? params.anchor
+      : undefined;
+  const placed = anchor
+    ? {
+        scale: 1,
+        x: params.viewport.width / 2 - anchor.x,
+        y: params.viewport.height / 2 - anchor.y,
+      }
+    : centerStarMapView({
+        canvas: params.canvas,
+        viewport: params.viewport,
+      });
   return clampStarMapView({
-    view: params.topAnchored ? { ...anchored, y: 0 } : anchored,
+    view: params.topAnchored ? { ...placed, y: 0 } : placed,
     canvas: params.canvas,
     viewport: params.viewport,
   });


### PR DESCRIPTION
## Summary

- The Star Map placed its opening view against the **middle of the canvas**, and the canvas is the bounding box of whatever the lens has laid out so far. A fleet arrives in pieces — health lands, peers enrol one at a time, each answers with its own navigation snapshot, and every card's real height arrives later still as the browser measures it — so that bounding box, and the middle the view was placed on, kept moving. The auto-place effect re-ran on each change and chased it: opening the map looked like it was flying itself somewhere, because it was, several times, before the fleet had finished arriving.
- The existing ownership rule (`operatorMovedViewRef`) only silences this *after* the operator pans. During a load the view is still the app's, so nothing stopped it.
- `placeStarMapView` now takes an optional canvas-space `anchor` and opens on a body: this machine's own cluster, or the galaxy core in the Projects lens, which has no instances. The anchor's canvas position moves by the same amount the bounding box does, so re-placing cancels out — the canvas grows around a map that has not moved. With no body yet (empty map, pre-health) it falls back to the canvas centre, which is the only point there is.
- The placement becomes a `useLayoutEffect`. As a passive effect it painted one frame with the body already in its new place under the old transform — the content jumping, then the view catching up, once per snapshot. The lens-switch release of view ownership had to move to a layout effect with it, or the placement reads the flag before the release clears it and the new lens inherits the old lens's pan.
- `viewAnchor` is memoised on its coordinates rather than on the layout object, which is rebuilt for every streamed update — the same rule `panZoomCanvas` already follows, so the placement stays off the every-delta cadence.
- **Behaviour change worth naming:** "Reset view" now returns to the home cluster rather than the canvas centre. That is the same thing its docstring always claimed — put the map back where it opens.

## Verification

- `pnpm test apps/desktop/src/renderer` — 3150 passed (201 files).
- `pnpm typecheck` — clean. `pnpm lint:eslint` — 0 errors, 43 warnings (unchanged baseline).
- New `star-map-load-drift.test.tsx` drives a fleet that arrives over time: peers enrol through real `federation/peerStatus/changed` notifications, each answers `getNavigationSnapshot` on its own round trip, then this machine's own threads land. It asserts the local body's **screen** position — the canvas transform composed with the body's canvas position — because either half alone agrees with the bug: a view chasing a moving anchor and a view holding a still one both change, and content moving inside a growing canvas is what is supposed to happen.
- Confirmed all three of those tests fail on the pre-fix code rather than passing vacuously: the first peer's arrival moved the home body ~500px in orbit and ~320px in lanes.
- Six unit cases added on `placeStarMapView` (opens on the anchor, holds it as the canvas grows, centres without one, keeps a column lens at the top edge, produces a view the clamp accepts unchanged, ignores a non-finite anchor).
- The lens-switch ordering bug above was caught by the existing `star-map-view-stability` suite, not by the new tests.

## Notes

- Desktop E2E was **not** run. The star-map specs launch a single-instance fixture, where the hub already sits at the canvas centre and the placement is therefore unchanged — but that reasoning is not proven on the lab. Worth a run if a reviewer wants it before merge.
- No change to the pan/zoom clamp, the ownership rule for an operator-moved view, or the flight/jump path (a jump still claims the view, so it is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
