### PR TITLE
fix(desktop): support slash commands in star map chat

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -178,10 +178,10 @@ export function CompactComposer(props: CompactComposerProps) {
     Boolean(segment),
   );
 
-  const send = useCallback(async () => {
+  const send = useCallback(async (commandText?: string) => {
     // The serialized text, not the plain draft: a mention chip is
     // zero-width until this splices its markdown back in.
-    const text = mentions.text.trim();
+    const text = (commandText ?? mentions.text).trim();
     if (!text) return;
     // Clear optimistically so the input frees up immediately, then put the
     // draft back — chips and all — if the send turned out to fail.
@@ -198,6 +198,21 @@ export function CompactComposer(props: CompactComposerProps) {
   // it has no binding for — Escape and Tab among them.
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (
+        event.key === "Enter"
+        && !event.shiftKey
+        && !event.altKey
+        && !event.metaKey
+        && !event.ctrlKey
+        && mentions.activeCommandText
+      ) {
+        // Enter runs the highlighted command in one step, matching the main
+        // composer. Tab and pointer selection still flow through the mention
+        // hook below and insert the command for further editing.
+        event.preventDefault();
+        void send(mentions.activeCommandText);
+        return;
+      }
       // An open mention popover claims the arrows, Enter, Tab, and Escape
       // before the send path sees them.
       if (mentions.handleKeyDown(event)) return;

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useId,
+  useMemo,
   useState,
   type ClipboardEvent,
   type DragEvent,
@@ -173,10 +174,6 @@ const MENU_VIEW_TITLES: Record<
  * line: chip on the left, Stop / Send pills on the right.
  */
 export function CompactComposer(props: CompactComposerProps) {
-  const mentions = useComposerMentions({
-    disabled: props.disabled,
-    sources: props.mentionSources,
-  });
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<SettingsMenuView>("root");
   const [imageAttachments, setImageAttachments] = useState<
@@ -187,6 +184,27 @@ export function CompactComposer(props: CompactComposerProps) {
   >([]);
   const [normalizingImageBatches, setNormalizingImageBatches] = useState(0);
   const normalizingImages = normalizingImageBatches > 0;
+  const hasAttachments =
+    imageAttachments.length > 0 || fileAttachments.length > 0;
+  const mentionSources = useMemo<ComposerMentionSources | undefined>(() => {
+    const sources = props.mentionSources;
+    if (
+      !hasAttachments
+      || !sources?.commands?.some((command) => command.requiresNoAttachments)
+    ) {
+      return sources;
+    }
+    return {
+      ...sources,
+      commands: sources.commands.filter(
+        (command) => !command.requiresNoAttachments,
+      ),
+    };
+  }, [hasAttachments, props.mentionSources]);
+  const mentions = useComposerMentions({
+    disabled: props.disabled,
+    sources: mentionSources,
+  });
   // Click-away and Escape close the menu, same hook as the composer
   // dropdowns. Without it the menu survives a click on the transcript
   // behind it and covers the conversation.

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -72,7 +72,7 @@ export type CompactComposerProps = {
   /** Thread's current fast-mode state, shown on the chip menu's toggle. */
   fastMode?: boolean;
   /**
-   * Populations the `$` / `@` / `#` popovers pick from. Optional on
+   * Populations the `$` / `/` / `@` / `#` popovers pick from. Optional on
    * purpose: a host that supplies nothing keeps the trigger characters as
    * literal prose, so adopting this component never requires them.
    */
@@ -124,10 +124,11 @@ const MENU_VIEW_TITLES: Record<
  * rather than hydrating it on focus, which would cost a click and a caret
  * every time the operator moved between cards.
  *
- * Mentions come from `useComposerMentions`, driven by whatever populations
- * the host can honestly supply through `mentionSources`. Nothing about the
- * pickers is re-implemented here: the triggers, ranking, token minting and
- * markdown serialization are the same modules the full composer calls.
+ * Mentions and slash commands come from `useComposerMentions`, driven by
+ * whatever populations the host can honestly supply through `mentionSources`.
+ * Nothing about the pickers is re-implemented here: the triggers, ranking,
+ * token minting and markdown serialization are the same modules the full
+ * composer calls.
  *
  * Model / reasoning / access render as a chip on a status strip below the
  * field — a strip, not ambient text inside the field, because the field

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -169,6 +169,7 @@ import {
   serializeDraftWithSkillTokens,
 } from "./composer-mention-tokens";
 import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
+import { findSlashCommandTrigger } from "./composer-slash-commands";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
 import { ProjectPicker } from "./ProjectPicker";
 import {
@@ -1127,27 +1128,6 @@ function buildConfiguredReviewCommand(
         displayText: "Review custom instructions",
       }
     : undefined;
-}
-
-function findSlashCommandTrigger(text: string, caret: number): {
-  end: number;
-  query: string;
-  start: number;
-} | undefined {
-  const prefix = text.slice(0, caret);
-  if (/\s$/.test(prefix)) {
-    return undefined;
-  }
-  const match = /^\/([^\r\n]*)$/.exec(prefix);
-  if (!match) {
-    return undefined;
-  }
-
-  return {
-    start: 0,
-    end: caret,
-    query: match[1] ?? "",
-  };
 }
 
 function formatDraftPreview(draft: QueuedTurnDraft): string {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -68,6 +68,29 @@ describe("CompactComposer", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
+  it("inserts a slash command from the shared autocomplete", async () => {
+    renderComposer({
+      mentionSources: {
+        commands: [
+          {
+            name: "session-info",
+            description: "Show ACP session details",
+            sourceLabel: "Grok",
+          },
+        ],
+      },
+    });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "/ses" } });
+    fireEvent.click(
+      screen.getByRole("option", { name: /\/session-info/i }),
+    );
+
+    await waitFor(() => {
+      expect((input as HTMLTextAreaElement).value).toBe("/session-info ");
+    });
+  });
+
   it("shows model, effort, and access mode as the status chip", () => {
     renderComposer({
       executionMode: "full-access",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -91,6 +91,53 @@ describe("CompactComposer", () => {
     });
   });
 
+  it.each([
+    ["review", "PwrAgent"],
+    ["compact", "Codex"],
+  ])("sends exact /%s on the first Enter", async (command, sourceLabel) => {
+    const { onSend } = renderComposer({
+      mentionSources: {
+        commands: [
+          {
+            name: command,
+            description: `Run ${command}`,
+            sourceLabel,
+          },
+        ],
+      },
+    });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: `/${command}` } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+      expect(onSend).toHaveBeenCalledWith(`/${command}`);
+    });
+  });
+
+  it("keeps Tab as autocomplete insertion for an exact slash command", async () => {
+    const { onSend } = renderComposer({
+      mentionSources: {
+        commands: [
+          {
+            name: "review",
+            description: "Review current changes",
+            sourceLabel: "PwrAgent",
+          },
+        ],
+      },
+    });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Tab" });
+
+    await waitFor(() => {
+      expect((input as HTMLTextAreaElement).value).toBe("/review ");
+    });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it("shows model, effort, and access mode as the status chip", () => {
     renderComposer({
       executionMode: "full-access",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -91,6 +91,39 @@ describe("CompactComposer", () => {
     });
   });
 
+  it("sends the highlighted slash command on the first Enter", async () => {
+    const { onSend } = renderComposer({
+      mentionSources: {
+        commands: [
+          {
+            name: "review",
+            description: "Review current changes",
+            sourceLabel: "PwrAgent",
+          },
+          {
+            name: "mcp",
+            description: "List MCP tools",
+            sourceLabel: "Codex",
+          },
+        ],
+      },
+    });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "/" } });
+    expect(
+      screen.getByRole("option", { name: /\/review/i }).getAttribute(
+        "aria-selected",
+      ),
+    ).toBe("true");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+      expect(onSend).toHaveBeenCalledWith("/review");
+    });
+  });
+
   it.each([
     ["review", "PwrAgent"],
     ["compact", "Codex"],

--- a/apps/desktop/src/renderer/src/features/composer/composer-slash-commands.ts
+++ b/apps/desktop/src/renderer/src/features/composer/composer-slash-commands.ts
@@ -1,0 +1,55 @@
+export type ComposerSlashCommand = {
+  aliases?: readonly string[];
+  description?: string;
+  name: string;
+  sourceLabel: string;
+};
+
+export function normalizeSlashCommandName(name: string): string {
+  return name.startsWith("/") ? name.slice(1) : name;
+}
+
+export function findSlashCommandTrigger(
+  text: string,
+  caret: number,
+): {
+  end: number;
+  query: string;
+  start: number;
+} | undefined {
+  const prefix = text.slice(0, caret);
+  if (/\s$/.test(prefix)) {
+    return undefined;
+  }
+  const match = /^\/([^\r\n]*)$/.exec(prefix);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    start: 0,
+    end: caret,
+    query: match[1] ?? "",
+  };
+}
+
+export function filterSlashCommandCandidates(
+  commands: readonly ComposerSlashCommand[],
+  query: string,
+): ComposerSlashCommand[] {
+  const typed = `/${query}`.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+  return commands.filter((command) => {
+    const name = normalizeSlashCommandName(command.name);
+    return (
+      `/${name}`.toLowerCase().startsWith(typed)
+      || (command.aliases ?? []).some((alias) =>
+        `/${normalizeSlashCommandName(alias)}`.toLowerCase().startsWith(typed)
+      )
+      || Boolean(
+        normalizedQuery
+        && command.description?.toLowerCase().includes(normalizedQuery),
+      )
+    );
+  });
+}

--- a/apps/desktop/src/renderer/src/features/composer/composer-slash-commands.ts
+++ b/apps/desktop/src/renderer/src/features/composer/composer-slash-commands.ts
@@ -53,3 +53,18 @@ export function filterSlashCommandCandidates(
     );
   });
 }
+
+export function slashCommandMatchesText(
+  command: ComposerSlashCommand,
+  text: string,
+): boolean {
+  const normalizedText = text.toLowerCase();
+  const commandName = `/${normalizeSlashCommandName(command.name)}`;
+  return (
+    commandName.toLowerCase() === normalizedText
+    || (command.aliases ?? []).some(
+      (alias) =>
+        `/${normalizeSlashCommandName(alias)}`.toLowerCase() === normalizedText,
+    )
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/composer-slash-commands.ts
+++ b/apps/desktop/src/renderer/src/features/composer/composer-slash-commands.ts
@@ -2,6 +2,8 @@ export type ComposerSlashCommand = {
   aliases?: readonly string[];
   description?: string;
   name: string;
+  /** Hide this client action while the compact composer holds attachments. */
+  requiresNoAttachments?: boolean;
   sourceLabel: string;
 };
 

--- a/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
@@ -107,6 +107,8 @@ export type ComposerMentionDraft = {
 };
 
 export type ComposerMentions = {
+  /** Canonical text for the highlighted runnable slash command. */
+  activeCommandText?: string;
   /** `aria-activedescendant` for the editor while a popover is open. */
   activeOptionId?: string;
   clear: () => void;
@@ -782,8 +784,15 @@ export function useComposerMentions(params: {
       {options}
     </div>
   ) : null;
+  const activeCommand =
+    open && kind === "commands"
+      ? commandOptions[activeOption] ?? commandOptions[0]
+      : undefined;
 
   return {
+    activeCommandText: activeCommand
+      ? `/${normalizeSlashCommandName(activeCommand.name)}`
+      : undefined,
     activeOptionId: open ? optionId(activeOption) : undefined,
     clear: () => {
       pendingProgrammaticChangeRef.current = undefined;

--- a/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
@@ -50,6 +50,12 @@ import {
   resolveThreadSummaryReference,
   serializeDraftWithSkillTokens,
 } from "./composer-mention-tokens";
+import {
+  filterSlashCommandCandidates,
+  findSlashCommandTrigger,
+  normalizeSlashCommandName,
+  type ComposerSlashCommand,
+} from "./composer-slash-commands";
 import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
 
 /**
@@ -57,7 +63,8 @@ import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
  *
  * Every field is optional and an absent one simply retires its trigger
  * character back to prose — a host that supplies nothing gets exactly the
- * literal `$`/`@`/`#` behaviour the compact composer had before mentions
+ * literal `$`, `/`, `@`, and `#` behaviour the compact composer had before
+ * mentions
  * existed. That is deliberate: `CompactComposer` is shared, and a required
  * source would be a breaking change for the next surface that adopts it.
  *
@@ -67,6 +74,8 @@ import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
  * for a list the operator may never ask for.
  */
 export type ComposerMentionSources = {
+  /** Slash commands offered by PwrAgent and the active provider. */
+  commands?: readonly ComposerSlashCommand[];
   /**
    * Identity key of the thread being written in. Never offered as a `#`
    * candidate — referencing the current thread tells the agent nothing it
@@ -77,7 +86,7 @@ export type ComposerMentionSources = {
   directories?: readonly NavigationDirectorySummary[];
   /** Called when `@` or `#` opens a popover. */
   ensureNavigationLoaded?: () => void;
-  /** Called when `$` opens a popover. */
+  /** Called when `$` or `/` opens a popover. */
   ensureSkillsLoaded?: () => void;
   /**
    * Peer thread search behind `#`. Omitted leaves `#` local-only; the
@@ -122,14 +131,15 @@ export type ComposerMentions = {
   text: string;
 };
 
-type MentionKind = "directories" | "hash" | "skills";
+type MentionKind = "commands" | "directories" | "hash" | "skills";
 
+const NO_COMMANDS: readonly ComposerSlashCommand[] = [];
 const NO_DIRECTORIES: readonly NavigationDirectorySummary[] = [];
 const NO_SKILLS: readonly AppServerSkillSummary[] = [];
 const NO_THREADS: readonly NavigationThreadSummary[] = [];
 
 /**
- * Mention autocomplete for a compact composer.
+ * Mention and command autocomplete for a compact composer.
  *
  * The full composer's popovers are woven through a 12,000-line component
  * that also owns queued turns, review mode, attachments, and draft
@@ -199,6 +209,7 @@ export function useComposerMentions(params: {
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   const skills = sources?.skills ?? NO_SKILLS;
+  const commands = sources?.commands ?? NO_COMMANDS;
   const directories = sources?.directories ?? NO_DIRECTORIES;
   const threads = sources?.threads ?? NO_THREADS;
 
@@ -210,6 +221,7 @@ export function useComposerMentions(params: {
     draft.length,
   );
   const skillTrigger = findSkillTrigger(draft, selectionStart);
+  const slashTrigger = findSlashCommandTrigger(draft, selectionStart);
   const directoryTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
   const rawHashTrigger = findHashReferenceTrigger(draft, selectionStart);
   const hashTrigger =
@@ -219,6 +231,7 @@ export function useComposerMentions(params: {
       : undefined;
 
   const skillQuery = skillTrigger?.query;
+  const slashQuery = slashTrigger?.query;
   const directoryQuery = directoryTrigger?.query;
   const hashQuery = hashTrigger?.query;
 
@@ -245,6 +258,13 @@ export function useComposerMentions(params: {
         : filterSkillAutocompleteCandidates(skills, skillQuery),
     [skillQuery, skills],
   );
+  const commandOptions = useMemo(
+    () =>
+      slashQuery === undefined
+        ? []
+        : filterSlashCommandCandidates(commands, slashQuery),
+    [commands, slashQuery],
+  );
   const directoryOptions = useMemo(
     () =>
       directoryQuery === undefined
@@ -270,6 +290,8 @@ export function useComposerMentions(params: {
   const kind: MentionKind | undefined =
     skillTrigger && skillOptions.length > 0
       ? "skills"
+      : slashTrigger && commandOptions.length > 0
+        ? "commands"
       : directoryTrigger && directoryOptions.length > 0
         ? "directories"
         : hashTrigger && hashOptions.length > 0
@@ -278,12 +300,16 @@ export function useComposerMentions(params: {
   const query =
     kind === "skills"
       ? (skillQuery ?? "")
+      : kind === "commands"
+        ? (slashQuery ?? "")
       : kind === "directories"
         ? (directoryQuery ?? "")
         : (hashQuery ?? "");
   const optionCount =
     kind === "skills"
       ? skillOptions.length
+      : kind === "commands"
+        ? commandOptions.length
       : kind === "directories"
         ? directoryOptions.length
         : kind === "hash"
@@ -292,6 +318,8 @@ export function useComposerMentions(params: {
   const activeTrigger =
     kind === "skills"
       ? skillTrigger
+      : kind === "commands"
+        ? slashTrigger
       : kind === "directories"
         ? directoryTrigger
         : kind === "hash"
@@ -314,7 +342,7 @@ export function useComposerMentions(params: {
     Boolean(kind) && !params.disabled && dismissKey !== dismissedKey;
   const activeOption = Math.min(activeIndex, Math.max(optionCount - 1, 0));
 
-  const skillsTriggered = Boolean(skillTrigger);
+  const skillsTriggered = Boolean(skillTrigger || slashTrigger);
   const navigationTriggered = Boolean(directoryTrigger || rawHashTrigger);
   const ensureSkillsLoaded = sources?.ensureSkillsLoaded;
   const ensureNavigationLoaded = sources?.ensureNavigationLoaded;
@@ -479,11 +507,53 @@ export function useComposerMentions(params: {
     });
   };
 
+  const insertCommand = (
+    trigger: { end: number; start: number },
+    command: ComposerSlashCommand,
+  ): void => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    const caret = Math.min(input.selectionStart ?? draft.length, draft.length);
+    const selectionEnd = Math.min(input.selectionEnd ?? caret, draft.length);
+    const before = draft.slice(0, trigger.start);
+    const after = draft.slice(Math.max(trigger.end, selectionEnd));
+    const insertText = `/${normalizeSlashCommandName(command.name)}`;
+    const trailingSpace = /^\s/.test(after) ? "" : " ";
+    const nextDraft = `${before}${insertText}${trailingSpace}${after}`;
+    const nextSelection = before.length + insertText.length + trailingSpace.length;
+    const nextSkillTokens = adjustSkillTokenIndexesForTextChange({
+      currentDraft: draft,
+      nextDraft,
+      skillTokens,
+    });
+
+    pendingProgrammaticChangeRef.current = {
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    flushSync(() => {
+      setContent({ draft: nextDraft, skillTokens: nextSkillTokens });
+      setActiveIndex(0);
+    });
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
+  };
+
   const commit = (index: number): void => {
     if (kind === "skills" && skillTrigger) {
       const skill = skillOptions[index] ?? skillOptions[0];
       if (skill) {
         insertToken(skillTrigger, (at) => createComposerSkillToken(skill, at));
+      }
+      return;
+    }
+    if (kind === "commands" && slashTrigger) {
+      const command = commandOptions[index] ?? commandOptions[0];
+      if (command) {
+        insertCommand(slashTrigger, command);
       }
       return;
     }
@@ -595,6 +665,25 @@ export function useComposerMentions(params: {
         { title: buildSkillTooltip(skill) || undefined },
       ),
     );
+  } else if (kind === "commands") {
+    label = "Commands";
+    options = commandOptions.map((command, index) => {
+      const name = normalizeSlashCommandName(command.name);
+      return renderOption(
+        index,
+        <>
+          <span className="compact-composer__mention-title">
+            <HighlightedAutocompleteLabel
+              label={`/${name}`}
+              query={query ? `/${query}` : "/"}
+            />
+          </span>
+          <span className="compact-composer__mention-meta">
+            {[command.sourceLabel, command.description].filter(Boolean).join(" · ")}
+          </span>
+        </>,
+      );
+    });
   } else if (kind === "directories") {
     label = "Directories";
     options = directoryOptions.map((directory, index) =>

--- a/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerMentions.tsx
@@ -54,6 +54,7 @@ import {
   filterSlashCommandCandidates,
   findSlashCommandTrigger,
   normalizeSlashCommandName,
+  slashCommandMatchesText,
   type ComposerSlashCommand,
 } from "./composer-slash-commands";
 import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
@@ -606,6 +607,19 @@ export function useComposerMentions(params: {
       (event.key === "Enter" && !event.shiftKey && !event.altKey)
       || (event.key === "Tab" && !event.shiftKey)
     ) {
+      if (
+        event.key === "Enter"
+        && kind === "commands"
+        && slashTrigger
+        && commandOptions.some((command) =>
+          slashCommandMatchesText(command, `/${slashTrigger.query}`)
+        )
+      ) {
+        // An exact command is already runnable. Leave Enter to the composer
+        // send path; Tab and pointer selection still perform insertion so
+        // autocomplete remains useful while the operator is composing one.
+        return false;
+      }
       event.preventDefault();
       commit(activeOption);
       return true;

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -15,6 +15,7 @@ import {
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
+import { formatBackendLabel } from "../../lib/backend-label";
 import { useBackendSummaries } from "../../lib/useBackendSummaries";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
@@ -29,6 +30,7 @@ import { useTranscriptWindow } from "../thread-detail/useTranscriptWindow";
 import { collectEditedFileGroups } from "../thread-detail/edited-file-groups";
 import { DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT } from "../../lib/thread-history-limits";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { parseReviewCommand } from "../../../../shared/review-command";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { useThreadSessionState } from "../../lib/useThreadSessionState";
 import { useThreadSkills } from "../../lib/useThreadSkills";
@@ -222,6 +224,19 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const ensureSkillsLoaded = threadSkills.ensureLoaded;
   const mentionSources = useMemo<ComposerMentionSources>(
     () => ({
+      commands: [
+        {
+          name: "review",
+          description: "Review current staged, unstaged, and untracked changes",
+          sourceLabel: "PwrAgent",
+        },
+        ...threadSkills.providerCommands.map((command) => ({
+          aliases: command.aliases,
+          description: command.description,
+          name: command.name,
+          sourceLabel: formatBackendLabel(command.backend ?? thread.source),
+        })),
+      ],
       currentThreadKey: buildThreadIdentityKey(thread.source, thread.id),
       directories: navigationSources.directories,
       ensureNavigationLoaded: navigationSources.ensureLoaded,
@@ -238,6 +253,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       navigationSources.directories,
       navigationSources.ensureLoaded,
       navigationSources.threads,
+      threadSkills.providerCommands,
       threadSkills.skills,
       thread.id,
       thread.source,
@@ -360,6 +376,61 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     async (text: string): Promise<boolean> => {
       setSendError(undefined);
       setSendNotice(undefined);
+
+      const reviewCommand = parseReviewCommand(text);
+      if (reviewCommand) {
+        if (sessionRef.current.threadBusy) {
+          setSendError("Cannot start a review while a turn is in progress.");
+          return false;
+        }
+        if (!desktopApi?.startReview) {
+          setSendError("Review is not available for this thread.");
+          return false;
+        }
+        try {
+          await desktopApi.startReview({
+            backend: thread.source,
+            federationTarget,
+            threadId: thread.id,
+            target: reviewCommand.target,
+            delivery: "inline",
+          });
+          return true;
+        } catch (error) {
+          setSendError(
+            error instanceof Error
+              ? error.message
+              : "Could not start that review.",
+          );
+          return false;
+        }
+      }
+
+      if (text.trim().toLowerCase() === "/compact") {
+        if (sessionRef.current.threadBusy) {
+          setSendError("Cannot compact while a turn is in progress.");
+          return false;
+        }
+        if (!desktopApi?.compactThread) {
+          setSendError("Compaction is not available for this thread.");
+          return false;
+        }
+        try {
+          await desktopApi.compactThread({
+            backend: thread.source,
+            federationTarget,
+            threadId: thread.id,
+          });
+          return true;
+        } catch (error) {
+          setSendError(
+            error instanceof Error
+              ? error.message
+              : "Could not compact the thread.",
+          );
+          return false;
+        }
+      }
 
       if (sessionRef.current.threadBusy) {
         if (!desktopApi?.steerTurn) {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -44,6 +44,10 @@ import {
   resizeChatCardRect,
   type ChatCardRect,
 } from "./star-map-chat-card-geometry";
+import {
+  StarMapReviewSetup,
+  type StarMapReviewRequest,
+} from "./StarMapReviewSetup";
 
 export type StarMapChatCardProps = {
   cardKey: string;
@@ -117,6 +121,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const rectRef = useRef(rect);
   rectRef.current = rect;
   const [sendError, setSendError] = useState<string | undefined>(undefined);
+  const [reviewSetupOpen, setReviewSetupOpen] = useState(false);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
+  const [reviewError, setReviewError] = useState<string | undefined>(undefined);
   // Where a mid-turn send actually landed. The operator cannot tell a steer
   // from a queue by looking at the transcript, and the answer differs by
   // backend, so the card says which one happened.
@@ -222,6 +229,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const threadSkills = useThreadSkills({ desktopApi, thread });
   const navigationSources = useComposerMentionSources({ desktopApi });
   const ensureSkillsLoaded = threadSkills.ensureLoaded;
+  const ensureNavigationLoaded = navigationSources.ensureLoaded;
   const mentionSources = useMemo<ComposerMentionSources>(
     () => ({
       commands: [
@@ -239,7 +247,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       ],
       currentThreadKey: buildThreadIdentityKey(thread.source, thread.id),
       directories: navigationSources.directories,
-      ensureNavigationLoaded: navigationSources.ensureLoaded,
+      ensureNavigationLoaded,
       ensureSkillsLoaded: () => {
         void ensureSkillsLoaded();
       },
@@ -251,7 +259,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       desktopApi,
       ensureSkillsLoaded,
       navigationSources.directories,
-      navigationSources.ensureLoaded,
+      ensureNavigationLoaded,
       navigationSources.threads,
       threadSkills.providerCommands,
       threadSkills.skills,
@@ -360,6 +368,46 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
    */
   const canSteer = Boolean(desktopApi?.steerTurn);
 
+  const closeReviewSetup = useCallback(() => {
+    if (reviewSubmitting) return;
+    setReviewError(undefined);
+    setReviewSetupOpen(false);
+  }, [reviewSubmitting]);
+
+  const submitReviewSetup = useCallback(
+    async (request: StarMapReviewRequest): Promise<void> => {
+      if (sessionRef.current.threadBusy) {
+        setReviewError("Cannot start a review while a turn is in progress.");
+        return;
+      }
+      if (!desktopApi?.startReview) {
+        setReviewError("Review is not available for this thread.");
+        return;
+      }
+      setReviewError(undefined);
+      setReviewSubmitting(true);
+      try {
+        await desktopApi.startReview({
+          backend: thread.source,
+          federationTarget,
+          threadId: thread.id,
+          ...request,
+          delivery: "inline",
+        });
+        setReviewSetupOpen(false);
+      } catch (error) {
+        setReviewError(
+          error instanceof Error
+            ? error.message
+            : "Could not start that review.",
+        );
+      } finally {
+        setReviewSubmitting(false);
+      }
+    },
+    [desktopApi, federationTarget, thread.id, thread.source],
+  );
+
   /**
    * Returns whether the turn actually reached the backend. A peer can drop
    * mid-send, and when it does the operator must get their text back and
@@ -386,6 +434,12 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         if (!desktopApi?.startReview) {
           setSendError("Review is not available for this thread.");
           return false;
+        }
+        if (text.trim().toLowerCase() === "/review") {
+          setReviewError(undefined);
+          setReviewSetupOpen(true);
+          ensureNavigationLoaded();
+          return true;
         }
         try {
           await desktopApi.startReview({
@@ -503,6 +557,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       cardKey,
       desktopApi,
       federationTarget,
+      ensureNavigationLoaded,
       thread.id,
       thread.source,
     ],
@@ -910,53 +965,68 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         </button>
       </header>
 
-      <div className="star-map-chat-card__transcript">
-        <TranscriptList
-          activeTurnId={session.activeTurnId}
-          activeTurnStartedAt={session.activeTurnStartedAt}
-          desktopApi={desktopApi}
-          entries={transcriptWindow.visibleEntries}
-          error={session.error}
-          loading={session.loading}
-          loadingMore={session.loadingMore}
-          onLoadOlder={transcriptWindow.loadOlder}
-          pagination={transcriptWindow.visiblePagination}
-          parentThreadId={thread.id}
-          pendingAssistantMessage={session.pendingAssistantMessage}
-          pendingMcpInteraction={session.pendingMcpInteraction}
-          pendingRequest={session.pendingRequest}
-          pendingStatusText={session.pendingStatusText}
-          pendingUserInput={session.pendingUserInput}
-          runningTurnUsageText={session.runningTurnUsageText}
-          threadId={thread.id}
-          transientMessages={session.transientMessages}
+      <div className="star-map-chat-card__body">
+        <div className="star-map-chat-card__transcript">
+          <TranscriptList
+            activeTurnId={session.activeTurnId}
+            activeTurnStartedAt={session.activeTurnStartedAt}
+            desktopApi={desktopApi}
+            entries={transcriptWindow.visibleEntries}
+            error={session.error}
+            loading={session.loading}
+            loadingMore={session.loadingMore}
+            onLoadOlder={transcriptWindow.loadOlder}
+            pagination={transcriptWindow.visiblePagination}
+            parentThreadId={thread.id}
+            pendingAssistantMessage={session.pendingAssistantMessage}
+            pendingMcpInteraction={session.pendingMcpInteraction}
+            pendingRequest={session.pendingRequest}
+            pendingStatusText={session.pendingStatusText}
+            pendingUserInput={session.pendingUserInput}
+            runningTurnUsageText={session.runningTurnUsageText}
+            threadId={thread.id}
+            transientMessages={session.transientMessages}
+          />
+        </div>
+
+        {sendError ? (
+          <p className="star-map-chat-card__error" role="alert">
+            {sendError}
+          </p>
+        ) : sendNotice ? (
+          <p className="star-map-chat-card__notice" role="status">
+            {sendNotice}
+          </p>
+        ) : undefined}
+
+        <MemoizedCompactComposer
+          busy={session.threadBusy}
+          canSteer={canSteer}
+          disabled={reviewSetupOpen}
+          executionMode={threadExecutionMode}
+          fastMode={threadFastMode}
+          mentionSources={mentionSources}
+          model={threadModel}
+          onInterrupt={onInterrupt}
+          onSend={send}
+          reasoningEffort={threadReasoningEffort}
+          secondaryActions={secondaryActions}
+          settingsMenu={settingsMenu}
+          threadTitle={thread.title}
         />
+
+        {reviewSetupOpen ? (
+          <StarMapReviewSetup
+            busy={session.threadBusy}
+            directories={navigationSources.directories}
+            error={reviewError}
+            onCancel={closeReviewSetup}
+            onSubmit={submitReviewSetup}
+            submitting={reviewSubmitting}
+            thread={thread}
+          />
+        ) : null}
       </div>
-
-      {sendError ? (
-        <p className="star-map-chat-card__error" role="alert">
-          {sendError}
-        </p>
-      ) : sendNotice ? (
-        <p className="star-map-chat-card__notice" role="status">
-          {sendNotice}
-        </p>
-      ) : undefined}
-
-      <MemoizedCompactComposer
-        busy={session.threadBusy}
-        canSteer={canSteer}
-        executionMode={threadExecutionMode}
-        fastMode={threadFastMode}
-        mentionSources={mentionSources}
-        model={threadModel}
-        onInterrupt={onInterrupt}
-        onSend={send}
-        reasoningEffort={threadReasoningEffort}
-        secondaryActions={secondaryActions}
-        settingsMenu={settingsMenu}
-        threadTitle={thread.title}
-      />
 
       {titleTooltip.tooltipNode}
       <span

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -181,6 +181,30 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     () => threadFederationTarget ?? readRendererFederationTarget(),
     [threadFederationTarget],
   );
+  const isAcpThread = thread.source.startsWith("acp:");
+  const [settingsMenuOpened, setSettingsMenuOpened] = useState(false);
+  const backendSummaries = useBackendSummaries(desktopApi, {
+    // Codex review is native and needs no describe. ACP review is a
+    // PwrAgent-managed child, so its explicit capability is authoritative
+    // even before the settings menu has ever been opened.
+    enabled: settingsMenuOpened || isAcpThread,
+    federationTarget,
+  });
+  const backendSummariesRef = useRef(backendSummaries);
+  backendSummariesRef.current = backendSummaries;
+  const onSettingsMenuOpen = useCallback(() => {
+    setSettingsMenuOpened(true);
+    // A failed describe retries on the next open through the hook's
+    // exported refresh path (a plain re-list for remote targets).
+    if (backendSummariesRef.current.error) {
+      void backendSummariesRef.current.refreshAcpAgents();
+    }
+  }, []);
+  const backendSummary = backendSummaries.backends.find(
+    (entry) => entry.kind === thread.source,
+  );
+  const supportsReview =
+    !isAcpThread || backendSummary?.capabilities.startReview === true;
 
   // The context satellite is a sibling rendered by the screen, so the session
   // data its panels need has to be published rather than passed down.
@@ -243,17 +267,33 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const mentionSources = useMemo<ComposerMentionSources>(
     () => ({
       commands: [
-        {
-          name: "review",
-          description: "Review current staged, unstaged, and untracked changes",
-          sourceLabel: "PwrAgent",
-        },
-        ...threadSkills.providerCommands.map((command) => ({
-          aliases: command.aliases,
-          description: command.description,
-          name: command.name,
-          sourceLabel: formatBackendLabel(command.backend ?? thread.source),
-        })),
+        ...(supportsReview
+          ? [
+              {
+                name: "review",
+                description:
+                  "Review current staged, unstaged, and untracked changes",
+                requiresNoAttachments: true,
+                sourceLabel: "PwrAgent",
+              },
+            ]
+          : []),
+        ...threadSkills.providerCommands.map((command) => {
+          const commandBackend = command.backend ?? thread.source;
+          const commandName = command.name.startsWith("/")
+            ? command.name.slice(1)
+            : command.name;
+          return {
+            aliases: command.aliases,
+            description: command.description,
+            name: command.name,
+            // Codex compaction is a client action. ACP commands remain
+            // ordinary prompt content and may accompany attachments.
+            requiresNoAttachments:
+              commandBackend === "codex" && commandName === "compact",
+            sourceLabel: formatBackendLabel(commandBackend),
+          };
+        }),
       ],
       currentThreadKey: buildThreadIdentityKey(thread.source, thread.id),
       directories: navigationSources.directories,
@@ -271,6 +311,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       navigationSources.directories,
       ensureNavigationLoaded,
       navigationSources.threads,
+      supportsReview,
       threadSkills.providerCommands,
       threadSkills.skills,
       thread.id,
@@ -391,6 +432,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
 
   const submitReviewSetup = useCallback(
     async (request: StarMapReviewRequest): Promise<void> => {
+      if (!supportsReview) {
+        setReviewError("Selected backend does not support reviews.");
+        return;
+      }
       if (sessionRef.current.threadBusy) {
         setReviewError("Cannot start a review while a turn is in progress.");
         return;
@@ -426,7 +471,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         setReviewSubmitting(false);
       }
     },
-    [desktopApi, federationTarget, thread.id, thread.source],
+    [desktopApi, federationTarget, supportsReview, thread.id, thread.source],
   );
 
   /**
@@ -483,8 +528,12 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         })),
       ];
 
-      const reviewCommand = parseReviewCommand(text);
+      const reviewCommand = supportsReview ? parseReviewCommand(text) : undefined;
       if (reviewCommand) {
+        if (imageAttachments.length > 0 || fileAttachments.length > 0) {
+          setSendError("/review does not accept attachments.");
+          return false;
+        }
         if (sessionRef.current.threadBusy) {
           setSendError("Cannot start a review while a turn is in progress.");
           return false;
@@ -518,7 +567,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         }
       }
 
-      if (text.trim().toLowerCase() === "/compact") {
+      if (
+        thread.source === "codex"
+        && text.trim().toLowerCase() === "/compact"
+      ) {
+        if (imageAttachments.length > 0 || fileAttachments.length > 0) {
+          setSendError("/compact does not accept attachments.");
+          return false;
+        }
         if (sessionRef.current.threadBusy) {
           setSendError("Cannot compact while a turn is in progress.");
           return false;
@@ -622,6 +678,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       desktopApi,
       federationTarget,
       ensureNavigationLoaded,
+      supportsReview,
       thread.id,
       thread.source,
     ],
@@ -663,25 +720,6 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   // on its props staying stable across snapshot refreshes.
   const threadRef = useRef(thread);
   threadRef.current = thread;
-
-  const [settingsMenuOpened, setSettingsMenuOpened] = useState(false);
-  const backendSummaries = useBackendSummaries(desktopApi, {
-    enabled: settingsMenuOpened,
-    federationTarget,
-  });
-  const backendSummariesRef = useRef(backendSummaries);
-  backendSummariesRef.current = backendSummaries;
-  const onSettingsMenuOpen = useCallback(() => {
-    setSettingsMenuOpened(true);
-    // A failed describe retries on the next open through the hook's
-    // exported refresh path (a plain re-list for remote targets).
-    if (backendSummariesRef.current.error) {
-      void backendSummariesRef.current.refreshAcpAgents();
-    }
-  }, []);
-  const backendSummary = backendSummaries.backends.find(
-    (entry) => entry.kind === thread.source,
-  );
 
   /**
    * Optimistic view of the chip's settings between a menu selection and

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -124,6 +124,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const [reviewSetupOpen, setReviewSetupOpen] = useState(false);
   const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [reviewError, setReviewError] = useState<string | undefined>(undefined);
+  const [reviewComposerKey, setReviewComposerKey] = useState(0);
   // Where a mid-turn send actually landed. The operator cannot tell a steer
   // from a queue by looking at the transcript, and the answer differs by
   // backend, so the card says which one happened.
@@ -372,6 +373,11 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     if (reviewSubmitting) return;
     setReviewError(undefined);
     setReviewSetupOpen(false);
+    // The editability transaction can echo Tiptap's pre-disable document
+    // after the send path cleared it. Remounting only at this explicit review
+    // boundary gives Cancel/Escape the main composer's clean-slate contract
+    // without discarding ordinary card drafts on unrelated renders.
+    setReviewComposerKey((current) => current + 1);
   }, [reviewSubmitting]);
 
   const submitReviewSetup = useCallback(
@@ -386,6 +392,12 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       }
       setReviewError(undefined);
       setReviewSubmitting(true);
+      // Match the main review composer: accepting the configured request
+      // closes the setup immediately. review/start can spend noticeable time
+      // resolving its model, workspace, and managed-child path; keeping the
+      // form onscreen until that promise settles makes a real click look dead.
+      setReviewSetupOpen(false);
+      setReviewComposerKey((current) => current + 1);
       try {
         await desktopApi.startReview({
           backend: thread.source,
@@ -396,7 +408,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         });
         setReviewSetupOpen(false);
       } catch (error) {
-        setReviewError(
+        setSendError(
           error instanceof Error
             ? error.message
             : "Could not start that review.",
@@ -1002,9 +1014,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         <MemoizedCompactComposer
           busy={session.threadBusy}
           canSteer={canSteer}
-          disabled={reviewSetupOpen}
+          disabled={reviewSetupOpen || reviewSubmitting}
           executionMode={threadExecutionMode}
           fastMode={threadFastMode}
+          key={reviewComposerKey}
           mentionSources={mentionSources}
           model={threadModel}
           onInterrupt={onInterrupt}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   useState,
   type FormEvent,
-  type KeyboardEvent,
 } from "react";
 import {
   buildReviewBranchOptions,
@@ -162,6 +161,7 @@ function buildReviewRequest(params: {
 }
 
 export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
+  const { busy, onCancel, onSubmit, submitting } = props;
   const workspaceOptions = useMemo(
     () => buildReviewWorkspaceOptions(props.thread),
     [props.thread],
@@ -185,11 +185,18 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
   const [commit, setCommit] = useState("");
   const [customInstructions, setCustomInstructions] = useState("");
   const targetRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const dialogRef = useRef<HTMLElement | null>(null);
   const branchListId = useId();
   const commitListId = useId();
 
   useEffect(() => {
-    targetRefs.current[0]?.focus();
+    // The compact editor also synchronizes editability when this mounts and
+    // can reclaim focus during that transaction. Focus one frame later, as
+    // the main review composer does, so keyboard commands land in the setup.
+    const frame = requestAnimationFrame(() => {
+      targetRefs.current[0]?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
   }, []);
 
   useEffect(() => {
@@ -198,38 +205,114 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
     }
   }, [branchEdited, branchOptions]);
 
-  const request = buildReviewRequest({
-    branch,
-    commit,
-    customInstructions,
-    target,
-    workspaceCwd,
-  });
+  const request = useMemo(
+    () => buildReviewRequest({
+      branch,
+      commit,
+      customInstructions,
+      target,
+      workspaceCwd,
+    }),
+    [branch, commit, customInstructions, target, workspaceCwd],
+  );
   const workspaceSelectionRequired = workspaceOptions.length > 1;
   const canSubmit = Boolean(
     request
     && (!workspaceSelectionRequired || workspaceCwd)
-    && !props.busy
-    && !props.submitting,
+    && !busy
+    && !submitting,
   );
 
   const submit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    if (canSubmit && request) props.onSubmit(request);
+    if (canSubmit && request) onSubmit(request);
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLElement>): void => {
-    if (event.key !== "Escape" || props.submitting) return;
-    event.preventDefault();
-    event.stopPropagation();
-    props.onCancel();
-  };
+  useEffect(() => {
+    const handleKeyDown = (event: globalThis.KeyboardEvent): void => {
+      const dialog = dialogRef.current;
+      const targetNode = event.target;
+      if (!dialog || !(targetNode instanceof Node)) return;
+      const ownerCard = dialog.closest(".star-map-chat-card");
+      if (!ownerCard?.contains(targetNode)) return;
+
+      if (event.key === "Escape" && !submitting) {
+        event.preventDefault();
+        event.stopPropagation();
+        onCancel();
+        return;
+      }
+      if (
+        event.key !== "Enter"
+        || event.shiftKey
+        || event.altKey
+        || event.metaKey
+        || event.ctrlKey
+      ) {
+        return;
+      }
+
+      const targetElement =
+        targetNode instanceof HTMLElement ? targetNode : undefined;
+      const insideDialog = dialog.contains(targetNode);
+      const insideDisabledComposer = Boolean(
+        targetElement?.closest(".compact-composer"),
+      );
+      if (!insideDialog && !insideDisabledComposer) return;
+      if (
+        targetElement?.closest("textarea, select")
+        || targetElement?.closest("[data-review-dismiss]")
+      ) {
+        return;
+      }
+
+      const requestedTarget = targetElement
+        ?.closest<HTMLElement>("[data-review-target]")
+        ?.dataset.reviewTarget as ReviewTargetChoice | undefined;
+      const nextRequest = requestedTarget
+        ? buildReviewRequest({
+            branch,
+            commit,
+            customInstructions,
+            target: requestedTarget,
+            workspaceCwd,
+          })
+        : request;
+      if (
+        !nextRequest
+        || (workspaceSelectionRequired && !workspaceCwd)
+        || busy
+        || submitting
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      onSubmit(nextRequest);
+    };
+
+    // Capture is intentional: the Star Map layer owns Escape at its root,
+    // while the disabled editor can retain focus underneath this sibling.
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [
+    branch,
+    busy,
+    commit,
+    customInstructions,
+    onCancel,
+    onSubmit,
+    request,
+    submitting,
+    workspaceCwd,
+    workspaceSelectionRequired,
+  ]);
 
   return (
     <section
       aria-label={`Start review for ${props.thread.title}`}
       className="star-map-review-setup"
-      onKeyDown={handleKeyDown}
+      ref={dialogRef}
       role="dialog"
     >
       <header className="star-map-review-setup__header">
@@ -240,6 +323,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
         <button
           aria-label="Close review setup"
           className="star-map-review-setup__close"
+          data-review-dismiss
           disabled={props.submitting}
           onClick={props.onCancel}
           type="button"
@@ -279,6 +363,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
                 className={`composer__review-option${
                   target === option.target ? " is-active" : ""
                 }`}
+                data-review-target={option.target}
                 key={option.target}
                 onClick={() => setTarget(option.target)}
                 ref={(node) => {
@@ -363,6 +448,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
         <footer className="star-map-review-setup__actions">
           <button
             className="composer__secondary-action"
+            data-review-dismiss
             disabled={props.submitting}
             onClick={props.onCancel}
             type="button"

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
@@ -1,0 +1,383 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
+import {
+  buildReviewBranchOptions,
+  findPreferredReviewWorkspaceCwd,
+  type AppServerReviewTarget,
+  type NavigationDirectorySummary,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
+
+type ReviewTargetChoice = AppServerReviewTarget["type"];
+
+export type StarMapReviewRequest = {
+  cwd?: string;
+  target: AppServerReviewTarget;
+};
+
+type StarMapReviewSetupProps = {
+  busy: boolean;
+  directories: readonly NavigationDirectorySummary[];
+  error?: string;
+  onCancel: () => void;
+  onSubmit: (request: StarMapReviewRequest) => void;
+  submitting: boolean;
+  thread: NavigationThreadSummary;
+};
+
+type ReviewWorkspaceOption = {
+  cwd: string;
+  key: string;
+  label: string;
+};
+
+const REVIEW_TARGET_OPTIONS: Array<{
+  description: string;
+  label: string;
+  target: ReviewTargetChoice;
+}> = [
+  {
+    target: "baseBranch",
+    label: "Base branch",
+    description: "Compare this branch with a base branch",
+  },
+  {
+    target: "uncommittedChanges",
+    label: "Current changes",
+    description: "Review staged, unstaged, and untracked files",
+  },
+  {
+    target: "commit",
+    label: "Commit",
+    description: "Review one commit by SHA",
+  },
+  {
+    target: "custom",
+    label: "Custom",
+    description: "Review using custom instructions",
+  },
+];
+
+function buildReviewWorkspaceOptions(
+  thread: NavigationThreadSummary,
+): ReviewWorkspaceOption[] {
+  const options: ReviewWorkspaceOption[] = [];
+  const seen = new Set<string>();
+  for (const directory of thread.linkedDirectories) {
+    const cwd = (directory.worktreePath ?? directory.path).trim();
+    if (!cwd || seen.has(cwd)) continue;
+    seen.add(cwd);
+    options.push({
+      cwd,
+      key: `${directory.id}:${cwd}`,
+      label: directory.label.trim() || cwd,
+    });
+  }
+  return options;
+}
+
+function normalizeWorkspacePath(value?: string): string | undefined {
+  const normalized = value?.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || undefined;
+}
+
+function workspaceMatches(left?: string, right?: string): boolean {
+  const normalizedLeft = normalizeWorkspacePath(left);
+  const normalizedRight = normalizeWorkspacePath(right);
+  return Boolean(
+    normalizedLeft
+    && normalizedRight
+    && normalizedLeft === normalizedRight,
+  );
+}
+
+function findReviewDirectory(
+  directories: readonly NavigationDirectorySummary[],
+  thread: NavigationThreadSummary,
+  workspaceCwd?: string,
+): NavigationDirectorySummary | undefined {
+  const linkedDirectory = thread.linkedDirectories.find((directory) =>
+    workspaceMatches(directory.worktreePath, workspaceCwd)
+    || workspaceMatches(directory.path, workspaceCwd)
+  );
+  return directories.find((directory) =>
+    workspaceMatches(directory.path, workspaceCwd)
+    || workspaceMatches(directory.path, linkedDirectory?.path)
+    || workspaceMatches(directory.path, linkedDirectory?.worktreePath)
+    || workspaceMatches(
+      directory.key.startsWith("directory:")
+        ? directory.key.slice("directory:".length)
+        : directory.key,
+      workspaceCwd,
+    )
+  );
+}
+
+function buildReviewRequest(params: {
+  branch: string;
+  commit: string;
+  customInstructions: string;
+  target: ReviewTargetChoice;
+  workspaceCwd?: string;
+}): StarMapReviewRequest | undefined {
+  const cwd = params.workspaceCwd?.trim() || undefined;
+  if (params.target === "uncommittedChanges") {
+    return {
+      ...(cwd ? { cwd } : {}),
+      target: { type: "uncommittedChanges" },
+    };
+  }
+  if (params.target === "baseBranch") {
+    const branch = params.branch.trim();
+    return branch
+      ? {
+          ...(cwd ? { cwd } : {}),
+          target: { type: "baseBranch", branch },
+        }
+      : undefined;
+  }
+  if (params.target === "commit") {
+    const sha = params.commit.trim();
+    return sha
+      ? {
+          ...(cwd ? { cwd } : {}),
+          target: { type: "commit", sha, title: null },
+        }
+      : undefined;
+  }
+  const instructions = params.customInstructions.trim();
+  return instructions
+    ? {
+        ...(cwd ? { cwd } : {}),
+        target: { type: "custom", instructions },
+      }
+    : undefined;
+}
+
+export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
+  const workspaceOptions = useMemo(
+    () => buildReviewWorkspaceOptions(props.thread),
+    [props.thread],
+  );
+  const preferredWorkspace = findPreferredReviewWorkspaceCwd(props.thread);
+  const initialWorkspace =
+    preferredWorkspace
+    ?? (workspaceOptions.length === 1 ? workspaceOptions[0]?.cwd : undefined);
+  const [workspaceCwd, setWorkspaceCwd] = useState(initialWorkspace);
+  const selectedDirectory = useMemo(
+    () => findReviewDirectory(props.directories, props.thread, workspaceCwd),
+    [props.directories, props.thread, workspaceCwd],
+  );
+  const branchOptions = useMemo(
+    () => buildReviewBranchOptions({ directory: selectedDirectory, thread: props.thread }),
+    [props.thread, selectedDirectory],
+  );
+  const [target, setTarget] = useState<ReviewTargetChoice>("baseBranch");
+  const [branch, setBranch] = useState(branchOptions[0] ?? "main");
+  const [branchEdited, setBranchEdited] = useState(false);
+  const [commit, setCommit] = useState("");
+  const [customInstructions, setCustomInstructions] = useState("");
+  const targetRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const branchListId = useId();
+  const commitListId = useId();
+
+  useEffect(() => {
+    targetRefs.current[0]?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!branchEdited && branchOptions[0]) {
+      setBranch(branchOptions[0]);
+    }
+  }, [branchEdited, branchOptions]);
+
+  const request = buildReviewRequest({
+    branch,
+    commit,
+    customInstructions,
+    target,
+    workspaceCwd,
+  });
+  const workspaceSelectionRequired = workspaceOptions.length > 1;
+  const canSubmit = Boolean(
+    request
+    && (!workspaceSelectionRequired || workspaceCwd)
+    && !props.busy
+    && !props.submitting,
+  );
+
+  const submit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (canSubmit && request) props.onSubmit(request);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>): void => {
+    if (event.key !== "Escape" || props.submitting) return;
+    event.preventDefault();
+    event.stopPropagation();
+    props.onCancel();
+  };
+
+  return (
+    <section
+      aria-label={`Start review for ${props.thread.title}`}
+      className="star-map-review-setup"
+      onKeyDown={handleKeyDown}
+      role="dialog"
+    >
+      <header className="star-map-review-setup__header">
+        <div>
+          <span className="star-map-review-setup__eyebrow">Review target</span>
+          <h2>Start review</h2>
+        </div>
+        <button
+          aria-label="Close review setup"
+          className="star-map-review-setup__close"
+          disabled={props.submitting}
+          onClick={props.onCancel}
+          type="button"
+        >
+          ×
+        </button>
+      </header>
+
+      <form className="star-map-review-setup__form" onSubmit={submit}>
+        <div className="star-map-review-setup__content">
+          {workspaceSelectionRequired ? (
+            <label className="composer__review-field">
+              <span>Project</span>
+              <select
+                aria-label="Review project"
+                className="composer__review-input"
+                value={workspaceCwd ?? ""}
+                onChange={(event) => {
+                  setWorkspaceCwd(event.target.value);
+                  setBranchEdited(false);
+                }}
+              >
+                <option disabled value="">Choose project</option>
+                {workspaceOptions.map((option) => (
+                  <option key={option.key} value={option.cwd}>
+                    {option.label} — {option.cwd}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+
+          <div className="composer__review-options">
+            {REVIEW_TARGET_OPTIONS.map((option, index) => (
+              <button
+                aria-pressed={target === option.target}
+                className={`composer__review-option${
+                  target === option.target ? " is-active" : ""
+                }`}
+                key={option.target}
+                onClick={() => setTarget(option.target)}
+                ref={(node) => {
+                  targetRefs.current[index] = node;
+                }}
+                type="button"
+              >
+                <span>{option.label}</span>
+                <small>{option.description}</small>
+              </button>
+            ))}
+          </div>
+
+          {target === "baseBranch" ? (
+            <label className="composer__review-field">
+              <span>Base branch</span>
+              <input
+                aria-label="Base branch"
+                className="composer__review-input"
+                list={branchListId}
+                onChange={(event) => {
+                  setBranch(event.target.value);
+                  setBranchEdited(true);
+                }}
+                value={branch}
+              />
+              <datalist id={branchListId}>
+                {branchOptions.map((option) => (
+                  <option key={option} value={option} />
+                ))}
+              </datalist>
+            </label>
+          ) : null}
+
+          {target === "commit" ? (
+            <label className="composer__review-field">
+              <span>Commit SHA</span>
+              <input
+                aria-label="Commit SHA"
+                className="composer__review-input"
+                list={commitListId}
+                onChange={(event) => setCommit(event.target.value)}
+                placeholder="abc1234"
+                value={commit}
+              />
+              <datalist id={commitListId}>
+                {(selectedDirectory?.gitStatus?.recentCommits ?? []).map(
+                  (option) => (
+                    <option key={option.sha} value={option.sha}>
+                      {option.subject}
+                    </option>
+                  ),
+                )}
+              </datalist>
+            </label>
+          ) : null}
+
+          {target === "custom" ? (
+            <label className="composer__review-field">
+              <span>Instructions</span>
+              <textarea
+                aria-label="Review instructions"
+                className="composer__review-input composer__review-input--textarea"
+                onChange={(event) => setCustomInstructions(event.target.value)}
+                value={customInstructions}
+              />
+            </label>
+          ) : null}
+
+          {props.busy ? (
+            <p className="star-map-review-setup__message" role="status">
+              This review can start when the current turn finishes.
+            </p>
+          ) : null}
+          {props.error ? (
+            <p className="star-map-review-setup__error" role="alert">
+              {props.error}
+            </p>
+          ) : null}
+        </div>
+
+        <footer className="star-map-review-setup__actions">
+          <button
+            className="composer__secondary-action"
+            disabled={props.submitting}
+            onClick={props.onCancel}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="composer__primary-action"
+            disabled={!canSubmit}
+            type="submit"
+          >
+            {props.submitting ? "Starting…" : "Start review"}
+          </button>
+        </footer>
+      </form>
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -305,6 +305,36 @@ describe("StarMapChatCard slash commands", () => {
   );
 
   it.each(["codex", "acp:grok"] as const)(
+    "opens highlighted /review from a bare slash on the first Enter for %s",
+    async (backend) => {
+      const desktopApi = buildApi({ startReview: vi.fn() });
+      renderCard({
+        desktopApi,
+        thread: localThread({ source: backend }),
+      });
+      const input = screen.getByRole("textbox", {
+        name: "Message Local work",
+      });
+      fireEvent.change(input, { target: { value: "/" } });
+      expect(
+        screen.getByRole("option", { name: /\/review/i }).getAttribute(
+          "aria-selected",
+        ),
+      ).toBe("true");
+
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(
+        await screen.findByRole("dialog", {
+          name: "Start review for Local work",
+        }),
+      ).toBeTruthy();
+      expect(desktopApi.startReview).not.toHaveBeenCalled();
+      expect(desktopApi.startTurn).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["codex", "acp:grok"] as const)(
     "submits the configured review through the %s review API",
     async (backend) => {
       const startReview = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -407,13 +407,139 @@ describe("StarMapChatCard slash commands", () => {
     const dialog = await screen.findByRole("dialog", {
       name: "Start review for Local work",
     });
+    // Tiptap can emit its pre-disable document once more while editability
+    // synchronizes. Cancel must still leave the same clean composer state as
+    // the main window, not resurrect the command and its autocomplete.
+    fireEvent.change(input, { target: { value: "/review" } });
     fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
 
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Start review for Local work" }),
+      ).toBeNull();
+    });
+    const restoredInput = screen.getByRole("textbox", {
+      name: "Message Local work",
+    }) as HTMLElement & { value: string };
+    expect(restoredInput.getAttribute("contenteditable")).toBe("true");
+    expect(restoredInput.value).toBe("");
+    expect(screen.queryByRole("listbox", { name: "Commands" })).toBeNull();
+    expect(desktopApi.startReview).not.toHaveBeenCalled();
+  });
+
+  it("cancels review setup on Escape even if the disabled editor kept focus", async () => {
+    const desktopApi = buildApi({ startReview: vi.fn() });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await screen.findByRole("dialog", { name: "Start review for Local work" });
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Start review for Local work" }),
+      ).toBeNull();
+    });
+    const restoredInput = screen.getByRole("textbox", {
+      name: "Message Local work",
+    }) as HTMLElement & { value: string };
+    expect(restoredInput.value).toBe("");
+    expect(screen.queryByRole("listbox", { name: "Commands" })).toBeNull();
+    expect(desktopApi.startReview).not.toHaveBeenCalled();
+  });
+
+  it("starts the selected review on Enter even if the disabled editor kept focus", async () => {
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t-local",
+      reviewThreadId: "review-1",
+      turnId: "turn-review-1",
+    }));
+    const desktopApi = buildApi({ startReview });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await screen.findByRole("dialog", { name: "Start review for Local work" });
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "t-local",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
     expect(
       screen.queryByRole("dialog", { name: "Start review for Local work" }),
     ).toBeNull();
-    expect(input.getAttribute("contenteditable")).toBe("true");
-    expect(desktopApi.startReview).not.toHaveBeenCalled();
+  });
+
+  it("starts the focused review target on Enter", async () => {
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t-local",
+      reviewThreadId: "review-1",
+      turnId: "turn-review-1",
+    }));
+    const desktopApi = buildApi({ startReview });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    const dialog = await screen.findByRole("dialog", {
+      name: "Start review for Local work",
+    });
+
+    fireEvent.keyDown(
+      within(dialog).getByRole("button", { name: /Current changes/ }),
+      { key: "Enter" },
+    );
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "t-local",
+        target: { type: "uncommittedChanges" },
+        delivery: "inline",
+      });
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Start review for Local work" }),
+    ).toBeNull();
+  });
+
+  it("closes review setup as soon as Start review is accepted", async () => {
+    let resolveStart: (() => void) | undefined;
+    const startReview = vi.fn(
+      () => new Promise<never>((resolve) => {
+        resolveStart = () => resolve(undefined as never);
+      }),
+    );
+    const desktopApi = buildApi({ startReview });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    const dialog = await screen.findByRole("dialog", {
+      name: "Start review for Local work",
+    });
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: /Current changes/ }),
+    );
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Start review" }),
+    );
+
+    expect(startReview).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("dialog", { name: "Start review for Local work" }),
+    ).toBeNull();
+    resolveStart?.();
   });
 
   it("closes review setup without disabling the card's terminal control", async () => {
@@ -451,7 +577,11 @@ describe("StarMapChatCard slash commands", () => {
     expect(
       screen.queryByRole("dialog", { name: "Start review for Local work" }),
     ).toBeNull();
-    expect(input.getAttribute("contenteditable")).toBe("true");
+    expect(
+      screen
+        .getByRole("textbox", { name: "Message Local work" })
+        .getAttribute("contenteditable"),
+    ).toBe("true");
   });
 
   it.each([false, true])(

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -220,6 +220,132 @@ describe("StarMapChatCard federation routing", () => {
   });
 });
 
+describe("StarMapChatCard slash commands", () => {
+  it.each([
+    ["Codex", "codex", "compact"],
+    ["ACP", "acp:grok", "session-info"],
+  ] as const)("loads and offers %s provider commands", async (
+    _provider,
+    backend,
+    command,
+  ) => {
+    const listSkills = vi.fn(async () => ({
+      backend,
+      fetchedAt: 1,
+      data: [
+        {
+          commands: [
+            {
+              name: command,
+              description: `Run ${command}`,
+              backend,
+              scope: "session" as const,
+              source: "provider" as const,
+            },
+          ],
+          skills: [],
+        },
+      ],
+    }));
+    const desktopApi = buildApi({ listSkills });
+    const thread = localThread({ source: backend });
+    renderCard({ desktopApi, thread });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Message Local work" }),
+      { target: { value: `/${command.slice(0, 3)}` } },
+    );
+
+    await waitFor(() => {
+      expect(listSkills).toHaveBeenCalledWith(
+        expect.objectContaining({ backend, threadId: "t-local" }),
+      );
+    });
+    expect(
+      await screen.findByRole("option", { name: new RegExp(`/${command}`, "i") }),
+    ).toBeTruthy();
+  });
+
+  it.each(["codex", "acp:grok"] as const)(
+    "routes PwrAgent /review through the %s review API",
+    async (backend) => {
+      const startReview = vi.fn(async () => ({
+        backend,
+        threadId: "t-local",
+        reviewThreadId: "review-1",
+        turnId: "turn-review-1",
+      }));
+      const desktopApi = buildApi({ startReview });
+      renderCard({
+        desktopApi,
+        thread: localThread({ source: backend }),
+      });
+      const input = screen.getByRole("textbox", {
+        name: "Message Local work",
+      });
+      fireEvent.change(input, { target: { value: "/review" } });
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+      await waitFor(() => {
+        expect(startReview).toHaveBeenCalledWith({
+          backend,
+          threadId: "t-local",
+          target: { type: "uncommittedChanges" },
+          delivery: "inline",
+        });
+      });
+      expect(desktopApi.startTurn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("routes Codex /compact through thread compaction", async () => {
+    const compactThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t-local",
+      turnId: "turn-compact-1",
+    }));
+    const desktopApi = buildApi({ compactThread });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/compact" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(compactThread).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "t-local",
+      });
+    });
+    expect(desktopApi.startTurn).not.toHaveBeenCalled();
+  });
+
+  it("sends an ACP-native slash command to the ACP session", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      threadId: "t-local",
+      turnId: "turn-acp-1",
+    }));
+    const desktopApi = buildApi({ startTurn });
+    renderCard({
+      desktopApi,
+      thread: localThread({ source: "acp:grok" }),
+    });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/session-info" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "acp:grok",
+          threadId: "t-local",
+          input: [{ type: "text", text: "/session-info" }],
+        }),
+      );
+    });
+  });
+});
+
 describe("StarMapChatCard send failures", () => {
   it("restores the draft and rolls back its optimistic message when the peer refuses", async () => {
     const desktopApi = buildApi({

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -7,7 +7,10 @@ import {
   within,
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  BackendCapabilities,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { normalizeImageFile } from "../../../lib/image-normalization";
 import { StarMapChatCard } from "../StarMapChatCard";
@@ -97,6 +100,50 @@ function buildApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
     onAgentEvent: vi.fn(() => () => undefined),
     ...overrides,
   } as unknown as DesktopApi;
+}
+
+function reviewCapabilities(startReview: boolean): BackendCapabilities {
+  return {
+    approvalRequests: true,
+    createThread: true,
+    interruptTurn: true,
+    listThreads: true,
+    multiDirectoryThreads: true,
+    readThread: true,
+    renameThread: true,
+    resumeThread: true,
+    startReview,
+    startTurn: true,
+    steerTurn: false,
+    toolUse: true,
+    transcriptPagination: false,
+  };
+}
+
+function reviewCapableApi(
+  backend: "codex" | "acp:grok",
+  overrides: Partial<DesktopApi> = {},
+): DesktopApi {
+  return buildApi({
+    ...(backend.startsWith("acp:")
+      ? {
+          listBackends: vi.fn(async () => ({
+            fetchedAt: 1,
+            backends: [
+              {
+                available: true,
+                capabilities: reviewCapabilities(true),
+                executionModes: [],
+                kind: backend,
+                label: "Grok",
+                methods: [],
+              },
+            ],
+          })),
+        }
+      : {}),
+    ...overrides,
+  });
 }
 
 type CardParams = {
@@ -558,6 +605,93 @@ describe("StarMapChatCard slash commands", () => {
     ).toBeTruthy();
   });
 
+  it("does not offer or intercept review for an unsupported ACP backend", async () => {
+    const startReview = vi.fn();
+    const startTurn = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      threadId: "t-local",
+      turnId: "turn-acp-1",
+    }));
+    const desktopApi = buildApi({
+      listBackends: vi.fn(async () => ({
+        fetchedAt: 1,
+        backends: [
+          {
+            available: true,
+            capabilities: reviewCapabilities(false),
+            executionModes: [],
+            kind: "acp:grok" as const,
+            label: "Grok",
+            methods: [],
+          },
+        ],
+      })),
+      startReview,
+      startTurn,
+    });
+    renderCard({
+      desktopApi,
+      thread: localThread({ source: "acp:grok" }),
+    });
+    await waitFor(() => {
+      expect(desktopApi.listBackends).toHaveBeenCalled();
+    });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/" } });
+    expect(screen.queryByRole("option", { name: /\/review/i })).toBeNull();
+
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "acp:grok",
+          input: [{ type: "text", text: "/review" }],
+        }),
+      );
+    });
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("keeps an attached image when /review is rejected", async () => {
+    const startReview = vi.fn();
+    const desktopApi = buildApi({ startReview });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["star-map"], "review.png", {
+      type: "image/png",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [image],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => image,
+            kind: "file",
+            type: "image/png",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+    await screen.findByRole("img", { name: "review.png" });
+    fireEvent.change(input, { target: { value: "/" } });
+    expect(screen.queryByRole("option", { name: /\/review/i })).toBeNull();
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(
+      /\/review does not accept attachments/i,
+    );
+    expect(screen.getByRole("img", { name: "review.png" })).toBeTruthy();
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
   it.each(["codex", "acp:grok"] as const)(
     "opens the review setup on the first Enter for %s",
     async (backend) => {
@@ -567,7 +701,7 @@ describe("StarMapChatCard slash commands", () => {
         reviewThreadId: "review-1",
         turnId: "turn-review-1",
       }));
-      const desktopApi = buildApi({ startReview });
+      const desktopApi = reviewCapableApi(backend, { startReview });
       renderCard({
         desktopApi,
         thread: localThread({ source: backend }),
@@ -575,6 +709,10 @@ describe("StarMapChatCard slash commands", () => {
       const input = screen.getByRole("textbox", {
         name: "Message Local work",
       });
+      if (backend.startsWith("acp:")) {
+        fireEvent.change(input, { target: { value: "/" } });
+        await screen.findByRole("option", { name: /\/review/i });
+      }
       fireEvent.change(input, { target: { value: "/review" } });
       fireEvent.keyDown(input, { key: "Enter" });
 
@@ -592,7 +730,9 @@ describe("StarMapChatCard slash commands", () => {
   it.each(["codex", "acp:grok"] as const)(
     "opens highlighted /review from a bare slash on the first Enter for %s",
     async (backend) => {
-      const desktopApi = buildApi({ startReview: vi.fn() });
+      const desktopApi = reviewCapableApi(backend, {
+        startReview: vi.fn(),
+      });
       renderCard({
         desktopApi,
         thread: localThread({ source: backend }),
@@ -602,7 +742,7 @@ describe("StarMapChatCard slash commands", () => {
       });
       fireEvent.change(input, { target: { value: "/" } });
       expect(
-        screen.getByRole("option", { name: /\/review/i }).getAttribute(
+        (await screen.findByRole("option", { name: /\/review/i })).getAttribute(
           "aria-selected",
         ),
       ).toBe("true");
@@ -628,7 +768,7 @@ describe("StarMapChatCard slash commands", () => {
         reviewThreadId: "review-1",
         turnId: "turn-review-1",
       }));
-      const desktopApi = buildApi({ startReview });
+      const desktopApi = reviewCapableApi(backend, { startReview });
       renderCard({
         desktopApi,
         thread: localThread({ source: backend }),
@@ -636,6 +776,10 @@ describe("StarMapChatCard slash commands", () => {
       const input = screen.getByRole("textbox", {
         name: "Message Local work",
       });
+      if (backend.startsWith("acp:")) {
+        fireEvent.change(input, { target: { value: "/" } });
+        await screen.findByRole("option", { name: /\/review/i });
+      }
       fireEvent.change(input, { target: { value: "/review" } });
       fireEvent.click(screen.getByRole("button", { name: "Send" }));
       const dialog = await screen.findByRole("dialog", {
@@ -951,6 +1095,137 @@ describe("StarMapChatCard slash commands", () => {
       expect(desktopApi.startTurn).not.toHaveBeenCalled();
     },
   );
+
+  it("keeps an attached file when /compact is rejected", async () => {
+    const compactThread = vi.fn();
+    const desktopApi = buildApi({
+      compactThread,
+      getPathForFile: vi.fn(() => "/tmp/brief.pdf"),
+      listSkills: vi.fn(async () => ({
+        backend: "codex" as const,
+        fetchedAt: 1,
+        data: [
+          {
+            commands: [
+              {
+                backend: "codex" as const,
+                description: "Compact the thread",
+                name: "compact",
+                scope: "session" as const,
+                source: "provider" as const,
+              },
+            ],
+            skills: [],
+          },
+        ],
+      })),
+    });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const pdf = new File(["%PDF-1.7"], "brief.pdf", {
+      type: "application/pdf",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [pdf],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => pdf,
+            kind: "file",
+            type: "application/pdf",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+    expect(await screen.findByText("brief.pdf")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "/" } });
+    await waitFor(() => {
+      expect(desktopApi.listSkills).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole("option", { name: /\/compact/i })).toBeNull();
+    fireEvent.change(input, { target: { value: "/compact" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(
+      /\/compact does not accept attachments/i,
+    );
+    expect(screen.getByText("brief.pdf")).toBeTruthy();
+    expect(compactThread).not.toHaveBeenCalled();
+  });
+
+  it("keeps ACP provider commands available with attachments", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      threadId: "t-local",
+      turnId: "turn-acp-1",
+    }));
+    const desktopApi = buildApi({
+      listSkills: vi.fn(async () => ({
+        backend: "acp:grok" as const,
+        fetchedAt: 1,
+        data: [
+          {
+            commands: [
+              {
+                backend: "acp:grok" as const,
+                description: "Show session details",
+                name: "session-info",
+                scope: "session" as const,
+                source: "provider" as const,
+              },
+            ],
+            skills: [],
+          },
+        ],
+      })),
+      startTurn,
+    });
+    renderCard({
+      desktopApi,
+      thread: localThread({ source: "acp:grok" }),
+    });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["star-map"], "context.png", {
+      type: "image/png",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [image],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => image,
+            kind: "file",
+            type: "image/png",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+    await screen.findByRole("img", { name: "context.png" });
+    fireEvent.change(input, { target: { value: "/ses" } });
+    expect(
+      await screen.findByRole("option", { name: /\/session-info/i }),
+    ).toBeTruthy();
+    fireEvent.change(input, { target: { value: "/session-info" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "acp:grok",
+          input: [
+            { type: "text", text: "/session-info" },
+            expect.objectContaining({ name: "context.png", type: "image" }),
+          ],
+        }),
+      );
+    });
+  });
 
   it("sends an ACP-native slash command to the ACP session", async () => {
     const startTurn = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,4 +1,11 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -267,7 +274,38 @@ describe("StarMapChatCard slash commands", () => {
   });
 
   it.each(["codex", "acp:grok"] as const)(
-    "routes PwrAgent /review through the %s review API",
+    "opens the review setup on the first Enter for %s",
+    async (backend) => {
+      const startReview = vi.fn(async () => ({
+        backend,
+        threadId: "t-local",
+        reviewThreadId: "review-1",
+        turnId: "turn-review-1",
+      }));
+      const desktopApi = buildApi({ startReview });
+      renderCard({
+        desktopApi,
+        thread: localThread({ source: backend }),
+      });
+      const input = screen.getByRole("textbox", {
+        name: "Message Local work",
+      });
+      fireEvent.change(input, { target: { value: "/review" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(
+        await screen.findByRole("dialog", {
+          name: "Start review for Local work",
+        }),
+      ).toBeTruthy();
+      expect(input.getAttribute("contenteditable")).toBe("false");
+      expect(startReview).not.toHaveBeenCalled();
+      expect(desktopApi.startTurn).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["codex", "acp:grok"] as const)(
+    "submits the configured review through the %s review API",
     async (backend) => {
       const startReview = vi.fn(async () => ({
         backend,
@@ -285,6 +323,15 @@ describe("StarMapChatCard slash commands", () => {
       });
       fireEvent.change(input, { target: { value: "/review" } });
       fireEvent.click(screen.getByRole("button", { name: "Send" }));
+      const dialog = await screen.findByRole("dialog", {
+        name: "Start review for Local work",
+      });
+      fireEvent.click(
+        within(dialog).getByRole("button", { name: /Current changes/ }),
+      );
+      fireEvent.click(
+        within(dialog).getByRole("button", { name: "Start review" }),
+      );
 
       await waitFor(() => {
         expect(startReview).toHaveBeenCalledWith({
@@ -294,30 +341,171 @@ describe("StarMapChatCard slash commands", () => {
           delivery: "inline",
         });
       });
-      expect(desktopApi.startTurn).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("dialog", {
+            name: "Start review for Local work",
+          }),
+        ).toBeNull();
+      });
     },
   );
 
-  it("routes Codex /compact through thread compaction", async () => {
-    const compactThread = vi.fn(async () => ({
-      backend: "codex" as const,
-      threadId: "t-local",
-      turnId: "turn-compact-1",
-    }));
-    const desktopApi = buildApi({ compactThread });
+  it("locks only the chat card that owns the review setup", async () => {
+    const firstApi = buildApi({ startReview: vi.fn() });
+    const secondApi = buildApi();
+    render(
+      <>
+        {card({ desktopApi: firstApi, thread: localThread() })}
+        <StarMapChatCard
+          cardKey="card-2"
+          desktopApi={secondApi}
+          onClose={() => undefined}
+          onOpenFull={() => undefined}
+          onRaise={() => undefined}
+          onRectChange={() => undefined}
+          rect={{ ...RECT, left: 500 }}
+          thread={localThread({ id: "t-second", title: "Other work" })}
+          scale={1}
+          bounds={{ width: 4000, height: 3000 }}
+          onToggleContext={() => undefined}
+          onToggleTerminal={() => undefined}
+          zIndex={41}
+        />
+      </>,
+    );
+    const firstInput = screen.getByRole("textbox", {
+      name: "Message Local work",
+    });
+    const secondInput = screen.getByRole("textbox", {
+      name: "Message Other work",
+    });
+    fireEvent.change(firstInput, { target: { value: "/review" } });
+    fireEvent.keyDown(firstInput, { key: "Enter" });
+    await screen.findByRole("dialog", { name: "Start review for Local work" });
+
+    expect(firstInput.getAttribute("contenteditable")).toBe("false");
+    expect(secondInput.getAttribute("contenteditable")).toBe("true");
+    fireEvent.change(secondInput, { target: { value: "still interactive" } });
+    fireEvent.keyDown(secondInput, { key: "Enter" });
+    await waitFor(() => {
+      expect(secondApi.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "t-second",
+          input: [{ type: "text", text: "still interactive" }],
+        }),
+      );
+    });
+  });
+
+  it("cancels the review setup and re-enables its composer", async () => {
+    const desktopApi = buildApi({ startReview: vi.fn() });
     renderCard({ desktopApi, thread: localThread() });
     const input = screen.getByRole("textbox", { name: "Message Local work" });
-    fireEvent.change(input, { target: { value: "/compact" } });
-    fireEvent.click(screen.getByRole("button", { name: "Send" }));
-
-    await waitFor(() => {
-      expect(compactThread).toHaveBeenCalledWith({
-        backend: "codex",
-        threadId: "t-local",
-      });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    const dialog = await screen.findByRole("dialog", {
+      name: "Start review for Local work",
     });
-    expect(desktopApi.startTurn).not.toHaveBeenCalled();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Start review for Local work" }),
+    ).toBeNull();
+    expect(input.getAttribute("contenteditable")).toBe("true");
+    expect(desktopApi.startReview).not.toHaveBeenCalled();
   });
+
+  it("closes review setup without disabling the card's terminal control", async () => {
+    const onToggleTerminal = vi.fn();
+    const desktopApi = buildApi({ startReview: vi.fn() });
+    render(
+      <StarMapChatCard
+        cardKey="card-1"
+        desktopApi={desktopApi}
+        onClose={() => undefined}
+        onOpenFull={() => undefined}
+        onRaise={() => undefined}
+        onRectChange={() => undefined}
+        rect={RECT}
+        thread={localThread()}
+        scale={1}
+        bounds={{ width: 4000, height: 3000 }}
+        onToggleContext={() => undefined}
+        onToggleTerminal={onToggleTerminal}
+        zIndex={40}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    const dialog = await screen.findByRole("dialog", {
+      name: "Start review for Local work",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Open terminal/ }));
+    expect(onToggleTerminal).toHaveBeenCalledWith("card-1");
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Close review setup" }),
+    );
+    expect(
+      screen.queryByRole("dialog", { name: "Start review for Local work" }),
+    ).toBeNull();
+    expect(input.getAttribute("contenteditable")).toBe("true");
+  });
+
+  it.each([false, true])(
+    "routes Codex /compact on the first Enter with provider commands loaded=%s",
+    async (commandsLoaded) => {
+      const compactThread = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "t-local",
+        turnId: "turn-compact-1",
+      }));
+      const desktopApi = buildApi({
+        compactThread,
+        ...(commandsLoaded
+          ? {
+              listSkills: vi.fn(async () => ({
+                backend: "codex" as const,
+                fetchedAt: 1,
+                data: [
+                  {
+                    commands: [
+                      {
+                        backend: "codex" as const,
+                        description: "Compact the thread",
+                        name: "compact",
+                        scope: "session" as const,
+                        source: "provider" as const,
+                      },
+                    ],
+                    skills: [],
+                  },
+                ],
+              })),
+            }
+          : {}),
+      });
+      renderCard({ desktopApi, thread: localThread() });
+      const input = screen.getByRole("textbox", {
+        name: "Message Local work",
+      });
+      fireEvent.change(input, { target: { value: "/compact" } });
+      if (commandsLoaded) {
+        await screen.findByRole("option", { name: /\/compact/i });
+      }
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(compactThread).toHaveBeenCalledWith({
+          backend: "codex",
+          threadId: "t-local",
+        });
+      });
+      expect(desktopApi.startTurn).not.toHaveBeenCalled();
+    },
+  );
 
   it("sends an ACP-native slash command to the ACP session", async () => {
     const startTurn = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13195,6 +13195,143 @@ textarea,
   overflow: hidden;
 }
 
+/* The body is a card-local stacking context. Review setup can cover the
+   transcript and composer without becoming a window-global modal, so another
+   chat card and the terminal satellite remain ordinary interactive siblings. */
+.star-map-chat-card__body {
+  display: flex;
+  position: relative;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.star-map-review-setup {
+  display: flex;
+  position: absolute;
+  z-index: 4;
+  inset: 0;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+}
+
+.star-map-review-setup__header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.star-map-review-setup__eyebrow {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.star-map-review-setup__header h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.star-map-review-setup__close {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.star-map-review-setup__close:hover:not(:disabled) {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.star-map-review-setup__close:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.star-map-review-setup__close:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.star-map-review-setup__form {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.star-map-review-setup__content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  padding: 10px 12px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.star-map-review-setup .composer__review-options {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.star-map-review-setup .composer__review-option {
+  min-height: 54px;
+  padding: 7px 8px;
+}
+
+.star-map-review-setup .composer__review-option span,
+.star-map-review-setup .composer__review-input {
+  font-size: 12px;
+}
+
+.star-map-review-setup__message,
+.star-map-review-setup__error {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.star-map-review-setup__message {
+  color: var(--text-secondary);
+}
+
+.star-map-review-setup__error {
+  color: var(--danger-text);
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.star-map-review-setup__actions {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+}
+
 .star-map-chat-card__error {
   flex: 0 0 auto;
   margin: 0;


### PR DESCRIPTION
## Summary

- load Codex and ACP provider command catalogs in the star-map chat composer
- execute the highlighted slash command on the first Enter, including opening `/review` directly from a bare `/`
- preserve Tab and click as autocomplete insertion for further editing
- route PwrAgent review and compact commands through their dedicated APIs while preserving provider-native slash input
- open bare `/review` in a card-scoped, scrollable setup layer with project and target controls
- support Enter-to-start and Escape-to-cancel even when the disabled editor retains focus beneath the review layer
- close review setup immediately when start is accepted, and clear `/review` plus its autocomplete on cancel, close, Escape, and submit
- disable only the owning card composer while review setup is open; other chat cards, card chrome, and terminal controls remain interactive

## Verification

- `pnpm test` (605 files, 8,725 passed, 6 skipped)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- focused compact composer and Star Map card tests cover Codex, ACP, highlighted-command Enter, loaded/unloaded `/compact`, keyboard and pointer review submit/cancel/close, stale Tiptap draft echoes, cross-card typing, and terminal access