### PR TITLE
fix(tests): source backend-registry git identity from the environment and neutralize ambient config

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import {
   copyFile,
   mkdir,
@@ -14,7 +15,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
   buildFederatedThreadRef,
@@ -270,9 +271,53 @@ function createDeferred<T>(): {
   return { promise, reject, resolve };
 }
 
+// Every `git` below runs against this environment instead of whatever the
+// machine happens to be configured with. Three separate reasons:
+//
+// 1. Identity. Supplying it as GIT_AUTHOR_*/GIT_COMMITTER_* removes the two
+//    `git config` spawns each repo used to pay for, and the `-c user.name=`
+//    argument pairs every `commit` used to carry. A commit is authored the
+//    same way whether the test set identity up or not, so no repo here can
+//    fail on "please tell me who you are" for having forgotten the setup.
+// 2. Ambient configuration. GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM point at an
+//    empty file, so a CI runner's global gitconfig cannot reach these repos:
+//    no credential helper, no `init.defaultBranch`, no `commit.gpgsign`
+//    waiting on a passphrase. What the assertions see is what this file set.
+// 3. Prompting. A git that blocks on a terminal prompt does not fail, it
+//    hangs, and a hang is charged to the whole test timeout rather than to
+//    the command that caused it.
+//
+// PwrGit's e2e sandbox (`apps/desktop/e2e/fixtures/git-sandbox.ts` there)
+// neutralizes config by pointing these at `/dev/null`. That path does not
+// exist on Windows, so this uses a real empty file, which reads as "no
+// configuration" on every platform. The non-interactive pair matches
+// `NON_INTERACTIVE_GIT_ENV` in PwrGit's `main/git/dugite.ts`; the dugite
+// binary it guards there is a production concern and is deliberately not
+// adopted here, since these spawns are test setup against PATH git.
+const gitConfigDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-git-config-"));
+const emptyGitConfigPath = path.join(gitConfigDir, "empty.gitconfig");
+writeFileSync(emptyGitConfigPath, "");
+
+const gitTestEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: emptyGitConfigPath,
+  GIT_CONFIG_SYSTEM: emptyGitConfigPath,
+  GIT_AUTHOR_NAME: "PwrAgent Tests",
+  GIT_AUTHOR_EMAIL: "tests@pwragent.local",
+  GIT_COMMITTER_NAME: "PwrAgent Tests",
+  GIT_COMMITTER_EMAIL: "tests@pwragent.local",
+  GIT_TERMINAL_PROMPT: "0",
+  GCM_INTERACTIVE: "Never",
+};
+
+afterAll(() => {
+  rmSync(gitConfigDir, { force: true, recursive: true });
+});
+
 async function git(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
     encoding: "utf8",
+    env: gitTestEnv,
     maxBuffer: 1024 * 1024 * 10,
   });
   return stdout.trim();
@@ -14489,16 +14534,7 @@ script = "printf setup-output"
     const repo = path.join(root, "app");
     await mkdir(repo, { recursive: true });
     await git(repo, ["init", "-b", "feature/metadata"]);
-    await git(repo, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "--allow-empty",
-      "-m",
-      "init",
-    ]);
+    await git(repo, ["commit", "--allow-empty", "-m", "init"]);
 
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "thread/metadata/update"] },
@@ -15415,8 +15451,6 @@ command = "pnpm dev"
     const worktreePath = path.join(root, "worktree");
     await mkdir(repoPath, { recursive: true });
     await git(repoPath, ["init", "-b", "main"]);
-    await git(repoPath, ["config", "user.email", "test@example.com"]);
-    await git(repoPath, ["config", "user.name", "Test User"]);
     await writeFile(path.join(repoPath, "README.md"), "hello\n", "utf8");
     await git(repoPath, ["add", "README.md"]);
     await git(repoPath, ["commit", "-m", "initial"]);
@@ -24631,15 +24665,7 @@ command = "pnpm dev"
     }
     await writeFile(path.join(root, "README.md"), "handoff\n", "utf8");
     await git(root, ["add", "README.md"]);
