### PR TITLE
fix(desktop): render recent threads during startup

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -3344,6 +3344,45 @@ describe("app server ipc", () => {
     );
   });
 
+  it("treats an empty full thread list as a complete lightweight baseline", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    const discoveredThread = {
+      id: "thread-discovered",
+      title: "Discovered thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      updatedAt: 2_000,
+    };
+    listThreads
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([discoveredThread]);
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    );
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {
+        forceRefresh: true,
+        refreshMode: "active-recent",
+      } satisfies GetNavigationSnapshotRequest,
+    );
+
+    expect(reconcileNavigationSnapshot).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        threads: [expect.objectContaining({ id: "thread-discovered" })],
+      }),
+    );
+    expect(reconcileNavigationSnapshot).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ partial: true }),
+    );
+  });
+
   it("returns backend scope all when listing threads without a backend filter", async () => {
     const { APP_SERVER_LIST_THREADS_CHANNEL } = await import("../../shared/ipc");
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -3278,6 +3278,11 @@ describe("app server ipc", () => {
       maxPages: 1,
       skipArchivedMetadataRefresh: true,
     });
+    expect(reconcileNavigationSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partial: true,
+      }),
+    );
     expect(rememberCompleteNavigationSnapshot).not.toHaveBeenCalled();
   });
 
@@ -3333,6 +3338,9 @@ describe("app server ipc", () => {
           expect.objectContaining({ id: "thread-stale" }),
         ],
       }),
