### PR TITLE
feat(desktop): neutral remote-turn marks and a tab-faithful Star Map Attention chip

### DIFF
--- a/apps/desktop/src/renderer/src/components/SignalCount.tsx
+++ b/apps/desktop/src/renderer/src/components/SignalCount.tsx
@@ -47,8 +47,13 @@ export function SignalCount(props: {
    */
   ariaHidden?: boolean;
   className?: string;
-  /** Extra `data-*` hooks, spread verbatim onto the wrapper. */
-  data?: Record<string, number | string | undefined>;
+  /**
+   * Extra `data-*` hooks, spread verbatim onto the wrapper. Keys are typed
+   * to the `data-` prefix rather than left open: the spread lands after this
+   * component's own attributes, so an open record could silently replace the
+   * computed class or the zero state.
+   */
+  data?: Record<`data-${string}`, number | string | undefined>;
   /**
    * A count with no words has to be able to explain itself. The directory
    * rail hangs a `useViewportTooltip` off these; the Attention readouts

--- a/apps/desktop/src/renderer/src/components/SignalCount.tsx
+++ b/apps/desktop/src/renderer/src/components/SignalCount.tsx
@@ -1,0 +1,81 @@
+import type { MouseEvent, ReactNode } from "react";
+
+/**
+ * One mark and the number it counts: "two turns running here", "seven threads
+ * to review", "one sub-agent working".
+ *
+ * The app says this same thing on five surfaces — the sidebar's Attention tab,
+ * the Star Map's Attention chip, the directory header counts, the active
+ * sub-agents strip and the running-automations strip — and they had drifted
+ * into three different renderings visible at once: the tab drew mark-then-count
+ * in mono, the directory headers drew count-then-mark, and the strips drew the
+ * count inside a bordered pill with no mark at all. An operator reading a
+ * window has to learn one shape, not three.
+ *
+ * The Attention tab is the shape they all take now: the mark first, because it
+ * is what says WHICH number this is, then the digits. Mono and tabular so a
+ * count changing from 9 to 10 does not shove the mark, and so a column of them
+ * lines up.
+ *
+ * Tone carries where the work is, and only that:
+ * - `active` — accent. Running on this machine; quitting interrupts it.
+ * - `remote-active` — neutral. Running on another instance; quitting does not.
+ * - `idle` — secondary. Nothing is running behind this number (threads waiting
+ *   to be reviewed, a strip holding only failures).
+ *
+ * See `isThreadRemoteWorkHere` for the predicate that picks between the first
+ * two, and `AttentionSignals.tsx` for the Attention-specific readouts built on
+ * this.
+ */
+export type SignalCountTone = "active" | "remote-active" | "idle";
+
+export function SignalCount(props: {
+  count: number;
+  /**
+   * The mark. Callers pass it rather than deriving it from the tone because
+   * "is anything running?" is not always "is the count zero?" — the strips
+   * count failures too, and draw a dormant bar beside a non-zero number when
+   * none of them are working.
+   */
+  indicator: ReactNode;
+  tone: SignalCountTone;
+  /**
+   * Hides the pair from the accessibility tree. The Attention readouts do
+   * this because their control's `aria-label` already spells every count
+   * out; the directory counts do not, because their digits ARE the
+   * announcement.
+   */
+  ariaHidden?: boolean;
+  className?: string;
+  /** Extra `data-*` hooks, spread verbatim onto the wrapper. */
+  data?: Record<string, number | string | undefined>;
+  /**
+   * A count with no words has to be able to explain itself. The directory
+   * rail hangs a `useViewportTooltip` off these; the Attention readouts
+   * leave them unset because their control owns the hover card.
+   */
+  onMouseEnter?: (event: MouseEvent<HTMLSpanElement>) => void;
+  onMouseLeave?: () => void;
+}) {
+  return (
+    <span
+      aria-hidden={props.ariaHidden ? "true" : undefined}
+      className={`signal-count signal-count--${props.tone}${
+        props.className ? ` ${props.className}` : ""
+      }`}
+      // A zero is drawn, never hidden — an idle surface has to read as
+      // "nothing here", which a vanishing count cannot do. Kept as an
+      // attribute rather than folded into the class: the grey also has to
+      // reach the orange cookie, which paints itself from accent tokens
+      // rather than `currentColor`, and an attribute selector is what the
+      // cookie rule already keys off.
+      data-zero={props.count === 0 ? "true" : undefined}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
+      {...props.data}
+    >
+      {props.indicator}
+      <span className="signal-count__value">{props.count}</span>
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/__tests__/signal-count.test.tsx
+++ b/apps/desktop/src/renderer/src/components/__tests__/signal-count.test.tsx
@@ -1,0 +1,85 @@
+import "@testing-library/jest-dom/vitest";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SignalCount } from "../SignalCount";
+
+/**
+ * The one shape the app uses to say "this many, and here is what kind".
+ *
+ * It exists because three renderings of it were once visible in a single
+ * window: the Attention tab drew mark-then-count in mono, the directory
+ * header counts drew count-then-mark, and the live strips drew a bordered
+ * pill with no mark at all. These tests pin the parts that made them read as
+ * different objects — the order, and the absence of chrome — so a fourth
+ * rendering cannot appear without failing here first.
+ */
+
+describe("SignalCount", () => {
+  it("draws the mark before the digits", () => {
+    // The direction the whole primitive exists to settle. The mark says
+    // WHICH number this is, so it leads; a surface that flips it reads as a
+    // different control even with identical tokens.
+    const { container } = render(
+      <SignalCount
+        count={4}
+        indicator={<span data-testid="mark" />}
+        tone="active"
+      />,
+    );
+    const signal = container.querySelector(".signal-count")!;
+    const children = [...signal.children];
+    expect(children[0]).toHaveAttribute("data-testid", "mark");
+    expect(children[1]).toHaveClass("signal-count__value");
+    expect(children[1]).toHaveTextContent("4");
+  });
+
+  it("carries the tone as a modifier and nothing else", () => {
+    for (const tone of ["active", "remote-active", "idle"] as const) {
+      const { container } = render(
+        <SignalCount count={1} indicator={<span />} tone={tone} />,
+      );
+      expect(container.querySelector(".signal-count")).toHaveClass(
+        `signal-count--${tone}`,
+      );
+    }
+  });
+
+  it("greys a zero rather than hiding it, and only a zero", () => {
+    // An idle surface has to read as "nothing here", which a vanishing count
+    // cannot do — the same rule the Attention tab has always followed.
+    const zero = render(
+      <SignalCount count={0} indicator={<span />} tone="active" />,
+    );
+    expect(zero.container.querySelector(".signal-count")).toHaveAttribute(
+      "data-zero",
+      "true",
+    );
+    expect(zero.container.querySelector(".signal-count")).toHaveTextContent("0");
+
+    const live = render(
+      <SignalCount count={2} indicator={<span />} tone="active" />,
+    );
+    expect(
+      live.container.querySelector(".signal-count"),
+    ).not.toHaveAttribute("data-zero");
+  });
+
+  it("stays in the accessibility tree unless the caller opts out", () => {
+    // The directory counts ARE the announcement; the Attention readouts hide
+    // because their control's aria-label already spells every count out.
+    const spoken = render(
+      <SignalCount count={1} indicator={<span />} tone="idle" />,
+    );
+    expect(
+      spoken.container.querySelector(".signal-count"),
+    ).not.toHaveAttribute("aria-hidden");
+
+    const silent = render(
+      <SignalCount ariaHidden count={1} indicator={<span />} tone="idle" />,
+    );
+    expect(silent.container.querySelector(".signal-count")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/automations/ActiveAutomationRunsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/ActiveAutomationRunsStrip.tsx
@@ -2,6 +2,8 @@ import { useState, type ReactNode } from "react";
 import type { AutomationDetail, NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { formatRunningDurationMs } from "../../lib/format-duration";
+import { SignalCount } from "../../components/SignalCount";
+import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import { useNowWhileActive } from "../thread-detail/context-panels/RailCardTiming";
 import { useAutomations } from "./useAutomations";
 
@@ -78,8 +80,23 @@ export function ActiveAutomationRunsStrip(props: {
     <section className="live-strip" aria-label={heading}>
       <div className="live-strip__header">
         <div className="live-strip__row live-strip__row--static">
+          {/* Same mark-and-number as the sub-agents strip below it and the
+              sidebar rail beside it — see `SignalCount.tsx`. This strip drew
+              a bare pill and no mark at all, so two sibling strips reported
+              the same kind of thing two different ways. */}
           <span className="live-strip__label">{heading}</span>
-          <span className="live-strip__count">{headingCount}</span>
+          <SignalCount
+            className="live-strip__count"
+            count={headingCount}
+            indicator={
+              running.length > 0 ? (
+                <ThinkingScanner compact />
+              ) : (
+                <span className="signal-count__dormant-scanner" />
+              )
+            }
+            tone={running.length > 0 ? "active" : "idle"}
+          />
           <span className="live-strip__row-spacer" />
           {failedNote ? (
             <span className="live-strip__note">{failedNote}</span>

--- a/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
@@ -42,7 +42,7 @@ import {
  * untouched component tinted by its parent's tokens — a peer's turn is running
  * for real, so it sweeps for real, on the same epoch as the rest.
  */
-export function AttentionTurnScanner(props: { count: number }) {
+function AttentionTurnScanner(props: { count: number }) {
   return props.count === 0 ? (
     <span className="lens-switch__dormant-scanner" />
   ) : (
@@ -116,7 +116,7 @@ export function AttentionReviewReadout(props: { count: number }) {
  * readout the operator just hovered — a card of bare labels would make them
  * re-derive which number is which.
  */
-export function AttentionCardRow(props: {
+function AttentionCardRow(props: {
   count: number;
   indicator: "turn" | "remote-turn" | "review";
   label: string;
@@ -193,7 +193,7 @@ export type AttentionCardOptions = {
  * sentences with em-dashes doing the structural work. See "Structured hover
  * cards" in AGENTS.md.
  */
-export function AttentionCard(props: AttentionCardCounts & AttentionCardOptions) {
+function AttentionCard(props: AttentionCardCounts & AttentionCardOptions) {
   const activeRemote = props.activeRemote;
   return (
     <>
@@ -276,8 +276,10 @@ export function useAttentionHoverCard(
   props: AttentionCardCounts & AttentionCardOptions & {
     /**
      * The portal element's class. `attention-card` at the sidebar's layer;
-     * surfaces inside a window that opens its own stacking context add a
-     * modifier that lifts the card above it (see `.attention-card--star-map`).
+     * a surface inside a window that opens its own stacking context appends
+     * that window's escape class to lift the card above it — the Star Map's
+     * chip passes `attention-card star-map-card__tooltip`, the same escape
+     * its thread-card tooltips use.
      */
     className?: string;
   },

--- a/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, type ReactNode } from "react";
+import { SignalCount } from "../../components/SignalCount";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import {
@@ -42,9 +43,9 @@ import {
  * untouched component tinted by its parent's tokens — a peer's turn is running
  * for real, so it sweeps for real, on the same epoch as the rest.
  */
-function AttentionTurnScanner(props: { count: number }) {
+export function AttentionTurnScanner(props: { count: number }) {
   return props.count === 0 ? (
-    <span className="lens-switch__dormant-scanner" />
+    <span className="signal-count__dormant-scanner" />
   ) : (
     <ThinkingScanner compact />
   );
@@ -72,24 +73,20 @@ export function AttentionTurnReadouts(props: {
   activeRemote?: number;
 }) {
   return (
-    <span aria-hidden="true" className="lens-switch__turns">
-      <span
-        className="lens-switch__signal lens-switch__signal--active"
-        data-attention-active-count={props.activeLocal}
-        data-zero={props.activeLocal === 0 ? "true" : undefined}
-      >
-        <AttentionTurnScanner count={props.activeLocal} />
-        <span>{props.activeLocal}</span>
-      </span>
+    <span aria-hidden="true" className="signal-count-stack">
+      <SignalCount
+        count={props.activeLocal}
+        data={{ "data-attention-active-count": props.activeLocal }}
+        indicator={<AttentionTurnScanner count={props.activeLocal} />}
+        tone="active"
+      />
       {props.activeRemote === undefined ? null : (
-        <span
-          className="lens-switch__signal lens-switch__signal--remote-active"
-          data-attention-remote-active-count={props.activeRemote}
-          data-zero={props.activeRemote === 0 ? "true" : undefined}
-        >
-          <AttentionTurnScanner count={props.activeRemote} />
-          <span>{props.activeRemote}</span>
-        </span>
+        <SignalCount
+          count={props.activeRemote}
+          data={{ "data-attention-remote-active-count": props.activeRemote }}
+          indicator={<AttentionTurnScanner count={props.activeRemote} />}
+          tone="remote-active"
+        />
       )}
     </span>
   );
@@ -98,15 +95,13 @@ export function AttentionTurnReadouts(props: {
 /** The orange cookie and its count: threads waiting to be looked at. */
 export function AttentionReviewReadout(props: { count: number }) {
   return (
-    <span
-      aria-hidden="true"
-      className="lens-switch__signal lens-switch__signal--review"
-      data-attention-review-count={props.count}
-      data-zero={props.count === 0 ? "true" : undefined}
-    >
-      <span className="thread-row__status-cookie" />
-      <span>{props.count}</span>
-    </span>
+    <SignalCount
+      ariaHidden
+      count={props.count}
+      data={{ "data-attention-review-count": props.count }}
+      indicator={<span className="thread-row__status-cookie" />}
+      tone="idle"
+    />
   );
 }
 
@@ -130,9 +125,9 @@ function AttentionCardRow(props: {
     >
       <span
         aria-hidden="true"
-        className={`lens-switch__signal lens-switch__signal--${
+        className={`signal-count signal-count--${
           props.indicator === "review"
-            ? "review"
+            ? "idle"
             : props.indicator === "remote-turn"
               ? "remote-active"
               : "active"

--- a/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import {
@@ -177,8 +177,6 @@ export type AttentionCardOptions = {
   caption: string;
   /** The third row's label — the tab says "To review", the map "Unread". */
   reviewLabel: string;
-  /** How the third row's count is read out, e.g. `formatReviewThreadCount`. */
-  formatReviewCount: (count: number) => string;
   /**
    * An optional closing line. The map's chip uses it to say what a click
    * does now that the chip shows no word — without it a sighted operator
@@ -268,10 +266,11 @@ export function describeAttentionCounts(
  * peer work after a peer starts a turn, on the one surface that exists to
  * answer "can I quit now?".
  *
- * The key guard is not optional: a React element is a new object on every
- * render, so feeding one straight into `update` would set state on every
- * render that very update caused. Compare the card's DATA and push only when
- * it moved.
+ * The push is keyed on the card's DATA, not its identity per render: the
+ * element is memoized on its counts and labels, so a new element means the
+ * numbers moved, and only then is an open card updated — feeding a fresh
+ * element in on every render would set state on every render that very
+ * update caused.
  */
 export function useAttentionHoverCard(
   props: AttentionCardCounts & AttentionCardOptions & {
@@ -289,28 +288,36 @@ export function useAttentionHoverCard(
   const tooltip = useViewportTooltip({
     className: props.className ?? "attention-card",
   });
-  const card = <AttentionCard {...props} />;
-  const latestCardRef = useRef(card);
-  latestCardRef.current = card;
-  const cardKey = [
-    props.activeLocal,
-    props.activeRemote ?? "off",
-    props.review,
-    props.title,
-    props.caption,
-    props.reviewLabel,
-    props.footer ?? "",
-  ].join("|");
-  const pushedCardKeyRef = useRef<string | undefined>(undefined);
+  const { activeLocal, activeRemote, review, title, caption, reviewLabel, footer } =
+    props;
+  // Built only when its data moves, not on every render of a host that
+  // re-renders per streamed item (the tab) or per pan frame (the map chip):
+  // the element is inert until hover, and the memo key below is also what
+  // decides whether an open card is pushed fresh content.
+  const card = useMemo(
+    () => (
+      <AttentionCard
+        activeLocal={activeLocal}
+        activeRemote={activeRemote}
+        review={review}
+        title={title}
+        caption={caption}
+        reviewLabel={reviewLabel}
+        footer={footer}
+      />
+    ),
+    [activeLocal, activeRemote, review, title, caption, reviewLabel, footer],
+  );
+  const pushedCardRef = useRef<ReactNode>(undefined);
   const tooltipVisible = tooltip.visible;
   const updateTooltip = tooltip.update;
   useEffect(() => {
-    const moved = pushedCardKeyRef.current !== cardKey;
-    pushedCardKeyRef.current = cardKey;
+    const moved = pushedCardRef.current !== card;
+    pushedCardRef.current = card;
     if (!moved || !tooltipVisible) {
       return;
     }
-    updateTooltip(latestCardRef.current);
-  }, [cardKey, tooltipVisible, updateTooltip]);
+    updateTooltip(card);
+  }, [card, tooltipVisible, updateTooltip]);
   return { card, tooltip };
 }

--- a/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
+import {
+  formatActiveThreadCount,
+  formatLocalActiveThreadCount,
+  formatRemoteActiveThreadCount,
+} from "./ThreadRowStatus";
+
+/**
+ * The Attention readouts, shared by every surface that reports them.
+ *
+ * The sidebar's Attention tab and the Star Map's Attention chip draw the SAME
+ * numbers — turns here, turns elsewhere, threads to look at — and an operator
+ * glancing between the two windows must not have to work out whether two
+ * slightly different oranges, or two different stackings, mean two different
+ * things. So the indicators, the zero state, the stacked turn column and the
+ * hover card that explains them live here once, and both controls render
+ * these rather than each keeping a copy that drifts (the map's copy HAD
+ * drifted: its turns sat in a row instead of the tab's column, and its signal
+ * row lost its layout rule to a CSS splice).
+ *
+ * Class names stay the tab's (`lens-switch__*`): they carry the colour and
+ * zero tokens, and `.attention-card__row` already reused them outside the
+ * switch for exactly this reason. See "Reuse existing chrome tokens" in
+ * CLAUDE.md — sharing the class is the strongest form of copying the tokens.
+ */
+
+/**
+ * The sweeping bar next to a turn count, or its idle stand-in.
+ *
+ * At zero this is a static element, NOT a greyed-out `ThinkingScanner`.
+ * Killing the sweep with CSS on a mounted scanner is a desync trap: `data-zero`
+ * lives on the parent span, so React would keep the same scanner element across
+ * the flip, its ref would never re-run, and the restarted animation would never
+ * be re-pinned to the shared epoch — leaving this readout drifting against
+ * every other scanner on screen. Swapping the element type guarantees a mount,
+ * so `syncThinkingScannerAnimation` runs and the beam comes back in phase. See
+ * ThinkingScanner.tsx and PR #1187.
+ *
+ * The remote readout's beam is neutral rather than accent, but it is the same
+ * untouched component tinted by its parent's tokens — a peer's turn is running
+ * for real, so it sweeps for real, on the same epoch as the rest.
+ */
+export function AttentionTurnScanner(props: { count: number }) {
+  return props.count === 0 ? (
+    <span className="lens-switch__dormant-scanner" />
+  ) : (
+    <ThinkingScanner compact />
+  );
+}
+
+/**
+ * The turn readouts, stacked: the accent scanner counts turns on this
+ * machine, the neutral one under it counts turns on other instances.
+ *
+ * One column so the second readout stacks under the first instead of widening
+ * the control. The Attention tab already floors the lens switch's narrowest
+ * track (see `.lens-switch`), and a third readout laid out across would take
+ * that room from the four icon tabs; on the map the band has the same problem
+ * with its chips. A single row is the common case and reads exactly as a bare
+ * readout would — a one-item column is its own content box, so nothing moves.
+ *
+ * `activeRemote` undefined means the remote readout is not on — no federated
+ * work has run recently — and the column reads exactly as it does on an
+ * instance that has never federated. The caller owns that decision (the tab
+ * lingers it for half a minute, the map ties it to fronting a peer) because
+ * only the caller knows what "recently" means on its surface.
+ */
+export function AttentionTurnReadouts(props: {
+  activeLocal: number;
+  activeRemote?: number;
+}) {
+  return (
+    <span aria-hidden="true" className="lens-switch__turns">
+      <span
+        className="lens-switch__signal lens-switch__signal--active"
+        data-attention-active-count={props.activeLocal}
+        data-zero={props.activeLocal === 0 ? "true" : undefined}
+      >
+        <AttentionTurnScanner count={props.activeLocal} />
+        <span>{props.activeLocal}</span>
+      </span>
+      {props.activeRemote === undefined ? null : (
+        <span
+          className="lens-switch__signal lens-switch__signal--remote-active"
+          data-attention-remote-active-count={props.activeRemote}
+          data-zero={props.activeRemote === 0 ? "true" : undefined}
+        >
+          <AttentionTurnScanner count={props.activeRemote} />
+          <span>{props.activeRemote}</span>
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** The orange cookie and its count: threads waiting to be looked at. */
+export function AttentionReviewReadout(props: { count: number }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="lens-switch__signal lens-switch__signal--review"
+      data-attention-review-count={props.count}
+      data-zero={props.count === 0 ? "true" : undefined}
+    >
+      <span className="thread-row__status-cookie" />
+      <span>{props.count}</span>
+    </span>
+  );
+}
+
+/**
+ * One line of the Attention hover card: the control's own indicator, what it
+ * counts, and the count. Repeating the indicator is what ties a row to the
+ * readout the operator just hovered — a card of bare labels would make them
+ * re-derive which number is which.
+ */
+export function AttentionCardRow(props: {
+  count: number;
+  indicator: "turn" | "remote-turn" | "review";
+  label: string;
+  /** What quitting does to this row's work. Omitted when nothing is at stake. */
+  note?: string;
+}) {
+  return (
+    <div
+      className="attention-card__row"
+      data-zero={props.count === 0 ? "true" : undefined}
+    >
+      <span
+        aria-hidden="true"
+        className={`lens-switch__signal lens-switch__signal--${
+          props.indicator === "review"
+            ? "review"
+            : props.indicator === "remote-turn"
+              ? "remote-active"
+              : "active"
+        }`}
+        data-zero={props.count === 0 ? "true" : undefined}
+      >
+        {props.indicator === "review" ? (
+          <span className="thread-row__status-cookie" />
+        ) : (
+          <AttentionTurnScanner count={props.count} />
+        )}
+      </span>
+      <span className="attention-card__row-text">
+        <span className="attention-card__row-label">{props.label}</span>
+        {props.note ? (
+          <span className="attention-card__row-note">{props.note}</span>
+        ) : null}
+      </span>
+      <span className="attention-card__row-value">{props.count}</span>
+    </div>
+  );
+}
+
+export type AttentionCardCounts = {
+  /** Turns on this machine (or all turns, where the split is off). */
+  activeLocal: number;
+  /**
+   * Turns on other instances. `undefined` means the split is off and the
+   * card names no machine — "In progress" is the whole truth on an
+   * unfederated instance, and naming the machine would raise a question
+   * the operator does not have.
+   */
+  activeRemote?: number;
+  /** Threads waiting to be looked at — "to review" or "unread", per surface. */
+  review: number;
+};
+
+export type AttentionCardOptions = {
+  /** What the control is called: the eyebrow and the first accessible term. */
+  title: string;
+  /** One line under the eyebrow saying what the control reports. */
+  caption: string;
+  /** The third row's label — the tab says "To review", the map "Unread". */
+  reviewLabel: string;
+  /** How the third row's count is read out, e.g. `formatReviewThreadCount`. */
+  formatReviewCount: (count: number) => string;
+  /**
+   * An optional closing line. The map's chip uses it to say what a click
+   * does now that the chip shows no word — without it a sighted operator
+   * has only the chip's fill to learn it is a filter.
+   */
+  footer?: string;
+};
+
+/**
+ * The hover card's content. A card, not a text tooltip: every other lens tab
+ * or chip explains itself in one line; this one reports two or three counts,
+ * each with its own indicator and — once a peer is running work — a
+ * consequence. Run through `.viewport-tooltip` that became four stacked
+ * sentences with em-dashes doing the structural work. See "Structured hover
+ * cards" in AGENTS.md.
+ */
+export function AttentionCard(props: AttentionCardCounts & AttentionCardOptions) {
+  const activeRemote = props.activeRemote;
+  return (
+    <>
+      <div className="attention-card__eyebrow">{props.title}</div>
+      <div className="attention-card__caption">{props.caption}</div>
+      <div className="attention-card__section">
+        <AttentionCardRow
+          count={props.activeLocal}
+          indicator="turn"
+          // Only qualify the row once there is something to tell it apart
+          // from.
+          label={activeRemote === undefined ? "In progress" : "In progress here"}
+          note={
+            activeRemote === undefined ? undefined : "Quitting interrupts these"
+          }
+        />
+        {activeRemote === undefined ? null : (
+          <AttentionCardRow
+            count={activeRemote}
+            indicator="remote-turn"
+            label="In progress elsewhere"
+            note="Quitting leaves these running"
+          />
+        )}
+        <AttentionCardRow
+          count={props.review}
+          indicator="review"
+          label={props.reviewLabel}
+        />
+      </div>
+      {props.footer ? (
+        <div className="attention-card__footer">{props.footer}</div>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * The counts spelled out for an accessible name: "1 active thread on this
+ * machine, 2 active threads on other instances, 3 threads to review". The
+ * machine is named only when the split is on, for the same reason the card
+ * only names it then.
+ */
+export function describeAttentionCounts(
+  counts: AttentionCardCounts,
+  formatReviewCount: (count: number) => string,
+): string {
+  return [
+    ...(counts.activeRemote === undefined
+      ? [formatActiveThreadCount(counts.activeLocal)]
+      : [
+        formatLocalActiveThreadCount(counts.activeLocal),
+        formatRemoteActiveThreadCount(counts.activeRemote),
+      ]),
+    formatReviewCount(counts.review),
+  ].join(", ");
+}
+
+/**
+ * The Attention hover card, wired to a trigger.
+ *
+ * Returns the tooltip handle (show/hide/node/id) and the card element to hand
+ * `show`. Creating the element is not rendering it: it stays an inert object
+ * until `show` hands it to the portal on hover or focus.
+ *
+ * Turns start and end while the pointer rests on the trigger, so fresh
+ * numbers are pushed into an already-open card rather than freezing it at
+ * hover-time values — the same thing `PrChip` does for a live PR status.
+ * Freezing is not cosmetic here: the card would keep claiming there is no
+ * peer work after a peer starts a turn, on the one surface that exists to
+ * answer "can I quit now?".
+ *
+ * The key guard is not optional: a React element is a new object on every
+ * render, so feeding one straight into `update` would set state on every
+ * render that very update caused. Compare the card's DATA and push only when
+ * it moved.
+ */
+export function useAttentionHoverCard(
+  props: AttentionCardCounts & AttentionCardOptions & {
+    /**
+     * The portal element's class. `attention-card` at the sidebar's layer;
+     * surfaces inside a window that opens its own stacking context add a
+     * modifier that lifts the card above it (see `.attention-card--star-map`).
+     */
+    className?: string;
+  },
+): {
+  card: ReactNode;
+  tooltip: ReturnType<typeof useViewportTooltip>;
+} {
+  const tooltip = useViewportTooltip({
+    className: props.className ?? "attention-card",
+  });
+  const card = <AttentionCard {...props} />;
+  const latestCardRef = useRef(card);
+  latestCardRef.current = card;
+  const cardKey = [
+    props.activeLocal,
+    props.activeRemote ?? "off",
+    props.review,
+    props.title,
+    props.caption,
+    props.reviewLabel,
+    props.footer ?? "",
+  ].join("|");
+  const pushedCardKeyRef = useRef<string | undefined>(undefined);
+  const tooltipVisible = tooltip.visible;
+  const updateTooltip = tooltip.update;
+  useEffect(() => {
+    const moved = pushedCardKeyRef.current !== cardKey;
+    pushedCardKeyRef.current = cardKey;
+    if (!moved || !tooltipVisible) {
+      return;
+    }
+    updateTooltip(latestCardRef.current);
+  }, [cardKey, tooltipVisible, updateTooltip]);
+  return { card, tooltip };
+}

--- a/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/AttentionSignals.tsx
@@ -43,7 +43,7 @@ import {
  * untouched component tinted by its parent's tokens — a peer's turn is running
  * for real, so it sweeps for real, on the same epoch as the rest.
  */
-export function AttentionTurnScanner(props: { count: number }) {
+function AttentionTurnScanner(props: { count: number }) {
   return props.count === 0 ? (
     <span className="signal-count__dormant-scanner" />
   ) : (

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -47,6 +47,10 @@ import {
 } from "../../lib/native-drag-interaction";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import {
+  SignalCount,
+  type SignalCountTone,
+} from "../../components/SignalCount";
+import {
   getSubthreadDisclosureCount,
   isSubthreadSectionCollapsed,
   NativeSubAgentsDisclosure,
@@ -429,37 +433,47 @@ function getDirectoryRowLinkedDirectoryMode(
  * the app keeps the node outside the interactive element and a structured
  * hover card (which AGENTS.md contemplates) would not be inert.
  */
+/**
+ * A directory header's live-turn or to-review count.
+ *
+ * `SignalCount`'s shape, which is the sidebar's Attention tab's shape: the
+ * mark first, then the digits. It used to be the other way round here, to
+ * keep the mark at a constant x down the right-aligned rail — the flip keeps
+ * that by giving the digits a fixed two-digit box instead (see
+ * `.directory-row__summary-meta .signal-count__value`), so the rail reads the
+ * same as the tab directly above it.
+ *
+ * Not `aria-hidden`, unlike the tab's readouts: the tab spells every count
+ * out in its control's `aria-label`, and here the digits ARE the
+ * announcement, with the tooltip text as the description.
+ */
 function DirectoryCount(props: {
   activeCount?: number;
   className: string;
   count: number;
   indicator: ReactElement;
   reviewCount?: number;
+  tone: SignalCountTone;
   tooltipText: string;
 }) {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
 
   return (
     <>
-      <span
+      <SignalCount
         className={props.className}
-        data-active-thread-count={props.activeCount}
-        data-review-thread-count={props.reviewCount}
+        count={props.count}
+        data={{
+          "data-active-thread-count": props.activeCount,
+          "data-review-thread-count": props.reviewCount,
+        }}
+        indicator={props.indicator}
+        tone={props.tone}
         onMouseEnter={(event) =>
           tooltip.show(event.currentTarget, props.tooltipText)
         }
         onMouseLeave={tooltip.hide}
-      >
-        {/* Count BEFORE the mark. The meta block is right-aligned, so
-            the mark (cookie / scanner) is the last thing before the row
-            edge and lands at one x on every directory; the count is
-            variable-width (1–3 digits) and grows LEFT into empty space.
-            Mark-first put the cookie left of the digits, so it zigzagged
-            row to row with the digit count — a ragged column of the one
-            glyph the eye scans the rail for. */}
-        <span>{props.count}</span>
-        {props.indicator}
-      </span>
+      />
       {tooltip.tooltipNode}
     </>
   );
@@ -1640,6 +1654,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   className="directory-row__active-count"
                   count={activeThreadCount}
                   indicator={<ThinkingScanner compact />}
+                  tone="active"
                   tooltipText={formatActiveThreadCount(activeThreadCount)}
                 />
               ) : null}
@@ -1651,6 +1666,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     <span aria-hidden="true" className="thread-row__status-cookie" />
                   }
                   reviewCount={reviewThreadCount}
+                  tone="idle"
                   tooltipText={formatReviewThreadCount(reviewThreadCount)}
                 />
               ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -410,14 +410,23 @@ function getDirectoryRowLinkedDirectoryMode(
 }
 
 /**
- * One activity count in a directory header: the number, then the indicator
- * (mark last, so the trailing count's mark sits at one x on every row — see
- * the inline comment; when both counts render, the leading scanner still
- * moves with the review digits). The words ("active", "to review") moved
- * into the tooltip — a
- * directory row is a dense line already carrying a chevron, a folder glyph,
- * an elided path, and a new-thread button, and two trailing phrases pushed
- * the label it belongs to down to a few characters.
+ * One activity count in a directory header.
+ *
+ * `SignalCount`'s shape, which is the Attention tab's shape directly above
+ * it: the mark, then the digits. The words ("active", "to review") live in
+ * the tooltip — a directory row is a dense line already carrying a chevron,
+ * a folder glyph, an elided path, and a new-thread button, and two trailing
+ * phrases pushed the label they belong to down to a few characters.
+ *
+ * This read count-then-mark until the rail and the tab were two renderings
+ * of one idea. That order existed to hold the mark at a constant x down the
+ * right-aligned rail; the flip keeps that with a fixed two-digit box on the
+ * digits instead (`.directory-row__summary-meta .signal-count__value`), so
+ * a 1-digit row and a 2-digit row still line their marks up.
+ *
+ * Not `aria-hidden`, unlike the tab's readouts: the tab spells every count
+ * out in its control's `aria-label`, and here the digits ARE the
+ * announcement, with the tooltip text as the description.
  *
  * The scanner and the orange cookie are the same marks the thread rows below
  * use for the same two states, so the header reads as a summary of the rows
@@ -432,20 +441,6 @@ function getDirectoryRowLinkedDirectoryMode(
  * `pointer-events: none` today, which masks it, but every other call site in
  * the app keeps the node outside the interactive element and a structured
  * hover card (which AGENTS.md contemplates) would not be inert.
- */
-/**
- * A directory header's live-turn or to-review count.
- *
- * `SignalCount`'s shape, which is the sidebar's Attention tab's shape: the
- * mark first, then the digits. It used to be the other way round here, to
- * keep the mark at a constant x down the right-aligned rail — the flip keeps
- * that by giving the digits a fixed two-digit box instead (see
- * `.directory-row__summary-meta .signal-count__value`), so the rail reads the
- * same as the tab directly above it.
- *
- * Not `aria-hidden`, unlike the tab's readouts: the tab spells every count
- * out in its control's `aria-label`, and here the digits ARE the
- * announcement, with the tooltip text as the description.
  */
 function DirectoryCount(props: {
   activeCount?: number;

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -28,7 +28,6 @@ import {
   resolveThreadParentKey,
 } from "@pwragent/shared";
 import {
-  isFederationViewerWindow,
   readRendererFederationLabel,
   readRendererFederationTarget,
 } from "../../lib/federation-window";
@@ -79,7 +78,7 @@ import {
   formatReviewThreadCount,
   isThreadActive,
   isThreadNeedingAttention,
-  isThreadRemoteWork,
+  isThreadRemoteWorkHere,
 } from "./ThreadRowStatus";
 import {
   AttentionReviewReadout,
@@ -610,10 +609,13 @@ export function Sidebar(props: SidebarProps) {
    * quit now?" is answerable from the tab alone — which it is not while one
    * number mixes work on two machines. A window fronting a peer never splits:
    * every row in it is that peer's work, so the viewer counts the peer's turns
-   * the way an unfederated instance counts its own. Same gate as the rows'
-   * own marks — see `isThreadRemoteWorkHere`.
+   * the way an unfederated instance counts its own.
+   *
+   * `isThreadRemoteWorkHere` IS that rule, and calling it here rather than
+   * re-spelling it is what makes "the tab counts it under elsewhere exactly
+   * when its row sweeps neutral" true by construction instead of by two
+   * expressions happening to agree.
    */
-  const splitTurnsByMachine = useMemo(() => !isFederationViewerWindow(), []);
   const attentionCounts = useMemo(() => {
     let activeLocal = 0;
     let activeRemote = 0;
@@ -621,14 +623,14 @@ export function Sidebar(props: SidebarProps) {
     for (const thread of attentionThreads) {
       if (!isThreadActive(thread, props.thinkingThreadKeys)) {
         review += 1;
-      } else if (splitTurnsByMachine && isThreadRemoteWork(thread)) {
+      } else if (isThreadRemoteWorkHere(thread)) {
         activeRemote += 1;
       } else {
         activeLocal += 1;
       }
     }
     return { activeLocal, activeRemote, review };
-  }, [attentionThreads, props.thinkingThreadKeys, splitTurnsByMachine]);
+  }, [attentionThreads, props.thinkingThreadKeys]);
   const remoteSignalVisible = useLingeringRemoteActiveSignal(
     attentionCounts.activeRemote,
   );

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -75,15 +75,18 @@ import { DirectoriesList } from "./DirectoriesList";
 import { RecentsList } from "./RecentsList";
 import { useHoverStableSnapshot } from "./useHoverStableSnapshot";
 import {
-  formatActiveThreadCount,
-  formatLocalActiveThreadCount,
-  formatRemoteActiveThreadCount,
   formatReviewThreadCount,
   isThreadActive,
   isThreadNeedingAttention,
   isThreadRemoteWork,
+  windowSplitsTurnsByMachine,
 } from "./ThreadRowStatus";
-import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
+import {
+  AttentionReviewReadout,
+  AttentionTurnReadouts,
+  describeAttentionCounts,
+  useAttentionHoverCard,
+} from "./AttentionSignals";
 
 type ThreadContextMenuPosition = {
   x: number;
@@ -621,10 +624,7 @@ export function Sidebar(props: SidebarProps) {
    * construction rather than by state. Only the window knows it has no stake
    * in any of it.
    */
-  const splitTurnsByMachine = useMemo(
-    () => readRendererFederationTarget() === undefined,
-    [],
-  );
+  const splitTurnsByMachine = useMemo(() => windowSplitsTurnsByMachine(), []);
   const attentionCounts = useMemo(() => {
     let activeLocal = 0;
     let activeRemote = 0;
@@ -2998,6 +2998,9 @@ function useLingeringRemoteActiveSignal(count: number): boolean {
  * makes an idle tab indistinguishable from a tab that lost its data. Grey is
  * also the honest colour — the accent is a signal here, so only a nonzero
  * count earns it.
+ *
+ * The readouts and the hover card are `AttentionSignals.tsx`'s, shared with
+ * the Star Map's Attention chip so the two windows draw one vocabulary.
  */
 function AttentionLensTab(props: {
   active: boolean;
@@ -3011,96 +3014,22 @@ function AttentionLensTab(props: {
   reviewThreadCount: number;
   onSelect: () => void;
 }) {
-  // A card, not a text tooltip. Every other lens tab explains itself in one
-  // line; this one reports two or three counts, each with its own indicator
-  // and — once a peer is running work — a consequence. Run through
-  // `.viewport-tooltip` that became four stacked sentences with em-dashes
-  // doing the structural work. See "Structured hover cards" in AGENTS.md.
-  const tooltip = useViewportTooltip({ className: "attention-card" });
-  const remoteActiveThreadCount = props.remoteActiveThreadCount;
-  // Creating this element is not rendering it: it stays an inert object until
-  // `show` hands it to the portal on hover or focus.
-  const card = (
-    <>
-      <div className="attention-card__eyebrow">{browseModeLabels.attention}</div>
-      <div className="attention-card__caption">
-        Threads in progress or waiting to be reviewed
-      </div>
-      <div className="attention-card__section">
-        <AttentionCardRow
-          count={props.activeThreadCount}
-          indicator="turn"
-          // Only qualify the row once there is something to tell it apart
-          // from. "In progress" is the whole truth on an unfederated
-          // instance, and naming the machine would raise a question the
-          // operator does not have.
-          label={
-            remoteActiveThreadCount === undefined
-              ? "In progress"
-              : "In progress here"
-          }
-          note={
-            remoteActiveThreadCount === undefined
-              ? undefined
-              : "Quitting interrupts these"
-          }
-        />
-        {remoteActiveThreadCount === undefined ? null : (
-          <AttentionCardRow
-            count={remoteActiveThreadCount}
-            indicator="remote-turn"
-            label="In progress elsewhere"
-            note="Quitting leaves these running"
-          />
-        )}
-        <AttentionCardRow
-          count={props.reviewThreadCount}
-          indicator="review"
-          label="To review"
-        />
-      </div>
-    </>
-  );
-  const accessibleName = [
-    browseModeLabels.attention,
-    ...(remoteActiveThreadCount === undefined
-      ? [formatActiveThreadCount(props.activeThreadCount)]
-      : [
-        formatLocalActiveThreadCount(props.activeThreadCount),
-        formatRemoteActiveThreadCount(remoteActiveThreadCount),
-      ]),
-    formatReviewThreadCount(props.reviewThreadCount),
-  ].join(", ");
-
-  // Turns start and end while the pointer rests on the tab, so push fresh
-  // numbers into an already-open card rather than freezing it at hover-time
-  // values — the same thing `PrChip` does for a live PR status. Freezing is
-  // not cosmetic here: the card would keep claiming there is no peer work
-  // after a peer starts a turn, on the one surface that exists to answer
-  // "can I quit now?".
-  //
-  // The key guard is not optional: a React element is a new object on every
-  // render, so feeding one straight into `update` would set state on every
-  // render that very update caused. Compare the card's DATA and push only
-  // when it moved.
-  const latestCardRef = useRef(card);
-  latestCardRef.current = card;
-  const cardKey = [
-    props.activeThreadCount,
-    remoteActiveThreadCount ?? "off",
-    props.reviewThreadCount,
-  ].join("|");
-  const pushedCardKeyRef = useRef<string | undefined>(undefined);
-  const tooltipVisible = tooltip.visible;
-  const updateTooltip = tooltip.update;
-  useEffect(() => {
-    const moved = pushedCardKeyRef.current !== cardKey;
-    pushedCardKeyRef.current = cardKey;
-    if (!moved || !tooltipVisible) {
-      return;
-    }
-    updateTooltip(latestCardRef.current);
-  }, [cardKey, tooltipVisible, updateTooltip]);
+  const counts = {
+    activeLocal: props.activeThreadCount,
+    activeRemote: props.remoteActiveThreadCount,
+    review: props.reviewThreadCount,
+  };
+  const { card, tooltip } = useAttentionHoverCard({
+    ...counts,
+    title: browseModeLabels.attention,
+    caption: "Threads in progress or waiting to be reviewed",
+    reviewLabel: "To review",
+    formatReviewCount: formatReviewThreadCount,
+  });
+  const accessibleName = `${browseModeLabels.attention}, ${describeAttentionCounts(
+    counts,
+    formatReviewThreadCount,
+  )}`;
 
   return (
     <>
@@ -3126,113 +3055,14 @@ function AttentionLensTab(props: {
         onMouseEnter={(event) => tooltip.show(event.currentTarget, card)}
         onMouseLeave={tooltip.hide}
       >
-        {/* One column so the second readout stacks under the first instead of
-            widening the tab. The Attention tab already floors the switch's
-            narrowest track (see `.lens-switch`), and a third readout laid out
-            across would take that room from the four icon tabs. */}
-        <span aria-hidden="true" className="lens-switch__turns">
-          <span
-            className="lens-switch__signal lens-switch__signal--active"
-            data-attention-active-count={props.activeThreadCount}
-            data-zero={props.activeThreadCount === 0 ? "true" : undefined}
-          >
-            <AttentionTurnScanner count={props.activeThreadCount} />
-            <span>{props.activeThreadCount}</span>
-          </span>
-          {remoteActiveThreadCount === undefined ? null : (
-            <span
-              className="lens-switch__signal lens-switch__signal--remote-active"
-              data-attention-remote-active-count={remoteActiveThreadCount}
-              data-zero={remoteActiveThreadCount === 0 ? "true" : undefined}
-            >
-              <AttentionTurnScanner count={remoteActiveThreadCount} />
-              <span>{remoteActiveThreadCount}</span>
-            </span>
-          )}
-        </span>
-        <span
-          aria-hidden="true"
-          className="lens-switch__signal lens-switch__signal--review"
-          data-attention-review-count={props.reviewThreadCount}
-          data-zero={props.reviewThreadCount === 0 ? "true" : undefined}
-        >
-          <span className="thread-row__status-cookie" />
-          <span>{props.reviewThreadCount}</span>
-        </span>
+        <AttentionTurnReadouts
+          activeLocal={props.activeThreadCount}
+          activeRemote={props.remoteActiveThreadCount}
+        />
+        <AttentionReviewReadout count={props.reviewThreadCount} />
       </button>
       {tooltip.tooltipNode}
     </>
-  );
-}
-
-/**
- * The sweeping bar next to one of the Attention tab's turn counts, or its idle
- * stand-in.
- *
- * At zero this is a static element, NOT a greyed-out `ThinkingScanner`.
- * Killing the sweep with CSS on a mounted scanner is a desync trap: `data-zero`
- * lives on the parent span, so React would keep the same scanner element across
- * the flip, its ref would never re-run, and the restarted animation would never
- * be re-pinned to the shared epoch — leaving this tab drifting against every
- * other scanner on screen. Swapping the element type guarantees a mount, so
- * `syncThinkingScannerAnimation` runs and the beam comes back in phase. See
- * ThinkingScanner.tsx and PR #1187.
- *
- * The remote readout's beam is neutral rather than accent, but it is the same
- * untouched component tinted by its parent's tokens — a peer's turn is running
- * for real, so it sweeps for real, on the same epoch as the rest.
- */
-function AttentionTurnScanner(props: { count: number }) {
-  return props.count === 0 ? (
-    <span className="lens-switch__dormant-scanner" />
-  ) : (
-    <ThinkingScanner compact />
-  );
-}
-
-/**
- * One line of the Attention hover card: the tab's own indicator, what it
- * counts, and the count. Repeating the indicator is what ties a row to the
- * readout the operator just hovered — a card of bare labels would make them
- * re-derive which number is which.
- */
-function AttentionCardRow(props: {
-  count: number;
-  indicator: "turn" | "remote-turn" | "review";
-  label: string;
-  /** What quitting does to this row's work. Omitted when nothing is at stake. */
-  note?: string;
-}) {
-  return (
-    <div
-      className="attention-card__row"
-      data-zero={props.count === 0 ? "true" : undefined}
-    >
-      <span
-        aria-hidden="true"
-        className={`lens-switch__signal lens-switch__signal--${
-          props.indicator === "review"
-            ? "review"
-            : props.indicator === "remote-turn"
-              ? "remote-active"
-              : "active"
-        }`}
-        data-zero={props.count === 0 ? "true" : undefined}
-      >
-        {props.indicator === "review" ? (
-          <span className="thread-row__status-cookie" />
-        ) : (
-          <AttentionTurnScanner count={props.count} />
-        )}
-      </span>
-      <span className="attention-card__row-text">
-        <span className="attention-card__row-label">{props.label}</span>
-        {props.note ? (
-          <span className="attention-card__row-note">{props.note}</span>
-        ) : null}
-      </span>
-      <span className="attention-card__row-value">{props.count}</span>
-    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   resolveThreadParentKey,
 } from "@pwragent/shared";
 import {
+  isFederationViewerWindow,
   readRendererFederationLabel,
   readRendererFederationTarget,
 } from "../../lib/federation-window";
@@ -79,7 +80,6 @@ import {
   isThreadActive,
   isThreadNeedingAttention,
   isThreadRemoteWork,
-  windowSplitsTurnsByMachine,
 } from "./ThreadRowStatus";
 import {
   AttentionReviewReadout,
@@ -608,23 +608,12 @@ export function Sidebar(props: SidebarProps) {
    * Live turns split again by where they run, but only in a window that can
    * see both kinds. Only this instance's turns hold shutdown open, so "can I
    * quit now?" is answerable from the tab alone — which it is not while one
-   * number mixes work on two machines.
-   *
-   * A window fronting a peer is exactly the window where that question has no
-   * content. Every row in it is that peer's work, and closing the viewer
-   * interrupts none of it — telling the operator what quitting would do to
-   * work they cannot interrupt is worse than saying nothing. So a viewer keeps
-   * the plain single readout, counting the peer's turns the way an unfederated
-   * instance counts its own.
-   *
-   * The gate has to be here rather than inside the predicate. A viewer reads
-   * its whole snapshot through the peer, and the main process stamps every row
-   * it returns as remote (`stampRemoteNavigationSnapshot`), so left to itself
-   * the split would report "0 here, everything elsewhere" — permanently, by
-   * construction rather than by state. Only the window knows it has no stake
-   * in any of it.
+   * number mixes work on two machines. A window fronting a peer never splits:
+   * every row in it is that peer's work, so the viewer counts the peer's turns
+   * the way an unfederated instance counts its own. Same gate as the rows'
+   * own marks — see `isThreadRemoteWorkHere`.
    */
-  const splitTurnsByMachine = useMemo(() => windowSplitsTurnsByMachine(), []);
+  const splitTurnsByMachine = useMemo(() => !isFederationViewerWindow(), []);
   const attentionCounts = useMemo(() => {
     let activeLocal = 0;
     let activeRemote = 0;
@@ -2960,22 +2949,25 @@ const REMOTE_ACTIVE_SIGNAL_LINGER_MS = 30_000;
  * running, or one that ended inside the linger window.
  */
 function useLingeringRemoteActiveSignal(count: number): boolean {
-  const [visible, setVisible] = useState(count > 0);
+  const [lingering, setLingering] = useState(count > 0);
   useEffect(() => {
     if (count > 0) {
-      setVisible(true);
+      setLingering(true);
       return;
     }
-    if (!visible) {
+    if (!lingering) {
       return;
     }
     const timer = setTimeout(
-      () => setVisible(false),
+      () => setLingering(false),
       REMOTE_ACTIVE_SIGNAL_LINGER_MS,
     );
     return () => clearTimeout(timer);
-  }, [count, visible]);
-  return visible;
+  }, [count, lingering]);
+  // A live count shows synchronously rather than one effect tick later: the
+  // thread rows colour a peer's turn in the same render it appears, and the
+  // tab must not lag them by a frame. State only carries the linger-out.
+  return count > 0 || lingering;
 }
 
 /**
@@ -3024,7 +3016,6 @@ function AttentionLensTab(props: {
     title: browseModeLabels.attention,
     caption: "Threads in progress or waiting to be reviewed",
     reviewLabel: "To review",
-    formatReviewCount: formatReviewThreadCount,
   });
   const accessibleName = `${browseModeLabels.attention}, ${describeAttentionCounts(
     counts,

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -26,7 +26,12 @@ import { PrChip } from "../pr-status/PrChip";
 import type { DropIndicatorPosition } from "./drag-drop";
 import { ReactionPicker } from "./ReactionPicker";
 import { ThreadMetaChips } from "./ThreadMetaChips";
-import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
+import {
+  getThreadRowStatus,
+  isThreadRemoteWork,
+  ThreadRowStatus,
+  windowSplitsTurnsByMachine,
+} from "./ThreadRowStatus";
 import { setThreadRowNativeDragPreview } from "./thread-row-drag-preview";
 
 const HOVER_PREFETCH_DELAY_MS = 750;
@@ -151,6 +156,14 @@ export function ThreadRow(props: ThreadRowProps) {
     && props.thread.federation.peerStatus !== "connected",
   );
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
+  // A peer's live turn sweeps in neutral rather than accent, on the same gate
+  // the Attention tab splits its counts on: in the main window the row's beam
+  // is grey exactly when the tab counts it under "elsewhere", and in a viewer
+  // fronting a peer neither of them makes the distinction.
+  const remoteWork =
+    status === "thinking"
+    && isThreadRemoteWork(props.thread)
+    && windowSplitsTurnsByMachine();
   // One expression for "this row carries the in-title pin": the row's
   // `--pinned` modifier class, the ", pinned" accessible-name suffix,
   // and the in-title pin render all derive from it, so the CSS class
@@ -387,7 +400,7 @@ export function ThreadRow(props: ThreadRowProps) {
             "Thinking"/"Unread update" tooltip) is not a dead zone. */}
         <span className="thread-row__header">
           <span className="thread-row__heading">
-            <ThreadRowStatus status={status} />
+            <ThreadRowStatus remoteWork={remoteWork} status={status} />
             <span className="thread-row__title">{props.thread.title}</span>
             {isPinnedRow ? (
               onSetThreadPin ? (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -28,9 +28,8 @@ import { ReactionPicker } from "./ReactionPicker";
 import { ThreadMetaChips } from "./ThreadMetaChips";
 import {
   getThreadRowStatus,
-  isThreadRemoteWork,
+  isThreadRemoteWorkHere,
   ThreadRowStatus,
-  windowSplitsTurnsByMachine,
 } from "./ThreadRowStatus";
 import { setThreadRowNativeDragPreview } from "./thread-row-drag-preview";
 
@@ -156,14 +155,6 @@ export function ThreadRow(props: ThreadRowProps) {
     && props.thread.federation.peerStatus !== "connected",
   );
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
-  // A peer's live turn sweeps in neutral rather than accent, on the same gate
-  // the Attention tab splits its counts on: in the main window the row's beam
-  // is grey exactly when the tab counts it under "elsewhere", and in a viewer
-  // fronting a peer neither of them makes the distinction.
-  const remoteWork =
-    status === "thinking"
-    && isThreadRemoteWork(props.thread)
-    && windowSplitsTurnsByMachine();
   // One expression for "this row carries the in-title pin": the row's
   // `--pinned` modifier class, the ", pinned" accessible-name suffix,
   // and the in-title pin render all derive from it, so the CSS class
@@ -400,7 +391,10 @@ export function ThreadRow(props: ThreadRowProps) {
             "Thinking"/"Unread update" tooltip) is not a dead zone. */}
         <span className="thread-row__header">
           <span className="thread-row__heading">
-            <ThreadRowStatus remoteWork={remoteWork} status={status} />
+            <ThreadRowStatus
+              remoteWork={isThreadRemoteWorkHere(props.thread)}
+              status={status}
+            />
             <span className="thread-row__title">{props.thread.title}</span>
             {isPinnedRow ? (
               onSetThreadPin ? (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -47,8 +47,14 @@ export function isThreadRemoteWork(thread: NavigationThreadSummary): boolean {
 }
 
 /**
- * Whether a thread's turn is a peer's work AS SEEN FROM THIS WINDOW — the
- * predicate every surface that colours a turn reads, so they cannot disagree.
+ * Whether a thread's turn is a peer's work AS SEEN FROM THIS WINDOW.
+ *
+ * Read by every surface that colours ONE thread's turn — the sidebar row and
+ * the Star Map card's marks, the transcript's pending line, and the Attention
+ * tab's split counts — so those cannot disagree. The aggregate directory
+ * header count (`DirectoriesList`) is deliberately NOT on it yet: it draws
+ * one scanner for N threads, so "some of these are a peer's" has no single
+ * colour, and splitting that readout is a design change rather than a gate.
  *
  * The main window can hold both kinds, and only its own turns hold shutdown
  * open, so it colours them apart: accent here, neutral elsewhere. A window

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -1,5 +1,6 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
 export type ThreadRowStatusKind = "thinking" | "unread";
@@ -43,6 +44,28 @@ export function formatActiveThreadCount(count: number): string {
  */
 export function isThreadRemoteWork(thread: NavigationThreadSummary): boolean {
   return thread.federation?.ref.target.scope === "remote";
+}
+
+/**
+ * Whether this window tells a peer's turns apart from its own at all.
+ *
+ * The main window can hold both kinds, and only its own turns hold shutdown
+ * open, so it colours them apart: accent here, neutral elsewhere. A window
+ * fronting a peer is exactly the window where that question has no content —
+ * every row in it is that peer's work (the main process stamps the whole
+ * snapshot remote, see `isThreadRemoteWork`), and closing the viewer
+ * interrupts none of it. Telling the operator what quitting would do to work
+ * they cannot interrupt is worse than saying nothing, so a viewer keeps the
+ * plain accent everywhere and counts the peer's turns the way an unfederated
+ * instance counts its own.
+ *
+ * One gate for every surface that colours a turn: the Attention tab's split
+ * counts, the thread rows' scanners, and the transcript's pending line. They
+ * agree by construction — a row's beam is neutral exactly when the tab counts
+ * it under "elsewhere".
+ */
+export function windowSplitsTurnsByMachine(): boolean {
+  return readRendererFederationTarget() === undefined;
 }
 
 export function formatLocalActiveThreadCount(count: number): string {
@@ -99,6 +122,15 @@ export function getThreadRowStatus(
 
 type ThreadRowStatusProps = {
   status?: ThreadRowStatusKind;
+  /**
+   * The live turn belongs to another instance. Same beam, neutral tokens:
+   * the accent means "this holds the app open", and a peer's turn does not.
+   * The caller decides — the sidebar row gates it on
+   * `windowSplitsTurnsByMachine()` to match its Attention tab, the Star Map
+   * card on the bare `isThreadRemoteWork` to match its Attention chip — so
+   * the mark always agrees with the readout that counts it.
+   */
+  remoteWork?: boolean;
 };
 
 export function ThreadRowStatus(props: ThreadRowStatusProps) {
@@ -113,13 +145,19 @@ export function ThreadRowStatus(props: ThreadRowStatusProps) {
   // since the transcript-gaps pass — the img role makes the label valid
   // on both surfaces and says what the mark is: a meaningful graphic.
   if (props.status === "thinking") {
+    // "on another instance" echoes `formatRemoteActiveThreadCount`, the
+    // phrase the Attention tab already reads out for the same turns.
+    const label = props.remoteWork ? "Thinking on another instance" : "Thinking";
     return (
       <span
-        aria-label="Thinking"
-        className="thread-row__status-indicator thread-row__status-indicator--thinking"
+        aria-label={label}
+        className={`thread-row__status-indicator thread-row__status-indicator--thinking${
+          props.remoteWork ? " thread-row__status-indicator--remote" : ""
+        }`}
+        data-remote-work={props.remoteWork ? "true" : undefined}
         data-thread-status="thinking"
         role="img"
-        title="Thinking"
+        title={label}
       >
         <ThinkingScanner compact />
       </span>

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -1,6 +1,6 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
-import { readRendererFederationTarget } from "../../lib/federation-window";
+import { isFederationViewerWindow } from "../../lib/federation-window";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
 export type ThreadRowStatusKind = "thinking" | "unread";
@@ -47,25 +47,22 @@ export function isThreadRemoteWork(thread: NavigationThreadSummary): boolean {
 }
 
 /**
- * Whether this window tells a peer's turns apart from its own at all.
+ * Whether a thread's turn is a peer's work AS SEEN FROM THIS WINDOW — the
+ * predicate every surface that colours a turn reads, so they cannot disagree.
  *
  * The main window can hold both kinds, and only its own turns hold shutdown
  * open, so it colours them apart: accent here, neutral elsewhere. A window
  * fronting a peer is exactly the window where that question has no content —
- * every row in it is that peer's work (the main process stamps the whole
- * snapshot remote, see `isThreadRemoteWork`), and closing the viewer
- * interrupts none of it. Telling the operator what quitting would do to work
- * they cannot interrupt is worse than saying nothing, so a viewer keeps the
- * plain accent everywhere and counts the peer's turns the way an unfederated
- * instance counts its own.
- *
- * One gate for every surface that colours a turn: the Attention tab's split
- * counts, the thread rows' scanners, and the transcript's pending line. They
- * agree by construction — a row's beam is neutral exactly when the tab counts
- * it under "elsewhere".
+ * every row in it is that peer's work, and closing the viewer interrupts none
+ * of it. Telling the operator what quitting would do to work they cannot
+ * interrupt is worse than saying nothing, so a viewer keeps the plain accent
+ * everywhere and counts the peer's turns the way an unfederated instance
+ * counts its own (`isFederationViewerWindow`). The Attention tab's counts
+ * split on the same gate, so a row's beam is neutral exactly when the tab
+ * counts it under "elsewhere".
  */
-export function windowSplitsTurnsByMachine(): boolean {
-  return readRendererFederationTarget() === undefined;
+export function isThreadRemoteWorkHere(thread: NavigationThreadSummary): boolean {
+  return isThreadRemoteWork(thread) && !isFederationViewerWindow();
 }
 
 export function formatLocalActiveThreadCount(count: number): string {
@@ -123,12 +120,9 @@ export function getThreadRowStatus(
 type ThreadRowStatusProps = {
   status?: ThreadRowStatusKind;
   /**
-   * The live turn belongs to another instance. Same beam, neutral tokens:
-   * the accent means "this holds the app open", and a peer's turn does not.
-   * The caller decides — the sidebar row gates it on
-   * `windowSplitsTurnsByMachine()` to match its Attention tab, the Star Map
-   * card on the bare `isThreadRemoteWork` to match its Attention chip — so
-   * the mark always agrees with the readout that counts it.
+   * The live turn belongs to another instance (`isThreadRemoteWorkHere`).
+   * Same beam, neutral tokens: the accent means "this holds the app open",
+   * and a peer's turn does not. Read only for the thinking mark.
    */
   remoteWork?: boolean;
 };

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2762,6 +2762,72 @@ describe("Sidebar", () => {
         expect(tab.querySelectorAll(".thinking-scanner")).toHaveLength(2);
       });
 
+      it("sweeps a peer's row in neutral, and says so, where the tab splits", () => {
+        // The row's mark is the tab's "elsewhere" readout, one thread at a
+        // time: same live sweep, neutral by token, so the list answers
+        // "which of these does quitting interrupt?" without the tab.
+        render(
+          <Sidebar {...remoteSidebarProps([activeThread, remoteActiveThread])} />,
+        );
+        const browseSection = screen.getByRole("region", { name: "Thread browser" });
+        const remoteButton = within(browseSection as HTMLElement).getByRole(
+          "button",
+          { name: "Remote active thread" },
+        );
+        const remoteMark = threadCard(remoteButton).querySelector(
+          '[data-thread-status="thinking"]',
+        );
+        expect(remoteMark).toHaveAttribute("data-remote-work", "true");
+        expect(remoteMark).toHaveClass("thread-row__status-indicator--remote");
+        expect(remoteMark).toHaveAttribute("title", "Thinking on another instance");
+        expect(remoteMark).toHaveAttribute(
+          "aria-label",
+          "Thinking on another instance",
+        );
+        // Not switched off: a peer's turn is running for real.
+        expect(remoteMark?.querySelector(".thinking-scanner")).not.toBeNull();
+
+        const localButton = within(browseSection as HTMLElement).getByRole(
+          "button",
+          { name: "Active thread" },
+        );
+        const localMark = threadCard(localButton).querySelector(
+          '[data-thread-status="thinking"]',
+        );
+        expect(localMark).not.toHaveAttribute("data-remote-work");
+        expect(localMark).toHaveAttribute("title", "Thinking");
+      });
+
+      it("keeps a peer's rows in accent in a window fronting that peer", () => {
+        // Same gate as the tab: a viewer has no stake in any of it, so its
+        // rows do not claim a distinction its tab does not make.
+        const windowWithTarget = window as typeof window & {
+          __pwragentFederationTarget?: unknown;
+        };
+        windowWithTarget.__pwragentFederationTarget = {
+          instanceId: "peer-1",
+          scope: "remote",
+        };
+        try {
+          render(<Sidebar {...remoteSidebarProps([remoteActiveThread])} />);
+          const browseSection = screen.getByRole("region", {
+            name: "Thread browser",
+          });
+          const remoteButton = within(browseSection as HTMLElement).getByRole(
+            "button",
+            { name: /Remote active thread/i },
+          );
+          const mark = threadCard(remoteButton).querySelector(
+            '[data-thread-status="thinking"]',
+          );
+          expect(mark).not.toBeNull();
+          expect(mark).not.toHaveAttribute("data-remote-work");
+          expect(mark).toHaveAttribute("title", "Thinking");
+        } finally {
+          delete windowWithTarget.__pwragentFederationTarget;
+        }
+      });
+
       it("holds a zeroed peer readout for the linger window, then drops it", () => {
         vi.useFakeTimers();
         try {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2294,6 +2294,17 @@ describe("Sidebar", () => {
     const reviewCount = summary!.querySelector("[data-review-thread-count]");
     expect(reviewCount).toHaveAttribute("data-review-thread-count", "1");
     expect(reviewCount).toHaveTextContent(/^1$/);
+    // The Attention tab's shape, not a second one: `.signal-count` with the
+    // mark BEFORE the digits. These counts read count-then-mark until the
+    // rail and the tab above it were three different renderings of one idea
+    // — see `SignalCount.tsx`.
+    for (const count of [activeCount!, reviewCount!]) {
+      expect(count).toHaveClass("signal-count");
+      expect(count.lastElementChild).toHaveClass("signal-count__value");
+      expect(count.firstElementChild).not.toHaveClass("signal-count__value");
+    }
+    expect(activeCount).toHaveClass("signal-count--active");
+    expect(reviewCount).toHaveClass("signal-count--idle");
 
     fireEvent.mouseEnter(activeCount!);
     expect((await screen.findByRole("tooltip")).textContent).toBe(
@@ -2628,7 +2639,7 @@ describe("Sidebar", () => {
 
         const zeroTab = screen.getByRole("tab", { name: /^Attention,/ });
         expect(
-          zeroTab.querySelector(".lens-switch__dormant-scanner"),
+          zeroTab.querySelector(".signal-count__dormant-scanner"),
         ).not.toBeNull();
         expect(zeroTab.querySelector(".thinking-scanner")).toBeNull();
         expect(getAnimations).not.toHaveBeenCalled();
@@ -2639,7 +2650,7 @@ describe("Sidebar", () => {
         const liveTab = screen.getByRole("tab", { name: /^Attention,/ });
         expect(liveTab.querySelector(".thinking-scanner")).not.toBeNull();
         expect(
-          liveTab.querySelector(".lens-switch__dormant-scanner"),
+          liveTab.querySelector(".signal-count__dormant-scanner"),
         ).toBeNull();
         expect(getAnimations).toHaveBeenCalled();
         expect(animations[0]!.startTime).toBe(0);

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -43,6 +43,7 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import { parseReviewCommand } from "../../../../shared/review-command";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { agentEventMatchesThread } from "../../lib/federated-thread-events";
+import { isThreadRemoteWork } from "../navigation/ThreadRowStatus";
 import { useThreadSessionState } from "../../lib/useThreadSessionState";
 import { useThreadSkills } from "../../lib/useThreadSkills";
 import {
@@ -1464,6 +1465,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             pendingMcpInteraction={session.pendingMcpInteraction}
             pendingRequest={session.pendingRequest}
             pendingStatusText={session.pendingStatusText}
+            // Ungated, like the map's thread cards: the map's Attention chip
+            // splits on the bare predicate, so the chat card's pending line
+            // agrees with the chip rather than with the main window's tab.
+            pendingRemoteWork={isThreadRemoteWork(thread)}
             pendingUserInput={session.pendingUserInput}
             runningTurnUsageText={session.runningTurnUsageText}
             threadId={thread.id}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -43,7 +43,7 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import { parseReviewCommand } from "../../../../shared/review-command";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { agentEventMatchesThread } from "../../lib/federated-thread-events";
-import { isThreadRemoteWork } from "../navigation/ThreadRowStatus";
+import { isThreadRemoteWorkHere } from "../navigation/ThreadRowStatus";
 import { useThreadSessionState } from "../../lib/useThreadSessionState";
 import { useThreadSkills } from "../../lib/useThreadSkills";
 import {
@@ -1465,10 +1465,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             pendingMcpInteraction={session.pendingMcpInteraction}
             pendingRequest={session.pendingRequest}
             pendingStatusText={session.pendingStatusText}
-            // Ungated, like the map's thread cards: the map's Attention chip
-            // splits on the bare predicate, so the chat card's pending line
-            // agrees with the chip rather than with the main window's tab.
-            pendingRemoteWork={isThreadRemoteWork(thread)}
+            pendingRemoteWork={isThreadRemoteWorkHere(thread)}
             pendingUserInput={session.pendingUserInput}
             runningTurnUsageText={session.runningTurnUsageText}
             threadId={thread.id}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
@@ -103,11 +103,10 @@ function StarMapAttentionFilterChip(
     title: props.definition.label,
     caption: "Threads in progress or unread",
     reviewLabel: "Unread",
-    formatReviewCount: formatUnreadThreadCount,
     footer: `Click to ${chrome.next}`,
-    // Inside `.star-map-window`, which opens its own stacking context: the
-    // portal needs the explicit layer the map's other tooltips carry.
-    className: "attention-card attention-card--star-map",
+    // Inside `.star-map-window`: the same explicit layer the map's other
+    // body-portaled tooltips carry (see `.star-map-card__tooltip`).
+    className: "attention-card star-map-card__tooltip",
   });
 
   return (

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterChip.tsx
@@ -1,36 +1,28 @@
 import {
-  formatActiveThreadCount,
-  formatLocalActiveThreadCount,
-  formatRemoteActiveThreadCount,
-} from "../navigation/ThreadRowStatus";
-import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
+  AttentionReviewReadout,
+  AttentionTurnReadouts,
+  describeAttentionCounts,
+  useAttentionHoverCard,
+} from "../navigation/AttentionSignals";
 import {
   filterState,
   type StarMapAttentionCounts,
   type StarMapFilterDefinition,
   type StarMapFilterSelection,
+  type StarMapFilterState,
 } from "./star-map-filters";
 
-/**
- * One tri-state filter chip.
- *
- * Extracted because the chips now render on two surfaces — the inline
- * strip in the top band, and the "Filters" popover the band collapses
- * into when the window is too narrow for the strip. Both must offer the
- * same control with the same label, and an aria-label this fiddly is not
- * something to keep in sync by hand.
- */
-export function StarMapFilterChip(props: {
+type StarMapFilterChipProps = {
   definition: StarMapFilterDefinition;
   selection: StarMapFilterSelection;
   count: number;
   /**
-   * Present only on the Attention chip, which draws two indicators
-   * instead of one number — a scanner for turns in progress and the
-   * orange cookie for unread, exactly as the sidebar's Attention tab
-   * does. Both are always drawn, greyed at zero rather than hidden: a
-   * missing indicator makes an idle chip look broken, which is the same
-   * rule the tab follows.
+   * Present only on the Attention chip, which draws the sidebar's
+   * Attention readouts instead of a label and a number — the stacked
+   * turn scanners and the orange cookie, each with its count, exactly as
+   * the sidebar's Attention tab does. All are always drawn, greyed at zero
+   * rather than hidden: a missing indicator makes an idle chip look
+   * broken, which is the same rule the tab follows.
    */
   attention?: StarMapAttentionCounts;
   /** Whether this map fronts any peer at all; see the indicators below. */
@@ -44,7 +36,132 @@ export function StarMapFilterChip(props: {
    * CSS takes it out of flow and out of the accessibility tree.
    */
   dropped?: boolean;
-}) {
+};
+
+/**
+ * One tri-state filter chip.
+ *
+ * Extracted because the chips now render on two surfaces — the inline
+ * strip in the top band, and the "Filters" popover the band collapses
+ * into when the window is too narrow for the strip. Both must offer the
+ * same control with the same label, and an aria-label this fiddly is not
+ * something to keep in sync by hand.
+ */
+export function StarMapFilterChip(props: StarMapFilterChipProps) {
+  if (props.attention) {
+    return (
+      <StarMapAttentionFilterChip {...props} attention={props.attention} />
+    );
+  }
+  const chrome = chipChrome(props);
+  return (
+    <button
+      type="button"
+      className={chrome.className}
+      tabIndex={chrome.tabIndex}
+      aria-hidden={chrome.ariaHidden}
+      aria-label={chrome.ariaLabel}
+      onClick={props.onCycle}
+    >
+      <ExcludeMark state={chrome.state} />
+      <span>{props.definition.label}</span>
+      <span className="star-map__filter-count">{props.count}</span>
+    </button>
+  );
+}
+
+/**
+ * The Attention chip: the sidebar's Attention tab, on the map.
+ *
+ * No visible word. Like the lens tab, the chip IS its readouts — the
+ * stacked turn scanners and the cookie say "in progress" and "unread"
+ * better than a label beside them could, and the label was width the band
+ * needs for the chips beside it. The name lives in the `aria-label` and in
+ * the hover card's eyebrow, the same place the lens tabs keep theirs.
+ *
+ * The hover card is the tab's card, shared component and shared class, with
+ * the map's own caption and third-row label: the tab's third readout counts
+ * "to review" (anything in the inbox) and the chip's counts unread, and the
+ * card must say what its number actually is. A closing line says what a
+ * click does, because with the word gone the chip's fill is the only other
+ * hint that it filters.
+ */
+function StarMapAttentionFilterChip(
+  props: StarMapFilterChipProps & { attention: StarMapAttentionCounts },
+) {
+  const chrome = chipChrome(props);
+  // The remote readout is omitted entirely when the map fronts no peers,
+  // the way the Attention tab omits it: a permanent 0 on a single-machine
+  // setup is noise, and it would take width from the chips beside it.
+  const counts = {
+    activeLocal: props.attention.activeLocal,
+    activeRemote: props.showRemoteTurns ? props.attention.activeRemote : undefined,
+    review: props.attention.unread,
+  };
+  const { card, tooltip } = useAttentionHoverCard({
+    ...counts,
+    title: props.definition.label,
+    caption: "Threads in progress or unread",
+    reviewLabel: "Unread",
+    formatReviewCount: formatUnreadThreadCount,
+    footer: `Click to ${chrome.next}`,
+    // Inside `.star-map-window`, which opens its own stacking context: the
+    // portal needs the explicit layer the map's other tooltips carry.
+    className: "attention-card attention-card--star-map",
+  });
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`${chrome.className} star-map__filter-chip--attention`}
+        tabIndex={chrome.tabIndex}
+        aria-hidden={chrome.ariaHidden}
+        // The numbers are drawn as marks, so without this the chip
+        // announces its filter state and nothing about what it counts.
+        aria-label={`${chrome.ariaLabel}. ${describeAttentionCounts(
+          counts,
+          formatUnreadThreadCount,
+        )}`}
+        // The card's consequence lines exist nowhere else — without this
+        // they are sighted-only, since the portal sits outside this
+        // button's subtree. Gated on `visible`: naming an absent element is
+        // a dangling reference.
+        aria-describedby={tooltip.visible ? tooltip.tooltipId : undefined}
+        onBlur={tooltip.hide}
+        onClick={() => {
+          tooltip.hide();
+          props.onCycle();
+        }}
+        onFocus={(event) => tooltip.show(event.currentTarget, card)}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, card)}
+        onMouseLeave={tooltip.hide}
+      >
+        <ExcludeMark state={chrome.state} />
+        {/* The tab's own layout: turns stacked in one column, the cookie
+            beside it. One wrapper gives the pair the tab's inner gap
+            without restating it on the chip, whose gap is the strip's. */}
+        <span aria-hidden="true" className="star-map__filter-signals">
+          <AttentionTurnReadouts
+            activeLocal={counts.activeLocal}
+            activeRemote={counts.activeRemote}
+          />
+          <AttentionReviewReadout count={counts.review} />
+        </span>
+      </button>
+      {tooltip.tooltipNode}
+    </>
+  );
+}
+
+/**
+ * Everything the two chip variants share: the tri-state class, the
+ * out-of-flow attributes of a dropped chip, and the accessible name that
+ * carries the state and what the next click does. Tri-state, so
+ * `aria-pressed` cannot describe it: exclude is neither pressed nor
+ * unpressed.
+ */
+function chipChrome(props: StarMapFilterChipProps) {
   const state = filterState(props.selection, props.definition.key);
   const next =
     state === "neutral"
@@ -52,136 +169,35 @@ export function StarMapFilterChip(props: {
       : state === "include"
         ? "hide these instead"
         : "stop filtering on this";
-
-  return (
-    <button
-      type="button"
-      className={`star-map__filter-chip star-map__filter-chip--${state}${
-        props.dropped ? " is-dropped" : ""
-      }`}
-      // Out of flow is not out of reach: without this a dropped chip is
-      // still in the tab order, focusable, and invisible.
-      tabIndex={props.dropped ? -1 : undefined}
-      aria-hidden={props.dropped ? true : undefined}
-      // Tri-state, so `aria-pressed` cannot describe it: exclude is
-      // neither pressed nor unpressed. The label carries the state
-      // and what the next click does.
-      aria-label={`${props.definition.label}: ${
-        state === "neutral"
-          ? "not filtered"
-          : state === "include"
-            ? "showing only these"
-            : "hidden"
-      } — click to ${next}${
-        props.attention
-          ? `. ${describeAttentionCounts(
-              props.attention,
-              props.showRemoteTurns ?? false,
-            )}`
-          : ""
-      }`}
-      onClick={props.onCycle}
-    >
-      {state === "exclude" ? (
-        <span className="star-map__filter-mark" aria-hidden="true">
-          −
-        </span>
-      ) : null}
-      <span>{props.definition.label}</span>
-      {props.attention ? (
-        <StarMapAttentionIndicators
-          counts={props.attention}
-          showRemoteTurns={props.showRemoteTurns ?? false}
-        />
-      ) : (
-        <span className="star-map__filter-count">{props.count}</span>
-      )}
-    </button>
-  );
+  return {
+    state,
+    next,
+    className: `star-map__filter-chip star-map__filter-chip--${state}${
+      props.dropped ? " is-dropped" : ""
+    }`,
+    // Out of flow is not out of reach: without this a dropped chip is
+    // still in the tab order, focusable, and invisible.
+    tabIndex: props.dropped ? -1 : undefined,
+    ariaHidden: props.dropped ? true : undefined,
+    ariaLabel: `${props.definition.label}: ${
+      state === "neutral"
+        ? "not filtered"
+        : state === "include"
+          ? "showing only these"
+          : "hidden"
+    } — click to ${next}`,
+  };
 }
 
-/**
- * The Attention chip's readouts, in the sidebar's vocabulary.
- *
- * Three signals, not two: turns here, turns elsewhere, and unread. The
- * local/remote split is the sidebar's and it is load-bearing — the accent
- * means "this holds the app open", and a peer's turn does not, so they
- * cannot share a colour even though both are "working".
- *
- * The remote readout is omitted entirely when the map fronts no peers,
- * the way the Attention tab omits it: a permanent 0 on a single-machine
- * setup is noise, and it would take width from the chips beside it.
- */
-function StarMapAttentionIndicators(props: {
-  counts: StarMapAttentionCounts;
-  showRemoteTurns: boolean;
-}) {
-  return (
-    <span aria-hidden="true" className="star-map__filter-signals">
-      <span
-        className="star-map__filter-signal star-map__filter-signal--active"
-        data-zero={props.counts.activeLocal === 0 ? "true" : undefined}
-      >
-        <AttentionTurnScanner count={props.counts.activeLocal} />
-        <span>{props.counts.activeLocal}</span>
-      </span>
-      {props.showRemoteTurns ? (
-        <span
-          className="star-map__filter-signal star-map__filter-signal--remote-active"
-          data-zero={props.counts.activeRemote === 0 ? "true" : undefined}
-        >
-          <AttentionTurnScanner count={props.counts.activeRemote} />
-          <span>{props.counts.activeRemote}</span>
-        </span>
-      ) : null}
-      <span
-        className="star-map__filter-signal star-map__filter-signal--review"
-        data-zero={props.counts.unread === 0 ? "true" : undefined}
-      >
-        <span className="thread-row__status-cookie" />
-        <span>{props.counts.unread}</span>
-      </span>
+function ExcludeMark(props: { state: StarMapFilterState }) {
+  return props.state === "exclude" ? (
+    <span className="star-map__filter-mark" aria-hidden="true">
+      −
     </span>
-  );
+  ) : null;
 }
 
-/**
- * The sweeping bar next to a turn count, or its idle stand-in.
- *
- * At zero this is a static element, NOT a greyed-out `ThinkingScanner`.
- * `data-zero` lives on the parent, so React would keep the same scanner
- * element across the flip, its ref would never re-run, and the restarted
- * animation would never be re-pinned to the shared epoch — this chip would
- * drift against every other scanner on screen. Swapping the element type
- * guarantees a mount. Same reasoning, same stand-in element, as the
- * sidebar's `AttentionTurnScanner`; see ThinkingScanner.tsx and PR #1187.
- */
-function AttentionTurnScanner(props: { count: number }) {
-  return props.count === 0 ? (
-    <span className="lens-switch__dormant-scanner" />
-  ) : (
-    <ThinkingScanner compact />
-  );
-}
-
-/**
- * What the Attention chip's two indicators say out loud.
- *
- * The numbers are drawn as marks, so without this the chip announces its
- * filter state and nothing about what it is counting. Split phrasing only
- * when a peer actually has work — "0 on other instances" on every
- * single-machine setup is noise.
- */
-function describeAttentionCounts(
-  counts: StarMapAttentionCounts,
-  showRemoteTurns = false,
-): string {
-  const active =
-    showRemoteTurns
-      ? [
-          formatLocalActiveThreadCount(counts.activeLocal),
-          formatRemoteActiveThreadCount(counts.activeRemote),
-        ].join(", ")
-      : formatActiveThreadCount(counts.activeLocal);
-  return `${active}, ${counts.unread} unread`;
+/** "3 unread" — the chip's third count, as the old label read it out. */
+function formatUnreadThreadCount(count: number): string {
+  return `${count} unread`;
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapFilterMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapFilterMenu.tsx
@@ -25,7 +25,7 @@ import {
 export function StarMapFilterMenu(props: {
   selection: StarMapFilterSelection;
   counts: Record<StarMapFilterKey, number>;
-  /** The Attention chip's two indicators; see `StarMapFilterChip`. */
+  /** The Attention chip's readouts; see `StarMapFilterChip`. */
   attention: StarMapAttentionCounts;
   showRemoteTurns: boolean;
   onCycle: (key: StarMapFilterKey) => void;

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -14,6 +14,7 @@ import {
 import { ThreadMetaChips } from "../navigation/ThreadMetaChips";
 import {
   getThreadRowStatus,
+  isThreadRemoteWork,
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
 import {
@@ -103,6 +104,11 @@ export function StarMapThreadCard(props: {
     thread,
     props.sessionKeys?.thinkingThreadKeys,
   );
+  // Ungated, unlike the sidebar row: the map's Attention chip splits its turn
+  // counts on the bare `isThreadRemoteWork` (`countAttentionSignals`), so the
+  // card's beam goes neutral exactly when the chip counts it under
+  // "elsewhere".
+  const remoteWork = status === "thinking" && isThreadRemoteWork(thread);
   // Cards live inside the clipped, transformed canvas, and a native
   // `title` cannot be styled, times out differently per platform, and
   // does not wrap on macOS Electron — see UI-THEME.md.
@@ -195,7 +201,7 @@ export function StarMapThreadCard(props: {
               Chat card open on the map
             </span>
           ) : null}
-          <ThreadRowStatus status={status} />
+          <ThreadRowStatus remoteWork={remoteWork} status={status} />
           <span
             className="star-map-card__title"
             onMouseEnter={(event) =>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -14,7 +14,7 @@ import {
 import { ThreadMetaChips } from "../navigation/ThreadMetaChips";
 import {
   getThreadRowStatus,
-  isThreadRemoteWork,
+  isThreadRemoteWorkHere,
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
 import {
@@ -104,11 +104,6 @@ export function StarMapThreadCard(props: {
     thread,
     props.sessionKeys?.thinkingThreadKeys,
   );
-  // Ungated, unlike the sidebar row: the map's Attention chip splits its turn
-  // counts on the bare `isThreadRemoteWork` (`countAttentionSignals`), so the
-  // card's beam goes neutral exactly when the chip counts it under
-  // "elsewhere".
-  const remoteWork = status === "thinking" && isThreadRemoteWork(thread);
   // Cards live inside the clipped, transformed canvas, and a native
   // `title` cannot be styled, times out differently per platform, and
   // does not wrap on macOS Electron — see UI-THEME.md.
@@ -201,7 +196,10 @@ export function StarMapThreadCard(props: {
               Chat card open on the map
             </span>
           ) : null}
-          <ThreadRowStatus remoteWork={remoteWork} status={status} />
+          <ThreadRowStatus
+            remoteWork={isThreadRemoteWorkHere(thread)}
+            status={status}
+          />
           <span
             className="star-map-card__title"
             onMouseEnter={(event) =>

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
@@ -228,7 +228,7 @@ describe("star map attention filter", () => {
     // The same card the sidebar tab opens, lifted above the map's stacking
     // context.
     expect(card).toHaveClass("attention-card");
-    expect(card).toHaveClass("attention-card--star-map");
+    expect(card).toHaveClass("star-map-card__tooltip");
     expect(card).toHaveTextContent(
       /AttentionThreads in progress or unreadIn progress hereQuitting interrupts these1In progress elsewhereQuitting leaves these running2Unread3/,
     );

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
@@ -119,8 +119,8 @@ describe("star map attention filter", () => {
     const { container } = renderMap([working, idle]);
     await waitFor(() => expect(chip()).toBeTruthy());
 
-    const active = container.querySelector(".lens-switch__signal--active");
-    const review = container.querySelector(".lens-switch__signal--review");
+    const active = container.querySelector(".signal-count--active");
+    const review = container.querySelector(".signal-count--idle");
     expect(active?.textContent).toBe("1");
     expect(active?.getAttribute("data-zero")).toBeNull();
     // Zero is drawn, not hidden: a missing indicator makes an idle chip
@@ -129,7 +129,7 @@ describe("star map attention filter", () => {
     expect(review?.getAttribute("data-zero")).toBe("true");
     // No peers on this map, so the remote readout is absent entirely.
     expect(
-      container.querySelector(".lens-switch__signal--remote-active"),
+      container.querySelector(".signal-count--remote-active"),
     ).toBeNull();
   });
 
@@ -154,8 +154,8 @@ describe("star map attention filter", () => {
   it("swaps the scanner element at zero rather than freezing it", async () => {
     const { container } = renderMap([idle]);
     await waitFor(() => expect(chip()).toBeTruthy());
-    const active = container.querySelector(".lens-switch__signal--active");
-    expect(active?.querySelector(".lens-switch__dormant-scanner")).not.toBeNull();
+    const active = container.querySelector(".signal-count--active");
+    expect(active?.querySelector(".signal-count__dormant-scanner")).not.toBeNull();
     expect(active?.querySelector(".thinking-scanner")).toBeNull();
   });
 
@@ -194,14 +194,14 @@ describe("star map attention filter", () => {
 
   it("stacks peer turns under local ones, in the tab's own column", () => {
     // The sidebar tab's layout, element for element: both turn readouts in
-    // one `.lens-switch__turns` column, the cookie beside the column rather
+    // one `.signal-count-stack` column, the cookie beside the column rather
     // than in it. A row of three was the drift this replaces.
     const { container } = renderChip(
       { activeLocal: 1, activeRemote: 2, unread: 3 },
       { showRemoteTurns: true },
     );
     const signals = container.querySelector(".star-map__filter-signals")!;
-    const turns = signals.querySelector(".lens-switch__turns")!;
+    const turns = signals.querySelector(".signal-count-stack")!;
     expect(turns).not.toBeNull();
     expect(
       turns.querySelector("[data-attention-active-count]"),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-attention-chip.test.tsx
@@ -1,21 +1,28 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapFilterChip } from "../StarMapFilterChip";
 import { StarMapScreen } from "../StarMapScreen";
 import {
   countAttentionSignals,
   readStoredFilterSelection,
+  STAR_MAP_FILTERS,
   threadPassesFilters,
 } from "../star-map-filters";
 
 /**
  * The Attention chip: one filter over "unread or working", drawn with the
- * sidebar's own three readouts.
+ * sidebar's own three readouts — the same elements, not a copy.
  *
  * These were two chips ("Unread", "Working"), and the Working half had no
  * coverage at all — which is how a filter nobody could see a non-zero
- * number on went unnoticed.
+ * number on went unnoticed. The copy of the readouts that followed then
+ * drifted from the tab in two ways nothing here caught: its turns sat in a
+ * row where the tab stacks them, and its signal row had lost its layout
+ * rule to a stray comment between two CSS selectors. The tests below pin
+ * the chip to the tab's own elements and column.
  */
 
 function thread(
@@ -112,8 +119,8 @@ describe("star map attention filter", () => {
     const { container } = renderMap([working, idle]);
     await waitFor(() => expect(chip()).toBeTruthy());
 
-    const active = container.querySelector(".star-map__filter-signal--active");
-    const review = container.querySelector(".star-map__filter-signal--review");
+    const active = container.querySelector(".lens-switch__signal--active");
+    const review = container.querySelector(".lens-switch__signal--review");
     expect(active?.textContent).toBe("1");
     expect(active?.getAttribute("data-zero")).toBeNull();
     // Zero is drawn, not hidden: a missing indicator makes an idle chip
@@ -122,8 +129,20 @@ describe("star map attention filter", () => {
     expect(review?.getAttribute("data-zero")).toBe("true");
     // No peers on this map, so the remote readout is absent entirely.
     expect(
-      container.querySelector(".star-map__filter-signal--remote-active"),
+      container.querySelector(".lens-switch__signal--remote-active"),
     ).toBeNull();
+  });
+
+  it("is its readouts, with no word beside them", async () => {
+    // Like the lens tab: the name lives in the accessible name and the hover
+    // card, not on the chip. The label was width the band needs for the
+    // chips beside it.
+    renderMap([working]);
+    await waitFor(() => expect(chip()).toBeTruthy());
+    expect(chip().textContent).not.toContain("Attention");
+    expect(chip().getAttribute("aria-label")).toMatch(/^Attention:/);
+    expect(chip().querySelector(".star-map__filter-signals")).not.toBeNull();
+    expect(chip().querySelector(".star-map__filter-count")).toBeNull();
   });
 
   /**
@@ -135,7 +154,7 @@ describe("star map attention filter", () => {
   it("swaps the scanner element at zero rather than freezing it", async () => {
     const { container } = renderMap([idle]);
     await waitFor(() => expect(chip()).toBeTruthy());
-    const active = container.querySelector(".star-map__filter-signal--active");
+    const active = container.querySelector(".lens-switch__signal--active");
     expect(active?.querySelector(".lens-switch__dormant-scanner")).not.toBeNull();
     expect(active?.querySelector(".thinking-scanner")).toBeNull();
   });
@@ -145,6 +164,88 @@ describe("star map attention filter", () => {
     await waitFor(() => expect(chip()).toBeTruthy());
     expect(chip().getAttribute("aria-label")).toContain("1 active thread");
     expect(chip().getAttribute("aria-label")).toContain("1 unread");
+  });
+
+  /**
+   * The remote readout needs a peer the map fronts, which is a federation
+   * health round-trip away from `StarMapScreen`; the chip itself is the
+   * unit under test here, so render it directly with the counts the screen
+   * would hand it.
+   */
+  const attentionDefinition = STAR_MAP_FILTERS.find(
+    (definition) => definition.key === "attention",
+  )!;
+
+  function renderChip(
+    attention: { activeLocal: number; activeRemote: number; unread: number },
+    options: { showRemoteTurns?: boolean; selection?: { attention?: "include" | "exclude" } } = {},
+  ) {
+    return render(
+      <StarMapFilterChip
+        definition={attentionDefinition}
+        selection={options.selection ?? {}}
+        count={0}
+        attention={attention}
+        showRemoteTurns={options.showRemoteTurns}
+        onCycle={() => undefined}
+      />,
+    );
+  }
+
+  it("stacks peer turns under local ones, in the tab's own column", () => {
+    // The sidebar tab's layout, element for element: both turn readouts in
+    // one `.lens-switch__turns` column, the cookie beside the column rather
+    // than in it. A row of three was the drift this replaces.
+    const { container } = renderChip(
+      { activeLocal: 1, activeRemote: 2, unread: 3 },
+      { showRemoteTurns: true },
+    );
+    const signals = container.querySelector(".star-map__filter-signals")!;
+    const turns = signals.querySelector(".lens-switch__turns")!;
+    expect(turns).not.toBeNull();
+    expect(
+      turns.querySelector("[data-attention-active-count]"),
+    ).toHaveAttribute("data-attention-active-count", "1");
+    expect(
+      turns.querySelector("[data-attention-remote-active-count]"),
+    ).toHaveAttribute("data-attention-remote-active-count", "2");
+    const review = signals.querySelector("[data-attention-review-count]")!;
+    expect(review).toHaveAttribute("data-attention-review-count", "3");
+    expect(turns.contains(review)).toBe(false);
+    // Both live, both sweeping — the remote one is neutral by token, not
+    // by being switched off.
+    expect(turns.querySelectorAll(".thinking-scanner")).toHaveLength(2);
+  });
+
+  it("explains itself in the tab's hover card", async () => {
+    renderChip(
+      { activeLocal: 1, activeRemote: 2, unread: 3 },
+      { showRemoteTurns: true },
+    );
+    const button = screen.getByRole("button", { name: /^Attention:/ });
+    fireEvent.mouseEnter(button);
+    const card = await screen.findByRole("tooltip");
+    // The same card the sidebar tab opens, lifted above the map's stacking
+    // context.
+    expect(card).toHaveClass("attention-card");
+    expect(card).toHaveClass("attention-card--star-map");
+    expect(card).toHaveTextContent(
+      /AttentionThreads in progress or unreadIn progress hereQuitting interrupts these1In progress elsewhereQuitting leaves these running2Unread3/,
+    );
+    // With no word on the chip, the card has to say what a click does.
+    expect(card).toHaveTextContent("Click to show only these");
+    // The consequence lines exist nowhere else, so the card is reachable to
+    // a screen reader rather than sighted-only.
+    expect(button).toHaveAttribute("aria-describedby", card.id);
+  });
+
+  it("names no machine in the card until the map fronts a peer", async () => {
+    renderChip({ activeLocal: 1, activeRemote: 0, unread: 0 });
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /^Attention:/ }));
+    const card = await screen.findByRole("tooltip");
+    expect(card).toHaveTextContent(/In progress1/);
+    expect(card.textContent).not.toContain("Quitting");
+    expect(card.textContent).not.toContain("elsewhere");
   });
 
   /**

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filter-fit.ts
@@ -2,10 +2,10 @@
  * How much of the filter strip the top band can show.
  *
  * The band is one row and the map window goes down to 800px, so at some
- * width the chips stop fitting beside the chrome — six of them today, and
- * the Attention chip is the widest, since it carries up to three readouts
- * rather than one count. Two earlier answers were both wrong in ways
- * worth recording:
+ * width the chips stop fitting beside the chrome — six of them today, each
+ * as wide as its label and live count (or, for the Attention chip, its
+ * readouts) make it. Two earlier answers were both wrong in ways worth
+ * recording:
  *
  * - Wrapping to a second row put chips over the star field and doubled
  *   the height of the band to show information already on it.

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -171,11 +171,17 @@ export function ActiveSubAgentsStrip(props: {
           <span className="live-strip__chevron" aria-hidden="true" />
           {/* The sidebar's mark-and-number, not a bordered pill: the same
               statement ("this many, working") must not look like a different
-              kind of object in another part of the window. Only genuine work
-              sweeps — a strip holding nothing but blocked or failed rows
-              draws the dormant bar beside its count. The count keeps its
-              full weight either way: a failure you have not dismissed is
-              still something to act on. */}
+              kind of object in another part of the window.
+
+              The two halves answer different questions, so they read
+              different values. The MARK answers "is anything progressing?"
+              — only genuine work sweeps, so a strip of blocked or failed
+              rows gets the dormant bar. The TONE answers "what is this a
+              count of?", which is what the heading and `headingCount`
+              already answer: `activeCount` for a live strip, failures
+              otherwise. Keying the tone on `running` instead would paint a
+              blocked-only strip's count idle grey under an "Active
+              sub-agents" heading. */}
           <span className="live-strip__label">{heading}</span>
           <SignalCount
             className="live-strip__count"
@@ -187,7 +193,7 @@ export function ActiveSubAgentsStrip(props: {
                 <span className="signal-count__dormant-scanner" />
               )
             }
-            tone={running.length > 0 ? "active" : "idle"}
+            tone={activeCount > 0 ? "active" : "idle"}
           />
           <span className="live-strip__row-spacer" />
           {/* Trailing, so the tally sits next to the Dismiss all that acts on

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -5,6 +5,7 @@ import type {
 } from "@pwragent/shared";
 import { isTerminalSubAgent } from "./context-panels/subagent-format";
 import { useNowWhileActive } from "./context-panels/RailCardTiming";
+import { SignalCount } from "../../components/SignalCount";
 import { ThinkingScanner } from "./ThinkingScanner";
 import { formatRunningDurationMs } from "../../lib/format-duration";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -168,14 +169,26 @@ export function ActiveSubAgentsStrip(props: {
           onClick={() => setExpanded((current) => !current)}
         >
           <span className="live-strip__chevron" aria-hidden="true" />
+          {/* The sidebar's mark-and-number, not a bordered pill: the same
+              statement ("this many, working") must not look like a different
+              kind of object in another part of the window. Only genuine work
+              sweeps — a strip holding nothing but blocked or failed rows
+              draws the dormant bar beside its count. The count keeps its
+              full weight either way: a failure you have not dismissed is
+              still something to act on. */}
           <span className="live-strip__label">{heading}</span>
-          <span className="live-strip__count">{headingCount}</span>
-          {/* Beside the count, not at the far edge. Parked after the spacer it
-              sat ~730px from the label it modifies and read as a stray artifact
-              rather than "these are working". Only genuine work sweeps — a
-              strip holding nothing but blocked or failed rows must not imply
-              something is progressing. */}
-          {running.length > 0 ? <ThinkingScanner compact /> : null}
+          <SignalCount
+            className="live-strip__count"
+            count={headingCount}
+            indicator={
+              running.length > 0 ? (
+                <ThinkingScanner compact />
+              ) : (
+                <span className="signal-count__dormant-scanner" />
+              )
+            }
+            tone={running.length > 0 ? "active" : "idle"}
+          />
           <span className="live-strip__row-spacer" />
           {/* Trailing, so the tally sits next to the Dismiss all that acts on
               it. Leading, it collided with the count and read as "1 12". */}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -61,6 +61,10 @@ import { agentEventMatchesThread } from "../../lib/federated-thread-events";
 import { useCelestialIcons } from "../../lib/useCelestialIcons";
 import { CelestialWatermark } from "../../components/CelestialWatermark";
 import { readRendererFederationTarget } from "../../lib/federation-window";
+import {
+  isThreadRemoteWork,
+  windowSplitsTurnsByMachine,
+} from "../navigation/ThreadRowStatus";
 import type {
   IntegratedTerminalPaneRemote,
   IntegratedTerminalsController,
@@ -1425,6 +1429,13 @@ export function ThreadView(props: ThreadViewProps) {
       ? selectedThread.federation.ref.target.instanceId
       : undefined,
   );
+  // The pending line's scanner goes neutral for a peer's turn on the same
+  // gate the sidebar row uses, so the transcript, the row and the Attention
+  // tab colour one turn the same way.
+  const transcriptRemoteWork =
+    selectedThread !== undefined
+    && isThreadRemoteWork(selectedThread)
+    && windowSplitsTurnsByMachine();
   const envActionRuns = readCodexEnvironmentActionRuns(
     selectedThread?.codexEnvironmentRuntime,
   );
@@ -3539,6 +3550,7 @@ export function ThreadView(props: ThreadViewProps) {
               pendingRequestBusy={pendingRequestBusy}
               pendingUserInput={props.pendingUserInput}
               pendingStatusText={props.pendingStatusText}
+              pendingRemoteWork={transcriptRemoteWork}
               runningTurnUsageText={props.runningTurnUsageText}
               expandedActivityIds={props.expandedTranscriptActivityIds}
               expandedWorkPhaseGroupIds={

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -61,10 +61,7 @@ import { agentEventMatchesThread } from "../../lib/federated-thread-events";
 import { useCelestialIcons } from "../../lib/useCelestialIcons";
 import { CelestialWatermark } from "../../components/CelestialWatermark";
 import { readRendererFederationTarget } from "../../lib/federation-window";
-import {
-  isThreadRemoteWork,
-  windowSplitsTurnsByMachine,
-} from "../navigation/ThreadRowStatus";
+import { isThreadRemoteWorkHere } from "../navigation/ThreadRowStatus";
 import type {
   IntegratedTerminalPaneRemote,
   IntegratedTerminalsController,
@@ -1430,12 +1427,10 @@ export function ThreadView(props: ThreadViewProps) {
       : undefined,
   );
   // The pending line's scanner goes neutral for a peer's turn on the same
-  // gate the sidebar row uses, so the transcript, the row and the Attention
-  // tab colour one turn the same way.
+  // predicate the thread row uses, so the transcript, the row and the
+  // Attention tab colour one turn the same way.
   const transcriptRemoteWork =
-    selectedThread !== undefined
-    && isThreadRemoteWork(selectedThread)
-    && windowSplitsTurnsByMachine();
+    selectedThread !== undefined && isThreadRemoteWorkHere(selectedThread);
   const envActionRuns = readCodexEnvironmentActionRuns(
     selectedThread?.codexEnvironmentRuntime,
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -109,7 +109,7 @@ type TranscriptListProps = {
    * sweeps in neutral rather than accent — the same vocabulary as the
    * thread row's mark and the Attention readouts: accent holds the app open,
    * a peer's turn does not. The caller owns the gate (see
-   * `windowSplitsTurnsByMachine`).
+   * `isThreadRemoteWorkHere`).
    */
   pendingRemoteWork?: boolean;
   runningTurnUsageText?: string;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -104,6 +104,14 @@ type TranscriptListProps = {
   pendingMcpInteraction?: PendingMcpInteractionState;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
+  /**
+   * The live turn belongs to another instance, so the pending line's scanner
+   * sweeps in neutral rather than accent — the same vocabulary as the
+   * thread row's mark and the Attention readouts: accent holds the app open,
+   * a peer's turn does not. The caller owns the gate (see
+   * `windowSplitsTurnsByMachine`).
+   */
+  pendingRemoteWork?: boolean;
   runningTurnUsageText?: string;
   pagination?: AppServerThreadReplayPagination;
   parentThreadId?: string;
@@ -1600,7 +1608,12 @@ export function TranscriptList(props: TranscriptListProps) {
               className="transcript-list__item transcript-list__pending-item"
               role="listitem"
             >
-              <div className="transcript-list__pending" role="status">
+              <div
+                className={`transcript-list__pending${
+                  props.pendingRemoteWork ? " transcript-list__pending--remote" : ""
+                }`}
+                role="status"
+              >
                 {props.pendingStatusText ? <ThinkingScanner /> : null}
                 {props.pendingStatusText ? <span>{props.pendingStatusText}</span> : null}
                 {props.runningTurnUsageText ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -51,6 +51,47 @@ describe("ActiveSubAgentsStrip", () => {
       expect(container).toBeEmptyDOMElement();
     });
 
+    it("counts on the app's shared mark-and-number, not a pill of its own", () => {
+      // This strip drew its count inside a bordered 18px pill with the
+      // scanner parked after it, so the same statement the sidebar makes
+      // two panes away ("this many, working") looked like a different kind
+      // of object in one window. See `SignalCount.tsx`.
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([buildSubAgent({ monitorId: "running-1" })])}
+        />,
+      );
+
+      const count = container.querySelector(".live-strip__count")!;
+      expect(count).toHaveClass("signal-count");
+      expect(count).toHaveClass("signal-count--active");
+      // Mark first, digits last — the order every other surface uses.
+      expect(count.firstElementChild).toHaveClass("thinking-scanner");
+      expect(count.lastElementChild).toHaveClass("signal-count__value");
+      expect(count.lastElementChild).toHaveTextContent("1");
+    });
+
+    it("swaps the sweep for the dormant bar when nothing is running", () => {
+      // A failure you have not dismissed still holds the strip open, but
+      // nothing is progressing — and the count keeps its full weight,
+      // because an undismissed failure is something to act on.
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "failed-1", status: "failed" }),
+          ])}
+        />,
+      );
+
+      const count = container.querySelector(".live-strip__count")!;
+      expect(count).toHaveClass("signal-count--idle");
+      expect(count.querySelector(".thinking-scanner")).toBeNull();
+      expect(count.firstElementChild).toHaveClass(
+        "signal-count__dormant-scanner",
+      );
+      expect(count).not.toHaveAttribute("data-zero");
+    });
+
     it("renders nothing when every sub-agent has finished", () => {
       // Successful and cancelled sub-agents leave immediately — the sidebar
       // and the rail panel already hold them.

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -71,6 +71,31 @@ describe("ActiveSubAgentsStrip", () => {
       expect(count.lastElementChild).toHaveTextContent("1");
     });
 
+    it("keeps the tone with the heading when only blocked rows are left", () => {
+      // The two halves of the readout answer different questions: the mark
+      // says whether anything is progressing (nothing is), the tone says
+      // what the number counts. A blocked sub-agent is still an ACTIVE one —
+      // `activeCount` includes it and the heading says so — so painting the
+      // count in the idle grey would have the strip contradict its own label.
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "blocked-1", status: "blocked" }),
+          ])}
+        />,
+      );
+
+      expect(screen.getByText("Active sub-agents")).toBeInTheDocument();
+      const count = container.querySelector(".live-strip__count")!;
+      expect(count).toHaveClass("signal-count--active");
+      expect(count).not.toHaveClass("signal-count--idle");
+      // Blocked is not progressing, so the beam still must not sweep.
+      expect(count.querySelector(".thinking-scanner")).toBeNull();
+      expect(count.firstElementChild).toHaveClass(
+        "signal-count__dormant-scanner",
+      );
+    });
+
     it("swaps the sweep for the dormant bar when nothing is running", () => {
       // A failure you have not dismissed still holds the strip open, but
       // nothing is progressing — and the count keeps its full weight,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1931,6 +1931,35 @@ Implementation notes remain in a readable bubble.`;
     );
   });
 
+  it("sweeps the pending line in neutral for a peer's turn", () => {
+    // Same vocabulary as the thread row's mark and the Attention readouts:
+    // the accent holds the app open, a peer's turn does not. The scanner
+    // still mounts — the turn is running, just not here — and only its
+    // tokens change, through the modifier class.
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Keep going.",
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingRemoteWork
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveClass("transcript-list__pending--remote");
+    expect(status.querySelector(".thinking-scanner")).not.toBeNull();
+  });
+
   // The other half of that contract. `.transcript-list__pending-item` is what
   // the bottom-padding override in app.css tests for `:last-child`, and the
   // wrapper made the pre-wrapper `.transcript-list__pending:last-child` form

--- a/apps/desktop/src/renderer/src/lib/federation-window.ts
+++ b/apps/desktop/src/renderer/src/lib/federation-window.ts
@@ -9,6 +9,22 @@ export function readRendererFederationTarget(): FederationRemoteTarget | undefin
     : undefined;
 }
 
+/**
+ * Whether this renderer is a viewer fronting a peer instance rather than the
+ * main window of this instance.
+ *
+ * A viewer reads its whole navigation snapshot through the peer, and the main
+ * process stamps every row it returns as remote (`stampRemoteNavigationSnapshot`)
+ * — so anything that tells "this instance's" work apart from "a peer's" has
+ * no content in a viewer: every row is the peer's, and closing the window
+ * interrupts none of it. Surfaces that split by machine (the Attention tab's
+ * counts, the thread rows' scanners, the transcript's pending line) gate on
+ * this so they all make, or all skip, the distinction together.
+ */
+export function isFederationViewerWindow(): boolean {
+  return readRendererFederationTarget() !== undefined;
+}
+
 export function readRendererFederationLabel(): string | undefined {
   const label = (window as typeof window & {
     __pwragentFederationLabel?: unknown;

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1766,7 +1766,7 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toContain("@keyframes pwragent-thinking-scanner-sweep");
     // Read the blocks out by selector rather than matching declarations
     // anywhere after the first `.thinking-scanner {` in the file. A descendant
-    // rule that retints the scanner (`.lens-switch__signal--remote-active
+    // rule that retints the scanner (`.signal-count--remote-active
     // .thinking-scanner`) ends with the same three characters, so an
     // unanchored pattern starts THERE and lazily bridges thousands of lines to
     // collect these declarations from wherever they happen to live — which

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3557,6 +3557,25 @@ textarea,
   color: var(--text-muted);
 }
 
+/* The Star Map chip's closing line ("Click to show only these"). Muted and
+   set off from the rows: it is an affordance note, not a fourth count. */
+.attention-card__footer {
+  margin-top: 9px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+/* The same card opened from the Star Map's Attention chip. Its trigger sits
+   inside `.star-map-window`, which opens a stacking context that scopes the
+   card z-scale — a body-portaled card left at 90 paints under the map, the
+   same escape `.star-map-card__tooltip` makes. */
+.attention-card--star-map {
+  z-index: 140;
+}
+
 /* The turn readouts, stacked. One row is the common case and reads exactly as
    it did when it was a bare child of the tab — a single-item column is its own
    content box, so nothing moves. The second row only exists while a peer has
@@ -3597,7 +3616,13 @@ textarea,
   color: var(--text-muted);
 }
 
-.lens-switch__signal--remote-active .thinking-scanner {
+/* One recipe for every beam that sweeps a peer's turn: the Attention
+   readout, the thread row's mark (sidebar and Star Map card), and the
+   transcript's pending line. They are the same statement — "running, but
+   not here" — so a second tint for one of them would be a second meaning. */
+.lens-switch__signal--remote-active .thinking-scanner,
+.thread-row__status-indicator--remote .thinking-scanner,
+.transcript-list__pending--remote .thinking-scanner {
   --thinking-scanner-tint: var(--text-muted);
   --thinking-scanner-tint-bright: var(--text-secondary);
   --thinking-scanner-track: var(--bg-panel-hover);
@@ -12938,78 +12963,41 @@ textarea,
 /* Stacked chips are full width, so the count goes to the far edge and
    makes a column. Only the count - `space-between` would also push the
    exclude mark off the label it negates, and "− ... Open PR" reads as two
-   separate things rather than one struck-through chip. */
-.star-map__filter-panel /* The Attention chip's readouts.
-   Token references copied from `.lens-switch__signal` and its modifiers, not
-   chosen to look similar: the map and the sidebar are reporting the SAME
-   three numbers, and an operator glancing between them must not have to
-   work out whether two different oranges mean two different things. If the
-   tab's tokens change, change these with them. */
+   separate things rather than one struck-through chip. The Attention chip's
+   readouts stay at the left edge like a label would: with no word on that
+   chip they ARE its label, and a column of indicators under the other
+   chips' counts would read as their count column. */
+.star-map__filter-panel .star-map__filter-count {
+  margin-left: auto;
+}
+
+/* The Attention chip's readouts: the sidebar Attention tab's own elements
+   (`AttentionSignals.tsx`), under the tab's own `.lens-switch__turns` and
+   `.lens-switch__signal` rules — not a copy of their tokens. The map and the
+   sidebar report the SAME three numbers, and an operator glancing between
+   the two windows must not have to work out whether two different oranges,
+   or a row here and a column there, mean two different things. This wrapper
+   only gives the pair the tab's inner gap (`.lens-switch__button--attention`).
+
+   NB: this is its own rule on purpose. It was once fused onto the panel
+   rule above by a stray comment between two selectors (PR #1805), which
+   scoped it to the popover and left the strip's chip with no layout at all:
+   the turn column and the cookie ran together with no gap. */
 .star-map__filter-signals {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   gap: 7px;
-}
-
-.star-map__filter-signal {
-  display: inline-flex;
-  /* Never the thing that gives: a half-eaten count reads as a different
-     number, so the indicator shrinks before the digits do. */
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 3px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-
-.star-map__filter-signal--active {
-  color: var(--accent-bright);
-}
-
-/* Turns on another instance. Neutral rather than accent, and that is the
-   whole point: the accent means "this holds the app open", and a peer's turn
-   does not. Still a live sweeping scanner — the work IS running, just not
-   on this machine. */
-.star-map__filter-signal--remote-active {
-  color: var(--text-muted);
-}
-
-.star-map__filter-signal--remote-active .thinking-scanner {
-  --thinking-scanner-tint: var(--text-muted);
-  --thinking-scanner-tint-bright: var(--text-secondary);
-  --thinking-scanner-track: var(--bg-panel-hover);
-}
-
-.star-map__filter-signal--review {
-  color: var(--text-secondary);
-}
-
-.star-map__filter-signal--review .thread-row__status-cookie {
-  width: 8px;
-  height: 8px;
-}
-
-/* Zero is still shown — an idle chip has to read as "nothing running,
-   nothing unread", which a vanishing count cannot do. It just stops
-   claiming the accent. */
-.star-map__filter-signal[data-zero="true"] {
-  color: var(--text-muted);
-}
-
-/* The cookie paints itself from accent tokens rather than `currentColor`,
-   so greying the text is not enough. */
-.star-map__filter-signal[data-zero="true"] .thread-row__status-cookie {
-  border-color: var(--border-subtle);
-  background: var(--text-muted);
-  box-shadow: none;
-}
-
-.star-map__filter-count {
-  margin-left: auto;
+  /* As tall as a labelled chip's content, so this chip stands level with
+     its neighbours whether it shows one turn row or two. The neighbours'
+     height comes from their count badge (`.star-map__filter-count`, a 15px
+     line box) plus the chip's 4px padding each side = 23px inside the
+     border; the stacked turn column is 22px (two 10px rows and a 2px gap),
+     so it fits without growing the chip. The chip's own padding goes to
+     zero for this: the tab does the same sum in a fixed 26px, and a strip
+     that grew by 7px whenever a peer started a turn would move the whole
+     top band. */
+  min-height: 23px;
 }
 
 .star-map__filter-chip {
@@ -13023,6 +13011,14 @@ textarea,
   color: var(--text-muted);
   font-size: 11px;
   cursor: pointer;
+}
+
+/* The Attention chip gives its vertical padding to `.star-map__filter-signals`
+   (its `min-height`, which see) so two stacked turn rows fit the height of a
+   labelled chip. After the base rule: same specificity, and source order is
+   what lets it win. */
+.star-map__filter-chip--attention {
+  padding-block: 0;
 }
 
 /* Tri-state. Neutral is the resting style above: not filtering on this.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3462,9 +3462,14 @@ textarea,
 
    Measurements are `.context-usage-card`'s (width, padding, radius, shadow,
    eyebrow, row scale) so the app's hover cards stay one family — that one
-   rather than `.pr-status-card` because both of these sit at z-index 90:
-   the lens switch is sidebar chrome and is not reachable from the Settings
-   overlay at 120, so neither needs the 140 a PR chip does. */
+   rather than `.pr-status-card`.
+
+   90 is the base layer, which is all the lens switch needs: it is sidebar
+   chrome and is not reachable from the Settings overlay at 120. A trigger
+   inside a window that opens its own stacking context appends that window's
+   escape class instead of getting a modifier here — the Star Map's Attention
+   chip wears `.star-map-card__tooltip` (140), declared later in this file, so
+   raising the map's z-scale moves both its card tooltips and this one. */
 .attention-card {
   position: fixed;
   z-index: 90;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3560,20 +3560,12 @@ textarea,
 /* The Star Map chip's closing line ("Click to show only these"). Muted and
    set off from the rows: it is an affordance note, not a fourth count. */
 .attention-card__footer {
-  margin-top: 9px;
-  padding-top: 8px;
+  margin-top: 10px;
+  padding-top: 9px;
   border-top: 1px solid var(--border-subtle);
   color: var(--text-muted);
   font-size: 11px;
   line-height: 1.3;
-}
-
-/* The same card opened from the Star Map's Attention chip. Its trigger sits
-   inside `.star-map-window`, which opens a stacking context that scopes the
-   card z-scale — a body-portaled card left at 90 paints under the map, the
-   same escape `.star-map-card__tooltip` makes. */
-.attention-card--star-map {
-  z-index: 140;
 }
 
 /* The turn readouts, stacked. One row is the common case and reads exactly as
@@ -12988,16 +12980,6 @@ textarea,
   flex: 0 0 auto;
   align-items: center;
   gap: 7px;
-  /* As tall as a labelled chip's content, so this chip stands level with
-     its neighbours whether it shows one turn row or two. The neighbours'
-     height comes from their count badge (`.star-map__filter-count`, a 15px
-     line box) plus the chip's 4px padding each side = 23px inside the
-     border; the stacked turn column is 22px (two 10px rows and a 2px gap),
-     so it fits without growing the chip. The chip's own padding goes to
-     zero for this: the tab does the same sum in a fixed 26px, and a strip
-     that grew by 7px whenever a peer started a turn would move the whole
-     top band. */
-  min-height: 23px;
 }
 
 .star-map__filter-chip {
@@ -13013,11 +12995,17 @@ textarea,
   cursor: pointer;
 }
 
-/* The Attention chip gives its vertical padding to `.star-map__filter-signals`
-   (its `min-height`, which see) so two stacked turn rows fit the height of a
-   labelled chip. After the base rule: same specificity, and source order is
-   what lets it win. */
+/* The Attention chip stands level with its labelled neighbours whether it
+   shows one turn row or two. 25px is a labelled chip's height: the count
+   badge's 15px line box (`.star-map__filter-count`) plus the 4px padding each
+   side plus the 1px borders, under the global border-box reset. The stacked
+   turn column is 22px (two 10px rows and a 2px gap), so with the vertical
+   padding handed to the min-height it fits without growing the chip — the tab
+   does the same sum in a fixed 26px, and a strip that grew by 7px whenever a
+   peer started a turn would move the whole top band. After the base rule:
+   same specificity, so source order is what lets it win. */
 .star-map__filter-chip--attention {
+  min-height: 25px;
   padding-block: 0;
 }
 
@@ -13038,6 +13026,13 @@ textarea,
   color: var(--text-muted);
   text-decoration: line-through;
   text-decoration-color: var(--danger-text);
+}
+
+/* The strike is for a label, and the Attention chip has none: the only text
+   on it is its counts, and a struck digit reads as a different number. The
+   dashed border and the `−` mark already carry "hidden" on their own. */
+.star-map__filter-chip--attention.star-map__filter-chip--exclude {
+  text-decoration: none;
 }
 
 .star-map__filter-mark {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3427,7 +3427,15 @@ textarea,
   padding: 0 7px;
 }
 
-.lens-switch__signal {
+/* One mark and the number it counts, on every surface that says it: the
+   Attention tab and the Star Map's Attention chip, the directory header
+   counts, and the sub-agent / automation strips. See `SignalCount.tsx` for
+   why they share it — three of these renderings were visible at once, in
+   three different shapes.
+
+   Mark first, then the digits: the mark is what says WHICH number this is.
+   Mono and tabular so 9 → 10 does not shove the mark and a column lines up. */
+.signal-count {
   display: inline-flex;
   /* Never the thing that gives: a half-eaten count reads as a different
      number, so the indicator shrinks before the digits do. */
@@ -3438,6 +3446,14 @@ textarea,
   font-size: 10px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
+}
+
+/* The cookie is a mark like any other here, so its size belongs to the
+   primitive rather than to one tone — the review readout is not the only
+   place it can appear. */
+.signal-count .thread-row__status-cookie {
+  width: 8px;
+  height: 8px;
 }
 
 /* The Drafts tab's count. Same mono, size and tabular figures as the Attention
@@ -3522,7 +3538,7 @@ textarea,
 /* Reuse of the tab's own readout classes, which carry the colour and the zero
    state. Inside the card they hold only the indicator, so drop the tab's inner
    gap and let the grid do the spacing. */
-.attention-card__row .lens-switch__signal {
+.attention-card__row .signal-count {
   justify-content: center;
   gap: 0;
 }
@@ -3581,7 +3597,7 @@ textarea,
 
    `flex-start` rather than centring: the two scanners have to share a left
    edge, or a one-digit count above a two-digit one visibly staggers them. */
-.lens-switch__turns {
+.signal-count-stack {
   display: flex;
   min-width: 0;
   flex: 0 0 auto;
@@ -3594,11 +3610,11 @@ textarea,
 /* Two rows have to fit the 26px tab, so the readouts drop to their own
    line box here. Only in the stacked column: a lone readout is centred in the
    tab and the line box never shows. */
-.lens-switch__turns .lens-switch__signal {
+.signal-count-stack .signal-count {
   line-height: 1;
 }
 
-.lens-switch__signal--active {
+.signal-count--active {
   color: var(--accent-bright);
 }
 
@@ -3609,7 +3625,7 @@ textarea,
 
    Still a live sweeping scanner, not a dormant bar: the work IS running, just
    not on this machine. */
-.lens-switch__signal--remote-active {
+.signal-count--remote-active {
   color: var(--text-muted);
 }
 
@@ -3617,7 +3633,7 @@ textarea,
    readout, the thread row's mark (sidebar and Star Map card), and the
    transcript's pending line. They are the same statement — "running, but
    not here" — so a second tint for one of them would be a second meaning. */
-.lens-switch__signal--remote-active .thinking-scanner,
+.signal-count--remote-active .thinking-scanner,
 .thread-row__status-indicator--remote .thinking-scanner,
 .transcript-list__pending--remote .thinking-scanner {
   --thinking-scanner-tint: var(--text-muted);
@@ -3625,13 +3641,11 @@ textarea,
   --thinking-scanner-track: var(--bg-panel-hover);
 }
 
-.lens-switch__signal--review {
+/* Nothing is running behind this number: threads waiting to be reviewed, or
+   a strip holding only failures. Secondary rather than muted — the count is
+   still something to act on, it just is not work in flight. */
+.signal-count--idle {
   color: var(--text-secondary);
-}
-
-.lens-switch__signal--review .thread-row__status-cookie {
-  width: 8px;
-  height: 8px;
 }
 
 /* Zero is still shown — an idle tab has to read as "nothing running, nothing
@@ -3640,7 +3654,7 @@ textarea,
    `--text-muted` rather than `--text-subtle`: the zero is the message here,
    not decoration, and only the muted token is on the ramp that clears AA
    against the darkest surface it can land on. */
-.lens-switch__signal[data-zero="true"] {
+.signal-count[data-zero="true"] {
   color: var(--text-muted);
 }
 
@@ -3648,7 +3662,7 @@ textarea,
    greying the text is not enough — it has to be neutralized explicitly. Safe
    to restyle in place: it is a static mark with no animation to fall out of
    step. */
-.lens-switch__signal[data-zero="true"] .thread-row__status-cookie {
+.signal-count[data-zero="true"] .thread-row__status-cookie {
   border-color: var(--border-subtle);
   background: var(--text-muted);
   box-shadow: none;
@@ -3662,7 +3676,7 @@ textarea,
    never re-pinned. So the zero state is its own element and the live state is
    an untouched `ThinkingScanner`. Matches `.thinking-scanner--mini`'s footprint
    so the tab does not reflow when the count leaves zero. */
-.lens-switch__dormant-scanner {
+.signal-count__dormant-scanner {
   display: block;
   flex: 0 0 auto;
   width: 16px;
@@ -3688,11 +3702,11 @@ textarea,
     padding: 0 4px;
   }
 
-  .lens-switch__signal {
+  .signal-count {
     gap: 2px;
   }
 
-  .lens-switch__turns {
+  .signal-count-stack {
     gap: 1px;
   }
 }
@@ -5943,24 +5957,24 @@ textarea,
   font-size: calc(var(--sidebar-title-size) - 1px);
 }
 
+/* Type, tone and the mark-first order are `.signal-count`'s; these two keep
+   only what is theirs. */
 .directory-row__active-count,
 .directory-row__review-count {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
-.directory-row__active-count {
-  color: var(--accent-bright);
-}
-
-.directory-row__review-count {
-  color: var(--text-secondary);
+/* The meta block is right-aligned, so whatever ends the row lands at one x on
+   every directory. Under the old count-then-mark order that was the mark
+   itself; mark-first (see `SignalCount.tsx`) ends the row with the digits
+   instead, and a 1-digit count would pull the mark a whole digit right of a
+   2-digit neighbour — a ragged column of the one glyph the eye scans the rail
+   for. A fixed two-digit box with the digits flush right restores the constant
+   mark x without giving up the shared order. Three digits still shift it, the
+   way three digits always shifted this row's left edge. */
+.directory-row__summary-meta .signal-count__value {
+  min-width: 2ch;
+  text-align: right;
 }
 
 /* The header count cookie inherits the base 10px size — it used to be a
@@ -12969,8 +12983,8 @@ textarea,
 }
 
 /* The Attention chip's readouts: the sidebar Attention tab's own elements
-   (`AttentionSignals.tsx`), under the tab's own `.lens-switch__turns` and
-   `.lens-switch__signal` rules — not a copy of their tokens. The map and the
+   (`AttentionSignals.tsx`), under the shared `.signal-count-stack` and
+   `.signal-count` rules — not a copy of their tokens. The map and the
    sidebar report the SAME three numbers, and an operator glancing between
    the two windows must not have to work out whether two different oranges,
    or a row here and a column there, mean two different things. This wrapper
@@ -24161,21 +24175,11 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* Counts rank via neutrals, never the accent ramp (UI-THEME "Accent ramp"). */
-.live-strip__count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  flex: 0 0 auto;
-  padding: 0 5px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 999px;
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
+/* Was a bordered 18px pill with no mark beside it, which made the same
+   statement the sidebar makes ("this many, working") look like a different
+   kind of object in the same window. It is `.signal-count` now; nothing is
+   left to say here beyond keeping it out of the flex squeeze, which the
+   primitive already does. */
 
 /* Secondary tally next to the count, e.g. "12 failed" beside one live run.
    Ranks below the count via neutrals, never the accent ramp. */

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -185,6 +185,15 @@ Rules:
   and the tooltip, never as visible text
 - Attention leads the switch and is the only tab that reports state: two
   indicators with counts, both grey at zero, zeros always shown
+- once a peer's turn is visible, the turn readout splits into a stacked
+  column: accent scanner for turns on this machine (quitting interrupts
+  them), neutral scanner under it for turns on other instances (quitting
+  leaves them running). The same neutral beam marks a peer's live turn on
+  its thread row and on the transcript's pending line. A window fronting a
+  peer never splits — every row there is that peer's work
+- the Star Map's Attention chip is the same control: the tab's readouts and
+  column, the tab's hover card, and no visible word (the name lives in the
+  `aria-label` and the card). See `AttentionSignals.tsx`
 - Inbox is the default thread lens, sorted by recent activity
 - Recents sorts by thread creation time
 - Inbox and Recents are pure sort orders: no pinned section, no pinned-first

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -194,6 +194,15 @@ Rules:
 - the Star Map's Attention chip is the same control: the tab's readouts and
   column, the tab's hover card, and no visible word (the name lives in the
   `aria-label` and the card). See `AttentionSignals.tsx`
+- **one mark-and-number everywhere.** Any surface saying "this many, and here
+  is what kind" uses `SignalCount` (`.signal-count`): the mark first, then the
+  digits, mono and tabular, no border and no fill. Tone says where the work is
+  — accent `--active` here, neutral `--remote-active` elsewhere, secondary
+  `--idle` for a number with nothing running behind it. It covers the Attention
+  tab, the Star Map's Attention chip, the directory header counts and the
+  sub-agent / automation strips; the strips' bordered count pill and the
+  directory rail's count-then-mark order are gone. A zero is greyed, never
+  hidden
 - Inbox is the default thread lens, sorted by recent activity
 - Recents sorts by thread creation time
 - Inbox and Recents are pure sort orders: no pinned section, no pinned-first


### PR DESCRIPTION
## Summary

Two follow-ups to the Attention tab's local/remote turn split:

**1. Remote turns on rows and in the transcript.** The tab already colours a peer's turn neutral ("in progress elsewhere — quitting leaves these running"), but the thread rows, Star Map cards and the transcript's pending line still swept every live turn in accent. They now use the same neutral tokens for a peer's turn, so the list answers "does quitting interrupt this?" one thread at a time.
- `ThreadRowStatus` gains `remoteWork`; the mark gets `thread-row__status-indicator--remote`, `data-remote-work`, and the label "Thinking on another instance".
- The sidebar row and `ThreadView` gate on the tab's own window gate (`windowSplitsTurnsByMachine`, extracted from `Sidebar`): a viewer fronting a peer keeps accent everywhere, exactly as its tab does. The Star Map card and chat card split on the bare `isThreadRemoteWork`, matching the map's chip — each surface agrees with the readout that counts it.
- One CSS recipe tints every remote beam (tab readout, row mark, pending line).

**2. Star Map Attention chip = the tab.** The chip's readouts were a hand copy of the tab's that had drifted: turns in a row instead of the tab's stacked column, and no spacing at all between the turns and the cookie. The chip is rebuilt on the tab's own elements, extracted from `Sidebar.tsx` into `AttentionSignals.tsx`:
- stacked local/remote turn column, cookie beside it, same classes and tokens;
- the tab's hover card (same component, same class, lifted above the map's stacking context), with the map's caption, an "Unread" third row, and a footer saying what a click does;
- no visible word on the chip — the name lives in the `aria-label` and the card, like the lens tabs;
- the chip stays level with its labelled neighbours (25px) whether it shows one turn row or two, so the top band doesn't jump when a peer starts a turn.

**Root cause of the "no spacing" bug:** #1805 spliced a comment between two CSS selectors, turning `.star-map__filter-panel .star-map__filter-count {` into `.star-map__filter-panel /*…*/ .star-map__filter-signals {` — the signal-row layout applied only inside the popover, and the panel's `margin-left: auto` count rule was lost. Both restored.

Style guide gains a note on the remote readout and the chip.

## Test plan
- [x] `pnpm --filter @pwragent/desktop typecheck`
- [x] `pnpm lint:eslint` on touched files, `pnpm lint:boundaries`, `pnpm lint:colors`
- [x] Full desktop renderer vitest project (208 files / 3301 tests) under Node 24
- [x] New tests: remote row mark + viewer-window gate (sidebar), remote pending line (transcript-list), stacked column / no label / hover card (star-map-attention-chip)
- [x] Static harness off the real `app.css`: chips measured level at 25px in strip and panel, turn column 22px, remote tints resolve to the neutral tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