-    await git(root, [
-      "-c",
-      "user.name=PwrAgent Tests",
-      "-c",
-      "user.email=tests@pwragent.local",
-      "commit",
-      "-m",
-      "initial",
-    ]);
+    await git(root, ["commit", "-m", "initial"]);
 
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
@@ -25522,15 +25548,7 @@ command = "pnpm dev"
         }
         await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
         await git(repoPath, ["add", "README.md"]);
-        await git(repoPath, [
-          "-c",
-          "user.name=PwrAgent Tests",
-          "-c",
-          "user.email=tests@pwragent.local",
-          "commit",
-          "-m",
-          "initial",
-        ]);
+        await git(repoPath, ["commit", "-m", "initial"]);
       }
 
       const parentDirectory = {
@@ -25676,15 +25694,7 @@ command = "pnpm dev"
         }
         await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
         await git(repoPath, ["add", "README.md"]);
-        await git(repoPath, [
-          "-c",
-          "user.name=PwrAgent Tests",
-          "-c",
-          "user.email=tests@pwragent.local",
-          "commit",
-          "-m",
-          "initial",
-        ]);
+        await git(repoPath, ["commit", "-m", "initial"]);
       }
 
       const parentDirectory = {
@@ -25806,15 +25816,7 @@ command = "pnpm dev"
     }
     await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
     await git(repoPath, ["add", "README.md"]);
-    await git(repoPath, [
-      "-c",
-      "user.name=PwrAgent Tests",
-      "-c",
-      "user.email=tests@pwragent.local",
-      "commit",
-      "-m",
-      "initial",
-    ]);
+    await git(repoPath, ["commit", "-m", "initial"]);
     await mkdir(callerWorktreePath, { recursive: true });
     await mkdir(path.join(worktreePath, ".codex", "environments"), { recursive: true });
     await writeFile(
@@ -26028,15 +26030,7 @@ command = "pnpm dev"
     }
     await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
     await git(repoPath, ["add", "README.md"]);
-    await git(repoPath, [
-      "-c",
-      "user.name=PwrAgent Tests",
-      "-c",
-      "user.email=tests@pwragent.local",
-      "commit",
-      "-m",
-      "initial",
-    ]);
+    await git(repoPath, ["commit", "-m", "initial"]);
     await mkdir(path.join(worktreePath, ".codex", "environments"), { recursive: true });
     await writeFile(
       path.join(worktreePath, ".codex", "environments", "environment.toml"),
@@ -27664,15 +27658,7 @@ script = "printf setup"
     }
     await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
     await git(repoPath, ["add", "README.md"]);
