### PR TITLE
fix(desktop): paint star map chat tethers under cards with an edge anchor

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -103,6 +103,7 @@ import {
   chatCardEdgeToward,
   dockContextRect,
   dockTerminalRect,
+  tetherExitPoint,
 } from "./star-map-chat-card-geometry";
 import type { StarMapCardMenuAction } from "./StarMapCardMenu";
 import { useStarMapChatCards } from "./useStarMapChatCards";
@@ -225,6 +226,12 @@ const STAR_MAP_LOAD_CARD_Z = 7000;
  * options) so a card being read is never underneath a control strip.
  */
 const STAR_MAP_CHAT_CARD_BASE_Z = 40;
+/**
+ * The dot where a chat tether surfaces from under its thread card. Also
+ * sets how far the exit point is pushed clear of the card (plus the 1px
+ * border) so the dot is never half-hidden under it.
+ */
+const TETHER_ANCHOR_RADIUS = 3;
 /**
  * How close an edge has to come before it latches, in SCREEN pixels so the
  * pull feels identical at every zoom. Wide enough to catch a deliberate
@@ -3436,6 +3443,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * A chat card whose thread has no card on the map (filtered out, or
    * folded into a cloud's overflow) simply gets no tether: a line to
    * nowhere is worse than no line.
+   *
+   * The arc runs to the thread card's centre but is painted UNDER the
+   * clouds (`.star-map__tethers` z-index), so the stretch across the card
+   * — and across any other card or menu in its way — is hidden; the dot
+   * marks where it surfaces from under its own card, so the pairing reads
+   * edge-to-edge. See `tetherExitPoint`.
    */
   const chatTethers = useMemo(() => {
     if (chatCards.cards.length === 0 || projectsMode) return [];
@@ -3458,15 +3471,30 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // A shallow arc, so the tether reads as part of the same sky as the
       // instance links rather than as a UI connector.
       const lift = 0.12;
+      const control = {
+        x: midX + (target.y - from.y) * lift,
+        y: midY - (target.x - from.x) * lift,
+      };
+      const anchor = tetherExitPoint({
+        from,
+        control,
+        to: target,
+        rect: {
+          left: source.x,
+          top: source.y,
+          width: source.width,
+          height: source.height,
+        },
+        margin: TETHER_ANCHOR_RADIUS + 1,
+      });
       return [
         {
           key: card.key,
           path:
             `M ${from.x.toFixed(2)} ${from.y.toFixed(2)}`
-            + ` Q ${(midX + (target.y - from.y) * lift).toFixed(2)}`
-            + ` ${(midY - (target.x - from.x) * lift).toFixed(2)}`
+            + ` Q ${control.x.toFixed(2)} ${control.y.toFixed(2)}`
             + ` ${target.x.toFixed(2)} ${target.y.toFixed(2)}`,
-          target,
+          anchor,
         },
       ];
     });
