### PR TITLE
fix(desktop): keep notice actions in footer

### DIFF
--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -171,7 +171,7 @@ export function AppNoticeToast(props: {
           <CloseIcon size={14} aria-hidden="true" />
         </button>
       </div>
-      {customActions.length > 0 ? (
+      {customActions.length > 0 && !props.navigation ? (
         <div className="app-notice-toast__custom-actions">
           {customActions.map((action) => (
             <button
@@ -193,6 +193,20 @@ export function AppNoticeToast(props: {
           <span className="app-notice-toast__position">
             {props.navigation.current} of {props.navigation.total}
           </span>
+          {customActions.length > 0 ? (
+            <div className="app-notice-toast__custom-actions">
+              {customActions.map((action) => (
+                <button
+                  key={action.label}
+                  className={`button button--${action.tone ?? "secondary"}`}
+                  type="button"
+                  onClick={action.onClick}
+                >
+                  {action.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
           <button
             className="app-notice-toast__icon-button"
             type="button"

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -186,10 +186,7 @@ export function AppNoticeToast(props: {
         </div>
       ) : null}
       {props.navigation ? (
-        <nav
-          className="app-notice-toast__navigation"
-          aria-label="Durable notices"
-        >
+        <div className="app-notice-toast__footer">
           <span className="app-notice-toast__position">
             {props.navigation.current} of {props.navigation.total}
           </span>
@@ -207,25 +204,30 @@ export function AppNoticeToast(props: {
               ))}
             </div>
           ) : null}
-          <button
-            className="app-notice-toast__icon-button"
-            type="button"
-            aria-label="Previous notice"
-            disabled={!props.navigation.onPrevious}
-            onClick={props.navigation.onPrevious}
+          <nav
+            className="app-notice-toast__navigation"
+            aria-label="Durable notices"
           >
-            <ChevronLeftIcon size={14} aria-hidden="true" />
-          </button>
-          <button
-            className="app-notice-toast__icon-button"
-            type="button"
-            aria-label="Next notice"
-            disabled={!props.navigation.onNext}
-            onClick={props.navigation.onNext}
-          >
-            <ChevronRightIcon size={14} aria-hidden="true" />
-          </button>
-        </nav>
+            <button
+              className="app-notice-toast__icon-button"
+              type="button"
+              aria-label="Previous notice"
+              disabled={!props.navigation.onPrevious}
+              onClick={props.navigation.onPrevious}
+            >
+              <ChevronLeftIcon size={14} aria-hidden="true" />
+            </button>
+            <button
+              className="app-notice-toast__icon-button"
+              type="button"
+              aria-label="Next notice"
+              disabled={!props.navigation.onNext}
+              onClick={props.navigation.onNext}
+            >
+              <ChevronRightIcon size={14} aria-hidden="true" />
+            </button>
+          </nav>
+        </div>
       ) : null}
       {autoDismiss ? (
         <span

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -271,16 +271,24 @@ describe("AppNoticeToast", () => {
 
   it("keeps operator actions in the existing durable-navigation row", () => {
     const onExamine = vi.fn();
+    const onMute = vi.fn();
     const { container } = render(
       <AppNoticeToast
         navigation={{ current: 1, total: 1 }}
         notice={{
           ...notice,
-          actions: [{
-            label: "Examine 20 cases",
-            onClick: onExamine,
-            tone: "primary",
-          }],
+          actions: [
+            {
+              label: "Examine 20 cases",
+              onClick: onExamine,
+              tone: "primary",
+            },
+            {
+              label: "Don't warn again",
+              onClick: onMute,
+              tone: "secondary",
+            },
+          ],
           autoDismiss: false,
         }}
         onDismiss={vi.fn()}
@@ -299,7 +307,9 @@ describe("AppNoticeToast", () => {
     )).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Examine 20 cases" }));
+    fireEvent.click(screen.getByRole("button", { name: "Don't warn again" }));
     expect(onExamine).toHaveBeenCalledTimes(1);
+    expect(onMute).toHaveBeenCalledTimes(1);
   });
 
   it("uses a notice-specific durable dismissal when supplied", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -303,7 +303,7 @@ describe("AppNoticeToast", () => {
     );
     const actionGroup = footer?.querySelector<HTMLElement>(
       ".app-notice-toast__custom-actions",
-    );
+    ) ?? null;
     const examineButton = screen.getByRole("button", {
       name: "Examine 20 cases",
     });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -269,7 +269,7 @@ describe("AppNoticeToast", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps operator actions in the existing durable-navigation row", () => {
+  it("keeps durable actions in the footer but outside navigation", () => {
     const onExamine = vi.fn();
     const onMute = vi.fn();
     const { container } = render(
@@ -298,16 +298,36 @@ describe("AppNoticeToast", () => {
     const navigation = screen.getByRole("navigation", {
       name: "Durable notices",
     });
-    const actionGroup = navigation.querySelector<HTMLElement>(
+    const footer = container.querySelector<HTMLElement>(
+      ".app-notice-toast__footer",
+    );
+    const actionGroup = footer?.querySelector<HTMLElement>(
       ".app-notice-toast__custom-actions",
     );
+    const examineButton = screen.getByRole("button", {
+      name: "Examine 20 cases",
+    });
+    const muteButton = screen.getByRole("button", {
+      name: "Don't warn again",
+    });
+
+    expect(footer).toBeInTheDocument();
     expect(actionGroup).toBeInTheDocument();
+    expect(navigation).not.toContainElement(actionGroup);
+    expect(navigation).not.toContainElement(examineButton);
+    expect(navigation).not.toContainElement(muteButton);
+    expect(navigation).toContainElement(
+      screen.getByRole("button", { name: "Previous notice" }),
+    );
+    expect(navigation).toContainElement(
+      screen.getByRole("button", { name: "Next notice" }),
+    );
     expect(container.querySelector(
       ".app-notice-toast > .app-notice-toast__custom-actions",
     )).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Examine 20 cases" }));
-    fireEvent.click(screen.getByRole("button", { name: "Don't warn again" }));
+    fireEvent.click(examineButton);
+    fireEvent.click(muteButton);
     expect(onExamine).toHaveBeenCalledTimes(1);
     expect(onMute).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -269,6 +269,39 @@ describe("AppNoticeToast", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps operator actions in the existing durable-navigation row", () => {
+    const onExamine = vi.fn();
+    const { container } = render(
+      <AppNoticeToast
+        navigation={{ current: 1, total: 1 }}
+        notice={{
+          ...notice,
+          actions: [{
+            label: "Examine 20 cases",
+            onClick: onExamine,
+            tone: "primary",
+          }],
+          autoDismiss: false,
+        }}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    const navigation = screen.getByRole("navigation", {
+      name: "Durable notices",
+    });
+    const actionGroup = navigation.querySelector<HTMLElement>(
+      ".app-notice-toast__custom-actions",
+    );
+    expect(actionGroup).toBeInTheDocument();
+    expect(container.querySelector(
+      ".app-notice-toast > .app-notice-toast__custom-actions",
+    )).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Examine 20 cases" }));
+    expect(onExamine).toHaveBeenCalledTimes(1);
+  });
+
   it("uses a notice-specific durable dismissal when supplied", () => {
     const durableDismiss = vi.fn();
     const stackDismiss = vi.fn();

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -495,6 +495,15 @@ describe("Tangerine Terminal theme contract", () => {
     expect(customActionsRule).toContain("justify-content: flex-end;");
   });
 
+  it("keeps durable toast actions on one navigation row", () => {
+    const customActionsRule = extractRuleBody(
+      css,
+      ".app-notice-toast__navigation .app-notice-toast__custom-actions",
+    );
+
+    expect(customActionsRule).toContain("flex-wrap: nowrap;");
+  });
+
   it("lets transcript scroll restoration own scroll anchoring", () => {
     expect(css).toMatch(
       /\.transcript-list__items\s*\{[\s\S]*?overflow-anchor:\s*none;[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -495,13 +495,26 @@ describe("Tangerine Terminal theme contract", () => {
     expect(customActionsRule).toContain("justify-content: flex-end;");
   });
 
-  it("keeps durable toast actions on one navigation row", () => {
+  it("lets long durable toast actions wrap without compressing labels", () => {
+    const footerRule = extractRuleBody(
+      css,
+      ".app-notice-toast__footer",
+    );
     const customActionsRule = extractRuleBody(
       css,
-      ".app-notice-toast__navigation .app-notice-toast__custom-actions",
+      ".app-notice-toast__footer .app-notice-toast__custom-actions",
+    );
+    const actionButtonRule = extractRuleBody(
+      css,
+      ".app-notice-toast__footer .app-notice-toast__custom-actions .button",
     );
 
-    expect(customActionsRule).toContain("flex-wrap: nowrap;");
+    expect(footerRule).toContain(
+      "grid-template-columns: auto minmax(0, 1fr) auto;",
+    );
+    expect(customActionsRule).toContain("min-width: 0;");
+    expect(customActionsRule).toContain("flex-wrap: wrap;");
+    expect(actionButtonRule).toContain("white-space: nowrap;");
   });
 
   it("lets transcript scroll restoration own scroll anchoring", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -485,10 +485,10 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
-  it("keeps custom toast actions from collapsing the message column", () => {
+  it("keeps standalone toast actions from collapsing the message column", () => {
     const customActionsRule = extractRuleBody(
       css,
-      ".app-notice-toast__custom-actions",
+      ".app-notice-toast > .app-notice-toast__custom-actions",
     );
 
     expect(customActionsRule).toContain("grid-column: 1 / -1;");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7143,24 +7143,33 @@ textarea,
   justify-content: flex-end;
 }
 
-.app-notice-toast__navigation .app-notice-toast__custom-actions {
-  min-width: 0;
-  flex-wrap: nowrap;
-  justify-content: flex-end;
-}
-
-.app-notice-toast__navigation {
-  display: flex;
+.app-notice-toast__footer {
+  display: grid;
   grid-column: 1 / -1;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: flex-end;
   gap: 6px;
   padding-top: 8px;
   border-top: 1px solid var(--border-subtle);
 }
 
+.app-notice-toast__footer .app-notice-toast__custom-actions {
+  min-width: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.app-notice-toast__footer .app-notice-toast__custom-actions .button {
+  white-space: nowrap;
+}
+
+.app-notice-toast__navigation {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .app-notice-toast__position {
-  margin-right: auto;
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 600;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7138,8 +7138,13 @@ textarea,
   align-self: start;
 }
 
-.app-notice-toast__custom-actions {
+.app-notice-toast > .app-notice-toast__custom-actions {
   grid-column: 1 / -1;
+  justify-content: flex-end;
+}
+
+.app-notice-toast__navigation .app-notice-toast__custom-actions {
+  min-width: 0;
   justify-content: flex-end;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7145,6 +7145,7 @@ textarea,
 
 .app-notice-toast__navigation .app-notice-toast__custom-actions {
   min-width: 0;
+  flex-wrap: nowrap;
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
## Summary
- place durable notice actions in the existing `1 of N` footer
- avoid adding a separate row for actions such as `Examine 20 cases`
- retain the standalone action-row fallback for direct toast rendering
- update component and theme contracts for the stable layout

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- focused ESLint
- `pnpm lint:colors`