### PR TITLE
fix(desktop): clear Star Map unread after accepted replies

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -76,6 +76,11 @@ export type StarMapChatCardProps = {
   onClose: (cardKey: string) => void;
   /** Escape hatch into the full thread surface. */
   onOpenFull: (thread: NavigationThreadSummary) => void;
+  /**
+   * Report an ordinary reply only after start/steer has been accepted.
+   * Attention keeps unread state until this signal arrives.
+   */
+  onUserRepliedToThread?: (thread: NavigationThreadSummary) => void;
   /** Refresh the owning navigation feed after a monitor is stopped. */
   onRefreshNavigation?: () => Promise<void>;
   onRaise: (cardKey: string) => void;
@@ -147,8 +152,18 @@ const MemoizedActiveSubAgentsStrip = memo(ActiveSubAgentsStrip);
  * handed, so a card over a peer's thread reads and writes on that peer.
  */
 export function StarMapChatCard(props: StarMapChatCardProps) {
-  const { bounds, cardKey, desktopApi, onOpenFull, onRaise, onRectChange, rect, scale, thread } =
-    props;
+  const {
+    bounds,
+    cardKey,
+    desktopApi,
+    onOpenFull,
+    onRaise,
+    onRectChange,
+    onUserRepliedToThread,
+    rect,
+    scale,
+    thread,
+  } = props;
   const dragRef = useRef<DragState | undefined>(undefined);
   // Read by callbacks that must not re-bind on every pointermove.
   const rectRef = useRef(rect);
@@ -790,6 +805,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             requestId: `star-map-chat-card:${cardKey}:${activeTurnId}:${Date.now()}`,
             threadId: thread.id,
           });
+          onUserRepliedToThread?.(threadRef.current);
           setSendNotice(
             response.disposition === "queued"
               ? "Queued for the next turn."
@@ -867,6 +883,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             );
           }
         }
+        onUserRepliedToThread?.(threadRef.current);
         return true;
       } catch (error) {
         if (props.composerDraftStore) {
@@ -893,8 +910,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       cardKey,
       composerScopeKey,
       desktopApi,
-      federationTarget,
       ensureNavigationLoaded,
+      federationTarget,
+      onUserRepliedToThread,
       supportsReview,
       thread.id,
       thread.source,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -80,7 +80,9 @@ export type StarMapChatCardProps = {
    * Report an ordinary reply only after start/steer has been accepted.
    * Attention keeps unread state until this signal arrives.
    */
-  onUserRepliedToThread?: (thread: NavigationThreadSummary) => void;
+  onUserRepliedToThread?: (
+    thread: NavigationThreadSummary,
+  ) => void | Promise<void>;
   /** Refresh the owning navigation feed after a monitor is stopped. */
   onRefreshNavigation?: () => Promise<void>;
   onRaise: (cardKey: string) => void;
@@ -230,6 +232,11 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   // — so it reads through here and depends on scalars instead.
   const sessionRef = useRef(session);
   sessionRef.current = session;
+  // For callbacks and effects that need the latest summary without taking
+  // the whole object as a dependency — the composer's memo boundary rests
+  // on its props staying stable across snapshot refreshes.
+  const threadRef = useRef(thread);
+  threadRef.current = thread;
 
   // Cap what actually mounts. Same window the full thread view uses, so a
   // card over a long thread holds tens of entries rather than thousands.
@@ -646,6 +653,26 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     [desktopApi, federationTarget, supportsReview, thread.id, thread.source],
   );
 
+  const reportAcceptedReply = useCallback(() => {
+    try {
+      void Promise.resolve(
+        onUserRepliedToThread?.(threadRef.current),
+      ).catch((error) => {
+        console.warn(
+          "Could not clear unread state after the accepted Star Map reply.",
+          error,
+        );
+      });
+    } catch (error) {
+      // Seen-state bookkeeping is downstream of backend acceptance. A
+      // bookkeeping failure must not roll back the accepted user message.
+      console.warn(
+        "Could not clear unread state after the accepted Star Map reply.",
+        error,
+      );
+    }
+  }, [onUserRepliedToThread]);
+
   /**
    * Returns whether the turn actually reached the backend. A peer can drop
    * mid-send, and when it does the operator must get their text back and
@@ -805,7 +832,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             requestId: `star-map-chat-card:${cardKey}:${activeTurnId}:${Date.now()}`,
             threadId: thread.id,
           });
-          onUserRepliedToThread?.(threadRef.current);
+          reportAcceptedReply();
           setSendNotice(
             response.disposition === "queued"
               ? "Queued for the next turn."
@@ -883,7 +910,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             );
           }
         }
-        onUserRepliedToThread?.(threadRef.current);
+        reportAcceptedReply();
         return true;
       } catch (error) {
         if (props.composerDraftStore) {
@@ -912,7 +939,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       desktopApi,
       ensureNavigationLoaded,
       federationTarget,
-      onUserRepliedToThread,
+      reportAcceptedReply,
       supportsReview,
       thread.id,
       thread.source,
@@ -951,12 +978,6 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
    * never pays for the describe. The hook takes the card's federation
    * target, so a card over a peer's thread lists the peer's models.
    */
-  // For callbacks and effects that need the latest summary without taking
-  // the whole object as a dependency — the composer's memo boundary rests
-  // on its props staying stable across snapshot refreshes.
-  const threadRef = useRef(thread);
-  threadRef.current = thread;
-
   /**
    * Optimistic view of the chip's settings between a menu selection and
    * the thread-state bus round-trip. Mirrors the optimistic snapshot patch

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -404,7 +404,9 @@ type StarMapScreenProps = {
   /** Open a local thread in the main window's full thread view. */
   onOpenLocalThread: (thread: NavigationThreadSummary) => void;
   /** Clear unread state after a chat card's reply reaches its backend. */
-  onUserRepliedToThread?: (thread: NavigationThreadSummary) => void;
+  onUserRepliedToThread?: (
+    thread: NavigationThreadSummary,
+  ) => void | Promise<void>;
   /** The local instance card's open action: focus the main window. */
   onFocusLocalInstance: () => void;
   /** Refresh the App's navigation snapshot (after intake creates locally). */
@@ -1039,6 +1041,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
     snapshotFetchedAtForThread: queueSnapshotFetchedAtForThread,
     threads: queueProjectionThreads,
   });
