### PR TITLE
test(desktop): make a Star Map window that never opens say why

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -33,6 +33,7 @@ import type { DesktopAppearanceTheme } from "@pwragent/shared";
 import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 import { stateDbPathForHomeRoot } from "./fixtures/readme-state-seeding";
+import { openStarMapWindow } from "./fixtures/star-map-window";
 import {
   buildAuditSubAgents,
   seedThreadSubAgents,
@@ -69,31 +70,6 @@ async function launchAuditApp(options?: {
   });
   await app.window.emulateMedia({ reducedMotion: "reduce" });
   return app;
-}
-
-/**
- * Poll `electronApp.windows()` for the dedicated Star Map window. The
- * BrowserWindow is created with `show: false`, so Playwright's `window`
- * event fires before the URL has loaded; polling sidesteps the race
- * (same pattern as `appearance-broadcast.spec.ts`).
- */
-async function waitForStarMapWindow(
-  app: Awaited<ReturnType<typeof launchElectronApp>>,
-): Promise<Page> {
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    for (const candidate of app.electronApp.windows()) {
-      if (candidate.url().includes("#star-map")) {
-        return candidate;
-      }
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  throw new Error(
-    `Star Map window did not open; current windows: ${app.electronApp
-      .windows()
-      .map((win) => win.url())
-      .join(", ")}`,
-  );
 }
 
 // The smoke thread never reaches the Star Map: `deriveInboxState` keeps a
@@ -538,8 +514,7 @@ for (const theme of AUDIT_THEMES) {
         await expect(attentionThread).toBeVisible();
         // The map lives in its own OS window; the header control spawns
         // it and every map assertion below runs against that window.
-        await app.window.getByRole("button", { name: "Open Star Map" }).click();
-        const mapWindow = await waitForStarMapWindow(app);
+        const mapWindow = await openStarMapWindow(app);
         // The audit harness emulates reduced motion per Page, and the map
         // window is a different Page than the one `launchAuditApp`
         // configured — without this the card rise animation leaves text

--- a/apps/desktop/e2e/fixtures/star-map-window.ts
+++ b/apps/desktop/e2e/fixtures/star-map-window.ts
@@ -1,0 +1,233 @@
+// Opening the Star Map's dedicated OS window, and reporting what went
+// wrong when it does not open.
+//
+// Three specs drive the map (`star-map-thread-flow`,
+// `star-map-chat-card-history`, and the star-map block in `a11y`) and each
+// carried its own copy of the wait. They shared a failure message too:
+// "Star Map window did not open; current windows: <the main window>",
+// which is what a Linux lane produced twice in a row on PR #1792 and is
+// the same sentence whether the renderer never sent the IPC, the main
+// process never made the window, or Playwright never attached to a window
+// that exists. Those have different fixes and the CI log is usually all
+// anybody has, so the wait now reports which one it was.
+import { expect, type ConsoleMessage, type Page } from "@playwright/test";
+import type { launchElectronApp } from "./electron-app";
+
+type LaunchedApp = Awaited<ReturnType<typeof launchElectronApp>>;
+
+/** How long the wait polls for the map window, and how often. */
+const WAIT_ATTEMPTS = 30;
+const WAIT_INTERVAL_MS = 200;
+
+/**
+ * Renderer-side noise captured across a click, so a wait that times out
+ * can print what the page said instead of leaving it in a trace artifact
+ * nobody downloads.
+ */
+type RendererErrorLog = {
+  entries: () => string[];
+  stop: () => void;
+};
+
+function recordRendererErrors(page: Page): RendererErrorLog {
+  const entries: string[] = [];
+  const onConsole = (message: ConsoleMessage): void => {
+    const type = message.type();
+    if (type !== "error" && type !== "warning") return;
+    entries.push(`console.${type}: ${message.text()}`);
+  };
+  const onPageError = (error: Error): void => {
+    entries.push(`pageerror: ${error.message}`);
+  };
+  page.on("console", onConsole);
+  page.on("pageerror", onPageError);
+  return {
+    entries: () => [...entries],
+    stop: () => {
+      page.off("console", onConsole);
+      page.off("pageerror", onPageError);
+    },
+  };
+}
+
+/**
+ * Cap on one diagnostic probe.
+ *
+ * Neither `page.evaluate` nor `electronApp.evaluate` takes a timeout, so each
+ * is bounded only by Playwright's 30s test timeout — and these run precisely
+ * when something has already gone wrong, including the case where the process
+ * being probed is the wedged one. Uncapped, a hung probe swallows this
+ * helper's 6s report and the run fails with a bare "Test timeout of 30000ms
+ * exceeded" instead, which says strictly less than the message this file
+ * replaced.
+ */
+const PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Both probes answer with a string and never reject, so a probe that loses
+ * this race simply stays unsettled — there is no rejection left to go
+ * unhandled.
+ */
+async function withProbeTimeout(
+  describe: () => Promise<string>,
+  label: string,
+): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      describe(),
+      new Promise<string>((resolve) => {
+        timer = setTimeout(
+          () => resolve(`${label} did not answer within ${PROBE_TIMEOUT_MS}ms`),
+          PROBE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Is the preload bridge that the header control calls actually live?
+ *
+ * `App.tsx` opens the map through `desktopApi?.openStarMapWindow?.()`, and
+ * `useDesktopApi` resolves that bridge by polling — so the control is
+ * mounted and clickable whether or not it can do anything yet, and a click
+ * that lands early is dropped without a sound. This is the single fact
+ * that tells that case apart from a main-process failure.
+ */
+async function describeStarMapBridge(page: Page): Promise<string> {
+  try {
+    return await page.evaluate(() => {
+      const bridge = (
+        window as Window & { pwragent?: Record<string, unknown> }
+      ).pwragent;
+      if (!bridge) return "window.pwragent is absent";
+      return `window.pwragent.openStarMapWindow is ${typeof bridge.openStarMapWindow}`;
+    });
+  } catch (error) {
+    return `bridge probe failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+  }
+}
+
+/**
+ * The main process's own window census. Playwright's `windows()` lists
+ * only the pages it has attached to, so a map window that exists but went
+ * unattached looks exactly like one that was never created — until these
+ * two lists disagree.
+ */
+async function describeMainProcessWindows(app: LaunchedApp): Promise<string> {
+  try {
+    const urls = await app.electronApp.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().map(
+        (win) => win.webContents.getURL() || "(no url)",
+      ),
+    );
+    return urls.length > 0 ? urls.join(", ") : "(none)";
+  } catch (error) {
+    return `window census failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+  }
+}
+
+/**
+ * Poll `electronApp.windows()` for the dedicated Star Map window. The
+ * BrowserWindow is created with `show: false`, so Playwright's `window`
+ * event fires before the URL has loaded; polling sidesteps the race
+ * (same pattern as `appearance-broadcast.spec.ts`).
+ *
+ * Deliberately not exported: this is the wait WITHOUT the readiness barrier,
+ * and handing a spec that version is exactly how the flake below comes back.
+ * Go through `openStarMapWindow`.
+ */
+async function waitForStarMapWindow(
+  app: LaunchedApp,
+  errorLog?: RendererErrorLog,
+): Promise<Page> {
+  for (let attempt = 0; attempt < WAIT_ATTEMPTS; attempt += 1) {
+    for (const candidate of app.electronApp.windows()) {
+      if (candidate.url().includes("#star-map")) {
+        return candidate;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, WAIT_INTERVAL_MS));
+  }
+
+  // Gathered only on the failing path: each probe is a round trip, and the
+  // bridge one runs script in a renderer that may already be wedged.
+  const [bridge, mainProcessWindows] = await Promise.all([
+    withProbeTimeout(
+      async () => await describeStarMapBridge(app.window),
+      "the renderer",
+    ),
+    withProbeTimeout(
+      async () => await describeMainProcessWindows(app),
+      "the main process",
+    ),
+  ]);
+  const rendererErrors = errorLog?.entries() ?? [];
+  throw new Error(
+    [
+      `Star Map window did not open after ${
+        (WAIT_ATTEMPTS * WAIT_INTERVAL_MS) / 1000
+      }s.`,
+      `  windows Playwright sees: ${app.electronApp
+        .windows()
+        .map((win) => win.url())
+        .join(", ")}`,
+      `  windows the main process has: ${mainProcessWindows}`,
+      `  preload bridge in the main window: ${bridge}`,
+      `  renderer errors during the wait: ${
+        rendererErrors.length > 0 ? rendererErrors.join(" | ") : "(none)"
+      }`,
+    ].join("\n"),
+  );
+}
+
+/**
+ * Click the main window's header control and wait for the map window.
+ *
+ * The `expect.poll` is a readiness barrier, and it is the fix for the
+ * flake this file was written for. `launchElectronApp` resolves on a
+ * MAIN-PROCESS global (the replay driver installed from the
+ * `BackendRegistry` constructor) — that says nothing about the renderer,
+ * and the main process registers `STAR_MAP_OPEN_WINDOW_CHANNEL` before it
+ * creates any window, so the only end that can still be unready when the
+ * button is clickable is the preload bridge. Every other star-map spec
+ * happened to wait for something the bridge has to serve — a thread row, a
+ * completed Settings flow — before clicking, which is why the one spec
+ * that clicks straight after launch was the only one that ever failed
+ * here. This makes the barrier explicit instead of incidental.
+ */
+export async function openStarMapWindow(app: LaunchedApp): Promise<Page> {
+  await expect
+    .poll(
+      async () =>
+        await app.window.evaluate(
+          () =>
+            typeof (
+              window as Window & {
+                pwragent?: { openStarMapWindow?: unknown };
+              }
+            ).pwragent?.openStarMapWindow,
+        ),
+      {
+        message:
+          "the main window's preload bridge never exposed openStarMapWindow,"
+          + " so the header control could never have opened the map",
+      },
+    )
+    .toBe("function");
+
+  const errorLog = recordRendererErrors(app.window);
+  try {
+    await app.window.getByRole("button", { name: "Open Star Map" }).click();
+    return await waitForStarMapWindow(app, errorLog);
+  } finally {
+    errorLog.stop();
+  }
+}

--- a/apps/desktop/e2e/star-map-chat-card-history.spec.ts
+++ b/apps/desktop/e2e/star-map-chat-card-history.spec.ts
@@ -1,12 +1,13 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 import {
   startInProcessFederationGateway,
   type InProcessFederationGateway,
 } from "./fixtures/federation-gateway";
+import { openStarMapWindow } from "./fixtures/star-map-window";
 
 /**
  * A Star Map chat card must not read or mount a whole large thread.
@@ -43,31 +44,6 @@ const TOTAL_TRANSCRIPT_BYTES = ENTRY_COUNT * BYTES_PER_ENTRY;
 const MAX_TRANSCRIPT_NODES = 4_000;
 /** Likewise: a bounded open is well under a megabyte. */
 const MAX_OPEN_BYTES = 4_000_000;
-
-/**
- * Poll `electronApp.windows()` for the dedicated Star Map window. The
- * BrowserWindow is created with `show: false`, so Playwright's `window`
- * event fires before the URL has loaded; polling sidesteps the race
- * (same pattern as `appearance-broadcast.spec.ts`).
- */
-async function waitForStarMapWindow(
-  app: Awaited<ReturnType<typeof launchElectronApp>>,
-): Promise<Page> {
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    for (const candidate of app.electronApp.windows()) {
-      if (candidate.url().includes("#star-map")) {
-        return candidate;
-      }
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  throw new Error(
-    `Star Map window did not open; current windows: ${app.electronApp
-      .windows()
-      .map((win) => win.url())
-      .join(", ")}`,
-  );
-}
 
 async function createLocalControlFixture(): Promise<{
   cleanup: () => Promise<void>;
@@ -165,8 +141,7 @@ test.describe("star map chat card history", () => {
 
     // Open the map — a dedicated OS window — and the peer's thread as a
     // floating chat card inside it.
-    await window.getByRole("button", { name: "Open Star Map" }).click();
-    const mapWindow = await waitForStarMapWindow(app);
+    const mapWindow = await openStarMapWindow(app);
     const starMap = mapWindow.getByRole("region", {
       name: "Star Map",
       exact: true,

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -13,35 +13,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
+import { openStarMapWindow } from "./fixtures/star-map-window";
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 
 const THREAD_TITLE = "Star map attention thread";
-
-/**
- * Poll `electronApp.windows()` for a window whose URL carries the map
- * hash. The BrowserWindow is created with `show: false`, so Playwright's
- * `window` event fires before the URL has loaded; polling sidesteps the
- * race (same pattern as `appearance-broadcast.spec.ts`).
- */
-async function waitForStarMapWindow(
-  app: Awaited<ReturnType<typeof launchElectronApp>>,
-): Promise<Page> {
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    for (const candidate of app.electronApp.windows()) {
-      if (candidate.url().includes("#star-map")) {
-        return candidate;
-      }
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  throw new Error(
-    `Star Map window did not open; current windows: ${app.electronApp
-      .windows()
-      .map((win) => win.url())
-      .join(", ")}`,
-  );
-}
 
 function countStarMapWindows(
   app: Awaited<ReturnType<typeof launchElectronApp>>,
@@ -262,8 +238,7 @@ test("opens a thread from the star map window in the main window", async () => {
       app.window.getByRole("button", { name: new RegExp(THREAD_TITLE, "i") }).first(),
     ).toBeVisible();
 
-    await app.window.getByRole("button", { name: "Open Star Map" }).click();
-    const mapWindow = await waitForStarMapWindow(app);
+    const mapWindow = await openStarMapWindow(app);
 
     // `exact` matters here: role-name matching is substring by default,
     // and once a chat card opens its "Chat: Star map attention thread"
@@ -341,8 +316,7 @@ test("keeps the star map's top band from overlapping itself", async () => {
   });
 
   try {
-    await app.window.getByRole("button", { name: "Open Star Map" }).click();
-    const mapWindow = await waitForStarMapWindow(app);
+    const mapWindow = await openStarMapWindow(app);
     const starMap = mapWindow.getByRole("region", {
       name: "Star Map",
       exact: true,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1928,7 +1928,25 @@ function DesktopAppShell(props: {
     ? undefined
     : {
         onOpen: () => {
-          void desktopApi?.openStarMapWindow?.();
+          // Both ends of this call are assumptions, not guarantees:
+          // `useDesktopApi` resolves the preload bridge by polling, so the
+          // control is mounted and clickable for however long that takes,
+          // and the channel is an `ipcRenderer.invoke` that can reject.
+          // The optional chaining stays — a half-built bridge must not
+          // throw out of a click handler — but a click that goes nowhere
+          // has to say so. Swallowing it cost a Star Map E2E failure six
+          // seconds of silence and a bare "window did not open", with
+          // nothing in the trace to say which end had dropped it.
+          if (!desktopApi?.openStarMapWindow) {
+            console.error(
+              "Open Star Map ignored: the desktop bridge is not ready.",
+              { bridgePresent: Boolean(desktopApi) },
+            );
+            return;
+          }
+          void desktopApi.openStarMapWindow().catch((error) => {
+            console.error("Opening the Star Map window failed.", error);
+          });
         },
       };
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -321,6 +321,61 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
+  // `useDesktopApi` resolves the preload bridge by polling, so the header's
+  // Star Map control mounts and is clickable whether or not the bridge has
+  // landed — and `desktopApi?.openStarMapWindow?.()` used to drop that click
+  // without a sound. A Linux E2E lane failed twice on exactly that shape
+  // (click, then six seconds of nothing, then "Star Map window did not
+  // open"), so the no-op has to be audible from the renderer console.
+  it("reports a Star Map click that the desktop bridge cannot serve", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+        // Deliberately absent: `openStarMapWindow`.
+      },
+    });
+
+    try {
+      render(<App />);
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Open Star Map" }),
+      );
+
+      expect(consoleError).toHaveBeenCalledWith(
+        "Open Star Map ignored: the desktop bridge is not ready.",
+        { bridgePresent: true },
+      );
+    } finally {
+      // Restore even when the assertion throws: `console.error` is how React
+      // reports act() and render warnings, so leaving it stubbed would mute
+      // every remaining test in this file and turn one failure into a
+      // misleading cascade.
+      consoleError.mockRestore();
+    }
+  });
+
   it("starts a new thread on a selected federation machine and profile", async () => {
     const federationListeners = new Set<(event: AgentEvent) => void>();
     const remoteTarget = { scope: "remote" as const, instanceId: "studio-work" };


### PR DESCRIPTION
Follow-up to #1788, independent of #1792.

## The flake

`Linux Desktop E2E (lane 2 of 2)` failed twice on #1792 — original plus retry — at
[star-map-thread-flow.spec.ts:338](apps/desktop/e2e/star-map-thread-flow.spec.ts) ›
"keeps the star map's top band from overlapping itself":

```
Star Map window did not open; current windows: file:///.../out/renderer/index.html
```

The trace showed the click on "Open Star Map" completing normally, six seconds of no
activity, then teardown. No second window, no renderer error. A re-run of the same
commit passed, and macOS lane 2 ran the identical spec on that commit in 1.8s.

## What the investigation found

Two of the three candidates are refuted:

- **The IPC handler is not the race.** `registerStarMapIpcHandlers()` runs at
  [index.ts:1248](apps/desktop/src/main/index.ts:1248) with no intervening top-level
  `await` before `createMainWindow` at
  [index.ts:1351](apps/desktop/src/main/index.ts:1351), so
  `STAR_MAP_OPEN_WINDOW_CHANNEL` is live before any window exists to click.
- **`showStarMapWindow` cannot throw before `new BrowserWindow`.**
  `readBootstrapAppearance` wraps its whole body in a `catch` that returns defaults,
  and `placementForSourceDisplay` is pure `screen.*` arithmetic.

That leaves the renderer, and the mechanism in the issue description holds up.
[App.tsx](apps/desktop/src/renderer/src/App.tsx) opened the map through
`desktopApi?.openStarMapWindow?.()`, and `useDesktopApi` resolves the preload bridge
by **polling** (`setTimeout(refresh, 16)`) — so the header control is mounted and
clickable whether or not the bridge has landed, and a click that lands early is
dropped without a sound. That is exactly the shape of the trace.

**A real ordering race, and it is in the harness.** `launchElectronApp` resolves on a
MAIN-PROCESS global (`__PWRAGENT_REPLAY_DRIVER__`, installed from the
`BackendRegistry` constructor) — it never waits on the renderer at all. The three
other star-map tests each happen to wait for something the bridge has to serve
before clicking: a thread row (`star-map-thread-flow` test 1, `a11y`), a completed
Settings + federation flow (`star-map-chat-card-history`). The failing test clicks
straight after launch. It is the only one of the four without a barrier, and it is
the only one that has ever failed this way.

## The change

- **Give the no-op a voice.** `App.tsx` now logs when the bridge cannot serve the
  click, and `.catch()`es a rejected invoke instead of leaving an unhandled
  rejection. The optional chaining stays — a half-built bridge must not throw out of
  a click handler — but the silence does not.
- **Give the wait a barrier.** New `e2e/fixtures/star-map-window.ts` replaces the
  three copies of `waitForStarMapWindow` the star-map and a11y specs each carried.
  Its `openStarMapWindow` polls for a live `window.pwragent.openStarMapWindow`
  before it clicks. That is the missing barrier, now explicit and shared instead of
  incidental and per-spec.
- **Make the next occurrence readable from the CI log**, not a downloaded trace. On
  timeout the wait reports: the windows Playwright sees, the windows the **main
  process** has (these disagree when a window exists but Playwright never attached),
  whether the preload bridge is live in the main window, and any renderer console
  errors captured across the click.

## Verification

- `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, `pnpm lint:codex-storage` — clean.
- 3191 renderer vitest tests pass, including a new gate in `app-shell.test.tsx`
  ("reports a Star Map click that the desktop bridge cannot serve"). Confirmed it
  fails against the pre-change `App.tsx` and passes after.
- All three touched E2E specs run green on the PwrSuiteLab macOS guest — 13 tests,
  including the test that flaked and both themes of the a11y star-map block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
