### PR TITLE
fix(desktop): simplify interruption notices

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -60,6 +60,7 @@ import type {
   ThreadOverlayState,
   ThreadToolAccounting,
   ThreadToolInvocationAlert,
+  ThreadSpendAlert,
   ThreadUsageLineRecord,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
@@ -459,12 +460,12 @@ function createOverlayStoreMock(params?: {
       backend: ThreadOverlayState["backend"];
       threadId: string;
     }) => overlays.get(`${backend}:${threadId}`),
-    markThreadSpendAlerted: async ({
-      alertedAt,
+    setThreadSpendAlertPending: async ({
+      alert,
       backend,
       threadId,
     }: {
-      alertedAt?: number;
+      alert: ThreadSpendAlert;
       backend: ThreadOverlayState["backend"];
       threadId: string;
     }) => {
@@ -475,13 +476,36 @@ function createOverlayStoreMock(params?: {
         executionMode: "default" as const,
         extraLinkedDirectories: [],
       };
-      if (current.threadSpendAlertedAt !== undefined) return current;
+      if (
+        current.threadSpendAlertedAt !== undefined
+        || current.threadSpendAlertPending !== undefined
+      ) return current;
       const next = {
         ...current,
-        threadSpendAlertedAt: alertedAt ?? Date.now(),
+        threadSpendAlertPending: alert,
       };
       overlays.set(key, next);
       return next;
+    },
+    acknowledgeThreadSpendAlert: async ({
+      alertId,
+      backend,
+      threadId,
+    }: {
+      alertId: string;
+      backend: ThreadOverlayState["backend"];
+      threadId: string;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key);
+      if (current?.threadSpendAlertPending?.alertId !== alertId) return false;
+      const next: ThreadOverlayState = {
+        ...current,
+        threadSpendAlertedAt: Date.now(),
+      };
+      delete next.threadSpendAlertPending;
+      overlays.set(key, next);
+      return true;
     },
     getThreadOverlayStates: async ({
       backend,
@@ -19862,7 +19886,7 @@ command = "pnpm dev"
     });
   });
 
-  it("emits active-turn alerts once per threshold and total spend once per thread", async () => {
+  it("replays total spend until renderer acknowledgement, then suppresses it", async () => {
     const activeLine: ThreadUsageLineRecord = {
       backend: "codex",
       cachedInputCostMicros: 0,
@@ -19953,10 +19977,15 @@ command = "pnpm dev"
         { kind: "thread-spend", spendMicros: 30_000_000 },
       ],
     });
-    expect(pricingEvents[1]?.notification.params).not.toHaveProperty(
-      "triggeredSpendAlerts",
-    );
-
+    expect(pricingEvents[1]?.notification.params).toMatchObject({
+      triggeredSpendAlerts: [
+        { kind: "thread-spend", spendMicros: 30_000_000 },
+      ],
+    });
+    const pendingAlert = (pricingEvents[1]?.notification.params as {
+      triggeredSpendAlerts?: ThreadSpendAlert[];
+    }).triggeredSpendAlerts?.[0];
+    expect(pendingAlert?.kind).toBe("thread-spend");
     await registry.close();
 
     const restartedRegistry = new DesktopBackendRegistry({
@@ -19973,7 +20002,58 @@ command = "pnpm dev"
     restartedRegistry.onEvent((event) => {
       restartedEvents.push(event);
     });
-    await (restartedRegistry as unknown as {
+    const emitRestartedPricing = (restartedRegistry as unknown as {
+      emitThreadPricingUpdated(params: {
+        backend: AppServerBackendKind;
+        threadId: string;
+      }): Promise<void>;
+    }).emitThreadPricingUpdated.bind(restartedRegistry);
+    await emitRestartedPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(restartedEvents[0]?.notification.params).toMatchObject({
+      triggeredSpendAlerts: [
+        { kind: "thread-spend", spendMicros: 30_000_000 },
+      ],
+    });
+
+    await (overlayStore as typeof overlayStore & {
+      acknowledgeThreadSpendAlert(params: {
+        alertId: string;
+        backend: AppServerBackendKind;
+        threadId: string;
+      }): Promise<boolean>;
+    }).acknowledgeThreadSpendAlert({
+      alertId: pendingAlert?.alertId ?? "missing",
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    await emitRestartedPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const acknowledgedPricingEvent = restartedEvents[1];
+    expect(acknowledgedPricingEvent?.notification.params).not.toHaveProperty(
+      "triggeredSpendAlerts",
+    );
+    await restartedRegistry.close();
+
+    const acknowledgedRegistry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: overlayStore as never,
+      resolveSpendAlertPolicy: () => ({
+        activeTurnSpendEnabled: true,
+        activeTurnSpendThresholdUsd: 5,
+        threadSpendEnabled: true,
+        threadSpendThresholdUsd: 25,
+      }),
+    });
+    const acknowledgedEvents: AgentEvent[] = [];
+    acknowledgedRegistry.onEvent((event) => {
+      acknowledgedEvents.push(event);
+    });
+    await (acknowledgedRegistry as unknown as {
       emitThreadPricingUpdated(params: {
         backend: AppServerBackendKind;
         threadId: string;
@@ -19982,10 +20062,10 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
     });
-    expect(restartedEvents[0]?.notification.params).not.toHaveProperty(
+    expect(acknowledgedEvents[0]?.notification.params).not.toHaveProperty(
       "triggeredSpendAlerts",
     );
-    await restartedRegistry.close();
+    await acknowledgedRegistry.close();
   });
 
   it("preserves every active turn while coalescing pricing updates", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -459,6 +459,30 @@ function createOverlayStoreMock(params?: {
       backend: ThreadOverlayState["backend"];
       threadId: string;
     }) => overlays.get(`${backend}:${threadId}`),
+    markThreadSpendAlerted: async ({
+      alertedAt,
+      backend,
+      threadId,
+    }: {
+      alertedAt?: number;
+      backend: ThreadOverlayState["backend"];
+      threadId: string;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      if (current.threadSpendAlertedAt !== undefined) return current;
+      const next = {
+        ...current,
+        threadSpendAlertedAt: alertedAt ?? Date.now(),
+      };
+      overlays.set(key, next);
+      return next;
+    },
     getThreadOverlayStates: async ({
       backend,
       threadIds,
@@ -19838,7 +19862,7 @@ command = "pnpm dev"
     });
   });
 
-  it("emits configured spend alerts once per threshold", async () => {
+  it("emits active-turn alerts once per threshold and total spend once per thread", async () => {
     const activeLine: ThreadUsageLineRecord = {
       backend: "codex",
       cachedInputCostMicros: 0,
@@ -19883,12 +19907,13 @@ command = "pnpm dev"
         usageLineCount: 1,
       }],
     };
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadPricing: vi.fn(async () => pricing),
+    };
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
-      overlayStore: {
-        ...createOverlayStoreMock(),
-        readThreadPricing: vi.fn(async () => pricing),
-      } as never,
+      overlayStore: overlayStore as never,
       resolveSpendAlertPolicy: () => ({
         activeTurnSpendEnabled: true,
         activeTurnSpendThresholdUsd: 5,
@@ -19933,6 +19958,34 @@ command = "pnpm dev"
     );
 
     await registry.close();
+
+    const restartedRegistry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: overlayStore as never,
+      resolveSpendAlertPolicy: () => ({
+        activeTurnSpendEnabled: true,
+        activeTurnSpendThresholdUsd: 5,
+        threadSpendEnabled: true,
+        threadSpendThresholdUsd: 25,
+      }),
+    });
+    const restartedEvents: AgentEvent[] = [];
+    restartedRegistry.onEvent((event) => {
+      restartedEvents.push(event);
+    });
+    await (restartedRegistry as unknown as {
+      emitThreadPricingUpdated(params: {
+        backend: AppServerBackendKind;
+        threadId: string;
+      }): Promise<void>;
+    }).emitThreadPricingUpdated({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(restartedEvents[0]?.notification.params).not.toHaveProperty(
+      "triggeredSpendAlerts",
+    );
+    await restartedRegistry.close();
   });
 
   it("preserves every active turn while coalescing pricing updates", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -736,7 +736,7 @@ describe("DesktopSettingsService", () => {
     });
   });
 
-  it("defaults tool-output alert triggers on and persists independent opt-outs", async () => {
+  it("defaults tool-output alert triggers off and persists independent opt-ins", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");
     const service = new DesktopSettingsService({
@@ -746,17 +746,17 @@ describe("DesktopSettingsService", () => {
     });
 
     expect((await service.readSettings()).general.toolOutputAlerts).toEqual({
-      outputCapHitsEnabled: { value: true, source: "default" },
-      repeatedLargeOutputsEnabled: { value: true, source: "default" },
+      outputCapHitsEnabled: { value: false, source: "default" },
+      repeatedLargeOutputsEnabled: { value: false, source: "default" },
       repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
       repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
-      repeatedQueuedChecksEnabled: { value: true, source: "default" },
+      repeatedQueuedChecksEnabled: { value: false, source: "default" },
     });
 
     await service.writeConfigPatch({
       general: {
         toolOutputAlerts: {
-          repeatedLargeOutputsEnabled: false,
+          repeatedLargeOutputsEnabled: true,
           repeatedLargeOutputMinimumCalls: 7,
           repeatedLargeOutputMinimumPercent: 65,
         },
@@ -764,7 +764,7 @@ describe("DesktopSettingsService", () => {
     });
 
     expect(fs.readFileSync(configPath, "utf8")).toContain(
-      "repeated_large_outputs_enabled = false",
+      "repeated_large_outputs_enabled = true",
     );
     expect(fs.readFileSync(configPath, "utf8")).toContain(
       "repeated_large_output_minimum_calls = 7",
@@ -773,11 +773,11 @@ describe("DesktopSettingsService", () => {
       "repeated_large_output_minimum_percent = 65",
     );
     expect(service.resolveToolOutputAlertPolicy()).toEqual({
-      outputCapHitsEnabled: true,
-      repeatedLargeOutputsEnabled: false,
+      outputCapHitsEnabled: false,
+      repeatedLargeOutputsEnabled: true,
       repeatedLargeOutputMinimumCalls: 7,
       repeatedLargeOutputMinimumPercent: 65,
-      repeatedQueuedChecksEnabled: true,
+      repeatedQueuedChecksEnabled: false,
     });
   });
 
@@ -791,7 +791,7 @@ describe("DesktopSettingsService", () => {
     });
 
     expect((await service.readSettings()).general.spendAlerts).toEqual({
-      activeTurnSpendEnabled: { value: true, source: "default" },
+      activeTurnSpendEnabled: { value: false, source: "default" },
       activeTurnSpendThresholdUsd: { value: 5, source: "default" },
       threadSpendEnabled: { value: true, source: "default" },
       threadSpendThresholdUsd: { value: 25, source: "default" },

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -153,6 +153,13 @@
     "rowsChanged": 27,
     "statements": 27
   },
+  "thread-spend-alert-boundary": {
+    "commits": 1,
+    "note": "one total-spend alert boundary for a thread; later pricing updates are read-only",
+    "observedWalBytes": 16480,
+    "rowsChanged": 1,
+    "statements": 1
+  },
   "tool-output-history-analysis": {
     "commits": 1,
     "note": "replace 25 deterministic history findings plus coverage metadata in one explicit analysis transaction",

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -154,11 +154,11 @@
     "statements": 27
   },
   "thread-spend-alert-boundary": {
-    "commits": 1,
-    "note": "one total-spend alert boundary for a thread; later pricing updates are read-only",
-    "observedWalBytes": 16480,
-    "rowsChanged": 1,
-    "statements": 1
+    "commits": 2,
+    "note": "one pending total-spend alert and one renderer acknowledgement; repeated updates and acknowledgements are read-only",
+    "observedWalBytes": 32960,
+    "rowsChanged": 2,
+    "statements": 2
   },
   "tool-output-history-analysis": {
     "commits": 1,

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -33,6 +33,14 @@ let stateDb: StateDb;
 let store: SqliteOverlayStore;
 let tempDir: string;
 
+const ALERTING_TOOL_OUTPUT_POLICY = {
+  outputCapHitsEnabled: true,
+  repeatedLargeOutputsEnabled: true,
+  repeatedLargeOutputMinimumCalls: 5,
+  repeatedLargeOutputMinimumPercent: 50,
+  repeatedQueuedChecksEnabled: true,
+};
+
 beforeEach(() => {
   process.env[SQLITE_WRITE_METRICS_ENV] = "1";
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-write-metrics-"));
@@ -202,6 +210,7 @@ describe("sqlite write metrics", () => {
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),
       overlayStore: store as never,
+      resolveToolOutputAlertPolicy: () => ALERTING_TOOL_OUTPUT_POLICY,
     });
     const emit = (registry as unknown as {
       emit(event: AgentEvent): Promise<void>;
@@ -256,6 +265,7 @@ describe("sqlite write metrics", () => {
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),
       overlayStore: store as never,
+      resolveToolOutputAlertPolicy: () => ALERTING_TOOL_OUTPUT_POLICY,
     });
     const emit = (registry as unknown as {
       emit(event: AgentEvent): Promise<void>;
@@ -482,6 +492,7 @@ describe("sqlite write metrics", () => {
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),
       overlayStore: store as never,
+      resolveToolOutputAlertPolicy: () => ALERTING_TOOL_OUTPUT_POLICY,
     });
     const emit = (registry as unknown as {
       emit(event: AgentEvent): Promise<void>;
@@ -530,6 +541,7 @@ describe("sqlite write metrics", () => {
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),
       overlayStore: store as never,
+      resolveToolOutputAlertPolicy: () => ALERTING_TOOL_OUTPUT_POLICY,
     });
     const emit = (registry as unknown as {
       emit(event: AgentEvent): Promise<void>;
@@ -803,6 +815,36 @@ describe("sqlite write metrics", () => {
       note:
         "one thread load lazily reprices 25 usage rows in ten-row progress batches; a second load is read-only",
       scenario: "thread-pricing-lazy-repair",
+      writes,
+    });
+  });
+
+  it("persists one total-spend alert boundary without repeat writes", async () => {
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.markThreadSpendAlerted({
+        alertedAt: 1_800_000_000_000,
+        backend: "codex",
+        threadId: "thread-spend-alert",
+      });
+      await store.markThreadSpendAlerted({
+        alertedAt: 1_800_000_000_001,
+        backend: "codex",
+        threadId: "thread-spend-alert",
+      });
+    });
+
+    expect(
+      (await store.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-spend-alert",
+      }))?.threadSpendAlertedAt,
+    ).toBe(1_800_000_000_000);
+    expectSqliteWriteBudget({
+      // The measured boundary is about 16 KB of WAL. Even 100 newly expensive
+      // threads per day project to roughly 1.6 MB/day, with no repeat writes.
+      note:
+        "one total-spend alert boundary for a thread; later pricing updates are read-only",
+      scenario: "thread-spend-alert-boundary",
       writes,
     });
   });

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -819,15 +819,36 @@ describe("sqlite write metrics", () => {
     });
   });
 
-  it("persists one total-spend alert boundary without repeat writes", async () => {
+  it("persists total-spend pending and acknowledgement without repeat writes", async () => {
+    const alert = {
+      alertId: "spend-alert:thread:codex:thread-spend-alert",
+      createdAt: 1_800_000_000_000,
+      currency: "USD" as const,
+      kind: "thread-spend" as const,
+      spendMicros: 30_000_000,
+      threadId: "thread-spend-alert",
+      thresholdMicros: 25_000_000,
+    };
     const { writes } = await measureSqliteWrites(async () => {
-      await store.markThreadSpendAlerted({
-        alertedAt: 1_800_000_000_000,
+      await store.setThreadSpendAlertPending({
+        alert,
         backend: "codex",
         threadId: "thread-spend-alert",
       });
-      await store.markThreadSpendAlerted({
-        alertedAt: 1_800_000_000_001,
+      await store.setThreadSpendAlertPending({
+        alert,
+        backend: "codex",
+        threadId: "thread-spend-alert",
+      });
+      await store.acknowledgeThreadSpendAlert({
+        acknowledgedAt: 1_800_000_000_001,
+        alertId: alert.alertId,
+        backend: "codex",
+        threadId: "thread-spend-alert",
+      });
+      await store.acknowledgeThreadSpendAlert({
+        acknowledgedAt: 1_800_000_000_002,
+        alertId: alert.alertId,
         backend: "codex",
         threadId: "thread-spend-alert",
       });
@@ -838,12 +859,13 @@ describe("sqlite write metrics", () => {
         backend: "codex",
         threadId: "thread-spend-alert",
       }))?.threadSpendAlertedAt,
-    ).toBe(1_800_000_000_000);
+    ).toBe(1_800_000_000_001);
     expectSqliteWriteBudget({
-      // The measured boundary is about 16 KB of WAL. Even 100 newly expensive
-      // threads per day project to roughly 1.6 MB/day, with no repeat writes.
+      // Pending delivery and its acknowledgement each commit once. At about
+      // 16 KB of WAL per commit, 100 newly expensive threads per day project
+      // to roughly 3.2 MB/day, with no repeat writes.
       note:
-        "one total-spend alert boundary for a thread; later pricing updates are read-only",
+        "one pending total-spend alert and one renderer acknowledgement; repeated updates and acknowledgements are read-only",
       scenario: "thread-spend-alert-boundary",
       writes,
     });

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -12,6 +12,14 @@ import {
   toolInvocationFromNotification,
 } from "../app-server/tool-invocation-accounting";
 
+const ALERTING_TOOL_OUTPUT_POLICY = {
+  outputCapHitsEnabled: true,
+  repeatedLargeOutputsEnabled: true,
+  repeatedLargeOutputMinimumCalls: 5,
+  repeatedLargeOutputMinimumPercent: 50,
+  repeatedQueuedChecksEnabled: true,
+};
+
 describe("tool invocation accounting", () => {
   it("normalizes shell commands into durable command categories", () => {
     expect(
@@ -255,7 +263,10 @@ describe("tool invocation accounting", () => {
       status: "completed",
       toolName: "browser_tabs",
     });
-    expect(detectLargeToolOutput({ current: invocation! })?.alert).toMatchObject({
+    expect(detectLargeToolOutput({
+      current: invocation!,
+      policy: ALERTING_TOOL_OUTPUT_POLICY,
+    })?.alert).toMatchObject({
       kind: "large-output",
       severity: "warning",
       toolName: "browser_tabs",
@@ -429,10 +440,12 @@ describe("tool invocation accounting", () => {
   it("detects output at half of the observed cap and escalates at the cap", () => {
     const warning = detectLargeToolOutput({
       current: buildOutputInvocation(20_000),
+      policy: ALERTING_TOOL_OUTPUT_POLICY,
       previousOutputChars: 19_999,
     });
     const critical = detectLargeToolOutput({
       current: buildOutputInvocation(40_000),
+      policy: ALERTING_TOOL_OUTPUT_POLICY,
       previousOutputChars: 39_999,
     });
 
@@ -480,6 +493,7 @@ describe("tool invocation accounting", () => {
           invocationId: `command-${index + 1}`,
           itemId: `command-${index + 1}`,
         },
+        policy: ALERTING_TOOL_OUTPUT_POLICY,
       })!;
       const incident = mergeLargeToolOutputIncident({
         current: aggregate,
@@ -533,6 +547,7 @@ describe("tool invocation accounting", () => {
   it("aggregates cases by turn and keeps a stable worst-case summary", () => {
     const first = detectLargeToolOutput({
       current: buildOutputInvocation(20_000),
+      policy: ALERTING_TOOL_OUTPUT_POLICY,
       previousOutputChars: 0,
     })!;
     const firstIncident = mergeLargeToolOutputIncident({ detection: first });
@@ -542,6 +557,7 @@ describe("tool invocation accounting", () => {
         invocationId: "command-2",
         itemId: "command-2",
       },
+      policy: ALERTING_TOOL_OUTPUT_POLICY,
       previousOutputChars: 0,
     })!;
     const secondIncident = mergeLargeToolOutputIncident({
@@ -561,11 +577,13 @@ describe("tool invocation accounting", () => {
   it("does not rewrite a live warning at terminal completion", () => {
     const live = detectLargeToolOutput({
       current: buildOutputInvocation(20_000),
+      policy: ALERTING_TOOL_OUTPUT_POLICY,
       previousOutputChars: 0,
     })!;
     const incident = mergeLargeToolOutputIncident({ detection: live });
     const terminal = detectLargeToolOutput({
       current: { ...buildOutputInvocation(20_000), status: "completed" },
+      policy: ALERTING_TOOL_OUTPUT_POLICY,
     })!;
     const completed = mergeLargeToolOutputIncident({
       current: incident.aggregate,
@@ -617,6 +635,7 @@ describe("tool invocation accounting", () => {
     const warning = mergeLargeToolOutputIncident({
       detection: detectLargeToolOutput({
         current: buildOutputInvocation(20_000),
+        policy: ALERTING_TOOL_OUTPUT_POLICY,
         previousOutputChars: 0,
       })!,
     });
@@ -624,6 +643,7 @@ describe("tool invocation accounting", () => {
       current: warning.aggregate,
       detection: detectLargeToolOutput({
         current: buildOutputInvocation(40_000),
+        policy: ALERTING_TOOL_OUTPUT_POLICY,
         previousOutputChars: 20_000,
       })!,
     });

--- a/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
+++ b/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
@@ -127,6 +127,20 @@ describe("usage spend alerts", () => {
       triggeredAlertIds,
     })).toEqual([]);
   });
+
+  it("suppresses the total-spend alert after the thread boundary is persisted", () => {
+    expect(detectUsageSpendAlerts({
+      backend: "codex",
+      policy: POLICY,
+      pricing: {
+        lines: [],
+        summaries: [pricingSummary(40_000_000)],
+      },
+      threadId: "thread-1",
+      threadSpendAlerted: true,
+      triggeredAlertIds: new Set(),
+    })).toEqual([]);
+  });
 });
 
 function usageLine(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6687,6 +6687,7 @@ type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
     | "listRemoteThreadPins"
     | "reconcileOrphanedThreadSubAgents"
     | "markThreadToolInvocationsNoisy"
+    | "markThreadSpendAlerted"
     | "persistThreadToolInvocationBoundary"
     | "upsertThreadUsageLines"
     | "writeThreadGitWorkingStateCacheEntry"
@@ -11317,16 +11318,33 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: params.threadId,
     });
+    const overlay = this.spendAlertPolicy.threadSpendEnabled
+      ? await this.overlayStore.getThreadOverlayState({
+          backend: params.backend,
+          threadId: params.threadId,
+        })
+      : undefined;
     const triggeredSpendAlerts = detectUsageSpendAlerts({
       ...(params.activeTurnIds ? { activeTurnIds: params.activeTurnIds } : {}),
       backend: params.backend,
       policy: this.spendAlertPolicy,
       pricing,
       threadId: params.threadId,
+      threadSpendAlerted: overlay?.threadSpendAlertedAt !== undefined,
       triggeredAlertIds: this.triggeredSpendAlertIds,
     });
     for (const alert of triggeredSpendAlerts) {
       this.triggeredSpendAlertIds.add(alert.alertId);
+    }
+    const threadSpendAlert = triggeredSpendAlerts.find(
+      (alert) => alert.kind === "thread-spend",
+    );
+    if (threadSpendAlert) {
+      await this.overlayStore.markThreadSpendAlerted?.({
+        alertedAt: threadSpendAlert.createdAt,
+        backend: params.backend,
+        threadId: params.threadId,
+      });
     }
     await this.emit({
       backend: params.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6687,7 +6687,7 @@ type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
     | "listRemoteThreadPins"
     | "reconcileOrphanedThreadSubAgents"
     | "markThreadToolInvocationsNoisy"
-    | "markThreadSpendAlerted"
+    | "setThreadSpendAlertPending"
     | "persistThreadToolInvocationBoundary"
     | "upsertThreadUsageLines"
     | "writeThreadGitWorkingStateCacheEntry"
@@ -11324,28 +11324,41 @@ export class DesktopBackendRegistry {
           threadId: params.threadId,
         })
       : undefined;
-    const triggeredSpendAlerts = detectUsageSpendAlerts({
+    const detectedSpendAlerts = detectUsageSpendAlerts({
       ...(params.activeTurnIds ? { activeTurnIds: params.activeTurnIds } : {}),
       backend: params.backend,
       policy: this.spendAlertPolicy,
       pricing,
       threadId: params.threadId,
-      threadSpendAlerted: overlay?.threadSpendAlertedAt !== undefined,
+      threadSpendAlerted:
+        overlay?.threadSpendAlertedAt !== undefined
+        || overlay?.threadSpendAlertPending !== undefined,
       triggeredAlertIds: this.triggeredSpendAlertIds,
     });
-    for (const alert of triggeredSpendAlerts) {
-      this.triggeredSpendAlertIds.add(alert.alertId);
+    for (const alert of detectedSpendAlerts) {
+      if (alert.kind === "active-turn-spend") {
+        this.triggeredSpendAlertIds.add(alert.alertId);
+      }
     }
-    const threadSpendAlert = triggeredSpendAlerts.find(
+    const detectedThreadSpendAlert = detectedSpendAlerts.find(
       (alert) => alert.kind === "thread-spend",
     );
-    if (threadSpendAlert) {
-      await this.overlayStore.markThreadSpendAlerted?.({
-        alertedAt: threadSpendAlert.createdAt,
-        backend: params.backend,
-        threadId: params.threadId,
-      });
-    }
+    const pendingOverlay = detectedThreadSpendAlert
+      ? await this.overlayStore.setThreadSpendAlertPending?.({
+          alert: detectedThreadSpendAlert,
+          backend: params.backend,
+          threadId: params.threadId,
+        })
+      : overlay;
+    const pendingThreadSpendAlert =
+      pendingOverlay?.threadSpendAlertPending
+      ?? detectedThreadSpendAlert;
+    const triggeredSpendAlerts = [
+      ...detectedSpendAlerts.filter(
+        (alert) => alert.kind === "active-turn-spend",
+      ),
+      ...(pendingThreadSpendAlert ? [pendingThreadSpendAlert] : []),
+    ];
     await this.emit({
       backend: params.backend,
       notification: {

--- a/apps/desktop/src/main/app-server/usage-spend-alerts.ts
+++ b/apps/desktop/src/main/app-server/usage-spend-alerts.ts
@@ -20,6 +20,7 @@ export function detectUsageSpendAlerts(params: {
     summaries: readonly ThreadPricingSummary[];
   };
   threadId: string;
+  threadSpendAlerted?: boolean;
   triggeredAlertIds: ReadonlySet<string>;
   now?: number;
 }): ThreadSpendAlert[] {
@@ -78,7 +79,6 @@ export function detectUsageSpendAlerts(params: {
       "thread",
       params.backend,
       params.threadId,
-      thresholdMicros,
     ].join(":");
     const spendMicros = params.pricing.summaries.reduce(
       (total, summary) =>
@@ -89,6 +89,7 @@ export function detectUsageSpendAlerts(params: {
     );
     if (
       spendMicros >= thresholdMicros
+      && !params.threadSpendAlerted
       && !params.triggeredAlertIds.has(alertId)
     ) {
       alerts.push({

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -127,6 +127,8 @@ import {
   type SetThreadReactionResponse,
   type SetThreadToolIncidentNoticeRequest,
   type SetThreadToolIncidentNoticeResponse,
+  type AcknowledgeThreadSpendAlertRequest,
+  type AcknowledgeThreadSpendAlertResponse,
   type SetNavigationBrowseModeRequest,
   type SetNavigationBrowseModeResponse,
   type ListThreadMigrationSourceThreadsRequest,
@@ -257,6 +259,7 @@ import {
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
+  NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_LIST_MODEL_SETTINGS_RECENTS_CHANNEL,
@@ -374,6 +377,7 @@ type AppServerOverlayStoreLike = OverlayStoreLike &
     | "listRemoteThreadPins"
     | "updateRemoteThreadPinSnapshots"
     | "setThreadToolIncidentNotice"
+    | "acknowledgeThreadSpendAlert"
   >;
 
 type ThreadPrRefreshContext = {
@@ -5848,6 +5852,29 @@ class DesktopAppServerService {
     };
   }
 
+  async acknowledgeThreadSpendAlert(
+    request: AcknowledgeThreadSpendAlertRequest,
+  ): Promise<AcknowledgeThreadSpendAlertResponse> {
+    const backend = request.backend ?? "codex";
+    const acknowledged = await this.getOverlayStore()
+      .acknowledgeThreadSpendAlert({
+        alertId: request.alertId,
+        backend,
+        threadId: request.threadId,
+      });
+    logDebug("acknowledgeThreadSpendAlert", {
+      acknowledged,
+      alertId: request.alertId,
+      backend,
+      threadId: request.threadId,
+    });
+    return {
+      acknowledged,
+      backend,
+      threadId: request.threadId,
+    };
+  }
+
   async setThreadReaction(
     request: SetThreadReactionRequest,
   ): Promise<SetThreadReactionResponse> {
@@ -7756,6 +7783,16 @@ export function registerAppServerIpcHandlers(): void {
       request: SetThreadToolIncidentNoticeRequest,
     ): Promise<SetThreadToolIncidentNoticeResponse> => {
       return await appServerService.setThreadToolIncidentNotice(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL,
+    async (
+      _event,
+      request: AcknowledgeThreadSpendAlertRequest,
+    ): Promise<AcknowledgeThreadSpendAlertResponse> => {
+      return await appServerService.acknowledgeThreadSpendAlert(request);
     },
   );
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_PIN_CHANNEL);

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2380,6 +2380,34 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return nextState;
   }
 
+  /**
+   * Records the one thread-lifetime total-spend warning boundary. Repeated
+   * calls are read-only so later pricing updates cannot turn this into a
+   * per-item SQLite write.
+   */
+  async markThreadSpendAlerted(params: {
+    alertedAt?: number;
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    if (current.threadSpendAlertedAt !== undefined) {
+      return current;
+    }
+    const nextState: ThreadOverlayState = {
+      ...current,
+      threadSpendAlertedAt: params.alertedAt ?? Date.now(),
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async setThreadArchiveTombstone(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -31,6 +31,7 @@ import type {
   ThreadToolInvocationSummary,
   ThreadPermissionTransition,
   ThreadPricingSummary,
+  ThreadSpendAlert,
   ThreadPrAutoDispatchEventKind,
   ThreadPrAutoDispatchPending,
   ThreadPullRequestWatchSummary,
@@ -2380,13 +2381,9 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return nextState;
   }
 
-  /**
-   * Records the one thread-lifetime total-spend warning boundary. Repeated
-   * calls are read-only so later pricing updates cannot turn this into a
-   * per-item SQLite write.
-   */
-  async markThreadSpendAlerted(params: {
-    alertedAt?: number;
+  /** Retains the threshold-crossing payload until a renderer receives it. */
+  async setThreadSpendAlertPending(params: {
+    alert: ThreadSpendAlert;
     backend: ThreadOverlayState["backend"];
     threadId: string;
   }): Promise<ThreadOverlayState> {
@@ -2397,15 +2394,42 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       executionMode: "default" as const,
       extraLinkedDirectories: [],
     };
-    if (current.threadSpendAlertedAt !== undefined) {
+    if (
+      current.threadSpendAlertedAt !== undefined
+      || current.threadSpendAlertPending !== undefined
+    ) {
       return current;
     }
     const nextState: ThreadOverlayState = {
       ...current,
-      threadSpendAlertedAt: params.alertedAt ?? Date.now(),
+      threadSpendAlertPending: params.alert,
     };
     this.putThread(threadKey, nextState);
     return nextState;
+  }
+
+  /** Consumes only the pending alert the renderer confirms it received. */
+  async acknowledgeThreadSpendAlert(params: {
+    acknowledgedAt?: number;
+    alertId: string;
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+  }): Promise<boolean> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey);
+    if (
+      !current
+      || current.threadSpendAlertPending?.alertId !== params.alertId
+    ) {
+      return false;
+    }
+    const nextState: ThreadOverlayState = {
+      ...current,
+      threadSpendAlertedAt: params.acknowledgedAt ?? Date.now(),
+    };
+    delete nextState.threadSpendAlertPending;
+    this.putThread(threadKey, nextState);
+    return true;
   }
 
   async setThreadArchiveTombstone(params: {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -158,6 +158,8 @@ import type {
   SetThreadReactionResponse,
   SetThreadToolIncidentNoticeRequest,
   SetThreadToolIncidentNoticeResponse,
+  AcknowledgeThreadSpendAlertRequest,
+  AcknowledgeThreadSpendAlertResponse,
   GetGhStatusRequest,
   GhStatus,
   ApproveMessagingPairingRequest,
@@ -656,6 +658,7 @@ import {
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
+  NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
@@ -1692,6 +1695,13 @@ const desktopApi = Object.freeze({
   ): Promise<SetThreadToolIncidentNoticeResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
+      request,
+    ),
+  acknowledgeThreadSpendAlert: async (
+    request: AcknowledgeThreadSpendAlertRequest,
+  ): Promise<AcknowledgeThreadSpendAlertResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL,
       request,
     ),
   setThreadPin: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -413,6 +413,27 @@ function DesktopAppShell(props: {
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
+  const acknowledgedSpendAlertIdsRef = useRef(new Set<string>());
+  const acknowledgeThreadSpendAlert = useCallback((params: {
+    alert: ThreadSpendAlert;
+    backend: AppServerBackendKind;
+  }): void => {
+    if (
+      params.alert.kind !== "thread-spend"
+      || acknowledgedSpendAlertIdsRef.current.has(params.alert.alertId)
+      || !desktopApi?.acknowledgeThreadSpendAlert
+    ) {
+      return;
+    }
+    acknowledgedSpendAlertIdsRef.current.add(params.alert.alertId);
+    void desktopApi.acknowledgeThreadSpendAlert({
+      alertId: params.alert.alertId,
+      backend: params.backend,
+      threadId: params.alert.threadId,
+    }).catch(() => {
+      acknowledgedSpendAlertIdsRef.current.delete(params.alert.alertId);
+    });
+  }, [desktopApi]);
   const {
     health: liveFederationHealth,
     refresh: refreshFederationHealth,
@@ -766,6 +787,12 @@ function DesktopAppShell(props: {
                 ...(threadLink ? { threadLink } : {}),
               }),
             });
+            if (!event.federationTarget) {
+              acknowledgeThreadSpendAlert({
+                alert,
+                backend: event.backend,
+              });
+            }
           }
         }
       }
@@ -1036,7 +1063,7 @@ function DesktopAppShell(props: {
         return;
       }
     });
-  }, [desktopApi]);
+  }, [acknowledgeThreadSpendAlert, desktopApi]);
   // `instant` is for callers that are about to hide the sidebar (the ⌘K peek):
   // a smooth scroll is animated over several frames, and hiding the sidebar
   // mid-animation abandons it wherever it got to. An instant scroll lands in one
@@ -1166,6 +1193,36 @@ function DesktopAppShell(props: {
     onThreadActionError: handleThreadActionError,
     threadViewVisible: mainView === "thread",
   });
+  useEffect(() => {
+    if (readRendererFederationTarget()) {
+      return;
+    }
+    for (const thread of navigation.threads) {
+      const alert = thread.threadSpendAlertPending;
+      if (!alert || thread.federation) {
+        continue;
+      }
+      dispatchAppNotice({
+        type: "show",
+        notice: buildSpendAlertNotice({
+          alert,
+          threadLink: {
+            backend: thread.source,
+            inThreadList: true,
+            threadId: thread.id,
+            title: thread.title,
+            titleSource: thread.titleSource,
+            gitBranch: thread.gitBranch,
+            linkedDirectories: thread.linkedDirectories,
+          },
+        }),
+      });
+      acknowledgeThreadSpendAlert({
+        alert,
+        backend: thread.source,
+      });
+    }
+  }, [acknowledgeThreadSpendAlert, navigation.threads]);
   useEffect(() => {
     if (!desktopApi?.onCopyLocalDiagnosticsInfoRequested) {
       return;

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -762,6 +762,96 @@ describe("App", () => {
 
   it.each([
     {
+      label: "the local window",
+      rendererTarget: undefined,
+      expected: true,
+    },
+    {
+      label: "a federation-only window",
+      rendererTarget: {
+        scope: "remote" as const,
+        instanceId: "remote-gateway",
+      },
+      expected: false,
+    },
+  ])("replays pending spend alerts only to $label", async ({
+    rendererTarget,
+    expected,
+  }) => {
+    if (rendererTarget) {
+      (window as typeof window & {
+        __pwragentFederationTarget?: unknown;
+      }).__pwragentFederationTarget = rendererTarget;
+    }
+    const acknowledgeThreadSpendAlert = vi.fn(async () => ({
+      acknowledged: true,
+      backend: "codex",
+      threadId: "thread-spend-pending",
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [{
+        id: "thread-spend-pending",
+        title: "Expensive build",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+        updatedAt: 2_000,
+        threadSpendAlertPending: {
+          alertId: "spend-alert:thread:codex:thread-spend-pending",
+          createdAt: 1_800_000_000_000,
+          currency: "USD" as const,
+          kind: "thread-spend" as const,
+          spendMicros: 31_000_000,
+          threadId: "thread-spend-pending",
+          thresholdMicros: 25_000_000,
+        },
+      }],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+      ...(rendererTarget ? { federationTarget: rendererTarget } : {}),
+    }));
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        acknowledgeThreadSpendAlert,
+        getNavigationSnapshot,
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+    await waitFor(() => expect(getNavigationSnapshot).toHaveBeenCalled());
+
+    if (!expected) {
+      expect(screen.queryByText("Thread spend threshold reached"))
+        .not.toBeInTheDocument();
+      expect(acknowledgeThreadSpendAlert).not.toHaveBeenCalled();
+      return;
+    }
+
+    expect(await screen.findByText("Thread spend threshold reached"))
+      .toBeInTheDocument();
+    await waitFor(() => {
+      expect(acknowledgeThreadSpendAlert).toHaveBeenCalledWith({
+        alertId: "spend-alert:thread:codex:thread-spend-pending",
+        backend: "codex",
+        threadId: "thread-spend-pending",
+      });
+    });
+  });
+
+  it.each([
+    {
       label: "local events in the main window",
       rendererTarget: undefined,
       eventTarget: undefined,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -741,7 +741,7 @@ describe("App", () => {
       ),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
     expect(
       screen.getByText("Repository: github.com/historical/retained-repo"),
     ).toBeInTheDocument();
@@ -1380,14 +1380,14 @@ describe("App", () => {
           source: "default",
         },
         toolOutputAlerts: {
-          outputCapHitsEnabled: { value: true, source: "default" },
-          repeatedLargeOutputsEnabled: { value: true, source: "default" },
+          outputCapHitsEnabled: { value: true, source: "config" },
+          repeatedLargeOutputsEnabled: { value: true, source: "config" },
           repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
           repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
-          repeatedQueuedChecksEnabled: { value: true, source: "default" },
+          repeatedQueuedChecksEnabled: { value: true, source: "config" },
         },
         spendAlerts: {
-          activeTurnSpendEnabled: { value: true, source: "default" },
+          activeTurnSpendEnabled: { value: true, source: "config" },
           activeTurnSpendThresholdUsd: { value: 5, source: "default" },
           threadSpendEnabled: { value: true, source: "default" },
           threadSpendThresholdUsd: { value: 25, source: "default" },

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
@@ -63,7 +63,7 @@ export function AppNoticeStack(props: {
         desktopApi={props.desktopApi}
         notice={activeNotice}
         onOpenThread={props.onOpenThread}
-        navigation={activeNotice && durableNotices.length > 1
+        navigation={activeNotice
           ? {
               current: activeIndex + 1,
               total: durableNotices.length,

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -22,6 +22,8 @@ export type AppNoticeToastNotice = {
   id: string;
   title: string;
   message: string;
+  /** Optional notice-specific dismissal, including any durable disposition. */
+  onDismiss?: () => void;
   detail?: string;
   threadLink?: ResolvedThreadLink;
   copyText?: string;
@@ -147,42 +149,42 @@ export function AppNoticeToast(props: {
       </div>
       <div
         className="app-notice-toast__actions"
-        data-custom-actions={customActions.length > 0 ? "true" : undefined}
       >
-        {customActions.length > 0
-          ? customActions.map((action) => (
-              <button
-                key={action.label}
-                className={`button button--${action.tone ?? "secondary"}`}
-                type="button"
-                onClick={action.onClick}
-              >
-                {action.label}
-              </button>
-            ))
-          : <>
-              <button
-                className="app-notice-toast__icon-button"
-                type="button"
-                aria-label="Copy notice"
-                title="Copy notice"
-                onClick={() => {
-                  void copyText(copyValue, props.desktopApi);
-                }}
-              >
-                <CopyIcon size={14} aria-hidden="true" />
-              </button>
-              <button
-                className="app-notice-toast__icon-button"
-                type="button"
-                aria-label="Dismiss notice"
-                title="Dismiss notice"
-                onClick={props.onDismiss}
-              >
-                <CloseIcon size={14} aria-hidden="true" />
-              </button>
-            </>}
+        <button
+          className="app-notice-toast__icon-button"
+          type="button"
+          aria-label="Copy notice"
+          title="Copy notice"
+          onClick={() => {
+            void copyText(copyValue, props.desktopApi);
+          }}
+        >
+          <CopyIcon size={14} aria-hidden="true" />
+        </button>
+        <button
+          className="app-notice-toast__icon-button"
+          type="button"
+          aria-label="Dismiss notice"
+          title="Dismiss notice"
+          onClick={props.notice.onDismiss ?? props.onDismiss}
+        >
+          <CloseIcon size={14} aria-hidden="true" />
+        </button>
       </div>
+      {customActions.length > 0 ? (
+        <div className="app-notice-toast__custom-actions">
+          {customActions.map((action) => (
+            <button
+              key={action.label}
+              className={`button button--${action.tone ?? "secondary"}`}
+              type="button"
+              onClick={action.onClick}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
       {props.navigation ? (
         <nav
           className="app-notice-toast__navigation"

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -115,6 +115,7 @@ export function buildGrokCliUpdateNotice(params: {
     title: "Grok update available",
     message: `Grok ${update.latestVersion} is available; ${update.currentVersion} is installed.`,
     detail: "Update Grok from x.ai/build, then restart active Grok sessions.",
+    onDismiss: params.onDismiss,
     tone: "warning",
     actions: [
       {
@@ -123,7 +124,6 @@ export function buildGrokCliUpdateNotice(params: {
         tone: "primary",
       },
       { label: "Tomorrow", onClick: params.onSnooze },
-      { label: "Dismiss version", onClick: params.onDismiss },
     ],
   };
 }

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
@@ -46,5 +46,13 @@ describe("AppNoticeStack", () => {
     fireEvent.click(screen.getByRole("button", { name: "Previous notice" }));
     expect(screen.getByText("First")).toBeInTheDocument();
     expect(screen.queryByText("Second")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(await screen.findByText("Third")).toBeInTheDocument();
+    expect(screen.getByText("1 of 1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous notice" }))
+      .toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next notice" }))
+      .toBeDisabled();
   });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -227,7 +227,7 @@ describe("AppNoticeToast", () => {
     expect(onNext).toHaveBeenCalledTimes(1);
   });
 
-  it("uses exactly the supplied operator actions for a persistent safety notice", () => {
+  it("keeps copy and dismiss controls alongside supplied operator actions", () => {
     vi.useFakeTimers();
     const leaveDisabled = vi.fn();
     const resume = vi.fn();
@@ -251,19 +251,38 @@ describe("AppNoticeToast", () => {
       />,
     );
 
-    expect(screen.getAllByRole("button")).toHaveLength(2);
-    expect(screen.queryByRole("button", { name: "Copy notice" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Dismiss notice" })).toBeNull();
+    expect(screen.getAllByRole("button")).toHaveLength(4);
+    expect(screen.getByRole("button", { name: "Copy notice" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dismiss notice" }))
+      .toBeInTheDocument();
     expect(
-      container.querySelector(".app-notice-toast__actions"),
-    ).toHaveAttribute("data-custom-actions", "true");
+      container.querySelector(".app-notice-toast__custom-actions"),
+    ).toBeInTheDocument();
     expect(container.querySelector(".app-notice-toast__timer")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Leave disabled" }));
     fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
     expect(leaveDisabled).toHaveBeenCalledTimes(1);
     expect(resume).toHaveBeenCalledTimes(1);
-    expect(onDismiss).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a notice-specific durable dismissal when supplied", () => {
+    const durableDismiss = vi.fn();
+    const stackDismiss = vi.fn();
+
+    render(
+      <AppNoticeToast
+        notice={{ ...notice, autoDismiss: false, onDismiss: durableDismiss }}
+        onDismiss={stackDismiss}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(durableDismiss).toHaveBeenCalledOnce();
+    expect(stackDismiss).not.toHaveBeenCalled();
   });
 
   it("starts a hover-paused countdown when repair progress flips to success", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/codex-missing-threads-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/codex-missing-threads-notice.test.ts
@@ -29,8 +29,6 @@ describe("buildCodexMissingThreadsNotice", () => {
     expect(notice?.message).toContain("40%");
     expect(notice?.message).toContain('"work"');
     expect(notice?.message).toContain("2 of 5");
-    // The notice replaces the toast's own dismiss control when it carries
-    // actions, so the two answers are the only way out of it.
     expect(notice?.actions?.map((action) => action.label)).toEqual([
       "Leave Everything Alone",
       "Archive the Missing Threads",
@@ -42,6 +40,9 @@ describe("buildCodexMissingThreadsNotice", () => {
 
     notice?.actions?.[1]?.onClick();
     expect(onArchive).toHaveBeenCalledTimes(1);
+
+    notice?.onDismiss?.();
+    expect(onKeep).toHaveBeenCalledTimes(2);
   });
 
   it("reports an automatic archive without asking anything", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/github-pr-authentication-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/github-pr-authentication-notice.test.ts
@@ -18,7 +18,6 @@ describe("buildGithubPrAuthenticationNotice", () => {
     });
     expect(notice.message).toMatch(/GitHub CLI/);
     expect(notice.actions?.map((action) => action.label)).toEqual([
-      "Dismiss",
       "Open Git settings",
     ]);
   });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/github-pr-saml-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/github-pr-saml-notice.test.ts
@@ -28,12 +28,11 @@ describe("buildGithubPrSamlEnforcementNotice", () => {
     });
     expect(notice.message).toMatch(/SAML SSO/);
     expect(notice.actions?.map((action) => action.label)).toEqual([
-      "Dismiss",
       "Open Git settings",
     ]);
 
+    notice.onDismiss?.();
     notice.actions?.[0]?.onClick();
-    notice.actions?.[1]?.onClick();
     expect(onDismiss).toHaveBeenCalledOnce();
     expect(onOpenGitSettings).toHaveBeenCalledOnce();
   });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -29,6 +29,7 @@ function grokEntry(
 describe("buildGrokCliUpdateNotice", () => {
   it("builds a version-keyed durable update notice", () => {
     const onOpenUpdatePage = vi.fn();
+    const onDismiss = vi.fn();
     const notice = buildGrokCliUpdateNotice({
       entry: grokEntry({
         status: "available",
@@ -38,7 +39,7 @@ describe("buildGrokCliUpdateNotice", () => {
       }),
       now: 200,
       onOpenUpdatePage,
-      onDismiss: vi.fn(),
+      onDismiss,
       onSnooze: vi.fn(),
     });
 
@@ -51,6 +52,8 @@ describe("buildGrokCliUpdateNotice", () => {
     });
     notice?.actions?.[0]?.onClick();
     expect(onOpenUpdatePage).toHaveBeenCalledWith(GROK_BUILD_UPDATE_URL);
+    notice?.onDismiss?.();
+    expect(onDismiss).toHaveBeenCalledOnce();
   });
 
   it("hides dismissed, snoozed, current, and failed checks", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/pr-auto-dispatch-budget-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/pr-auto-dispatch-budget-notice.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { buildPrAutoDispatchBudgetNotice } from "../pr-auto-dispatch-budget-notice";
 
 describe("buildPrAutoDispatchBudgetNotice", () => {
-  it("creates a persistent acknowledgement notice with the two safety actions", () => {
+  it("uses the standard dismissal for the safe leave-disabled outcome", () => {
     const onLeaveDisabled = vi.fn();
     const onResume = vi.fn();
     const notice = buildPrAutoDispatchBudgetNotice({
@@ -23,13 +23,10 @@ describe("buildPrAutoDispatchBudgetNotice", () => {
       title: "Auto-fix PR paused",
       tone: "warning",
     });
-    expect(notice?.actions?.map((action) => action.label)).toEqual([
-      "Leave disabled",
-      "Resume",
-    ]);
+    expect(notice?.actions?.map((action) => action.label)).toEqual(["Resume"]);
 
+    notice?.onDismiss?.();
     notice?.actions?.[0]?.onClick();
-    notice?.actions?.[1]?.onClick();
     expect(onLeaveDisabled).toHaveBeenCalledTimes(1);
     expect(onResume).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -192,8 +192,9 @@ describe("resolveToolIncidentVisibility", () => {
 
 describe("buildToolAccountingNotice", () => {
   it("carries one notice id per thread, not per turn", () => {
+    const onDismiss = vi.fn();
     const notice = buildToolAccountingNotice({
-      onDismiss: vi.fn(),
+      onDismiss,
       onExamine: vi.fn(),
       showCost: false,
       summary: summaryFor(),
@@ -201,6 +202,11 @@ describe("buildToolAccountingNotice", () => {
 
     expect(notice.id).toBe("tool-accounting:codex:thread-1");
     expect(notice.message).toContain("3 tool calls flagged across 2 turns");
+    expect(notice.actions?.map((action) => action.label)).not.toContain(
+      "Dismiss",
+    );
+    notice.onDismiss?.();
+    expect(onDismiss).toHaveBeenCalledOnce();
   });
 
   it("offers a mute for a warning but not for a cap hit", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
@@ -1,10 +1,5 @@
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
-/**
- * The confirmation notice replaces the toast's own dismiss control with its
- * two answers, so whatever dismisses it must agree with this id exactly — a
- * mismatch strands the operator with a prompt they cannot close.
- */
 export const CODEX_MISSING_THREADS_CONFIRMATION_NOTICE_ID =
   "codex-missing-threads:confirmation";
 
@@ -97,6 +92,7 @@ export function buildCodexMissingThreadsNotice(params: {
       "Archiving removes them from this PwrAgent profile and can be undone from the Archived lens. Leaving them alone changes nothing, and nothing else is archived automatically for the rest of this session.",
     id: CODEX_MISSING_THREADS_CONFIRMATION_NOTICE_ID,
     message: `${share} of the threads in PwrAgent profile "${signal.profileName}" (${signal.missingCount} of ${signal.totalCount}) are reported missing by Codex. That is expected if those Codex sessions were deleted, but it also happens when a PwrAgent profile is connected to the wrong Codex profile.`,
+    onDismiss: params.onKeep,
     title: "Threads missing from Codex",
     tone: "warning",
   };

--- a/apps/desktop/src/renderer/src/features/notifications/github-pr-authentication-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/github-pr-authentication-notice.ts
@@ -8,7 +8,6 @@ export function buildGithubPrAuthenticationNotice(params: {
 }): AppNoticeToastNotice {
   return {
     actions: [
-      { label: "Dismiss", onClick: params.onDismiss },
       {
         label: "Open Git settings",
         onClick: params.onOpenGitSettings,
@@ -20,6 +19,7 @@ export function buildGithubPrAuthenticationNotice(params: {
     id: "github-pr-authentication-failure",
     message:
       "PwrAgent couldn't read pull request status through the GitHub CLI. Check `gh auth status`, then re-authenticate with `gh auth login` if needed.",
+    onDismiss: params.onDismiss,
     title: "GitHub PR status unavailable",
     tone: "error",
   };

--- a/apps/desktop/src/renderer/src/features/notifications/github-pr-saml-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/github-pr-saml-notice.ts
@@ -15,10 +15,6 @@ export function buildGithubPrSamlEnforcementNotice(params: {
   return {
     actions: [
       {
-        label: "Dismiss",
-        onClick: params.onDismiss,
-      },
-      {
         label: "Open Git settings",
         onClick: params.onOpenGitSettings,
         tone: "primary",
@@ -29,6 +25,7 @@ export function buildGithubPrSamlEnforcementNotice(params: {
     id: `github-pr-saml:${githubPrAccessTargetKey(params.event.target)}`,
     message:
       "PwrAgent can't read pull requests for this repository because its organization requires SAML SSO. Re-authorize the GitHub CLI for that organization, then retry.",
+    onDismiss: params.onDismiss,
     title: "GitHub access blocked by SSO",
     tone: "error",
   };

--- a/apps/desktop/src/renderer/src/features/notifications/pr-auto-dispatch-budget-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/pr-auto-dispatch-budget-notice.ts
@@ -11,11 +11,6 @@ export function buildPrAutoDispatchBudgetNotice(params: {
   return {
     actions: [
       {
-        label: "Leave disabled",
-        onClick: params.onLeaveDisabled,
-        tone: "secondary",
-      },
-      {
         label: "Resume",
         onClick: params.onResume,
         tone: "primary",
@@ -27,6 +22,7 @@ export function buildPrAutoDispatchBudgetNotice(params: {
     id: `pr-auto-dispatch-budget-paused:${params.status.pausedAt ?? "current"}`,
     message:
       "The automatic repair budget is empty, so Auto-fix PR is paused for this PwrAgent profile.",
+    onDismiss: params.onLeaveDisabled,
     title: "Auto-fix PR paused",
     tone: "warning",
   };

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -24,11 +24,6 @@ export function buildToolAccountingNotice(params: {
         onClick: params.onExamine,
         tone: "primary" as const,
       },
-      {
-        label: "Dismiss",
-        onClick: params.onDismiss,
-        tone: "secondary" as const,
-      },
       /* Muting is offered only below critical. Silencing "output is getting
          large" is a reasonable call; silencing "output hit the cap and was
          truncated" is not something to offer in one click. */
@@ -47,6 +42,7 @@ export function buildToolAccountingNotice(params: {
       showCost: params.showCost,
       summary,
     }),
+    onDismiss: params.onDismiss,
     threadLink: params.threadLink,
     title: critical
       ? "Tool output hit the cap"

--- a/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
@@ -60,6 +60,12 @@ export function PricingSettings(props: {
     DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS;
   const toolOutputAlerts = props.snapshot.general.toolOutputAlerts;
   const spendAlerts = props.snapshot.general.spendAlerts;
+  const alertsEnabled =
+    spendAlerts.activeTurnSpendEnabled.value
+    || spendAlerts.threadSpendEnabled.value
+    || toolOutputAlerts.outputCapHitsEnabled.value
+    || toolOutputAlerts.repeatedLargeOutputsEnabled.value
+    || toolOutputAlerts.repeatedQueuedChecksEnabled.value;
   const displayControlsDisabled = props.saving || !threadPricingSummary.value;
   const repeatedLargeOutputDescription =
     `Alert after ${toolOutputAlerts.repeatedLargeOutputMinimumCalls.value.toLocaleString()} tool calls in one turn each produce at least ${toolOutputAlerts.repeatedLargeOutputMinimumPercent.value.toLocaleString()}% of the model-visible output cap.`;
@@ -146,7 +152,8 @@ export function PricingSettings(props: {
         eyebrow="Usage"
         title="Alerts"
         description="Choose which costly or lossy tool-use patterns should interrupt you."
-        chip={sourceBadge(toolOutputAlerts.repeatedLargeOutputsEnabled)}
+        chip={alertsEnabled ? "On" : "Off"}
+        chipKind={alertsEnabled ? "ok" : "default"}
       >
         <div className="settings-fields">
           <SettingsField

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -130,14 +130,14 @@ function createSnapshot(
         source: "default",
       },
       toolOutputAlerts: {
-        outputCapHitsEnabled: { value: true, source: "default" },
-        repeatedLargeOutputsEnabled: { value: true, source: "default" },
+        outputCapHitsEnabled: { value: true, source: "config" },
+        repeatedLargeOutputsEnabled: { value: true, source: "config" },
         repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
         repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
-        repeatedQueuedChecksEnabled: { value: true, source: "default" },
+        repeatedQueuedChecksEnabled: { value: true, source: "config" },
       },
       spendAlerts: {
-        activeTurnSpendEnabled: { value: true, source: "default" },
+        activeTurnSpendEnabled: { value: true, source: "config" },
         activeTurnSpendThresholdUsd: { value: 5, source: "default" },
         threadSpendEnabled: { value: true, source: "default" },
         threadSpendThresholdUsd: { value: 25, source: "default" },

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -172,6 +172,8 @@ import type {
   SetThreadReactionResponse,
   SetThreadToolIncidentNoticeRequest,
   SetThreadToolIncidentNoticeResponse,
+  AcknowledgeThreadSpendAlertRequest,
+  AcknowledgeThreadSpendAlertResponse,
   SetThreadParentRequest,
   SetThreadParentResponse,
   SetThreadPinRequest,
@@ -926,6 +928,9 @@ export type DesktopApi = {
   setThreadToolIncidentNotice?: (
     request: SetThreadToolIncidentNoticeRequest,
   ) => Promise<SetThreadToolIncidentNoticeResponse>;
+  acknowledgeThreadSpendAlert?: (
+    request: AcknowledgeThreadSpendAlertRequest,
+  ) => Promise<AcknowledgeThreadSpendAlertResponse>;
   setThreadPin?: (
     request: SetThreadPinRequest
   ) => Promise<SetThreadPinResponse>;

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -488,7 +488,7 @@ describe("Tangerine Terminal theme contract", () => {
   it("keeps custom toast actions from collapsing the message column", () => {
     const customActionsRule = extractRuleBody(
       css,
-      '.app-notice-toast__actions[data-custom-actions="true"]',
+      ".app-notice-toast__custom-actions",
     );
 
     expect(customActionsRule).toContain("grid-column: 1 / -1;");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6954,6 +6954,7 @@ textarea,
   left: 16px;
   bottom: 16px;
   display: flex;
+  width: min(420px, calc(100vw - 32px));
   max-width: min(420px, calc(100vw - 32px));
   flex-direction: column;
   align-items: flex-start;
@@ -6982,6 +6983,7 @@ textarea,
 
 .app-notice-toast {
   overflow: hidden;
+  width: 100%;
   grid-template-columns: minmax(0, 1fr) auto;
   border: 1px solid var(--border-subtle);
   background: color-mix(in srgb, var(--bg-panel-elevated) 96%, var(--text-muted) 4%);
@@ -7094,6 +7096,7 @@ textarea,
 }
 
 .app-notice-toast__actions,
+.app-notice-toast__custom-actions,
 .app-update-banner__actions {
   display: flex;
   flex-wrap: wrap;
@@ -7104,7 +7107,7 @@ textarea,
   align-self: start;
 }
 
-.app-notice-toast__actions[data-custom-actions="true"] {
+.app-notice-toast__custom-actions {
   grid-column: 1 / -1;
   justify-content: flex-end;
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -162,6 +162,8 @@ export const NAVIGATION_SET_THREAD_REACTION_CHANNEL =
   "navigation:set-thread-reaction";
 export const NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL =
   "navigation:set-thread-tool-incident-notice";
+export const NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL =
+  "navigation:acknowledge-thread-spend-alert";
 export const NAVIGATION_SET_THREAD_PIN_CHANNEL =
   "navigation:set-thread-pin";
 export const NAVIGATION_SET_THREAD_AGENT_CHANNEL =

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -67,14 +67,14 @@ describe("desktop settings contracts", () => {
           source: "default",
         },
         toolOutputAlerts: {
-          outputCapHitsEnabled: { value: true, source: "default" },
-          repeatedLargeOutputsEnabled: { value: true, source: "default" },
+          outputCapHitsEnabled: { value: false, source: "default" },
+          repeatedLargeOutputsEnabled: { value: false, source: "default" },
           repeatedLargeOutputMinimumCalls: { value: 5, source: "default" },
           repeatedLargeOutputMinimumPercent: { value: 50, source: "default" },
-          repeatedQueuedChecksEnabled: { value: true, source: "default" },
+          repeatedQueuedChecksEnabled: { value: false, source: "default" },
         },
         spendAlerts: {
-          activeTurnSpendEnabled: { value: true, source: "default" },
+          activeTurnSpendEnabled: { value: false, source: "default" },
           activeTurnSpendThresholdUsd: { value: 5, source: "default" },
           threadSpendEnabled: { value: true, source: "default" },
           threadSpendThresholdUsd: { value: 25, source: "default" },

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1864,6 +1864,12 @@ export type ThreadOverlayState = {
    * the cost baseline does not reset on restart.
    */
   toolIncidentNotice?: ThreadToolIncidentNoticeState;
+  /**
+   * Set when the total-spend alert first interrupts for this thread. The
+   * boundary is intentionally threshold-independent: total spend is a single
+   * thread-lifetime warning, even when the configured threshold later moves.
+   */
+  threadSpendAlertedAt?: number;
   /** User-curated position in the pinned section. Undefined means unpinned. */
   pinnedRank?: string;
   /**

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -39,6 +39,19 @@ import type {
   TaskMonitorUsageSnapshot,
 } from "./task-monitor-tools";
 import type { ThreadHandoffOrigin } from "./thread-orchestration-tools";
+import type { ThreadSpendAlert } from "../token-usage-pricing";
+
+export type AcknowledgeThreadSpendAlertRequest = {
+  alertId: string;
+  backend?: AppServerBackendKind;
+  threadId: string;
+};
+
+export type AcknowledgeThreadSpendAlertResponse = {
+  acknowledged: boolean;
+  backend: AppServerBackendKind;
+  threadId: string;
+};
 
 export type InboxReason = "new-thread" | "updated-since-seen";
 
@@ -107,6 +120,8 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   modelMigrationRevision?: string;
   /** Last explicit model/reasoning change made outside a migration. */
   modelSettingsManuallyUpdatedAt?: number;
+  /** Total-spend warning waiting for a local renderer to receive it. */
+  threadSpendAlertPending?: ThreadSpendAlert;
   /**
    * Optional Agent/persona marker. When present, this thread is intended
    * to act as a personal Agent surface.
@@ -1865,11 +1880,13 @@ export type ThreadOverlayState = {
    */
   toolIncidentNotice?: ThreadToolIncidentNoticeState;
   /**
-   * Set when the total-spend alert first interrupts for this thread. The
+   * Set when a local renderer confirms receipt of the total-spend alert. The
    * boundary is intentionally threshold-independent: total spend is a single
    * thread-lifetime warning, even when the configured threshold later moves.
    */
   threadSpendAlertedAt?: number;
+  /** Durable alert payload retained until a local renderer acknowledges it. */
+  threadSpendAlertPending?: ThreadSpendAlert;
   /** User-curated position in the pinned section. Undefined means unpinned. */
   pinnedRank?: string;
   /**

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -170,17 +170,16 @@ export const MIN_REPEATED_LARGE_OUTPUT_PERCENT = 1;
 export const MAX_REPEATED_LARGE_OUTPUT_PERCENT = 100;
 
 /**
- * Tool-output alerts stay on by default, but the large-output warning is
- * deliberately a repeated-pattern signal rather than a one-call tripwire.
- * Operators can independently select the qualifying output size and how many
- * calls in one turn must reach it before the warning interrupts them.
+ * Tool-output accounting remains available in thread diagnostics without
+ * interrupting every operator by default. Operators who want live warnings
+ * can opt into each trigger independently.
  */
 export const DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT: DesktopToolOutputAlertPolicy = {
-  outputCapHitsEnabled: true,
-  repeatedLargeOutputsEnabled: true,
+  outputCapHitsEnabled: false,
+  repeatedLargeOutputsEnabled: false,
   repeatedLargeOutputMinimumCalls: TOOL_OUTPUT_WARNING_INVOCATIONS,
   repeatedLargeOutputMinimumPercent: TOOL_OUTPUT_WARNING_PERCENT,
-  repeatedQueuedChecksEnabled: true,
+  repeatedQueuedChecksEnabled: false,
 };
 
 export type DesktopSpendAlertPolicy = {
@@ -194,7 +193,7 @@ export const MIN_SPEND_ALERT_THRESHOLD_USD = 0.01;
 export const MAX_SPEND_ALERT_THRESHOLD_USD = 10_000;
 
 export const DESKTOP_SPEND_ALERT_POLICY_DEFAULT: DesktopSpendAlertPolicy = {
-  activeTurnSpendEnabled: true,
+  activeTurnSpendEnabled: false,
   activeTurnSpendThresholdUsd: 5,
   threadSpendEnabled: true,
   threadSpendThresholdUsd: 25,

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -266,6 +266,9 @@ export function materializeNavigationThreads(params: {
       modelMigrationRevision: overlay?.modelMigrationRevision,
       modelSettingsManuallyUpdatedAt:
         overlay?.modelSettingsManuallyUpdatedAt,
+      ...(overlay?.threadSpendAlertPending
+        ? { threadSpendAlertPending: overlay.threadSpendAlertPending }
+        : {}),
       serviceTier: overlay?.serviceTier ?? thread.serviceTier,
       fastMode: overlay?.fastMode ?? thread.fastMode,
       prAutoDispatchEnabled: overlay?.prAutoDispatchEnabled ?? false,


### PR DESCRIPTION
## Summary

- keep total thread spend as the only interruptive alert enabled by default; active-turn spend and tool-output alerts become opt-in
- persist the total-spend boundary in the thread overlay so it fires once per thread across application restarts
- give durable notices consistent Copy and Dismiss controls, stable width, and persistent queue navigation through `1 of 1`
- keep notice-specific dismissal semantics for tool incidents, authentication failures, update prompts, and safety notices

## SQLite write budget

The total-spend marker costs one commit and one changed row when a thread first crosses the boundary. The measured WAL growth is 16,480 bytes; at 100 newly expensive threads per day, that projects to about 1.6 MB/day. Later pricing updates are read-only.

## Validation

- 821 focused tests across settings, spend detection, backend registry, app shell, and notice components
- 32 SQLite write-metrics tests
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
