### PR TITLE
fix(desktop): create a new state database in one commit instead of 52

### DIFF
--- a/apps/desktop/src/main/__tests__/state-db-creation.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db-creation.test.ts
@@ -9,36 +9,81 @@ let tempDir: string;
 
 /**
  * Counts top-level sqlite commits the way the production write-accounting in
- * `sqlite-write-metrics.ts` does — a `db.transaction()` call that is already
- * inside a transaction runs as a savepoint and commits nothing of its own.
+ * `sqlite-write-metrics.ts` does — a `db.transaction()` call already inside a
+ * transaction runs as a savepoint and commits nothing of its own, while any
+ * statement issued outside one commits implicitly.
  *
  * That accounting cannot be reused directly here: `StateDb.open` attaches it
  * *after* schema setup, so it can never see the writes that build a database.
  * Patching the prototype is the only seam that observes an open from outside.
+ *
+ * `exec` is counted as well as `transaction`, so a write moved out of the
+ * creation wrapper is caught rather than going uncounted — that regression is
+ * the whole reason this helper exists. Schema setup issues no bare
+ * `prepare(...).run()` outside a transaction, so `prepare` is left alone.
  */
 function countCommitsDuring(run: () => void): number {
   const originalTransaction = Database.prototype.transaction;
+  const originalExec = Database.prototype.exec;
   let commits = 0;
+
   Database.prototype.transaction = function patched(
     this: Database.Database,
     fn: (...args: unknown[]) => unknown,
   ) {
-    const inner = originalTransaction.call(this, fn);
-    const counted = (...args: unknown[]): unknown => {
-      const nested = this.inTransaction;
-      const result = (inner as (...a: unknown[]) => unknown)(...args);
-      if (!nested) {
-        commits += 1;
+    const inner = originalTransaction.call(this, fn) as unknown as Record<
+      string,
+      unknown
+    >;
+    const count = <T extends (...args: unknown[]) => unknown>(
+      transactionFn: T,
+    ): T =>
+      ((...args: unknown[]) => {
+        const nested = this.inTransaction;
+        const result = transactionFn(...args);
+        if (!nested) {
+          commits += 1;
+        }
+        return result;
+      }) as T;
+
+    const counted = count(
+      inner as unknown as (...args: unknown[]) => unknown,
+    ) as unknown as Record<string, unknown>;
+    // `.default` / `.deferred` / `.immediate` / `.exclusive` hang off the
+    // returned callable and are NOT enumerable, so they have to be rewrapped
+    // one at a time. `sqlite-write-metrics.ts` lost them once and every
+    // `tx.immediate(...)` caller died with "is not a function".
+    for (const variant of ["default", "deferred", "immediate", "exclusive"]) {
+      const original = inner[variant];
+      if (typeof original === "function") {
+        Object.defineProperty(counted, variant, {
+          configurable: true,
+          value: count(original as (...args: unknown[]) => unknown),
+          writable: true,
+        });
       }
-      return result;
-    };
-    return counted as ReturnType<typeof originalTransaction>;
+    }
+    return counted as unknown as ReturnType<typeof originalTransaction>;
   } as typeof Database.prototype.transaction;
+
+  Database.prototype.exec = function patchedExec(
+    this: Database.Database,
+    source: string,
+  ) {
+    const nested = this.inTransaction;
+    const result = originalExec.call(this, source);
+    if (!nested) {
+      commits += 1;
+    }
+    return result;
+  } as typeof Database.prototype.exec;
 
   try {
     run();
   } finally {
     Database.prototype.transaction = originalTransaction;
+    Database.prototype.exec = originalExec;
   }
   return commits;
 }

--- a/apps/desktop/src/main/__tests__/state-db-creation.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db-creation.test.ts
@@ -1,0 +1,129 @@
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CURRENT_STATE_DB_USER_VERSION, StateDb } from "../state/state-db";
+
+let tempDir: string;
+
+/**
+ * Counts top-level sqlite commits the way the production write-accounting in
+ * `sqlite-write-metrics.ts` does — a `db.transaction()` call that is already
+ * inside a transaction runs as a savepoint and commits nothing of its own.
+ *
+ * That accounting cannot be reused directly here: `StateDb.open` attaches it
+ * *after* schema setup, so it can never see the writes that build a database.
+ * Patching the prototype is the only seam that observes an open from outside.
+ */
+function countCommitsDuring(run: () => void): number {
+  const originalTransaction = Database.prototype.transaction;
+  let commits = 0;
+  Database.prototype.transaction = function patched(
+    this: Database.Database,
+    fn: (...args: unknown[]) => unknown,
+  ) {
+    const inner = originalTransaction.call(this, fn);
+    const counted = (...args: unknown[]): unknown => {
+      const nested = this.inTransaction;
+      const result = (inner as (...a: unknown[]) => unknown)(...args);
+      if (!nested) {
+        commits += 1;
+      }
+      return result;
+    };
+    return counted as ReturnType<typeof originalTransaction>;
+  } as typeof Database.prototype.transaction;
+
+  try {
+    run();
+  } finally {
+    Database.prototype.transaction = originalTransaction;
+  }
+  return commits;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-state-db-creation-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+describe("StateDb.open — database creation", () => {
+  it("builds a brand-new database in a single commit", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    let stateDb: StateDb | undefined;
+
+    const commits = countCommitsDuring(() => {
+      stateDb = StateDb.open(dbPath);
+    });
+
+    try {
+      // One commit, not one per schema version. A fresh file has no earlier
+      // user_version to resume from, so per-version commits bought it nothing
+      // and cost a WAL flush each — the cost that pushed Windows CI runners
+      // past the 30s per-test budget on suites that open a db per test.
+      expect(commits).toBe(1);
+    } finally {
+      stateDb?.close();
+    }
+  });
+
+  it("still applies every migration while creating inside that transaction", () => {
+    const stateDb = StateDb.open(path.join(tempDir, "state.db"));
+
+    try {
+      expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+        CURRENT_STATE_DB_USER_VERSION,
+      );
+      // Spot-check objects from across the ladder — v1 (`meta`), v50
+      // (`acp_available_commands`), and a v51 column — because a savepoint
+      // that silently swallowed part of it would still report the right
+      // version.
+      const names = new Set(
+        (
+          stateDb.raw
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+            .all() as { name: string }[]
+        ).map((row) => row.name),
+      );
+      expect(names).toContain("meta");
+      expect(names).toContain("acp_available_commands");
+      const invocationColumns = new Set(
+        (
+          stateDb.raw.pragma("table_info(thread_tool_invocations)") as {
+            name: string;
+          }[]
+        ).map((column) => column.name),
+      );
+      expect(invocationColumns).toContain("suggested_prompt");
+    } finally {
+      stateDb.close();
+    }
+  });
+
+  it("keeps one commit per version when upgrading an existing database", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    const created = StateDb.open(dbPath);
+    created.raw.pragma("user_version = 48");
+    created.close();
+
+    let reopened: StateDb | undefined;
+    const commits = countCommitsDuring(() => {
+      reopened = StateDb.open(dbPath);
+    });
+
+    try {
+      // An upgrade keeps per-version granularity on purpose: a partial failure
+      // has a previous user_version to resume from on the next launch.
+      expect(commits).toBeGreaterThan(1);
+      expect(reopened?.raw.pragma("user_version", { simple: true })).toBe(
+        CURRENT_STATE_DB_USER_VERSION,
+      );
+    } finally {
+      reopened?.close();
+    }
+  });
+});

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1116,402 +1116,428 @@ export class StateDb {
     db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
 
+    const userVersion = db.pragma("user_version", { simple: true }) as number;
+    const freshDatabase = userVersion === 0;
+    if (freshDatabase) {
+      // Has to precede the first write and cannot be set from inside a
+      // transaction, so it stays outside the wrapper below.
+      db.pragma("auto_vacuum = INCREMENTAL");
+    }
+
     // Migrations are wrapped in transactions so a partial failure
     // (mid-DDL crash, transient disk error) rolls back cleanly and the
     // next launch retries from the previous user_version. Without the
     // transaction the table could exist with the old user_version, and
     // the next launch would throw "table already exists" on retry.
-    const userVersion = db.pragma("user_version", { simple: true }) as number;
-    if (userVersion === 0) {
-      db.pragma("auto_vacuum = INCREMENTAL");
-      db.transaction(() => {
-        db.exec(SCHEMA_V1);
-        if (options?.profileName) {
-          db.prepare("UPDATE meta SET value = ? WHERE key = 'profile_name'").run(
-            options.profileName,
-          );
-        }
-        db.pragma("user_version = 1");
-      })();
+    const applySchema = (): void => {
+      if (freshDatabase) {
+        db.transaction(() => {
+          db.exec(SCHEMA_V1);
+          if (options?.profileName) {
+            db.prepare("UPDATE meta SET value = ? WHERE key = 'profile_name'").run(
+              options.profileName,
+            );
+          }
+          db.pragma("user_version = 1");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 2) {
+        db.transaction(() => {
+          db.exec(SCHEMA_V2);
+          db.pragma("user_version = 2");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 3) {
+        db.transaction(() => {
+          db.exec(SCHEMA_V3);
+          db.pragma("user_version = 3");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 4) {
+        db.transaction(() => {
+          db.exec(SCHEMA_V4);
+          db.pragma("user_version = 4");
+        })();
+      }
+      ensureCurrentSchema(db);
+      if ((db.pragma("user_version", { simple: true }) as number) < 5) {
+        db.transaction(() => {
+          db.pragma("user_version = 5");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 6) {
+        db.transaction(() => {
+          db.exec(COMPOSER_DRAFT_RECOVERY_SCHEMA);
+          db.pragma("user_version = 6");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 7) {
+        db.transaction(() => {
+          // Directory pin persistence — see plan
+          // 2026-05-09-002-feat-directory-pinning-plan.md Unit B.
+          // Additive table, no data migration; the same DDL also
+          // lives in `ensureCurrentSchema` so re-instantiated dbs
+          // converge.
+          db.exec(DIRECTORY_OVERLAY_SCHEMA);
+          db.pragma("user_version = 7");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 8) {
+        db.transaction(() => {
+          db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
+          db.pragma("user_version = 8");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 9) {
+        db.transaction(() => {
+          db.exec(ACP_AGENT_SCHEMA);
+          db.pragma("user_version = 9");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 10) {
+        db.transaction(() => {
+          db.exec(ACP_SESSION_SCHEMA);
+          db.pragma("user_version = 10");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 11) {
+        db.transaction(() => {
+          db.exec(AUTOMATION_SCHEMA);
+          db.pragma("user_version = 11");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 12) {
+        db.transaction(() => {
+          db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
+          db.pragma("user_version = 12");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 13) {
+        db.transaction(() => {
+          db.exec(THREAD_SEARCH_SCHEMA);
+          db.pragma("user_version = 13");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 14) {
+        db.transaction(() => {
+          db.exec(PR_STATUS_CACHE_SCHEMA);
+          db.exec(PR_LOOKUP_CACHE_SCHEMA);
+          db.pragma("user_version = 14");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 15) {
+        db.transaction(() => {
+          ensurePullRequestProviderColumns(db);
+          db.pragma("user_version = 15");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 16) {
+        db.transaction(() => {
+          db.exec(THREAD_GIT_WORKING_STATE_SCHEMA);
+          db.pragma("user_version = 16");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 17) {
+        db.transaction(() => {
+          db.exec(THREAD_USAGE_PRICING_SCHEMA);
+          db.pragma("user_version = 17");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 18) {
+        db.transaction(() => {
+          ensureThreadUsagePricingProviderScope(db);
+          db.pragma("user_version = 18");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 19) {
+        db.transaction(() => {
+          ensureThreadUsagePricingCumulativeColumns(db);
+          db.pragma("user_version = 19");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 20) {
+        db.transaction(() => {
+          repairThreadUsageLineCreatedAt(db);
+          db.pragma("user_version = 20");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 21) {
+        db.transaction(() => {
+          ensureThreadUsagePricingIndexes(db);
+          db.pragma("user_version = 21");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 22) {
+        db.transaction(() => {
+          repairTokenUsagePricing(db);
+          db.pragma("user_version = 22");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 23) {
+        db.transaction(() => {
+          // Inbound-run idempotency: promote source_event_key to a column +
+          // index so duplicate provider deliveries can be deduped. Additive;
+          // the same column/index also live in AUTOMATION_SCHEMA so
+          // re-instantiated dbs converge.
+          ensureAutomationRunSourceEventKey(db);
+          db.pragma("user_version = 23");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 24) {
+        db.transaction(() => {
+          // Observed context-replay tallies on the usage line. DEPRECATED (see
+          // issue #947): the tally has since moved to thread_usage_turns (v25), but
+          // these columns are still dual-written during the transition so older
+          // locally-run builds keep working. Additive; the same columns also live
+          // in THREAD_USAGE_PRICING_SCHEMA so re-instantiated dbs converge.
+          ensureThreadUsageObservedReplayColumns(db);
+          db.pragma("user_version = 24");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 25) {
+        db.transaction(() => {
+          // Relocate the observed context-replay tally onto thread_usage_turns —
+          // the per-turn record hydration refreshes via COALESCE, immune to the
+          // usage *line* supersession lifecycle. Additive columns that also live in
+          // THREAD_USAGE_PRICING_SCHEMA; the ALTERs are guarded by tableColumnExists
+          // so a fresh db (schema already carries them) no-ops.
+          ensureThreadUsageTurnObservedReplayColumns(db);
+          db.pragma("user_version = 25");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 26) {
+        db.transaction(() => {
+          ensureThreadUsageAttributedColumn(db);
+          db.pragma("user_version = 26");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 27) {
+        db.transaction(() => {
+          db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
+          db.pragma("user_version = 27");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 28) {
+        db.transaction(() => {
+          repairTokenUsagePricing(db);
+          db.pragma("user_version = 28");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 29) {
+        db.transaction(() => {
+          repairTokenUsagePricing(db);
+          db.pragma("user_version = 29");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 30) {
+        db.transaction(() => {
+          ensureThreadMessageOriginSchema(db);
+          db.pragma("user_version = 30");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 31) {
+        db.transaction(() => {
+          ensureThreadMessageOriginSchema(db);
+          db.pragma("user_version = 31");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 32) {
+        db.transaction(() => {
+          repairTokenUsagePricing(db);
+          db.pragma("user_version = 32");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 33) {
+        db.transaction(() => {
+          db.exec(MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA);
+          db.pragma("user_version = 33");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 34) {
+        db.transaction(() => {
+          db.exec(PR_AUTO_DISPATCH_SCHEMA);
+          db.pragma("user_version = 34");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 35) {
+        db.transaction(() => {
+          db.exec(MESSAGING_OBSERVED_SURFACE_SCHEMA);
+          backfillObservedMessagingSurfaces(db);
+          db.pragma("user_version = 35");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 36) {
+        db.transaction(() => {
+          db.exec(PR_STATUS_WATCH_SCHEMA);
+          db.exec(`
+            DELETE FROM pr_auto_dispatch_claims
+            WHERE rowid NOT IN (
+              SELECT MIN(rowid)
+              FROM pr_auto_dispatch_claims
+              GROUP BY pr_key, fingerprint
+            );
+          `);
+          db.exec(PR_AUTO_DISPATCH_SCHEMA);
+          db.exec(PR_AUTO_DISPATCH_GLOBAL_FINGERPRINT_INDEX);
+          db.pragma("user_version = 36");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 37) {
+        db.transaction(() => {
+          db.exec(PR_AUTO_DISPATCH_BUDGET_SCHEMA);
+          db.pragma("user_version = 37");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 38) {
+        db.transaction(() => {
+          db.exec(FEDERATION_SCHEMA);
+          db.pragma("user_version = 38");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 39) {
+        db.transaction(() => {
+          db.exec(SCHEDULED_THREAD_ACTION_SCHEMA);
+          db.pragma("user_version = 39");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 40) {
+        db.transaction(() => {
+          ensureScheduledThreadActionMetadataColumns(db);
+          db.pragma("user_version = 40");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 41) {
+        db.transaction(() => {
+          // Working-state semantics now account for deleted squash-merged PR
+          // heads. Cached pre-v41 counts can therefore show false unpushed
+          // badges indefinitely for worktrees outside the startup probe budget.
+          // This table is derived state and is safe to repopulate lazily.
+          db.prepare("DELETE FROM thread_git_working_state").run();
+          db.pragma("user_version = 41");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 42) {
+        db.transaction(() => {
+          repairReenrolledFederationPeerRevocations(db);
+          db.pragma("user_version = 42");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 43) {
+        db.transaction(() => {
+          // Viewer-owned pins of remote federated threads (Cmd+K "add to my
+          // list"). Deliberately local-only state: the owning instance never
+          // learns it has been pinned.
+          db.exec(REMOTE_THREAD_PIN_SCHEMA);
+          db.pragma("user_version = 43");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 44) {
+        db.transaction(() => {
+          db.exec(STAR_MAP_ARRANGEMENT_SCHEMA);
+          db.pragma("user_version = 44");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 45) {
+        db.transaction(() => {
+          // Revoking a peer used to hard-delete its pins. Tombstone them
+          // instead so a re-enrollment can restore the operator's list.
+          ensureRemoteThreadPinRevokedAtColumn(db);
+          db.pragma("user_version = 45");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 46) {
+        db.transaction(() => {
+          // Routing knowledge is broader than the curated pin list: agent tools
+          // also create and discover remote threads that the viewer never pins.
+          db.exec(REMOTE_THREAD_TARGET_SCHEMA);
+          db.exec(`
+  INSERT OR IGNORE INTO remote_thread_targets(
+    instance_id,
+    backend,
+    thread_id,
+    instance_label,
+    first_seen_at,
+    last_seen_at
+  )
+  SELECT
+    remote_thread_pins.instance_id,
+    remote_thread_pins.backend,
+    remote_thread_pins.thread_id,
+    COALESCE(federation_peers.label, remote_thread_pins.instance_id),
+    remote_thread_pins.added_at,
+    remote_thread_pins.added_at
+  FROM remote_thread_pins
+  LEFT JOIN federation_peers
+    ON federation_peers.peer_id = remote_thread_pins.instance_id
+  `);
+          db.pragma("user_version = 46");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 47) {
+        db.transaction(() => {
+          db.exec(REMOTE_DIRECTORY_OVERLAY_SCHEMA);
+          db.pragma("user_version = 47");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 48) {
+        db.transaction(() => {
+          db.pragma("user_version = 48");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 49) {
+        db.transaction(() => {
+          migrateRawThreadIdentityKeysToLegacyStorage(db);
+          db.pragma("user_version = 49");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 50) {
+        db.transaction(() => {
+          // Additive table, no data migration; the same DDL also lives in
+          // `ensureCurrentSchema` so re-instantiated dbs converge.
+          db.exec(ACP_AVAILABLE_COMMANDS_SCHEMA);
+          db.pragma("user_version = 50");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 51) {
+        db.transaction(() => {
+          ensureThreadToolIncidentExplorerSchema(db);
+          db.pragma("user_version = 51");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 52) {
+        db.transaction(() => {
+          repairCodexTurnUsageFromCumulativeSnapshots(db);
+          db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
+        })();
+      }
+      // Keep current-version databases converged without asking pre-v36 profiles
+      // to install the unique index before the migration above removes duplicates.
+      db.exec(PR_AUTO_DISPATCH_GLOBAL_FINGERPRINT_INDEX);
+    };
+
+    // A brand-new file has no previous version to fall back to, so the
+    // per-version commits buy it nothing — they only cost 52 commits, and 52
+    // WAL flushes, to reach a shape one commit could write. Creating inside a
+    // single transaction turns the nested `db.transaction()` calls into
+    // savepoints, so the ladder above stays the one source of truth for the
+    // schema while a fresh database costs one commit. It is also stricter than
+    // the old path: a creation that fails part-way now leaves no half-built
+    // file behind instead of a file stamped with whichever version it reached.
+    //
+    // An upgrade keeps its per-version commits, where the granularity is the
+    // whole point: a partial failure there has a previous user_version to
+    // resume from on the next launch.
+    if (freshDatabase) {
+      db.transaction(applySchema)();
+    } else {
+      applySchema();
     }
-    if ((db.pragma("user_version", { simple: true }) as number) < 2) {
-      db.transaction(() => {
-        db.exec(SCHEMA_V2);
-        db.pragma("user_version = 2");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 3) {
-      db.transaction(() => {
-        db.exec(SCHEMA_V3);
-        db.pragma("user_version = 3");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 4) {
-      db.transaction(() => {
-        db.exec(SCHEMA_V4);
-        db.pragma("user_version = 4");
-      })();
-    }
-    ensureCurrentSchema(db);
-    if ((db.pragma("user_version", { simple: true }) as number) < 5) {
-      db.transaction(() => {
-        db.pragma("user_version = 5");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 6) {
-      db.transaction(() => {
-        db.exec(COMPOSER_DRAFT_RECOVERY_SCHEMA);
-        db.pragma("user_version = 6");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 7) {
-      db.transaction(() => {
-        // Directory pin persistence — see plan
-        // 2026-05-09-002-feat-directory-pinning-plan.md Unit B.
-        // Additive table, no data migration; the same DDL also
-        // lives in `ensureCurrentSchema` so re-instantiated dbs
-        // converge.
-        db.exec(DIRECTORY_OVERLAY_SCHEMA);
-        db.pragma("user_version = 7");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 8) {
-      db.transaction(() => {
-        db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
-        db.pragma("user_version = 8");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 9) {
-      db.transaction(() => {
-        db.exec(ACP_AGENT_SCHEMA);
-        db.pragma("user_version = 9");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 10) {
-      db.transaction(() => {
-        db.exec(ACP_SESSION_SCHEMA);
-        db.pragma("user_version = 10");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 11) {
-      db.transaction(() => {
-        db.exec(AUTOMATION_SCHEMA);
-        db.pragma("user_version = 11");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 12) {
-      db.transaction(() => {
-        db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
-        db.pragma("user_version = 12");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 13) {
-      db.transaction(() => {
-        db.exec(THREAD_SEARCH_SCHEMA);
-        db.pragma("user_version = 13");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 14) {
-      db.transaction(() => {
-        db.exec(PR_STATUS_CACHE_SCHEMA);
-        db.exec(PR_LOOKUP_CACHE_SCHEMA);
-        db.pragma("user_version = 14");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 15) {
-      db.transaction(() => {
-        ensurePullRequestProviderColumns(db);
-        db.pragma("user_version = 15");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 16) {
-      db.transaction(() => {
-        db.exec(THREAD_GIT_WORKING_STATE_SCHEMA);
-        db.pragma("user_version = 16");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 17) {
-      db.transaction(() => {
-        db.exec(THREAD_USAGE_PRICING_SCHEMA);
-        db.pragma("user_version = 17");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 18) {
-      db.transaction(() => {
-        ensureThreadUsagePricingProviderScope(db);
-        db.pragma("user_version = 18");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 19) {
-      db.transaction(() => {
-        ensureThreadUsagePricingCumulativeColumns(db);
-        db.pragma("user_version = 19");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 20) {
-      db.transaction(() => {
-        repairThreadUsageLineCreatedAt(db);
-        db.pragma("user_version = 20");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 21) {
-      db.transaction(() => {
-        ensureThreadUsagePricingIndexes(db);
-        db.pragma("user_version = 21");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 22) {
-      db.transaction(() => {
-        repairTokenUsagePricing(db);
-        db.pragma("user_version = 22");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 23) {
-      db.transaction(() => {
-        // Inbound-run idempotency: promote source_event_key to a column +
-        // index so duplicate provider deliveries can be deduped. Additive;
-        // the same column/index also live in AUTOMATION_SCHEMA so
-        // re-instantiated dbs converge.
-        ensureAutomationRunSourceEventKey(db);
-        db.pragma("user_version = 23");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 24) {
-      db.transaction(() => {
-        // Observed context-replay tallies on the usage line. DEPRECATED (see
-        // issue #947): the tally has since moved to thread_usage_turns (v25), but
-        // these columns are still dual-written during the transition so older
-        // locally-run builds keep working. Additive; the same columns also live
-        // in THREAD_USAGE_PRICING_SCHEMA so re-instantiated dbs converge.
-        ensureThreadUsageObservedReplayColumns(db);
-        db.pragma("user_version = 24");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 25) {
-      db.transaction(() => {
-        // Relocate the observed context-replay tally onto thread_usage_turns —
-        // the per-turn record hydration refreshes via COALESCE, immune to the
-        // usage *line* supersession lifecycle. Additive columns that also live in
-        // THREAD_USAGE_PRICING_SCHEMA; the ALTERs are guarded by tableColumnExists
-        // so a fresh db (schema already carries them) no-ops.
-        ensureThreadUsageTurnObservedReplayColumns(db);
-        db.pragma("user_version = 25");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 26) {
-      db.transaction(() => {
-        ensureThreadUsageAttributedColumn(db);
-        db.pragma("user_version = 26");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 27) {
-      db.transaction(() => {
-        db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
-        db.pragma("user_version = 27");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 28) {
-      db.transaction(() => {
-        repairTokenUsagePricing(db);
-        db.pragma("user_version = 28");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 29) {
-      db.transaction(() => {
-        repairTokenUsagePricing(db);
-        db.pragma("user_version = 29");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 30) {
-      db.transaction(() => {
-        ensureThreadMessageOriginSchema(db);
-        db.pragma("user_version = 30");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 31) {
-      db.transaction(() => {
-        ensureThreadMessageOriginSchema(db);
-        db.pragma("user_version = 31");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 32) {
-      db.transaction(() => {
-        repairTokenUsagePricing(db);
-        db.pragma("user_version = 32");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 33) {
-      db.transaction(() => {
-        db.exec(MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA);
-        db.pragma("user_version = 33");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 34) {
-      db.transaction(() => {
-        db.exec(PR_AUTO_DISPATCH_SCHEMA);
-        db.pragma("user_version = 34");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 35) {
-      db.transaction(() => {
-        db.exec(MESSAGING_OBSERVED_SURFACE_SCHEMA);
-        backfillObservedMessagingSurfaces(db);
-        db.pragma("user_version = 35");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 36) {
-      db.transaction(() => {
-        db.exec(PR_STATUS_WATCH_SCHEMA);
-        db.exec(`
-          DELETE FROM pr_auto_dispatch_claims
-          WHERE rowid NOT IN (
-            SELECT MIN(rowid)
-            FROM pr_auto_dispatch_claims
-            GROUP BY pr_key, fingerprint
-          );
-        `);
-        db.exec(PR_AUTO_DISPATCH_SCHEMA);
-        db.exec(PR_AUTO_DISPATCH_GLOBAL_FINGERPRINT_INDEX);
-        db.pragma("user_version = 36");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 37) {
-      db.transaction(() => {
-        db.exec(PR_AUTO_DISPATCH_BUDGET_SCHEMA);
-        db.pragma("user_version = 37");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 38) {
-      db.transaction(() => {
-        db.exec(FEDERATION_SCHEMA);
-        db.pragma("user_version = 38");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 39) {
-      db.transaction(() => {
-        db.exec(SCHEDULED_THREAD_ACTION_SCHEMA);
-        db.pragma("user_version = 39");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 40) {
-      db.transaction(() => {
-        ensureScheduledThreadActionMetadataColumns(db);
-        db.pragma("user_version = 40");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 41) {
-      db.transaction(() => {
-        // Working-state semantics now account for deleted squash-merged PR
-        // heads. Cached pre-v41 counts can therefore show false unpushed
-        // badges indefinitely for worktrees outside the startup probe budget.
-        // This table is derived state and is safe to repopulate lazily.
-        db.prepare("DELETE FROM thread_git_working_state").run();
-        db.pragma("user_version = 41");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 42) {
-      db.transaction(() => {
-        repairReenrolledFederationPeerRevocations(db);
-        db.pragma("user_version = 42");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 43) {
-      db.transaction(() => {
-        // Viewer-owned pins of remote federated threads (Cmd+K "add to my
-        // list"). Deliberately local-only state: the owning instance never
-        // learns it has been pinned.
-        db.exec(REMOTE_THREAD_PIN_SCHEMA);
-        db.pragma("user_version = 43");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 44) {
-      db.transaction(() => {
-        db.exec(STAR_MAP_ARRANGEMENT_SCHEMA);
-        db.pragma("user_version = 44");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 45) {
-      db.transaction(() => {
-        // Revoking a peer used to hard-delete its pins. Tombstone them
-        // instead so a re-enrollment can restore the operator's list.
-        ensureRemoteThreadPinRevokedAtColumn(db);
-        db.pragma("user_version = 45");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 46) {
-      db.transaction(() => {
-        // Routing knowledge is broader than the curated pin list: agent tools
-        // also create and discover remote threads that the viewer never pins.
-        db.exec(REMOTE_THREAD_TARGET_SCHEMA);
-        db.exec(`
-INSERT OR IGNORE INTO remote_thread_targets(
-  instance_id,
-  backend,
-  thread_id,
-  instance_label,
-  first_seen_at,
-  last_seen_at
-)
-SELECT
-  remote_thread_pins.instance_id,
-  remote_thread_pins.backend,
-  remote_thread_pins.thread_id,
-  COALESCE(federation_peers.label, remote_thread_pins.instance_id),
-  remote_thread_pins.added_at,
-  remote_thread_pins.added_at
-FROM remote_thread_pins
-LEFT JOIN federation_peers
-  ON federation_peers.peer_id = remote_thread_pins.instance_id
-`);
-        db.pragma("user_version = 46");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 47) {
-      db.transaction(() => {
-        db.exec(REMOTE_DIRECTORY_OVERLAY_SCHEMA);
-        db.pragma("user_version = 47");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 48) {
-      db.transaction(() => {
-        db.pragma("user_version = 48");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 49) {
-      db.transaction(() => {
-        migrateRawThreadIdentityKeysToLegacyStorage(db);
-        db.pragma("user_version = 49");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 50) {
-      db.transaction(() => {
-        // Additive table, no data migration; the same DDL also lives in
-        // `ensureCurrentSchema` so re-instantiated dbs converge.
-        db.exec(ACP_AVAILABLE_COMMANDS_SCHEMA);
-        db.pragma("user_version = 50");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 51) {
-      db.transaction(() => {
-        ensureThreadToolIncidentExplorerSchema(db);
-        db.pragma("user_version = 51");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 52) {
-      db.transaction(() => {
-        repairCodexTurnUsageFromCumulativeSnapshots(db);
-        db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
-      })();
-    }
-    // Keep current-version databases converged without asking pre-v36 profiles
-    // to install the unique index before the migration above removes duplicates.
-    db.exec(PR_AUTO_DISPATCH_GLOBAL_FINGERPRINT_INDEX);
 
     // Dev-only write accounting, attached only after schema setup so the
-    // report ranks steady-state writes. Migrations commit once per version on
-    // a fresh database, which on a suite that opens a temp db per test would
-    // otherwise swamp the signal — the heaviest "writer" would just be
-    // whichever file opened the most databases. Off unless
+    // report ranks steady-state writes. Creating a database still commits
+    // once, and an upgrade once per version, which on a suite that opens a
+    // temp db per test would otherwise skew the signal toward whichever file
+    // opened the most databases. Off unless
     // PWRAGENT_DEV_SQLITE_WRITE_METRICS is set, and
     // `rejectDevOnlyEnvVarsInProduction` clears that variable on packaged
     // builds before anything reads it, so a shipped app never patches its db.


### PR DESCRIPTION
## What

`StateDb.open` builds every brand-new database at the **v1 schema** and then walks it through all 51 migrations to reach v52, committing once per version:

```ts
if (userVersion === 0) {
  db.transaction(() => { db.exec(SCHEMA_V1); db.pragma("user_version = 1"); })();
}
if (... < 2) { db.transaction(() => { ... })(); }   // ×51
```

On a fresh file those per-version commits buy nothing — there is no earlier `user_version` to resume from — and each one flushes its dirty pages to the WAL. Several of the steps are data-repair passes (`repairCodexTurnUsageFromCumulativeSnapshots`, `migrateRawThreadIdentityKeysToLegacyStorage`) scanning tables that are definitionally empty, each in its own transaction.

This wraps creation in a single transaction. better-sqlite3 runs a nested `db.transaction()` as a savepoint, so **the ladder stays the one source of truth for the schema** — no squashed `SCHEMA_CURRENT` baseline to hand-maintain and drift. Upgrades are untouched and keep their per-version commits, where the granularity is the whole point.

Reviewing tip: `git diff -w` is 32 insertions / 6 deletions. The rest of the diff is a 2-space reindent of the ladder into the `applySchema` closure.

## Measured

Fresh `StateDb.open` on a temp file, macOS, `better-sqlite3` in WAL / `synchronous = NORMAL`:

| | before | after |
|---|---|---|
| commits | 52 | **1** |
| WAL bytes written | 1235 KB | **897 KB** |
| resulting db file | 892 KB | 892 KB |
| wall time (median of 15) | ~15.6ms | ~15.9ms |

Both WAL figures were dead stable across five samples each. The 338 KB saved is pages one migration dirtied and a later commit wrote again.

**Wall time on macOS is unchanged, and I want to be straight about that.** With `synchronous = NORMAL` a WAL commit does not `fsync`, so on a fast APFS SSD collapsing 52 commits costs almost nothing in time. The reduction here is in commit count and bytes written — i.e. in filesystem operations, which is what a Defender-armed Windows CI runner charges for.

## Why this is worth doing

The `desktop-main` suite performs **685 file-backed `StateDb.open` calls per run** (plus 197 in-memory), measured by instrumenting `open` and running the project.

The Windows lane has been failing on that cost. Pulling every failed `Windows desktop-main` job across the 60 most recent runs — all attempts, including re-runs, which the default `gh run list` view hides — gives 5 failures, and **every timeout among them is a `StateDb.open` on a temp file**:

| job | dur | failure |
|---|---|---|
| 96435123332 | 8.6m | `thread-search-service` (**hook**) + `overlay-store-permission-transitions` |
| 96430143894 | 8.3m | `backend-registry` real-git-worktree |
| 96284065517 | 8.4m | `overlay-store-usage-pricing` (**hook**) + `messaging-store-sqlite` (**hook**) |
| 96416730591 | 4.1m | assertion failure, not a timeout |
| 96302478073 | 4.6m | detached-process failure, not a timeout |

Two details worth noting:

- Three of those are **`Hook timed out`** — the `beforeEach` that is `mkdtemp` + `StateDb.open`, not the test body. The `thread-search-service` test named in the annotation inserts two rows.
- In `overlay-store-permission-transitions.test.ts`, five of six tests use `openInMemoryStateDb()` and have never failed. The one that fails is the only one that touches a real file.

All three timeouts landed on jobs running 8.3–8.6m against a 4.4m median / 5.3m p90. (A *successful* job also ran 8.0m, so the stall is more common than the failure; 30s is just where the tail clips.)

Also worth recording: the reported durations were 50730ms and 34140ms against a 30000ms budget. Vitest truncates a genuinely-hung test at the timeout and reports real elapsed time for work that blocks the event loop — I verified this three ways. `better-sqlite3` is synchronous, so those are real elapsed times, not artifacts of the budget being 30s.

Per `CLAUDE.md` this deliberately does **not** raise `testTimeout`, reduce workers, add retries, or skip on Windows.

## Tests

New `apps/desktop/src/main/__tests__/state-db-creation.test.ts`:

- creation costs exactly **1** commit
- the ladder still fully applies inside that transaction — asserts `CURRENT_STATE_DB_USER_VERSION` plus objects from v1, v50, and a v51 column, since a savepoint that swallowed part of the ladder would still report the right version
- an upgrade still commits **more than once**, pinning the deliberate asymmetry

The existing `sqlite-write-budget` harness could not be reused: `StateDb.open` attaches write accounting *after* schema setup, so it can never observe the writes that build a database. The test patches `Database.prototype.transaction` and counts non-nested commits exactly the way `sqlite-write-metrics.ts` does.

## Verification

- `pnpm test --project desktop-main` — 324 files, 4652 passed, 6 skipped, green.
  - An earlier run of the same suite had two 5s timeouts in `codex-environment-runtime.test.ts` and `index.test.ts`; both pass alone and the next full run was clean. That is the known pre-existing full-suite load flake, not this change.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:sql`, `pnpm lint:boundaries`, `pnpm lint:codex-storage` — all clean.

**Not verified on Windows.** I have no Windows lab run for this, so I am not claiming the CI flake is fixed — only that the cost it was failing on is measurably lower. The honest read is: land it and read the next few Windows runs.

## Related

Separate work is in flight to cut subprocess count in `backend-registry.test.ts` (the one non-sqlite timeout above). That one is roughly 1 timeout in 60 runs and landed on an 8.3m job, so it looks like the same runner-wide stall rather than a git-specific hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
