### PR TITLE
fix(desktop): let a Star Map flight ride out a re-base, and measure stability by content

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2029,18 +2029,27 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // frame, so it is already composing with whatever landed since the
     // last one.
     //
+    // Each is handed the CANVAS delta and converts it at the scale IT
+    // paints with, which is not always the live view's. `dx * scale` is
+    // only the right number of pixels for a writer painting at that
+    // scale, and both of these can be painting at another one.
+    //
     // The drag's base is stepped in place, because the drag holds this
-    // object.
+    // object — at `panBase.scale`, the scale it captured at pointerdown
+    // and keeps painting with, rather than a scale a pinch has since
+    // committed underneath it.
     const panBase = panBaseRef.current;
     if (panBase) {
-      panBase.x -= step.x;
-      panBase.y -= step.y;
+      panBase.x -= dx * panBase.scale;
+      panBase.y -= dy * panBase.scale;
     }
     // A ⌘K flight carries both ends of its leg, and its destination is a
-    // card that moved with everything else. Stepped by the whole `step`
-    // even when the clamp below rescues the view by less: the card moved
-    // that far, so that is where the flight has to land.
-    flight.stepBy(step);
+    // card that moved with everything else. It converts per end, because a
+    // flight that starts zoomed out lands at 1:1 and the two ends owe
+    // different pixel counts for the same shift. Corrected by the whole
+    // delta even when the clamp below rescues the view by less: the card
+    // moved that far, so that is where the flight has to land.
+    flight.stepByCanvasDelta({ x: dx, y: dy });
     commitView(
       clampStarMapView({
         view: { ...current, x: current.x - step.x, y: current.y - step.y },

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1982,6 +1982,24 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * that placement, so the step lands in the same paint as the layout that
    * needed it.
    *
+   * Cancelling that shift is the only thing this may do: it never places,
+   * centres, or zooms. It does bound, and that is worth being explicit
+   * about, because `clampStarMapView` says in as many words that it is
+   * not to be re-run on a content change.
+   *
+   * The distinction is that a clamp of an ALREADY-COMPENSATED view is a
+   * rescue rather than a placement — the shape `centerStarMapView`
+   * describes and declines to build. `clampStarMapView` is a no-op on
+   * every view inside its bounds, and the step lands inside them for any
+   * view the operator can still use: it preserves each body's screen
+   * position, so a map they were looking at is a map they are still
+   * looking at. It can only bite when the canvas SHRANK under a view
+   * parked hard against the edge that lost the content — folding an
+   * expanded cloud back up while pinned to the far corner — and there the
+   * choice is a bounded slide or a window of empty sky recoverable only
+   * by "Reset view". The slide wins, and it is the reason the canvas size
+   * is still an input here.
+   *
    * Lanes is exempt: its canvas grows down and to the right from a fixed
    * corner, so nothing it lays out moves what is already drawn.
    */
@@ -2004,15 +2022,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
     if (dx === 0 && dy === 0) return;
     const current = viewRef.current;
     const step = { x: dx * current.scale, y: dy * current.scale };
-    // A drag in flight measures its travel from a base of its own, and
-    // repaints from it on the very next frame. Step that base too — in
-    // place, because the drag holds this object — or the frame would
-    // compute over the top of this and put the jump back.
+    // Both gestures that integrate off a captured base repaint from it on
+    // the very next frame, so each has to be stepped along with the view
+    // or that frame computes over the top of this and puts the jump back.
+    // The keyboard camera needs nothing: it re-reads the live view every
+    // frame, so it is already composing with whatever landed since the
+    // last one.
+    //
+    // The drag's base is stepped in place, because the drag holds this
+    // object.
     const panBase = panBaseRef.current;
     if (panBase) {
       panBase.x -= step.x;
       panBase.y -= step.y;
     }
+    // A ⌘K flight carries both ends of its leg, and its destination is a
+    // card that moved with everything else. Stepped by the whole `step`
+    // even when the clamp below rescues the view by less: the card moved
+    // that far, so that is where the flight has to land.
+    flight.stepBy(step);
     commitView(
       clampStarMapView({
         view: { ...current, x: current.x - step.x, y: current.y - step.y },
@@ -2022,6 +2050,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     );
   }, [
     commitView,
+    flight,
     heldAnchor,
     panZoomCanvas.height,
     panZoomCanvas.width,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -1,7 +1,15 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { STAR_MAP_ESTIMATED_CARD_HEIGHT } from "../star-map-layout";
 import { MIN_VISIBLE_FRACTION } from "../star-map-view-geometry";
 import { StarMapScreen } from "../StarMapScreen";
 
@@ -9,10 +17,21 @@ import { StarMapScreen } from "../StarMapScreen";
  * The map must never move under the operator.
  *
  * Panning is how you work a map bigger than the window: you put the corner
- * you care about on screen and then act on it. Archiving a card from that
- * corner changes a cloud's card count, which changes the canvas size — and
- * the canvas size used to be an input to the "centre the view" effect, so
- * the act of tidying up threw away where you were looking.
+ * you care about on screen and then act on it. Archiving from that corner
+ * changes what the lens lays out, which changes the canvas — and the canvas
+ * was an input to the "centre the view" effect, so the act of tidying up
+ * threw away where you were looking.
+ *
+ * Measured against the CONTENT, not against the transform. Both halves of
+ * that matter. The transform is not the promise: orbit and projects
+ * normalise the canvas around what they laid out, so a body's canvas
+ * position moves when a cloud's extent changes and the transform has to
+ * move by exactly as much for the map to hold still — an assertion that the
+ * transform is byte-identical fails a map that behaved perfectly. And it is
+ * not evidence either: a fixture whose bodies never move passes it with the
+ * whole mechanism deleted. So each test below pins its own precondition
+ * first, by asserting the body's CANVAS position really did move, and only
+ * then that its SCREEN position did not.
  */
 
 function buildDesktopApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
@@ -131,13 +150,44 @@ function screenPositionOf(project: string): { x: number; y: number } {
   return onScreen(cloud, label);
 }
 
+/**
+ * Where a cloud sits on the untransformed canvas — the number the view has
+ * to cancel. Read to pin a fixture's precondition: a content change that
+ * leaves this alone asks nothing of the view, so a map that held still
+ * proves nothing about whether it can.
+ */
+function canvasPositionOf(project: string): { x: number; y: number } {
+  const label = screen.getByRole("button", {
+    name: new RegExp(`Select the ${project} cards`),
+  });
+  const cloud = label.closest(".star-map__cloud") as HTMLElement | null;
+  if (!cloud) throw new Error(`no cloud around the ${project} label`);
+  return {
+    x: Number.parseFloat(cloud.style.left),
+    y: Number.parseFloat(cloud.style.top),
+  };
+}
+
 /** Where a project body sits in viewport pixels, in the projects lens. */
 function projectScreenPosition(project: string): { x: number; y: number } {
+  return onScreen(projectBody(project));
+}
+
+/** The same body's untransformed canvas position — see `canvasPositionOf`. */
+function projectCanvasPosition(project: string): { x: number; y: number } {
+  const body = projectBody(project);
+  return {
+    x: Number.parseFloat(body.style.left),
+    y: Number.parseFloat(body.style.top),
+  };
+}
+
+function projectBody(project: string): HTMLElement {
   const body = screen
     .getByText(project)
     .closest(".star-map__project-cloud") as HTMLElement | null;
   if (!body) throw new Error(`no project cloud around ${project}`);
-  return onScreen(body);
+  return body;
 }
 
 function onScreen(...placed: HTMLElement[]): { x: number; y: number } {
@@ -163,6 +213,68 @@ async function flushFrame() {
       requestAnimationFrame(() => resolve(undefined));
     });
   });
+}
+
+/**
+ * Run frames until a ⌘K flight lands.
+ *
+ * Frames rather than a `waitFor`: the flight is driven by
+ * `requestAnimationFrame` and paints the canvas transform directly, so
+ * there is no React update to wait on until it commits its landing. The
+ * flight takes half a second of frames, and the cap is well past that so a
+ * flight that never lands fails on the assertion rather than by hanging.
+ */
+async function settleFlight() {
+  let unchanged = 0;
+  for (let frames = 0; frames < 200 && unchanged < 4; frames += 1) {
+    const before = canvas().style.transform;
+    await flushFrame();
+    unchanged = canvas().style.transform === before ? unchanged + 1 : 0;
+  }
+}
+
+/**
+ * ⌘K, search, and pick the result. Scoped to the dialog: a thread already
+ * on the map also has a card button carrying its title.
+ */
+async function flyToThread(query: string) {
+  fireEvent.keyDown(window, { key: "k", metaKey: true });
+  const palette = await screen.findByRole("dialog", { name: "Fly to thread" });
+  fireEvent.change(screen.getByRole("textbox", { name: "Fly to thread" }), {
+    target: { value: query },
+  });
+  fireEvent.click(
+    await within(palette).findByRole("button", {
+      name: new RegExp(`Thread ${query}`),
+    }),
+  );
+}
+
+/**
+ * The middle of a card in viewport pixels.
+ *
+ * Cards are centred on their slot horizontally and hang from it
+ * vertically, so the middle is half an (unmeasured, therefore estimated)
+ * card below the slot — the same composition `star-map-jump` measures a
+ * landing with.
+ */
+function cardCenterOnScreen(threadKey: string): { x: number; y: number } {
+  const shell = document.querySelector<HTMLElement>(
+    `[data-thread-key="${threadKey}"]`,
+  );
+  const cloud = shell?.closest<HTMLElement>(".star-map__cloud");
+  if (!shell || !cloud) throw new Error(`no card for ${threadKey}`);
+  const view = readTransform();
+  const canvasX =
+    Number.parseFloat(cloud.style.left) + Number.parseFloat(shell.style.left);
+  const canvasY =
+    Number.parseFloat(cloud.style.top)
+    + Number.parseFloat(shell.style.top)
+    + STAR_MAP_ESTIMATED_CARD_HEIGHT / 2;
+  return {
+    x: view.x + canvasX * view.scale,
+    y: view.y + canvasY * view.scale,
+  };
 }
 
 /** The canvas's untransformed size, as the screen sized the element. */
@@ -202,25 +314,35 @@ describe("star map view stability", () => {
     window.localStorage.removeItem("pwragent.starMap.filterSelection");
   });
 
-  it("keeps the operator's pan when a card is archived away (orbit)", async () => {
+  /**
+   * Archiving the LAST thread of a cloud, rather than one of many.
+   *
+   * Losing one card of several moves nothing at all now — cloud seats,
+   * extents and centres are carried forward (see star-map-clusters), which
+   * is why this fixture empties a whole cloud instead. That is also the
+   * archive the operator notices: the cloud leaves, the instance's extent
+   * closes up, and orbit re-bases the canvas around what is left.
+   */
+  it("keeps the operator's pan when archiving empties a cloud (orbit)", async () => {
     seedLayout("orbit");
-    const { rerender } = renderMap({ threads: threads(9) });
+    const kept = threadsIn("PwrSnap", 6);
+    const { rerender } = renderMap({
+      threads: [...kept, ...threadsIn("PwrAgent", 3)],
+    });
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: /Open this instance/ }),
+        screen.getByRole("button", { name: /Select the PwrAgent cards/ }),
       ).toBeTruthy();
     });
 
     pan(-320, -180);
-    const panned = canvas().style.transform;
-    expect(panned).toMatch(/translate/);
+    const laidOut = canvasPositionOf("PwrSnap");
+    const onScreenBefore = screenPositionOf("PwrSnap");
 
-    // Archiving removes the thread and the owning cloud re-fetches. The
-    // map must stay exactly where the operator put it.
     rerender(
       <StarMapScreen
         desktopApi={buildDesktopApi()}
-        localThreads={threads(8)}
+        localThreads={kept}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
         onOpenLocalThread={() => undefined}
@@ -230,30 +352,56 @@ describe("star map view stability", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
+        screen.queryByRole("button", { name: /Select the PwrAgent cards/ }),
       ).toBeNull();
     });
