### PR TITLE
fix(desktop): make Star Map chat cards legible — visible edges, slimmer title bar

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import {
   buildThreadIdentityKey,
+  isCelestialIconId,
   isRemoteFederationTarget,
   type CelestialIconId,
   type NavigationLaunchpadFileAttachment,
@@ -153,7 +154,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   }, []);
   // The card is draggable and clipped; a native `title` fights both, and
   // UI-THEME.md rules it out regardless.
-  const titleTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const barTooltip = useViewportTooltip({ className: "viewport-tooltip" });
 
   // Without a limit `readThread` returns the thread from its first message.
   // On a large thread that is the entire transcript — hundreds of MB over
@@ -205,6 +206,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         : undefined,
     [remoteInstanceId],
   );
+  /* Where ↗ actually lands, which is not the same place for every card:
+     a peer's thread opens in a window fronting that peer, a local one in
+     the main window. The glyph alone cannot say that, so the tooltip
+     does — and it names the peer, since a card only shows its instance
+     as an icon now. */
+  const openFullTooltip = props.instanceLabel && remoteInstanceId
+    ? `Open in a window connected to ${props.instanceLabel}`
+    : "Open in the main window";
   const isAcpThread = thread.source.startsWith("acp:");
   const backendSummaries = useBackendSummaries(desktopApi, {
     // The composer needs model/runtime image capability before its first
@@ -1073,58 +1082,104 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         <span
           className="star-map-chat-card__title"
           onMouseEnter={(event) =>
-            titleTooltip.show(event.currentTarget, thread.title)
+            barTooltip.show(event.currentTarget, thread.title)
           }
-          onMouseLeave={titleTooltip.hide}
+          onMouseLeave={barTooltip.hide}
         >
           {thread.title}
         </span>
         {props.instanceLabel ? (
-          <span className="star-map-chat-card__instance">
-            {props.instanceLabel}
+          /* Identity, not prose. The machine name ran to a full hostname
+             plus directory ("Harold-MBP-M2-Max / work") and took more of
+             the bar than the thread title beside it, so the icon carries
+             it and the name lives in the tooltip and the accessible
+             name. The icon is the SAME celestial mark the map gives this
+             instance, so a card and its star read as one thing.
+
+             Text is the fallback whenever no mark can render: before the
+             assignment snapshot lands `iconFor` returns undefined, and a
+             peer on a newer build can name an icon this build has never
+             heard of — the celestial contract says treat that as
+             unassigned, and `CelestialIcon` renders null for it, which
+             would leave an empty slot where the instance should be.
+             Identity must never silently vanish. */
+          <span
+            className={`star-map-chat-card__instance${
+              isCelestialIconId(props.instanceIcon)
+                ? " star-map-chat-card__instance--icon"
+                : ""
+            }`}
+            onMouseEnter={(event) =>
+              barTooltip.show(event.currentTarget, props.instanceLabel)
+            }
+            onMouseLeave={barTooltip.hide}
+          >
+            {isCelestialIconId(props.instanceIcon) ? (
+              <CelestialIcon
+                aria-label={`Instance: ${props.instanceLabel}`}
+                icon={props.instanceIcon}
+                size={14}
+              />
+            ) : (
+              props.instanceLabel
+            )}
           </span>
         ) : undefined}
-        <button
-          aria-expanded={props.contextOpen ?? false}
-          aria-label={
-            props.contextOpen
-              ? `Hide thread context for ${thread.title}`
-              : `Show thread context for ${thread.title}`
-          }
-          className={`star-map-chat-card__rail-toggle${
-            props.contextOpen ? " is-on" : ""
-          }`}
-          onClick={() => props.onToggleContext(cardKey)}
-          onPointerDown={(event) => event.stopPropagation()}
-          type="button"
-        >
-          ⌸
-        </button>
-        <button
-          aria-expanded={props.terminalOpen ?? false}
-          aria-label={
-            props.terminalOpen
-              ? `Close terminal for ${thread.title}`
-              : `Open terminal for ${thread.title}`
-          }
-          className={`star-map-chat-card__rail-toggle${
-            props.terminalOpen ? " is-on" : ""
-          }`}
-          onClick={() => props.onToggleTerminal(cardKey)}
-          onPointerDown={(event) => event.stopPropagation()}
-          type="button"
-        >
-          &gt;_
-        </button>
-        <button
-          aria-label={`Open ${thread.title} in the full thread view`}
-          className="star-map-chat-card__expand"
-          onClick={() => onOpenFull(thread)}
-          onPointerDown={(event) => event.stopPropagation()}
-          type="button"
-        >
-          Open
-        </button>
+        {/* One group, so the three things the operator DOES to a card read
+            as a cluster instead of three lone glyphs drifting between the
+            title and the close button. Close stays outside it: a
+            destructive control should not sit flush against the controls
+            the hand reaches for repeatedly. */}
+        <span className="star-map-chat-card__actions">
+          <button
+            aria-expanded={props.contextOpen ?? false}
+            aria-label={
+              props.contextOpen
+                ? `Hide thread context for ${thread.title}`
+                : `Show thread context for ${thread.title}`
+            }
+            className={`star-map-chat-card__rail-toggle${
+              props.contextOpen ? " is-on" : ""
+            }`}
+            onClick={() => props.onToggleContext(cardKey)}
+            onPointerDown={(event) => event.stopPropagation()}
+            type="button"
+          >
+            ⌸
+          </button>
+          <button
+            aria-expanded={props.terminalOpen ?? false}
+            aria-label={
+              props.terminalOpen
+                ? `Close terminal for ${thread.title}`
+                : `Open terminal for ${thread.title}`
+            }
+            className={`star-map-chat-card__rail-toggle${
+              props.terminalOpen ? " is-on" : ""
+            }`}
+            onClick={() => props.onToggleTerminal(cardKey)}
+            onPointerDown={(event) => event.stopPropagation()}
+            type="button"
+          >
+            &gt;_
+          </button>
+          <button
+            aria-label={`Open ${thread.title} in the full thread view`}
+            className="star-map-chat-card__expand"
+            onClick={() => onOpenFull(thread)}
+            onMouseEnter={(event) =>
+              barTooltip.show(event.currentTarget, openFullTooltip)
+            }
+            onMouseLeave={barTooltip.hide}
+            onPointerDown={(event) => event.stopPropagation()}
+            type="button"
+          >
+            {/* Was the word "Open". The glyph says the same thing in a
+                sixth of the bar, and it is the one control here that leaves
+                the map, so it earns the direction the other two do not. */}
+            ↗
+          </button>
+        </span>
         <button
           aria-label={`Close chat: ${thread.title}`}
           className="star-map-chat-card__close"
@@ -1214,7 +1269,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           />
         ) : null}
       </div>
