### PR TITLE
refactor(desktop): anchor the Star Map projects lens on the heaviest project

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1768,7 +1768,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   /**
    * The body the map opens on, in canvas units: this machine's own
-   * cluster, or the galaxy core in the lens that has no instances.
+   * cluster, or the heaviest project in the lens that has no instances.
    *
    * Opening on a body rather than on the middle of the canvas is what
    * makes a load sit still. Every lens sizes its canvas to the bounding
@@ -1784,21 +1784,28 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const anchorBody = useMemo(() => {
     if (projectsMode) {
       // Projects pool threads across the fleet, so there is no local body
-      // to hold; the arms converge on the core and seat outward from it.
-      return projectLayout.projects.length > 0 ? projectLayout.core : undefined;
+      // to hold; the first seat — the heaviest project — is the body this
+      // lens is about. `computeProjectLayout` sorts by mass itself and
+      // seats that project at radius zero, so the anchor names the body
+      // rather than the point, and holds if the packing ever stops
+      // putting a body on the core.
+      //
+      // Deliberately the CURRENT first seat rather than one latched for
+      // the life of the lens. The seat does not move — it is the core —
+      // so a project overtaking another during a load swaps who sits
+      // there without moving where "there" is, and the anchor holds. A
+      // latch would instead ride one project's own rank, and a project
+      // that loses the top seat is pushed outward past everything
+      // heavier: the anchor would drag the whole map after it, which is
+      // the drift this anchor exists to prevent.
+      return projectLayout.projects[0];
     }
     return (
       bodies.find((body) => body.instanceId === localInstanceId)
       ?? bodies.find((body) => body.isHub)
       ?? bodies[0]
     );
-  }, [
-    bodies,
-    localInstanceId,
-    projectLayout.core,
-    projectLayout.projects.length,
-    projectsMode,
-  ]);
+  }, [bodies, localInstanceId, projectLayout.projects, projectsMode]);
   /**
    * The same point, rebuilt only when it actually moves.
    *

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-load-drift.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-load-drift.test.tsx
@@ -151,6 +151,29 @@ function homeBodyScreenPosition(): { x: number; y: number } {
   };
 }
 
+/**
+ * Where a project's cloud lands in the window, in viewport pixels.
+ *
+ * Composed the same way `homeBodyScreenPosition` is, and for the same
+ * reason: the projects lens normalises its canvas around whatever it has
+ * seated, so a project's own canvas position moves on every snapshot and
+ * neither half of the composition means anything on its own.
+ */
+function projectCloudScreenPosition(label: string): { x: number; y: number } {
+  const canvas = document.querySelector(".star-map__canvas") as HTMLElement;
+  if (!canvas) throw new Error("canvas not found");
+  const view = parseTransform(canvas.style.transform);
+  const name = [...document.querySelectorAll(".star-map-project__name")].find(
+    (node) => node.textContent === label,
+  );
+  const cloud = name?.closest(".star-map__project-cloud") as HTMLElement | null;
+  if (!cloud) throw new Error(`project not on the map: ${label}`);
+  return {
+    x: view.x + Number.parseFloat(cloud.style.left) * view.scale,
+    y: view.y + Number.parseFloat(cloud.style.top) * view.scale,
+  };
+}
+
 /** Let pending snapshots, measurements and placements settle. */
 async function settle() {
   await act(async () => {
@@ -189,6 +212,27 @@ async function openMap(fleet: LoadingFleet) {
     expect(
       screen.getAllByRole("button", { name: /Open this instance/ }).length,
     ).toBeGreaterThan(0);
+  });
+  await settle();
+  return rendered;
+}
+
+/**
+ * Open straight into the projects lens.
+ *
+ * Unlike the instance lenses, this one draws nothing at all until some
+ * thread has a project to pool into, so it opens with this machine's own
+ * threads already in hand rather than with an empty feed.
+ */
+async function openProjectsMap(
+  fleet: LoadingFleet,
+  localThreads: NavigationThreadSummary[],
+) {
+  const rendered = render(
+    renderMap({ desktopApi: fleet.desktopApi, localThreads }),
+  );
+  await waitFor(() => {
+    expect(document.querySelector(".star-map__project-cloud")).toBeTruthy();
   });
   await settle();
   return rendered;
@@ -252,6 +296,54 @@ describe("star map load drift", () => {
     await settle();
 
     expect(homeBodyScreenPosition()).toEqual(opened);
+  });
+
+  it("opens on the heaviest project", async () => {
+    seedLayout("projects");
+    const fleet = buildLoadingFleet(fleetThreads());
+    // This machine's own project is the biggest one on the map until a
+    // peer's snapshot says otherwise.
+    await openProjectsMap(fleet, threads(14, "PwrSnap", "l"));
+    await fleet.announce("pwr_a");
+
+    // Not merely on the middle of the canvas, which is the bounding box of
+    // whatever has been laid out so far and moves as the fleet arrives.
+    expect(projectCloudScreenPosition("PwrSnap")).toEqual({
+      x: VIEWPORT.width / 2,
+      y: VIEWPORT.height / 2,
+    });
+  });
+
+  it("holds the anchored project still while the fleet loads (projects)", async () => {
+    seedLayout("projects");
+    const fleet = buildLoadingFleet(fleetThreads());
+    await openProjectsMap(fleet, threads(14, "PwrSnap", "l"));
+    const opened = projectCloudScreenPosition("PwrSnap");
+
+    // Each peer pools its threads into a project of its own, and every
+    // project already seated is re-seated around the new mass spread — a
+    // canvas resize on each snapshot, from a different bounding box.
+    for (const peerId of ["pwr_a", "pwr_b"]) {
+      await fleet.announce(peerId);
+      expect(projectCloudScreenPosition("PwrSnap")).toEqual(opened);
+    }
+  });
+
+  it("hands the first seat to a heavier project without moving the map", async () => {
+    seedLayout("projects");
+    const fleet = buildLoadingFleet(fleetThreads());
+    await openProjectsMap(fleet, threads(14, "PwrSnap", "l"));
+    const seat = projectCloudScreenPosition("PwrSnap");
+
+    // Gamma is bigger than this machine's own project, so it takes the
+    // first seat the moment its snapshot lands. The map still holds: the
+    // seat is the core itself, so the new occupant lands exactly where the
+    // old one sat. This is why the anchor re-reads the seat rather than
+    // latching onto the project that opened on it — a latch would ride
+    // PwrSnap outward and drag the whole map after it.
+    await fleet.announce("pwr_c");
+
+    expect(projectCloudScreenPosition("Gamma")).toEqual(seat);
   });
 
   it("holds the home cluster still while the fleet loads (lanes)", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-load-drift.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-load-drift.test.tsx
@@ -163,14 +163,34 @@ function projectCloudScreenPosition(label: string): { x: number; y: number } {
   const canvas = document.querySelector(".star-map__canvas") as HTMLElement;
   if (!canvas) throw new Error("canvas not found");
   const view = parseTransform(canvas.style.transform);
-  const name = [...document.querySelectorAll(".star-map-project__name")].find(
-    (node) => node.textContent === label,
-  );
-  const cloud = name?.closest(".star-map__project-cloud") as HTMLElement | null;
-  if (!cloud) throw new Error(`project not on the map: ${label}`);
+  // Two projects can share a display label — `threadProjectLabel` names a
+  // project after its repo folder, and two checkouts of the same repo have
+  // the same folder name — so an ambiguous match is an unusable fixture
+  // rather than a cloud to measure.
+  const names = [
+    ...document.querySelectorAll(".star-map-project__name"),
+  ].filter((node) => node.textContent === label);
+  if (names.length === 0) throw new Error(`project not on the map: ${label}`);
+  if (names.length > 1) {
+    throw new Error(`more than one project labelled ${label}`);
+  }
+  const cloud = names[0].closest(
+    ".star-map__project-cloud",
+  ) as HTMLElement | null;
+  if (!cloud) throw new Error(`project cloud not found: ${label}`);
+  const left = Number.parseFloat(cloud.style.left);
+  const top = Number.parseFloat(cloud.style.top);
+  // A cloud positioned any other way — by a transform, say, the way the
+  // body inside it already centres itself — parses to NaN, and `toEqual`
+  // counts NaN equal to NaN. Every assertion built on this would then pass
+  // while measuring nothing, which is the failure this whole file is
+  // written to avoid.
+  if (!Number.isFinite(left) || !Number.isFinite(top)) {
+    throw new Error(`project ${label} is not positioned by left/top`);
+  }
   return {
-    x: view.x + Number.parseFloat(cloud.style.left) * view.scale,
-    y: view.y + Number.parseFloat(cloud.style.top) * view.scale,
+    x: view.x + left * view.scale,
+    y: view.y + top * view.scale,
   };
 }
 


### PR DESCRIPTION
## Read this first: #1793 overtook the premise

This started as a follow-up to #1789, to fix the projects lens opening on a hole — `CORE_RADIUS` was 260, so no project was seated at the core and `anchorBody` opened on empty space with the galaxy ringed around it.

**#1793 fixed that independently**, and landed while this was in progress. It replaced `CORE_RADIUS` with `ARM_REFERENCE_RADIUS` (which explicitly does not reserve a hole) and starts the first project's search at `radius = sqrt(claimed / …)` with `claimed = 0` — so the heaviest project is now seated **exactly on the core**.

Verified against the rebased layout: for every fleet shape I probed, `projects[0]` sits at `core + (0, 0)`.

So **this changes no pixels today**. `projectLayout.core` and `projectLayout.projects[0]` are the same point. Merge it for the coverage and the stated intent, or close it — both are reasonable.

## What it does

`anchorBody`'s projects branch returns `projectLayout.projects[0]` instead of `projectLayout.core`. It names the body instead of the coordinate: `computeProjectLayout` sorts by mass itself and seats a project on the core, and if the packing ever stops doing that, the anchor follows the body rather than reverting to the empty middle the anchor exists to avoid.

## Current seat, not a latch

The heaviest project can change identity mid-load as snapshots land, so the anchor could in principle jump. It does not, because the seat does not move — it is the core — so a project overtaking another swaps who sits there without moving where "there" is.

Latching to the first project key would be **worse**, and I measured it rather than arguing it: with a latch probe in place, when Gamma overtakes PwrSnap the latched project is pushed outward past everything heavier and the map slides **~680px in both axes**. That is exactly the drift this anchor exists to prevent.

## Tests

Three projects-lens cases added to `star-map-load-drift.test.tsx`, which had none. They assert composed **screen** position (canvas transform × the cloud's canvas position), per that file's own warning that asserting the transform alone agrees with the bug:

- opens on the heaviest project
- holds the anchored project still while the fleet loads (projects)
- hands the first seat to a heavier project without moving the map

They pass before and after this commit, as they should — the core anchor was already correct post-#1793. So they were checked against the two regressions they exist to catch:

| Probe | Result |
|---|---|
| Drop the projects anchor (canvas-centring, the #1789 bug) | all three fail |
| Latch the anchor to the first project key | the third fails |

Nothing was added to `star-map-projects.test.ts` — #1793's `seats the heaviest project on the core` already pins that invariant.

## Verification

- `pnpm test apps/desktop/src/renderer` — 205 files, 3206 tests, all pass
- `pnpm typecheck` — clean
- `pnpm lint:eslint` — 0 errors, 43 warnings (baseline)

Hand-formatted per `CLAUDE.md`; no Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)