### PR TITLE
feat(desktop): one Attention chip on the Star Map, in the sidebar's vocabulary

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
@@ -172,7 +172,7 @@ function AttentionTurnScanner(props: { count: number }) {
  * when a peer actually has work — "0 on other instances" on every
  * single-machine setup is noise.
  */
-export function describeAttentionCounts(
+function describeAttentionCounts(
   counts: StarMapAttentionCounts,
   showRemoteTurns = false,
 ): string {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
@@ -1,5 +1,12 @@
 import {
+  formatActiveThreadCount,
+  formatLocalActiveThreadCount,
+  formatRemoteActiveThreadCount,
+} from "../navigation/ThreadRowStatus";
+import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
+import {
   filterState,
+  type StarMapAttentionCounts,
   type StarMapFilterDefinition,
   type StarMapFilterSelection,
 } from "./star-map-filters";
@@ -17,6 +24,17 @@ export function StarMapFilterChip(props: {
   definition: StarMapFilterDefinition;
   selection: StarMapFilterSelection;
   count: number;
+  /**
+   * Present only on the Attention chip, which draws two indicators
+   * instead of one number — a scanner for turns in progress and the
+   * orange cookie for unread, exactly as the sidebar's Attention tab
+   * does. Both are always drawn, greyed at zero rather than hidden: a
+   * missing indicator makes an idle chip look broken, which is the same
+   * rule the tab follows.
+   */
+  attention?: StarMapAttentionCounts;
+  /** Whether this map fronts any peer at all; see the indicators below. */
+  showRemoteTurns?: boolean;
   onCycle: () => void;
   /**
    * Dropped from the strip because the band ran out of room for it. The
@@ -54,7 +72,14 @@ export function StarMapFilterChip(props: {
           : state === "include"
             ? "showing only these"
             : "hidden"
-      } — click to ${next}`}
+      } — click to ${next}${
+        props.attention
+          ? `. ${describeAttentionCounts(
+              props.attention,
+              props.showRemoteTurns ?? false,
+            )}`
+          : ""
+      }`}
       onClick={props.onCycle}
     >
       {state === "exclude" ? (
@@ -63,7 +88,100 @@ export function StarMapFilterChip(props: {
         </span>
       ) : null}
       <span>{props.definition.label}</span>
-      <span className="star-map__filter-count">{props.count}</span>
+      {props.attention ? (
+        <StarMapAttentionIndicators
+          counts={props.attention}
+          showRemoteTurns={props.showRemoteTurns ?? false}
+        />
+      ) : (
+        <span className="star-map__filter-count">{props.count}</span>
+      )}
     </button>
   );
+}
+
+/**
+ * The Attention chip's readouts, in the sidebar's vocabulary.
+ *
+ * Three signals, not two: turns here, turns elsewhere, and unread. The
+ * local/remote split is the sidebar's and it is load-bearing — the accent
+ * means "this holds the app open", and a peer's turn does not, so they
+ * cannot share a colour even though both are "working".
+ *
+ * The remote readout is omitted entirely when the map fronts no peers,
+ * the way the Attention tab omits it: a permanent 0 on a single-machine
+ * setup is noise, and it would take width from the chips beside it.
+ */
+function StarMapAttentionIndicators(props: {
+  counts: StarMapAttentionCounts;
+  showRemoteTurns: boolean;
+}) {
+  return (
+    <span aria-hidden="true" className="star-map__filter-signals">
+      <span
+        className="star-map__filter-signal star-map__filter-signal--active"
+        data-zero={props.counts.activeLocal === 0 ? "true" : undefined}
+      >
+        <AttentionTurnScanner count={props.counts.activeLocal} />
+        <span>{props.counts.activeLocal}</span>
+      </span>
+      {props.showRemoteTurns ? (
+        <span
+          className="star-map__filter-signal star-map__filter-signal--remote-active"
+          data-zero={props.counts.activeRemote === 0 ? "true" : undefined}
+        >
+          <AttentionTurnScanner count={props.counts.activeRemote} />
+          <span>{props.counts.activeRemote}</span>
+        </span>
+      ) : null}
+      <span
+        className="star-map__filter-signal star-map__filter-signal--review"
+        data-zero={props.counts.unread === 0 ? "true" : undefined}
+      >
+        <span className="thread-row__status-cookie" />
+        <span>{props.counts.unread}</span>
+      </span>
+    </span>
+  );
+}
+
+/**
+ * The sweeping bar next to a turn count, or its idle stand-in.
+ *
+ * At zero this is a static element, NOT a greyed-out `ThinkingScanner`.
+ * `data-zero` lives on the parent, so React would keep the same scanner
+ * element across the flip, its ref would never re-run, and the restarted
+ * animation would never be re-pinned to the shared epoch — this chip would
+ * drift against every other scanner on screen. Swapping the element type
+ * guarantees a mount. Same reasoning, same stand-in element, as the
+ * sidebar's `AttentionTurnScanner`; see ThinkingScanner.tsx and PR #1187.
+ */
+function AttentionTurnScanner(props: { count: number }) {
+  return props.count === 0 ? (
+    <span className="lens-switch__dormant-scanner" />
+  ) : (
+    <ThinkingScanner compact />
+  );
+}
+
+/**
+ * What the Attention chip's two indicators say out loud.
+ *
+ * The numbers are drawn as marks, so without this the chip announces its
+ * filter state and nothing about what it is counting. Split phrasing only
+ * when a peer actually has work — "0 on other instances" on every
+ * single-machine setup is noise.
+ */
+export function describeAttentionCounts(
+  counts: StarMapAttentionCounts,
+  showRemoteTurns = false,
+): string {
+  const active =
+    showRemoteTurns
+      ? [
+          formatLocalActiveThreadCount(counts.activeLocal),
+          formatRemoteActiveThreadCount(counts.activeRemote),
+        ].join(", ")
+      : formatActiveThreadCount(counts.activeLocal);
+  return `${active}, ${counts.unread} unread`;
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { StarMapFilterChip } from "./StarMapFilterChip";
 import {
   STAR_MAP_FILTERS,
+  type StarMapAttentionCounts,
   type StarMapFilterKey,
   type StarMapFilterSelection,
 } from "./star-map-filters";
@@ -24,6 +25,9 @@ import {
 export function StarMapFilterMenu(props: {
   selection: StarMapFilterSelection;
   counts: Record<StarMapFilterKey, number>;
+  /** The Attention chip's two indicators; see `StarMapFilterChip`. */
+  attention: StarMapAttentionCounts;
+  showRemoteTurns: boolean;
   onCycle: (key: StarMapFilterKey) => void;
   onClear: () => void;
 }) {
@@ -86,6 +90,10 @@ export function StarMapFilterMenu(props: {
               definition={definition}
               selection={props.selection}
               count={props.counts[definition.key]}
+              attention={
+                definition.key === "attention" ? props.attention : undefined
+              }
+              showRemoteTurns={props.showRemoteTurns}
               onCycle={() => props.onCycle(definition.key)}
             />
           ))}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -61,7 +61,9 @@ import {
   type StarMapCloudMemory,
 } from "./star-map-clusters";
 import {
+  addAttentionCounts,
   addFilterMatchCounts,
+  countAttentionSignals,
   countFilterMatches,
   cycleFilterState,
   readStoredFilterSelection,
@@ -1112,6 +1114,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
           selectFilteredThreads({
             threads,
             selection: filterSelection,
+            // Peers get the session keys too. Withholding them dropped
+            // half of `isThreadActive` for every remote thread — a peer's
+            // turn could only register through `threadStatus`, so the
+            // renderer-observed thinking state counted for local work and
+            // silently not for anyone else's.
+            sessionKeys: props.sessionKeys,
             summonedKeys,
           }),
         ),
@@ -1474,7 +1482,45 @@ export function StarMapScreen(props: StarMapScreenProps) {
     for (const threads of remote.threadsByInstance.values()) {
       counts = addFilterMatchCounts(
         counts,
-        countFilterMatches({ selection: filterSelection, threads }),
+        // See `attentionByInstance`: the counts have to ask the same
+        // question the filter does, or a chip reports a number the map
+        // then declines to draw.
+        countFilterMatches({
+          selection: filterSelection,
+          sessionKeys: props.sessionKeys,
+          threads,
+        }),
+      );
+    }
+    return counts;
+  }, [filterSelection, props.localThreads, props.sessionKeys, remote]);
+
+  /**
+   * The Attention chip's two indicators.
+   *
+   * Counted alongside `filterCounts` rather than derived from it: that
+   * map holds one number per chip, and this chip draws two — plus the
+   * local/remote split inside the first, which no single-key tally can
+   * carry.
+   */
+  const attentionCounts = useMemo(() => {
+    let counts = countAttentionSignals({
+      selection: filterSelection,
+      sessionKeys: props.sessionKeys,
+      threads: props.localThreads.filter(
+        (thread) =>
+          !thread.federation
+          || !isRemoteFederationTarget(thread.federation.ref.target),
+      ),
+    });
+    for (const threads of remote.threadsByInstance.values()) {
+      counts = addAttentionCounts(
+        counts,
+        countAttentionSignals({
+          selection: filterSelection,
+          sessionKeys: props.sessionKeys,
+          threads,
+        }),
       );
     }
     return counts;
@@ -4525,6 +4571,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 definition={definition}
                 selection={filterSelection}
                 count={filterCounts[definition.key]}
+                attention={
+                  definition.key === "attention" ? attentionCounts : undefined
+                }
+                showRemoteTurns={peers.length > 0}
                 dropped={filterFit === "reduced" && droppableFilters.has(index)}
                 onCycle={() => cycleFilter(definition.key)}
               />
@@ -4542,6 +4592,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
           <StarMapFilterMenu
             selection={filterSelection}
             counts={filterCounts}
+            attention={attentionCounts}
+            showRemoteTurns={peers.length > 0}
             onCycle={cycleFilter}
             onClear={clearFilters}
           />

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1526,6 +1526,22 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return counts;
   }, [filterSelection, props.localThreads, props.sessionKeys, remote]);
 
+  /**
+   * Whether the Attention chip draws its remote-turn readout.
+   *
+   * Fronting a peer is the reason to draw it — a permanent 0 on a
+   * single-machine setup is noise. The count is ORed in so the readout
+   * can never hide a non-zero: `peers` is the capability and
+   * `activeRemote` is the fact, and they part company for a frame when a
+   * peer leaves the directory, since the retention pass that drops its
+   * threads is an effect and runs after the render that shrank `peers`.
+   * The cards are on their way out in that frame too, so this is belt
+   * and braces rather than a bug being fixed — but it is free, and it
+   * makes "the drawn numbers account for every card the filter matched"
+   * true in every frame instead of almost every frame.
+   */
+  const showRemoteTurns = peers.length > 0 || attentionCounts.activeRemote > 0;
+
   // Which chips the band has room for. The chips carry live counts, so
   // the width they need is a property of the data rather than of the
   // window — see `resolveFilterFit` for the two constants that were wrong
@@ -4574,7 +4590,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 attention={
                   definition.key === "attention" ? attentionCounts : undefined
                 }
-                showRemoteTurns={peers.length > 0}
+                showRemoteTurns={showRemoteTurns}
                 dropped={filterFit === "reduced" && droppableFilters.has(index)}
                 onCycle={() => cycleFilter(definition.key)}
               />
@@ -4593,7 +4609,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             selection={filterSelection}
             counts={filterCounts}
             attention={attentionCounts}
-            showRemoteTurns={peers.length > 0}
+            showRemoteTurns={showRemoteTurns}
             onCycle={cycleFilter}
             onClear={clearFilters}
           />

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -716,7 +716,7 @@ describe("StarMapScreen", () => {
     // Scope to the chip row: thread cards also expose an "Unread" status.
     const filterRow = screen.getByRole("group", { name: "Thread filters" });
     const unreadChip = within(filterRow).getByRole("button", {
-      name: /^Unread:/,
+      name: /^Attention:/,
     });
 
     // First click isolates rather than hides — the thread IS unread, so it
@@ -726,13 +726,13 @@ describe("StarMapScreen", () => {
 
     // Second click flips the same chip to exclude.
     fireEvent.click(
-      within(filterRow).getByRole("button", { name: /^Unread:/ }),
+      within(filterRow).getByRole("button", { name: /^Attention:/ }),
     );
     expect(card()).toBeNull();
 
     // Third click returns to neutral.
     fireEvent.click(
-      within(filterRow).getByRole("button", { name: /^Unread:/ }),
+      within(filterRow).getByRole("button", { name: /^Attention:/ }),
     );
     expect(card()).toBeTruthy();
   });
@@ -1587,7 +1587,7 @@ describe("StarMapScreen", () => {
     const filterRow = screen.getByRole("group", { name: "Thread filters" });
     // Exclude the only reason this card is on the map.
     const unread = () =>
-      within(filterRow).getByRole("button", { name: /^Unread:/ });
+      within(filterRow).getByRole("button", { name: /^Attention:/ });
     fireEvent.click(unread());
     fireEvent.click(unread());
 
@@ -1626,7 +1626,7 @@ describe("StarMapScreen", () => {
     const panel = screen.getByRole("dialog", { name: "Thread filters" });
     // Exclude the only reason this card is on the map, through the popover.
     const unread = () =>
-      within(panel).getByRole("button", { name: /^Unread:/ });
+      within(panel).getByRole("button", { name: /^Attention:/ });
     fireEvent.click(unread());
     fireEvent.click(unread());
 
@@ -1639,7 +1639,7 @@ describe("StarMapScreen", () => {
     // show the state the popover just set.
     const strip = screen.getByRole("group", { name: "Thread filters" });
     expect(
-      within(strip).getByRole("button", { name: /^Unread: hidden/ }),
+      within(strip).getByRole("button", { name: /^Attention: hidden/ }),
     ).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Thread filters: 1 active" }),
@@ -1671,7 +1671,7 @@ describe("StarMapScreen", () => {
     ).toBeNull();
 
     fireEvent.click(
-      within(filterRow).getByRole("button", { name: /^Unread:/ }),
+      within(filterRow).getByRole("button", { name: /^Attention:/ }),
     );
     fireEvent.click(within(filterRow).getByRole("button", { name: "Clear" }));
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+import {
+  countAttentionSignals,
+  readStoredFilterSelection,
+  threadPassesFilters,
+} from "../star-map-filters";
+
+/**
+ * The Attention chip: one filter over "unread or working", drawn with the
+ * sidebar's own three readouts.
+ *
+ * These were two chips ("Unread", "Working"), and the Working half had no
+ * coverage at all — which is how a filter nobody could see a non-zero
+ * number on went unnoticed.
+ */
+
+function thread(
+  id: string,
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [{ id: "d", label: "a", path: "/repo/a", kind: "local" }],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 100,
+    ...overrides,
+  } as unknown as NavigationThreadSummary;
+}
+
+const working = thread("working", { threadStatus: "active" } as never);
+const unread = thread("unread", {
+  inbox: { inInbox: true, reason: "updated-since-seen" },
+} as never);
+const idle = thread("idle");
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function renderMap(threads: NavigationThreadSummary[]) {
+  return render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={threads}
+      sessionKeys={{}}
+      localInstanceLabel="Harold-MBP"
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+}
+
+function chip(): HTMLElement {
+  return screen.getByRole("button", { name: /^Attention:/ });
+}
+
+describe("star map attention filter", () => {
+  it("matches a thread that is unread OR working", () => {
+    const selection = { attention: "include" } as const;
+    expect(threadPassesFilters({ selection, thread: working })).toBe(true);
+    expect(threadPassesFilters({ selection, thread: unread })).toBe(true);
+    expect(threadPassesFilters({ selection, thread: idle })).toBe(false);
+  });
+
+  /**
+   * The half of `isThreadActive` the map used to drop for peers: the
+   * renderer-observed thinking state arrives as a session key, and the
+   * remote counting path was called without one.
+   */
+  it("counts a live turn observed only through a session key", () => {
+    expect(
+      countAttentionSignals({
+        selection: {},
+        sessionKeys: { thinkingThreadKeys: { "codex:idle": true } },
+        threads: [idle],
+      }),
+    ).toEqual({ activeLocal: 1, activeRemote: 0, unread: 0 });
+  });
+
+  it("splits live turns by where they are running", () => {
+    const remote = thread("remote", {
+      threadStatus: "active",
+      federation: { ref: { target: { scope: "remote", instanceId: "peer" } } },
+    } as never);
+    expect(
+      countAttentionSignals({ selection: {}, threads: [working, remote, unread] }),
+    ).toEqual({ activeLocal: 1, activeRemote: 1, unread: 1 });
+  });
+
+  it("draws a count for each signal, greyed at zero", async () => {
+    const { container } = renderMap([working, idle]);
+    await waitFor(() => expect(chip()).toBeTruthy());
+
+    const active = container.querySelector(".star-map__filter-signal--active");
+    const review = container.querySelector(".star-map__filter-signal--review");
+    expect(active?.textContent).toBe("1");
+    expect(active?.getAttribute("data-zero")).toBeNull();
+    // Zero is drawn, not hidden: a missing indicator makes an idle chip
+    // look broken rather than idle.
+    expect(review?.textContent).toBe("0");
+    expect(review?.getAttribute("data-zero")).toBe("true");
+    // No peers on this map, so the remote readout is absent entirely.
+    expect(
+      container.querySelector(".star-map__filter-signal--remote-active"),
+    ).toBeNull();
+  });
+
+  /**
+   * The zero state must be a DIFFERENT element, not a stopped scanner:
+   * every `ThinkingScanner` is pinned to one document-timeline epoch by a
+   * mount-time ref, and an animation CSS stops and restarts under a live
+   * element is never re-pinned. See ThinkingScanner.tsx and PR #1187.
+   */
+  it("swaps the scanner element at zero rather than freezing it", async () => {
+    const { container } = renderMap([idle]);
+    await waitFor(() => expect(chip()).toBeTruthy());
+    const active = container.querySelector(".star-map__filter-signal--active");
+    expect(active?.querySelector(".lens-switch__dormant-scanner")).not.toBeNull();
+    expect(active?.querySelector(".thinking-scanner")).toBeNull();
+  });
+
+  it("says both numbers out loud", async () => {
+    renderMap([working, unread]);
+    await waitFor(() => expect(chip()).toBeTruthy());
+    expect(chip().getAttribute("aria-label")).toContain("1 active thread");
+    expect(chip().getAttribute("aria-label")).toContain("1 unread");
+  });
+
+  /**
+   * An operator who left either old chip on has a stored blob naming a key
+   * that no longer exists. Dropping it silently would turn a narrowed map
+   * back into an unfiltered one at the next launch.
+   */
+  it("carries a pre-merge Unread or Working selection forward", () => {
+    for (const stored of [
+      { unread: "include" },
+      { active: "include" },
+      { unread: "exclude", active: "include" },
+    ]) {
+      window.localStorage.setItem(
+        "pwragent.starMap.filterSelection",
+        JSON.stringify(stored),
+      );
+      expect(readStoredFilterSelection().attention).toBe("include");
+    }
+
+    window.localStorage.setItem(
+      "pwragent.starMap.filterSelection",
+      JSON.stringify({ active: "exclude" }),
+    );
+    expect(readStoredFilterSelection().attention).toBe("exclude");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filters.test.ts
@@ -79,7 +79,7 @@ describe("selectFilteredThreads", () => {
   it("isolates on a single include, keeping pins alongside", () => {
     // A pin outranks the attention chips: the sidebar's Pins section and the
     // map are meant to agree about what the operator curated.
-    expect(ids({ unread: "include" })).toEqual([
+    expect(ids({ attention: "include" })).toEqual([
       "pinned",
       "unread",
       "unread-agent",
@@ -87,7 +87,7 @@ describe("selectFilteredThreads", () => {
   });
 
   it("unions includes WITHIN a facet", () => {
-    expect(ids({ unread: "include", pr: "include" })).toEqual([
+    expect(ids({ attention: "include", pr: "include" })).toEqual([
       "pinned",
       "pr",
       "unread",
@@ -98,7 +98,7 @@ describe("selectFilteredThreads", () => {
   it("intersects includes ACROSS facets", () => {
     // "unread AND agent-driven" — not "unread or agent-driven", which is
     // what a flat union would give and is never what the operator means.
-    expect(ids({ unread: "include", agent: "include" })).toEqual([
+    expect(ids({ attention: "include", agent: "include" })).toEqual([
       "pinned",
       "unread-agent",
     ]);
@@ -114,14 +114,14 @@ describe("selectFilteredThreads", () => {
   });
 
   it("lets an exclude override an include in another facet", () => {
-    expect(ids({ unread: "include", agent: "exclude" })).toEqual([
+    expect(ids({ attention: "include", agent: "exclude" })).toEqual([
       "pinned",
       "unread",
     ]);
   });
 
   it("supports include and exclude in the same facet", () => {
-    expect(ids({ unread: "include", pr: "exclude" })).toEqual([
+    expect(ids({ attention: "include", pr: "exclude" })).toEqual([
       "pinned",
       "unread",
       "unread-agent",
@@ -142,7 +142,7 @@ describe("selectFilteredThreads", () => {
   it("lets an explicit pinned exclude hide a pin the chips would keep", () => {
     // The override has exactly one counterweight: asking to see everything
     // EXCEPT pins. Without it the chip would be a control that cannot act.
-    expect(ids({ unread: "include", pinned: "exclude" })).toEqual([
+    expect(ids({ attention: "include", pinned: "exclude" })).toEqual([
       "unread",
       "unread-agent",
     ]);
@@ -205,19 +205,19 @@ describe("threadPassesFilters", () => {
 describe("countFilterMatches", () => {
   it("counts what each chip is about", () => {
     const counts = countFilterMatches({ selection: {}, threads: all });
-    expect(counts.unread).toBe(2);
+    expect(counts.attention).toBe(2);
     expect(counts.pinned).toBe(1);
     expect(counts.agent).toBe(2);
     expect(counts.pr).toBe(1);
   });
 
   it("counts against the other facets' current selection", () => {
-    // With agents excluded, the unread chip speaks for one card, not two.
+    // With agents excluded, the attention chip speaks for one card, not two.
     const counts = countFilterMatches({
       selection: { agent: "exclude" },
       threads: all,
     });
-    expect(counts.unread).toBe(1);
+    expect(counts.attention).toBe(1);
   });
 
   it("does not let a chip's own state suppress its count", () => {
@@ -237,7 +237,7 @@ describe("selectFilteredThreads summons", () => {
     // camera is about to fly to its card, so the lens has to draw one.
     expect(
       selectFilteredThreads({
-        selection: { unread: "include" },
+        selection: { attention: "include" },
         threads: [unread, withPr],
         summonedKeys: new Set(["codex:pr"]),
       }).map((entry) => entry.id),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-jump.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-jump.test.tsx
@@ -231,7 +231,7 @@ describe("Star Map ⌘K", () => {
     // The chip itself is untouched: this is one card the operator asked for
     // by name, not a filter that quietly stopped applying.
     expect(
-      screen.getByRole("button", { name: /^Unread: showing only these/ }),
+      screen.getByRole("button", { name: /^Attention: showing only these/ }),
     ).not.toBeNull();
     expect(
       screen.queryByRole("button", { name: "Open thread: Windows job wrapper" }),

--- a/apps/desktop/src/renderer/src/features/star-map/attention.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/attention.ts
@@ -1,5 +1,6 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
+import { isThreadActive } from "../navigation/ThreadRowStatus";
 import { isOpenPullRequest } from "./star-map-preferences";
 
 export const STAR_MAP_ATTENTION_CATEGORIES = [
@@ -37,10 +38,11 @@ export function threadAttentionCategories(
   if (thread.inbox.inInbox && thread.inbox.reason === "updated-since-seen") {
     categories.push("unread");
   }
-  if (
-    thread.threadStatus === "active"
-    || sessionKeys?.thinkingThreadKeys?.[key] === true
-  ) {
+  // The sidebar's predicate, not a copy of it. `isThreadActive` carries a
+  // standing instruction to keep it shared "so their numbers match the
+  // animated thread-row marker exactly" — and the map had drifted into its
+  // own copy, which is the drift that instruction exists to prevent.
+  if (isThreadActive(thread, sessionKeys?.thinkingThreadKeys)) {
     categories.push("active");
   }
   if (

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
@@ -2,8 +2,10 @@
  * How much of the filter strip the top band can show.
  *
  * The band is one row and the map window goes down to 800px, so at some
- * width the seven chips stop fitting beside the chrome. Two earlier
- * answers were both wrong in ways worth recording:
+ * width the chips stop fitting beside the chrome — six of them today, and
+ * the Attention chip is the widest, since it carries up to three readouts
+ * rather than one count. Two earlier answers were both wrong in ways
+ * worth recording:
  *
  * - Wrapping to a second row put chips over the star field and doubled
  *   the height of the band to show information already on it.

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
@@ -123,11 +123,16 @@ export type StarMapAttentionCounts = {
   unread: number;
 };
 
-export const EMPTY_ATTENTION_COUNTS: StarMapAttentionCounts = {
+/**
+ * Frozen and module-private: its only job is to seed a fresh tally, and a
+ * shared mutable "empty" is one careless caller away from every later
+ * reader starting from a non-zero.
+ */
+const EMPTY_ATTENTION_COUNTS: StarMapAttentionCounts = Object.freeze({
   activeLocal: 0,
   activeRemote: 0,
   unread: 0,
-};
+});
 
 export function countAttentionSignals(params: {
   selection: StarMapFilterSelection;

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
@@ -3,6 +3,7 @@ import {
   comparePinnedThreads,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
+import { isThreadRemoteWork } from "../navigation/ThreadRowStatus";
 import {
   isAgentThread,
   threadAttentionCategories,
@@ -36,8 +37,13 @@ export type StarMapFilterState = "neutral" | "include" | "exclude";
 export type StarMapFilterFacet = "attention" | "pinned" | "agent";
 
 export type StarMapFilterKey =
-  | "unread"
-  | "active"
+  /**
+   * Unread OR a live turn — the two signals the sidebar's Attention tab
+   * carries as one tab with two indicators, and now the map's one chip
+   * with the same two. They were separate chips, which made "show me what
+   * wants me" two clicks and read as two unrelated questions.
+   */
+  | "attention"
   | "approval"
   | "pr"
   | "unpushed"
@@ -51,8 +57,7 @@ export type StarMapFilterDefinition = {
 };
 
 export const STAR_MAP_FILTERS: readonly StarMapFilterDefinition[] = [
-  { facet: "attention", key: "unread", label: "Unread" },
-  { facet: "attention", key: "active", label: "Working" },
+  { facet: "attention", key: "attention", label: "Attention" },
   { facet: "attention", key: "approval", label: "Needs input" },
   { facet: "attention", key: "pr", label: "Open PR" },
   { facet: "attention", key: "unpushed", label: "Unpushed" },
@@ -92,9 +97,75 @@ export function threadMatchesFilter(
 ): boolean {
   if (key === "agent") return isAgentThread(thread);
   if (key === "pinned") return isPinnedThread(thread);
-  return threadAttentionCategories(thread, sessionKeys).some(
-    (category) => category === key,
-  );
+  const categories = threadAttentionCategories(thread, sessionKeys);
+  if (key === "attention") {
+    return categories.some(
+      (category) => category === "unread" || category === "active",
+    );
+  }
+  return categories.some((category) => category === key);
+}
+
+/**
+ * The two numbers the Attention chip draws, and the split inside the
+ * first of them.
+ *
+ * Counted the way `countFilterMatches` counts: against the threads that
+ * already pass every OTHER facet, so the chip answers "how many is this
+ * about right now" rather than a global tally. Live turns split local from
+ * remote because the sidebar's Attention card does — quitting interrupts
+ * the first and leaves the second running, so they are not interchangeable
+ * even though both are "working".
+ */
+export type StarMapAttentionCounts = {
+  activeLocal: number;
+  activeRemote: number;
+  unread: number;
+};
+
+export const EMPTY_ATTENTION_COUNTS: StarMapAttentionCounts = {
+  activeLocal: 0,
+  activeRemote: 0,
+  unread: 0,
+};
+
+export function countAttentionSignals(params: {
+  selection: StarMapFilterSelection;
+  sessionKeys?: StarMapSessionKeys;
+  threads: readonly NavigationThreadSummary[];
+}): StarMapAttentionCounts {
+  const counts: StarMapAttentionCounts = { ...EMPTY_ATTENTION_COUNTS };
+  const otherFacets = FACETS.filter((facet) => facet !== "attention");
+  for (const thread of params.threads) {
+    if (thread.archivedAt !== undefined) continue;
+    const passesOthers = otherFacets.every((facet) =>
+      passesFacet({
+        facet,
+        selection: params.selection,
+        sessionKeys: params.sessionKeys,
+        thread,
+      }),
+    );
+    if (!passesOthers) continue;
+    const categories = threadAttentionCategories(thread, params.sessionKeys);
+    if (categories.includes("unread")) counts.unread += 1;
+    if (categories.includes("active")) {
+      if (isThreadRemoteWork(thread)) counts.activeRemote += 1;
+      else counts.activeLocal += 1;
+    }
+  }
+  return counts;
+}
+
+export function addAttentionCounts(
+  left: StarMapAttentionCounts,
+  right: StarMapAttentionCounts,
+): StarMapAttentionCounts {
+  return {
+    activeLocal: left.activeLocal + right.activeLocal,
+    activeRemote: left.activeRemote + right.activeRemote,
+    unread: left.unread + right.unread,
+  };
 }
 
 const FACETS: StarMapFilterFacet[] = ["attention", "pinned", "agent"];
@@ -314,6 +385,22 @@ function isFilterState(value: unknown): value is StarMapFilterState {
 }
 
 /**
+ * The state a pre-merge `unread` / `active` pair carries forward, or
+ * undefined when neither said anything.
+ */
+function mergeLegacyAttentionStates(
+  values: readonly unknown[],
+): StarMapFilterState | undefined {
+  let result: StarMapFilterState | undefined;
+  for (const value of values) {
+    if (!isFilterState(value) || value === "neutral") continue;
+    if (value === "include") return "include";
+    result = value;
+  }
+  return result;
+}
+
+/**
  * Read the stored selection, migrating the pre-facet shape.
  *
  * The old model stored the set of ENABLED attention categories and started
@@ -334,15 +421,39 @@ export function readStoredFilterSelection(): StarMapFilterSelection {
           selection[definition.key] = value;
         }
       }
+      // `unread` and `active` were two chips before they became one, and
+      // an operator who left either one on has a stored blob naming a key
+      // that no longer exists. Reading it forward matters more than it
+      // looks: dropping it silently would turn a narrowed map back into
+      // an unfiltered one at the next launch, with nothing on screen to
+      // say why. Include wins over exclude when the two disagree — the
+      // combined chip cannot express "unread but not working", and
+      // showing more than asked beats hiding what was asked for.
+      const merged = mergeLegacyAttentionStates([
+        parsed.unread,
+        parsed.active,
+      ]);
+      if (merged && selection.attention === undefined) {
+        selection.attention = merged;
+      }
       return selection;
     }
 
     const legacyRaw = window.localStorage.getItem(LEGACY_CATEGORY_KEY);
     if (legacyRaw) {
       const enabled = JSON.parse(legacyRaw) as unknown;
-      const attention = facetKeys("attention");
-      if (Array.isArray(enabled) && enabled.length < attention.length) {
-        for (const key of attention) {
+      // The pre-facet blob stored the OLD category names, two of which
+      // now share one chip, so it is read against those rather than
+      // against today's keys.
+      const legacyAttentionKeys = ["unread", "active", "approval", "pr", "unpushed"];
+      if (
+        Array.isArray(enabled)
+        && enabled.length < legacyAttentionKeys.length
+      ) {
+        if (enabled.includes("unread") || enabled.includes("active")) {
+          selection.attention = "include";
+        }
+        for (const key of ["approval", "pr", "unpushed"] as const) {
           if (enabled.includes(key)) selection[key] = "include";
         }
       }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12818,7 +12818,76 @@ textarea,
    makes a column. Only the count - `space-between` would also push the
    exclude mark off the label it negates, and "− ... Open PR" reads as two
    separate things rather than one struck-through chip. */
-.star-map__filter-panel .star-map__filter-count {
+.star-map__filter-panel /* The Attention chip's readouts.
+   Token references copied from `.lens-switch__signal` and its modifiers, not
+   chosen to look similar: the map and the sidebar are reporting the SAME
+   three numbers, and an operator glancing between them must not have to
+   work out whether two different oranges mean two different things. If the
+   tab's tokens change, change these with them. */
+.star-map__filter-signals {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 7px;
+}
+
+.star-map__filter-signal {
+  display: inline-flex;
+  /* Never the thing that gives: a half-eaten count reads as a different
+     number, so the indicator shrinks before the digits do. */
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 3px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.star-map__filter-signal--active {
+  color: var(--accent-bright);
+}
+
+/* Turns on another instance. Neutral rather than accent, and that is the
+   whole point: the accent means "this holds the app open", and a peer's turn
+   does not. Still a live sweeping scanner — the work IS running, just not
+   on this machine. */
+.star-map__filter-signal--remote-active {
+  color: var(--text-muted);
+}
+
+.star-map__filter-signal--remote-active .thinking-scanner {
+  --thinking-scanner-tint: var(--text-muted);
+  --thinking-scanner-tint-bright: var(--text-secondary);
+  --thinking-scanner-track: var(--bg-panel-hover);
+}
+
+.star-map__filter-signal--review {
+  color: var(--text-secondary);
+}
+
+.star-map__filter-signal--review .thread-row__status-cookie {
+  width: 8px;
+  height: 8px;
+}
+
+/* Zero is still shown — an idle chip has to read as "nothing running,
+   nothing unread", which a vanishing count cannot do. It just stops
+   claiming the accent. */
+.star-map__filter-signal[data-zero="true"] {
+  color: var(--text-muted);
+}
+
+/* The cookie paints itself from accent tokens rather than `currentColor`,
+   so greying the text is not enough. */
+.star-map__filter-signal[data-zero="true"] .thread-row__status-cookie {
+  border-color: var(--border-subtle);
+  background: var(--text-muted);
+  box-shadow: none;
+}
+
+.star-map__filter-count {
   margin-left: auto;
 }
 


### PR DESCRIPTION
## Summary

The Star Map had two chips, **Unread** and **Working**, asking one question in two clicks. They are now one **Attention** chip carrying the sidebar's own three readouts — turns here, turns elsewhere, unread — using its predicates and its tokens.

Chasing a report that "Working never shows a non-zero value" turned up two real defects underneath the redesign:

**The map had its own copy of "is this thread working."** [`isThreadActive`](apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx) carries a standing instruction — *"Keep this predicate shared with aggregate activity counts so their numbers match the animated thread-row marker exactly"* — and `star-map/attention.ts` had drifted into reimplementing it. It imports the shared one now.

**Peers were counted with half the predicate.** `selectFilteredThreads` and `countFilterMatches` were called **without** `sessionKeys` for every remote instance, and with them for the local one. A live turn the renderer observes as a thinking key therefore counted for our own threads and silently not for anyone else's — on a fleet where the work is spread across machines, most of "Working" could not register.

**Three readouts, not a number.** Live turns split local from remote because the sidebar's Attention tab splits them, and the split is load-bearing: the accent means "this holds the app open", and a peer's turn does not. Zero is drawn greyed rather than hidden, per the rule the tab follows — a missing indicator makes an idle chip look broken instead of idle. The remote readout is omitted entirely when the map fronts no peer, so a single-machine setup carries no permanent 0.

Token references are **copied** from `.lens-switch__signal`, not chosen to look similar. The two surfaces report the same three numbers, and two oranges that differed would read as two different meanings.

The zero-state scanner is a **separate element**, never a stopped `ThinkingScanner`: `data-zero` sits on the parent, so React would keep the same scanner across the flip, its mount ref would not re-run, and the restarted animation would never be re-pinned to the shared epoch — this chip would drift against every other scanner on screen. Same reasoning and the same stand-in element as the sidebar's `AttentionTurnScanner` (PR #1187).

## Verification

- `pnpm typecheck`, `lint:eslint`, `lint:colors`, `lint:boundaries` — clean.
- `pnpm test apps/desktop/src/renderer` — 206 files / 3210 tests pass.
- New `star-map-attention-chip.test.ts` covers what had no coverage at all: the combined match (unread OR working), a live turn seen **only** through a session key (the peer bug), the local/remote split, the greyed zero, the scanner element swap, the spoken counts, and the stored-selection migration.
- `Working` previously appeared nowhere in `star-map-filters.test.ts` — which is how a filter with a plumbing gap went unnoticed.

## Notes

- **Migration**: a stored selection naming either old chip reads forward to the combined one. Include beats exclude when they disagree — the single chip cannot express "unread but not working", and showing more than asked beats hiding what was asked for. The pre-facet blob is migrated against the old category names too.
- **Trade-off accepted deliberately**: you can no longer isolate *just* unread or *just* working. That was the explicit choice when picking this shape over a split-hit-box chip.
- **Not run in the real app.** Desktop E2E does not run on this machine, so the visual result is unverified — worth a look in a dev instance before merge, particularly the chip's width in the top band, since it now carries up to three readouts and the band's fit is decided by measuring chips.
- **The original report is not fully explained.** The chip is plumbed end-to-end — feed it a thread with `threadStatus: "active"` and it renders `Working 1` — and `threadStatus` is live-patched by `thread/status/changed`. The peer `sessionKeys` gap is a real cause but only for remote work. If "Working 0" persists on a single-machine setup after this, the next thing to check is whether the sidebar shows a thinking scanner at the same moment the chip reads 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