+  const refreshRemoteInstance = remote.refreshInstance;
+  const onUserRepliedToThread = props.onUserRepliedToThread;
+  const reportUserRepliedToThread = useCallback(
+    async (thread: NavigationThreadSummary): Promise<void> => {
+      await onUserRepliedToThread?.(thread);
+      const target = thread.federation?.ref.target;
+      if (target && isRemoteFederationTarget(target)) {
+        // `markThreadsSeen` optimistically patches the local navigation
+        // snapshot, but peer cards render from `useStarMapThreads`. Refresh
+        // that owning feed only after its seen watermark reaches the peer.
+        await refreshRemoteInstance(target.instanceId);
+      }
+    },
+    [onUserRepliedToThread, refreshRemoteInstance],
+  );
   const arrangement = useStarMapArrangement({ desktopApi: props.desktopApi });
   // Load-card membership lives in the synced arrangement, so a card opened
   // on one machine is on the map from every machine in the fleet.
@@ -2475,7 +2492,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, [localInstanceId]);
 
   const onRefreshLocalThreads = props.onRefreshLocalThreads;
-  const refreshRemoteInstance = remote.refreshInstance;
   /**
    * Refresh whichever cloud owns a thread. Archive removes it from the
    * owning instance, so the map has to re-fetch rather than guess.
@@ -4487,7 +4503,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               }
               onClose={chatCards.close}
               onOpenFull={openThreadFully}
-              onUserRepliedToThread={props.onUserRepliedToThread}
+              onUserRepliedToThread={reportUserRepliedToThread}
               onRefreshNavigation={() =>
                 refreshOwner(cardInstanceId ?? localInstanceId)
               }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -403,6 +403,8 @@ type StarMapScreenProps = {
   localInstanceLabel?: string;
   /** Open a local thread in the main window's full thread view. */
   onOpenLocalThread: (thread: NavigationThreadSummary) => void;
