### PR TITLE
fix(desktop): surface sub-agents in star map chats

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -25,6 +25,7 @@ import {
 import { useComposerMentionSources } from "../composer/useComposerMentionSources";
 import type { ComposerMentionSources } from "../composer/useComposerMentions";
 import { TranscriptList } from "../thread-detail/TranscriptList";
+import { ActiveSubAgentsStrip } from "../thread-detail/ActiveSubAgentsStrip";
 import { useTranscriptWindow } from "../thread-detail/useTranscriptWindow";
 import { collectEditedFileGroups } from "../thread-detail/edited-file-groups";
 import { DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT } from "../../lib/thread-history-limits";
@@ -52,6 +53,8 @@ export type StarMapChatCardProps = {
   onClose: (cardKey: string) => void;
   /** Escape hatch into the full thread surface. */
   onOpenFull: (thread: NavigationThreadSummary) => void;
+  /** Refresh the owning navigation feed after a monitor is stopped. */
+  onRefreshNavigation?: () => Promise<void>;
   onRaise: (cardKey: string) => void;
   onRectChange: (cardKey: string, rect: ChatCardRect) => void;
   /** Satellite cards, docked to this card and owned by the controller. */
@@ -97,6 +100,7 @@ type DragState = {
  * `star-map-chat-card-render-cost.test.tsx` pins the result.
  */
 const MemoizedCompactComposer = memo(CompactComposer);
+const MemoizedActiveSubAgentsStrip = memo(ActiveSubAgentsStrip);
 
 /**
  * One chat card, anchored in the star map.
@@ -871,6 +875,12 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           {sendNotice}
         </p>
       ) : undefined}
+
+      <MemoizedActiveSubAgentsStrip
+        desktopApi={desktopApi}
+        onRefreshNavigation={props.onRefreshNavigation}
+        thread={thread}
+      />
 
       <MemoizedCompactComposer
         busy={session.threadBusy}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -401,7 +401,7 @@ type StarMapScreenProps = {
   /** The local instance card's open action: focus the main window. */
   onFocusLocalInstance: () => void;
   /** Refresh the App's navigation snapshot (after intake creates locally). */
-  onRefreshLocalThreads?: () => void;
+  onRefreshLocalThreads?: () => Promise<void>;
   /** Settings -> Pricing, for the chat cards' context satellites. */
   pricingDisplayOptions?: { codexCredits: boolean; usd: boolean };
   threadPricingSummaryEnabled?: boolean;
@@ -2442,19 +2442,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
     setSelection((current) => (current.size > 0 ? new Set() : current));
   }, [localInstanceId]);
 
+  const onRefreshLocalThreads = props.onRefreshLocalThreads;
+  const refreshRemoteInstance = remote.refreshInstance;
   /**
    * Refresh whichever cloud owns a thread. Archive removes it from the
    * owning instance, so the map has to re-fetch rather than guess.
    */
   const refreshOwner = useCallback(
-    (instanceId: string) => {
+    async (instanceId: string): Promise<void> => {
       if (instanceId === localInstanceId) {
-        props.onRefreshLocalThreads?.();
+        await onRefreshLocalThreads?.();
       } else {
-        setRemoteRefreshNonce((nonce) => nonce + 1);
+        await refreshRemoteInstance(instanceId);
       }
     },
-    [localInstanceId, props],
+    [localInstanceId, onRefreshLocalThreads, refreshRemoteInstance],
   );
 
   /**
@@ -2583,7 +2585,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         for (const instanceId of new Set(
           targets.map((target) => target.instanceId),
         )) {
-          refreshOwner(instanceId);
+          void refreshOwner(instanceId);
         }
       });
     },
@@ -4452,9 +4454,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
               }
               onClose={chatCards.close}
               onOpenFull={openThreadFully}
-              onRefreshNavigation={async () => {
-                refreshOwner(cardInstanceId ?? localInstanceId);
-              }}
+              onRefreshNavigation={() =>
+                refreshOwner(cardInstanceId ?? localInstanceId)
+              }
               onRaise={chatCards.raise}
               onRectChange={chatCards.setRect}
               rect={card.rect}
@@ -4546,7 +4548,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               ),
             );
             if (created.instanceId === localInstanceId) {
-              props.onRefreshLocalThreads?.();
+              void props.onRefreshLocalThreads?.();
             } else {
               setRemoteRefreshNonce((nonce) => nonce + 1);
             }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -4452,6 +4452,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
               }
               onClose={chatCards.close}
               onOpenFull={openThreadFully}
+              onRefreshNavigation={async () => {
+                refreshOwner(cardInstanceId ?? localInstanceId);
+              }}
               onRaise={chatCards.raise}
               onRectChange={chatCards.setRect}
               rect={card.rect}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -117,9 +117,7 @@ export function StarMapWindow() {
         onFocusLocalInstance={() => {
           void desktopApi?.focusMainWindowFromStarMap?.();
         }}
-        onRefreshLocalThreads={() => {
-          void navigation.refresh?.();
-        }}
+        onRefreshLocalThreads={navigation.refresh}
       />
     </div>
   );

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -169,6 +169,76 @@ describe("StarMapChatCard transcript loading", () => {
   });
 });
 
+describe("StarMapChatCard sub-agents", () => {
+  it("surfaces a running monitor above the compact composer", () => {
+    const desktopApi = buildApi();
+    renderCard({
+      desktopApi,
+      thread: localThread({
+        subAgents: [
+          {
+            monitorId: "monitor-1",
+            task: "Watch the production rollout",
+            status: "running",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            backend: "codex",
+            monitorThreadId: "monitor-thread",
+            monitorTurnId: "monitor-turn",
+          },
+        ],
+      }),
+    });
+
+    const strip = screen.getByRole("region", { name: "Active sub-agents" });
+    expect(strip.textContent).toContain("Watch the production rollout");
+    expect(strip.compareDocumentPosition(screen.getByRole("textbox")))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("stops a remote monitor on its owning instance", async () => {
+    const stopSubAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t-remote",
+      monitorId: "monitor-remote",
+      stoppedAt: Date.now(),
+    }));
+    const desktopApi = buildApi({ stopSubAgent });
+    renderCard({
+      desktopApi,
+      thread: remoteThread({
+        subAgents: [
+          {
+            monitorId: "monitor-remote",
+            task: "Watch the peer rollout",
+            status: "running",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            backend: "codex",
+            monitorThreadId: "monitor-thread",
+            monitorTurnId: "monitor-turn",
+          },
+        ],
+      }),
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Stop sub-agent: Watch the peer rollout",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(stopSubAgent).toHaveBeenCalledWith({
+        backend: "codex",
+        federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+        threadId: "t-remote",
+        monitorId: "monitor-remote",
+      });
+    });
+  });
+});
+
 describe("StarMapChatCard federation routing", () => {
   it("hydrates a peer's thread against that peer", async () => {
     const desktopApi = buildApi();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -668,6 +669,79 @@ describe("StarMapScreen", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps a stopped monitor disabled until local navigation refreshes", async () => {
+    let resolveRefresh: (() => void) | undefined;
+    const refreshPending = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const onRefreshLocalThreads = vi.fn(() => refreshPending);
+    const stopSubAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t1",
+      monitorId: "monitor-1",
+      stoppedAt: Date.now(),
+    }));
+    render(
+      <StarMapScreen
+        desktopApi={{
+          ...buildDesktopApi(),
+          stopSubAgent,
+        } as unknown as DesktopApi}
+        localThreads={[
+          {
+            ...unreadThread("t1"),
+            subAgents: [
+              {
+                monitorId: "monitor-1",
+                task: "Watch production",
+                status: "running",
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+                backend: "codex",
+                monitorThreadId: "monitor-thread",
+                monitorTurnId: "monitor-turn",
+              },
+            ],
+          },
+        ]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+        onRefreshLocalThreads={onRefreshLocalThreads}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open thread: Thread t1/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open thread: Thread t1" }),
+    );
+    const stop = await screen.findByRole("button", {
+      name: "Stop sub-agent: Watch production",
+    });
+    fireEvent.click(stop);
+
+    await waitFor(() => {
+      expect(onRefreshLocalThreads).toHaveBeenCalledTimes(1);
+    });
+    expect(stop.textContent).toBe("Stopping…");
+    expect((stop as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(stop);
+    expect(stopSubAgent).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRefresh?.();
+      await refreshPending;
+    });
+    await waitFor(() => {
+      expect((stop as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+
   it("closes a chat card from its close button", async () => {
     render(
       <StarMapScreen
@@ -1060,7 +1134,7 @@ describe("StarMapScreen", () => {
       backend: "codex" as const,
       threadId: "t1",
     }));
-    const onRefreshLocalThreads = vi.fn();
+    const onRefreshLocalThreads = vi.fn(async () => undefined);
     render(
       <StarMapScreen
         desktopApi={{ ...buildDesktopApi(), archiveThread } as unknown as DesktopApi}
@@ -1157,7 +1231,7 @@ describe("StarMapScreen", () => {
       threadId: "t1",
       renamedAt: 1,
     }));
-    const onRefreshLocalThreads = vi.fn();
+    const onRefreshLocalThreads = vi.fn(async () => undefined);
     render(
       <StarMapScreen
         desktopApi={{ ...buildDesktopApi(), renameThread } as unknown as DesktopApi}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -62,7 +62,7 @@ function renderMap(
   count: number,
   overrides?: {
     desktopApi?: DesktopApi;
-    onRefreshLocalThreads?: () => void;
+    onRefreshLocalThreads?: () => Promise<void>;
   },
 ) {
   const desktopApi = overrides?.desktopApi ?? buildDesktopApi();
@@ -489,7 +489,7 @@ describe("star map card menu acts on the selection", () => {
         return { backend: "codex" as const, threadId: request.threadId };
       }),
     } as unknown as Partial<DesktopApi>);
-    const onRefreshLocalThreads = vi.fn();
+    const onRefreshLocalThreads = vi.fn(async () => undefined);
     renderMap(3, { desktopApi, onRefreshLocalThreads });
     await ready();
     await sweepEverything();
@@ -522,7 +522,7 @@ describe("star map card menu acts on the selection", () => {
 
   it("refreshes an owning cloud once, not once per archived card", async () => {
     const desktopApi = buildMutatingDesktopApi();
-    const onRefreshLocalThreads = vi.fn();
+    const onRefreshLocalThreads = vi.fn(async () => undefined);
     renderMap(4, { desktopApi, onRefreshLocalThreads });
     await ready();
     await sweepEverything();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapThreads.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapThreads.test.tsx
@@ -1,7 +1,8 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type {
   FederationPeerSummary,
+  NavigationSnapshot,
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -115,5 +116,55 @@ describe("useStarMapThreads", () => {
       expect(result.current.unreachableInstanceIds.has("pwr_a")).toBe(true);
     });
     expect(result.current.threadsByInstance.get("pwr_a")).toHaveLength(1);
+  });
+
+  it("resolves a manual refresh only after the peer snapshot is applied", async () => {
+    let resolveRefresh: ((snapshot: NavigationSnapshot) => void) | undefined;
+    const pendingRefresh = new Promise<NavigationSnapshot>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const getNavigationSnapshot = vi
+      .fn<NonNullable<DesktopApi["getNavigationSnapshot"]>>()
+      .mockResolvedValueOnce({
+        threads: [
+          { id: "thread-before" } as unknown as NavigationThreadSummary,
+        ],
+      } as NavigationSnapshot)
+      .mockImplementationOnce(async () => await pendingRefresh);
+    const desktopApi = { getNavigationSnapshot } as DesktopApi;
+    const { result } = renderHook(() =>
+      useStarMapThreads({
+        desktopApi,
+        peers: [peer("pwr_a", "connected")],
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.threadsByInstance.get("pwr_a")?.[0]?.id,
+      ).toBe("thread-before");
+    });
+
+    let settled = false;
+    const refresh = result.current.refreshInstance("pwr_a").then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await act(async () => {
+      resolveRefresh?.({
+        threads: [
+          { id: "thread-after" } as unknown as NavigationThreadSummary,
+        ],
+      } as NavigationSnapshot);
+      await refresh;
+    });
+
+    expect(settled).toBe(true);
+    expect(result.current.threadsByInstance.get("pwr_a")?.[0]?.id).toBe(
+      "thread-after",
+    );
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   FederationPeerSummary,
   NavigationThreadSummary,
@@ -18,7 +18,14 @@ export type StarMapRemoteThreads = {
    * instead of vanishing.
    */
   staleInstanceIds: Set<string>;
+  /** Refresh one owning peer and resolve only after its snapshot is applied. */
+  refreshInstance: (instanceId: string) => Promise<void>;
 };
+
+type StarMapRemoteThreadState = Omit<
+  StarMapRemoteThreads,
+  "refreshInstance"
+>;
 
 /**
  * Remote attention-thread feed for the Star Map: one navigation snapshot
@@ -39,7 +46,7 @@ export function useStarMapThreads(params: {
   refreshNonce?: number;
 }): StarMapRemoteThreads {
   const desktopApi = params.desktopApi;
-  const [state, setState] = useState<StarMapRemoteThreads>({
+  const [state, setState] = useState<StarMapRemoteThreadState>({
     threadsByInstance: new Map(),
     unreachableInstanceIds: new Set(),
     staleInstanceIds: new Set(),
@@ -62,6 +69,62 @@ export function useStarMapThreads(params: {
     .sort()
     .join("\n");
   const generationRef = useRef(0);
+
+  const refreshInstanceForGeneration = useCallback(
+    async (instanceId: string, generation: number): Promise<void> => {
+      if (!desktopApi?.getNavigationSnapshot) return;
+      try {
+        const snapshot = await desktopApi.getNavigationSnapshot({
+          federationTarget: { scope: "remote", instanceId },
+        });
+        if (generationRef.current !== generation) return;
+        setState((current) => {
+          const threadsByInstance = new Map(current.threadsByInstance);
+          threadsByInstance.set(instanceId, snapshot.threads);
+          const unreachableInstanceIds = new Set(
+            current.unreachableInstanceIds,
+          );
+          unreachableInstanceIds.delete(instanceId);
+          const staleInstanceIds = new Set(current.staleInstanceIds);
+          staleInstanceIds.delete(instanceId);
+          return {
+            threadsByInstance,
+            unreachableInstanceIds,
+            staleInstanceIds,
+          };
+        });
+      } catch (error) {
+        if (generationRef.current === generation) {
+          setState((current) => {
+            const unreachableInstanceIds = new Set(
+              current.unreachableInstanceIds,
+            );
+            unreachableInstanceIds.add(instanceId);
+            // A failed refresh keeps whatever cards we already had; the
+            // instance card carries the unreachable marker instead.
+            const staleInstanceIds = new Set(current.staleInstanceIds);
+            if (current.threadsByInstance.has(instanceId)) {
+              staleInstanceIds.add(instanceId);
+            }
+            return {
+              ...current,
+              unreachableInstanceIds,
+              staleInstanceIds,
+            };
+          });
+        }
+        throw error;
+      }
+    },
+    [desktopApi],
+  );
+
+  const refreshInstance = useCallback(
+    async (instanceId: string): Promise<void> => {
+      await refreshInstanceForGeneration(instanceId, generationRef.current);
+    },
+    [refreshInstanceForGeneration],
+  );
 
   // Retention pass: drop only peers that left the directory, and mark
   // everything we hold but cannot currently reach as stale.
@@ -111,48 +174,9 @@ export function useStarMapThreads(params: {
 
     const fetchAll = () => {
       for (const instanceId of instanceIds) {
-        void desktopApi
-          .getNavigationSnapshot?.({
-            federationTarget: { scope: "remote", instanceId },
-          })
-          .then((snapshot) => {
-            if (generationRef.current !== generation) return;
-            setState((current) => {
-              const threadsByInstance = new Map(current.threadsByInstance);
-              threadsByInstance.set(instanceId, snapshot.threads);
-              const unreachableInstanceIds = new Set(
-                current.unreachableInstanceIds,
-              );
-              unreachableInstanceIds.delete(instanceId);
-              const staleInstanceIds = new Set(current.staleInstanceIds);
-              staleInstanceIds.delete(instanceId);
-              return {
-                threadsByInstance,
-                unreachableInstanceIds,
-                staleInstanceIds,
-              };
-            });
-          })
-          .catch(() => {
-            if (generationRef.current !== generation) return;
-            setState((current) => {
-              const unreachableInstanceIds = new Set(
-                current.unreachableInstanceIds,
-              );
-              unreachableInstanceIds.add(instanceId);
-              // A failed refresh keeps whatever cards we already had; the
-              // instance card carries the unreachable marker instead.
-              const staleInstanceIds = new Set(current.staleInstanceIds);
-              if (current.threadsByInstance.has(instanceId)) {
-                staleInstanceIds.add(instanceId);
-              }
-              return {
-                ...current,
-                unreachableInstanceIds,
-                staleInstanceIds,
-              };
-            });
-          });
+        void refreshInstanceForGeneration(instanceId, generation).catch(
+          () => undefined,
+        );
       }
     };
 
@@ -162,7 +186,13 @@ export function useStarMapThreads(params: {
       generationRef.current += 1;
       clearInterval(timer);
     };
-  }, [desktopApi, connectedIds, params.enabled, params.refreshNonce]);
+  }, [
+    connectedIds,
+    desktopApi?.getNavigationSnapshot,
+    params.enabled,
+    params.refreshNonce,
+    refreshInstanceForGeneration,
+  ]);
 
-  return state;
+  return { ...state, refreshInstance };
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13223,6 +13223,18 @@ textarea,
   user-select: text;
 }
 
+/* The full thread view surfaces monitor jobs and native sub-agents in the
+   band above its composer. A floating chat is still an operating surface for
+   that same thread, so carry the shared strip into the equivalent position
+   instead of making the operator open the full window to discover live work.
+   The component returns null while empty, leaving no reserved gap. */
+.star-map-chat-card > .live-strip {
+  flex: 0 0 auto;
+  padding: 4px 0;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
 /* Compact composer: for surfaces with no vertical budget. The field sits
    over a one-line status strip: the model/effort/access chip (which is
    also the settings-menu trigger) on the left, the Stop/Send pills on the


### PR DESCRIPTION
## Summary

- show the shared active sub-agent strip above the Star Map compact composer
- preserve monitor state, duration, failure handling, and Stop controls
- refresh the correct local or federated navigation feed after stopping a monitor

## Tests

- pnpm test apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
- pnpm --filter @pwragent/desktop typecheck
- pnpm lint:eslint