### PR TITLE
fix(desktop): support attachments in Star Map composer

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -2,16 +2,33 @@ import {
   useCallback,
   useId,
   useState,
+  type ClipboardEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
-import type { ThreadExecutionMode } from "@pwragent/shared";
+import type {
+  NavigationLaunchpadImageAttachment,
+  ThreadExecutionMode,
+} from "@pwragent/shared";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
   ChevronUpIcon,
+  CloseIcon,
 } from "../../icons";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
+import {
+  normalizeImageFile,
+  type ImageFallbackRequest,
+  type ImageFallbackResponse,
+} from "../../lib/image-normalization";
+import {
+  formatPastedImageAlt,
+  formatPastedImageName,
+  getImageFilesFromDataTransfer,
+  isGifFile,
+  readFileAsImageDataUrl,
+} from "./composer-image-files";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
 import { useDismissableMenu } from "./ComposerDropdown";
 import {
@@ -79,12 +96,20 @@ export type CompactComposerProps = {
   mentionSources?: ComposerMentionSources;
   /** Thread's current model, the chip's leading segment. */
   model?: string;
+  normalizeImageForUpload?: (
+    request: ImageFallbackRequest,
+  ) => Promise<ImageFallbackResponse>;
+  onImageError?: (message?: string) => void;
   onInterrupt?: () => void;
   /**
    * Resolve `false` to hand the text back to the input — a send that never
    * reached the backend must not cost the operator what they typed.
    */
-  onSend: (text: string) => void | boolean | Promise<boolean | void>;
+  onSend: (
+    text: string,
+    images?: NavigationLaunchpadImageAttachment[],
+  ) => void | boolean | Promise<boolean | void>;
+  pastedImageMaxPatches?: number;
   placeholder?: string;
   reasoningEffort?: string;
   /** Rendered at the bottom of the settings chip's menu. */
@@ -95,6 +120,8 @@ export type CompactComposerProps = {
 };
 
 type SettingsMenuView = "access" | "model" | "reasoning" | "root";
+
+const MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS = 5;
 
 const MENU_VIEW_TITLES: Record<
   Exclude<SettingsMenuView, "root">,
@@ -143,12 +170,21 @@ export function CompactComposer(props: CompactComposerProps) {
   });
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<SettingsMenuView>("root");
+  const [imageAttachments, setImageAttachments] = useState<
+    NavigationLaunchpadImageAttachment[]
+  >([]);
+  const [normalizingImages, setNormalizingImages] = useState(false);
   // Click-away and Escape close the menu, same hook as the composer
   // dropdowns. Without it the menu survives a click on the transcript
   // behind it and covers the conversation.
   const closeMenu = useCallback(() => setMenuOpen(false), []);
   const menuRef = useDismissableMenu<HTMLDivElement>(menuOpen, closeMenu);
-  const { onSend } = props;
+  const {
+    normalizeImageForUpload,
+    onImageError,
+    onSend,
+    pastedImageMaxPatches,
+  } = props;
   // Several cards can be open at once and the editor puts this on a DOM
   // `id`; a shared literal would give the map duplicate ids.
   const inputId = `compact-composer-${useId()}`;
@@ -181,16 +217,101 @@ export function CompactComposer(props: CompactComposerProps) {
     // The serialized text, not the plain draft: a mention chip is
     // zero-width until this splices its markdown back in.
     const text = mentions.text.trim();
-    if (!text) return;
+    if ((!text && imageAttachments.length === 0) || normalizingImages) return;
     // Clear optimistically so the input frees up immediately, then put the
     // draft back — chips and all — if the send turned out to fail.
     const previous = mentions.snapshot;
+    const previousImages = imageAttachments;
     mentions.clear();
-    const delivered = await onSend(text);
+    setImageAttachments([]);
+    const delivered = await (
+      previousImages.length > 0
+        ? onSend(text, previousImages)
+        : onSend(text)
+    );
     if (delivered === false) {
       mentions.restore(previous);
+      setImageAttachments(previousImages);
     }
-  }, [mentions, onSend]);
+  }, [imageAttachments, mentions, normalizingImages, onSend]);
+
+  const onPaste = useCallback(
+    (event: ClipboardEvent<HTMLElement>) => {
+      const pastedImages = getImageFilesFromDataTransfer(event.clipboardData);
+      if (pastedImages.length === 0) return;
+
+      event.preventDefault();
+      onImageError?.(undefined);
+      const remaining =
+        MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS - imageAttachments.length;
+      if (remaining <= 0) {
+        onImageError?.(
+          `You can attach up to ${MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS} images per message.`,
+        );
+        return;
+      }
+      const accepted = pastedImages.slice(0, remaining);
+      if (accepted.length < pastedImages.length) {
+        onImageError?.(
+          `You can attach up to ${MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS} images per message.`,
+        );
+      }
+
+      setNormalizingImages(true);
+      void Promise.all(
+        accepted.map(async ({ file, type }, index) => {
+          const fallbackName = formatPastedImageName(type, index);
+          if (isGifFile(file, type)) {
+            return {
+              id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+              name: file.name || fallbackName,
+              size: file.size,
+              type: "image/gif",
+              url: await readFileAsImageDataUrl(file, "image/gif"),
+            };
+          }
+
+          const normalized = await normalizeImageFile(file, {
+            fallback: normalizeImageForUpload,
+            maxPatchCount: pastedImageMaxPatches,
+            sourceMimeType: type,
+          });
+          return {
+            height: normalized.height,
+            id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+            name: file.name || fallbackName,
+            size: normalized.size,
+            type: normalized.mimeType,
+            url: normalized.dataUrl,
+            width: normalized.width,
+          };
+        }),
+      )
+        .then((attachments) => {
+          setImageAttachments((current) => [
+            ...current,
+            ...attachments.filter(
+              (attachment) =>
+                !current.some((existing) => existing.url === attachment.url),
+            ),
+          ].slice(0, MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS));
+        })
+        .catch((error: unknown) => {
+          onImageError?.(
+            error instanceof Error
+              ? error.message
+              : "The pasted image could not be read.",
+          );
+        })
+        .finally(() => setNormalizingImages(false));
+    },
+    [
+      imageAttachments.length,
+      normalizeImageForUpload,
+      onImageError,
+      pastedImageMaxPatches,
+    ],
+  );
 
   // The editor forwards the keys it does not claim itself: Enter without
   // Shift or Alt (both of which insert a newline), the arrows, and anything