+  /** Clear unread state after a chat card's reply reaches its backend. */
+  onUserRepliedToThread?: (thread: NavigationThreadSummary) => void;
   /** The local instance card's open action: focus the main window. */
   onFocusLocalInstance: () => void;
   /** Refresh the App's navigation snapshot (after intake creates locally). */
@@ -4485,6 +4487,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               }
               onClose={chatCards.close}
               onOpenFull={openThreadFully}
+              onUserRepliedToThread={props.onUserRepliedToThread}
               onRefreshNavigation={() =>
                 refreshOwner(cardInstanceId ?? localInstanceId)
               }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
 import { getDesktopApi, useDesktopApi } from "../../lib/desktop-api";
 import { useThreadNavigation } from "../../lib/useThreadNavigation";
 import { useThreadSessionState } from "../../lib/useThreadSessionState";
@@ -41,6 +42,13 @@ export function StarMapWindow() {
     composerDraftStore,
     threads: navigation.threads,
   });
+  const markThreadsSeen = navigation.markThreadsSeen;
+  const reportUserRepliedToThread = useCallback(
+    (thread: NavigationThreadSummary) => {
+      void markThreadsSeen([thread]);
+    },
+    [markThreadsSeen],
+  );
 
   // The renderer-side document title is what macOS shows in the Window
   // menu (the BrowserWindow's `title` option gets overridden by `<title>`
@@ -119,6 +127,7 @@ export function StarMapWindow() {
             threadId: thread.id,
           });
         }}
+        onUserRepliedToThread={reportUserRepliedToThread}
         onFocusLocalInstance={() => {
           void desktopApi?.focusMainWindowFromStarMap?.();
         }}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapWindow.tsx
@@ -44,9 +44,8 @@ export function StarMapWindow() {
   });
   const markThreadsSeen = navigation.markThreadsSeen;
   const reportUserRepliedToThread = useCallback(
-    (thread: NavigationThreadSummary) => {
-      void markThreadsSeen([thread]);
-    },
+    (thread: NavigationThreadSummary): Promise<void> =>
+      markThreadsSeen([thread]),
     [markThreadsSeen],
   );
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -173,6 +173,7 @@ type CardParams = {
   desktopApi: DesktopApi;
   instanceIcon?: string;
   instanceLabel?: string;
+  onUserRepliedToThread?: (thread: NavigationThreadSummary) => void;
   pastedImageMaxPatches?: number;
   thread: NavigationThreadSummary;
 };
@@ -190,6 +191,7 @@ function card(params: CardParams) {
       instanceLabel={params.instanceLabel}
       onClose={() => undefined}
       onOpenFull={() => undefined}
+      onUserRepliedToThread={params.onUserRepliedToThread}
       onRaise={() => undefined}
       onRectChange={() => undefined}
       pastedImageMaxPatches={params.pastedImageMaxPatches}
@@ -386,7 +388,11 @@ describe("StarMapChatCard federation routing", () => {
 
   it("starts a turn on the owning peer and clears the sent draft", async () => {
     const desktopApi = buildApi();
-    renderCard({ desktopApi, thread: remoteThread() });
+    const onUserRepliedToThread = vi.fn();
+    const thread = remoteThread({
+      inbox: { inInbox: true, reason: "updated-since-seen" },
+    });
+    renderCard({ desktopApi, onUserRepliedToThread, thread });
     const input = await typeAndSend("Remote work", "ship it");
 
     await waitFor(() => {
@@ -402,6 +408,7 @@ describe("StarMapChatCard federation routing", () => {
     await waitFor(() => {
       expect(input.value).toBe("");
     });
+    expect(onUserRepliedToThread).toHaveBeenCalledWith(thread);
   });
 
   it("leaves a local thread's target to the window's own scope", async () => {
@@ -941,8 +948,10 @@ describe("StarMapChatCard slash commands", () => {
         turnId: "turn-review-1",
       }));
       const desktopApi = reviewCapableApi(backend, { startReview });
+      const onUserRepliedToThread = vi.fn();
       renderCard({
         desktopApi,
+        onUserRepliedToThread,
         thread: localThread({ source: backend }),
       });
       const input = screen.getByRole("textbox", {
@@ -979,6 +988,7 @@ describe("StarMapChatCard slash commands", () => {
           }),
         ).toBeNull();
       });
+      expect(onUserRepliedToThread).not.toHaveBeenCalled();
     },
   );
 
@@ -1248,7 +1258,12 @@ describe("StarMapChatCard slash commands", () => {
             }
           : {}),
       });
-      renderCard({ desktopApi, thread: localThread() });
+      const onUserRepliedToThread = vi.fn();
+      renderCard({
+        desktopApi,
+        onUserRepliedToThread,
+        thread: localThread(),
+      });
       const input = screen.getByRole("textbox", {
         name: "Message Local work",
       });
@@ -1265,6 +1280,7 @@ describe("StarMapChatCard slash commands", () => {
         });
       });
       expect(desktopApi.startTurn).not.toHaveBeenCalled();
+      expect(onUserRepliedToThread).not.toHaveBeenCalled();
     },
   );
 
