### PR TITLE
feat(desktop): restore Star Map workspaces

### DIFF
--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -127,7 +127,7 @@
   },
   "star-map-workspace-gesture": {
     "commits": 1,
-    "note": "one completed Star Map open/close/move/resize/toggle or camera gesture, persisted as one atomic workspace row",
+    "note": "one coalesced Star Map open/close/move/resize/toggle or camera gesture, feature-pinned to one API call and persisted as one atomic workspace row",
     "observedWalBytes": 8240,
     "rowsChanged": 1,
     "statements": 1

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -125,6 +125,13 @@
     "rowsChanged": 8,
     "statements": 8
   },
+  "star-map-workspace-gesture": {
+    "commits": 1,
+    "note": "one completed Star Map open/close/move/resize/toggle or camera gesture, persisted as one atomic workspace row",
+    "observedWalBytes": 8240,
+    "rowsChanged": 1,
+    "statements": 1
+  },
   "streamed-command-output": {
     "commits": 2,
     "note": "500 streamed output deltas plus the completion for one command",

--- a/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { StarMapArrangementEntry } from "@pwragent/shared";
+import {
+  STAR_MAP_WORKSPACE_KEY,
+  STAR_MAP_WORKSPACE_VERSION,
+  type StarMapArrangementEntry,
+  type StarMapWorkspaceSnapshot,
+} from "@pwragent/shared";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
 import { openInMemoryStateDb } from "./sqlite-test-utils";
@@ -18,6 +23,50 @@ function entry(
     updatedAt: 1_000,
     by: "pwr_local",
     ...overrides,
+  };
+}
+
+function workspace(): StarMapWorkspaceSnapshot {
+  return {
+    version: STAR_MAP_WORKSPACE_VERSION,
+    cards: [
+      {
+        key: "pwr_remote::codex:t1",
+        ownerInstanceId: "pwr_remote",
+        thread: {
+          id: "t1",
+          title: "Persist this chat",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+          inbox: { inInbox: true },
+          federation: {
+            ref: {
+              backend: "codex",
+              threadId: "t1",
+              target: { scope: "remote", instanceId: "pwr_remote" },
+            },
+            instanceLabel: "Remote Mac",
+          },
+        },
+        geometry: {
+          anchor: {
+            kind: "thread",
+            instanceId: "pwr_remote",
+            threadKey: "codex:t1",
+          },
+          dx: 28,
+          dy: -10,
+          fallbackRect: { left: 500, top: 220, width: 420, height: 520 },
+        },
+        contextOpen: true,
+        terminalOpen: true,
+        terminalHeight: 300,
+      },
+    ],
+    views: {
+      orbit: { x: -120, y: 80, scale: 0.8 },
+    },
   };
 }
 