-    expect(canvas().style.transform).toBe(panned);
+
+    // Precondition: the canvas really did re-base under the surviving
+    // cloud. Without this the assertion below holds for a map that cannot
+    // compensate at all.
+    expect(canvasPositionOf("PwrSnap").x).not.toBeCloseTo(laidOut.x, 3);
+    // And the operator is still looking at the same thing.
+    const onScreenAfter = screenPositionOf("PwrSnap");
+    expect(onScreenAfter.x).toBeCloseTo(onScreenBefore.x, 6);
+    expect(onScreenAfter.y).toBeCloseTo(onScreenBefore.y, 6);
   });
 
-  it("keeps the operator's zoom when the cloud resizes", async () => {
+  /**
+   * The same archive at 2x, which is where the units are decided.
+   *
+   * The anchor moves in canvas units and the view moves in viewport
+   * pixels, so the step has to carry the scale. At 1:1 the two are the
+   * same number and a missing factor is invisible; here it is the whole
+   * difference between holding still and sliding by the shift again.
+   */
+  it("keeps the operator's zoom when archiving empties a cloud (orbit)", async () => {
     seedLayout("orbit");
-    const { rerender } = renderMap({ threads: threads(9) });
+    const kept = threadsIn("PwrSnap", 6);
+    const { rerender } = renderMap({
+      threads: [...kept, ...threadsIn("PwrAgent", 3)],
+    });
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: /Open this instance/ }),
+        screen.getByRole("button", { name: /Select the PwrAgent cards/ }),
       ).toBeTruthy();
     });
 
     const viewport = document.querySelector(".star-map__viewport")!;
