### PR TITLE
test(desktop): cover Star Map composer attachments

### DIFF
--- a/apps/desktop/e2e/fixtures/star-map/composer-attachments.fixture.json
+++ b/apps/desktop/e2e/fixtures/star-map/composer-attachments.fixture.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
     "backend": "codex",
-    "scenario": "star-map-attention",
-    "threadId": "thread-star-map-active"
+    "scenario": "star-map-composer-attachments",
+    "threadId": "thread-star-map-attachments"
   },
   "steps": [
     {
@@ -17,7 +17,8 @@
         "methods": [
           "thread/list",
           "thread/read",
-          "skills/list"
+          "skills/list",
+          "turn/start"
         ]
       }
     },
@@ -27,14 +28,21 @@
       "method": "thread/list",
       "result": [
         {
-          "id": "thread-star-map-active",
+          "id": "thread-star-map-attachments",
           "title": "Star map attention thread",
           "titleSource": "explicit",
-          "summary": "An active thread, so the map has a card to audit.",
+          "summary": "An idle thread with unpushed work for attachment sends.",
           "source": "codex",
           "executionMode": "default",
-          "threadStatus": "active",
+          "threadStatus": "idle",
           "gitBranch": "feature/star-map-audit",
+          "gitWorkingState": {
+            "dirtyFiles": 0,
+            "dirtyAdditions": 0,
+            "dirtyDeletions": 0,
+            "untrackedFiles": 0,
+            "unpushedCommits": 1
+          },
           "linkedDirectories": [
             {
               "id": "star-map-worktree-dir",
@@ -49,29 +57,14 @@
             "reason": "new-thread"
           },
           "updatedAt": 1760000100000
-        },
-        {
-          "id": "thread-star-map-second",
-          "title": "Second star map attention thread",
-          "titleSource": "explicit",
-          "summary": "A second card, so the lane stacks more than one body.",
-          "source": "codex",
-          "executionMode": "default",
-          "threadStatus": "active",
-          "linkedDirectories": [
-            {
-              "id": "star-map-local-dir",
-              "kind": "local",
-              "label": "PwrSnap",
-              "path": "/repo/PwrSnap"
-            }
-          ],
-          "inbox": {
-            "inInbox": false
-          },
-          "updatedAt": 1760000000000
         }
       ]
+    },
+    {
+      "id": "skills-list-1",
+      "kind": "response",
+      "method": "skills/list",
+      "result": []
     },
     {
       "id": "thread-read-1",
@@ -110,6 +103,15 @@
           "supportsPagination": false,
           "hasPreviousPage": false
         }
+      }
+    },
+    {
+      "id": "turn-start-1",
+      "kind": "response",
+      "method": "turn/start",
+      "result": {
+        "threadId": "thread-star-map-attachments",
+        "turnId": "turn-star-map-attachment"
       }
     }
   ]

--- a/apps/desktop/e2e/fixtures/star-map/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/star-map/replay.fixture.json
@@ -17,7 +17,8 @@
         "methods": [
           "thread/list",
           "thread/read",
-          "skills/list"
+          "skills/list",
+          "turn/start"
         ]
       }
     },
@@ -30,11 +31,18 @@
           "id": "thread-star-map-active",
           "title": "Star map attention thread",
           "titleSource": "explicit",
-          "summary": "An active thread, so the map has a card to audit.",
+          "summary": "An idle thread with unpushed work, so the map has a card to audit.",
           "source": "codex",
           "executionMode": "default",
-          "threadStatus": "active",
+          "threadStatus": "idle",
           "gitBranch": "feature/star-map-audit",
+          "gitWorkingState": {
+            "dirtyFiles": 0,
+            "dirtyAdditions": 0,
+            "dirtyDeletions": 0,
+            "untrackedFiles": 0,
+            "unpushedCommits": 1
+          },
           "linkedDirectories": [
             {
               "id": "star-map-worktree-dir",
@@ -110,6 +118,15 @@
           "supportsPagination": false,
           "hasPreviousPage": false
         }
+      }
+    },
+    {
+      "id": "turn-start-1",
+      "kind": "response",
+      "method": "turn/start",
+      "result": {
+        "threadId": "thread-star-map-active",
+        "turnId": "turn-star-map-attachment"
       }
     }
   ]