@@ -1618,12 +1634,13 @@ describe("StarMapChatCard send failures", () => {
   });
 
   it("restores the draft and rolls back its optimistic message when the peer refuses", async () => {
+    const onUserRepliedToThread = vi.fn();
     const desktopApi = buildApi({
       startTurn: vi.fn(async () => {
         throw new Error("peer is offline");
       }),
     } as unknown as Partial<DesktopApi>);
-    renderCard({ desktopApi, thread: remoteThread() });
+    renderCard({ desktopApi, onUserRepliedToThread, thread: remoteThread() });
     const input = await typeAndSend("Remote work", "do not lose me");
 
     // A send that never reached the backend must not cost the operator
@@ -1641,20 +1658,23 @@ describe("StarMapChatCard send failures", () => {
     expect((await screen.findByRole("alert")).textContent).toMatch(
       /peer is offline/,
     );
+    expect(onUserRepliedToThread).not.toHaveBeenCalled();
   });
 
   it("shows the message optimistically while the turn is in flight", async () => {
     // Baseline for the rollback test below: without this, "the message is
     // gone after a failure" could pass simply because it never appeared.
+    const onUserRepliedToThread = vi.fn();
     const desktopApi = buildApi({
       startTurn: vi.fn(() => new Promise(() => undefined)),
     } as unknown as Partial<DesktopApi>);
-    renderCard({ desktopApi, thread: remoteThread() });
+    renderCard({ desktopApi, onUserRepliedToThread, thread: remoteThread() });
     await typeAndSend("Remote work", "in flight");
 
     expect(
       await screen.findByText("in flight", { ignore: IGNORE_COMPOSER }),
     ).toBeTruthy();
+    expect(onUserRepliedToThread).not.toHaveBeenCalled();
   });
 });
 