-      {titleTooltip.tooltipNode}
+      {barTooltip.tooltipNode}
       {/* Portals to the body, so the card's clip and transform miss it. */}
       {fullAccessRiskDialog}
       <span

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -206,6 +206,20 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         : undefined,
     [remoteInstanceId],
   );
+  /* Every control in the bar is a glyph now, so every one of them needs
+     the same hover affordance — a lone tooltip on ↗ reads as the other
+     two being broken. The toggles say what the click will DO, which is
+     the opposite of the state they are in. Short on purpose: the
+     `aria-label` carries the thread title for screen readers, but a
+     tooltip repeating it beside the title it names is noise. */
+  const contextTooltip = {
+    hide: "Hide thread context",
+    show: "Show thread context",
+  };
+  const terminalTooltip = {
+    close: "Close terminal",
+    open: "Open terminal",
+  };
   /* Where ↗ actually lands, which is not the same place for every card:
      a peer's thread opens in a window fronting that peer, a local one in
      the main window. The glyph alone cannot say that, so the tooltip
@@ -1141,7 +1155,22 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             className={`star-map-chat-card__rail-toggle${
               props.contextOpen ? " is-on" : ""
             }`}
-            onClick={() => props.onToggleContext(cardKey)}
+            onClick={() => {
+              props.onToggleContext(cardKey);
+              // The pointer is still on the button and the label just
+              // flipped. Without this the tooltip keeps offering the
+              // action the operator already took.
+              barTooltip.update(
+                props.contextOpen ? contextTooltip.show : contextTooltip.hide,
+              );
+            }}
+            onMouseEnter={(event) =>
+              barTooltip.show(
+                event.currentTarget,
+                props.contextOpen ? contextTooltip.hide : contextTooltip.show,
+              )
+            }
+            onMouseLeave={barTooltip.hide}
             onPointerDown={(event) => event.stopPropagation()}
             type="button"
           >
@@ -1157,7 +1186,19 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             className={`star-map-chat-card__rail-toggle${
               props.terminalOpen ? " is-on" : ""
             }`}
-            onClick={() => props.onToggleTerminal(cardKey)}
+            onClick={() => {
+              props.onToggleTerminal(cardKey);
+              barTooltip.update(
+                props.terminalOpen ? terminalTooltip.open : terminalTooltip.close,
+              );
+            }}
+            onMouseEnter={(event) =>
+              barTooltip.show(
+                event.currentTarget,
+                props.terminalOpen ? terminalTooltip.close : terminalTooltip.open,
+              )
+            }
+            onMouseLeave={barTooltip.hide}
             onPointerDown={(event) => event.stopPropagation()}
             type="button"
           >
@@ -1184,6 +1225,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           aria-label={`Close chat: ${thread.title}`}
           className="star-map-chat-card__close"
           onClick={() => props.onClose(cardKey)}
+          onMouseEnter={(event) =>
+            barTooltip.show(event.currentTarget, "Close chat")
+          }
+          onMouseLeave={barTooltip.hide}
           onPointerDown={(event) => event.stopPropagation()}
           type="button"
         >

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
+  type ReactNode,
 } from "react";
 import {
   buildThreadIdentityKey,
@@ -155,6 +156,27 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   // The card is draggable and clipped; a native `title` fights both, and
   // UI-THEME.md rules it out regardless.
   const barTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  /* Which element the visible bar tooltip belongs to. A toggle re-labels
+     its tooltip after the click (the pointer has not left the button, so
+     a stale label would sit there offering the action just taken), and
+     `update` writes to whatever is on screen — including a tooltip some
+     OTHER control put there. Keyboard-activating a toggle while the
+     pointer rests on the title used to rewrite the title's tooltip in
+     place. Only the owner re-labels. */
+  const barTooltipAnchorRef = useRef<HTMLElement | null>(null);
+  const showBarTooltip = (target: HTMLElement, content: ReactNode): void => {
+    barTooltipAnchorRef.current = target;
+    barTooltip.show(target, content);
+  };
+  const hideBarTooltip = (): void => {
+    barTooltipAnchorRef.current = null;
+    barTooltip.hide();
+  };
+  const relabelBarTooltip = (owner: HTMLElement, content: ReactNode): void => {
+    if (barTooltipAnchorRef.current === owner) {
+      barTooltip.update(content);
+    }
+  };
 
   // Without a limit `readThread` returns the thread from its first message.
   // On a large thread that is the entire transcript — hundreds of MB over