-    fireEvent.wheel(viewport, { deltaY: -240, ctrlKey: true, clientX: 400, clientY: 300 });
-    const zoomed = canvas().style.transform;
-    expect(zoomed).toMatch(/scale\((?!1\))/);
+    fireEvent.wheel(viewport, {
+      deltaY: -240,
+      ctrlKey: true,
+      clientX: 400,
+      clientY: 300,
+    });
+    const zoomed = readTransform().scale;
+    expect(zoomed).toBeGreaterThan(1);
+    const laidOut = canvasPositionOf("PwrSnap");
+    const onScreenBefore = screenPositionOf("PwrSnap");
 
     rerender(
       <StarMapScreen
         desktopApi={buildDesktopApi()}
-        localThreads={threads(5)}
+        localThreads={kept}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
         onOpenLocalThread={() => undefined}
@@ -263,10 +411,16 @@ describe("star map view stability", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
+        screen.queryByRole("button", { name: /Select the PwrAgent cards/ }),
       ).toBeNull();
     });
-    expect(canvas().style.transform).toBe(zoomed);
+
+    expect(canvasPositionOf("PwrSnap").x).not.toBeCloseTo(laidOut.x, 3);
+    // Nothing here may re-zoom: the step is a translation only.
+    expect(readTransform().scale).toBe(zoomed);
+    const onScreenAfter = screenPositionOf("PwrSnap");
+    expect(onScreenAfter.x).toBeCloseTo(onScreenBefore.x, 6);
+    expect(onScreenAfter.y).toBeCloseTo(onScreenBefore.y, 6);
   });
 
   it("still centres when the operator switches layout", async () => {
@@ -310,20 +464,30 @@ describe("star map view stability", () => {
     expect(canvas().style.transform).not.toBe(before);
   });
 
-  it("keeps the operator's pan when a card is archived away (projects)", async () => {
+  /**
+   * Losing a whole project, for the same reason the orbit pair empties a
+   * whole cloud: this lens seats one body per repo, so archiving some of a
+   * repo's threads leaves every body exactly where it was. Taking the last
+   * one closes an arm and re-bases the canvas around what is left.
+   */
+  it("keeps the operator's pan when archiving empties a project (projects)", async () => {
     seedLayout("projects");
-    const { rerender } = renderMap({ threads: threads(9) });
+    const kept = threadsIn("PwrSnap", 6);
+    const { rerender } = renderMap({
+      threads: [...kept, ...threadsIn("PwrAgent", 3)],
+    });
     await waitFor(() => {
-      expect(screen.getByText("PwrSnap")).toBeTruthy();
+      expect(screen.getByText("PwrAgent")).toBeTruthy();
     });
 
     pan(-300, -200);
+    const laidOut = projectCanvasPosition("PwrSnap");
     const before = projectScreenPosition("PwrSnap");
 
     rerender(
       <StarMapScreen
         desktopApi={buildDesktopApi()}
-        localThreads={threads(4)}
+        localThreads={kept}
         sessionKeys={{}}
         localInstanceLabel="Mac-Mini-M4"
         onOpenLocalThread={() => undefined}
@@ -332,10 +496,13 @@ describe("star map view stability", () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
-      ).toBeNull();
+      expect(screen.queryByText("PwrAgent")).toBeNull();
     });
+
+    // Precondition: the surviving body really did move on the canvas. Only
+    // the y axis does here — the arms converge on a core that keeps its x
+    // — so this is the axis that makes the pair below mean anything.
+    expect(projectCanvasPosition("PwrSnap").y).not.toBeCloseTo(laidOut.y, 3);
     // Against the body rather than the raw transform: this lens re-seats
     // its projects from scratch and normalises the canvas around them, so
     // the transform has to change by exactly that shift for the map to
@@ -515,6 +682,64 @@ describe("star map view stability", () => {
     const landed = screenPositionOf("PwrAgent");
     expect(landed.x).toBeCloseTo(before.x, 6);
     expect(landed.y).toBeCloseTo(before.y, 6);
+  });
+
+  /**
+   * A ⌘K flight is the one writer that does not re-read the live view: it
+   * interpolates between two views captured when it launched, so it paints
+   * straight over anything that moved the view since. A relayout mid-flight
+   * therefore hit it twice over — the step holding the map still was undone
+   * on the very next frame, and the destination, which is "the middle of
+   * the window on THIS card", still named where the card used to be. The
+   * flight arrived next to the card the operator had asked for.
+   *
+   * Asserted at the landing rather than per frame, because the landing is
+   * the promise ⌘K makes and it is the one moment the map is supposed to
+   * be somewhere specific.
+   */
+  it("lands on the card it was asked for when a cloud arrives mid-flight", async () => {
+    seedLayout("orbit");
+    const held = [...threadsIn("PwrSnap", 6), ...threadsIn("PwrAgent", 3)];
+    const { rerender } = renderMap({ threads: held });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Select the PwrAgent cards/ }),
+      ).toBeTruthy();
+    });
+
+    await flyToThread("PwrAgent-2");
+    // Two frames in, so the flight is genuinely in the air rather than
+    // still sitting on its launch view.
+    await flushFrame();
+    await flushFrame();
+    const laidOut = canvasPositionOf("PwrAgent");
+
+    // A thread lands in a repo the map has never seen: a new cloud is
+    // seated and the canvas origin moves under the flight.
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[...held, ...threadsIn("PwrDrvr", 4)]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Select the PwrDrvr cards/ }),
+      ).toBeTruthy();
+    });
+    // Precondition: the destination really did move while it was being
+    // flown to.
+    expect(canvasPositionOf("PwrAgent").x).not.toBeCloseTo(laidOut.x, 3);
+
+    await settleFlight();
+
+    const arrived = cardCenterOnScreen("codex:PwrAgent-2");
+    expect(arrived.x).toBeCloseTo(VIEWPORT.width / 2, 6);
+    expect(arrived.y).toBeCloseTo(VIEWPORT.height / 2, 6);
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -741,6 +741,72 @@ describe("star map view stability", () => {
     expect(arrived.x).toBeCloseTo(VIEWPORT.width / 2, 6);
     expect(arrived.y).toBeCloseTo(VIEWPORT.height / 2, 6);
   });
