### PR TITLE
fix(desktop): gate star map image attachments

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -1,7 +1,9 @@
 import {
   useCallback,
+  useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
   type ClipboardEvent,
   type DragEvent,
@@ -94,6 +96,14 @@ export type CompactComposerProps = {
   executionMode?: ThreadExecutionMode;
   /** Thread's current fast-mode state, shown on the chip menu's toggle. */
   fastMode?: boolean;
+  /**
+   * Whether the active model/runtime accepts image input. `undefined` keeps
+   * the backward-compatible assumption that images are supported; only an
+   * explicit `false` gates paste, drop, and send.
+   */
+  imagesSupported?: boolean;
+  /** Model/runtime label used in the image-capability feedback. */
+  imagesUnsupportedLabel?: string;
   /**
    * Populations the `$` / `/` / `@` / `#` popovers pick from. Optional on
    * purpose: a host that supplies nothing keeps the trigger characters as
@@ -218,6 +228,17 @@ export function CompactComposer(props: CompactComposerProps) {
     onSend,
     pastedImageMaxPatches,
   } = props;
+  const imagesSupported = props.imagesSupported !== false;
+  const imagesUnsupportedMessage = `${
+    props.imagesUnsupportedLabel ?? "This mode"
+  } doesn't support image attachments.`;
+  // Image normalization is asynchronous. A model can change while it is in
+  // flight, so completion must consult the live gate rather than the value
+  // captured when the paste began.
+  const imagesSupportedRef = useRef(imagesSupported);
+  const imagesUnsupportedMessageRef = useRef(imagesUnsupportedMessage);
+  imagesSupportedRef.current = imagesSupported;
+  imagesUnsupportedMessageRef.current = imagesUnsupportedMessage;
   // Several cards can be open at once and the editor puts this on a DOM
   // `id`; a shared literal would give the map duplicate ids.
   const inputId = `compact-composer-${useId()}`;
@@ -254,6 +275,10 @@ export function CompactComposer(props: CompactComposerProps) {
       (!text && imageAttachments.length === 0 && fileAttachments.length === 0)
       || normalizingImages
     ) return;
+    if (!imagesSupported && imageAttachments.length > 0) {
+      onAttachmentError?.(imagesUnsupportedMessage);
+      return;
+    }
     // Clear optimistically so the input frees up immediately, then put the
     // draft back — chips and all — if the send turned out to fail.
     const previous = mentions.snapshot;
@@ -272,11 +297,35 @@ export function CompactComposer(props: CompactComposerProps) {
       setImageAttachments(previousImages);
       setFileAttachments(previousFiles);
     }
-  }, [fileAttachments, imageAttachments, mentions, normalizingImages, onSend]);
+  }, [
+    fileAttachments,
+    imageAttachments,
+    imagesSupported,
+    imagesUnsupportedMessage,
+    mentions,
+    normalizingImages,
+    onAttachmentError,
+    onSend,
+  ]);
+
+  useEffect(() => {
+    if (!imagesSupported && imageAttachments.length > 0) {
+      onAttachmentError?.(imagesUnsupportedMessage);
+    }
+  }, [
+    imageAttachments.length,
+    imagesSupported,
+    imagesUnsupportedMessage,
+    onAttachmentError,
+  ]);
 
   const attachImages = useCallback(
     (pastedImages: ReturnType<typeof getImageFilesFromDataTransfer>) => {
       if (pastedImages.length === 0) return;
+      if (!imagesSupported) {
+        onAttachmentError?.(imagesUnsupportedMessage);
+        return;
+      }
       const remaining =
         MAX_COMPACT_COMPOSER_IMAGE_ATTACHMENTS - imageAttachments.length;
       if (remaining <= 0) {
@@ -323,6 +372,10 @@ export function CompactComposer(props: CompactComposerProps) {
         }),
       )
         .then((attachments) => {
+          if (!imagesSupportedRef.current) {
+            onAttachmentError?.(imagesUnsupportedMessageRef.current);
+            return;
+          }
           setImageAttachments((current) => [
             ...current,
             ...attachments.filter(
@@ -344,6 +397,8 @@ export function CompactComposer(props: CompactComposerProps) {
     },
     [
       imageAttachments.length,
+      imagesSupported,
+      imagesUnsupportedMessage,
       normalizeImageForUpload,
       onAttachmentError,
       pastedImageMaxPatches,
@@ -922,6 +977,7 @@ export function CompactComposer(props: CompactComposerProps) {
           disabled={
             props.disabled
             || normalizingImages
+            || (!imagesSupported && imageAttachments.length > 0)
             || (
               mentions.text.trim().length === 0
               && imageAttachments.length === 0

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -272,6 +272,79 @@ describe("CompactComposer", () => {
     );
   });
 
+  it("rejects pasted and dropped images when image input is unsupported", () => {
+    vi.mocked(normalizeImageFile).mockClear();
+    const onAttachmentError = vi.fn();
+    const { container } = renderComposer({
+      imagesSupported: false,
+      imagesUnsupportedLabel: "GPT-5.3-Codex-Spark",
+      onAttachmentError,
+    });
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    const pasted = new File(["pasted"], "pasted.png", {
+      type: "image/png",
+    });
+    const dropped = new File(["dropped"], "dropped.png", {
+      type: "image/png",
+    });
+
+    pasteImage(input, pasted);
+    fireEvent.drop(input, {
+      dataTransfer: {
+        files: [dropped],
+        items: [
+          {
+            getAsFile: () => dropped,
+            kind: "file",
+            type: dropped.type,
+          },
+        ],
+      },
+    });
+
+    expect(onAttachmentError).toHaveBeenLastCalledWith(
+      "GPT-5.3-Codex-Spark doesn't support image attachments.",
+    );
+    expect(normalizeImageFile).not.toHaveBeenCalled();
+    expect(container.querySelector(".compact-composer__attachment")).toBeNull();
+  });
+
+  it("stops an attached image from sending when image support changes", async () => {
+    const onAttachmentError = vi.fn();
+    const onSend = vi.fn();
+    const view = render(
+      <CompactComposer
+        imagesSupported
+        imagesUnsupportedLabel="Visionless model"
+        onAttachmentError={onAttachmentError}
+        onSend={onSend}
+        threadTitle="Thread t1"
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    const image = new File(["image"], "image.png", { type: "image/png" });
+
+    pasteImage(input, image);
+    await screen.findByRole("img", { name: "image.png" });
+
+    view.rerender(
+      <CompactComposer
+        imagesSupported={false}
+        imagesUnsupportedLabel="Visionless model"
+        onAttachmentError={onAttachmentError}
+        onSend={onSend}
+        threadTitle="Thread t1"
+      />,
+    );
+    fireEvent.change(input, { target: { value: "Describe this" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(onAttachmentError).toHaveBeenLastCalledWith(
+      "Visionless model doesn't support image attachments.",
+    );
+  });
+
   it("shows model, effort, and access mode as the status chip", () => {
     renderComposer({
       executionMode: "full-access",

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -186,13 +186,24 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     threadKey: buildThreadIdentityKey(thread.source, thread.id),
   });
 
-  // `readRendererFederationTarget` mints a fresh object per call, so in a
-  // federation window an unmemoized read would rebind every callback that
-  // routes through it on each render.
+  // Backend capability belongs to the instance the thread lives on. Reduce
+  // the target to its stable identity before rebuilding the object: every
+  // navigation poll replaces `thread.federation.ref.target`, and handing that
+  // fresh object to `useBackendSummaries` would eagerly describe the remote
+  // backend again for every open card on every poll.
   const threadFederationTarget = thread.federation?.ref.target;
+  const remoteInstanceId = useMemo(() => {
+    const target = threadFederationTarget ?? readRendererFederationTarget();
+    return target && isRemoteFederationTarget(target)
+      ? target.instanceId
+      : undefined;
+  }, [threadFederationTarget]);
   const federationTarget = useMemo(
-    () => threadFederationTarget ?? readRendererFederationTarget(),
-    [threadFederationTarget],
+    () =>
+      remoteInstanceId
+        ? ({ scope: "remote", instanceId: remoteInstanceId } as const)
+        : undefined,
+    [remoteInstanceId],
   );
   const isAcpThread = thread.source.startsWith("acp:");
   const backendSummaries = useBackendSummaries(desktopApi, {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -132,6 +132,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const rectRef = useRef(rect);
   rectRef.current = rect;
   const [sendError, setSendError] = useState<string | undefined>(undefined);
+  const [attachmentError, setAttachmentError] = useState<string | undefined>(
+    undefined,
+  );
   const [reviewSetupOpen, setReviewSetupOpen] = useState(false);
   const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [reviewError, setReviewError] = useState<string | undefined>(undefined);
@@ -140,6 +143,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   // from a queue by looking at the transcript, and the answer differs by
   // backend, so the card says which one happened.
   const [sendNotice, setSendNotice] = useState<string | undefined>(undefined);
+  const onAttachmentError = useCallback((message?: string): void => {
+    setAttachmentError(message);
+    if (message) {
+      // One card-local feedback slot: the newest actionable problem wins.
+      setSendError(undefined);
+      setSendNotice(undefined);
+    }
+  }, []);
   // The card is draggable and clipped; a native `title` fights both, and
   // UI-THEME.md rules it out regardless.
   const titleTooltip = useViewportTooltip({ className: "viewport-tooltip" });
@@ -184,18 +195,15 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     [threadFederationTarget],
   );
   const isAcpThread = thread.source.startsWith("acp:");
-  const [settingsMenuOpened, setSettingsMenuOpened] = useState(false);
   const backendSummaries = useBackendSummaries(desktopApi, {
-    // Codex review is native and needs no describe. ACP review is a
-    // PwrAgent-managed child, so its explicit capability is authoritative
-    // even before the settings menu has ever been opened.
-    enabled: settingsMenuOpened || isAcpThread,
+    // The composer needs model/runtime image capability before its first
+    // paste or drop. Keep this target-scoped so a remote card reads the
+    // owning peer's provider summary rather than the viewer's.
     federationTarget,
   });
   const backendSummariesRef = useRef(backendSummaries);
   backendSummariesRef.current = backendSummaries;
   const onSettingsMenuOpen = useCallback(() => {
-    setSettingsMenuOpened(true);
     // A failed describe retries on the next open through the hook's
     // exported refresh path (a plain re-list for remote targets).
     if (backendSummariesRef.current.error) {
@@ -495,6 +503,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       fileAttachments: NavigationLaunchpadFileAttachment[] = [],
     ): Promise<boolean> => {
       setSendError(undefined);
+      setAttachmentError(undefined);
       setSendNotice(undefined);
       const fileReferences = fileAttachments
         .map((attachment) =>
@@ -748,6 +757,28 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const threadFastMode = optimisticSettings.fastMode ?? thread.fastMode;
   const threadExecutionMode =
     optimisticSettings.executionMode ?? thread.executionMode;
+  const modelOptions = backendSummary?.launchpadOptions?.models ?? [];
+  const selectedModelOption =
+    modelOptions.find((option) => option.id === threadModel)
+    ?? modelOptions.find((option) => option.current)
+    ?? modelOptions.find((option) => option.supportsReasoning)
+    ?? modelOptions[0];
+  // Match the full composer: only explicit negative capability signals gate
+  // images. An absent summary or undefined field remains backward-compatible
+  // and assumes support, including for remote owners on older versions.
+  const imagesSupported =
+    selectedModelOption?.supportsImage !== false
+    && backendSummary?.acp?.runtime?.agentCapabilities?.prompt?.image !== false;
+  const imagesUnsupportedLabel =
+    selectedModelOption?.label
+    ?? threadModel
+    ?? backendSummary?.label
+    ?? "This mode";
+  useEffect(() => {
+    if (imagesSupported) {
+      setAttachmentError(undefined);
+    }
+  }, [imagesSupported]);
   useEffect(() => {
     // Via the ref so the effect can key on the four scalar fields alone.
     const summary = threadRef.current;
@@ -1124,9 +1155,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           thread={thread}
         />
 
-        {sendError ? (
+        {sendError || attachmentError ? (
           <p className="star-map-chat-card__error" role="alert">
-            {sendError}
+            {sendError ?? attachmentError}
           </p>
         ) : sendNotice ? (
           <p className="star-map-chat-card__notice" role="status">
@@ -1144,11 +1175,13 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           executionMode={threadExecutionMode}
           fastMode={threadFastMode}
           getPathForFile={desktopApi?.getPathForFile}
+          imagesSupported={imagesSupported}
+          imagesUnsupportedLabel={imagesUnsupportedLabel}
           key={reviewComposerKey}
           mentionSources={mentionSources}
           model={threadModel}
           normalizeImageForUpload={desktopApi?.normalizeImageForUpload}
-          onAttachmentError={setSendError}
+          onAttachmentError={onAttachmentError}
           onInterrupt={onInterrupt}
           onSend={send}
           pastedImageMaxPatches={props.pastedImageMaxPatches}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -191,6 +191,30 @@ async function typeAndSend(title: string, text: string) {
   return input as HTMLElement & { value: string };
 }
 
+function transferImage(
+  input: HTMLElement,
+  file: File,
+  event: "drop" | "paste",
+): void {
+  const transfer = {
+    files: [file],
+    getData: () => "",
+    items: [
+      {
+        getAsFile: () => file,
+        kind: "file",
+        type: file.type,
+      },
+    ],
+    types: ["Files"],
+  };
+  if (event === "paste") {
+    fireEvent.paste(input, { clipboardData: transfer });
+  } else {
+    fireEvent.drop(input, { dataTransfer: transfer });
+  }
+}
+
 /**
  * Text queries match the composer's own content, so a draft would satisfy a
  * "this reached the transcript" assertion on its own.
@@ -405,6 +429,123 @@ describe("StarMapChatCard federation routing", () => {
         }),
       );
     });
+  });
+
+  it("keeps image paste enabled for a remote thread with no negative capability", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: remoteThread() });
+    const input = screen.getByRole("textbox", { name: "Message Remote work" });
+    const image = new File(["remote"], "remote.png", {
+      type: "image/png",
+    });
+
+    transferImage(input, image, "paste");
+    await screen.findByRole("img", { name: "remote.png" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+          input: [
+            {
+              type: "image",
+              name: "remote.png",
+              url: "data:image/png;base64,c3Rhci1tYXA=",
+            },
+          ],
+        }),
+      );
+    });
+  });
+
+  it("rejects images for a Codex model that reports supportsImage false", async () => {
+    vi.mocked(normalizeImageFile).mockClear();
+    const desktopApi = buildApi({
+      listBackends: vi.fn(async () => ({
+        fetchedAt: 1,
+        backends: [
+          {
+            available: true,
+            capabilities: reviewCapabilities(false),
+            executionModes: [],
+            kind: "codex" as const,
+            label: "Codex",
+            launchpadOptions: {
+              models: [
+                {
+                  id: "gpt-5.3-codex-spark",
+                  label: "GPT-5.3-Codex-Spark",
+                  supportsImage: false,
+                },
+              ],
+            },
+            methods: [],
+          },
+        ],
+      })),
+    });
+    renderCard({
+      desktopApi,
+      thread: localThread({ model: "gpt-5.3-codex-spark" }),
+    });
+    await waitFor(() => expect(desktopApi.listBackends).toHaveBeenCalled());
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["spark"], "spark.png", { type: "image/png" });
+
+    transferImage(input, image, "paste");
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "GPT-5.3-Codex-Spark doesn't support image attachments.",
+    );
+    expect(normalizeImageFile).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Pasted images")).toBeNull();
+  });
+
+  it("rejects images when an ACP runtime reports prompt.image false", async () => {
+    vi.mocked(normalizeImageFile).mockClear();
+    const desktopApi = buildApi({
+      listBackends: vi.fn(async () => ({
+        fetchedAt: 1,
+        backends: [
+          {
+            acp: {
+              registryId: "grok",
+              distributionKinds: ["binary" as const],
+              installStatus: "installed" as const,
+              authStatus: "authenticated" as const,
+              verificationStatus: "verified" as const,
+              runtime: {
+                schemaVersion: 1 as const,
+                status: "discovered" as const,
+                agentCapabilities: { prompt: { image: false } },
+              },
+            },
+            available: true,
+            capabilities: reviewCapabilities(false),
+            executionModes: [],
+            kind: "acp:grok" as const,
+            label: "Grok",
+            methods: [],
+          },
+        ],
+      })),
+    });
+    renderCard({
+      desktopApi,
+      thread: localThread({ source: "acp:grok", model: "grok-4" }),
+    });
+    await waitFor(() => expect(desktopApi.listBackends).toHaveBeenCalled());
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["grok"], "grok.png", { type: "image/png" });
+
+    transferImage(input, image, "drop");
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "grok-4 doesn't support image attachments.",
+    );
+    expect(normalizeImageFile).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Pasted images")).toBeNull();
   });
 
   it("uses the configured image patch budget when normalizing", async () => {
@@ -1757,7 +1898,11 @@ describe("StarMapChatCard settings menu", () => {
             launchpadOptions: {
               models: [
                 { id: "gpt-5-codex", supportsFast: true },
-                { id: "gpt-5-spark", supportsFast: false },
+                {
+                  id: "gpt-5-spark",
+                  supportsFast: false,
+                  supportsImage: false,
+                },
               ],
               reasoningEfforts: ["low", "medium", "high"],
               supportsFastMode: true,
@@ -1777,13 +1922,10 @@ describe("StarMapChatCard settings menu", () => {
     );
   }
 
-  it("describes the backend once, on first open, with the card's target", async () => {
+  it("describes the backend once on mount with the card's target", async () => {
     const desktopApi = settingsApi();
     renderCard({ desktopApi, thread: remoteThread({ model: "gpt-5-codex" }) });
     await screen.findByRole("button", { name: "Send" });
-    expect(desktopApi.listBackends).not.toHaveBeenCalled();
-
-    await openSettingsMenu();
     await waitFor(() => {
       expect(desktopApi.listBackends).toHaveBeenCalledTimes(1);
     });
@@ -1792,7 +1934,10 @@ describe("StarMapChatCard settings menu", () => {
       federationTarget: { scope: "remote", instanceId: "pwr_peer" },
     });
 
-    // Reopening reuses the loaded options rather than describing again.
+    // Opening and reopening reuse the loaded options rather than describing
+    // again. Image capability gating needs the same summary before the first
+    // paste, not only after the settings door has opened.
+    await openSettingsMenu();
     fireEvent.keyDown(document, { key: "Escape" });
     await openSettingsMenu();
     expect(desktopApi.listBackends).toHaveBeenCalledTimes(1);
@@ -1817,6 +1962,28 @@ describe("StarMapChatCard settings menu", () => {
         }),
       );
     });
+  });
+
+  it("updates image gating immediately after an optimistic model change", async () => {
+    vi.mocked(normalizeImageFile).mockClear();
+    const desktopApi = settingsApi();
+    renderCard({ desktopApi, thread: localThread({ model: "gpt-5-codex" }) });
+    await openSettingsMenu();
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Model/ }));
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "gpt-5-spark" }),
+    );
+    await screen.findByText("gpt-5-spark");
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    const image = new File(["spark"], "spark.png", { type: "image/png" });
+
+    transferImage(input, image, "paste");
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "gpt-5-spark doesn't support image attachments.",
+    );
+    expect(normalizeImageFile).not.toHaveBeenCalled();
   });
 
   /**

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-data.test.tsx
@@ -120,6 +120,7 @@ function buildApi(entries: AppServerThreadEntry[] = []): DesktopApi {
           kind: "codex",
           label: "OpenAI",
           available: true,
+          executionModes: [],
         },
       ],
     })),


### PR DESCRIPTION
## Summary

- load target-scoped backend image capabilities before Star Map image paste or drop
- reject unsupported images for Codex models and ACP runtimes while preserving undefined-as-supported and remote image behavior
- block existing attachments from sending after model capability changes and show card-local feedback

## Tests

- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
- pnpm test apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-render-cost.test.tsx
- pnpm --filter @pwragent/desktop typecheck
- pnpm lint:eslint
- pnpm lint:boundaries