### PR TITLE
fix(desktop): pin top-level remote child rows

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -159,7 +159,7 @@ export function ThreadRow(props: ThreadRowProps) {
   // instead of a per-hover `:has()` subtree scan (same optimization the
   // DirectoriesList header modifiers document).
   const isPinnedRow =
-    Boolean(props.thread.pinnedRank) && !props.thread.parentThreadId;
+    Boolean(props.thread.pinnedRank) && !props.nested;
   const [pickerOpen, setPickerOpen] = useState(false);
   const rowRef = useRef<HTMLDivElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);
@@ -519,9 +519,11 @@ export function ThreadRow(props: ThreadRowProps) {
         {/* Hover-revealed pin affordance for UNPINNED rows only — a
             pinned row's always-visible in-title pin IS the unpin
             control, so a second pin here would be a double affordance.
-            Sub-threads cannot be pinned. */}
+            Visibly nested sub-threads cannot be pinned. A remote child
+            whose parent is absent from a full remote-viewer snapshot is
+            rendered as a top-level row and remains pinnable. */}
         {onSetThreadPin
-          && !props.thread.parentThreadId
+          && !props.nested
           && !props.thread.pinnedRank ? (
           <button
             aria-label="Pin thread"

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -388,6 +388,49 @@ describe("ThreadRow chip flow", () => {
     );
   });
 
+  it("pins a remote child rendered as a top-level row", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    renderRow({
+      thread: {
+        ...baseThread,
+        parentThreadId: "parent-on-another-instance",
+        parentThreadInstanceId: "parent-instance",
+        federation: {
+          instanceLabel: "Remote Mac",
+          ref: {
+            backend: "codex",
+            target: {
+              scope: "remote",
+              instanceId: "child-instance",
+            },
+            threadId: baseThread.id,
+          },
+        },
+      },
+      onSetThreadPin,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin thread" }));
+    expect(onSetThreadPin).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "thread-chips" }),
+      true,
+    );
+  });
+
+  it("keeps a visibly nested sub-thread out of the pinned section", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    renderRow({
+      nested: true,
+      thread: {
+        ...baseThread,
+        parentThreadId: "visible-parent",
+      },
+      onSetThreadPin,
+    });
+
+    expect(screen.queryByRole("button", { name: "Pin thread" })).toBeNull();
+  });
+
   it("does not invoke onSelectThread when the add-reaction smiley is clicked", () => {
     const { container, onSelectThread } = renderRow();
     const addReaction = container.querySelector(


### PR DESCRIPTION
## Summary

- allow remote child threads rendered as top-level rows to show the pin action
- keep genuinely nested sub-threads excluded from the pinned section
- add regression coverage for the full remote-viewer shape

## Root cause

A cross-instance child can retain parent metadata even when its parent is absent from the full remote-viewer snapshot. The directory model correctly renders that orphaned child as top-level, but ThreadRow used parentThreadId instead of the actual nested render state and hid the pin control.

## Testing

- pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/directory-thread-render-model.test.ts
- pnpm lint:eslint
- pnpm typecheck
- pnpm lint:boundaries