+    );
+    expect(reconcileNavigationSnapshot).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ partial: true }),
     );
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10276,6 +10276,45 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("keeps the startup prewarm bounded to summary-only active pages", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({
+      callerReason: "startup-prewarm",
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
+    });
+
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      enrichDirectories: false,
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
+    });
+    expect(codexClient.lastListNativeSubAgentThreadsParams).toEqual({
+      limit: 50,
+      maxPages: 1,
+    });
+    expect(codexClient.readThreadCalls).toEqual([]);
+
+    await registry.close();
+  });
+
   it("deduplicates identical linked directories in thread summaries", async () => {
     const repoPath = "/Users/fixture-user/projects/PwrAgent";
     const firstWorktreePath = "/Users/fixture-user/.codex/worktrees/wt1/PwrAgent";

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1431,6 +1431,44 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("keeps a bounded startup list on the summary protocol surface", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.listThreads({
+      enrichDirectories: false,
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    const requests = transport!.sentMessages.map((message) =>
+      JSON.parse(message) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      },
+    );
+    expect(requests.filter((request) => request.method === "thread/list"))
+      .toEqual([
+        expect.objectContaining({
+          params: {
+            archived: false,
+            limit: 50,
+            sortKey: "updated_at",
+            sourceKinds: ["cli", "vscode"],
+            useStateDbOnly: true,
+          },
+        }),
+      ]);
+    expect(requests.some((request) => request.method === "thread/read")).toBe(false);
+
+    await client.close();
+  });
+
   it("keeps spawned agents out of navigation and exposes them for parent disclosure", async () => {
     MockTransport.threadListResultBySearchTerm.set("native-subagent-source", [
       {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1229,6 +1229,9 @@ describe("bootstrapApp", () => {
     });
     expect(listThreadsMock).toHaveBeenCalledWith({
       callerReason: "startup-prewarm",
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/overlay-store-partial-navigation.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-partial-navigation.test.ts
@@ -1,0 +1,139 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppServerThreadSummary } from "@pwragent/shared";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+function buildThread(params: {
+  id: string;
+  path: string;
+  updatedAt: number;
+}): AppServerThreadSummary {
+  return {
+    id: params.id,
+    title: params.id,
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [
+      {
+        id: params.path,
+        kind: "local",
+        label: path.basename(params.path),
+        path: params.path,
+      },
+    ],
+    updatedAt: params.updatedAt,
+  };
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-partial-nav-test-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("SqliteOverlayStore partial navigation snapshots", () => {
+  it("renders overlays without replacing the full navigation baseline", async () => {
+    const pinnedThread = buildThread({
+      id: "thread-pinned",
+      path: "/repo/alpha",
+      updatedAt: 2_000,
+    });
+    const recentThread = buildThread({
+      id: "thread-recent",
+      path: "/repo/beta",
+      updatedAt: 3_000,
+    });
+    const olderThread = buildThread({
+      id: "thread-older",
+      path: "/repo/gamma",
+      updatedAt: 1_000,
+    });
+    await store.setThreadPin({
+      backend: "codex",
+      threadId: pinnedThread.id,
+      pinnedRank: "1024",
+    });
+    await store.markThreadSeen({
+      backend: "codex",
+      threadId: pinnedThread.id,
+      seenAt: 2_100,
+      seenUpdatedAt: pinnedThread.updatedAt,
+    });
+    await store.setDirectoryPin({
+      directoryKey: "directory:/repo/alpha",
+      pinnedRank: "1024",
+    });
+    await store.setDirectoryThreadsCollapsed({
+      directoryKey: "directory:/repo/alpha",
+      collapsed: true,
+    });
+
+    const partial = await store.reconcileNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 3_100,
+      partial: true,
+      threads: [recentThread, pinnedThread],
+    });
+
+    expect(partial.threads.map((thread) => thread.id)).toEqual([
+      "thread-recent",
+      "thread-pinned",
+    ]);
+    expect(partial.threads.find((thread) => thread.id === pinnedThread.id)).toMatchObject({
+      inbox: { inInbox: false },
+      pinnedRank: "1024",
+    });
+    expect(partial.directories.find((directory) => directory.path === "/repo/alpha"))
+      .toMatchObject({
+        directoryThreadsCollapsed: true,
+        pinnedRank: "1024",
+      });
+    expect(
+      stateDb.raw.prepare("SELECT payload FROM backends WHERE scope = ?").get("all"),
+    ).toBeUndefined();
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: recentThread.id,
+    })).resolves.toBeUndefined();
+
+    const full = await store.reconcileNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 3_200,
+      threads: [recentThread, pinnedThread, olderThread],
+    });
+
+    expect(full.threads.map((thread) => thread.id)).toEqual([
+      "thread-recent",
+      "thread-pinned",
+      "thread-older",
+    ]);
+    expect(full.threads.every((thread) => thread.inbox.inInbox === false)).toBe(true);
+    expect(full.threads.find((thread) => thread.id === pinnedThread.id)).toMatchObject({
+      pinnedRank: "1024",
+    });
+    expect(full.directories.find((directory) => directory.path === "/repo/alpha"))
+      .toMatchObject({
+        directoryThreadsCollapsed: true,
+        pinnedRank: "1024",
+      });
+    expect(
+      stateDb.raw.prepare("SELECT payload FROM backends WHERE scope = ?").get("all"),
+    ).toBeDefined();
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: olderThread.id,
+    })).resolves.toBeDefined();
+  });
+});

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -425,6 +425,9 @@ function prewarmInitialThreadList(): void {
   void getDesktopBackendRegistry()
     .listThreads({
       callerReason: "startup-prewarm",
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
     })
     .then((threads) => {
       recordStartupProfileEvent({

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2126,6 +2126,7 @@ class DesktopAppServerService {
     const refreshMode = request.refreshMode ?? "full";
     const activeRecentRefresh = refreshMode === "active-recent";
     const cacheKey = buildThreadSnapshotCacheKey(backend, request.filter);
+    const hasCachedFullThreads = this.lastFullNavigationThreadsByKey.has(cacheKey);
     const cachedFullThreads = this.lastFullNavigationThreadsByKey.get(cacheKey);
     const fetchedThreads = await getDesktopBackendRegistry().listThreads({
       backend: backend === "all" ? undefined : backend,
@@ -2146,7 +2147,7 @@ class DesktopAppServerService {
       : fetchedThreads;
     const partialSnapshot =
       activeRecentRefresh
-      && (!cachedFullThreads || cachedFullThreads.length === 0);
+      && !hasCachedFullThreads;
     if (!activeRecentRefresh) {
       this.lastFullNavigationThreadsByKey.set(cacheKey, threads);
     }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2126,6 +2126,7 @@ class DesktopAppServerService {
     const refreshMode = request.refreshMode ?? "full";
     const activeRecentRefresh = refreshMode === "active-recent";
     const cacheKey = buildThreadSnapshotCacheKey(backend, request.filter);
+    const cachedFullThreads = this.lastFullNavigationThreadsByKey.get(cacheKey);
     const fetchedThreads = await getDesktopBackendRegistry().listThreads({
       backend: backend === "all" ? undefined : backend,
       callerReason: activeRecentRefresh
@@ -2139,10 +2140,13 @@ class DesktopAppServerService {
     });
     const threads = activeRecentRefresh
       ? mergeRecentThreadsIntoCachedSnapshot(
-          this.lastFullNavigationThreadsByKey.get(cacheKey),
+          cachedFullThreads,
           fetchedThreads,
         )
       : fetchedThreads;
+    const partialSnapshot =
+      activeRecentRefresh
+      && (!cachedFullThreads || cachedFullThreads.length === 0);
     if (!activeRecentRefresh) {
       this.lastFullNavigationThreadsByKey.set(cacheKey, threads);
     }
@@ -2157,6 +2161,7 @@ class DesktopAppServerService {
       automationsByThreadKey,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
+      ...(partialSnapshot ? { partial: true } : {}),
       queuedExecutionModesByThreadKey,
       queuedTurnsByThreadKey,
       threads,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -694,13 +694,20 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
      * sees queued messages, mirroring queuedExecutionModesByThreadKey.
      */
     queuedTurnsByThreadKey?: Record<string, ThreadQueuedTurnSummary[]>;
+    /**
+     * A bounded provider page that is useful for early rendering but does not
+     * represent the complete backend. Partial snapshots must not replace the
+     * durable completeness baseline or initialize per-thread seen metadata.
+     */
+    partial?: boolean;
     threads: AppServerThreadSummary[];
     workspaceRoots?: string[];
   }): Promise<NavigationSnapshot> {
     const backendState = this.getBackend(params.backend);
     const firstSnapshot = !backendState?.lastSnapshotHash;
+    const persistReconciliation = params.partial !== true;
 
-    if (firstSnapshot) {
+    if (persistReconciliation && firstSnapshot) {
       for (const thread of params.threads) {
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const current = this.getThread(threadKey);
@@ -754,7 +761,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       }
     }
 
-    for (const thread of params.threads) {
+    for (const thread of persistReconciliation ? params.threads : []) {
       if (!isAcpBackendId(thread.source) || !thread.executionMode) {
         continue;
       }
@@ -779,7 +786,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     // Agent names originate from the thread title when a thread is promoted
     // or created as an Agent. Keep that invariant across older builds that
     // renamed only the provider thread and left the overlay name stale.
-    for (const thread of params.threads) {
+    for (const thread of persistReconciliation ? params.threads : []) {
       const threadTitle = thread.title.trim();
       if (!threadTitle) {
         continue;
@@ -869,14 +876,18 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       launchpadDefaults: snapshot.launchpadDefaults,
       threads: snapshot.threads,
     });
-    const unchanged = backendState?.lastSnapshotHash === nextHash;
+    const unchanged =
+      persistReconciliation
+      && backendState?.lastSnapshotHash === nextHash;
 
-    this.putBackend(params.backend, {
-      knownThreadKeys: params.threads.map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id),
-      ),
-      lastSnapshotHash: nextHash,
-    });
+    if (persistReconciliation) {
+      this.putBackend(params.backend, {
+        knownThreadKeys: params.threads.map((thread) =>
+          buildThreadIdentityKey(thread.source, thread.id),
+        ),
+        lastSnapshotHash: nextHash,
+      });
+    }
 
     return { ...snapshot, unchanged };
   }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1164,6 +1164,7 @@ function DesktopAppShell(props: {
     lightweightNavigationRefresh:
       settings.snapshot?.experimental.lightweightNavigationRefresh?.value ?? false,
     onThreadActionError: handleThreadActionError,
+    progressiveInitialRefresh: true,
     threadViewVisible: mainView === "thread",
   });
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -163,6 +163,147 @@ describe("useThreadNavigation", () => {
     expect(result.current.error).toBeUndefined();
   });
 
+  it("renders a recent page before reconciling the full startup snapshot", async () => {
+    const recentSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-recent"],
+      threads: [
+        {
+          id: "thread-recent",
+          title: "Recent thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "updated-since-seen" },
+          pinnedRank: "1024",
+          updatedAt: 3_000,
+        },
+      ],
+      directories: [
+        {
+          key: "directory:/repo/alpha",
+          kind: "directory",
+          label: "alpha",
+          path: "/repo/alpha",
+          threadKeys: ["codex:thread-recent"],
+          needsAttentionCount: 1,
+          latestUpdatedAt: 3_000,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const fullSnapshot: NavigationSnapshot = {
+      ...recentSnapshot,
+      fetchedAt: 2,
+      inboxThreadKeys: ["codex:thread-new", "codex:thread-recent"],
+      threads: [
+        {
+          id: "thread-new",
+          title: "Newer thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "updated-since-seen" },
+          updatedAt: 4_000,
+        },
+        recentSnapshot.threads[0]!,
+      ],
+      directories: [
+        ...recentSnapshot.directories,
+        {
+          key: "directory:/repo/beta",
+          kind: "directory",
+          label: "beta",
+          path: "/repo/beta",
+          threadKeys: ["codex:thread-new"],
+          needsAttentionCount: 1,
+          latestUpdatedAt: 4_000,
+        },
+      ],
+    };
+    const recentResponse = createDeferred<
+      Awaited<ReturnType<NonNullable<DesktopApi["getNavigationSnapshotTransport"]>>>
+    >();
+    const fullResponse = createDeferred<
+      Awaited<ReturnType<NonNullable<DesktopApi["getNavigationSnapshotTransport"]>>>
+    >();
+    const getNavigationSnapshotTransport = vi
+      .fn<NonNullable<DesktopApi["getNavigationSnapshotTransport"]>>()
+      .mockReturnValueOnce(recentResponse.promise)
+      .mockReturnValueOnce(fullResponse.promise);
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshotTransport,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadNavigation(desktopApi, { progressiveInitialRefresh: true }),
+    );
+
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(1);
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(1, {
+      refreshMode: "active-recent",
+      transport: { protocol: 1 },
+    });
+
+    act(() => {
+      recentResponse.resolve({
+        kind: "full",
+        revision: "recent-revision",
+        snapshot: recentSnapshot,
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-recent",
+      ]);
+      expect(result.current.selectedThread?.id).toBe("thread-recent");
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(2);
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(2, {
+      refreshMode: "full",
+      transport: { protocol: 1 },
+    });
+
+    act(() => {
+      fullResponse.resolve({
+        kind: "full",
+        revision: "full-revision",
+        snapshot: fullSnapshot,
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-new",
+        "thread-recent",
+      ]);
+    });
+
+    expect(result.current.selectedThread?.id).toBe("thread-recent");
+    expect(result.current.threads.find((thread) => thread.id === "thread-recent"))
+      .toMatchObject({
+        inbox: { inInbox: true, reason: "updated-since-seen" },
+        pinnedRank: "1024",
+      });
+    expect(result.current.directories.map((directory) => directory.path)).toEqual([
+      "/repo/alpha",
+      "/repo/beta",
+    ]);
+    expect(result.current.inboxThreads.map((thread) => thread.id)).toEqual([
+      "thread-new",
+      "thread-recent",
+    ]);
+  });
+
   it("defers navigation deltas during a drag and preserves the dropped pin rank", async () => {
     const buildSnapshot = (title: string): NavigationSnapshot => ({
       backend: "all",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2815,6 +2815,7 @@ function reviewDisplayTextFromTarget(
 type UseThreadNavigationOptions = {
   enabled?: boolean;
   lightweightNavigationRefresh?: boolean;
+  progressiveInitialRefresh?: boolean;
   threadViewVisible?: boolean;
   /**
    * Publishes create / rename / archive / discard failures to the app's
@@ -3084,6 +3085,7 @@ export function useThreadNavigation(
   const rendererFederationTarget = readRendererFederationTarget();
   const isRendererFederationWindow = Boolean(rendererFederationTarget);
   const lightweightNavigationRefresh = options.lightweightNavigationRefresh ?? false;
+  const progressiveInitialRefresh = options.progressiveInitialRefresh ?? false;
   const threadViewVisible = options.threadViewVisible ?? true;
   const [browseMode, setBrowseMode] = useState<BrowseMode>(readBridgedBrowseMode);
   const [selectedItemKey, setSelectedItemKey] = useState<string>();
@@ -3342,6 +3344,7 @@ export function useThreadNavigation(
           forceRefresh: Boolean(options?.forceRefresh),
           hasCurrentResponse: Boolean(stateRef.current.response),
           preferredSelectionKey: preferredSelectionKey ?? null,
+          refreshMode: options?.refreshMode ?? "full",
         });
         const snapshotRequest =
           options?.forceRefresh || options?.refreshMode || federationTarget
@@ -3422,6 +3425,7 @@ export function useThreadNavigation(
         desktopApi.recordStartupProfileEvent?.("navigation-refresh:snapshot", {
           directoryCount: snapshot.directories.length,
           forceRefresh: Boolean(options?.forceRefresh),
+          refreshMode: options?.refreshMode ?? "full",
           threadCount: snapshot.threads.length,
           transportKind,
           unchanged: Boolean(snapshot.unchanged),
@@ -3794,8 +3798,27 @@ export function useThreadNavigation(
       return;
     }
 
+    if (
+      progressiveInitialRefresh
+      && desktopApi?.getNavigationSnapshotTransport
+      && !readRendererFederationTarget()
+    ) {
+      void refresh(undefined, undefined, false, {
+        refreshMode: "active-recent",
+      });
+      void refresh(undefined, undefined, false, {
+        refreshMode: "full",
+      });
+      return;
+    }
+
     void refresh();
-  }, [enabled, refresh]);
+  }, [
+    desktopApi?.getNavigationSnapshotTransport,
+    enabled,
+    progressiveInitialRefresh,
+    refresh,
+  ]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary

- render one bounded active/recent Codex summary page before the full navigation refresh
- keep the partial page out of the durable completeness/seen baseline, then reconcile the full result through the existing navigation path
- preserve selection, pins, unread state, directories, and ordering during the partial-to-full transition
- add no SQLite schema, transcript persistence, or new steady-state write path

Built on the startup fix from #1818. That PR was squash-merged before this draft
was opened, so this PR now targets `main` and contains only the follow-up change.

## Findings

PwrAgent SQLite does not contain a complete durable provider-owned navigation list. It persists navigation overlays (pins, seen state, directory state, and related metadata). `thread_search_documents` is an on-demand search projection, can be incomplete/stale, and does not carry the full navigation/status shape. Using it as a startup cache would therefore trade correctness for speed. Transcript/history remains protocol-owned and is not persisted in PwrAgent SQLite.

The startup capture shows the bounded prewarm uses only Codex App Server `thread/list`:

- ordinary page: `{ archived: false, limit: 50, sortKey: "updated_at", sourceKinds: ["cli", "vscode"], useStateDbOnly: true }`
- native worker discovery: the same payload with `sourceKinds: ["subAgentThreadSpawn"]`
- response shape: `{ data, nextCursor, backwardsCursor }`; 50 ordinary rows plus 11 native-worker rows in the captured profile
- both list responses contained zero turns; status was `notLoaded`
- captured response sizes were 108,701 and 45,526 bytes; preview totals were 63,682 and 33,737 bytes (maximums 4,767 and 24,186 bytes)
- selected-thread `thread/read` was separate and limited to five turns

The later full refresh paginated seven ordinary active pages (326 raw rows), ran one native-worker page, and refreshed archived metadata separately. Startup also issued `initialize`/`initialized`, `model/list`, `account/read`, and `account/rateLimits/read`; none are transcript-history reads.

## Startup timing

Existing dev-profile evidence before this change: 279 visible threads took about 4.7-4.9 seconds to prewarm, and the first navigation rows appeared about 5.2 seconds after window show.

After this change (`.local/startup-cpu-2026-08-20-2305-e17ed1`):

- useful partial rows: 3.821 seconds after window show (109 aggregate rows, including ACP backends)
- eventual full snapshot: 5.517 seconds after window show (283 aggregate rows)
- partial-to-full reconciliation: 1.696 seconds
- selected `thread/read`: separate, 121 ms

That moves useful rows about 1.38 seconds / 27% earlier on this profile while preserving eventual full correctness.

## Validation

- focused Vitest: 5 files, 961 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `git diff --check`