--- a/apps/desktop/e2e/star-map-composer-attachments.spec.ts
+++ b/apps/desktop/e2e/star-map-composer-attachments.spec.ts
@@ -1,0 +1,265 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+import { startInProcessFederationGateway } from "./fixtures/federation-gateway";
+import { openStarMapWindow } from "./fixtures/star-map-window";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(
+  specDir,
+  "fixtures/star-map/replay.fixture.json",
+);
+const LOCAL_THREAD_TITLE = "Star map attention thread";
+const REMOTE_THREAD_TITLE = "Remote attachment thread";
+
+type StartTurnInputItem = {
+  mimeType?: string;
+  name?: string;
+  path?: string;
+  text?: string;
+  textPreview?: string;
+  type: string;
+};
+
+type StartTurnRequest = {
+  input: StartTurnInputItem[];
+  threadId: string;
+};
+
+async function openChatCard(
+  mapWindow: Page,
+  title: string,
+): Promise<Locator> {
+  const starMap = mapWindow.getByRole("region", {
+    name: "Star Map",
+    exact: true,
+  });
+  await expect(starMap).toBeVisible();
+  const threadCard = starMap.getByRole("button", {
+    name: `Open thread: ${title}`,
+  });
+  await expect(threadCard).toBeVisible({ timeout: 30_000 });
+  await threadCard.click();
+
+  const chatCard = mapWindow.getByRole("region", {
+    name: `Chat: ${title}`,
+  });
+  await expect(chatCard).toBeVisible();
+  return chatCard;
+}
+
+async function attachPng(
+  messageInput: Locator,
+  options: { color: string; event: "drop" | "paste"; name: string },
+): Promise<void> {
+  await messageInput.evaluate(async (input, params) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 24;
+    canvas.height = 16;
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("Canvas context not available");
+    context.fillStyle = params.color;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((value) => {
+        if (value) resolve(value);
+        else reject(new Error("Could not create PNG blob"));
+      }, "image/png");
+    });
+    const file = new File([blob], params.name, { type: "image/png" });
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    input.dispatchEvent(
+      params.event === "paste"
+        ? new ClipboardEvent("paste", {
+            bubbles: true,
+            cancelable: true,
+            clipboardData: dataTransfer,
+          })
+        : new DragEvent("drop", {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer,
+          }),
+    );
+  }, options);
+}
+
+async function attachFilesystemFile(
+  mapWindow: Page,
+  messageInput: Locator,
+  localPath: string,
+): Promise<void> {
+  await mapWindow.evaluate(() => {
+    const fileInput = document.createElement("input");
+    fileInput.id = "star-map-e2e-file-input";
+    fileInput.type = "file";
+    document.body.append(fileInput);
+  });
+  const fileInput = mapWindow.locator("#star-map-e2e-file-input");
+  await fileInput.setInputFiles(localPath);
+  await messageInput.evaluate((input) => {
+    const file = document.querySelector<HTMLInputElement>(
+      "#star-map-e2e-file-input",
+    )?.files?.[0];
+    if (!file) throw new Error("Filesystem-backed test file was not selected");
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    input.dispatchEvent(
+      new DragEvent("drop", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }),
+    );
+  });
+}
+
+test("sends pasted, dropped, and local-file attachments from a Star Map chat card", async () => {
+  test.slow();
+  const fileRoot = await mkdtemp(
+    path.join(os.tmpdir(), "pwragent-star-map-attachments-"),
+  );
+  const notesPath = path.join(fileRoot, "star-map-notes.txt");
+  await writeFile(notesPath, "renderer preload attachment evidence\n", "utf8");
+  const app = await launchElectronApp({ fixturePath });
+
+  try {
+    const mapWindow = await openStarMapWindow(app);
+    const chatCard = await openChatCard(mapWindow, LOCAL_THREAD_TITLE);
+    const messageInput = chatCard.getByRole("textbox", {
+      name: `Message ${LOCAL_THREAD_TITLE}`,
+    });
+
+    await attachPng(messageInput, {
+      color: "#2255aa",
+      event: "paste",
+      name: "pasted-star-map.png",
+    });
+    const pastedPreview = chatCard.getByRole("img", {
+      name: "pasted-star-map.png",
+    });
+    await expect(pastedPreview).toBeVisible();
+    await expect(pastedPreview).toHaveAttribute("src", /^data:image\/png;base64,/);
+
+    await attachPng(messageInput, {
+      color: "#aa5522",
+      event: "drop",
+      name: "dropped-star-map.png",
+    });
+    const droppedPreview = chatCard.getByRole("img", {
+      name: "dropped-star-map.png",
+    });
+    await expect(droppedPreview).toBeVisible();
+    await expect(droppedPreview).toHaveAttribute("src", /^data:image\/png;base64,/);
+
+    await attachFilesystemFile(mapWindow, messageInput, notesPath);
+    await expect(
+      chatCard.locator('[aria-label="Attached files"]'),
+    ).toContainText("star-map-notes.txt");
+
+    await messageInput.fill("Inspect these Star Map attachments");
+    await chatCard.getByRole("button", { name: "Send" }).click();
+
+    await expect.poll(async () => await app.getLastStartTurn()).not.toBeNull();
+    const request = await app.getLastStartTurn() as StartTurnRequest;
+    expect(request.threadId).toBe("thread-star-map-active");
+
+    const textInput = request.input.find((item) => item.type === "text");
+    expect(textInput?.text).toContain("Inspect these Star Map attachments");
+    expect(textInput?.text).toContain(`[@star-map-notes.txt](${notesPath})`);
+
+    const imageInputs = request.input.filter(
+      (item) => item.type === "localImage",
+    );
+    expect(imageInputs.map((item) => item.name)).toEqual([
+      "pasted-star-map.png",
+      "dropped-star-map.png",
+    ]);
+    for (const imageInput of imageInputs) {
+      expect(imageInput.path).toBeTruthy();
+      const imageBytes = await readFile(imageInput.path!);
+      expect(imageBytes.subarray(0, 8).toString("hex")).toBe(
+        "89504e470d0a1a0a",
+      );
+    }
+
+    const localFileInput = request.input.find(
+      (item) => item.type === "localFile",
+    );
+    expect(localFileInput).toEqual(
+      expect.objectContaining({
+        mimeType: "text/plain",
+        name: "star-map-notes.txt",
+        path: notesPath,
+        textPreview: "renderer preload attachment evidence\n",
+        type: "localFile",
+      }),
+    );
+  } finally {
+    await app.close();
+    await rm(fileRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects a local file on a remote Star Map chat card", async () => {
+  test.slow();
+  const fileRoot = await mkdtemp(
+    path.join(os.tmpdir(), "pwragent-star-map-remote-attachment-"),
+  );
+  const notesPath = path.join(fileRoot, "remote-notes.txt");
+  await writeFile(notesPath, "must remain local\n", "utf8");
+  const gateway = await startInProcessFederationGateway({
+    threads: [
+      {
+        id: "remote-attachment-thread",
+        title: REMOTE_THREAD_TITLE,
+        threadStatus: "active",
+        updatedAt: Date.now(),
+      },
+    ],
+  });
+  const app = await launchElectronApp({
+    fixturePath,
+    secretStorage: "memory",
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "Open settings" }).click();
+    await app.window
+      .getByRole("navigation", { name: "Settings sections" })
+      .getByRole("button", { name: "Federation" })
+      .click();
+    await app.window.getByLabel("Import invite").fill(gateway.invite);
+    await app.window.getByRole("button", { name: "Import invite" }).click();
+    await gateway.waitForConnection(30_000);
+    await expect(
+      app.window
+        .getByRole("region", { name: "Connection" })
+        .getByText("Connected", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
+    await app.window.getByRole("button", { name: "Exit Settings" }).click();
+
+    const mapWindow = await openStarMapWindow(app);
+    const chatCard = await openChatCard(mapWindow, REMOTE_THREAD_TITLE);
+    const messageInput = chatCard.getByRole("textbox", {
+      name: `Message ${REMOTE_THREAD_TITLE}`,
+    });
+    await attachFilesystemFile(mapWindow, messageInput, notesPath);
+
+    await expect(chatCard.getByRole("alert")).toContainText(
+      "Local files cannot be attached to a thread on another instance.",
+    );
+    await expect(
+      chatCard.locator('[aria-label="Attached files"]'),
+    ).toHaveCount(0);
+    await expect(chatCard.locator(".compact-composer__send")).toBeDisabled();
+  } finally {
+    await app.close();
+    await gateway.close();
+    await rm(fileRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/e2e/star-map-composer-attachments.spec.ts
+++ b/apps/desktop/e2e/star-map-composer-attachments.spec.ts
@@ -10,7 +10,7 @@ import { openStarMapWindow } from "./fixtures/star-map-window";
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 const fixturePath = path.resolve(
   specDir,
-  "fixtures/star-map/replay.fixture.json",
+  "fixtures/star-map/composer-attachments.fixture.json",
 );
 const LOCAL_THREAD_TITLE = "Star map attention thread";
 const REMOTE_THREAD_TITLE = "Remote attachment thread";
@@ -166,7 +166,7 @@ test("sends pasted, dropped, and local-file attachments from a Star Map chat car
 
     await expect.poll(async () => await app.getLastStartTurn()).not.toBeNull();
     const request = await app.getLastStartTurn() as StartTurnRequest;
-    expect(request.threadId).toBe("thread-star-map-active");
+    expect(request.threadId).toBe("thread-star-map-attachments");
 
     const textInput = request.input.find((item) => item.type === "text");
     expect(textInput?.text).toContain("Inspect these Star Map attachments");


### PR DESCRIPTION
## Summary

- add real Electron coverage for PNG paste and drag/drop in a Star Map chat card
- verify filesystem-backed local files reach the recorded turn/start payload
- cover remote-thread local-file rejection through the federation-backed Star Map path

## Tests

- pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/star-map-composer-attachments.spec.ts
- pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/star-map-thread-flow.spec.ts
- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
- pnpm typecheck
- pnpm lint:eslint