@@ -1775,7 +1795,9 @@ describe("StarMapChatCard steering a live turn", () => {
 
   it("steers the running turn instead of starting a second one", async () => {
     const desktopApi = busyApi();
-    renderCard({ desktopApi, thread: localThread(BUSY) });
+    const onUserRepliedToThread = vi.fn();
+    const thread = localThread(BUSY);
+    renderCard({ desktopApi, onUserRepliedToThread, thread });
     await screen.findByRole("button", { name: "Steer" });
     await typeAndSend("Local work", "also check the logs");
 
@@ -1793,9 +1815,11 @@ describe("StarMapChatCard steering a live turn", () => {
     expect(
       await screen.findByText("Steered into the running turn."),
     ).toBeTruthy();
+    expect(onUserRepliedToThread).toHaveBeenCalledWith(thread);
   });
 
   it("says so when the backend held the message for the next turn", async () => {
+    const onUserRepliedToThread = vi.fn();
     const desktopApi = busyApi({
       steerTurn: vi.fn(async () => ({
         backend: "codex",
@@ -1804,22 +1828,29 @@ describe("StarMapChatCard steering a live turn", () => {
         disposition: "queued",
       })),
     } as unknown as Partial<DesktopApi>);
-    renderCard({ desktopApi, thread: localThread(BUSY) });
+    const thread = localThread(BUSY);
+    renderCard({ desktopApi, onUserRepliedToThread, thread });
     await screen.findByRole("button", { name: "Steer" });
     await typeAndSend("Local work", "and then deploy");
 
     // Steered and queued are both accepted sends that land in different
     // places, and only the backend knows which happened.
     expect(await screen.findByText("Queued for the next turn.")).toBeTruthy();
+    expect(onUserRepliedToThread).toHaveBeenCalledWith(thread);
   });
 
   it("gives the text back when the backend refuses to steer", async () => {
+    const onUserRepliedToThread = vi.fn();
     const desktopApi = busyApi({
       steerTurn: vi.fn(async () => {
         throw new Error("Selected backend does not support turn/steer");
       }),
     } as unknown as Partial<DesktopApi>);
-    renderCard({ desktopApi, thread: localThread(BUSY) });
+    renderCard({
+      desktopApi,
+      onUserRepliedToThread,
+      thread: localThread(BUSY),
+    });
     await screen.findByRole("button", { name: "Steer" });
     const input = await typeAndSend("Local work", "do not lose me");
 
@@ -1834,6 +1865,7 @@ describe("StarMapChatCard steering a live turn", () => {
         screen.queryByText("do not lose me", { ignore: IGNORE_COMPOSER }),
       ).toBeNull();
     });
+    expect(onUserRepliedToThread).not.toHaveBeenCalled();
   });
 
   it("keeps a peer's steer pointed at that peer", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -173,7 +173,9 @@ type CardParams = {
   desktopApi: DesktopApi;
   instanceIcon?: string;
   instanceLabel?: string;
-  onUserRepliedToThread?: (thread: NavigationThreadSummary) => void;
+  onUserRepliedToThread?: (
+    thread: NavigationThreadSummary,
+  ) => void | Promise<void>;
   pastedImageMaxPatches?: number;
   thread: NavigationThreadSummary;
 };

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -73,6 +73,17 @@ function seedLayout(layout: "lanes" | "orbit" | "projects") {
   );
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
 describe("StarMapScreen", () => {
   it("marks a card whose thread holds an unsent draft", async () => {
     // Drafts ride a prop of their own rather than `sessionKeys`, which the
@@ -640,6 +651,138 @@ describe("StarMapScreen", () => {
       }),
     );
     expect(onOpenLocalThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes a remote card only after its accepted reply is marked seen", async () => {
+    const remoteTarget = {
+      scope: "remote" as const,
+      instanceId: "pwr_peer",
+    };
+    const remoteUnreadThread = {
+      ...unreadThread("remote"),
+      federation: {
+        instanceLabel: "Studio Mac",
+        ref: {
+          backend: "codex" as const,
+          target: remoteTarget,
+          threadId: "remote",
+        },
+      },
+    } as NavigationThreadSummary;
+    const remoteSeenThread = {
+      ...remoteUnreadThread,
+      inbox: { inInbox: false, lastSeenUpdatedAt: 100 },
+    } as NavigationThreadSummary;
+    const markSeen = createDeferred<void>();
+    const onUserRepliedToThread = vi.fn(() => markSeen.promise);
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      threads:
+        getNavigationSnapshot.mock.calls.length === 1
+          ? [remoteUnreadThread]
+          : [remoteSeenThread],
+      inboxThreadKeys:
+        getNavigationSnapshot.mock.calls.length === 1
+          ? ["codex:remote"]
+          : [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "remote",
+      turnId: "turn-remote",
+    }));
+    const desktopApi = {
+      readFederationHealth: vi.fn(async () => ({
+        health: {
+          enabled: true,
+          role: "gateway" as const,
+          status: "listening" as const,
+          instanceId: "pwr_local",
+          localLabel: "Local Mac",
+          peers: [{
+            id: "pwr_peer",
+            label: "Studio Mac",
+            role: "client" as const,
+            status: "connected" as const,
+            capabilities: ["thread_navigation" as const],
+          }],
+        },
+      })),
+      getNavigationSnapshot,
+      onAgentEvent: vi.fn(() => () => undefined),
+      readThread: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "remote",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+        },
+      })),
+      startTurn,
+    } as unknown as DesktopApi;
+
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        onOpenLocalThread={() => undefined}
+        onUserRepliedToThread={onUserRepliedToThread}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    const remoteOpenButton = await screen.findByRole("button", {
+      name: "Open thread: Thread remote",
+    });
+    expect(
+      starMapCard(remoteOpenButton).querySelector(
+        '[data-thread-status="unread"]',
+      ),
+    ).not.toBeNull();
+    fireEvent.click(remoteOpenButton);
+    const chat = await screen.findByRole("region", {
+      name: "Chat: Thread remote",
+    });
+    const input = within(chat).getByRole("textbox", {
+      name: "Message Thread remote",
+    });
+    fireEvent.change(input, { target: { value: "ship the fix" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalled();
+      expect(onUserRepliedToThread).toHaveBeenCalledWith(remoteUnreadThread);
+    });
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      markSeen.resolve();
+      await markSeen.promise;
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+    });
+    expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+      federationTarget: remoteTarget,
+    });
+    await waitFor(() => {
+      expect(
+        starMapCard(
+          screen.getByRole("button", {
+            name: "Open thread: Thread remote",
+          }),
+        ).querySelector('[data-thread-status="unread"]'),
+      ).toBeNull();
+    });
   });
 
   it("raises an already-open chat card instead of stacking a duplicate", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapWindow.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { beforeEach, expect, it, vi } from "vitest";
+import { StarMapWindow } from "../StarMapWindow";
+
+const testState = vi.hoisted(() => ({
+  markThreadsSeen: vi.fn(),
+  remoteThread: {
+    id: "thread-remote",
+    title: "Remote work",
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 42,
+    federation: {
+      instanceLabel: "Studio Mac",
+      ref: {
+        backend: "codex",
+        threadId: "thread-remote",
+        target: { scope: "remote", instanceId: "pwr_peer" },
+      },
+    },
+  },
+}));
+
+vi.mock("../../../lib/desktop-api", () => ({
+  getDesktopApi: () => ({ platform: "linux" }),
+  useDesktopApi: () => ({ markThreadSeen: vi.fn() }),
+}));
+
+vi.mock("../../../lib/useThreadNavigation", () => ({
+  useThreadNavigation: () => ({
+    markThreadsSeen: testState.markThreadsSeen,
+    refresh: vi.fn(),
+    threads: [],
+  }),
+}));
+
+vi.mock("../../../lib/useThreadSessionState", () => ({
+  useThreadSessionState: () => ({
+    approvalRequestThreadKeys: {},
+    inputRequestThreadKeys: {},
+    thinkingThreadKeys: {},
+  }),
+}));
+
+vi.mock("../../composer/useComposerDraftStore", () => ({
+  useComposerDraftStore: () => ({}),
+}));
+
+vi.mock("../../composer/useDurableComposerDraftStore", () => ({
+  useDurableComposerDraftStore: () => ({}),
+}));
+
+vi.mock("../../../lib/useThreadDraftIndicators", () => ({
+  useThreadDraftIndicators: () => ({}),
+}));
+
+vi.mock("../../settings/useDesktopSettings", () => ({
+  useDesktopSettings: () => ({ snapshot: undefined }),
+}));
+
+vi.mock("../StarMapScreen", () => ({
+  StarMapScreen: (props: {
+    onUserRepliedToThread?: (thread: NavigationThreadSummary) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => props.onUserRepliedToThread?.(
+        testState.remoteThread as NavigationThreadSummary,
+      )}
+    >
+      Report accepted reply
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  testState.markThreadsSeen.mockReset();
+});
+
+it("routes an accepted remote reply through navigation seen state", () => {
+  render(<StarMapWindow />);
+
+  fireEvent.click(screen.getByRole("button", { name: "Report accepted reply" }));
+
+  expect(testState.markThreadsSeen).toHaveBeenCalledWith([
+    testState.remoteThread,
+  ]);
+});


### PR DESCRIPTION
## Summary

- clear Star Map unread state only after a new turn or steer is accepted
- route accepted replies through the existing navigation seen-state mechanism with federation targeting intact
- keep failed, pending, /review, and /compact submissions from clearing unread state

## Testing

- `pnpm test apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapWindow.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- ESLint on all changed files