### PR TITLE
fix(desktop): settle the missing-thread audit instead of pumping the clock

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -70,6 +70,7 @@ import type {
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 import {
   buildCodexFastModeMismatchNotificationParams,
+  CODEX_MISSING_THREAD_EVALUATION_DELAY_MS,
   DesktopBackendRegistry,
   getCodexFastModeMismatchWarning,
 } from "../app-server/backend-registry";
@@ -44732,14 +44733,42 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
   });
 
   /**
-   * The audit runs on a debounce and then archives through several awaited
-   * hops. Stepping the clock in slices drains those microtasks; a single jump
-   * fires the timer and returns before the archive completes.
+   * Runs the missing-thread audit to completion.
+   *
+   * Each wait is for a specific thing, not for a guessed amount of time. The
+   * first settles the fire-and-forget workspace synchronizations, whose
+   * rejections are what arm the audit at all. The clock then advances by
+   * exactly the debounce so the audit starts. The second settles the audit
+   * itself, however many awaited hops its archive path happens to take — the
+   * count differs by platform, and pumping a fixed number of fake-timer ticks
+   * instead is what made this flaky on Windows (#1793).
    */
-  async function flushMissingCodexThreadAudit(): Promise<void> {
-    for (let step = 0; step < 50; step += 1) {
-      await vi.advanceTimersByTimeAsync(100);
-    }
+  /**
+   * Runs the missing-thread audit to completion. Each wait is for a specific
+   * thing rather than for a guessed amount of time, and the two waits cover
+   * different failures:
+   *
+   * - The FIRST settles the fire-and-forget workspace synchronizations. Their
+   *   rejections are what arm the audit, so without this the clock can advance
+   *   past the debounce before the timer is armed — after which the timer is
+   *   due 2s into a future that never arrives, the audit never runs, and the
+   *   archive assertion sees an empty list. That is the reported Windows
+   *   symptom (#1793), and it is the wait that is NOT load-bearing on macOS:
+   *   locally the rejection has always landed first.
+   * - The SECOND settles the audit itself, however many awaited hops its
+   *   archive path takes. This one IS load-bearing everywhere — drop it and
+   *   the test fails locally, because the audit is still running when the
+   *   debounce timer fires.
+   *
+   * The pump this replaces (50 ticks of 100ms) satisfied the second by budget
+   * — the audit settled by tick 20 — and the first only by luck of ordering.
+   */
+  async function settleMissingCodexThreadAudit(
+    registry: DesktopBackendRegistry,
+  ): Promise<void> {
+    await registry.whenMissingCodexThreadWorkSettledForTests();
+    await vi.advanceTimersByTimeAsync(CODEX_MISSING_THREAD_EVALUATION_DELAY_MS);
+    await registry.whenMissingCodexThreadWorkSettledForTests();
   }
 
   function buildMissingThreadFixture(params: {
@@ -44849,13 +44878,20 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
       });
 
       await registry.listThreads({ backend: "codex", forceRefresh: true });
-      await flushMissingCodexThreadAudit();
+      await settleMissingCodexThreadAudit(registry);
 
-      expect(codexClient.archivedThreadIds).toEqual(["thread-missing"]);
+      // Assert the decision before its effect. A bare empty-archive failure
+      // cannot tell "the audit never ran" from "the audit ran and asked
+      // instead", and those have completely different causes.
       const update = events.find(
         (event) =>
           event.notification.method === "codex/missingThreads/updated",
       );
+      expect(update?.notification.params).toMatchObject({
+        status: "archived",
+        totalCount: 10,
+      });
+      expect(codexClient.archivedThreadIds).toEqual(["thread-missing"]);
       expect(update?.notification.params).toMatchObject({
         archivedCount: 1,
         failedCount: 0,
@@ -44897,7 +44933,7 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
       });
 
       await registry.listThreads({ backend: "codex", forceRefresh: true });
-      await flushMissingCodexThreadAudit();
+      await settleMissingCodexThreadAudit(registry);
 
       expect(codexClient.archivedThreadIds).toEqual([]);
       const update = events.find(
@@ -44935,7 +44971,7 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
       const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
 
       await registry.listThreads({ backend: "codex", forceRefresh: true });
-      await flushMissingCodexThreadAudit();
+      await settleMissingCodexThreadAudit(registry);
       const callsBeforeAnswer = codexClient.updateThreadWorkspaceCallCount;
       expect(callsBeforeAnswer).toBe(2);
 
@@ -44951,7 +44987,7 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
       });
 
       await registry.listThreads({ backend: "codex", forceRefresh: true });
