### PR TITLE
fix(desktop): stop the endless retry for threads Codex no longer has

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -44730,4 +44730,273 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
       await registry.canonicalizeNavigationThreadPullRequests(threads),
     ).toBe(threads);
   });
+
+  /**
+   * The audit runs on a debounce and then archives through several awaited
+   * hops. Stepping the clock in slices drains those microtasks; a single jump
+   * fires the timer and returns before the archive completes.
+   */
+  async function flushMissingCodexThreadAudit(): Promise<void> {
+    for (let step = 0; step < 50; step += 1) {
+      await vi.advanceTimersByTimeAsync(100);
+    }
+  }
+
+  function buildMissingThreadFixture(params: {
+    missingThreadIds: string[];
+    presentThreadIds: string[];
+  }) {
+    const buildThread = (id: string): AppServerThreadSummary => ({
+      id,
+      title: `Thread ${id}`,
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: `directory:/repo/${id}`,
+          label: id,
+          path: `/repo/${id}`,
+          kind: "local",
+        },
+      ],
+      projectKey: `/repo/${id}`,
+      source: "codex",
+      updatedAt: 2,
+    });
+    const overlays = Object.fromEntries(
+      params.missingThreadIds.map((id) => [
+        buildThreadIdentityKey("codex", id),
+        {
+          backend: "codex" as const,
+          threadId: id,
+          executionMode: "default" as const,
+          // A handoff directory whose path differs from the provider CWD is
+          // what schedules the workspace synchronization this audit hangs off.
+          extraLinkedDirectories: [
+            {
+              id: `pwragent-handoff:codex:${id}`,
+              label: id,
+              path: `/repo/${id}`,
+              worktreePath: `/worktrees/${id}`,
+              kind: "worktree" as const,
+            },
+          ],
+        },
+      ]),
+    );
+    return {
+      overlays,
+      threads: [
+        ...params.missingThreadIds.map(buildThread),
+        ...params.presentThreadIds.map(buildThread),
+      ],
+    };
+  }
+
+  class MissingThreadCodexClient extends MockBackendClient {
+    constructor(
+      private readonly missingThreadIds: Set<string>,
+      options: ConstructorParameters<typeof MockBackendClient>[0],
+    ) {
+      super(options);
+    }
+
+    updateThreadWorkspaceCallCount = 0;
+    readonly archivedThreadIds: string[] = [];
+
+    override async updateThreadWorkspace(params: {
+      threadId: string;
+      cwd: string;
+    }): Promise<{ threadId: string }> {
+      this.updateThreadWorkspaceCallCount += 1;
+      if (this.missingThreadIds.has(params.threadId)) {
+        throw new Error(
+          `json-rpc error (-32600): thread not found: ${params.threadId}`,
+        );
+      }
+      return { threadId: params.threadId };
+    }
+
+    override async archiveThread(params: {
+      threadId: string;
+    }): Promise<{ threadId: string }> {
+      this.archivedThreadIds.push(params.threadId);
+      if (this.missingThreadIds.has(params.threadId)) {
+        throw new Error(
+          `json-rpc error (-32600): thread not found: ${params.threadId}`,
+        );
+      }
+      return { threadId: params.threadId };
+    }
+  }
+
+  it("archives Codex threads reported missing when they are a small share of the profile", async () => {
+    vi.useFakeTimers();
+    try {
+      const missingThreadIds = new Set(["thread-missing"]);
+      const fixture = buildMissingThreadFixture({
+        missingThreadIds: [...missingThreadIds],
+        presentThreadIds: ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+      });
+      const codexClient = new MissingThreadCodexClient(missingThreadIds, {
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: fixture.threads,
+      });
+      const overlayStore = createOverlayStoreMock({ overlays: fixture.overlays });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+      const events: AgentEvent[] = [];
+      registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await flushMissingCodexThreadAudit();
+
+      expect(codexClient.archivedThreadIds).toEqual(["thread-missing"]);
+      const update = events.find(
+        (event) =>
+          event.notification.method === "codex/missingThreads/updated",
+      );
+      expect(update?.notification.params).toMatchObject({
+        archivedCount: 1,
+        failedCount: 0,
+        missingCount: 1,
+        status: "archived",
+        threadIds: ["thread-missing"],
+        totalCount: 10,
+      });
+      await expect(
+        overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-missing",
+        }),
+      ).resolves.toMatchObject({ archiveTombstonedAt: expect.any(Number) });
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("asks before archiving when Codex reports more than a fifth of the profile missing", async () => {
+    vi.useFakeTimers();
+    try {
+      const missingThreadIds = new Set(["thread-missing-1", "thread-missing-2"]);
+      const fixture = buildMissingThreadFixture({
+        missingThreadIds: [...missingThreadIds],
+        presentThreadIds: ["a", "b", "c"],
+      });
+      const codexClient = new MissingThreadCodexClient(missingThreadIds, {
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: fixture.threads,
+      });
+      const overlayStore = createOverlayStoreMock({ overlays: fixture.overlays });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+      const events: AgentEvent[] = [];
+      registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await flushMissingCodexThreadAudit();
+
+      expect(codexClient.archivedThreadIds).toEqual([]);
+      const update = events.find(
+        (event) =>
+          event.notification.method === "codex/missingThreads/updated",
+      );
+      expect(update?.notification.params).toMatchObject({
+        missingCount: 2,
+        status: "confirmationRequired",
+        totalCount: 5,
+      });
+      expect(
+        (update?.notification.params as { threadIds: string[] }).threadIds.sort(),
+      ).toEqual(["thread-missing-1", "thread-missing-2"]);
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying missing Codex threads the operator chose to keep", async () => {
+    vi.useFakeTimers();
+    try {
+      const missingThreadIds = new Set(["thread-missing-1", "thread-missing-2"]);
+      const fixture = buildMissingThreadFixture({
+        missingThreadIds: [...missingThreadIds],
+        presentThreadIds: ["a", "b", "c"],
+      });
+      const codexClient = new MissingThreadCodexClient(missingThreadIds, {
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: fixture.threads,
+      });
+      const overlayStore = createOverlayStoreMock({ overlays: fixture.overlays });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await flushMissingCodexThreadAudit();
+      const callsBeforeAnswer = codexClient.updateThreadWorkspaceCallCount;
+      expect(callsBeforeAnswer).toBe(2);
+
+      await expect(
+        registry.resolveMissingCodexThreads({
+          action: "keep",
+          threadIds: ["thread-missing-1", "thread-missing-2"],
+        }),
+      ).resolves.toEqual({
+        action: "keep",
+        archivedThreadIds: [],
+        failedThreadIds: [],
+      });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await flushMissingCodexThreadAudit();
+
+      expect(codexClient.updateThreadWorkspaceCallCount).toBe(callsBeforeAnswer);
+      expect(codexClient.archivedThreadIds).toEqual([]);
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("archives the missing Codex threads once when both windows answer the prompt", async () => {
+    vi.useFakeTimers();
+    try {
+      const missingThreadIds = new Set(["thread-missing-1", "thread-missing-2"]);
+      const fixture = buildMissingThreadFixture({
+        missingThreadIds: [...missingThreadIds],
+        presentThreadIds: ["a", "b", "c"],
+      });
+      const codexClient = new MissingThreadCodexClient(missingThreadIds, {
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: fixture.threads,
+      });
+      const overlayStore = createOverlayStoreMock({ overlays: fixture.overlays });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await flushMissingCodexThreadAudit();
+
+      const threadIds = ["thread-missing-1", "thread-missing-2"];
+      const first = await registry.resolveMissingCodexThreads({
+        action: "archive",
+        threadIds,
+      });
+      const second = await registry.resolveMissingCodexThreads({
+        action: "archive",
+        threadIds,
+      });
+
+      expect(first.archivedThreadIds.sort()).toEqual(threadIds);
+      expect(second.archivedThreadIds).toEqual([]);
+      expect(codexClient.archivedThreadIds.sort()).toEqual(threadIds);
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -175,6 +175,8 @@ import {
   projectNavigationLaunchpadProviderSettings,
   type RestoreWorktreeRequest,
   type RestoreWorktreeResponse,
+  type ResolveMissingCodexThreadsRequest,
+  type ResolveMissingCodexThreadsResponse,
   type RestoreThreadRequest,
   type RestoreThreadResponse,
   type RestoreThreadWorktreeResult,
@@ -4892,6 +4894,38 @@ function shouldEnrichThreadDirectories(
   }
 }
 
+/**
+ * Missing threads above this share of the visible Codex thread list stop being
+ * a stale-row cleanup and start looking like a misconfiguration — most likely
+ * this PwrAgent profile pointing at the wrong Codex authentication profile.
+ * PwrAgent asks instead of archiving when the share is above the threshold.
+ */
+const CODEX_MISSING_THREAD_CONFIRMATION_RATIO = 0.2;
+
+/**
+ * Missing-thread failures arrive one per thread as each pending workspace
+ * synchronization rejects. Coalesce a startup burst into one decision so the
+ * ratio is computed against every thread Codex lost, not the first one.
+ */
+const CODEX_MISSING_THREAD_EVALUATION_DELAY_MS = 2_000;
+
+/**
+ * Codex answers any thread-scoped request for a thread it can no longer
+ * resolve with `thread not found: <id>`. `thread/list` keeps returning the
+ * row — the list is served from Codex's session index, not from the rollout —
+ * so PwrAgent sees a thread that exists for browsing and does not exist for
+ * every operation that has to open it.
+ */
+function isCodexMissingThreadError(error: unknown, threadId: string): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  const normalizedThreadId = threadId.trim().toLowerCase();
+  if (!normalizedThreadId || !message.includes(normalizedThreadId)) {
+    return false;
+  }
+
+  return message.includes("thread not found:");
+}
+
 function isCodexMissingRolloutArchiveError(
   error: unknown,
   threadId: string,
@@ -4905,6 +4939,10 @@ function isCodexMissingRolloutArchiveError(
   return (
     message.includes("no rollout found for thread id")
     || message.includes("failed to locate rollout for thread")
+    // `thread not found` reaches the same dead end as a missing rollout:
+    // Codex cannot archive what it cannot open, so the archive falls through
+    // to the local tombstone that already hides stale `thread/list` rows.
+    || message.includes("thread not found:")
   );
 }
 
@@ -6877,6 +6915,25 @@ export class DesktopBackendRegistry {
   private codexInvalidIdRecoveryDrain?: Promise<void>;
   private codexInvalidIdRecoveryBarrier?: Promise<void>;
   private resolveCodexInvalidIdRecoveryBarrier?: () => void;
+  /**
+   * Threads Codex answered `thread not found` for during this session. An id
+   * stays here once it lands, whatever the audit decides, so a later
+   * `thread/list` cannot reschedule the retries this set exists to suppress.
+   * Only a successful thread-scoped write clears one.
+   */
+  private readonly missingCodexThreadIds = new Set<string>();
+  /** The subset still awaiting an archive-or-keep outcome. */
+  private readonly unresolvedMissingCodexThreadIds = new Set<string>();
+  private missingCodexThreadEvaluationTimer?: ReturnType<typeof setTimeout>;
+  private missingCodexThreadEvaluation?: Promise<void>;
+  private missingCodexThreadPromptOpen = false;
+  /**
+   * Visible (non-tombstoned, non-archived) Codex thread count from the most
+   * recent full `thread/list`. It is the denominator for the missing-thread
+   * ratio, so it is only recorded from the full-list path — never from the
+   * single-thread repair path, whose "list" is one thread.
+   */
+  private codexVisibleThreadCount = 0;
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly activeCodexReviewTurnKeys = new Set<string>();
   private readonly activeCodexReviewInterruptTurnIds = new Map<string, string>();
@@ -18405,6 +18462,11 @@ export class DesktopBackendRegistry {
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }
+    if (this.missingCodexThreadEvaluationTimer) {
+      clearTimeout(this.missingCodexThreadEvaluationTimer);
+      this.missingCodexThreadEvaluationTimer = undefined;
+    }
+    await this.missingCodexThreadEvaluation;
     // Live usage and command output may each have one bounded window sitting
     // in memory. `closed` prevents either drain from re-arming its timer; the
     // serialized flush chains ensure no write survives close().
@@ -20245,6 +20307,16 @@ export class DesktopBackendRegistry {
     const visibleThreads = threadsWithPending.filter(
       (thread) => overlaysByThreadId[thread.id]?.archiveTombstonedAt === undefined,
     );
+    // A search-filtered or page-limited list is a subset, not the profile, so
+    // it must not become the missing-thread denominator.
+    if (
+      !params.archived
+      && !params.filter
+      && params.limit === undefined
+      && params.maxPages === undefined
+    ) {
+      this.recordCodexVisibleThreadCount(visibleThreads.length);
+    }
     this.schedulePendingCodexWorkspaceCwdSyncs({
       overlaysByThreadId,
       threads: visibleThreads,
@@ -24371,6 +24443,12 @@ export class DesktopBackendRegistry {
     threads: AppServerThreadSummary[];
   }): void {
     for (const thread of params.threads) {
+      // Codex already told us it cannot open this thread. Retrying the
+      // workspace write on every `thread/list` produced one warning per list
+      // per thread forever; the missing-thread audit owns the outcome now.
+      if (this.isCodexThreadKnownMissing(thread.id)) {
+        continue;
+      }
       const handoffDirectory = params.overlaysByThreadId[
         thread.id
       ]?.extraLinkedDirectories.find(isHandoffDirectory);
@@ -24415,9 +24493,16 @@ export class DesktopBackendRegistry {
       cwd: params.cwd,
     })
       .then(() => {
+        // A thread Codex can write to is a thread Codex still has. Clear any
+        // earlier verdict so a reconnected profile recovers on its own.
+        this.clearMissingCodexThread(params.threadId);
         this.invalidateThreadListCache("codex");
       })
       .catch((error) => {
+        if (isCodexMissingThreadError(error, params.threadId)) {
+          this.recordMissingCodexThread(params.threadId);
+          return;
+        }
         backendRegistryLog.warn(
           "pending Codex workspace CWD synchronization failed; will retry",
           {
@@ -24437,6 +24522,209 @@ export class DesktopBackendRegistry {
       cwd: params.cwd,
       promise,
     });
+  }
+
+  private isCodexThreadKnownMissing(threadId: string): boolean {
+    return this.missingCodexThreadIds.has(threadId);
+  }
+
+  private clearMissingCodexThread(threadId: string): void {
+    this.missingCodexThreadIds.delete(threadId);
+    this.unresolvedMissingCodexThreadIds.delete(threadId);
+  }
+
+  /**
+   * Records the visible Codex thread count as the denominator for the
+   * missing-thread ratio. Only the full `thread/list` path may call this.
+   */
+  private recordCodexVisibleThreadCount(count: number): void {
+    this.codexVisibleThreadCount = count;
+  }
+
+  private recordMissingCodexThread(threadId: string): void {
+    // Only a thread that is newly missing needs a decision. Re-recording an
+    // already-decided thread would re-open a prompt the operator answered.
+    if (this.missingCodexThreadIds.has(threadId)) {
+      return;
+    }
+    this.missingCodexThreadIds.add(threadId);
+    this.unresolvedMissingCodexThreadIds.add(threadId);
+    backendRegistryLog.warn(
+      "Codex reports thread missing; suspending thread-scoped retries",
+      { threadId },
+    );
+    this.scheduleMissingCodexThreadAudit();
+  }
+
+  private scheduleMissingCodexThreadAudit(): void {
+    if (
+      this.closed
+      || this.missingCodexThreadEvaluationTimer
+      || this.missingCodexThreadEvaluation
+    ) {
+      return;
+    }
+    this.missingCodexThreadEvaluationTimer = setTimeout(() => {
+      this.missingCodexThreadEvaluationTimer = undefined;
+      this.missingCodexThreadEvaluation = this.auditMissingCodexThreads()
+        .catch((error) => {
+          backendRegistryLog.error("Codex missing-thread audit failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        })
+        .finally(() => {
+          this.missingCodexThreadEvaluation = undefined;
+        });
+    }, CODEX_MISSING_THREAD_EVALUATION_DELAY_MS);
+    this.missingCodexThreadEvaluationTimer.unref?.();
+  }
+
+  private async auditMissingCodexThreads(): Promise<void> {
+    if (this.closed || this.missingCodexThreadPromptOpen) {
+      return;
+    }
+    const threadIds = [...this.unresolvedMissingCodexThreadIds];
+    if (threadIds.length === 0) {
+      return;
+    }
+
+    // An unrecorded count means no full list has landed yet. Falling back to
+    // the missing count itself yields a ratio of 1, so an unknown denominator
+    // asks the operator rather than archiving on a guess.
+    const totalCount = Math.max(this.codexVisibleThreadCount, threadIds.length);
+    const ratio = threadIds.length / totalCount;
+    if (ratio > CODEX_MISSING_THREAD_CONFIRMATION_RATIO) {
+      this.missingCodexThreadPromptOpen = true;
+      backendRegistryLog.warn(
+        "Codex missing-thread share exceeds the automatic archive threshold",
+        {
+          missingCount: threadIds.length,
+          totalCount,
+          threadIds,
+        },
+      );
+      await this.emitCodexMissingThreadsUpdate({
+        missingCount: threadIds.length,
+        profileName: this.resolveMissingCodexThreadProfileName(),
+        status: "confirmationRequired",
+        threadIds,
+        totalCount,
+      });
+      return;
+    }
+
+    const result = await this.archiveMissingCodexThreads(threadIds);
+    await this.emitCodexMissingThreadsUpdate({
+      archivedCount: result.archived.length,
+      failedCount: result.failed.length,
+      missingCount: threadIds.length,
+      profileName: this.resolveMissingCodexThreadProfileName(),
+      status: "archived",
+      threadIds,
+      totalCount,
+    });
+  }
+
+  private async archiveMissingCodexThreads(threadIds: string[]): Promise<{
+    archived: string[];
+    failed: string[];
+  }> {
+    const archived: string[] = [];
+    const failed: string[] = [];
+    for (const threadId of threadIds) {
+      this.unresolvedMissingCodexThreadIds.delete(threadId);
+      try {
+        // `archiveThread` recognizes `thread not found` as an already-missing
+        // thread, so this performs the local tombstone plus the worktree,
+        // messaging, and child cleanup instead of failing on Codex's rejection.
+        await this.archiveThread({ backend: "codex", threadId });
+        archived.push(threadId);
+      } catch (error) {
+        failed.push(threadId);
+        backendRegistryLog.warn("archiving a missing Codex thread failed", {
+          error: error instanceof Error ? error.message : String(error),
+          threadId,
+        });
+      }
+    }
+    if (archived.length > 0) {
+      this.invalidateThreadListCache("codex");
+    }
+    if (archived.length > 0 || failed.length > 0) {
+      backendRegistryLog.warn("archived Codex threads reported missing", {
+        archivedCount: archived.length,
+        failedCount: failed.length,
+      });
+    }
+    return { archived, failed };
+  }
+
+  /**
+   * Applies the operator's answer to a missing-thread confirmation prompt.
+   * `keep` leaves the threads in place and suppresses both the prompt and the
+   * thread-scoped retries for the rest of this session; a reconnected Codex
+   * profile clears the suppression on the first successful thread-scoped
+   * write, and a restart re-asks if the threads are still missing.
+   */
+  async resolveMissingCodexThreads(
+    request: ResolveMissingCodexThreadsRequest,
+  ): Promise<ResolveMissingCodexThreadsResponse> {
+    // Every subscribed window renders the same prompt, so the answer can
+    // arrive more than once. Claiming the ids here makes the second answer a
+    // no-op instead of a second pass of worktree and messaging cleanup.
+    const threadIds = request.threadIds.filter(
+      (threadId) =>
+        threadId.trim()
+        && this.unresolvedMissingCodexThreadIds.delete(threadId),
+    );
+    this.missingCodexThreadPromptOpen = false;
+    if (request.action === "keep") {
+      // The ids stay in `missingCodexThreadIds`, which is what keeps the
+      // thread visible, its retries suspended, and this prompt closed.
+      backendRegistryLog.warn("keeping Codex threads reported missing", {
+        threadCount: threadIds.length,
+      });
+      return { action: "keep", archivedThreadIds: [], failedThreadIds: [] };
+    }
+
+    const result = await this.archiveMissingCodexThreads(threadIds);
+    return {
+      action: "archive",
+      archivedThreadIds: result.archived,
+      failedThreadIds: result.failed,
+    };
+  }
+
+  private resolveMissingCodexThreadProfileName(): string {
+    try {
+      return resolveActiveProfileName();
+    } catch {
+      // The prompt names the profile only to help the operator recognize a
+      // Codex profile mismatch. It stays useful without the name.
+      return "default";
+    }
+  }
+
+  private async emitCodexMissingThreadsUpdate(
+    params: Extract<
+      AppServerNotification,
+      { method: "codex/missingThreads/updated" }
+    >["params"],
+  ): Promise<void> {
+    try {
+      await this.emit({
+        backend: "codex",
+        notification: {
+          method: "codex/missingThreads/updated",
+          params,
+        },
+      });
+    } catch (error) {
+      backendRegistryLog.warn("Codex missing-thread notification failed", {
+        error: error instanceof Error ? error.message : String(error),
+        status: params.status,
+      });
+    }
   }
 
   private scheduleThreadTitleGeneration(params: {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -151,6 +151,8 @@ import {
   type ListWorktreeUnpublishedCommitsResponse,
   type GetWorktreeUnpublishedCommitDiffRequest,
   type GetWorktreeUnpublishedCommitDiffResponse,
+  type ResolveMissingCodexThreadsRequest,
+  type ResolveMissingCodexThreadsResponse,
   type RestoreThreadRequest,
   type RestoreThreadResponse,
   type ThreadGitWorkingState,
@@ -215,6 +217,7 @@ import {
   APP_SERVER_ARCHIVE_WORKTREE_CHANNEL,
   APP_SERVER_HANDOFF_THREAD_WORKSPACE_CHANNEL,
   APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL,
+  APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL,
   APP_SERVER_RESTORE_THREAD_CHANNEL,
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
@@ -1839,6 +1842,25 @@ class DesktopAppServerService {
       cleanupCount: response.cleanup.length,
     });
 
+    return response;
+  }
+
+  async resolveMissingCodexThreads(
+    request: ResolveMissingCodexThreadsRequest,
+  ): Promise<ResolveMissingCodexThreadsResponse> {
+    const response = await getDesktopBackendRegistry()
+      .resolveMissingCodexThreads(request);
+    for (const threadId of response.archivedThreadIds) {
+      await getDesktopFederationRuntime().ungroupRemoteChildrenOfArchivedThread({
+        backend: "codex",
+        parentThreadId: threadId,
+      });
+    }
+    logDebug("resolveMissingCodexThreads", {
+      action: response.action,
+      archivedCount: response.archivedThreadIds.length,
+      failedCount: response.failedThreadIds.length,
+    });
     return response;
   }
 
@@ -7545,6 +7567,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.archiveThread(request);
     },
   );
+  ipcMain.removeHandler(APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL);
+  ipcMain.handle(
+    APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL,
+    async (
+      _event,
+      request: ResolveMissingCodexThreadsRequest,
+    ): Promise<ResolveMissingCodexThreadsResponse> => {
+      return await appServerService.resolveMissingCodexThreads(request);
+    },
+  );
   ipcMain.removeHandler(APP_SERVER_RESTORE_THREAD_CHANNEL);
   ipcMain.handle(
     APP_SERVER_RESTORE_THREAD_CHANNEL,
@@ -8305,6 +8337,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_THREAD_CHANNEL);
+  ipcMain.removeHandler(APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_RESTORE_THREAD_CHANNEL);
   ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCES_CHANNEL);
   ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -263,6 +263,8 @@ import type {
   SetCodexThreadEnvironmentResponse,
   RestoreWorktreeRequest,
   RestoreWorktreeResponse,
+  ResolveMissingCodexThreadsRequest,
+  ResolveMissingCodexThreadsResponse,
   RestoreThreadRequest,
   RestoreThreadResponse,
   RunAutomationNowResponse,
@@ -516,6 +518,7 @@ import {
   APP_SERVER_ARCHIVE_WORKTREE_CHANNEL,
   APP_SERVER_HANDOFF_THREAD_WORKSPACE_CHANNEL,
   APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL,
+  APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL,
   APP_SERVER_RESTORE_THREAD_CHANNEL,
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
@@ -1407,6 +1410,13 @@ const desktopApi = Object.freeze({
     request: ArchiveThreadRequest,
   ): Promise<ArchiveThreadResponse> =>
     await ipcRenderer.invoke(APP_SERVER_ARCHIVE_THREAD_CHANNEL, request),
+  resolveMissingCodexThreads: async (
+    request: ResolveMissingCodexThreadsRequest,
+  ): Promise<ResolveMissingCodexThreadsResponse> =>
+    await ipcRenderer.invoke(
+      APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL,
+      request,
+    ),
   restoreThread: async (
     request: RestoreThreadRequest,
   ): Promise<RestoreThreadResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -114,6 +114,8 @@ import {
   threadActionErrorNoticeId,
   type ThreadActionErrorKind,
 } from "./features/notifications/thread-action-error-notice";
+import { buildCodexMissingThreadsNotice } from "./features/notifications/codex-missing-threads-notice";
+import type { CodexMissingThreadsSignal } from "./features/notifications/codex-missing-threads-notice";
 import { buildPrAutoDispatchBudgetNotice } from "./features/notifications/pr-auto-dispatch-budget-notice";
 import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNotices";
 import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
@@ -927,6 +929,34 @@ function DesktopAppShell(props: {
             threadLink,
           }),
         });
+        return;
+      }
+      if (event.notification.method === "codex/missingThreads/updated") {
+        const signal = event.notification.params as CodexMissingThreadsSignal;
+        const resolve = (action: "archive" | "keep") => {
+          dispatchAppNotice({
+            type: "dismiss",
+            id: "codex-missing-threads:confirmation",
+          });
+          void desktopApi
+            .resolveMissingCodexThreads?.({
+              action,
+              threadIds: signal.threadIds,
+            })
+            .catch(() => {
+              // The main process logs the failure. Re-showing the prompt here
+              // would fight the operator's answer; the audit runs again on the
+              // next launch if the threads are still missing.
+            });
+        };
+        const notice = buildCodexMissingThreadsNotice({
+          onArchive: () => resolve("archive"),
+          onKeep: () => resolve("keep"),
+          signal,
+        });
+        if (notice) {
+          dispatchAppNotice({ type: "show", notice });
+        }
         return;
       }
       // Params are cast explicitly: the AppServerNotification union is too

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/codex-missing-threads-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/codex-missing-threads-notice.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildCodexMissingThreadsNotice,
+  formatMissingThreadShare,
+} from "../codex-missing-threads-notice";
+
+describe("buildCodexMissingThreadsNotice", () => {
+  it("asks with both answers, naming the profile and the share", () => {
+    const onArchive = vi.fn();
+    const onKeep = vi.fn();
+    const notice = buildCodexMissingThreadsNotice({
+      onArchive,
+      onKeep,
+      signal: {
+        missingCount: 2,
+        profileName: "work",
+        status: "confirmationRequired",
+        threadIds: ["thread-1", "thread-2"],
+        totalCount: 5,
+      },
+    });
+
+    expect(notice).toMatchObject({
+      autoDismiss: false,
+      id: "codex-missing-threads:confirmation",
+      title: "Threads missing from Codex",
+      tone: "warning",
+    });
+    expect(notice?.message).toContain("40%");
+    expect(notice?.message).toContain('"work"');
+    expect(notice?.message).toContain("2 of 5");
+    // The notice replaces the toast's own dismiss control when it carries
+    // actions, so the two answers are the only way out of it.
+    expect(notice?.actions?.map((action) => action.label)).toEqual([
+      "Leave Everything Alone",
+      "Archive the Missing Threads",
+    ]);
+
+    notice?.actions?.[0]?.onClick();
+    expect(onKeep).toHaveBeenCalledTimes(1);
+    expect(onArchive).not.toHaveBeenCalled();
+
+    notice?.actions?.[1]?.onClick();
+    expect(onArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an automatic archive without asking anything", () => {
+    const notice = buildCodexMissingThreadsNotice({
+      onArchive: vi.fn(),
+      onKeep: vi.fn(),
+      signal: {
+        archivedCount: 1,
+        failedCount: 0,
+        missingCount: 1,
+        profileName: "default",
+        status: "archived",
+        threadIds: ["thread-1"],
+        totalCount: 10,
+      },
+    });
+
+    expect(notice).toMatchObject({
+      id: "codex-missing-threads:archived",
+      title: "Archived missing threads",
+      tone: "neutral",
+    });
+    expect(notice?.actions).toBeUndefined();
+    expect(notice?.autoDismiss).toBeUndefined();
+    expect(notice?.message).toContain("1 thread");
+  });
+
+  it("warns when some of the missing threads could not be archived", () => {
+    const notice = buildCodexMissingThreadsNotice({
+      onArchive: vi.fn(),
+      onKeep: vi.fn(),
+      signal: {
+        archivedCount: 1,
+        failedCount: 2,
+        missingCount: 3,
+        profileName: "default",
+        status: "archived",
+        threadIds: ["thread-1", "thread-2", "thread-3"],
+        totalCount: 20,
+      },
+    });
+
+    expect(notice?.tone).toBe("warning");
+    expect(notice?.detail).toContain("2 threads could not be archived");
+  });
+
+  it("produces nothing when there is no thread to report", () => {
+    expect(
+      buildCodexMissingThreadsNotice({
+        onArchive: vi.fn(),
+        onKeep: vi.fn(),
+        signal: {
+          missingCount: 0,
+          profileName: "default",
+          status: "confirmationRequired",
+          threadIds: [],
+          totalCount: 10,
+        },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("formatMissingThreadShare", () => {
+  it("rounds to whole percents", () => {
+    expect(formatMissingThreadShare({ missingCount: 1, totalCount: 3 }))
+      .toBe("33%");
+  });
+
+  it("never rounds a partial loss up to the whole profile", () => {
+    expect(formatMissingThreadShare({ missingCount: 999, totalCount: 1_000 }))
+      .toBe("99%");
+    expect(formatMissingThreadShare({ missingCount: 10, totalCount: 10 }))
+      .toBe("100%");
+  });
+
+  it("never reports a real loss as 0%", () => {
+    expect(formatMissingThreadShare({ missingCount: 1, totalCount: 1_000 }))
+      .toBe("1%");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
@@ -1,0 +1,95 @@
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export type CodexMissingThreadsSignal = {
+  status: "archived" | "confirmationRequired";
+  threadIds: string[];
+  missingCount: number;
+  totalCount: number;
+  profileName: string;
+  archivedCount?: number;
+  failedCount?: number;
+};
+
+export function formatMissingThreadShare(params: {
+  missingCount: number;
+  totalCount: number;
+}): string {
+  if (params.totalCount <= 0) return "100%";
+  const share = (params.missingCount / params.totalCount) * 100;
+  // A near-miss reads better rounded than truncated, but 99.6% must not
+  // become "100% of threads" while some threads are still fine.
+  const rounded = share >= 99.5 && params.missingCount < params.totalCount
+    ? 99
+    : Math.round(share);
+  return `${Math.max(rounded, 1)}%`;
+}
+
+function pluralizeThreads(count: number): string {
+  return count === 1 ? "1 thread" : `${count} threads`;
+}
+
+/**
+ * Builds the notice for a `codex/missingThreads/updated` signal.
+ *
+ * `confirmationRequired` is the interesting case: a large missing share is
+ * more likely a Codex profile mismatch than genuinely deleted sessions, and
+ * archiving on that guess would empty a working profile's sidebar. The notice
+ * stays durable until the operator answers, and both answers are reversible —
+ * archived threads restore, and keeping them only defers the decision.
+ */
+export function buildCodexMissingThreadsNotice(params: {
+  onArchive: () => void;
+  onKeep: () => void;
+  signal: CodexMissingThreadsSignal;
+}): AppNoticeToastNotice | undefined {
+  const { signal } = params;
+  if (signal.threadIds.length === 0) return undefined;
+
+  if (signal.status === "archived") {
+    const archivedCount = signal.archivedCount ?? 0;
+    const failedCount = signal.failedCount ?? 0;
+    if (archivedCount === 0 && failedCount === 0) return undefined;
+
+    return {
+      detail: failedCount > 0
+        ? `${pluralizeThreads(failedCount)} could not be archived and stayed in the sidebar.`
+        : "Restore them from the Archived lens if this was not what you wanted.",
+      id: "codex-missing-threads:archived",
+      message: archivedCount > 0
+        ? `Codex no longer has ${pluralizeThreads(archivedCount)} from this PwrAgent profile, so PwrAgent archived them.`
+        : `Codex no longer has ${pluralizeThreads(signal.missingCount)} from this PwrAgent profile, and archiving them failed.`,
+      title: archivedCount > 0
+        ? "Archived missing threads"
+        : "Missing threads not archived",
+      tone: failedCount > 0 ? "warning" : "neutral",
+      transientSlot: "codex-missing-threads",
+    };
+  }
+
+  const share = formatMissingThreadShare({
+    missingCount: signal.missingCount,
+    totalCount: signal.totalCount,
+  });
+
+  return {
+    actions: [
+      {
+        label: "Leave Everything Alone",
+        onClick: params.onKeep,
+        tone: "secondary",
+      },
+      {
+        label: "Archive the Missing Threads",
+        onClick: params.onArchive,
+        tone: "primary",
+      },
+    ],
+    autoDismiss: false,
+    detail:
+      "Archiving removes them from this PwrAgent profile and can be undone from the Archived lens. Leaving them alone changes nothing and stops this prompt until the next launch.",
+    id: "codex-missing-threads:confirmation",
+    message: `${share} of the threads in PwrAgent profile "${signal.profileName}" (${signal.missingCount} of ${signal.totalCount}) are reported missing by Codex. That is expected if those Codex sessions were deleted, but it also happens when a PwrAgent profile is connected to the wrong Codex profile.`,
+    title: "Threads missing from Codex",
+    tone: "warning",
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -287,6 +287,8 @@ import type {
   SetCodexThreadEnvironmentResponse,
   RestoreWorktreeRequest,
   RestoreWorktreeResponse,
+  ResolveMissingCodexThreadsRequest,
+  ResolveMissingCodexThreadsResponse,
   RestoreThreadRequest,
   RestoreThreadResponse,
   RunAutomationNowResponse,
@@ -635,6 +637,9 @@ export type DesktopApi = {
   archiveThread?: (
     request: ArchiveThreadRequest
   ) => Promise<ArchiveThreadResponse>;
+  resolveMissingCodexThreads?: (
+    request: ResolveMissingCodexThreadsRequest
+  ) => Promise<ResolveMissingCodexThreadsResponse>;
   restoreThread?: (
     request: RestoreThreadRequest
   ) => Promise<RestoreThreadResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -62,6 +62,8 @@ export const GITHUB_PR_SAML_ENFORCEMENT_EVENT_CHANNEL =
 export const GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL =
   "app-server:github-pr-authentication-failure";
 export const APP_SERVER_ARCHIVE_THREAD_CHANNEL = "app-server:archive-thread";
+export const APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL =
+  "app-server:resolve-missing-codex-threads";
 export const APP_SERVER_RESTORE_THREAD_CHANNEL = "app-server:restore-thread";
 export const APP_SERVER_ARCHIVE_WORKTREE_CHANNEL = "app-server:archive-worktree";
 export const APP_SERVER_RESTORE_WORKTREE_CHANNEL = "app-server:restore-worktree";

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -746,6 +746,23 @@ export type ArchiveThreadResponse = {
   cleanup: ArchiveThreadCleanupResult[];
 };
 
+/**
+ * Answers a `codex/missingThreads/updated` confirmation prompt. `archive`
+ * tombstones the threads Codex lost; `keep` leaves them in place and stops
+ * PwrAgent from re-asking for the rest of the session, which is the right
+ * answer when this PwrAgent profile is pointed at the wrong Codex profile.
+ */
+export type ResolveMissingCodexThreadsRequest = {
+  action: "archive" | "keep";
+  threadIds: ThreadIdentifier[];
+};
+
+export type ResolveMissingCodexThreadsResponse = {
+  action: "archive" | "keep";
+  archivedThreadIds: ThreadIdentifier[];
+  failedThreadIds: ThreadIdentifier[];
+};
+
 export type RestoreThreadRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
@@ -1258,6 +1275,25 @@ export type AppServerNotification =
         recoveryError?: string;
         removedMessageIdCount?: number;
         backupPath?: string;
+      };
+    }
+  | {
+      /**
+       * Codex reported `thread not found` for threads that its `thread/list`
+       * still returns. `archived` reports the cleanup PwrAgent already
+       * performed; `confirmationRequired` means the missing share was large
+       * enough to look like a Codex profile mismatch, so the operator decides.
+       */
+      method: "codex/missingThreads/updated";
+      params: {
+        status: "archived" | "confirmationRequired";
+        threadIds: string[];
+        missingCount: number;
+        totalCount: number;
+        /** Active PwrAgent profile, so the prompt can name what is affected. */
+        profileName: string;
+        archivedCount?: number;
+        failedCount?: number;
       };
     }
   | {


### PR DESCRIPTION
## Summary

- Codex's `thread/list` is served from its session index rather than from the rollout, so it keeps returning threads it can no longer open. Every thread-scoped operation on one fails with `thread not found: <id>`, and the pending workspace CWD synchronization had no terminal state — each `thread/list` re-armed the write and logged the failure again, forever.
- `isCodexMissingThreadError` recognizes that message, and the same string joins `isCodexMissingRolloutArchiveError` so `archiveThread` falls through to the local tombstone that already exists for missing rollouts (`ThreadOverlayState.archiveTombstonedAt`) instead of throwing.
- A missing thread is recorded and skipped by `schedulePendingCodexWorkspaceCwdSyncs`, turning one warning per list per thread into one per thread per session. A successful workspace write clears the record, so reconnecting the right Codex profile self-heals.
- Failures coalesce over a 2s debounce, then divide by the visible thread count from the last unfiltered, unpaginated `thread/list`. **At or below 20%** the threads are archived through the normal `archiveThread` path (worktree, messaging, and child cleanup all run) with a transient toast. **Above 20%** the operator gets a durable prompt naming the profile and the share, with **Leave Everything Alone** and **Archive the Missing Threads** — a large share is more likely a PwrAgent profile pointed at the wrong Codex authentication profile than genuinely deleted sessions, and archiving on that guess would empty a working profile's sidebar.
- One registry method backs both buttons and claims thread IDs synchronously, so a second window answering the same prompt is a no-op rather than a second pass of worktree cleanup.

The originating log:

```
(pwragent:backend-registry) › pending Codex workspace CWD synchronization failed; will retry error="json-rpc error (-32600): thread not found: 019e6a86-…" threadId=019e6a86-… workspaceCwd=/Users/…/worktrees/mpv8akmv/GifGrabber
```

…repeating three times in half a second, for each of two threads.

## Verification

- `pnpm test` — 597 files, 8587 passed, 5 skipped.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors; 43 pre-existing warnings), `pnpm lint:boundaries` (no violations), `pnpm lint:codex-storage` — all clean.
- New coverage: four registry tests (auto-archive below threshold, prompt above it, "keep" suppressing further retries, duplicate answers archiving once) and seven notice-builder tests.
- Not exercised in a running app — the audit is driven by fixture-injected `thread not found` rejections rather than a live Codex profile.

## Notes

Two design points worth review attention:

- **"Known missing" is deliberately a separate set from "awaiting a decision."** Archiving calls `listThreads` internally, which re-scheduled the workspace sync for the thread being archived and re-recorded it as missing; a single set looped. Known-missing suppresses retries and is cleared only by a successful write; the unresolved subset is consumed by the operator's answer.
- **`codex/missingThreads/updated` is intentionally absent from `NAVIGATION_EVENT_METHODS`.** A peer cannot act on a local Codex profile mismatch, and the prompt's buttons would archive the wrong instance's threads. `broadcastAgentEvent` already skips federation windows for non-remote events, so only local windows see it.

**Scope limit:** the audit is fed by exactly one signal — the workspace-CWD synchronization. A thread Codex lost that has no pending handoff directory never triggers a thread-scoped write, so it is never detected and just sits in the sidebar. Widening the feed (a `readThread` failure on open is the obvious next one) is a small change on the same predicate but raises the false-positive surface, so it is left for a separate decision.

Per the session's product decision, "Leave Everything Alone" holds for the session only — no schema change — so a restart re-asks if the threads are still missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
