### PR TITLE
feat(desktop): turn the compact composer's ambient label into a settings chip

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
 } from "react";
 import type { ThreadExecutionMode } from "@pwragent/shared";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
@@ -20,6 +21,34 @@ export type CompactComposerAction = {
   onSelect: () => void;
 };
 
+export type CompactComposerSettingsOption = {
+  id: string;
+  label?: string;
+};
+
+/**
+ * Everything the settings chip's menu can offer beyond the host's plain
+ * actions. Each section renders only when its options AND its callback are
+ * supplied, so a host exposes exactly what its thread can actually change.
+ */
+export type CompactComposerSettingsMenu = {
+  /** True while the host is still fetching the option lists. */
+  loading?: boolean;
+  /**
+   * Called when the menu opens. Lazy on purpose: a card the operator only
+   * reads must not pay for a backend describe it never shows.
+   */
+  onOpen?: () => void;
+  executionModes?: Array<{ label: string; mode: ThreadExecutionMode }>;
+  models?: CompactComposerSettingsOption[];
+  reasoningEfforts?: string[];
+  supportsFastMode?: boolean;
+  onSelectExecutionMode?: (mode: ThreadExecutionMode) => void;
+  onSelectModel?: (model: string) => void;
+  onSelectReasoningEffort?: (effort: string) => void;
+  onToggleFastMode?: (enabled: boolean) => void;
+};
+
 export type CompactComposerProps = {
   busy?: boolean;
   /**
@@ -30,13 +59,15 @@ export type CompactComposerProps = {
   canSteer?: boolean;
   disabled?: boolean;
   executionMode?: ThreadExecutionMode;
+  /** Thread's current fast-mode state, shown on the chip menu's toggle. */
+  fastMode?: boolean;
   /**
    * Populations the `$` / `@` / `#` popovers pick from. Optional on
    * purpose: a host that supplies nothing keeps the trigger characters as
    * literal prose, so adopting this component never requires them.
    */
   mentionSources?: ComposerMentionSources;
-  /** Thread's current model, shown as ambient state rather than a control. */
+  /** Thread's current model, the chip's leading segment. */
   model?: string;
   onInterrupt?: () => void;
   /**
@@ -46,8 +77,10 @@ export type CompactComposerProps = {
   onSend: (text: string) => void | boolean | Promise<boolean | void>;
   placeholder?: string;
   reasoningEffort?: string;
-  /** Consolidated under the kebab; the row itself stays one line tall. */
+  /** Rendered at the bottom of the settings chip's menu. */
   secondaryActions?: CompactComposerAction[];
+  /** Setting sections for the chip menu; see the type's doc comment. */
+  settingsMenu?: CompactComposerSettingsMenu;
   threadTitle: string;
 };
 
@@ -55,6 +88,28 @@ const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
   default: "Default",
   "full-access": "Full access",
 };
