### PR TITLE
fix(desktop): remove synchronous HMR storage access

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -64,30 +64,16 @@ describe("useThreadNavigation", () => {
     vi.restoreAllMocks();
   });
 
-  it("restores the selected thread after a full renderer reload", async () => {
+  it("does not synchronously access browser storage during navigation startup", async () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem");
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    const removeItem = vi.spyOn(Storage.prototype, "removeItem");
     const snapshot: NavigationSnapshot = {
       backend: "all",
       fetchedAt: 1,
       unchanged: false,
       inboxThreadKeys: [],
-      threads: [
-        {
-          id: "thread-1",
-          title: "First thread",
-          titleSource: "explicit",
-          source: "codex",
-          linkedDirectories: [],
-          inbox: { inInbox: false },
-        },
-        {
-          id: "thread-2",
-          title: "Focused before reload",
-          titleSource: "explicit",
-          source: "codex",
-          linkedDirectories: [],
-          inbox: { inInbox: false },
-        },
-      ],
+      threads: [],
       directories: [],
       launchpadDefaults: {
         backend: "codex",
@@ -98,23 +84,15 @@ describe("useThreadNavigation", () => {
       getNavigationSnapshot: vi.fn(async () => snapshot),
       onAgentEvent: () => () => undefined,
     };
-    const firstRenderer = renderHook(() => useThreadNavigation(desktopApi));
-    await waitFor(() => {
-      expect(firstRenderer.result.current.selectedThread?.id).toBe("thread-1");
-    });
-    act(() => {
-      firstRenderer.result.current.selectThread(snapshot.threads[1]!);
-    });
-    await waitFor(() => {
-      expect(firstRenderer.result.current.selectedThread?.id).toBe("thread-2");
-    });
-    firstRenderer.unmount();
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
 
-    const reloadedRenderer = renderHook(() => useThreadNavigation(desktopApi));
     await waitFor(() => {
-      expect(reloadedRenderer.result.current.selectedThread?.id).toBe("thread-2");
+      expect(result.current.loaded).toBe(true);
     });
-    reloadedRenderer.unmount();
+
+    expect(getItem).not.toHaveBeenCalled();
+    expect(setItem).not.toHaveBeenCalled();
+    expect(removeItem).not.toHaveBeenCalled();
   });
 
   function createDeferred<T>(): {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -115,7 +115,6 @@ const NAVIGATION_ACTIVITY_EVENTS = [
   "paste",
   "pointerdown",
 ] as const;
-const RELOAD_SELECTION_STORAGE_KEY = "pwragent.navigation.reloadSelection";
 
 const DEFAULT_BROWSE_MODE = DEFAULT_NAVIGATION_BROWSE_MODE;
 const normalizeBrowseMode = normalizeNavigationBrowseMode;
@@ -128,34 +127,6 @@ function readBridgedBrowseMode(): BrowseMode {
     __pwragentNavigationPreferences?: { browseMode?: unknown };
   }).__pwragentNavigationPreferences;
   return normalizeBrowseMode(bridged?.browseMode);
-}
-
-function readReloadSelectionKey(): string | undefined {
-  if (typeof window === "undefined") {
-    return undefined;
-  }
-
-  try {
-    return window.sessionStorage.getItem(RELOAD_SELECTION_STORAGE_KEY) ?? undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function writeReloadSelectionKey(selectionKey?: string): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    if (selectionKey) {
-      window.sessionStorage.setItem(RELOAD_SELECTION_STORAGE_KEY, selectionKey);
-    } else {
-      window.sessionStorage.removeItem(RELOAD_SELECTION_STORAGE_KEY);
-    }
-  } catch {
-    // Navigation still works when the renderer denies storage access.
-  }
 }
 
 function isRendererViewForeground(): boolean {
@@ -3210,7 +3181,6 @@ export function useThreadNavigation(
   });
   const [viewForeground, setViewForeground] = useState(isRendererViewForeground);
   const prChipLocationIndexRef = useRef<PrChipLocationIndex | undefined>(undefined);
-  const reloadSelectionKeyRef = useRef(readReloadSelectionKey());
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
   const retainedUnreadThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
@@ -3824,20 +3794,8 @@ export function useThreadNavigation(
       return;
     }
 
-    // sessionStorage is scoped to this BrowserWindow and survives the full
-    // page reload Vite uses when an HMR update reaches the renderer entry.
-    // Feed the remembered selection through the normal validated preferred-
-    // selection path so a removed thread falls back instead of stranding the
-    // detail pane on a stale key.
-    void refresh(reloadSelectionKeyRef.current);
+    void refresh();
   }, [enabled, refresh]);
-
-  useEffect(() => {
-    if (!state.response) {
-      return;
-    }
-    writeReloadSelectionKey(selectedItemKey);
-  }, [selectedItemKey, state.response]);
 
   useEffect(() => {
     if (

--- a/apps/desktop/src/renderer/src/test/setup.ts
+++ b/apps/desktop/src/renderer/src/test/setup.ts
@@ -1,5 +1,3 @@
-import { afterEach } from "vitest";
-
 /**
  * jsdom implements `getClientRects` on Element but not on Range, and
  * ProseMirror asks a Range for its rects whenever it scrolls a selection
@@ -25,13 +23,6 @@ if (typeof Range.prototype.getClientRects !== "function") {
 }
 
 const originalConsoleError = console.error.bind(console);
-
-afterEach(() => {
-  // Renderer windows keep reload-only state in sessionStorage. Vitest reuses
-  // one jsdom window across files in a worker, so clear that window-scoped
-  // state at the test boundary just as closing a real BrowserWindow would.
-  window.sessionStorage.clear();
-});
 
 console.error = (...args: unknown[]) => {
   // The renderer suite asserts the visible states around these async paths.


### PR DESCRIPTION
## Summary

- remove the renderer HMR selection persistence that synchronously reads and writes `sessionStorage`
- restore the original unqualified navigation refresh on renderer startup
- replace reload-selection coverage with a regression test that startup navigation never touches browser storage

## Profiling evidence

Startup CPU profiling attributed about 2.9–3.3 seconds of renderer self time to `readReloadSelectionKey`. After this change, `useThreadNavigation` dropped from about 2,880 ms to 17.8 ms of self CPU and the storage frame disappeared.

The code was unconditional, so the cost affected packaged builds as well as development even though the behavior only benefited HMR. The `releases/1.0` tree does not contain this storage path.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (138 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- repeat startup CPU profile
- `git diff --check`