### PR TITLE
fix(desktop): gate every renderer surface on the Full Access warning

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -92,6 +92,26 @@ summary.
 - Interactive Star Map children must guard canvas pan, wheel, and keyboard
   handlers before shipping.
 
+### Full Access Escalation
+
+- Every renderer surface that can raise a thread's execution mode routes the
+  selection through `useExecutionModeSelection`
+  ([lib/useExecutionModeSelection.tsx](src/renderer/src/lib/useExecutionModeSelection.tsx)),
+  never through `desktopApi.setThreadExecutionMode` directly. The gate owns the
+  "Enable Full Access?" confirmation and the dismissed-forever preference; a
+  surface that calls the API itself is a one-click, un-gated escalation, which
+  is what the Star Map chat card's settings chip was while the dialog lived
+  inside `Composer`.
+- A surface with a live settings snapshot (the main window's `App`) passes
+  `dismissed` / `onDismiss`; anything else lets the gate read and write the
+  preference itself.
+- Messaging surfaces deliberately do NOT share this gate. An escalation
+  requested over Telegram or Discord is made by a remote actor, so
+  `MessagingController.ensureFullAccessEscalationAllowed` gates it on the
+  `thread.execution.full_access` permission, the operator's `warningPolicy`,
+  and a per-contact dismissal. The desktop-local preference is the operator's
+  own acknowledgement and must never dismiss a contact's warning.
+
 ## Codex Data Boundary
 
 Desktop code must not inspect Codex-owned storage directly. Do not open, parse,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -139,6 +139,7 @@ import {
   FEDERATED_THREAD_SEARCH_LIMIT,
   useFederatedThreadSearch,
 } from "../../lib/useFederatedThreadSearch";
+import { useExecutionModeSelection } from "../../lib/useExecutionModeSelection";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   findSkillTrigger,
@@ -2934,12 +2935,6 @@ export function Composer(props: ComposerProps) {
       }
     };
   }, []);
-  const [fullAccessRiskDialogOpen, setFullAccessRiskDialogOpen] =
-    useState(false);
-  const [fullAccessRiskDontWarnAgain, setFullAccessRiskDontWarnAgain] =
-    useState(false);
-  const [fullAccessRiskSaving, setFullAccessRiskSaving] = useState(false);
-  const [fullAccessRiskError, setFullAccessRiskError] = useState<string>();
   const [autocompleteLayout, setAutocompleteLayout] = useState<{
     maxHeight: number;
     placement: "above" | "below";
@@ -8652,40 +8647,21 @@ export function Composer(props: ComposerProps) {
     }
   };
 
