### PR TITLE
fix(tests): wait on sampling progress, not the clock

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -107,16 +107,87 @@ function deferred<T = void>() {
   return { promise, resolve, reject };
 }
 
+/**
+ * Progress-based synchronization for the sampling loop.
+ *
+ * `vi.waitFor` polls against a wall-clock budget (1s by default) while one
+ * sampling iteration awaits real disk writes, so on a loaded CI runner the
+ * budget expires before the loop has advanced and this suite flakes while
+ * passing locally. It is also not side-effect free under fake timers: it
+ * advances them between retries, which drives the very loop being measured
+ * (see the sample-count comment further down for the flake that caused).
+ *
+ * Waiting on the profiler's own `onSampleCaptured` signal removes the clock
+ * from both problems — the wait ends when the work actually finishes, bounded
+ * only by the test timeout, and nothing is stepped forward to find that out.
+ */
+function createSampleTracker() {
+  let captured = 0;
+  let waiters: Array<{ ready: () => boolean; resolve: () => void }> = [];
+
+  function flush(): void {
+    waiters = waiters.filter((waiter) => {
+      if (!waiter.ready()) return true;
+      waiter.resolve();
+      return false;
+    });
+  }
+
+  async function waitUntil(ready: () => boolean): Promise<void> {
+    if (ready()) return;
+    await new Promise<void>((resolve) => {
+      waiters.push({ ready, resolve });
+    });
+  }
+
+  return {
+    onSampleCaptured: () => {
+      captured += 1;
+      flush();
+    },
+    capturedCount: () => captured,
+    waitUntil,
+    /** Resolves once `target` sampling iterations have fully completed. */
+    async waitForCount(target: number): Promise<void> {
+      await waitUntil(() => captured >= target);
+    },
+  };
+}
+
 describe("RendererHotCpuProfiler", () => {
   const cleanups: Array<() => Promise<void>> = [];
   const profilers: RendererHotCpuProfiler[] = [];
 
+  const sampleTrackers = new WeakMap<
+    RendererHotCpuProfiler,
+    ReturnType<typeof createSampleTracker>
+  >();
+
   function createProfiler(
     options: ConstructorParameters<typeof RendererHotCpuProfiler>[0],
   ): RendererHotCpuProfiler {
-    const profiler = new RendererHotCpuProfiler(options);
+    const tracker = createSampleTracker();
+    const profiler = new RendererHotCpuProfiler({
+      ...options,
+      onSampleCaptured: () => {
+        options.onSampleCaptured?.();
+        tracker.onSampleCaptured();
+      },
+    });
+    sampleTrackers.set(profiler, tracker);
     profilers.push(profiler);
     return profiler;
+  }
+
+  /** Sampling-progress tracker for a profiler built by `createProfiler`. */
+  function samplesOf(
+    profiler: RendererHotCpuProfiler,
+  ): ReturnType<typeof createSampleTracker> {
+    const tracker = sampleTrackers.get(profiler);
+    if (!tracker) {
+      throw new Error("Profiler was not created through createProfiler().");
+    }
+    return tracker;
   }
 
   afterEach(async () => {
@@ -169,9 +240,10 @@ describe("RendererHotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await vi.waitFor(() => {
-      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
-    });
+    await samplesOf(profiler).waitUntil(
+      () => debuggerApi.attach.mock.calls.length > 0,
+    );
+    expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
 
     expect(debuggerApi.sendCommand).toHaveBeenNthCalledWith(1, "Profiler.enable");
     expect(debuggerApi.sendCommand).toHaveBeenNthCalledWith(2, "Profiler.start");
@@ -260,7 +332,9 @@ describe("RendererHotCpuProfiler", () => {
 
     const { target } = createTarget();
     const profileWritten = deferred();
+    const profileWriteStarted = deferred();
     const onProfileWritten = vi.fn(async () => {
+      profileWriteStarted.resolve();
       await profileWritten.promise;
     });
     let nowCallCount = 0;
@@ -284,9 +358,11 @@ describe("RendererHotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await vi.waitFor(() => {
-      expect(onProfileWritten).toHaveBeenCalledTimes(1);
-    });
+    // Not a sample-progress wait: sampling is paused for the duration of a
+    // profile, so the loop publishes nothing more until the profile ends —
+    // and this test deliberately holds `onProfileWritten` open forever.
+    await profileWriteStarted.promise;
+    expect(onProfileWritten).toHaveBeenCalledTimes(1);
 
     let stopResolved = false;
     const stopPromise = profiler.stop("test-complete").then(() => {
@@ -435,17 +511,20 @@ describe("RendererHotCpuProfiler", () => {
     try {
       await profiler.start();
       await vi.advanceTimersByTimeAsync(0);
-      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(1));
+      await samplesOf(profiler).waitForCount(1);
+      expect(getAppMetrics).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(config.intervalMs);
-      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(2));
+      await samplesOf(profiler).waitForCount(2);
+      expect(getAppMetrics).toHaveBeenCalledTimes(2);
       await vi.advanceTimersByTimeAsync(config.intervalMs);
-      await vi.waitFor(() => expect(debuggerApi.attach).toHaveBeenCalledWith("1.3"));
+      await samplesOf(profiler).waitForCount(3);
+      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
 
       expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.start");
       expect(getAppMetrics).toHaveBeenCalledTimes(3);
-      // `Profiler.start` precedes async profile-start bookkeeping. Wait until
-      // its duration timer is registered before asking fake timers to run it.
-      await vi.waitFor(() => expect(vi.getTimerCount()).toBe(1));
+      // The sample signal fires after profile-start bookkeeping has armed the
+      // duration timer, so it is already the only pending timer here.
+      expect(vi.getTimerCount()).toBe(1);
 
       await vi.advanceTimersByTimeAsync(config.intervalMs * 4);
       expect(getAppMetrics).toHaveBeenCalledTimes(3);
@@ -456,7 +535,8 @@ describe("RendererHotCpuProfiler", () => {
       await vi.waitFor(() => expect(debuggerApi.detach).toHaveBeenCalled());
 
       await vi.advanceTimersByTimeAsync(config.intervalMs);
-      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(4));
+      await samplesOf(profiler).waitForCount(4);
+      expect(getAppMetrics).toHaveBeenCalledTimes(4);
 
       // Stop the profiler BEFORE asserting the sample file. The sampler is a
       // self-rescheduling setTimeout loop, and `vi.waitFor` advances fake
@@ -577,9 +657,10 @@ describe("RendererHotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await vi.waitFor(() => {
-      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
-    });
+    await samplesOf(profiler).waitUntil(
+      () => debuggerApi.attach.mock.calls.length > 0,
+    );
+    expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
     await profiler.stop("test-complete");
 
     const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
@@ -642,9 +723,10 @@ describe("RendererHotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await vi.waitFor(() => {
-      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
-    });
+    await samplesOf(profiler).waitUntil(
+      () => debuggerApi.attach.mock.calls.length > 0,
+    );
+    expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
     await profiler.stop("test-complete");
 
     const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
@@ -718,12 +800,13 @@ describe("RendererHotCpuProfiler", () => {
       await profiler.start();
 
       await vi.advanceTimersByTimeAsync(config.startDelayMs);
-      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(1));
+      await samplesOf(profiler).waitForCount(1);
       await vi.advanceTimersByTimeAsync(config.intervalMs);
-      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(2));
+      await samplesOf(profiler).waitForCount(2);
       await vi.advanceTimersByTimeAsync(config.intervalMs);
-      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(3));
-      await vi.waitFor(() => expect(debuggerApi.attach).toHaveBeenCalledWith("1.3"));
+      await samplesOf(profiler).waitForCount(3);
+      expect(getAppMetrics).toHaveBeenCalledTimes(3);
+      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
       await vi.advanceTimersByTimeAsync(config.profileDurationMs);
 
       await vi.waitFor(() => {
@@ -924,8 +1007,10 @@ describe("RendererHotCpuProfiler", () => {
     if (!sessionResult.ok) return;
 
     const startSnapshot = deferred();
+    const startSnapshotRequested = deferred();
     const { target, debuggerApi } = createTarget();
     target.takeHeapSnapshot.mockImplementation(async () => {
+      startSnapshotRequested.resolve();
       await startSnapshot.promise;
     });
     let nowCallCount = 0;
@@ -948,9 +1033,11 @@ describe("RendererHotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await vi.waitFor(() => {
-      expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(1);
-    });
+    // Not a sample-progress wait: the start snapshot is awaited inside the
+    // sampling iteration and this test holds it open, so the iteration never
+    // completes. Wait on the snapshot request instead.
+    await startSnapshotRequested.promise;
+    expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(1);
 
     const stopProfiler = profiler.stop("settings-disabled");
     await vi.waitFor(() => {
@@ -1010,23 +1097,9 @@ describe("RendererHotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await vi.waitFor(async () => {
-      const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line));
-
-      expect(events).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: "profile-skipped",
-            detail: expect.objectContaining({
-              reason: "debugger-already-attached",
-            }),
-          }),
-        ]),
-      );
-    });
+    // The skip is recorded inside the sampling iteration that would have
+    // started the profile, so three completed samples settle this file.
+    await samplesOf(profiler).waitForCount(3);
 
     expect(debuggerApi.attach).not.toHaveBeenCalled();
 

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -123,20 +123,35 @@ function deferred<T = void>() {
  */
 function createSampleTracker() {
   let captured = 0;
-  let waiters: Array<{ ready: () => boolean; resolve: () => void }> = [];
+  let waiters: Array<{
+    label: string;
+    ready: () => boolean;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  }> = [];
 
   function flush(): void {
     waiters = waiters.filter((waiter) => {
-      if (!waiter.ready()) return true;
+      // A predicate that throws would otherwise escape through the profiler's
+      // `finally`, rejecting the sampling chain and leaving this wait pending
+      // forever. Fail the wait that owns the predicate instead.
+      let ready: boolean;
+      try {
+        ready = waiter.ready();
+      } catch (error) {
+        waiter.reject(error);
+        return false;
+      }
+      if (!ready) return true;
       waiter.resolve();
       return false;
     });
   }
 
-  async function waitUntil(ready: () => boolean): Promise<void> {
+  async function waitUntil(ready: () => boolean, label: string): Promise<void> {
     if (ready()) return;
-    await new Promise<void>((resolve) => {
-      waiters.push({ ready, resolve });
+    await new Promise<void>((resolve, reject) => {
+      waiters.push({ label, ready, resolve, reject });
     });
   }
 
@@ -145,11 +160,16 @@ function createSampleTracker() {
       captured += 1;
       flush();
     },
-    capturedCount: () => captured,
+    /**
+     * Waits still outstanding. Non-empty only after a test has already failed,
+     * since every wait is awaited — see the afterEach that reports them.
+     */
+    pendingLabels: (): string[] =>
+      waiters.map((waiter) => `${waiter.label} (after ${captured} samples)`),
     waitUntil,
     /** Resolves once `target` sampling iterations have fully completed. */
     async waitForCount(target: number): Promise<void> {
-      await waitUntil(() => captured >= target);
+      await waitUntil(() => captured >= target, `${target} completed samples`);
     },
   };
 }
@@ -192,10 +212,21 @@ describe("RendererHotCpuProfiler", () => {
 
   afterEach(async () => {
     vi.useRealTimers();
-    await Promise.all(
-      profilers.splice(0).map((profiler) => profiler.stop("test-cleanup")),
+    const created = profilers.splice(0);
+    const pendingWaits = created.flatMap(
+      (profiler) => sampleTrackers.get(profiler)?.pendingLabels() ?? [],
     );
+    await Promise.all(created.map((profiler) => profiler.stop("test-cleanup")));
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+    if (pendingWaits.length > 0) {
+      // Reachable only when the test has already failed, because every wait is
+      // awaited. It turns an opaque "Test timed out in 5000ms" into the name of
+      // the thing that never happened — the diagnostic `vi.waitFor` used to
+      // give for free by reporting the assertion it was retrying.
+      throw new Error(
+        `Sampling waits never resolved: ${pendingWaits.join("; ")}`,
+      );
+    }
   });
 
   it("records a renderer CPU profile after sustained hot samples", async () => {
@@ -242,6 +273,7 @@ describe("RendererHotCpuProfiler", () => {
     await profiler.start();
     await samplesOf(profiler).waitUntil(
       () => debuggerApi.attach.mock.calls.length > 0,
+      "debugger attach",
     );
     expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
 
@@ -659,6 +691,7 @@ describe("RendererHotCpuProfiler", () => {
     await profiler.start();
     await samplesOf(profiler).waitUntil(
       () => debuggerApi.attach.mock.calls.length > 0,
+      "debugger attach",
     );
     expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
     await profiler.stop("test-complete");
@@ -725,6 +758,7 @@ describe("RendererHotCpuProfiler", () => {
     await profiler.start();
     await samplesOf(profiler).waitUntil(
       () => debuggerApi.attach.mock.calls.length > 0,
+      "debugger attach",
     );
     expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
     await profiler.stop("test-complete");

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -71,6 +71,7 @@ export class RendererHotCpuProfiler {
   private readonly logger: Logger;
   private readonly now: () => Date;
   private readonly onHeapSnapshotLimitReached?: () => void | Promise<void>;
+  private readonly onSampleCaptured?: () => void;
   private readonly onProfileWritten?: (
     event: HotCpuProfileCapturedEvent,
   ) => void | Promise<void>;
@@ -107,6 +108,17 @@ export class RendererHotCpuProfiler {
     now?: () => Date;
     onHeapSnapshotLimitReached?: () => void | Promise<void>;
     onProfileWritten?: (event: HotCpuProfileCapturedEvent) => void | Promise<void>;
+    /**
+     * Fires once per completed sampling iteration, after the sample has been
+     * written and any profile it triggered has started.
+     *
+     * The loop is a self-rescheduling timer whose body awaits real disk
+     * writes, so it publishes no progress an observer can wait on. Without
+     * this, a test can only poll on a wall-clock budget and hope the machine
+     * is fast enough — which is exactly how this suite flaked on loaded CI
+     * while passing locally. Unused in production.
+     */
+    onSampleCaptured?: () => void;
   }) {
     this.config = options.config;
     this.getAppMetrics = options.getAppMetrics;
@@ -114,6 +126,7 @@ export class RendererHotCpuProfiler {
     this.now = options.now ?? (() => new Date());
     this.onHeapSnapshotLimitReached = options.onHeapSnapshotLimitReached;
     this.onProfileWritten = options.onProfileWritten;
+    this.onSampleCaptured = options.onSampleCaptured;
     this.session = options.session;
     this.target = options.target;
   }
@@ -290,6 +303,9 @@ export class RendererHotCpuProfiler {
       } else {
         this.samplingPausedForProfile = true;
       }
+      // After rescheduling, so an observer woken here already sees the next
+      // timer armed and can assert on timer state without a second wait.
+      this.onSampleCaptured?.();
     }
   }
 


### PR DESCRIPTION
## Summary

- `apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts` has been failing intermittently on CI while passing locally. It is not a logical conflict from any recent merge: `apps/desktop/src/main/diagnostics/` has not changed since #1469 (2026-08-10), and the test file has not changed either.
- The tests drove a self-rescheduling sampling loop and then polled for its effects with `vi.waitFor`. That is a wall-clock budget — 1s by default — spent on iterations that each `await` real disk writes, so the assertion holds only while the machine is fast enough. **On an idle M5 Max the worst affected test used 264ms of that 1s budget**; a loaded 2-vCPU runner has no such headroom.
- Polling was also not side-effect free. Under fake timers `vi.waitFor` advances them between retries, so it drove the very loop it was measuring. The file already carries a comment about the earlier flake that caused (`expected length 4, got 23`), worked around by stopping the profiler before asserting rather than by removing the clock.
- `RendererHotCpuProfiler` now publishes `onSampleCaptured`, fired once per completed iteration after the sample is written and any profile it triggered has started. It is the same optional-hook shape as `onProfileWritten` and `onHeapSnapshotLimitReached` beside it, and is unused in production. Tests wait on that signal instead of polling: a wait ends when the work actually finishes, bounded only by the test timeout, and nothing is stepped forward to find out.

Per-test durations on an idle machine, before → after:

| Test | Before | After |
|---|---|---|
| captures bounded heap snapshots around a hot CPU profile | 235ms | 57ms |
| pauses process metric sampling while the renderer CPU profiler is active | 215ms | 55ms |
| starts a profile after consecutive slowburn samples | 60ms | 16ms |
| starts a profile after one hot sample in spike mode | 57ms | 11ms |
| skips profiling when a debugger is already attached | 57ms | 17ms |
| **file total** | **1085ms** | **494ms** |

The saving is the polling interval that was previously being burned waiting for work that had already finished.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts` — 14 passed
- Soak: 8 consecutive runs of that file under 24 CPU hogs on an 18-core machine — 8/8 green
- `pnpm test` (full workspace) — 603 files, 8674 passed, 6 skipped, 0 failed
- `pnpm typecheck` — pass
- `pnpm lint:eslint` — pass (0 errors)
- Desktop E2E was not run.

Note on the soak: the *unfixed* file also survives CPU contention on this machine, so the soak is a regression check rather than proof of the fix. The evidence for the fix is the margin measurement above — the budget was single-digit multiples of the observed cost, and the waits no longer have a budget at all.

## Notes

Three waits deliberately do **not** use the new signal, each commented at the call site. Sampling pauses for the duration of a profile, and two of these tests hold a profile write or a start heap snapshot open forever — so those iterations never complete and a progress wait would hang (it did, while I was writing this; that is how each comment got its reason). Those wait on the operation itself through a deferred instead.

Unrelated defect noticed while reading `captureSample`, **not fixed here**: on the `metric-not-found` path the method calls `scheduleNextSample()` and then `return`s from inside the `try`, so the `finally` schedules a *second* timer. `this.intervalTimer` only retains the later handle, so each such sample doubles the number of live sampling chains — the rate compounds while a renderer's metric is missing (a crashed or reloading renderer). It is bounded rather than a leak, since orphaned callbacks bail on `this.stopped`, and it does not affect the tests here because their metrics always match the target pid. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
