### PR TITLE
perf(desktop): fill a Star Map cloud in scattered beats, on a 500ms budget

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -33,6 +33,7 @@ import {
   type StarMapSessionKeys,
 } from "./attention";
 import {
+  cardRiseDelayMs,
   cloudDetentRadius,
   computeCardSlots,
   computeStarMapLayout,
@@ -3078,7 +3079,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   : undefined
               }
               hasUnsentDraft={props.draftThreadKeys?.[threadKey] === true}
-              riseDelayMs={index * 45}
+              // Budgeted, not per-card: `star-map-rise` blanks a card
+              // through its delay, and an orbit cloud has no card cap.
+              riseDelayMs={cardRiseDelayMs({ index, count: visible.length })}
               entering={enteringThreadKeys.has(threadKey)}
               located={locatedThreadKey === threadKey}
               instanceIcon={celestialIcons.iconFor(

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -3171,6 +3171,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // mounting mid-gesture can be grouped against a view one frame stale,
     // and the worst that costs is one card in the wrong beat of a 500ms
     // entrance. Reading the ref would make render impure for no gain.
+    //
+    // KNOWN LIMIT, deliberately not papered over here: this deal is not
+    // frozen once a card's entrance has begun. `view` and `slots` both
+    // move inside the 500ms window — the placement effect above re-runs on
+    // every canvas resize during a load — so a card can be re-dealt from
+    // one beat to a later one while it is mid-fade. `star-map-rise` fills
+    // `backwards`, which makes a raised delay the animation's BEFORE
+    // phase: measured in Chromium with the clock pinned 100ms into the
+    // 200ms fade, `animation-delay: 0` computes to opacity 0.5 and 300ms
+    // computes to opacity 0. The card blanks and fades again.
+    //
+    // Freezing each card's delay at its first paint does NOT fix this, and
+    // was tried: the map places its own view across renders that land
+    // after that paint, so the frozen value is the pre-placement one, in
+    // which every card reads as off-screen and the whole cloud flattens
+    // back to a single switch-on. A real fix has to decide when the
+    // entrance may start relative to the map settling its view — either
+    // gate the entrance on a settled view, or stagger by mounting the
+    // groups rather than by delaying them. Both are their own change.
     const riseDelays = cardRiseDelays(
       placements.map((placement) =>
         isPointInView({

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -33,7 +33,7 @@ import {
   type StarMapSessionKeys,
 } from "./attention";
 import {
-  cardRiseDelayMs,
+  cardRiseDelays,
   cloudDetentRadius,
   computeCardSlots,
   computeStarMapLayout,
@@ -111,6 +111,7 @@ import {
 import {
   clampStarMapView,
   isOverviewZoom,
+  isPointInView,
   MAX_ZOOM,
   MIN_ZOOM,
   overviewChromeScale,
@@ -2938,6 +2939,62 @@ export function StarMapScreen(props: StarMapScreenProps) {
       loadSlot ? [...position.slots, loadSlot] : position.slots,
     );
     const overflow = threads.length - visible.length;
+    // Placement is resolved before the JSX rather than inside it because
+    // the entrance has to know which cards the window actually contains,
+    // and that question needs the very anchor each card renders at.
+    const drawn = overview && position.clusters ? [] : visible;
+    const placements = drawn.map((thread, index) => {
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const storedOffset = arrangement.offsetFor(
+        position.instanceId,
+        threadKey,
+      );
+      const cardCluster =
+        position.clusterIndexByCard !== undefined
+          ? position.clusters?.[position.clusterIndexByCard[index]]
+          : undefined;
+      // A placed card anchors to its cloud's centre instead of its
+      // scatter slot: cloudmates arriving or archiving away reflow the
+      // scatter, and an offset over a moving slot made every arranged
+      // card jump. See `clusterAnchorFor`.
+      const anchored = cardCluster !== undefined && storedOffset !== undefined;
+      return {
+        thread,
+        threadKey,
+        storedOffset,
+        anchored,
+        cardCluster,
+        // The scatter slot, kept alongside the anchor: a first drop has to
+        // re-express its result from the cloud centre, and by then the
+        // anchor is that centre.
+        slot: slots[index],
+        anchorSlot: anchored
+          ? { dx: cardCluster.center.x, dy: cardCluster.center.y }
+          : slots[index],
+      };
+    });
+    // Reads committed view state, not the live ref a pan writes: a card
+    // mounting mid-gesture can be grouped against a view one frame stale,
+    // and the worst that costs is one card in the wrong beat of a 500ms
+    // entrance. Reading the ref would make render impure for no gain.
+    const riseDelays = cardRiseDelays(
+      placements.map((placement) =>
+        isPointInView({
+          point: {
+            x:
+              position.x
+              + placement.anchorSlot.dx
+              + (placement.storedOffset?.dx ?? 0),
+            y:
+              position.y
+              + placement.anchorSlot.dy
+              + (placement.storedOffset?.dy ?? 0),
+          },
+          view,
+          viewport: viewportSize,
+        }),
+      ),
+    );
     return (
       <div
         key={`cloud:${position.instanceId}`}
@@ -3049,26 +3106,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
             onDismiss={() => toggleLoadCard(position.instanceId)}
           />
         ) : null}
-        {(overview && position.clusters ? [] : visible).map((thread, index) => {
-          const slot = slots[index];
-          const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-          const storedOffset = arrangement.offsetFor(
-            position.instanceId,
+        {placements.map((placement, index) => {
+          const {
+            anchored,
+            anchorSlot,
+            cardCluster,
+            slot,
+            storedOffset,
+            thread,
             threadKey,
-          );
-          const cardCluster =
-            position.clusterIndexByCard !== undefined
-              ? position.clusters?.[position.clusterIndexByCard[index]]
-              : undefined;
-          // A placed card anchors to its cloud's centre instead of its
-          // scatter slot: cloudmates arriving or archiving away reflow the
-          // scatter, and an offset over a moving slot made every arranged
-          // card jump. See `clusterAnchorFor`.
-          const anchored =
-            cardCluster !== undefined && storedOffset !== undefined;
-          const anchorSlot = anchored
-            ? { dx: cardCluster.center.x, dy: cardCluster.center.y }
-            : slot;
+          } = placement;
           return (
             <StarMapThreadCard
               key={threadKey}
@@ -3079,9 +3126,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   : undefined
               }
               hasUnsentDraft={props.draftThreadKeys?.[threadKey] === true}
-              // Budgeted, not per-card: `star-map-rise` blanks a card
-              // through its delay, and an orbit cloud has no card cap.
-              riseDelayMs={cardRiseDelayMs({ index, count: visible.length })}
+              // Scattered beats over the cards in view, not a sweep over
+              // every card that exists. See `cardRiseDelays`.
+              riseDelayMs={riseDelays[index]}
               entering={enteringThreadKeys.has(threadKey)}
               located={locatedThreadKey === threadKey}
               instanceIcon={celestialIcons.iconFor(

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   federatedThreadIdentityKey,
@@ -5,11 +8,15 @@ import {
 } from "@pwragent/shared";
 import { threadAttentionCategories } from "../attention";
 import {
+  cardRiseDelayMs,
   cloudDetentRadius,
   computeStarMapLayout,
   computeCardSlots,
   generateStarField,
   resolveCardDragOffset,
+  STAR_MAP_RISE_DURATION_MS,
+  STAR_MAP_RISE_STEP_MS,
+  STAR_MAP_RISE_TOTAL_MS,
   visibleCardCount,
   type StarMapCardSlot,
 } from "../star-map-layout";
@@ -382,5 +389,63 @@ describe("resolveCardDragOffset", () => {
     // The resistance already absorbed stays behind as a constant lag.
     expect(near).toBeLessThan(detentRadius + 400);
     expect(near).toBeGreaterThan(detentRadius + 200);
+  });
+});
+
+describe("cardRiseDelayMs", () => {
+  it("keeps the full step while the cloud fits inside the budget", () => {
+    // Three cards span two gaps at 45ms, so nothing about the settle a
+    // small cloud already had needs to change.
+    expect(cardRiseDelayMs({ index: 0, count: 3 })).toBe(0);
+    expect(cardRiseDelayMs({ index: 1, count: 3 })).toBe(
+      STAR_MAP_RISE_STEP_MS,
+    );
+    expect(cardRiseDelayMs({ index: 2, count: 3 })).toBe(
+      STAR_MAP_RISE_STEP_MS * 2,
+    );
+  });
+
+  it("lands the last card on budget however large the cloud is", () => {
+    // The regression this exists for: an orbit cloud is capped per
+    // cluster, not per cloud, so `index * 45` grew without bound.
+    for (const count of [1, 2, 8, 40, 160, 1_000]) {
+      const last = cardRiseDelayMs({ index: count - 1, count });
+      expect(last + STAR_MAP_RISE_DURATION_MS).toBeLessThanOrEqual(
+        STAR_MAP_RISE_TOTAL_MS,
+      );
+    }
+    // 160 cards at the old flat step blanked the tail for over 7s.
+    expect(cardRiseDelayMs({ index: 159, count: 160 })).toBeLessThan(159 * 45);
+  });
+
+  it("compresses the step rather than dropping the stagger", () => {
+    // A cap (`Math.min(index * 45, spread)`) would fire every card past
+    // the cap together, which loses the sweep the animation is for.
+    const count = 160;
+    const delays = Array.from({ length: count }, (_, index) =>
+      cardRiseDelayMs({ index, count }),
+    );
+    expect(delays[0]).toBe(0);
+    expect(delays[count - 1]).toBeGreaterThan(0);
+    for (let index = 1; index < count; index += 1) {
+      expect(delays[index]).toBeGreaterThanOrEqual(delays[index - 1]);
+    }
+  });
+
+  it("matches the duration app.css actually animates", () => {
+    // The budget is delay + duration, so a duration edited in the
+    // stylesheet alone silently pushes the last card past 500ms.
+    const css = readFileSync(
+      path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../../../styles/app.css",
+      ),
+      "utf8",
+    );
+    const rule = /\.star-map-card-shell \{[^}]*animation:\s*star-map-rise\s+(\d+)ms/.exec(
+      css,
+    );
+    expect(rule).not.toBeNull();
+    expect(Number(rule![1])).toBe(STAR_MAP_RISE_DURATION_MS);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -8,14 +8,15 @@ import {
 } from "@pwragent/shared";
 import { threadAttentionCategories } from "../attention";
 import {
-  cardRiseDelayMs,
+  cardRiseDelays,
   cloudDetentRadius,
   computeStarMapLayout,
   computeCardSlots,
   generateStarField,
   resolveCardDragOffset,
   STAR_MAP_RISE_DURATION_MS,
-  STAR_MAP_RISE_STEP_MS,
+  STAR_MAP_RISE_GROUP_STEP_MS,
+  STAR_MAP_RISE_MAX_GROUPS,
   STAR_MAP_RISE_TOTAL_MS,
   visibleCardCount,
   type StarMapCardSlot,
@@ -392,49 +393,94 @@ describe("resolveCardDragOffset", () => {
   });
 });
 
-describe("cardRiseDelayMs", () => {
-  it("keeps the full step while the cloud fits inside the budget", () => {
-    // Three cards span two gaps at 45ms, so nothing about the settle a
-    // small cloud already had needs to change.
-    expect(cardRiseDelayMs({ index: 0, count: 3 })).toBe(0);
-    expect(cardRiseDelayMs({ index: 1, count: 3 })).toBe(
-      STAR_MAP_RISE_STEP_MS,
-    );
-    expect(cardRiseDelayMs({ index: 2, count: 3 })).toBe(
-      STAR_MAP_RISE_STEP_MS * 2,
-    );
+describe("cardRiseDelays", () => {
+  const allInView = (count: number) =>
+    cardRiseDelays(new Array<boolean>(count).fill(true));
+
+  it("gives an off-screen card no delay at all", () => {
+    // Budget spent on a card the operator cannot see is budget spent on
+    // nothing, and counting them made an in-view group depend on how many
+    // cards happened to be parked off to the side.
+    const delays = cardRiseDelays([false, true, false, true, false]);
+    expect(delays[0]).toBe(0);
+    expect(delays[2]).toBe(0);
+    expect(delays[4]).toBe(0);
   });
 
   it("lands the last card on budget however large the cloud is", () => {
     // The regression this exists for: an orbit cloud is capped per
-    // cluster, not per cloud, so `index * 45` grew without bound.
+    // cluster, not per cloud, so a per-card step grew without bound.
     for (const count of [1, 2, 8, 40, 160, 1_000]) {
-      const last = cardRiseDelayMs({ index: count - 1, count });
+      const last = Math.max(...allInView(count));
       expect(last + STAR_MAP_RISE_DURATION_MS).toBeLessThanOrEqual(
         STAR_MAP_RISE_TOTAL_MS,
       );
     }
-    // 160 cards at the old flat step blanked the tail for over 7s.
-    expect(cardRiseDelayMs({ index: 159, count: 160 })).toBeLessThan(159 * 45);
   });
 
-  it("compresses the step rather than dropping the stagger", () => {
-    // A cap (`Math.min(index * 45, spread)`) would fire every card past
-    // the cap together, which loses the sweep the animation is for.
-    const count = 160;
-    const delays = Array.from({ length: count }, (_, index) =>
-      cardRiseDelayMs({ index, count }),
-    );
-    expect(delays[0]).toBe(0);
-    expect(delays[count - 1]).toBeGreaterThan(0);
-    for (let index = 1; index < count; index += 1) {
-      expect(delays[index]).toBeGreaterThanOrEqual(delays[index - 1]);
+  it("uses whole group steps, never a per-card slide", () => {
+    for (const delay of allInView(50)) {
+      expect(delay % STAR_MAP_RISE_GROUP_STEP_MS).toBe(0);
     }
+  });
+
+  it("keeps the groups within one card of each other", () => {
+    const delays = allInView(50);
+    const sizes = new Map<number, number>();
+    for (const delay of delays) {
+      sizes.set(delay, (sizes.get(delay) ?? 0) + 1);
+    }
+    expect(sizes.size).toBe(STAR_MAP_RISE_MAX_GROUPS);
+    const counts = [...sizes.values()];
+    expect(Math.max(...counts) - Math.min(...counts)).toBeLessThanOrEqual(1);
+  });
+
+  it("scatters each group instead of sweeping the card order", () => {
+    // The complaint this answers: stepping by index reads as one wipe,
+    // because clusters are seated contiguously so index order is roughly
+    // spatial. Neighbours therefore must NOT share a beat wholesale.
+    const delays = allInView(50);
+    // The property that separates a scatter from a wipe is that the delay
+    // does not rise with the index. Both the old per-card step and an
+    // ordered deal are monotonic; only a scramble is not.
+    const monotonic = delays.every(
+      (delay, index) => index === 0 || delay >= delays[index - 1],
+    );
+    expect(monotonic).toBe(false);
+    // Each group must also reach across the cloud rather than owning a
+    // contiguous run of it.
+    for (let group = 0; group < STAR_MAP_RISE_MAX_GROUPS; group += 1) {
+      const members = delays.flatMap((delay, index) =>
+        delay === group * STAR_MAP_RISE_GROUP_STEP_MS ? [index] : [],
+      );
+      expect(members.length).toBeGreaterThan(0);
+      const span = members[members.length - 1] - members[0];
+      expect(span).toBeGreaterThan(delays.length / 2);
+    }
+    // Nor may it be the plain round-robin over the card order. That also
+    // spans the cloud, but it is periodic: in a ring, lighting every Nth
+    // seat is a rotating pattern rather than a scatter.
+    const roundRobin = delays.map(
+      (_, index) =>
+        (index % STAR_MAP_RISE_MAX_GROUPS) * STAR_MAP_RISE_GROUP_STEP_MS,
+    );
+    expect(delays).not.toEqual(roundRobin);
+  });
+
+  it("gives a cloud smaller than one group per card its own beats", () => {
+    // Small clouds keep the settle they always had rather than flattening
+    // to a single switch-on.
+    const delays = cardRiseDelays([true, true, true]);
+    expect(new Set(delays).size).toBe(3);
+  });
+
+  it("is deterministic, so a re-render cannot re-deal a card", () => {
+    expect(allInView(50)).toEqual(allInView(50));
   });
 
   it("matches the duration app.css actually animates", () => {
     // The budget is delay + duration, so a duration edited in the
-    // stylesheet alone silently pushes the last card past 500ms.
+    // stylesheet alone silently pushes the last card past the total.
     const css = readFileSync(
       path.resolve(
         path.dirname(fileURLToPath(import.meta.url)),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -397,14 +397,19 @@ describe("cardRiseDelays", () => {
   const allInView = (count: number) =>
     cardRiseDelays(new Array<boolean>(count).fill(true));
 
-  it("gives an off-screen card no delay at all", () => {
+  it("deals only the cards in view, and skips the rest", () => {
     // Budget spent on a card the operator cannot see is budget spent on
     // nothing, and counting them made an in-view group depend on how many
     // cards happened to be parked off to the side.
     const delays = cardRiseDelays([false, true, false, true, false]);
-    expect(delays[0]).toBe(0);
-    expect(delays[2]).toBe(0);
-    expect(delays[4]).toBe(0);
+    expect([delays[0], delays[2], delays[4]]).toEqual([0, 0, 0]);
+    // The two in view take the first two beats between them — asserting
+    // only the zeroes above would hold just as well for an all-zero deal,
+    // which is every card popping at once.
+    expect([delays[1], delays[3]].sort((a, b) => a - b)).toEqual([
+      0,
+      STAR_MAP_RISE_GROUP_STEP_MS,
+    ]);
   });
 
   it("lands the last card on budget however large the cloud is", () => {
@@ -474,7 +479,12 @@ describe("cardRiseDelays", () => {
     expect(new Set(delays).size).toBe(3);
   });
 
-  it("is deterministic, so a re-render cannot re-deal a card", () => {
+  it("deals the same cards the same way every call", () => {
+    // Determinism only: the same `onScreen` in, the same delays out. It is
+    // NOT a guarantee that a mounted card keeps its beat — the deal moves
+    // when the view or the card slots move, and freezing it after the
+    // first paint is StarMapThreadCard's job, pinned in
+    // star-map-performance.test.
     expect(allInView(50)).toEqual(allInView(50));
   });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
@@ -87,6 +87,37 @@ describe("star map idle performance", () => {
     expect(movingRule).toContain("will-change: transform;");
   });
 
+  it("brings a cloud in as scattered groups, not one flat switch-on", async () => {
+    // The pure dealing is pinned in star-map-logic.test; this is the wiring
+    // — that the delays reach the shells at all, and that a real cloud
+    // produces more than one beat. A regression here looks like every card
+    // sharing a delay, which is the "they all appear at once" complaint.
+    const threads = Array.from({ length: 24 }, (_, index) =>
+      thread(`t${index}`),
+    );
+    const { container } = render(screen(threads));
+    const shells = await waitFor(() => {
+      const nodes = [
+        ...container.querySelectorAll<HTMLElement>(".star-map-card-shell"),
+      ].filter((shell) => shell.dataset.threadKey);
+      if (nodes.length === 0) throw new Error("no cards");
+      return nodes;
+    });
+    const delays = shells.map((shell) => shell.style.animationDelay);
+    expect(new Set(delays).size).toBeGreaterThan(1);
+    // And the beats must not climb with the card order: a delay that rises
+    // monotonically is a wipe with a direction, which is the "they all
+    // appear in the same order" complaint this answers.
+    // An unset delay is the empty string, and parseFloat("") is NaN —
+    // which makes every comparison false and would pass this test for the
+    // wrong reason. The first card's missing style means zero.
+    const ms = delays.map((delay) => Number.parseFloat(delay) || 0);
+    const monotonic = ms.every(
+      (delay, index) => index === 0 || delay >= ms[index - 1],
+    );
+    expect(monotonic).toBe(false);
+  });
+
   it("updates card layout from ResizeObserver without reading offsetHeight", async () => {
     // The expected card position is a lanes-geometry number; the default
     // lens is orbit now, so pin the layout the assertion assumes.

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
@@ -8,7 +8,9 @@ import {
   centerStarMapView,
   clampStarMapView,
   isOverviewZoom,
+  isPointInView,
   overviewChromeScale,
+  STAR_MAP_IN_VIEW_MARGIN,
   starMapSkyOffset,
   type StarMapView,
 } from "../star-map-view-geometry";
@@ -216,5 +218,87 @@ describe("starMapSkyOffset", () => {
       x: 0,
       y: 0,
     });
+  });
+});
+
+describe("isPointInView", () => {
+  const centred: StarMapView = { x: 0, y: 0, scale: 1 };
+
+  it("maps a canvas point through translate-then-scale", () => {
+    // transform-origin is 0 0, so the point paints at
+    // `canvas * scale + view`, not `(canvas + view) * scale`. Getting the
+    // order backwards only shows up away from the origin.
+    const view: StarMapView = { x: 100, y: 50, scale: 0.5 };
+    // 2000 * 0.5 + 100 = 1100, inside a 1280-wide window.
+    expect(
+      isPointInView({
+        point: { x: 2000, y: 200 },
+        view,
+        viewport: VIEWPORT,
+        margin: 0,
+      }),
+    ).toBe(true);
+    // The other order would be (2000 + 100) * 0.5 = 1050 — also inside,
+    // so pin a point the two readings disagree about: 2400 * 0.5 + 100 =
+    // 1300 is outside, while (2400 + 100) * 0.5 = 1250 would be inside.
+    expect(
+      isPointInView({
+        point: { x: 2400, y: 200 },
+        view,
+        viewport: VIEWPORT,
+        margin: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts an anchor just outside the window", () => {
+    // A card is anchored by its top-centre, so the anchor leaves the
+    // window before the card does. The margin is what keeps a half-visible
+    // card in the entrance.
+    expect(
+      isPointInView({
+        point: { x: -STAR_MAP_IN_VIEW_MARGIN + 1, y: 400 },
+        view: centred,
+        viewport: VIEWPORT,
+      }),
+    ).toBe(true);
+    expect(
+      isPointInView({
+        point: { x: -STAR_MAP_IN_VIEW_MARGIN - 1, y: 400 },
+        view: centred,
+        viewport: VIEWPORT,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a point past the far edge on either axis", () => {
+    expect(
+      isPointInView({
+        point: { x: VIEWPORT.width + 400, y: 400 },
+        view: centred,
+        viewport: VIEWPORT,
+      }),
+    ).toBe(false);
+    expect(
+      isPointInView({
+        point: { x: 400, y: VIEWPORT.height + 400 },
+        view: centred,
+        viewport: VIEWPORT,
+      }),
+    ).toBe(false);
+  });
+
+  it("pulls far more of the canvas into view as the map zooms out", () => {
+    const point = { x: 4000, y: 3000 };
+    expect(
+      isPointInView({ point, view: centred, viewport: VIEWPORT }),
+    ).toBe(false);
+    expect(
+      isPointInView({
+        point,
+        view: { x: 0, y: 0, scale: MIN_ZOOM },
+        viewport: VIEWPORT,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -174,6 +174,43 @@ export function computeCardSlots(
 }
 
 /**
+ * Total wall time a cloud's entrance may occupy, from the first card's
+ * first frame to the last card's last one.
+ *
+ * `star-map-rise` carries `backwards`, so a card holds `opacity: 0`
+ * through its delay: the stagger is not decoration layered over visible
+ * cards, it is how long each card stays blank. A flat `index * step` is
+ * therefore only safe while the card count is bounded, and in the orbit
+ * lens it is not - clusters cap at ORBIT_MAX_CARDS_PER_GROUP but their
+ * COUNT does not, so a cloud of forty small projects staggered at 45ms
+ * left its last card invisible for over seven seconds and read as data
+ * still arriving.
+ */
+export const STAR_MAP_RISE_TOTAL_MS = 500;
+/** Duration of `star-map-rise`; pinned to app.css by star-map-logic.test. */
+export const STAR_MAP_RISE_DURATION_MS = 380;
+/** Per-card step, used whole while the cloud can afford it. */
+export const STAR_MAP_RISE_STEP_MS = 45;
+
+/**
+ * Entrance delay for one card of a `count`-card cloud.
+ *
+ * A cloud small enough to fit inside the budget keeps the full step, so
+ * the constellation settle is unchanged where it was never the problem.
+ * A larger one compresses the step instead of dropping the stagger, which
+ * keeps the sweep direction legible while landing every card on budget.
+ */
+export function cardRiseDelayMs(params: {
+  index: number;
+  count: number;
+}): number {
+  const spread = STAR_MAP_RISE_TOTAL_MS - STAR_MAP_RISE_DURATION_MS;
+  const gaps = Math.max(1, params.count - 1);
+  const step = Math.min(STAR_MAP_RISE_STEP_MS, spread / gaps);
+  return Math.round(params.index * step);
+}
+
+/**
  * How many cards fit between the instance anchor and the bottom of the
  * viewport. Always yields at least one so a lane never renders empty when
  * it has something to show.

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -179,35 +179,79 @@ export function computeCardSlots(
  *
  * `star-map-rise` carries `backwards`, so a card holds `opacity: 0`
  * through its delay: the stagger is not decoration layered over visible
- * cards, it is how long each card stays blank. A flat `index * step` is
+ * cards, it is how long each card stays blank. A per-card delay is
  * therefore only safe while the card count is bounded, and in the orbit
  * lens it is not - clusters cap at ORBIT_MAX_CARDS_PER_GROUP but their
- * COUNT does not, so a cloud of forty small projects staggered at 45ms
- * left its last card invisible for over seven seconds and read as data
- * still arriving.
+ * COUNT does not.
  */
 export const STAR_MAP_RISE_TOTAL_MS = 500;
 /** Duration of `star-map-rise`; pinned to app.css by star-map-logic.test. */
-export const STAR_MAP_RISE_DURATION_MS = 380;
-/** Per-card step, used whole while the cloud can afford it. */
-export const STAR_MAP_RISE_STEP_MS = 45;
+export const STAR_MAP_RISE_DURATION_MS = 200;
+/**
+ * Gap between one entrance group and the next. The point of the entrance
+ * is that the cloud arrives as a few scattered pops rather than as one
+ * flat switch-on, and a step much under this reads as the switch again.
+ */
+export const STAR_MAP_RISE_GROUP_STEP_MS = 100;
+/**
+ * How many groups the budget affords. Derived rather than chosen, so the
+ * total cannot drift when the duration or the step is retuned.
+ */
+export const STAR_MAP_RISE_MAX_GROUPS =
+  Math.floor(
+    (STAR_MAP_RISE_TOTAL_MS - STAR_MAP_RISE_DURATION_MS)
+      / STAR_MAP_RISE_GROUP_STEP_MS,
+  ) + 1;
 
 /**
- * Entrance delay for one card of a `count`-card cloud.
- *
- * A cloud small enough to fit inside the budget keeps the full step, so
- * the constellation settle is unchanged where it was never the problem.
- * A larger one compresses the step instead of dropping the stagger, which
- * keeps the sweep direction legible while landing every card on budget.
+ * Deterministic scramble. Not `Math.random`: the delay is read during
+ * render, so a card that re-renders mid-entrance would otherwise jump to
+ * a different group, and a test could not name an expected order.
  */
-export function cardRiseDelayMs(params: {
-  index: number;
-  count: number;
-}): number {
-  const spread = STAR_MAP_RISE_TOTAL_MS - STAR_MAP_RISE_DURATION_MS;
-  const gaps = Math.max(1, params.count - 1);
-  const step = Math.min(STAR_MAP_RISE_STEP_MS, spread / gaps);
-  return Math.round(params.index * step);
+function mixIndex(value: number): number {
+  let hash = Math.imul(value ^ 0x9e3779b9, 0x85ebca6b);
+  hash ^= hash >>> 13;
+  hash = Math.imul(hash, 0xc2b2ae35);
+  return (hash ^ (hash >>> 16)) >>> 0;
+}
+
+/**
+ * Entrance delay per card, indexed alongside `onScreen`.
+ *
+ * Two rules, both about what the operator can actually see:
+ *
+ * Cards outside the window get no delay at all. Animating them spends
+ * budget on nothing - the operator will pan to them long after the
+ * entrance is over - and it is what made an in-view group depend on how
+ * many cards happened to be off to the side.
+ *
+ * In-view cards are scattered across a few groups instead of stepped one
+ * by one. A per-card step ordered by index is a sweep along the flat card
+ * order, and since clusters are seated contiguously that order is roughly
+ * spatial: it reads as a single wipe with an obvious direction. Scrambling
+ * first and then dealing round-robin keeps the groups within one card of
+ * each other in size while scattering each one across the whole cloud, so
+ * the map fills in as a handful of pops in different places.
+ */
+export function cardRiseDelays(onScreen: readonly boolean[]): number[] {
+  const delays = new Array<number>(onScreen.length).fill(0);
+  const inView: number[] = [];
+  for (let index = 0; index < onScreen.length; index += 1) {
+    if (onScreen[index]) inView.push(index);
+  }
+  // Fewer cards than groups: each one gets its own beat, which is the
+  // settle a small cloud always had.
+  const groups = Math.max(
+    1,
+    Math.min(STAR_MAP_RISE_MAX_GROUPS, inView.length),
+  );
+  // Sorted by the scramble, not shuffled in place: `Array.prototype.sort`
+  // is the only ordering primitive here that is stable across engines.
+  inView.sort((left, right) => mixIndex(left) - mixIndex(right));
+  for (let rank = 0; rank < inView.length; rank += 1) {
+    delays[inView[rank]] = (rank % groups) * STAR_MAP_RISE_GROUP_STEP_MS;
+  }
+  return delays;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -201,6 +201,39 @@ export function starMapSkyOffset(params: {
 }
 
 /**
+ * Viewport-pixel slack around the window when deciding whether a card is
+ * worth animating. A card is anchored by its top-centre, so the anchor can
+ * sit a card's width outside the window while the card itself is partly
+ * inside it - and being generous here is free, because the only cost of a
+ * false positive is one more card in an entrance group.
+ */
+export const STAR_MAP_IN_VIEW_MARGIN = 160;
+
+/**
+ * Whether a canvas point currently falls inside the window.
+ *
+ * `transform-origin` is `0 0`, so the canvas point `(x, y)` paints at
+ * `(x * scale + view.x, y * scale + view.y)` - the same mapping the module
+ * header describes for the canvas rect as a whole.
+ */
+export function isPointInView(params: {
+  point: { x: number; y: number };
+  view: StarMapView;
+  viewport: StarMapViewBox;
+  margin?: number;
+}): boolean {
+  const margin = params.margin ?? STAR_MAP_IN_VIEW_MARGIN;
+  const screenX = params.point.x * params.view.scale + params.view.x;
+  const screenY = params.point.y * params.view.scale + params.view.y;
+  return (
+    screenX >= -margin
+    && screenX <= params.viewport.width + margin
+    && screenY >= -margin
+    && screenY <= params.viewport.height + margin
+  );
+}
+
+/**
  * The view that puts the middle of the canvas in the middle of the window
  * at 1:1. Used to place the map on open, on a lens switch, and by "Reset
  * view".

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11778,7 +11778,11 @@ textarea,
    than a button nested in a button. */
 .star-map-card-shell {
   position: absolute;
-  animation: star-map-rise 380ms ease-out backwards;
+  /* Shorter than it looks like it wants to be, on purpose: the entrance
+     budget is delay + duration, and the delay channel is what carries the
+     scattered group cadence (see cardRiseDelays). A longer fade here buys
+     a smoother single card by spending the groups. */
+  animation: star-map-rise 200ms ease-out backwards;
 }
 
 .star-map-card {


### PR DESCRIPTION
## Summary

Two commits against the Star Map cloud entrance. The first bounded it; the second changed its shape after the bound made a second problem obvious.

**`cff7b975a` — budget the entrance to 500ms.** Cards staggered at a flat `index * 45`ms. `star-map-rise` carries `backwards`, so a card holds `opacity: 0` *through* its delay — the stagger is not decoration layered over visible cards, it is how long each card stays blank. That is only safe while the card count is bounded. In lanes it is (`LANE_MAX_CARDS_PER_INSTANCE` caps at 40, tail at ~2.1s); in the **orbit lens it is not** — clusters cap at `ORBIT_MAX_CARDS_PER_GROUP` but their *count* does not, and `index` is flat across the whole cloud. Forty small projects left the last card invisible for over seven seconds, which reads as data still arriving.

**`1b605c8eb` — scatter it, and only over what is on screen.** Bounded, the per-card step showed its real defect: clusters are seated contiguously, so the flat card order is roughly spatial and stepping along it is a *wipe with a direction* — every card appearing in the same order.

- **Off-screen cards get no delay at all.** Budget spent on a card the operator cannot see is spent on nothing, and counting them made an in-view card's beat depend on how many cards happened to be parked off to the side. `isPointInView` joins `star-map-view-geometry.ts`, where the `translate`-then-`scale` mapping it needs is already documented.
- **In-view cards are dealt into groups**: scramble deterministically, then deal round-robin. Groups stay within one card of each other in size while each spreads across the whole cloud, so the map fills in as a handful of pops in different places. Not `Math.random` — the delay is read during render, so a card re-rendering mid-entrance would jump groups and no test could name an expected deal.
- **Group count is derived from the budget**, not chosen, so the 500ms total cannot drift when the step or duration is retuned. Fitting four groups a legible 100ms apart costs the per-card fade, which drops 380ms → 200ms.

Measured deal, 50 cards in view: 4 groups of 13/13/12/12, 100ms apart, last frame at 500ms. Three cards in view still get their own beats, so a small cloud keeps the settle it always had.

| Cards in view | Before (commit 1) | Before (main) | Now |
|---|---|---|---|
| 3 | 470ms | 470ms | 400ms |
| 50 | 500ms, one sweep | 2.6s | 500ms, 4 scattered beats |
| 160 | 500ms, one sweep | 7.53s | 500ms, 4 scattered beats |

## Verification

- `pnpm test apps/desktop/src/renderer/src` — 3154 passed (200 files).
- `pnpm typecheck` clean; `pnpm lint:eslint` 0 errors (43 pre-existing warnings, unchanged count).
- **Both new gates verified to fail on the old behavior, not just pass on the new one:**
  - Reverting the render path to `index * 45` fails the wiring test (`expected true to be false` on the monotonicity check).
  - Replacing the scramble with a plain ordered deal fails the scatter test.
  - Editing `star-map-rise` to `420ms` in the stylesheet fails the budget test (`expected 420 to be 380`, checked on commit 1).
- Writing those gates surfaced a real hole: an unset `animation-delay` is `""`, and `parseFloat("")` is `NaN`, which makes every comparison false — the monotonicity assertion passed against the old sweep for the wrong reason until the first card's missing style was read as zero.

## Notes

- **Virtualization is deliberately not in here.** Card heights come from a `ResizeObserver` over *mounted* cards (`StarMapScreen.tsx:680`) and feed `computeClusterCloud`'s `heightForThread`. Never mounting an off-screen card leaves it at the 112px estimate, so mounting it on pan would reflow the cloud under the operator — the exact failure the existing code comments warn about ("an offset over a moving slot made every arranged card jump"). `flightRects` for ⌘K reads mounted rects too. It wants its own change, its own height strategy, and its own tests. Worth noting the map already virtualizes coarsely by zoom: below `STAR_MAP_OVERVIEW_ZOOM` it drops every card for one label per cloud.
- The entrance still replays on the overview-zoom remount (`StarMapScreen.tsx:3052`), now as a 500ms scatter rather than a seven-second sweep.
- Reduced motion is unaffected — `.star-map-card-shell { animation: none }` already zeroes the whole thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
