### PR TITLE
fix(desktop): stop the star map jumping when a cloud is unfolded

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -544,9 +544,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const operatorMovedViewRef = useRef(false);
   /**
-   * The view an in-flight canvas pan is measuring its pointer travel from,
-   * or undefined when no drag is running. Anything that moves the view
-   * under the drag has to move this with it (see `canvasOriginRef`).
+   * The view the most recent in-flight canvas pan is measuring its pointer
+   * travel from, or undefined when no drag is running. Anything that moves
+   * the view under the drag has to move this with it (see `viewAnchorRef`)
+   * — in place, since the drag itself holds the same object.
    */
   const panBaseRef = useRef<StarMapView | undefined>(undefined);
 
@@ -801,23 +802,38 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // Read from the live ref, not React state: a keyboard flight may have
     // moved the view since the last commit.
     //
-    // Held in a ref rather than this closure, and applied to the pointer's
-    // travel rather than baked into an absolute position, because the base
-    // can move under a drag: a relayout that shifts the canvas origin steps
-    // the view to hold the map still (see `canvasOriginRef`), and a base
-    // captured by value would recompute over the top of that on the next
-    // frame and put the jump back.
-    panBaseRef.current = { ...viewRef.current };
+    // The base is applied to the pointer's travel rather than baked into
+    // an absolute position, and the ref points at it, because the base can
+    // move under a drag: a relayout that shifts the map's anchor steps the
+    // view to hold the map still (see `viewAnchorRef`) and steps this with
+    // it, where a base captured by value would recompute over the top of
+    // that on the next frame and put the jump back.
+    //
+    // This drag reads its own object rather than the ref, so a second
+    // pointer starting its own pan — two fingers on a touchscreen — leaves
+    // this one measuring from where IT was pressed instead of inheriting
+    // the newer drag's base and re-adding its own travel to it.
+    const base = { ...viewRef.current };
+    panBaseRef.current = base;
     /** Pointer travel since the press. Applied to the live base. */
     let travelX = 0;
     let travelY = 0;
     let frame = 0;
-    const bounds = { canvas: panZoomCanvas, viewport: viewportSize };
+    /**
+     * Read at use, not captured: a cloud arriving mid-drag resizes the
+     * canvas, and clamping against the size the map had at pointerdown
+     * would pull the view in against bounds that no longer exist.
+     */
+    const bounds = () => ({
+      canvas: canvasBoundsRef.current,
+      viewport: viewportSizeRef.current,
+    });
     /** Where the drag wants the view, unclamped. Both writers clamp it. */
-    const dragged = (): StarMapView => {
-      const base = panBaseRef.current ?? viewRef.current;
-      return { scale: base.scale, x: base.x + travelX, y: base.y + travelY };
-    };
+    const dragged = (): StarMapView => ({
+      scale: base.scale,
+      x: base.x + travelX,
+      y: base.y + travelY,
+    });
     const move = (pointerEvent: globalThis.PointerEvent) => {
       travelX = pointerEvent.clientX - startX;
       travelY = pointerEvent.clientY - startY;
@@ -834,7 +850,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           // transform straight onto the canvas, so an unclamped live path
           // would let the map leave the window and then jump back on
           // pointerup when the clamped state landed.
-          paintView(clampStarMapView({ view: dragged(), ...bounds }));
+          paintView(clampStarMapView({ view: dragged(), ...bounds() }));
         });
       }
     };
@@ -855,13 +871,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // before any frame ran still commits where the pointer actually
       // ended up.
       const landed = dragged();
-      panBaseRef.current = undefined;
+      // Only if this drag is still the current one: a second pointer may
+      // have taken the ref, and its pan is not this one's to end.
+      if (panBaseRef.current === base) panBaseRef.current = undefined;
       commitView(
         clampStarMapView({
           // Scale from the live view, not the base: a pinch mid-drag is
           // the one part of the gesture the base does not own.
           view: { ...viewRef.current, x: landed.x, y: landed.y },
-          ...bounds,
+          ...bounds(),
         }),
       );
     };
@@ -1807,62 +1825,57 @@ export function StarMapScreen(props: StarMapScreenProps) {
   ]);
 
   /**
-   * Where the map's origin sits on the canvas right now, per lens. Lanes
-   * grows down and to the right from a fixed corner, so it has none.
-   */
-  const canvasOrigin = orbitMode
-    ? orbit.origin
-    : projectsMode
-      ? projectLayout.core
-      : undefined;
-
-  /**
    * Hold the operator's view against the map rather than against the
    * canvas.
    *
    * Orbit and projects normalise their canvas so the leftmost, topmost
-   * thing drawn clears the padding. That makes the origin — and every body
-   * measured from it — move whenever a cloud's extent changes on those
-   * edges, while the view transform stays exactly where it was. Expanding
-   * a cloud with its "+N more" chip slid the whole map several hundred
-   * pixels sideways, and collapsing it slid the map back: the operator
-   * asked one cloud for more cards and the map jumped out from under them.
+   * thing drawn clears the padding. That makes the anchor — and every body
+   * measured alongside it — move whenever a cloud's extent changes on
+   * those edges, while the view transform stays exactly where it was.
+   * Expanding a cloud with its "+N more" chip slid the whole map several
+   * hundred pixels sideways, and collapsing it slid the map back: the
+   * operator asked one cloud for more cards and the map jumped out from
+   * under them.
    *
-   * So when the origin moves, the view moves with it by the same amount in
+   * So when the anchor moves, the view moves with it by the same amount in
    * viewport pixels, and the world point under any given pixel is the one
-   * that was there before. Only while the view is the operator's: before
-   * that the centring effect above owns it and places it against the new
-   * canvas itself. Layout effect, so the compensation lands in the same
-   * paint as the layout that needed it.
+   * that was there before. The same `viewAnchor` the placement above holds
+   * an unplaced map on, deliberately: the two paths differ in who owns the
+   * view, not in which body the map is held by. Only while the view is the
+   * operator's — before that the placement owns it. Layout effect, like
+   * that placement, so the step lands in the same paint as the layout that
+   * needed it.
+   *
+   * Lanes is exempt: its canvas grows down and to the right from a fixed
+   * corner, so nothing it lays out moves what is already drawn.
    */
