### PR TITLE
fix(desktop): pack the Star Map galaxy by need and cloud its projects

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapProjectBody.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapProjectBody.tsx
@@ -12,10 +12,26 @@ export function StarMapProjectBody(props: {
   label: string;
   projectKey: string;
   threadCount: number;
+  /**
+   * Counter-scale for the overview zoom, where the canvas shrinks under
+   * the body. Composed into the centring transform rather than applied by
+   * the caller, because `.star-map-project` centres itself on its origin
+   * and a wrapper transform would move it off that origin.
+   */
+  scale?: number;
 }) {
   const labelTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const scale = props.scale ?? 1;
   return (
-    <div className="star-map-project" data-project-key={props.projectKey}>
+    <div
+      className="star-map-project"
+      data-project-key={props.projectKey}
+      style={
+        scale === 1
+          ? undefined
+          : { transform: `translate(-50%, -50%) scale(${scale})` }
+      }
+    >
       <span className="star-map-project__glow" aria-hidden="true" />
       <span className="star-map-project__core" aria-hidden="true" />
       <span

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -83,7 +83,10 @@ import {
   groupThreadsByProject,
   instanceIdByThreadKey,
 } from "./star-map-projects";
-import { computeProjectLayout } from "./star-map-project-layout";
+import {
+  computeProjectLayout,
+  EMPTY_PROJECT_LAYOUT,
+} from "./star-map-project-layout";
 import { StarMapProjectBody } from "./StarMapProjectBody";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { StarMapChatCard } from "./StarMapChatCard";
@@ -162,6 +165,24 @@ const PROJECT_CLUSTER_SCOPE = "project:";
 
 function projectClusterScope(projectKey: string): string {
   return `${PROJECT_CLUSTER_SCOPE}${projectKey}`;
+}
+
+/**
+ * Accessible name for a parent/child cloud's pill.
+ *
+ * Shared by both lenses so the two cannot drift, and counting rather than
+ * interpolating a fixed plural: a parent with exactly one child is the
+ * commonest shape there is, and "its 1 replies" is what a screen reader
+ * would have said.
+ */
+function parentClusterSelectLabel(params: {
+  label: string;
+  threadCount: number;
+}): string {
+  const replies = Math.max(0, params.threadCount - 1);
+  return `Select the ${params.label} thread and its ${replies} ${
+    replies === 1 ? "reply" : "replies"
+  }`;
 }
 
 /** Breathing room past the longest column / widest lane when panning. */
@@ -1384,25 +1405,31 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return clouds;
   }, [cardHeights, expandedClusters, projects, projectsMode]);
 
-  const projectLayout = useMemo(
-    () =>
-      computeProjectLayout({
-        cardWidth: ORBIT_CARD_WIDTH,
-        projects: projects.map((project) => {
-          const cloud = projectClouds?.get(project.key);
-          return {
-            key: project.key,
-            cardCount: cloud?.threads.length ?? project.threads.length,
-            // Spacing tracks the seated clouds, exactly as instance
-            // spacing does — see the `extents` argument to
-            // `computeOrbitPlacement`.
-            extent: cloud?.extent,
-            mass: project.mass,
-          };
-        }),
+  /**
+   * Gated on the lens like `projectClouds`, and for a sharper reason than
+   * saving work: without the clouds the card count falls back to a
+   * project's FULL thread list, so the other lenses would pack the whole
+   * galaxy over every thread in the fleet on every streamed delta and
+   * throw the result away — every reader below is behind `projectsMode`.
+   */
+  const projectLayout = useMemo(() => {
+    if (!projectClouds) return EMPTY_PROJECT_LAYOUT;
+    return computeProjectLayout({
+      cardWidth: ORBIT_CARD_WIDTH,
+      projects: projects.map((project) => {
+        const cloud = projectClouds.get(project.key);
+        return {
+          key: project.key,
+          cardCount: cloud?.threads.length ?? 0,
+          // Spacing tracks the seated clouds, exactly as instance
+          // spacing does — see the `extents` argument to
+          // `computeOrbitPlacement`.
+          extent: cloud?.extent,
+          mass: project.mass,
+        };
       }),
-    [projectClouds, projects],
-  );
+    });
+  }, [projectClouds, projects]);
 
   /**
    * A filtered-to-nothing map is otherwise indistinguishable from a
@@ -3043,16 +3070,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, []);
 
   /**
-   * A cloud's label pill selects its visible cards as one group, so the
-   * existing group drag moves the whole cloud. Only visible cards join —
-   * a hidden card has no shell to move, and a selection entry that cannot
-   * be seen would surface as a card teleporting on some later expand.
-   */
-  /**
    * Select every card in the list, or clear them if they are all already
    * selected. Takes keys rather than a cloud because the two lenses scope
    * cards differently: an instance's cloud is all one instance's cards,
    * while a project pools cards from every machine in the federation.
+   *
+   * Which keys a caller passes is the caller's business — both pills
+   * below pass their cloud's VISIBLE cards, for the reason on
+   * `toggleClusterSelection`.
    */
   const toggleCardKeySelection = useCallback((keys: readonly string[]) => {
     if (keys.length === 0) return;
@@ -3067,6 +3092,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
     });
   }, []);
 
+  /**
+   * A cloud's label pill selects its visible cards as one group, so the
+   * existing group drag moves the whole cloud. Only visible cards join —
+   * a hidden card has no shell to move, and a selection entry that cannot
+   * be seen would surface as a card teleporting on some later expand.
+   */
   const toggleClusterSelection = useCallback(
     (instanceId: string, cluster: StarMapClusterPlacement) => {
       toggleCardKeySelection(
@@ -3733,9 +3764,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
               aria-pressed={allSelected}
               aria-label={
                 cluster.isParentGroup
-                  ? `Select the ${cluster.label} thread and its ${
-                      cluster.threads.length - 1
-                    } replies`
+                  ? parentClusterSelectLabel({
+                      label: cluster.label,
+                      threadCount: cluster.threads.length,
+                    })
                   : `Select the ${cluster.label} cards (${cluster.threads.length} threads)`
               }
               onClick={() =>
@@ -4172,9 +4204,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
                             : {}),
                         }}
                         aria-pressed={allSelected}
-                        aria-label={`Select the ${cluster.label} thread and its ${
-                          cluster.threads.length - 1
-                        } replies`}
+                        aria-label={parentClusterSelectLabel({
+                          label: cluster.label,
+                          threadCount: cluster.threads.length,
+                        })}
                         onClick={() => toggleCardKeySelection(clusterCardKeys)}
                       >
                         <span

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MutableRefObject,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
 } from "react";
@@ -45,8 +46,6 @@ import {
   type StarMapCardSlot,
 } from "./star-map-layout";
 import {
-  cardRingExtent,
-  cardRingSlots,
   computeOrbitPlacement,
   galaxyArmPath,
   shouldPanOnWheel,
@@ -153,12 +152,18 @@ const STAR_COUNT = 130;
 /** Orbit clouds use a fixed card width; lanes narrow theirs to fit. */
 const ORBIT_CARD_WIDTH = 200;
 /**
- * Projects-lens ring cap: a ring crowds geometrically, so a project body
- * stays shallower than a column. The orbit lens no longer rings — its caps
- * live in star-map-clusters (per-group plus a cloud backstop), each cloud
- * carrying its own "+N more" chip instead of truncating silently.
+ * Scope prefix for a project's cloud state.
+ *
+ * Cloud memory and the expanded set are keyed by the body a cloud hangs
+ * off. A project's catch-all cloud is keyed by the project itself, so
+ * without a prefix the two lenses would share entries for it.
  */
-const PROJECT_MAX_CARDS_PER_BODY = 16;
+const PROJECT_CLUSTER_SCOPE = "project:";
+
+function projectClusterScope(projectKey: string): string {
+  return `${PROJECT_CLUSTER_SCOPE}${projectKey}`;
+}
+
 /** Breathing room past the longest column / widest lane when panning. */
 const LANE_CANVAS_PADDING = 120;
 /**
@@ -519,6 +524,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * must not itself schedule a render. See `StarMapCloudMemory`.
    */
   const cloudMemory = useRef(new Map<string, StarMapCloudMemory>());
+  /**
+   * The same, per project key, for the Projects lens. Kept in its own map
+   * rather than sharing one keyed space: a project pools threads from every
+   * instance, so its clouds are a different set of clouds even when a
+   * project key and an instance id could not collide.
+   */
+  const projectCloudMemory = useRef(new Map<string, StarMapCloudMemory>());
   // Orbit places bodies on a canvas larger than the window, so the surface
   // pans and zooms rather than compressing the map to fit.
   const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
@@ -1249,26 +1261,55 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [clusterClouds],
   );
 
