### PR TITLE
fix(tests): stabilize macOS E2E lifecycle coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,7 +506,7 @@ jobs:
           lookup-only: "true"
 
   desktop-e2e-macos:
-    name: macOS Desktop E2E (lane ${{ matrix.lane }} of 2)
+    name: macOS Desktop E2E (lane ${{ matrix.lane }} of 4)
     # The restricted PwrDrvr organization runner group exposes this label only
     # to PwrAgent and PwrSnap. The host Tart VM runs Electron on its virtual
     # display, so neither CI nor manual test work takes over an operator's Mac.
@@ -521,14 +521,17 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, pwrdrvr-macos]
     needs: [changes, macos-install-deps]
     strategy:
-      # Keep both lab VMs busy when they are idle, while avoiding a third
-      # queued lane when one is already serving another job. Do not cancel the
-      # other shard on failure: its artifacts can distinguish a real failure
-      # from a flaky one and make the follow-up rerun smaller.
+      # Bound each Playwright process to roughly half the previous number of
+      # Electron launches. The persistent 8 GB guest remains healthy under
+      # measured memory pressure, but Virtualization.framework kernel clients
+      # still accumulate across a long lane; the two-app federation lifecycle
+      # previously ran last after 105 launches. Keep only the two lab VMs busy
+      # concurrently, and do not cancel the other shards on failure: their
+      # artifacts distinguish a product failure from guest degradation.
       fail-fast: false
       max-parallel: 2
       matrix:
-        lane: [1, 2]
+        lane: [1, 2, 3, 4]
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -583,7 +586,7 @@ jobs:
           PWRAGENT_E2E_SHUTDOWN_CIRCUIT_BREAKER: "1"
         run: >-
           pnpm --filter @pwragent/desktop test:e2e
-          --shard=${{ matrix.lane }}/2
+          --shard=${{ matrix.lane }}/4
 
       - name: Upload macOS Playwright artifacts
         uses: actions/upload-artifact@v7