-  const canvasOriginRef = useRef<
+  const heldAnchor = orbitMode || projectsMode ? viewAnchor : undefined;
+  const viewAnchorRef = useRef<
     { layout: string; x: number; y: number } | undefined
   >(undefined);
   useLayoutEffect(() => {
-    const previous = canvasOriginRef.current;
-    canvasOriginRef.current = canvasOrigin
-      ? { layout: preferences.layout, ...canvasOrigin }
+    const previous = viewAnchorRef.current;
+    viewAnchorRef.current = heldAnchor
+      ? { layout: preferences.layout, ...heldAnchor }
       : undefined;
-    if (!canvasOrigin || !previous) return;
+    if (!heldAnchor || !previous) return;
     // A lens switch is a different map on a different canvas, not this
-    // one moving; the ownership reset and the centring effect place it.
+    // one moving; the ownership reset and the placement above place it.
     if (previous.layout !== preferences.layout) return;
     if (!operatorMovedViewRef.current) return;
-    const dx = canvasOrigin.x - previous.x;
-    const dy = canvasOrigin.y - previous.y;
+    const dx = heldAnchor.x - previous.x;
+    const dy = heldAnchor.y - previous.y;
     if (dx === 0 && dy === 0) return;
     const current = viewRef.current;
     const step = { x: dx * current.scale, y: dy * current.scale };
     // A drag in flight measures its travel from a base of its own, and
-    // repaints from it on the very next frame. Step that base too, or the
-    // frame would compute over the top of this and put the jump back.
+    // repaints from it on the very next frame. Step that base too — in
+    // place, because the drag holds this object — or the frame would
+    // compute over the top of this and put the jump back.
     const panBase = panBaseRef.current;
     if (panBase) {
-      panBaseRef.current = {
-        ...panBase,
-        x: panBase.x - step.x,
-        y: panBase.y - step.y,
-      };
+      panBase.x -= step.x;
+      panBase.y -= step.y;
     }
     commitView(
       clampStarMapView({
@@ -1872,8 +1885,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }),
     );
   }, [
-    canvasOrigin,
     commitView,
+    heldAnchor,
     panZoomCanvas.height,
     panZoomCanvas.width,
     preferences.layout,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -543,6 +543,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * nothing that merely changes the map's contents may move it.
    */
   const operatorMovedViewRef = useRef(false);
+  /**
+   * The view an in-flight canvas pan is measuring its pointer travel from,
+   * or undefined when no drag is running. Anything that moves the view
+   * under the drag has to move this with it (see `canvasOriginRef`).
+   */
+  const panBaseRef = useRef<StarMapView | undefined>(undefined);
 
   /**
    * Move the view without telling React. For gesture frames: writes the
@@ -794,15 +800,33 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // scale from state; the drag has always worked this way.
     // Read from the live ref, not React state: a keyboard flight may have
     // moved the view since the last commit.
-    const base = viewRef.current;
-    /** Latest raw pointer position, unclamped. Both writers clamp it. */
-    let pointerX = base.x;
-    let pointerY = base.y;
+    //
+    // Held in a ref rather than this closure, and applied to the pointer's
+    // travel rather than baked into an absolute position, because the base
+    // can move under a drag: a relayout that shifts the canvas origin steps
+    // the view to hold the map still (see `canvasOriginRef`), and a base
+    // captured by value would recompute over the top of that on the next
+    // frame and put the jump back.
+    panBaseRef.current = { ...viewRef.current };
+    /** Pointer travel since the press. Applied to the live base. */
+    let travelX = 0;
+    let travelY = 0;
     let frame = 0;
     const bounds = { canvas: panZoomCanvas, viewport: viewportSize };
+    /** Where the drag wants the view, unclamped. Both writers clamp it. */
+    const dragged = (): StarMapView => {
+      const base = panBaseRef.current ?? viewRef.current;
+      return { scale: base.scale, x: base.x + travelX, y: base.y + travelY };
+    };
     const move = (pointerEvent: globalThis.PointerEvent) => {
-      pointerX = base.x + pointerEvent.clientX - startX;
-      pointerY = base.y + pointerEvent.clientY - startY;
+      travelX = pointerEvent.clientX - startX;
+      travelY = pointerEvent.clientY - startY;
+      // Ownership from the first travel, not from the release: a cloud can
+      // arrive while the drag is still running, and until the view is the
+      // operator's the auto-centre answers that by re-placing the view they
+      // are in the middle of setting. `stop` sets it too, for the flick
+      // that commits before any frame has run.
+      operatorMovedViewRef.current = true;
       if (!frame) {
         frame = requestAnimationFrame(() => {
           frame = 0;
@@ -810,12 +834,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           // transform straight onto the canvas, so an unclamped live path
           // would let the map leave the window and then jump back on
           // pointerup when the clamped state landed.
-          paintView(
-            clampStarMapView({
-              view: { x: pointerX, y: pointerY, scale: base.scale },
-              ...bounds,
-            }),
-          );
+          paintView(clampStarMapView({ view: dragged(), ...bounds }));
         });
       }
     };
@@ -835,9 +854,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // has to be in bounds on its own account — and a flick released
       // before any frame ran still commits where the pointer actually
       // ended up.
+      const landed = dragged();
+      panBaseRef.current = undefined;
       commitView(
         clampStarMapView({
-          view: { ...viewRef.current, x: pointerX, y: pointerY },
+          // Scale from the live view, not the base: a pinch mid-drag is
+          // the one part of the gesture the base does not own.
+          view: { ...viewRef.current, x: landed.x, y: landed.y },
           ...bounds,
         }),
       );
@@ -1814,11 +1837,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const canvasOriginRef = useRef<
     { layout: string; x: number; y: number } | undefined
-  >(
-    canvasOrigin
-      ? { layout: preferences.layout, ...canvasOrigin }
-      : undefined,
-  );
+  >(undefined);
   useLayoutEffect(() => {
     const previous = canvasOriginRef.current;
     canvasOriginRef.current = canvasOrigin
@@ -1833,13 +1852,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
     const dy = canvasOrigin.y - previous.y;
     if (dx === 0 && dy === 0) return;
     const current = viewRef.current;
+    const step = { x: dx * current.scale, y: dy * current.scale };
+    // A drag in flight measures its travel from a base of its own, and
+    // repaints from it on the very next frame. Step that base too, or the
+    // frame would compute over the top of this and put the jump back.
+    const panBase = panBaseRef.current;
+    if (panBase) {
+      panBaseRef.current = {
+        ...panBase,
+        x: panBase.x - step.x,
+        y: panBase.y - step.y,
+      };
+    }
     commitView(
       clampStarMapView({
-        view: {
-          ...current,
-          x: current.x - dx * current.scale,
-          y: current.y - dy * current.scale,
-        },
+        view: { ...current, x: current.x - step.x, y: current.y - step.y },
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
       }),

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -55,7 +55,7 @@ import {
   buildInstanceClusters,
   computeClusterCloud,
   emptyCloudMemory,
-  forgetCluster,
+  refitCluster,
   resolveCloudDrop,
   type StarMapClusterPlacement,
   type StarMapCloudMemory,
@@ -1208,11 +1208,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   const toggleClusterExpanded = useCallback(
     (instanceId: string, clusterKey: string) => {
-      // Unfolding or folding a cloud is a request to re-fit THAT cloud, so
-      // it forgets its seats and centre. Everything else keeps its layout.
+      // Unfolding or folding a cloud is a request to re-fit THAT cloud's
+      // rings, so it can grow outward and shrink back. Its centre and its
+      // seats stay: the cards already on screen are not what changed.
       cloudMemory.current.set(
         instanceId,
-        forgetCluster(
+        refitCluster(
           cloudMemory.current.get(instanceId) ?? emptyCloudMemory(),
           clusterKey,
         ),
@@ -1780,6 +1781,77 @@ export function StarMapScreen(props: StarMapScreenProps) {
     viewAnchor,
     viewportSize.width,
     viewportSize.height,
+  ]);
+
+  /**
+   * Where the map's origin sits on the canvas right now, per lens. Lanes
+   * grows down and to the right from a fixed corner, so it has none.
+   */
+  const canvasOrigin = orbitMode
+    ? orbit.origin
+    : projectsMode
+      ? projectLayout.core
+      : undefined;
+
+  /**
+   * Hold the operator's view against the map rather than against the
+   * canvas.
+   *
+   * Orbit and projects normalise their canvas so the leftmost, topmost
+   * thing drawn clears the padding. That makes the origin — and every body
+   * measured from it — move whenever a cloud's extent changes on those
+   * edges, while the view transform stays exactly where it was. Expanding
+   * a cloud with its "+N more" chip slid the whole map several hundred
+   * pixels sideways, and collapsing it slid the map back: the operator
+   * asked one cloud for more cards and the map jumped out from under them.
+   *
+   * So when the origin moves, the view moves with it by the same amount in
+   * viewport pixels, and the world point under any given pixel is the one
+   * that was there before. Only while the view is the operator's: before
+   * that the centring effect above owns it and places it against the new
+   * canvas itself. Layout effect, so the compensation lands in the same
+   * paint as the layout that needed it.
+   */
+  const canvasOriginRef = useRef<
+    { layout: string; x: number; y: number } | undefined
+  >(
+    canvasOrigin
+      ? { layout: preferences.layout, ...canvasOrigin }
+      : undefined,
+  );
+  useLayoutEffect(() => {
+    const previous = canvasOriginRef.current;
+    canvasOriginRef.current = canvasOrigin
+      ? { layout: preferences.layout, ...canvasOrigin }
+      : undefined;
+    if (!canvasOrigin || !previous) return;
+    // A lens switch is a different map on a different canvas, not this
+    // one moving; the ownership reset and the centring effect place it.
+    if (previous.layout !== preferences.layout) return;
+    if (!operatorMovedViewRef.current) return;
+    const dx = canvasOrigin.x - previous.x;
+    const dy = canvasOrigin.y - previous.y;
+    if (dx === 0 && dy === 0) return;
+    const current = viewRef.current;
+    commitView(
+      clampStarMapView({
+        view: {
+          ...current,
+          x: current.x - dx * current.scale,
+          y: current.y - dy * current.scale,
+        },
+        canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+        viewport: { width: viewportSize.width, height: viewportSize.height },
+      }),
+    );
+  }, [
+    canvasOrigin,
+    commitView,
+    panZoomCanvas.height,
+    panZoomCanvas.width,
+    preferences.layout,
+    viewportSize.height,
+    viewportSize.width,
   ]);
 
   /**
@@ -3069,11 +3141,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
       );
       arrangement.setCardPosition(params.instanceId, threadKey, null);
       // The target cloud is about to gain or lose a card, so it re-fits
-      // rather than trying to seat the newcomer in a shape built without
-      // it. Every other cloud keeps its layout.
+      // its rings around the newcomer rather than wearing the radius the
+      // old membership needed. Every other cloud keeps its layout.
       cloudMemory.current.set(
         params.instanceId,
-        forgetCluster(
+        refitCluster(
           cloudMemory.current.get(params.instanceId) ?? emptyCloudMemory(),
           drop.clusterKey,
         ),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
@@ -3,7 +3,7 @@ import type { NavigationThreadSummary } from "@pwragent/shared";
 import {
   buildInstanceClusters,
   computeClusterCloud,
-  forgetCluster,
+  refitCluster,
   orderParentAdjacent,
   resolveCloudDrop,
   ORBIT_MAX_CARDS_PER_GROUP,
@@ -588,7 +588,7 @@ describe("layout stability", () => {
     const alphaKey = "directory:/repo/alpha";
     const after = layout(
       threads,
-      forgetCluster(before.memory, alphaKey),
+      refitCluster(before.memory, alphaKey),
       [alphaKey],
     );
     const beta = after.clusters.find((cluster) => cluster.key !== alphaKey)!;
@@ -598,6 +598,162 @@ describe("layout stability", () => {
     expect(beta.center).toEqual(previousBeta.center);
     const alpha = after.clusters.find((cluster) => cluster.key === alphaKey)!;
     expect(alpha.slots).toHaveLength(14);
+  });
+
+  /**
+   * Expanding a cloud used to drop its centre and its seats, which made it
+   * an arrival again — seated from the base radius outward along its own
+   * bearing, which is rarely where it was. The operator asked for two more
+   * cards and the cloud they were reading vanished across the map.
+   */
+  it("expands a cloud where it stands when it has the room", () => {
+    // One past the cap: the extra card takes a free seat in the rings the
+    // cloud already has, so there is nothing to re-fit.
+    const threads = [
+      ...project("alpha", ORBIT_MAX_CARDS_PER_GROUP + 1),
+      ...project("beta", 4),
+    ];
+    const alphaKey = "directory:/repo/alpha";
+    const before = layout(threads);
+    const after = layout(threads, refitCluster(before.memory, alphaKey), [
+      alphaKey,
+    ]);
+
+    const previousAlpha = before.clusters.find(
+      (cluster) => cluster.key === alphaKey,
+    )!;
+    const alpha = after.clusters.find((cluster) => cluster.key === alphaKey)!;
+    expect(alpha.center).toEqual(previousAlpha.center);
+    // Every card that was on screen is exactly where it was; the one the
+    // operator asked for is the only new geometry.
+    const was = slotByThread(before);
+    const now = slotByThread(after);
+    for (const [id, slot] of was) {
+      expect(now.get(id)).toEqual(slot);
+    }
+    expect(now.size).toBe(was.size + 1);
+  });
+
+  it("moves a cloud that outgrows its spot no further than it has to", () => {
+    const threads = [...project("alpha", 14), ...project("beta", 4)];
+    const alphaKey = "directory:/repo/alpha";
+    const before = layout(threads);
+    const after = layout(threads, refitCluster(before.memory, alphaKey), [
+      alphaKey,
+    ]);
+    const previousAlpha = before.clusters.find(
+      (cluster) => cluster.key === alphaKey,
+    )!;
+    const alpha = after.clusters.find((cluster) => cluster.key === alphaKey)!;
+
+    // Fourteen cards need a ring the eight did not, and that ring would
+    // swallow the instance's own chrome, so this cloud does have to move.
+    expect(alpha.extent.rx).toBeGreaterThan(previousAlpha.extent.rx);
+    // It moves no further than it grew, so the old and new footprints
+    // overlap — the difference between "made room" and "teleported".
+    const moved = Math.hypot(
+      alpha.center.x - previousAlpha.center.x,
+      alpha.center.y - previousAlpha.center.y,
+    );
+    expect(moved).toBeGreaterThan(0);
+    expect(moved).toBeLessThanOrEqual(
+      Math.hypot(
+        alpha.extent.rx - previousAlpha.extent.rx,
+        alpha.extent.ry - previousAlpha.extent.ry,
+      ),
+    );
+    // Away from the body, not through it.
+    expect(Math.hypot(alpha.center.x, alpha.center.y)).toBeGreaterThan(
+      Math.hypot(previousAlpha.center.x, previousAlpha.center.y),
+    );
+    // The cards it already had keep their places within the cloud.
+    const was = slotByThread(before);
+    const now = slotByThread(after);
+    for (const thread of project("alpha", ORBIT_MAX_CARDS_PER_GROUP)) {
+      const slot = was.get(thread.id)!;
+      const taken = now.get(thread.id)!;
+      expect(taken.dx - alpha.center.x).toBeCloseTo(
+        slot.dx - previousAlpha.center.x,
+        9,
+      );
+      expect(taken.dy - alpha.center.y).toBeCloseTo(
+        slot.dy - previousAlpha.center.y,
+        9,
+      );
+    }
+  });
+
+  /**
+   * The map the operator actually has: several clouds around one body,
+   * with the one they unfold hemmed in by a neighbour. It cannot grow
+   * where it stands — something has to give — and what gives is this
+   * cloud's position and nothing else. Its cloudmates hold, and it carries
+   * its own cards with it rather than reshuffling them, so what the
+   * operator follows is one cloud moving, not a new map.
+   */
+  it("moves only the unfolded cloud on a crowded map", () => {
+    const threads = [
+      ...project("alpha", 10),
+      ...project("beta", 4),
+      ...project("gamma", 5),
+      ...project("delta", 3),
+    ];
+    const alphaKey = "directory:/repo/alpha";
+    const before = layout(threads);
+    const after = layout(threads, refitCluster(before.memory, alphaKey), [
+      alphaKey,
+    ]);
+
+    const at = (cloud: ReturnType<typeof computeClusterCloud>) =>
+      cloud.clusters.find((cluster) => cluster.key === alphaKey)!.center;
+    const from = at(before);
+    const moved = at(after);
+
+    for (const cluster of before.clusters) {
+      if (cluster.key === alphaKey) continue;
+      expect(
+        after.clusters.find((entry) => entry.key === cluster.key)!.center,
+      ).toEqual(cluster.center);
+    }
+    const was = slotByThread(before);
+    const now = slotByThread(after);
+    for (const thread of project("alpha", ORBIT_MAX_CARDS_PER_GROUP)) {
+      const slot = was.get(thread.id)!;
+      const taken = now.get(thread.id)!;
+      expect(taken.dx - moved.x).toBeCloseTo(slot.dx - from.x, 9);
+      expect(taken.dy - moved.y).toBeCloseTo(slot.dy - from.y, 9);
+    }
+  });
+
+  it("collapses a cloud back to the size it started at, in place", () => {
+    const threads = [...project("alpha", 14), ...project("beta", 4)];
+    const alphaKey = "directory:/repo/alpha";
+    const before = layout(threads);
+    const expanded = layout(threads, refitCluster(before.memory, alphaKey), [
+      alphaKey,
+    ]);
+    const collapsed = layout(threads, refitCluster(expanded.memory, alphaKey));
+
+    const previousAlpha = before.clusters.find(
+      (cluster) => cluster.key === alphaKey,
+    )!;
+    const expandedAlpha = expanded.clusters.find(
+      (cluster) => cluster.key === alphaKey,
+    )!;
+    const alpha = collapsed.clusters.find(
+      (cluster) => cluster.key === alphaKey,
+    )!;
+
+    // Rings are grow-only, so without dropping that one entry the cloud
+    // would keep the radius the expanded cards needed.
+    expect(alpha.extent).toEqual(previousAlpha.extent);
+    // Folding is not a reason to move: the cloud stays where the operator
+    // last saw it, holding the cards that stay visible.
+    expect(alpha.center).toEqual(expandedAlpha.center);
+    const was = slotByThread(expanded);
+    for (const [id, slot] of slotByThread(collapsed)) {
+      expect(was.get(id)).toEqual(slot);
+    }
   });
 
   it("lays out the same way twice from a cold start", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -139,6 +139,61 @@ describe("computeOrbitPlacement", () => {
     }
   });
 
+  /**
+   * The screen holds the operator's view against this point, so it has to
+   * be the truth about where the map's origin ended up. The canvas is
+   * normalised around whatever is drawn, so a cloud growing on the left or
+   * top edge slides every body — a translation the view has to undo, and
+   * cannot undo without being told about it.
+   */
+  it("reports where the origin landed on the canvas", () => {
+    const counts = new Map([
+      ["pwr_local", 6],
+      ["pwr_a", 3],
+      ["pwr_b", 0],
+      ["pwr_c", 8],
+    ]);
+    // pwr_c is the widest child and stays that way below, so nothing here
+    // re-spaces the ring: the only thing that changes is where the drawn
+    // content starts, which is exactly the case the view compensates for.
+    const extents = new Map([
+      ["pwr_local", { rx: 400, ry: 300 }],
+      ["pwr_a", { rx: 200, ry: 180 }],
+      ["pwr_b", { rx: 200, ry: 180 }],
+      ["pwr_c", { rx: 500, ry: 420 }],
+    ]);
+    const placement = computeOrbitPlacement({
+      nodes,
+      cardCounts: counts,
+      cardWidth: 220,
+      extents,
+    });
+    // The hub is the origin, so its canvas position is the origin's.
+    const hub = placement.instances.find((instance) => instance.isHub)!;
+    expect(placement.origin).toEqual({ x: hub.x, y: hub.y });
+
+    const grown = computeOrbitPlacement({
+      nodes,
+      cardCounts: counts,
+      cardWidth: 220,
+      extents: new Map(extents).set("pwr_a", { rx: 420, ry: 380 }),
+    });
+    expect(grown.origin).not.toEqual(placement.origin);
+    // Every body moved by exactly the origin's shift, which is what makes
+    // compensating for it at the view enough to hold the map still.
+    const shift = {
+      x: grown.origin.x - placement.origin.x,
+      y: grown.origin.y - placement.origin.y,
+    };
+    for (const instance of placement.instances) {
+      const moved = grown.instances.find(
+        (candidate) => candidate.instanceId === instance.instanceId,
+      )!;
+      expect(moved.x - instance.x).toBeCloseTo(shift.x, 9);
+      expect(moved.y - instance.y).toBeCloseTo(shift.y, 9);
+    }
+  });
+
   it("spaces bodies so neighbouring card rings cannot touch", () => {
     const counts = new Map([
       ["pwr_local", 6],

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -140,13 +140,13 @@ describe("computeOrbitPlacement", () => {
   });
 
   /**
-   * The screen holds the operator's view against this point, so it has to
-   * be the truth about where the map's origin ended up. The canvas is
-   * normalised around whatever is drawn, so a cloud growing on the left or
-   * top edge slides every body — a translation the view has to undo, and
-   * cannot undo without being told about it.
+   * Why holding the view on a single body is enough to hold the whole map
+   * still: the canvas is normalised around whatever is drawn, so a cloud
+   * growing on the left or top edge slides every body by the same amount.
+   * The screen anchors the view to one of them (`viewAnchor`) and gets the
+   * rest for free.
    */
-  it("reports where the origin landed on the canvas", () => {
+  it("slides every body together when a cloud grows on an edge", () => {
     const counts = new Map([
       ["pwr_local", 6],
       ["pwr_a", 3],
@@ -168,23 +168,17 @@ describe("computeOrbitPlacement", () => {
       cardWidth: 220,
       extents,
     });
-    // The hub is the origin, so its canvas position is the origin's.
-    const hub = placement.instances.find((instance) => instance.isHub)!;
-    expect(placement.origin).toEqual({ x: hub.x, y: hub.y });
-
     const grown = computeOrbitPlacement({
       nodes,
       cardCounts: counts,
       cardWidth: 220,
       extents: new Map(extents).set("pwr_a", { rx: 420, ry: 380 }),
     });
-    expect(grown.origin).not.toEqual(placement.origin);
-    // Every body moved by exactly the origin's shift, which is what makes
-    // compensating for it at the view enough to hold the map still.
-    const shift = {
-      x: grown.origin.x - placement.origin.x,
-      y: grown.origin.y - placement.origin.y,
-    };
+
+    const hub = placement.instances.find((instance) => instance.isHub)!;
+    const movedHub = grown.instances.find((instance) => instance.isHub)!;
+    const shift = { x: movedHub.x - hub.x, y: movedHub.y - hub.y };
+    expect(Math.hypot(shift.x, shift.y)).toBeGreaterThan(0);
     for (const instance of placement.instances) {
       const moved = grown.instances.find(
         (candidate) => candidate.instanceId === instance.instanceId,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -421,6 +421,48 @@ describe("star map view stability", () => {
   });
 
   /**
+   * Two pointers can be on the map at once — two fingers on a touchscreen
+   * — and each press starts its own pan. They already fight over the
+   * transform, which is old news; what they must not do is lose track of
+   * where they were pressed. A single shared base meant the first finger
+   * to lift took the other one's base with it, and the survivor started
+   * measuring its travel from a view that already contained that travel:
+   * the map bolted, faster every frame.
+   */
+  it("keeps a second pan measuring from its own press", async () => {
+    seedLayout("orbit");
+    renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance/ }),
+      ).toBeTruthy();
+    });
+
+    const viewport = document.querySelector(".star-map__viewport")!;
+    fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+    fireEvent.pointerMove(window, { clientX: 400, clientY: 300 });
+    await flushFrame();
+
+    // A second finger lands and drags while the first is still down.
+    fireEvent.pointerDown(viewport, { button: 0, clientX: 600, clientY: 500 });
+    fireEvent.pointerMove(window, { clientX: 560, clientY: 460 });
+    await flushFrame();
+    const held = readTransform();
+
+    // The first finger lifts. The second is still down and has not moved,
+    // so the frame it paints next has to land where it already was.
+    fireEvent.pointerUp(window, { clientX: 400, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 560, clientY: 460 });
+    await flushFrame();
+
+    const after = readTransform();
+    expect(after.x).toBeCloseTo(held.x, 6);
+    expect(after.y).toBeCloseTo(held.y, 6);
+
+    fireEvent.pointerUp(window, { clientX: 560, clientY: 460 });
+  });
+
+  /**
    * A relayout does not wait for the operator to let go of the map. The
    * drag measures its pointer travel from a base of its own and repaints
    * from it on the next frame, so holding the view still has to step that

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -53,6 +53,28 @@ function threads(count: number): NavigationThreadSummary[] {
   return Array.from({ length: count }, (_, index) => thread(`t${index}`));
 }
 
+/** A thread in a directory of its own, so it clouds separately. */
+function threadIn(id: string, project: string): NavigationThreadSummary {
+  return {
+    ...thread(id),
+    id,
+    linkedDirectories: [
+      {
+        id: `${project}-dir`,
+        label: project,
+        path: `/repos/${project}`,
+        kind: "local",
+      },
+    ],
+  } as unknown as NavigationThreadSummary;
+}
+
+function threadsIn(project: string, count: number): NavigationThreadSummary[] {
+  return Array.from({ length: count }, (unused, index) =>
+    threadIn(`${project}-${index}`, project),
+  );
+}
+
 function seedLayout(layout: "lanes" | "orbit" | "projects") {
   window.localStorage.setItem(
     "pwragent.starMap.viewPreferences",
@@ -92,6 +114,47 @@ function parseTransform(raw: string): { x: number; y: number; scale: number } {
 
 function readTransform(): { x: number; y: number; scale: number } {
   return parseTransform(canvas().style.transform);
+}
+
+/**
+ * Where a cloud's label sits in viewport pixels: its own canvas position,
+ * through the canvas transform. Composed from the two independent things
+ * that place it, so a layout that moves the bodies and a view that moves
+ * the canvas both show up here — which is the whole question when the
+ * complaint is "the map jumped".
+ */
+function screenPositionOf(project: string): { x: number; y: number } {
+  const label = screen.getByRole("button", {
+    name: new RegExp(`Select the ${project} cards`),
+  });
+  const cloud = label.closest(".star-map__cloud") as HTMLElement | null;
+  if (!cloud) throw new Error(`no cloud around the ${project} label`);
+  return onScreen(cloud, label);
+}
+
+/** Where a project body sits in viewport pixels, in the projects lens. */
+function projectScreenPosition(project: string): { x: number; y: number } {
+  const body = screen
+    .getByText(project)
+    .closest(".star-map__project-cloud") as HTMLElement | null;
+  if (!body) throw new Error(`no project cloud around ${project}`);
+  return onScreen(body);
+}
+
+function onScreen(...placed: HTMLElement[]): { x: number; y: number } {
+  const view = readTransform();
+  const canvasX = placed.reduce(
+    (total, element) => total + Number.parseFloat(element.style.left),
+    0,
+  );
+  const canvasY = placed.reduce(
+    (total, element) => total + Number.parseFloat(element.style.top),
+    0,
+  );
+  return {
+    x: view.x + canvasX * view.scale,
+    y: view.y + canvasY * view.scale,
+  };
 }
 
 /** The canvas's untransformed size, as the screen sized the element. */
@@ -247,7 +310,7 @@ describe("star map view stability", () => {
     });
 
     pan(-300, -200);
-    const panned = canvas().style.transform;
+    const before = projectScreenPosition("PwrSnap");
 
     rerender(
       <StarMapScreen
@@ -265,7 +328,88 @@ describe("star map view stability", () => {
         screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
       ).toBeNull();
     });
-    expect(canvas().style.transform).toBe(panned);
+    // Against the body rather than the raw transform: this lens re-seats
+    // its projects from scratch and normalises the canvas around them, so
+    // the transform has to change by exactly that shift for the map to
+    // hold still. What the operator is owed is the pixels, not the number.
+    const after = projectScreenPosition("PwrSnap");
+    expect(after.x).toBeCloseTo(before.x, 6);
+    expect(after.y).toBeCloseTo(before.y, 6);
+  });
+
+  /**
+   * Unfolding a cloud it has the room for must move nothing at all. The
+   * fold state used to drop the cloud's remembered centre and seats, which
+   * made it an arrival again — re-seated from the base radius outward
+   * along its own bearing, which is rarely where it was. The operator
+   * asked for one more card and the cloud they were reading vanished.
+   */
+  it("unfolds a cloud that has the room without moving anything", async () => {
+    seedLayout("orbit");
+    renderMap({
+      threads: [...threadsIn("PwrSnap", 9), ...threadsIn("PwrAgent", 3)],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Show 1 more PwrSnap threads/ }),
+      ).toBeTruthy();
+    });
+
+    pan(-320, -180);
+    const unfolded = screenPositionOf("PwrSnap");
+    const untouched = screenPositionOf("PwrAgent");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show 1 more PwrSnap threads/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /^Open thread:/ }),
+      ).toHaveLength(12);
+    });
+
+    expect(screenPositionOf("PwrSnap").x).toBeCloseTo(unfolded.x, 6);
+    expect(screenPositionOf("PwrSnap").y).toBeCloseTo(unfolded.y, 6);
+    expect(screenPositionOf("PwrAgent").x).toBeCloseTo(untouched.x, 6);
+    expect(screenPositionOf("PwrAgent").y).toBeCloseTo(untouched.y, 6);
+  });
+
+  /**
+   * Unfolding a cloud used to move the whole map out from under the
+   * operator, twice over: the cloud itself was re-seated from scratch and
+   * reappeared somewhere else, and the canvas — which is normalised so the
+   * outermost cloud clears the padding — re-based its origin under a view
+   * that had not moved, sliding every other body several hundred pixels
+   * sideways. Clicking "+N more" is a request for two more cards, not for
+   * a new map.
+   */
+  it("keeps the map still when the operator unfolds a cloud", async () => {
+    seedLayout("orbit");
+    renderMap({
+      threads: [...threadsIn("PwrSnap", 14), ...threadsIn("PwrAgent", 3)],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Show \d+ more PwrSnap threads/ }),
+      ).toBeTruthy();
+    });
+
+    pan(-320, -180);
+    const before = screenPositionOf("PwrAgent");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show \d+ more PwrSnap threads/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Show fewer PwrSnap threads/ }),
+      ).toBeTruthy();
+    });
+
+    // The cloud the operator did not touch is still under the same pixels.
+    const after = screenPositionOf("PwrAgent");
+    expect(after.x).toBeCloseTo(before.x, 6);
+    expect(after.y).toBeCloseTo(before.y, 6);
   });
 });
 