-  const toggleClusterExpanded = useCallback(
-    (instanceId: string, clusterKey: string) => {
+  /**
+   * Expand or collapse one cloud, in whichever lens owns it.
+   *
+   * `scopeId` names the body the cloud hangs off — an instance id in the
+   * Instances lens, a `project:`-prefixed key in Projects — and keys both
+   * the cloud memory and the expanded set, so the two lenses cannot read
+   * each other's state for a cloud key they happen to share (they always
+   * do: a project's catch-all cloud is keyed by the project itself).
+   */
+  const toggleClusterExpandedIn = useCallback(
+    (
+      memory: MutableRefObject<Map<string, StarMapCloudMemory>>,
+      scopeId: string,
+      clusterKey: string,
+    ) => {
       // Unfolding or folding a cloud is a request to re-fit THAT cloud's
       // rings, so it can grow outward and shrink back. Its centre and its
       // seats stay: the cards already on screen are not what changed.
-      cloudMemory.current.set(
-        instanceId,
+      memory.current.set(
+        scopeId,
         refitCluster(
-          cloudMemory.current.get(instanceId) ?? emptyCloudMemory(),
+          memory.current.get(scopeId) ?? emptyCloudMemory(),
           clusterKey,
         ),
       );
       setExpandedClusters((current) => {
         const next = new Set(current);
-        const key = `${instanceId}::${clusterKey}`;
+        const key = `${scopeId}::${clusterKey}`;
         if (!next.delete(key)) next.add(key);
         return next;
       });
     },
     [],
+  );
+
+  const toggleClusterExpanded = useCallback(
+    (instanceId: string, clusterKey: string) =>
+      toggleClusterExpandedIn(cloudMemory, instanceId, clusterKey),
+    [toggleClusterExpandedIn],
+  );
+
+  const toggleProjectClusterExpanded = useCallback(
+    (projectKey: string, clusterKey: string) =>
+      toggleClusterExpandedIn(
+        projectCloudMemory,
+        projectClusterScope(projectKey),
+        clusterKey,
+      ),
+    [toggleClusterExpandedIn],
   );
 
   const projects = useMemo(
@@ -1281,20 +1322,86 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [attentionByInstance],
   );
 
+  /**
+   * Card key for a thread in the Projects lens.
+   *
+   * Cards there are scoped by their OWNING instance, not by the project, so
+   * anything addressing them by key — selection, the camera — has to agree
+   * with the card's own `cardKey` exactly. Kept in one place because they
+   * disagreeing is silent: the selection would simply never highlight.
+   */
+  const projectCardKey = useCallback(
+    (thread: NavigationThreadSummary) => {
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const owner = projectThreadOwners.get(threadKey) ?? localInstanceId;
+      return `${owner ?? "project"}::${threadKey}`;
+    },
+    [localInstanceId, projectThreadOwners],
+  );
+
+  /**
+   * Projects-lens clouds: a project's pooled threads grouped the same way
+   * an instance's are, so a parent thread and its children read as one
+   * body of work inside the project's solar system instead of scattering
+   * around a flat ring.
+   *
+   * `buildInstanceClusters` buckets by project key, so handing it a single
+   * project's threads yields exactly that project's parent/child clouds
+   * plus one catch-all — the same grouping, the same per-cloud caps, and
+   * the same working "+N more" chip the Instances lens already has. The
+   * flat ring this replaces capped the whole body at sixteen cards and
+   * said nothing about the seventeenth.
+   *
+   * Undefined outside the lens so the others pay nothing for it.
+   */
+  const projectClouds = useMemo(() => {
+    if (!projectsMode) return undefined;
+    const clouds = new Map<string, ReturnType<typeof computeClusterCloud>>();
+    for (const project of projects) {
+      const scopeId = projectClusterScope(project.key);
+      const prefix = `${scopeId}::`;
+      const expandedKeys = new Set<string>();
+      for (const entry of expandedClusters) {
+        if (entry.startsWith(prefix)) {
+          expandedKeys.add(entry.slice(prefix.length));
+        }
+      }
+      const cloud = computeClusterCloud({
+        clusters: buildInstanceClusters({
+          threads: project.threads,
+          expandedKeys,
+        }),
+        cardWidth: ORBIT_CARD_WIDTH,
+        heightForThread: (threadKey) =>
+          cardHeights.get(threadKey) ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
+        memory: projectCloudMemory.current.get(scopeId),
+      });
+      // See `clusterClouds`: carrying the layout forward is what keeps an
+      // archived thread from moving everything else.
+      projectCloudMemory.current.set(scopeId, cloud.memory);
+      clouds.set(project.key, cloud);
+    }
+    return clouds;
+  }, [cardHeights, expandedClusters, projects, projectsMode]);
+
   const projectLayout = useMemo(
     () =>
       computeProjectLayout({
         cardWidth: ORBIT_CARD_WIDTH,
-        projects: projects.map((project) => ({
-          key: project.key,
-          cardCount: Math.min(
-            project.threads.length,
-            PROJECT_MAX_CARDS_PER_BODY,
-          ),
-          mass: project.mass,
-        })),
+        projects: projects.map((project) => {
+          const cloud = projectClouds?.get(project.key);
+          return {
+            key: project.key,
+            cardCount: cloud?.threads.length ?? project.threads.length,
+            // Spacing tracks the seated clouds, exactly as instance
+            // spacing does — see the `extents` argument to
+            // `computeOrbitPlacement`.
+            extent: cloud?.extent,
+            mass: project.mass,
+          };
+        }),
       }),
-    [projects],
+    [projectClouds, projects],
   );
 
   /**
@@ -2614,11 +2721,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
     );
     for (const project of projects) {
       const placement = placementByKey.get(project.key);
-      if (!placement) continue;
-      const visible = project.threads.slice(0, PROJECT_MAX_CARDS_PER_BODY);
-      const slots = cardRingSlots(visible.length, ORBIT_CARD_WIDTH);
-      visible.forEach((thread, index) => {
-        const slot = slots[index];
+      const cloud = projectClouds?.get(project.key);
+      if (!placement || !cloud) continue;
+      cloud.threads.forEach((thread, index) => {
+        const slot = cloud.slots[index];
         if (!slot) return;
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const owner = projectThreadOwners.get(threadKey) ?? localInstanceId;
@@ -2627,10 +2733,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
         const height =
           cardHeights.get(threadKey) || STAR_MAP_ESTIMATED_CARD_HEIGHT;
         rects.set(`${owner}::${threadKey}`, {
-          // Ring cards are centred on their slot both ways (`centered`),
-          // unlike the lane and cloud slots that hang from the top.
+          // Cloud slots hang from the card's TOP edge, and the cards are
+          // drawn from the same slots, so the rect follows suit — the
+          // ring-centred form this replaced described a different card.
           x: placement.x + slot.dx - ORBIT_CARD_WIDTH / 2,
-          y: placement.y + slot.dy - height / 2,
+          y: placement.y + slot.dy,
           width: ORBIT_CARD_WIDTH,
           height,
         });
@@ -2640,6 +2747,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, [
     cardHeights,
     localInstanceId,
+    projectClouds,
     projectLayout,
     projects,
     projectThreadOwners,
@@ -2940,26 +3048,37 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * a hidden card has no shell to move, and a selection entry that cannot
    * be seen would surface as a card teleporting on some later expand.
    */
+  /**
+   * Select every card in the list, or clear them if they are all already
+   * selected. Takes keys rather than a cloud because the two lenses scope
+   * cards differently: an instance's cloud is all one instance's cards,
+   * while a project pools cards from every machine in the federation.
+   */
+  const toggleCardKeySelection = useCallback((keys: readonly string[]) => {
+    if (keys.length === 0) return;
+    setSelection((current) => {
+      const allSelected = keys.every((key) => current.has(key));
+      const next = new Set(current);
+      for (const key of keys) {
+        if (allSelected) next.delete(key);
+        else next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
   const toggleClusterSelection = useCallback(
     (instanceId: string, cluster: StarMapClusterPlacement) => {
-      const keys = cluster.threads
-        .slice(0, cluster.visibleCount)
-        .map(
-          (thread) =>
-            `${instanceId}::${buildThreadIdentityKey(thread.source, thread.id)}`,
-        );
-      if (keys.length === 0) return;
-      setSelection((current) => {
-        const allSelected = keys.every((key) => current.has(key));
-        const next = new Set(current);
-        for (const key of keys) {
-          if (allSelected) next.delete(key);
-          else next.add(key);
-        }
-        return next;
-      });
+      toggleCardKeySelection(
+        cluster.threads
+          .slice(0, cluster.visibleCount)
+          .map(
+            (thread) =>
+              `${instanceId}::${buildThreadIdentityKey(thread.source, thread.id)}`,
+          ),
+      );
     },
-    [],
+    [toggleCardKeySelection],
   );
 
   const commitSelectionMove = useCallback(
@@ -3595,8 +3714,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
               key={`cluster-label:${cluster.key}`}
               type="button"
               className={`star-map__cluster-label${
-                overview ? " star-map__cluster-label--overview" : ""
-              }`}
+                cluster.isParentGroup
+                  ? " star-map__cluster-label--parent"
+                  : ""
+              }${overview ? " star-map__cluster-label--overview" : ""}`}
               style={{
                 left: cluster.labelSlot.dx,
                 // In overview the label IS the cloud, so it sits on the
@@ -3610,11 +3731,28 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   : {}),
               }}
               aria-pressed={allSelected}
-              aria-label={`Select the ${cluster.label} cards (${cluster.threads.length} threads)`}
+              aria-label={
+                cluster.isParentGroup
+                  ? `Select the ${cluster.label} thread and its ${
+                      cluster.threads.length - 1
+                    } replies`
+                  : `Select the ${cluster.label} cards (${cluster.threads.length} threads)`
+              }
               onClick={() =>
                 toggleClusterSelection(position.instanceId, cluster)
               }
             >
+              {/* A parent/child cloud is named after its parent THREAD,
+                  not after a project, and wearing identical chrome it was
+                  indistinguishable from one — an operator counting clouds
+                  around an instance counted four thread groups as four
+                  extra projects. The mark says which kind of thing the
+                  name is. */}
+              {cluster.isParentGroup ? (
+                <span className="star-map__cluster-kind" aria-hidden="true">
+                  ↳
+                </span>
+              ) : null}
               <span className="star-map__cluster-name">{cluster.label}</span>
               <span className="star-map__cluster-count">
                 {cluster.threads.length}
@@ -3915,13 +4053,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
               const project = projects.find(
                 (entry) => entry.key === placement.key,
               );
-              if (!project) return null;
-              const visible = project.threads.slice(
-                0,
-                PROJECT_MAX_CARDS_PER_BODY,
-              );
-              const slots = cardRingSlots(visible.length, ORBIT_CARD_WIDTH);
-              const ringOverflow = project.threads.length - visible.length;
+              const cloud = projectClouds?.get(placement.key);
+              if (!project || !cloud) return null;
               return (
                 <div
                   key={`project:${placement.key}`}
@@ -3932,8 +4065,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
                     label={project.label}
                     projectKey={project.key}
                     threadCount={project.threads.length}
+                    // In overview the body is the only thing naming the
+                    // project, so it counter-scales to stay readable —
+                    // the same treatment instance bodies get.
+                    scale={overview ? chromeScale : 1}
                   />
-                  {visible.map((thread, index) => {
+                  {(overview ? [] : cloud.threads).map((thread, index) => {
                     const threadKey = buildThreadIdentityKey(
                       thread.source,
                       thread.id,
@@ -3960,11 +4097,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         instanceIcon={celestialIcons.iconFor(
                           owner === localInstanceId ? undefined : owner,
                         )}
-                        cardKey={`${owner ?? "project"}::${buildThreadIdentityKey(
-                          thread.source,
-                          thread.id,
-                        )}`}
-                        baseSlot={slots[index]}
+                        cardKey={projectCardKey(thread)}
+                        // Selection was never wired here: the lens had no
+                        // cloud pill to sweep a group with, so a selected
+                        // card had no way to become one. The parent/child
+                        // pills give it one, and a pill that reports
+                        // `aria-pressed` while nothing highlights is worse
+                        // than no pill.
+                        selected={selection.has(projectCardKey(thread))}
+                        onToggleSelect={() =>
+                          toggleSelected(projectCardKey(thread))
+                        }
+                        baseSlot={cloud.slots[index]}
                         // No drag here on purpose: arrangements are keyed
                         // and synced per federation instance, and a project
                         // is not an instance. Giving projects their own
@@ -3972,8 +4116,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         // this lens simply do not move rather than moving
                         // and failing to persist.
                         width={ORBIT_CARD_WIDTH}
-                        centered
-                        stackIndex={index}
+                        // Cloud slots hang from the card's top edge, unlike
+                        // the ring slots this lens used to seat from.
+                        // Clamped like the orbit lens: a project draws more
+                        // cards than the old sixteen-card ring did, and a
+                        // card that climbs past the cap paints over the
+                        // cloud chrome above it (star-map-z-layers).
+                        stackIndex={Math.min(index, STAR_MAP_CARD_MAX_Z)}
                         // The project IS the sun here, so the project chip
                         // is redundant; the machine is what you cannot
                         // otherwise tell, so the instance chip earns its
@@ -3989,21 +4138,93 @@ export function StarMapScreen(props: StarMapScreenProps) {
                       />
                     );
                   })}
-                  {/* The ring truncates silently otherwise — the same lie
-                      the orbit lens used to tell. */}
-                  {ringOverflow > 0 ? (
-                    <span
-                      className="star-map__cloud-overflow"
-                      style={{
-                        transform: `translate(-50%, ${
-                          cardRingExtent(visible.length, ORBIT_CARD_WIDTH).ry
-                          + 24
-                        }px)`,
-                      }}
-                    >
-                      +{ringOverflow} more
-                    </span>
-                  ) : null}
+                  {cloud.clusters.map((cluster) => {
+                    // The project body already names the catch-all cloud
+                    // and counts it. Labelling it again puts the project's
+                    // own name on the map twice, a step from the confusion
+                    // this lens exists to avoid — so only the parent/child
+                    // clouds, which the body cannot name, get a caption.
+                    if (cluster.chromeless || !cluster.isParentGroup) {
+                      return null;
+                    }
+                    const clusterCardKeys = cluster.threads
+                      .slice(0, cluster.visibleCount)
+                      .map((member) => projectCardKey(member));
+                    const allSelected =
+                      clusterCardKeys.length > 0
+                      && clusterCardKeys.every((key) => selection.has(key));
+                    return (
+                      <button
+                        key={`project-cluster-label:${cluster.key}`}
+                        type="button"
+                        className={`star-map__cluster-label star-map__cluster-label--parent${
+                          overview ? " star-map__cluster-label--overview" : ""
+                        }`}
+                        style={{
+                          left: cluster.labelSlot.dx,
+                          top: overview
+                            ? cluster.center.y
+                            : cluster.labelSlot.dy,
+                          ...(overview
+                            ? {
+                                transform: `translate(-50%, -50%) scale(${chromeScale})`,
+                              }
+                            : {}),
+                        }}
+                        aria-pressed={allSelected}
+                        aria-label={`Select the ${cluster.label} thread and its ${
+                          cluster.threads.length - 1
+                        } replies`}
+                        onClick={() => toggleCardKeySelection(clusterCardKeys)}
+                      >
+                        <span
+                          className="star-map__cluster-kind"
+                          aria-hidden="true"
+                        >
+                          ↳
+                        </span>
+                        <span className="star-map__cluster-name">
+                          {cluster.label}
+                        </span>
+                        <span className="star-map__cluster-count">
+                          {cluster.threads.length}
+                        </span>
+                      </button>
+                    );
+                  })}
+                  {/* Per-cloud overflow, and it works: the flat ring this
+                      replaced printed one "+N more" for the whole body and
+                      gave the operator no way to see those threads. */}
+                  {overview
+                    ? null
+                    : cloud.clusters.map((cluster) =>
+                        cluster.overflowSlot ? (
+                          <button
+                            key={`project-cluster-overflow:${cluster.key}`}
+                            type="button"
+                            className="star-map__cluster-overflow"
+                            style={{
+                              left: cluster.overflowSlot.dx,
+                              top: cluster.overflowSlot.dy,
+                            }}
+                            aria-label={
+                              cluster.overflow > 0
+                                ? `Show ${cluster.overflow} more ${cluster.label} threads`
+                                : `Show fewer ${cluster.label} threads`
+                            }
+                            onClick={() =>
+                              toggleProjectClusterExpanded(
+                                project.key,
+                                cluster.key,
+                              )
+                            }
+                          >
+                            {cluster.overflow > 0
+                              ? `+${cluster.overflow} more`
+                              : "Show fewer"}
+                          </button>
+                        ) : null,
+                      )}
                 </div>
               );
             })

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2735,10 +2735,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * `cardRects`.
    *
    * Kept separate rather than folded into that map because `cardRects` is
-   * the drag/snap/marquee geometry, and cards in this lens deliberately do
-   * not move (a project is not an instance, so there is no arrangement row
-   * to persist an offset to). This is read for one thing only: knowing
-   * where a card the operator asked for is, so the camera can go there.
+   * the drag/snap geometry, and cards in this lens deliberately do not
+   * move (a project is not an instance, so there is no arrangement row to
+   * persist an offset to).
+   *
+   * Read for the two things that are about where a card IS rather than
+   * where it may be dragged to: flying the camera to a card the operator
+   * asked for, and sweeping a marquee over it. Both reach it through
+   * `flightRects`.
    */
   const projectCardRects = useMemo(() => {
     const rects = new Map<string, SnapRect>();
@@ -2998,7 +3002,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
         );
         setSelection((current) => {
           const hits = mode === "add" ? new Set(current) : new Set<string>();
-          for (const [key, cardRect] of cardRects) {
+          // The lens's own geometry, not `cardRects`: that map is built
+          // from instance bodies and is empty in Projects, so a sweep
+          // there hit nothing and — in `replace` mode — wiped whatever
+          // the cloud pills had selected. Outside Projects `flightRects`
+          // IS `cardRects`, so nothing else moves.
+          for (const [key, cardRect] of flightRects) {
             if (rectIntersects(cardRect, box)) hits.add(key);
           }
           return hits;
@@ -3010,7 +3019,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       window.addEventListener("pointercancel", stop);
       return true;
     },
-    [cardRects, view.scale],
+    [flightRects, view.scale],
   );
 
   /**
@@ -4484,10 +4493,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
           <StarMapViewOptions
             preferences={preferences}
             onChange={(next) => {
-              // A lens change re-places every card, and one lens (projects)
-              // paints no selected state at all. Carrying a selection across
-              // that boundary leaves the operator holding cards they can no
-              // longer point at — which the kebab would then act on.
+              // A lens change re-places every card. Every lens paints
+              // selected state now, so a selection WOULD carry over intact
+              // — and that is the problem: the cards are somewhere else
+              // entirely, and the operator is left holding a selection
+              // they did not sweep on the map now in front of them, which
+              // the kebab would then act on.
               if (next.layout !== preferences.layout) setSelection(new Set());
               setPreferences(next);
               writeStoredPreferences(next);
@@ -4587,8 +4598,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
           <span>
             {selection.size === 1 ? "1 card selected" : `${selection.size} cards selected`}
           </span>
+          {/* Projects cards carry no `drag` — a project is not an
+              instance, so there is no arrangement row to persist an offset
+              to — and offering a gesture that only pans the canvas is
+              worse than offering none. */}
           <span className="star-map__selection-hint" aria-hidden="true">
-            drag to move · ⇧-click to amend
+            {projectsMode
+              ? "⇧-click to amend"
+              : "drag to move · ⇧-click to amend"}
           </span>
           <button
             type="button"

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
@@ -89,10 +89,16 @@ export function StarMapViewOptions(props: {
                   props.onChange({ ...props.preferences, layout: mode })
                 }
               >
+                {/* "Instances", not "Orbit": every lens here is orbital,
+                    so the old name described the drawing rather than what
+                    the lens is FOR, and it did not pair with "Projects" —
+                    the choice is which thing a body stands for. The stored
+                    id stays `orbit` so an operator's saved layout survives
+                    the rename. */}
                 {mode === "lanes"
                   ? "Lanes"
                   : mode === "orbit"
-                    ? "Orbit"
+                    ? "Instances"
                     : "Projects"}
               </button>
             ))}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-clouds.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-clouds.test.tsx
@@ -1,0 +1,207 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * Projects-lens clouds.
+ *
+ * The lens used to seat a project's threads on one flat ring capped at
+ * sixteen cards, with a single dead "+N more" caption for the whole body:
+ * a parent thread and its children scattered around the ring like any
+ * other cards, and the seventeenth thread was unreachable. It now groups
+ * the same way the Instances lens does — parent/child clouds plus a
+ * catch-all, each with its own working chip.
+ */
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function thread(params: {
+  id: string;
+  path: string;
+  label: string;
+  title?: string;
+  parentThreadId?: string;
+}): NavigationThreadSummary {
+  return {
+    id: params.id,
+    title: params.title ?? `Thread ${params.id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      { id: `dir-${params.path}`, label: params.label, path: params.path, kind: "local" },
+    ],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 100,
+    ...(params.parentThreadId
+      ? { parentThreadId: params.parentThreadId, parentThreadBackend: "codex" }
+      : {}),
+  } as unknown as NavigationThreadSummary;
+}
+
+function renderProjects(threads: NavigationThreadSummary[]) {
+  window.localStorage.setItem(
+    "pwragent.starMap.viewPreferences",
+    JSON.stringify({ layout: "projects" }),
+  );
+  return render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={threads}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+}
+
+describe("star map projects lens clouds", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("gives a parent thread and its children their own cloud", async () => {
+    renderProjects([
+      thread({ id: "p1", path: "/repo/alpha", label: "AlphaDir", title: "Root work" }),
+      thread({
+        id: "c1",
+        parentThreadId: "p1",
+        path: "/repo/alpha",
+        label: "AlphaDir",
+        title: "Child one",
+      }),
+      thread({
+        id: "c2",
+        parentThreadId: "p1",
+        path: "/repo/alpha",
+        label: "AlphaDir",
+        title: "Child two",
+      }),
+      thread({ id: "loose", path: "/repo/alpha", label: "AlphaDir" }),
+    ]);
+
+    // The parent group is captioned by its parent's title, and says so:
+    // "N threads" would read exactly like a project cloud, which is the
+    // ambiguity that made an operator count thread groups as projects.
+    const label = await screen.findByRole("button", {
+      name: "Select the Root work thread and its 2 replies",
+    });
+    expect(label.className).toContain("star-map__cluster-label--parent");
+    expect(label.textContent).toContain("Root work");
+
+    // The catch-all is NOT labelled: the project body already names and
+    // counts the project, so a second pill would print it twice.
+    expect(
+      screen.queryByRole("button", { name: /Select the alpha cards/ }),
+    ).toBeNull();
+  });
+
+  it("expands past the per-cloud cap from the chip", async () => {
+    renderProjects(
+      Array.from({ length: 11 }, (unused, index) =>
+        thread({ id: `t${index}`, path: "/repo/alpha", label: "AlphaDir" }),
+      ),
+    );
+
+    const chip = await screen.findByRole("button", {
+      name: /Show 3 more alpha threads/,
+    });
+    expect(chip.textContent).toBe("+3 more");
+    expect(
+      screen.getAllByRole("button", { name: /^Open thread:/ }),
+    ).toHaveLength(8);
+
+    // Re-query at click time: card measurement re-renders the map.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show 3 more alpha threads/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /^Open thread:/ }),
+      ).toHaveLength(11);
+    });
+  });
+
+  it("keeps two projects' clouds independent", async () => {
+    renderProjects([
+      thread({ id: "a1", path: "/repo/alpha", label: "AlphaDir", title: "Alpha root" }),
+      thread({
+        id: "a2",
+        parentThreadId: "a1",
+        path: "/repo/alpha",
+        label: "AlphaDir",
+        title: "Alpha child",
+      }),
+      thread({ id: "b1", path: "/repo/beta", label: "BetaDir", title: "Beta root" }),
+      thread({
+        id: "b2",
+        parentThreadId: "b1",
+        path: "/repo/beta",
+        label: "BetaDir",
+        title: "Beta child",
+      }),
+    ]);
+
+    await screen.findByRole("button", {
+      name: "Select the Alpha root thread and its 1 replies",
+    });
+    await screen.findByRole("button", {
+      name: "Select the Beta root thread and its 1 replies",
+    });
+  });
+
+  it("selects a parent cloud's cards from its pill", async () => {
+    const { container } = renderProjects([
+      thread({ id: "p1", path: "/repo/alpha", label: "AlphaDir", title: "Root work" }),
+      thread({
+        id: "c1",
+        parentThreadId: "p1",
+        path: "/repo/alpha",
+        label: "AlphaDir",
+        title: "Child one",
+      }),
+      thread({ id: "loose", path: "/repo/alpha", label: "AlphaDir" }),
+    ]);
+    // Card keys name their owning instance, and the map drops a selection
+    // swept against the placeholder id the moment the durable one lands.
+    // This lens draws no instance body to wait on, so wait on the keys.
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-card-key="pwr_local::codex:p1"]'),
+      ).not.toBeNull();
+    });
+    const name = "Select the Root work thread and its 1 replies";
+    await screen.findByRole("button", { name });
+
+    fireEvent.click(screen.getByRole("button", { name }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name }).getAttribute("aria-pressed"),
+      ).toBe("true");
+    });
+    // The parent and its child only — the loose thread is a cloudmate of
+    // neither, and pooling by project would have swept it in too.
+    expect(
+      container.querySelectorAll(".star-map-card-shell--selected"),
+    ).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-clouds.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-clouds.test.tsx
@@ -169,6 +169,47 @@ describe("star map projects lens clouds", () => {
     });
   });
 
