### PR TITLE
fix(desktop): restore monitor controls and transcripts

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -36825,7 +36825,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("stops blocked active task monitors without starting recovery", async () => {
+  it("stops pending active task monitors without starting recovery", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "turn/interrupt"] },
       models: TEST_TASK_MONITOR_MODELS,
@@ -36880,8 +36880,8 @@ script = "printf setup"
         tool: "inject_progress",
         arguments: {
           monitorId,
-          status: "blocked",
-          message: "Waiting for an external dependency.",
+          status: "pending",
+          message: "Waiting for external work.",
         },
       },
     } as AppServerPendingRequestNotification);
@@ -36889,7 +36889,7 @@ script = "printf setup"
       backend: "codex",
       threadId: "thread-1",
     })).resolves.toMatchObject({
-      subAgents: [expect.objectContaining({ status: "blocked" })],
+      subAgents: [expect.objectContaining({ status: "pending" })],
     });
     const monitorRecord = (registry as unknown as {
       taskMonitorDelegations: Map<string, { finalizationStarted?: boolean }>;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14651,7 +14651,11 @@ export class DesktopBackendRegistry {
     if (!subAgent) {
       throw new Error("Sub-agent was not found on this thread.");
     }
-    if (subAgent.status !== "running" && subAgent.status !== "blocked") {
+    if (
+      subAgent.status !== "pending"
+      && subAgent.status !== "running"
+      && subAgent.status !== "blocked"
+    ) {
       throw new Error("Sub-agent is no longer running.");
     }
     const taskMonitor = this.taskMonitorDelegations.get(params.monitorId);

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -204,7 +204,9 @@ export function ActiveSubAgentsStrip(props: {
             const blockedRow = isBlockedSubAgent(subAgent);
             const stopping = stoppingIds.has(subAgent.monitorId);
             const canStop =
-              (subAgent.status === "running" || blockedRow)
+              (subAgent.status === "pending"
+                || subAgent.status === "running"
+                || blockedRow)
               && Boolean(subAgent.monitorThreadId)
               && Boolean(subAgent.monitorTurnId)
               && Boolean(props.desktopApi?.stopSubAgent);

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
@@ -26,8 +26,6 @@ export function TranscriptSubAgentCall(props: TranscriptSubAgentCallProps) {
     return null;
   }
 
-  const canOpenTranscript =
-    call.origin === "codex-native" && call.backend === "codex";
   const origin = call.origin === "codex-native"
     ? "Codex native agent"
     : "PwrAgent sub-agent";
@@ -66,7 +64,7 @@ export function TranscriptSubAgentCall(props: TranscriptSubAgentCallProps) {
                 ) : null}
               </div>
               {agent.message ? <p className="transcript-subagent__message">{agent.message}</p> : null}
-              {canOpenTranscript && openSubAgentTranscriptWindow ? (
+              {openSubAgentTranscriptWindow ? (
                 <button
                   className="button button--ghost transcript-subagent__action"
                   type="button"

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -579,6 +579,22 @@ describe("ActiveSubAgentsStrip", () => {
       expect(screen.queryByRole("button", { name: /^Stop sub-agent:/ })).toBeNull();
     });
 
+    it("offers Stop while a monitor reports pending external work", () => {
+      render(
+        <ActiveSubAgentsStrip
+          desktopApi={{ stopSubAgent: vi.fn() } as unknown as DesktopApi}
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "pending" }),
+          ])}
+        />,
+      );
+      expect(
+        screen.getByRole("button", {
+          name: "Stop sub-agent: Watch the deployment",
+        }),
+      ).toBeInTheDocument();
+    });
+
     it("recovers the button after a failed stop instead of leaving it stuck", async () => {
       const stopSubAgent = vi.fn().mockRejectedValue(new Error("nope"));
       render(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -538,7 +538,7 @@ describe("ThreadContextPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not offer a transcript for a detached review child", () => {
+  it("offers a transcript for a detached review child", () => {
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
     (window as Window & { pwragent?: unknown }).pwragent = {
       openSubAgentTranscriptWindow,
@@ -565,10 +565,10 @@ describe("ThreadContextPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
     expect(
-      within(screen.getByRole("dialog")).queryByRole("button", {
+      within(screen.getByRole("dialog")).getByRole("button", {
         name: "Open transcript",
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
   });
 
   it("labels Codex native sub-agent usage separately from monitor usage", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -122,7 +122,7 @@ describe("TranscriptCommandOutput", () => {
     });
   });
 
-  it("does not offer a transcript for a PwrAgent-managed sub-agent", () => {
+  it("opens a transcript for a PwrAgent-managed sub-agent", () => {
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
     (window as Window & { pwragent?: unknown }).pwragent = {
       openSubAgentTranscriptWindow,
@@ -153,9 +153,13 @@ describe("TranscriptCommandOutput", () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("button", { name: "Open transcript" }),
-    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open transcript" }));
+
+    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
+      backend: "acp:gemini",
+      threadId: "monitor-thread-1",
+      title: "Build monitor",
+    });
   });
 
   it("renders structured ACP tool invocations without pretending they are shell commands", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -22,7 +22,7 @@ import {
 } from "./subagent-format";
 import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
 import { RailStatusChip } from "./RailStatusChip";
-import { isCodexNativeSubAgent, subAgentOriginLabel } from "./subagent-kind";
+import { subAgentOriginLabel } from "./subagent-kind";
 
 type SubAgentDetailsModalProps = {
   defaultBackend: AppServerBackendKind;
@@ -126,7 +126,6 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const running = !isTerminalSubAgent(subAgent);
   const now = useNowWhileActive(running);
   const transcriptThreadId =
-    isCodexNativeSubAgent(subAgent) &&
     subAgent.monitorThreadId &&
     subAgent.monitorThreadId !== props.parentThreadId
       ? subAgent.monitorThreadId

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -136,7 +136,9 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 : undefined;
             const stopping = stoppingIds.has(subAgent.monitorId);
             const canStop =
-              (subAgent.status === "running" || subAgent.status === "blocked")
+              (subAgent.status === "pending"
+                || subAgent.status === "running"
+                || subAgent.status === "blocked")
               && Boolean(subAgent.monitorThreadId)
               && Boolean(subAgent.monitorTurnId)
               && Boolean(props.desktopApi?.stopSubAgent);

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
@@ -167,4 +167,33 @@ describe("SubAgentDetailsModal", () => {
       title: "Epicurus",
     });
   });
+
+  it("opens a running non-Codex monitor transcript", () => {
+    const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true as const }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      openSubAgentTranscriptWindow,
+    };
+    render(
+      <SubAgentDetailsModal
+        defaultBackend="acp:claude"
+        parentThreadId="parent-thread"
+        subAgent={{
+          ...subAgent,
+          backend: "acp:claude",
+          monitorId: "monitor-job-1",
+          monitorThreadId: "claude-monitor-thread",
+          monitorTurnId: undefined,
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open transcript" }));
+
+    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
+      backend: "acp:claude",
+      threadId: "claude-monitor-thread",
+      title: LONG_TASK,
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -72,6 +72,28 @@ describe("SubAgentsPanel", () => {
     expect(onRefreshNavigation).toHaveBeenCalledTimes(1);
   });
 
+  it("offers Stop while a monitor reports pending external work", () => {
+    const activeSubAgent = thread.subAgents?.[0];
+    expect(activeSubAgent).toBeDefined();
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent: vi.fn() } as unknown as DesktopApi}
+        thread={{
+          ...thread,
+          subAgents: [
+            {
+              ...activeSubAgent!,
+              status: "pending",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+  });
+
   it("keeps the control available and reports an interruption failure", async () => {
     const stopSubAgent = vi.fn(async () => {
       throw new Error("Sub-agent is no longer running.");


### PR DESCRIPTION
## Summary

- allow active monitor jobs in the `pending` external-work state to be stopped from both transcript-adjacent sub-agent surfaces
- accept pending monitor cancellation in the backend registry
- expose view-only transcript windows for PwrAgent-managed, detached-review, and non-Codex child threads
- preserve the guard that prevents an inline review from reopening its parent transcript as a child

## Regression coverage

The renderer regressions were first confirmed red in four focused tests. A backend regression then reproduced cancellation failing for a live pending monitor before the implementation change.

## Verification

- `pnpm test` — 8,707 passed, 6 skipped
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warnings only
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`