@@ -464,13 +608,18 @@ describe("star map view bounds", () => {
     });
   });
 
-  it("lets a shrinking canvas strand the view, recovered by Reset", async () => {
-    // Pins the known gap rather than implying there isn't one. The bounds
-    // are a function of canvas size, and the clamp deliberately does not
-    // re-run on a content change — so a canvas that shrinks out from under
-    // a legally-parked view can leave nothing on screen. Recovery is
-    // manual. If a future change closes this properly, this test should
-    // fail and be rewritten, not deleted.
+  it("keeps a strip on screen when a folding cloud shrinks the canvas", async () => {
+    // This used to strand the view outright, and said so. The bounds are a
+    // function of canvas size and the clamp does not re-run on a content
+    // change, so a canvas that shrank out from under a legally-parked view
+    // left nothing on screen and only Reset brought it back.
+    //
+    // Holding the view against the map closed the common case: a shrink at
+    // the left or top edge moves the canvas origin, the view follows it,
+    // and that move goes through the clamp. What is left of the gap is a
+    // shrink that leaves the origin exactly where it was — the canvas
+    // losing width off its right edge alone — which still does not
+    // re-clamp. Reset still recovers, and is asserted below.
     //
     // The shrink is driven by folding an expanded cloud back up. Archiving
     // no longer shrinks anything: cloud seats, extents and centres are
@@ -509,8 +658,10 @@ describe("star map view bounds", () => {
     expect(narrow.width).toBeLessThan(
       wide.width - VIEWPORT.width * MIN_VISIBLE_FRACTION,
     );
-    const stranded = readTransform();
-    expect(visible(stranded.x, narrow.width, VIEWPORT.width)).toBe(0);
+    const folded = readTransform();
+    expect(
+      visible(folded.x, narrow.width, VIEWPORT.width),
+    ).toBeGreaterThanOrEqual(VIEWPORT.width * MIN_VISIBLE_FRACTION);
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));
     fireEvent.click(screen.getByRole("button", { name: "Reset view" }));

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -57,7 +57,6 @@ function threads(count: number): NavigationThreadSummary[] {
 function threadIn(id: string, project: string): NavigationThreadSummary {
   return {
     ...thread(id),
-    id,
     linkedDirectories: [
       {
         id: `${project}-dir`,
@@ -155,6 +154,15 @@ function onScreen(...placed: HTMLElement[]): { x: number; y: number } {
     x: view.x + canvasX * view.scale,
     y: view.y + canvasY * view.scale,
   };
+}
+
+/** Let a gesture's animation frame run so it writes the live transform. */
+async function flushFrame() {
+  await act(async () => {
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => resolve(undefined));
+    });
+  });
 }
 
 /** The canvas's untransformed size, as the screen sized the element. */
@@ -411,6 +419,61 @@ describe("star map view stability", () => {
     expect(after.x).toBeCloseTo(before.x, 6);
     expect(after.y).toBeCloseTo(before.y, 6);
   });
+
+  /**
+   * A relayout does not wait for the operator to let go of the map. The
+   * drag measures its pointer travel from a base of its own and repaints
+   * from it on the next frame, so holding the view still has to step that
+   * base too — a base captured by value simply painted the jump back.
+   */
+  it("keeps the map still when a cloud arrives mid-drag", async () => {
+    seedLayout("orbit");
+    const held = [...threadsIn("PwrSnap", 6), ...threadsIn("PwrAgent", 3)];
+    const { rerender } = renderMap({ threads: held });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Select the PwrAgent cards/ }),
+      ).toBeTruthy();
+    });
+
+    const viewport = document.querySelector(".star-map__viewport")!;
+    fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+    fireEvent.pointerMove(window, { clientX: 400, clientY: 300 });
+    await flushFrame();
+    const before = screenPositionOf("PwrAgent");
+
+    // A thread lands in a repo the map has never seen: a new cloud is
+    // seated, the instance's extent grows and the canvas origin moves.
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[...held, ...threadsIn("PwrDrvr", 4)]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Select the PwrDrvr cards/ }),
+      ).toBeTruthy();
+    });
+
+    // Same pointer position, so anything that moved was the map, not the
+    // drag. The frame after the relayout is the one that used to undo the
+    // compensation.
+    fireEvent.pointerMove(window, { clientX: 400, clientY: 300 });
+    await flushFrame();
+    const during = screenPositionOf("PwrAgent");
+    expect(during.x).toBeCloseTo(before.x, 6);
+    expect(during.y).toBeCloseTo(before.y, 6);
+
+    fireEvent.pointerUp(window, { clientX: 400, clientY: 300 });
+    const landed = screenPositionOf("PwrAgent");
+    expect(landed.x).toBeCloseTo(before.x, 6);
+    expect(landed.y).toBeCloseTo(before.y, 6);
+  });
 });
 
 /**
@@ -438,15 +501,6 @@ describe("star map view bounds", () => {
       ).toBeTruthy();
     });
     return rendered;
-  }
-
-  /** Let the pan's animation frame run so it writes the live transform. */
-  async function flushFrame() {
-    await act(async () => {
-      await new Promise((resolve) => {
-        requestAnimationFrame(() => resolve(undefined));
-      });
-    });
   }
 
   it("keeps a strip of canvas on screen when dragged off the top-left", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
@@ -75,6 +75,8 @@ const SEAT_RADIUS_STEP = 26;
 const SEAT_MAX_PROBES = 240;
 /** Clouds are wide and short-ish, so seating stretches horizontally. */
 const SEAT_ASPECT_X = 1.3;
+/** Directions tried around a cloud that is re-fitting into a new size. */
+const REFIT_BEARINGS = 16;
 
 export type StarMapClusterSpec = {
   /** Stable identity: project key, or `${projectKey}::pc:${parentKey}`. */
@@ -326,8 +328,10 @@ export function buildInstanceClusters(params: {
  * So seats are remembered per thread, ring allocation only grows, and a
  * cloud keeps the centre it was given. A new thread takes the lowest free
  * seat; a new cloud is seated around what is already placed. Nothing that
- * was already on screen moves unless the operator asks for it (expand or
- * collapse drops that cloud's memory, and the map re-fits it).
+ * was already on screen moves unless the operator asks for it — and even
+ * then only what they asked for: expand and collapse drop that cloud's
+ * ring allocation alone (see `refitCluster`), so it grows and shrinks
+ * around the centre and the seats it already has.
  */
 export type StarMapCloudMemory = {
   /** Cloud centre per cluster key, body-relative. */
@@ -342,18 +346,35 @@ export function emptyCloudMemory(): StarMapCloudMemory {
   return { centers: new Map(), seats: new Map(), rings: new Map() };
 }
 
-/** Forget one cloud, so the next layout re-fits it from scratch. */
-export function forgetCluster(
+/**
+ * Let one cloud re-fit its rings, in place.
+ *
+ * Only the ring allocation goes. Rings are grow-only (see
+ * `computeClusterCloud`), so without this a cloud the operator collapses
+ * would keep the radius its expanded cards needed — a ring of empty space
+ * where the cards used to be.
+ *
+ * The centre and the seats stay, on purpose. Dropping them made the cloud
+ * an arrival again, and an arrival is seated from the base radius outward
+ * along its own bearing — so expanding a cloud teleported it across the
+ * map, and collapsing it teleported it somewhere else again, while the
+ * cards that were still on screen shuffled into different seats. Keeping
+ * both means an expand grows the cloud outward around the centre it
+ * already has, a collapse pulls it back in, and every card that stays
+ * visible stays exactly where the operator last saw it. If the grown
+ * cloud lands on a neighbour, `computeClusterCloud` re-seats it then —
+ * the cloud that changed is still the one that moves.
+ */
+export function refitCluster(
   memory: StarMapCloudMemory,
   clusterKey: string,
 ): StarMapCloudMemory {
-  const centers = new Map(memory.centers);
-  const seats = new Map(memory.seats);
+  if (!memory.rings.has(clusterKey)) return memory;
   const rings = new Map(memory.rings);
-  centers.delete(clusterKey);
-  seats.delete(clusterKey);
   rings.delete(clusterKey);
-  return { centers, seats, rings };
+  // Centres and seats carry through by reference: a layout reads its
+  // memory and returns fresh maps, it never writes back into this one.
+  return { centers: memory.centers, seats: memory.seats, rings };
 }
 
 /**
@@ -548,6 +569,57 @@ function seatCluster(params: {
   return center;
 }
 
+/**
+ * Re-seat a cloud that has outgrown the spot it is in, as near to that
+ * spot as it can be put.
+ *
+ * A cloud the operator has been looking at is not a cloud to re-seat like
+ * an arrival: seating one from the base radius outward along its key's
+ * bearing sent an expanded cloud a screen and a half away, which is how
+ * "+2 more" came to mean "and now find your threads again". Nor is walking
+ * outward along that bearing enough on its own — the bearing is often
+ * blocked by the very neighbour the growth ran into, and the cloud sails
+ * past it just as far.
+ *
+ * So the search is around where the cloud already is: rings of increasing
+ * radius, each swept from the outward bearing inwards to either side, and
+ * the first clear spot wins. Sweeping outward-first keeps the natural
+ * answer — a cloud grows away from the body — while allowing the sideways
+ * step that a blocked bearing needs. The distance it moves is then bounded
+ * by the room it actually needed, not by the map.
+ */
+function reseatCluster(params: {
+  key: string;
+  from: { x: number; y: number };
+  extent: { rx: number; ry: number };
+  placed: readonly Box[];
+}): { x: number; y: number } {
+  if (isClear(boxFor(params.from, params.extent), params.placed)) {
+    return params.from;
+  }
+  const outward = Math.atan2(params.from.y, params.from.x / SEAT_ASPECT_X);
+  for (let step = 1; step <= SEAT_MAX_PROBES; step += 1) {
+    const radius = step * SEAT_RADIUS_STEP;
+    for (let bearing = 0; bearing < REFIT_BEARINGS; bearing += 1) {
+      // 0, +1, -1, +2, -2 … around the outward direction.
+      const turn = Math.ceil(bearing / 2) * (bearing % 2 === 0 ? -1 : 1);
+      const angle = outward + (turn * 2 * Math.PI) / REFIT_BEARINGS;
+      const center = {
+        x: params.from.x + Math.cos(angle) * radius * SEAT_ASPECT_X,
+        y: params.from.y + Math.sin(angle) * radius,
+      };
+      if (isClear(boxFor(center, params.extent), params.placed)) return center;
+    }
+  }
+  // Nowhere within reach of where it stands: fall back to the arrival
+  // walk, which is guaranteed to leave the instance's chrome behind.
+  return seatCluster({
+    extent: params.extent,
+    key: params.key,
+    placed: params.placed,
+  });
+}
+
 /** Extent an instance claims when its clouds are empty — its own body. */
 const EMPTY_CLOUD_EXTENT = 70;
 
@@ -588,7 +660,7 @@ export function computeClusterCloud(params: {
       highestSeat < 0 ? 0 : seatAddress(highestSeat, params.cardWidth).ring;
     // Grow-only: an outermost card leaving must not pull the cloud in and
     // shove its neighbours around. Collapsing the cloud is the operator's
-    // call and drops this memory (see `forgetCluster`).
+    // call and drops this one entry (see `refitCluster`).
     const rings = Math.max(needed, previous.rings.get(spec.key) ?? 0);
     nextRings.set(spec.key, rings);
     return {
@@ -633,6 +705,9 @@ export function computeClusterCloud(params: {
   const lonely =
     sized.length === 1 && previous.centers.size === 0 ? sized[0] : undefined;
   for (const cluster of [...reseat, ...arrivals]) {
+    // A cloud that was already somewhere is re-fitted near where it
+    // stands; a new one is seated on its own bearing.
+    const held = previous.centers.get(cluster.spec.key);
     const center =
       cluster === lonely
         ? {
@@ -644,11 +719,18 @@ export function computeClusterCloud(params: {
               + CLOUD_LABEL_ROOM
               + cluster.extent.ry,
           }
-        : seatCluster({
-            extent: cluster.extent,
-            key: cluster.spec.key,
-            placed,
-          });
+        : held
+          ? reseatCluster({
+              extent: cluster.extent,
+              from: held,
+              key: cluster.spec.key,
+              placed,
+            })
+          : seatCluster({
+              extent: cluster.extent,
+              key: cluster.spec.key,
+              placed,
+            });
     nextCenters.set(cluster.spec.key, center);
     placed.push(boxFor(center, cluster.extent));
   }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -15,16 +15,6 @@ export type OrbitPlacement = {
   links: { fromInstanceId: string; toInstanceId: string }[];
   canvasWidth: number;
   canvasHeight: number;
-  /**
-   * Where the map's origin — the hub — sits on the canvas.
-   *
-   * The canvas is normalised so the leftmost, topmost thing drawn clears
-   * the padding, which means the origin moves whenever any cloud's extent
-   * changes on those edges. Every body moves with it, so a view stored in
-   * canvas pixels is looking somewhere else afterwards. Reported here so
-   * the screen can hold its view against the map instead.
-   */
-  origin: { x: number; y: number };
 };
 
 /* Cards are wide and short (~2:1), so their rings are ellipses rather than
@@ -294,13 +284,7 @@ export function computeOrbitPlacement(params: {
 }): OrbitPlacement {
   const root = params.nodes.find((node) => node.depth === 0);
   if (!root) {
-    return {
-      instances: [],
-      links: [],
-      canvasWidth: 0,
-      canvasHeight: 0,
-      origin: { x: 0, y: 0 },
-    };
+    return { instances: [], links: [], canvasWidth: 0, canvasHeight: 0 };
   }
   const extentFor = (instanceId: string) =>
     params.extents?.get(instanceId)
@@ -400,7 +384,6 @@ export function computeOrbitPlacement(params: {
 
   return {
     instances,
-    origin: { x: offsetX, y: offsetY },
     links: params.nodes
       .filter((node) => node.parentId)
       .map((node) => ({

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -15,6 +15,16 @@ export type OrbitPlacement = {
   links: { fromInstanceId: string; toInstanceId: string }[];
   canvasWidth: number;
   canvasHeight: number;
+  /**
+   * Where the map's origin — the hub — sits on the canvas.
+   *
+   * The canvas is normalised so the leftmost, topmost thing drawn clears
+   * the padding, which means the origin moves whenever any cloud's extent
+   * changes on those edges. Every body moves with it, so a view stored in
+   * canvas pixels is looking somewhere else afterwards. Reported here so
+   * the screen can hold its view against the map instead.
+   */
+  origin: { x: number; y: number };
 };
 
 /* Cards are wide and short (~2:1), so their rings are ellipses rather than
@@ -284,7 +294,13 @@ export function computeOrbitPlacement(params: {
 }): OrbitPlacement {
   const root = params.nodes.find((node) => node.depth === 0);
   if (!root) {
-    return { instances: [], links: [], canvasWidth: 0, canvasHeight: 0 };
+    return {
+      instances: [],
+      links: [],
+      canvasWidth: 0,
+      canvasHeight: 0,
+      origin: { x: 0, y: 0 },
+    };
   }
   const extentFor = (instanceId: string) =>
     params.extents?.get(instanceId)
@@ -384,6 +400,7 @@ export function computeOrbitPlacement(params: {
 
   return {
     instances,
+    origin: { x: offsetX, y: offsetY },
     links: params.nodes
       .filter((node) => node.parentId)
       .map((node) => ({


### PR DESCRIPTION
## Summary

- Clicking a cloud's `+N more` chip (or `Show fewer`) moved the map out from under the operator. Two independent causes, which is why it looked inconsistent: sometimes the cloud vanished, sometimes the whole screen slid a few hundred pixels.
- **The cloud vanished.** `toggleClusterExpanded` called `forgetCluster`, which deleted that cloud's remembered **centre, seats and ring allocation**. With no centre the layout treated it as a brand-new cloud and re-seated it from the base radius outward along its key's bearing — measured at **1550px** of teleport on a four-cloud instance. Folding it back did the same thing again.
- `forgetCluster` → `refitCluster`, which drops **only** the ring allocation. Rings are grow-only, so a fold needs that to shrink; the centre and the seats stay, so a cloud that has the room grows outward around the centre it already has and every visible card keeps its exact position.
- A cloud that genuinely outgrows its spot still has to move, but no longer like an arrival. New `reseatCluster` searches rings of increasing radius **around where the cloud stands**, each swept from the outward bearing to either side, and takes the first clear spot. It carries its cards with it; its cloudmates hold.
- **The whole map slid.** `computeOrbitPlacement` normalises the canvas so the leftmost/topmost drawn thing clears the padding (`offsetX = CANVAS_PADDING - minX`). Growing a cloud's extent moves `minX`, so every body translates while the view transform stays where it was — measured at 232–480px per instance on the same fixture, sliding back on fold.
- `OrbitPlacement` now reports the `origin` it landed on, and the screen holds the operator's view against the map: when the origin moves, the view moves by the same amount, so the world point under any given pixel is the one that was there before. This covers the projects lens too, which re-seats its bodies from scratch on every change.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/star-map` — 481 pass (33 files).
- `pnpm test apps/desktop/src/renderer` — 3148 pass (200 files).
- `pnpm typecheck`, `pnpm lint:eslint` — clean (43 pre-existing warnings, 0 errors, none in star-map).
- Both new guards were checked to bite before being kept: restoring the memory drop fails `collapses a cloud back to the size it started at, in place`; disabling the view compensation fails `keeps the map still when the operator unfolds a cloud` with a 180px screen shift.
- New coverage: `star-map-clusters.test.ts` (unfold with room moves nothing; unfold without room moves no further than the cloud grew; a crowded map moves only the unfolded cloud; fold returns to its original size in place), `star-map-view-stability.test.tsx` (two screen-level tests that click the real chip and assert cloud positions *through* the canvas transform, rather than against the transform itself), `star-map-orbit.test.ts` (the origin is the hub's canvas position, and an extent change translates every body by exactly that shift).

## Notes

- Two existing tests were rewritten rather than deleted, both because the behaviour they pinned has changed:
  - `keeps the operator's pan when a card is archived away (projects)` asserted the raw transform was untouched. That lens re-seats from scratch and re-normalises around the result, so holding the map still now *requires* the transform to change by exactly that shift. It asserts the project body's screen position instead — the pixels are what the operator is owed, not the number.
  - `lets a shrinking canvas strand the view, recovered by Reset` pinned a known gap and asked to be rewritten if anything ever closed it. A shrink at the left or top edge moves the origin, the view follows it, and that move goes through the clamp — so the guaranteed strip survives. What remains of the gap is a shrink that leaves the origin exactly where it was; the comment says so, and Reset recovery is still asserted.
- Accepted behaviour: a cloud hemmed in between the instance body and a neighbour still has to move to make room when unfolded (~700px in the crowded fixture) — it now slides to the nearest clear spot with nothing else moving, where before it was flung across the map. The alternative is pushing the neighbouring clouds aside instead, which moves more things; happy to switch if that reads better.
- `refitCluster` is also used by the cloud-drop regroup path, which gains the same "re-fit in place, don't teleport" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
