### PR TITLE
fix(desktop): derive dev-restart root from the script location

### DIFF
--- a/.agents/skills/pwragent-dev-restart/SKILL.md
+++ b/.agents/skills/pwragent-dev-restart/SKILL.md
@@ -5,36 +5,44 @@ description: Safely restart the local PwrAgent Electron development app after pu
 
 # PwrAgent Dev Restart
 
-Use this skill when the running Electron app must be stopped and restarted from a freshly updated checkout, especially after merging a PR into `~/github/PwrAgnt`.
+Use this skill when the running Electron app must be stopped and restarted from a freshly updated checkout, especially after merging a PR.
+
+Run the commands below from the checkout you want to restart. The script derives
+its default root from its own location, so it targets the checkout it ships in,
+including a git worktree.
 
 ## Workflow
 
 1. Confirm the target checkout is updated and clean enough to run:
 
    ```bash
-   git -C /Users/huntharo/github/PwrAgnt status --short --branch
-   git -C /Users/huntharo/github/PwrAgnt log -1 --oneline --decorate
+   git status --short --branch
+   ```
+
+   ```bash
+   git log -1 --oneline --decorate
    ```
 
 2. Dry-run the restart to see which processes would be stopped:
 
    ```bash
-   .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh \
-     schedule --root /Users/huntharo/github/PwrAgnt --delay 30 --dry-run
+   .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh schedule --delay 30 --dry-run
    ```
 
 3. Schedule the restart and answer the user before the delay expires:
 
    ```bash
-   .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh \
-     schedule --root /Users/huntharo/github/PwrAgnt --delay 30
+   .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh schedule --delay 30
    ```
 
 4. After the delay, verify the app came back:
 
    ```bash
-   tail -120 /Users/huntharo/github/PwrAgnt/.local/pwragent-dev-restart.log
-   pgrep -fl '/Users/huntharo/github/PwrAgnt|PwrAgent|pnpm.*dev|electron-vite'
+   tail -120 .local/pwragent-dev-restart.log
+   ```
+
+   ```bash
+   pgrep -fl "$PWD|PwrAgent|pnpm.*dev|electron-vite"
    ```
 
 ## Script Notes
@@ -44,6 +52,12 @@ Use this skill when the running Electron app must be stopped and restarted from 
 - It excludes Codex helper processes whose serialized command payloads mention the checkout path but are not part of the PwrAgent dev process tree.
 - With `--detach-start`, the script starts the dev command in a detached `tmux` session when `tmux` is available. This survives parent command cleanup while keeping the dev logs in the configured restart log.
 - It uses a `nohup` sleep wrapper for the delayed timer. Do not use `launchctl submit` here: launchd can keep descendant `pnpm dev` processes in the submitted job context and relaunch them after they exit.
-- Default root is `/Users/huntharo/github/PwrAgnt`.
+- Default root is derived from the script location: the checkout that contains
+  `.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh`. Pass
+  `--root PATH` to target a different checkout.
+- The root must be a pnpm workspace root (`package.json` and
+  `pnpm-workspace.yaml`). The script stops processes whose command line matches
+  the root path, so it refuses a broad root that would match unrelated
+  processes.
 - Default log is `<root>/.local/pwragent-dev-restart.log`.
 - Use `--dry-run` before scheduling unless the user explicitly asks to restart immediately.

--- a/.agents/skills/pwragent-dev-restart/SKILL.md
+++ b/.agents/skills/pwragent-dev-restart/SKILL.md
@@ -49,7 +49,13 @@ including a git worktree.
 
 - The script stops processes matching the target checkout path and their bounded parent dev-server chain, then starts `pnpm dev:dev` from the checkout.
 - The script discovers running processes by checkout path. It does not require a pidfile or a previous skill-started instance.
-- It excludes Codex helper processes whose serialized command payloads mention the checkout path but are not part of the PwrAgent dev process tree.
+- It excludes helper and coding-agent CLI processes whose serialized command
+  payloads mention the checkout path but are not part of the PwrAgent dev
+  process tree.
+- It also never signals its own ancestors. The shell or agent session that
+  starts the restart is usually a grandparent or higher, and its command line
+  can contain the checkout path. `schedule` passes that protected pid set to the
+  detached `restart-now` child, which is reparented and cannot discover it.
 - With `--detach-start`, the script starts the dev command in a detached `tmux` session when `tmux` is available. This survives parent command cleanup while keeping the dev logs in the configured restart log.
 - It uses a `nohup` sleep wrapper for the delayed timer. Do not use `launchctl submit` here: launchd can keep descendant `pnpm dev` processes in the submitted job context and relaunch them after they exit.
 - Default root is derived from the script location: the checkout that contains