+
+type SettingsMenuView = "access" | "model" | "reasoning" | "root";
+
+function ChevronIcon(props: { direction: "back" | "forward" | "up" }) {
+  const path =
+    props.direction === "up"
+      ? "M3 10l5-5 5 5"
+      : props.direction === "back"
+        ? "M10 3L5 8l5 5"
+        : "M6 3l5 5-5 5";
+  return (
+    <svg aria-hidden="true" fill="none" height="10" viewBox="0 0 16 16" width="10">
+      <path
+        d={path}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.75"
+      />
+    </svg>
+  );
+}
 
 /**
  * Composer for surfaces with no vertical budget — currently the star map's
@@ -80,10 +135,12 @@ const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
  * pickers is re-implemented here: the triggers, ranking, token minting and
  * markdown serialization are the same modules the full composer calls.
  *
- * Two moves buy back the height: secondary actions consolidate under a
- * single kebab, and model / reasoning effort render as right-aligned
- * ambient text *inside* the input rather than as chips below it — they are
- * state to be aware of, not controls to reach for.
+ * Model / reasoning / access render as a chip on a status strip below the
+ * field — a strip, not ambient text inside the field, because the field
+ * scrolls at max height and anything pinned inside it ends up painting
+ * over the draft. The chip doubles as the trigger for the settings menu,
+ * which also absorbs the host's secondary actions; the strip stays one
+ * line: chip on the left, Stop / Send pills on the right.
  */
 export function CompactComposer(props: CompactComposerProps) {
   const mentions = useComposerMentions({
@@ -91,19 +148,36 @@ export function CompactComposer(props: CompactComposerProps) {
     sources: props.mentionSources,
   });
   const [menuOpen, setMenuOpen] = useState(false);
+  const [menuView, setMenuView] = useState<SettingsMenuView>("root");
   const menuRef = useRef<HTMLDivElement | null>(null);
   const { onSend } = props;
   // Several cards can be open at once and the editor puts this on a DOM
   // `id`; a shared literal would give the map duplicate ids.
   const inputId = `compact-composer-${useId()}`;
 
-  const ambient = [
-    props.model,
-    props.reasoningEffort,
-    props.executionMode ? EXECUTION_MODE_LABELS[props.executionMode] : undefined,
-  ]
-    .filter((part): part is string => Boolean(part))
-    .join(" · ");
+  const settings = props.settingsMenu;
+  const settingsOnOpen = settings?.onOpen;
+
+  const accessLabel = props.executionMode
+    ? EXECUTION_MODE_LABELS[props.executionMode]
+    : undefined;
+  const chipSegments = [
+    props.model
+      ? { danger: false, key: "model", text: props.model }
+      : undefined,
+    props.reasoningEffort
+      ? { danger: false, key: "reasoning", text: props.reasoningEffort }
+      : undefined,
+    accessLabel
+      ? {
+          danger: props.executionMode === "full-access",
+          key: "access",
+          text: accessLabel,
+        }
+      : undefined,
+  ].filter((segment): segment is NonNullable<typeof segment> =>
+    Boolean(segment),
+  );
 
   const send = useCallback(async () => {
     // The serialized text, not the plain draft: a mention chip is
@@ -139,8 +213,8 @@ export function CompactComposer(props: CompactComposerProps) {
     [mentions, props.disabled, send],
   );
 
-  // Click-away and Escape close the kebab. Without this the menu survives
-  // a click on the transcript behind it and covers the conversation.
+  // Click-away and Escape close the menu. Without this it survives a click
+  // on the transcript behind it and covers the conversation.
   useEffect(() => {
     if (!menuOpen) return;
     const onPointerDown = (event: PointerEvent) => {
@@ -157,7 +231,269 @@ export function CompactComposer(props: CompactComposerProps) {
     };
   }, [menuOpen]);
 
+  const toggleMenu = useCallback(() => {
+    if (!menuOpen) {
+      setMenuView("root");
+      settingsOnOpen?.();
+    }
+    setMenuOpen(!menuOpen);
+  }, [menuOpen, settingsOnOpen]);
+
+  const closeAndSelect = useCallback((select: () => void) => {
+    setMenuOpen(false);
+    select();
+  }, []);
+
   const actions = props.secondaryActions ?? [];
+  // A section renders only when its mutation callback exists; the option
+  // lists may still be loading the first time the menu opens.
+  const modelSection = Boolean(
+    settings?.onSelectModel
+      && (settings.loading || (settings.models?.length ?? 0) > 0),
+  );
+  const reasoningSection = Boolean(
+    settings?.onSelectReasoningEffort
+      && (settings.loading || (settings.reasoningEfforts?.length ?? 0) > 0),
+  );
+  const fastSection = Boolean(
+    settings?.onToggleFastMode && settings.supportsFastMode,
+  );
+  const accessSection = Boolean(
+    settings?.onSelectExecutionMode
+      && (settings.executionModes?.length ?? 0) > 1,
+  );
+  const hasSettingsRows =
+    modelSection || reasoningSection || fastSection || accessSection;
+  const hasMenu = hasSettingsRows || actions.length > 0;
+
+  const settingRow = (
+    label: string,
+    value: ReactNode,
+    view: SettingsMenuView,
+  ) => (
+    <button
+      aria-haspopup="menu"
+      className="compact-composer__menu-item compact-composer__menu-item--setting"
+      onClick={() => setMenuView(view)}
+      role="menuitem"
+      type="button"
+    >
+      <span className="compact-composer__menu-label">{label}</span>
+      {value}
+      <span aria-hidden="true" className="compact-composer__menu-chevron">
+        <ChevronIcon direction="forward" />
+      </span>
+    </button>
+  );
+
+  const optionRow = (params: {
+    checked: boolean;
+    danger?: boolean;
+    key: string;
+    label: string;
+    onSelect: () => void;
+  }) => (
+    <button
+      aria-checked={params.checked}
+      className="compact-composer__menu-item compact-composer__menu-item--option"
+      key={params.key}
+      onClick={() => closeAndSelect(params.onSelect)}
+      role="menuitemradio"
+      type="button"
+    >
+      <span aria-hidden="true" className="compact-composer__menu-check">
+        {params.checked ? "✓" : ""}
+      </span>
+      <span
+        className={
+          params.danger
+            ? "compact-composer__menu-label compact-composer__menu-label--danger"
+            : "compact-composer__menu-label"
+        }
+      >
+        {params.label}
+      </span>
+    </button>
+  );
+
+  const submenu = (title: string, rows: ReactNode) => (
+    <>
+      <button
+        className="compact-composer__menu-item compact-composer__menu-item--back"
+        onClick={() => setMenuView("root")}
+        role="menuitem"
+        type="button"
+      >
+        <span aria-hidden="true" className="compact-composer__menu-chevron">
+          <ChevronIcon direction="back" />
+        </span>
+        Back
+      </button>
+      <div className="compact-composer__menu-eyebrow">{title}</div>
+      {rows}
+    </>
+  );
+
+  const emptySubmenuNotice = (
+    <div className="compact-composer__menu-empty">
+      {settings?.loading ? "Loading options…" : "No options available."}
+    </div>
+  );
+
+  let menuContent: ReactNode;
+  if (menuView === "model") {
+    const options = settings?.models ?? [];
+    menuContent = submenu(
+      "Model",
+      options.length
+        ? options.map((option) =>
+            optionRow({
+              checked: option.id === props.model,
+              key: option.id,
+              label: option.label ?? option.id,
+              onSelect: () => settings?.onSelectModel?.(option.id),
+            }),
+          )
+        : emptySubmenuNotice,
+    );
+  } else if (menuView === "reasoning") {
+    const efforts = settings?.reasoningEfforts ?? [];
+    menuContent = submenu(
+      "Reasoning",
+      efforts.length
+        ? efforts.map((effort) =>
+            optionRow({
+              checked: effort === props.reasoningEffort,
+              key: effort,
+              label: effort,
+              onSelect: () => settings?.onSelectReasoningEffort?.(effort),
+            }),
+          )
+        : emptySubmenuNotice,
+    );
+  } else if (menuView === "access") {
+    const modes = settings?.executionModes ?? [];
+    menuContent = submenu(
+      "Access",
+      modes.map((entry) =>
+        optionRow({
+          checked: entry.mode === props.executionMode,
+          danger: entry.mode === "full-access",
+          key: entry.mode,
+          label: entry.label,
+          onSelect: () => settings?.onSelectExecutionMode?.(entry.mode),
+        }),
+      ),
+    );
+  } else {
+    menuContent = (
+      <>
+        {modelSection
+          ? settingRow(
+              "Model",
+              <span className="compact-composer__menu-value">
+                {props.model}
+              </span>,
+              "model",
+            )
+          : null}
+        {reasoningSection
+          ? settingRow(
+              "Reasoning",
+              <span className="compact-composer__menu-value">
+                {props.reasoningEffort}
+              </span>,
+              "reasoning",
+            )
+          : null}
+        {fastSection ? (
+          <button
+            aria-checked={Boolean(props.fastMode)}
+            className="compact-composer__menu-item compact-composer__menu-item--setting"
+            onClick={() => settings?.onToggleFastMode?.(!props.fastMode)}
+            role="menuitemcheckbox"
+            type="button"
+          >
+            <span className="compact-composer__menu-label">Fast mode</span>
+            <span
+              aria-hidden="true"
+              className={
+                props.fastMode
+                  ? "compact-composer__menu-toggle is-checked"
+                  : "compact-composer__menu-toggle"
+              }
+            >
+              <span className="compact-composer__menu-toggle-thumb" />
+            </span>
+          </button>
+        ) : null}
+        {accessSection
+          ? settingRow(
+              "Access",
+              props.executionMode === "full-access" ? (
+                <span className="compact-composer__menu-value compact-composer__menu-value--danger">
+                  {accessLabel}
+                </span>
+              ) : (
+                <span className="compact-composer__menu-value">
+                  {accessLabel ?? "Default"}
+                </span>
+              ),
+              "access",
+            )
+          : null}
+        {hasSettingsRows && actions.length > 0 ? (
+          <div
+            aria-hidden="true"
+            className="compact-composer__menu-separator"
+          />
+        ) : null}
+        {actions.map((action) => (
+          <button
+            className="compact-composer__menu-item"
+            disabled={action.disabled}
+            key={action.key}
+            onClick={() => {
+              setMenuOpen(false);
+              action.onSelect();
+            }}
+            role="menuitem"
+            type="button"
+          >
+            {action.label}
+          </button>
+        ))}
+      </>
+    );
+  }
+
+  const chipContent =
+    chipSegments.length > 0 ? (
+      <>
+        {chipSegments.map((segment, index) => (
+          <span key={segment.key} className="compact-composer__chip-part">
+            {index > 0 ? (
+              <span aria-hidden="true" className="compact-composer__chip-dot">
+                ·
+              </span>
+            ) : null}
+            <span
+              className={
+                segment.danger
+                  ? "compact-composer__chip-segment compact-composer__chip-segment--danger"
+                  : "compact-composer__chip-segment"
+              }
+            >
+              {segment.text}
+            </span>
+          </span>
+        ))}
+      </>
+    ) : (
+      // A thread with no model info still needs a door to the menu; the
+      // bare glyph is the old kebab's, on the chip's own geometry.
+      <span aria-hidden="true">⋯</span>
+    );
 
   return (
     <div className="compact-composer">
@@ -181,50 +517,50 @@ export function CompactComposer(props: CompactComposerProps) {
             that is what keeps the list within `.star-map-chat-card`, the
             selector every camera-gesture guard tests against. */}
         {mentions.popover}
-        {ambient ? (
-          // Ambient, not interactive: the label belongs to the input, so
-          // screen readers reach it through the field rather than as a
-          // separate stop.
-          <span aria-hidden="true" className="compact-composer__ambient">
-            {ambient}
-          </span>
-        ) : null}
       </div>
 
-      <div className="compact-composer__controls">
-        {actions.length > 0 ? (
+      <div className="compact-composer__strip">
+        {hasMenu ? (
           <div className="compact-composer__menu" ref={menuRef}>
             <button
               aria-expanded={menuOpen}
               aria-haspopup="menu"
-              aria-label="More actions"
-              className="compact-composer__kebab"
-              onClick={() => setMenuOpen((open) => !open)}
+              aria-label="Thread settings"
+              className={
+                menuOpen
+                  ? "compact-composer__chip is-open"
+                  : "compact-composer__chip"
+              }
+              onClick={toggleMenu}
               type="button"
             >
-              ⋯
+              {chipContent}
+              <span
+                aria-hidden="true"
+                className="compact-composer__chip-chevron"
+              >
+                <ChevronIcon direction="up" />
+              </span>
             </button>
+            {/* Same in-card anchoring rule as the mention popover above. */}
             {menuOpen ? (
               <div className="compact-composer__menu-list" role="menu">
-                {actions.map((action) => (
-                  <button
-                    className="compact-composer__menu-item"
-                    disabled={action.disabled}
-                    key={action.key}
-                    onClick={() => {
-                      setMenuOpen(false);
-                      action.onSelect();
-                    }}
-                    role="menuitem"
-                    type="button"
-                  >
-                    {action.label}
-                  </button>
-                ))}
+                {menuContent}
               </div>
             ) : null}
           </div>
+        ) : chipSegments.length > 0 ? (
+          // No menu to open (a host with no actions and no settings), so
+          // the chip is informational only.
+          <span
+            aria-hidden="true"
+            className="compact-composer__chip compact-composer__chip--static"
+          >
+            {chipContent}
+          </span>
         ) : null}
+
+        <span className="compact-composer__spacer" />
 
         {props.busy && props.onInterrupt ? (
           <button

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -1,14 +1,19 @@
 import {
   useCallback,
-  useEffect,
   useId,
-  useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
 import type { ThreadExecutionMode } from "@pwragent/shared";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+} from "../../icons";
+import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
+import { useDismissableMenu } from "./ComposerDropdown";
 import {
   useComposerMentions,
   type ComposerMentionSources,
@@ -32,6 +37,11 @@ export type CompactComposerSettingsOption = {
  * supplied, so a host exposes exactly what its thread can actually change.
  */
 export type CompactComposerSettingsMenu = {
+  /**
+   * The host's option fetch failed. Keeps the setting rows visible so the
+   * failure is reportable in place instead of the rows silently vanishing.
+   */
+  loadFailed?: boolean;
   /** True while the host is still fetching the option lists. */
   loading?: boolean;
   /**
@@ -84,32 +94,16 @@ export type CompactComposerProps = {
   threadTitle: string;
 };
 
-const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
-  default: "Default",
-  "full-access": "Full access",
-};
-
 type SettingsMenuView = "access" | "model" | "reasoning" | "root";
 
-function ChevronIcon(props: { direction: "back" | "forward" | "up" }) {
-  const path =
-    props.direction === "up"
-      ? "M3 10l5-5 5 5"
-      : props.direction === "back"
-        ? "M10 3L5 8l5 5"
-        : "M6 3l5 5-5 5";
-  return (
-    <svg aria-hidden="true" fill="none" height="10" viewBox="0 0 16 16" width="10">
-      <path
-        d={path}
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="1.75"
-      />
-    </svg>
-  );
-}
+const MENU_VIEW_TITLES: Record<
+  Exclude<SettingsMenuView, "root">,
+  string
+> = {
+  access: "Access",
+  model: "Model",
+  reasoning: "Reasoning",
+};
 
 /**
  * Composer for surfaces with no vertical budget — currently the star map's
@@ -149,7 +143,11 @@ export function CompactComposer(props: CompactComposerProps) {
   });
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<SettingsMenuView>("root");
-  const menuRef = useRef<HTMLDivElement | null>(null);
+  // Click-away and Escape close the menu, same hook as the composer
+  // dropdowns. Without it the menu survives a click on the transcript
+  // behind it and covers the conversation.
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+  const menuRef = useDismissableMenu<HTMLDivElement>(menuOpen, closeMenu);
   const { onSend } = props;
   // Several cards can be open at once and the editor puts this on a DOM
   // `id`; a shared literal would give the map duplicate ids.
@@ -159,7 +157,7 @@ export function CompactComposer(props: CompactComposerProps) {
   const settingsOnOpen = settings?.onOpen;
 
   const accessLabel = props.executionMode
-    ? EXECUTION_MODE_LABELS[props.executionMode]
+    ? formatExecutionModeLabel(props.executionMode)
     : undefined;
   const chipSegments = [
     props.model
@@ -213,24 +211,6 @@ export function CompactComposer(props: CompactComposerProps) {
     [mentions, props.disabled, send],
   );
 
-  // Click-away and Escape close the menu. Without this it survives a click
-  // on the transcript behind it and covers the conversation.
-  useEffect(() => {
-    if (!menuOpen) return;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) setMenuOpen(false);
-    };
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setMenuOpen(false);
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [menuOpen]);
-
   const toggleMenu = useCallback(() => {
     if (!menuOpen) {
       setMenuView("root");
@@ -239,21 +219,30 @@ export function CompactComposer(props: CompactComposerProps) {
     setMenuOpen(!menuOpen);
   }, [menuOpen, settingsOnOpen]);
 
-  const closeAndSelect = useCallback((select: () => void) => {
-    setMenuOpen(false);
-    select();
-  }, []);
+  const closeAndSelect = useCallback(
+    (select: () => void) => {
+      closeMenu();
+      select();
+    },
+    [closeMenu],
+  );
 
   const actions = props.secondaryActions ?? [];
-  // A section renders only when its mutation callback exists; the option
-  // lists may still be loading the first time the menu opens.
+  // A section renders only when its mutation callback exists. The option
+  // lists may still be loading the first time the menu opens, and a failed
+  // load keeps the rows visible so the failure is reported in place rather
+  // than the rows silently vanishing.
   const modelSection = Boolean(
     settings?.onSelectModel
-      && (settings.loading || (settings.models?.length ?? 0) > 0),
+      && (settings.loading
+        || settings.loadFailed
+        || (settings.models?.length ?? 0) > 0),
   );
   const reasoningSection = Boolean(
     settings?.onSelectReasoningEffort
-      && (settings.loading || (settings.reasoningEfforts?.length ?? 0) > 0),
+      && (settings.loading
+        || settings.loadFailed
+        || (settings.reasoningEfforts?.length ?? 0) > 0),
   );
   const fastSection = Boolean(
     settings?.onToggleFastMode && settings.supportsFastMode,
@@ -273,7 +262,7 @@ export function CompactComposer(props: CompactComposerProps) {
   ) => (
     <button
       aria-haspopup="menu"
-      className="compact-composer__menu-item compact-composer__menu-item--setting"
+      className="compact-composer__menu-item"
       onClick={() => setMenuView(view)}
       role="menuitem"
       type="button"
@@ -281,7 +270,7 @@ export function CompactComposer(props: CompactComposerProps) {
       <span className="compact-composer__menu-label">{label}</span>
       {value}
       <span aria-hidden="true" className="compact-composer__menu-chevron">
-        <ChevronIcon direction="forward" />
+        <ChevronRightIcon size={10} />
       </span>
     </button>
   );
@@ -295,7 +284,7 @@ export function CompactComposer(props: CompactComposerProps) {
   }) => (
     <button
       aria-checked={params.checked}
-      className="compact-composer__menu-item compact-composer__menu-item--option"
+      className="compact-composer__menu-item"
       key={params.key}
       onClick={() => closeAndSelect(params.onSelect)}
       role="menuitemradio"
@@ -304,14 +293,12 @@ export function CompactComposer(props: CompactComposerProps) {
       <span aria-hidden="true" className="compact-composer__menu-check">
         {params.checked ? "✓" : ""}
       </span>
-      <span
-        className={
-          params.danger
-            ? "compact-composer__menu-label compact-composer__menu-label--danger"
-            : "compact-composer__menu-label"
-        }
-      >
-        {params.label}
+      <span className="compact-composer__menu-label">
+        {params.danger ? (
+          <span className="compact-composer__danger-pill">{params.label}</span>
+        ) : (
+          params.label
+        )}
       </span>
     </button>
   );
@@ -325,68 +312,86 @@ export function CompactComposer(props: CompactComposerProps) {
         type="button"
       >
         <span aria-hidden="true" className="compact-composer__menu-chevron">
-          <ChevronIcon direction="back" />
+          <ChevronLeftIcon size={10} />
         </span>
         Back
       </button>
-      <div className="compact-composer__menu-eyebrow">{title}</div>
+      {/* The menu container carries the view's name; the visible eyebrow
+          is decoration on top of it, not a menu child in its own right. */}
+      <div aria-hidden="true" className="compact-composer__menu-eyebrow">
+        {title}
+      </div>
       {rows}
     </>
   );
 
+  // A disabled menuitem, not a bare div: `role="menu"` only admits menu
+  // children, and this notice has to be announced too.
   const emptySubmenuNotice = (
-    <div className="compact-composer__menu-empty">
-      {settings?.loading ? "Loading options…" : "No options available."}
+    <div
+      aria-disabled="true"
+      className="compact-composer__menu-empty"
+      role="menuitem"
+    >
+      {settings?.loading
+        ? "Loading options…"
+        : settings?.loadFailed
+          ? "Couldn't load options."
+          : "No options available."}
     </div>
   );
 
-  let menuContent: ReactNode;
-  if (menuView === "model") {
-    const options = settings?.models ?? [];
-    menuContent = submenu(
-      "Model",
-      options.length
-        ? options.map((option) =>
-            optionRow({
-              checked: option.id === props.model,
-              key: option.id,
-              label: option.label ?? option.id,
-              onSelect: () => settings?.onSelectModel?.(option.id),
-            }),
-          )
-        : emptySubmenuNotice,
-    );
-  } else if (menuView === "reasoning") {
-    const efforts = settings?.reasoningEfforts ?? [];
-    menuContent = submenu(
-      "Reasoning",
-      efforts.length
-        ? efforts.map((effort) =>
-            optionRow({
-              checked: effort === props.reasoningEffort,
-              key: effort,
-              label: effort,
-              onSelect: () => settings?.onSelectReasoningEffort?.(effort),
-            }),
-          )
-        : emptySubmenuNotice,
-    );
-  } else if (menuView === "access") {
-    const modes = settings?.executionModes ?? [];
-    menuContent = submenu(
-      "Access",
-      modes.map((entry) =>
-        optionRow({
-          checked: entry.mode === props.executionMode,
-          danger: entry.mode === "full-access",
-          key: entry.mode,
-          label: entry.label,
-          onSelect: () => settings?.onSelectExecutionMode?.(entry.mode),
-        }),
-      ),
-    );
-  } else {
-    menuContent = (
+  // Built only while the menu is open: this component re-renders per
+  // keystroke, and a closed menu must not cost an element tree per key.
+  const menuBody = (): ReactNode => {
+    if (menuView === "model") {
+      const options = settings?.models ?? [];
+      return submenu(
+        MENU_VIEW_TITLES.model,
+        options.length
+          ? options.map((option) =>
+              optionRow({
+                checked: option.id === props.model,
+                key: option.id,
+                label: option.label ?? option.id,
+                onSelect: () => settings?.onSelectModel?.(option.id),
+              }),
+            )
+          : emptySubmenuNotice,
+      );
+    }
+    if (menuView === "reasoning") {
+      const efforts = settings?.reasoningEfforts ?? [];
+      return submenu(
+        MENU_VIEW_TITLES.reasoning,
+        efforts.length
+          ? efforts.map((effort) =>
+              optionRow({
+                checked: effort === props.reasoningEffort,
+                key: effort,
+                label: effort,
+                onSelect: () => settings?.onSelectReasoningEffort?.(effort),
+              }),
+            )
+          : emptySubmenuNotice,
+      );
+    }
+    if (menuView === "access") {
+      const modes = settings?.executionModes ?? [];
+      return submenu(
+        MENU_VIEW_TITLES.access,
+        modes.map((entry) =>
+          optionRow({
+            checked: entry.mode === props.executionMode,
+            danger: entry.mode === "full-access",
+            key: entry.mode,
+            label: entry.label,
+            onSelect: () => settings?.onSelectExecutionMode?.(entry.mode),
+          }),
+        ),
+      );
+    }
+    return (
       <>
         {modelSection
           ? settingRow(
@@ -409,7 +414,7 @@ export function CompactComposer(props: CompactComposerProps) {
         {fastSection ? (
           <button
             aria-checked={Boolean(props.fastMode)}
-            className="compact-composer__menu-item compact-composer__menu-item--setting"
+            className="compact-composer__menu-item"
             onClick={() => settings?.onToggleFastMode?.(!props.fastMode)}
             role="menuitemcheckbox"
             type="button"
@@ -431,22 +436,19 @@ export function CompactComposer(props: CompactComposerProps) {
           ? settingRow(
               "Access",
               props.executionMode === "full-access" ? (
-                <span className="compact-composer__menu-value compact-composer__menu-value--danger">
+                <span className="compact-composer__danger-pill">
                   {accessLabel}
                 </span>
               ) : (
                 <span className="compact-composer__menu-value">
-                  {accessLabel ?? "Default"}
+                  {accessLabel ?? formatExecutionModeLabel("default")}
                 </span>
               ),
               "access",
             )
           : null}
         {hasSettingsRows && actions.length > 0 ? (
-          <div
-            aria-hidden="true"
-            className="compact-composer__menu-separator"
-          />
+          <div className="compact-composer__menu-separator" role="separator" />
         ) : null}
         {actions.map((action) => (
           <button
@@ -454,7 +456,7 @@ export function CompactComposer(props: CompactComposerProps) {
             disabled={action.disabled}
             key={action.key}
             onClick={() => {
-              setMenuOpen(false);
+              closeMenu();
               action.onSelect();
             }}
             role="menuitem"
@@ -465,7 +467,7 @@ export function CompactComposer(props: CompactComposerProps) {
         ))}
       </>
     );
-  }
+  };
 
   const chipContent =
     chipSegments.length > 0 ? (
@@ -480,7 +482,7 @@ export function CompactComposer(props: CompactComposerProps) {
             <span
               className={
                 segment.danger
-                  ? "compact-composer__chip-segment compact-composer__chip-segment--danger"
+                  ? "compact-composer__danger-pill"
                   : "compact-composer__chip-segment"
               }
             >
@@ -494,6 +496,15 @@ export function CompactComposer(props: CompactComposerProps) {
       // bare glyph is the old kebab's, on the chip's own geometry.
       <span aria-hidden="true">⋯</span>
     );
+
+  // Keep the visible readout inside the accessible name (label-in-name):
+  // a voice-control user saying "click Full Access" must land here.
+  const chipLabel =
+    chipSegments.length > 0
+      ? `Thread settings: ${chipSegments
+          .map((segment) => segment.text)
+          .join(" · ")}`
+      : "Thread settings";
 
   return (
     <div className="compact-composer">
@@ -525,7 +536,7 @@ export function CompactComposer(props: CompactComposerProps) {
             <button
               aria-expanded={menuOpen}
               aria-haspopup="menu"
-              aria-label="Thread settings"
+              aria-label={chipLabel}
               className={
                 menuOpen
                   ? "compact-composer__chip is-open"
@@ -539,23 +550,29 @@ export function CompactComposer(props: CompactComposerProps) {
                 aria-hidden="true"
                 className="compact-composer__chip-chevron"
               >
-                <ChevronIcon direction="up" />
+                <ChevronUpIcon size={10} />
               </span>
             </button>
             {/* Same in-card anchoring rule as the mention popover above. */}
             {menuOpen ? (
-              <div className="compact-composer__menu-list" role="menu">
-                {menuContent}
+              <div
+                aria-label={
+                  menuView === "root"
+                    ? "Thread settings"
+                    : MENU_VIEW_TITLES[menuView]
+                }
+                className="compact-composer__menu-list"
+                role="menu"
+              >
+                {menuBody()}
               </div>
             ) : null}
           </div>
         ) : chipSegments.length > 0 ? (
           // No menu to open (a host with no actions and no settings), so
-          // the chip is informational only.
-          <span
-            aria-hidden="true"
-            className="compact-composer__chip compact-composer__chip--static"
-          >
+          // the chip is informational only — plain readable text, no
+          // interactive affordance.
+          <span className="compact-composer__chip compact-composer__chip--static">
             {chipContent}
           </span>
         ) : null}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -68,22 +68,38 @@ describe("CompactComposer", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("shows model, effort, and access mode as one ambient string", () => {
+  it("shows model, effort, and access mode as the status chip", () => {
     renderComposer({
       executionMode: "full-access",
       model: "gpt-5-codex",
       reasoningEffort: "high",
     });
-    expect(screen.getByText("gpt-5-codex · high · Full access")).toBeTruthy();
+    // Segments, not one joined string: the access segment carries its own
+    // warning treatment.
+    expect(screen.getByText("gpt-5-codex")).toBeTruthy();
+    expect(screen.getByText("high")).toBeTruthy();
+    expect(screen.getByText("Full access")).toBeTruthy();
   });
 
-  it("omits optional ambient and action chrome when unconfigured", () => {
+  it("omits optional chip and menu chrome when unconfigured", () => {
     renderComposer();
     expect(
       screen.getByRole("textbox", { name: "Message Thread t1" }),
     ).toBeTruthy();
     expect(screen.queryByText(/·/)).toBeNull();
-    expect(screen.queryByRole("button", { name: "More actions" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Thread settings" }),
+    ).toBeNull();
+  });
+
+  it("keeps the chip informational when there is nothing to open", () => {
+    // Model info with no settings callbacks and no actions: readout only,
+    // no menu trigger.
+    renderComposer({ model: "gpt-5-codex" });
+    expect(screen.getByText("gpt-5-codex")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Thread settings" }),
+    ).toBeNull();
   });
 
   it("offers Steer alongside Stop while a turn is running", () => {
@@ -128,7 +144,7 @@ describe("CompactComposer", () => {
     renderComposer({
       secondaryActions: [{ key: "a", label: "Compact thread", onSelect }],
     });
-    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Thread settings" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Compact thread" }));
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("menu")).toBeNull();
@@ -139,7 +155,7 @@ describe("CompactComposer", () => {
     renderComposer({
       secondaryActions: [{ key: "a", label: "Compact thread", onSelect }],
     });
-    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Thread settings" }));
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("menu")).toBeNull();
     expect(onSelect).not.toHaveBeenCalled();
@@ -152,9 +168,155 @@ describe("CompactComposer", () => {
         { disabled: true, key: "a", label: "Compact thread", onSelect },
       ],
     });
-    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Thread settings" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Compact thread" }));
     expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("CompactComposer settings menu", () => {
+  const settingsMenu = (
+    overrides: Partial<
+      NonNullable<Parameters<typeof CompactComposer>[0]["settingsMenu"]>
+    > = {},
+  ) => ({
+    executionModes: [
+      { label: "Default access", mode: "default" as const },
+      { label: "Full access", mode: "full-access" as const },
+    ],
+    models: [
+      { id: "gpt-5-codex", label: "gpt-5-codex" },
+      { id: "gpt-5-spark" },
+    ],
+    reasoningEfforts: ["low", "medium", "high"],
+    supportsFastMode: true,
+    onSelectExecutionMode: vi.fn(),
+    onSelectModel: vi.fn(),
+    onSelectReasoningEffort: vi.fn(),
+    onToggleFastMode: vi.fn(),
+    ...overrides,
+  });
+
+  function openMenu() {
+    fireEvent.click(screen.getByRole("button", { name: "Thread settings" }));
+  }
+
+  it("asks the host to load options when the menu opens", () => {
+    // Lazy on purpose: a card the operator only reads must not pay for a
+    // backend describe it never shows.
+    const onOpen = vi.fn();
+    renderComposer({ settingsMenu: settingsMenu({ onOpen }) });
+    expect(onOpen).not.toHaveBeenCalled();
+    openMenu();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects a model from the submenu and closes", () => {
+    const menu = settingsMenu();
+    renderComposer({ model: "gpt-5-codex", settingsMenu: menu });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Model/ }));
+    const current = screen.getByRole("menuitemradio", { name: "gpt-5-codex" });
+    expect(current.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "gpt-5-spark" }));
+    expect(menu.onSelectModel).toHaveBeenCalledWith("gpt-5-spark");
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("selects a reasoning effort from the submenu", () => {
+    const menu = settingsMenu();
+    renderComposer({ reasoningEffort: "high", settingsMenu: menu });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Reasoning/ }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "medium" }));
+    expect(menu.onSelectReasoningEffort).toHaveBeenCalledWith("medium");
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("toggles fast mode in place without closing the menu", () => {
+    const menu = settingsMenu();
+    renderComposer({ fastMode: false, settingsMenu: menu });
+    openMenu();
+    const toggle = screen.getByRole("menuitemcheckbox", { name: "Fast mode" });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(toggle);
+    expect(menu.onToggleFastMode).toHaveBeenCalledWith(true);
+    // Still open: a toggle is not a leaf selection.
+    expect(screen.getByRole("menu")).toBeTruthy();
+  });
+
+  it("switches access mode from the submenu", () => {
+    const menu = settingsMenu();
+    renderComposer({ executionMode: "default", settingsMenu: menu });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Access/ }));
+    fireEvent.click(
+      screen.getByRole("menuitemradio", { name: "Full access" }),
+    );
+    expect(menu.onSelectExecutionMode).toHaveBeenCalledWith("full-access");
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("returns to the root view through Back", () => {
+    renderComposer({ settingsMenu: settingsMenu() });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Model/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Back" }));
+    expect(screen.getByRole("menuitem", { name: /Reasoning/ })).toBeTruthy();
+  });
+
+  it("reopens on the root view after browsing a submenu", () => {
+    renderComposer({ settingsMenu: settingsMenu() });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Model/ }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /Model/ })).toBeTruthy();
+  });
+
+  it("reports a still-loading submenu instead of an empty list", () => {
+    renderComposer({
+      settingsMenu: settingsMenu({ loading: true, models: undefined }),
+    });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Model/ }));
+    expect(screen.getByText("Loading options…")).toBeTruthy();
+  });
+
+  it("hides setting sections whose options cannot load", () => {
+    // No models, no efforts, nothing loading: only Access has anything to
+    // offer, so Model and Reasoning rows do not render at all.
+    renderComposer({
+      settingsMenu: settingsMenu({
+        loading: false,
+        models: [],
+        reasoningEfforts: [],
+        supportsFastMode: false,
+      }),
+    });
+    openMenu();
+    expect(screen.queryByRole("menuitem", { name: /Model/ })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /Reasoning/ })).toBeNull();
+    expect(
+      screen.queryByRole("menuitemcheckbox", { name: "Fast mode" }),
+    ).toBeNull();
+    expect(screen.getByRole("menuitem", { name: /Access/ })).toBeTruthy();
+  });
+
+  it("separates settings from host actions in one menu", () => {
+    const onSelect = vi.fn();
+    renderComposer({
+      secondaryActions: [
+        { key: "open-full", label: "Open in full view", onSelect },
+      ],
+      settingsMenu: settingsMenu(),
+    });
+    openMenu();
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Open in full view" }),
+    );
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -75,10 +75,11 @@ describe("CompactComposer", () => {
       reasoningEffort: "high",
     });
     // Segments, not one joined string: the access segment carries its own
-    // warning treatment.
+    // warning treatment. Labels come from formatExecutionModeLabel so every
+    // surface names the modes identically.
     expect(screen.getByText("gpt-5-codex")).toBeTruthy();
     expect(screen.getByText("high")).toBeTruthy();
-    expect(screen.getByText("Full access")).toBeTruthy();
+    expect(screen.getByText("Full Access")).toBeTruthy();
   });
 
   it("omits optional chip and menu chrome when unconfigured", () => {
@@ -181,8 +182,8 @@ describe("CompactComposer settings menu", () => {
     > = {},
   ) => ({
     executionModes: [
-      { label: "Default access", mode: "default" as const },
-      { label: "Full access", mode: "full-access" as const },
+      { label: "Default Access", mode: "default" as const },
+      { label: "Full Access", mode: "full-access" as const },
     ],
     models: [
       { id: "gpt-5-codex", label: "gpt-5-codex" },
@@ -198,7 +199,9 @@ describe("CompactComposer settings menu", () => {
   });
 
   function openMenu() {
-    fireEvent.click(screen.getByRole("button", { name: "Thread settings" }));
+    // The chip's accessible name carries the visible readout after the
+    // "Thread settings:" prefix (label-in-name), so match on the prefix.
+    fireEvent.click(screen.getByRole("button", { name: /^Thread settings/ }));
   }
 
   it("asks the host to load options when the menu opens", () => {
@@ -251,10 +254,26 @@ describe("CompactComposer settings menu", () => {
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /Access/ }));
     fireEvent.click(
-      screen.getByRole("menuitemradio", { name: "Full access" }),
+      screen.getByRole("menuitemradio", { name: "Full Access" }),
     );
     expect(menu.onSelectExecutionMode).toHaveBeenCalledWith("full-access");
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("keeps setting rows visible and reports a failed option load", () => {
+    // A failed describe must not make the rows silently vanish — the
+    // submenu says the load failed instead.
+    renderComposer({
+      settingsMenu: settingsMenu({
+        loadFailed: true,
+        loading: false,
+        models: undefined,
+        reasoningEfforts: undefined,
+      }),
+    });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Model/ }));
+    expect(screen.getByText("Couldn't load options.")).toBeTruthy();
   });
 
   it("returns to the root view through Back", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -10,11 +10,12 @@ import {
 } from "react";
 import {
   buildThreadIdentityKey,
-  type BackendLaunchpadOptions,
   type CelestialIconId,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
+import { formatExecutionModeLabel } from "../../lib/execution-mode";
+import { useBackendSummaries } from "../../lib/useBackendSummaries";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   CompactComposer,
@@ -460,38 +461,81 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   }, [interrupt]);
 
   /**
-   * Launchpad options for the settings chip's menu, described once per card
-   * and only when the menu first opens — a card the operator only reads
-   * never pays for the backend describe. `listBackends` takes the card's
-   * federation target, so a card over a peer's thread lists the peer's
-   * models.
+   * Backend describe for the settings chip's menu, shared through
+   * `useBackendSummaries` so the card follows the app's refresh events and
+   * provider-status agent events instead of caching one describe forever.
+   * Disabled until the menu first opens — a card the operator only reads
+   * never pays for the describe. The hook takes the card's federation
+   * target, so a card over a peer's thread lists the peer's models.
    */
-  const [backendOptions, setBackendOptions] = useState<
-    BackendLaunchpadOptions | undefined
-  >();
-  const [backendOptionsState, setBackendOptionsState] = useState<
-    "error" | "idle" | "loaded" | "loading"
-  >("idle");
-  const loadBackendOptions = useCallback(() => {
-    if (backendOptionsState === "loading" || backendOptionsState === "loaded") {
-      return;
+  // For callbacks and effects that need the latest summary without taking
+  // the whole object as a dependency — the composer's memo boundary rests
+  // on its props staying stable across snapshot refreshes.
+  const threadRef = useRef(thread);
+  threadRef.current = thread;
+
+  const [settingsMenuOpened, setSettingsMenuOpened] = useState(false);
+  const backendSummaries = useBackendSummaries(desktopApi, {
+    enabled: settingsMenuOpened,
+    federationTarget,
+  });
+  const backendSummariesRef = useRef(backendSummaries);
+  backendSummariesRef.current = backendSummaries;
+  const onSettingsMenuOpen = useCallback(() => {
+    setSettingsMenuOpened(true);
+    // A failed describe retries on the next open through the hook's
+    // exported refresh path (a plain re-list for remote targets).
+    if (backendSummariesRef.current.error) {
+      void backendSummariesRef.current.refreshAcpAgents();
     }
-    if (!desktopApi?.listBackends) return;
-    setBackendOptionsState("loading");
-    desktopApi
-      .listBackends({ federationTarget })
-      .then((response) => {
-        const backend = response.backends.find(
-          (entry) => entry.kind === thread.source,
-        );
-        setBackendOptions(backend?.launchpadOptions);
-        setBackendOptionsState("loaded");
-      })
-      .catch(() => {
-        // Retried on the next open; the submenus report the empty state.
-        setBackendOptionsState("error");
-      });
-  }, [backendOptionsState, desktopApi, federationTarget, thread.source]);
+  }, []);
+  const backendSummary = backendSummaries.backends.find(
+    (entry) => entry.kind === thread.source,
+  );
+
+  /**
+   * Optimistic view of the chip's settings between a menu selection and
+   * the thread-state bus round-trip. Mirrors the optimistic snapshot patch
+   * `useThreadNavigation.setThreadModelSettings` applies, which this
+   * surface cannot reach; without it the chip lags a click behind and a
+   * second Fast-mode click re-sends the same value instead of toggling.
+   * Entries drop as soon as the live summary reflects them, and the whole
+   * overlay clears when a mutation fails.
+   */
+  const [optimisticSettings, setOptimisticSettings] = useState<
+    Partial<
+      Pick<
+        NavigationThreadSummary,
+        "executionMode" | "fastMode" | "model" | "reasoningEffort"
+      >
+    >
+  >({});
+  const threadId = thread.id;
+  const threadSource = thread.source;
+  const threadModel = optimisticSettings.model ?? thread.model;
+  const threadReasoningEffort =
+    optimisticSettings.reasoningEffort ?? thread.reasoningEffort;
+  const threadFastMode = optimisticSettings.fastMode ?? thread.fastMode;
+  const threadExecutionMode =
+    optimisticSettings.executionMode ?? thread.executionMode;
+  useEffect(() => {
+    // Via the ref so the effect can key on the four scalar fields alone.
+    const summary = threadRef.current;
+    setOptimisticSettings((current) => {
+      const kept = Object.entries(current).filter(
+        ([key, value]) =>
+          summary[key as keyof NavigationThreadSummary] !== value,
+      );
+      return kept.length === Object.keys(current).length
+        ? current
+        : Object.fromEntries(kept);
+    });
+  }, [
+    thread.executionMode,
+    thread.fastMode,
+    thread.model,
+    thread.reasoningEffort,
+  ]);
 
   /**
    * The settings chip's menu: the same mutations the full composer's chip
@@ -499,109 +543,132 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
    * handoff and environments need the handoff dialog and launchpad state —
    * those stay behind Open in full view).
    *
-   * Deliberately delta-stable: nothing here reads the streaming session, so
-   * the memo boundary on the composer holds through a running turn.
+   * Deliberately delta-stable: nothing here reads the streaming session,
+   * and the deps are scalars, so the memo boundary on the composer holds
+   * through a running turn and across snapshot refreshes.
    */
   const settingsMenu = useMemo<CompactComposerSettingsMenu | undefined>(() => {
     if (!desktopApi) return undefined;
+    const setModelSettings = desktopApi.setThreadModelSettings;
+    const setExecutionMode = desktopApi.setThreadExecutionMode;
     const patchModelSettings = (
       patch: Partial<
         Pick<NavigationThreadSummary, "model" | "reasoningEffort" | "fastMode">
       >,
     ) => {
+      if (!setModelSettings) return;
+      setOptimisticSettings((current) => ({
+        ...current,
+        ...("model" in patch && patch.model !== undefined
+          ? { model: patch.model }
+          : {}),
+        ...("reasoningEffort" in patch && patch.reasoningEffort !== undefined
+          ? { reasoningEffort: patch.reasoningEffort }
+          : {}),
+        ...("fastMode" in patch && patch.fastMode !== undefined
+          ? { fastMode: patch.fastMode }
+          : {}),
+      }));
       // Same request construction as useThreadNavigation's
       // setThreadModelSettings: carry the current model when the patch does
-      // not name one, and only send fastMode for Codex threads.
-      void desktopApi
-        .setThreadModelSettings?.({
-          backend: thread.source,
-          federationTarget,
-          threadId: thread.id,
-          ...("model" in patch
-            ? { model: patch.model }
-            : thread.model
-              ? { model: thread.model }
-              : {}),
-          ...("reasoningEffort" in patch
-            ? { reasoningEffort: patch.reasoningEffort }
+      // not name one, and only send fastMode for Codex threads. The carried
+      // model is the optimistic one, so a reasoning or fast change made
+      // before a model change round-trips cannot revert the model.
+      void setModelSettings({
+        backend: threadSource,
+        federationTarget,
+        threadId,
+        ...("model" in patch
+          ? { model: patch.model }
+          : threadModel
+            ? { model: threadModel }
             : {}),
-          ...(thread.source === "codex" && "fastMode" in patch
-            ? { fastMode: patch.fastMode }
-            : {}),
-        })
-        .catch((error: unknown) => {
-          setSendError(
-            error instanceof Error
-              ? error.message
-              : "Could not change model settings.",
-          );
-        });
+        ...("reasoningEffort" in patch
+          ? { reasoningEffort: patch.reasoningEffort }
+          : {}),
+        ...(threadSource === "codex" && "fastMode" in patch
+          ? { fastMode: patch.fastMode }
+          : {}),
+      }).catch((error: unknown) => {
+        setOptimisticSettings({});
+        setSendError(
+          error instanceof Error
+            ? error.message
+            : "Could not change model settings.",
+        );
+      });
     };
-    const models = backendOptions?.models;
+    const launchpadOptions = backendSummary?.launchpadOptions;
+    const models = launchpadOptions?.models;
     const currentModelOption = models?.find(
-      (option) => option.id === thread.model,
+      (option) => option.id === threadModel,
     );
     const reasoningEfforts =
       currentModelOption?.reasoningEfforts
-      ?? backendOptions?.reasoningEfforts
+      ?? launchpadOptions?.reasoningEfforts
       ?? [];
     const supportsReasoning =
       currentModelOption?.supportsReasoning
-      ?? Boolean(backendOptions?.reasoningEfforts?.length);
+      ?? Boolean(launchpadOptions?.reasoningEfforts?.length);
     const supportsFast =
-      thread.source === "codex"
+      threadSource === "codex"
         ? currentModelOption?.supportsFast
-          ?? backendOptions?.supportsFastMode
+          ?? launchpadOptions?.supportsFastMode
           ?? false
         : false;
-    const canPatchModelSettings = Boolean(desktopApi.setThreadModelSettings);
+    // Only the modes the backend actually describes as available — the
+    // same filter the full composer applies, so an ACP thread with no
+    // approval-mode support is never offered a Full access row.
+    const availableExecutionModes = backendSummary?.executionModes
+      .filter((mode) => mode.available)
+      .map((mode) => ({
+        label: formatExecutionModeLabel(mode.mode),
+        mode: mode.mode,
+      }));
     return {
-      loading:
-        Boolean(desktopApi.listBackends)
-        && (backendOptionsState === "idle" || backendOptionsState === "loading"),
-      onOpen: loadBackendOptions,
-      executionModes: desktopApi.setThreadExecutionMode
-        ? [
-            { label: "Default access", mode: "default" as const },
-            { label: "Full access", mode: "full-access" as const },
-          ]
-        : undefined,
+      loading: Boolean(desktopApi.listBackends) && !backendSummaries.loaded,
+      loadFailed: Boolean(backendSummaries.error),
+      onOpen: onSettingsMenuOpen,
+      executionModes: setExecutionMode ? availableExecutionModes : undefined,
       models: models?.map((option) => ({
         id: option.id,
         label: option.label,
       })),
       reasoningEfforts: supportsReasoning ? reasoningEfforts : [],
       supportsFastMode: supportsFast,
-      onSelectExecutionMode: desktopApi.setThreadExecutionMode
+      onSelectExecutionMode: setExecutionMode
         ? (mode) => {
-            void desktopApi
-              .setThreadExecutionMode?.({
-                backend: thread.source,
-                executionMode: mode,
-                federationTarget,
-                threadId: thread.id,
-              })
-              .catch((error: unknown) => {
-                setSendError(
-                  error instanceof Error
-                    ? error.message
-                    : "Could not change access mode.",
-                );
-              });
+            setOptimisticSettings((current) => ({
+              ...current,
+              executionMode: mode,
+            }));
+            void setExecutionMode({
+              backend: threadSource,
+              executionMode: mode,
+              federationTarget,
+              threadId,
+            }).catch((error: unknown) => {
+              setOptimisticSettings({});
+              setSendError(
+                error instanceof Error
+                  ? error.message
+                  : "Could not change access mode.",
+              );
+            });
           }
         : undefined,
-      onSelectModel: canPatchModelSettings
+      onSelectModel: setModelSettings
         ? (model) => {
             // Mirror the full composer's model change: a model that cannot
             // reason clears the effort, one that cannot go fast clears fast.
             const nextOption = models?.find((option) => option.id === model);
             const nextSupportsReasoning =
               nextOption?.supportsReasoning
-              ?? Boolean(backendOptions?.reasoningEfforts?.length);
+              ?? Boolean(launchpadOptions?.reasoningEfforts?.length);
             const nextSupportsFast =
-              thread.source === "codex"
+              threadSource === "codex"
                 ? nextOption?.supportsFast
-                  ?? backendOptions?.supportsFastMode
+                  ?? launchpadOptions?.supportsFastMode
                   ?? false
                 : false;
             patchModelSettings({
@@ -611,21 +678,24 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             });
           }
         : undefined,
-      onSelectReasoningEffort: canPatchModelSettings
+      onSelectReasoningEffort: setModelSettings
         ? (reasoningEffort) => patchModelSettings({ reasoningEffort })
         : undefined,
       onToggleFastMode:
-        canPatchModelSettings && thread.source === "codex"
+        setModelSettings && threadSource === "codex"
           ? (enabled) => patchModelSettings({ fastMode: enabled })
           : undefined,
     };
   }, [
-    backendOptions,
-    backendOptionsState,
+    backendSummaries.error,
+    backendSummaries.loaded,
+    backendSummary,
     desktopApi,
     federationTarget,
-    loadBackendOptions,
-    thread,
+    onSettingsMenuOpen,
+    threadId,
+    threadModel,
+    threadSource,
   ]);
 
   /**
@@ -645,9 +715,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         onSelect: () => {
           void desktopApi
             .compactThread?.({
-              backend: thread.source,
+              backend: threadSource,
               federationTarget,
-              threadId: thread.id,
+              threadId,
             })
             .catch((error: unknown) => {
               setSendError(
@@ -662,10 +732,19 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     entries.push({
       key: "open-full",
       label: "Open in full view",
-      onSelect: () => onOpenFull(thread),
+      // Via the ref so a snapshot refresh does not re-mint the actions and
+      // re-render the memoized composer.
+      onSelect: () => onOpenFull(threadRef.current),
     });
     return entries;
-  }, [desktopApi, federationTarget, onOpenFull, session.threadBusy, thread]);
+  }, [
+    desktopApi,
+    federationTarget,
+    onOpenFull,
+    session.threadBusy,
+    threadId,
+    threadSource,
+  ]);
 
   const style: CSSProperties = {
     left: `${rect.left}px`,
@@ -796,13 +875,13 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       <MemoizedCompactComposer
         busy={session.threadBusy}
         canSteer={canSteer}
-        executionMode={thread.executionMode}
-        fastMode={thread.fastMode}
+        executionMode={threadExecutionMode}
+        fastMode={threadFastMode}
         mentionSources={mentionSources}
-        model={thread.model}
+        model={threadModel}
         onInterrupt={onInterrupt}
         onSend={send}
-        reasoningEffort={thread.reasoningEffort}
+        reasoningEffort={threadReasoningEffort}
         secondaryActions={secondaryActions}
         settingsMenu={settingsMenu}
         threadTitle={thread.title}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import {
   buildThreadIdentityKey,
+  type BackendLaunchpadOptions,
   type CelestialIconId,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
@@ -18,6 +19,7 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   CompactComposer,
   type CompactComposerAction,
+  type CompactComposerSettingsMenu,
 } from "../composer/CompactComposer";
 import { useComposerMentionSources } from "../composer/useComposerMentionSources";
 import type { ComposerMentionSources } from "../composer/useComposerMentions";
@@ -458,39 +460,181 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   }, [interrupt]);
 
   /**
-   * Everything the card can do with only a thread summary and the desktop
-   * bridge. Anything needing the backend list, skills, or launchpad state
-   * lives behind the header's Open button in the full thread view.
+   * Launchpad options for the settings chip's menu, described once per card
+   * and only when the menu first opens — a card the operator only reads
+   * never pays for the backend describe. `listBackends` takes the card's
+   * federation target, so a card over a peer's thread lists the peer's
+   * models.
+   */
+  const [backendOptions, setBackendOptions] = useState<
+    BackendLaunchpadOptions | undefined
+  >();
+  const [backendOptionsState, setBackendOptionsState] = useState<
+    "error" | "idle" | "loaded" | "loading"
+  >("idle");
+  const loadBackendOptions = useCallback(() => {
+    if (backendOptionsState === "loading" || backendOptionsState === "loaded") {
+      return;
+    }
+    if (!desktopApi?.listBackends) return;
+    setBackendOptionsState("loading");
+    desktopApi
+      .listBackends({ federationTarget })
+      .then((response) => {
+        const backend = response.backends.find(
+          (entry) => entry.kind === thread.source,
+        );
+        setBackendOptions(backend?.launchpadOptions);
+        setBackendOptionsState("loaded");
+      })
+      .catch(() => {
+        // Retried on the next open; the submenus report the empty state.
+        setBackendOptionsState("error");
+      });
+  }, [backendOptionsState, desktopApi, federationTarget, thread.source]);
+
+  /**
+   * The settings chip's menu: the same mutations the full composer's chip
+   * row drives, minus what a floating card cannot honestly host (workspace
+   * handoff and environments need the handoff dialog and launchpad state —
+   * those stay behind Open in full view).
+   *
+   * Deliberately delta-stable: nothing here reads the streaming session, so
+   * the memo boundary on the composer holds through a running turn.
+   */
+  const settingsMenu = useMemo<CompactComposerSettingsMenu | undefined>(() => {
+    if (!desktopApi) return undefined;
+    const patchModelSettings = (
+      patch: Partial<
+        Pick<NavigationThreadSummary, "model" | "reasoningEffort" | "fastMode">
+      >,
+    ) => {
+      // Same request construction as useThreadNavigation's
+      // setThreadModelSettings: carry the current model when the patch does
+      // not name one, and only send fastMode for Codex threads.
+      void desktopApi
+        .setThreadModelSettings?.({
+          backend: thread.source,
+          federationTarget,
+          threadId: thread.id,
+          ...("model" in patch
+            ? { model: patch.model }
+            : thread.model
+              ? { model: thread.model }
+              : {}),
+          ...("reasoningEffort" in patch
+            ? { reasoningEffort: patch.reasoningEffort }
+            : {}),
+          ...(thread.source === "codex" && "fastMode" in patch
+            ? { fastMode: patch.fastMode }
+            : {}),
+        })
+        .catch((error: unknown) => {
+          setSendError(
+            error instanceof Error
+              ? error.message
+              : "Could not change model settings.",
+          );
+        });
+    };
+    const models = backendOptions?.models;
+    const currentModelOption = models?.find(
+      (option) => option.id === thread.model,
+    );
+    const reasoningEfforts =
+      currentModelOption?.reasoningEfforts
+      ?? backendOptions?.reasoningEfforts
+      ?? [];
+    const supportsReasoning =
+      currentModelOption?.supportsReasoning
+      ?? Boolean(backendOptions?.reasoningEfforts?.length);
+    const supportsFast =
+      thread.source === "codex"
+        ? currentModelOption?.supportsFast
+          ?? backendOptions?.supportsFastMode
+          ?? false
+        : false;
+    const canPatchModelSettings = Boolean(desktopApi.setThreadModelSettings);
+    return {
+      loading:
+        Boolean(desktopApi.listBackends)
+        && (backendOptionsState === "idle" || backendOptionsState === "loading"),
+      onOpen: loadBackendOptions,
+      executionModes: desktopApi.setThreadExecutionMode
+        ? [
+            { label: "Default access", mode: "default" as const },
+            { label: "Full access", mode: "full-access" as const },
+          ]
+        : undefined,
+      models: models?.map((option) => ({
+        id: option.id,
+        label: option.label,
+      })),
+      reasoningEfforts: supportsReasoning ? reasoningEfforts : [],
+      supportsFastMode: supportsFast,
+      onSelectExecutionMode: desktopApi.setThreadExecutionMode
+        ? (mode) => {
+            void desktopApi
+              .setThreadExecutionMode?.({
+                backend: thread.source,
+                executionMode: mode,
+                federationTarget,
+                threadId: thread.id,
+              })
+              .catch((error: unknown) => {
+                setSendError(
+                  error instanceof Error
+                    ? error.message
+                    : "Could not change access mode.",
+                );
+              });
+          }
+        : undefined,
+      onSelectModel: canPatchModelSettings
+        ? (model) => {
+            // Mirror the full composer's model change: a model that cannot
+            // reason clears the effort, one that cannot go fast clears fast.
+            const nextOption = models?.find((option) => option.id === model);
+            const nextSupportsReasoning =
+              nextOption?.supportsReasoning
+              ?? Boolean(backendOptions?.reasoningEfforts?.length);
+            const nextSupportsFast =
+              thread.source === "codex"
+                ? nextOption?.supportsFast
+                  ?? backendOptions?.supportsFastMode
+                  ?? false
+                : false;
+            patchModelSettings({
+              model,
+              ...(nextSupportsReasoning ? {} : { reasoningEffort: undefined }),
+              ...(nextSupportsFast ? {} : { fastMode: undefined }),
+            });
+          }
+        : undefined,
+      onSelectReasoningEffort: canPatchModelSettings
+        ? (reasoningEffort) => patchModelSettings({ reasoningEffort })
+        : undefined,
+      onToggleFastMode:
+        canPatchModelSettings && thread.source === "codex"
+          ? (enabled) => patchModelSettings({ fastMode: enabled })
+          : undefined,
+    };
+  }, [
+    backendOptions,
+    backendOptionsState,
+    desktopApi,
+    federationTarget,
+    loadBackendOptions,
+    thread,
+  ]);
+
+  /**
+   * Plain actions at the bottom of the settings chip's menu. Anything
+   * needing skills or launchpad state lives behind the header's Open button
+   * in the full thread view.
    */
   const secondaryActions = useMemo<CompactComposerAction[]>(() => {
     const entries: CompactComposerAction[] = [];
-    const nextMode =
-      thread.executionMode === "full-access" ? "default" : "full-access";
-    if (desktopApi?.setThreadExecutionMode) {
-      entries.push({
-        key: "execution-mode",
-        label:
-          nextMode === "full-access"
-            ? "Switch to full access"
-            : "Switch to default access",
-        onSelect: () => {
-          void desktopApi
-            .setThreadExecutionMode?.({
-              backend: thread.source,
-              executionMode: nextMode,
-              federationTarget,
-              threadId: thread.id,
-            })
-            .catch((error: unknown) => {
-              setSendError(
-                error instanceof Error
-                  ? error.message
-                  : "Could not change access mode.",
-              );
-            });
-        },
-      });
-    }
     if (desktopApi?.compactThread) {
       entries.push({
         key: "compact",
@@ -653,12 +797,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         busy={session.threadBusy}
         canSteer={canSteer}
         executionMode={thread.executionMode}
+        fastMode={thread.fastMode}
         mentionSources={mentionSources}
         model={thread.model}
         onInterrupt={onInterrupt}
         onSend={send}
         reasoningEffort={thread.reasoningEffort}
         secondaryActions={secondaryActions}
+        settingsMenu={settingsMenu}
         threadTitle={thread.title}
       />
 

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2193,6 +2193,28 @@ export function StarMapScreen(props: StarMapScreenProps) {
     () => new Set(chatCards.cards.map((card) => card.key)),
     [chatCards.cards],
   );
+  /**
+   * Live summaries for the open chat cards. `useStarMapChatCards` stores
+   * the summary captured at open time and never reconciles it, which was
+   * fine while cards only displayed the transcript — but the composer's
+   * settings chip and menu read (and write) model / effort / access from
+   * the summary, so a frozen copy would never reflect the very change the
+   * menu just made. Card keys are thread identity keys, so the lookup is
+   * direct. Undefined while no card is open so the map costs nothing then.
+   */
+  const liveChatCardThreads = useMemo(() => {
+    if (chatCards.cards.length === 0) return undefined;
+    const byKey = new Map<string, NavigationThreadSummary>();
+    for (const thread of props.localThreads) {
+      byKey.set(buildThreadIdentityKey(thread.source, thread.id), thread);
+    }
+    for (const threads of remote.threadsByInstance.values()) {
+      for (const thread of threads) {
+        byKey.set(buildThreadIdentityKey(thread.source, thread.id), thread);
+      }
+    }
+    return byKey;
+  }, [chatCards.cards.length, props.localThreads, remote.threadsByInstance]);
   const { desktopApi, onFocusLocalInstance, onOpenLocalThread } = props;
   const openInstance = useCallback(
     (instanceId: string) => {
@@ -4277,7 +4299,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
             finds the open chats exactly where they were left, which is the
             whole point of opening five of them and scooting off. */}
         {chatCards.cards.map((card) => {
-          const target = card.thread.federation?.ref.target;
+          // The card list stores the summary captured at open time, but the
+          // composer's settings chip reads model / effort / access from it,
+          // so serve the freshest row the feeds carry and fall back to the
+          // stored snapshot when the thread has left its feed.
+          const liveThread = liveChatCardThreads?.get(card.key) ?? card.thread;
+          const target = liveThread.federation?.ref.target;
           const cardInstanceId =
             target && isRemoteFederationTarget(target)
               ? target.instanceId
@@ -4299,7 +4326,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               onRaise={chatCards.raise}
               onRectChange={chatCards.setRect}
               rect={card.rect}
-              thread={card.thread}
+              thread={liveThread}
               scale={view.scale}
               bounds={panZoomCanvas}
               contextOpen={card.contextOpen}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -712,7 +712,10 @@ describe("StarMapChatCard settings menu", () => {
             available: true,
             methods: [],
             capabilities: {},
-            executionModes: [],
+            executionModes: [
+              { mode: "default", label: "Default Access", available: true },
+              { mode: "full-access", label: "Full Access", available: true },
+            ],
             launchpadOptions: {
               models: [
                 { id: "gpt-5-codex", supportsFast: true },
@@ -732,7 +735,7 @@ describe("StarMapChatCard settings menu", () => {
 
   async function openSettingsMenu() {
     fireEvent.click(
-      await screen.findByRole("button", { name: "Thread settings" }),
+      await screen.findByRole("button", { name: /^Thread settings/ }),
     );
   }
 
@@ -747,6 +750,7 @@ describe("StarMapChatCard settings menu", () => {
       expect(desktopApi.listBackends).toHaveBeenCalledTimes(1);
     });
     expect(desktopApi.listBackends).toHaveBeenCalledWith({
+      includeUnavailable: true,
       federationTarget: { scope: "remote", instanceId: "pwr_peer" },
     });
 
@@ -787,7 +791,7 @@ describe("StarMapChatCard settings menu", () => {
 
     fireEvent.click(await screen.findByRole("menuitem", { name: /Access/ }));
     fireEvent.click(
-      await screen.findByRole("menuitemradio", { name: "Full access" }),
+      await screen.findByRole("menuitemradio", { name: "Full Access" }),
     );
     await waitFor(() => {
       expect(desktopApi.setThreadExecutionMode).toHaveBeenCalledWith({
@@ -797,6 +801,42 @@ describe("StarMapChatCard settings menu", () => {
         threadId: "t-local",
       });
     });
+  });
+
+  it("hides Access when the backend describes only one available mode", async () => {
+    // The ACP shape: the registry describes no full-access mode, and
+    // setThreadExecutionMode would be an acknowledged no-op — so the menu
+    // must not offer a working-looking Full Access row.
+    const desktopApi = settingsApi({
+      listBackends: vi.fn(async () => ({
+        fetchedAt: 1,
+        backends: [
+          {
+            kind: "codex",
+            label: "Codex",
+            available: true,
+            methods: [],
+            capabilities: {},
+            executionModes: [
+              { mode: "default", label: "Default Access", available: true },
+              { mode: "full-access", label: "Full Access", available: false },
+            ],
+            launchpadOptions: {
+              models: [{ id: "gpt-5-codex", supportsFast: true }],
+              reasoningEfforts: ["low", "high"],
+              supportsFastMode: true,
+            },
+          },
+        ],
+      })),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: localThread({ model: "gpt-5-codex" }) });
+    await openSettingsMenu();
+
+    // The fast toggle only renders once the describe landed, so its
+    // presence proves Access's absence is a decision, not a race.
+    await screen.findByRole("menuitemcheckbox", { name: "Fast mode" });
+    expect(screen.queryByRole("menuitem", { name: /Access/ })).toBeNull();
   });
 
   it("toggles fast mode for a model that supports it", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -695,3 +695,130 @@ describe("StarMapChatCard mentions", () => {
     expect(shouldStartCanvasPan(option)).toBe(false);
   });
 });
+
+describe("StarMapChatCard settings menu", () => {
+  beforeEach(() => {
+    resetComposerMentionSourcesCache();
+  });
+
+  function settingsApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
+    return buildApi({
+      listBackends: vi.fn(async () => ({
+        fetchedAt: 1,
+        backends: [
+          {
+            kind: "codex",
+            label: "Codex",
+            available: true,
+            methods: [],
+            capabilities: {},
+            executionModes: [],
+            launchpadOptions: {
+              models: [
+                { id: "gpt-5-codex", supportsFast: true },
+                { id: "gpt-5-spark", supportsFast: false },
+              ],
+              reasoningEfforts: ["low", "medium", "high"],
+              supportsFastMode: true,
+            },
+          },
+        ],
+      })),
+      setThreadExecutionMode: vi.fn(async () => ({})),
+      setThreadModelSettings: vi.fn(async () => ({})),
+      ...overrides,
+    } as unknown as Partial<DesktopApi>);
+  }
+
+  async function openSettingsMenu() {
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Thread settings" }),
+    );
+  }
+
+  it("describes the backend once, on first open, with the card's target", async () => {
+    const desktopApi = settingsApi();
+    renderCard({ desktopApi, thread: remoteThread({ model: "gpt-5-codex" }) });
+    await screen.findByRole("button", { name: "Send" });
+    expect(desktopApi.listBackends).not.toHaveBeenCalled();
+
+    await openSettingsMenu();
+    await waitFor(() => {
+      expect(desktopApi.listBackends).toHaveBeenCalledTimes(1);
+    });
+    expect(desktopApi.listBackends).toHaveBeenCalledWith({
+      federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+    });
+
+    // Reopening reuses the loaded options rather than describing again.
+    fireEvent.keyDown(document, { key: "Escape" });
+    await openSettingsMenu();
+    expect(desktopApi.listBackends).toHaveBeenCalledTimes(1);
+  });
+
+  it("changes the model through the submenu, on the thread's own target", async () => {
+    const desktopApi = settingsApi();
+    renderCard({ desktopApi, thread: remoteThread({ model: "gpt-5-codex" }) });
+    await openSettingsMenu();
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Model/ }));
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "gpt-5-spark" }),
+    );
+    await waitFor(() => {
+      expect(desktopApi.setThreadModelSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+          model: "gpt-5-spark",
+          threadId: "t-remote",
+        }),
+      );
+    });
+  });
+
+  it("switches access mode through the Access submenu", async () => {
+    const desktopApi = settingsApi();
+    renderCard({
+      desktopApi,
+      thread: localThread({ executionMode: "default", model: "gpt-5-codex" }),
+    });
+    await openSettingsMenu();
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Access/ }));
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "Full access" }),
+    );
+    await waitFor(() => {
+      expect(desktopApi.setThreadExecutionMode).toHaveBeenCalledWith({
+        backend: "codex",
+        executionMode: "full-access",
+        federationTarget: undefined,
+        threadId: "t-local",
+      });
+    });
+  });
+
+  it("toggles fast mode for a model that supports it", async () => {
+    const desktopApi = settingsApi();
+    renderCard({
+      desktopApi,
+      thread: localThread({ fastMode: false, model: "gpt-5-codex" }),
+    });
+    await openSettingsMenu();
+
+    fireEvent.click(
+      await screen.findByRole("menuitemcheckbox", { name: "Fast mode" }),
+    );
+    await waitFor(() => {
+      expect(desktopApi.setThreadModelSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          fastMode: true,
+          model: "gpt-5-codex",
+          threadId: "t-local",
+        }),
+      );
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
@@ -234,8 +234,8 @@ describe("StarMapChatCard streaming render cost", () => {
     });
   });
 
-  it("closes the kebab's compaction door once the stream makes it busy", async () => {
-    // The kebab is where a frozen composer does real damage. Compaction
+  it("closes the menu's compaction door once the stream makes it busy", async () => {
+    // The settings menu is where a frozen composer does real damage. Compaction
     // rewrites history, so `secondaryActions` gates it on `threadBusy`; a
     // card still rendering the pre-turn array would leave that door open
     // mid-turn. Asserting on an action whose props never change — "Open in
@@ -260,7 +260,9 @@ describe("StarMapChatCard streaming render cost", () => {
     await screen.findByRole("textbox", { name: "Message Local work" });
     await settleInitialRead(desktopApi);
 
-    fireEvent.click(await screen.findByRole("button", { name: "More actions" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Thread settings" }),
+    );
     const compact = (await screen.findByRole("menuitem", {
       name: "Compact thread",
     })) as HTMLButtonElement;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13193,7 +13193,9 @@ textarea,
   cursor: pointer;
 }
 
-.compact-composer__chip:hover,
+/* Hover affordance only where a click does something — the static
+   informational variant keeps the resting look. */
+.compact-composer__chip:hover:not(.compact-composer__chip--static),
 .compact-composer__chip.is-open {
   border-color: var(--accent-border);
   background: var(--bg-panel-hover);
@@ -13223,19 +13225,33 @@ textarea,
   color: var(--text-muted);
 }
 
-/* Full access keeps its warning color as the one accent segment; the rest
-   of the chip stays neutral so the signal cannot be missed. */
-.compact-composer__chip-segment--danger {
-  color: var(--accent);
+/* Full Access carries the solid-accent warning fill wherever it appears —
+   chip segment, root-menu value, submenu option. Accent as fill with
+   `--button-text`, never accent as text, per the accent-ramp rules. */
+.compact-composer__danger-pill {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--button-text);
+  font-size: 10px;
   font-weight: 600;
 }
 
-.compact-composer__chip-chevron {
-  display: none;
+/* One chevron recipe for the chip and the menu rows; the chip's is
+   hover/open-gated below. */
+.compact-composer__chip-chevron,
+.compact-composer__menu-chevron {
   flex: 0 0 auto;
   align-items: center;
   color: var(--text-muted);
   line-height: 0;
+}
+
+.compact-composer__chip-chevron {
+  display: none;
 }
 
 .compact-composer__chip:hover .compact-composer__chip-chevron,
@@ -13332,7 +13348,11 @@ textarea,
 
 /* Anchored to the chip and opening upward, in-card for the same reason as
    the mention list above; capped with its own scroll so a long model list
-   opens over the transcript rather than out of the card. */
+   opens over the transcript rather than out of the card. The cap must fit
+   the smallest card the geometry allows (CHAT_CARD_MIN_HEIGHT, 280px):
+   the menu bottom sits ~36px above the card bottom and the title bar takes
+   ~31px, so anything taller than ~213px would be clipped by the card's
+   `overflow: hidden` — scrolled content can't help a clipped box. */
 .compact-composer__menu-list {
   display: flex;
   position: absolute;
@@ -13342,7 +13362,7 @@ textarea,
   flex-direction: column;
   min-width: 210px;
   max-width: 280px;
-  max-height: 252px;
+  max-height: 200px;
   padding: 4px;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -13400,11 +13420,6 @@ textarea,
   text-overflow: ellipsis;
 }
 
-.compact-composer__menu-label--danger {
-  color: var(--accent);
-  font-weight: 600;
-}
-
 .compact-composer__menu-value {
   flex: 0 1 auto;
   min-width: 0;
@@ -13415,24 +13430,8 @@ textarea,
   text-overflow: ellipsis;
 }
 
-/* Full Access carries the solid-accent warning fill in the value slot,
-   the same signal as the main composer's danger chip. */
-.compact-composer__menu-value--danger {
-  flex: 0 0 auto;
-  padding: 1px 7px;
-  border-radius: 999px;
-  background: var(--accent);
-  color: var(--button-text);
-  font-size: 9px;
-  font-weight: 600;
-}
-
 .compact-composer__menu-chevron {
   display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  color: var(--text-muted);
-  line-height: 0;
 }
 
 /* Leading 12px column — empty until the row is the current selection,
@@ -13468,8 +13467,8 @@ textarea,
   font-size: 11px;
 }
 
-/* Same switch anatomy as the thread-options menu toggle, at the card's
-   scale. */
+/* Same switch anatomy (and motion) as the thread-options menu toggle, at
+   the card's scale. */
 .compact-composer__menu-toggle {
   display: inline-flex;
   flex: 0 0 auto;
@@ -13481,6 +13480,9 @@ textarea,
   border: 1px solid var(--border-strong);
   border-radius: 999px;
   background: var(--bg-input);
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
 }
 
 .compact-composer__menu-toggle-thumb {
@@ -13488,6 +13490,9 @@ textarea,
   height: 10px;
   border-radius: 50%;
   background: var(--text-muted);
+  transition:
+    transform 120ms ease,
+    background 120ms ease;
 }
 
 .compact-composer__menu-toggle.is-checked {
@@ -13501,20 +13506,24 @@ textarea,
   background: var(--button-text);
 }
 
-/* Send wears the main composer's action-pill recipe
+/* Send and Stop wear the main composer's action-pill recipe
    (.composer__actions .button / .composer__primary-action), scaled to the
    card's 22px control height, so the strip reads as one family with the
-   full view. */
-.compact-composer__send {
+   full view. Shared metrics here; each button carries only its own tone. */
+.compact-composer__send,
+.compact-composer__stop {
   flex: 0 0 auto;
   min-height: 22px;
   padding: 2px 12px;
-  border: 1px solid var(--accent-border);
   border-radius: 999px;
-  background: var(--bg-row-active);
-  color: var(--accent-bright);
   font-size: 11px;
   cursor: pointer;
+}
+
+.compact-composer__send {
+  border: 1px solid var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
 }
 
 .compact-composer__send:hover:not(:disabled) {
@@ -13533,15 +13542,9 @@ textarea,
 /* Sits beside Send during a live turn, so it reads as the secondary of the
    two rather than as a second accent button competing with it. */
 .compact-composer__stop {
-  flex: 0 0 auto;
-  min-height: 22px;
-  padding: 2px 12px;
   border: 1px solid var(--border-subtle);
-  border-radius: 999px;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 11px;
-  cursor: pointer;
 }
 
 .compact-composer__stop:hover {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13113,13 +13113,16 @@ textarea,
   font-size: 11px;
 }
 
-/* Compact composer: for surfaces with no vertical budget. Secondary
-   actions collapse under the kebab and model/effort render as ambient text
-   inside the field, so the whole control row stays one line tall. */
+/* Compact composer: for surfaces with no vertical budget. The field sits
+   over a one-line status strip: the model/effort/access chip (which is
+   also the settings-menu trigger) on the left, the Stop/Send pills on the
+   right. The chip lives on the strip, not inside the field — anything
+   pinned inside the field paints over the draft once the editor scrolls
+   at max height. */
 .compact-composer {
   display: flex;
   flex: 0 0 auto;
-  align-items: flex-end;
+  flex-direction: column;
   gap: 6px;
   padding: 8px;
   border-top: 1px solid var(--border-subtle);
@@ -13148,9 +13151,7 @@ textarea,
 
 .compact-composer .composer-tiptap-input__editor {
   min-height: 42px;
-  /* Bottom padding reserves the ambient model/effort strip so typed text
-     never runs underneath it. */
-  padding: 6px 8px 16px;
+  padding: 6px 8px;
 }
 
 .compact-composer
@@ -13160,24 +13161,93 @@ textarea,
   left: 8px;
 }
 
-.compact-composer__ambient {
-  position: absolute;
-  right: 9px;
-  bottom: 5px;
-  max-width: 70%;
-  overflow: hidden;
-  color: var(--text-muted);
+.compact-composer__strip {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+}
+
+.compact-composer__spacer {
+  flex: 1 1 auto;
+}
+
+/* The settings chip: the thread's model · effort · access readout, and the
+   trigger for the settings menu. Neutral at rest, accent border on hover /
+   open (same move as the main composer's pill dropdowns); the chevron only
+   appears once the chip is interactive-looking. */
+.compact-composer__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
   font-size: 10px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.compact-composer__chip:hover,
+.compact-composer__chip.is-open {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.compact-composer__chip--static {
+  cursor: default;
+}
+
+.compact-composer__chip-part {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.compact-composer__chip-segment {
+  min-width: 0;
+  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  pointer-events: none;
+}
+
+.compact-composer__chip-dot {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+/* Full access keeps its warning color as the one accent segment; the rest
+   of the chip stays neutral so the signal cannot be missed. */
+.compact-composer__chip-segment--danger {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.compact-composer__chip-chevron {
+  display: none;
+  flex: 0 0 auto;
+  align-items: center;
+  color: var(--text-muted);
+  line-height: 0;
+}
+
+.compact-composer__chip:hover .compact-composer__chip-chevron,
+.compact-composer__chip.is-open .compact-composer__chip-chevron {
+  display: inline-flex;
 }
 
 /* Mention autocomplete (`$` skills, `@` directories, `#` threads and PRs).
 
-   Anchored to the field and opening upward, the same shape as the kebab's
-   menu two rules down — a floating card has nothing below the composer to
-   open into. It renders inside the card rather than through a body portal
+   Anchored to the field and opening upward, the same shape as the settings
+   chip's menu further down — a floating card has nothing below the composer
+   to open into. It renders inside the card rather than through a body portal
    so it stays under `.star-map-chat-card`, which is the ancestor every
    star-map gesture guard tests for; a portalled list would take arrow keys
    and wheel events straight to the camera.
@@ -13251,43 +13321,31 @@ textarea,
   display: none;
 }
 
-.compact-composer__controls {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 4px;
-}
-
+/* Chip + menu wrapper: the chip must be able to shrink and truncate, and
+   the menu anchors to it. */
 .compact-composer__menu {
+  display: flex;
   position: relative;
+  min-width: 0;
+  max-width: 70%;
 }
 
-.compact-composer__kebab {
-  padding: 5px 7px;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 13px;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.compact-composer__kebab:hover,
-.compact-composer__kebab[aria-expanded="true"] {
-  border-color: var(--accent-border);
-  color: var(--text-primary);
-}
-
+/* Anchored to the chip and opening upward, in-card for the same reason as
+   the mention list above; capped with its own scroll so a long model list
+   opens over the transcript rather than out of the card. */
 .compact-composer__menu-list {
   display: flex;
   position: absolute;
-  right: 0;
   bottom: calc(100% + 6px);
+  left: 0;
   z-index: 2;
   flex-direction: column;
-  min-width: 190px;
+  min-width: 210px;
+  max-width: 280px;
+  max-height: 252px;
   padding: 4px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
@@ -13295,7 +13353,12 @@ textarea,
 }
 
 .compact-composer__menu-item {
-  padding: 6px 8px;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 5px 8px;
   border: none;
   border-radius: 5px;
   background: transparent;
@@ -13305,8 +13368,18 @@ textarea,
   cursor: pointer;
 }
 
+/* Shared popover highlight language (`--accent-soft` tint), matching the
+   mention list two rules up and the main composer's pickers. */
 .compact-composer__menu-item:hover:not(:disabled) {
-  background: var(--bg-panel-hover);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.compact-composer__menu-item:hover:not(:disabled)
+  .compact-composer__menu-value,
+.compact-composer__menu-item:hover:not(:disabled)
+  .compact-composer__menu-chevron {
+  color: inherit;
 }
 
 .compact-composer__menu-item:disabled {
@@ -13314,15 +13387,140 @@ textarea,
   cursor: default;
 }
 
+.compact-composer__menu-item--back {
+  color: var(--text-muted);
+}
+
+.compact-composer__menu-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  font-weight: 500;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.compact-composer__menu-label--danger {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.compact-composer__menu-value {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 10px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Full Access carries the solid-accent warning fill in the value slot,
+   the same signal as the main composer's danger chip. */
+.compact-composer__menu-value--danger {
+  flex: 0 0 auto;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--button-text);
+  font-size: 9px;
+  font-weight: 600;
+}
+
+.compact-composer__menu-chevron {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  color: var(--text-muted);
+  line-height: 0;
+}
+
+/* Leading 12px column — empty until the row is the current selection,
+   then a ✓. Same anatomy as the shared picker rows. */
+.compact-composer__menu-check {
+  flex: 0 0 12px;
+  width: 12px;
+  color: var(--accent-bright);
+  font-size: 10px;
+  text-align: center;
+}
+
+.compact-composer__menu-eyebrow {
+  flex: 0 0 auto;
+  padding: 5px 8px 3px;
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.compact-composer__menu-separator {
+  flex: 0 0 auto;
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--border-subtle);
+}
+
+.compact-composer__menu-empty {
+  padding: 6px 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* Same switch anatomy as the thread-options menu toggle, at the card's
+   scale. */
+.compact-composer__menu-toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  box-sizing: border-box;
+  width: 28px;
+  height: 16px;
+  padding: 2px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--bg-input);
+}
+
+.compact-composer__menu-toggle-thumb {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.compact-composer__menu-toggle.is-checked {
+  border-color: var(--accent-border);
+  background: var(--accent);
+}
+
+.compact-composer__menu-toggle.is-checked
+  .compact-composer__menu-toggle-thumb {
+  transform: translateX(12px);
+  background: var(--button-text);
+}
+
+/* Send wears the main composer's action-pill recipe
+   (.composer__actions .button / .composer__primary-action), scaled to the
+   card's 22px control height, so the strip reads as one family with the
+   full view. */
 .compact-composer__send {
   flex: 0 0 auto;
-  padding: 6px 12px;
+  min-height: 22px;
+  padding: 2px 12px;
   border: 1px solid var(--accent-border);
-  border-radius: 6px;
-  background: var(--accent-soft);
-  color: var(--text-primary);
+  border-radius: 999px;
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
   font-size: 11px;
   cursor: pointer;
+}
+
+.compact-composer__send:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--button-text);
 }
 
 .compact-composer__send:disabled {
@@ -13336,9 +13534,10 @@ textarea,
    two rather than as a second accent button competing with it. */
 .compact-composer__stop {
   flex: 0 0 auto;
-  padding: 6px 12px;
+  min-height: 22px;
+  padding: 2px 12px;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
+  border-radius: 999px;
   background: transparent;
   color: var(--text-secondary);
   font-size: 11px;


### PR DESCRIPTION
## The bug

The compact composer (Star Map chat cards) painted `model · effort · access` as ambient text pinned inside the input field. The 16px bottom padding that "reserved" space for it is content padding inside the scrolling editor, so once a draft hits the field's 108px max height the reserve scrolls away and the label paints straight over the bottom line of what you're typing.

## The fix

Design exploration: [Compact Composer Model Chip](https://claude.ai/code/artifact/f5f04ef8-4da9-4c4e-8253-71dc00d06ac9) (Option A + both refinements).

The composer becomes a field over a one-line **status strip**:

- **Settings chip** — the model/effort/access readout moves onto the strip, outside the scroll region, so it can never collide with the draft again. Full access keeps its warning color as the chip's one accent segment; hover/open get the accent border + chevron, same move as the main composer's pill dropdowns.
- **Settings menu** — clicking the chip opens an in-card, upward-opening menu (same rules as the mention list: no body portal, so the star-map gesture guards keep covering it; capped with its own scroll). Root rows: **Model ›**, **Reasoning ›**, **Fast mode** toggle, **Access ›**, then the host's actions (**Compact thread**, **Open in full view**) below a separator.
- **Kebab removed** — its Switch-access item became the Access submenu; nothing else was left in it.
- **Send/Stop become pills** — the main composer's action-pill recipe (`.composer__actions .button`: 999px radius, `--accent-border`, `--bg-row-active` fill, `--accent-bright` text, solid accent on hover) scaled to the card's 22px control height, retiring the chocolate-chunk buttons.

## Wiring

- No new IPC. Rows reuse `setThreadModelSettings` / `setThreadExecutionMode`, so changes fan out through the thread-state update bus like every other surface.
- Model changes mirror the full composer's semantics: a model that can't reason clears the effort, one that can't go fast clears fast mode; fast is Codex-only.
- Launchpad options are described lazily via `listBackends` on first menu open, once per card, on the card's federation target — a card over a peer's thread lists the peer's models, and a card the operator only reads never pays for the describe.
- `CompactComposer` stays presentational (`settingsMenu` prop, host-supplied callbacks) and the memo boundary holds: the new props are delta-stable, pinned by the existing render-cost test.

## Deferred

Workspace handoff and environment selection stay behind **Open in full view** — they need the handoff strategy dialog and launchpad state a floating card doesn't host. Follow-up if wanted.

## Verification

- `pnpm test` for composer + star-map + styles: 51 files, 1088 tests passed (new coverage: chip states, submenu select/back/escape flows, lazy `listBackends`, federation routing, fast-mode toggle).
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors, no new warnings), `pnpm lint:colors`, `pnpm lint:boundaries` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)