### PR TITLE
fix(desktop): declare prChipModifiers on the persisted draft token

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3123,6 +3123,9 @@ describe("Composer", () => {
     expect(chip).toHaveClass("pr-chip--failing");
     expect(chip).toHaveClass("pr-chip--draft");
     expect(chip).not.toHaveClass("pr-chip--unknown");
+    // The draft modifier only lifts the label; the bar is the affordance the
+    // sidebar chip renders, so the composer chip has to draw it too.
+    expect(chip?.querySelector(".pr-chip__draft-bar")).not.toBeNull();
   });
 
   it("rebuilds a GitLab merge request chip from a prompt-only launchpad restore", async () => {

--- a/packages/shared/src/contracts/composer-drafts.ts
+++ b/packages/shared/src/contracts/composer-drafts.ts
@@ -36,6 +36,13 @@ export type ComposerDraftSkillToken = {
    * the full provider URL.
    */
   kind?: "directory" | "file" | "pull-request" | "thread";
+  /**
+   * Pull-request chips only: the `pr-chip--*` modifiers that give the chip its
+   * status color, resolved when the chip was minted. Persisted with the draft
+   * so a recovered chip comes back the color it had rather than a gray
+   * "status unknown" dot. Absent on drafts written before chips carried it.
+   */
+  prChipModifiers?: string[];
 };
 
 export type ComposerDraftSnapshotRecord = {


### PR DESCRIPTION
Follow-up to #1771 (squash-merged before these review fixes landed).

## The contract gap

Composer PR chips carry their `pr-chip--*` status modifiers on the mention token, and `useDurableComposerDraftStore` writes that token straight through `ComposerDraftSkillToken` into the recovery record — but the contract never declared the field.

TypeScript let it through (no excess-property check on a non-literal assignment), and `composer-draft-recovery-store` happens to round-trip the payload verbatim via `...draft`, so a recovered chip keeps its color today **by accident**. `snapshotFromDraftRecord` types the restored tokens as never having the field, so the moment that store normalizes tokens field-by-field — the way it already does for `imageAttachments` and `fileAttachments` — every recovered PR chip silently reverts to the gray "status unknown" dot, with no type error anywhere to catch it.

Declaring the optional field makes the persisted shape match what actually crosses the boundary.

## Missing coverage

The draft bar is a conditional child of the chip's Tiptap DOM spec (`modifiers.includes("pr-chip--draft")`), added in #1771 and asserted nowhere. An inverted condition, a wrong class name, or a malformed nested DOM-spec array would have left the suite green while a draft chip rendered as a lifted, bar-less label — the exact misalignment the branch exists to prevent. The restored-chip test now asserts the element.

## Verification

`typecheck` (shared + desktop), `lint:eslint` (0 errors), and the composer + draft-recovery suites (460 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)