--- a/apps/desktop/e2e/app-quit-lifecycle.spec.ts
+++ b/apps/desktop/e2e/app-quit-lifecycle.spec.ts
@@ -210,6 +210,17 @@ test("acknowledges a repeat quit request and exits once the prompt is answered",
     await expect(
       app.window.locator(".integrated-terminal .xterm-rows"),
     ).toContainText("PWRAGENT_QUIT_BLOCKER_READY");
+    // Seeing the marker only proves that the shell completed `echo`. On a
+    // loaded guest, node-pty can still report the shell as the foreground
+    // process for the brief interval before `sleep` takes the terminal. Quit
+    // during that interval correctly sees no blocker and exits without a
+    // prompt. Wait on the exact main-process snapshot used by QuitManager so
+    // this test asks for quit only after the condition it intends to exercise.
+    await expect
+      .poll(async () =>
+        (await app.getIntegratedTerminalQuitSnapshot())?.count ?? 0
+      )
+      .toBe(1);
 
     const dialogPromise = app.electronApp.waitForEvent("window");
     requestQuit(app.electronApp);

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -169,6 +169,10 @@ type LaunchResult = {
     html?: string;
     text: string;
   } | undefined>;
+  getIntegratedTerminalQuitSnapshot: () => Promise<{
+    count: number;
+    sessionIds: string[];
+  } | undefined>;
   advance: (params?: {
     executionMode?: ThreadExecutionMode;
     stepId?: string;
@@ -502,6 +506,10 @@ async function finishElectronLaunch(args: {
     window,
     getClipboardSnapshot: async () =>
       await electronApp.evaluate(() => globalThis.__PWRAGENT_E2E_CLIPBOARD__),
+    getIntegratedTerminalQuitSnapshot: async () =>
+      await electronApp.evaluate(() =>
+        globalThis.__PWRAGENT_E2E_GET_INTEGRATED_TERMINAL_QUIT_SNAPSHOT__?.()
+      ),
     advance: async (advanceParams) => {
       await electronApp.evaluate(async (_electron, value) => {
         await globalThis.__PWRAGENT_REPLAY_DRIVER__?.advance(value);

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -1,4 +1,4 @@
-import { ipcMain, type WebContents } from "electron";
+import { app, ipcMain, type WebContents } from "electron";
 import {
   INTEGRATED_TERMINAL_CLOSE_CHANNEL,
   INTEGRATED_TERMINAL_CREATE_CHANNEL,
@@ -35,6 +35,12 @@ let service: IntegratedTerminalService | undefined;
 let federationBridge: FederationTerminalBridge | undefined;
 let serviceDisposalPromise: Promise<void> | undefined;
 
+declare global {
+  var __PWRAGENT_E2E_GET_INTEGRATED_TERMINAL_QUIT_SNAPSHOT__:
+    | (() => IntegratedTerminalQuitSnapshot)
+    | undefined;
+}
+
 function broadcastSessions(
   sessions: IntegratedTerminalSessionSummary[],
 ): void {
@@ -66,6 +72,10 @@ export function registerIntegratedTerminalIpcHandlers(): void {
   federationBridge ??= new FederationTerminalBridge({
     localSessionsFor: () => service?.listSessions() ?? [],
   });
+  if (process.env.PWRAGENT_E2E === "1" && !app.isPackaged) {
+    globalThis.__PWRAGENT_E2E_GET_INTEGRATED_TERMINAL_QUIT_SNAPSHOT__ =
+      getIntegratedTerminalQuitSnapshot;
+  }
 
   ipcMain.removeHandler(INTEGRATED_TERMINAL_CREATE_CHANNEL);
   ipcMain.handle(
@@ -181,6 +191,7 @@ export function disposeIntegratedTerminalIpcHandlers(): Promise<void> {
   // tearing down anyway and the owner's disconnect reap ends the shells.
   federationBridge?.dispose();
   federationBridge = undefined;
+  delete globalThis.__PWRAGENT_E2E_GET_INTEGRATED_TERMINAL_QUIT_SNAPSHOT__;
   return serviceDisposalPromise;
 }
 


### PR DESCRIPTION
## Summary

- expose the integrated-terminal quit snapshot only to unpackaged E2E launches
- make the repeat-quit lifecycle test wait for the same blocker snapshot used by `QuitManager`
- remove the race where xterm had printed the shell's `echo` marker but node-pty had not yet observed `sleep` as the foreground process
- split macOS E2E into four shards while keeping `max-parallel: 2`, bounding each Playwright process to 41–65 tests instead of 105–106

## Failure analysis

The flaky `app-quit-lifecycle` failure was a readiness race. The test used terminal output as its readiness signal, but output from `echo` can arrive before the shell hands the foreground terminal to `sleep`. A quit in that interval correctly sees no active terminal work and exits without opening the dialog, causing Playwright's window wait to reject.

The shutdown-circuit failure is a separate persistent-runner resource condition. The identical two-app force-kill occurs at the end of lane 1 across unrelated merge SHAs, after roughly 105 healthy Electron closes. Main run [32529403498](https://github.com/pwrdrvr/PwrAgent/actions/runs/32529403498) reproduced the exact pair: the readiness race at test 18, followed by both federation apps becoming unreachable at test 106 with no product shutdown phase observed.

An instrumented full lane in the separate 8 GB Tart guest never fell below 69% free memory, including while the two federation apps were active, so increasing RAM or reducing memory peak is not the evidence-based fix. Kernel counters did show 19 additional `AppleVideoToolboxParavirtualizationUserClient` objects across two full lanes despite the existing Chromium codec switches. Four shards reset the Playwright/Node process after 41–65 tests and move the two-app federation lifecycle from last in lane 1 to test 40/41 in lane 2, while `max-parallel: 2` preserves the two-runner concurrency ceiling.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts` (43 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- Tart macOS, focused repeat-quit lifecycle: 20/20 passed
- Tart macOS, full lane 1 shard: 85 passed, 21 skipped; both reported tests passed on their first attempt, with no abnormal shutdown circuits
- four-shard distribution: 65 / 41 / 53 / 52 tests
- Tart macOS shard 2/4: 31 passed, 10 skipped; federation lifecycle passed as test 40/41 with no abnormal shutdown circuits

CI failures investigated:

- https://github.com/pwrdrvr/PwrAgent/actions/runs/32517215890/job/96881516316?pr=1826
- https://github.com/pwrdrvr/PwrAgent/actions/runs/32529403498