@@ -3483,12 +3511,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
         {chatTethers.map((tether) => (
           <g key={tether.key}>
             <path className="star-map__tether" d={tether.path} />
-            <circle
-              className="star-map__tether-anchor"
-              cx={tether.target.x}
-              cy={tether.target.y}
-              r={3}
-            />
+            {tether.anchor ? (
+              <circle
+                className="star-map__tether-anchor"
+                cx={tether.anchor.x.toFixed(2)}
+                cy={tether.anchor.y.toFixed(2)}
+                r={TETHER_ANCHOR_RADIUS}
+              />
+            ) : null}
           </g>
         ))}
       </svg>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -227,9 +227,9 @@ const STAR_MAP_LOAD_CARD_Z = 7000;
  */
 const STAR_MAP_CHAT_CARD_BASE_Z = 40;
 /**
- * The dot where a chat tether surfaces from under its thread card. Also
- * sets how far the exit point is pushed clear of the card (plus the 1px
- * border) so the dot is never half-hidden under it.
+ * The dot at each end of a chat tether, where the line clears its card.
+ * Also sets how far the exit point is pushed out (plus the 1px border) so
+ * a dot is never half-hidden under the card it belongs to.
  */
 const TETHER_ANCHOR_RADIUS = 3;
 /**
@@ -3446,9 +3446,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
    *
    * The arc runs to the thread card's centre but is painted UNDER the
    * clouds (`.star-map__tethers` z-index), so the stretch across the card
-   * — and across any other card or menu in its way — is hidden; the dot
-   * marks where it surfaces from under its own card, so the pairing reads
-   * edge-to-edge. See `tetherExitPoint`.
+   * — and across any other card or menu in its way — is hidden. A dot at
+   * each end marks where the line clears its own card, so the pairing
+   * reads edge-to-edge rather than centre-to-centre. See
+   * `tetherExitPoint`.
    */
   const chatTethers = useMemo(() => {
     if (chatCards.cards.length === 0 || projectsMode) return [];
@@ -3475,7 +3476,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
         x: midX + (target.y - from.y) * lift,
         y: midY - (target.x - from.x) * lift,
       };
-      const anchor = tetherExitPoint({
+      const margin = TETHER_ANCHOR_RADIUS + 1;
+      const threadAnchor = tetherExitPoint({
         from,
         control,
         to: target,
@@ -3485,7 +3487,19 @@ export function StarMapScreen(props: StarMapScreenProps) {
           width: source.width,
           height: source.height,
         },
-        margin: TETHER_ANCHOR_RADIUS + 1,
+        margin,
+      });
+      // The same walk from the other end. A quadratic reversed is the
+      // same curve with the same control point, so swapping the
+      // endpoints traces this arc backwards from the chat card and finds
+      // where it clears ITS border — no second algorithm, and the two
+      // dots sit the same distance clear of their own card.
+      const chatAnchor = tetherExitPoint({
+        from: target,
+        control,
+        to: from,
+        rect: card.rect,
+        margin,
       });
       return [
         {
@@ -3494,7 +3508,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
             `M ${from.x.toFixed(2)} ${from.y.toFixed(2)}`
             + ` Q ${control.x.toFixed(2)} ${control.y.toFixed(2)}`
             + ` ${target.x.toFixed(2)} ${target.y.toFixed(2)}`,
-          anchor,
+          anchors: [chatAnchor, threadAnchor].filter(
+            (point): point is { x: number; y: number } => point !== undefined,
+          ),
         },
       ];
     });
@@ -3511,14 +3527,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
         {chatTethers.map((tether) => (
           <g key={tether.key}>
             <path className="star-map__tether" d={tether.path} />
-            {tether.anchor ? (
+            {tether.anchors.map((point, index) => (
               <circle
+                key={index}
                 className="star-map__tether-anchor"
-                cx={tether.anchor.x.toFixed(2)}
-                cy={tether.anchor.y.toFixed(2)}
+                cx={point.x.toFixed(2)}
+                cy={point.y.toFixed(2)}
                 r={TETHER_ANCHOR_RADIUS}
               />
-            ) : null}
+            ))}
           </g>
         ))}
       </svg>

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
@@ -17,6 +17,7 @@ import {
   placeChatCardBesideAnchor,
   raiseChatCard,
   resizeChatCardRect,
+  tetherExitPoint,
 } from "../star-map-chat-card-geometry";
 
 const viewport = { width: 1440, height: 900 };
@@ -272,6 +273,59 @@ describe("chatCardEdgeToward", () => {
       x: 200,
       y: 150,
     });
+  });
+});
+
+describe("tetherExitPoint", () => {
+  // Thread card 200x100 at (100,100); its centre is (200,150).
+  const rect = { left: 100, top: 100, width: 200, height: 100 };
+  const to = { x: 200, y: 150 };
+
+  it("lands just outside the edge the arc leaves through", () => {
+    // Chat card off to the right: a straight chord would leave through
+    // the right edge at x=300.
+    const from = { x: 800, y: 150 };
+    const point = tetherExitPoint({
+      from,
+      control: { x: 500, y: 150 },
+      to,
+      rect,
+      margin: 4,
+    });
+    expect(point).toBeDefined();
+    expect(point!.x).toBeCloseTo(304, 1);
+    expect(point!.y).toBeCloseTo(150, 1);
+  });
+
+  it("follows the bowed arc rather than the straight chord", () => {
+    const from = { x: 800, y: 150 };
+    // Control point pulled well below the chord: the arc dips, so it
+    // surfaces below the centre line.
+    const point = tetherExitPoint({
+      from,
+      control: { x: 500, y: 450 },
+      to,
+      rect,
+      margin: 4,
+    });
+    expect(point).toBeDefined();
+    expect(point!.y).toBeGreaterThan(150);
+    // Still sits on the inflated border, clear of the card.
+    const onRight = Math.abs(point!.x - 304) < 0.5;
+    const onBottom = Math.abs(point!.y - 204) < 0.5;
+    expect(onRight || onBottom).toBe(true);
+  });
+
+  it("reports nothing when the arc never leaves the card", () => {
+    // Chat card opened on top of its own thread card: both ends inside.
+    const point = tetherExitPoint({
+      from: { x: 150, y: 120 },
+      control: { x: 170, y: 130 },
+      to,
+      rect,
+      margin: 4,
+    });
+    expect(point).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -659,6 +659,13 @@ describe("star map chat cards in map space", () => {
     await waitFor(() => {
       expect(container.querySelector(".star-map__tether")).not.toBeNull();
     });
+    // One dot at each end: the line reads card-edge to card-edge, not
+    // centre to centre. Both are placed by walking the same arc from
+    // opposite ends, so a missing one means an endpoint stopped clearing
+    // its own card.
+    expect(
+      container.querySelectorAll(".star-map__tether-anchor"),
+    ).toHaveLength(2);
     const shell = cardShell(container, "codex:a1");
     const chat = container.querySelector(".star-map-chat-card") as HTMLElement;
     // Beside its card rather than cascaded into a corner: the horizontal

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-z-layers.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-z-layers.test.ts
@@ -69,4 +69,14 @@ describe("star map cloud paint layers", () => {
   it("keeps the nebula smudge under its cards", () => {
     expect(zIndexIn(".star-map__cluster-halo")).toBe(0);
   });
+
+  it("paints chat tethers under the clouds", () => {
+    // The tether aims at its thread card's centre and relies on the card
+    // to hide the stretch underneath it; above the clouds it crossed the
+    // cards, their kebab menus and the cluster chrome as a dashed line
+    // over the text.
+    expect(zIndexIn(".star-map__tethers")).toBeLessThan(
+      zIndexIn(".star-map__cloud"),
+    );
+  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
@@ -213,6 +213,81 @@ export function chatCardEdgeToward(
   return { x: centerX + dx * scale, y: centerY + dy * scale };
 }
 
+type Point = { x: number; y: number };
+
+function quadraticPointAt(
+  from: Point,
+  control: Point,
+  to: Point,
+  t: number,
+): Point {
+  const u = 1 - t;
+  return {
+    x: u * u * from.x + 2 * u * t * control.x + t * t * to.x,
+    y: u * u * from.y + 2 * u * t * control.y + t * t * to.y,
+  };
+}
+
+/**
+ * Where a tether surfaces from under the thread card it belongs to.
+ *
+ * The tether is a quadratic arc from the chat card's edge to the thread
+ * card's CENTRE, painted underneath the cards. Aiming at the centre keeps
+ * the line pointing at the card however the pair is arranged; painting it
+ * underneath hides the stretch that would otherwise cross the card's
+ * text. What the eye then needs is a mark at the point where the line
+ * comes out from under the card, so the pairing reads edge-to-edge.
+ *
+ * Walked along the arc from the centre outward rather than intersected
+ * with the chord: the arc bows, so the straight-line exit would put the
+ * dot beside the line instead of on it. `margin` inflates the rect so the
+ * dot (radius plus the card's border) sits fully clear of the card instead
+ * of half under it. Returns nothing when the arc never leaves the inflated
+ * rect — the chat card sits on top of its own thread card, and a dot
+ * under the chat would be invisible anyway.
+ */
+export function tetherExitPoint(args: {
+  from: Point;
+  control: Point;
+  to: Point;
+  rect: ChatCardRect;
+  margin: number;
+}): Point | undefined {
+  const { from, control, to, rect, margin } = args;
+  const left = rect.left - margin;
+  const top = rect.top - margin;
+  const right = rect.left + rect.width + margin;
+  const bottom = rect.top + rect.height + margin;
+  const inside = (point: Point): boolean =>
+    point.x >= left && point.x <= right && point.y >= top && point.y <= bottom;
+  if (!inside(to)) return to;
+  const STEPS = 128;
+  let insideT = 1;
+  let firstOutsideT: number | undefined;
+  for (let step = STEPS - 1; step >= 0; step -= 1) {
+    const t = step / STEPS;
+    if (inside(quadraticPointAt(from, control, to, t))) {
+      insideT = t;
+    } else {
+      firstOutsideT = t;
+      break;
+    }
+  }
+  if (firstOutsideT === undefined) return undefined;
+  // Bisect the crossing so the dot lands on the edge, not up to one step
+  // past it.
+  let outsideT: number = firstOutsideT;
+  for (let i = 0; i < 16; i += 1) {
+    const mid = (insideT + outsideT) / 2;
+    if (inside(quadraticPointAt(from, control, to, mid))) {
+      insideT = mid;
+    } else {
+      outsideT = mid;
+    }
+  }
+  return quadraticPointAt(from, control, to, outsideT);
+}
+
 /** Gap between a chat card and a satellite docked to it. */
 export const CHAT_CARD_DOCK_GAP = 12;
 /** Panel width inside the docked context card; the rail's own minimum. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -30111,12 +30111,20 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* Tether from an open chat card to the thread card it belongs to. Drawn
-   inside the canvas, so it pans and zooms with both endpoints. */
+   inside the canvas, so it pans and zooms with both endpoints.
+
+   Painted UNDER the clouds (`.star-map__cloud` is z-index 1): the line is a
+   wayfinding aid, not a foreground object, and at z-index 2 it crossed
+   thread cards, their kebab menus and cluster chrome as a dashed scribble
+   over the text. Below them, the stretch that runs under its own card is
+   hidden too, which is what lets the anchor dot mark the edge where the
+   line comes out — the arc still aims at the card's centre. Chat cards sit
+   far above either way. Pinned by star-map-z-layers.test.ts. */
 .star-map__tethers {
   position: absolute;
   left: 0;
   top: 0;
-  z-index: 2;
+  z-index: 0;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

- The chat-card tether SVG (`.star-map__tethers`) was at `z-index: 2` while every `.star-map__cloud` (thread cards, their kebab menus, cluster chrome) is `z-index: 1`, so the dashed line painted across card text and through open menus. It now sits at `z-index: 0`, under the clouds — a wayfinding line, not a foreground object. Chat cards (z 40+) already covered it.
- The arc still aims at the thread card's centre, but since it is now painted under the card the stretch across it is hidden. The anchor dot moves from the card centre to the point where the arc surfaces from under its own card, so the pairing reads edge-to-edge: chat-card edge → dot on the thread-card edge.
- New `tetherExitPoint` in `star-map-chat-card-geometry.ts` walks the actual quadratic arc back from the centre and bisects the crossing of the card rect inflated by dot radius + 1px border, so the dot sits fully clear of the edge and on the bowed line (not beside it on the straight chord). Returns nothing when the arc never leaves the card (chat card opened on top of its own thread card) and no dot is drawn.
- `TETHER_ANCHOR_RADIUS = 3` replaces the magic `r={3}`.

## Verification

- `star-map-z-layers.test.ts`: new case pins `.star-map__tethers` below `.star-map__cloud`.
- `star-map-chat-card-geometry.test.ts`: 3 new `tetherExitPoint` cases (lands on the inflated edge, follows the bowed arc rather than the chord, undefined when fully covered).
- All 39 star-map test files + theme contract: 661/661 pass. `pnpm --filter @pwragent/desktop typecheck` clean; ESLint clean on touched files.
- Checked visually in a standalone before/after harness in headless Chromium: before, the line crosses the thread card's title with the dot floating on the text; after, the line is visible only outside the card with the dot on the edge where it exits.

## Notes

- Not exercised in the live Electron dev profile — the change is a z-index swap plus dot placement, validated in the harness and unit tests.
- Decision trade-off: with the line under the clouds, a tether passing behind a dense lane stack is hidden for that stretch. It stays visible on both sides, and the edge dot marks the owner, so that seemed the right side of the trade versus lines over menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