-    await git(repoPath, [
-      "-c",
-      "user.name=PwrAgent Tests",
-      "-c",
-      "user.email=tests@pwragent.local",
-      "commit",
-      "-m",
-      "initial",
-    ]);
+    await git(repoPath, ["commit", "-m", "initial"]);
     await mkdir(worktreePath, { recursive: true });
     const sourceRuntime: CodexThreadEnvironmentRuntime = {
       environmentId: "environment",
@@ -28047,15 +28033,7 @@ script = "printf setup"
       await git(seedPath, ["init", "-b", "main"]);
       await writeFile(path.join(seedPath, "README.md"), "seed\n", "utf8");
       await git(seedPath, ["add", "README.md"]);
-      await git(seedPath, [
-        "-c",
-        "user.name=PwrAgent Tests",
-        "-c",
-        "user.email=tests@pwragent.local",
-        "commit",
-        "-m",
-        "initial",
-      ]);
+      await git(seedPath, ["commit", "-m", "initial"]);
       await git(seedPath, ["remote", "add", "origin", remotePath]);
       await git(seedPath, ["push", "origin", "main"]);
       await git(repoPath, [
@@ -28145,15 +28123,7 @@ script = "printf setup"
     }
     await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
     await git(repoPath, ["add", "README.md"]);
-    await git(repoPath, [
-      "-c",
-      "user.name=PwrAgent Tests",
-      "-c",
-      "user.email=tests@pwragent.local",
-      "commit",
-      "-m",
-      "initial",
-    ]);
+    await git(repoPath, ["commit", "-m", "initial"]);
     await git(repoPath, ["worktree", "add", "--detach", worktreePath, "main"]);
 
     const linkedDirectory = {
@@ -28259,15 +28229,7 @@ script = "printf setup"
         }
         await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
         await git(repoPath, ["add", "README.md"]);
-        await git(repoPath, [
-          "-c",
-          "user.name=PwrAgent Tests",
-          "-c",
-          "user.email=tests@pwragent.local",
-          "commit",
-          "-m",
-          "initial",
-        ]);
+        await git(repoPath, ["commit", "-m", "initial"]);
       }
 
       const parentDirectory = {
@@ -28394,15 +28356,7 @@ script = "printf setup"
       }
       await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
-      await git(repoPath, [
-        "-c",
-        "user.name=PwrAgent Tests",
-        "-c",
-        "user.email=tests@pwragent.local",
-        "commit",
-        "-m",
-        "initial",
-      ]);
+      await git(repoPath, ["commit", "-m", "initial"]);
       await git(repoPath, ["branch", "develop"]);
 
       const scratchDirectory = {
@@ -28672,15 +28626,7 @@ script = "printf setup"
       }
       await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
-      await git(repoPath, [
-        "-c",
-        "user.name=PwrAgent Tests",
-        "-c",
-        "user.email=tests@pwragent.local",
-        "commit",
-        "-m",
-        "initial",
-      ]);
+      await git(repoPath, ["commit", "-m", "initial"]);
 
       const scratchDirectory = {
         id: expectedDir(scratchPath),
@@ -28970,15 +28916,7 @@ script = "printf setup"
       }
       await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
-      await git(repoPath, [
-        "-c",
-        "user.name=PwrAgent Tests",
-        "-c",
-        "user.email=tests@pwragent.local",
-        "commit",
-        "-m",
-        "initial",
-      ]);
+      await git(repoPath, ["commit", "-m", "initial"]);
       await git(repoPath, ["worktree", "add", "--detach", worktreePath, "main"]);
 
       const linkedDirectory = {
@@ -29135,15 +29073,7 @@ script = "printf setup"
         }
         await writeFile(path.join(repo, "README.md"), "handoff\n", "utf8");
         await git(repo, ["add", "README.md"]);
-        await git(repo, [
-          "-c",
-          "user.name=PwrAgent Tests",
-          "-c",
-          "user.email=tests@pwragent.local",
-          "commit",
-          "-m",
-          "initial",
-        ]);
+        await git(repo, ["commit", "-m", "initial"]);
       }
 
       const parentDirectory = {
@@ -29284,15 +29214,7 @@ script = "printf setup"
       }
       await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
-      await git(repoPath, [
-        "-c",
-        "user.name=PwrAgent Tests",
-        "-c",
-        "user.email=tests@pwragent.local",
-        "commit",
-        "-m",
-        "initial",
-      ]);
+      await git(repoPath, ["commit", "-m", "initial"]);
 
       const sourceRuntime: CodexThreadEnvironmentRuntime = {
         environmentId: "environment",
@@ -29417,15 +29339,7 @@ script = "printf setup"
     }
     await writeFile(path.join(root, "README.md"), "handoff\n", "utf8");
     await git(root, ["add", "README.md"]);
-    await git(root, [
-      "-c",
-      "user.name=PwrAgent Tests",
-      "-c",
-      "user.email=tests@pwragent.local",
-      "commit",
-      "-m",
-      "initial",
-    ]);
+    await git(root, ["commit", "-m", "initial"]);
 
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
@@ -33000,15 +32914,7 @@ script = "printf setup"
     }
     await writeFile(path.join(repoPath, "README.md"), "kube manifests\n", "utf8");
     await git(repoPath, ["add", "README.md"]);