@@ -103,5 +152,77 @@ describe("star map arrangement overlay", () => {
     const result = await store.mergeStarMapArrangement([malformed]);
     expect(result.accepted).toEqual([]);
     expect(await store.readStarMapArrangement()).toEqual([]);
+  });
+});
+
+describe("star map workspace overlay", () => {
+  it("round-trips viewer-owned cards, satellites, geometry, and cameras", async () => {
+    const written = await store.writeStarMapWorkspace(workspace());
+
+    expect(written).toMatchObject({
+      ...workspace(),
+      revision: 1,
+    });
+    expect(written.updatedAt).toBeGreaterThan(0);
+    expect(await store.readStarMapWorkspace()).toEqual(written);
+  });
+
+  it("increments the revision while replacing the workspace atomically", async () => {
+    await store.writeStarMapWorkspace(workspace());
+    const next = workspace();
+    next.cards[0].terminalOpen = false;
+
+    const written = await store.writeStarMapWorkspace(next);
+
+    expect(written.revision).toBe(2);
+    expect((await store.readStarMapWorkspace()).cards[0].terminalOpen).toBe(
+      false,
+    );
+    expect(
+      stateDb.raw.prepare(
+        "SELECT COUNT(*) AS count FROM star_map_workspace",
+      ).get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("degrades a malformed payload to an empty workspace", async () => {
+    stateDb.raw.prepare(
+      `INSERT INTO star_map_workspace(
+         workspace_key,
+         revision,
+         updated_at,
+         payload
+       ) VALUES (?, 1, 100, ?)`,
+    ).run(STAR_MAP_WORKSPACE_KEY, "{not-json");
+
+    expect(await store.readStarMapWorkspace()).toMatchObject({
+      cards: [],
+      revision: 0,
+      updatedAt: 0,
+      views: {},
+    });
+  });
+
+  it("keeps valid cards when another saved card is corrupt", async () => {
+    const partial = workspace();
+    partial.cards.push({
+      ...partial.cards[0],
+      key: "wrong-owner::codex:t2",
+      thread: { ...partial.cards[0].thread, id: "t2" },
+    });
+    stateDb.raw.prepare(
+      `INSERT INTO star_map_workspace(
+         workspace_key,
+         revision,
+         updated_at,
+         payload
+       ) VALUES (?, 3, 100, ?)`,
+    ).run(STAR_MAP_WORKSPACE_KEY, JSON.stringify(partial));
+
+    expect(await store.readStarMapWorkspace()).toMatchObject({
+      cards: workspace().cards,
+      revision: 3,
+      updatedAt: 100,
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
@@ -57,6 +57,8 @@ function workspace(): StarMapWorkspaceSnapshot {
           },
           dx: 28,
           dy: -10,
+          instanceDx: 160,
+          instanceDy: 80,
           fallbackRect: { left: 500, top: 220, width: 420, height: 520 },
         },
         contextOpen: true,
@@ -224,6 +226,34 @@ describe("star map workspace overlay", () => {
     const recovered = await store.writeStarMapWorkspace(workspace(), 1);
     expect(recovered.revision).toBe(2);
     expect(await store.readStarMapWorkspace()).toEqual(recovered);
+  });
+
+  it("refuses to overwrite a workspace written by a future version", async () => {
+    const futurePayload = JSON.stringify({
+      ...workspace(),
+      version: STAR_MAP_WORKSPACE_VERSION + 1,
+      futureField: { preserve: true },
+    });
+    stateDb.raw.prepare(
+      `INSERT INTO star_map_workspace(
+         workspace_key,
+         revision,
+         updated_at,
+         payload
+       ) VALUES (?, 9, 100, ?)`,
+    ).run(STAR_MAP_WORKSPACE_KEY, futurePayload);
+
+    await expect(store.readStarMapWorkspace()).rejects.toThrow(
+      "Unsupported Star Map workspace version: 2",
+    );
+    await expect(
+      store.writeStarMapWorkspace(workspace(), 9),
+    ).rejects.toThrow("Unsupported Star Map workspace version: 2");
+    expect(
+      stateDb.raw.prepare(
+        "SELECT revision, payload FROM star_map_workspace",
+      ).get(),
+    ).toEqual({ revision: 9, payload: futurePayload });
   });
 
   it("keeps valid cards when another saved card is corrupt", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
@@ -157,7 +157,7 @@ describe("star map arrangement overlay", () => {
 
 describe("star map workspace overlay", () => {
   it("round-trips viewer-owned cards, satellites, geometry, and cameras", async () => {
-    const written = await store.writeStarMapWorkspace(workspace());
+    const written = await store.writeStarMapWorkspace(workspace(), 0);
 
     expect(written).toMatchObject({
       ...workspace(),
@@ -168,11 +168,11 @@ describe("star map workspace overlay", () => {
   });
 
   it("increments the revision while replacing the workspace atomically", async () => {
-    await store.writeStarMapWorkspace(workspace());
+    await store.writeStarMapWorkspace(workspace(), 0);
     const next = workspace();
     next.cards[0].terminalOpen = false;
 
-    const written = await store.writeStarMapWorkspace(next);
+    const written = await store.writeStarMapWorkspace(next, 1);
 
     expect(written.revision).toBe(2);
     expect((await store.readStarMapWorkspace()).cards[0].terminalOpen).toBe(
@@ -183,6 +183,25 @@ describe("star map workspace overlay", () => {
         "SELECT COUNT(*) AS count FROM star_map_workspace",
       ).get(),
     ).toEqual({ count: 1 });
+  });
+
+  it("rejects a stale full-snapshot write instead of losing newer state", async () => {
+    const otherInstanceStore = new SqliteOverlayStore(stateDb);
+    const first = workspace();
+    const second = workspace();
+    second.cards[0].terminalOpen = false;
+
+    await store.writeStarMapWorkspace(first, 0);
+
+    await expect(
+      otherInstanceStore.writeStarMapWorkspace(second, 0),
+    ).rejects.toThrow(
+      "Star Map workspace revision conflict: expected 0, found 1",
+    );
+    expect(await store.readStarMapWorkspace()).toMatchObject({
+      cards: first.cards,
+      revision: 1,
+    });
   });
 
   it("degrades a malformed payload to an empty workspace", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts
@@ -204,7 +204,7 @@ describe("star map workspace overlay", () => {
     });
   });
 
-  it("degrades a malformed payload to an empty workspace", async () => {
+  it("degrades a malformed payload without losing its durable revision", async () => {
     stateDb.raw.prepare(
       `INSERT INTO star_map_workspace(
          workspace_key,
@@ -216,10 +216,14 @@ describe("star map workspace overlay", () => {
 
     expect(await store.readStarMapWorkspace()).toMatchObject({
       cards: [],
-      revision: 0,
-      updatedAt: 0,
+      revision: 1,
+      updatedAt: 100,
       views: {},
     });
+
+    const recovered = await store.writeStarMapWorkspace(workspace(), 1);
+    expect(recovered.revision).toBe(2);
+    expect(await store.readStarMapWorkspace()).toEqual(recovered);
   });
 
   it("keeps valid cards when another saved card is corrupt", async () => {

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -138,16 +138,19 @@ describe("sqlite write metrics", () => {
       views: { orbit: { x: -40, y: 60, scale: 0.8 } },
     };
 
-    // One completed gesture can replace many card fields, but it is one row
-    // and one transaction. Pointermove frames never call this path. At an
-    // intentionally heavy 1,000 completed actions/day, the observed ~8 KB
-    // WAL cost projects to about 8 MB/day; ordinary use is far below that.
+    // The renderer card test pins raise + drag to one commit callback, and the
+    // controller test "coalesces raising a non-top card and dragging it into
+    // one write" pins that callback to one API call. This measured region is
+    // the API call's database half: one row and one transaction, independent
+    // of pointermove count. At an intentionally heavy 1,000 completed
+    // actions/day, the observed ~8 KB WAL cost projects to about 8 MB/day;
+    // ordinary use is far below that.
     const { writes } = await measureSqliteWrites(async () => {
-      await store.writeStarMapWorkspace(workspace);
+      await store.writeStarMapWorkspace(workspace, 0);
     });
 
     expectSqliteWriteBudget({
-      note: "one completed Star Map open/close/move/resize/toggle or camera gesture, persisted as one atomic workspace row",
+      note: "one coalesced Star Map open/close/move/resize/toggle or camera gesture, feature-pinned to one API call and persisted as one atomic workspace row",
       scenario: "star-map-workspace-gesture",
       writes,
     });

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -5,6 +5,7 @@ import type {
   AgentEvent,
   AppServerThreadReplay,
   AppServerThreadSummary,
+  StarMapWorkspaceSnapshot,
   TaskMonitorUsageSnapshot,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
@@ -97,6 +98,59 @@ describe("sqlite write metrics", () => {
     const metrics = readSqliteWriteMetrics();
     expect(metrics?.statements).toBe(50);
     expect(metrics?.commits).toBe(1);
+  });
+
+  it("persists one completed Star Map workspace gesture in one commit", async () => {
+    const workspace: StarMapWorkspaceSnapshot = {
+      version: 1,
+      cards: [
+        {
+          key: "pwr_local::codex:thread-1",
+          ownerInstanceId: "pwr_local",
+          thread: {
+            id: "thread-1",
+            inbox: { inInbox: true },
+            linkedDirectories: [],
+            source: "codex",
+            title: "A saved desk",
+            titleSource: "derived",
+          },
+          geometry: {
+            anchor: {
+              kind: "thread",
+              instanceId: "pwr_local",
+              threadKey: "codex:thread-1",
+            },
+            dx: 24,
+            dy: 12,
+            fallbackRect: {
+              left: 300,
+              top: 200,
+              width: 420,
+              height: 520,
+            },
+          },
+          contextOpen: true,
+          terminalOpen: true,
+          terminalHeight: 280,
+        },
+      ],
+      views: { orbit: { x: -40, y: 60, scale: 0.8 } },
+    };
+
+    // One completed gesture can replace many card fields, but it is one row
+    // and one transaction. Pointermove frames never call this path. At an
+    // intentionally heavy 1,000 completed actions/day, the observed ~8 KB
+    // WAL cost projects to about 8 MB/day; ordinary use is far below that.
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.writeStarMapWorkspace(workspace);
+    });
+
+    expectSqliteWriteBudget({
+      note: "one completed Star Map open/close/move/resize/toggle or camera gesture, persisted as one atomic workspace row",
+      scenario: "star-map-workspace-gesture",
+      writes,
+    });
   });
 
   it("persists one explicit history analysis in one transaction", async () => {

--- a/apps/desktop/src/main/ipc/star-map.ts
+++ b/apps/desktop/src/main/ipc/star-map.ts
@@ -2,14 +2,17 @@ import { BrowserWindow, ipcMain, type WebContents } from "electron";
 import type {
   FederationTarget,
   ReadStarMapArrangementResponse,
+  ReadStarMapWorkspaceResponse,
   SetStarMapCardPositionRequest,
   StarMapArrangementEntry,
   StarMapIntakeRequest,
   StarMapIntakeResponse,
+  WriteStarMapWorkspaceRequest,
 } from "@pwragent/shared";
 import {
   isRemoteFederationTarget,
   isStarMapArrangementEntry,
+  isStarMapWorkspaceSnapshot,
 } from "@pwragent/shared";
 import {
   STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL,
@@ -17,7 +20,9 @@ import {
   STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL,
   STAR_MAP_OPEN_WINDOW_CHANNEL,
   STAR_MAP_READ_ARRANGEMENT_CHANNEL,
+  STAR_MAP_READ_WORKSPACE_CHANNEL,
   STAR_MAP_SET_CARD_POSITION_CHANNEL,
+  STAR_MAP_WRITE_WORKSPACE_CHANNEL,
   WINDOW_SHOW_THREAD_CHANNEL,
 } from "../../shared/ipc";
 import type { WindowShowThreadRequest } from "../../shared/window-show-thread";
@@ -43,7 +48,9 @@ function primaryMainWindowWebContents(): WebContents | undefined {
 
 export function registerStarMapIpcHandlers(): void {
   ipcMain.removeHandler(STAR_MAP_READ_ARRANGEMENT_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_READ_WORKSPACE_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_SET_CARD_POSITION_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_WRITE_WORKSPACE_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_INTAKE_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL);
@@ -135,11 +142,34 @@ export function registerStarMapIpcHandlers(): void {
       };
     },
   );
+  ipcMain.handle(
+    STAR_MAP_READ_WORKSPACE_CHANNEL,
+    async (): Promise<ReadStarMapWorkspaceResponse> => ({
+      workspace: await getDesktopOverlayStore().readStarMapWorkspace(),
+    }),
+  );
+  ipcMain.handle(
+    STAR_MAP_WRITE_WORKSPACE_CHANNEL,
+    async (
+      _event,
+      request: WriteStarMapWorkspaceRequest,
+    ): Promise<ReadStarMapWorkspaceResponse> => {
+      if (!isStarMapWorkspaceSnapshot(request?.workspace)) {
+        throw new Error("Invalid Star Map workspace");
+      }
+      return {
+        workspace: await getDesktopOverlayStore()
+          .writeStarMapWorkspace(request.workspace),
+      };
+    },
+  );
 }
 
 export function disposeStarMapIpcHandlers(): void {
   ipcMain.removeHandler(STAR_MAP_READ_ARRANGEMENT_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_READ_WORKSPACE_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_SET_CARD_POSITION_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_WRITE_WORKSPACE_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_INTAKE_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL);

--- a/apps/desktop/src/main/ipc/star-map.ts
+++ b/apps/desktop/src/main/ipc/star-map.ts
@@ -157,9 +157,16 @@ export function registerStarMapIpcHandlers(): void {
       if (!isStarMapWorkspaceSnapshot(request?.workspace)) {
         throw new Error("Invalid Star Map workspace");
       }
+      if (
+        typeof request.baseRevision !== "number"
+        || !Number.isSafeInteger(request.baseRevision)
+        || request.baseRevision < 0
+      ) {
+        throw new Error("Invalid Star Map workspace base revision");
+      }
       return {
         workspace: await getDesktopOverlayStore()
-          .writeStarMapWorkspace(request.workspace),
+          .writeStarMapWorkspace(request.workspace, request.baseRevision),
       };
     },
   );

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -3418,6 +3418,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
 
   async writeStarMapWorkspace(
     snapshot: StarMapWorkspaceSnapshot,
+    baseRevision: number,
   ): Promise<StarMapWorkspaceState> {
     if (!isStarMapWorkspaceSnapshot(snapshot)) {
       throw new Error("Invalid Star Map workspace");
@@ -3428,7 +3429,13 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         `SELECT revision FROM star_map_workspace
          WHERE workspace_key = ?`,
       ).get(STAR_MAP_WORKSPACE_KEY) as { revision: number } | undefined;
-      const revision = (current?.revision ?? 0) + 1;
+      const currentRevision = current?.revision ?? 0;
+      if (currentRevision !== baseRevision) {
+        throw new Error(
+          `Star Map workspace revision conflict: expected ${baseRevision}, found ${currentRevision}`,
+        );
+      }
+      const revision = currentRevision + 1;
       this.stateDb.raw.prepare(
         `INSERT OR REPLACE INTO star_map_workspace(
            workspace_key,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -3404,7 +3404,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         JSON.parse(row.payload) as unknown,
       );
       if (!snapshot) {
-        return emptyStarMapWorkspaceState();
+        return {
+          ...emptyStarMapWorkspaceState(),
+          revision: row.revision,
+          updatedAt: row.updated_at,
+        };
       }
       return {
         ...snapshot,
@@ -3412,7 +3416,11 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         updatedAt: row.updated_at,
       };
     } catch {
-      return emptyStarMapWorkspaceState();
+      return {
+        ...emptyStarMapWorkspaceState(),
+        revision: row.revision,
+        updatedAt: row.updated_at,
+      };
     }
   }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -37,6 +37,8 @@ import type {
   ThreadPullRequestWatchSummary,
   RemoteThreadPin,
   StarMapArrangementEntry,
+  StarMapWorkspaceSnapshot,
+  StarMapWorkspaceState,
   ThreadQuestionnaireActivity,
   ThreadSubAgentSummary,
   ThreadTurnFailure,
@@ -45,8 +47,12 @@ import type {
 } from "@pwragent/shared";
 import {
   isStarMapArrangementEntry,
+  isStarMapWorkspaceSnapshot,
   mergeStarMapArrangementEntries,
+  parseStarMapWorkspaceSnapshot,
   starMapArrangementEntryKey,
+  emptyStarMapWorkspaceState,
+  STAR_MAP_WORKSPACE_KEY,
   DEFAULT_PULL_REQUEST_PROVIDER,
   AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
   MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
@@ -3381,6 +3387,69 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     });
     write();
     return { accepted };
+  }
+
+  async readStarMapWorkspace(): Promise<StarMapWorkspaceState> {
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT revision, updated_at, payload FROM star_map_workspace
+         WHERE workspace_key = ?`,
+      )
+      .get(STAR_MAP_WORKSPACE_KEY) as
+      | { revision: number; updated_at: number; payload: string }
+      | undefined;
+    if (!row) return emptyStarMapWorkspaceState();
+    try {
+      const snapshot = parseStarMapWorkspaceSnapshot(
+        JSON.parse(row.payload) as unknown,
+      );
+      if (!snapshot) {
+        return emptyStarMapWorkspaceState();
+      }
+      return {
+        ...snapshot,
+        revision: row.revision,
+        updatedAt: row.updated_at,
+      };
+    } catch {
+      return emptyStarMapWorkspaceState();
+    }
+  }
+
+  async writeStarMapWorkspace(
+    snapshot: StarMapWorkspaceSnapshot,
+  ): Promise<StarMapWorkspaceState> {
+    if (!isStarMapWorkspaceSnapshot(snapshot)) {
+      throw new Error("Invalid Star Map workspace");
+    }
+    const updatedAt = Date.now();
+    const write = this.stateDb.raw.transaction(() => {
+      const current = this.stateDb.raw.prepare(
+        `SELECT revision FROM star_map_workspace
+         WHERE workspace_key = ?`,
+      ).get(STAR_MAP_WORKSPACE_KEY) as { revision: number } | undefined;
+      const revision = (current?.revision ?? 0) + 1;
+      this.stateDb.raw.prepare(
+        `INSERT OR REPLACE INTO star_map_workspace(
+           workspace_key,
+           revision,
+           updated_at,
+           payload
+         ) VALUES (?, ?, ?, ?)`,
+      ).run(
+        STAR_MAP_WORKSPACE_KEY,
+        revision,
+        updatedAt,
+        JSON.stringify(snapshot),
+      );
+      return revision;
+    });
+    const revision = write();
+    return {
+      ...snapshot,
+      revision,
+      updatedAt,
+    };
   }
 
   async setThreadPullRequests(params: {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -53,6 +53,7 @@ import {
   starMapArrangementEntryKey,
   emptyStarMapWorkspaceState,
   STAR_MAP_WORKSPACE_KEY,
+  STAR_MAP_WORKSPACE_VERSION,
   DEFAULT_PULL_REQUEST_PROVIDER,
   AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
   MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
@@ -84,6 +85,21 @@ import type {
 } from "./remote-thread-target-store.js";
 
 const THREAD_PRICING_LAZY_REPRICE_BATCH_SIZE = 10;
+
+class UnsupportedStarMapWorkspaceVersionError extends Error {}
+
+function assertSupportedStarMapWorkspacePayload(value: unknown): void {
+  if (!value || typeof value !== "object") return;
+  const version = (value as { version?: unknown }).version;
+  if (
+    typeof version === "number"
+    && version !== STAR_MAP_WORKSPACE_VERSION
+  ) {
+    throw new UnsupportedStarMapWorkspaceVersionError(
+      `Unsupported Star Map workspace version: ${version}`,
+    );
+  }
+}
 
 export type DirectoryGitStatusCacheEntry = {
   directoryKey: string;
@@ -3399,22 +3415,9 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       | { revision: number; updated_at: number; payload: string }
       | undefined;
     if (!row) return emptyStarMapWorkspaceState();
+    let payload: unknown;
     try {
-      const snapshot = parseStarMapWorkspaceSnapshot(
-        JSON.parse(row.payload) as unknown,
-      );
-      if (!snapshot) {
-        return {
-          ...emptyStarMapWorkspaceState(),
-          revision: row.revision,
-          updatedAt: row.updated_at,
-        };
-      }
-      return {
-        ...snapshot,
-        revision: row.revision,
-        updatedAt: row.updated_at,
-      };
+      payload = JSON.parse(row.payload) as unknown;
     } catch {
       return {
         ...emptyStarMapWorkspaceState(),
@@ -3422,6 +3425,20 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         updatedAt: row.updated_at,
       };
     }
+    assertSupportedStarMapWorkspacePayload(payload);
+    const snapshot = parseStarMapWorkspaceSnapshot(payload);
+    if (!snapshot) {
+      return {
+        ...emptyStarMapWorkspaceState(),
+        revision: row.revision,
+        updatedAt: row.updated_at,
+      };
+    }
+    return {
+      ...snapshot,
+      revision: row.revision,
+      updatedAt: row.updated_at,
+    };
   }
 
   async writeStarMapWorkspace(
@@ -3434,9 +3451,24 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     const updatedAt = Date.now();
     const write = this.stateDb.raw.transaction(() => {
       const current = this.stateDb.raw.prepare(
-        `SELECT revision FROM star_map_workspace
+        `SELECT revision, payload FROM star_map_workspace
          WHERE workspace_key = ?`,
-      ).get(STAR_MAP_WORKSPACE_KEY) as { revision: number } | undefined;
+      ).get(STAR_MAP_WORKSPACE_KEY) as
+        | { revision: number; payload: string }
+        | undefined;
+      if (current) {
+        try {
+          assertSupportedStarMapWorkspacePayload(
+            JSON.parse(current.payload) as unknown,
+          );
+        } catch (error) {
+          if (error instanceof UnsupportedStarMapWorkspaceVersionError) {
+            throw error;
+          }
+          // Malformed same-version payloads remain recoverable by a guarded
+          // revision-matched write, as the read path already promises.
+        }
+      }
       const currentRevision = current?.revision ?? 0;
       if (currentRevision !== baseRevision) {
         throw new Error(

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 52;
+export const CURRENT_STATE_DB_USER_VERSION = 53;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -255,6 +255,18 @@ const STAR_MAP_ARRANGEMENT_SCHEMA = `
 CREATE TABLE IF NOT EXISTS star_map_arrangement (
   entry_key TEXT PRIMARY KEY,
   payload   TEXT NOT NULL
+);
+`;
+
+/* Viewer-owned Star Map desk state. Unlike `star_map_arrangement`, this is
+   local profile state and never crosses federation. One atomic payload keeps
+   the open-card set, z-order, satellite flags, and lens cameras consistent. */
+const STAR_MAP_WORKSPACE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS star_map_workspace (
+  workspace_key TEXT PRIMARY KEY,
+  revision      INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  payload       TEXT NOT NULL
 );
 `;
 
@@ -1534,6 +1546,12 @@ export class StateDb {
       if ((db.pragma("user_version", { simple: true }) as number) < 52) {
         db.transaction(() => {
           repairCodexTurnUsageFromCumulativeSnapshots(db);
+          db.pragma("user_version = 52");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 53) {
+        db.transaction(() => {
+          db.exec(STAR_MAP_WORKSPACE_SCHEMA);
           db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
         })();
       }
@@ -2123,6 +2141,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensureRemoteThreadPinRevokedAtColumn(db);
     db.exec(REMOTE_THREAD_TARGET_SCHEMA);
     db.exec(STAR_MAP_ARRANGEMENT_SCHEMA);
+    db.exec(STAR_MAP_WORKSPACE_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -352,9 +352,11 @@ import type {
   SetFederationEventSubscriptionsRequest,
   SetFederationEventSubscriptionsResponse,
   ReadStarMapArrangementResponse,
+  ReadStarMapWorkspaceResponse,
   SetStarMapCardPositionRequest,
   StarMapIntakeRequest,
   StarMapIntakeResponse,
+  WriteStarMapWorkspaceRequest,
   FederationTarget,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
@@ -574,7 +576,9 @@ import {
   STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL,
   STAR_MAP_OPEN_WINDOW_CHANNEL,
   STAR_MAP_READ_ARRANGEMENT_CHANNEL,
+  STAR_MAP_READ_WORKSPACE_CHANNEL,
   STAR_MAP_SET_CARD_POSITION_CHANNEL,
+  STAR_MAP_WRITE_WORKSPACE_CHANNEL,
   FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
   FEDERATION_TAILSCALE_STATUS_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
@@ -1067,6 +1071,12 @@ const desktopApi = Object.freeze({
     request: SetStarMapCardPositionRequest,
   ): Promise<ReadStarMapArrangementResponse> =>
     await ipcRenderer.invoke(STAR_MAP_SET_CARD_POSITION_CHANNEL, request),
+  readStarMapWorkspace: async (): Promise<ReadStarMapWorkspaceResponse> =>
+    await ipcRenderer.invoke(STAR_MAP_READ_WORKSPACE_CHANNEL),
+  writeStarMapWorkspace: async (
+    request: WriteStarMapWorkspaceRequest,
+  ): Promise<ReadStarMapWorkspaceResponse> =>
+    await ipcRenderer.invoke(STAR_MAP_WRITE_WORKSPACE_CHANNEL, request),
   dispatchStarMapIntake: async (
     request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
   ): Promise<StarMapIntakeResponse> =>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -86,7 +86,7 @@ export type StarMapChatCardProps = {
   ) => void | Promise<void>;
   /** Refresh the owning navigation feed after a monitor is stopped. */
   onRefreshNavigation?: () => Promise<void>;
-  onRaise: (cardKey: string) => void;
+  onRaise: (cardKey: string, persist?: boolean) => boolean | void;
   onRectChange: (cardKey: string, rect: ChatCardRect) => void;
   onRectCommit?: (cardKey: string, rect: ChatCardRect) => void;
   resolveRect?: (
@@ -117,6 +117,7 @@ export type StarMapChatCardProps = {
 type DragState = {
   kind: "move" | "resize";
   moved: boolean;
+  raised: boolean;
   pointerId: number;
   originX: number;
   originY: number;
@@ -514,10 +515,11 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     (event: ReactPointerEvent, kind: DragState["kind"]) => {
       if (event.button !== 0) return;
       event.preventDefault();
-      onRaise(cardKey);
+      event.stopPropagation();
       dragRef.current = {
         kind,
         moved: false,
+        raised: onRaise(cardKey, false) === true,
         pointerId: event.pointerId,
         originX: event.clientX,
         originY: event.clientY,
@@ -571,7 +573,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       if (!drag || drag.pointerId !== event.pointerId) return;
       dragRef.current = undefined;
       onGuidesChange?.([]);
-      if (drag.moved) onRectCommit?.(cardKey, drag.lastRect);
+      if (drag.moved || drag.raised) {
+        onRectCommit?.(cardKey, drag.lastRect);
+      }
       event.currentTarget.releasePointerCapture?.(event.pointerId);
     },
     [cardKey, onGuidesChange, onRectCommit],

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -61,6 +61,7 @@ import {
   resizeChatCardRect,
   type ChatCardRect,
 } from "./star-map-chat-card-geometry";
+import type { AlignmentGuide } from "./star-map-snapping";
 import {
   StarMapReviewSetup,
   type StarMapReviewRequest,
@@ -87,6 +88,12 @@ export type StarMapChatCardProps = {
   onRefreshNavigation?: () => Promise<void>;
   onRaise: (cardKey: string) => void;
   onRectChange: (cardKey: string, rect: ChatCardRect) => void;
+  onRectCommit?: (cardKey: string, rect: ChatCardRect) => void;
+  resolveRect?: (
+    rect: ChatCardRect,
+    kind: "move" | "resize",
+  ) => { rect: ChatCardRect; guides: AlignmentGuide[] };
+  onGuidesChange?: (guides: AlignmentGuide[]) => void;
   /** Satellite cards, docked to this card and owned by the controller. */
   contextOpen?: boolean;
   terminalOpen?: boolean;
@@ -109,10 +116,12 @@ export type StarMapChatCardProps = {
 
 type DragState = {
   kind: "move" | "resize";
+  moved: boolean;
   pointerId: number;
   originX: number;
   originY: number;
   startRect: ChatCardRect;
+  lastRect: ChatCardRect;
 };
 
 function queuedTurnPreview(queued: ComposerQueuedTurnSnapshot): string {
@@ -158,11 +167,14 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     bounds,
     cardKey,
     desktopApi,
+    onGuidesChange,
     onOpenFull,
     onRaise,
     onRectChange,
+    onRectCommit,
     onUserRepliedToThread,
     rect,
+    resolveRect,
     scale,
     thread,
   } = props;
@@ -505,10 +517,12 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       onRaise(cardKey);
       dragRef.current = {
         kind,
+        moved: false,
         pointerId: event.pointerId,
         originX: event.clientX,
         originY: event.clientY,
         startRect: rect,
+        lastRect: rect,
       };
       event.currentTarget.setPointerCapture?.(event.pointerId);
     },
@@ -523,7 +537,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       const zoom = scale > 0 ? scale : 1;
       const deltaX = (event.clientX - drag.originX) / zoom;
       const deltaY = (event.clientY - drag.originY) / zoom;
-      const next =
+      const raw =
         drag.kind === "move"
           ? clampChatCardRect(
               {
@@ -539,17 +553,29 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
               deltaY,
               viewport: bounds,
             });
+      const resolved = !event.altKey && resolveRect
+        ? resolveRect(raw, drag.kind)
+        : { rect: raw, guides: [] };
+      const next = resolved.rect;
+      drag.moved = true;
+      drag.lastRect = next;
+      onGuidesChange?.(resolved.guides);
       onRectChange(cardKey, next);
     },
-    [bounds, cardKey, onRectChange, scale],
+    [bounds, cardKey, onGuidesChange, onRectChange, resolveRect, scale],
   );
 
-  const endDrag = useCallback((event: ReactPointerEvent) => {
-    const drag = dragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    dragRef.current = undefined;
-    event.currentTarget.releasePointerCapture?.(event.pointerId);
-  }, []);
+  const endDrag = useCallback(
+    (event: ReactPointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      dragRef.current = undefined;
+      onGuidesChange?.([]);
+      if (drag.moved) onRectCommit?.(cardKey, drag.lastRect);
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    },
+    [cardKey, onGuidesChange, onRectCommit],
+  );
 
   // No window-resize clamp: the card is anchored in the map, not in the
   // window. Resizing the window changes what part of the galaxy is on

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -164,6 +164,7 @@ export function StarMapTerminalCard(props: {
   zIndex: number;
   onClose: () => void;
   onHeightChange: (height: number) => void;
+  onHeightCommit?: (height: number) => void;
 }) {
   const thread = props.thread;
   const target = thread.federation?.ref.target ?? readRendererFederationTarget();
@@ -186,9 +187,6 @@ export function StarMapTerminalCard(props: {
   };
 
   const onHeightChange = props.onHeightChange;
-  const resizeBy = (delta: number) => {
-    onHeightChange(clampTerminalCardHeight(props.rect.height + delta));
-  };
 
   const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
@@ -199,15 +197,20 @@ export function StarMapTerminalCard(props: {
     // The card lives inside the pan/zoom canvas, so a screen pixel is not a
     // card pixel. Same conversion the host card's own resize grip makes.
     const zoom = props.scale > 0 ? props.scale : 1;
+    let changed = false;
+    let lastHeight = startHeight;
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       const delta = (moveEvent.clientY - startY) / zoom;
-      onHeightChange(clampTerminalCardHeight(startHeight + delta));
+      lastHeight = clampTerminalCardHeight(startHeight + delta);
+      changed = true;
+      onHeightChange(lastHeight);
     };
     const stopResize = () => {
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener("pointerup", stopResize);
       window.removeEventListener("pointercancel", stopResize);
+      if (changed) props.onHeightCommit?.(lastHeight);
     };
 
     window.addEventListener("pointermove", handlePointerMove);
@@ -218,10 +221,18 @@ export function StarMapTerminalCard(props: {
   const handleResizeKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      resizeBy(STAR_MAP_TERMINAL_RESIZE_STEP);
+      const height = clampTerminalCardHeight(
+        props.rect.height + STAR_MAP_TERMINAL_RESIZE_STEP,
+      );
+      onHeightChange(height);
+      props.onHeightCommit?.(height);
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
-      resizeBy(-STAR_MAP_TERMINAL_RESIZE_STEP);
+      const height = clampTerminalCardHeight(
+        props.rect.height - STAR_MAP_TERMINAL_RESIZE_STEP,
+      );
+      onHeightChange(height);
+      props.onHeightCommit?.(height);
     }
   };
 

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -84,6 +84,7 @@ import {
   resolveSnap,
   type AlignmentGuide,
   type SnapRect,
+  type SnapTarget,
 } from "./star-map-snapping";
 import { buildFederationTopology } from "./star-map-topology";
 import {
@@ -245,6 +246,14 @@ const TETHER_ANCHOR_RADIUS = 3;
  * operator was not aiming at.
  */
 const SNAP_THRESHOLD_PX = 6;
+/**
+ * Ignore objects beyond this SCREEN-space edge distance. Alignment along one
+ * axis alone is not enough: without this bound a card can latch to a matching
+ * edge on the other side of the galaxy and draw a guide across the map.
+ */
+const SNAP_PROXIMITY_PX = 96;
+const THREAD_SNAP_TARGET_TYPES = ["thread-card"] as const;
+const CHAT_SNAP_TARGET_TYPES = ["chat-card"] as const;
 /**
  * How far a press on empty canvas may travel and still count as a click
  * that clears the selection, rather than a pan the operator abandoned.
@@ -3139,9 +3148,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
   );
 
   useLayoutEffect(() => {
-    if (!chatCards.hydrated) return;
+    if (!chatCards.hydrated || !federationLayoutReady) return;
     chatCards.resolveRestoredAnchors(resolveWorkspaceAnchor);
-  }, [chatCards, resolveWorkspaceAnchor]);
+  }, [chatCards, federationLayoutReady, resolveWorkspaceAnchor]);
 
   useEffect(() => {
     if (!pendingFlight) return;
@@ -3550,12 +3559,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
         // offset never changes and every "alignment" against them is a
         // false latch at whatever spacing the group already had.
         const passengers = selection.has(selfKey) ? selection : undefined;
-        const others: SnapRect[] = [];
+        const targets: SnapTarget[] = [];
         for (const [key, rect] of cardRects) {
           if (key === selfKey || passengers?.has(key)) continue;
-          others.push(rect);
+          targets.push({ type: "thread-card", rect });
         }
-        if (others.length === 0) return unchanged;
+        if (targets.length === 0) return unchanged;
 
         const body = bodies.find((entry) => entry.instanceId === instanceId);
         const lane = lanes.get(instanceId);
@@ -3575,16 +3584,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
           ?? (lane?.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT);
         const scale = view.scale > 0 ? view.scale : 1;
         const snap = resolveSnap({
-          defaultGap: STAR_MAP_CARD_GAP,
           moving: {
-            // Cards are centred on their slot (marginLeft is -width/2), so
-            // the rect's left edge sits half a card back.
-            x: body.x + baseSlot.dx + offset.dx - cardWidth / 2,
-            y: body.y + baseSlot.dy + offset.dy,
-            width: cardWidth,
-            height,
+            type: "thread-card",
+            rect: {
+              // Cards are centred on their slot (marginLeft is -width/2), so
+              // the rect's left edge sits half a card back.
+              x: body.x + baseSlot.dx + offset.dx - cardWidth / 2,
+              y: body.y + baseSlot.dy + offset.dy,
+              width: cardWidth,
+              height,
+            },
           },
-          others,
+          targets,
+          spec: {
+            targetTypes: THREAD_SNAP_TARGET_TYPES,
+            proximity: SNAP_PROXIMITY_PX / scale,
+            spacingGaps: [STAR_MAP_CARD_GAP],
+          },
           threshold: SNAP_THRESHOLD_PX / scale,
         });
         return {
@@ -3610,13 +3626,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
         terminalOpen: card.terminalOpen,
         terminalHeight: card.terminalHeight,
       });
-      const moving: SnapRect = {
-        x: movingGroup.left,
-        y: movingGroup.top,
-        width: movingGroup.width,
-        height: movingGroup.height,
+      const moving: SnapTarget = {
+        type: "chat-card",
+        rect: {
+          x: movingGroup.left,
+          y: movingGroup.top,
+          width: movingGroup.width,
+          height: movingGroup.height,
+        },
       };
-      const others: SnapRect[] = [...flightRects.values()];
+      const targets: SnapTarget[] = [];
       for (const other of chatCards.cards) {
         if (other.key === cardKey) continue;
         const group = chatCardGroupRect(other.rect, {
@@ -3624,16 +3643,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
           terminalOpen: other.terminalOpen,
           terminalHeight: other.terminalHeight,
         });
-        others.push({
-          x: group.left,
-          y: group.top,
-          width: group.width,
-          height: group.height,
+        targets.push({
+          type: "chat-card",
+          rect: {
+            x: group.left,
+            y: group.top,
+            width: group.width,
+            height: group.height,
+          },
         });
       }
-      const threshold = SNAP_THRESHOLD_PX / (view.scale > 0 ? view.scale : 1);
+      const scale = view.scale > 0 ? view.scale : 1;
+      const threshold = SNAP_THRESHOLD_PX / scale;
+      const spec = {
+        targetTypes: CHAT_SNAP_TARGET_TYPES,
+        proximity: SNAP_PROXIMITY_PX / scale,
+        spacingGaps: [STAR_MAP_CARD_GAP],
+      };
       if (kind === "resize") {
-        const snap = resolveResizeSnap({ moving, others, threshold });
+        const snap = resolveResizeSnap({ moving, targets, spec, threshold });
         return {
           rect: resizeChatCardRect({
             rect: next,
@@ -3645,9 +3673,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
         };
       }
       const snap = resolveSnap({
-        defaultGap: STAR_MAP_CARD_GAP,
         moving,
-        others,
+        targets,
+        spec,
         threshold,
       });
       return {
@@ -3659,7 +3687,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         guides: snap.guides,
       };
     },
-    [chatCards.cards, flightRects, panZoomCanvas, view.scale],
+    [chatCards.cards, panZoomCanvas, view.scale],
   );
 
   const commitChatCardRect = useCallback(

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1042,6 +1042,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
     enabled: true,
     refreshNonce: remoteRefreshNonce,
   });
+  const federationLayoutReady =
+    !props.desktopApi?.readFederationHealth
+    || (
+      health !== undefined
+      && (
+        !props.desktopApi.getNavigationSnapshot
+        || peers.every(
+          (peer) =>
+            peer.status !== "connected"
+            || !peer.capabilities.includes("thread_navigation")
+            || remote.threadsByInstance.has(peer.id)
+            || remote.unreachableInstanceIds.has(peer.id),
+        )
+      )
+    );
   const queueProjectionThreads = useMemo(
     () => [
       ...props.localThreads,
@@ -2088,9 +2103,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
   useLayoutEffect(() => {
     if (!chatCards.hydrated) return;
     if (restoredViewLayoutRef.current === preferences.layout) return;
-    restoredViewLayoutRef.current = preferences.layout;
     const saved = chatCards.viewFor(preferences.layout);
-    if (!saved) return;
+    if (!saved) {
+      restoredViewLayoutRef.current = preferences.layout;
+      return;
+    }
+    if (!federationLayoutReady) return;
+    restoredViewLayoutRef.current = preferences.layout;
+    // The operator may use the map while a peer's first snapshot is still
+    // loading. Their movement outranks a delayed startup restoration.
+    if (operatorMovedViewRef.current) return;
     operatorMovedViewRef.current = true;
     commitView(
       clampStarMapView({
@@ -2102,6 +2124,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, [
     chatCards,
     commitView,
+    federationLayoutReady,
     panZoomCanvas.height,
     panZoomCanvas.width,
     preferences.layout,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2546,6 +2546,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
           break;
         }
       }
+      const ownerBody = bodies.find(
+        (body) => body.instanceId === ownerInstanceId,
+      );
       const placement = anchor
         ? {
             anchor: {
@@ -2555,6 +2558,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 threadKey,
               },
               point: { x: anchor.x, y: anchor.y },
+              instancePoint: ownerBody
+                ? { x: ownerBody.x, y: ownerBody.y }
+                : undefined,
             },
             sourceRect: {
               height: anchor.height,
@@ -2572,7 +2578,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         { persist: Boolean(remoteOwner || health?.instanceId) },
       );
     },
-    [chatCards, health?.instanceId, localInstanceId],
+    [bodies, chatCards, health?.instanceId, localInstanceId],
   );
 
   /**
@@ -3128,7 +3134,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   const resolveWorkspaceAnchor = useCallback(
     (anchor: StarMapWorkspaceAnchor) => {
-      if (anchor.kind === "canvas") return { x: 0, y: 0 };
+      if (anchor.kind === "canvas") {
+        return { point: { x: 0, y: 0 }, basis: "anchor" as const };
+      }
       if (anchor.kind === "thread") {
         const rect = flightRects.get(
           starMapWorkspaceCardKey({
@@ -3136,13 +3144,31 @@ export function StarMapScreen(props: StarMapScreenProps) {
             threadKey: anchor.threadKey,
           }),
         );
-        if (rect) return { x: rect.x, y: rect.y };
-        return undefined;
+        if (rect) {
+          return {
+            point: { x: rect.x, y: rect.y },
+            basis: "anchor" as const,
+          };
+        }
+        const ownerBody = bodies.find(
+          (candidate) => candidate.instanceId === anchor.instanceId,
+        );
+        return ownerBody
+          ? {
+              point: { x: ownerBody.x, y: ownerBody.y },
+              basis: "instance" as const,
+            }
+          : undefined;
       }
       const body = bodies.find(
         (candidate) => candidate.instanceId === anchor.instanceId,
       );
-      return body ? { x: body.x, y: body.y } : undefined;
+      return body
+        ? {
+            point: { x: body.x, y: body.y },
+            basis: "anchor" as const,
+          }
+        : undefined;
     },
     [bodies, flightRects],
   );
@@ -3696,6 +3722,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
       if (!card) return;
       const source = flightRects.get(cardKey);
       if (source) {
+        const body = bodies.find(
+          (candidate) => candidate.instanceId === card.ownerInstanceId,
+        );
         chatCards.commitRect(cardKey, rect, {
           anchor: {
             kind: "thread",
@@ -3703,6 +3732,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             threadKey: card.threadKey,
           },
           point: { x: source.x, y: source.y },
+          instancePoint: body ? { x: body.x, y: body.y } : undefined,
         });
         return;
       }
@@ -4879,7 +4909,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                     <StarMapTerminalCard
                       desktopApi={props.desktopApi}
                       thread={card.thread}
-                      threadKey={card.key}
+                      threadKey={card.threadKey}
                       rect={dockTerminalRect(card.rect, {
                         contextOpen: card.contextOpen,
                         height:

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -970,6 +970,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, []);
 
   const localInstanceId = health?.instanceId ?? "local";
+  useEffect(() => {
+    if (!health?.instanceId || !chatCards.hydrated) return;
+    chatCards.remapOwner("local", health.instanceId);
+  }, [chatCards, health?.instanceId]);
   const peers = useMemo(() => {
     const visible = (health?.peers ?? []).filter(
       (peer) => peer.status !== "revoked",
@@ -2497,10 +2501,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // callback only ever runs after a render has computed it.
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
       const target = thread.federation?.ref.target;
-      const ownerInstanceId =
-        target && isRemoteFederationTarget(target)
-          ? target.instanceId
-          : localInstanceId;
+      const remoteOwner = target && isRemoteFederationTarget(target);
+      const ownerInstanceId = remoteOwner ? target.instanceId : localInstanceId;
       const sourceKey = starMapWorkspaceCardKey({
         instanceId: ownerInstanceId,
         threadKey,
@@ -2512,31 +2514,33 @@ export function StarMapScreen(props: StarMapScreenProps) {
           break;
         }
       }
+      const placement = anchor
+        ? {
+            anchor: {
+              anchor: {
+                kind: "thread" as const,
+                instanceId: ownerInstanceId,
+                threadKey,
+              },
+              point: { x: anchor.x, y: anchor.y },
+            },
+            sourceRect: {
+              height: anchor.height,
+              width: anchor.width,
+              x: anchor.x,
+              y: anchor.y,
+            },
+            bounds: canvasBoundsRef.current,
+          }
+        : undefined;
       chatCards.open(
         ownerInstanceId,
         thread,
-        anchor
-          ? {
-              anchor: {
-                anchor: {
-                  kind: "thread",
-                  instanceId: ownerInstanceId,
-                  threadKey,
-                },
-                point: { x: anchor.x, y: anchor.y },
-              },
-              sourceRect: {
-                height: anchor.height,
-                width: anchor.width,
-                x: anchor.x,
-                y: anchor.y,
-              },
-              bounds: canvasBoundsRef.current,
-            }
-          : undefined,
+        placement,
+        { persist: Boolean(remoteOwner || health?.instanceId) },
       );
     },
-    [chatCards, localInstanceId],
+    [chatCards, health?.instanceId, localInstanceId],
   );
 
   /**
@@ -3101,6 +3105,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           }),
         );
         if (rect) return { x: rect.x, y: rect.y };
+        return undefined;
       }
       const body = bodies.find(
         (candidate) => candidate.instanceId === anchor.instanceId,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -16,10 +16,12 @@ import {
   formatFederationPeerDisplayLabel,
   formatFederationPeerDisplayLabelParts,
   isRemoteFederationTarget,
+  starMapWorkspaceCardKey,
   STAR_MAP_LOAD_CARD_KEY,
   STAR_MAP_LOAD_CARD_POSITION_KEY,
   type FederationPeerSummary,
   type NavigationThreadSummary,
+  type StarMapWorkspaceAnchor,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ComposerDraftStore } from "../composer/useComposerDraftStore";
@@ -78,6 +80,7 @@ import {
 import {
   marqueeRect,
   rectIntersects,
+  resolveResizeSnap,
   resolveSnap,
   type AlignmentGuide,
   type SnapRect,
@@ -100,10 +103,13 @@ import {
   STAR_MAP_TERMINAL_CARD_HEIGHT,
 } from "./StarMapSatelliteCards";
 import {
+  chatCardGroupRect,
   chatCardEdgeToward,
   dockContextRect,
   dockTerminalRect,
+  resizeChatCardRect,
   tetherExitPoint,
+  type ChatCardRect,
 } from "./star-map-chat-card-geometry";
 import type { StarMapCardMenuAction } from "./StarMapCardMenu";
 import { useStarMapChatCards } from "./useStarMapChatCards";
@@ -552,6 +558,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [preferences, setPreferences] = useState<StarMapViewPreferences>(
     readStoredPreferences,
   );
+  const chatCards = useStarMapChatCards({ desktopApi: props.desktopApi });
   /**
    * Project clouds the operator expanded past the per-group cap, keyed
    * `instanceId::clusterKey`. View-local like the selection: how much of a
@@ -650,6 +657,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
     },
     [paintView],
   );
+  const commitViewAndPersist = useCallback(
+    (next: StarMapView) => {
+      commitView(next);
+      chatCards.commitView(preferences.layout, next);
+    },
+    [chatCards, commitView, preferences.layout],
+  );
   /**
    * ⌘K flies the camera; the operator's own hands outrank it.
    *
@@ -661,7 +675,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const flight = useStarMapFlight({
     liveViewRef: viewRef,
     onPaint: paintView,
-    onCommit: commitView,
+    onCommit: commitViewAndPersist,
   });
   /**
    * The thread a pick is travelling to, by identity key.
@@ -930,7 +944,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // Only if this drag is still the current one: a second pointer may
       // have taken the ref, and its pan is not this one's to end.
       if (panBaseRef.current === base) panBaseRef.current = undefined;
-      commitView(
+      commitViewAndPersist(
         clampStarMapView({
           // Scale from the live view, not the base: a pinch mid-drag is
           // the one part of the gesture the base does not own.
@@ -1876,13 +1890,28 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return { width: right, height: bottom };
   }, [bodies, viewportSize.height, viewportSize.width]);
 
-  const panZoomCanvas = orbitMode
-    ? { width: orbit.canvasWidth, height: orbit.canvasHeight }
-    : projectsMode
-      ? { width: projectLayout.canvasWidth, height: projectLayout.canvasHeight }
-      : lanesCanvas;
+  const panZoomCanvas = useMemo(
+    () =>
+      orbitMode
+        ? { width: orbit.canvasWidth, height: orbit.canvasHeight }
+        : projectsMode
+          ? {
+              width: projectLayout.canvasWidth,
+              height: projectLayout.canvasHeight,
+            }
+          : lanesCanvas,
+    [
+      lanesCanvas,
+      orbit.canvasHeight,
+      orbit.canvasWidth,
+      orbitMode,
+      projectLayout.canvasHeight,
+      projectLayout.canvasWidth,
+      projectsMode,
+    ],
+  );
 
-  /** Canvas extent for callbacks defined above it (see `cardRectsRef`). */
+  /** Canvas extent for callbacks defined above it. */
   const canvasBoundsRef = useRef(panZoomCanvas);
   canvasBoundsRef.current = panZoomCanvas;
 
@@ -1973,8 +2002,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }
       if (wheelIdleTimer !== undefined) window.clearTimeout(wheelIdleTimer);
       wheelIdleTimer = window.setTimeout(() => {
+        const completedOwner = wheelOwner;
         wheelOwner = undefined;
         wheelIdleTimer = undefined;
+        if (completedOwner === "canvas" && operatorMovedViewRef.current) {
+          commitViewAndPersist(viewRef.current);
+        }
       }, WHEEL_GESTURE_IDLE_MS);
       if (wheelOwner === "embedded") return;
       event.preventDefault();
@@ -2028,6 +2061,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, [
     abortFlight,
     commitView,
+    commitViewAndPersist,
     topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
@@ -2043,6 +2077,33 @@ export function StarMapScreen(props: StarMapScreenProps) {
   useLayoutEffect(() => {
     operatorMovedViewRef.current = false;
   }, [preferences.layout]);
+
+  const restoredViewLayoutRef = useRef<
+    StarMapViewPreferences["layout"] | undefined
+  >(undefined);
+  useLayoutEffect(() => {
+    if (!chatCards.hydrated) return;
+    if (restoredViewLayoutRef.current === preferences.layout) return;
+    restoredViewLayoutRef.current = preferences.layout;
+    const saved = chatCards.viewFor(preferences.layout);
+    if (!saved) return;
+    operatorMovedViewRef.current = true;
+    commitView(
+      clampStarMapView({
+        view: saved,
+        canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+        viewport: { width: viewportSize.width, height: viewportSize.height },
+      }),
+    );
+  }, [
+    chatCards,
+    commitView,
+    panZoomCanvas.height,
+    panZoomCanvas.width,
+    preferences.layout,
+    viewportSize.height,
+    viewportSize.width,
+  ]);
 
   /**
    * Hold the map on its home cluster so the operator does not open onto
@@ -2235,17 +2296,19 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // keyboard camera's next frame reads the live ref. Committing to state
     // alone would be silently overwritten by that frame — and, because
     // React's last-rendered transform still matched, would not even repaint.
-    commitView(
-      placeStarMapView({
-        anchor: viewAnchor,
-        canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
-        viewport: { width: viewportSize.width, height: viewportSize.height },
-        topAnchored: topAnchoredView,
-      }),
-    );
+    const reset = placeStarMapView({
+      anchor: viewAnchor,
+      canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+      viewport: { width: viewportSize.width, height: viewportSize.height },
+      topAnchored: topAnchoredView,
+    });
+    commitView(reset);
+    chatCards.resetView(preferences.layout);
   }, [
     abortFlight,
+    chatCards,
     commitView,
+    preferences.layout,
     topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
@@ -2272,7 +2335,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     canvas: panZoomCanvas,
     viewport: viewportSize,
     onPaint: paintView,
-    onCommit: commitView,
+    onCommit: commitViewAndPersist,
     onMoveStart: claimView,
     onResetView: resetView,
   });
@@ -2372,7 +2435,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return labels;
   }, [displayLabelPartsById, peers]);
 
-  const chatCards = useStarMapChatCards();
   /** Threads with a chat card open, so their card can say so. */
   const chattingThreadKeys = useMemo(
     () => new Set(chatCards.cards.map((card) => card.key)),
@@ -2391,15 +2453,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
     if (chatCards.cards.length === 0) return undefined;
     const byKey = new Map<string, NavigationThreadSummary>();
     for (const thread of props.localThreads) {
-      byKey.set(buildThreadIdentityKey(thread.source, thread.id), thread);
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      byKey.set(
+        starMapWorkspaceCardKey({ instanceId: localInstanceId, threadKey }),
+        thread,
+      );
     }
-    for (const threads of remote.threadsByInstance.values()) {
+    for (const [instanceId, threads] of remote.threadsByInstance) {
       for (const thread of threads) {
-        byKey.set(buildThreadIdentityKey(thread.source, thread.id), thread);
+        const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+        byKey.set(starMapWorkspaceCardKey({ instanceId, threadKey }), thread);
       }
     }
     return byKey;
-  }, [chatCards.cards.length, props.localThreads, remote.threadsByInstance]);
+  }, [
+    chatCards.cards.length,
+    localInstanceId,
+    props.localThreads,
+    remote.threadsByInstance,
+  ]);
   const { desktopApi, onFocusLocalInstance, onOpenLocalThread } = props;
   const openInstance = useCallback(
     (instanceId: string) => {
@@ -2424,24 +2496,36 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // is read through a ref because it is declared further down; the
       // callback only ever runs after a render has computed it.
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const target = thread.federation?.ref.target;
+      const ownerInstanceId =
+        target && isRemoteFederationTarget(target)
+          ? target.instanceId
+          : localInstanceId;
+      const sourceKey = starMapWorkspaceCardKey({
+        instanceId: ownerInstanceId,
+        threadKey,
+      });
       let anchor: SnapRect | undefined;
-      // `cardRects` is built from the lane/orbit bodies, which is NOT where
-      // the projects lens draws its cards — anchoring to it there would
-      // open the chat at a position unrelated to anything on screen. That
-      // lens falls back to the cascade until it publishes its own rects.
-      if (!projectsModeRef.current) {
-        for (const [key, rect] of cardRectsRef.current) {
-          if (key.endsWith(`::${threadKey}`)) {
-            anchor = rect;
-            break;
-          }
+      for (const [key, rect] of flightRectsRef.current) {
+        if (key === sourceKey) {
+          anchor = rect;
+          break;
         }
       }
       chatCards.open(
+        ownerInstanceId,
         thread,
         anchor
           ? {
               anchor: {
+                anchor: {
+                  kind: "thread",
+                  instanceId: ownerInstanceId,
+                  threadKey,
+                },
+                point: { x: anchor.x, y: anchor.y },
+              },
+              sourceRect: {
                 height: anchor.height,
                 width: anchor.width,
                 x: anchor.x,
@@ -2452,7 +2536,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           : undefined,
       );
     },
-    [chatCards],
+    [chatCards, localInstanceId],
   );
 
   /**
@@ -2804,7 +2888,19 @@ export function StarMapScreen(props: StarMapScreenProps) {
                     threadId: target.thread.id,
                   })
                   .then(() => {
-                    chatCards.close(threadKey);
+                    const federationTarget =
+                      target.thread.federation?.ref.target;
+                    const ownerInstanceId =
+                      federationTarget
+                      && isRemoteFederationTarget(federationTarget)
+                        ? federationTarget.instanceId
+                        : localInstanceId;
+                    chatCards.close(
+                      starMapWorkspaceCardKey({
+                        instanceId: ownerInstanceId,
+                        threadKey,
+                      }),
+                    );
                     // An archived card is gone for good, unlike one a
                     // filter or a flapping instance takes off the map, so
                     // the selection drops it rather than counting it
@@ -2840,6 +2936,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       chatCards,
       desktopApi,
       dropFromSelection,
+      localInstanceId,
       openThreadFully,
       runOnCardTargets,
     ],
@@ -2932,11 +3029,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * them (opening a chat card beside its thread). Refs rather than deps so
    * those callbacks stay stable across every snapshot.
    */
-  const cardRectsRef = useRef(cardRects);
-  cardRectsRef.current = cardRects;
-  const projectsModeRef = useRef(projectsMode);
-  projectsModeRef.current = projectsMode;
-
   /**
    * Card geometry for the projects lens, which seats its cards around
    * project bodies rather than instance bodies and so appears nowhere in
@@ -2995,6 +3087,33 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   /** Where every card the current lens draws sits, by card key. */
   const flightRects = projectsMode ? projectCardRects : cardRects;
+  const flightRectsRef = useRef(flightRects);
+  flightRectsRef.current = flightRects;
+
+  const resolveWorkspaceAnchor = useCallback(
+    (anchor: StarMapWorkspaceAnchor) => {
+      if (anchor.kind === "canvas") return { x: 0, y: 0 };
+      if (anchor.kind === "thread") {
+        const rect = flightRects.get(
+          starMapWorkspaceCardKey({
+            instanceId: anchor.instanceId,
+            threadKey: anchor.threadKey,
+          }),
+        );
+        if (rect) return { x: rect.x, y: rect.y };
+      }
+      const body = bodies.find(
+        (candidate) => candidate.instanceId === anchor.instanceId,
+      );
+      return body ? { x: body.x, y: body.y } : undefined;
+    },
+    [bodies, flightRects],
+  );
+
+  useLayoutEffect(() => {
+    if (!chatCards.hydrated) return;
+    chatCards.resolveRestoredAnchors(resolveWorkspaceAnchor);
+  }, [chatCards, resolveWorkspaceAnchor]);
 
   useEffect(() => {
     if (!pendingFlight) return;
@@ -3450,6 +3569,107 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [bodies, cardRects, lanes, selection, view.scale],
   );
 
+  const resolveChatCardRect = useCallback(
+    (
+      cardKey: string,
+      next: ChatCardRect,
+      kind: "move" | "resize",
+    ): { rect: ChatCardRect; guides: AlignmentGuide[] } => {
+      const card = chatCards.cards.find((entry) => entry.key === cardKey);
+      if (!card) return { rect: next, guides: [] };
+      const movingGroup = chatCardGroupRect(next, {
+        contextOpen: card.contextOpen,
+        terminalOpen: card.terminalOpen,
+        terminalHeight: card.terminalHeight,
+      });
+      const moving: SnapRect = {
+        x: movingGroup.left,
+        y: movingGroup.top,
+        width: movingGroup.width,
+        height: movingGroup.height,
+      };
+      const others: SnapRect[] = [...flightRects.values()];
+      for (const other of chatCards.cards) {
+        if (other.key === cardKey) continue;
+        const group = chatCardGroupRect(other.rect, {
+          contextOpen: other.contextOpen,
+          terminalOpen: other.terminalOpen,
+          terminalHeight: other.terminalHeight,
+        });
+        others.push({
+          x: group.left,
+          y: group.top,
+          width: group.width,
+          height: group.height,
+        });
+      }
+      const threshold = SNAP_THRESHOLD_PX / (view.scale > 0 ? view.scale : 1);
+      if (kind === "resize") {
+        const snap = resolveResizeSnap({ moving, others, threshold });
+        return {
+          rect: resizeChatCardRect({
+            rect: next,
+            deltaX: snap.dw,
+            deltaY: snap.dh,
+            viewport: panZoomCanvas,
+          }),
+          guides: snap.guides,
+        };
+      }
+      const snap = resolveSnap({
+        defaultGap: STAR_MAP_CARD_GAP,
+        moving,
+        others,
+        threshold,
+      });
+      return {
+        rect: {
+          ...next,
+          left: next.left + snap.dx,
+          top: next.top + snap.dy,
+        },
+        guides: snap.guides,
+      };
+    },
+    [chatCards.cards, flightRects, panZoomCanvas, view.scale],
+  );
+
+  const commitChatCardRect = useCallback(
+    (cardKey: string, rect: ChatCardRect) => {
+      const card = chatCards.cards.find((entry) => entry.key === cardKey);
+      if (!card) return;
+      const source = flightRects.get(cardKey);
+      if (source) {
+        chatCards.commitRect(cardKey, rect, {
+          anchor: {
+            kind: "thread",
+            instanceId: card.ownerInstanceId,
+            threadKey: card.threadKey,
+          },
+          point: { x: source.x, y: source.y },
+        });
+        return;
+      }
+      const body = bodies.find(
+        (candidate) => candidate.instanceId === card.ownerInstanceId,
+      );
+      chatCards.commitRect(
+        cardKey,
+        rect,
+        body
+          ? {
+              anchor: {
+                kind: "instance",
+                instanceId: card.ownerInstanceId,
+              },
+              point: { x: body.x, y: body.y },
+            }
+          : undefined,
+      );
+    },
+    [bodies, chatCards, flightRects],
+  );
+
   /**
    * A line from each open chat card to the thread card it belongs to.
    *
@@ -3472,13 +3692,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const chatTethers = useMemo(() => {
     if (chatCards.cards.length === 0 || projectsMode) return [];
     return chatCards.cards.flatMap((card) => {
-      let source: SnapRect | undefined;
-      for (const [key, rect] of cardRects) {
-        if (key.endsWith(`::${card.key}`)) {
-          source = rect;
-          break;
-        }
-      }
+      const source = cardRects.get(card.key);
       if (!source) return [];
       const target = {
         x: source.x + source.width / 2,
@@ -3879,7 +4093,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
               stackIndex={Math.min(index, STAR_MAP_CARD_MAX_Z)}
               cardKey={`${position.instanceId}::${threadKey}`}
               selected={selection.has(`${position.instanceId}::${threadKey}`)}
-              chatting={chattingThreadKeys.has(threadKey)}
+              chatting={chattingThreadKeys.has(
+                starMapWorkspaceCardKey({
+                  instanceId: position.instanceId,
+                  threadKey,
+                }),
+              )}
               onToggleSelect={() =>
                 toggleSelected(`${position.instanceId}::${threadKey}`)
               }
@@ -4554,10 +4773,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
               onRefreshNavigation={() =>
                 refreshOwner(cardInstanceId ?? localInstanceId)
               }
+              onGuidesChange={setActiveGuides}
               onRaise={chatCards.raise}
+              onRectCommit={commitChatCardRect}
               onRectChange={chatCards.setRect}
               pastedImageMaxPatches={props.pastedImageMaxPatches}
               rect={card.rect}
+              resolveRect={(rect, kind) =>
+                resolveChatCardRect(card.key, rect, kind)
+              }
               thread={liveThread}
               scale={view.scale}
               bounds={panZoomCanvas}
@@ -4610,6 +4834,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
                       onClose={() => chatCards.toggleTerminal(card.key)}
                       onHeightChange={(height) =>
                         chatCards.setTerminalHeight(card.key, height)
+                      }
+                      onHeightCommit={(height) =>
+                        chatCards.commitTerminalHeight(card.key, height)
                       }
                     />
                   ) : null}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -255,6 +255,56 @@ function transferImage(
  */
 const IGNORE_COMPOSER = ".composer-tiptap-input, .composer-tiptap-input *";
 
+describe("StarMapChatCard gesture persistence", () => {
+  it("raises in memory and commits once when dragging a non-top card", () => {
+    const onRaise = vi.fn(() => true);
+    const onRectChange = vi.fn();
+    const onRectCommit = vi.fn();
+    const { container } = render(
+      <StarMapChatCard
+        cardKey="card-1"
+        desktopApi={buildApi()}
+        onClose={() => undefined}
+        onOpenFull={() => undefined}
+        onRaise={onRaise}
+        onRectChange={onRectChange}
+        onRectCommit={onRectCommit}
+        rect={RECT}
+        thread={localThread()}
+        scale={1}
+        bounds={{ width: 4000, height: 3000 }}
+        onToggleContext={() => undefined}
+        onToggleTerminal={() => undefined}
+        zIndex={40}
+      />,
+    );
+    const header = container.querySelector(".star-map-chat-card__bar");
+    expect(header).not.toBeNull();
+
+    fireEvent.pointerDown(header as Element, {
+      button: 0,
+      clientX: 100,
+      clientY: 100,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(header as Element, {
+      clientX: 125,
+      clientY: 120,
+      pointerId: 1,
+    });
+    fireEvent.pointerUp(header as Element, {
+      clientX: 125,
+      clientY: 120,
+      pointerId: 1,
+    });
+
+    expect(onRaise).toHaveBeenCalledTimes(1);
+    expect(onRaise).toHaveBeenCalledWith("card-1", false);
+    expect(onRectChange).toHaveBeenCalledTimes(1);
+    expect(onRectCommit).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("StarMapChatCard transcript loading", () => {
   it("asks for the last few turns rather than the whole thread", async () => {
     const desktopApi = buildApi();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -11,6 +11,12 @@ import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapScreen } from "../StarMapScreen";
 
+vi.mock("../../thread-detail/IntegratedTerminal", () => ({
+  IntegratedTerminal: (props: { threadKey: string }) => (
+    <div data-testid="star-map-terminal-pane" data-thread-key={props.threadKey} />
+  ),
+}));
+
 /**
  * The whole card for a thread, given its open-thread button.
  *
@@ -943,6 +949,8 @@ describe("StarMapScreen", () => {
                 },
                 dx: 20,
                 dy: 30,
+                instanceDx: 50,
+                instanceDy: 60,
                 fallbackRect: {
                   left: 600,
                   top: 240,
@@ -974,8 +982,16 @@ describe("StarMapScreen", () => {
     const chat = await screen.findByRole("region", {
       name: "Chat: Disconnected workspace chat",
     });
-    expect(chat.style.left).toBe("600px");
-    expect(chat.style.top).toBe("240px");
+    const remoteBody = screen.getByRole("button", {
+      name: "Focus Remote Mac",
+    }).closest<HTMLElement>(".star-map__anchor");
+    expect(remoteBody).toBeTruthy();
+    expect(Number.parseFloat(chat.style.left)).toBeCloseTo(
+      Number.parseFloat(remoteBody?.style.left ?? "") + 50,
+    );
+    expect(Number.parseFloat(chat.style.top)).toBeCloseTo(
+      Number.parseFloat(remoteBody?.style.top ?? "") + 60,
+    );
     expect(
       screen.getByRole("region", {
         name: "Thread context: Disconnected workspace chat",
@@ -986,6 +1002,11 @@ describe("StarMapScreen", () => {
         name: "Terminal: Disconnected workspace chat",
       }),
     ).toBeTruthy();
+    expect(
+      (await screen.findByTestId("star-map-terminal-pane")).getAttribute(
+        "data-thread-key",
+      ),
+    ).toBe("codex:t-remote");
   });
 
   it("waits for the owning thread layout before restoring a chat anchor", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -988,6 +988,151 @@ describe("StarMapScreen", () => {
     ).toBeTruthy();
   });
 
+  it("waits for the owning thread layout before restoring a chat anchor", async () => {
+    type HealthResponse = Awaited<
+      ReturnType<NonNullable<DesktopApi["readFederationHealth"]>>
+    >;
+    type SnapshotResponse = Awaited<
+      ReturnType<NonNullable<DesktopApi["getNavigationSnapshot"]>>
+    >;
+    const health = createDeferred<HealthResponse>();
+    const remoteSnapshot = createDeferred<SnapshotResponse>();
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readFederationHealth: vi.fn(() => health.promise),
+      getNavigationSnapshot: vi.fn(() => remoteSnapshot.promise),
+      readStarMapWorkspace: vi.fn(async () => ({
+        workspace: {
+          version: 1 as const,
+          revision: 3,
+          updatedAt: 100,
+          cards: [
+            {
+              key: "pwr_remote::codex:t-remote",
+              ownerInstanceId: "pwr_remote",
+              thread: {
+                ...unreadThread("t-remote"),
+                title: "Anchored remote chat",
+                federation: {
+                  ref: {
+                    backend: "codex" as const,
+                    threadId: "t-remote",
+                    target: {
+                      scope: "remote" as const,
+                      instanceId: "pwr_remote",
+                    },
+                  },
+                  instanceLabel: "Remote Mac",
+                  peerStatus: "connected" as const,
+                },
+              },
+              geometry: {
+                anchor: {
+                  kind: "thread" as const,
+                  instanceId: "pwr_remote",
+                  threadKey: "codex:t-remote",
+                },
+                dx: 24,
+                dy: 36,
+                fallbackRect: {
+                  left: 300,
+                  top: 240,
+                  width: 420,
+                  height: 520,
+                },
+              },
+              contextOpen: false,
+              terminalOpen: false,
+            },
+          ],
+          views: {},
+        },
+      })),
+    };
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    const chat = await screen.findByRole("region", {
+      name: "Chat: Anchored remote chat",
+    });
+    expect(chat.style.left).toBe("300px");
+    expect(chat.style.top).toBe("240px");
+
+    await act(async () => {
+      health.resolve({
+        health: {
+          enabled: true,
+          role: "gateway",
+          status: "listening",
+          instanceId: "pwr_local",
+          peers: [
+            {
+              id: "pwr_remote",
+              label: "Remote Mac",
+              role: "client",
+              status: "connected",
+              capabilities: ["thread_navigation"],
+            },
+          ],
+        },
+      });
+      await health.promise;
+    });
+    expect(chat.style.left).toBe("300px");
+    expect(chat.style.top).toBe("240px");
+
+    await act(async () => {
+      remoteSnapshot.resolve({
+        fetchedAt: 200,
+        threads: [
+          {
+            ...unreadThread("t-remote"),
+            title: "Anchored remote chat",
+            federation: {
+              ref: {
+                backend: "codex" as const,
+                threadId: "t-remote",
+                target: {
+                  scope: "remote" as const,
+                  instanceId: "pwr_remote",
+                },
+              },
+              instanceLabel: "Remote Mac",
+              peerStatus: "connected" as const,
+            },
+          },
+        ],
+      } as unknown as SnapshotResponse);
+      await remoteSnapshot.promise;
+    });
+
+    await waitFor(() => {
+      const shell = document.querySelector<HTMLElement>(
+        '[data-card-key="pwr_remote::codex:t-remote"]',
+      );
+      const cloud = shell?.closest<HTMLElement>(".star-map__cloud");
+      expect(shell).toBeTruthy();
+      expect(cloud).toBeTruthy();
+      const threadLeft =
+        Number.parseFloat(cloud?.style.left ?? "")
+        + Number.parseFloat(shell?.style.left ?? "")
+        + Number.parseFloat(shell?.style.marginLeft ?? "");
+      const threadTop =
+        Number.parseFloat(cloud?.style.top ?? "")
+        + Number.parseFloat(shell?.style.top ?? "");
+      expect(Number.parseFloat(chat.style.left)).toBeCloseTo(threadLeft + 24);
+      expect(Number.parseFloat(chat.style.top)).toBeCloseTo(threadTop + 36);
+    });
+  });
+
   it("waits for the initial federation layout before restoring the camera", async () => {
     seedLayout("orbit");
     type HealthResponse = Awaited<

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -988,6 +988,100 @@ describe("StarMapScreen", () => {
     ).toBeTruthy();
   });
 
+  it("waits for the initial federation layout before restoring the camera", async () => {
+    seedLayout("orbit");
+    type HealthResponse = Awaited<
+      ReturnType<NonNullable<DesktopApi["readFederationHealth"]>>
+    >;
+    type SnapshotResponse = Awaited<
+      ReturnType<NonNullable<DesktopApi["getNavigationSnapshot"]>>
+    >;
+    const health = createDeferred<HealthResponse>();
+    const remoteSnapshot = createDeferred<SnapshotResponse>();
+    const getNavigationSnapshot = vi.fn(() => remoteSnapshot.promise);
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readFederationHealth: vi.fn(() => health.promise),
+      getNavigationSnapshot,
+      readStarMapWorkspace: vi.fn(async () => ({
+        workspace: {
+          version: 1 as const,
+          revision: 3,
+          updatedAt: 100,
+          cards: [],
+          views: { orbit: { x: -600, y: 0, scale: 0.5 } },
+        },
+      })),
+    };
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    const canvas = () =>
+      container.querySelector<HTMLElement>(".star-map__canvas");
+    const savedTransform = "translate(-600px, 0px) scale(0.5)";
+
+    await waitFor(() => expect(canvas()).not.toBeNull());
+    expect(canvas()?.style.transform).not.toBe(savedTransform);
+
+    await act(async () => {
+      health.resolve({
+        health: {
+          enabled: true,
+          role: "gateway",
+          status: "listening",
+          instanceId: "pwr_local",
+          peers: [
+            {
+              id: "pwr_remote",
+              label: "Remote Mac",
+              role: "client",
+              status: "connected",
+              capabilities: ["thread_navigation"],
+            },
+          ],
+        },
+      });
+      await health.promise;
+    });
+    await waitFor(() => expect(getNavigationSnapshot).toHaveBeenCalledTimes(1));
+    expect(canvas()?.style.transform).not.toBe(savedTransform);
+    const transformBeforeRemoteSnapshot = canvas()?.style.transform;
+
+    await act(async () => {
+      remoteSnapshot.resolve({
+        fetchedAt: 200,
+        threads: Array.from({ length: 30 }, (_, index) => ({
+          ...unreadThread(`remote-${index}`),
+          federation: {
+            ref: {
+              backend: "codex" as const,
+              threadId: `remote-${index}`,
+              target: {
+                scope: "remote" as const,
+                instanceId: "pwr_remote",
+              },
+            },
+            instanceLabel: "Remote Mac",
+            peerStatus: "connected" as const,
+          },
+        })),
+      } as unknown as SnapshotResponse);
+      await remoteSnapshot.promise;
+    });
+
+    await waitFor(() => {
+      expect(canvas()?.style.transform).toContain("scale(0.5)");
+    });
+    expect(canvas()?.style.transform).not.toBe(transformBeforeRemoteSnapshot);
+  });
+
   it("keeps a stopped monitor disabled until local navigation refreshes", async () => {
     let resolveRefresh: (() => void) | undefined;
     const refreshPending = new Promise<void>((resolve) => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -51,7 +51,7 @@ function unreadThread(id: string): NavigationThreadSummary {
   return {
     id,
     title: `Thread ${id}`,
-    titleSource: "generated",
+              titleSource: "derived",
     linkedDirectories: [
       {
         id: "dir-1",
@@ -810,6 +810,91 @@ describe("StarMapScreen", () => {
     expect(
       screen.getAllByRole("region", { name: "Chat: Thread t1" }),
     ).toHaveLength(1);
+  });
+
+  it("restores an open disconnected chat with its context and terminal", async () => {
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readStarMapWorkspace: vi.fn(async () => ({
+        workspace: {
+          version: 1 as const,
+          revision: 3,
+          updatedAt: 100,
+          cards: [
+            {
+              key: "pwr_remote::codex:t-remote",
+              ownerInstanceId: "pwr_remote",
+              thread: {
+                id: "t-remote",
+                inbox: { inInbox: true },
+                linkedDirectories: [],
+                source: "codex" as const,
+                title: "Disconnected workspace chat",
+                titleSource: "derived" as const,
+                federation: {
+                  ref: {
+                    backend: "codex" as const,
+                    threadId: "t-remote",
+                    target: {
+                      scope: "remote" as const,
+                      instanceId: "pwr_remote",
+                    },
+                  },
+                  instanceLabel: "Remote Mac",
+                  peerStatus: "disconnected" as const,
+                },
+              },
+              geometry: {
+                anchor: {
+                  kind: "thread" as const,
+                  instanceId: "pwr_remote",
+                  threadKey: "codex:t-remote",
+                },
+                dx: 20,
+                dy: 30,
+                fallbackRect: {
+                  left: 600,
+                  top: 240,
+                  width: 420,
+                  height: 520,
+                },
+              },
+              contextOpen: true,
+              terminalOpen: true,
+              terminalHeight: 300,
+            },
+          ],
+          views: {},
+        },
+      })),
+    };
+
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("region", {
+        name: "Chat: Disconnected workspace chat",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("region", {
+        name: "Thread context: Disconnected workspace chat",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("region", {
+        name: "Terminal: Disconnected workspace chat",
+      }),
+    ).toBeTruthy();
   });
 
   it("keeps a stopped monitor disabled until local navigation refreshes", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -812,9 +812,100 @@ describe("StarMapScreen", () => {
     ).toHaveLength(1);
   });
 
+  it("does not persist a local chat under the pre-health placeholder id", async () => {
+    type HealthResponse = Awaited<
+      ReturnType<NonNullable<DesktopApi["readFederationHealth"]>>
+    >;
+    let resolveHealth: (value: HealthResponse) => void = () => {};
+    const healthRead = new Promise<HealthResponse>((resolve) => {
+      resolveHealth = resolve;
+    });
+    const writeStarMapWorkspace = vi.fn(
+      async ({ baseRevision, workspace }) => ({
+        workspace: {
+          ...workspace,
+          revision: baseRevision + 1,
+          updatedAt: 200,
+        },
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      readFederationHealth: vi.fn(() => healthRead),
+      readStarMapWorkspace: vi.fn(async () => ({
+        workspace: {
+          version: 1 as const,
+          cards: [],
+          views: {},
+          revision: 0,
+          updatedAt: 0,
+        },
+      })),
+      writeStarMapWorkspace,
+      onAgentEvent: vi.fn(() => () => undefined),
+    };
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Open thread: Thread t1/ }),
+    );
+    await screen.findByRole("region", { name: "Chat: Thread t1" });
+    expect(writeStarMapWorkspace).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveHealth({
+        health: {
+          enabled: false,
+          role: "client",
+          status: "disabled",
+          instanceId: "pwr_local",
+          peers: [],
+        },
+      });
+    });
+
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(1));
+    expect(writeStarMapWorkspace).toHaveBeenCalledWith({
+      baseRevision: 0,
+      workspace: expect.objectContaining({
+        cards: [
+          expect.objectContaining({
+            key: "pwr_local::codex:t1",
+            ownerInstanceId: "pwr_local",
+          }),
+        ],
+      }),
+    });
+  });
+
   it("restores an open disconnected chat with its context and terminal", async () => {
     const desktopApi: DesktopApi = {
       ...buildDesktopApi(),
+      readFederationHealth: vi.fn(async () => ({
+        health: {
+          enabled: true,
+          role: "gateway" as const,
+          status: "listening" as const,
+          instanceId: "pwr_local",
+          peers: [
+            {
+              id: "pwr_remote",
+              label: "Remote Mac",
+              role: "client" as const,
+              status: "disconnected" as const,
+              capabilities: [],
+            },
+          ],
+        },
+      })) as unknown as DesktopApi["readFederationHealth"],
       readStarMapWorkspace: vi.fn(async () => ({
         workspace: {
           version: 1 as const,
@@ -880,11 +971,11 @@ describe("StarMapScreen", () => {
       />,
     );
 
-    expect(
-      await screen.findByRole("region", {
-        name: "Chat: Disconnected workspace chat",
-      }),
-    ).toBeTruthy();
+    const chat = await screen.findByRole("region", {
+      name: "Chat: Disconnected workspace chat",
+    });
+    expect(chat.style.left).toBe("600px");
+    expect(chat.style.top).toBe("240px");
     expect(
       screen.getByRole("region", {
         name: "Thread context: Disconnected workspace chat",

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
@@ -10,6 +10,7 @@ import {
   CHAT_CARD_MIN_HEIGHT,
   CHAT_CARD_MIN_WIDTH,
   cascadeChatCardRect,
+  chatCardGroupRect,
   chatCardEdgeToward,
   clampChatCardRect,
   dockContextRect,
@@ -367,5 +368,21 @@ describe("satellite docking", () => {
     const after = dockContextRect(moved);
     expect(after.left - before.left).toBe(300);
     expect(after.top - before.top).toBe(-120);
+  });
+
+  it("treats open satellites as occupied group space for snapping", () => {
+    const group = chatCardGroupRect(host, {
+      contextOpen: true,
+      terminalOpen: true,
+      terminalHeight: 300,
+    });
+    const context = dockContextRect(host);
+    const terminal = dockTerminalRect(host, {
+      contextOpen: true,
+      height: 300,
+    });
+
+    expect(group.width).toBe(context.left + context.width - host.left);
+    expect(group.height).toBe(terminal.top + terminal.height - host.top);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
@@ -3,6 +3,7 @@ import {
   marqueeRect,
   observedGaps,
   rectIntersects,
+  resolveResizeSnap,
   resolveSnap,
   type SnapRect,
 } from "../star-map-snapping";
@@ -93,6 +94,30 @@ describe("resolveSnap alignment", () => {
     });
     expect(result.dx).toBe(-4);
     expect(result.dy).toBe(-3);
+  });
+});
+
+describe("resolveResizeSnap", () => {
+  it("matches a neighbouring card width without moving the origin", () => {
+    const result = resolveResizeSnap({
+      moving: { x: 100, y: 400, width: 194, height: 100 },
+      others: [card(500, 0)],
+      threshold: 8,
+    });
+
+    expect(result.dw).toBe(6);
+    expect(result.guides.some((guide) => guide.axis === "x")).toBe(true);
+  });
+
+  it("aligns the resized bottom edge with a neighbour", () => {
+    const result = resolveResizeSnap({
+      moving: { x: 500, y: 0, width: 200, height: 96 },
+      others: [card(0, 0)],
+      threshold: 8,
+    });
+
+    expect(result.dh).toBe(4);
+    expect(result.guides.some((guide) => guide.axis === "y")).toBe(true);
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   marqueeRect,
-  observedGaps,
   rectIntersects,
   resolveResizeSnap,
   resolveSnap,
+  snapCandidates,
   type SnapRect,
+  type SnapSpec,
+  type SnapTarget,
 } from "../star-map-snapping";
 
 const CARD = { width: 200, height: 100 };
@@ -14,11 +16,35 @@ function card(x: number, y: number): SnapRect {
   return { x, y, ...CARD };
 }
 
-const SNAP = { defaultGap: 12, threshold: 8 };
+const THREAD_SPEC: SnapSpec = {
+  targetTypes: ["thread-card"],
+  proximity: 96,
+  spacingGaps: [12],
+};
+
+function target(
+  rect: SnapRect,
+  type: SnapTarget["type"] = "thread-card",
+): SnapTarget {
+  return { type, rect };
+}
+
+function snap(
+  moving: SnapRect,
+  others: readonly SnapRect[],
+  spec = THREAD_SPEC,
+) {
+  return resolveSnap({
+    moving: target(moving),
+    targets: others.map((rect) => target(rect)),
+    spec,
+    threshold: 8,
+  });
+}
 
 describe("resolveSnap alignment", () => {
   it("does nothing when there is nothing to snap to", () => {
-    expect(resolveSnap({ ...SNAP, moving: card(0, 0), others: [] })).toEqual({
+    expect(snap(card(0, 0), [])).toEqual({
       dx: 0,
       dy: 0,
       guides: [],
@@ -27,71 +53,43 @@ describe("resolveSnap alignment", () => {
 
   it("latches a near-miss left edge", () => {
     // 5px off a shared left edge, inside the 8px tolerance.
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(105, 400),
-      others: [card(100, 0)],
-    });
+    const result = snap(card(105, 150), [card(100, 0)]);
     expect(result.dx).toBe(-5);
   });
 
   it("leaves an edge alone once it is out of tolerance", () => {
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(120, 400),
-      others: [card(100, 0)],
-    });
+    const result = snap(card(120, 150), [card(100, 0)]);
     expect(result.dx).toBe(0);
   });
 
   it("aligns centres, not just edges", () => {
     // Moving centre 203, other centre 200 → pull left by 3.
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(103, 400),
-      others: [card(100, 0)],
-    });
+    const result = snap(card(103, 150), [card(100, 0)]);
     expect(result.dx).toBe(-3);
   });
 
   it("aligns a right edge to another card's left edge", () => {
     // Moving right edge 397 wants the neighbour's left edge at 400.
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(197, 0),
-      others: [card(400, 0)],
-    });
+    const result = snap(card(197, 0), [card(400, 0)]);
     expect(result.dx).toBe(3);
   });
 
   it("prefers the smallest adjustment among competing neighbours", () => {
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(106, 400),
-      others: [card(100, 0), card(108, 900)],
-    });
+    const result = snap(card(106, 150), [card(100, 0), card(108, 160)]);
     expect(result.dx).toBe(2);
   });
 
   it("emits a guide spanning both cards so the snap is explainable", () => {
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(105, 400),
-      others: [card(100, 0)],
-    });
+    const result = snap(card(105, 150), [card(100, 0)]);
     const guide = result.guides.find((entry) => entry.axis === "x");
     expect(guide?.at).toBe(100);
     // Spans from the topmost card's top to the bottom card's bottom.
     expect(guide?.start).toBe(0);
-    expect(guide?.end).toBe(500);
+    expect(guide?.end).toBe(250);
   });
 
   it("snaps both axes independently", () => {
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(104, 603),
-      others: [card(100, 600)],
-    });
+    const result = snap(card(104, 603), [card(100, 600)]);
     expect(result.dx).toBe(-4);
     expect(result.dy).toBe(-3);
   });
@@ -100,8 +98,9 @@ describe("resolveSnap alignment", () => {
 describe("resolveResizeSnap", () => {
   it("matches a neighbouring card width without moving the origin", () => {
     const result = resolveResizeSnap({
-      moving: { x: 100, y: 400, width: 194, height: 100 },
-      others: [card(500, 0)],
+      moving: target({ x: 100, y: 150, width: 194, height: 100 }),
+      targets: [target(card(300, 0))],
+      spec: THREAD_SPEC,
       threshold: 8,
     });
 
@@ -111,8 +110,9 @@ describe("resolveResizeSnap", () => {
 
   it("aligns the resized bottom edge with a neighbour", () => {
     const result = resolveResizeSnap({
-      moving: { x: 500, y: 0, width: 200, height: 96 },
-      others: [card(0, 0)],
+      moving: target({ x: 250, y: 0, width: 200, height: 96 }),
+      targets: [target(card(0, 0))],
+      spec: THREAD_SPEC,
       threshold: 8,
     });
 
@@ -121,68 +121,67 @@ describe("resolveResizeSnap", () => {
   });
 });
 
-describe("observedGaps", () => {
-  it("reports the gap between two stacked cards", () => {
-    expect(observedGaps([card(0, 0), card(0, 130)], "y")).toEqual([30]);
+describe("snapCandidates", () => {
+  it("keeps only allowed card types within the proximity radius", () => {
+    const nearThread = target(card(250, 0));
+    const nearChat = target(card(0, 150), "chat-card");
+    const farThread = target(card(0, 300));
+
+    expect(
+      snapCandidates({
+        moving: target(card(0, 0)),
+        targets: [nearThread, nearChat, farThread],
+        spec: THREAD_SPEC,
+      }),
+    ).toEqual([nearThread.rect]);
   });
 
-  it("ignores cards that do not overlap across the axis", () => {
-    // Side by side, so there is no vertical stack to measure.
-    expect(observedGaps([card(0, 0), card(500, 130)], "y")).toEqual([]);
+  it("does not treat a matching edge across the map as nearby", () => {
+    const result = snap(card(105, 1_000), [card(100, 0)]);
+    expect(result).toEqual({ dx: 0, dy: 0, guides: [] });
   });
 
-  it("ignores touching cards rather than reporting a zero interval", () => {
-    expect(observedGaps([card(0, 0), card(0, 100)], "y")).toEqual([]);
-  });
+  it("lets chat cards select chat cards without selecting nearby threads", () => {
+    const result = resolveSnap({
+      moving: target(card(105, 150), "chat-card"),
+      targets: [
+        target(card(100, 150)),
+        target(card(108, 150), "chat-card"),
+      ],
+      spec: {
+        ...THREAD_SPEC,
+        targetTypes: ["chat-card"],
+      },
+      threshold: 8,
+    });
 
-  it("collects every distinct gap in the arrangement", () => {
-    const gaps = observedGaps(
-      [card(0, 0), card(0, 130), card(0, 250)],
-      "y",
-    );
-    // 30 between the first pair, 20 between the second, 150 end to end.
-    expect(gaps).toEqual([20, 30, 150]);
+    expect(result.dx).toBe(3);
   });
 });
 
 describe("resolveSnap spacing", () => {
-  it("matches a spacing the arrangement already uses", () => {
-    // Two cards 30px apart; a third dragged near that interval takes it.
-    const others = [card(0, 0), card(0, 130)];
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(0, 264),
-      others,
+  it("matches an explicitly configured layout gap", () => {
+    const result = snap(card(0, 264), [card(0, 130)], {
+      ...THREAD_SPEC,
+      spacingGaps: [12, 30],
     });
     expect(result.dy).toBe(-4);
     expect(result.spacing).toEqual({ axis: "y", gap: 30 });
   });
 
-  it("offers the default gap when the arrangement has none of its own", () => {
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(0, 116),
-      others: [card(0, 0)],
-    });
+  it("offers the card-grid gap supplied by the caller", () => {
+    const result = snap(card(0, 116), [card(0, 0)]);
     expect(result.dy).toBe(-4);
     expect(result.spacing).toEqual({ axis: "y", gap: 12 });
   });
 
   it("spaces above a neighbour as readily as below", () => {
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(0, -117),
-      others: [card(0, 0)],
-    });
+    const result = snap(card(0, -117), [card(0, 0)]);
     expect(result.dy).toBe(5);
   });
 
   it("does not space against a card it is not stacked with", () => {
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(900, 116),
-      others: [card(0, 0)],
-    });
+    const result = snap(card(900, 116), [card(0, 0)]);
     expect(result.dy).toBe(0);
     expect(result.spacing).toBeUndefined();
   });
@@ -190,11 +189,7 @@ describe("resolveSnap spacing", () => {
   it("lets alignment win an axis over spacing", () => {
     // Tops are 3px apart AND a spacing candidate is nearby; the visible
     // edge match is the stronger cue, so it takes the axis.
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(0, 3),
-      others: [card(0, 0)],
-    });
+    const result = snap(card(0, 3), [card(0, 0)]);
     expect(result.dy).toBe(-3);
     expect(result.spacing).toBeUndefined();
   });
@@ -202,10 +197,9 @@ describe("resolveSnap spacing", () => {
   it("aligns one axis and spaces the other — the stacking case", () => {
     // Dragged slightly off a shared left edge and slightly off the
     // established 30px gap: X aligns, Y takes the spacing detent.
-    const result = resolveSnap({
-      ...SNAP,
-      moving: card(4, 264),
-      others: [card(0, 0), card(0, 130)],
+    const result = snap(card(4, 264), [card(0, 130)], {
+      ...THREAD_SPEC,
+      spacingGaps: [30],
     });
     expect(result.dx).toBe(-4);
     expect(result.dy).toBe(-4);

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   marqueeRect,
+  observedGaps,
   rectIntersects,
   resolveResizeSnap,
   resolveSnap,
@@ -159,12 +160,31 @@ describe("snapCandidates", () => {
   });
 });
 
+describe("observedGaps", () => {
+  it("derives adjacent row gaps without spanning an intervening card", () => {
+    expect(
+      observedGaps({
+        axis: "y",
+        maxGap: 96,
+        rects: [card(0, 0), card(0, 130), card(0, 250)],
+      }),
+    ).toEqual([20, 30]);
+  });
+
+  it("does not learn gaps beyond the proximity specification", () => {
+    expect(
+      observedGaps({
+        axis: "y",
+        maxGap: 96,
+        rects: [card(0, 0), card(0, 300)],
+      }),
+    ).toEqual([]);
+  });
+});
+
 describe("resolveSnap spacing", () => {
-  it("matches an explicitly configured layout gap", () => {
-    const result = snap(card(0, 264), [card(0, 130)], {
-      ...THREAD_SPEC,
-      spacingGaps: [12, 30],
-    });
+  it("matches a gap observed in the nearby arrangement", () => {
+    const result = snap(card(0, 264), [card(0, 0), card(0, 130)]);
     expect(result.dy).toBe(-4);
     expect(result.spacing).toEqual({ axis: "y", gap: 30 });
   });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
@@ -279,6 +279,122 @@ describe("useStarMapChatCards", () => {
     expect(writeStarMapWorkspace.mock.calls[1][0].baseRevision).toBe(5);
   });
 
+  it("rebases queued semantic changes after a revision conflict", async () => {
+    const initial = savedWorkspace();
+    const concurrentCard = {
+      ...initial.workspace.cards[0],
+      key: "pwr_remote::codex:t-concurrent",
+      thread: {
+        ...initial.workspace.cards[0].thread,
+        id: "t-concurrent",
+        title: "Opened in another window",
+      },
+    };
+    const concurrent: ReadStarMapWorkspaceResponse = {
+      workspace: {
+        ...initial.workspace,
+        revision: 5,
+        updatedAt: 150,
+        cards: [
+          {
+            ...initial.workspace.cards[0],
+            geometry: {
+              ...initial.workspace.cards[0].geometry,
+              fallbackRect: {
+                ...initial.workspace.cards[0].geometry.fallbackRect,
+                left: 920,
+              },
+            },
+          },
+          concurrentCard,
+        ],
+      },
+    };
+    const readStarMapWorkspace = vi
+      .fn<NonNullable<DesktopApi["readStarMapWorkspace"]>>()
+      .mockResolvedValueOnce(initial)
+      .mockResolvedValue(concurrent);
+    let rejectForConflict = true;
+    const writeStarMapWorkspace = vi.fn(
+      async ({ baseRevision, workspace }: WriteStarMapWorkspaceRequest) => {
+        if (rejectForConflict) {
+          rejectForConflict = false;
+          throw new Error(
+            "Star Map workspace revision conflict: expected 4, found 5",
+          );
+        }
+        return {
+          workspace: {
+            ...workspace,
+            revision: baseRevision + 1,
+            updatedAt: 200,
+          },
+        };
+      },
+    );
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace,
+      writeStarMapWorkspace,
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.toggleContext("pwr_remote::codex:t-remote");
+      result.current.toggleTerminal("pwr_remote::codex:t-remote");
+    });
+
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(3));
+    expect(readStarMapWorkspace).toHaveBeenCalledTimes(2);
+    expect(writeStarMapWorkspace.mock.calls[1][0]).toMatchObject({
+      baseRevision: 5,
+      workspace: {
+        cards: [
+          expect.objectContaining({
+            key: "pwr_remote::codex:t-remote",
+            contextOpen: false,
+            terminalOpen: true,
+            geometry: expect.objectContaining({
+              fallbackRect: expect.objectContaining({ left: 920 }),
+            }),
+          }),
+          expect.objectContaining({
+            key: "pwr_remote::codex:t-concurrent",
+          }),
+        ],
+      },
+    });
+    expect(writeStarMapWorkspace.mock.calls[2][0]).toMatchObject({
+      baseRevision: 6,
+      workspace: {
+        cards: [
+          expect.objectContaining({
+            key: "pwr_remote::codex:t-remote",
+            contextOpen: false,
+            terminalOpen: false,
+            geometry: expect.objectContaining({
+              fallbackRect: expect.objectContaining({ left: 920 }),
+            }),
+          }),
+          expect.objectContaining({
+            key: "pwr_remote::codex:t-concurrent",
+          }),
+        ],
+      },
+    });
+
+    act(() => result.current.toggleContext("pwr_remote::codex:t-remote"));
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(4));
+    expect(writeStarMapWorkspace.mock.calls[3][0].baseRevision).toBe(7);
+    expect(
+      writeStarMapWorkspace.mock.calls[3][0].workspace.cards,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "pwr_remote::codex:t-concurrent" }),
+      ]),
+    );
+  });
+
   it("merges operator changes made while the saved workspace is loading", async () => {
     let resolveRead: (value: ReadStarMapWorkspaceResponse) => void = () => {};
     const read = new Promise<ReadStarMapWorkspaceResponse>((resolve) => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
@@ -43,6 +43,8 @@ function savedWorkspace(): ReadStarMapWorkspaceResponse {
             },
             dx: 40,
             dy: 30,
+            instanceDx: -100,
+            instanceDy: -50,
             fallbackRect: {
               left: 700,
               top: 300,
@@ -94,14 +96,37 @@ describe("useStarMapChatCards", () => {
     await waitFor(() => expect(result.current.hydrated).toBe(true));
 
     act(() => {
-      result.current.resolveRestoredAnchors(() => ({ x: 100, y: 200 }));
+      result.current.resolveRestoredAnchors(() => ({
+        point: { x: 100, y: 200 },
+        basis: "anchor",
+      }));
     });
     expect(result.current.cards[0].rect).toMatchObject({ left: 140, top: 230 });
 
     act(() => {
-      result.current.resolveRestoredAnchors(() => ({ x: 900, y: 900 }));
+      result.current.resolveRestoredAnchors(() => ({
+        point: { x: 900, y: 900 },
+        basis: "anchor",
+      }));
     });
     expect(result.current.cards[0].rect).toMatchObject({ left: 140, top: 230 });
+  });
+
+  it("uses the separately persisted instance basis when a thread is absent", async () => {
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.resolveRestoredAnchors(() => ({
+        point: { x: 500, y: 400 },
+        basis: "instance",
+      }));
+    });
+
+    expect(result.current.cards[0].rect).toMatchObject({ left: 400, top: 350 });
   });
 
   it("keeps pointer frames memory-only and writes once at commit", async () => {
@@ -277,6 +302,48 @@ describe("useStarMapChatCards", () => {
     await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(2));
     expect(writeStarMapWorkspace.mock.calls[0][0].baseRevision).toBe(4);
     expect(writeStarMapWorkspace.mock.calls[1][0].baseRevision).toBe(5);
+  });
+
+  it("carries a failed workspace change into the next boundary", async () => {
+    let failNextWrite = true;
+    const writeStarMapWorkspace = vi.fn(
+      async ({ baseRevision, workspace }: WriteStarMapWorkspaceRequest) => {
+        if (failNextWrite) {
+          failNextWrite = false;
+          throw new Error("temporary database failure");
+        }
+        return {
+          workspace: {
+            ...workspace,
+            revision: baseRevision + 1,
+            updatedAt: 200,
+          },
+        };
+      },
+    );
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+      writeStarMapWorkspace,
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => result.current.toggleContext("pwr_remote::codex:t-remote"));
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(1));
+    act(() => result.current.toggleTerminal("pwr_remote::codex:t-remote"));
+
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(2));
+    expect(writeStarMapWorkspace.mock.calls[1][0]).toMatchObject({
+      baseRevision: 4,
+      workspace: {
+        cards: [
+          expect.objectContaining({
+            contextOpen: false,
+            terminalOpen: false,
+          }),
+        ],
+      },
+    });
   });
 
   it("rebases queued semantic changes after a revision conflict", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
@@ -1,0 +1,189 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  STAR_MAP_WORKSPACE_VERSION,
+  type ReadStarMapWorkspaceResponse,
+  type WriteStarMapWorkspaceRequest,
+} from "@pwragent/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { useStarMapChatCards } from "../useStarMapChatCards";
+
+function savedWorkspace(): ReadStarMapWorkspaceResponse {
+  return {
+    workspace: {
+      version: STAR_MAP_WORKSPACE_VERSION,
+      revision: 4,
+      updatedAt: 100,
+      cards: [
+        {
+          key: "pwr_remote::codex:t-remote",
+          ownerInstanceId: "pwr_remote",
+          thread: {
+            id: "t-remote",
+            inbox: { inInbox: true },
+            linkedDirectories: [],
+            source: "codex",
+            title: "Offline but still open",
+            titleSource: "derived",
+            federation: {
+              ref: {
+                backend: "codex",
+                threadId: "t-remote",
+                target: { scope: "remote", instanceId: "pwr_remote" },
+              },
+              instanceLabel: "Remote Mac",
+              peerStatus: "disconnected",
+            },
+          },
+          geometry: {
+            anchor: {
+              kind: "thread",
+              instanceId: "pwr_remote",
+              threadKey: "codex:t-remote",
+            },
+            dx: 40,
+            dy: 30,
+            fallbackRect: {
+              left: 700,
+              top: 300,
+              width: 420,
+              height: 520,
+            },
+          },
+          contextOpen: true,
+          terminalOpen: true,
+          terminalHeight: 320,
+        },
+      ],
+      views: { orbit: { x: -200, y: 90, scale: 0.75 } },
+    },
+  };
+}
+
+describe("useStarMapChatCards", () => {
+  it("restores disconnected chats and their complete compound-card state", async () => {
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    expect(result.current.cards).toHaveLength(1);
+    expect(result.current.cards[0]).toMatchObject({
+      key: "pwr_remote::codex:t-remote",
+      ownerInstanceId: "pwr_remote",
+      contextOpen: true,
+      terminalOpen: true,
+      terminalHeight: 320,
+      rect: { left: 700, top: 300, width: 420, height: 520 },
+      thread: { title: "Offline but still open" },
+    });
+    expect(result.current.viewFor("orbit")).toEqual({
+      x: -200,
+      y: 90,
+      scale: 0.75,
+    });
+  });
+
+  it("resolves a saved relative anchor once without jumping later", async () => {
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.resolveRestoredAnchors(() => ({ x: 100, y: 200 }));
+    });
+    expect(result.current.cards[0].rect).toMatchObject({ left: 140, top: 230 });
+
+    act(() => {
+      result.current.resolveRestoredAnchors(() => ({ x: 900, y: 900 }));
+    });
+    expect(result.current.cards[0].rect).toMatchObject({ left: 140, top: 230 });
+  });
+
+  it("keeps pointer frames memory-only and writes once at commit", async () => {
+    const writeStarMapWorkspace = vi.fn(
+      async ({ workspace }: WriteStarMapWorkspaceRequest) => ({
+        workspace: { ...workspace, revision: 5, updatedAt: 200 },
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+      writeStarMapWorkspace,
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    const nextRect = { left: 800, top: 400, width: 500, height: 600 };
+    act(() => {
+      result.current.setRect("pwr_remote::codex:t-remote", nextRect);
+      result.current.setRect("pwr_remote::codex:t-remote", {
+        ...nextRect,
+        left: 801,
+      });
+    });
+    expect(writeStarMapWorkspace).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.commitRect(
+        "pwr_remote::codex:t-remote",
+        nextRect,
+        {
+          anchor: {
+            kind: "instance",
+            instanceId: "pwr_remote",
+          },
+          point: { x: 200, y: 100 },
+        },
+      );
+    });
+
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(1));
+    expect(writeStarMapWorkspace).toHaveBeenCalledWith({
+      workspace: expect.objectContaining({
+        cards: [
+          expect.objectContaining({
+            geometry: expect.objectContaining({ dx: 600, dy: 300 }),
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("merges operator changes made while the saved workspace is loading", async () => {
+    let resolveRead: (value: ReadStarMapWorkspaceResponse) => void = () => {};
+    const read = new Promise<ReadStarMapWorkspaceResponse>((resolve) => {
+      resolveRead = resolve;
+    });
+    const writeStarMapWorkspace = vi.fn(
+      async ({ workspace }: WriteStarMapWorkspaceRequest) => ({
+        workspace: { ...workspace, revision: 5, updatedAt: 200 },
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(() => read),
+      writeStarMapWorkspace,
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    const thread = {
+      ...savedWorkspace().workspace.cards[0].thread,
+      id: "t-local",
+      title: "Opened during launch",
+      federation: undefined,
+    };
+
+    act(() => result.current.open("pwr_local", thread));
+    expect(writeStarMapWorkspace).not.toHaveBeenCalled();
+
+    await act(async () => resolveRead(savedWorkspace()));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(1));
+    expect(result.current.cards.map((card) => card.key)).toEqual([
+      "pwr_remote::codex:t-remote",
+      "pwr_local::codex:t-local",
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx
@@ -143,6 +143,7 @@ describe("useStarMapChatCards", () => {
 
     await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(1));
     expect(writeStarMapWorkspace).toHaveBeenCalledWith({
+      baseRevision: 4,
       workspace: expect.objectContaining({
         cards: [
           expect.objectContaining({
@@ -151,6 +152,131 @@ describe("useStarMapChatCards", () => {
         ],
       }),
     });
+  });
+
+  it("coalesces raising a non-top card and dragging it into one write", async () => {
+    const writeStarMapWorkspace = vi.fn(
+      async ({ baseRevision, workspace }: WriteStarMapWorkspaceRequest) => ({
+        workspace: {
+          ...workspace,
+          revision: baseRevision + 1,
+          updatedAt: 200,
+        },
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+      writeStarMapWorkspace,
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    const secondThread = {
+      ...savedWorkspace().workspace.cards[0].thread,
+      id: "t-second",
+      title: "Second card",
+    };
+    act(() => {
+      result.current.open(
+        "pwr_remote",
+        secondThread,
+        undefined,
+        { persist: false },
+      );
+    });
+
+    const nextRect = { left: 760, top: 360, width: 460, height: 560 };
+    act(() => {
+      expect(
+        result.current.raise("pwr_remote::codex:t-remote", false),
+      ).toBe(true);
+      result.current.setRect("pwr_remote::codex:t-remote", nextRect);
+      result.current.commitRect("pwr_remote::codex:t-remote", nextRect);
+    });
+
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(1));
+    expect(writeStarMapWorkspace).toHaveBeenCalledWith({
+      baseRevision: 4,
+      workspace: expect.objectContaining({
+        cards: expect.arrayContaining([
+          expect.objectContaining({
+            key: "pwr_remote::codex:t-remote",
+            geometry: expect.objectContaining({ fallbackRect: nextRect }),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("keeps placeholder local cards memory-only until remapping the owner", async () => {
+    const writeStarMapWorkspace = vi.fn(
+      async ({ baseRevision, workspace }: WriteStarMapWorkspaceRequest) => ({
+        workspace: {
+          ...workspace,
+          revision: baseRevision + 1,
+          updatedAt: 200,
+        },
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+      writeStarMapWorkspace,
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    const localThread = {
+      ...savedWorkspace().workspace.cards[0].thread,
+      id: "t-local",
+      title: "Local before health",
+      federation: undefined,
+    };
+
+    act(() => {
+      result.current.open("local", localThread, undefined, { persist: false });
+    });
+    expect(writeStarMapWorkspace).not.toHaveBeenCalled();
+
+    act(() => result.current.remapOwner("local", "pwr_local"));
+
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(1));
+    expect(result.current.cards.at(-1)).toMatchObject({
+      key: "pwr_local::codex:t-local",
+      ownerInstanceId: "pwr_local",
+    });
+    expect(writeStarMapWorkspace).toHaveBeenCalledWith({
+      baseRevision: 4,
+      workspace: expect.objectContaining({
+        cards: expect.arrayContaining([
+          expect.objectContaining({ key: "pwr_local::codex:t-local" }),
+        ]),
+      }),
+    });
+  });
+
+  it("advances the optimistic base revision after each queued write", async () => {
+    const writeStarMapWorkspace = vi.fn(
+      async ({ baseRevision, workspace }: WriteStarMapWorkspaceRequest) => ({
+        workspace: {
+          ...workspace,
+          revision: baseRevision + 1,
+          updatedAt: 200,
+        },
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      readStarMapWorkspace: vi.fn(async () => savedWorkspace()),
+      writeStarMapWorkspace,
+    };
+    const { result } = renderHook(() => useStarMapChatCards({ desktopApi }));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.toggleContext("pwr_remote::codex:t-remote");
+      result.current.toggleTerminal("pwr_remote::codex:t-remote");
+    });
+
+    await waitFor(() => expect(writeStarMapWorkspace).toHaveBeenCalledTimes(2));
+    expect(writeStarMapWorkspace.mock.calls[0][0].baseRevision).toBe(4);
+    expect(writeStarMapWorkspace.mock.calls[1][0].baseRevision).toBe(5);
   });
 
   it("merges operator changes made while the saved workspace is loading", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
@@ -339,3 +339,40 @@ export function dockTerminalRect(
     height: options?.height ?? CHAT_CARD_TERMINAL_HEIGHT,
   };
 }
+
+/** Compound bounds used when a chat group aligns or spaces against another
+ * object. Satellites occupy real map space even though their positions derive
+ * from the host, so snapping only the host would invite another card to land
+ * underneath an open context rail or terminal. */
+export function chatCardGroupRect(
+  host: ChatCardRect,
+  options?: {
+    contextOpen?: boolean;
+    terminalOpen?: boolean;
+    terminalHeight?: number;
+  },
+): ChatCardRect {
+  const context = options?.contextOpen ? dockContextRect(host) : undefined;
+  const terminal = options?.terminalOpen
+    ? dockTerminalRect(host, {
+        contextOpen: options.contextOpen,
+        height: options.terminalHeight,
+      })
+    : undefined;
+  const right = Math.max(
+    host.left + host.width,
+    context ? context.left + context.width : Number.NEGATIVE_INFINITY,
+    terminal ? terminal.left + terminal.width : Number.NEGATIVE_INFINITY,
+  );
+  const bottom = Math.max(
+    host.top + host.height,
+    context ? context.top + context.height : Number.NEGATIVE_INFINITY,
+    terminal ? terminal.top + terminal.height : Number.NEGATIVE_INFINITY,
+  );
+  return {
+    left: host.left,
+    top: host.top,
+    width: right - host.left,
+    height: bottom - host.top,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
@@ -1,4 +1,4 @@
-import type { PrSummary } from "@pwragent/shared";
+import type { PrSummary, StarMapWorkspaceLayout } from "@pwragent/shared";
 
 /**
  * Per-operator view preferences for the Star Map. These are viewing
@@ -18,7 +18,7 @@ export type StarMapCardFields = {
   terminalPullRequests: boolean;
 };
 
-export type StarMapLayoutMode = "lanes" | "orbit" | "projects";
+export type StarMapLayoutMode = StarMapWorkspaceLayout;
 
 export type StarMapViewPreferences = {
   /**

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
@@ -5,8 +5,8 @@
  *
  * - **Alignment** — a dragged card's left / centre / right (and top /
  *   middle / bottom) latching onto the same edge of a nearby card.
- * - **Spacing** — once cards are stacked, matching one of the explicit
- *   layout gaps supplied by the caller.
+ * - **Spacing** — once cards are stacked, matching an explicit layout gap
+ *   or an adjacent gap already used by nearby cards of the allowed type.
  *
  * Candidate selection is part of the engine rather than a caller-side
  * convention. Each moving object and target has a type, and a proximity
@@ -70,6 +70,8 @@ export type ResizeSnapResult = {
 
 /** Two cards count as stacked when they overlap this much across the axis. */
 const CROSS_AXIS_OVERLAP = 8;
+/** Smaller positive intervals read as touching rather than deliberate gaps. */
+const MIN_MEANINGFUL_GAP = 4;
 
 function edgesFor(rect: SnapRect, axis: SnapAxis): number[] {
   return axis === "x"
@@ -93,7 +95,8 @@ function rectDistance(a: SnapRect, b: SnapRect): number {
 
 /**
  * Resolve the typed, nearby target set once per pointer frame. Alignment,
- * spacing, and resize all consume this same bounded set.
+ * spacing latches, and resize consume this strict set; observed-gap discovery
+ * looks only one card span farther through `spacingObservationCandidates`.
  */
 export function snapCandidates(params: {
   moving: SnapTarget;
@@ -112,6 +115,77 @@ export function snapCandidates(params: {
     candidates.push(target.rect);
   }
   return candidates;
+}
+
+function primaryStart(rect: SnapRect, axis: SnapAxis): number {
+  return axis === "x" ? rect.x : rect.y;
+}
+
+function primaryEnd(rect: SnapRect, axis: SnapAxis): number {
+  return primaryStart(rect, axis)
+    + (axis === "x" ? rect.width : rect.height);
+}
+
+/**
+ * Adjacent gaps in local rows or columns. Grouping and sorting replace the
+ * old all-pairs scan: the work is O(n log n), and an interval spanning an
+ * intervening card no longer masquerades as reusable whitespace.
+ */
+export function observedGaps(params: {
+  axis: SnapAxis;
+  maxGap: number;
+  rects: readonly SnapRect[];
+}): number[] {
+  if (params.rects.length < 2 || params.maxGap < MIN_MEANINGFUL_GAP) return [];
+  const byCrossAxis = [...params.rects].sort(
+    (left, right) => spanStart(left, params.axis) - spanStart(right, params.axis),
+  );
+  const groups: SnapRect[][] = [];
+  let groupEnd = Number.NEGATIVE_INFINITY;
+  for (const rect of byCrossAxis) {
+    const start = spanStart(rect, params.axis);
+    if (groups.length === 0 || start > groupEnd - CROSS_AXIS_OVERLAP) {
+      groups.push([rect]);
+      groupEnd = spanEnd(rect, params.axis);
+      continue;
+    }
+    groups[groups.length - 1].push(rect);
+    groupEnd = Math.max(groupEnd, spanEnd(rect, params.axis));
+  }
+
+  const gaps = new Set<number>();
+  for (const group of groups) {
+    group.sort(
+      (left, right) => primaryStart(left, params.axis)
+        - primaryStart(right, params.axis),
+    );
+    for (let index = 1; index < group.length; index += 1) {
+      const gap = primaryStart(group[index], params.axis)
+        - primaryEnd(group[index - 1], params.axis);
+      if (gap < MIN_MEANINGFUL_GAP || gap > params.maxGap) continue;
+      gaps.add(Math.round(gap));
+    }
+  }
+  return [...gaps].sort((left, right) => left - right);
+}
+
+function spacingObservationCandidates(params: {
+  moving: SnapTarget;
+  targets: readonly SnapTarget[];
+  spec: SnapSpec;
+}): SnapRect[] {
+  // One card-span beyond the active snap radius is enough to see the prior
+  // neighbour whose gap the moving card is continuing, without reopening a
+  // galaxy-wide alignment search.
+  return snapCandidates({
+    ...params,
+    spec: {
+      ...params.spec,
+      proximity:
+        params.spec.proximity
+        + Math.max(params.moving.rect.width, params.moving.rect.height),
+    },
+  });
 }
 
 /**
@@ -225,6 +299,7 @@ export function resolveSnap(params: {
 
   const others = snapCandidates(params);
   if (others.length === 0) return { dx: 0, dy: 0, guides: [] };
+  const spacingObservations = spacingObservationCandidates(params);
 
   const result: SnapResult = { dx: 0, dy: 0, guides: [] };
   for (const axis of ["x", "y"] as const) {
@@ -242,7 +317,16 @@ export function resolveSnap(params: {
     }
     const spaced = spaceAxis({
       axis,
-      gaps: params.spec.spacingGaps,
+      gaps: [
+        ...new Set([
+          ...params.spec.spacingGaps,
+          ...observedGaps({
+            axis,
+            maxGap: params.spec.proximity,
+            rects: spacingObservations,
+          }),
+        ]),
+      ],
       moving: params.moving.rect,
       others,
       threshold: params.threshold,

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
@@ -1,15 +1,18 @@
 /**
  * Snapping for hand-arranged star map cards.
  *
- * Two kinds, both computed in absolute canvas coordinates so cards from
- * different clouds can align with each other:
+ * Two kinds, both computed in absolute canvas coordinates:
  *
  * - **Alignment** — a dragged card's left / centre / right (and top /
  *   middle / bottom) latching onto the same edge of a nearby card.
- * - **Spacing** — once cards are stacked, matching a gap that already
- *   exists in the arrangement rather than a fixed ladder of pixel values.
- *   An arbitrary 2/5/10px ladder fights the operator; a spacing they
- *   already chose is one they meant.
+ * - **Spacing** — once cards are stacked, matching one of the explicit
+ *   layout gaps supplied by the caller.
+ *
+ * Candidate selection is part of the engine rather than a caller-side
+ * convention. Each moving object and target has a type, and a proximity
+ * spec limits both the allowed target types and the search radius. This
+ * keeps a card from latching onto an aligned object several clouds away,
+ * and keeps each pointer frame linear in the number of potential targets.
  */
 
 export type SnapRect = {
@@ -21,6 +24,22 @@ export type SnapRect = {
 };
 
 export type SnapAxis = "x" | "y";
+
+export type SnapTargetType = "thread-card" | "chat-card";
+
+export type SnapTarget = {
+  type: SnapTargetType;
+  rect: SnapRect;
+};
+
+export type SnapSpec = {
+  /** Candidate types this moving object is allowed to snap to. */
+  targetTypes: readonly SnapTargetType[];
+  /** Maximum edge-to-edge distance, in canvas units. */
+  proximity: number;
+  /** Deliberate layout gaps, in canvas units. */
+  spacingGaps: readonly number[];
+};
 
 /**
  * A line to draw so the operator can see WHY the card latched. Without it
@@ -49,8 +68,6 @@ export type ResizeSnapResult = {
   guides: AlignmentGuide[];
 };
 
-/** Gaps below this are treated as "touching" rather than a real interval. */
-const MIN_MEANINGFUL_GAP = 4;
 /** Two cards count as stacked when they overlap this much across the axis. */
 const CROSS_AXIS_OVERLAP = 8;
 
@@ -66,6 +83,35 @@ function spanStart(rect: SnapRect, axis: SnapAxis): number {
 
 function spanEnd(rect: SnapRect, axis: SnapAxis): number {
   return axis === "x" ? rect.y + rect.height : rect.x + rect.width;
+}
+
+function rectDistance(a: SnapRect, b: SnapRect): number {
+  const dx = Math.max(a.x - (b.x + b.width), b.x - (a.x + a.width), 0);
+  const dy = Math.max(a.y - (b.y + b.height), b.y - (a.y + a.height), 0);
+  return Math.hypot(dx, dy);
+}
+
+/**
+ * Resolve the typed, nearby target set once per pointer frame. Alignment,
+ * spacing, and resize all consume this same bounded set.
+ */
+export function snapCandidates(params: {
+  moving: SnapTarget;
+  targets: readonly SnapTarget[];
+  spec: SnapSpec;
+}): SnapRect[] {
+  if (params.spec.proximity < 0 || params.spec.targetTypes.length === 0) {
+    return [];
+  }
+  const candidates: SnapRect[] = [];
+  for (const target of params.targets) {
+    if (!params.spec.targetTypes.includes(target.type)) continue;
+    if (rectDistance(params.moving.rect, target.rect) > params.spec.proximity) {
+      continue;
+    }
+    candidates.push(target.rect);
+  }
+  return candidates;
 }
 
 /**
@@ -122,46 +168,16 @@ function overlapsAcross(
 }
 
 /**
- * Gaps the arrangement already contains along `axis`, between cards that
- * are stacked on it. These become the detents, which is why the snapping
- * gets tighter the more the operator has already arranged.
- */
-export function observedGaps(
-  rects: readonly SnapRect[],
-  axis: SnapAxis,
-): number[] {
-  const gaps = new Set<number>();
-  for (let i = 0; i < rects.length; i += 1) {
-    for (let j = i + 1; j < rects.length; j += 1) {
-      const a = rects[i];
-      const b = rects[j];
-      if (!overlapsAcross(a, b, axis)) continue;
-      const aStart = axis === "x" ? a.x : a.y;
-      const aSize = axis === "x" ? a.width : a.height;
-      const bStart = axis === "x" ? b.x : b.y;
-      const bSize = axis === "x" ? b.width : b.height;
-      const gap =
-        aStart < bStart ? bStart - (aStart + aSize) : aStart - (bStart + bSize);
-      if (gap >= MIN_MEANINGFUL_GAP) gaps.add(Math.round(gap));
-    }
-  }
-  return [...gaps].sort((left, right) => left - right);
-}
-
-/**
- * Snap the moving card so it sits a known gap from a stacked neighbour.
+ * Snap the moving card so it sits a configured gap from a stacked neighbour.
  * Only considered on an axis alignment did not already claim.
  */
 function spaceAxis(params: {
   axis: SnapAxis;
-  defaultGap: number;
+  gaps: readonly number[];
   moving: SnapRect;
   others: readonly SnapRect[];
   threshold: number;
 }): { delta: number; gap: number } | undefined {
-  const gaps = [...observedGaps(params.others, params.axis)];
-  if (!gaps.includes(params.defaultGap)) gaps.push(params.defaultGap);
-
   const movingStart = params.axis === "x" ? params.moving.x : params.moving.y;
   const movingSize =
     params.axis === "x" ? params.moving.width : params.moving.height;
@@ -171,7 +187,7 @@ function spaceAxis(params: {
     if (!overlapsAcross(params.moving, other, params.axis)) continue;
     const otherStart = params.axis === "x" ? other.x : other.y;
     const otherSize = params.axis === "x" ? other.width : other.height;
-    for (const gap of gaps) {
+    for (const gap of params.gaps) {
       // Sitting after the neighbour, and sitting before it.
       const candidates = [
         otherStart + otherSize + gap,
@@ -197,22 +213,25 @@ function spaceAxis(params: {
  * the arrangement this exists to make easy.
  */
 export function resolveSnap(params: {
-  defaultGap: number;
-  moving: SnapRect;
-  others: readonly SnapRect[];
+  moving: SnapTarget;
+  targets: readonly SnapTarget[];
+  spec: SnapSpec;
   /** Canvas-space tolerance; callers convert from a screen-space value. */
   threshold: number;
 }): SnapResult {
-  if (params.threshold <= 0 || params.others.length === 0) {
+  if (params.threshold <= 0 || params.targets.length === 0) {
     return { dx: 0, dy: 0, guides: [] };
   }
+
+  const others = snapCandidates(params);
+  if (others.length === 0) return { dx: 0, dy: 0, guides: [] };
 
   const result: SnapResult = { dx: 0, dy: 0, guides: [] };
   for (const axis of ["x", "y"] as const) {
     const aligned = alignAxis({
       axis,
-      moving: params.moving,
-      others: params.others,
+      moving: params.moving.rect,
+      others,
       threshold: params.threshold,
     });
     if (aligned) {
@@ -223,9 +242,9 @@ export function resolveSnap(params: {
     }
     const spaced = spaceAxis({
       axis,
-      defaultGap: params.defaultGap,
-      moving: params.moving,
-      others: params.others,
+      gaps: params.spec.spacingGaps,
+      moving: params.moving.rect,
+      others,
       threshold: params.threshold,
     });
     if (!spaced) continue;
@@ -244,21 +263,28 @@ export function resolveSnap(params: {
  * origins.
  */
 export function resolveResizeSnap(params: {
-  moving: SnapRect;
-  others: readonly SnapRect[];
+  moving: SnapTarget;
+  targets: readonly SnapTarget[];
+  spec: SnapSpec;
   threshold: number;
 }): ResizeSnapResult {
   const result: ResizeSnapResult = { dw: 0, dh: 0, guides: [] };
-  if (params.threshold <= 0 || params.others.length === 0) return result;
+  if (params.threshold <= 0 || params.targets.length === 0) return result;
+  const others = snapCandidates(params);
+  if (others.length === 0) return result;
 
   for (const axis of ["x", "y"] as const) {
-    const movingStart = axis === "x" ? params.moving.x : params.moving.y;
-    const movingSize = axis === "x" ? params.moving.width : params.moving.height;
+    const movingStart = axis === "x"
+      ? params.moving.rect.x
+      : params.moving.rect.y;
+    const movingSize = axis === "x"
+      ? params.moving.rect.width
+      : params.moving.rect.height;
     const movingEnd = movingStart + movingSize;
     let best:
       | { delta: number; guide: AlignmentGuide }
       | undefined;
-    for (const other of params.others) {
+    for (const other of others) {
       const otherSize = axis === "x" ? other.width : other.height;
       const targets = [
         ...edgesFor(other, axis),
@@ -274,11 +300,11 @@ export function resolveResizeSnap(params: {
             axis,
             at: target,
             start: Math.min(
-              spanStart(params.moving, axis),
+              spanStart(params.moving.rect, axis),
               spanStart(other, axis),
             ),
             end: Math.max(
-              spanEnd(params.moving, axis),
+              spanEnd(params.moving.rect, axis),
               spanEnd(other, axis),
             ),
           },

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
@@ -43,6 +43,12 @@ export type SnapResult = {
   spacing?: { axis: SnapAxis; gap: number };
 };
 
+export type ResizeSnapResult = {
+  dw: number;
+  dh: number;
+  guides: AlignmentGuide[];
+};
+
 /** Gaps below this are treated as "touching" rather than a real interval. */
 const MIN_MEANINGFUL_GAP = 4;
 /** Two cards count as stacked when they overlap this much across the axis. */
@@ -226,6 +232,63 @@ export function resolveSnap(params: {
     if (axis === "x") result.dx = spaced.delta;
     else result.dy = spaced.delta;
     result.spacing = { axis, gap: spaced.gap };
+  }
+  return result;
+}
+
+/**
+ * Snap a bottom-right resize. Unlike movement, the top-left stays pinned:
+ * candidates change width/height to align the moving right/bottom edge or to
+ * match a neighbour's dimension. This is the missing half of making chat
+ * cards form deliberate rows and columns rather than merely aligning their
+ * origins.
+ */
+export function resolveResizeSnap(params: {
+  moving: SnapRect;
+  others: readonly SnapRect[];
+  threshold: number;
+}): ResizeSnapResult {
+  const result: ResizeSnapResult = { dw: 0, dh: 0, guides: [] };
+  if (params.threshold <= 0 || params.others.length === 0) return result;
+
+  for (const axis of ["x", "y"] as const) {
+    const movingStart = axis === "x" ? params.moving.x : params.moving.y;
+    const movingSize = axis === "x" ? params.moving.width : params.moving.height;
+    const movingEnd = movingStart + movingSize;
+    let best:
+      | { delta: number; guide: AlignmentGuide }
+      | undefined;
+    for (const other of params.others) {
+      const otherSize = axis === "x" ? other.width : other.height;
+      const targets = [
+        ...edgesFor(other, axis),
+        movingStart + otherSize,
+      ];
+      for (const target of targets) {
+        const delta = target - movingEnd;
+        if (Math.abs(delta) > params.threshold) continue;
+        if (best && Math.abs(delta) >= Math.abs(best.delta)) continue;
+        best = {
+          delta,
+          guide: {
+            axis,
+            at: target,
+            start: Math.min(
+              spanStart(params.moving, axis),
+              spanStart(other, axis),
+            ),
+            end: Math.max(
+              spanEnd(params.moving, axis),
+              spanEnd(other, axis),
+            ),
+          },
+        };
+      }
+    }
+    if (!best) continue;
+    if (axis === "x") result.dw = best.delta;
+    else result.dh = best.delta;
+    result.guides.push(best.guide);
   }
   return result;
 }

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
@@ -1,175 +1,510 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   buildThreadIdentityKey,
+  snapshotStarMapWorkspaceThread,
+  starMapWorkspaceCardKey,
+  STAR_MAP_WORKSPACE_VERSION,
   type NavigationThreadSummary,
+  type StarMapWorkspaceAnchor,
+  type StarMapWorkspaceLayout,
+  type StarMapWorkspaceSnapshot,
+  type StarMapWorkspaceThreadSnapshot,
+  type StarMapWorkspaceView,
 } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
 import {
   cascadeChatCardRect,
   placeChatCardBesideAnchor,
-  raiseChatCard,
   type ChatCardRect,
 } from "./star-map-chat-card-geometry";
 
 export type StarMapChatCardEntry = {
   key: string;
+  ownerInstanceId: string;
+  threadKey: string;
   rect: ChatCardRect;
-  thread: NavigationThreadSummary;
-  /** The context satellite card is open, docked to the right. */
-  contextOpen?: boolean;
-  /** The terminal satellite card is open, docked below. */
-  terminalOpen?: boolean;
-  /** Operator-resized terminal height; the dock geometry supplies a default. */
+  thread: StarMapWorkspaceThreadSnapshot;
+  anchor: StarMapWorkspaceAnchor;
+  anchorDx: number;
+  anchorDy: number;
+  /** One initial relative-anchor resolution; a later peer connection must
+   * not teleport an already-visible card away from its fallback rectangle. */
+  pendingAnchorRestore: boolean;
+  contextOpen: boolean;
+  terminalOpen: boolean;
   terminalHeight?: number;
+};
+
+export type StarMapChatCardAnchorPlacement = {
+  anchor: StarMapWorkspaceAnchor;
+  point: { x: number; y: number };
+};
+
+type StarMapChatCardsState = {
+  cards: StarMapChatCardEntry[];
+  views: Partial<Record<StarMapWorkspaceLayout, StarMapWorkspaceView>>;
 };
 
 export type StarMapChatCardsController = {
   cards: StarMapChatCardEntry[];
+  hydrated: boolean;
   close: (cardKey: string) => void;
   closeAll: () => void;
-  /** Stack depth of a card, lowest first. */
   depthOf: (cardKey: string) => number;
-  /**
-   * Open a card for a thread. `placement` puts it beside the thread's own
-   * card on the map; without one the card cascades from a corner, which
-   * is the fallback when the thread has no card on screen (filtered out,
-   * or folded into a cloud's overflow).
-   */
   open: (
+    ownerInstanceId: string,
     thread: NavigationThreadSummary,
     placement?: {
-      anchor: { x: number; y: number; width: number; height: number };
+      anchor: StarMapChatCardAnchorPlacement;
       bounds: { width: number; height: number };
+      sourceRect: { x: number; y: number; width: number; height: number };
     },
   ) => void;
   raise: (cardKey: string) => void;
+  /** Pointer-frame update. Deliberately memory-only. */
   setRect: (cardKey: string, rect: ChatCardRect) => void;
-  /** Open/close the satellites. They live on the entry, so closing the
-   * chat card closes its whole group for free. */
+  /** Completed gesture: update relative geometry and persist once. */
+  commitRect: (
+    cardKey: string,
+    rect: ChatCardRect,
+    anchor?: StarMapChatCardAnchorPlacement,
+  ) => void;
+  resolveRestoredAnchors: (
+    resolve: (
+      anchor: StarMapWorkspaceAnchor,
+    ) => { x: number; y: number } | undefined,
+  ) => void;
   toggleContext: (cardKey: string) => void;
   toggleTerminal: (cardKey: string) => void;
   setTerminalHeight: (cardKey: string, height: number) => void;
+  commitTerminalHeight: (cardKey: string, height: number) => void;
+  viewFor: (layout: StarMapWorkspaceLayout) => StarMapWorkspaceView | undefined;
+  commitView: (
+    layout: StarMapWorkspaceLayout,
+    view: StarMapWorkspaceView,
+  ) => void;
+  resetView: (layout: StarMapWorkspaceLayout) => void;
 };
+
+const EMPTY_STATE: StarMapChatCardsState = { cards: [], views: {} };
 
 function viewportSize(): { width: number; height: number } {
   if (typeof window === "undefined") return { width: 1440, height: 900 };
   return { width: window.innerWidth, height: window.innerHeight };
 }
 
-/**
- * Owns the set of floating chat cards over the star map.
- *
- * Cards are keyed by thread identity, so clicking the same thread twice
- * raises the existing card instead of stacking a duplicate on top of it.
- * Geometry lives here rather than in each card so that the cascade can see
- * how many cards are already open.
- */
-export function useStarMapChatCards(): StarMapChatCardsController {
-  const [cards, setCards] = useState<StarMapChatCardEntry[]>([]);
-  const [order, setOrder] = useState<readonly string[]>([]);
+function snapshotFor(state: StarMapChatCardsState): StarMapWorkspaceSnapshot {
+  return {
+    version: STAR_MAP_WORKSPACE_VERSION,
+    cards: state.cards.map((card) => ({
+      key: card.key,
+      ownerInstanceId: card.ownerInstanceId,
+      thread: card.thread,
+      geometry: {
+        anchor: card.anchor,
+        dx: card.anchorDx,
+        dy: card.anchorDy,
+        fallbackRect: card.rect,
+      },
+      contextOpen: card.contextOpen,
+      terminalOpen: card.terminalOpen,
+      terminalHeight: card.terminalHeight,
+    })),
+    views: state.views,
+  };
+}
 
-  const raise = useCallback((cardKey: string) => {
-    setOrder((current) => raiseChatCard(current, cardKey));
-  }, []);
+function entryFromSnapshot(
+  card: StarMapWorkspaceSnapshot["cards"][number],
+): StarMapChatCardEntry {
+  return {
+    key: card.key,
+    ownerInstanceId: card.ownerInstanceId,
+    threadKey: buildThreadIdentityKey(card.thread.source, card.thread.id),
+    rect: card.geometry.fallbackRect,
+    thread: card.thread,
+    anchor: card.geometry.anchor,
+    anchorDx: card.geometry.dx,
+    anchorDy: card.geometry.dy,
+    pendingAnchorRestore: true,
+    contextOpen: card.contextOpen,
+    terminalOpen: card.terminalOpen,
+    terminalHeight: card.terminalHeight,
+  };
+}
+
+/**
+ * Owns the viewer-local Star Map desk. Live drag frames stay in React memory;
+ * completed gestures and explicit open/close/toggle actions enqueue one full,
+ * atomic workspace snapshot through the main-process profile database.
+ */
+export function useStarMapChatCards(params: {
+  desktopApi?: DesktopApi;
+}): StarMapChatCardsController {
+  const [state, setState] = useState<StarMapChatCardsState>(EMPTY_STATE);
+  const [hydrated, setHydrated] = useState(false);
+  const stateRef = useRef(state);
+  const mutatedBeforeHydrationRef = useRef(false);
+  const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const desktopApi = params.desktopApi;
+
+  const enqueueWrite = useCallback(
+    (next: StarMapChatCardsState) => {
+      if (!desktopApi?.writeStarMapWorkspace) return;
+      const snapshot = snapshotFor(next);
+      writeQueueRef.current = writeQueueRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          await desktopApi.writeStarMapWorkspace?.({ workspace: snapshot });
+        });
+    },
+    [desktopApi],
+  );
+
+  const applyState = useCallback(
+    (next: StarMapChatCardsState, persist: boolean) => {
+      stateRef.current = next;
+      setState(next);
+      if (persist) {
+        if (!hydrated) {
+          mutatedBeforeHydrationRef.current = true;
+        } else {
+          enqueueWrite(next);
+        }
+      }
+    },
+    [enqueueWrite, hydrated],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void desktopApi
+      ?.readStarMapWorkspace?.()
+      .then((response) => {
+        if (cancelled) return;
+        const restored: StarMapChatCardsState = {
+          cards: response.workspace.cards.map(entryFromSnapshot),
+          views: response.workspace.views,
+        };
+        const current = stateRef.current;
+        const next = mutatedBeforeHydrationRef.current
+          ? {
+              cards: [
+                ...restored.cards.filter(
+                  (card) => !current.cards.some((entry) => entry.key === card.key),
+                ),
+                ...current.cards,
+              ],
+              views: { ...restored.views, ...current.views },
+            }
+          : restored;
+        stateRef.current = next;
+        setState(next);
+        setHydrated(true);
+        if (mutatedBeforeHydrationRef.current) enqueueWrite(next);
+      })
+      .catch(() => {
+        if (!cancelled) setHydrated(true);
+      });
+    if (!desktopApi?.readStarMapWorkspace) setHydrated(true);
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopApi, enqueueWrite]);
+
+  const raise = useCallback(
+    (cardKey: string) => {
+      const current = stateRef.current;
+      const index = current.cards.findIndex((card) => card.key === cardKey);
+      if (index === -1 || index === current.cards.length - 1) return;
+      const card = current.cards[index];
+      applyState(
+        {
+          ...current,
+          cards: [
+            ...current.cards.slice(0, index),
+            ...current.cards.slice(index + 1),
+            card,
+          ],
+        },
+        true,
+      );
+    },
+    [applyState],
+  );
 
   const open = useCallback(
     (
+      ownerInstanceId: string,
       thread: NavigationThreadSummary,
       placement?: {
-        anchor: { x: number; y: number; width: number; height: number };
+        anchor: StarMapChatCardAnchorPlacement;
         bounds: { width: number; height: number };
+        sourceRect: { x: number; y: number; width: number; height: number };
       },
     ) => {
-      const key = buildThreadIdentityKey(thread.source, thread.id);
-      setCards((current) => {
-        if (current.some((card) => card.key === key)) return current;
-        return [
-          ...current,
-          {
-            key,
-            rect: placement
-              ? placeChatCardBesideAnchor({
-                  anchor: placement.anchor,
-                  bounds: placement.bounds,
-                  occupied: current.map((card) => card.rect),
-                })
-              : cascadeChatCardRect({
-                  openCardCount: current.length,
-                  viewport: viewportSize(),
-                }),
-            thread,
-          },
-        ];
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const key = starMapWorkspaceCardKey({
+        instanceId: ownerInstanceId,
+        threadKey,
       });
-      raise(key);
-    },
-    [raise],
-  );
-
-  const close = useCallback((cardKey: string) => {
-    setCards((current) => current.filter((card) => card.key !== cardKey));
-    setOrder((current) => current.filter((entry) => entry !== cardKey));
-  }, []);
-
-  const closeAll = useCallback(() => {
-    setCards([]);
-    setOrder([]);
-  }, []);
-
-  const setRect = useCallback((cardKey: string, rect: ChatCardRect) => {
-    setCards((current) =>
-      current.map((card) => (card.key === cardKey ? { ...card, rect } : card)),
-    );
-  }, []);
-
-  const toggleContext = useCallback((cardKey: string) => {
-    setCards((current) =>
-      current.map((card) =>
-        card.key === cardKey
-          ? { ...card, contextOpen: !card.contextOpen }
-          : card,
-      ),
-    );
-  }, []);
-
-  const toggleTerminal = useCallback((cardKey: string) => {
-    setCards((current) =>
-      current.map((card) =>
-        card.key === cardKey
-          ? { ...card, terminalOpen: !card.terminalOpen }
-          : card,
-      ),
-    );
-  }, []);
-
-  const setTerminalHeight = useCallback(
-    (cardKey: string, height: number) => {
-      setCards((current) =>
-        current.map((card) =>
-          card.key === cardKey ? { ...card, terminalHeight: height } : card,
-        ),
+      const current = stateRef.current;
+      const existingIndex = current.cards.findIndex((card) => card.key === key);
+      if (existingIndex >= 0) {
+        const existing = current.cards[existingIndex];
+        applyState(
+          {
+            ...current,
+            cards: [
+              ...current.cards.slice(0, existingIndex),
+              ...current.cards.slice(existingIndex + 1),
+              {
+                ...existing,
+                thread: snapshotStarMapWorkspaceThread(thread),
+              },
+            ],
+          },
+          true,
+        );
+        return;
+      }
+      const rect = placement
+        ? placeChatCardBesideAnchor({
+            anchor: placement.sourceRect,
+            bounds: placement.bounds,
+            occupied: current.cards.map((card) => card.rect),
+          })
+        : cascadeChatCardRect({
+            openCardCount: current.cards.length,
+            viewport: viewportSize(),
+          });
+      const anchor = placement?.anchor ?? {
+        anchor: { kind: "canvas" } as const,
+        point: { x: 0, y: 0 },
+      };
+      applyState(
+        {
+          ...current,
+          cards: [
+            ...current.cards,
+            {
+              key,
+              ownerInstanceId,
+              threadKey,
+              rect,
+              thread: snapshotStarMapWorkspaceThread(thread),
+              anchor: anchor.anchor,
+              anchorDx: rect.left - anchor.point.x,
+              anchorDy: rect.top - anchor.point.y,
+              pendingAnchorRestore: false,
+              contextOpen: false,
+              terminalOpen: false,
+            },
+          ],
+        },
+        true,
       );
     },
-    [],
+    [applyState],
+  );
+
+  const close = useCallback(
+    (cardKey: string) => {
+      const current = stateRef.current;
+      const cards = current.cards.filter((card) => card.key !== cardKey);
+      if (cards.length === current.cards.length) return;
+      applyState({ ...current, cards }, true);
+    },
+    [applyState],
+  );
+
+  const closeAll = useCallback(() => {
+    const current = stateRef.current;
+    if (current.cards.length === 0) return;
+    applyState({ ...current, cards: [] }, true);
+  }, [applyState]);
+
+  const setRect = useCallback(
+    (cardKey: string, rect: ChatCardRect) => {
+      const current = stateRef.current;
+      const cards = current.cards.map((card) =>
+        card.key === cardKey ? { ...card, rect } : card,
+      );
+      applyState({ ...current, cards }, false);
+    },
+    [applyState],
+  );
+
+  const commitRect = useCallback(
+    (
+      cardKey: string,
+      rect: ChatCardRect,
+      anchor?: StarMapChatCardAnchorPlacement,
+    ) => {
+      const current = stateRef.current;
+      const cards = current.cards.map((card) => {
+        if (card.key !== cardKey) return card;
+        const placement = anchor ?? {
+          anchor: { kind: "canvas" } as const,
+          point: { x: 0, y: 0 },
+        };
+        return {
+          ...card,
+          rect,
+          anchor: placement.anchor,
+          anchorDx: rect.left - placement.point.x,
+          anchorDy: rect.top - placement.point.y,
+          pendingAnchorRestore: false,
+        };
+      });
+      applyState({ ...current, cards }, true);
+    },
+    [applyState],
+  );
+
+  const resolveRestoredAnchors = useCallback(
+    (
+      resolve: (
+        anchor: StarMapWorkspaceAnchor,
+      ) => { x: number; y: number } | undefined,
+    ) => {
+      const current = stateRef.current;
+      if (!current.cards.some((card) => card.pendingAnchorRestore)) return;
+      const cards = current.cards.map((card) => {
+        if (!card.pendingAnchorRestore) return card;
+        const point = resolve(card.anchor);
+        return {
+          ...card,
+          rect: point
+            ? {
+                ...card.rect,
+                left: point.x + card.anchorDx,
+                top: point.y + card.anchorDy,
+              }
+            : card.rect,
+          pendingAnchorRestore: false,
+        };
+      });
+      applyState({ ...current, cards }, false);
+    },
+    [applyState],
+  );
+
+  const toggleFlag = useCallback(
+    (cardKey: string, flag: "contextOpen" | "terminalOpen") => {
+      const current = stateRef.current;
+      const cards = current.cards.map((card) =>
+        card.key === cardKey ? { ...card, [flag]: !card[flag] } : card,
+      );
+      applyState({ ...current, cards }, true);
+    },
+    [applyState],
+  );
+
+  const toggleContext = useCallback(
+    (cardKey: string) => toggleFlag(cardKey, "contextOpen"),
+    [toggleFlag],
+  );
+  const toggleTerminal = useCallback(
+    (cardKey: string) => toggleFlag(cardKey, "terminalOpen"),
+    [toggleFlag],
+  );
+
+  const updateTerminalHeight = useCallback(
+    (cardKey: string, height: number, persist: boolean) => {
+      const current = stateRef.current;
+      const cards = current.cards.map((card) =>
+        card.key === cardKey ? { ...card, terminalHeight: height } : card,
+      );
+      applyState({ ...current, cards }, persist);
+    },
+    [applyState],
+  );
+
+  const setTerminalHeight = useCallback(
+    (cardKey: string, height: number) =>
+      updateTerminalHeight(cardKey, height, false),
+    [updateTerminalHeight],
+  );
+  const commitTerminalHeight = useCallback(
+    (cardKey: string, height: number) =>
+      updateTerminalHeight(cardKey, height, true),
+    [updateTerminalHeight],
+  );
+
+  const viewFor = useCallback(
+    (layout: StarMapWorkspaceLayout) => state.views[layout],
+    [state.views],
+  );
+
+  const commitView = useCallback(
+    (layout: StarMapWorkspaceLayout, view: StarMapWorkspaceView) => {
+      const current = stateRef.current;
+      applyState(
+        { ...current, views: { ...current.views, [layout]: view } },
+        true,
+      );
+    },
+    [applyState],
+  );
+
+  const resetView = useCallback(
+    (layout: StarMapWorkspaceLayout) => {
+      const current = stateRef.current;
+      if (!current.views[layout]) return;
+      const views = { ...current.views };
+      delete views[layout];
+      applyState({ ...current, views }, true);
+    },
+    [applyState],
   );
 
   const depthOf = useCallback(
     (cardKey: string) => {
-      const index = order.indexOf(cardKey);
+      const index = state.cards.findIndex((card) => card.key === cardKey);
       return index === -1 ? 0 : index;
     },
-    [order],
+    [state.cards],
   );
 
-  return {
-    cards,
-    close,
-    closeAll,
-    depthOf,
-    open,
-    raise,
-    setRect,
-    setTerminalHeight,
-    toggleContext,
-    toggleTerminal,
-  };
+  return useMemo(
+    () => ({
+      cards: state.cards,
+      hydrated,
+      close,
+      closeAll,
+      commitRect,
+      commitTerminalHeight,
+      commitView,
+      depthOf,
+      open,
+      raise,
+      resetView,
+      resolveRestoredAnchors,
+      setRect,
+      setTerminalHeight,
+      toggleContext,
+      toggleTerminal,
+      viewFor,
+    }),
+    [
+      close,
+      closeAll,
+      commitRect,
+      commitTerminalHeight,
+      commitView,
+      depthOf,
+      hydrated,
+      open,
+      raise,
+      resetView,
+      resolveRestoredAnchors,
+      setRect,
+      setTerminalHeight,
+      state.cards,
+      toggleContext,
+      toggleTerminal,
+      viewFor,
+    ],
+  );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
@@ -89,31 +89,162 @@ export type StarMapChatCardsController = {
 };
 
 const EMPTY_STATE: StarMapChatCardsState = { cards: [], views: {} };
+const WORKSPACE_LAYOUTS: readonly StarMapWorkspaceLayout[] = [
+  "lanes",
+  "orbit",
+  "projects",
+];
 
 function viewportSize(): { width: number; height: number } {
   if (typeof window === "undefined") return { width: 1440, height: 900 };
   return { width: window.innerWidth, height: window.innerHeight };
 }
 
+function snapshotCard(
+  card: StarMapChatCardEntry,
+): StarMapWorkspaceSnapshot["cards"][number] {
+  return {
+    key: card.key,
+    ownerInstanceId: card.ownerInstanceId,
+    thread: card.thread,
+    geometry: {
+      anchor: card.anchor,
+      dx: card.anchorDx,
+      dy: card.anchorDy,
+      fallbackRect: card.rect,
+    },
+    contextOpen: card.contextOpen,
+    terminalOpen: card.terminalOpen,
+    terminalHeight: card.terminalHeight,
+  };
+}
+
 function snapshotFor(state: StarMapChatCardsState): StarMapWorkspaceSnapshot {
   return {
     version: STAR_MAP_WORKSPACE_VERSION,
-    cards: state.cards.map((card) => ({
-      key: card.key,
-      ownerInstanceId: card.ownerInstanceId,
-      thread: card.thread,
-      geometry: {
-        anchor: card.anchor,
-        dx: card.anchorDx,
-        dy: card.anchorDy,
-        fallbackRect: card.rect,
-      },
-      contextOpen: card.contextOpen,
-      terminalOpen: card.terminalOpen,
-      terminalHeight: card.terminalHeight,
-    })),
+    cards: state.cards.map(snapshotCard),
     views: state.views,
   };
+}
+
+function snapshotsMatch(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function raisedCardKey(
+  base: StarMapWorkspaceSnapshot,
+  next: StarMapWorkspaceSnapshot,
+): string | undefined {
+  if (base.cards.length !== next.cards.length || next.cards.length === 0) {
+    return undefined;
+  }
+  const candidate = next.cards.at(-1)?.key;
+  if (!candidate) return undefined;
+  const baseKeys = base.cards.map((card) => card.key);
+  const nextKeys = next.cards.map((card) => card.key);
+  if (
+    !baseKeys.every((key) => nextKeys.includes(key))
+    || snapshotsMatch(baseKeys, nextKeys)
+  ) {
+    return undefined;
+  }
+  const moved = [...baseKeys.filter((key) => key !== candidate), candidate];
+  return snapshotsMatch(moved, nextKeys) ? candidate : undefined;
+}
+
+function rebaseCardChange(params: {
+  base: StarMapWorkspaceSnapshot["cards"][number];
+  next: StarMapWorkspaceSnapshot["cards"][number];
+  latest?: StarMapWorkspaceSnapshot["cards"][number];
+}): StarMapWorkspaceSnapshot["cards"][number] {
+  const latest = params.latest ?? params.base;
+  return {
+    key: params.next.key,
+    ownerInstanceId:
+      params.base.ownerInstanceId === params.next.ownerInstanceId
+        ? latest.ownerInstanceId
+        : params.next.ownerInstanceId,
+    thread: snapshotsMatch(params.base.thread, params.next.thread)
+      ? latest.thread
+      : params.next.thread,
+    geometry: snapshotsMatch(params.base.geometry, params.next.geometry)
+      ? latest.geometry
+      : params.next.geometry,
+    contextOpen:
+      params.base.contextOpen === params.next.contextOpen
+        ? latest.contextOpen
+        : params.next.contextOpen,
+    terminalOpen:
+      params.base.terminalOpen === params.next.terminalOpen
+        ? latest.terminalOpen
+        : params.next.terminalOpen,
+    terminalHeight:
+      params.base.terminalHeight === params.next.terminalHeight
+        ? latest.terminalHeight
+        : params.next.terminalHeight,
+  };
+}
+
+/**
+ * Reapply one viewer gesture to a newer durable snapshot. Each queued write
+ * carries the before/after pair from the local semantic boundary, so a peer
+ * window's intervening cards and camera changes survive a revision conflict.
+ */
+function rebaseWorkspaceChange(params: {
+  base: StarMapWorkspaceSnapshot;
+  next: StarMapWorkspaceSnapshot;
+  latest: StarMapWorkspaceSnapshot;
+}): StarMapWorkspaceSnapshot {
+  const baseByKey = new Map(params.base.cards.map((card) => [card.key, card]));
+  const nextByKey = new Map(params.next.cards.map((card) => [card.key, card]));
+  let cards = params.latest.cards.filter(
+    (card) => !(baseByKey.has(card.key) && !nextByKey.has(card.key)),
+  );
+  for (const nextCard of params.next.cards) {
+    const baseCard = baseByKey.get(nextCard.key);
+    if (baseCard && snapshotsMatch(baseCard, nextCard)) continue;
+    const index = cards.findIndex((card) => card.key === nextCard.key);
+    const rebasedCard = baseCard
+      ? rebaseCardChange({
+          base: baseCard,
+          next: nextCard,
+          latest: index >= 0 ? cards[index] : undefined,
+        })
+      : nextCard;
+    if (index >= 0) {
+      cards = [
+        ...cards.slice(0, index),
+        rebasedCard,
+        ...cards.slice(index + 1),
+      ];
+    } else {
+      cards = [...cards, rebasedCard];
+    }
+  }
+  const raised = raisedCardKey(params.base, params.next);
+  if (raised) {
+    const card = cards.find((entry) => entry.key === raised);
+    if (card) cards = [...cards.filter((entry) => entry.key !== raised), card];
+  }
+
+  const views = { ...params.latest.views };
+  for (const layout of WORKSPACE_LAYOUTS) {
+    if (snapshotsMatch(params.base.views[layout], params.next.views[layout])) {
+      continue;
+    }
+    const nextView = params.next.views[layout];
+    if (nextView) views[layout] = nextView;
+    else delete views[layout];
+  }
+  return {
+    version: STAR_MAP_WORKSPACE_VERSION,
+    cards,
+    views,
+  };
+}
+
+function isWorkspaceRevisionConflict(error: unknown): boolean {
+  return String(error).includes("Star Map workspace revision conflict");
 }
 
 function entryFromSnapshot(
@@ -148,21 +279,58 @@ export function useStarMapChatCards(params: {
   const stateRef = useRef(state);
   const mutatedBeforeHydrationRef = useRef(false);
   const revisionRef = useRef(0);
+  const persistedWorkspaceRef = useRef(snapshotFor(EMPTY_STATE));
+  const queuedWorkspaceRef = useRef(snapshotFor(EMPTY_STATE));
   const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
   const desktopApi = params.desktopApi;
 
   const enqueueWrite = useCallback(
     (next: StarMapChatCardsState) => {
-      if (!desktopApi?.writeStarMapWorkspace) return;
+      const writeWorkspace = desktopApi?.writeStarMapWorkspace;
+      if (!writeWorkspace) return;
+      const readWorkspace = desktopApi?.readStarMapWorkspace;
+      const base = queuedWorkspaceRef.current;
       const snapshot = snapshotFor(next);
+      queuedWorkspaceRef.current = snapshot;
       writeQueueRef.current = writeQueueRef.current
         .catch(() => undefined)
         .then(async () => {
-          const response = await desktopApi.writeStarMapWorkspace?.({
-            baseRevision: revisionRef.current,
-            workspace: snapshot,
+          let rebased = rebaseWorkspaceChange({
+            base,
+            next: snapshot,
+            latest: persistedWorkspaceRef.current,
           });
-          if (response) revisionRef.current = response.workspace.revision;
+          for (;;) {
+            try {
+              const response = await writeWorkspace({
+                baseRevision: revisionRef.current,
+                workspace: rebased,
+              });
+              revisionRef.current = response.workspace.revision;
+              persistedWorkspaceRef.current = {
+                version: response.workspace.version,
+                cards: response.workspace.cards,
+                views: response.workspace.views,
+              };
+              return;
+            } catch (error) {
+              if (!readWorkspace || !isWorkspaceRevisionConflict(error)) {
+                throw error;
+              }
+              const response = await readWorkspace();
+              revisionRef.current = response.workspace.revision;
+              persistedWorkspaceRef.current = {
+                version: response.workspace.version,
+                cards: response.workspace.cards,
+                views: response.workspace.views,
+              };
+              rebased = rebaseWorkspaceChange({
+                base,
+                next: snapshot,
+                latest: persistedWorkspaceRef.current,
+              });
+            }
+          }
         });
     },
     [desktopApi],
@@ -189,6 +357,9 @@ export function useStarMapChatCards(params: {
           cards: response.workspace.cards.map(entryFromSnapshot),
           views: response.workspace.views,
         };
+        const restoredSnapshot = snapshotFor(restored);
+        persistedWorkspaceRef.current = restoredSnapshot;
+        queuedWorkspaceRef.current = restoredSnapshot;
         const current = stateRef.current;
         const next = mutatedBeforeHydrationRef.current
           ? {
@@ -205,6 +376,7 @@ export function useStarMapChatCards(params: {
         setState(next);
         setHydrated(true);
         if (mutatedBeforeHydrationRef.current) enqueueWrite(next);
+        else queuedWorkspaceRef.current = snapshotFor(next);
       })
       .catch(() => {
         if (!cancelled) setHydrated(true);

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
@@ -59,8 +59,10 @@ export type StarMapChatCardsController = {
       bounds: { width: number; height: number };
       sourceRect: { x: number; y: number; width: number; height: number };
     },
+    options?: { persist?: boolean },
   ) => void;
-  raise: (cardKey: string) => void;
+  raise: (cardKey: string, persist?: boolean) => boolean;
+  remapOwner: (placeholderInstanceId: string, durableInstanceId: string) => void;
   /** Pointer-frame update. Deliberately memory-only. */
   setRect: (cardKey: string, rect: ChatCardRect) => void;
   /** Completed gesture: update relative geometry and persist once. */
@@ -145,6 +147,7 @@ export function useStarMapChatCards(params: {
   const [hydrated, setHydrated] = useState(false);
   const stateRef = useRef(state);
   const mutatedBeforeHydrationRef = useRef(false);
+  const revisionRef = useRef(0);
   const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
   const desktopApi = params.desktopApi;
 
@@ -155,7 +158,11 @@ export function useStarMapChatCards(params: {
       writeQueueRef.current = writeQueueRef.current
         .catch(() => undefined)
         .then(async () => {
-          await desktopApi.writeStarMapWorkspace?.({ workspace: snapshot });
+          const response = await desktopApi.writeStarMapWorkspace?.({
+            baseRevision: revisionRef.current,
+            workspace: snapshot,
+          });
+          if (response) revisionRef.current = response.workspace.revision;
         });
     },
     [desktopApi],
@@ -165,13 +172,8 @@ export function useStarMapChatCards(params: {
     (next: StarMapChatCardsState, persist: boolean) => {
       stateRef.current = next;
       setState(next);
-      if (persist) {
-        if (!hydrated) {
-          mutatedBeforeHydrationRef.current = true;
-        } else {
-          enqueueWrite(next);
-        }
-      }
+      if (!hydrated) mutatedBeforeHydrationRef.current = true;
+      if (persist && hydrated) enqueueWrite(next);
     },
     [enqueueWrite, hydrated],
   );
@@ -182,6 +184,7 @@ export function useStarMapChatCards(params: {
       ?.readStarMapWorkspace?.()
       .then((response) => {
         if (cancelled) return;
+        revisionRef.current = response.workspace.revision;
         const restored: StarMapChatCardsState = {
           cards: response.workspace.cards.map(entryFromSnapshot),
           views: response.workspace.views,
@@ -213,10 +216,10 @@ export function useStarMapChatCards(params: {
   }, [desktopApi, enqueueWrite]);
 
   const raise = useCallback(
-    (cardKey: string) => {
+    (cardKey: string, persist = true): boolean => {
       const current = stateRef.current;
       const index = current.cards.findIndex((card) => card.key === cardKey);
-      if (index === -1 || index === current.cards.length - 1) return;
+      if (index === -1 || index === current.cards.length - 1) return false;
       const card = current.cards[index];
       applyState(
         {
@@ -227,8 +230,46 @@ export function useStarMapChatCards(params: {
             card,
           ],
         },
-        true,
+        persist,
       );
+      return true;
+    },
+    [applyState],
+  );
+
+  const remapOwner = useCallback(
+    (placeholderInstanceId: string, durableInstanceId: string) => {
+      if (placeholderInstanceId === durableInstanceId) return;
+      const current = stateRef.current;
+      if (
+        !current.cards.some(
+          (card) => card.ownerInstanceId === placeholderInstanceId,
+        )
+      ) {
+        return;
+      }
+      const cards: StarMapChatCardEntry[] = [];
+      for (const card of current.cards) {
+        const remapped = card.ownerInstanceId === placeholderInstanceId
+          ? {
+              ...card,
+              key: starMapWorkspaceCardKey({
+                instanceId: durableInstanceId,
+                threadKey: card.threadKey,
+              }),
+              ownerInstanceId: durableInstanceId,
+              anchor:
+                card.anchor.kind !== "canvas"
+                && card.anchor.instanceId === placeholderInstanceId
+                  ? { ...card.anchor, instanceId: durableInstanceId }
+                  : card.anchor,
+            }
+          : card;
+        const duplicate = cards.findIndex((entry) => entry.key === remapped.key);
+        if (duplicate >= 0) cards.splice(duplicate, 1);
+        cards.push(remapped);
+      }
+      applyState({ ...current, cards }, true);
     },
     [applyState],
   );
@@ -242,7 +283,9 @@ export function useStarMapChatCards(params: {
         bounds: { width: number; height: number };
         sourceRect: { x: number; y: number; width: number; height: number };
       },
+      options?: { persist?: boolean },
     ) => {
+      const persist = options?.persist ?? true;
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
       const key = starMapWorkspaceCardKey({
         instanceId: ownerInstanceId,
@@ -264,7 +307,7 @@ export function useStarMapChatCards(params: {
               },
             ],
           },
-          true,
+          persist,
         );
         return;
       }
@@ -302,7 +345,7 @@ export function useStarMapChatCards(params: {
             },
           ],
         },
-        true,
+        persist,
       );
     },
     [applyState],
@@ -479,6 +522,7 @@ export function useStarMapChatCards(params: {
       depthOf,
       open,
       raise,
+      remapOwner,
       resetView,
       resolveRestoredAnchors,
       setRect,
@@ -497,6 +541,7 @@ export function useStarMapChatCards(params: {
       hydrated,
       open,
       raise,
+      remapOwner,
       resetView,
       resolveRestoredAnchors,
       setRect,

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
@@ -27,6 +27,8 @@ export type StarMapChatCardEntry = {
   anchor: StarMapWorkspaceAnchor;
   anchorDx: number;
   anchorDy: number;
+  instanceDx?: number;
+  instanceDy?: number;
   /** One initial relative-anchor resolution; a later peer connection must
    * not teleport an already-visible card away from its fallback rectangle. */
   pendingAnchorRestore: boolean;
@@ -38,6 +40,13 @@ export type StarMapChatCardEntry = {
 export type StarMapChatCardAnchorPlacement = {
   anchor: StarMapWorkspaceAnchor;
   point: { x: number; y: number };
+  /** Owner-body basis used when a thread card is unavailable on restore. */
+  instancePoint?: { x: number; y: number };
+};
+
+export type StarMapChatCardAnchorResolution = {
+  point: { x: number; y: number };
+  basis: "anchor" | "instance";
 };
 
 type StarMapChatCardsState = {
@@ -74,7 +83,7 @@ export type StarMapChatCardsController = {
   resolveRestoredAnchors: (
     resolve: (
       anchor: StarMapWorkspaceAnchor,
-    ) => { x: number; y: number } | undefined,
+    ) => StarMapChatCardAnchorResolution | undefined,
   ) => void;
   toggleContext: (cardKey: string) => void;
   toggleTerminal: (cardKey: string) => void;
@@ -100,6 +109,13 @@ function viewportSize(): { width: number; height: number } {
   return { width: window.innerWidth, height: window.innerHeight };
 }
 
+function instancePointForPlacement(
+  placement: StarMapChatCardAnchorPlacement,
+): { x: number; y: number } | undefined {
+  if (placement.instancePoint) return placement.instancePoint;
+  return placement.anchor.kind === "instance" ? placement.point : undefined;
+}
+
 function snapshotCard(
   card: StarMapChatCardEntry,
 ): StarMapWorkspaceSnapshot["cards"][number] {
@@ -111,6 +127,8 @@ function snapshotCard(
       anchor: card.anchor,
       dx: card.anchorDx,
       dy: card.anchorDy,
+      instanceDx: card.instanceDx,
+      instanceDy: card.instanceDy,
       fallbackRect: card.rect,
     },
     contextOpen: card.contextOpen,
@@ -259,6 +277,8 @@ function entryFromSnapshot(
     anchor: card.geometry.anchor,
     anchorDx: card.geometry.dx,
     anchorDy: card.geometry.dy,
+    instanceDx: card.geometry.instanceDx,
+    instanceDy: card.geometry.instanceDy,
     pendingAnchorRestore: true,
     contextOpen: card.contextOpen,
     terminalOpen: card.terminalOpen,
@@ -282,6 +302,7 @@ export function useStarMapChatCards(params: {
   const persistedWorkspaceRef = useRef(snapshotFor(EMPTY_STATE));
   const queuedWorkspaceRef = useRef(snapshotFor(EMPTY_STATE));
   const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const writeFailedRef = useRef(false);
   const desktopApi = params.desktopApi;
 
   const enqueueWrite = useCallback(
@@ -289,12 +310,18 @@ export function useStarMapChatCards(params: {
       const writeWorkspace = desktopApi?.writeStarMapWorkspace;
       if (!writeWorkspace) return;
       const readWorkspace = desktopApi?.readStarMapWorkspace;
-      const base = queuedWorkspaceRef.current;
+      const queuedBase = queuedWorkspaceRef.current;
       const snapshot = snapshotFor(next);
       queuedWorkspaceRef.current = snapshot;
-      writeQueueRef.current = writeQueueRef.current
-        .catch(() => undefined)
-        .then(async () => {
+      writeQueueRef.current = writeQueueRef.current.then(async () => {
+        // If the prior boundary failed, `queuedBase` contains state that was
+        // never durable. Reapply the complete local delta from the last
+        // successful snapshot so a later gesture carries the failed change
+        // forward instead of silently treating it as already saved.
+        const base = writeFailedRef.current
+          ? persistedWorkspaceRef.current
+          : queuedBase;
+        try {
           let rebased = rebaseWorkspaceChange({
             base,
             next: snapshot,
@@ -312,6 +339,7 @@ export function useStarMapChatCards(params: {
                 cards: response.workspace.cards,
                 views: response.workspace.views,
               };
+              writeFailedRef.current = false;
               return;
             } catch (error) {
               if (!readWorkspace || !isWorkspaceRevisionConflict(error)) {
@@ -331,7 +359,10 @@ export function useStarMapChatCards(params: {
               });
             }
           }
-        });
+        } catch {
+          writeFailedRef.current = true;
+        }
+      });
     },
     [desktopApi],
   );
@@ -497,6 +528,7 @@ export function useStarMapChatCards(params: {
         anchor: { kind: "canvas" } as const,
         point: { x: 0, y: 0 },
       };
+      const instancePoint = instancePointForPlacement(anchor);
       applyState(
         {
           ...current,
@@ -511,6 +543,12 @@ export function useStarMapChatCards(params: {
               anchor: anchor.anchor,
               anchorDx: rect.left - anchor.point.x,
               anchorDy: rect.top - anchor.point.y,
+              instanceDx: instancePoint
+                ? rect.left - instancePoint.x
+                : undefined,
+              instanceDy: instancePoint
+                ? rect.top - instancePoint.y
+                : undefined,
               pendingAnchorRestore: false,
               contextOpen: false,
               terminalOpen: false,
@@ -563,12 +601,19 @@ export function useStarMapChatCards(params: {
           anchor: { kind: "canvas" } as const,
           point: { x: 0, y: 0 },
         };
+        const instancePoint = instancePointForPlacement(placement);
         return {
           ...card,
           rect,
           anchor: placement.anchor,
           anchorDx: rect.left - placement.point.x,
           anchorDy: rect.top - placement.point.y,
+          instanceDx: instancePoint
+            ? rect.left - instancePoint.x
+            : undefined,
+          instanceDy: instancePoint
+            ? rect.top - instancePoint.y
+            : undefined,
           pendingAnchorRestore: false,
         };
       });
@@ -581,20 +626,27 @@ export function useStarMapChatCards(params: {
     (
       resolve: (
         anchor: StarMapWorkspaceAnchor,
-      ) => { x: number; y: number } | undefined,
+      ) => StarMapChatCardAnchorResolution | undefined,
     ) => {
       const current = stateRef.current;
       if (!current.cards.some((card) => card.pendingAnchorRestore)) return;
       const cards = current.cards.map((card) => {
         if (!card.pendingAnchorRestore) return card;
-        const point = resolve(card.anchor);
+        const resolution = resolve(card.anchor);
+        const offset = resolution?.basis === "instance"
+          && card.instanceDx !== undefined
+          && card.instanceDy !== undefined
+            ? { dx: card.instanceDx, dy: card.instanceDy }
+            : resolution?.basis === "anchor"
+              ? { dx: card.anchorDx, dy: card.anchorDy }
+              : undefined;
         return {
           ...card,
-          rect: point
+          rect: resolution && offset
             ? {
                 ...card.rect,
-                left: point.x + card.anchorDx,
-                top: point.y + card.anchorDy,
+                left: resolution.point.x + offset.dx,
+                top: resolution.point.y + offset.dy,
               }
             : card.rect,
           pendingAnchorRestore: false,

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -154,9 +154,11 @@ import type {
   SetFederationEventSubscriptionsRequest,
   SetFederationEventSubscriptionsResponse,
   ReadStarMapArrangementResponse,
+  ReadStarMapWorkspaceResponse,
   SetStarMapCardPositionRequest,
   StarMapIntakeRequest,
   StarMapIntakeResponse,
+  WriteStarMapWorkspaceRequest,
   FederationTarget,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
@@ -606,6 +608,10 @@ export type DesktopApi = {
   setStarMapCardPosition?: (
     request: SetStarMapCardPositionRequest,
   ) => Promise<ReadStarMapArrangementResponse>;
+  readStarMapWorkspace?: () => Promise<ReadStarMapWorkspaceResponse>;
+  writeStarMapWorkspace?: (
+    request: WriteStarMapWorkspaceRequest,
+  ) => Promise<ReadStarMapWorkspaceResponse>;
   dispatchStarMapIntake?: (
     request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
   ) => Promise<StarMapIntakeResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -20,6 +20,8 @@ export const FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL =
   "federation:set-event-subscriptions";
 export const STAR_MAP_READ_ARRANGEMENT_CHANNEL = "star-map:read-arrangement";
 export const STAR_MAP_SET_CARD_POSITION_CHANNEL = "star-map:set-card-position";
+export const STAR_MAP_READ_WORKSPACE_CHANNEL = "star-map:read-workspace";
+export const STAR_MAP_WRITE_WORKSPACE_CHANNEL = "star-map:write-workspace";
 export const STAR_MAP_INTAKE_CHANNEL = "star-map:intake";
 /**
  * Fire-and-forget IPC: opens the dedicated Federation Star Map window

--- a/docs/brainstorms/2026-08-21-star-map-workspace-restoration-requirements.md
+++ b/docs/brainstorms/2026-08-21-star-map-workspace-restoration-requirements.md
@@ -1,0 +1,179 @@
+# Star Map durable workspace restoration — product requirements
+
+**Date:** 2026-08-21
+**Status:** accepted product requirement; implemented on the feature branch
+**Scope:** restore the operator's working Star Map after closing and reopening it, including open chats, attached context and terminal cards, geometry, and the useful part of the camera state.
+
+This note records the requirement behind the operator feedback. It is a decision record, not an implementation script.
+
+---
+
+## 1. Outcome
+
+Closing and reopening Star Map must feel like returning to a desk, not generating a new dashboard.
+
+The operator should see approximately the same chats, in approximately the same relationships, with the same context sidebars and terminal cards open. Restoration must not depend on the owning PwrAgent instance being connected. A disconnected thread can be stale, but it must not disappear from the saved workspace.
+
+"Approximately" allows PwrAgent to keep cards reachable when a window, lens, canvas, cloud, or card has changed. It does not permit silently discarding the arrangement.
+
+## 2. Current gap
+
+Star Map currently persists and federates operator-dragged offsets for thread cards and load cards. Those offsets are relative to generated slots, which already gives the base map useful resilience across viewport and topology changes.
+
+Floating chat cards are different today:
+
+- The open chat set is React state only.
+- Each chat rectangle is React state only.
+- Context-sidebar open state is React state only.
+- Terminal open state and terminal height are React state only.
+- Card stacking order is React state only.
+- The map camera begins as a fresh view on each mount.
+- Chat-card movement and resizing do not use the thread-card alignment and spacing guides.
+
+Closing Star Map therefore loses the working surface even though the underlying thread-card arrangement survives.
+
+## 3. Workspace ownership
+
+The restored workspace is **viewer-owned profile state**.
+
+- Persist it in the local PwrAgent profile database under `PWRAGENT_HOME`, not in a remote instance and not only in browser `localStorage`.
+- Do not derive workspace membership from the current local or federated navigation feeds.
+- Do not federate the open chat set, context-sidebar state, terminal state, or camera as part of the shared fleet arrangement. Opening a transcript is a viewing action on this machine, not a command to open it on every machine.
+- Cross-device personal-workspace sync can be designed separately. It must not be smuggled into the existing shared card-arrangement protocol.
+- If more than one Star Map window can edit the same workspace, use revisions or last-writer-wins timestamps at semantic update boundaries so one window cannot overwrite a newer complete snapshot accidentally.
+
+## 4. Durable chat identity and disconnected restoration
+
+Every saved chat must include enough identity and display data to restore without its owner:
+
+- Owning federation instance ID, including the durable local instance ID.
+- Backend source and thread ID.
+- A versioned, bounded thread-display snapshot: title, directory labels or paths needed by the card, and the federation reference needed to reconnect.
+- The saved geometry and panel state described below.
+
+The owning instance ID is part of the durable card key. A backend/thread ID pair alone is not sufficient across a fleet.
+
+On Star Map startup:
+
+1. Read the workspace before waiting for federation navigation feeds.
+2. Render saved cards immediately from the bounded display snapshot.
+3. Mark cards whose owner is unavailable as disconnected or stale without removing them.
+4. Disable or explain actions that require the unavailable owner; keep local actions such as move, resize, close, and rearrange available.
+5. Rehydrate transcript and live thread data when the owner reconnects, without changing the card's restored geometry.
+
+Persisting "terminal open" restores the terminal card and its geometry. It does not promise to resurrect a dead shell process or pretend a disconnected remote terminal is live.
+
+## 5. Relative geometry
+
+Save chat geometry in Star Map canvas units, not screen pixels. A saved card has both an anchor relationship and a last-resolved rectangle:
+
+```ts
+type StarMapWorkspaceAnchor =
+  | { kind: "thread"; instanceId: string; threadKey: string }
+  | { kind: "instance"; instanceId: string }
+  | { kind: "canvas" };
+
+type StarMapWorkspaceGeometry = {
+  anchor: StarMapWorkspaceAnchor;
+  dx: number;
+  dy: number;
+  width: number;
+  height: number;
+  fallbackRect: { left: number; top: number; width: number; height: number };
+};
+```
+
+The exact persisted schema may differ, but it must preserve these semantics.
+
+Anchor resolution follows this order:
+
+1. The thread card, when that card is present in the current lens.
+2. The owning instance's cloud or body, when the thread card is unavailable.
+3. The last-resolved canvas rectangle, when neither relative anchor can be resolved.
+
+Important behavior:
+
+- A cloud or source thread card moving between sessions carries its related chats with it.
+- A temporarily filtered, folded, missing, or disconnected thread still opens at its last useful canvas location.
+- If restoration used the fallback rectangle because an anchor was missing, a later peer connection must not make an already-visible chat jump. Adopt the newly available anchor on the next operator move or the next save boundary.
+- Lens changes may resolve the same saved relationship through different visible anchors. Keep one open-chat workspace across lenses; do not silently create separate open sets.
+- Clamp only enough to leave the title bar or another move handle reachable. A different viewport size must not flatten the arrangement into a new auto-layout.
+- Context and terminal cards are satellites of the chat card. Their positions derive from their host so the compound group moves as one.
+
+## 6. Saved state
+
+For each open chat, save at least:
+
+- Durable fleet-qualified identity.
+- Bounded display snapshot for offline restoration.
+- Relative anchor and fallback rectangle.
+- Chat width and height.
+- Whether the context sidebar is open.
+- Whether the terminal is open.
+- Operator-adjusted terminal height and any future adjustable satellite dimension.
+- Stack order or another stable front-to-back ordering.
+
+Save the Star Map view per layout lens:
+
+- Camera pan and zoom after the operator has moved it.
+- The current layout lens and existing view preferences continue to restore.
+- On a changed viewport or canvas, restore and clamp the camera rather than replaying raw screen coordinates.
+- If the saved camera cannot show any saved chat group, prefer a bounded view containing the most recently active saved chat over opening onto empty sky.
+
+Transient composer text continues to use the existing draft system. Do not duplicate draft bodies inside the Star Map workspace record.
+
+## 7. Sizing, alignment, and grids
+
+Open chats should use the same visual placement language as the cards already arranged on Star Map.
+
+- Reuse the existing absolute-canvas alignment and observed-spacing engine instead of adding a second, subtly different snapping system.
+- Preserve a screen-space snap threshold so snapping feels the same at every zoom.
+- Moving a chat group should align left, center, right, top, middle, and bottom edges with nearby chat groups and eligible map cards.
+- Reuse gaps already present in the arrangement, with the existing default card gap as the initial detent.
+- Resizing should offer equal-width, equal-height, and aligned-edge detents so rows and columns can become clean grids without pixel hunting.
+- Treat a chat plus its open context and terminal satellites as one compound bounding box for inter-group spacing. Do not align another card into space occupied by a satellite.
+- Keep the existing chat default and minimum sizes as the baseline. Export shared geometry tokens rather than copying numeric constants.
+- Show the same alignment guides during the gesture that explain thread-card snapping.
+- Provide a temporary modifier to bypass snapping for precise free placement.
+
+Snapped geometry is ordinary persisted geometry. Reopening Star Map must preserve the grid rather than running auto-layout again.
+
+## 8. Persistence and write budget
+
+Workspace persistence must be event-boundary based:
+
+- Write once after a completed move or resize, not on every pointer event.
+- Write after open, close, sidebar toggle, terminal toggle, terminal resize completion, and stack-order changes that need to survive restart.
+- Write camera state at the end of a pan or zoom gesture, not per animation frame.
+- Make a related workspace update one transaction.
+- Perform no SQLite writes while a transcript streams, while Star Map is idle, or merely because a navigation or federation snapshot arrived.
+
+Add a checked-in SQLite write budget around the user action itself, following the desktop write-volume guidance. A drag should cost a constant number of commits independent of pointer-event count.
+
+## 9. Restore safety and evolution
+
+- Version the workspace payload or schema.
+- Validate finite geometry values and bound stored display snapshots.
+- Ignore or quarantine an invalid card record without discarding the rest of the workspace.
+- An explicitly closed chat must stay closed after restart.
+- A deleted or permanently unavailable thread may remain as an offline card until the operator closes it. Do not infer deletion from one missing snapshot.
+- Preserve unknown future fields when practical, or migrate explicitly. Avoid turning an older desktop into a workspace eraser.
+
+## 10. Acceptance scenarios
+
+1. Open five local and remote chats, open context on two, open terminals on three, resize and arrange them in a grid, close Star Map, and reopen it. The same five compound groups return with the same panel states, sizes, order, and approximate layout.
+2. Repeat with all remote instances disconnected before PwrAgent starts. Remote cards render immediately as stale/disconnected shells and remain movable and closable.
+3. Reconnect one owner. Its card hydrates in place; it does not teleport to a newly resolved anchor.
+4. Move an instance cloud between sessions. Chats anchored to it preserve their relative relationship when restoration can resolve that anchor initially.
+5. Reopen on a smaller display. Every saved chat remains recoverable, while relative spacing and sizes are disturbed only as much as reachability requires.
+6. Close one restored chat, close Star Map, and reopen. That chat does not return.
+7. Drag or resize through hundreds of pointer events. The action consumes a constant bounded number of SQLite commits.
+8. Stream a busy transcript for several minutes with several chats open. Workspace persistence makes zero streaming-driven commits.
+
+## 11. Non-goals for the first implementation
+
+- Resurrecting terminal processes across an application restart.
+- Federating which transcripts this viewer has open.
+- Replacing the existing composer-draft persistence.
+- Re-running auto-layout over a hand-arranged restored workspace.
+- Hiding saved chats merely because their owner, thread feed, filter, or source card is temporarily unavailable.

--- a/packages/shared/src/contracts/__tests__/star-map.test.ts
+++ b/packages/shared/src/contracts/__tests__/star-map.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   isStarMapArrangementEntry,
+  isStarMapWorkspaceSnapshot,
   mergeStarMapArrangementEntries,
+  parseStarMapWorkspaceSnapshot,
   starMapArrangementEntryKey,
+  starMapWorkspaceCardKey,
+  STAR_MAP_WORKSPACE_VERSION,
   type StarMapArrangementEntry,
 } from "../star-map";
 
@@ -16,6 +20,77 @@ const entry = (
   updatedAt: 100,
   by: "pwr_a",
   ...overrides,
+});
+
+describe("isStarMapWorkspaceSnapshot", () => {
+  const workspace = () => ({
+    version: STAR_MAP_WORKSPACE_VERSION,
+    cards: [
+      {
+        key: starMapWorkspaceCardKey({
+          instanceId: "pwr_remote",
+          threadKey: "acp:gemini:t1",
+        }),
+        ownerInstanceId: "pwr_remote",
+        thread: {
+          id: "t1",
+          inbox: { inInbox: true },
+          linkedDirectories: [],
+          source: "acp:gemini" as const,
+          title: "Saved remote chat",
+          titleSource: "derived" as const,
+        },
+        geometry: {
+          anchor: {
+            kind: "thread" as const,
+            instanceId: "pwr_remote",
+            threadKey: "acp:gemini:t1",
+          },
+          dx: 20,
+          dy: 30,
+          fallbackRect: {
+            left: 400,
+            top: 200,
+            width: 420,
+            height: 520,
+          },
+        },
+        contextOpen: true,
+        terminalOpen: false,
+      },
+    ],
+    views: { orbit: { x: 10, y: -20, scale: 0.75 } },
+  });
+
+  it("accepts fleet-qualified cards and finite per-lens views", () => {
+    expect(isStarMapWorkspaceSnapshot(workspace())).toBe(true);
+  });
+
+  it("rejects mismatched owner keys and non-finite geometry", () => {
+    const wrongKey = workspace();
+    wrongKey.cards[0].key = "pwr_other::acp:gemini:t1";
+    expect(isStarMapWorkspaceSnapshot(wrongKey)).toBe(false);
+
+    const nonFinite = workspace();
+    nonFinite.cards[0].geometry.fallbackRect.left = Number.NaN;
+    expect(isStarMapWorkspaceSnapshot(nonFinite)).toBe(false);
+  });
+
+  it("recovers valid cards and views from a partially corrupt payload", () => {
+    const partial = workspace();
+    partial.cards.push({
+      ...partial.cards[0],
+      key: "wrong-owner::acp:gemini:t2",
+      thread: { ...partial.cards[0].thread, id: "t2" },
+    });
+    partial.views.orbit.scale = Number.NaN;
+
+    expect(parseStarMapWorkspaceSnapshot(partial)).toEqual({
+      version: STAR_MAP_WORKSPACE_VERSION,
+      cards: [workspace().cards[0]],
+      views: {},
+    });
+  });
 });
 
 const sorted = (entries: StarMapArrangementEntry[]) =>

--- a/packages/shared/src/contracts/__tests__/star-map.test.ts
+++ b/packages/shared/src/contracts/__tests__/star-map.test.ts
@@ -76,6 +76,19 @@ describe("isStarMapWorkspaceSnapshot", () => {
     expect(isStarMapWorkspaceSnapshot(nonFinite)).toBe(false);
   });
 
+  it("accepts only complete finite instance-relative fallback offsets", () => {
+    const complete = workspace();
+    Object.assign(complete.cards[0].geometry, {
+      instanceDx: 100,
+      instanceDy: -40,
+    });
+    expect(isStarMapWorkspaceSnapshot(complete)).toBe(true);
+
+    const halfOffset = workspace();
+    Object.assign(halfOffset.cards[0].geometry, { instanceDx: 100 });
+    expect(isStarMapWorkspaceSnapshot(halfOffset)).toBe(false);
+  });
+
   it("recovers valid cards and views from a partially corrupt payload", () => {
     const partial = workspace();
     partial.cards.push({

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -214,6 +214,13 @@ export type StarMapWorkspaceCard = {
     anchor: StarMapWorkspaceAnchor;
     dx: number;
     dy: number;
+    /**
+     * Separate owner-body basis for a thread card that is filtered, folded,
+     * or unavailable on the next launch. Optional for version-1 rows written
+     * before this fallback was recorded.
+     */
+    instanceDx?: number;
+    instanceDy?: number;
     fallbackRect: StarMapWorkspaceRect;
   };
   contextOpen: boolean;
@@ -352,6 +359,8 @@ function isStarMapWorkspaceCard(value: unknown): value is StarMapWorkspaceCard {
   const geometry = card.geometry as
     | Partial<StarMapWorkspaceCard["geometry"]>
     | undefined;
+  const hasInstanceOffset =
+    geometry?.instanceDx !== undefined || geometry?.instanceDy !== undefined;
   if (
     typeof card.key !== "string"
     || typeof card.ownerInstanceId !== "string"
@@ -361,6 +370,11 @@ function isStarMapWorkspaceCard(value: unknown): value is StarMapWorkspaceCard {
     || !isStarMapWorkspaceAnchor(geometry.anchor)
     || !isFiniteNumber(geometry.dx)
     || !isFiniteNumber(geometry.dy)
+    || (hasInstanceOffset
+      && (
+        !isFiniteNumber(geometry.instanceDx)
+        || !isFiniteNumber(geometry.instanceDy)
+      ))
     || !isStarMapWorkspaceRect(geometry.fallbackRect)
     || typeof card.contextOpen !== "boolean"
     || typeof card.terminalOpen !== "boolean"

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -244,6 +244,8 @@ export type ReadStarMapWorkspaceResponse = {
 };
 
 export type WriteStarMapWorkspaceRequest = {
+  /** Revision returned by the read or previous successful write. */
+  baseRevision: number;
   workspace: StarMapWorkspaceSnapshot;
 };
 

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -1,3 +1,5 @@
+import type { NavigationThreadSummary } from "./navigation";
+
 /**
  * Star Map card arrangement: operator-dragged offsets for attention-thread
  * cards, keyed by owning instance + thread identity, synced across the
@@ -148,6 +150,301 @@ export type SetStarMapCardPositionRequest = {
   dx: number | null;
   dy: number | null;
 };
+
+/* ==== Viewer-owned workspace ==== */
+
+export const STAR_MAP_WORKSPACE_VERSION = 1 as const;
+export const STAR_MAP_WORKSPACE_KEY = "default";
+
+export type StarMapWorkspaceLayout = "lanes" | "orbit" | "projects";
+
+export type StarMapWorkspaceRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export type StarMapWorkspaceAnchor =
+  | {
+      kind: "thread";
+      instanceId: string;
+      threadKey: string;
+    }
+  | {
+      kind: "instance";
+      instanceId: string;
+    }
+  | { kind: "canvas" };
+
+/**
+ * The bounded part of a navigation row needed to paint and reconnect an open
+ * chat before its owning instance has answered the first federation poll.
+ * Transcript entries, tool output, PR history, and other growing collections
+ * deliberately do not belong in this snapshot.
+ */
+export type StarMapWorkspaceThreadSnapshot = Pick<
+  NavigationThreadSummary,
+  "id" | "inbox" | "linkedDirectories" | "source" | "title" | "titleSource"
+> &
+  Partial<
+    Pick<
+      NavigationThreadSummary,
+      | "createdAt"
+      | "executionMode"
+      | "fastMode"
+      | "federation"
+      | "forkSourceThreadId"
+      | "model"
+      | "primaryGitRepository"
+      | "projectKey"
+      | "reasoningEffort"
+      | "serviceTier"
+      | "updatedAt"
+      | "workspaceHandoff"
+    >
+  >;
+
+export type StarMapWorkspaceCard = {
+  /** Fleet-qualified key; see `starMapWorkspaceCardKey`. */
+  key: string;
+  ownerInstanceId: string;
+  thread: StarMapWorkspaceThreadSnapshot;
+  geometry: {
+    anchor: StarMapWorkspaceAnchor;
+    dx: number;
+    dy: number;
+    fallbackRect: StarMapWorkspaceRect;
+  };
+  contextOpen: boolean;
+  terminalOpen: boolean;
+  terminalHeight?: number;
+};
+
+export type StarMapWorkspaceView = {
+  x: number;
+  y: number;
+  scale: number;
+};
+
+export type StarMapWorkspaceSnapshot = {
+  version: typeof STAR_MAP_WORKSPACE_VERSION;
+  /** Lowest first, highest/front-most last. */
+  cards: StarMapWorkspaceCard[];
+  views: Partial<Record<StarMapWorkspaceLayout, StarMapWorkspaceView>>;
+};
+
+export type StarMapWorkspaceState = StarMapWorkspaceSnapshot & {
+  revision: number;
+  updatedAt: number;
+};
+
+export type ReadStarMapWorkspaceResponse = {
+  workspace: StarMapWorkspaceState;
+};
+
+export type WriteStarMapWorkspaceRequest = {
+  workspace: StarMapWorkspaceSnapshot;
+};
+
+export function emptyStarMapWorkspaceState(): StarMapWorkspaceState {
+  return {
+    version: STAR_MAP_WORKSPACE_VERSION,
+    cards: [],
+    views: {},
+    revision: 0,
+    updatedAt: 0,
+  };
+}
+
+export function starMapWorkspaceCardKey(params: {
+  instanceId: string;
+  threadKey: string;
+}): string {
+  return `${params.instanceId}::${params.threadKey}`;
+}
+
+export function snapshotStarMapWorkspaceThread(
+  thread: NavigationThreadSummary,
+): StarMapWorkspaceThreadSnapshot {
+  return {
+    id: thread.id,
+    inbox: thread.inbox,
+    linkedDirectories: thread.linkedDirectories.slice(0, 32),
+    source: thread.source,
+    title: thread.title.slice(0, 512),
+    titleSource: thread.titleSource,
+    createdAt: thread.createdAt,
+    executionMode: thread.executionMode,
+    fastMode: thread.fastMode,
+    federation: thread.federation,
+    forkSourceThreadId: thread.forkSourceThreadId,
+    model: thread.model,
+    primaryGitRepository: thread.primaryGitRepository,
+    projectKey: thread.projectKey,
+    reasoningEffort: thread.reasoningEffort,
+    serviceTier: thread.serviceTier,
+    updatedAt: thread.updatedAt,
+    workspaceHandoff: thread.workspaceHandoff,
+  };
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isStarMapWorkspaceRect(value: unknown): value is StarMapWorkspaceRect {
+  if (!value || typeof value !== "object") return false;
+  const rect = value as Partial<StarMapWorkspaceRect>;
+  return (
+    isFiniteNumber(rect.left)
+    && isFiniteNumber(rect.top)
+    && isFiniteNumber(rect.width)
+    && rect.width > 0
+    && isFiniteNumber(rect.height)
+    && rect.height > 0
+  );
+}
+
+function isStarMapWorkspaceAnchor(
+  value: unknown,
+): value is StarMapWorkspaceAnchor {
+  if (!value || typeof value !== "object") return false;
+  const anchor = value as Partial<StarMapWorkspaceAnchor> & {
+    instanceId?: unknown;
+    threadKey?: unknown;
+  };
+  if (anchor.kind === "canvas") return true;
+  if (
+    (anchor.kind === "instance" || anchor.kind === "thread")
+    && typeof anchor.instanceId === "string"
+    && anchor.instanceId.length > 0
+  ) {
+    return anchor.kind === "instance"
+      || (typeof anchor.threadKey === "string" && anchor.threadKey.length > 0);
+  }
+  return false;
+}
+
+function isStarMapWorkspaceThreadSnapshot(
+  value: unknown,
+): value is StarMapWorkspaceThreadSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const thread = value as Partial<StarMapWorkspaceThreadSnapshot>;
+  return (
+    typeof thread.id === "string"
+    && thread.id.length > 0
+    && typeof thread.source === "string"
+    && thread.source.length > 0
+    && typeof thread.title === "string"
+    && typeof thread.titleSource === "string"
+    && Array.isArray(thread.linkedDirectories)
+    && thread.linkedDirectories.length <= 32
+    && Boolean(thread.inbox && typeof thread.inbox === "object")
+  );
+}
+
+function isStarMapWorkspaceCard(value: unknown): value is StarMapWorkspaceCard {
+  if (!value || typeof value !== "object") return false;
+  const card = value as Partial<StarMapWorkspaceCard>;
+  const geometry = card.geometry as
+    | Partial<StarMapWorkspaceCard["geometry"]>
+    | undefined;
+  if (
+    typeof card.key !== "string"
+    || typeof card.ownerInstanceId !== "string"
+    || card.ownerInstanceId.length === 0
+    || !isStarMapWorkspaceThreadSnapshot(card.thread)
+    || !geometry
+    || !isStarMapWorkspaceAnchor(geometry.anchor)
+    || !isFiniteNumber(geometry.dx)
+    || !isFiniteNumber(geometry.dy)
+    || !isStarMapWorkspaceRect(geometry.fallbackRect)
+    || typeof card.contextOpen !== "boolean"
+    || typeof card.terminalOpen !== "boolean"
+    || (card.terminalHeight !== undefined
+      && (!isFiniteNumber(card.terminalHeight) || card.terminalHeight <= 0))
+  ) {
+    return false;
+  }
+  return card.key === starMapWorkspaceCardKey({
+    instanceId: card.ownerInstanceId,
+    threadKey: buildThreadKey(card.thread),
+  });
+}
+
+function buildThreadKey(thread: StarMapWorkspaceThreadSnapshot): string {
+  return `${thread.source}:${thread.id}`;
+}
+
+function isStarMapWorkspaceView(value: unknown): value is StarMapWorkspaceView {
+  if (!value || typeof value !== "object") return false;
+  const view = value as Partial<StarMapWorkspaceView>;
+  return (
+    isFiniteNumber(view.x)
+    && isFiniteNumber(view.y)
+    && isFiniteNumber(view.scale)
+    && view.scale > 0
+  );
+}
+
+/**
+ * Decode a stored workspace defensively. A corrupt card or lens camera is
+ * omitted without taking the operator's remaining desk state with it.
+ */
+export function parseStarMapWorkspaceSnapshot(
+  value: unknown,
+): StarMapWorkspaceSnapshot | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const snapshot = value as Partial<StarMapWorkspaceSnapshot>;
+  if (
+    snapshot.version !== STAR_MAP_WORKSPACE_VERSION
+    || !Array.isArray(snapshot.cards)
+    || snapshot.cards.length > 256
+    || !snapshot.views
+    || typeof snapshot.views !== "object"
+  ) {
+    return undefined;
+  }
+  const keys = new Set<string>();
+  const cards: StarMapWorkspaceCard[] = [];
+  for (const card of snapshot.cards) {
+    if (!isStarMapWorkspaceCard(card) || keys.has(card.key)) continue;
+    keys.add(card.key);
+    cards.push(card);
+  }
+  const views: StarMapWorkspaceSnapshot["views"] = {};
+  for (const layout of ["lanes", "orbit", "projects"] as const) {
+    const view = snapshot.views[layout];
+    if (isStarMapWorkspaceView(view)) views[layout] = view;
+  }
+  return { version: STAR_MAP_WORKSPACE_VERSION, cards, views };
+}
+
+export function isStarMapWorkspaceSnapshot(
+  value: unknown,
+): value is StarMapWorkspaceSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const snapshot = value as Partial<StarMapWorkspaceSnapshot>;
+  if (
+    snapshot.version !== STAR_MAP_WORKSPACE_VERSION
+    || !Array.isArray(snapshot.cards)
+    || snapshot.cards.length > 256
+    || !snapshot.cards.every(isStarMapWorkspaceCard)
+    || !snapshot.views
+    || typeof snapshot.views !== "object"
+  ) {
+    return false;
+  }
+  const keys = new Set(snapshot.cards.map((card) => card.key));
+  if (keys.size !== snapshot.cards.length) return false;
+  for (const layout of ["lanes", "orbit", "projects"] as const) {
+    const view = snapshot.views[layout];
+    if (!view) continue;
+    if (!isStarMapWorkspaceView(view)) return false;
+  }
+  return true;
+}
 
 /* ==== AI intake ==== */
 


### PR DESCRIPTION
## Summary

- persist the viewer-local Star Map desk in the profile database: open chats, z-order, context/terminal satellites, terminal height, relative/fallback geometry, and per-lens camera state
- restore bounded thread snapshots before federation peers reconnect, then hydrate live data in place without teleporting visible cards
- add compound-card snapping for aligned edges and equal resize dimensions, reusing the existing Star Map guides and screen-space snap threshold
- serialize semantic workspace updates and keep pointer frames/streaming memory-only; one measured completed action costs one SQLite commit and 8,240 WAL bytes
- record the accepted product requirements and recovery/evolution behavior

## Verification

- `pnpm test packages/shared/src/contracts/__tests__/star-map.test.ts apps/desktop/src/main/__tests__/overlay-store-star-map.test.ts apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapChatCards.test.tsx apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapTerminalCard.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/state-db-creation.test.ts apps/desktop/src/main/__tests__/state-db.test.ts apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts`
- `UPDATE_SQLITE_WRITE_BUDGETS=1 pnpm test apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts -t "Star Map workspace"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build`
- `pnpm --filter @pwragent/desktop test:e2e e2e/star-map-thread-flow.spec.ts e2e/star-map-chat-card-history.spec.ts` (3 passed)