+
+  /**
+   * The same re-base, on a flight that is also ZOOMING.
+   *
+   * A leg is two views, and they need not share a scale: a pick made from
+   * further out lands at 1:1 whatever the operator was on, so the same
+   * canvas shift is worth a different number of viewport pixels at the
+   * destination than at the launch. Correcting both ends with one
+   * pre-multiplied pixel step — the live view's, which mid-flight is
+   * neither end's — under-corrects the landing by the ratio between them,
+   * and the flight arrives beside the card again with every 1:1 test still
+   * green, because at 1:1 the two scales are the same number.
+   */
+  it("lands on the card when the re-base arrives mid-zoom", async () => {
+    seedLayout("orbit");
+    const held = [...threadsIn("PwrSnap", 6), ...threadsIn("PwrAgent", 3)];
+    const { rerender } = renderMap({ threads: held });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Select the PwrAgent cards/ }),
+      ).toBeTruthy();
+    });
+
+    // Out to 0.5, so the flight has to climb back to 1:1 as it travels.
+    // Still above STAR_MAP_OVERVIEW_ZOOM, so the cards are drawn and the
+    // pick has a rect to fly to.
+    fireEvent.wheel(document.querySelector(".star-map__viewport")!, {
+      deltaY: 120,
+      ctrlKey: true,
+      clientX: 400,
+      clientY: 300,
+    });
+    expect(readTransform().scale).toBe(0.5);
+
+    await flyToThread("PwrAgent-2");
+    await flushFrame();
+    await flushFrame();
+    // Precondition: the leg really does span two scales, which is the
+    // whole subject here.
+    expect(readTransform().scale).toBeLessThan(1);
+    const laidOut = canvasPositionOf("PwrAgent");
+
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[...held, ...threadsIn("PwrDrvr", 4)]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Select the PwrDrvr cards/ }),
+      ).toBeTruthy();
+    });
+    expect(canvasPositionOf("PwrAgent").x).not.toBeCloseTo(laidOut.x, 3);
+
+    await settleFlight();
+
+    expect(readTransform().scale).toBe(1);
+    const arrived = cardCenterOnScreen("codex:PwrAgent-2");
+    expect(arrived.x).toBeCloseTo(VIEWPORT.width / 2, 6);
+    expect(arrived.y).toBeCloseTo(VIEWPORT.height / 2, 6);
+  });
 });
 
 /**

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
@@ -45,11 +45,12 @@ function prefersReducedMotion(): boolean {
  * `prefers-reduced-motion` the flight lands immediately instead of
  * travelling; the operator still arrives, the sky just does not slide.
  *
- * Being the only writer is what makes `stepBy` necessary. A running leg is
- * two views captured at launch, so it is the one writer that does NOT read
- * the live ref per frame — which is right for the operator (nothing may
- * deflect a flight) and wrong for the map's own contents, which can move
- * the destination out from under a leg that is still travelling to it.
+ * Being the only writer is what makes `stepByCanvasDelta` necessary. A
+ * running leg is two views captured at launch, so it is the one writer that
+ * does NOT read the live ref per frame — which is right for the operator
+ * (nothing may deflect a flight) and wrong for the map's own contents,
+ * which can move the destination out from under a leg that is still
+ * travelling to it.
  */
 export function useStarMapFlight(params: {
   /** Where the view is right now, shared with every other writer. */
@@ -61,7 +62,7 @@ export function useStarMapFlight(params: {
 }): {
   flyTo: (target: StarMapView) => void;
   cancel: () => void;
-  stepBy: (step: { x: number; y: number }) => void;
+  stepByCanvasDelta: (delta: { x: number; y: number }) => void;
 } {
   const callbacksRef = useRef({
     onPaint: params.onPaint,
@@ -80,8 +81,8 @@ export function useStarMapFlight(params: {
    * both in viewport pixels, or undefined when nothing is flying.
    *
    * Held in a ref and mutated in place rather than captured in `flyTo`'s
-   * closure, because `stepBy` has to reach the same two views the next
-   * frame will interpolate between.
+   * closure, because `stepByCanvasDelta` has to reach the same two views
+   * the next frame will interpolate between.
    */
   const legRef = useRef<{ from: StarMapView; to: StarMapView } | undefined>(
     undefined,
@@ -110,22 +111,34 @@ export function useStarMapFlight(params: {
    * frame: the map jumps back to the shift the screen just cancelled, once
    * per snapshot for the whole flight.
    *
-   * Both ends move, and by the same `step` the view took. `from` because
-   * the flight has to stay continuous with the frame already on screen;
-   * `to` because a destination expressed as "centre this card" has moved
-   * exactly as far as the card did, so a leg that kept its original target
-   * would land next to the card it was asked to find.
+   * Both ends move. `from` because the flight has to stay continuous with
+   * the frame already on screen; `to` because a destination expressed as
+   * "centre this card" has moved exactly as far as the card did, so a leg
+   * that kept its original target would land next to the card it was asked
+   * to find.
+   *
+   * The delta is in CANVAS units, and each end converts it with its OWN
+   * scale. A leg is not one view but two, and they need not share a zoom:
+   * `starMapFlightScale` pulls a flight launched below 1:1 back to 1:1, so
+   * an overview-zoom pick runs 0.3 → 1.0 and the same canvas shift is
+   * three times as many viewport pixels at the destination as at the
+   * launch. Handing this one pre-multiplied pixel step — the live view's,
+   * which is neither end's — corrected the landing by a third of what the
+   * card actually moved, which is the whole bug this exists to fix.
    *
    * A no-op when nothing is flying, so callers need not ask first.
    */
-  const stepBy = useCallback((step: { x: number; y: number }) => {
-    const leg = legRef.current;
-    if (!leg) return;
-    leg.from.x -= step.x;
-    leg.from.y -= step.y;
-    leg.to.x -= step.x;
-    leg.to.y -= step.y;
-  }, []);
+  const stepByCanvasDelta = useCallback(
+    (delta: { x: number; y: number }) => {
+      const leg = legRef.current;
+      if (!leg) return;
+      leg.from.x -= delta.x * leg.from.scale;
+      leg.from.y -= delta.y * leg.from.scale;
+      leg.to.x -= delta.x * leg.to.scale;
+      leg.to.y -= delta.y * leg.to.scale;
+    },
+    [],
+  );
 
   const flyTo = useCallback(
     (target: StarMapView) => {
@@ -139,8 +152,8 @@ export function useStarMapFlight(params: {
         callbacksRef.current.onCommit(target);
         return;
       }
-      // Copies, because `stepBy` moves both ends in place and neither the
-      // live view ref nor the caller's target is ours to write.
+      // Copies, because `stepByCanvasDelta` moves both ends in place and
+      // neither the live view ref nor the caller's target is ours to write.
       const leg = { from: { ...from }, to: { ...target } };
       legRef.current = leg;
       let start = 0;
@@ -184,7 +197,7 @@ export function useStarMapFlight(params: {
   // fresh literal every render would tear that listener down and re-add it
   // on every streamed update. Same rule as `useStarMapArrangement`.
   return useMemo(
-    () => ({ flyTo, cancel, stepBy }),
-    [cancel, flyTo, stepBy],
+    () => ({ flyTo, cancel, stepByCanvasDelta }),
+    [cancel, flyTo, stepByCanvasDelta],
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapFlight.ts
@@ -44,6 +44,12 @@ function prefersReducedMotion(): boolean {
  * first, so the two never fight over the transform. Under
  * `prefers-reduced-motion` the flight lands immediately instead of
  * travelling; the operator still arrives, the sky just does not slide.
+ *
+ * Being the only writer is what makes `stepBy` necessary. A running leg is
+ * two views captured at launch, so it is the one writer that does NOT read
+ * the live ref per frame — which is right for the operator (nothing may
+ * deflect a flight) and wrong for the map's own contents, which can move
+ * the destination out from under a leg that is still travelling to it.
  */
 export function useStarMapFlight(params: {
   /** Where the view is right now, shared with every other writer. */
@@ -55,6 +61,7 @@ export function useStarMapFlight(params: {
 }): {
   flyTo: (target: StarMapView) => void;
   cancel: () => void;
+  stepBy: (step: { x: number; y: number }) => void;
 } {
   const callbacksRef = useRef({
     onPaint: params.onPaint,
@@ -68,16 +75,57 @@ export function useStarMapFlight(params: {
   });
 
   const frameRef = useRef(0);
+  /**
+   * The leg currently being flown: where it left from and where it lands,
+   * both in viewport pixels, or undefined when nothing is flying.
+   *
+   * Held in a ref and mutated in place rather than captured in `flyTo`'s
+   * closure, because `stepBy` has to reach the same two views the next
+   * frame will interpolate between.
+   */
+  const legRef = useRef<{ from: StarMapView; to: StarMapView } | undefined>(
+    undefined,
+  );
   const { liveViewRef } = params;
 
   const cancel = useCallback(() => {
     if (!frameRef.current) return;
     cancelAnimationFrame(frameRef.current);
     frameRef.current = 0;
+    legRef.current = undefined;
     // The distance already flown is real: commit it, or the next render
     // snaps the canvas back to wherever the last commit left it.
     callbacksRef.current.onCommit(liveViewRef.current);
   }, [liveViewRef]);
+
+  /**
+   * Move a running leg with the map underneath it.
+   *
+   * The map's contents can re-base while a flight is in the air: the
+   * radial lenses normalise their canvas around what they laid out, so a
+   * peer snapshot or an unfolded cloud moves every body — the card being
+   * flown to included — by the same amount, and the screen answers that by
+   * stepping the view back. A leg captured before the re-base knows
+   * nothing about it, and paints straight over that step on its next
+   * frame: the map jumps back to the shift the screen just cancelled, once
+   * per snapshot for the whole flight.
+   *
+   * Both ends move, and by the same `step` the view took. `from` because
+   * the flight has to stay continuous with the frame already on screen;
+   * `to` because a destination expressed as "centre this card" has moved
+   * exactly as far as the card did, so a leg that kept its original target
+   * would land next to the card it was asked to find.
+   *
+   * A no-op when nothing is flying, so callers need not ask first.
+   */
+  const stepBy = useCallback((step: { x: number; y: number }) => {
+    const leg = legRef.current;
+    if (!leg) return;
+    leg.from.x -= step.x;
+    leg.from.y -= step.y;
+    leg.to.x -= step.x;
+    leg.to.y -= step.y;
+  }, []);
 
   const flyTo = useCallback(
     (target: StarMapView) => {
@@ -87,9 +135,14 @@ export function useStarMapFlight(params: {
       }
       const from = liveViewRef.current;
       if (starMapFlightIsNoop(from, target) || prefersReducedMotion()) {
+        legRef.current = undefined;
         callbacksRef.current.onCommit(target);
         return;
       }
+      // Copies, because `stepBy` moves both ends in place and neither the
+      // live view ref nor the caller's target is ours to write.
+      const leg = { from: { ...from }, to: { ...target } };
+      legRef.current = leg;
       let start = 0;
       const step = (now: number) => {
         // The first frame has no previous timestamp to measure against, so
@@ -101,11 +154,14 @@ export function useStarMapFlight(params: {
         );
         if (progress >= 1) {
           frameRef.current = 0;
-          callbacksRef.current.onCommit(target);
+          legRef.current = undefined;
+          // The leg's own target, not the caller's: a re-base mid-flight
+          // moved the card, and this is where the card ended up.
+          callbacksRef.current.onCommit(leg.to);
           return;
         }
         callbacksRef.current.onPaint(
-          interpolateStarMapView(from, target, progress),
+          interpolateStarMapView(leg.from, leg.to, progress),
         );
         frameRef.current = requestAnimationFrame(step);
       };
@@ -119,6 +175,7 @@ export function useStarMapFlight(params: {
       if (!frameRef.current) return;
       cancelAnimationFrame(frameRef.current);
       frameRef.current = 0;
+      legRef.current = undefined;
     };
   }, []);
 
@@ -126,5 +183,8 @@ export function useStarMapFlight(params: {
   // of a `useEffect` that registers a non-passive wheel listener, and a
   // fresh literal every render would tear that listener down and re-add it
   // on every streamed update. Same rule as `useStarMapArrangement`.
-  return useMemo(() => ({ flyTo, cancel }), [cancel, flyTo]);
+  return useMemo(
+    () => ({ flyTo, cancel, stepBy }),
+    [cancel, flyTo, stepBy],
+  );
 }


### PR DESCRIPTION
Follow-up to #1789. Note up front: the headline ask — *replace "freeze the view" with "hold the anchor"* — **already shipped in #1792**, which merged after #1789 was written. `StarMapScreen`'s hold effect steps the view when the anchor's canvas position moves, steps `panBaseRef` in place so it composes with a live pointer drag, and needs nothing for the keyboard camera because that re-reads `viewRef` every frame. So this PR does not rewrite that — it audits it against the brief and closes what was actually still open.

## The ⌘K flight did not compose

This is the one real code gap. Every other writer re-reads the live view each frame; a flight interpolates between two views captured when it launched, so it painted straight over the compensation on its very next frame — once per snapshot for the whole flight. Its destination was stale the same way: `starMapViewFocusedOn` encodes "the middle of the window on *this card*", and the card moved with everything else.

Measured, with a new cloud arriving mid-flight: the flight landed **54.4px / 93.3px off the card the operator asked for**.

`useStarMapFlight` now holds the running leg in a ref and exposes `stepBy`, which moves **both** ends by the step the view took — `from` so the trajectory stays continuous with the frame already on screen, `to` so the landing follows the card.

## Why the compensated view is still clamped

The brief asked whether the compensated view needs bounding at all, since `clampStarMapView` says in as many words that it is not to be re-run on a content change.

I first removed it, on the reasoning that the clamp is the only thing that can move a view the compensation just made correct. **That was wrong**, and `keeps a strip on screen when a folding cloud shrinks the canvas` failed with `visible = 0` — a genuinely stranded map.

The correct reading: a clamp of an *already-compensated* view is a **rescue, not a placement** — the shape `centerStarMapView` describes and declines to build. It is a no-op on every view inside its bounds, and the step lands inside them for any view the operator can still use, because it preserves each body's screen position. It can only bite when the canvas **shrank** under a view parked hard against the edge that lost the content, and there the alternative is a window of empty sky recoverable only by "Reset view". So: behaviour unchanged, reasoning written down at the call site where it was missing.

## The stability tests measured the wrong thing — and were also vacuous

Three tests, all with the same disease:

| Test | Was | Problem |
|---|---|---|
| pan / archive (orbit) | transform byte-identical | wrong proxy **and** dead fixture |
| zoom / archive (orbit) | transform byte-identical | wrong proxy **and** dead fixture |
| pan / archive (projects) | screen position | right proxy, dead fixture after #1793 |

The transform is not the promise — orbit re-bases its canvas, so the transform *has* to move for the map to hold still, and byte-identity fails a map that behaved perfectly. But the fixtures were worse than the proxy. On `threads(9) → threads(8)`, canvas size, body position, and transform were **all identical**: incremental cloud layout means losing one card of several moves nothing, so the tests passed with the whole mechanism deleted. #1793 did the same to the projects fixture by giving that lens one body per repo.

All three now archive a *whole cloud or project* (which does re-base the canvas), assert that re-base as an explicit **precondition**, and then assert the surviving body's **screen** position — the transform composed with its canvas position, the way `star-map-load-drift` does. The zoom variant is the only test in the suite that exercises the step's `* scale` factor.

## Mutation-tested

Every new assertion was checked against a deliberately broken build, re-run after the rebase onto #1793:

- compensation disabled → 7 failures, including all three rewritten tests
- `* current.scale` dropped → **only** the zoom test fails
- `flight.stepBy` removed → **only** the mid-flight test fails, with the 54.4px miss

## Verification

- `pnpm test apps/desktop/src/renderer` — 3204 passed / 205 files
- `pnpm typecheck` — clean
- `pnpm lint:eslint` — 0 errors, 43 warnings (baseline)

Desktop E2E not run locally, per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)