-  const requestExecutionModeSelection = (
-    executionMode: ThreadExecutionMode,
-  ): void => {
-    const currentExecutionMode =
-      props.launchpad?.executionMode ?? props.thread?.executionMode ?? "default";
-    if (
-      currentExecutionMode === "default" &&
-      executionMode === "full-access" &&
-      !props.fullAccessRiskWarningDismissed
-    ) {
-      setFullAccessRiskDontWarnAgain(false);
-      setFullAccessRiskError(undefined);
-      setFullAccessRiskDialogOpen(true);
-      return;
-    }
-
-    applyExecutionModeSelection(executionMode);
-  };
-
-  const confirmFullAccessRisk = async (): Promise<void> => {
-    setFullAccessRiskSaving(true);
-    setFullAccessRiskError(undefined);
-    try {
-      if (fullAccessRiskDontWarnAgain) {
-        await props.onDismissFullAccessRiskWarning?.();
-      }
-      setFullAccessRiskDialogOpen(false);
-      applyExecutionModeSelection("full-access");
-    } catch (error) {
-      setFullAccessRiskError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setFullAccessRiskSaving(false);
-    }
-  };
+  // The Full Access confirmation lives in the shared gate so every
+  // surface that can escalate a thread honors it; `App` owns this
+  // window's settings snapshot, so the composer hands the preference and
+  // its write down rather than letting the gate read them again.
+  const { fullAccessRiskDialog, requestExecutionModeSelection } =
+    useExecutionModeSelection({
+      applyExecutionMode: applyExecutionModeSelection,
+      currentExecutionMode:
+        props.launchpad?.executionMode
+        ?? props.thread?.executionMode
+        ?? "default",
+      desktopApi: props.desktopApi,
+      dismissed: props.fullAccessRiskWarningDismissed ?? false,
+      onDismiss: props.onDismissFullAccessRiskWarning,
+    });
 
   const handleThreadModelSettingsPatch = (
     patch: Partial<
@@ -9605,82 +9581,6 @@ export function Composer(props: ComposerProps) {
     handlePlainComposerKeyDown(event);
   };
 
-  const fullAccessRiskDialog = fullAccessRiskDialogOpen
-    ? createPortal(
-        <div className="full-access-warning-modal">
-          <div
-            aria-labelledby="full-access-warning-title"
-            aria-modal="true"
-            className="full-access-warning-dialog"
-            role="dialog"
-          >
-            <div className="full-access-warning-dialog__header">
-              <h2 id="full-access-warning-title">Enable Full Access?</h2>
-              <button
-                aria-label="Cancel Full Access warning"
-                className="workspace-handoff-dialog__close"
-                disabled={fullAccessRiskSaving}
-                type="button"
-                onClick={() => {
-                  setFullAccessRiskDialogOpen(false);
-                }}
-              >
-                ×
-              </button>
-            </div>
-            <p>
-              Full Access allows network access and read/write access to almost
-              all files on this machine.
-            </p>
-            <p>
-              That means data can be exfiltrated unintentionally, or by
-              malicious code the agent downloads and executes through a supply
-              chain attack on npm, PyPI, Rust crates, Go modules, or a similar
-              dependency source.
-            </p>
-            <label className="composer__checkbox full-access-warning-dialog__checkbox">
-              <input
-                checked={fullAccessRiskDontWarnAgain}
-                disabled={fullAccessRiskSaving}
-                type="checkbox"
-                onChange={(event) =>
-                  setFullAccessRiskDontWarnAgain(event.currentTarget.checked)
-                }
-              />
-              <span>Do not warn me again on this desktop.</span>
-            </label>
-            {fullAccessRiskError ? (
-              <p className="full-access-warning-dialog__error" role="alert">
-                {fullAccessRiskError}
-              </p>
-            ) : null}
-            <div className="full-access-warning-dialog__actions">
-              <button
-                className="button button--secondary"
-                disabled={fullAccessRiskSaving}
-                type="button"
-                onClick={() => {
-                  setFullAccessRiskDialogOpen(false);
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                className="button button--primary"
-                disabled={fullAccessRiskSaving}
-                type="button"
-                onClick={() => {
-                  void confirmFullAccessRisk();
-                }}
-              >
-                I Understand and Accept the Risks
-              </button>
-            </div>
-          </div>
-        </div>,
-        document.body,
-      )
-    : null;
   const pdfPreviewPathSet = new Set(
     pdfPreviewReferences.map((reference) => reference.path),
   );

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -12,10 +12,12 @@ import {
   buildThreadIdentityKey,
   type CelestialIconId,
   type NavigationThreadSummary,
+  type ThreadExecutionMode,
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { useBackendSummaries } from "../../lib/useBackendSummaries";
+import { useExecutionModeSelection } from "../../lib/useExecutionModeSelection";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   CompactComposer,
@@ -538,6 +540,46 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   ]);
 
   /**
+   * Escalating a thread to Full Access goes through the shared gate
+   * rather than straight to `setThreadExecutionMode`. The confirmation
+   * used to be composer-local state, which made this chip a one-click,
+   * un-gated escalation. This window carries no settings state of its
+   * own, so the gate reads the dismissed-forever preference itself.
+   */
+  const applyExecutionMode = useCallback(
+    (executionMode: ThreadExecutionMode): void => {
+      const setExecutionMode = desktopApi?.setThreadExecutionMode;
+      if (!setExecutionMode) return;
+      setOptimisticSettings((current) => ({
+        ...current,
+        executionMode,
+      }));
+      void setExecutionMode({
+        backend: threadSource,
+        executionMode,
+        federationTarget,
+        threadId,
+      }).catch((error: unknown) => {
+        setOptimisticSettings({});
+        setSendError(
+          error instanceof Error
+            ? error.message
+            : "Could not change access mode.",
+        );
+      });
+    },
+    [desktopApi, federationTarget, threadId, threadSource],
+  );
+  const { fullAccessRiskDialog, requestExecutionModeSelection } =
+    useExecutionModeSelection({
+      applyExecutionMode,
+      // The optimistic value, so a second click while the first
+      // escalation round-trips does not re-prompt.
+      currentExecutionMode: threadExecutionMode,
+      desktopApi,
+    });
+
+  /**
    * The settings chip's menu: the same mutations the full composer's chip
    * row drives, minus what a floating card cannot honestly host (workspace
    * handoff and environments need the handoff dialog and launchpad state —
@@ -636,26 +678,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       })),
       reasoningEfforts: supportsReasoning ? reasoningEfforts : [],
       supportsFastMode: supportsFast,
+      // The gate decides between prompting and applying; the apply half
+      // is `applyExecutionMode` above.
       onSelectExecutionMode: setExecutionMode
-        ? (mode) => {
-            setOptimisticSettings((current) => ({
-              ...current,
-              executionMode: mode,
-            }));
-            void setExecutionMode({
-              backend: threadSource,
-              executionMode: mode,
-              federationTarget,
-              threadId,
-            }).catch((error: unknown) => {
-              setOptimisticSettings({});
-              setSendError(
-                error instanceof Error
-                  ? error.message
-                  : "Could not change access mode.",
-              );
-            });
-          }
+        ? requestExecutionModeSelection
         : undefined,
       onSelectModel: setModelSettings
         ? (model) => {
@@ -693,6 +719,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     desktopApi,
     federationTarget,
     onSettingsMenuOpen,
+    requestExecutionModeSelection,
     threadId,
     threadModel,
     threadSource,
@@ -888,6 +915,8 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       />
 
       {titleTooltip.tooltipNode}
+      {/* Portals to the body, so the card's clip and transform miss it. */}
+      {fullAccessRiskDialog}
       <span
         aria-hidden="true"
         className="star-map-chat-card__resize"

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,9 +1,17 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapChatCard } from "../StarMapChatCard";
 import { resetComposerMentionSourcesCache } from "../../composer/useComposerMentionSources";
