### PR TITLE
fix(desktop): keep the startup thread instead of flashing the composer

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1789,6 +1789,14 @@ function DesktopAppShell(props: {
     }
 
     startupLandingStateRef.current = "complete";
+    if (navigation.selectedThreadKey) {
+      // Navigation already landed on a thread: a selection restored across a
+      // renderer reload, or the snapshot's fallback pick. Swapping that for
+      // the workspace composer flashes the thread's transcript and leaves a
+      // back entry pointing at it, so the composer is the startup landing
+      // only when there is no thread to show.
+      return;
+    }
     setMainView("thread");
     void openWorkspaceLaunchpad(startupBackend.kind);
   }, [
@@ -1796,6 +1804,7 @@ function DesktopAppShell(props: {
     backendSummaries.loaded,
     desktopApi,
     navigation.loaded,
+    navigation.selectedThreadKey,
     onboardingOpen,
     openWorkspaceLaunchpad,
     settings.snapshot?.onboarding?.completed.value,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -8,9 +8,11 @@ import {
   waitFor,
   within
 } from "@testing-library/react";
+import { resolveNewThreadBackend } from "@pwragent/shared";
 import type {
   AgentEvent,
   AppServerBackendKind,
+  BackendSummary,
   CreateScheduledThreadActionRequest,
   DesktopPwrAgentProfileSummary,
   DesktopSettingsSnapshot,
@@ -2706,6 +2708,44 @@ describe("App", () => {
   });
 
   it("keeps the startup thread selection instead of opening the workspace composer", async () => {
+    const startupBackends: BackendSummary[] = [
+      {
+        kind: "codex",
+        // `BackendSummary.source` is the discovery channel ("builtin" | "acp"),
+        // not the backend kind — and `selectableNewThreadBackends` reads it.
+        source: "builtin",
+        label: "Codex",
+        available: true,
+        methods: ["thread/start", "turn/start"],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: true,
+          transcriptPagination: true,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [
+          {
+            mode: "default",
+            label: "Default Access",
+            available: true,
+            isDefault: true,
+          },
+        ],
+      },
+    ];
+    // Pin the precondition this test depends on: the startup landing effect
+    // reaches the guard under test only when a backend can create a thread.
+    // An unselectable fixture sends it down the onboarding branch instead,
+    // where every assertion below passes without exercising the guard.
+    expect(resolveNewThreadBackend(startupBackends)).toBeDefined();
     const ensureDirectoryLaunchpad = vi.fn(async () => ({
       launchpad: {
         directoryKey: "workspace:new-thread",
@@ -2754,37 +2794,7 @@ describe("App", () => {
         }),
         listBackends: async () => ({
           fetchedAt: Date.now(),
-          backends: [
-            {
-              kind: "codex" as const,
-              source: "codex" as const,
-              label: "Codex",
-              available: true,
-              methods: ["thread/start", "turn/start"],
-              capabilities: {
-                listThreads: true,
-                createThread: true,
-                resumeThread: true,
-                renameThread: true,
-                readThread: true,
-                startTurn: true,
-                interruptTurn: true,
-                steerTurn: true,
-                transcriptPagination: true,
-                toolUse: true,
-                approvalRequests: true,
-                multiDirectoryThreads: true,
-              },
-              executionModes: [
-                {
-                  mode: "default" as const,
-                  label: "Default Access",
-                  available: true,
-                  isDefault: true,
-                },
-              ],
-            },
-          ],
+          backends: startupBackends,
         }),
         getNavigationSnapshot: async () => ({
           backend: "all" as const,
@@ -2818,14 +2828,16 @@ describe("App", () => {
 
     render(<App />);
 
-    const threadRow = await screen.findByRole("button", { name: "Existing thread" });
     await waitFor(() => {
-      expect(threadRow).toHaveAttribute("aria-pressed", "true");
+      expect(
+        screen.getByRole("button", { name: "Existing thread" }),
+      ).toHaveAttribute("aria-pressed", "true");
     });
     // Three flushes cover the startup landing decision: the backend list
     // resolves, the effect runs, and `ensureDirectoryLaunchpad` would have
-    // settled. Without them a launchpad that opens one tick later reads as
-    // "never opened" and the regression passes unnoticed.
+    // settled. Measured against the unguarded effect — the launchpad opens
+    // inside this window — so the negative assertions below are load-bearing
+    // rather than merely early.
     await flushReactUpdates();
     await flushReactUpdates();
     await flushReactUpdates();

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -2598,7 +2598,7 @@ describe("App", () => {
     });
   });
 
-  it("opens a directory-less composer on startup with a usable ACP backend", async () => {
+  it("opens a directory-less composer on startup when no thread can be selected", async () => {
     const ensureDirectoryLaunchpad = vi.fn(async () => ({
       launchpad: {
         directoryKey: "workspace:new-thread",
@@ -2676,6 +2676,120 @@ describe("App", () => {
           backend: "all" as const,
           fetchedAt: Date.now(),
           unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        ensureDirectoryLaunchpad,
+        onAgentEvent: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("textbox", { name: "New thread" }),
+    ).toBeInTheDocument();
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: undefined,
+      preferredBackend: "acp:grok",
+    });
+    await flushReactUpdates();
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the startup thread selection instead of opening the workspace composer", async () => {
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "workspace:new-thread",
+        directoryKind: "workspace" as const,
+        directoryLabel: "Workspaces",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        workMode: "local" as const,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        readSettings: async () => ({
+          snapshot: {
+            general: {
+              appearance: {
+                theme: { value: "system", source: "default" },
+                density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
+                transcriptTextSize: { value: "md", source: "default" },
+              },
+            },
+            onboarding: {
+              completed: { value: true, source: "config" },
+              completedSource: { value: "migrated", source: "default" },
+            },
+            imageUploads: {
+              pastedImageMaxPatches: { value: 1536, source: "default" },
+            },
+            experimental: {
+              fullAccessRiskWarningDismissed: {
+                value: false,
+                source: "default",
+              },
+            },
+          } as DesktopSettingsSnapshot,
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex" as const,
+              source: "codex" as const,
+              label: "Codex",
+              available: true,
+              methods: ["thread/start", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                renameThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: true,
+                transcriptPagination: true,
+                toolUse: true,
+                approvalRequests: true,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [
+                {
+                  mode: "default" as const,
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+              ],
+            },
+          ],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
           inboxThreadKeys: ["codex:thread-existing"],
           threads: [
             {
@@ -2704,18 +2818,22 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(
-      await screen.findByRole("textbox", { name: "New thread" }),
-    ).toBeInTheDocument();
-    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
-      directoryKey: "workspace:new-thread",
-      directoryKind: "workspace",
-      directoryLabel: "Workspaces",
-      directoryPath: undefined,
-      preferredBackend: "acp:grok",
+    const threadRow = await screen.findByRole("button", { name: "Existing thread" });
+    await waitFor(() => {
+      expect(threadRow).toHaveAttribute("aria-pressed", "true");
     });
+    // Three flushes cover the startup landing decision: the backend list
+    // resolves, the effect runs, and `ensureDirectoryLaunchpad` would have
+    // settled. Without them a launchpad that opens one tick later reads as
+    // "never opened" and the regression passes unnoticed.
     await flushReactUpdates();
-    expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+    await flushReactUpdates();
+    await flushReactUpdates();
+    expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: "New thread" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Existing thread" }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   it("preserves replay fixture navigation instead of opening the startup composer", async () => {


### PR DESCRIPTION
## Problem

Loading a profile with existing threads flashed a thread and then jumped to the new-thread screen — with a back button pointing at the thread it had just left.

The startup landing effect added in #1721 runs once backends finish loading and unconditionally calls `openWorkspaceLaunchpad`. Navigation loads first and resolves a selection (a restored key, or the snapshot's fallback pick), so the transcript renders, then the composer replaces it and pushes a history entry.

## Fix

[App.tsx](apps/desktop/src/renderer/src/App.tsx:1792): skip the workspace composer when `navigation.selectedThreadKey` is already set. The startup landing stays "complete" either way, so a later refresh does not re-open the composer. Composer-to-composer startups (no threads, or only a directory launchpad to fall back to) are unchanged.

## Tests

- New failing-before/passing-after test: `keeps the startup thread selection instead of opening the workspace composer` — a snapshot with one thread must keep that thread selected, must not render the New thread composer, and must not call `ensureDirectoryLaunchpad`.
- The existing startup-composer test carried a thread in its snapshot while asserting the composer opened — exactly the regression. Its snapshot is now empty, matching its intent (no thread to land on), and its name says so.

Verified: `pnpm test apps/desktop/src/renderer` — 202 files, 3161 tests passed. `pnpm typecheck` and `pnpm lint:eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)