--- a/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
+++ b/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
@@ -5,7 +5,7 @@ usage() {
   cat <<'USAGE'
 Usage:
   restart-pwragent-dev.zsh schedule [--root PATH] [--delay SECONDS] [--log PATH] [--dry-run]
-  restart-pwragent-dev.zsh restart-now [--root PATH] [--log PATH] [--dry-run] [--detach-start]
+  restart-pwragent-dev.zsh restart-now [--root PATH] [--log PATH] [--dry-run] [--detach-start] [--protect-pids "PID ..."]
 
 Schedules or performs a local PwrAgent dev-profile restart. The restart stops
 processes that match the target checkout path plus the bounded parent
@@ -50,6 +50,7 @@ delay="30"
 log_path=""
 dry_run="false"
 detach_start="false"
+inherited_protected_pids=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -76,6 +77,11 @@ while [[ $# -gt 0 ]]; do
       detach_start="true"
       shift
       ;;
+    --protect-pids)
+      [[ $# -ge 2 ]] || die "--protect-pids requires a pid list"
+      inherited_protected_pids="${2//[^0-9 ]/}"
+      shift 2
+      ;;
     *)
       die "unknown argument: $1"
       ;;
@@ -101,12 +107,35 @@ mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
 
 script_path="${0:A}"
 
+# Never signal this script's own ancestors. One of them is the shell or agent
+# session that started the restart, and its command line can contain the
+# checkout path, which makes it match the `pgrep -f "$root"` pattern. Skipping
+# only $$ and $PPID is not enough: the session is usually a grandparent or
+# higher, behind an intermediate shell whose command line does not match.
+#
+# `schedule` passes this set down to the detached `restart-now` child through
+# --protect-pids. That child is reparented after nohup, so it cannot discover
+# the scheduling session on its own.
+protected_pids=""
+collect_protected_pids() {
+  local pid="$$"
+  while [[ -n "$pid" && "$pid" != "0" && "$pid" != "1" ]]; do
+    protected_pids="$protected_pids $pid"
+    pid="$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ')"
+  done
+  protected_pids="$protected_pids $inherited_protected_pids"
+}
+collect_protected_pids
+
+is_protected_pid() {
+  [[ " $protected_pids " == *" $1 "* ]]
+}
+
 matching_pids() {
   local command pattern="$1"
   pgrep -f "$pattern" 2>/dev/null | while read -r pid; do
     [[ -z "$pid" ]] && continue
-    [[ "$pid" == "$$" ]] && continue
-    [[ "$pid" == "$PPID" ]] && continue
+    is_protected_pid "$pid" && continue
     command="$(process_command "$pid")"
     [[ "$command" == *"restart-pwragent-dev.zsh"* ]] && continue
     is_restart_excluded_process "$command" && continue
@@ -148,11 +177,11 @@ is_restart_excluded_process() {
 candidate_pids() {
   local command parent pid
   for pid in $(matching_pids "$root"); do
-    [[ "$pid" != "$$" && "$pid" != "$PPID" ]] && print -r -- "$pid"
+    is_protected_pid "$pid" || print -r -- "$pid"
 
     parent="$(parent_pid "$pid")"
     while [[ -n "$parent" && "$parent" != "0" && "$parent" != "1" ]]; do
-      [[ "$parent" == "$$" || "$parent" == "$PPID" ]] && break
+      is_protected_pid "$parent" && break
       command="$(process_command "$parent")"
       is_restart_excluded_process "$command" && break
       if [[ "$command" == *"$root"* ]] || is_dev_chain_parent "$command"; then
@@ -190,7 +219,7 @@ stop_matches() {
 
 schedule_restart() {
   local command restart_command
-  restart_command="$(shell_quote "$script_path") restart-now --root $(shell_quote "$root") --log $(shell_quote "$log_path") --detach-start"
+  restart_command="$(shell_quote "$script_path") restart-now --root $(shell_quote "$root") --log $(shell_quote "$log_path") --detach-start --protect-pids $(shell_quote "$protected_pids")"
   [[ "$dry_run" == "true" ]] && restart_command="$restart_command --dry-run"
   command="sleep $(shell_quote "$delay"); nohup /bin/zsh -lc $(shell_quote "$restart_command") >> $(shell_quote "$log_path") 2>&1 &"
 

--- a/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
+++ b/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
@@ -43,7 +43,9 @@ if [[ -z "$mode" || "$mode" == "--help" || "$mode" == "-h" ]]; then
 fi
 shift
 
-root="/Users/huntharo/github/PwrAgnt"
+# The script lives at <root>/.agents/skills/pwragent-dev-restart/scripts/,
+# so the checkout root is five directory levels above it.
+root="${0:A:h:h:h:h:h}"
 delay="30"
 log_path=""
 dry_run="false"
@@ -85,6 +87,12 @@ done
 
 root="${root:A}"
 [[ -d "$root" ]] || die "root does not exist: $root"
+
+# `matching_pids` uses the root path as a `pgrep -f` pattern, so a broad root
+# such as `/` or `$HOME` would match and kill unrelated processes. Require the
+# root to look like the pnpm workspace this script is meant to restart.
+[[ -f "$root/package.json" && -f "$root/pnpm-workspace.yaml" ]] \
+  || die "root is not a PwrAgent checkout: $root"
 
 if [[ -z "$log_path" ]]; then
   log_path="$root/.local/pwragent-dev-restart.log"
@@ -130,6 +138,10 @@ is_restart_excluded_process() {
   [[ "$command" == *"/.codex/computer-use/"* ]] && return 0
   [[ "$command" == *"SkyComputerUseClient"* ]] && return 0
   [[ "$command" == *"turn-ended"* ]] && return 0
+  # Coding-agent CLI sessions carry the checkout path in their arguments for the
+  # same reason. They are not part of the PwrAgent dev process tree.
+  [[ "$command" == *"/Application Support/Claude/claude-code/"* ]] && return 0
+  [[ "$command" == *"/Claude.app/Contents/Helpers/disclaimer"* ]] && return 0
   return 1
 }
 


### PR DESCRIPTION
## Problem

`.agents/skills/pwragent-dev-restart` hardcoded `/Users/huntharo/github/PwrAgnt` as its default root, and repeated that same path in all six SKILL.md examples plus the "Default root is ..." note.

That directory does not exist. Following the skill verbatim died at step 1 on `git -C <missing dir>`, and the default was unusable from a git worktree or for any other contributor. The skill landed incidentally in #1227 (a Slack App Home messaging PR), so it was never reviewed as a tool.

## Fix

Derive the default root from the script's own location, the same `${0:A}` mechanism the script already used for `script_path`:

```zsh
root="${0:A:h:h:h:h:h}"
```

The script lives at `<root>/.agents/skills/pwragent-dev-restart/scripts/`, so the root is five `:h` levels up. Verified empirically for both the main checkout and a worktree rather than counting by eye. `--root` still works as an explicit override, and the existing `[[ -d "$root" ]] || die` validation is unchanged.

SKILL.md examples are now repo-relative and drop the explicit `--root`, so the derived default is what the workflow actually exercises.

## Two safety guards

`matching_pids` uses the root path as a `pgrep -f` pattern and the script kills what it matches, so the root has to be precise. Previously the dead default made the script exit before reaching that code; now that the default resolves to a live checkout, two guards keep it honest:

1. **Reject a broad root.** The root must be a pnpm workspace root (`package.json` and `pnpm-workspace.yaml`), which the script needs anyway to run `pnpm dev:dev`. `--root "$HOME"` now fails with `root is not a PwrAgent checkout` instead of matching half the process table.

2. **Exclude coding-agent CLI sessions.** A dry run against the real checkout listed **20 candidate processes, all of them Claude Code sessions** — none were dev-app processes. They carry the checkout path in their arguments, exactly the hazard the existing Codex helper exclusions in `is_restart_excluded_process` were written for. Added the Claude Code CLI and its launcher helper to that same list. After the change both roots report 0 candidates with no dev app running.

Without guard 2 this PR would have made the skill's default path actively destructive to concurrent agent sessions, so it is included rather than deferred.

## Verification

- `zsh -n` syntax check passes.
- `--help` works.
- `schedule --dry-run` run from the worktree and with `--root` pointed at the main checkout: both resolve the correct root, both report 0 candidates, nothing killed.
- No non-dry-run restart was performed — that would kill the operator's running dev app.
- No `/Users/` path remains anywhere under the skill directory.

No test-fixture sanitization changes are bundled here.