+  /**
+   * The sweep reads this lens's own card geometry. It used to read
+   * `cardRects`, which is empty by construction here, so a marquee
+   * selected nothing and — in `replace` mode — wiped whatever the cloud
+   * pills had selected. Invisible while the lens painted no selected state
+   * at all; a broken affordance the moment it did.
+   */
+  it("sweeps a marquee over project cards", async () => {
+    const { container } = renderProjects([
+      thread({ id: "a1", path: "/repo/alpha", label: "AlphaDir" }),
+      thread({ id: "a2", path: "/repo/alpha", label: "AlphaDir" }),
+      thread({ id: "b1", path: "/repo/beta", label: "BetaDir" }),
+    ]);
+    // Card keys name their owning instance; a sweep against the
+    // placeholder id is dropped the moment the durable one lands.
+    await waitFor(() => {
+      const keys = [
+        ...container.querySelectorAll(".star-map-card-shell[data-thread-key]"),
+      ].map((shell) => (shell as HTMLElement).dataset.cardKey ?? "");
+      expect(keys.length).toBe(3);
+      expect(keys.every((key) => key.startsWith("pwr_local::"))).toBe(true);
+    });
+
+    const viewport = container.querySelector(".star-map__viewport");
+    if (!(viewport instanceof HTMLElement)) throw new Error("no viewport");
+    fireEvent.pointerDown(viewport, {
+      button: 0,
+      shiftKey: true,
+      clientX: -4000,
+      clientY: -4000,
+    });
+    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll(".star-map-card-shell--selected"),
+      ).toHaveLength(3);
+    });
+  });
+
   it("selects a parent cloud's cards from its pill", async () => {
     const { container } = renderProjects([
       thread({ id: "p1", path: "/repo/alpha", label: "AlphaDir", title: "Root work" }),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-clouds.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-clouds.test.tsx
@@ -162,10 +162,10 @@ describe("star map projects lens clouds", () => {
     ]);
 
     await screen.findByRole("button", {
-      name: "Select the Alpha root thread and its 1 replies",
+      name: "Select the Alpha root thread and its 1 reply",
     });
     await screen.findByRole("button", {
-      name: "Select the Beta root thread and its 1 replies",
+      name: "Select the Beta root thread and its 1 reply",
     });
   });
 
@@ -189,7 +189,7 @@ describe("star map projects lens clouds", () => {
         container.querySelector('[data-card-key="pwr_local::codex:p1"]'),
       ).not.toBeNull();
     });
-    const name = "Select the Root work thread and its 1 replies";
+    const name = "Select the Root work thread and its 1 reply";
     await screen.findByRole("button", { name });
 
     fireEvent.click(screen.getByRole("button", { name }));

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-layout.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-layout.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { computeProjectLayout } from "../star-map-project-layout";
+
+/**
+ * Projects-lens galaxy packing.
+ *
+ * The rule these pin is "a project sits as far out as the projects
+ * already placed force it to, and no further". The layout this replaced
+ * mapped mass onto an absolute radius over a fixed span, which decided a
+ * project's distance from the core before anything had been placed.
+ */
+
+const CARD_WIDTH = 200;
+
+function layoutOf(
+  projects: readonly { key: string; cardCount: number; mass?: number }[],
+) {
+  return computeProjectLayout({ cardWidth: CARD_WIDTH, projects });
+}
+
+/** Distance of each project from the galactic core, by key. */
+function radii(layout: ReturnType<typeof layoutOf>): Map<string, number> {
+  return new Map(
+    layout.projects.map((project) => [
+      project.key,
+      Math.hypot(project.x - layout.core.x, project.y - layout.core.y),
+    ]),
+  );
+}
+
+function overlappingPairs(layout: ReturnType<typeof layoutOf>): string[] {
+  const pairs: string[] = [];
+  for (let left = 0; left < layout.projects.length; left += 1) {
+    for (let right = left + 1; right < layout.projects.length; right += 1) {
+      const a = layout.projects[left];
+      const b = layout.projects[right];
+      if (
+        Math.abs(a.x - b.x) < a.rx + b.rx
+        && Math.abs(a.y - b.y) < a.ry + b.ry
+      ) {
+        pairs.push(`${a.key}/${b.key}`);
+      }
+    }
+  }
+  return pairs;
+}
+
+describe("computeProjectLayout", () => {
+  it("seats the heaviest project on the core", () => {
+    const layout = layoutOf([
+      { cardCount: 12, key: "busy", mass: 30 },
+      { cardCount: 2, key: "quiet", mass: 3 },
+    ]);
+    const distances = radii(layout);
+    expect(distances.get("busy")).toBe(0);
+    expect(distances.get("quiet")).toBeGreaterThan(0);
+  });
+
+  it("orders radially by mass whatever order the caller passes", () => {
+    const heaviestFirst = radii(
+      layoutOf([
+        { cardCount: 12, key: "busy", mass: 30 },
+        { cardCount: 4, key: "middling", mass: 9 },
+        { cardCount: 2, key: "quiet", mass: 3 },
+      ]),
+    );
+    const lightestFirst = radii(
+      layoutOf([
+        { cardCount: 2, key: "quiet", mass: 3 },
+        { cardCount: 4, key: "middling", mass: 9 },
+        { cardCount: 12, key: "busy", mass: 30 },
+      ]),
+    );
+    // Same galaxy either way — the seat order is derived, not trusted.
+    expect([...lightestFirst]).toEqual([...heaviestFirst]);
+    expect(heaviestFirst.get("busy")).toBe(0);
+    expect(heaviestFirst.get("quiet")).toBeGreaterThan(
+      heaviestFirst.get("middling")!,
+    );
+  });
+
+  /**
+   * The case the old mass-to-radius mapping got worst. Three one-thread
+   * projects have almost no spread in mass, so every one of them but the
+   * heaviest normalised to the lightest end of the span and landed at the
+   * rim, 1160px out, around an empty middle.
+   */
+  it("keeps a small fleet compact instead of flinging it to the rim", () => {
+    const distances = radii(
+      layoutOf([
+        { cardCount: 1, key: "a", mass: 2 },
+        { cardCount: 1, key: "b", mass: 2 },
+        { cardCount: 2, key: "c", mass: 3 },
+      ]),
+    );
+    for (const [key, radius] of distances) {
+      expect({ key, radius: radius < 600 }).toEqual({ key, radius: true });
+    }
+  });
+
+  it("never overlaps two projects' drawn extents", () => {
+    // A spread wide enough that the light tail has to tuck between the
+    // heavy clouds rather than queue behind them on its own arm.
+    const projects = Array.from({ length: 24 }, (_, index) => ({
+      cardCount: Math.max(1, 16 - index),
+      key: `project-${index}`,
+      mass: 40 - index,
+    }));
+    expect(overlappingPairs(layoutOf(projects))).toEqual([]);
+  });
+
+  it("spaces projects by the extent the caller supplies, not the ring", () => {
+    const wide = computeProjectLayout({
+      cardWidth: CARD_WIDTH,
+      projects: [
+        { cardCount: 1, extent: { rx: 900, ry: 400 }, key: "wide", mass: 9 },
+        { cardCount: 1, key: "next", mass: 4 },
+      ],
+    });
+    const narrow = layoutOf([
+      { cardCount: 1, key: "wide", mass: 9 },
+      { cardCount: 1, key: "next", mass: 4 },
+    ]);
+    expect(radii(wide).get("next")!).toBeGreaterThan(
+      radii(narrow).get("next")!,
+    );
+  });
+
+  it("is deterministic", () => {
+    const projects = [
+      { cardCount: 9, key: "one", mass: 14 },
+      { cardCount: 3, key: "two", mass: 6 },
+      { cardCount: 1, key: "three", mass: 2 },
+    ];
+    expect(layoutOf(projects)).toEqual(layoutOf(projects));
+  });
+
+  it("returns an empty galaxy for an empty fleet", () => {
+    const layout = layoutOf([]);
+    expect(layout.projects).toEqual([]);
+    expect(layout.arms).toEqual([]);
+    expect(layout.canvasWidth).toBe(0);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-layout.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-project-layout.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { computeProjectLayout } from "../star-map-project-layout";
+import {
+  computeProjectLayout,
+  EMPTY_PROJECT_LAYOUT,
+} from "../star-map-project-layout";
 
 /**
  * Projects-lens galaxy packing.
@@ -135,10 +138,16 @@ describe("computeProjectLayout", () => {
     expect(layoutOf(projects)).toEqual(layoutOf(projects));
   });
 
-  it("returns an empty galaxy for an empty fleet", () => {
-    const layout = layoutOf([]);
-    expect(layout.projects).toEqual([]);
-    expect(layout.arms).toEqual([]);
-    expect(layout.canvasWidth).toBe(0);
+  /**
+   * Identity, not just shape. `anchorBody` in StarMapScreen memoises on
+   * `projectLayout.core`, and the lenses that are not drawing projects
+   * hold this same constant — a fresh literal per call would churn that
+   * dependency on every render for a lens with no projects on screen.
+   */
+  it("returns the shared empty galaxy for an empty fleet", () => {
+    expect(layoutOf([])).toBe(EMPTY_PROJECT_LAYOUT);
+    expect(EMPTY_PROJECT_LAYOUT.projects).toEqual([]);
+    expect(EMPTY_PROJECT_LAYOUT.arms).toEqual([]);
+    expect(EMPTY_PROJECT_LAYOUT.canvasWidth).toBe(0);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -580,36 +580,71 @@ describe("star map card menu acts on the selection", () => {
 });
 
 /**
- * The projects lens paints no selected state on its cards, and its cards
- * are not where the lane geometry says they are. A selection there is one
- * the operator can neither see nor point at — which is exactly what a
- * destructive menu action must not be about.
+ * Selection in the projects lens.
+ *
+ * This block used to assert the opposite — that a sweep here selected
+ * nothing. That guard came in with the change that pointed the card menu
+ * at the selection, and its reason was that the lens "paints no selected
+ * state on its cards, and its cards are not where the lane geometry says
+ * they are": a selection the operator could neither see nor point at, with
+ * a destructive menu action aimed at it.
+ *
+ * Both halves of that were descriptions of the implementation rather than
+ * requirements, and both are now false. The lens paints selected state,
+ * and the sweep reads the lens's own card geometry (`projectCardRects`)
+ * instead of the instance-only map that was empty here. What the guard was
+ * protecting — an invisible selection — cannot arise, so the lens gets the
+ * multi-select the one lens that pools work across every machine wants.
+ *
+ * Group DRAG is still absent, and stays absent: a project is not an
+ * instance, so there is no arrangement row to persist an offset to.
  */
-describe("star map selection stops at the projects lens", () => {
+describe("star map selection in the projects lens", () => {
   afterEach(() => {
     window.localStorage.removeItem("pwragent.starMap.viewPreferences");
     window.localStorage.removeItem("pwragent.starMap.filterSelection");
   });
 
-  it("selects nothing when a sweep runs under the projects lens", async () => {
+  it("sweeps the lens's own card geometry", async () => {
     window.localStorage.setItem(
       "pwragent.starMap.viewPreferences",
       JSON.stringify({ layout: "projects" }),
     );
     const desktopApi = buildMutatingDesktopApi();
     renderMap(4, { desktopApi });
-    // The cards are on screen, so the sweep has something to miss.
     await waitFor(() => expect(shells()).toHaveLength(4));
 
     await sweepEverything();
-    await act(async () => {
-      await Promise.resolve();
+
+    await waitFor(() => {
+      expect(screen.getByText("4 cards selected")).toBeTruthy();
+    });
+    // Painted, not just counted — the half the old guard was right to
+    // insist on.
+    expect(selectedShells()).toHaveLength(4);
+    // And the kebab is about the whole selection, which is only safe
+    // because the operator can see what it is about.
+    openCardMenu("t0");
+    expect(
+      screen.getByRole("menuitem", { name: "Archive 4 threads" }),
+    ).toBeTruthy();
+  });
+
+  it("offers no drag in its selection hint", async () => {
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ layout: "projects" }),
+    );
+    renderMap(4);
+    await waitFor(() => expect(shells()).toHaveLength(4));
+    await sweepEverything();
+    await waitFor(() => {
+      expect(screen.getByText("4 cards selected")).toBeTruthy();
     });
 
-    expect(screen.queryByText(/cards? selected/)).toBeNull();
-    // And the kebab is about the card it hangs off, singular.
-    openCardMenu("t0");
-    expect(screen.getByRole("menuitem", { name: "Archive thread" })).toBeTruthy();
+    // Cards here carry no `drag`, so the bar must not name one.
+    const hint = document.querySelector(".star-map__selection-hint");
+    expect(hint?.textContent).toBe("⇧-click to amend");
   });
 
   it("drops a selection swept before the durable instance id arrived", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-project-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-project-layout.ts
@@ -35,29 +35,70 @@ const CANVAS_PADDING = 160;
 const ARM_COUNT = 3;
 /** Tightness of the spiral: bigger unwinds faster. */
 const ARM_PITCH = 0.42;
-/** Where the heaviest project sits, measured from the core. */
-const CORE_RADIUS = 260;
 /**
- * How far past the core the lightest project is thrown.
- *
- * Mass sets a target radius on this span; collisions only ever push a
- * project further out from there. Ordering alone was not enough — it made
- * the 4th-heaviest project land as far out as the 12th whenever the arms
- * fell that way, which is a queue, not gravity.
+ * Radius the arm bearings are measured from. Purely the spiral's own
+ * reference length — it does NOT reserve an empty hole of this size at
+ * the core, which is what the constant it replaced used to do.
  */
-const RIM_SPREAD = 900;
-/** How far outward to probe when a candidate seat collides. */
-const RADIUS_STEP = 36;
+const ARM_REFERENCE_RADIUS = 260;
+
+/**
+ * Share of the disc that unequal elliptical clouds actually fill once
+ * they are seated on arms, measured over a few hundred synthetic fleets.
+ *
+ * This turns "how much cloud is already placed" into "how far out the
+ * next one has to start looking", which is the whole point: the radius a
+ * project gets is now a consequence of the space its neighbours occupy,
+ * not a number assigned to it up front. Too high and every project starts
+ * its search inside its neighbours and probes outward one step at a time;
+ * too low and the galaxy re-acquires the empty middle this replaced.
+ */
+const PACKING_EFFICIENCY = 0.55;
+
+/** How far outward to probe when every bearing at a radius collides. */
+const RADIUS_STEP = 20;
+/**
+ * Bearings tried at each radius, alternating either side of the arm.
+ *
+ * A single bearing per radius makes a small project queue behind whatever
+ * is on its arm, however much room there is on the next one along — the
+ * single largest source of empty canvas in the old layout. Fanning out
+ * lets a light cloud tuck into a gap between two heavy ones instead of
+ * being pushed to the rim, and the first bearing tried is still the arm's
+ * own, so the galaxy keeps its shape.
+ */
+const BEARING_PROBES = 7;
 const MAX_PROBES = 400;
 
 /** Angle of a point on arm `index` at radius `r`. */
 function armAngle(index: number, radius: number): number {
   return (
     (index * 2 * Math.PI) / ARM_COUNT
-    + Math.log(Math.max(radius, 1) / CORE_RADIUS) / ARM_PITCH
+    + Math.log(Math.max(radius, 1) / ARM_REFERENCE_RADIUS) / ARM_PITCH
   );
 }
 
+/**
+ * Bearing offset for probe `index`: 0, then alternating either side of
+ * the arm in equal steps, out to half the angular pitch between arms.
+ */
+function bearingOffset(index: number): number {
+  if (index <= 0) return 0;
+  const side = index % 2 === 1 ? 1 : -1;
+  const step = Math.ceil(index / 2);
+  return (side * step * (2 * Math.PI)) / (ARM_COUNT * BEARING_PROBES);
+}
+
+/**
+ * Rectangular separation, deliberately.
+ *
+ * `cardRingExtent` reports the half-extents of the box that CONTAINS every
+ * card in the cloud, so two non-overlapping boxes provably cannot have two
+ * overlapping cards. Testing the clouds as ellipses instead packs a few
+ * percent tighter and lets real cards from different projects overlap by
+ * up to ~60px, because the Minkowski sum of two ellipses of different
+ * aspect is not the ellipse of their summed radii.
+ */
 function overlaps(
   a: { x: number; y: number; rx: number; ry: number },
   b: { x: number; y: number; rx: number; ry: number },
@@ -71,15 +112,39 @@ function overlaps(
 /**
  * Seat projects along the arms, busiest nearest the core.
  *
- * Each project walks outward along its arm until it clears everything
- * already placed, so a dense project pushes its neighbours further out
- * rather than overlapping them. Placement is deterministic: same input,
- * same galaxy, so the map does not reshuffle between renders.
+ * Each project starts its search at the radius the already-seated clouds
+ * force it to — the radius of a disc big enough to hold them — and then
+ * probes bearings, and only then steps outward. Distance is therefore a
+ * consequence of how much cloud is in the way, which is what "as far apart
+ * as they need to be" means.
+ *
+ * The layout this replaced mapped mass onto an ABSOLUTE radius across a
+ * fixed 900px span, so a project's distance from the core was decided
+ * before anything was placed: on a real nine-project fleet, five of the
+ * nine seated without a single collision probe — nothing had crowded them,
+ * they were simply thrown that far. It read worst on small fleets, where
+ * three one-thread projects have almost no spread in mass and every one of
+ * them but the heaviest landed at the rim, 1160px out, around an empty
+ * middle.
+ *
+ * Placement is deterministic: same input, same galaxy, so the map does not
+ * reshuffle between renders.
  */
 export function computeProjectLayout(params: {
   cardWidth: number;
-  /** Visible card count per project key, in the order to place them. */
-  projects: readonly { key: string; cardCount: number; mass?: number }[];
+  projects: readonly {
+    key: string;
+    /** Visible card count, for the ring-shaped fallback extent. */
+    cardCount: number;
+    /**
+     * Half-extent of what this project actually draws. Supplied by the
+     * caller from its seated clouds — the same arrangement
+     * `computeOrbitPlacement` uses — so project spacing tracks the real
+     * drawing rather than a ring formula that the clouds no longer follow.
+     */
+    extent?: { rx: number; ry: number };
+    mass?: number;
+  }[];
 }): ProjectLayout {
   if (params.projects.length === 0) {
     return {
@@ -91,60 +156,65 @@ export function computeProjectLayout(params: {
     };
   }
 
-  // Mass sets where a project WANTS to sit. Normalised against the
-  // heaviest so the galaxy looks the same whether the fleet has three
-  // threads or three hundred.
-  const masses = params.projects.map(
-    (project) => project.mass ?? project.cardCount,
+  // Seat order IS radial order now, so the ordering is enforced here
+  // rather than trusted from the caller: with mass no longer naming a
+  // radius, a caller that passed its projects in some other order would
+  // silently seat a dormant one-thread project at the galactic core.
+  const ordered = [...params.projects].sort(
+    (left, right) =>
+      (right.mass ?? right.cardCount) - (left.mass ?? left.cardCount)
+      || left.key.localeCompare(right.key),
   );
-  const heaviest = Math.max(...masses, 1);
-  const lightest = Math.min(...masses, heaviest);
-  const span = heaviest - lightest;
-  /**
-   * With no spread in mass there is nothing to rank, so everything is
-   * equally heavy and belongs at the core — the common shape for a small
-   * or new fleet, where every project has one thread of similar age.
-   * Deriving `pull` from a zero span instead gave every project the
-   * *lightest* treatment and flung the whole galaxy to the rim around an
-   * empty centre.
-   */
-  const ranked = span > 1e-6;
 
   const seated: (ProjectPlacement & { radius: number })[] = [];
-  params.projects.forEach((project, index) => {
-    const extent = cardRingExtent(project.cardCount, params.cardWidth);
+  /** Cloud area already claimed, each cloud's share of the gap included. */
+  let claimed = 0;
+  ordered.forEach((project, index) => {
+    const extent =
+      project.extent ?? cardRingExtent(project.cardCount, params.cardWidth);
     const arm = index % ARM_COUNT;
-    const pull = ranked ? (masses[index] - lightest) / span : 1;
-    // Square-root so the middle of the pack spreads out rather than
-    // bunching against the rim; heavy projects still dominate the core.
-    let radius = CORE_RADIUS + RIM_SPREAD * Math.sqrt(1 - pull);
+    let radius = Math.sqrt(claimed / (Math.PI * PACKING_EFFICIENCY));
+    let placed = false;
 
-    for (let probe = 0; probe < MAX_PROBES; probe += 1) {
+    for (let probe = 0; probe < MAX_PROBES && !placed; probe += 1) {
+      for (let bearing = 0; bearing < BEARING_PROBES; bearing += 1) {
+        // Below the reference radius the spiral winds arbitrarily fast, so
+        // bearings are read from a floor rather than from the true radius.
+        const angle =
+          armAngle(arm, Math.max(radius, ARM_REFERENCE_RADIUS / 4))
+          + bearingOffset(bearing);
+        const candidate = {
+          key: project.key,
+          rx: extent.rx,
+          ry: extent.ry,
+          x: Math.cos(angle) * radius,
+          y: Math.sin(angle) * radius,
+        };
+        if (!seated.some((other) => overlaps(candidate, other))) {
+          seated.push({ ...candidate, radius });
+          placed = true;
+          break;
+        }
+      }
+      if (!placed) radius += RADIUS_STEP;
+    }
+    if (!placed) {
+      // Exhausted the probe budget: seat it at the outermost radius tried
+      // rather than dropping the project off the map entirely.
       const angle = armAngle(arm, radius);
-      const candidate = {
+      seated.push({
         key: project.key,
+        radius,
         rx: extent.rx,
         ry: extent.ry,
         x: Math.cos(angle) * radius,
         y: Math.sin(angle) * radius,
-      };
-      if (!seated.some((other) => overlaps(candidate, other))) {
-        seated.push({ ...candidate, radius });
-        return;
-      }
-      radius += RADIUS_STEP;
+      });
     }
-    // Exhausted the probe budget: seat it at the outermost radius tried
-    // rather than dropping the project off the map entirely.
-    const angle = armAngle(arm, radius);
-    seated.push({
-      key: project.key,
-      radius,
-      rx: extent.rx,
-      ry: extent.ry,
-      x: Math.cos(angle) * radius,
-      y: Math.sin(angle) * radius,
-    });
+    claimed +=
+      Math.PI
+      * (extent.rx + PROJECT_GAP / 2)
+      * (extent.ry + PROJECT_GAP / 2);
   });
 
   let minX = Infinity;
@@ -161,7 +231,7 @@ export function computeProjectLayout(params: {
   const offsetY = CANVAS_PADDING - minY;
   const outermost = seated.reduce(
     (furthest, project) => Math.max(furthest, project.radius),
-    CORE_RADIUS,
+    ARM_REFERENCE_RADIUS,
   );
 
   return {
@@ -189,11 +259,12 @@ function buildArms(params: {
   outermost: number;
 }): string[] {
   const arms: string[] = [];
+  const start = ARM_REFERENCE_RADIUS * 0.35;
   const end = params.outermost * 1.18;
   for (let index = 0; index < ARM_COUNT; index += 1) {
     const points: string[] = [];
     for (let step = 0; step <= 48; step += 1) {
-      const radius = CORE_RADIUS * 0.35 + (end - CORE_RADIUS * 0.35) * (step / 48);
+      const radius = start + (end - start) * (step / 48);
       const angle = armAngle(index, radius);
       const x = Math.cos(angle) * radius + params.offsetX;
       const y = Math.sin(angle) * radius + params.offsetY;

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-project-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-project-layout.ts
@@ -19,6 +19,22 @@ export type ProjectLayout = {
   projects: ProjectPlacement[];
 };
 
+/**
+ * The galaxy with nothing in it.
+ *
+ * Shared and frozen so a caller holding it across renders holds the same
+ * object: `anchorBody` memoises on `projectLayout.core`, and a fresh
+ * literal per render would churn that identity for a lens that is not
+ * even drawing projects.
+ */
+export const EMPTY_PROJECT_LAYOUT: ProjectLayout = Object.freeze({
+  arms: [],
+  canvasHeight: 0,
+  canvasWidth: 0,
+  core: { x: 0, y: 0 },
+  projects: [],
+});
+
 /** Clearance between two projects' outermost cards. */
 const PROJECT_GAP = 72;
 const CANVAS_PADDING = 160;
@@ -80,7 +96,14 @@ function armAngle(index: number, radius: number): number {
 
 /**
  * Bearing offset for probe `index`: 0, then alternating either side of
- * the arm in equal steps, out to half the angular pitch between arms.
+ * the arm in equal steps.
+ *
+ * The step is a `BEARING_PROBES`-th of the angular pitch between arms, so
+ * the widest offset reaches `floor(BEARING_PROBES / 2)` steps — 6/7 of
+ * the way to the midpoint between two arms at the current seven, and
+ * asymptotically the midpoint as the count grows. It deliberately stops
+ * short: a project that swung past the midpoint would be seated nearer
+ * the NEXT arm than its own.
  */
 function bearingOffset(index: number): number {
   if (index <= 0) return 0;
@@ -146,15 +169,7 @@ export function computeProjectLayout(params: {
     mass?: number;
   }[];
 }): ProjectLayout {
-  if (params.projects.length === 0) {
-    return {
-      arms: [],
-      canvasHeight: 0,
-      canvasWidth: 0,
-      core: { x: 0, y: 0 },
-      projects: [],
-    };
-  }
+  if (params.projects.length === 0) return EMPTY_PROJECT_LAYOUT;
 
   // Seat order IS radial order now, so the ordering is enforced here
   // rather than trusted from the caller: with mass no longer naming a
@@ -250,8 +265,15 @@ export function computeProjectLayout(params: {
 }
 
 /**
- * The faint arms drawn behind the projects. Sampled from the same spiral
- * the seats use, so a project always sits on the arm it appears to.
+ * The faint arms drawn behind the projects, sampled from the same spiral
+ * the seats are read from.
+ *
+ * A project no longer sits exactly ON its arm: `bearingOffset` fans a
+ * crowded seat up to `floor(BEARING_PROBES / 2)` steps either side, which
+ * is what lets a light cloud tuck into a gap instead of queueing at the
+ * rim. The arms are the galaxy's grain, not a rail — do not re-derive a
+ * project's position from a sampled arm point, and do not "fix" a project
+ * that looks off-arm by removing the sweep.
  */
 function buildArms(params: {
   offsetX: number;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11737,6 +11737,21 @@ textarea,
   font-size: 12px;
 }
 
+/* A parent/child cloud is named after a THREAD; a project cloud is named
+   after a project. They looked identical, so a map with four thread
+   groups around an instance read as four extra projects. The mark and the
+   quieter name are the only difference — the chrome stays one family. */
+.star-map__cluster-label--parent {
+  font-style: italic;
+}
+
+.star-map__cluster-kind {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-style: normal;
+  line-height: 1;
+}
+
 .star-map__cluster-name {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

Reported from a Star Map where **ten clouds around one instance did not reconcile with eight project bodies**. Four separate problems came out of chasing it.

**Parent/child clouds were indistinguishable from project clouds.** In the Instances lens, [`buildInstanceClusters`](apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts) splits each parent thread with children into its own cloud labelled with the parent's *title* — wearing chrome identical to a cloud named after a project. At overview zoom the label is the only thing drawn, so four thread groups read as four extra projects. That is the whole count discrepancy: 6 projects + 4 parent groups. Parent clouds now carry a `↳` mark, an italic name, and an aria-label reading "…thread and its N replies".

**The Projects lens had no clouds at all.** It seated a project's pooled threads on one flat ring capped at 16 cards with a single *dead* `+N more` caption for the whole body — a parent thread and its children scattered like any other cards, and the 17th thread was unreachable. It now runs the same grouping the Instances lens does: parent/child clouds plus a catch-all, each with its own working expand chip. The catch-all stays unlabelled, since the project body already names and counts it.

**Distance was assigned, not computed.** `computeProjectLayout` mapped mass onto an **absolute** radius over a fixed 900px span, so how far a project sat from the core was decided before anything was placed. On the reported nine-project fleet, **five of nine seated without a single collision probe** — nothing had crowded them, they were simply thrown that far. It read worst on small fleets, where three one-thread projects have almost no spread in mass and every one but the heaviest landed at the rim, 1160px out, around an empty middle. A project now starts its search at the radius the already-seated clouds force it to (disc area at a measured packing efficiency), fans across seven bearings before stepping outward, and is spaced by the extent it actually draws — the same arrangement `computeOrbitPlacement` already uses.

| Reported fleet (9 projects) | before | after |
|---|---|---|
| canvas | 3126×2982 | **2712×2476** |
| cloud area / canvas | 18.9% | **26.2%** |
| heaviest project | r=260 | **r=0** |
| next project | r=851 | r=653 |
| 3 one-thread projects | 1338×2600 | **~1116×926** |

**"Orbit" is now "Instances".** Every lens here is orbital, so the old name described the drawing rather than what the lens is *for*, and it did not pair with "Projects" — the choice is which thing a body stands for.

## Verification

- `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:colors`, `pnpm lint:boundaries` — all clean.
- `pnpm test apps/desktop/src/renderer` — 202 files / 3152 tests pass.
- New `star-map-project-layout.test.ts` pins the packing rules: heaviest on the core, radial order derived rather than trusted from the caller, no two extents overlapping across a 24-project fleet, caller-supplied extents driving spacing, determinism, and the small-fleet case (every project inside 600px, where the old mapping put two of three at 1160).
- New `star-map-project-clouds.test.tsx` pins the Projects lens: a parent thread and its children get their own captioned cloud, the catch-all is *not* labelled twice, the per-cloud chip expands past the cap, two projects' clouds stay independent, and a parent pill selects its own cards and not a cloudmate-of-neither.
- The elliptical separation test was measured and **rejected**: it packs 0.2% tighter and lets cards from different projects overlap by up to 60px across 400 random fleets. The rectangular test is safe by construction — `cardRingExtent` reports the box containing every card.

## Notes

- **Not run in the real app.** Desktop E2E does not run on this machine, so the visual result is unverified — worth a look in a dev instance before merge.
- **Behaviour change:** the Projects lens goes from 16-cards-per-body to 8-per-cloud. Fewer cards up front, but the chips actually work now, where the old single caption was inert.
- Card **selection** in the Projects lens was never wired (`selected`/`onToggleSelect` were absent). The new parent pills report `aria-pressed`, so it is wired now rather than shipping a pill that highlights nothing.
- The Projects lens now collapses to labels at overview zoom. `star-map-flight` already documented that below `STAR_MAP_OVERVIEW_ZOOM` the map draws no cards; this lens was the exception.
- The stored layout id stays `"orbit"` so an operator's saved choice survives the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