-    await git(repoPath, [
-      "-c",
-      "user.name=PwrAgent Tests",
-      "-c",
-      "user.email=tests@pwragent.local",
-      "commit",
-      "-m",
-      "initial",
-    ]);
+    await git(repoPath, ["commit", "-m", "initial"]);
     await mkdir(path.dirname(worktreePath), { recursive: true });
     await git(repoPath, [
       "worktree",
@@ -40007,8 +39913,6 @@ script = "printf setup"
     try {
       await mkdir(repoPath, { recursive: true });
       await git(repoPath, ["init", "-b", "main"]);
-      await git(repoPath, ["config", "user.email", "test@example.com"]);
-      await git(repoPath, ["config", "user.name", "Test User"]);
       await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
       await git(repoPath, ["commit", "-m", "initial"]);
@@ -41050,8 +40954,6 @@ script = "printf setup"
     try {
       await mkdir(repoPath, { recursive: true });
       await git(repoPath, ["init", "-b", "main"]);
-      await git(repoPath, ["config", "user.email", "test@example.com"]);
-      await git(repoPath, ["config", "user.name", "Test User"]);
       await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
       await git(repoPath, ["commit", "-m", "initial"]);
@@ -41143,8 +41045,6 @@ script = "printf setup"
     try {
       await mkdir(repoPath, { recursive: true });
       await git(repoPath, ["init", "-b", "main"]);
-      await git(repoPath, ["config", "user.email", "test@example.com"]);
-      await git(repoPath, ["config", "user.name", "Test User"]);
       await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
       await git(repoPath, ["commit", "-m", "initial"]);
@@ -41226,8 +41126,6 @@ script = "printf setup"
     try {
       await mkdir(repoPath, { recursive: true });
       await git(repoPath, ["init", "-b", "main"]);
-      await git(repoPath, ["config", "user.email", "test@example.com"]);
-      await git(repoPath, ["config", "user.name", "Test User"]);
       await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
       await git(repoPath, ["add", "README.md"]);
       await git(repoPath, ["commit", "-m", "initial"]);
@@ -41537,16 +41435,7 @@ script = "printf setup"
     const repo = path.join(root, "app");
     await mkdir(repo, { recursive: true });
     await git(repo, ["init", "-b", "feature/old"]);
-    await git(repo, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "--allow-empty",
-      "-m",
-      "init",
-    ]);
+    await git(repo, ["commit", "--allow-empty", "-m", "init"]);
 
     const thread: AppServerThreadSummary = {
       id: "thread-branch",
@@ -41656,16 +41545,7 @@ script = "printf setup"
       const repo = path.join(root, "app");
       await mkdir(repo, { recursive: true });
       await git(repo, ["init", "-b", "feature/old"]);
-      await git(repo, [
-        "-c",
-        "user.email=test@example.com",
-        "-c",
-        "user.name=Test User",
-        "commit",
-        "--allow-empty",
-        "-m",
-        "init",
-      ]);
+      await git(repo, ["commit", "--allow-empty", "-m", "init"]);
 
       const acpBackendId = "acp:kimi" as AcpBackendId;
       const overlayStore = createOverlayStoreMock({
@@ -41778,16 +41658,7 @@ script = "printf setup"
     const repo = path.join(root, "app");
     await mkdir(repo, { recursive: true });
     await git(repo, ["init", "-b", "main"]);
-    await git(repo, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "--allow-empty",
-      "-m",
-      "init",
-    ]);
+    await git(repo, ["commit", "--allow-empty", "-m", "init"]);
     await git(repo, ["switch", "--detach", "HEAD"]);
 
     const acpBackendId = "acp:grok" as AcpBackendId;
@@ -45176,5 +45047,43 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("real-repo git test environment", () => {
+  // Without this guard the hardening above is invisible: the suite would keep
+  // passing on a machine whose global gitconfig happens to supply an identity,
+  // and would only break on a runner that does not. Both halves are asserted
+  // from a repo built exactly the way every other real-repo test builds one.
+  it("authors commits from the environment and reads no ambient config", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-git-env-guard-"));
+    try {
+      await git(root, ["init", "-b", "main"]);
+    } catch {
+      await git(root, ["init"]);
+      await git(root, ["checkout", "-b", "main"]);
+    }
+    await writeFile(path.join(root, "README.md"), "guard\n", "utf8");
+    await git(root, ["add", "README.md"]);
+    await git(root, ["commit", "-m", "initial"]);
+
+    // No `git config user.*` ran for this repo, so the commit is proof that
+    // GIT_AUTHOR_*/GIT_COMMITTER_* carried the identity on their own.
+    expect(
+      await git(root, ["log", "-1", "--format=%an|%ae|%cn|%ce"]),
+    ).toBe(
+      "PwrAgent Tests|tests@pwragent.local|PwrAgent Tests|tests@pwragent.local",
+    );
+
+    // `--list` folds system + global + local together, so an empty result for
+    // these prefixes means the runner's gitconfig never reached the repo. A
+    // leaked `credential.*` is the one that matters most: it is what turns a
+    // git spawn into a process waiting on a prompt nobody can answer.
+    const effectiveConfig = await git(root, ["config", "--list"]);
+    expect(
+      effectiveConfig
+        .split(/\r?\n/)
+        .filter((entry) => /^(user\.|credential\.|commit\.gpgsign=)/.test(entry)),
+    ).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -279,10 +279,12 @@ function createDeferred<T>(): {
 //    argument pairs every `commit` used to carry. A commit is authored the
 //    same way whether the test set identity up or not, so no repo here can
 //    fail on "please tell me who you are" for having forgotten the setup.
-// 2. Ambient configuration. GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM point at an
-//    empty file, so a CI runner's global gitconfig cannot reach these repos:
-//    no credential helper, no `init.defaultBranch`, no `commit.gpgsign`
-//    waiting on a passphrase. What the assertions see is what this file set.
+// 2. Ambient configuration. Global config is redirected to an empty file and
+//    system config is switched off, so a runner's gitconfig cannot reach
+//    these repos: no credential helper, no `init.defaultBranch`, no
+//    `commit.gpgsign` waiting on a passphrase. What the assertions see is
+//    what this file set. Repo-location variables are unset for the same
+//    reason — see the entries below.
 // 3. Prompting. A git that blocks on a terminal prompt does not fail, it
 //    hangs, and a hang is charged to the whole test timeout rather than to
 //    the command that caused it.
@@ -300,8 +302,27 @@ writeFileSync(emptyGitConfigPath, "");
 
 const gitTestEnv: NodeJS.ProcessEnv = {
   ...process.env,
+  // A repo-location variable inherited from the outside would redirect every
+  // command below at whatever repo the suite was launched from — `git rebase
+  // -x`, a pre-push hook, and any npm lifecycle script running inside a git
+  // operation all export these. `git -C <fixture>` does not override them, so
+  // an inherited GIT_DIR would point `add` and `commit` at the outer repo's
+  // index while the fixture path only chose the cwd. Node drops env keys whose
+  // value is undefined, so this unsets them for the child.
+  GIT_DIR: undefined,
+  GIT_WORK_TREE: undefined,
+  GIT_INDEX_FILE: undefined,
+  GIT_OBJECT_DIRECTORY: undefined,
+  GIT_COMMON_DIR: undefined,
   GIT_CONFIG_GLOBAL: emptyGitConfigPath,
   GIT_CONFIG_SYSTEM: emptyGitConfigPath,
+  // GIT_CONFIG_SYSTEM replaces `$(prefix)/etc/gitconfig`, but Git for Windows
+  // reads a second system-level file at `%PROGRAMDATA%\Git\config` that the
+  // installer writes to — including, in a default install, a credential
+  // helper. That one is gated on GIT_CONFIG_NOSYSTEM rather than on the path
+  // override, so the path override alone would leave the exact setting this
+  // env exists to keep out, on the exact platform it matters for.
+  GIT_CONFIG_NOSYSTEM: "1",
   GIT_AUTHOR_NAME: "PwrAgent Tests",
   GIT_AUTHOR_EMAIL: "tests@pwragent.local",
   GIT_COMMITTER_NAME: "PwrAgent Tests",


### PR DESCRIPTION
## What this is

Process-count and env-hygiene work on the real-repo tests in
`apps/desktop/src/main/__tests__/backend-registry.test.ts`. It lowers the
file's exposure to a slow runner. **It is not a flake fix, and I am not
claiming it fixes one** — see "On the timeout" below.

## Spawn count

Measured by counting calls through the file's `git()` helper across a full run
of the file, before and after:

| | git spawns per run |
|---|---|
| before | 118 |
| after | 108 |
| after, including the new guard test | 113 |

547 tests pass (546 before, plus the guard).

Two changes get there:

- **10 `git config` spawns removed.** Five fixture repos each ran
  `git config user.email` + `git config user.name` purely to set identity.
  Identity now comes from `GIT_AUTHOR_*` / `GIT_COMMITTER_*` on the helper's
  env, so those spawns are gone.
- **20 inline `-c user.name=… -c user.email=…` argument pairs removed.** These
  cost no spawns — they rode along on a `commit` — but they were a second
  source of identity truth, and with env identity they are dead weight. Their
  removal is most of the diff's line count.

## Does this save CI time? No — measurably, no.

Asked directly, so measured directly rather than left to implication.

`backend-registry.test.ts` on the Windows `desktop-main` lane, from six recent
`main` runs:

| run | duration |
|---|---|
| 32382685196 | 26,834 ms |
| 32392611910 | 29,382 ms |
| 32369836019 | 29,805 ms |
| 32392437294 | 29,849 ms |
| 32402542057 | 35,318 ms |
| 32391449267 | 41,501 ms |

Median ~29.8s, and a **14.7s spread between fastest and slowest**. This PR's
Windows run came in at **26,492 ms — with one more test than any of those**,
which is below the fastest of the six. That looks great and it is worth
approximately nothing: it is a single sample at the low end of a distribution
whose natural variance dwarfs anything this change could do.

The arithmetic says the same. The net spawn change is **5**, not 10 — the guard
test spends 5 of them back (118 → 108 → 113). A `git config` spawn measures
14.2 ms on macOS here; Windows process creation is several times worse, so call
it 0.1–0.5s saved against ~15s of run-to-run noise in this one file. It is not
recoverable from CI timings and I am not going to claim it.

**So the spawn table above is not the reason to take this PR.** Fewer processes
is a real but immaterial side effect. What the change actually buys is the env
hardening: fixture repos no longer depend on what the runner's gitconfig
happens to contain, and no spawn can reach a credential prompt. That removes a
hang *mode*; it does not make the fast path faster.

## Env hardening

```
GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM  →  an empty file
GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL
GIT_COMMITTER_NAME / GIT_COMMITTER_EMAIL
GIT_TERMINAL_PROMPT=0
GCM_INTERACTIVE=Never
```

Nothing in this repo set any of these before, so every fixture repo inherited
whatever the machine had. On my own workstation, an unneutralized fixture repo
resolves a real user identity, a real signing key, and an OS-keychain
credential helper. On a CI runner it is whatever that image ships. The
prompting pair is the one that matters for wall-clock: a git that blocks on a
credential or passphrase prompt does not fail, it hangs, and a hang is billed
to the whole test timeout rather than to the command that caused it.

## Which PwrGit patterns transferred, and which did not

**Transferred:**

- Identity via `GIT_AUTHOR_*` / `GIT_COMMITTER_*`, from
  `apps/desktop/e2e/fixtures/git-sandbox.ts`.
- `GIT_TERMINAL_PROMPT=0` + `GCM_INTERACTIVE=Never`, from
  `NON_INTERACTIVE_GIT_ENV` in `apps/desktop/src/main/git/dugite.ts`.

**Did not transfer — `/dev/null` for the config vars.** PwrGit points
`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at `/dev/null`. That path does not
exist on Windows (the equivalent device is `NUL`), and the prompt to do this
work flagged the risk that a wrong path makes git fail outright rather than
quietly ignore config. Rather than branch on platform, this creates a real
empty file in a per-run `mkdtemp` dir and points both vars at it. An empty
config file is unambiguously "no configuration" on every platform, needs no
device-name special case, and does not depend on how a given git build
resolves an unopenable path. Cleaned up in `afterAll`.

**Did not transfer — dugite. Explicitly out of scope.** PwrGit routes
production git through a bundled dugite binary; these spawns are test setup
against PATH git. Switching the helper would change what the test executes
without removing a single spawn, and PwrAgent's own production git already has
its own path (`app-server/git-executable.ts`). Ruled out deliberately, not
overlooked.

**Considered and declined — `GIT_OPTIONAL_LOCKS=0`.** PwrGit's
`NO_OPTIONAL_LOCKS` exists so a read-only probe does not contend with a
mutating command's lock. The helper's spawns here are sequential and mostly
mutating, so there is no contention for it to relieve.

## Is the Windows Job wrapper involved?

**Not in the path this PR changes.** The `git()` helper is a plain
`execFile` of PATH git with no wrapper, and it never runs `worktree remove` —
only `worktree add` and `worktree list`.

The wrapper *is* involved elsewhere in this same file, on the production side:
`app-server/worktree-archive-service.ts` runs
`["worktree", "remove", "--force", …]` through `runGit` →
`app-server/git-executable.ts` → `wrapCommandInWindowsJob`, with
`ownProcessTree: true`. That is the path #1769 prewarms via
`src/test-setup/windows-job-wrapper-prewarm.ts` and that #1773 keeps startup
tests off of. **This PR does not touch it**, and the two changes are
independent: #1769 addressed the wrapper's cold start, this addresses the
setup spawns that run before the wrapper is ever reached.

## On the timeout — what the CI history actually says

I measured before framing this, across the 60 most recent runs, counting all
attempts including re-runs (the default `gh run list` view hides those):

- `Windows desktop-main` failed **5 times in 60 runs**.
- This test timed out **exactly once** (run `32370595604`, job `96430143894`).
  The other `backend-registry` failure in that window was a *different* test
  failing an assertion, not a timeout.
- All **three** timeout failures across those 5 jobs landed on jobs running
  **8.3–8.6 minutes**, against a **4.4m median** and **5.3m p90**. The two
  non-timeout failures landed on normal-speed 4.1m and 4.6m jobs.
- A **successful** job also ran 8.0m.

That pattern reads as a runner-wide I/O stall, not a git-specific hang — the
other two timeout failures in the window were `StateDb.open()` on temp sqlite
files, unrelated to git and being handled separately. One timeout in 60 runs
is not enough signal to confirm or refute a fix either way. Fewer processes
and no possible credential prompt is a smaller target on a slow runner; that
is the whole claim.

No timeout was raised, no worker count reduced, no serial lane added, no retry
introduced, and nothing skipped on Windows.

## The guard test

Env hardening is invisible by construction: the suite would keep passing on a
machine whose global gitconfig happens to supply an identity, and break only
on a runner that does not. One new test builds a repo the same way every other
real-repo test does and asserts both halves —

- the commit carries the env identity, with no `git config` having run for
  that repo;
- `git config --list` (which folds system + global + local together) yields no
  `user.*`, `credential.*`, or `commit.gpgsign` entry.

I verified it is a real gate rather than a restatement: with `env: gitTestEnv`
removed from the helper, it fails on the machine's real identity.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 547
  passed, macOS.
- `pnpm typecheck` — clean.
- `pnpm lint:eslint` — 0 errors (43 pre-existing warnings, none in this file).
- Formatted by hand; no Prettier was run.

**Windows confirmation is pending.** No PwrSuiteLab Windows VM was available
for this change, and desktop E2E is not run on this machine. The Windows
`desktop-main` CI lane on this PR is the first real Windows signal, and the
empty-file config approach is specifically the part that deserves a look there.

## Post-review fixes (`/code-review --fix`)

Two real gaps found reviewing this diff, both now fixed in
[`131b5aad7`](https://github.com/pwrdrvr/PwrAgent/commit/131b5aad7):

1. **`GIT_CONFIG_SYSTEM` did not cover Git for Windows.** It replaces
   `$(prefix)/etc/gitconfig`, but Git for Windows reads a *second*
   system-level file at `%PROGRAMDATA%\Git\config` — the one its installer
   writes a credential helper into — and that file is gated on
   `GIT_CONFIG_NOSYSTEM`, not on the path override. The original env therefore
   left the exact setting it exists to exclude, on the exact platform it
   matters for. The GitHub runner's copy is empty, which is why CI passed and
   why this would have shown up first on a developer machine or the lab VM.
   Now sets `GIT_CONFIG_NOSYSTEM=1` alongside the path override.

2. **Inherited repo-location variables silently redirect every fixture
   command.** `gitTestEnv` spread `process.env` without clearing `GIT_DIR` /
   `GIT_WORK_TREE` / `GIT_INDEX_FILE`; `git -C <fixture>` sets only the cwd and
   does not override them. Reproduced: with `GIT_DIR` pointing at an outer
   repo, `git -C fixture add README.md` **exits 0 having staged the file into
   the outer repo's index**. No error, wrong repo. `git rebase -x`, a pre-push
   hook, and npm lifecycle scripts inside a git operation all export it. This
   one is pre-existing rather than introduced here, but this env is now the
   place that owns the answer, so it is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)