### PR TITLE
fix(release): repair Windows Authenticode verification for bundled Grok

### DIFF
--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -516,6 +516,32 @@ function assertRequiredGrokBundle() {
   console.log(`  verified bundled Grok runtime: ${bundledExecutable}`);
 }
 
+// Windows PowerShell 5.1 inherits this process's PSModulePath, and the hosted
+// runner's value is PowerShell 7-oriented. Autoloading Windows PowerShell's own
+// Microsoft.PowerShell.Security then fails ("the module could not be loaded"),
+// which left `Get-AuthenticodeSignature` undefined and the release reporting an
+// empty signature status. Prefer pwsh, and pin Windows PowerShell to its own
+// module locations when it is the only shell available.
+const WINDOWS_SIGNATURE_PRELUDE = [
+  "$ErrorActionPreference = 'Stop'",
+  "if ($PSVersionTable.PSEdition -ne 'Core') { $env:PSModulePath = \"$PSHOME\\Modules;$env:ProgramFiles\\WindowsPowerShell\\Modules\" }",
+  "Import-Module Microsoft.PowerShell.Security",
+];
+
+function windowsPowerShellCommand() {
+  for (const candidate of ["pwsh.exe", "powershell.exe"]) {
+    const probe = spawnSync(
+      candidate,
+      ["-NoProfile", "-NonInteractive", "-Command", "exit 0"],
+      { stdio: "ignore" },
+    );
+    if (!probe.error && probe.status === 0) {
+      return candidate;
+    }
+  }
+  return "powershell.exe";
+}
+
 function verifyPackagedGrok(resourcesDirectory) {
   const executable = process.platform === "win32" ? "grok.exe" : "grok";
   const bundledExecutable = join(
@@ -552,12 +578,17 @@ function verifyPackagedGrok(resourcesDirectory) {
     runChecked("codesign", codesignArgs);
   } else if (process.platform === "win32" && requireSigning) {
     runChecked(
-      "powershell.exe",
+      windowsPowerShellCommand(),
       [
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        "$signature = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE; if ($signature.Status -ne 'Valid') { throw \"Bundled Grok Authenticode signature is $($signature.Status): $($signature.StatusMessage)\" }; if ($signature.SignerCertificate.Subject -notmatch '(^|,\\s*)CN=PwrDrvr LLC(,|$)') { throw \"Bundled Grok signer is not PwrDrvr LLC: $($signature.SignerCertificate.Subject)\" }",
+        [
+          ...WINDOWS_SIGNATURE_PRELUDE,
+          "$signature = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE",
+          "if ($signature.Status -ne 'Valid') { throw \"Bundled Grok Authenticode signature is $($signature.Status): $($signature.StatusMessage)\" }",
+          "if ($signature.SignerCertificate.Subject -notmatch '(^|,\\s*)CN=PwrDrvr LLC(,|$)') { throw \"Bundled Grok signer is not PwrDrvr LLC: $($signature.SignerCertificate.Subject)\" }",
+        ].join("; "),
       ],
       { env: { PWRAGENT_VERIFY_EXECUTABLE: bundledExecutable } },
     );

--- a/apps/desktop/src/main/__tests__/windows-signature-prelude.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-signature-prelude.test.ts
@@ -4,7 +4,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { WINDOWS_SIGNATURE_PRELUDE } from "../acp/grok-managed-runtime";
+import {
+  WINDOWS_SIGNATURE_PRELUDE,
+  windowsSignatureVerification,
+} from "../acp/grok-managed-runtime";
 
 const releaseScriptPath = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -25,6 +28,27 @@ describe("Windows Authenticode verification prelude", () => {
     for (const statement of WINDOWS_SIGNATURE_PRELUDE) {
       expect(releaseScript).toContain(JSON.stringify(statement).slice(1, -1));
     }
+  });
+
+  // `-Command <string>` must be the last argument: PowerShell appends anything
+  // after it to the command text rather than binding it to $args, so a path
+  // passed as a trailing argument turns the script into a parse error and the
+  // check fails on every packaged Windows build.
+  it("passes the verified paths through the environment, not argv", () => {
+    const { args, env } = windowsSignatureVerification(
+      "C:\\Program Files\\PwrAgent\\PwrAgent.exe",
+      "C:\\Users\\me\\.pwragent\\agents\\grok\\grok.exe",
+    );
+    expect(args[args.length - 2]).toBe("-Command");
+    expect(args).toHaveLength(5);
+    expect(args.join(" ")).not.toContain("$args[");
+    expect(args[4]).toContain("$env:PWRAGENT_VERIFY_APPLICATION");
+    expect(args[4]).toContain("$env:PWRAGENT_VERIFY_RUNTIME");
+    expect(env).toEqual({
+      PWRAGENT_VERIFY_APPLICATION: "C:\\Program Files\\PwrAgent\\PwrAgent.exe",
+      PWRAGENT_VERIFY_RUNTIME:
+        "C:\\Users\\me\\.pwragent\\agents\\grok\\grok.exe",
+    });
   });
 
   it.runIf(process.platform === "win32")(

--- a/apps/desktop/src/main/__tests__/windows-signature-prelude.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-signature-prelude.test.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { WINDOWS_SIGNATURE_PRELUDE } from "../acp/grok-managed-runtime";
+
+const releaseScriptPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "scripts",
+  "release.mjs",
+);
+
+describe("Windows Authenticode verification prelude", () => {
+  // The release script cannot import main-process TypeScript, so it carries its
+  // own copy. Keep the two in lockstep: a v1.1.0-alpha.1 release failed because
+  // `Get-AuthenticodeSignature` could not autoload Microsoft.PowerShell.Security,
+  // and a repair that lands in only one caller leaves the other broken.
+  it("matches the copy embedded in the release script", () => {
+    const releaseScript = readFileSync(releaseScriptPath, "utf8");
+    for (const statement of WINDOWS_SIGNATURE_PRELUDE) {
+      expect(releaseScript).toContain(JSON.stringify(statement).slice(1, -1));
+    }
+  });
+
+  it.runIf(process.platform === "win32")(
+    "resolves Get-AuthenticodeSignature under Windows PowerShell",
+    () => {
+      const systemRoot = process.env.SystemRoot ?? "C:\\Windows";
+      const signedSystemFile = join(
+        systemRoot,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+      const result = spawnSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          [
+            ...WINDOWS_SIGNATURE_PRELUDE,
+            "(Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE).Status",
+          ].join("; "),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PWRAGENT_VERIFY_EXECUTABLE: signedSystemFile,
+          },
+        },
+      );
+      expect(
+        `${result.stdout ?? ""}${result.stderr ?? ""}`,
+      ).not.toContain("could not be loaded");
+      expect(result.status).toBe(0);
+      expect((result.stdout ?? "").trim()).not.toBe("");
+    },
+  );
+});

--- a/apps/desktop/src/main/acp/grok-managed-runtime.ts
+++ b/apps/desktop/src/main/acp/grok-managed-runtime.ts
@@ -646,6 +646,17 @@ async function validateExtractedBundle(
   return command;
 }
 
+// Windows PowerShell 5.1 inherits the parent process's PSModulePath. When that
+// value is PowerShell 7-oriented, autoloading Windows PowerShell's own
+// Microsoft.PowerShell.Security fails ("the module could not be loaded") and
+// Get-AuthenticodeSignature never runs. Pin the Windows PowerShell module
+// locations and import the module explicitly so a failure names its own cause.
+export const WINDOWS_SIGNATURE_PRELUDE = [
+  "$ErrorActionPreference = 'Stop'",
+  "if ($PSVersionTable.PSEdition -ne 'Core') { $env:PSModulePath = \"$PSHOME\\Modules;$env:ProgramFiles\\WindowsPowerShell\\Modules\" }",
+  "Import-Module Microsoft.PowerShell.Security",
+];
+
 async function verifyMatchingPlatformSignature(
   command: string,
   applicationCommand: string,
@@ -689,6 +700,7 @@ async function verifyMatchingPlatformSignature(
       "-NonInteractive",
       "-Command",
       [
+        ...WINDOWS_SIGNATURE_PRELUDE,
         "$application = Get-AuthenticodeSignature -LiteralPath $args[0]",
         "$runtime = Get-AuthenticodeSignature -LiteralPath $args[1]",
         "if ($application.Status -ne 'Valid' -or $runtime.Status -ne 'Valid') { exit 1 }",

--- a/apps/desktop/src/main/acp/grok-managed-runtime.ts
+++ b/apps/desktop/src/main/acp/grok-managed-runtime.ts
@@ -657,6 +657,39 @@ export const WINDOWS_SIGNATURE_PRELUDE = [
   "Import-Module Microsoft.PowerShell.Security",
 ];
 
+// `powershell.exe -Command <string>` does NOT bind trailing arguments to
+// $args — the docs are explicit that a string command must come last because
+// everything after it is appended to the command text. ($args binding needs
+// -File, or -CommandWithArgs, which Windows PowerShell 5.1 does not have.) So
+// the two paths travel in the child environment instead, the way
+// scripts/release.mjs already passes PWRAGENT_VERIFY_EXECUTABLE.
+export function windowsSignatureVerification(
+  applicationCommand: string,
+  runtimeCommand: string,
+): { args: string[]; env: Record<string, string> } {
+  return {
+    args: [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      [
+        ...WINDOWS_SIGNATURE_PRELUDE,
+        "$application = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_APPLICATION",
+        "$runtime = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_RUNTIME",
+        "if ($application.Status -ne 'Valid' -or $runtime.Status -ne 'Valid') { exit 1 }",
+        "if ($null -eq $application.SignerCertificate -or $null -eq $runtime.SignerCertificate) { exit 1 }",
+        "if ($runtime.SignerCertificate.Subject -cne $application.SignerCertificate.Subject) { exit 1 }",
+        "if ($runtime.SignerCertificate.Issuer -cne $application.SignerCertificate.Issuer) { exit 1 }",
+      ].join("; "),
+    ],
+    env: {
+      PWRAGENT_VERIFY_APPLICATION: applicationCommand,
+      PWRAGENT_VERIFY_RUNTIME: runtimeCommand,
+    },
+  };
+}
+
 async function verifyMatchingPlatformSignature(
   command: string,
   applicationCommand: string,
@@ -694,23 +727,10 @@ async function verifyMatchingPlatformSignature(
   }
 
   if (platform === "win32") {
-    await execFile("powershell.exe", [
-      "-NoLogo",
-      "-NoProfile",
-      "-NonInteractive",
-      "-Command",
-      [
-        ...WINDOWS_SIGNATURE_PRELUDE,
-        "$application = Get-AuthenticodeSignature -LiteralPath $args[0]",
-        "$runtime = Get-AuthenticodeSignature -LiteralPath $args[1]",
-        "if ($application.Status -ne 'Valid' -or $runtime.Status -ne 'Valid') { exit 1 }",
-        "if ($null -eq $application.SignerCertificate -or $null -eq $runtime.SignerCertificate) { exit 1 }",
-        "if ($runtime.SignerCertificate.Subject -cne $application.SignerCertificate.Subject) { exit 1 }",
-        "if ($runtime.SignerCertificate.Issuer -cne $application.SignerCertificate.Issuer) { exit 1 }",
-      ].join("; "),
-      applicationCommand,
-      command,
-    ]);
+    const verification = windowsSignatureVerification(applicationCommand, command);
+    await execFile("powershell.exe", verification.args, {
+      env: { ...process.env, ...verification.env },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- The [v1.1.0-alpha.1 Windows release job](https://github.com/pwrdrvr/PwrAgent/actions/runs/32190371908/job/95885837084) signed everything successfully and then failed in `verify packaged Grok runtime`: `Get-AuthenticodeSignature` "was found in the module 'Microsoft.PowerShell.Security', but the module could not be loaded". Windows PowerShell 5.1 inherits the release process's `PSModulePath`, and the hosted runner's value is PowerShell 7-oriented, so autoloading Windows PowerShell's own Security module fails. `$signature` then stayed empty, producing the confusing follow-on `Bundled Grok Authenticode signature is :` with nothing after the colon.
- `apps/desktop/scripts/release.mjs` now prefers `pwsh.exe` — the shell electron-builder itself resolved and used for Trusted Signing in that same job — and falls back to `powershell.exe`.
- When Windows PowerShell is all that is available, a shared prelude pins `$env:PSModulePath` to its own module locations and imports `Microsoft.PowerShell.Security` explicitly, so a load failure names its own cause instead of cascading. `$ErrorActionPreference = 'Stop'` keeps a cmdlet that never ran from being reported as a signature verdict.
- The same PowerShell block guards the bundled Grok runtime at launch on user machines (`apps/desktop/src/main/acp/grok-managed-runtime.ts`), so it gets the identical repair — a machine with an unusual module path would otherwise refuse to start bundled Grok with the same opaque error.
- New `apps/desktop/src/main/__tests__/windows-signature-prelude.test.ts` pins the release script's copy of the prelude against the main-process constant, and on Windows runs the prelude against a signed system binary.

## Verification

- `pnpm lint:eslint` — 0 errors (43 pre-existing warnings).
- `pnpm typecheck` — clean.
- `pnpm lint:boundaries` — no dependency violations.
- `pnpm test apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts apps/desktop/src/main/__tests__/windows-signature-prelude.test.ts` — 13 passed, 1 skipped (the Windows-only case).
- `node --check apps/desktop/scripts/release.mjs`.
- The Windows half of the new test is the real check on the diagnosis, and the existing `windows-latest` CI lanes run it on this PR.

## Notes

- v1.0.2 and v1.0.3 both released successfully around the failure because the 1.0 release branch predates the Grok bundle and has no such verification step. This check has only ever run on the 1.1 line, so it has never passed a Windows release.
- The prelude is duplicated rather than shared: `release.mjs` is a plain script that cannot import main-process TypeScript. The lockstep test exists so a repair cannot land in only one of the two callers.
- Not changed: the macOS `codesign` branch of the same verification, which was working.