@@ -224,10 +246,26 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
      a peer's thread opens in a window fronting that peer, a local one in
      the main window. The glyph alone cannot say that, so the tooltip
      does — and it names the peer, since a card only shows its instance
-     as an icon now. */
-  const openFullTooltip = props.instanceLabel && remoteInstanceId
-    ? `Open in a window connected to ${props.instanceLabel}`
-    : "Open in the main window";
+     as an icon now.
+
+     Asks the SAME question `openThreadFully` asks — the thread's own ref,
+     not `remoteInstanceId`, which also answers yes for a local thread in
+     a window that carries a federation target. Two predicates for one
+     sentence is how a tooltip ends up describing the other branch.
+
+     The peer's name is decoration here, never the deciding factor:
+     StarMapScreen reads it straight out of `displayLabelById` with no
+     fallback, so an unlinked peer leaves it undefined — and gating the
+     whole sentence on it told the operator "main window" right before
+     opening a federation window. */
+  const opensPeerWindow = Boolean(
+    threadFederationTarget && isRemoteFederationTarget(threadFederationTarget),
+  );
+  const openFullTooltip = !opensPeerWindow
+    ? "Open in the main window"
+    : props.instanceLabel
+      ? `Open in a window connected to ${props.instanceLabel}`
+      : "Open in a window connected to that instance";
   const isAcpThread = thread.source.startsWith("acp:");
   const backendSummaries = useBackendSummaries(desktopApi, {
     // The composer needs model/runtime image capability before its first
@@ -1096,9 +1134,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         <span
           className="star-map-chat-card__title"
           onMouseEnter={(event) =>
-            barTooltip.show(event.currentTarget, thread.title)
+            showBarTooltip(event.currentTarget, thread.title)
           }
-          onMouseLeave={barTooltip.hide}
+          onMouseLeave={hideBarTooltip}
         >
           {thread.title}
         </span>
@@ -1124,9 +1162,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
                 : ""
             }`}
             onMouseEnter={(event) =>
-              barTooltip.show(event.currentTarget, props.instanceLabel)
+              showBarTooltip(event.currentTarget, props.instanceLabel)
             }
-            onMouseLeave={barTooltip.hide}
+            onMouseLeave={hideBarTooltip}
           >
             {isCelestialIconId(props.instanceIcon) ? (
               <CelestialIcon
@@ -1155,22 +1193,20 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             className={`star-map-chat-card__rail-toggle${
               props.contextOpen ? " is-on" : ""
             }`}
-            onClick={() => {
+            onClick={(event) => {
               props.onToggleContext(cardKey);
-              // The pointer is still on the button and the label just
-              // flipped. Without this the tooltip keeps offering the
-              // action the operator already took.
-              barTooltip.update(
+              relabelBarTooltip(
+                event.currentTarget,
                 props.contextOpen ? contextTooltip.show : contextTooltip.hide,
               );
             }}
             onMouseEnter={(event) =>
-              barTooltip.show(
+              showBarTooltip(
                 event.currentTarget,
                 props.contextOpen ? contextTooltip.hide : contextTooltip.show,
               )
             }
-            onMouseLeave={barTooltip.hide}
+            onMouseLeave={hideBarTooltip}
             onPointerDown={(event) => event.stopPropagation()}
             type="button"
           >
@@ -1186,19 +1222,20 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             className={`star-map-chat-card__rail-toggle${
               props.terminalOpen ? " is-on" : ""
             }`}
-            onClick={() => {
+            onClick={(event) => {
               props.onToggleTerminal(cardKey);
-              barTooltip.update(
+              relabelBarTooltip(
+                event.currentTarget,
                 props.terminalOpen ? terminalTooltip.open : terminalTooltip.close,
               );
             }}
             onMouseEnter={(event) =>
-              barTooltip.show(
+              showBarTooltip(
                 event.currentTarget,
                 props.terminalOpen ? terminalTooltip.close : terminalTooltip.open,
               )
             }
-            onMouseLeave={barTooltip.hide}
+            onMouseLeave={hideBarTooltip}
             onPointerDown={(event) => event.stopPropagation()}
             type="button"
           >
@@ -1209,9 +1246,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             className="star-map-chat-card__expand"
             onClick={() => onOpenFull(thread)}
             onMouseEnter={(event) =>
-              barTooltip.show(event.currentTarget, openFullTooltip)
+              showBarTooltip(event.currentTarget, openFullTooltip)
             }
-            onMouseLeave={barTooltip.hide}
+            onMouseLeave={hideBarTooltip}
             onPointerDown={(event) => event.stopPropagation()}
             type="button"
           >
@@ -1226,9 +1263,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           className="star-map-chat-card__close"
           onClick={() => props.onClose(cardKey)}
           onMouseEnter={(event) =>
-            barTooltip.show(event.currentTarget, "Close chat")
+            showBarTooltip(event.currentTarget, "Close chat")
           }
-          onMouseLeave={barTooltip.hide}
+          onMouseLeave={hideBarTooltip}
           onPointerDown={(event) => event.stopPropagation()}
           type="button"
         >

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -2348,3 +2348,74 @@ describe("StarMapChatCard title bar", () => {
     expect(actions?.querySelector(".star-map-chat-card__close")).toBeNull();
   });
 });
+
+describe("StarMapChatCard title bar tooltips", () => {
+  function hoverTooltipText(control: Element): string | undefined {
+    fireEvent.mouseEnter(control);
+    return document.querySelector('[role="tooltip"]')?.textContent ?? undefined;
+  }
+
+  it("gives every bar control a hover tooltip, not just some of them", () => {
+    // The bar lost its words: the instance is an icon, Open is ↗, and the
+    // toggles were always glyphs. A tooltip on only one of them reads as
+    // the others being broken — which is exactly how it shipped and how
+    // it got caught. This asserts the SET, so the next glyph added here
+    // cannot land without one.
+    renderCard({
+      desktopApi: buildApi(),
+      instanceIcon: "moon",
+      instanceLabel: "Studio Mac",
+      thread: remoteThread(),
+    });
+
+    const bar = screen.getByRole("banner", { hidden: true });
+    const controls = [
+      ...bar.querySelectorAll("button, .star-map-chat-card__instance"),
+    ];
+    expect(controls.length).toBe(5);
+    for (const control of controls) {
+      expect(hoverTooltipText(control)).toBeTruthy();
+      fireEvent.mouseLeave(control);
+    }
+  });
+
+  it("says what a toggle will do, and keeps saying it after the click", () => {
+    // A toggle's tooltip names the ACTION, which is the opposite of the
+    // state it is in. The pointer does not leave on click, so a label
+    // left un-flipped would sit there offering the thing just done.
+    const view = renderCard({
+      desktopApi: buildApi(),
+      instanceLabel: "Studio Mac",
+      thread: remoteThread(),
+    });
+
+    const terminal = screen.getByRole("button", {
+      name: "Open terminal for Remote work",
+    });
+    expect(hoverTooltipText(terminal)).toBe("Open terminal");
+    fireEvent.click(terminal);
+    expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(
+      "Close terminal",
+    );
+    view.unmount();
+  });
+
+  it("names the peer in the ↗ tooltip, since the bar only shows its icon", () => {
+    // ↗ does not land in the same place for every card, and the machine
+    // is no longer written out beside it.
+    renderCard({
+      desktopApi: buildApi(),
+      instanceIcon: "moon",
+      instanceLabel: "Studio Mac",
+      thread: remoteThread(),
+    });
+
+    expect(
+      hoverTooltipText(
+        screen.getByRole("button", {
+          name: "Open Remote work in the full thread view",
+        }),
+      ),
+    ).toBe("Open in a window connected to Studio Mac");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -9,6 +9,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   BackendCapabilities,
+  CelestialIconId,
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -160,7 +161,10 @@ function card(params: CardParams) {
     <StarMapChatCard
       cardKey="card-1"
       desktopApi={params.desktopApi}
-      instanceIcon={params.instanceIcon as never}
+      /* Cast the VALUE, not the prop: the unknown-id case needs to pass
+         an id this build does not know, but the prop's own type must stay
+         checked so a future change to it still fails here. */
+      instanceIcon={params.instanceIcon as CelestialIconId | undefined}
       instanceLabel={params.instanceLabel}
       onClose={() => undefined}
       onOpenFull={() => undefined}
@@ -2398,6 +2402,46 @@ describe("StarMapChatCard title bar tooltips", () => {
       "Close terminal",
     );
     view.unmount();
+  });
+
+  it("leaves a tooltip another control owns alone when a toggle fires", () => {
+    // A toggle re-labels its own tooltip after the click. `update` writes
+    // to whatever tooltip is on screen, so without an owner check a
+    // keyboard activation — pointer still resting on the title, focus
+    // moved by Tab — rewrote the TITLE's tooltip in place.
+    renderCard({
+      desktopApi: buildApi(),
+      instanceLabel: "Studio Mac",
+      thread: remoteThread(),
+    });
+
+    const title = document.querySelector(".star-map-chat-card__title");
+    expect(hoverTooltipText(title as Element)).toBe("Remote work");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show thread context for Remote work" }),
+    );
+    expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(
+      "Remote work",
+    );
+  });
+
+  it("tells a peer card where ↗ lands even with no label for that peer", () => {
+    // The label is decoration; the destination is not. StarMapScreen
+    // reads the label straight out of `displayLabelById`, so an unlinked
+    // peer leaves it undefined — and the sentence used to collapse to
+    // "the main window" while ↗ opened a federation window.
+    renderCard({
+      desktopApi: buildApi(),
+      thread: remoteThread(),
+    });
+
+    expect(
+      hoverTooltipText(
+        screen.getByRole("button", {
+          name: "Open Remote work in the full thread view",
+        }),
+      ),
+    ).toBe("Open in a window connected to that instance");
   });
 
   it("names the peer in the ↗ tooltip, since the bar only shows its icon", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -149,6 +149,8 @@ function reviewCapableApi(
 
 type CardParams = {
   desktopApi: DesktopApi;
+  instanceIcon?: string;
+  instanceLabel?: string;
   pastedImageMaxPatches?: number;
   thread: NavigationThreadSummary;
 };
@@ -158,6 +160,8 @@ function card(params: CardParams) {
     <StarMapChatCard
       cardKey="card-1"
       desktopApi={params.desktopApi}
+      instanceIcon={params.instanceIcon as never}
+      instanceLabel={params.instanceLabel}
       onClose={() => undefined}
       onOpenFull={() => undefined}
       onRaise={() => undefined}
@@ -2271,5 +2275,76 @@ describe("StarMapChatCard settings menu", () => {
         }),
       );
     });
+  });
+});
+
+describe("StarMapChatCard title bar", () => {
+  it("carries the instance as its celestial mark, not as bar text", () => {
+    // The bar has one scarce resource: horizontal room the thread title
+    // needs. A full hostname plus directory ("Harold-MBP-M2-Max / work")
+    // spent more of it than the title did, so the machine reads as the
+    // same mark the map already gives it and the name moves to the
+    // accessible name and the hover tooltip. Assert BOTH halves: the
+    // name must be gone from the bar's text, and still reachable by
+    // name — dropping it entirely would trade a cramped title for an
+    // unidentifiable card.
+    renderCard({
+      desktopApi: buildApi(),
+      instanceIcon: "moon",
+      instanceLabel: "Studio Mac",
+      thread: remoteThread(),
+    });
+
+    const banner = screen.getByRole("banner", { hidden: true });
+    expect(banner.textContent).not.toContain("Studio Mac");
+    expect(
+      screen.getByRole("img", { name: "Instance: Studio Mac" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the name visible when no celestial mark can render", () => {
+    // Two ways to have a label and no usable icon: the assignment
+    // snapshot has not landed yet (undefined), or a peer on a newer
+    // build named an id this build does not know — the celestial
+    // contract makes that "unassigned" and CelestialIcon renders null
+    // for it. Either way the slot must fall back to the name rather
+    // than going blank.
+    for (const instanceIcon of [undefined, "quasar"]) {
+      const view = renderCard({
+        desktopApi: buildApi(),
+        instanceIcon,
+        instanceLabel: "Studio Mac",
+        thread: remoteThread(),
+      });
+
+      const banner = screen.getByRole("banner", { hidden: true });
+      expect(banner.textContent).toContain("Studio Mac");
+      view.unmount();
+    }
+  });
+
+  it("gathers the card's controls into one group, close kept apart", () => {
+    // Three lone glyphs drifting across the bar read as unrelated; the
+    // group is what makes them one row of controls. Close stays outside
+    // it — a destructive control should not sit flush against the ones
+    // the hand reaches for repeatedly.
+    renderCard({
+      desktopApi: buildApi(),
+      instanceIcon: "moon",
+      instanceLabel: "Studio Mac",
+      thread: remoteThread(),
+    });
+
+    const actions = document.querySelector(".star-map-chat-card__actions");
+    expect(actions).toBeTruthy();
+    const grouped = [...(actions?.querySelectorAll("button") ?? [])].map(
+      (button) => button.getAttribute("aria-label"),
+    );
+    expect(grouped).toEqual([
+      "Show thread context for Remote work",
+      "Open terminal for Remote work",
+      "Open Remote work in the full thread view",
+    ]);
+    expect(actions?.querySelector(".star-map-chat-card__close")).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1056,6 +1056,41 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("gives floating Star Map cards an edge the eye can find on a black sky", () => {
+    // Chat cards and their satellites float over the sky and over each
+    // other. The sky is black and the card surface one step above it, so
+    // a dark popover shadow alone vanishes where one card overlaps the
+    // next, and a `--border-subtle` edge weighs the same as the message
+    // bubbles inside the card — the operator could not see where one card
+    // stopped and the next began. Both families must read the shared
+    // float tokens (edge and lift treatment), and the dark theme must
+    // keep the light halo that separates a card from the sky.
+    for (const selector of [".star-map-chat-card", ".star-map-satellite-card"]) {
+      const rule = extractRuleBody(css, selector);
+      expect(rule).toContain("border: 1px solid var(--star-map-float-border);");
+      expect(rule).toContain("box-shadow: var(--star-map-float-shadow);");
+      expect(rule).not.toContain("var(--border-subtle)");
+      expect(rule).not.toContain("var(--shadow-popover)");
+    }
+    const darkRoot = extractRuleBody(css, ":root");
+    expect(darkRoot).toMatch(
+      /--star-map-float-border:\s*color-mix\(in srgb, var\(--text-primary\) \d+%, transparent\);/,
+    );
+    // Inner highlight, 1px dark ring, light halo, lift shadow — in that
+    // order, so the ring sits between the rim and the glow.
+    expect(darkRoot).toMatch(
+      /--star-map-float-shadow:\s*inset 0 0 0 1px color-mix\(in srgb, var\(--text-primary\) \d+%, transparent\),\s*0 0 0 1px color-mix\(in srgb, var\(--shadow-base\) \d+%, transparent\),\s*0 0 0 2px color-mix\(in srgb, var\(--text-primary\) \d+%, transparent\),\s*0 0 \d+px color-mix\(in srgb, var\(--text-primary\) \d+%, transparent\),\s*0 \d+px \d+px color-mix\(in srgb, var\(--shadow-base\) \d+%, transparent\);/,
+    );
+    // Light theme drops the glow (invisible on white) and softens the
+    // ring so it does not read as a drawn outline.
+    const lightRoot = extractRuleBody(css, ':root[data-theme="light"]');
+    expect(lightRoot).toContain("--star-map-float-border: var(--border-strong);");
+    expect(lightRoot).toMatch(/--star-map-float-shadow:\s*inset 0 0 0 1px/);
+    expect(lightRoot).not.toMatch(
+      /--star-map-float-shadow:[^;]*,\s*0 0 \d+px color-mix\(in srgb, var\(--text-primary\)/,
+    );
+  });
+
   it("lays the Star Map's top band out as one row its controls cannot escape", () => {
     // The band's clusters used to position themselves independently —
     // chrome pinned to the left edge, chips translated to the window's

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -90,6 +90,28 @@
   --button-text: #120800;
   --shadow-popover: 0 18px 48px rgba(0, 0, 0, 0.42);
 
+  /* Edge treatment for the Star Map's floating chat cards and their
+     satellites (`.star-map-chat-card`, `.star-map-satellite-card`). The
+     sky is black and the card surface sits one step above it, so a plain
+     popover shadow vanishes: where one card overlaps another it lands on
+     an equally dark surface, and a `--border-subtle` edge weighs the same
+     as the message bubbles INSIDE the card, so nothing told the eye where
+     one card stopped and the next began. The rim is brighter than
+     `--border-strong` and the shadow stacks four layers: a 1px inner
+     highlight lifts the rim above the card's own content, a 1px dark ring
+     outside the rim keeps two touching rims from merging into one, a soft
+     light halo lets the card glow against the sky the way every other
+     map body does, and a heavy lift shadow darkens whatever it sits on.
+     Light theme overrides both: on white the glow is invisible and a
+     black ring would read as a hard outline. */
+  --star-map-float-border: color-mix(in srgb, var(--text-primary) 26%, transparent);
+  --star-map-float-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 8%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--shadow-base) 85%, transparent),
+    0 0 0 2px color-mix(in srgb, var(--text-primary) 5%, transparent),
+    0 0 28px color-mix(in srgb, var(--text-primary) 7%, transparent),
+    0 22px 56px color-mix(in srgb, var(--shadow-base) 70%, transparent);
+
   /* Theme-following surface overlays. Derived from base tokens via
      color-mix so they follow whichever theme is active — flip the base
      and every alpha variant follows automatically. Mathematically
@@ -379,6 +401,15 @@
   /* Lighter drop-shadow on light surface (the dark theme's 42% is too
      heavy against white). */
   --shadow-popover: 0 18px 48px rgba(0, 0, 0, 0.18);
+
+  /* Floating Star Map cards on white: the strong border already separates
+     card from sky and card from card, so no glow, and the dark ring drops
+     to a hairline so it does not read as a drawn outline. */
+  --star-map-float-border: var(--border-strong);
+  --star-map-float-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 4%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--shadow-base) 10%, transparent),
+    0 18px 48px color-mix(in srgb, var(--shadow-base) 18%, transparent);
 
   /* Light-surface drop shadows need much lower alpha than dark-surface
      ones — at the dark-theme values (32 / 40 / 58%) on white, the soft
@@ -13143,12 +13174,14 @@ textarea,
   position: absolute;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--star-map-float-border);
   border-radius: 8px;
   /* Opaque: cards overlap each other and the map, and a translucent card
      would let the transcript underneath bleed into this one's text. */
   background: var(--bg-panel);
-  box-shadow: var(--shadow-popover);
+  /* Edge and lift come from the --star-map-float-* tokens; the rationale
+     sits on their definition. */
+  box-shadow: var(--star-map-float-shadow);
   color: var(--text-primary);
 }
 
@@ -30115,10 +30148,10 @@ a.transcript-message__messaging-origin:focus-visible {
   position: absolute;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--star-map-float-border);
   border-radius: 8px;
   background: var(--bg-panel);
-  box-shadow: var(--shadow-popover);
+  box-shadow: var(--star-map-float-shadow);
   color: var(--text-primary);
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13230,8 +13230,40 @@ textarea,
 .star-map-chat-card__instance {
   z-index: 1;
   flex: 0 0 auto;
+  /* Cap the text fallback. A hostname plus directory can run past the
+     title itself, and the fallback only appears while the instance has
+     no icon assigned — it must never win the bar back. */
+  max-width: 140px;
+  overflow: hidden;
   color: var(--text-muted);
   font-size: 10px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* The icon form: the same celestial mark the map gives this instance,
+   at bar scale. `--text-muted` keeps it a quiet identity stamp rather
+   than a third control competing with the two live toggles beside it. */
+.star-map-chat-card__instance--icon {
+  display: inline-flex;
+  align-items: center;
+  max-width: none;
+  color: var(--text-muted);
+}
+
+/* The card's controls, gathered. 8px is the bar's own rhythm and reads
+   as three unrelated glyphs; 2px makes them one group with the title's
+   gap on one side and the close button's on the other. */
+.star-map-chat-card__actions {
+  z-index: 1;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 2px;
+  /* Plus the bar's own 8px: the instance mark is identity, not a control,
+     and at the bar's flat rhythm it read as a fourth button in the row.
+     The wider gutter puts the boundary where the meaning changes. */
+  margin-left: 6px;
 }
 
 .star-map-chat-card__expand,
@@ -13245,6 +13277,16 @@ textarea,
   color: var(--text-secondary);
   font-size: 11px;
   cursor: pointer;
+}
+
+/* Sized and coloured with the rail toggles it now sits beside, so the
+   group reads as one row of controls instead of a word wearing a
+   button. Same radius as those toggles, not the close button's. */
+.star-map-chat-card__expand {
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1;
 }
 
 .star-map-chat-card__close {

--- a/docs/UI-THEME.md
+++ b/docs/UI-THEME.md
@@ -243,6 +243,10 @@ custom theme:
   derive from it.
 - `--shadow-popover` — light theme reduces alpha (0.42 → 0.18) because
   heavy shadows over white read poorly; not a base color.
+- `--star-map-float-border` / `--star-map-float-shadow` — the edge and
+  lift of the Star Map's floating chat cards and satellites. The dark
+  stack adds a light halo so a card separates from the black sky and from
+  a card beneath it; light theme drops the halo and softens the ring.
 - `--chat-column-max` (`940px`) — layout token, not a color.
 
 #### Derived tokens


### PR DESCRIPTION
## Summary

Two problems with the Star Map's floating chat cards, both about reading them at a glance.

**1. The edges were invisible.** Where two cards overlap, the eye could not find the boundary between them.
- The rim used `--border-subtle`, the same 10% cream weight as the message bubbles **inside** the card, so the outline read as just another bubble edge rather than the card's boundary.
- The only lift was `--shadow-popover`, black at 42% — the sky is black and a neighbouring card is `#0a0a0a`, so that shadow lands on an equally dark surface and disappears, precisely where two stacked cards overlap.
- Adds `--star-map-float-border` / `--star-map-float-shadow` beside `--shadow-popover` in the dark `:root`, with a light-theme override. The dark stack is a brighter rim (26% cream) plus four shadow layers: a 1px inner highlight (the `.composer__autocomplete` pattern) lifts the rim above the card's own content, a 1px dark ring outside the rim keeps two touching rims from merging into one, a soft light halo separates the card from the black sky and falls visibly on a card beneath it, and a heavier lift shadow darkens whatever it sits on. Light theme drops the halo (invisible on white) and softens the ring to a hairline.
- `.star-map-chat-card` and `.star-map-satellite-card` — the terminal that docks beside a chat card — both read the tokens, so the floating family stays consistent.

**2. The title bar spent more room on the machine than on the thread.** "Harold-MBP-M2-Max / work" truncated the title to "Find unpushed commits across ..." on a 520px card.
- The instance reads as its celestial mark instead of its name — the same icon the map already gives that machine, so a card and its star are one thing. The name moves to the icon's accessible name and a hover tooltip.
- Text stays the fallback whenever no mark can render: before the assignment snapshot lands `iconFor` returns undefined, and a peer on a newer build can name an id this build treats as unassigned (`CelestialIcon` renders null for it). The fallback is guarded on the known id set, not on the icon merely being defined, so identity never silently vanishes.
- "Open" becomes ↗ — same meaning in a sixth of the width. Its destination differs per card (a peer's thread opens in a window fronting that peer, a local one in the main window), so the tooltip says which and names the peer now that the bar shows it only as an icon.
- Context, terminal, and ↗ gather into one 2px group instead of the bar's 8px rhythm; close stays outside it, and the identity mark keeps a wider gutter so it does not read as a fourth button.

## Verification

- `pnpm test` on `features/star-map/__tests__` + `styles/__tests__` — 696 pass across 44 files.
- New theme-contract case locks both card rules to the float tokens, the dark layer order (highlight → ring → halo → lift), and the light override having no halo. Confirmed it **fails** against the previous CSS, then restored.
- Three new `StarMapChatCard` cases: the machine name is gone from the bar's text but still reachable by accessible name; the name stays visible when no mark can render (undefined *and* unknown-id); the three controls are grouped in order with close outside the group.
- `pnpm lint:colors` passes, `typecheck` passes, ESLint clean on the changed files.
- Rendered both changes off the real `app.css` in headless Chromium, dark and light, including two overlapping cards plus a terminal satellite.
- The ↗ button's `aria-label` is unchanged, so `star-map-thread-flow.spec.ts` and the `StarMapScreen` unit selector that drive it keep working.

## Notes

- Thread cards (`.star-map-card`) are deliberately untouched — they read fine at their size and spacing.
- Two knobs if the edge wants to pop more or less: the rim alpha (26%) and the halo (`0 0 28px` at 7%). Both live in one token.
- **Follow-up, not in this PR:** making ↗ mount a remote thread in *this* window's viewer instead of opening a separate federation window. The main window's snapshot merges remote rows only via `mergePinnedRemoteThreads`, so "mount" means creating a viewer-side `remote_thread_pins` row — a persistent side effect from an open action, which is a product call worth making deliberately. It also needs the federation ref through `WindowShowThreadRequest` (which carries only backend + threadId today) and its own cross-window E2E.
- CI: `macOS Desktop E2E (lane 1 of 2)` fails on `federation-remote-window.spec.ts` via `ElectronShutdownCircuitOpenError`. Lane 1 runs no star-map or visual-regression specs, so nothing in this diff is exercised there; the spec's assertions pass and only teardown's shutdown-health guard throws (90 healthy closes, then 2 force-kills at ~7s). Both attempts landed on the same runner guest `host_macos_stable_01`, which the error text says to recycle before retrying. Lane 2 — which owns every star-map and visual-regression spec — passed 92/92 twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