+import { resetFullAccessRiskWarningCache } from "../../../lib/useExecutionModeSelection";
 import { isStarMapTypingTarget } from "../star-map-keyboard";
 import { shouldPanOnWheel, shouldStartCanvasPan } from "../star-map-orbit";
 import {
@@ -699,6 +707,9 @@ describe("StarMapChatCard mentions", () => {
 describe("StarMapChatCard settings menu", () => {
   beforeEach(() => {
     resetComposerMentionSourcesCache();
+    // The dismissed-forever preference is cached window-wide so N cards
+    // share one settings read; that cache outlives a render tree.
+    resetFullAccessRiskWarningCache();
   });
 
   function settingsApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
@@ -781,22 +792,189 @@ describe("StarMapChatCard settings menu", () => {
     });
   });
 
-  it("switches access mode through the Access submenu", async () => {
+  /**
+   * The Full Access confirmation is the shared renderer gate, not the
+   * composer's own state: this chip escalated a thread in one un-gated
+   * click for as long as the dialog lived inside `Composer`.
+   */
+  async function chooseAccessMode(label: string): Promise<void> {
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Access/ }));
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: label }));
+  }
+
+  /** Settings reads resolve a tick after mount; the gate reads false until then. */
+  async function settleDismissedRead(desktopApi: DesktopApi): Promise<void> {
+    await waitFor(() => {
+      expect(desktopApi.readSettings).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  function settingsSnapshotApi(
+    fullAccessRiskWarningDismissed: boolean,
+    overrides: Partial<DesktopApi> = {},
+  ): DesktopApi {
+    return settingsApi({
+      readSettings: vi.fn(async () => ({
+        snapshot: {
+          experimental: {
+            fullAccessRiskWarningDismissed: {
+              value: fullAccessRiskWarningDismissed,
+            },
+          },
+        },
+      })),
+      ...overrides,
+    } as unknown as Partial<DesktopApi>);
+  }
+
+  it("confirms the first escalation to Full Access before applying it", async () => {
     const desktopApi = settingsApi();
     renderCard({
       desktopApi,
       thread: localThread({ executionMode: "default", model: "gpt-5-codex" }),
     });
     await openSettingsMenu();
+    await chooseAccessMode("Full Access");
 
-    fireEvent.click(await screen.findByRole("menuitem", { name: /Access/ }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Enable Full Access?",
+    });
+    expect(dialog.textContent).toContain("network access");
+    expect(dialog.textContent).toContain("supply chain attack");
+    expect(desktopApi.setThreadExecutionMode).not.toHaveBeenCalled();
+
     fireEvent.click(
-      await screen.findByRole("menuitemradio", { name: "Full Access" }),
+      within(dialog).getByRole("button", {
+        name: "I Understand and Accept the Risks",
+      }),
     );
     await waitFor(() => {
       expect(desktopApi.setThreadExecutionMode).toHaveBeenCalledWith({
         backend: "codex",
         executionMode: "full-access",
+        federationTarget: undefined,
+        threadId: "t-local",
+      });
+    });
+  });
+
+  it("leaves the thread on Default Access when the warning is cancelled", async () => {
+    const desktopApi = settingsApi();
+    renderCard({
+      desktopApi,
+      thread: localThread({ executionMode: "default", model: "gpt-5-codex" }),
+    });
+    await openSettingsMenu();
+    await chooseAccessMode("Full Access");
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Enable Full Access?",
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Enable Full Access?" }),
+      ).toBeNull();
+    });
+    expect(desktopApi.setThreadExecutionMode).not.toHaveBeenCalled();
+    // The chip carries the mode in its accessible name, so this is the
+    // operator's own view of the thread still being on Default Access —
+    // the optimistic patch must not have run either.
+    const chip = await screen.findByRole("button", {
+      name: /^Thread settings/,
+    });
+    expect(chip.getAttribute("aria-label")).toContain("Default Access");
+  });
+
+  it("skips the warning once the operator dismissed it on this desktop", async () => {
+    const desktopApi = settingsSnapshotApi(true);
+    renderCard({
+      desktopApi,
+      thread: localThread({ executionMode: "default", model: "gpt-5-codex" }),
+    });
+    await settleDismissedRead(desktopApi);
+    await openSettingsMenu();
+    await chooseAccessMode("Full Access");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Enable Full Access?" }),
+    ).toBeNull();
+    await waitFor(() => {
+      expect(desktopApi.setThreadExecutionMode).toHaveBeenCalledWith({
+        backend: "codex",
+        executionMode: "full-access",
+        federationTarget: undefined,
+        threadId: "t-local",
+      });
+    });
+  });
+
+  it("persists the dismissal this window from the card's own dialog", async () => {
+    // No `App` above this window to own the preference, so the gate reads
+    // and writes the setting itself.
+    const writeSettingsConfig = vi.fn(async () => ({
+      snapshot: {
+        experimental: { fullAccessRiskWarningDismissed: { value: true } },
+      },
+    }));
+    const desktopApi = settingsSnapshotApi(false, {
+      writeSettingsConfig,
+    } as unknown as Partial<DesktopApi>);
+    renderCard({
+      desktopApi,
+      thread: localThread({ executionMode: "default", model: "gpt-5-codex" }),
+    });
+    await settleDismissedRead(desktopApi);
+    await openSettingsMenu();
+    await chooseAccessMode("Full Access");
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Enable Full Access?",
+    });
+    fireEvent.click(
+      within(dialog).getByLabelText("Do not warn me again on this desktop."),
+    );
+    fireEvent.click(
+      within(dialog).getByRole("button", {
+        name: "I Understand and Accept the Risks",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(writeSettingsConfig).toHaveBeenCalledWith({
+        patch: { experimental: { fullAccessRiskWarningDismissed: true } },
+      });
+      expect(desktopApi.setThreadExecutionMode).toHaveBeenCalledWith(
+        expect.objectContaining({ executionMode: "full-access" }),
+      );
+    });
+  });
+
+  it("drops back to Default Access without a confirmation", async () => {
+    // The gate is an escalation gate; de-escalating is never risky and
+    // must stay one click.
+    const desktopApi = settingsApi();
+    renderCard({
+      desktopApi,
+      thread: localThread({
+        executionMode: "full-access",
+        model: "gpt-5-codex",
+      }),
+    });
+    await openSettingsMenu();
+    await chooseAccessMode("Default Access");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Enable Full Access?" }),
+    ).toBeNull();
+    await waitFor(() => {
+      expect(desktopApi.setThreadExecutionMode).toHaveBeenCalledWith({
+        backend: "codex",
+        executionMode: "default",
         federationTarget: undefined,
         threadId: "t-local",
       });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -861,6 +861,45 @@ describe("StarMapChatCard settings menu", () => {
     });
   });
 
+  it("keeps the warning's input off the map behind it", async () => {
+    // The dialog portals out of the card's DOM but not out of its React
+    // tree, and in the Star Map window its ancestors are the map's own
+    // `onPointerDown` (canvas pan, marquee, click-to-drop-selection) and
+    // `onKeyDown` (Escape unwinds the selection). The dialog sits outside
+    // every `.star-map-*` container `shouldStartCanvasPan` tests for, so
+    // without containment a drag on the scrim pans the map underneath it.
+    const onPointerDown = vi.fn();
+    const onKeyDown = vi.fn();
+    const desktopApi = settingsApi();
+    render(
+      <div onKeyDown={onKeyDown} onPointerDown={onPointerDown}>
+        {card({
+          desktopApi,
+          thread: localThread({
+            executionMode: "default",
+            model: "gpt-5-codex",
+          }),
+        })}
+      </div>,
+    );
+    await openSettingsMenu();
+    await chooseAccessMode("Full Access");
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Enable Full Access?",
+    });
+    const scrim = dialog.closest(".full-access-warning-modal");
+    expect(scrim).not.toBeNull();
+    onPointerDown.mockClear();
+    onKeyDown.mockClear();
+
+    fireEvent.pointerDown(scrim as Element, { button: 0 });
+    fireEvent.keyDown(scrim as Element, { key: "Escape" });
+
+    expect(onPointerDown).not.toHaveBeenCalled();
+    expect(onKeyDown).not.toHaveBeenCalled();
+  });
+
   it("leaves the thread on Default Access when the warning is cancelled", async () => {
     const desktopApi = settingsApi();
     renderCard({

--- a/apps/desktop/src/renderer/src/lib/useExecutionModeSelection.tsx
+++ b/apps/desktop/src/renderer/src/lib/useExecutionModeSelection.tsx
@@ -215,7 +215,21 @@ export function useExecutionModeSelection(
 
   const fullAccessRiskDialog = dialogOpen
     ? createPortal(
-        <div className="full-access-warning-modal">
+        <div
+          className="full-access-warning-modal"
+          // A modal scrim must not leak input to what it covers. The
+          // portal escapes the host's DOM but NOT its React tree, and
+          // this gate now renders from inside the Star Map, whose
+          // ancestors handle both events: a press anywhere on the scrim
+          // or the dialog's prose passes `shouldStartCanvasPan` — the
+          // dialog is outside every `.star-map-*` container it tests for
+          // — so the map takes focus and pans under the dialog, and
+          // Escape reaches the map's own handler and drops the
+          // operator's card selection. The card's inner controls stop
+          // propagation the same way for the same reason.
+          onKeyDown={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
           <div
             aria-labelledby="full-access-warning-title"
             aria-modal="true"

--- a/apps/desktop/src/renderer/src/lib/useExecutionModeSelection.tsx
+++ b/apps/desktop/src/renderer/src/lib/useExecutionModeSelection.tsx
@@ -1,0 +1,294 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import type { ThreadExecutionMode } from "@pwragent/shared";
+import type { DesktopApi } from "./desktop-api";
+import {
+  invalidateDesktopSettingsRead,
+  readDesktopSettingsCoalesced,
+  rememberDesktopSettingsSnapshot,
+} from "./settings-read-coordinator";
+
+/**
+ * The renderer's single gate on escalating a thread to Full Access.
+ *
+ * Every surface that can raise a thread's execution mode routes its
+ * selection through here instead of calling `setThreadExecutionMode`
+ * directly, so the "Enable Full Access?" confirmation cannot be bypassed
+ * by adding a new menu. The gate used to live inside `Composer`, which
+ * meant the Star Map chat card's settings chip escalated a thread in one
+ * un-gated click.
+ *
+ * Messaging surfaces (Telegram/Discord `togglePermissionsMode`) do NOT
+ * share this gate, and that is deliberate: an escalation requested from
+ * chat is made by a remote actor, so `MessagingController` gates it on
+ * the `thread.execution.full_access` RBAC permission, the operator's
+ * `warningPolicy`, and a per-contact `fullAccessWarningDismissed` flag.
+ * This desktop-local "do not warn me again on this desktop" preference is
+ * the operator's own acknowledgement and must never dismiss the warning
+ * shown to a messaging contact.
+ */
+
+/**
+ * Window-wide view of the dismissed-forever preference.
+ *
+ * Shared rather than per-hook so a dismissal accepted in one card is
+ * honored by every other surface in the same window without a re-read,
+ * and so N mounted cards issue one settings read between them.
+ */
+let dismissedCache: boolean | undefined;
+let dismissedRead: Promise<void> | undefined;
+let dismissedReadToken = 0;
+const dismissedListeners = new Set<(dismissed: boolean) => void>();
+
+function publishDismissed(dismissed: boolean): void {
+  dismissedCache = dismissed;
+  for (const listener of dismissedListeners) {
+    listener(dismissed);
+  }
+}
+
+/** Test seam: module state outlives a render tree. */
+export function resetFullAccessRiskWarningCache(): void {
+  dismissedCache = undefined;
+  dismissedRead = undefined;
+}
+
+function loadDismissed(desktopApi: DesktopApi): Promise<void> {
+  if (dismissedRead) {
+    return dismissedRead;
+  }
+  const token = ++dismissedReadToken;
+  dismissedRead = (async () => {
+    try {
+      const response = await readDesktopSettingsCoalesced(desktopApi);
+      publishDismissed(
+        response.snapshot.experimental.fullAccessRiskWarningDismissed?.value
+          === true,
+      );
+    } catch {
+      // Unreadable settings leave the warning on: the gate fails closed,
+      // and the next request retries the read.
+      if (dismissedReadToken === token) {
+        dismissedRead = undefined;
+      }
+    }
+  })();
+  return dismissedRead;
+}
+
+async function persistDismissed(desktopApi: DesktopApi): Promise<void> {
+  if (!desktopApi.writeSettingsConfig) {
+    throw new Error("Could not save the Full Access warning preference.");
+  }
+  invalidateDesktopSettingsRead(desktopApi);
+  const response = await desktopApi.writeSettingsConfig({
+    patch: { experimental: { fullAccessRiskWarningDismissed: true } },
+  });
+  rememberDesktopSettingsSnapshot(desktopApi, response);
+  publishDismissed(true);
+}
+
+export type ExecutionModeSelectionOptions = {
+  /**
+   * Applies the mode once the gate is satisfied. Called synchronously for
+   * a de-escalation or an already-acknowledged escalation, and from the
+   * dialog's accept button otherwise.
+   */
+  applyExecutionMode: (executionMode: ThreadExecutionMode) => void;
+  /** The target's current mode — a thread's, or a launchpad draft's. */
+  currentExecutionMode?: ThreadExecutionMode;
+  desktopApi?: DesktopApi;
+  /**
+   * Overrides the settings-backed preference for a surface that already
+   * holds a live snapshot (the main window's `App` owns one and keeps it
+   * current). Leave it undefined and the hook reads the preference
+   * itself, which is what a surface with no settings state — the Star Map
+   * chat card — relies on.
+   */
+  dismissed?: boolean;
+  /** Paired override for the write half of `dismissed`. */
+  onDismiss?: () => Promise<void>;
+};
+
+export type ExecutionModeSelection = {
+  /**
+   * Mount this where the surface renders. It portals to `document.body`,
+   * so its position in the tree does not matter.
+   */
+  fullAccessRiskDialog: ReactNode;
+  /**
+   * Stable across renders so a memoized menu that closes over it does not
+   * churn; the latest options are read through a ref.
+   */
+  requestExecutionModeSelection: (executionMode: ThreadExecutionMode) => void;
+};
+
+export function useExecutionModeSelection(
+  options: ExecutionModeSelectionOptions,
+): ExecutionModeSelection {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dontWarnAgain, setDontWarnAgain] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string>();
+  const [readDismissed, setReadDismissed] = useState(dismissedCache ?? false);
+
+  const ownsPreference = options.dismissed === undefined;
+  const desktopApi = options.desktopApi;
+
+  useEffect(() => {
+    if (!ownsPreference || !desktopApi?.readSettings) {
+      return;
+    }
+    let active = true;
+    const listener = (dismissed: boolean): void => {
+      if (active) {
+        setReadDismissed(dismissed);
+      }
+    };
+    dismissedListeners.add(listener);
+    if (dismissedCache !== undefined) {
+      setReadDismissed(dismissedCache);
+    }
+    void loadDismissed(desktopApi);
+    return () => {
+      active = false;
+      dismissedListeners.delete(listener);
+    };
+  }, [desktopApi, ownsPreference]);
+
+  const dismissed = options.dismissed ?? readDismissed;
+  const dismissedRef = useRef(dismissed);
+  dismissedRef.current = dismissed;
+
+  const requestExecutionModeSelection = useCallback(
+    (executionMode: ThreadExecutionMode): void => {
+      const current = optionsRef.current;
+      if (
+        executionMode === "full-access"
+        && current.currentExecutionMode !== "full-access"
+        && !dismissedRef.current
+      ) {
+        setDontWarnAgain(false);
+        setError(undefined);
+        setDialogOpen(true);
+        return;
+      }
+
+      current.applyExecutionMode(executionMode);
+    },
+    [],
+  );
+
+  const confirm = useCallback(async (): Promise<void> => {
+    setSaving(true);
+    setError(undefined);
+    try {
+      if (dontWarnAgain) {
+        const current = optionsRef.current;
+        if (current.onDismiss) {
+          await current.onDismiss();
+        } else if (current.desktopApi) {
+          await persistDismissed(current.desktopApi);
+        }
+      }
+      setDialogOpen(false);
+      optionsRef.current.applyExecutionMode("full-access");
+    } catch (confirmError) {
+      setError(
+        confirmError instanceof Error
+          ? confirmError.message
+          : String(confirmError),
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [dontWarnAgain]);
+
+  const fullAccessRiskDialog = dialogOpen
+    ? createPortal(
+        <div className="full-access-warning-modal">
+          <div
+            aria-labelledby="full-access-warning-title"
+            aria-modal="true"
+            className="full-access-warning-dialog"
+            role="dialog"
+          >
+            <div className="full-access-warning-dialog__header">
+              <h2 id="full-access-warning-title">Enable Full Access?</h2>
+              <button
+                aria-label="Cancel Full Access warning"
+                className="workspace-handoff-dialog__close"
+                disabled={saving}
+                type="button"
+                onClick={() => {
+                  setDialogOpen(false);
+                }}
+              >
+                ×
+              </button>
+            </div>
+            <p>
+              Full Access allows network access and read/write access to almost
+              all files on this machine.
+            </p>
+            <p>
+              That means data can be exfiltrated unintentionally, or by
+              malicious code the agent downloads and executes through a supply
+              chain attack on npm, PyPI, Rust crates, Go modules, or a similar
+              dependency source.
+            </p>
+            <label className="composer__checkbox full-access-warning-dialog__checkbox">
+              <input
+                checked={dontWarnAgain}
+                disabled={saving}
+                type="checkbox"
+                onChange={(event) =>
+                  setDontWarnAgain(event.currentTarget.checked)
+                }
+              />
+              <span>Do not warn me again on this desktop.</span>
+            </label>
+            {error ? (
+              <p className="full-access-warning-dialog__error" role="alert">
+                {error}
+              </p>
+            ) : null}
+            <div className="full-access-warning-dialog__actions">
+              <button
+                className="button button--secondary"
+                disabled={saving}
+                type="button"
+                onClick={() => {
+                  setDialogOpen(false);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                className="button button--primary"
+                disabled={saving}
+                type="button"
+                onClick={() => {
+                  void confirm();
+                }}
+              >
+                I Understand and Accept the Risks
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
+
+  return { fullAccessRiskDialog, requestExecutionModeSelection };
+}


### PR DESCRIPTION
## Summary

- The "Enable Full Access?" risk confirmation was Composer-local UI state, so it guarded exactly one surface. Every other caller of `desktopApi.setThreadExecutionMode` bypassed it — including the Star Map chat card's settings chip, where escalating a thread to Full Access was one un-gated click.
- Lifted the gate into a shared `useExecutionModeSelection` hook (`apps/desktop/src/renderer/src/lib/useExecutionModeSelection.tsx`) that owns the dismissed-forever preference, renders the confirmation dialog, and only then applies the mode. `Composer.tsx` and `StarMapChatCard.tsx` both route through it; the dialog markup, copy, class names, and checkbox semantics moved over verbatim.
- The hook reads and writes the preference itself by default, via the same `settings-read-coordinator` helpers `useDesktopSettings` uses — so a surface with no settings state of its own (the Star Map window) is gated without threading props down to it. The value is cached window-wide, so N open cards issue one settings read between them and a dismissal accepted in one card is honored by the others. A surface that already holds a live snapshot (the main window, where `App` owns settings) passes `dismissed` / `onDismiss` instead. An unreadable settings snapshot fails closed and keeps warning.
- Composer sheds ~130 lines: four pieces of dialog state, the inline dialog JSX, and its local gate logic. Its existing `fullAccessRiskWarningDismissed` / `onDismissFullAccessRiskWarning` props and the `App`/`ThreadView` plumbing are unchanged, so the dismissed-forever setting semantics are identical.

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint:eslint` on the touched files — 0 errors (pre-existing warnings only).
- `pnpm lint:boundaries` — no violations (1539 modules).
- Targeted suites: `StarMapChatCard.test.tsx`, `star-map-chat-card-render-cost.test.tsx`, `composer.test.tsx`, `app-shell.test.tsx` — 366 passed.
- Full renderer project: 141 failed / 3089 passed. I measured the same run with this change parked and got an identical 141 failed / 3085 passed — the failures are all `window.localStorage` being undefined in twelve star-map spec files, pre-existing on this checkout and unrelated (`StarMapScreen.test.tsx` fails 41/41 standalone at baseline too).
- Mutation-checked the new dismissed-flag test: flipping its fixture to `false` fails it, so it isn't passing for the wrong reason.

New tests in `StarMapChatCard.test.tsx`, all driving the card's real settings-chip menu:

- first escalation to Full Access prompts, and only applies on accept;
- Cancel leaves the thread on Default Access — asserted through the chip's accessible name, which also covers the optimistic patch not having run;
- a dismissed preference skips the prompt entirely;
- checking "Do not warn me again" persists through `writeSettingsConfig` from the card's own dialog (the self-owned write path);
- de-escalation back to Default Access stays one click.

The pre-existing "switches access mode through the Access submenu" test was folded into the first of these, since that path is now gated.

## Notes

- **Messaging surfaces deliberately do not share this gate.** `MessagingController.ensureFullAccessEscalationAllowed` already weighs the `thread.execution.full_access` RBAC permission, the operator's `warningPolicy` (`never`/`always`/`dismissable`), and a *per-contact* `fullAccessWarningDismissed`. An escalation requested over Telegram or Discord is made by a remote actor, so the desktop-local "do not warn me again on this desktop" flag — the operator's own acknowledgement — must never silence a contact's warning. That rationale is in the hook's doc comment and in a new "Full Access Escalation" section in `apps/desktop/AGENTS.md`, along with the rule that new renderer surfaces route through the hook rather than calling the API directly.
- The gate reads the card's *optimistic* execution mode, so a second click while the first escalation round-trips does not re-prompt.
- `requestExecutionModeSelection` is referentially stable (latest options via a ref), which is what lets the Star Map card keep its delta-stable settings-menu memo — the render-cost spec that pins that boundary still passes.
- Only two renderer surfaces can escalate today and both are now gated; `useThreadNavigation.setThreadExecutionMode` is reached only through `App`'s `onSetExecutionMode`, which only Composer consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