@@ -520,6 +641,7 @@ export function CompactComposer(props: CompactComposerProps) {
           markdownConversion
           onChange={mentions.handleChange}
           onKeyDown={onKeyDown}
+          onPaste={onPaste}
           placeholder={props.placeholder ?? "Reply…"}
           skillTokens={mentions.skillTokens}
           value={mentions.draft}
@@ -529,6 +651,35 @@ export function CompactComposer(props: CompactComposerProps) {
             selector every camera-gesture guard tests against. */}
         {mentions.popover}
       </div>
+
+      {imageAttachments.length > 0 ? (
+        <div
+          aria-label="Pasted images"
+          className="compact-composer__attachments"
+        >
+          {imageAttachments.map((attachment, index) => (
+            <div className="compact-composer__attachment" key={attachment.id}>
+              <img
+                alt={formatPastedImageAlt(attachment, index)}
+                className="compact-composer__attachment-preview"
+                src={attachment.url}
+              />
+              <button
+                aria-label={`Remove ${attachment.name}`}
+                className="compact-composer__attachment-remove"
+                onClick={() => {
+                  setImageAttachments((current) =>
+                    current.filter((candidate) => candidate.id !== attachment.id),
+                  );
+                }}
+                type="button"
+              >
+                <CloseIcon aria-hidden="true" size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       <div className="compact-composer__strip">
         {hasMenu ? (
@@ -596,7 +747,11 @@ export function CompactComposer(props: CompactComposerProps) {
           className="compact-composer__send"
           disabled={
             props.disabled
-            || mentions.text.trim().length === 0
+            || normalizingImages
+            || (
+              mentions.text.trim().length === 0
+              && imageAttachments.length === 0
+            )
             || (props.busy && props.canSteer === false)
           }
           onClick={() => void send()}

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -3,10 +3,12 @@ import {
   useId,
   useState,
   type ClipboardEvent,
+  type DragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
 import type {
+  NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
   ThreadExecutionMode,
 } from "@pwragent/shared";
@@ -26,6 +28,8 @@ import {
   formatPastedImageAlt,
   formatPastedImageName,
   getImageFilesFromDataTransfer,
+  getNonImageFilesFromDataTransfer,
+  hasAnyFiles,
   isGifFile,
   readFileAsImageDataUrl,
 } from "./composer-image-files";
@@ -84,6 +88,7 @@ export type CompactComposerProps = {
    * fire a send that is guaranteed to bounce.
    */
   canSteer?: boolean;
+  canAttachLocalFiles?: boolean;
   disabled?: boolean;
   executionMode?: ThreadExecutionMode;
   /** Thread's current fast-mode state, shown on the chip menu's toggle. */
@@ -96,10 +101,11 @@ export type CompactComposerProps = {
   mentionSources?: ComposerMentionSources;
   /** Thread's current model, the chip's leading segment. */
   model?: string;
+  getPathForFile?: (file: File) => string;
   normalizeImageForUpload?: (
     request: ImageFallbackRequest,
   ) => Promise<ImageFallbackResponse>;
-  onImageError?: (message?: string) => void;
+  onAttachmentError?: (message?: string) => void;
   onInterrupt?: () => void;
   /**
    * Resolve `false` to hand the text back to the input — a send that never
@@ -108,6 +114,7 @@ export type CompactComposerProps = {
   onSend: (
     text: string,
     images?: NavigationLaunchpadImageAttachment[],
+    files?: NavigationLaunchpadFileAttachment[],
   ) => void | boolean | Promise<boolean | void>;
   pastedImageMaxPatches?: number;
   placeholder?: string;
@@ -122,6 +129,7 @@ export type CompactComposerProps = {
 type SettingsMenuView = "access" | "model" | "reasoning" | "root";
 
 const MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS = 5;
+const MAX_COMPACT_COMPOSER_FILE_ATTACHMENTS = 20;
 
 const MENU_VIEW_TITLES: Record<
   Exclude<SettingsMenuView, "root">,
@@ -173,6 +181,9 @@ export function CompactComposer(props: CompactComposerProps) {
   const [imageAttachments, setImageAttachments] = useState<
     NavigationLaunchpadImageAttachment[]
   >([]);
+  const [fileAttachments, setFileAttachments] = useState<
+    NavigationLaunchpadFileAttachment[]
+  >([]);
   const [normalizingImages, setNormalizingImages] = useState(false);
   // Click-away and Escape close the menu, same hook as the composer
   // dropdowns. Without it the menu survives a click on the transcript
@@ -180,8 +191,10 @@ export function CompactComposer(props: CompactComposerProps) {
   const closeMenu = useCallback(() => setMenuOpen(false), []);
   const menuRef = useDismissableMenu<HTMLDivElement>(menuOpen, closeMenu);
   const {
+    canAttachLocalFiles = true,
+    getPathForFile,
     normalizeImageForUpload,
-    onImageError,
+    onAttachmentError,
     onSend,
     pastedImageMaxPatches,
   } = props;
@@ -217,42 +230,44 @@ export function CompactComposer(props: CompactComposerProps) {
     // The serialized text, not the plain draft: a mention chip is
     // zero-width until this splices its markdown back in.
     const text = mentions.text.trim();
-    if ((!text && imageAttachments.length === 0) || normalizingImages) return;
+    if (
+      (!text && imageAttachments.length === 0 && fileAttachments.length === 0)
+      || normalizingImages
+    ) return;
     // Clear optimistically so the input frees up immediately, then put the
     // draft back — chips and all — if the send turned out to fail.
     const previous = mentions.snapshot;
     const previousImages = imageAttachments;
+    const previousFiles = fileAttachments;
     mentions.clear();
     setImageAttachments([]);
+    setFileAttachments([]);
     const delivered = await (
-      previousImages.length > 0
-        ? onSend(text, previousImages)
+      previousImages.length > 0 || previousFiles.length > 0
+        ? onSend(text, previousImages, previousFiles)
         : onSend(text)
     );
     if (delivered === false) {
       mentions.restore(previous);
       setImageAttachments(previousImages);
+      setFileAttachments(previousFiles);
     }
-  }, [imageAttachments, mentions, normalizingImages, onSend]);
+  }, [fileAttachments, imageAttachments, mentions, normalizingImages, onSend]);
 
-  const onPaste = useCallback(
-    (event: ClipboardEvent<HTMLElement>) => {
-      const pastedImages = getImageFilesFromDataTransfer(event.clipboardData);
+  const attachImages = useCallback(
+    (pastedImages: ReturnType<typeof getImageFilesFromDataTransfer>) => {
       if (pastedImages.length === 0) return;
-
-      event.preventDefault();
-      onImageError?.(undefined);
       const remaining =
         MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS - imageAttachments.length;
       if (remaining <= 0) {
-        onImageError?.(
+        onAttachmentError?.(
           `You can attach up to ${MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS} images per message.`,
         );
         return;
       }
       const accepted = pastedImages.slice(0, remaining);
       if (accepted.length < pastedImages.length) {
-        onImageError?.(
+        onAttachmentError?.(
           `You can attach up to ${MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS} images per message.`,
         );
       }
@@ -297,7 +312,7 @@ export function CompactComposer(props: CompactComposerProps) {
           ].slice(0, MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS));
         })
         .catch((error: unknown) => {
-          onImageError?.(
+          onAttachmentError?.(
             error instanceof Error
               ? error.message
               : "The pasted image could not be read.",
@@ -308,9 +323,102 @@ export function CompactComposer(props: CompactComposerProps) {
     [
       imageAttachments.length,
       normalizeImageForUpload,
-      onImageError,
+      onAttachmentError,
       pastedImageMaxPatches,
     ],
+  );
+
+  const attachLocalFiles = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) return;
+      if (!canAttachLocalFiles) {
+        onAttachmentError?.(
+          "Local files cannot be attached to a thread on another instance.",
+        );
+        return;
+      }
+
+      const knownPaths = new Set(
+        fileAttachments.map((attachment) => attachment.path),
+      );
+      const resolved: NavigationLaunchpadFileAttachment[] = [];
+      let unresolved = 0;
+      for (const file of files) {
+        const path = getPathForFile?.(file) ?? "";
+        if (!path) {
+          unresolved += 1;
+          continue;
+        }
+        if (knownPaths.has(path)) continue;
+        knownPaths.add(path);
+        resolved.push({
+          id: `${path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+          label: file.name || path.split(/[\\/]/).pop() || path,
+          path,
+        });
+      }
+      if (unresolved > 0) {
+        onAttachmentError?.(
+          "Could not resolve a local path for the pasted file.",
+        );
+      }
+      if (resolved.length === 0) return;
+
+      const remaining =
+        MAX_COMPACT_COMPOSER_FILE_ATTACHMENTS - fileAttachments.length;
+      if (resolved.length > remaining) {
+        onAttachmentError?.(
+          `You can attach up to ${MAX_COMPACT_COMPOSER_FILE_ATTACHMENTS} files per message.`,
+        );
+      }
+      setFileAttachments((current) => [
+        ...current,
+        ...resolved.slice(0, Math.max(0, remaining)),
+      ]);
+    },
+    [
+      canAttachLocalFiles,
+      fileAttachments,
+      getPathForFile,
+      onAttachmentError,
+    ],
+  );
+
+  const attachTransferredFiles = useCallback(
+    (dataTransfer: DataTransfer): boolean => {
+      const images = getImageFilesFromDataTransfer(dataTransfer);
+      const files = getNonImageFilesFromDataTransfer(dataTransfer);
+      if (images.length === 0 && files.length === 0) return false;
+      onAttachmentError?.(undefined);
+      attachLocalFiles(files);
+      attachImages(images);
+      return true;
+    },
+    [attachImages, attachLocalFiles, onAttachmentError],
+  );
+
+  const onPaste = useCallback(
+    (event: ClipboardEvent<HTMLElement>) => {
+      if (attachTransferredFiles(event.clipboardData)) {
+        event.preventDefault();
+      }
+    },
+    [attachTransferredFiles],
+  );
+
+  const onDragOver = useCallback((event: DragEvent<HTMLElement>) => {
+    if (!hasAnyFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const onDrop = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      if (attachTransferredFiles(event.dataTransfer)) {
+        event.preventDefault();
+      }
+    },
+    [attachTransferredFiles],
   );
 
   // The editor forwards the keys it does not claim itself: Enter without
@@ -640,6 +748,8 @@ export function CompactComposer(props: CompactComposerProps) {
           label={`Message ${props.threadTitle}`}
           markdownConversion
           onChange={mentions.handleChange}
+          onDragOver={onDragOver}
+          onDrop={onDrop}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
           placeholder={props.placeholder ?? "Reply…"}
@@ -677,6 +787,33 @@ export function CompactComposer(props: CompactComposerProps) {
                 <CloseIcon aria-hidden="true" size={10} />
               </button>
             </div>
+          ))}
+        </div>
+      ) : null}
+
+      {fileAttachments.length > 0 ? (
+        <div
+          aria-label="Attached files"
+          className="compact-composer__files"
+        >
+          {fileAttachments.map((attachment) => (
+            <span className="compact-composer__file" key={attachment.id}>
+              <span className="compact-composer__file-label">
+                {attachment.label}
+              </span>
+              <button
+                aria-label={`Remove ${attachment.label}`}
+                className="compact-composer__file-remove"
+                onClick={() => {
+                  setFileAttachments((current) =>
+                    current.filter((candidate) => candidate.id !== attachment.id),
+                  );
+                }}
+                type="button"
+              >
+                <CloseIcon aria-hidden="true" size={9} />
+              </button>
+            </span>
           ))}
         </div>
       ) : null}
@@ -751,6 +888,7 @@ export function CompactComposer(props: CompactComposerProps) {
             || (
               mentions.text.trim().length === 0
               && imageAttachments.length === 0
+              && fileAttachments.length === 0
             )
             || (props.busy && props.canSteer === false)
           }

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -184,7 +184,8 @@ export function CompactComposer(props: CompactComposerProps) {
   const [fileAttachments, setFileAttachments] = useState<
     NavigationLaunchpadFileAttachment[]
   >([]);
-  const [normalizingImages, setNormalizingImages] = useState(false);
+  const [normalizingImageBatches, setNormalizingImageBatches] = useState(0);
+  const normalizingImages = normalizingImageBatches > 0;
   // Click-away and Escape close the menu, same hook as the composer
   // dropdowns. Without it the menu survives a click on the transcript
   // behind it and covers the conversation.
@@ -272,7 +273,7 @@ export function CompactComposer(props: CompactComposerProps) {
         );
       }
 
-      setNormalizingImages(true);
+      setNormalizingImageBatches((current) => current + 1);
       void Promise.all(
         accepted.map(async ({ file, type }, index) => {
           const fallbackName = formatPastedImageName(type, index);
@@ -318,7 +319,9 @@ export function CompactComposer(props: CompactComposerProps) {
               : "The pasted image could not be read.",
           );
         })
-        .finally(() => setNormalizingImages(false));
+        .finally(() => {
+          setNormalizingImageBatches((current) => Math.max(0, current - 1));
+        });
     },
     [
       imageAttachments.length,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -168,6 +168,16 @@ import {
   resolveThreadSummaryReference,
   serializeDraftWithSkillTokens,
 } from "./composer-mention-tokens";
+import {
+  formatPastedImageAlt,
+  formatPastedImageName,
+  getImageFilesFromDataTransfer,
+  getNonImageFilesFromDataTransfer,
+  hasAnyFiles,
+  isGifFile,
+  readFileAsImageDataUrl,
+  type ComposerImageFile,
+} from "./composer-image-files";
 import { HighlightedAutocompleteLabel } from "./HighlightedAutocompleteLabel";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
 import { ProjectPicker } from "./ProjectPicker";
@@ -538,11 +548,6 @@ type PendingProgrammaticComposerChange = {
   expectedSkillTokensSignature: string;
   staleDraft: string;
   staleSkillTokensSignature: string;
-};
-
-type ComposerImageFile = {
-  file: File;
-  type: string;
 };
 
 type ModelOption = NonNullable<
@@ -12314,179 +12319,6 @@ function formatCompactNumber(value: number): string {
   return String(Math.round(value));
 }
 
-function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImageFile[] {
-  const files: ComposerImageFile[] = [];
-  const seenFiles = new Set<string>();
-  let foundImageItem = false;
-
-  for (const item of Array.from(dataTransfer.items)) {
-    if (item.kind !== "file") {
-      continue;
-    }
-
-    const file = item.getAsFile();
-    if (!file) {
-      continue;
-    }
-
-    const type = isSupportedComposerImageMimeType(item.type)
-      ? item.type
-      : inferTransferImageType(file);
-    if (!type) {
-      continue;
-    }
-
-    foundImageItem = true;
-    const key = buildFileKey(file);
-    if (!seenFiles.has(key)) {
-      files.push({ file, type });
-      seenFiles.add(key);
-    }
-  }
-
-  if (foundImageItem) {
-    return files;
-  }
-
-  for (const file of Array.from(dataTransfer.files)) {
-    const type = inferTransferImageType(file);
-    if (!type) {
-      continue;
-    }
-
-    const key = buildFileKey(file);
-    if (!seenFiles.has(key)) {
-      files.push({ file, type });
-      seenFiles.add(key);
-    }
-  }
-
-  return files;
-}
-
-/**
- * Sibling of getImageFilesFromDataTransfer for the path-only file tray:
- * every dropped/pasted File that is NOT an image (those keep the existing
- * attach-image path), deduped by content key.
- */
-function getNonImageFilesFromDataTransfer(dataTransfer: DataTransfer): File[] {
-  const files: File[] = [];
-  const seenFiles = new Set<string>();
-  let foundFileItem = false;
-
-  for (const item of Array.from(dataTransfer.items)) {
-    if (item.kind !== "file") {
-      continue;
-    }
-
-    const file = item.getAsFile();
-    if (!file) {
-      continue;
-    }
-
-    foundFileItem = true;
-    if (
-      isSupportedComposerImageMimeType(item.type)
-      || inferTransferImageType(file)
-    ) {
-      continue;
-    }
-
-    const key = buildFileKey(file);
-    if (!seenFiles.has(key)) {
-      files.push(file);
-      seenFiles.add(key);
-    }
-  }
-
-  if (foundFileItem) {
-    return files;
-  }
-
-  for (const file of Array.from(dataTransfer.files)) {
-    if (inferTransferImageType(file)) {
-      continue;
-    }
-
-    const key = buildFileKey(file);
-    if (!seenFiles.has(key)) {
-      files.push(file);
-      seenFiles.add(key);
-    }
-  }
-
-  return files;
-}
-
-function hasAnyFiles(dataTransfer: DataTransfer): boolean {
-  for (const item of Array.from(dataTransfer.items)) {
-    if (item.kind === "file") {
-      return true;
-    }
-  }
-
-  return dataTransfer.files.length > 0;
-}
-
-function buildFileKey(file: File): string {
-  return `${file.name}:${file.type}:${file.size}:${file.lastModified}`;
-}
-
-function inferTransferImageType(file: File): string | undefined {
-  if (isSupportedComposerImageMimeType(file.type)) {
-    return file.type;
-  }
-
-  const extension = file.name.toLowerCase().split(".").pop();
-  return extension === "gif" ? "image/gif" : undefined;
-}
-
-// Keep this list aligned with formats the composer deliberately normalizes or
-// preserves. An arbitrary `image/*` MIME (for example, a huge TIFF) is a local
-// file reference, not authorization to read and upload its contents.
-function isSupportedComposerImageMimeType(type: string): boolean {
-  switch (type.trim().toLowerCase()) {
-    case "image/gif":
-    case "image/heic":
-    case "image/heif":
-    case "image/jpeg":
-    case "image/jpg":
-    case "image/png":
-    case "image/svg+xml":
-    case "image/webp":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function isGifFile(file: File, type: string): boolean {
-  return inferTransferImageType(file) === "image/gif" || type.toLowerCase() === "image/gif";
-}
-
-function readFileAsImageDataUrl(file: File, mimeType: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      if (typeof reader.result === "string") {
-        if (reader.result.startsWith(`data:${mimeType}`)) {
-          resolve(reader.result);
-          return;
-        }
-        if (/^data:[^,]*,/i.test(reader.result)) {
-          resolve(reader.result.replace(/^data:[^,]*,/i, `data:${mimeType};base64,`));
-          return;
-        }
-      }
-      reject(new Error("The image did not produce an image data URL."));
-    });
-    reader.addEventListener("error", () => {
-      reject(reader.error ?? new Error("The image could not be read."));
-    });
-    reader.readAsDataURL(file);
-  });
-}
-
 /**
  * Small, fast, non-cryptographic 53-bit hash (cyrb53) over an image data URL.
  * Used only to bucket like-sized attachments for in-memory de-duplication; it
@@ -12560,18 +12392,6 @@ function formatImageDimensions(
     return undefined;
   }
   return `${Math.round(width)}×${Math.round(height)}`;
-}
-
-function formatPastedImageName(type: string, index: number): string {
-  const extension = type.split("/")[1] || "png";
-  return `pasted-image-${index + 1}.${extension}`;
-}
-
-function formatPastedImageAlt(
-  attachment: Pick<ComposerImageAttachment, "name">,
-  index: number
-): string {
-  return attachment.name || `Pasted image ${index + 1}`;
 }
 
 function formatBytes(size: number): string {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -1,10 +1,63 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   NavigationDirectorySummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
+import { normalizeImageFile } from "../../../lib/image-normalization";
 import { CompactComposer } from "../CompactComposer";
+
+vi.mock("../../../lib/image-normalization", () => ({
+  normalizeImageFile: vi.fn(),
+}));
+
+type NormalizedImage = Awaited<ReturnType<typeof normalizeImageFile>>;
+
+function normalizedImage(file: File): NormalizedImage {
+  return {
+    conversionPath: "renderer",
+    dataUrl: `data:image/png;base64,${file.name}`,
+    height: 24,
+    mimeType: "image/png",
+    original: {
+      height: 24,
+      mimeType: file.type,
+      name: file.name,
+      size: file.size,
+      width: 32,
+    },
+    size: file.size,
+    width: 32,
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function pasteImage(input: HTMLElement, file: File): void {
+  fireEvent.paste(input, {
+    clipboardData: {
+      files: [file],
+      getData: () => "",
+      items: [
+        {
+          getAsFile: () => file,
+          kind: "file",
+          type: file.type,
+        },
+      ],
+      types: ["Files"],
+    },
+  });
+}
 
 function renderComposer(overrides: Partial<Parameters<typeof CompactComposer>[0]> = {}) {
   const onSend = vi.fn();
@@ -31,6 +84,12 @@ function pasteMarkdown(input: HTMLElement, text: string): void {
 }
 
 describe("CompactComposer", () => {
+  beforeEach(() => {
+    vi.mocked(normalizeImageFile).mockImplementation(async (file) =>
+      normalizedImage(file),
+    );
+  });
+
   it("sends on Enter and clears the draft", () => {
     const { onSend } = renderComposer();
     const input = screen.getByRole("textbox", { name: "Message Thread t1" });
@@ -66,6 +125,48 @@ describe("CompactComposer", () => {
     fireEvent.change(input, { target: { value: "should not go" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("keeps send disabled until every overlapping image batch finishes", async () => {
+    const first = deferred<NormalizedImage>();
+    const second = deferred<NormalizedImage>();
+    vi.mocked(normalizeImageFile)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { onSend } = renderComposer();
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    const firstFile = new File(["first"], "first.png", {
+      type: "image/png",
+    });
+    const secondFile = new File(["second"], "second.png", {
+      type: "image/png",
+    });
+
+    pasteImage(input, firstFile);
+    pasteImage(input, secondFile);
+    fireEvent.change(input, { target: { value: "Send both" } });
+    const send = screen.getByRole("button", { name: "Send" }) as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+
+    await act(async () => first.resolve(normalizedImage(firstFile)));
+    await screen.findByRole("img", { name: "first.png" });
+    expect(send.disabled).toBe(true);
+    fireEvent.click(send);
+    expect(onSend).not.toHaveBeenCalled();
+
+    await act(async () => second.resolve(normalizedImage(secondFile)));
+    await screen.findByRole("img", { name: "second.png" });
+    await waitFor(() => expect(send.disabled).toBe(false));
+    fireEvent.click(send);
+
+    expect(onSend).toHaveBeenCalledWith(
+      "Send both",
+      expect.arrayContaining([
+        expect.objectContaining({ name: "first.png" }),
+        expect.objectContaining({ name: "second.png" }),
+      ]),
+      [],
+    );
   });
 
   it("shows model, effort, and access mode as the status chip", () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer-image-files.test.ts
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer-image-files.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getImageFilesFromDataTransfer } from "../composer-image-files";
+
+function imageTransfer(files: File[]): DataTransfer {
+  return {
+    files,
+    items: files.map((file) => ({
+      getAsFile: () => file,
+      kind: "file",
+      type: file.type,
+    })),
+  } as unknown as DataTransfer;
+}
+
+describe("composer image transfer formats", () => {
+  it("keeps the full composer image format set available to compact surfaces", () => {
+    const files = [
+      new File(["gif"], "animated.gif", { type: "image/gif" }),
+      new File(["heic"], "camera.heic", { type: "image/heic" }),
+      new File(["heif"], "camera.heif", { type: "image/heif" }),
+      new File(["jpeg"], "photo.jpeg", { type: "image/jpeg" }),
+      new File(["jpg"], "photo.jpg", { type: "image/jpg" }),
+      new File(["png"], "capture.png", { type: "image/png" }),
+      new File(["svg"], "diagram.svg", { type: "image/svg+xml" }),
+      new File(["webp"], "capture.webp", { type: "image/webp" }),
+    ];
+
+    expect(
+      getImageFilesFromDataTransfer(imageTransfer(files)).map(
+        ({ file, type }) => [file.name, type],
+      ),
+    ).toEqual(files.map((file) => [file.name, file.type]));
+  });
+
+  it("does not treat PDFs or arbitrary image MIME types as uploadable images", () => {
+    const files = [
+      new File(["%PDF"], "brief.pdf", { type: "application/pdf" }),
+      new File(["tiff"], "scan.tiff", { type: "image/tiff" }),
+    ];
+
+    expect(getImageFilesFromDataTransfer(imageTransfer(files))).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/composer-image-files.ts
+++ b/apps/desktop/src/renderer/src/features/composer/composer-image-files.ts
@@ -1,0 +1,201 @@
+export type ComposerImageFile = {
+  file: File;
+  type: string;
+};
+
+export function getImageFilesFromDataTransfer(
+  dataTransfer: DataTransfer,
+): ComposerImageFile[] {
+  const files: ComposerImageFile[] = [];
+  const seenFiles = new Set<string>();
+  let foundImageItem = false;
+
+  for (const item of Array.from(dataTransfer.items)) {
+    if (item.kind !== "file") {
+      continue;
+    }
+
+    const file = item.getAsFile();
+    if (!file) {
+      continue;
+    }
+
+    const type = isSupportedComposerImageMimeType(item.type)
+      ? item.type
+      : inferTransferImageType(file);
+    if (!type) {
+      continue;
+    }
+
+    foundImageItem = true;
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push({ file, type });
+      seenFiles.add(key);
+    }
+  }
+
+  if (foundImageItem) {
+    return files;
+  }
+
+  for (const file of Array.from(dataTransfer.files)) {
+    const type = inferTransferImageType(file);
+    if (!type) {
+      continue;
+    }
+
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push({ file, type });
+      seenFiles.add(key);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Every dropped/pasted File that is not an image. Image files stay on the
+ * upload path; callers can turn the rest into path-only references.
+ */
+export function getNonImageFilesFromDataTransfer(
+  dataTransfer: DataTransfer,
+): File[] {
+  const files: File[] = [];
+  const seenFiles = new Set<string>();
+  let foundFileItem = false;
+
+  for (const item of Array.from(dataTransfer.items)) {
+    if (item.kind !== "file") {
+      continue;
+    }
+
+    const file = item.getAsFile();
+    if (!file) {
+      continue;
+    }
+
+    foundFileItem = true;
+    if (
+      isSupportedComposerImageMimeType(item.type)
+      || inferTransferImageType(file)
+    ) {
+      continue;
+    }
+
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push(file);
+      seenFiles.add(key);
+    }
+  }
+
+  if (foundFileItem) {
+    return files;
+  }
+
+  for (const file of Array.from(dataTransfer.files)) {
+    if (inferTransferImageType(file)) {
+      continue;
+    }
+
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push(file);
+      seenFiles.add(key);
+    }
+  }
+
+  return files;
+}
+
+export function hasAnyFiles(dataTransfer: DataTransfer): boolean {
+  for (const item of Array.from(dataTransfer.items)) {
+    if (item.kind === "file") {
+      return true;
+    }
+  }
+
+  return dataTransfer.files.length > 0;
+}
+
+function buildFileKey(file: File): string {
+  return `${file.name}:${file.type}:${file.size}:${file.lastModified}`;
+}
+
+function inferTransferImageType(file: File): string | undefined {
+  if (isSupportedComposerImageMimeType(file.type)) {
+    return file.type;
+  }
+
+  const extension = file.name.toLowerCase().split(".").pop();
+  return extension === "gif" ? "image/gif" : undefined;
+}
+
+// Keep this list aligned with formats the composer deliberately normalizes or
+// preserves. An arbitrary image MIME such as TIFF remains a local file rather
+// than authorization to read and upload its contents.
+function isSupportedComposerImageMimeType(type: string): boolean {
+  switch (type.trim().toLowerCase()) {
+    case "image/gif":
+    case "image/heic":
+    case "image/heif":
+    case "image/jpeg":
+    case "image/jpg":
+    case "image/png":
+    case "image/svg+xml":
+    case "image/webp":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isGifFile(file: File, type: string): boolean {
+  return inferTransferImageType(file) === "image/gif"
+    || type.toLowerCase() === "image/gif";
+}
+
+export function readFileAsImageDataUrl(
+  file: File,
+  mimeType: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string") {
+        if (reader.result.startsWith(`data:${mimeType}`)) {
+          resolve(reader.result);
+          return;
+        }
+        if (/^data:[^,]*,/i.test(reader.result)) {
+          resolve(
+            reader.result.replace(
+              /^data:[^,]*,/i,
+              `data:${mimeType};base64,`,
+            ),
+          );
+          return;
+        }
+      }
+      reject(new Error("The image did not produce an image data URL."));
+    });
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error("The image could not be read."));
+    });
+    reader.readAsDataURL(file);
+  });
+}
+
+export function formatPastedImageName(type: string, index: number): string {
+  const extension = type.split("/")[1] || "png";
+  return `pasted-image-${index + 1}.${extension}`;
+}
+
+export function formatPastedImageAlt(
+  attachment: { name: string },
+  index: number,
+): string {
+  return attachment.name || `Pasted image ${index + 1}`;
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -10,12 +10,15 @@ import {
 } from "react";
 import {
   buildThreadIdentityKey,
+  isRemoteFederationTarget,
   type CelestialIconId,
+  type NavigationLaunchpadFileAttachment,
   type NavigationLaunchpadImageAttachment,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
+import { buildDirectoryReferenceMarkdown } from "../../lib/directory-references";
 import { useBackendSummaries } from "../../lib/useBackendSummaries";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
@@ -361,20 +364,41 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     async (
       text: string,
       imageAttachments: NavigationLaunchpadImageAttachment[] = [],
+      fileAttachments: NavigationLaunchpadFileAttachment[] = [],
     ): Promise<boolean> => {
       setSendError(undefined);
       setSendNotice(undefined);
+      const fileReferences = fileAttachments
+        .map((attachment) =>
+          buildDirectoryReferenceMarkdown({
+            label: attachment.label,
+            path: attachment.path,
+          }),
+        )
+        .join("\n");
+      const displayText = fileReferences
+        ? text
+          ? `${text}\n\n${fileReferences}`
+          : fileReferences
+        : text;
       const imageParts = imageAttachments.map((attachment, index) => ({
         alt: attachment.name || `Pasted image ${index + 1}`,
         type: "image" as const,
         url: attachment.url,
       }));
       const input = [
-        ...(text ? [{ type: "text" as const, text }] : []),
+        ...(displayText
+          ? [{ type: "text" as const, text: displayText }]
+          : []),
         ...imageAttachments.map((attachment) => ({
           name: attachment.name,
           type: "image" as const,
           url: attachment.url,
+        })),
+        ...fileAttachments.map((attachment) => ({
+          name: attachment.label,
+          path: attachment.path,
+          type: "localFile" as const,
         })),
       ];
 
@@ -396,7 +420,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           return false;
         }
         const optimisticId = sessionRef.current.addOptimisticUserMessage(
-          text,
+          displayText,
           imageParts,
         );
         try {
@@ -429,7 +453,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
 
       if (!desktopApi?.startTurn) return false;
       const optimisticId = sessionRef.current.addOptimisticUserMessage(
-        text,
+        displayText,
         imageParts,
       );
       try {
@@ -897,13 +921,17 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
 
       <MemoizedCompactComposer
         busy={session.threadBusy}
+        canAttachLocalFiles={
+          !federationTarget || !isRemoteFederationTarget(federationTarget)
+        }
         canSteer={canSteer}
         executionMode={threadExecutionMode}
         fastMode={threadFastMode}
+        getPathForFile={desktopApi?.getPathForFile}
         mentionSources={mentionSources}
         model={threadModel}
         normalizeImageForUpload={desktopApi?.normalizeImageForUpload}
-        onImageError={setSendError}
+        onAttachmentError={setSendError}
         onInterrupt={onInterrupt}
         onSend={send}
         reasoningEffort={threadReasoningEffort}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -11,6 +11,7 @@ import {
 import {
   buildThreadIdentityKey,
   type CelestialIconId,
+  type NavigationLaunchpadImageAttachment,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
@@ -357,9 +358,25 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
    * allow.
    */
   const send = useCallback(
-    async (text: string): Promise<boolean> => {
+    async (
+      text: string,
+      imageAttachments: NavigationLaunchpadImageAttachment[] = [],
+    ): Promise<boolean> => {
       setSendError(undefined);
       setSendNotice(undefined);
+      const imageParts = imageAttachments.map((attachment, index) => ({
+        alt: attachment.name || `Pasted image ${index + 1}`,
+        type: "image" as const,
+        url: attachment.url,
+      }));
+      const input = [
+        ...(text ? [{ type: "text" as const, text }] : []),
+        ...imageAttachments.map((attachment) => ({
+          name: attachment.name,
+          type: "image" as const,
+          url: attachment.url,
+        })),
+      ];
 
       if (sessionRef.current.threadBusy) {
         if (!desktopApi?.steerTurn) {
@@ -378,13 +395,16 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           );
           return false;
         }
-        const optimisticId = sessionRef.current.addOptimisticUserMessage(text);
+        const optimisticId = sessionRef.current.addOptimisticUserMessage(
+          text,
+          imageParts,
+        );
         try {
           const response = await desktopApi.steerTurn({
             backend: thread.source,
             expectedTurnId: activeTurnId,
             federationTarget,
-            input: [{ type: "text", text }],
+            input,
             // Main dedupes retries by request id, so it has to be fresh per
             // attempt or a corrected resend would return the first result.
             requestId: `star-map-chat-card:${cardKey}:${activeTurnId}:${Date.now()}`,
@@ -408,13 +428,16 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       }
 
       if (!desktopApi?.startTurn) return false;
-      const optimisticId = sessionRef.current.addOptimisticUserMessage(text);
+      const optimisticId = sessionRef.current.addOptimisticUserMessage(
+        text,
+        imageParts,
+      );
       try {
         await desktopApi.startTurn({
           backend: thread.source,
           federationTarget,
           threadId: thread.id,
-          input: [{ type: "text", text }],
+          input,
         });
         return true;
       } catch (error) {
@@ -879,6 +902,8 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         fastMode={threadFastMode}
         mentionSources={mentionSources}
         model={threadModel}
+        normalizeImageForUpload={desktopApi?.normalizeImageForUpload}
+        onImageError={setSendError}
         onInterrupt={onInterrupt}
         onSend={send}
         reasoningEffort={threadReasoningEffort}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -75,6 +75,7 @@ export type StarMapChatCardProps = {
   thread: NavigationThreadSummary;
   /** Stack position; the host owns the order, we only read our depth. */
   zIndex: number;
+  pastedImageMaxPatches?: number;
 };
 
 type DragState = {
@@ -934,6 +935,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         onAttachmentError={setSendError}
         onInterrupt={onInterrupt}
         onSend={send}
+        pastedImageMaxPatches={props.pastedImageMaxPatches}
         reasoningEffort={threadReasoningEffort}
         secondaryActions={secondaryActions}
         settingsMenu={settingsMenu}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -404,6 +404,7 @@ type StarMapScreenProps = {
   onRefreshLocalThreads?: () => void;
   /** Settings -> Pricing, for the chat cards' context satellites. */
   pricingDisplayOptions?: { codexCredits: boolean; usd: boolean };
+  pastedImageMaxPatches?: number;
   threadPricingSummaryEnabled?: boolean;
 };
 
@@ -4454,6 +4455,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               onOpenFull={openThreadFully}
               onRaise={chatCards.raise}
               onRectChange={chatCards.setRect}
+              pastedImageMaxPatches={props.pastedImageMaxPatches}
               rect={card.rect}
               thread={liveThread}
               scale={view.scale}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -97,6 +97,9 @@ export function StarMapWindow() {
           thinkingThreadKeys: session.thinkingThreadKeys,
         }}
         localInstanceLabel={settings.snapshot?.federation.instanceLabel.value}
+        pastedImageMaxPatches={
+          settings.snapshot?.imageUploads.pastedImageMaxPatches.value
+        }
         pricingDisplayOptions={{
           codexCredits:
             settings.snapshot?.experimental.threadPricingDisplayCodexCredits

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -11,6 +11,24 @@ import {
   DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
 } from "../../../lib/thread-history-limits";
 
+vi.mock("../../../lib/image-normalization", () => ({
+  normalizeImageFile: vi.fn(async (file: File) => ({
+    conversionPath: "renderer" as const,
+    dataUrl: "data:image/png;base64,c3Rhci1tYXA=",
+    height: 24,
+    mimeType: "image/png" as const,
+    original: {
+      height: 24,
+      mimeType: file.type,
+      name: file.name,
+      size: file.size,
+      width: 32,
+    },
+    size: file.size,
+    width: 32,
+  })),
+}));
+
 const RECT = { left: 40, top: 40, width: 420, height: 520 };
 
 /**
@@ -217,6 +235,48 @@ describe("StarMapChatCard federation routing", () => {
     expect(request.threadId).toBe("t-local");
     // No per-thread ref, so nothing overrides the renderer's own target.
     expect(request.federationTarget).toBeUndefined();
+  });
+
+  it("pastes a PNG into the outgoing turn", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["star-map"], "star-map.png", {
+      type: "image/png",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [image],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => image,
+            kind: "file",
+            type: "image/png",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+    await screen.findByRole("img", { name: "star-map.png" });
+    fireEvent.change(input, { target: { value: "What is wrong here?" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [
+            { type: "text", text: "What is wrong here?" },
+            {
+              type: "image",
+              name: "star-map.png",
+              url: "data:image/png;base64,c3Rhci1tYXA=",
+            },
+          ],
+        }),
+      );
+    });
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -278,6 +278,123 @@ describe("StarMapChatCard federation routing", () => {
       );
     });
   });
+
+  it("preserves an animated GIF instead of normalizing it", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["GIF89a"], "animated.gif", {
+      type: "image/gif",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [image],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => image,
+            kind: "file",
+            type: "image/gif",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+    await screen.findByRole("img", { name: "animated.gif" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [
+            {
+              type: "image",
+              name: "animated.gif",
+              url: "data:image/gif;base64,R0lGODlh",
+            },
+          ],
+        }),
+      );
+    });
+  });
+
+  it("sends a pasted PDF through the existing local-file turn path", async () => {
+    const desktopApi = buildApi({
+      getPathForFile: vi.fn(() => "/tmp/brief.pdf"),
+    });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const pdf = new File(["%PDF-1.7"], "brief.pdf", {
+      type: "application/pdf",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [pdf],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => pdf,
+            kind: "file",
+            type: "application/pdf",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+    expect(await screen.findByText("brief.pdf")).toBeTruthy();
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [
+            {
+              type: "text",
+              text: "[@brief.pdf](/tmp/brief.pdf)",
+            },
+            {
+              name: "brief.pdf",
+              path: "/tmp/brief.pdf",
+              type: "localFile",
+            },
+          ],
+        }),
+      );
+    });
+  });
+
+  it("does not attach a local PDF to a remote thread", async () => {
+    const getPathForFile = vi.fn(() => "/tmp/brief.pdf");
+    const desktopApi = buildApi({ getPathForFile });
+    renderCard({ desktopApi, thread: remoteThread() });
+    const input = screen.getByRole("textbox", { name: "Message Remote work" });
+    const pdf = new File(["%PDF-1.7"], "brief.pdf", {
+      type: "application/pdf",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [pdf],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => pdf,
+            kind: "file",
+            type: "application/pdf",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(
+      /another instance/,
+    );
+    expect(getPathForFile).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Attached files")).toBeNull();
+  });
 });
 
 describe("StarMapChatCard send failures", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { normalizeImageFile } from "../../../lib/image-normalization";
 import { StarMapChatCard } from "../StarMapChatCard";
 import { resetComposerMentionSourcesCache } from "../../composer/useComposerMentionSources";
 import { isStarMapTypingTarget } from "../star-map-keyboard";
@@ -93,6 +94,7 @@ function buildApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
 
 type CardParams = {
   desktopApi: DesktopApi;
+  pastedImageMaxPatches?: number;
   thread: NavigationThreadSummary;
 };
 
@@ -105,6 +107,7 @@ function card(params: CardParams) {
       onOpenFull={() => undefined}
       onRaise={() => undefined}
       onRectChange={() => undefined}
+      pastedImageMaxPatches={params.pastedImageMaxPatches}
       rect={RECT}
       thread={params.thread}
       scale={1}
@@ -277,6 +280,41 @@ describe("StarMapChatCard federation routing", () => {
         }),
       );
     });
+  });
+
+  it("uses the configured image patch budget when normalizing", async () => {
+    vi.mocked(normalizeImageFile).mockClear();
+    const desktopApi = buildApi();
+    renderCard({
+      desktopApi,
+      pastedImageMaxPatches: 321,
+      thread: localThread(),
+    });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["star-map"], "star-map.png", {
+      type: "image/png",
+    });
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        files: [image],
+        getData: () => "",
+        items: [
+          {
+            getAsFile: () => image,
+            kind: "file",
+            type: "image/png",
+          },
+        ],
+        types: ["Files"],
+      },
+    });
+
+    await screen.findByRole("img", { name: "star-map.png" });
+    expect(normalizeImageFile).toHaveBeenCalledWith(
+      image,
+      expect.objectContaining({ maxPatchCount: 321 }),
+    );
   });
 
   it("preserves an animated GIF instead of normalizing it", async () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13340,7 +13340,7 @@ textarea,
   min-height: 22px;
   padding: 0 3px 0 7px;
   border: 1px solid var(--border-subtle);
-  border-radius: 999px;
+  border-radius: 6px;
   background: var(--bg-input);
   color: var(--text-secondary);
   font-size: 10px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13272,6 +13272,56 @@ textarea,
   left: 8px;
 }
 
+.compact-composer__attachments {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 6px;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.compact-composer__attachment {
+  position: relative;
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+}
+
+.compact-composer__attachment-preview {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.compact-composer__attachment-remove {
+  display: inline-flex;
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.compact-composer__attachment-remove:hover,
+.compact-composer__attachment-remove:focus-visible {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+  outline: none;
+}
+
 .compact-composer__strip {
   display: flex;
   flex: 0 0 auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13322,6 +13322,59 @@ textarea,
   outline: none;
 }
 
+.compact-composer__files {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 4px;
+  max-height: 52px;
+  overflow-y: auto;
+}
+
+.compact-composer__file {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 180px;
+  min-height: 22px;
+  padding: 0 3px 0 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
+.compact-composer__file-label {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.compact-composer__file-remove {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.compact-composer__file-remove:hover,
+.compact-composer__file-remove:focus-visible {
+  background: var(--bg-panel-hover);
+  color: var(--accent-bright);
+  outline: none;
+}
+
 .compact-composer__strip {
   display: flex;
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary

- accept pasted and dropped attachments in the Star Map compact composer using the same DataTransfer image parsing as the full composer
- support GIF, HEIC/HEIF, JPEG/JPG, PNG, SVG, and WebP, preserving GIF animation and normalizing the other supported image formats
- route PDFs and other local files through the existing `localFile` backend contract, including attachment-only sends and remote-instance filesystem safeguards
- show compact removable image previews and file pills
- include image/file inputs and optimistic image parts in both Star Map start and steer requests, restoring attachments when a send is rejected
- add renderer regression coverage for PNG, GIF, the complete image MIME allowlist, PDF-only sends, and remote file rejection

## Validation

- focused composer, Star Map, render-cost, image-format, and theme-contract suites — 445 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warnings only
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Follow-up audit

A separate read-only Star Map composer audit found additional parity gaps that this focused attachment fix does not expand into: durable card drafts, PDF thumbnail/lightbox previews, model capability gating before image attachment, accepted-reply unread clearing, scheduling/review flows, and durable queued-turn editing. Those should be handled as follow-up work rather than folded into this attachment regression fix.