-      await flushMissingCodexThreadAudit();
+      await settleMissingCodexThreadAudit(registry);
 
       expect(codexClient.updateThreadWorkspaceCallCount).toBe(callsBeforeAnswer);
       expect(codexClient.archivedThreadIds).toEqual([]);
@@ -44978,7 +45014,7 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
       const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
 
       await registry.listThreads({ backend: "codex", forceRefresh: true });
-      await flushMissingCodexThreadAudit();
+      await settleMissingCodexThreadAudit(registry);
 
       const threadIds = ["thread-missing-1", "thread-missing-2"];
       const first = await registry.resolveMissingCodexThreads({
@@ -44993,6 +45029,148 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
       expect(first.archivedThreadIds.sort()).toEqual(threadIds);
       expect(second.archivedThreadIds).toEqual([]);
       expect(codexClient.archivedThreadIds.sort()).toEqual(threadIds);
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-asks when another Codex thread goes missing after an unanswered prompt", async () => {
+    vi.useFakeTimers();
+    try {
+      const missingThreadIds = new Set(["thread-missing-1", "thread-missing-2"]);
+      const fixture = buildMissingThreadFixture({
+        missingThreadIds: ["thread-missing-1", "thread-missing-2"],
+        presentThreadIds: ["a", "b", "c"],
+      });
+      const codexClient = new MissingThreadCodexClient(missingThreadIds, {
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: fixture.threads,
+      });
+      const overlayStore = createOverlayStoreMock({ overlays: fixture.overlays });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+      const events: AgentEvent[] = [];
+      registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      // The first prompt is emitted before any window subscribes. Nothing
+      // answers it, so a latched flag would disable the audit for the session.
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await settleMissingCodexThreadAudit(registry);
+      expect(
+        events.filter(
+          (event) =>
+            event.notification.method === "codex/missingThreads/updated",
+        ),
+      ).toHaveLength(1);
+
+      missingThreadIds.add("thread-missing-3");
+      const extended = buildMissingThreadFixture({
+        missingThreadIds: [
+          "thread-missing-1",
+          "thread-missing-2",
+          "thread-missing-3",
+        ],
+        presentThreadIds: ["a", "b", "c"],
+      });
+      codexClient.setThreads(extended.threads);
+      await overlayStore.addLinkedDirectory({
+        backend: "codex",
+        threadId: "thread-missing-3",
+        directory: {
+          id: "pwragent-handoff:codex:thread-missing-3",
+          label: "thread-missing-3",
+          path: "/repo/thread-missing-3",
+          worktreePath: "/worktrees/thread-missing-3",
+          kind: "worktree",
+        },
+      });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await settleMissingCodexThreadAudit(registry);
+
+      const updates = events.filter(
+        (event) => event.notification.method === "codex/missingThreads/updated",
+      );
+      expect(updates).toHaveLength(2);
+      expect(updates[1]?.notification.params).toMatchObject({
+        status: "confirmationRequired",
+      });
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never auto-archives again once the operator has kept missing threads", async () => {
+    vi.useFakeTimers();
+    try {
+      const missingThreadIds = new Set(["thread-missing-1", "thread-missing-2"]);
+      const fixture = buildMissingThreadFixture({
+        missingThreadIds: ["thread-missing-1", "thread-missing-2"],
+        presentThreadIds: ["a", "b", "c"],
+      });
+      const codexClient = new MissingThreadCodexClient(missingThreadIds, {
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: fixture.threads,
+      });
+      const overlayStore = createOverlayStoreMock({ overlays: fixture.overlays });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+      const events: AgentEvent[] = [];
+      registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await settleMissingCodexThreadAudit(registry);
+      // 2 of 5 is above the threshold, so this round asks.
+      expect(codexClient.archivedThreadIds).toEqual([]);
+
+      await registry.resolveMissingCodexThreads({
+        action: "keep",
+        threadIds: ["thread-missing-1", "thread-missing-2"],
+      });
+
+      missingThreadIds.add("thread-missing-3");
+      const extended = buildMissingThreadFixture({
+        missingThreadIds: [
+          "thread-missing-1",
+          "thread-missing-2",
+          "thread-missing-3",
+        ],
+        presentThreadIds: ["a", "b", "c"],
+      });
+      codexClient.setThreads(extended.threads);
+      await overlayStore.addLinkedDirectory({
+        backend: "codex",
+        threadId: "thread-missing-3",
+        directory: {
+          id: "pwragent-handoff:codex:thread-missing-3",
+          label: "thread-missing-3",
+          path: "/repo/thread-missing-3",
+          worktreePath: "/worktrees/thread-missing-3",
+          kind: "worktree",
+        },
+      });
+
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await settleMissingCodexThreadAudit(registry);
+
+      // 1 of 5 is at or under the threshold, so the ratio alone would archive
+      // it. The operator already said the Codex profile may be wrong, and
+      // deciding for them now would archive a thread from the very profile
+      // they asked us to leave alone.
+      expect(codexClient.archivedThreadIds).toEqual([]);
+      const updates = events.filter(
+        (event) => event.notification.method === "codex/missingThreads/updated",
+      );
+      expect(updates.at(-1)?.notification.params).toMatchObject({
+        status: "confirmationRequired",
+        threadIds: ["thread-missing-3"],
+      });
 
       await registry.close();
     } finally {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4907,7 +4907,7 @@ const CODEX_MISSING_THREAD_CONFIRMATION_RATIO = 0.2;
  * synchronization rejects. Coalesce a startup burst into one decision so the
  * ratio is computed against every thread Codex lost, not the first one.
  */
-const CODEX_MISSING_THREAD_EVALUATION_DELAY_MS = 2_000;
+export const CODEX_MISSING_THREAD_EVALUATION_DELAY_MS = 2_000;
 
 /**
  * Codex answers any thread-scoped request for a thread it can no longer
@@ -6919,14 +6919,22 @@ export class DesktopBackendRegistry {
    * Threads Codex answered `thread not found` for during this session. An id
    * stays here once it lands, whatever the audit decides, so a later
    * `thread/list` cannot reschedule the retries this set exists to suppress.
-   * Only a successful thread-scoped write clears one.
+   * Because the scheduler skips these threads, nothing it does can clear one;
+   * only an operator-driven workspace handoff, which bypasses the scheduler,
+   * can prove the thread came back. Otherwise the suppression lasts the
+   * session, and a restart re-audits from scratch.
    */
   private readonly missingCodexThreadIds = new Set<string>();
   /** The subset still awaiting an archive-or-keep outcome. */
   private readonly unresolvedMissingCodexThreadIds = new Set<string>();
   private missingCodexThreadEvaluationTimer?: ReturnType<typeof setTimeout>;
   private missingCodexThreadEvaluation?: Promise<void>;
-  private missingCodexThreadPromptOpen = false;
+  /**
+   * Set once the operator answers a missing-thread prompt with "keep". That
+   * answer means they suspect a Codex profile mismatch, so nothing may be
+   * auto-archived afterwards: every later audit asks instead of deciding.
+   */
+  private missingCodexThreadsKeptThisSession = false;
   /**
    * Visible (non-tombstoned, non-archived) Codex thread count from the most
    * recent full `thread/list`. It is the denominator for the missing-thread
@@ -24436,6 +24444,12 @@ export class DesktopBackendRegistry {
         cwd,
       });
     });
+    // A thread Codex can write to is a thread Codex still has. Clearing here
+    // rather than in the scheduler's success path is what makes this
+    // reachable: the scheduler skips every thread already recorded missing, so
+    // only a caller that bypasses it — an operator-driven workspace handoff —
+    // can prove the thread came back.
+    this.clearMissingCodexThread(params.threadId);
   }
 
   private schedulePendingCodexWorkspaceCwdSyncs(params: {
@@ -24493,9 +24507,6 @@ export class DesktopBackendRegistry {
       cwd: params.cwd,
     })
       .then(() => {
-        // A thread Codex can write to is a thread Codex still has. Clear any
-        // earlier verdict so a reconnected profile recovers on its own.
-        this.clearMissingCodexThread(params.threadId);
         this.invalidateThreadListCache("codex");
       })
       .catch((error) => {
@@ -24522,6 +24533,32 @@ export class DesktopBackendRegistry {
       cwd: params.cwd,
       promise,
     });
+  }
+
+  /**
+   * Resolves once no missing-thread work is in flight: every pending workspace
+   * CWD synchronization has settled — that rejection is what records a missing
+   * thread and arms the audit — and any running audit has finished.
+   *
+   * This exists because the work is deliberately fire-and-forget, so nothing a
+   * caller awaits tells it when the audit has run. A test that instead pumped
+   * fake timers for a fixed number of ticks was guessing how many awaited hops
+   * the archive path takes; that count differs by platform, and the Windows job
+   * flaked on it (#1793). Loop rather than assume one pass drains everything:
+   * the audit archives through `listThreads`, which can schedule further
+   * synchronizations. The bound is a runaway guard — reaching it means
+   * something is re-arming without converging, which is a bug worth seeing.
+   */
+  async whenMissingCodexThreadWorkSettledForTests(): Promise<void> {
+    for (let pass = 0; pass < 10; pass += 1) {
+      const pendingSyncs = [...this.pendingCodexWorkspaceCwdSyncs.values()];
+      const evaluation = this.missingCodexThreadEvaluation;
+      if (pendingSyncs.length === 0 && !evaluation) {
+        return;
+      }
+      await Promise.all(pendingSyncs.map((pending) => pending.promise));
+      await evaluation;
+    }
   }
 
   private isCodexThreadKnownMissing(threadId: string): boolean {
@@ -24580,7 +24617,7 @@ export class DesktopBackendRegistry {
   }
 
   private async auditMissingCodexThreads(): Promise<void> {
-    if (this.closed || this.missingCodexThreadPromptOpen) {
+    if (this.closed) {
       return;
     }
     const threadIds = [...this.unresolvedMissingCodexThreadIds];
@@ -24593,11 +24630,19 @@ export class DesktopBackendRegistry {
     // asks the operator rather than archiving on a guess.
     const totalCount = Math.max(this.codexVisibleThreadCount, threadIds.length);
     const ratio = threadIds.length / totalCount;
-    if (ratio > CODEX_MISSING_THREAD_CONFIRMATION_RATIO) {
-      this.missingCodexThreadPromptOpen = true;
+    // The audit only runs when a thread is newly missing, so re-emitting is
+    // not a loop: it revises a prompt the operator has not answered yet. The
+    // notice id is stable, so the renderer replaces rather than stacks. This
+    // is also the recovery path when the first prompt was emitted before any
+    // window had subscribed to the event channel.
+    if (
+      ratio > CODEX_MISSING_THREAD_CONFIRMATION_RATIO
+      || this.missingCodexThreadsKeptThisSession
+    ) {
       backendRegistryLog.warn(
-        "Codex missing-thread share exceeds the automatic archive threshold",
+        "Codex missing threads need an operator decision",
         {
+          keptThisSession: this.missingCodexThreadsKeptThisSession,
           missingCount: threadIds.length,
           totalCount,
           threadIds,
@@ -24677,10 +24722,10 @@ export class DesktopBackendRegistry {
         threadId.trim()
         && this.unresolvedMissingCodexThreadIds.delete(threadId),
     );
-    this.missingCodexThreadPromptOpen = false;
     if (request.action === "keep") {
       // The ids stay in `missingCodexThreadIds`, which is what keeps the
-      // thread visible, its retries suspended, and this prompt closed.
+      // thread visible and its retries suspended.
+      this.missingCodexThreadsKeptThisSession = true;
       backendRegistryLog.warn("keeping Codex threads reported missing", {
         threadCount: threadIds.length,
       });

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1851,10 +1851,20 @@ class DesktopAppServerService {
     const response = await getDesktopBackendRegistry()
       .resolveMissingCodexThreads(request);
     for (const threadId of response.archivedThreadIds) {
-      await getDesktopFederationRuntime().ungroupRemoteChildrenOfArchivedThread({
-        backend: "codex",
-        parentThreadId: threadId,
-      });
+      // The archives are already committed. One unreachable peer must not
+      // skip the ungrouping the remaining threads still need, nor reject a
+      // call whose result the caller uses to report what happened.
+      try {
+        await getDesktopFederationRuntime().ungroupRemoteChildrenOfArchivedThread({
+          backend: "codex",
+          parentThreadId: threadId,
+        });
+      } catch (error) {
+        logDebug("resolveMissingCodexThreads remote ungroup failed", {
+          error: error instanceof Error ? error.message : String(error),
+          threadId,
+        });
+      }
     }
     logDebug("resolveMissingCodexThreads", {
       action: response.action,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -114,7 +114,10 @@ import {
   threadActionErrorNoticeId,
   type ThreadActionErrorKind,
 } from "./features/notifications/thread-action-error-notice";
-import { buildCodexMissingThreadsNotice } from "./features/notifications/codex-missing-threads-notice";
+import {
+  buildCodexMissingThreadsNotice,
+  CODEX_MISSING_THREADS_CONFIRMATION_NOTICE_ID,
+} from "./features/notifications/codex-missing-threads-notice";
 import type { CodexMissingThreadsSignal } from "./features/notifications/codex-missing-threads-notice";
 import { buildPrAutoDispatchBudgetNotice } from "./features/notifications/pr-auto-dispatch-budget-notice";
 import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNotices";
@@ -936,7 +939,7 @@ function DesktopAppShell(props: {
         const resolve = (action: "archive" | "keep") => {
           dispatchAppNotice({
             type: "dismiss",
-            id: "codex-missing-threads:confirmation",
+            id: CODEX_MISSING_THREADS_CONFIRMATION_NOTICE_ID,
           });
           void desktopApi
             .resolveMissingCodexThreads?.({

--- a/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
@@ -1,5 +1,13 @@
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
+/**
+ * The confirmation notice replaces the toast's own dismiss control with its
+ * two answers, so whatever dismisses it must agree with this id exactly — a
+ * mismatch strands the operator with a prompt they cannot close.
+ */
+export const CODEX_MISSING_THREADS_CONFIRMATION_NOTICE_ID =
+  "codex-missing-threads:confirmation";
+
 export type CodexMissingThreadsSignal = {
   status: "archived" | "confirmationRequired";
   threadIds: string[];
@@ -86,8 +94,8 @@ export function buildCodexMissingThreadsNotice(params: {
     ],
     autoDismiss: false,
     detail:
-      "Archiving removes them from this PwrAgent profile and can be undone from the Archived lens. Leaving them alone changes nothing and stops this prompt until the next launch.",
-    id: "codex-missing-threads:confirmation",
+      "Archiving removes them from this PwrAgent profile and can be undone from the Archived lens. Leaving them alone changes nothing, and nothing else is archived automatically for the rest of this session.",
+    id: CODEX_MISSING_THREADS_CONFIRMATION_NOTICE_ID,
     message: `${share} of the threads in PwrAgent profile "${signal.profileName}" (${signal.missingCount} of ${signal.totalCount}) are reported missing by Codex. That is expected if those Codex sessions were deleted, but it also happens when a PwrAgent profile is connected to the wrong Codex profile.`,
     title: "Threads missing from Codex",
     tone: "warning",


### PR DESCRIPTION
## Summary

Follow-up to #1791. Two things, both of which should have been in that PR:

**1. Fixes the Windows-only flake it shipped.** `flushMissingCodexThreadAudit` advanced fake timers 50 times by 100ms and hoped the audit had finished. It is replaced by two waits that each name what they wait for, via a new `whenMissingCodexThreadWorkSettledForTests()` seam on the registry.

Measuring first showed the two waits cover *different* failures, which is the part worth knowing:

- The wait **before** the clock advance settles the fire-and-forget workspace synchronizations. Their rejections are what arm the audit, so without it the clock can pass the debounce before the timer exists — the timer is then due 2s into a future that never arrives, the audit never runs, and the archive assertion sees an empty list. That is the reported symptom. It is also the wait that is **not** load-bearing on macOS, which is why this only ever failed on Windows: locally the rejection has always landed first.
- The wait **after** settles the audit itself. That one *is* load-bearing everywhere — dropping it fails locally, because the audit is still running when the debounce fires.

The old pump satisfied the second by budget (locally the audit settled by tick 20 of 50) and the first only by luck of ordering.

**2. Carries the four `/code-review` findings from #1791 that were never committed** before that PR merged. They are not on `main` today.

- `clearMissingCodexThread` was **unreachable**: its only call sat on a success path the scheduler skips for exactly the threads that could be cleared. Moved to `updateThreadWorkspaceCwd`, which the operator-driven handoff reaches without the scheduler, and corrected the doc comment that promised a self-heal the code could not deliver.
- `missingCodexThreadPromptOpen` **latched permanently**. Emitted to zero subscribers — a startup list before any window subscribes — it was never reset, and every later audit returned at its first line, disabling the feature for the session. Removed; the audit only runs on a newly missing thread, so re-emitting revises an unanswered prompt rather than looping, and the stable notice id makes the renderer replace rather than stack.
- Removing that latch would have let a later single missing thread fall under the 20% threshold and be auto-archived out of a profile the operator had just asked us to leave alone. `missingCodexThreadsKeptThisSession` now makes every audit after a "keep" answer ask rather than decide. Notice copy updated to match.
- The confirmation notice id was **duplicated as a literal** in `App.tsx`. Since the toast drops its own dismiss control when it carries actions, a rename would have stranded an undismissable prompt. Exported as a shared constant.
- The **federation ungroup loop aborted on the first throw**, skipping the remaining threads after their archives were already committed. Each call is now isolated.

## Verification

- `pnpm test` — 599 files, 8622 passed, 5 skipped.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` — clean.
- Both waits in the new helper were verified individually: dropping the post-timer settle fails the suite locally, dropping the pre-timer settle does not — which is the asymmetry described above.
- Both behavioral fixes carry regression tests verified to **fail** against the pre-fix code, not just pass against the new one.
- **I could not reproduce the Windows failure on macOS.** The mechanism above is the one consistent with the evidence (a probe showed the audit armed at tick 0 and settled by tick 20 of 50, and the denominator was stable at 10/5/6), not one I observed directly. The new waits do not depend on knowing which it was.

## Notes

Per the CLAUDE.md rule, this does not raise the pump count or the timeout — the wait is no longer budget-based at all.

The small-share test now asserts the emitted decision and its `totalCount` **before** asserting the archive. A bare `expected [] to deeply equal ['thread-missing']` cannot distinguish "the audit never ran" from "the audit ran and asked instead", and those have completely different causes; the reordered assertion names which one happened.

`whenMissingCodexThreadWorkSettledForTests` is deliberately named as a test seam rather than dressed up as production API. `close()` still awaits only the audit promise — extending it to also await pending workspace synchronizations would change shutdown behavior and risk hanging quit on an unresponsive Codex, which is not something a flake fix should do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
