### PR TITLE
fix(desktop): advertise stable names in federation invites

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-advertised-endpoints.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-advertised-endpoints.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import type { FederationTailscaleStatus } from "@pwragent/shared";
+import {
+  buildFederationAdvertisedEndpoints,
+  federationHostnameEndpointCandidate,
+  federationTailscaleAdvertisementFromStatus,
+  type FederationAdvertisedEndpointInputs,
+} from "../federation/federation-advertised-endpoints";
+
+const LAN_INTERFACE = {
+  name: "en0",
+  address: "192.168.4.115",
+  family: "IPv4" as const,
+  internal: false,
+};
+const LOOPBACK_INTERFACE = {
+  name: "lo0",
+  address: "127.0.0.1",
+  family: "IPv4" as const,
+  internal: true,
+};
+
+function inputs(
+  overrides: Partial<FederationAdvertisedEndpointInputs> = {},
+): FederationAdvertisedEndpointInputs {
+  return {
+    listenHost: "0.0.0.0",
+    listenPort: 47830,
+    hostname: "studio.local",
+    platform: "darwin",
+    interfaceAddresses: [LOOPBACK_INTERFACE, LAN_INTERFACE],
+    ...overrides,
+  };
+}
+
+describe("federationHostnameEndpointCandidate", () => {
+  it("uses a dotted hostname as-is", () => {
+    expect(
+      federationHostnameEndpointCandidate({
+        hostname: "studio.local",
+        platform: "darwin",
+      }),
+    ).toBe("studio.local");
+  });
+
+  it("appends .local to a bare name on an mDNS platform", () => {
+    expect(
+      federationHostnameEndpointCandidate({
+        hostname: "studio",
+        platform: "darwin",
+      }),
+    ).toBe("studio.local");
+  });
+
+  it("leaves a bare Windows name alone", () => {
+    // Windows answers for its name over LLMNR, not mDNS, so a synthesized
+    // .local would never resolve and would cost every client a dial timeout.
+    expect(
+      federationHostnameEndpointCandidate({
+        hostname: "studio",
+        platform: "win32",
+      }),
+    ).toBe("studio");
+  });
+
+  it("rejects a hostname that cannot be a URL authority", () => {
+    expect(
+      federationHostnameEndpointCandidate({
+        hostname: "Harold's Mac.local",
+        platform: "darwin",
+      }),
+    ).toBeUndefined();
+    expect(
+      federationHostnameEndpointCandidate({ hostname: "  ", platform: "linux" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("buildFederationAdvertisedEndpoints", () => {
+  it("advertises the machine name ahead of its current address", () => {
+    expect(buildFederationAdvertisedEndpoints(inputs())).toEqual([
+      "ws://studio.local:47830",
+      "ws://192.168.4.115:47830",
+    ]);
+  });
+
+  it("puts an operator public URL first", () => {
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({ publicUrl: "wss://federation.example.com" }),
+      ),
+    ).toEqual([
+      "wss://federation.example.com",
+      "ws://studio.local:47830",
+      "ws://192.168.4.115:47830",
+    ]);
+  });
+
+  it("dials the tailnet name directly when Serve is not configured", () => {
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({ tailscale: { dnsName: "studio.tail1234.ts.net" } }),
+      ),
+    ).toEqual([
+      "ws://studio.local:47830",
+      "ws://studio.tail1234.ts.net:47830",
+      "ws://192.168.4.115:47830",
+    ]);
+  });
+
+  it("prefers a configured Serve URL over the raw tailnet dial", () => {
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({
+          tailscale: {
+            dnsName: "studio.tail1234.ts.net",
+            serveUrl: "wss://studio.tail1234.ts.net/pwragent-federation",
+          },
+        }),
+      ),
+    ).toEqual([
+      "ws://studio.local:47830",
+      "wss://studio.tail1234.ts.net/pwragent-federation",
+      "ws://192.168.4.115:47830",
+    ]);
+  });
+
+  it("drops the CGNAT literal that the tailnet name already covers", () => {
+    const endpoints = buildFederationAdvertisedEndpoints(
+      inputs({
+        interfaceAddresses: [
+          LAN_INTERFACE,
+          {
+            name: "utun11",
+            address: "100.102.158.117",
+            family: "IPv4",
+            internal: false,
+          },
+        ],
+        tailscale: { dnsName: "studio.tail1234.ts.net" },
+      }),
+    );
+    expect(endpoints).not.toContain("ws://100.102.158.117:47830");
+  });
+
+  it("keeps the CGNAT literal when no tailnet name was resolved", () => {
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({
+          interfaceAddresses: [
+            {
+              name: "utun11",
+              address: "100.102.158.117",
+              family: "IPv4",
+              internal: false,
+            },
+          ],
+        }),
+      ),
+    ).toContain("ws://100.102.158.117:47830");
+  });
+
+  it("skips internal, link-local, and IPv6 addresses", () => {
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({
+          hostname: "  ",
+          interfaceAddresses: [
+            LOOPBACK_INTERFACE,
+            {
+              name: "en1",
+              address: "169.254.10.4",
+              family: "IPv4",
+              internal: false,
+            },
+            { name: "en0", address: "fe80::1", family: "IPv6", internal: false },
+            {
+              name: "en0",
+              address: "fd3c:de03::1",
+              family: "IPv6",
+              internal: false,
+            },
+            LAN_INTERFACE,
+          ],
+        }),
+      ),
+    ).toEqual(["ws://192.168.4.115:47830"]);
+  });
+
+  it("skips host-only bridges that no peer can reach", () => {
+    // A VM or Internet Sharing bridge is not flagged `internal`, so without
+    // the name filter every client burns a connect timeout on it each cycle.
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({
+          hostname: "  ",
+          interfaceAddresses: [
+            {
+              name: "bridge100",
+              address: "192.168.2.1",
+              family: "IPv4",
+              internal: false,
+            },
+            {
+              name: "docker0",
+              address: "172.17.0.1",
+              family: "IPv4",
+              internal: false,
+            },
+            LAN_INTERFACE,
+          ],
+        }),
+      ),
+    ).toEqual(["ws://192.168.4.115:47830"]);
+  });
+
+  it("advertises only the bound address when the listener is not on a wildcard", () => {
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({
+          listenHost: "192.168.4.115",
+          interfaceAddresses: [
+            LAN_INTERFACE,
+            {
+              name: "en1",
+              address: "10.9.0.2",
+              family: "IPv4",
+              internal: false,
+            },
+          ],
+        }),
+      ),
+    ).toEqual(["ws://studio.local:47830", "ws://192.168.4.115:47830"]);
+  });
+
+  it("keeps a loopback-bound invite honest about the binding", () => {
+    // Names and LAN literals would all refuse: nothing off this machine can
+    // reach a loopback listener, and an invite must not imply otherwise.
+    expect(
+      buildFederationAdvertisedEndpoints(inputs({ listenHost: "127.0.0.1" })),
+    ).toEqual(["ws://127.0.0.1:47830"]);
+  });
+
+  it("de-duplicates a public URL that repeats a synthesized endpoint", () => {
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({ publicUrl: "ws://Studio.local:47830" }),
+      ),
+    ).toEqual(["ws://Studio.local:47830", "ws://192.168.4.115:47830"]);
+  });
+
+  it("returns nothing for an unusable port", () => {
+    expect(buildFederationAdvertisedEndpoints(inputs({ listenPort: 0 }))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("federationTailscaleAdvertisementFromStatus", () => {
+  function status(
+    overrides: Partial<FederationTailscaleStatus> = {},
+  ): FederationTailscaleStatus {
+    return {
+      installed: true,
+      connected: true,
+      serveConfigured: false,
+      funnelConfigured: false,
+      dnsName: "studio.tail1234.ts.net",
+      gatewayUrl: "wss://studio.tail1234.ts.net/pwragent-federation",
+      ...overrides,
+    };
+  }
+
+  it("ignores the Serve URL until Serve or Funnel is configured", () => {
+    expect(federationTailscaleAdvertisementFromStatus(status())).toEqual({
+      dnsName: "studio.tail1234.ts.net",
+    });
+  });
+
+  it("carries the Serve URL once it is configured", () => {
+    expect(
+      federationTailscaleAdvertisementFromStatus(
+        status({ serveConfigured: true }),
+      ),
+    ).toEqual({
+      dnsName: "studio.tail1234.ts.net",
+      serveUrl: "wss://studio.tail1234.ts.net/pwragent-federation",
+    });
+  });
+
+  it("advertises nothing while the device is disconnected", () => {
+    expect(
+      federationTailscaleAdvertisementFromStatus(status({ connected: false })),
+    ).toBeUndefined();
+  });
+
+  it("advertises nothing when Tailscale reports no name", () => {
+    expect(
+      federationTailscaleAdvertisementFromStatus(
+        status({ dnsName: undefined, gatewayUrl: undefined }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-advertised-endpoints.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-advertised-endpoints.test.ts
@@ -108,10 +108,33 @@ describe("buildFederationAdvertisedEndpoints", () => {
     ]);
   });
 
-  it("prefers a configured Serve URL over the raw tailnet dial", () => {
+  it("keeps the raw tailnet dial behind a configured Serve URL", () => {
+    // A Serve handler is configured outside the app and can drift out of
+    // date; when it does, the raw dial is the only tailnet path left.
     expect(
       buildFederationAdvertisedEndpoints(
         inputs({
+          tailscale: {
+            dnsName: "studio.tail1234.ts.net",
+            serveUrl: "wss://studio.tail1234.ts.net/pwragent-federation",
+          },
+        }),
+      ),
+    ).toEqual([
+      "ws://studio.local:47830",
+      "wss://studio.tail1234.ts.net/pwragent-federation",
+      "ws://studio.tail1234.ts.net:47830",
+      "ws://192.168.4.115:47830",
+    ]);
+  });
+
+  it("omits the raw tailnet dial when the listener is pinned to one address", () => {
+    // The tailnet interface is not bound, so that endpoint could never answer.
+    // The Serve handler still can — it proxies from the tailnet to loopback.
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({
+          listenHost: "192.168.4.115",
           tailscale: {
             dnsName: "studio.tail1234.ts.net",
             serveUrl: "wss://studio.tail1234.ts.net/pwragent-federation",
@@ -239,6 +262,21 @@ describe("buildFederationAdvertisedEndpoints", () => {
     expect(
       buildFederationAdvertisedEndpoints(inputs({ listenHost: "127.0.0.1" })),
     ).toEqual(["ws://127.0.0.1:47830"]);
+  });
+
+  it("never carries a loopback literal behind a public URL", () => {
+    // On another machine that literal reaches the client's OWN listener. A
+    // gateway-identity mismatch is an auth-class failure, which aborts the
+    // endpoint walk rather than falling through, so a tunnel that is briefly
+    // down would surface as a permanently rejected pairing.
+    expect(
+      buildFederationAdvertisedEndpoints(
+        inputs({
+          listenHost: "127.0.0.1",
+          publicUrl: "wss://federation.example.com",
+        }),
+      ),
+    ).toEqual(["wss://federation.example.com"]);
   });
 
   it("de-duplicates a public URL that repeats a synthesized endpoint", () => {

--- a/apps/desktop/src/main/federation/federation-advertised-endpoints.ts
+++ b/apps/desktop/src/main/federation/federation-advertised-endpoints.ts
@@ -51,7 +51,8 @@ export type FederationInterfaceAddress = {
  * bridges for VMs and Internet Sharing, container bridges, and the link-local
  * radios macOS uses for AirDrop. They are not marked `internal`, so without
  * this list a machine running Docker or a VM advertises an address that every
- * client dials and every client times out on. VPN tunnels are deliberately
+ * client dials and every client times out on. `veth` also covers the Windows
+ * Hyper-V switches named `vEthernet (...)`. VPN tunnels are deliberately
  * absent — a corporate tunnel can be a real path, and Tailscale's own address
  * is handled by the CGNAT rule below.
  */
@@ -65,7 +66,6 @@ const HOST_ONLY_INTERFACE_PREFIXES = [
   "llw",
   "lxcbr",
   "veth",
-  "vethernet",
   "virbr",
   "vmenet",
   "vmnet",
@@ -124,10 +124,14 @@ export function buildFederationAdvertisedEndpoints(
   if (publicUrl) candidates.push(publicUrl);
 
   if (LOOPBACK_LISTEN_HOSTS.has(listenHost)) {
-    // A loopback-bound gateway serves nothing off this machine. Advertising
-    // its name or LAN literals would hand every client an endpoint that
-    // refuses, so keep the invite honest about the binding instead.
-    candidates.push(formatEndpoint(listenHost, port));
+    // A loopback-bound gateway serves nothing off this machine, so the honest
+    // answer is the loopback URL itself — an invite imported by a second
+    // profile on this same box still connects through it. It must never be
+    // appended behind a public URL, though: on another machine that literal
+    // reaches the client's OWN listener, and a gateway-identity mismatch is an
+    // auth-class failure, which aborts the endpoint walk rather than falling
+    // through to the next candidate.
+    if (!publicUrl) candidates.push(formatEndpoint(listenHost, port));
     return finalizeEndpoints(candidates);
   }
 
@@ -137,15 +141,19 @@ export function buildFederationAdvertisedEndpoints(
   });
   if (hostname) candidates.push(formatEndpoint(hostname, port));
 
-  const tailnet = tailscaleCandidate(inputs.tailscale, port);
-  if (tailnet) candidates.push(tailnet);
+  const tailnet = tailscaleCandidates({
+    tailscale: inputs.tailscale,
+    listenHost,
+    port,
+  });
+  candidates.push(...tailnet);
 
   candidates.push(
     ...literalCandidates({
       listenHost,
       port,
       interfaceAddresses: inputs.interfaceAddresses ?? [],
-      hasTailnetCandidate: tailnet !== undefined,
+      hasTailnetCandidate: tailnet.length > 0,
     }),
   );
 
@@ -154,9 +162,9 @@ export function buildFederationAdvertisedEndpoints(
 
 /**
  * Narrows a Tailscale status to what an invite can advertise. A Serve or
- * Funnel handler is preferred over the raw tailnet dial because the operator
- * configured it deliberately and it survives a firewall that blocks the
- * federation port on the tailnet interface.
+ * Funnel handler is carried only once configured; it is ordered ahead of the
+ * raw tailnet dial because the operator set it up deliberately and it survives
+ * a firewall that blocks the federation port on the tailnet interface.
  */
 export function federationTailscaleAdvertisementFromStatus(
   status: FederationTailscaleStatus,
@@ -189,15 +197,33 @@ export function collectFederationInterfaceAddresses(): FederationInterfaceAddres
   return collected;
 }
 
-function tailscaleCandidate(
-  tailscale: FederationTailscaleAdvertisement | undefined,
-  port: number,
-): string | undefined {
-  const serveUrl = tailscale?.serveUrl?.trim();
-  if (serveUrl) return serveUrl;
-  const dnsName = tailscale?.dnsName?.trim().replace(/\.$/, "");
-  if (!dnsName || !DNS_NAME_PATTERN.test(dnsName)) return undefined;
-  return formatEndpoint(dnsName, port);
+/**
+ * Tailnet paths to this gateway, the operator's Serve handler first.
+ *
+ * Both are emitted when both apply: a Serve handler is configured separately
+ * from the app and can drift out of date, and when it does the raw dial is the
+ * only tailnet path left. The raw dial is conditional, though — it reaches the
+ * federation port on the tailnet interface, which only a wildcard listener
+ * binds. Behind a listener pinned to one address it can never answer, so it
+ * would cost every client a connect timeout on every reconnect cycle.
+ */
+function tailscaleCandidates(params: {
+  tailscale: FederationTailscaleAdvertisement | undefined;
+  listenHost: string;
+  port: number;
+}): string[] {
+  const candidates: string[] = [];
+  const serveUrl = params.tailscale?.serveUrl?.trim();
+  if (serveUrl) candidates.push(serveUrl);
+  const dnsName = params.tailscale?.dnsName?.trim().replace(/\.$/, "");
+  if (
+    dnsName
+    && DNS_NAME_PATTERN.test(dnsName)
+    && WILDCARD_LISTEN_HOSTS.has(params.listenHost)
+  ) {
+    candidates.push(formatEndpoint(dnsName, params.port));
+  }
+  return candidates;
 }
 
 function literalCandidates(params: {

--- a/apps/desktop/src/main/federation/federation-advertised-endpoints.ts
+++ b/apps/desktop/src/main/federation/federation-advertised-endpoints.ts
@@ -1,0 +1,266 @@
+// Default endpoint set written into new enrollment invites when the operator
+// has not pinned an explicit advertised list.
+//
+// An invite is copied once and lived with for months, so the one thing it must
+// not carry alone is a DHCP literal. When the lease moves, every enrolled
+// client keeps dialing an address that now belongs to a different machine,
+// which answers the SYN with a reset — an endless ECONNREFUSED with no way
+// back short of re-enrolling. Names that follow the machine therefore come
+// first, and address literals stay only as the fallback for networks that
+// block mDNS.
+//
+// Widening the list is safe by construction: every endpoint in an invite
+// authenticates against the same pinned gateway signing key and Noise static
+// key, so a stale or wrong candidate can only cost a dial, never reach a
+// different gateway (see federation-endpoints.ts for the walk order). It is
+// not free, though — a candidate that blackholes rather than refuses burns a
+// full connect timeout on every reconnect cycle. So this builder emits few,
+// plausible candidates rather than every address the host owns.
+
+import os from "node:os";
+import {
+  type FederationTailscaleStatus,
+  isFederationGatewayEndpointUrl,
+} from "@pwragent/shared";
+
+/**
+ * Upper bound on a synthesized list. Each unreachable candidate costs a
+ * client one connect timeout per reconnect cycle, so the default set stays
+ * short; an operator who needs more paths pins them explicitly.
+ */
+const MAX_ADVERTISED_ENDPOINTS = 6;
+
+const LOOPBACK_LISTEN_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+const WILDCARD_LISTEN_HOSTS = new Set(["", "0.0.0.0", "::", "[::]", "*"]);
+
+/** Conservative DNS-label shape: rejects the spaces and quotes a descriptive
+ * machine name can carry, which would otherwise reach clients as an
+ * unparseable URL. */
+const DNS_NAME_PATTERN =
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*$/;
+
+export type FederationInterfaceAddress = {
+  name: string;
+  address: string;
+  family: string | number;
+  internal: boolean;
+};
+
+/**
+ * Interface name prefixes whose addresses cannot serve a remote peer: host-only
+ * bridges for VMs and Internet Sharing, container bridges, and the link-local
+ * radios macOS uses for AirDrop. They are not marked `internal`, so without
+ * this list a machine running Docker or a VM advertises an address that every
+ * client dials and every client times out on. VPN tunnels are deliberately
+ * absent — a corporate tunnel can be a real path, and Tailscale's own address
+ * is handled by the CGNAT rule below.
+ */
+const HOST_ONLY_INTERFACE_PREFIXES = [
+  "anpi",
+  "awdl",
+  "br-",
+  "bridge",
+  "cni",
+  "docker",
+  "llw",
+  "lxcbr",
+  "veth",
+  "vethernet",
+  "virbr",
+  "vmenet",
+  "vmnet",
+  "vboxnet",
+];
+
+export type FederationTailscaleAdvertisement = {
+  dnsName?: string;
+  serveUrl?: string;
+};
+
+export type FederationAdvertisedEndpointInputs = {
+  listenHost: string;
+  listenPort: number;
+  hostname: string;
+  platform: NodeJS.Platform;
+  publicUrl?: string;
+  interfaceAddresses?: readonly FederationInterfaceAddress[];
+  tailscale?: FederationTailscaleAdvertisement;
+};
+
+/**
+ * The name an invite should carry for this machine, or undefined when the
+ * hostname cannot serve as one.
+ *
+ * macOS already returns the mDNS name from `os.hostname()` (`Studio.local`),
+ * so any dotted name is used as-is — that also covers a real FQDN on a
+ * managed network. A bare name gets `.local` appended only where the platform
+ * answers mDNS for it: Windows advertises over LLMNR rather than mDNS, so a
+ * synthesized `.local` there would never resolve and would cost every client
+ * a dial timeout on each cycle.
+ */
+export function federationHostnameEndpointCandidate(params: {
+  hostname: string;
+  platform: NodeJS.Platform;
+}): string | undefined {
+  const hostname = params.hostname.trim().replace(/\.$/, "");
+  if (!hostname || !DNS_NAME_PATTERN.test(hostname)) return undefined;
+  if (hostname.includes(".")) return hostname;
+  if (params.platform === "win32") return hostname;
+  return `${hostname}.local`;
+}
+
+/**
+ * Endpoints for a new invite, most durable first: the operator's public URL,
+ * this machine's name, its tailnet path, then address literals.
+ */
+export function buildFederationAdvertisedEndpoints(
+  inputs: FederationAdvertisedEndpointInputs,
+): string[] {
+  const port = inputs.listenPort;
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) return [];
+  const listenHost = inputs.listenHost.trim().toLowerCase();
+  const candidates: string[] = [];
+  const publicUrl = inputs.publicUrl?.trim();
+  if (publicUrl) candidates.push(publicUrl);
+
+  if (LOOPBACK_LISTEN_HOSTS.has(listenHost)) {
+    // A loopback-bound gateway serves nothing off this machine. Advertising
+    // its name or LAN literals would hand every client an endpoint that
+    // refuses, so keep the invite honest about the binding instead.
+    candidates.push(formatEndpoint(listenHost, port));
+    return finalizeEndpoints(candidates);
+  }
+
+  const hostname = federationHostnameEndpointCandidate({
+    hostname: inputs.hostname,
+    platform: inputs.platform,
+  });
+  if (hostname) candidates.push(formatEndpoint(hostname, port));
+
+  const tailnet = tailscaleCandidate(inputs.tailscale, port);
+  if (tailnet) candidates.push(tailnet);
+
+  candidates.push(
+    ...literalCandidates({
+      listenHost,
+      port,
+      interfaceAddresses: inputs.interfaceAddresses ?? [],
+      hasTailnetCandidate: tailnet !== undefined,
+    }),
+  );
+
+  return finalizeEndpoints(candidates);
+}
+
+/**
+ * Narrows a Tailscale status to what an invite can advertise. A Serve or
+ * Funnel handler is preferred over the raw tailnet dial because the operator
+ * configured it deliberately and it survives a firewall that blocks the
+ * federation port on the tailnet interface.
+ */
+export function federationTailscaleAdvertisementFromStatus(
+  status: FederationTailscaleStatus,
+): FederationTailscaleAdvertisement | undefined {
+  if (!status.connected) return undefined;
+  const serveUrl =
+    status.serveConfigured || status.funnelConfigured
+      ? status.gatewayUrl
+      : undefined;
+  if (!serveUrl && !status.dnsName) return undefined;
+  return {
+    ...(status.dnsName ? { dnsName: status.dnsName } : {}),
+    ...(serveUrl ? { serveUrl } : {}),
+  };
+}
+
+/** Non-internal interface addresses of this machine, in `os` order. */
+export function collectFederationInterfaceAddresses(): FederationInterfaceAddress[] {
+  const collected: FederationInterfaceAddress[] = [];
+  for (const [name, entries] of Object.entries(os.networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      collected.push({
+        name,
+        address: entry.address,
+        family: entry.family,
+        internal: entry.internal,
+      });
+    }
+  }
+  return collected;
+}
+
+function tailscaleCandidate(
+  tailscale: FederationTailscaleAdvertisement | undefined,
+  port: number,
+): string | undefined {
+  const serveUrl = tailscale?.serveUrl?.trim();
+  if (serveUrl) return serveUrl;
+  const dnsName = tailscale?.dnsName?.trim().replace(/\.$/, "");
+  if (!dnsName || !DNS_NAME_PATTERN.test(dnsName)) return undefined;
+  return formatEndpoint(dnsName, port);
+}
+
+function literalCandidates(params: {
+  listenHost: string;
+  port: number;
+  interfaceAddresses: readonly FederationInterfaceAddress[];
+  hasTailnetCandidate: boolean;
+}): string[] {
+  if (!WILDCARD_LISTEN_HOSTS.has(params.listenHost)) {
+    // Bound to one address: that address is the only literal that can serve,
+    // so enumerating the other interfaces would only add dead candidates.
+    return [formatEndpoint(params.listenHost, params.port)];
+  }
+  const literals: string[] = [];
+  for (const entry of params.interfaceAddresses) {
+    if (entry.internal || isHostOnlyInterface(entry.name)) continue;
+    // IPv6 is deliberately omitted: link-local addresses need a scope id that
+    // does not survive the trip to another machine, and a routable v6 address
+    // is reached through the same names already advertised above.
+    if (entry.family !== "IPv4" && entry.family !== 4) continue;
+    const address = entry.address.trim();
+    if (!address || address.startsWith("169.254.")) continue;
+    // The tailnet name already covers this address and resolves from any
+    // network, so the CGNAT literal would be a redundant extra dial.
+    if (params.hasTailnetCandidate && isCarrierGradeNat(address)) continue;
+    literals.push(formatEndpoint(address, params.port));
+  }
+  return literals;
+}
+
+function isHostOnlyInterface(name: string): boolean {
+  const normalized = name.trim().toLowerCase();
+  return HOST_ONLY_INTERFACE_PREFIXES.some((prefix) =>
+    normalized.startsWith(prefix),
+  );
+}
+
+/** Tailscale's 100.64.0.0/10 range. */
+function isCarrierGradeNat(address: string): boolean {
+  const octets = address.split(".");
+  if (octets.length !== 4 || octets[0] !== "100") return false;
+  const second = Number(octets[1]);
+  return Number.isInteger(second) && second >= 64 && second <= 127;
+}
+
+function formatEndpoint(host: string, port: number): string {
+  const authority = host.includes(":") && !host.startsWith("[")
+    ? `[${host}]`
+    : host;
+  return `ws://${authority}:${port}`;
+}
+
+function finalizeEndpoints(candidates: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const endpoints: string[] = [];
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (!trimmed || !isFederationGatewayEndpointUrl(trimmed)) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    endpoints.push(trimmed);
+    if (endpoints.length >= MAX_ADVERTISED_ENDPOINTS) break;
+  }
+  return endpoints;
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -274,6 +274,11 @@ import {
   type FederationClientWebSocketClient,
   type FederationGatewayConnection,
 } from "./federation-transport";
+import {
+  buildFederationAdvertisedEndpoints,
+  collectFederationInterfaceAddresses,
+  type FederationTailscaleAdvertisement,
+} from "./federation-advertised-endpoints";
 import { orderFederationEndpointAttempts } from "./federation-endpoints";
 import {
   dialFederationSshEndpoint,
@@ -1450,6 +1455,12 @@ export class DesktopFederationRuntime {
   async generateInvite(request: {
     label?: string;
     ttlMs?: number;
+    /**
+     * Tailnet identity to advertise, injected by the caller. The Tailscale
+     * service reaches back into this runtime to verify the listener, so
+     * reading it from here would close a dependency cycle.
+     */
+    tailscale?: FederationTailscaleAdvertisement;
   }): Promise<{ invite: string; expiresAt: number }> {
     const settings = await getDesktopSettingsService().readSettings();
     const mode = settings.federation.mode.value;
@@ -1461,14 +1472,10 @@ export class DesktopFederationRuntime {
     const advertisedEndpoints = settings.federation.advertisedEndpoints.value
       .map((endpoint) => endpoint.trim())
       .filter((endpoint) => endpoint.length > 0);
-    const fallbackUrl =
-      settings.federation.publicUrl.value.trim() || this.listenUrl;
     const gatewayEndpoints =
       advertisedEndpoints.length > 0
         ? advertisedEndpoints
-        : fallbackUrl
-          ? [fallbackUrl]
-          : [];
+        : this.defaultAdvertisedEndpoints(settings, request.tailscale);
     const gatewayUrl = gatewayEndpoints[0];
     if (!gatewayUrl) {
       throw new Error("Federation gateway URL is not configured.");
@@ -1502,6 +1509,37 @@ export class DesktopFederationRuntime {
       }),
       expiresAt,
     };
+  }
+
+  /**
+   * Endpoints for an invite when the operator has pinned no advertised list.
+   *
+   * Synthesized from names that follow the machine rather than from whatever
+   * address it happens to hold today — an invite outlives a DHCP lease, and a
+   * literal that has since moved leaves every enrolled client dialing a
+   * stranger. See federation-advertised-endpoints.ts for the ordering rules.
+   */
+  private defaultAdvertisedEndpoints(
+    settings: DesktopSettingsSnapshot,
+    tailscale?: FederationTailscaleAdvertisement,
+  ): string[] {
+    const publicUrl = settings.federation.publicUrl.value.trim();
+    const endpoints = buildFederationAdvertisedEndpoints({
+      listenHost: settings.federation.listenHost.value,
+      listenPort: settings.federation.listenPort.value,
+      hostname: hostname(),
+      platform: process.platform,
+      interfaceAddresses: collectFederationInterfaceAddresses(),
+      ...(publicUrl ? { publicUrl } : {}),
+      ...(tailscale ? { tailscale } : {}),
+    });
+    if (endpoints.length > 0) return endpoints;
+    // Nothing on this machine produced a usable candidate (an unusable
+    // hostname on a listener bound to a wildcard with no external address).
+    // The listener URL is wrong for a remote peer, but a caller that can see
+    // it can still repair it by hand, which beats an invite with no endpoint.
+    const fallbackUrl = publicUrl || this.listenUrl;
+    return fallbackUrl ? [fallbackUrl] : [];
   }
 
   async importInvite(invite: string): Promise<{

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1456,11 +1456,15 @@ export class DesktopFederationRuntime {
     label?: string;
     ttlMs?: number;
     /**
-     * Tailnet identity to advertise, injected by the caller. The Tailscale
-     * service reaches back into this runtime to verify the listener, so
-     * reading it from here would close a dependency cycle.
+     * Reads the tailnet identity to advertise. Injected by the caller because
+     * the Tailscale service reaches back into this runtime to verify the
+     * listener, so reading it from here would close a dependency cycle. It
+     * stays a thunk so an operator who pinned an explicit advertised list
+     * never pays for a Tailscale CLI spawn whose result is discarded.
      */
-    tailscale?: FederationTailscaleAdvertisement;
+    readTailscaleAdvertisement?: () => Promise<
+      FederationTailscaleAdvertisement | undefined
+    >;
   }): Promise<{ invite: string; expiresAt: number }> {
     const settings = await getDesktopSettingsService().readSettings();
     const mode = settings.federation.mode.value;
@@ -1475,7 +1479,10 @@ export class DesktopFederationRuntime {
     const gatewayEndpoints =
       advertisedEndpoints.length > 0
         ? advertisedEndpoints
-        : this.defaultAdvertisedEndpoints(settings, request.tailscale);
+        : await this.defaultAdvertisedEndpoints(
+            settings,
+            request.readTailscaleAdvertisement,
+          );
     const gatewayUrl = gatewayEndpoints[0];
     if (!gatewayUrl) {
       throw new Error("Federation gateway URL is not configured.");
@@ -1519,11 +1526,25 @@ export class DesktopFederationRuntime {
    * literal that has since moved leaves every enrolled client dialing a
    * stranger. See federation-advertised-endpoints.ts for the ordering rules.
    */
-  private defaultAdvertisedEndpoints(
+  private async defaultAdvertisedEndpoints(
     settings: DesktopSettingsSnapshot,
-    tailscale?: FederationTailscaleAdvertisement,
-  ): string[] {
+    readTailscaleAdvertisement?: () => Promise<
+      FederationTailscaleAdvertisement | undefined
+    >,
+  ): Promise<string[]> {
     const publicUrl = settings.federation.publicUrl.value.trim();
+    if (!publicUrl && !this.listenUrl) {
+      // Nothing designated a URL and no listener is up to name. Minting an
+      // invite here would hand a peer endpoints that cannot answer until the
+      // bind is repaired — most often another instance already holds the port,
+      // since every profile defaults to the same one. Say that instead.
+      throw new Error(
+        this.gatewayListenerError
+          ? `Federation gateway is not listening: ${this.gatewayListenerError}`
+          : "Federation gateway is not listening yet. Wait for it to start, or set a Public URL.",
+      );
+    }
+    const tailscale = await readTailscaleAdvertisement?.();
     const endpoints = buildFederationAdvertisedEndpoints({
       listenHost: settings.federation.listenHost.value,
       listenPort: settings.federation.listenPort.value,

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -50,6 +50,10 @@ import {
   FEDERATION_TAILSCALE_STATUS_CHANNEL,
 } from "../../shared/ipc";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import {
+  federationTailscaleAdvertisementFromStatus,
+  type FederationTailscaleAdvertisement,
+} from "../federation/federation-advertised-endpoints";
 import { getFederationTailscaleService } from "../federation/federation-tailscale";
 import { createFederationWindow } from "../federation/federation-window";
 
@@ -278,8 +282,13 @@ export function registerFederationIpcHandlers(): void {
     async (
       _event,
       request: GenerateFederationInviteRequest = {},
-    ): Promise<GenerateFederationInviteResponse> =>
-      await getDesktopFederationRuntime().generateInvite(request),
+    ): Promise<GenerateFederationInviteResponse> => {
+      const tailscale = await readInviteTailscaleAdvertisement();
+      return await getDesktopFederationRuntime().generateInvite({
+        ...request,
+        ...(tailscale ? { tailscale } : {}),
+      });
+    },
   );
   ipcMain.handle(
     FEDERATION_IMPORT_INVITE_CHANNEL,
@@ -334,6 +343,37 @@ export function registerFederationIpcHandlers(): void {
       });
     },
   );
+}
+
+/**
+ * How long invite generation waits for Tailscale before advertising without
+ * a tailnet endpoint. Generating an invite is a button press and `readStatus`
+ * shells out to the CLI, so a hung daemon must not hold the click for the
+ * command timeout — the cost of giving up is one endpoint fewer in the
+ * invite, and the operator can still paste a tailnet URL by hand.
+ */
+const INVITE_TAILSCALE_BUDGET_MS = 2_000;
+
+async function readInviteTailscaleAdvertisement(): Promise<
+  FederationTailscaleAdvertisement | undefined
+> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    const status = await Promise.race([
+      getFederationTailscaleService().readStatus(),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), INVITE_TAILSCALE_BUDGET_MS);
+      }),
+    ]);
+    return status
+      ? federationTailscaleAdvertisementFromStatus(status)
+      : undefined;
+  } catch {
+    // A tailnet endpoint is a bonus path, never a precondition for enrolling.
+    return undefined;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -282,13 +282,11 @@ export function registerFederationIpcHandlers(): void {
     async (
       _event,
       request: GenerateFederationInviteRequest = {},
-    ): Promise<GenerateFederationInviteResponse> => {
-      const tailscale = await readInviteTailscaleAdvertisement();
-      return await getDesktopFederationRuntime().generateInvite({
+    ): Promise<GenerateFederationInviteResponse> =>
+      await getDesktopFederationRuntime().generateInvite({
         ...request,
-        ...(tailscale ? { tailscale } : {}),
-      });
-    },
+        readTailscaleAdvertisement: readInviteTailscaleAdvertisement,
+      }),
   );
   ipcMain.handle(
     FEDERATION_IMPORT_INVITE_CHANNEL,

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -623,7 +623,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           />
           <SettingsField
             label="Advertised endpoints"
-            sub="Gateway mode: endpoints written into new enrollment invites, one per line. Defaults to the Public URL when empty."
+            sub="Gateway mode: endpoints written into new enrollment invites, one per line. Leave empty to advertise this machine's name, its tailnet name, and its current addresses — names keep working after the address changes."
             control={
               <textarea
                 aria-label="Advertised endpoints"


### PR DESCRIPTION
## Summary

- An enrollment invite carried a single endpoint, taken from the operator's Public URL or the raw listener URL (`ws://${listenHost}:${port}`, which is `ws://0.0.0.0:47830` for any real gateway). In practice that meant a hand-typed LAN literal. An invite is copied once and lived with for months, so when the gateway's DHCP lease moved, every enrolled client kept dialing an address that now belonged to a different machine — which answers the SYN with a reset. The operator saw an endless `ECONNREFUSED` with no way back short of re-enrolling.
- `generateInvite` now defaults to a synthesized set, ordered most-durable-first: the operator's Public URL, this machine's name, its tailnet path, then address literals. The multi-endpoint path already existed end to end — `importInvite` writes every entry into `gateway_endpoints`, and `connectToGateway` walks them last-good-first — so a moved address now costs one failed dial instead of a dead pairing.
- New `federation-advertised-endpoints.ts` holds the builder as a pure function, plus a `FederationTailscaleStatus` mapper and an `os.networkInterfaces()` collector.
- An explicit `advertised_endpoints` list still overrides all of this; the Settings help text now describes what the empty default does.

On a Mac with Tailscale, the default set comes out as:

```
ws://Studio.local:47830 | ws://studio.tail1234.ts.net:47830 | ws://192.168.4.49:47830
```

## Verification

- `pnpm typecheck` — pass
- `pnpm lint:eslint` — pass (0 errors)
- `pnpm lint:boundaries` — pass, no cycle (1535 modules, 5117 dependencies)
- `pnpm test` across `federation-advertised-endpoints`, `federation-runtime`, `federation-enrollment`, `federation-endpoints`, `federation-tailscale`, `federation-endpoint-fallback`, `federation-runtime-startup`, `desktop-config-federation` — 133 passed, 20 of them new
- Desktop E2E was not run.

## Notes

Widening the endpoint set is safe by construction: every endpoint authenticates against the same pinned gateway signing key and Noise static key, so an extra candidate can only change reachability, never which gateway is trusted (see the header comment in `federation-endpoints.ts`). It is not free, though — a candidate that blackholes rather than refuses burns `FEDERATION_CONNECT_TIMEOUT_MS` (20s) per reconnect cycle. So the builder stays deliberately narrow, and each exclusion is there for a reason worth reviewing:

- **`.local` is platform-gated.** A bare hostname gains `.local` only where the platform answers mDNS for it. macOS already returns `Studio.local` from `os.hostname()`. Windows advertises over LLMNR rather than mDNS, so a synthesized `.local` there would never resolve and would cost every client a timeout per cycle.
- **Host-only interfaces are skipped** — VM and Internet Sharing bridges, container bridges, AirDrop radios. These are *not* flagged `internal`, so without the filter a machine running Docker or a VM advertises an address no peer can reach. This was found by running the builder against a real machine, which emitted a `bridge100` address on the first pass. VPN tunnels are deliberately left in, since a corporate tunnel can be a genuine path.
- **IPv6 is omitted** — link-local needs a scope id that does not survive the trip to another machine, and a routable v6 address is reached through the names already advertised.
- **A loopback-bound listener advertises only loopback.** Names and LAN literals would all refuse, and the invite must not imply otherwise.

The tailnet identity is read in the IPC handler and injected into `generateInvite` rather than read from the runtime: `federation-tailscale` imports `federation-runtime` for its listener check, so reading it there would close a dependency cycle that `lint:boundaries` rejects. It is capped at a 2s budget so a hung `tailscaled` cannot stall the button press.

This fixes invites issued from now on. Existing enrollments still carry whatever literal they were given and need either a config edit or a fresh invite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
