### PR TITLE
feat(desktop): Star Map edge arrows to off-screen bodies

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapEdgeArrows.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapEdgeArrows.tsx
@@ -1,0 +1,107 @@
+import { memo, useMemo, useSyncExternalStore, type CSSProperties } from "react";
+import type { CelestialIconId } from "@pwragent/shared";
+import { CelestialIcon } from "../../icons";
+import {
+  computeStarMapEdgeArrows,
+  type StarMapEdgeTarget,
+} from "./star-map-edge-arrows";
+import type { StarMapView, StarMapViewBox } from "./star-map-view-geometry";
+
+/** A body the arrows can point at: an instance or a project sun. */
+export type StarMapEdgeArrowTarget = StarMapEdgeTarget & {
+  label: string;
+  kind: "instance" | "project";
+  /** The instance's celestial icon; projects carry a core dot instead. */
+  icon?: CelestialIconId;
+};
+
+/**
+ * Pointers on the edge of the window to every body the window is not
+ * showing, each turned to the bearing of its body and clickable to fly
+ * there. The geometry is `computeStarMapEdgeArrows`; this is the DOM.
+ *
+ * Reads the LIVE view, not React's. A drag, a keyboard flight and a ⌘K
+ * flight all paint the canvas transform by hand for their whole duration
+ * and commit to state only on landing, so an overlay fed from state would
+ * sit still through every gesture and jump at the end — the opposite of
+ * "the arrows move as you pan". `subscribe` is pinged on every paint, and
+ * `useSyncExternalStore` re-renders just this component, synchronously,
+ * so the arrows and the canvas land in the same frame. That is cheap
+ * because the component is a dozen nodes; the screen as a whole is not,
+ * which is why `paintView` exists in the first place.
+ *
+ * Memoised against its props for the same reason: a commit re-renders the
+ * screen, and this must not pay for that twice (once by the store, once
+ * by the parent) unless a target or the window actually changed.
+ */
+export const StarMapEdgeArrows = memo(function StarMapEdgeArrows(props: {
+  targets: readonly StarMapEdgeArrowTarget[];
+  viewport: StarMapViewBox;
+  /** Called on every write of the live view, committed or painted. */
+  subscribe: (listener: () => void) => () => void;
+  /** The view as the canvas transform shows it right now. */
+  getView: () => StarMapView;
+  onFlyTo: (target: StarMapEdgeArrowTarget) => void;
+}) {
+  const view = useSyncExternalStore(props.subscribe, props.getView);
+  const arrows = useMemo(
+    () =>
+      computeStarMapEdgeArrows({
+        targets: props.targets,
+        view,
+        viewport: props.viewport,
+      }),
+    [props.targets, props.viewport, view],
+  );
+  // Nothing off-screen, nothing in the tree: an empty group has nothing to
+  // announce and would only be a landmark for a screen reader to visit.
+  if (arrows.length === 0) return null;
+  return (
+    <div
+      className="star-map__edge-arrows"
+      role="group"
+      aria-label="Off-screen bodies"
+    >
+      {arrows.map((arrow) => (
+        <button
+          key={arrow.target.key}
+          type="button"
+          className={`star-map__edge-arrow star-map__edge-arrow--${arrow.edge}`}
+          // The button is the pill; the head hangs off it back at the
+          // rail point. Position is the tip of the head, and the per-edge
+          // CSS translates the pill inward from there and slides it along
+          // the edge by `--star-map-edge-shift` (see the geometry), while
+          // the head undoes that slide so it stays on the ray.
+          style={
+            {
+              left: arrow.x,
+              top: arrow.y,
+              "--star-map-edge-angle": `${arrow.angle}deg`,
+              "--star-map-edge-shift": `${arrow.labelShift}px`,
+            } as CSSProperties
+          }
+          aria-label={`Fly to ${arrow.target.label}`}
+          onClick={() => props.onFlyTo(arrow.target)}
+        >
+          <span className="star-map__edge-arrow-head" aria-hidden="true">
+            {/* A dart pointing +x; `rotate(var(--star-map-edge-angle))`
+                turns it along the ray. */}
+            <svg viewBox="0 0 18 18" width="18" height="18">
+              <path d="M2.5 2.5 L16 9 L2.5 15.5 L6.2 9 Z" />
+            </svg>
+          </span>
+          {arrow.target.icon ? (
+            <CelestialIcon
+              icon={arrow.target.icon}
+              size={14}
+              className="star-map__edge-arrow-icon"
+            />
+          ) : arrow.target.kind === "project" ? (
+            <span className="star-map__edge-arrow-core" aria-hidden="true" />
+          ) : null}
+          <span className="star-map__edge-arrow-name">{arrow.target.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+});

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapEdgeArrows.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapEdgeArrows.tsx
@@ -1,8 +1,9 @@
-import { memo, useMemo, useSyncExternalStore, type CSSProperties } from "react";
+import { memo, useSyncExternalStore, type CSSProperties } from "react";
 import type { CelestialIconId } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import {
   computeStarMapEdgeArrows,
+  type StarMapEdgeObstacle,
   type StarMapEdgeTarget,
 } from "./star-map-edge-arrows";
 import type { StarMapView, StarMapViewBox } from "./star-map-view-geometry";
@@ -14,6 +15,66 @@ export type StarMapEdgeArrowTarget = StarMapEdgeTarget & {
   /** The instance's celestial icon; projects carry a core dot instead. */
   icon?: CelestialIconId;
 };
+
+type StarMapEdgeArrowsProps = {
+  targets: readonly StarMapEdgeArrowTarget[];
+  /** Screen rects of the map's readouts, to slide pills clear of. */
+  obstacles: readonly StarMapEdgeObstacle[];
+  /** Called on every write of the live view, committed or painted. */
+  subscribe: (listener: () => void) => () => void;
+  /** The view as the canvas transform shows it right now. */
+  getView: () => StarMapView;
+  /** The window box as the live path sees it, not as React state has it. */
+  getViewport: () => StarMapViewBox;
+  onFlyTo: (target: StarMapEdgeArrowTarget) => void;
+};
+
+/**
+ * Whether two target lists describe the same bodies in the same places.
+ *
+ * The screen rebuilds `targets` on essentially every render — the array
+ * hangs off `bodies`, which hangs off the streamed thread feed and off
+ * `view.scale` — so a reference check makes `memo` a no-op: measured, ten
+ * renders with no body moved produced ten overlay renders and ten full
+ * geometry passes. Comparing the handful of fields an arrow actually
+ * draws from is far cheaper than the render it prevents.
+ */
+function sameTargets(
+  a: readonly StarMapEdgeArrowTarget[],
+  b: readonly StarMapEdgeArrowTarget[],
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((target, index) => {
+    const other = b[index];
+    return (
+      target.key === other.key
+      && target.x === other.x
+      && target.y === other.y
+      && target.label === other.label
+      && target.kind === other.kind
+      && target.icon === other.icon
+      && target.labelWidth === other.labelWidth
+    );
+  });
+}
+
+function sameObstacles(
+  a: readonly StarMapEdgeObstacle[],
+  b: readonly StarMapEdgeObstacle[],
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((box, index) => {
+    const other = b[index];
+    return (
+      box.left === other.left
+      && box.top === other.top
+      && box.right === other.right
+      && box.bottom === other.bottom
+    );
+  });
+}
 
 /**
  * Pointers on the edge of the window to every body the window is not
@@ -30,78 +91,87 @@ export type StarMapEdgeArrowTarget = StarMapEdgeTarget & {
  * because the component is a dozen nodes; the screen as a whole is not,
  * which is why `paintView` exists in the first place.
  *
- * Memoised against its props for the same reason: a commit re-renders the
- * screen, and this must not pay for that twice (once by the store, once
- * by the parent) unless a target or the window actually changed.
+ * The window box comes from the live path too (`getViewport`), for the
+ * same reason: a resize writes the new box synchronously in the observer
+ * and only commits it to state a frame later, so an overlay reading the
+ * state would place its rail against the previous window for that frame.
+ *
+ * No `useMemo` around the geometry: `view` is a fresh object on every
+ * painted frame, so a memo keyed on it could never hit — it would be one
+ * discarded deps array per frame for a cache that always misses. The
+ * cheap win is upstream, in the memo comparator, which stops the render
+ * from happening at all when nothing moved.
  */
-export const StarMapEdgeArrows = memo(function StarMapEdgeArrows(props: {
-  targets: readonly StarMapEdgeArrowTarget[];
-  viewport: StarMapViewBox;
-  /** Called on every write of the live view, committed or painted. */
-  subscribe: (listener: () => void) => () => void;
-  /** The view as the canvas transform shows it right now. */
-  getView: () => StarMapView;
-  onFlyTo: (target: StarMapEdgeArrowTarget) => void;
-}) {
-  const view = useSyncExternalStore(props.subscribe, props.getView);
-  const arrows = useMemo(
-    () =>
-      computeStarMapEdgeArrows({
-        targets: props.targets,
-        view,
-        viewport: props.viewport,
-      }),
-    [props.targets, props.viewport, view],
-  );
-  // Nothing off-screen, nothing in the tree: an empty group has nothing to
-  // announce and would only be a landmark for a screen reader to visit.
-  if (arrows.length === 0) return null;
-  return (
-    <div
-      className="star-map__edge-arrows"
-      role="group"
-      aria-label="Off-screen bodies"
-    >
-      {arrows.map((arrow) => (
-        <button
-          key={arrow.target.key}
-          type="button"
-          className={`star-map__edge-arrow star-map__edge-arrow--${arrow.edge}`}
-          // The button is the pill; the head hangs off it back at the
-          // rail point. Position is the tip of the head, and the per-edge
-          // CSS translates the pill inward from there and slides it along
-          // the edge by `--star-map-edge-shift` (see the geometry), while
-          // the head undoes that slide so it stays on the ray.
-          style={
-            {
-              left: arrow.x,
-              top: arrow.y,
-              "--star-map-edge-angle": `${arrow.angle}deg`,
-              "--star-map-edge-shift": `${arrow.labelShift}px`,
-            } as CSSProperties
-          }
-          aria-label={`Fly to ${arrow.target.label}`}
-          onClick={() => props.onFlyTo(arrow.target)}
-        >
-          <span className="star-map__edge-arrow-head" aria-hidden="true">
-            {/* A dart pointing +x; `rotate(var(--star-map-edge-angle))`
-                turns it along the ray. */}
-            <svg viewBox="0 0 18 18" width="18" height="18">
-              <path d="M2.5 2.5 L16 9 L2.5 15.5 L6.2 9 Z" />
-            </svg>
-          </span>
-          {arrow.target.icon ? (
-            <CelestialIcon
-              icon={arrow.target.icon}
-              size={14}
-              className="star-map__edge-arrow-icon"
-            />
-          ) : arrow.target.kind === "project" ? (
-            <span className="star-map__edge-arrow-core" aria-hidden="true" />
-          ) : null}
-          <span className="star-map__edge-arrow-name">{arrow.target.label}</span>
-        </button>
-      ))}
-    </div>
-  );
-});
+export const StarMapEdgeArrows = memo(
+  function StarMapEdgeArrows(props: StarMapEdgeArrowsProps) {
+    const view = useSyncExternalStore(props.subscribe, props.getView);
+    const arrows = computeStarMapEdgeArrows({
+      obstacles: props.obstacles,
+      targets: props.targets,
+      view,
+      viewport: props.getViewport(),
+    });
+    // Nothing off-screen, nothing in the tree: an empty group has nothing
+    // to announce and would only be a landmark for a screen reader to
+    // visit.
+    if (arrows.length === 0) return null;
+    return (
+      <div
+        className="star-map__edge-arrows"
+        role="group"
+        aria-label="Off-screen bodies"
+      >
+        {arrows.map((arrow) => (
+          <button
+            key={arrow.target.key}
+            type="button"
+            className={`star-map__edge-arrow star-map__edge-arrow--${arrow.edge}`}
+            // The button is the pill; the head hangs off it back at the
+            // rail point. Position is the arrow's point on the rail, and
+            // the per-edge CSS translates the pill inward from there and
+            // slides it along the edge by `--star-map-edge-shift` (see the
+            // geometry), while the head undoes that slide so it stays on
+            // the ray.
+            style={
+              {
+                left: arrow.x,
+                top: arrow.y,
+                "--star-map-edge-angle": `${arrow.angle}deg`,
+                "--star-map-edge-shift": `${arrow.labelShift}px`,
+              } as CSSProperties
+            }
+            aria-label={`Fly to ${arrow.target.label}`}
+            onClick={() => props.onFlyTo(arrow.target)}
+          >
+            <span className="star-map__edge-arrow-head" aria-hidden="true">
+              {/* A dart pointing +x; `rotate(var(--star-map-edge-angle))`
+                  turns it along the ray. */}
+              <svg viewBox="0 0 18 18" width="18" height="18">
+                <path d="M2.5 2.5 L16 9 L2.5 15.5 L6.2 9 Z" />
+              </svg>
+            </span>
+            {arrow.target.icon ? (
+              <CelestialIcon
+                icon={arrow.target.icon}
+                size={14}
+                className="star-map__edge-arrow-icon"
+              />
+            ) : arrow.target.kind === "project" ? (
+              <span className="star-map__edge-arrow-core" aria-hidden="true" />
+            ) : null}
+            <span className="star-map__edge-arrow-name">
+              {arrow.target.label}
+            </span>
+          </button>
+        ))}
+      </div>
+    );
+  },
+  (previous, next) =>
+    previous.subscribe === next.subscribe
+    && previous.getView === next.getView
+    && previous.getViewport === next.getViewport
+    && previous.onFlyTo === next.onFlyTo
+    && sameObstacles(previous.obstacles, next.obstacles)
+    && sameTargets(previous.targets, next.targets),
+);

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapKeyHint.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapKeyHint.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from "react";
 import type { StarMapCameraKey } from "./star-map-keyboard";
 import { useKeyboardLayoutLabels } from "./useKeyboardLayoutLabels";
 
@@ -20,7 +21,16 @@ import { useKeyboardLayoutLabels } from "./useKeyboardLayoutLabels";
  * the correct keys are the ones engraved Z Q S D — drawing "W" there would
  * point at the wrong key while the right one silently worked.
  */
-export function StarMapKeyHint(props: { held: ReadonlySet<StarMapCameraKey> }) {
+export function StarMapKeyHint(props: {
+  held: ReadonlySet<StarMapCameraKey>;
+  /**
+   * The hint is opaque chrome parked in the bottom-left corner, which is
+   * also where an edge arrow for a body off that corner lands. The screen
+   * measures this box and hands it to the arrows as an obstacle to slide
+   * clear of, so the two no longer stack.
+   */
+  ref?: RefObject<HTMLDivElement | null>;
+}) {
   const labels = useKeyboardLayoutLabels();
 
   const cap = (key: StarMapCameraKey, label: string, modifier?: string) => (
@@ -36,6 +46,7 @@ export function StarMapKeyHint(props: { held: ReadonlySet<StarMapCameraKey> }) {
   return (
     <div
       className="star-map__key-hint"
+      ref={props.ref}
       role="note"
       // The caps are a picture of a keyboard; spelling them out one glyph
       // at a time is noise. One sentence carries the whole control set,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -138,6 +138,11 @@ import {
   type StarMapFilterFit,
 } from "./star-map-filter-fit";
 import { StarMapKeyHint } from "./StarMapKeyHint";
+import {
+  StarMapEdgeArrows,
+  type StarMapEdgeArrowTarget,
+} from "./StarMapEdgeArrows";
+import { estimateStarMapEdgeLabelWidth } from "./star-map-edge-arrows";
 import { useStarMapCameraKeys } from "./useStarMapCameraKeys";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
 import {
@@ -608,6 +613,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const panBaseRef = useRef<StarMapView | undefined>(undefined);
 
   /**
+   * Whoever wants to know about a view write the moment it is painted,
+   * committed or not. Today that is the edge arrows: they sit in screen
+   * space over the map, and the transform string on the canvas is the
+   * only other record of a gesture frame. Pinged from `paintView`, so a
+   * subscriber sees exactly the frames the canvas does — no more, and no
+   * frame late.
+   */
+  const viewListenersRef = useRef(new Set<() => void>());
+  const subscribeToLiveView = useCallback((listener: () => void) => {
+    viewListenersRef.current.add(listener);
+    return () => {
+      viewListenersRef.current.delete(listener);
+    };
+  }, []);
+  const readLiveView = useCallback(() => viewRef.current, []);
+
+  /**
    * Move the view without telling React. For gesture frames: writes the
    * live ref and the transform, so the next frame of any writer composes
    * on top of it rather than on a stale base.
@@ -631,6 +653,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       sky.style.setProperty("--star-map-sky-x", `${offset.x}px`);
       sky.style.setProperty("--star-map-sky-y", `${offset.y}px`);
     }
+    for (const listener of viewListenersRef.current) listener();
   }, []);
 
   /**
@@ -3099,6 +3122,94 @@ export function StarMapScreen(props: StarMapScreenProps) {
   );
 
   /**
+   * The bodies the edge arrows can point at, in the current lens: every
+   * instance in the radial and lane lenses, every project sun in
+   * Projects. Canvas units, like the bodies themselves. The arrows only
+   * want a point, a name and an icon, so this is a projection of the
+   * layout rather than the layout — the overlay re-renders on every
+   * gesture frame and should hold nothing it does not read.
+   */
+  const edgeArrowTargets = useMemo((): StarMapEdgeArrowTarget[] => {
+    if (projectsMode) {
+      const labelByKey = new Map(
+        projects.map((project) => [project.key, project.label]),
+      );
+      return projectLayout.projects.map((placement) => {
+        const label = labelByKey.get(placement.key) ?? placement.key;
+        return {
+          key: `project:${placement.key}`,
+          x: placement.x,
+          y: placement.y,
+          label,
+          kind: "project" as const,
+          labelWidth: estimateStarMapEdgeLabelWidth(label, { icon: true }),
+        };
+      });
+    }
+    return bodies.map((body) => {
+      const label = displayLabelById.get(body.instanceId) ?? body.instanceId;
+      const icon = celestialIcons.iconFor(
+        body.instanceId === localInstanceId ? undefined : body.instanceId,
+      );
+      return {
+        key: `instance:${body.instanceId}`,
+        x: body.x,
+        y: body.y,
+        label,
+        kind: "instance" as const,
+        icon,
+        labelWidth: estimateStarMapEdgeLabelWidth(label, {
+          icon: icon !== undefined,
+        }),
+      };
+    });
+  }, [
+    bodies,
+    celestialIcons,
+    displayLabelById,
+    localInstanceId,
+    projectLayout,
+    projects,
+    projectsMode,
+  ]);
+
+  /**
+   * An edge arrow's click: fly to the body it points at.
+   *
+   * Flies now rather than arming `pendingFlight`: the arrow was drawn
+   * from the body's current geometry, so there is somewhere to fly to by
+   * definition. At the operator's own zoom, not the ⌘K landing zoom — a
+   * body is legible at every zoom the map allows, and someone looking at
+   * the fleet from far out asked to be taken to a body, not to be zoomed
+   * in on it.
+   */
+  const flyToEdgeTarget = useCallback(
+    (target: StarMapEdgeArrowTarget) => {
+      // A ⌘K pick still waiting for its card would otherwise land later
+      // and fly the map away again.
+      setPendingFlight(undefined);
+      // Arriving somewhere is the operator moving the view — the same
+      // claim a drag, a camera key and a ⌘K flight make.
+      operatorMovedViewRef.current = true;
+      flight.flyTo(
+        starMapViewFocusedOn({
+          rect: { x: target.x, y: target.y, width: 0, height: 0 },
+          canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+          viewport: { width: viewportSize.width, height: viewportSize.height },
+          scale: viewRef.current.scale,
+        }),
+      );
+    },
+    [
+      flight,
+      panZoomCanvas.width,
+      panZoomCanvas.height,
+      viewportSize.width,
+      viewportSize.height,
+    ],
+  );
+
+  /**
    * Everything the ⌘K palette can search: this window's own threads and
    * every peer feed the map has fetched, deduped by identity (a pinned
    * remote thread appears in both). Archived threads are left out — the map
@@ -4618,6 +4729,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
             })}
         </div>
       </div>
+      {/* Every body the window is not showing, pointed at from the edge.
+          Beside the viewport rather than in it on purpose: the arrows are
+          screen-space and the canvas transform must not move them. */}
+      <StarMapEdgeArrows
+        targets={edgeArrowTargets}
+        viewport={viewportSize}
+        subscribe={subscribeToLiveView}
+        getView={readLiveView}
+        onFlyTo={flyToEdgeTarget}
+      />
       {jumpOpen ? (
         // The same palette the main window's ⌘K opens, doing the same job
         // for a different surface: there it scrolls a list to a row, here

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -142,7 +142,10 @@ import {
   StarMapEdgeArrows,
   type StarMapEdgeArrowTarget,
 } from "./StarMapEdgeArrows";
-import { estimateStarMapEdgeLabelWidth } from "./star-map-edge-arrows";
+import {
+  estimateStarMapEdgeLabelWidth,
+  type StarMapEdgeObstacle,
+} from "./star-map-edge-arrows";
 import { useStarMapCameraKeys } from "./useStarMapCameraKeys";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
 import {
@@ -441,6 +444,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
   const skyRef = useRef<SVGSVGElement>(null);
+  // The two always-on readouts the edge arrows have to route around.
+  const keyHintRef = useRef<HTMLDivElement>(null);
+  const selectionBarRef = useRef<HTMLDivElement>(null);
   const { health } = useFederationHealth({ desktopApi: props.desktopApi });
   const celestialIcons = useCelestialIcons({ desktopApi: props.desktopApi });
   const [filterSelection, setFilterSelection] =
@@ -620,14 +626,27 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * subscriber sees exactly the frames the canvas does — no more, and no
    * frame late.
    */
-  const viewListenersRef = useRef(new Set<() => void>());
+  // Lazily, not `useRef(new Set())`: a ref's argument is evaluated on every
+  // render and discarded on all but the first, and this is the map's hottest
+  // component — a pinch alone would allocate 60-120 throwaway Sets a second
+  // on the very render path `paintView` exists to keep cheap.
+  const viewListenersRef = useRef<Set<() => void> | undefined>(undefined);
   const subscribeToLiveView = useCallback((listener: () => void) => {
-    viewListenersRef.current.add(listener);
+    const listeners = (viewListenersRef.current ??= new Set());
+    listeners.add(listener);
     return () => {
-      viewListenersRef.current.delete(listener);
+      listeners.delete(listener);
     };
   }, []);
   const readLiveView = useCallback(() => viewRef.current, []);
+  /**
+   * The window box as the live path sees it, for the same reason
+   * `readLiveView` exists: the edge arrows are placed against BOTH, and
+   * reading one from a ref and the other from React state left them
+   * positioning against the previous window for a frame after every
+   * resize step — arrows trailing the window edge through a drag-resize.
+   */
+  const readLiveViewport = useCallback(() => viewportSizeRef.current, []);
 
   /**
    * Move the view without telling React. For gesture frames: writes the
@@ -653,7 +672,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
       sky.style.setProperty("--star-map-sky-x", `${offset.x}px`);
       sky.style.setProperty("--star-map-sky-y", `${offset.y}px`);
     }
-    for (const listener of viewListenersRef.current) listener();
+    // Copied before iterating: a listener is free to unsubscribe from
+    // inside its own notification (React does exactly that when the
+    // overlay unmounts mid-frame), and mutating the Set under its own
+    // iterator is how that turns into a skipped listener.
+    const listeners = viewListenersRef.current;
+    if (listeners?.size) for (const listener of [...listeners]) listener();
   }, []);
 
   /**
@@ -747,7 +771,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
         // stale wrap from a wider window leaves the sky short of the new
         // right or bottom edge for that frame.
         viewportSizeRef.current = { width: rect.width, height: rect.height };
-        paintView(viewRef.current);
+        // A COPY, not the live object: `paintView` notifies the live-view
+        // subscribers, and they compare snapshots by identity. Handed the
+        // same object back they would correctly conclude the view had not
+        // moved — and the edge arrows, which are placed against the window
+        // as well as the view, would keep last frame's rail until the state
+        // commit below landed a frame later.
+        paintView({ ...viewRef.current });
         setViewportSize((current) =>
           current.width === rect.width && current.height === rect.height
             ? current
@@ -2282,6 +2312,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     operatorMovedViewRef.current = true;
   }, [abortFlight]);
 
+
   /**
    * WASD / arrows fly the camera, `-` and `=` work the zoom, `0` resets.
    *
@@ -2505,6 +2536,68 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   /** Cards the operator has gathered, by card key. */
   const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
+
+  /**
+   * Where the map's own readouts sit, so an edge arrow can slide clear of
+   * them instead of being drawn underneath one.
+   *
+   * The key hint and the selection bar paint ABOVE the arrows and are
+   * near-opaque, and both live in the bottom band the arrows' own rail
+   * reaches — a body off the bottom-left put its pill entirely inside the
+   * hint, and a body straight down put its dart under the selection bar,
+   * where the bar's own pointer-events made it unclickable too.
+   *
+   * Measured off a ResizeObserver rather than per frame: the hint's box is
+   * effectively constant and the bar's changes only when the selection
+   * count's width does, so reading it on the arrows' render path would be
+   * a forced layout sixty times a second for a number that almost never
+   * moves. Rects are relative to the layer, which is the arrows' own
+   * coordinate space (both it and the overlay are `inset: 0`).
+   */
+  const [edgeArrowObstacles, setEdgeArrowObstacles] = useState<
+    readonly StarMapEdgeObstacle[]
+  >([]);
+  const hasSelection = selection.size > 0;
+  useLayoutEffect(() => {
+    const layer = layerRef.current;
+    if (!layer) return;
+    const measure = () => {
+      const origin = layer.getBoundingClientRect();
+      const next: StarMapEdgeObstacle[] = [];
+      for (const element of [keyHintRef.current, selectionBarRef.current]) {
+        if (!element) continue;
+        const rect = element.getBoundingClientRect();
+        if (!(rect.width > 0) || !(rect.height > 0)) continue;
+        next.push({
+          left: rect.left - origin.left,
+          top: rect.top - origin.top,
+          right: rect.right - origin.left,
+          bottom: rect.bottom - origin.top,
+        });
+      }
+      setEdgeArrowObstacles((current) =>
+        current.length === next.length
+        && current.every(
+          (box, index) =>
+            box.left === next[index].left
+            && box.top === next[index].top
+            && box.right === next[index].right
+            && box.bottom === next[index].bottom,
+        )
+          ? current
+          : next,
+      );
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    for (const element of [keyHintRef.current, selectionBarRef.current]) {
+      if (element) observer.observe(element);
+    }
+    return () => observer.disconnect();
+    // `hasSelection` swaps the selection bar in and out, so the observed
+    // element set changes with it; the viewport size moves both boxes.
+  }, [hasSelection, viewportSize.height, viewportSize.width]);
   /** The live sweep rect, while a marquee drag is in flight. */
   const [marquee, setMarquee] = useState<SnapRect | undefined>(undefined);
 
@@ -3058,6 +3151,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
         scale: starMapFlightScale(viewRef.current.scale),
+        // Same latent hole the edge arrows made systematic: a ⌘K pick of a
+        // card near the top of a lane column would otherwise open sky above
+        // the headers. A cap, so a card deep in a column still travels.
+        topAnchored: topAnchoredView,
       }),
     );
     // Canvas and viewport enter as their measurements rather than as the
@@ -3073,6 +3170,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     panZoomCanvas.height,
     pendingFlight,
     toggleClusterExpanded,
+    topAnchoredView,
     viewportSize.width,
     viewportSize.height,
   ]);
@@ -3191,12 +3289,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // Arriving somewhere is the operator moving the view — the same
       // claim a drag, a camera key and a ⌘K flight make.
       operatorMovedViewRef.current = true;
+      // The arrow is about to be culled: it exists only while its body is
+      // off-screen, and this flight brings the body back. Chromium focused
+      // the button on mousedown, so without this the focused element is
+      // removed mid-flight and focus lands on `document.body` — outside
+      // the layer, whose Escape handler is a React `onKeyDown` and so
+      // stops firing. `startCanvasPan` restores focus for exactly this
+      // reason (see its own comment); this path owes the same.
+      layerRef.current?.focus();
       flight.flyTo(
         starMapViewFocusedOn({
           rect: { x: target.x, y: target.y, width: 0, height: 0 },
           canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
           viewport: { width: viewportSize.width, height: viewportSize.height },
           scale: viewRef.current.scale,
+          topAnchored: topAnchoredView,
         }),
       );
     },
@@ -3204,6 +3311,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       flight,
       panZoomCanvas.width,
       panZoomCanvas.height,
+      topAnchoredView,
       viewportSize.width,
       viewportSize.height,
     ],
@@ -4728,17 +4836,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
               );
             })}
         </div>
+        {/* Every body the window is not showing, pointed at from the edge.
+            A sibling of the CANVAS, inside the viewport: screen-space, so
+            the canvas transform must not move it — but inside, because the
+            viewport owns the non-passive wheel listener. Mounted beside the
+            viewport instead, a wheel over an arrow pill reached no listener
+            at all and the map froze under the cursor. `shouldStartCanvasPan`
+            already excludes `button`, so being in the pan's subtree costs
+            nothing. */}
+        <StarMapEdgeArrows
+          targets={edgeArrowTargets}
+          obstacles={edgeArrowObstacles}
+          subscribe={subscribeToLiveView}
+          getView={readLiveView}
+          getViewport={readLiveViewport}
+          onFlyTo={flyToEdgeTarget}
+        />
       </div>
-      {/* Every body the window is not showing, pointed at from the edge.
-          Beside the viewport rather than in it on purpose: the arrows are
-          screen-space and the canvas transform must not move them. */}
-      <StarMapEdgeArrows
-        targets={edgeArrowTargets}
-        viewport={viewportSize}
-        subscribe={subscribeToLiveView}
-        getView={readLiveView}
-        onFlyTo={flyToEdgeTarget}
-      />
       {jumpOpen ? (
         // The same palette the main window's ⌘K opens, doing the same job
         // for a different surface: there it scrolls a list to a row, here
@@ -4975,12 +5089,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
         </div>
       ) : null}
       {/* Bottom-left: the keys the map flies with. */}
-      <StarMapKeyHint held={heldCameraKeys} />
+      <StarMapKeyHint held={heldCameraKeys} ref={keyHintRef} />
       {/* The only thing on the surface that admits a selection exists.
           `role="status"` so the count is heard, not just seen — the cards
           themselves carry no selected state to a screen reader. */}
       {selection.size > 0 ? (
-        <div className="star-map__selection" role="status" aria-live="polite">
+        <div
+          className="star-map__selection"
+          ref={selectionBarRef}
+          role="status"
+          aria-live="polite"
+        >
           <span>
             {selection.size === 1 ? "1 card selected" : `${selection.size} cards selected`}
           </span>

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -1259,14 +1259,17 @@ describe("StarMapScreen", () => {
       />,
     );
     await waitFor(() => {
-      // Disambiguated label: the profile suffix rides along.
-      expect(screen.getByText(/Sleepy-Dev-Box/)).toBeTruthy();
+      // Disambiguated label: the profile suffix rides along. The name can
+      // show more than once — the body sits off-screen at the opening
+      // view, so its edge arrow names it too — and hiding the instance
+      // has to take every one of them with it.
+      expect(screen.getAllByText(/Sleepy-Dev-Box/).length).toBeGreaterThan(0);
     });
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));
     fireEvent.click(screen.getByLabelText("Hide offline instances"));
     await waitFor(() => {
-      expect(screen.queryByText(/Sleepy-Dev-Box/)).toBeNull();
+      expect(screen.queryAllByText(/Sleepy-Dev-Box/)).toHaveLength(0);
     });
     // The local instance is never hidden by this option.
     expect(screen.getByText("Local")).toBeTruthy();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -29,6 +29,19 @@ function starMapCard(openButton: HTMLElement): HTMLElement {
   return card;
 }
 
+/**
+ * The transformed canvas the map's bodies and cards live on.
+ *
+ * Queries about what the LENS drew scope to this, because the edge-arrow
+ * overlay is a sibling of it and repeats body and project names for
+ * everything currently off-screen.
+ */
+function canvas(): HTMLElement {
+  const element = document.querySelector(".star-map__canvas");
+  if (!(element instanceof HTMLElement)) throw new Error("no canvas");
+  return element;
+}
+
 function buildDesktopApi(): DesktopApi {
   return {
     readFederationHealth: vi.fn(async () => ({
@@ -1258,17 +1271,22 @@ describe("StarMapScreen", () => {
         onFocusLocalInstance={() => undefined}
       />,
     );
+    // Scoped to the canvas, not the window: the body sits off-screen at
+    // the opening view, so its edge arrow names it too, and an unscoped
+    // query would resolve to two. Scoping rather than relaxing to
+    // `getAllByText` keeps the guarantee that matters here — that the
+    // BODY rendered exactly once — instead of accepting any count.
+    const bodyLabel = () =>
+      within(canvas()).getAllByText(/Sleepy-Dev-Box/);
     await waitFor(() => {
-      // Disambiguated label: the profile suffix rides along. The name can
-      // show more than once — the body sits off-screen at the opening
-      // view, so its edge arrow names it too — and hiding the instance
-      // has to take every one of them with it.
-      expect(screen.getAllByText(/Sleepy-Dev-Box/).length).toBeGreaterThan(0);
+      // Disambiguated label: the profile suffix rides along.
+      expect(bodyLabel()).toHaveLength(1);
     });
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));
     fireEvent.click(screen.getByLabelText("Hide offline instances"));
     await waitFor(() => {
+      // Hidden everywhere, arrow included.
       expect(screen.queryAllByText(/Sleepy-Dev-Box/)).toHaveLength(0);
     });
     // The local instance is never hidden by this option.

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrow-render-cost.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrow-render-cost.test.tsx
@@ -1,0 +1,185 @@
+import { memo } from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+
+/**
+ * What the edge arrows are allowed to cost per frame.
+ *
+ * The overlay deliberately re-renders on every PAINTED frame — that is the
+ * whole point, and the behavioural spec pins it. What it must not do is
+ * re-render when nothing about the map moved: `targets` is rebuilt by the
+ * screen on essentially every render (it hangs off the streamed thread
+ * feed and off `view.scale`), so a reference-equality `memo` was a no-op —
+ * ten screen renders with no body moved produced ten overlay renders and
+ * ten full geometry passes, on the surface whose entire `paintView` design
+ * exists to keep that path cheap.
+ *
+ * The counting stand-in preserves the REAL memo boundary by re-wrapping the
+ * real component's inner function together with its real comparator; the
+ * same shape as star-map-chat-card-render-cost.test.tsx.
+ */
+const renders = { count: 0 };
+
+vi.mock("../StarMapEdgeArrows", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../StarMapEdgeArrows")>();
+  const real = actual.StarMapEdgeArrows as unknown as {
+    type: (props: never) => unknown;
+    compare: ((a: never, b: never) => boolean) | null;
+  };
+  return {
+    ...actual,
+    StarMapEdgeArrows: memo((props: never) => {
+      renders.count += 1;
+      return real.type(props) as never;
+    }, real.compare ?? undefined),
+  };
+});
+
+const { StarMapScreen } = await import("../StarMapScreen");
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function thread(id: string, updatedAt = 100): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      { id: `${id}-dir`, label: "PwrSnap", path: "/repos/PwrSnap", kind: "local" },
+    ],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt,
+  } as unknown as NavigationThreadSummary;
+}
+
+function canvas(): HTMLElement {
+  const element = document.querySelector(".star-map__canvas");
+  if (!(element instanceof HTMLElement)) throw new Error("no canvas");
+  return element;
+}
+
+function viewport(): HTMLElement {
+  const element = document.querySelector(".star-map__viewport");
+  if (!(element instanceof HTMLElement)) throw new Error("no viewport");
+  return element;
+}
+
+function arrowCount(): number {
+  return document.querySelectorAll(".star-map__edge-arrow").length;
+}
+
+describe("star map edge arrow render cost", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+    renders.count = 0;
+  });
+
+  it("does not re-render when the thread feed churns but no body moves", async () => {
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ layout: "orbit" }),
+    );
+    const threads = Array.from({ length: 6 }, (_, index) => thread(`t${index}`));
+    const { rerender } = render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={threads}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    // Get at least one arrow on screen so the overlay has real work to do.
+    fireEvent.pointerDown(viewport(), { button: 0, clientX: 500, clientY: 400 });
+    fireEvent.pointerMove(window, { clientX: -500, clientY: 400 });
+    fireEvent.pointerUp(window, { clientX: -500, clientY: 400 });
+    await waitFor(() => {
+      expect(arrowCount()).toBeGreaterThan(0);
+    });
+
+    const baseline = renders.count;
+    // Ten fresh snapshots of the SAME threads: new arrays, new objects,
+    // nothing moved. This is what a streaming turn looks like to the
+    // screen, and it used to cost ten overlay renders.
+    for (let round = 0; round < 10; round += 1) {
+      const churned = threads.map((entry) => ({ ...entry }));
+      rerender(
+        <StarMapScreen
+          desktopApi={buildDesktopApi()}
+          localThreads={churned}
+          sessionKeys={{}}
+          localInstanceLabel="Mac-Mini-M4"
+          onOpenLocalThread={() => undefined}
+          onFocusLocalInstance={() => undefined}
+        />,
+      );
+    }
+    expect(renders.count - baseline).toBe(0);
+  });
+
+  it("still re-renders once per painted frame of a gesture", async () => {
+    // The other half of the contract: the memo must not be so eager that
+    // the arrows stop tracking the map. A held drag paints frames without
+    // committing to React, and each one has to reach the overlay.
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ layout: "orbit" }),
+    );
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={Array.from({ length: 6 }, (_, index) => thread(`t${index}`))}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+
+    const baseline = renders.count;
+    const before = canvas().style.transform;
+    fireEvent.pointerDown(viewport(), { button: 0, clientX: 900, clientY: 400 });
+    for (let frame = 1; frame <= 3; frame += 1) {
+      fireEvent.pointerMove(window, {
+        clientX: 900 - frame * 120,
+        clientY: 400,
+      });
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+      });
+    }
+    fireEvent.pointerUp(window, { clientX: 540, clientY: 400 });
+    // The gesture really moved the map...
+    expect(canvas().style.transform).not.toBe(before);
+    // ...and the overlay tracked it rather than sitting still.
+    expect(renders.count).toBeGreaterThan(baseline);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows-css.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows-css.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  STAR_MAP_EDGE_HEAD_SPAN,
+  STAR_MAP_EDGE_LABEL_HEIGHT,
+  STAR_MAP_EDGE_LABEL_MAX_WIDTH,
+} from "../star-map-edge-arrows";
+
+/**
+ * The edge arrows decide which pills to draw by boxing them in TypeScript
+ * and testing those boxes for overlap — but the boxes only describe the
+ * real thing while the numbers agree with the stylesheet that draws it.
+ * Nothing in the build ties them together, and the failure mode is silent
+ * in both directions: retune the pill in CSS and the culler keeps measuring
+ * the old box, so two arrows are placed and drawn on top of each other;
+ * change the constant and every dart detaches from its pill. Both ship with
+ * a green geometry suite, because that suite is pure arithmetic over these
+ * same constants.
+ *
+ * Same shape as star-map-satellite-css.test.ts and star-map-z-layers.test.ts:
+ * read app.css and pin the contract, so it cannot disappear quietly.
+ */
+const CSS = readFileSync(
+  path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../styles/app.css",
+  ),
+  "utf8",
+);
+
+/** The body of one rule, by exact selector. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(CSS);
+  if (!match) throw new Error(`No CSS rule for ${selector}`);
+  return match[1];
+}
+
+describe("star map edge arrow CSS contract", () => {
+  it("keeps the pill's drawn height and max width in sync with the collision box", () => {
+    const pill = ruleBody(".star-map__edge-arrow");
+    expect(/height:\s*(\d+)px/.exec(pill)?.[1]).toBe(
+      String(STAR_MAP_EDGE_LABEL_HEIGHT),
+    );
+    expect(/max-width:\s*(\d+)px/.exec(pill)?.[1]).toBe(
+      String(STAR_MAP_EDGE_LABEL_MAX_WIDTH),
+    );
+  });
+
+  it("pulls the pill inward from the rail by exactly the head span, on all four edges", () => {
+    // The geometry hangs the collision box `STAR_MAP_EDGE_HEAD_SPAN`
+    // inside the rail point; these transforms are what put the drawn pill
+    // there. A mismatch means the culler is reasoning about a rectangle
+    // the browser does not paint.
+    for (const edge of ["right", "left", "top", "bottom"] as const) {
+      const body = ruleBody(`.star-map__edge-arrow--${edge}`);
+      // The per-edge rules carry nothing but the transform, so every
+      // pixel length in them is a head span — `calc(-100% - 22px)` on the
+      // far edges, a bare `22px` on the near ones.
+      const spans = [...body.matchAll(/(\d+)px/g)].map((match) =>
+        Number(match[1]),
+      );
+      expect(
+        spans,
+        `${edge} pill transform should pull in by ${STAR_MAP_EDGE_HEAD_SPAN}px`,
+      ).toContain(STAR_MAP_EDGE_HEAD_SPAN);
+    }
+  });
+
+  it("sizes the pill's padding and border the way the width estimate assumes", () => {
+    // `estimateStarMapEdgeLabelWidth` adds 20px of padding and 2px of
+    // border to the measured text. Under the renderer's global
+    // `box-sizing: border-box` the border is part of the width, so an
+    // estimate that skipped it under-measured every pill by 2px.
+    const pill = ruleBody(".star-map__edge-arrow");
+    expect(/padding:\s*0\s+(\d+)px/.exec(pill)?.[1]).toBe("10");
+    expect(/border:\s*(\d+)px\s+solid/.exec(pill)?.[1]).toBe("1");
+  });
+
+  it("keeps the overlay under every readout it has to slide clear of", () => {
+    // The arrows route AROUND the key hint and the selection bar rather
+    // than fighting them for the layer, so those two must keep painting
+    // above. If that ever inverts, the sliding is dead weight and an
+    // arrow would cover a control instead.
+    const layerOf = (selector: string) => {
+      const declaration = /z-index:\s*(\d+)/.exec(ruleBody(selector));
+      if (!declaration) throw new Error(`No z-index in ${selector}`);
+      return Number(declaration[1]);
+    };
+    const arrows = layerOf(".star-map__edge-arrows");
+    expect(arrows).toBeLessThan(layerOf(".star-map__key-hint"));
+    expect(arrows).toBeLessThan(layerOf(".star-map__selection"));
+    // And below the top band, which the rail's top inset reserves for.
+    expect(arrows).toBeLessThan(layerOf(".star-map__top-band"));
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeStarMapEdgeArrows,
+  estimateStarMapEdgeLabelWidth,
+  STAR_MAP_EDGE_INSET,
+  STAR_MAP_EDGE_LABEL_MAX_WIDTH,
+  type StarMapEdgeTarget,
+} from "../star-map-edge-arrows";
+
+/**
+ * The geometry behind the edge arrows: which bodies get one, which side of
+ * the window it sits on, where on that side, which way it points, and
+ * which arrows give way when two would land on each other. The screen's
+ * wiring — that the overlay moves with every painted frame and that a
+ * click flies there — is `star-map-edge-arrows.test.tsx`.
+ */
+
+const VIEWPORT = { width: 1280, height: 800 };
+const IDENTITY = { x: 0, y: 0, scale: 1 };
+const CENTER = { x: VIEWPORT.width / 2, y: VIEWPORT.height / 2 };
+const RAIL = {
+  left: STAR_MAP_EDGE_INSET.left,
+  top: STAR_MAP_EDGE_INSET.top,
+  right: VIEWPORT.width - STAR_MAP_EDGE_INSET.right,
+  bottom: VIEWPORT.height - STAR_MAP_EDGE_INSET.bottom,
+};
+
+function target(
+  key: string,
+  x: number,
+  y: number,
+  labelWidth?: number,
+): StarMapEdgeTarget {
+  return { key, x, y, labelWidth };
+}
+
+/** A body at a screen offset from the middle of the window, at 1:1. */
+function fromCenter(key: string, dx: number, dy: number, labelWidth?: number) {
+  return target(key, CENTER.x + dx, CENTER.y + dy, labelWidth);
+}
+
+function arrowsFor(
+  targets: StarMapEdgeTarget[],
+  view = IDENTITY,
+  viewport = VIEWPORT,
+) {
+  return computeStarMapEdgeArrows({ targets, view, viewport });
+}
+
+describe("computeStarMapEdgeArrows", () => {
+  it("draws nothing for a body the window is showing", () => {
+    expect(arrowsFor([target("a", 100, 100)])).toEqual([]);
+    // The window's edge is inclusive: a body centred exactly on it is
+    // still half on screen.
+    expect(arrowsFor([target("b", VIEWPORT.width, 400)])).toEqual([]);
+    expect(arrowsFor([target("c", 640, 0)])).toEqual([]);
+  });
+
+  it("sits on the rail where the line from the middle of the window leaves it, pointing at the body", () => {
+    const [arrow] = arrowsFor([fromCenter("right", 3000, 0)]);
+    expect(arrow?.edge).toBe("right");
+    expect(arrow?.x).toBe(RAIL.right);
+    expect(arrow?.y).toBe(CENTER.y);
+    expect(arrow?.angle).toBe(0);
+    expect(arrow?.distance).toBe(3000);
+    expect(arrow?.labelShift).toBe(0);
+  });
+
+  it("picks the side the ray leaves through and turns the arrow to its bearing", () => {
+    // Steep: the ray reaches the top before the right side. 45° up-right
+    // from the middle, so the exit is as far right of centre as the top
+    // rail is above it.
+    const [steep] = arrowsFor([fromCenter("steep", 1000, -1000)]);
+    const rise = CENTER.y - RAIL.top;
+    expect(steep?.edge).toBe("top");
+    expect(steep?.y).toBe(RAIL.top);
+    expect(steep?.x).toBeCloseTo(CENTER.x + rise, 6);
+    expect(steep?.angle).toBeCloseTo(-45, 6);
+
+    // Shallow: the ray reaches the right side first.
+    const [shallow] = arrowsFor([fromCenter("shallow", 2000, -200)]);
+    const run = RAIL.right - CENTER.x;
+    expect(shallow?.edge).toBe("right");
+    expect(shallow?.x).toBe(RAIL.right);
+    expect(shallow?.y).toBeCloseTo(CENTER.y - (200 * run) / 2000, 6);
+    expect(shallow?.angle).toBeCloseTo((Math.atan2(-200, 2000) * 180) / Math.PI, 6);
+  });
+
+  it("keeps the top rail below the top band and the rest at the window edge", () => {
+    const arrows = arrowsFor([
+      fromCenter("up", 0, -900),
+      fromCenter("down", 0, 900),
+      fromCenter("left", -2000, 0),
+    ]);
+    const byKey = new Map(arrows.map((arrow) => [arrow.target.key, arrow]));
+    expect(byKey.get("up")).toMatchObject({ edge: "top", y: RAIL.top, angle: -90 });
+    expect(byKey.get("down")).toMatchObject({ edge: "bottom", y: RAIL.bottom, angle: 90 });
+    expect(byKey.get("left")).toMatchObject({ edge: "left", x: RAIL.left, angle: 180 });
+    // The band is the reason the top is deeper; the rest only clear the
+    // window edge. Pinned so a change here is made on purpose.
+    expect(STAR_MAP_EDGE_INSET.top).toBeGreaterThan(STAR_MAP_EDGE_INSET.bottom);
+  });
+
+  it("maps the body through the view before deciding anything", () => {
+    // A canvas point the window would show at rest is off to the right
+    // once the map is panned 2000px that way.
+    const panned = arrowsFor([target("a", 100, 100)], { x: 2000, y: 0, scale: 1 });
+    expect(panned.map((arrow) => arrow.edge)).toEqual(["right"]);
+    // And a body far out on the canvas is inside the window at a zoom
+    // that pulls it in.
+    expect(arrowsFor([target("b", 3000, 400)], { x: 0, y: 0, scale: 0.2 })).toEqual([]);
+    // The bearing is of the SCREEN offset: zoom shrinks the canvas about
+    // the origin, so the same canvas point reads at a different angle.
+    const [zoomed] = arrowsFor(
+      [target("c", 4000, 4000)],
+      { x: 0, y: 0, scale: 0.5 },
+    );
+    expect(zoomed?.angle).toBeCloseTo(
+      (Math.atan2(2000 - CENTER.y, 2000 - CENTER.x) * 180) / Math.PI,
+      6,
+    );
+  });
+
+  it("orders nearest first and drops an arrow whose pill would land on one already placed", () => {
+    // Two bodies in almost the same direction share the near one's arrow.
+    const shared = arrowsFor([
+      fromCenter("far", 4500, 20),
+      fromCenter("near", 2500, 0),
+    ]);
+    expect(shared.map((arrow) => arrow.target.key)).toEqual(["near"]);
+
+    // Two bodies on the same side but well apart each keep theirs, the
+    // nearer listed first.
+    const apart = arrowsFor([
+      fromCenter("low", 2360, 1200),
+      fromCenter("level", 2360, 0),
+    ]);
+    expect(apart.map((arrow) => arrow.target.key)).toEqual(["level", "low"]);
+    expect(apart.every((arrow) => arrow.edge === "right")).toBe(true);
+  });
+
+  it("lets narrower pills pack tighter than the worst case", () => {
+    // Their rays leave the bottom rail about 160px apart. Assumed as wide
+    // as a pill can be, the two collide; told they are short names, both
+    // fit.
+    const wide = arrowsFor([
+      fromCenter("a", -250, 1200),
+      fromCenter("b", 250, 1200),
+    ]);
+    expect(wide).toHaveLength(1);
+    const narrow = arrowsFor([
+      fromCenter("a", -250, 1200, 50),
+      fromCenter("b", 250, 1200, 50),
+    ]);
+    expect(narrow).toHaveLength(2);
+  });
+
+  it("slides a pill along the edge to stay inside the rail near a corner, leaving the head on the ray", () => {
+    // Leaves through the top rail close to its right end.
+    const [arrow] = arrowsFor([fromCenter("corner", 1700, -1000)]);
+    expect(arrow?.edge).toBe("top");
+    const exitX = CENTER.x + (1700 * (CENTER.y - RAIL.top)) / 1000;
+    expect(arrow?.x).toBeCloseTo(exitX, 6);
+    // A full-width pill centred there would overhang the rail; it slides
+    // left by exactly the overhang.
+    const farthestCenter = RAIL.right - STAR_MAP_EDGE_LABEL_MAX_WIDTH / 2;
+    expect(arrow?.labelShift).toBeCloseTo(farthestCenter - exitX, 6);
+    expect(arrow!.labelShift).toBeLessThan(0);
+    // A pill narrow enough to fit needs no slide.
+    const [narrow] = arrowsFor([fromCenter("corner", 1700, -1000, 60)]);
+    expect(narrow?.labelShift).toBe(0);
+  });
+
+  it("keeps a pill sliding into a corner off the pill arriving from the adjacent side", () => {
+    // One leaves through the top near the right corner, one through the
+    // right side near the top corner; their pills would meet in the
+    // corner. The nearer body keeps its arrow.
+    const arrows = arrowsFor([
+      fromCenter("side", 2000, -1000),
+      fromCenter("top", 1700, -1000),
+    ]);
+    expect(arrows.map((arrow) => arrow.target.key)).toEqual(["top"]);
+  });
+
+  it("breaks a distance tie by key so two bodies never trade places between frames", () => {
+    const arrows = arrowsFor([
+      fromCenter("b", 3000, 0),
+      fromCenter("a", 3000, 0),
+    ]);
+    expect(arrows.map((arrow) => arrow.target.key)).toEqual(["a"]);
+  });
+
+  it("returns nothing for an unmeasured window", () => {
+    expect(
+      arrowsFor([fromCenter("a", 3000, 0)], IDENTITY, { width: 0, height: 0 }),
+    ).toEqual([]);
+  });
+
+  it("falls back to the window's own edges when it is too small for the rail", () => {
+    const viewport = { width: 300, height: 60 };
+    const [arrow] = arrowsFor([target("a", 150, -500)], IDENTITY, viewport);
+    expect(arrow?.edge).toBe("top");
+    expect(arrow?.y).toBe(0);
+  });
+});
+
+describe("estimateStarMapEdgeLabelWidth", () => {
+  it("grows with the label, adds room for an icon, and caps at the pill's max width", () => {
+    const short = estimateStarMapEdgeLabelWidth("ab");
+    const longer = estimateStarMapEdgeLabelWidth("abcdef");
+    expect(longer).toBeGreaterThan(short);
+    expect(estimateStarMapEdgeLabelWidth("ab", { icon: true })).toBeGreaterThan(
+      short,
+    );
+    expect(
+      estimateStarMapEdgeLabelWidth("a".repeat(200), { icon: true }),
+    ).toBe(STAR_MAP_EDGE_LABEL_MAX_WIDTH);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   computeStarMapEdgeArrows,
   estimateStarMapEdgeLabelWidth,
+  STAR_MAP_EDGE_BODY_HALF_EXTENT,
+  STAR_MAP_EDGE_HEAD_SPAN,
   STAR_MAP_EDGE_INSET,
+  STAR_MAP_EDGE_LABEL_HEIGHT,
   STAR_MAP_EDGE_LABEL_MAX_WIDTH,
+  type StarMapEdgeObstacle,
   type StarMapEdgeTarget,
 } from "../star-map-edge-arrows";
 
@@ -43,8 +47,62 @@ function arrowsFor(
   targets: StarMapEdgeTarget[],
   view = IDENTITY,
   viewport = VIEWPORT,
+  obstacles: StarMapEdgeObstacle[] = [],
 ) {
-  return computeStarMapEdgeArrows({ targets, view, viewport });
+  return computeStarMapEdgeArrows({ obstacles, targets, view, viewport });
+}
+
+/**
+ * The pill's box as the CSS actually draws it, from the returned arrow.
+ *
+ * The spec used to pin only the arrow's point on the rail, which left the
+ * box the cull is decided from unpinned: the head span, the clearance and
+ * whether the box follows the corner slide could each be set wrong with
+ * every assertion still green. Deriving the box here the way the
+ * stylesheet does is what lets a test speak about the thing that collides.
+ */
+function pillBox(arrow: {
+  edge: string;
+  x: number;
+  y: number;
+  labelShift: number;
+  target: { labelWidth?: number };
+}) {
+  const width = arrow.target.labelWidth ?? STAR_MAP_EDGE_LABEL_MAX_WIDTH;
+  const halfHeight = STAR_MAP_EDGE_LABEL_HEIGHT / 2;
+  if (arrow.edge === "left" || arrow.edge === "right") {
+    const inner =
+      arrow.edge === "right"
+        ? arrow.x - STAR_MAP_EDGE_HEAD_SPAN
+        : arrow.x + STAR_MAP_EDGE_HEAD_SPAN;
+    const centerY = arrow.y + arrow.labelShift;
+    return {
+      left: arrow.edge === "right" ? inner - width : inner,
+      right: arrow.edge === "right" ? inner : inner + width,
+      top: centerY - halfHeight,
+      bottom: centerY + halfHeight,
+    };
+  }
+  const inner =
+    arrow.edge === "bottom"
+      ? arrow.y - STAR_MAP_EDGE_HEAD_SPAN
+      : arrow.y + STAR_MAP_EDGE_HEAD_SPAN;
+  const centerX = arrow.x + arrow.labelShift;
+  return {
+    left: centerX - width / 2,
+    right: centerX + width / 2,
+    top: arrow.edge === "bottom" ? inner - STAR_MAP_EDGE_LABEL_HEIGHT : inner,
+    bottom: arrow.edge === "bottom" ? inner : inner + STAR_MAP_EDGE_LABEL_HEIGHT,
+  };
+}
+
+function overlaps(
+  a: { left: number; top: number; right: number; bottom: number },
+  b: { left: number; top: number; right: number; bottom: number },
+): boolean {
+  return (
+    a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
+  );
 }
 
 describe("computeStarMapEdgeArrows", () => {
@@ -190,6 +248,166 @@ describe("computeStarMapEdgeArrows", () => {
     expect(arrows.map((arrow) => arrow.target.key)).toEqual(["a"]);
   });
 
+  it("waits until every pixel of a body has left before arrowing it", () => {
+    // A body is a ~146px-tall drawing centred on the point the arrow aims
+    // at, so culling on the bare centre draws the dart on top of a body
+    // the operator can still see — and, because placement is nearest
+    // first, that spurious arrow suppresses the arrow for a body that is
+    // genuinely invisible.
+    const stillVisible = fromCenter("straddling", 0, 0);
+    stillVisible.x = VIEWPORT.width + STAR_MAP_EDGE_BODY_HALF_EXTENT - 1;
+    stillVisible.y = 400;
+    expect(arrowsFor([stillVisible])).toEqual([]);
+
+    const fullyGone = { ...stillVisible, key: "gone" };
+    fullyGone.x = VIEWPORT.width + STAR_MAP_EDGE_BODY_HALF_EXTENT + 1;
+    expect(arrowsFor([fullyGone]).map((arrow) => arrow.target.key)).toEqual([
+      "gone",
+    ]);
+  });
+
+  it("scales the body's margin with the zoom, because the body scales too", () => {
+    // The half-extent is in canvas units. At 2x a body draws twice as
+    // large on screen, so it stays visible twice as far past the edge.
+    const target = { key: "a", x: 0, y: 0, labelWidth: 80 };
+    const justOutsideAt1x = {
+      ...target,
+      x: (VIEWPORT.width + STAR_MAP_EDGE_BODY_HALF_EXTENT + 1) / 2,
+      y: 200,
+    };
+    expect(
+      arrowsFor([justOutsideAt1x], { x: 0, y: 0, scale: 2 }),
+    ).toEqual([]);
+    expect(arrowsFor([justOutsideAt1x], { x: 0, y: 0, scale: 1 })).toHaveLength(
+      0,
+    );
+    const wellOutside = { ...target, x: 2000, y: 200 };
+    expect(arrowsFor([wellOutside], { x: 0, y: 0, scale: 2 })).toHaveLength(1);
+  });
+
+  it("does not let a straddling body suppress the arrow for an invisible one", () => {
+    // The regression in full: both bodies are at nearly the same bearing,
+    // and the nearer one is still on screen. Before the margin, the
+    // visible body won the cull and the invisible one got nothing.
+    const straddling = { key: "visible", x: VIEWPORT.width + 40, y: 400 };
+    const gone = { key: "invisible", x: VIEWPORT.width + 900, y: 410 };
+    expect(arrowsFor([straddling, gone]).map((arrow) => arrow.target.key))
+      .toEqual(["invisible"]);
+  });
+
+  it("slides a pill along its edge to clear one of the map's readouts", () => {
+    // The camera key hint's measured box, bottom-left.
+    const keyHint: StarMapEdgeObstacle = {
+      left: 16,
+      top: VIEWPORT.height - 75,
+      right: 364,
+      bottom: VIEWPORT.height - 18,
+    };
+    // A body down and to the left: its ray leaves the bottom rail inside
+    // the hint.
+    const target = fromCenter("body", -1200, 1200, 120);
+    const [unblocked] = arrowsFor([target]);
+    expect(unblocked?.edge).toBe("bottom");
+    expect(overlaps(pillBox(unblocked!), keyHint)).toBe(true);
+
+    const [slid] = arrowsFor([target], IDENTITY, VIEWPORT, [keyHint]);
+    // Same arrow, same rail point and same bearing — only the pill moved.
+    expect(slid?.edge).toBe("bottom");
+    expect(slid?.x).toBeCloseTo(unblocked!.x, 6);
+    expect(slid?.angle).toBeCloseTo(unblocked!.angle, 6);
+    expect(overlaps(pillBox(slid!), keyHint)).toBe(false);
+    // And it is still on the map rather than dropped.
+    expect(slid?.labelShift).not.toBe(0);
+  });
+
+  it("keeps a slid pill inside the rail rather than pushing it out of the window", () => {
+    const wideObstacle: StarMapEdgeObstacle = {
+      left: 0,
+      top: VIEWPORT.height - 75,
+      right: VIEWPORT.width,
+      bottom: VIEWPORT.height - 18,
+    };
+    // Nothing can clear a full-width obstacle; the pill stays put rather
+    // than being shoved off-screen or dropped, because a partly covered
+    // arrow still beats no arrow.
+    const [arrow] = arrowsFor(
+      [fromCenter("body", -1200, 1200, 120)],
+      IDENTITY,
+      VIEWPORT,
+      [wideObstacle],
+    );
+    expect(arrow).toBeDefined();
+    const box = pillBox(arrow!);
+    expect(box.left).toBeGreaterThanOrEqual(RAIL.left);
+    expect(box.right).toBeLessThanOrEqual(RAIL.right);
+  });
+
+  it("only routes around an obstacle that actually covers that edge", () => {
+    // A readout in the TOP-left cannot affect a bottom-rail pill, however
+    // far along the edge it reaches.
+    const topLeft: StarMapEdgeObstacle = {
+      left: 0,
+      top: 0,
+      right: 400,
+      bottom: 120,
+    };
+    const target = fromCenter("body", -1200, 1200, 120);
+    const [plain] = arrowsFor([target]);
+    const [withObstacle] = arrowsFor([target], IDENTITY, VIEWPORT, [topLeft]);
+    expect(withObstacle?.labelShift).toBe(plain?.labelShift);
+  });
+
+  it("measures the collision box where the CSS draws the pill, head span included", () => {
+    // Two arrows on adjacent edges whose rail points are far apart but
+    // whose PILLS meet in the corner. Only a box built from the corner-slid
+    // centre, hanging inward by the head span, sees the collision — the
+    // three mutations that survived before (head span dropped, clearance
+    // zeroed, box built from the unshifted exit point) all miss it.
+    const top = fromCenter("top", 1180, -1000, 170);
+    const side = fromCenter("side", 2000, -1080, 170);
+    const both = arrowsFor([top, side]);
+    const placed = both.map((arrow) => arrow.target.key);
+    // Exactly one survives, and it is the nearer.
+    expect(placed).toEqual(["top"]);
+    // Proof the two really would have overlapped: place each alone and
+    // compare the boxes the CSS would draw.
+    const [topAlone] = arrowsFor([top]);
+    const [sideAlone] = arrowsFor([side]);
+    expect(topAlone?.edge).toBe("top");
+    expect(sideAlone?.edge).toBe("right");
+    expect(overlaps(pillBox(topAlone!), pillBox(sideAlone!))).toBe(true);
+  });
+
+  it("leaves room for the dart between the rail point and the pill, on every edge", () => {
+    // Structural, not a restatement of the constant: the pill's near edge
+    // must sit strictly inside the rail point with at least the drawn
+    // glyph's width between them, or the dart is painted over its own
+    // label. (The exact span is pinned against the stylesheet in
+    // star-map-edge-arrows-css.test.ts, which is what stops the two
+    // drifting.)
+    const DART_WIDTH = 18;
+    const cases = [
+      { key: "r", dx: 3000, dy: 0, edge: "right" },
+      { key: "l", dx: -3000, dy: 0, edge: "left" },
+      { key: "u", dx: 0, dy: -3000, edge: "top" },
+      { key: "d", dx: 0, dy: 3000, edge: "bottom" },
+    ] as const;
+    for (const probe of cases) {
+      const [arrow] = arrowsFor([fromCenter(probe.key, probe.dx, probe.dy, 90)]);
+      expect(arrow?.edge).toBe(probe.edge);
+      const box = pillBox(arrow!);
+      const gap =
+        probe.edge === "right"
+          ? arrow!.x - box.right
+          : probe.edge === "left"
+            ? box.left - arrow!.x
+            : probe.edge === "bottom"
+              ? arrow!.y - box.bottom
+              : box.top - arrow!.y;
+      expect(gap).toBeGreaterThanOrEqual(DART_WIDTH);
+    }
+  });
+
   it("returns nothing for an unmeasured window", () => {
     expect(
       arrowsFor([fromCenter("a", 3000, 0)], IDENTITY, { width: 0, height: 0 }),
@@ -215,5 +433,49 @@ describe("estimateStarMapEdgeLabelWidth", () => {
     expect(
       estimateStarMapEdgeLabelWidth("a".repeat(200), { icon: true }),
     ).toBe(STAR_MAP_EDGE_LABEL_MAX_WIDTH);
+  });
+
+  /**
+   * The estimate drives the ONLY overlap test, so it has to err high.
+   * These are measured rendered widths at the pill's real 11px/500 — the
+   * flat 6.4-per-character estimate this replaced came in UNDER every one
+   * of them, by up to 43px against a 6px clearance, and two arrows the
+   * culler judged clear drew one on top of the other.
+   */
+  it("never under-measures a label the pill will actually draw", () => {
+    const measured: [string, number][] = [
+      ["mac-mini-m4", 114.59],
+      ["WWW-BUILD-01", 130.63],
+      ["WIN-EC2-SANDBOX", 151.41],
+      ["DESKTOP-QJ7K2LM", 151.31],
+      ["Harold-MBP-M5-Max", 156.84],
+      ["1234567890", 110.91],
+      ["开发服务器一号", 115.97],
+      ["ビルドマシン", 106.89],
+      ["PwrSnap", 89.55],
+    ];
+    for (const [label, rendered] of measured) {
+      const estimate = estimateStarMapEdgeLabelWidth(label, { icon: true });
+      // Capped labels are ellipsised rather than drawn wide, so the cap is
+      // the honest answer for anything past it.
+      const target = Math.min(rendered, STAR_MAP_EDGE_LABEL_MAX_WIDTH);
+      expect(
+        estimate,
+        `${label}: estimated ${estimate}, renders ${rendered}`,
+      ).toBeGreaterThanOrEqual(target);
+    }
+  });
+
+  it("counts a surrogate pair as one wide glyph, not two narrow ones", () => {
+    // `label.length` counts UTF-16 units, so an emoji or an astral
+    // ideograph used to be measured as two separate narrow characters.
+    // Iterating by code point makes it one wide one — the same width as
+    // any other wide glyph.
+    expect(estimateStarMapEdgeLabelWidth("𝟘")).toBe(
+      estimateStarMapEdgeLabelWidth("一"),
+    );
+    expect(estimateStarMapEdgeLabelWidth("𝟘")).toBeGreaterThan(
+      estimateStarMapEdgeLabelWidth("a"),
+    );
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.tsx
@@ -6,7 +6,10 @@ import {
   computeStarMapEdgeArrows,
   STAR_MAP_EDGE_INSET,
 } from "../star-map-edge-arrows";
-import { starMapViewFocusedOn } from "../star-map-flight";
+import {
+  STAR_MAP_FLIGHT_SCALE,
+  starMapViewFocusedOn,
+} from "../star-map-flight";
 import { StarMapScreen } from "../StarMapScreen";
 
 /**
@@ -137,7 +140,10 @@ async function flushFrame() {
   });
 }
 
-async function renderMap(layout: "orbit" | "projects", threads: NavigationThreadSummary[]) {
+async function renderMap(
+  layout: "orbit" | "projects" | "lanes",
+  threads: NavigationThreadSummary[],
+) {
   window.localStorage.setItem(
     "pwragent.starMap.viewPreferences",
     JSON.stringify({ layout }),
@@ -241,7 +247,7 @@ describe("star map edge arrows", () => {
     fireEvent.pointerUp(window, { clientX: 500, clientY: 550 });
   });
 
-  it("flies the camera to the body when clicked, at the operator's zoom, and the arrow goes away", async () => {
+  it("flies the camera to the body when clicked, and the arrow goes away", async () => {
     await renderMap("orbit", [thread("t1", "PwrSnap")]);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
@@ -267,6 +273,147 @@ describe("star map edge arrows", () => {
     });
     // The body is back in the window, so nothing points at it any more.
     expect(arrowFor(LOCAL_LABEL)).toBeNull();
+  });
+
+  it("arrives at the operator's own zoom rather than the palette's landing zoom", async () => {
+    // The claim this file is named for, made falsifiable. At scale 1 the
+    // operator's zoom and `starMapFlightScale`'s 1:1 landing are the same
+    // number, so the assertion above passes either way — swapping the one
+    // for the other in `flyToEdgeTarget` left all five tests green. Zoom
+    // out first and the two diverge: the palette would pull the map back
+    // to 1, and a body is legible at every zoom the map allows, so someone
+    // looking at the whole fleet asked to be taken to a body, not zoomed
+    // in on it.
+    await renderMap("orbit", [thread("t1", "PwrSnap")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    // One gentle pinch: half scale, well below STAR_MAP_FLIGHT_SCALE but
+    // still leaving the pan clamp room to push a body off the window —
+    // slammed to MIN_ZOOM the whole canvas fits and nothing can leave.
+    fireEvent.wheel(viewport(), {
+      ctrlKey: true,
+      deltaY: 120,
+      clientX: 640,
+      clientY: 400,
+    });
+    const zoomedOut = canvasView().scale;
+    expect(zoomedOut).toBeLessThan(STAR_MAP_FLIGHT_SCALE);
+    // Push a body out of the window at that zoom.
+    pan(-1000, -400);
+    const arrow = arrowFor(LOCAL_LABEL);
+    expect(arrow).not.toBeNull();
+
+    fireEvent.click(arrow!);
+    await waitFor(() => {
+      expect(arrowFor(LOCAL_LABEL)).toBeNull();
+    });
+    // The zoom the operator set, untouched.
+    expect(canvasView().scale).toBeCloseTo(zoomedOut, 6);
+    expect(canvasView().scale).not.toBeCloseTo(STAR_MAP_FLIGHT_SCALE, 6);
+  });
+
+  it("keeps the map's keyboard after an arrow click, so Escape still unwinds", async () => {
+    // The clicked button is culled the moment the flight lands — the test
+    // above asserts exactly that — and Chromium focuses a button on
+    // mousedown. Without an explicit hand-back, focus falls to
+    // `document.body`, which is outside the layer, and the layer's Escape
+    // handler is a React onKeyDown: the selection could no longer be
+    // dropped from the keyboard until the operator clicked the sky.
+    await renderMap("orbit", [thread("t1", "PwrSnap"), thread("t2", "PwrAgent")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    // Sweep a selection so Escape has something to unwind. Shift-drag on
+    // bare sky is the map's own marquee gesture.
+    fireEvent.pointerDown(viewport(), {
+      button: 0,
+      shiftKey: true,
+      clientX: -4000,
+      clientY: -4000,
+    });
+    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+    await screen.findByText(/card[s]? selected/);
+
+    pan(-1000, 0);
+    const arrow = arrowFor(LOCAL_LABEL);
+    expect(arrow).not.toBeNull();
+    // jsdom does not focus on click the way Chromium does; do it by hand
+    // so the assertion is about the hand-back, not about jsdom.
+    arrow!.focus();
+    fireEvent.click(arrow!);
+
+    await waitFor(() => {
+      expect(arrowFor(LOCAL_LABEL)).toBeNull();
+    });
+    const layer = document.querySelector(".star-map");
+    expect(document.activeElement).toBe(layer);
+    expect(document.activeElement).not.toBe(document.body);
+
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByText(/card selected/)).toBeNull();
+    });
+  });
+
+  it("still pans and zooms the map when the wheel is over an arrow pill", async () => {
+    // The overlay is a sibling of the CANVAS, inside the viewport, because
+    // the viewport owns the only non-passive wheel listener on the map.
+    // Mounted beside the viewport instead, an arrow pill was a dead zone:
+    // `pointer-events: auto` made it the wheel's target and the event
+    // reached no listener, so the map froze under the cursor.
+    await renderMap("orbit", [thread("t1", "PwrSnap")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    pan(-1000, 0);
+    const arrow = arrowFor(LOCAL_LABEL);
+    expect(arrow).not.toBeNull();
+
+    // Negative deltas move the map back toward where it came from: the
+    // drag above parked it against the pan clamp, and a wheel further into
+    // the clamp is legitimately a no-op.
+    const beforePan = canvasView();
+    fireEvent.wheel(arrow!, { deltaX: -40, deltaY: -30 });
+    const afterPan = canvasView();
+    expect(afterPan.x).not.toBeCloseTo(beforePan.x, 3);
+    expect(afterPan.y).not.toBeCloseTo(beforePan.y, 3);
+
+    const beforeZoom = canvasView().scale;
+    fireEvent.wheel(arrow!, {
+      ctrlKey: true,
+      deltaY: -240,
+      clientX: 100,
+      clientY: 400,
+    });
+    expect(canvasView().scale).toBeGreaterThan(beforeZoom);
+  });
+
+  it("does not park the lanes lens above the top of its canvas", async () => {
+    // Lanes hangs its columns from a fixed top edge and seats every body
+    // on one row near it, so centring a body's y opens a band of empty sky
+    // above the lane headers with the columns shoved down — the state
+    // `topAnchored` exists to prevent, reachable from every single arrow
+    // click in this lens and escapable only through "Reset view".
+    await renderMap("lanes", [thread("t1", "PwrSnap"), thread("t2", "PwrAgent")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    // Push the body row off the top of the window.
+    pan(0, -400);
+    const arrow = arrowFor(LOCAL_LABEL);
+    expect(arrow).not.toBeNull();
+    expect(arrow!.className).toContain("star-map__edge-arrow--top");
+
+    fireEvent.click(arrow!);
+    await waitFor(() => {
+      expect(arrowFor(LOCAL_LABEL)).toBeNull();
+    });
+    // A positive y is the canvas origin sitting BELOW the window's, i.e.
+    // sky above the headers. Every other view write in this lens produces
+    // zero or less.
+    expect(canvasView().y).toBeLessThanOrEqual(0);
   });
 
   it("names project suns in the Projects lens, with the sun's core standing in for an icon", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-edge-arrows.test.tsx
@@ -1,0 +1,314 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import {
+  computeStarMapEdgeArrows,
+  STAR_MAP_EDGE_INSET,
+} from "../star-map-edge-arrows";
+import { starMapViewFocusedOn } from "../star-map-flight";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * The edge arrows on the live screen: that a body panned out of the
+ * window gets one, that it tracks the gesture frame by frame rather than
+ * only the landing, and that clicking it flies the camera to the body.
+ * The geometry itself — which side, where, which way — is
+ * `star-map-edge-arrows.test.ts`; here it is only used to say where an
+ * arrow SHOULD be for the transform the canvas is actually showing.
+ */
+
+/** The viewport the screen assumes until a real measurement arrives. */
+const VIEWPORT = { width: 1280, height: 800 };
+
+const LOCAL_LABEL = "Harold-MBP-M5-Max";
+const PEER_LABEL = "Mac-Mini-M4";
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: true,
+        role: "gateway" as const,
+        status: "listening" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: LOCAL_LABEL,
+        localProfileName: "default",
+        peers: [
+          {
+            id: "pwr_mini",
+            label: PEER_LABEL,
+            profileName: "default",
+            role: "client" as const,
+            // Offline on purpose: a body on the map with no thread feed to
+            // fetch, so the screen needs nothing beyond health.
+            status: "disconnected" as const,
+            capabilities: [],
+          },
+        ],
+      },
+    })) as unknown as DesktopApi["readFederationHealth"],
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function thread(id: string, directory: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      {
+        id: `${id}-dir`,
+        label: directory,
+        path: `/repos/${directory}`,
+        kind: "local",
+      },
+    ],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+function px(value: string | undefined): number {
+  return Number.parseFloat(value ?? "0");
+}
+
+function canvas(): HTMLElement {
+  const element = document.querySelector<HTMLElement>(".star-map__canvas");
+  if (!element) throw new Error("canvas not found");
+  return element;
+}
+
+/** The view as the canvas transform currently shows it. */
+function canvasView(): { x: number; y: number; scale: number } {
+  const raw = canvas().style.transform;
+  const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(raw);
+  if (!match) throw new Error(`unparsable transform: ${raw}`);
+  return { x: Number(match[1]), y: Number(match[2]), scale: Number(match[3]) };
+}
+
+function canvasSize(): { width: number; height: number } {
+  return { width: px(canvas().style.width), height: px(canvas().style.height) };
+}
+
+/** Where the layout put an instance body, in canvas units. */
+function bodyPoint(instanceId: string): { x: number; y: number } {
+  const anchor = document
+    .querySelector(`[data-instance-id="${instanceId}"]`)
+    ?.closest<HTMLElement>(".star-map__anchor");
+  if (!anchor) throw new Error(`no body for ${instanceId}`);
+  return { x: px(anchor.style.left), y: px(anchor.style.top) };
+}
+
+function arrowButtons(): HTMLButtonElement[] {
+  return [...document.querySelectorAll<HTMLButtonElement>(".star-map__edge-arrow")];
+}
+
+function arrowFor(label: string): HTMLButtonElement | null {
+  return (
+    arrowButtons().find(
+      (button) => button.getAttribute("aria-label") === `Fly to ${label}`,
+    ) ?? null
+  );
+}
+
+function viewport(): Element {
+  const element = document.querySelector(".star-map__viewport");
+  if (!element) throw new Error("viewport not found");
+  return element;
+}
+
+/** Drag the canvas by a fixed delta and let go, the way an operator pans. */
+function pan(dx: number, dy: number) {
+  fireEvent.pointerDown(viewport(), { button: 0, clientX: 500, clientY: 400 });
+  fireEvent.pointerMove(window, { clientX: 500 + dx, clientY: 400 + dy });
+  fireEvent.pointerUp(window, { clientX: 500 + dx, clientY: 400 + dy });
+}
+
+/** Let one animation frame run, so a gesture paints a frame. */
+async function flushFrame() {
+  await act(async () => {
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => resolve(undefined));
+    });
+  });
+}
+
+async function renderMap(layout: "orbit" | "projects", threads: NavigationThreadSummary[]) {
+  window.localStorage.setItem(
+    "pwragent.starMap.viewPreferences",
+    JSON.stringify({ layout }),
+  );
+  render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={threads}
+      sessionKeys={{}}
+      localInstanceLabel="fallback"
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+}
+
+describe("star map edge arrows", () => {
+  beforeEach(() => {
+    // Flights travel over half a second of frames; under reduced motion
+    // they land in one commit, which is the state the click assertion is
+    // about. jsdom answers every media query with `false` otherwise.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        onchange: null,
+        dispatchEvent: () => false,
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("points at a body the operator has panned out of the window, from the side it left by", async () => {
+    await renderMap("orbit", [thread("t1", "PwrSnap")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    // The map opens on the local body, so it is in the window and has no arrow.
+    expect(arrowFor(LOCAL_LABEL)).toBeNull();
+
+    // Drag the map a long way left: the local body leaves through the
+    // left side of the window.
+    pan(-1000, 0);
+
+    const arrow = arrowFor(LOCAL_LABEL);
+    expect(arrow).not.toBeNull();
+    expect(arrow!.className).toContain("star-map__edge-arrow--left");
+    expect(arrow!.style.left).toBe(`${STAR_MAP_EDGE_INSET.left}px`);
+    // Exactly where the geometry puts it for the transform on screen, not
+    // somewhere that merely looks left.
+    const [expected] = computeStarMapEdgeArrows({
+      targets: [{ key: "local", ...bodyPoint("pwr_local") }],
+      view: canvasView(),
+      viewport: VIEWPORT,
+    });
+    expect(expected?.edge).toBe("left");
+    expect(px(arrow!.style.top)).toBeCloseTo(expected!.y, 3);
+    expect(arrow!.style.getPropertyValue("--star-map-edge-angle")).toBe(
+      `${expected!.angle}deg`,
+    );
+    // And the group is what a screen reader lands on, named.
+    expect(screen.getByRole("group", { name: "Off-screen bodies" })).toBeTruthy();
+  });
+
+  it("moves with every painted frame of a drag, not only the landing", async () => {
+    await renderMap("orbit", [thread("t1", "PwrSnap")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    pan(-1000, 0);
+    const before = px(arrowFor(LOCAL_LABEL)!.style.top);
+
+    // A second drag, held: the pointer moves and a frame paints, but the
+    // pointer has NOT come up, so React state still holds the last landing.
+    fireEvent.pointerDown(viewport(), { button: 0, clientX: 500, clientY: 400 });
+    fireEvent.pointerMove(window, { clientX: 500, clientY: 400 + 150 });
+    await flushFrame();
+
+    const during = arrowFor(LOCAL_LABEL);
+    expect(during).not.toBeNull();
+    // The body is now further up-left of the window's middle, so the
+    // arrow on the left rail has ridden up to meet the steeper ray.
+    expect(px(during!.style.top)).not.toBeCloseTo(before, 3);
+    const [expected] = computeStarMapEdgeArrows({
+      targets: [{ key: "local", ...bodyPoint("pwr_local") }],
+      view: canvasView(),
+      viewport: VIEWPORT,
+    });
+    expect(px(during!.style.top)).toBeCloseTo(expected!.y, 3);
+
+    fireEvent.pointerUp(window, { clientX: 500, clientY: 550 });
+  });
+
+  it("flies the camera to the body when clicked, at the operator's zoom, and the arrow goes away", async () => {
+    await renderMap("orbit", [thread("t1", "PwrSnap")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    pan(-1000, 0);
+    const arrow = arrowFor(LOCAL_LABEL);
+    expect(arrow).not.toBeNull();
+
+    const body = bodyPoint("pwr_local");
+    const expected = starMapViewFocusedOn({
+      rect: { x: body.x, y: body.y, width: 0, height: 0 },
+      canvas: canvasSize(),
+      viewport: VIEWPORT,
+      scale: canvasView().scale,
+    });
+    fireEvent.click(arrow!);
+
+    await waitFor(() => {
+      const view = canvasView();
+      expect(view.x).toBeCloseTo(expected.x, 3);
+      expect(view.y).toBeCloseTo(expected.y, 3);
+      expect(view.scale).toBeCloseTo(expected.scale, 6);
+    });
+    // The body is back in the window, so nothing points at it any more.
+    expect(arrowFor(LOCAL_LABEL)).toBeNull();
+  });
+
+  it("names project suns in the Projects lens, with the sun's core standing in for an icon", async () => {
+    await renderMap("projects", [
+      thread("t1", "PwrSnap"),
+      thread("t2", "PwrAgent"),
+    ]);
+    await waitFor(() => {
+      expect(document.querySelector(".star-map-project")).not.toBeNull();
+    });
+    // Every project sits near the galactic core the map opens on; drag
+    // the whole galaxy off to the right so the suns leave through the
+    // right side of the window. The clamp bounds the pan, but it only ever
+    // has to clear the window.
+    pan(1500, 0);
+
+    const projectArrows = arrowButtons().filter((button) =>
+      /^Fly to (PwrSnap|PwrAgent)$/.test(button.getAttribute("aria-label") ?? ""),
+    );
+    expect(projectArrows.length).toBeGreaterThan(0);
+    for (const button of projectArrows) {
+      expect(button.className).toContain("star-map__edge-arrow--right");
+      expect(button.querySelector(".star-map__edge-arrow-core")).not.toBeNull();
+      expect(button.querySelector(".star-map__edge-arrow-icon")).toBeNull();
+    }
+    // Instances are not bodies in this lens, so nothing points at one.
+    expect(arrowFor(LOCAL_LABEL)).toBeNull();
+    expect(arrowFor(PEER_LABEL)).toBeNull();
+  });
+
+  it("keeps the overlay out of the tree while every body is in the window", async () => {
+    await renderMap("orbit", [thread("t1", "PwrSnap")]);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+    });
+    // The peer may or may not fit at the opening zoom depending on the
+    // ring layout; fly both into the window by zooming far out first.
+    fireEvent.wheel(viewport(), { ctrlKey: true, deltaY: 600, clientX: 640, clientY: 400 });
+    fireEvent.wheel(viewport(), { ctrlKey: true, deltaY: 600, clientX: 640, clientY: 400 });
+    await waitFor(() => {
+      expect(arrowButtons()).toHaveLength(0);
+    });
+    expect(screen.queryByRole("group", { name: "Off-screen bodies" })).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -477,7 +477,9 @@ describe("star map view stability", () => {
       threads: [...kept, ...threadsIn("PwrAgent", 3)],
     });
     await waitFor(() => {
-      expect(screen.getByText("PwrAgent")).toBeTruthy();
+      // Possibly twice: the lighter project seats off-screen at the
+      // opening view, so its edge arrow names it as well as its sun.
+      expect(screen.getAllByText("PwrAgent").length).toBeGreaterThan(0);
     });
 
     pan(-300, -200);
@@ -496,7 +498,7 @@ describe("star map view stability", () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText("PwrAgent")).toBeNull();
+      expect(screen.queryAllByText("PwrAgent")).toHaveLength(0);
     });
 
     // Precondition: the surviving body really did move on the canvas. Only

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -182,8 +182,17 @@ function projectCanvasPosition(project: string): { x: number; y: number } {
   };
 }
 
+/**
+ * A project's sun, by name.
+ *
+ * Scoped to the canvas: the edge-arrow overlay is a sibling of it and
+ * names every project currently off-screen, so an unscoped `getByText`
+ * throws "Found multiple elements" as soon as a pan takes this project's
+ * sun out of the window — turning a geometry assertion into an unrelated
+ * query error.
+ */
 function projectBody(project: string): HTMLElement {
-  const body = screen
+  const body = within(canvas())
     .getByText(project)
     .closest(".star-map__project-cloud") as HTMLElement | null;
   if (!body) throw new Error(`no project cloud around ${project}`);
@@ -477,9 +486,10 @@ describe("star map view stability", () => {
       threads: [...kept, ...threadsIn("PwrAgent", 3)],
     });
     await waitFor(() => {
-      // Possibly twice: the lighter project seats off-screen at the
-      // opening view, so its edge arrow names it as well as its sun.
-      expect(screen.getAllByText("PwrAgent").length).toBeGreaterThan(0);
+      // The SUN, not merely the name: the lighter project seats
+      // off-screen at the opening view, so its edge arrow names it too,
+      // and this barrier is what a geometry measurement below depends on.
+      expect(within(canvas()).getAllByText("PwrAgent")).toHaveLength(1);
     });
 
     pan(-300, -200);

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-edge-arrows.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-edge-arrows.ts
@@ -1,0 +1,319 @@
+/**
+ * Edge arrows: where the rest of the map is.
+ *
+ * The pan clamp keeps a strip of canvas in the window, but a strip of
+ * canvas is not a body. The operator can park the window on empty sky
+ * between two clouds with every instance off-screen and nothing to say
+ * which way to drag — the map is recoverable, it just gives no hint. So
+ * for every body the window is not showing, the screen draws a pointer
+ * on the edge of the window where a line from the middle of the window
+ * to that body would leave it, turned to the bearing of that line. A pan
+ * that swings the body round swings its arrow round the edge with it; a
+ * pan toward it walks the arrow inward until the body itself comes on
+ * and the arrow goes away. Clicking one flies the camera there.
+ *
+ * Everything here is pure: the component owns the DOM and the timing,
+ * this owns the rules. Coordinates are the ones the rest of the view
+ * geometry speaks — canvas units for a target, viewport pixels for
+ * everything returned.
+ */
+
+import type { StarMapView, StarMapViewBox } from "./star-map-view-geometry";
+
+export type StarMapEdge = "top" | "right" | "bottom" | "left";
+
+export type StarMapEdgeInset = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+/**
+ * How far in from the window the arrows sit, per side — the "rail" they
+ * ride along.
+ *
+ * The top is deeper than the rest because the top of the map is not sky.
+ * The top band (wordmark, Find, View, the filter chips) owns the first
+ * ~40px, and on macOS the window's glass drag strip covers 52px: an arrow
+ * drawn under either is an arrow nobody can click. The other three sides
+ * only clear the window edge by enough to read as "at the edge" rather
+ * than "cut off by it"; the bottom matches the key hint's own inset so the
+ * two line up when they share the row.
+ */
+export const STAR_MAP_EDGE_INSET: StarMapEdgeInset = {
+  top: 56,
+  right: 16,
+  bottom: 18,
+  left: 16,
+};
+
+/**
+ * The label pill's height, in viewport px — a filter chip's height,
+ * because it is drawn with the chip's tokens. Used here only to keep the
+ * pill inside the rail and to keep two pills off each other; the CSS owns
+ * the real box.
+ */
+export const STAR_MAP_EDGE_LABEL_HEIGHT = 25;
+
+/** The pill's `max-width` in CSS; a longer name is ellipsised inside it. */
+export const STAR_MAP_EDGE_LABEL_MAX_WIDTH = 180;
+
+/**
+ * Head glyph plus the gap between it and the pill, measured inward from
+ * the rail along the edge's normal. The glyph's tip sits ON the rail and
+ * the pill hangs off the glyph's inner side, so this is how far in the
+ * pill's near edge lands. Mirrors `.star-map__edge-arrow` (18px head +
+ * 4px gap).
+ */
+export const STAR_MAP_EDGE_HEAD_SPAN = 22;
+
+/** Clear space demanded between two pills before the farther one is dropped. */
+const LABEL_CLEARANCE = 6;
+
+/** What a target must carry: a point on the canvas and a stable identity. */
+export type StarMapEdgeTarget = {
+  key: string;
+  /** Canvas-space point the arrow aims at — the body's centre. */
+  x: number;
+  y: number;
+  /**
+   * Estimated width of this target's pill. Arrows are culled nearest-first
+   * by whether their pills would overlap, so this decides how tightly two
+   * arrows on one edge can pack. Absent, the pill is assumed to be as wide
+   * as it can be, which over-culls and never overdraws.
+   */
+  labelWidth?: number;
+};
+
+export type StarMapEdgeArrow<T extends StarMapEdgeTarget = StarMapEdgeTarget> = {
+  target: T;
+  /** Which side of the rail the arrow sits on. */
+  edge: StarMapEdge;
+  /** Where the glyph's tip sits, in viewport pixels: on the rail. */
+  x: number;
+  y: number;
+  /**
+   * Bearing from the middle of the window to the target, in degrees,
+   * clockwise from +x the way CSS `rotate()` reads them (the screen's y
+   * points down). 0 is straight right, -90 straight up.
+   */
+  angle: number;
+  /** Viewport-pixel distance from the middle of the window to the target. */
+  distance: number;
+  /**
+   * How far the pill is slid along its edge, away from the glyph, to stay
+   * inside the rail. Zero except near a corner, where a pill centred on
+   * the glyph would hang out of the window.
+   */
+  labelShift: number;
+};
+
+/**
+ * Roughly how wide a pill will draw for a label.
+ *
+ * 11px text in the UI sans averages a little over 6px a glyph; the
+ * estimate rounds up on purpose. Over-estimating drops an arrow that
+ * would have fitted, under-estimating draws two pills on top of each
+ * other, and only one of those is a bug you can see. Padding, icon and
+ * gap mirror the pill's CSS.
+ */
+export function estimateStarMapEdgeLabelWidth(
+  label: string,
+  options?: { icon?: boolean },
+): number {
+  const padding = 20;
+  const icon = options?.icon ? 20 : 0;
+  return Math.min(
+    STAR_MAP_EDGE_LABEL_MAX_WIDTH,
+    padding + icon + label.length * 6.4,
+  );
+}
+
+type Rail = { left: number; top: number; right: number; bottom: number };
+
+type Box = { left: number; top: number; right: number; bottom: number };
+
+function clamp(value: number, min: number, max: number): number {
+  // A pill wider than the rail has no legal position; the middle is the
+  // least wrong one.
+  if (min > max) return (min + max) / 2;
+  return Math.min(Math.max(value, min), max);
+}
+
+function boxesCollide(a: Box, b: Box): boolean {
+  return (
+    a.left < b.right + LABEL_CLEARANCE
+    && b.left < a.right + LABEL_CLEARANCE
+    && a.top < b.bottom + LABEL_CLEARANCE
+    && b.top < a.bottom + LABEL_CLEARANCE
+  );
+}
+
+/**
+ * The arrows to draw for a view.
+ *
+ * For each target outside the WINDOW — not outside the rail: a body under
+ * the top band is still a body the operator can see — cast a ray from the
+ * middle of the window through the target and take the point where it
+ * leaves the rail. That point is the arrow; the ray's bearing is its
+ * angle. Then place nearest-first, and drop any arrow whose pill would
+ * land on one already placed, on any edge: two bodies in nearly the same
+ * direction share one arrow — the nearer — rather than two unreadable
+ * ones, and a pill sliding into a corner cannot cover the pill that
+ * arrived from the adjacent edge.
+ */
+export function computeStarMapEdgeArrows<T extends StarMapEdgeTarget>(params: {
+  targets: readonly T[];
+  view: StarMapView;
+  viewport: StarMapViewBox;
+  inset?: StarMapEdgeInset;
+}): StarMapEdgeArrow<T>[] {
+  const { view, viewport } = params;
+  if (!(viewport.width > 0) || !(viewport.height > 0)) return [];
+  const inset = params.inset ?? STAR_MAP_EDGE_INSET;
+  let rail: Rail = {
+    left: inset.left,
+    top: inset.top,
+    right: viewport.width - inset.right,
+    bottom: viewport.height - inset.bottom,
+  };
+  // A window too small for its insets has no rail; the window's own edges
+  // are better than none.
+  if (rail.right <= rail.left || rail.bottom <= rail.top) {
+    rail = { left: 0, top: 0, right: viewport.width, bottom: viewport.height };
+  }
+  // The ray leaves from the middle of the window. Clamped into the rail so
+  // the exit below is always ahead of the source — only a window shorter
+  // than the top inset can put the middle outside it.
+  const sourceX = clamp(viewport.width / 2, rail.left, rail.right);
+  const sourceY = clamp(viewport.height / 2, rail.top, rail.bottom);
+
+  type Candidate = Omit<StarMapEdgeArrow<T>, "labelShift">;
+  const candidates: Candidate[] = [];
+  for (const target of params.targets) {
+    // `transform-origin: 0 0`, so a canvas point paints at
+    // `point * scale + view` — the same mapping as `isPointInView`.
+    const screenX = target.x * view.scale + view.x;
+    const screenY = target.y * view.scale + view.y;
+    if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) continue;
+    if (
+      screenX >= 0
+      && screenX <= viewport.width
+      && screenY >= 0
+      && screenY <= viewport.height
+    ) {
+      continue;
+    }
+    const dx = screenX - sourceX;
+    const dy = screenY - sourceY;
+    const distance = Math.hypot(dx, dy);
+    if (!(distance > 0)) continue;
+    // The exit is the nearest rail side ahead of the ray: the smallest
+    // positive multiple of the direction that lands on a side. Only the
+    // side the ray is heading for on each axis can be ahead of it. The
+    // source is inside the rail, so at least one side is.
+    let t = Number.POSITIVE_INFINITY;
+    let edge: StarMapEdge = "right";
+    if (dx > 0) {
+      const tx = (rail.right - sourceX) / dx;
+      if (tx < t) {
+        t = tx;
+        edge = "right";
+      }
+    } else if (dx < 0) {
+      const tx = (rail.left - sourceX) / dx;
+      if (tx < t) {
+        t = tx;
+        edge = "left";
+      }
+    }
+    if (dy > 0) {
+      const ty = (rail.bottom - sourceY) / dy;
+      if (ty < t) {
+        t = ty;
+        edge = "bottom";
+      }
+    } else if (dy < 0) {
+      const ty = (rail.top - sourceY) / dy;
+      if (ty < t) {
+        t = ty;
+        edge = "top";
+      }
+    }
+    if (!Number.isFinite(t)) continue;
+    candidates.push({
+      target,
+      edge,
+      x: sourceX + dx * t,
+      y: sourceY + dy * t,
+      angle: (Math.atan2(dy, dx) * 180) / Math.PI,
+      distance,
+    });
+  }
+
+  // Nearest first, and a stable tie-break so two bodies at one distance do
+  // not trade places between frames.
+  candidates.sort(
+    (left, right) =>
+      left.distance - right.distance
+      || (left.target.key < right.target.key
+        ? -1
+        : left.target.key > right.target.key
+          ? 1
+          : 0),
+  );
+
+  const placed: Box[] = [];
+  const arrows: StarMapEdgeArrow<T>[] = [];
+  for (const candidate of candidates) {
+    const width = Math.min(
+      STAR_MAP_EDGE_LABEL_MAX_WIDTH,
+      candidate.target.labelWidth ?? STAR_MAP_EDGE_LABEL_MAX_WIDTH,
+    );
+    const halfWidth = width / 2;
+    const halfHeight = STAR_MAP_EDGE_LABEL_HEIGHT / 2;
+    let labelShift: number;
+    let box: Box;
+    if (candidate.edge === "left" || candidate.edge === "right") {
+      const centerY = clamp(
+        candidate.y,
+        rail.top + halfHeight,
+        rail.bottom - halfHeight,
+      );
+      labelShift = centerY - candidate.y;
+      const inner =
+        candidate.edge === "right"
+          ? candidate.x - STAR_MAP_EDGE_HEAD_SPAN
+          : candidate.x + STAR_MAP_EDGE_HEAD_SPAN;
+      box = {
+        left: candidate.edge === "right" ? inner - width : inner,
+        right: candidate.edge === "right" ? inner : inner + width,
+        top: centerY - halfHeight,
+        bottom: centerY + halfHeight,
+      };
+    } else {
+      const centerX = clamp(
+        candidate.x,
+        rail.left + halfWidth,
+        rail.right - halfWidth,
+      );
+      labelShift = centerX - candidate.x;
+      const inner =
+        candidate.edge === "bottom"
+          ? candidate.y - STAR_MAP_EDGE_HEAD_SPAN
+          : candidate.y + STAR_MAP_EDGE_HEAD_SPAN;
+      box = {
+        left: centerX - halfWidth,
+        right: centerX + halfWidth,
+        top: candidate.edge === "bottom" ? inner - STAR_MAP_EDGE_LABEL_HEIGHT : inner,
+        bottom:
+          candidate.edge === "bottom" ? inner : inner + STAR_MAP_EDGE_LABEL_HEIGHT,
+      };
+    }
+    if (placed.some((other) => boxesCollide(other, box))) continue;
+    placed.push(box);
+    arrows.push({ ...candidate, labelShift });
+  }
+  return arrows;
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-edge-arrows.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-edge-arrows.ts
@@ -61,15 +61,61 @@ export const STAR_MAP_EDGE_LABEL_MAX_WIDTH = 180;
 
 /**
  * Head glyph plus the gap between it and the pill, measured inward from
- * the rail along the edge's normal. The glyph's tip sits ON the rail and
- * the pill hangs off the glyph's inner side, so this is how far in the
+ * the rail along the edge's normal. The glyph's OUTER EDGE sits on the
+ * rail and the pill hangs off its inner side, so this is how far in the
  * pill's near edge lands. Mirrors `.star-map__edge-arrow` (18px head +
  * 4px gap).
+ *
+ * The drawn tip lands a few pixels inside the rail rather than exactly on
+ * it — the glyph is centred 9px in and its tip is 7px from that centre,
+ * so the tip's inset varies between 3px and 8.5px as the dart rotates.
+ * That is inherent to rotating a glyph about a fixed point and is well
+ * inside the rail's own inset; it is recorded here so nobody re-derives
+ * the constant from a "tip exactly on the rail" reading that was never
+ * true.
  */
 export const STAR_MAP_EDGE_HEAD_SPAN = 22;
 
+/**
+ * Half-extent of a body's drawing, in CANVAS units.
+ *
+ * An arrow points at a body's centre, but a body is not a point: the hub
+ * instance draws a 116px disc with a glow reaching 72px from centre and a
+ * label pill hanging 73px below it. Culling on the bare centre therefore
+ * calls a body off-screen while half of it is still in the window, and
+ * the arrow is then drawn ON TOP of the body it points at — the dart
+ * lands on the instance's own name pill.
+ *
+ * Worse, culling runs nearest-first: a straddling body is the nearest
+ * candidate, so it is placed first and suppresses the arrow for a body
+ * that really is invisible. That is the failure the feature exists to
+ * prevent, caused by the feature itself.
+ *
+ * Sized to the largest body (the hub's 73px column half-height) so no
+ * body is ever arrowed while a pixel of it is on screen. Erring large is
+ * free: it only delays the arrow until the body has fully left.
+ */
+export const STAR_MAP_EDGE_BODY_HALF_EXTENT = 74;
+
 /** Clear space demanded between two pills before the farther one is dropped. */
 const LABEL_CLEARANCE = 6;
+
+/**
+ * A screen-space rectangle an arrow must not be drawn under.
+ *
+ * The map's own always-on readouts — the camera key hint bottom-left, the
+ * selection bar bottom-centre — sit at a HIGHER layer than the arrows and
+ * are translucent, so an arrow underneath one is a smudge behind the WASD
+ * caps rather than a pointer. The rail's top inset already reserves room
+ * for the top band; these are the same problem on the other three sides,
+ * and they move, so they are passed in rather than baked into an inset.
+ */
+export type StarMapEdgeObstacle = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
 
 /** What a target must carry: a point on the canvas and a stable identity. */
 export type StarMapEdgeTarget = {
@@ -90,7 +136,10 @@ export type StarMapEdgeArrow<T extends StarMapEdgeTarget = StarMapEdgeTarget> = 
   target: T;
   /** Which side of the rail the arrow sits on. */
   edge: StarMapEdge;
-  /** Where the glyph's tip sits, in viewport pixels: on the rail. */
+  /**
+   * The arrow's point on the rail, in viewport pixels: where the ray
+   * leaves it, and where the head glyph's outer edge is placed.
+   */
   x: number;
   y: number;
   /**
@@ -110,23 +159,75 @@ export type StarMapEdgeArrow<T extends StarMapEdgeTarget = StarMapEdgeTarget> = 
 };
 
 /**
+ * Advance width of one character at the pill's 11px / weight 500, in px.
+ *
+ * Per character class rather than one average, because the classes are
+ * far apart and instance labels are hostnames — the case a flat average
+ * is worst at. Measured against the rendered pill: lowercase runs ~5.8,
+ * uppercase and digits 7.3-7.9, and a CJK or otherwise full-width glyph
+ * is about one em, which is font-independent. A flat 6.4 under-measured
+ * `WIN-EC2-SANDBOX` by 15px and a seven-character CJK label by 31px —
+ * five times the clearance the culler works with.
+ *
+ * Every class rounds UP, which is the direction that matters: see
+ * `estimateStarMapEdgeLabelWidth`.
+ */
+function glyphAdvance(codePoint: number): number {
+  // The CJK/Hangul/Kana blocks plus the full-width forms — everything the
+  // Unicode east-asian-width tables call W or F, coarsely. A codepoint
+  // above the BMP is either an emoji or a rare ideograph; both draw wide.
+  if (
+    (codePoint >= 0x1100 && codePoint <= 0x115f)
+    || (codePoint >= 0x2e80 && codePoint <= 0xa4cf)
+    || (codePoint >= 0xac00 && codePoint <= 0xd7a3)
+    || (codePoint >= 0xf900 && codePoint <= 0xfaff)
+    || (codePoint >= 0xfe30 && codePoint <= 0xfe6f)
+    || (codePoint >= 0xff00 && codePoint <= 0xff60)
+    || (codePoint >= 0xffe0 && codePoint <= 0xffe6)
+    || codePoint > 0xffff
+  ) {
+    return 11.5;
+  }
+  // Uppercase and digits. `-`, `.` and `/` are narrow and fall through to
+  // the lowercase figure, which over-counts them — deliberately.
+  if (
+    (codePoint >= 0x41 && codePoint <= 0x5a)
+    || (codePoint >= 0x30 && codePoint <= 0x39)
+  ) {
+    return 8;
+  }
+  return 6.6;
+}
+
+/**
  * Roughly how wide a pill will draw for a label.
  *
- * 11px text in the UI sans averages a little over 6px a glyph; the
- * estimate rounds up on purpose. Over-estimating drops an arrow that
- * would have fitted, under-estimating draws two pills on top of each
- * other, and only one of those is a bug you can see. Padding, icon and
- * gap mirror the pill's CSS.
+ * The estimate rounds up on purpose. Over-estimating drops an arrow that
+ * would have fitted; under-estimating draws two pills on top of each
+ * other, and only one of those is a bug you can see. Padding, border,
+ * icon and gap mirror the pill's CSS — the border counts because the
+ * renderer is `box-sizing: border-box` throughout, so the 1px on each
+ * side is part of the width the culler has to reason about.
+ *
+ * Capped at the pill's own `max-width`: past that the label ellipsises
+ * rather than growing, so a longer name is not a wider box.
  */
 export function estimateStarMapEdgeLabelWidth(
   label: string,
   options?: { icon?: boolean },
 ): number {
   const padding = 20;
+  const border = 2;
   const icon = options?.icon ? 20 : 0;
+  let text = 0;
+  // Iterated by code POINT: a surrogate pair is one wide glyph, and
+  // `label.length` would count it as two narrow ones.
+  for (const character of label) {
+    text += glyphAdvance(character.codePointAt(0) ?? 0);
+  }
   return Math.min(
     STAR_MAP_EDGE_LABEL_MAX_WIDTH,
-    padding + icon + label.length * 6.4,
+    padding + border + icon + text,
   );
 }
 
@@ -139,6 +240,69 @@ function clamp(value: number, min: number, max: number): number {
   // least wrong one.
   if (min > max) return (min + max) / 2;
   return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Slide a pill along its edge until it clears the map's own readouts.
+ *
+ * Slide rather than drop: an arrow that gives way to the key hint has
+ * stopped doing its one job, and the operator is left with no cue for a
+ * body they cannot see. Moving it a few tens of pixels along the same
+ * edge keeps the cue and costs only that the dart no longer sits at the
+ * pill's middle — which is already true near every corner, and is what
+ * `labelShift` exists to express.
+ *
+ * Two passes, because clearing one readout can slide a pill into the
+ * next; two is enough for the map's two, and a fixed bound cannot loop.
+ * If neither side of an obstacle fits inside the rail the pill stays put
+ * — a partly-covered arrow still beats no arrow.
+ */
+function slideClearOfObstacles(params: {
+  /** Current pill centre along the edge's free axis. */
+  center: number;
+  /** Half the pill's extent along that axis. */
+  half: number;
+  /** The pill's fixed span on the other axis. */
+  crossMin: number;
+  crossMax: number;
+  railMin: number;
+  railMax: number;
+  /** True when the free axis is x (the top and bottom edges). */
+  horizontal: boolean;
+  obstacles: readonly StarMapEdgeObstacle[];
+}): number {
+  if (params.obstacles.length === 0) return params.center;
+  let center = params.center;
+  for (let pass = 0; pass < 2; pass += 1) {
+    let moved = false;
+    for (const obstacle of params.obstacles) {
+      const crossMin = params.horizontal ? obstacle.top : obstacle.left;
+      const crossMax = params.horizontal ? obstacle.bottom : obstacle.right;
+      // Clear on the fixed axis: this obstacle cannot cover this edge.
+      if (crossMax <= params.crossMin || crossMin >= params.crossMax) continue;
+      const obstacleMin = params.horizontal ? obstacle.left : obstacle.top;
+      const obstacleMax = params.horizontal ? obstacle.right : obstacle.bottom;
+      if (obstacleMax <= center - params.half) continue;
+      if (obstacleMin >= center + params.half) continue;
+      const before = obstacleMin - params.half - LABEL_CLEARANCE;
+      const after = obstacleMax + params.half + LABEL_CLEARANCE;
+      const beforeFits = before - params.half >= params.railMin;
+      const afterFits = after + params.half <= params.railMax;
+      const preferBefore =
+        beforeFits
+        && (!afterFits
+          || Math.abs(before - center) <= Math.abs(after - center));
+      if (preferBefore) {
+        center = before;
+        moved = true;
+      } else if (afterFits) {
+        center = after;
+        moved = true;
+      }
+    }
+    if (!moved) break;
+  }
+  return clamp(center, params.railMin + params.half, params.railMax - params.half);
 }
 
 function boxesCollide(a: Box, b: Box): boolean {
@@ -168,6 +332,12 @@ export function computeStarMapEdgeArrows<T extends StarMapEdgeTarget>(params: {
   view: StarMapView;
   viewport: StarMapViewBox;
   inset?: StarMapEdgeInset;
+  /**
+   * Screen-space rects the map's own readouts occupy. A pill that would
+   * land on one slides along its edge to clear it rather than being drawn
+   * underneath it.
+   */
+  obstacles?: readonly StarMapEdgeObstacle[];
 }): StarMapEdgeArrow<T>[] {
   const { view, viewport } = params;
   if (!(viewport.width > 0) || !(viewport.height > 0)) return [];
@@ -188,6 +358,7 @@ export function computeStarMapEdgeArrows<T extends StarMapEdgeTarget>(params: {
   // than the top inset can put the middle outside it.
   const sourceX = clamp(viewport.width / 2, rail.left, rail.right);
   const sourceY = clamp(viewport.height / 2, rail.top, rail.bottom);
+  const obstacles = params.obstacles ?? [];
 
   type Candidate = Omit<StarMapEdgeArrow<T>, "labelShift">;
   const candidates: Candidate[] = [];
@@ -197,11 +368,15 @@ export function computeStarMapEdgeArrows<T extends StarMapEdgeTarget>(params: {
     const screenX = target.x * view.scale + view.x;
     const screenY = target.y * view.scale + view.y;
     if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) continue;
+    // The body's DRAWING, not its centre: a body is arrowed only once
+    // every pixel of it has left the window. The half-extent is in canvas
+    // units, so it scales with the zoom exactly as the body does.
+    const bodyMargin = STAR_MAP_EDGE_BODY_HALF_EXTENT * view.scale;
     if (
-      screenX >= 0
-      && screenX <= viewport.width
-      && screenY >= 0
-      && screenY <= viewport.height
+      screenX >= -bodyMargin
+      && screenX <= viewport.width + bodyMargin
+      && screenY >= -bodyMargin
+      && screenY <= viewport.height + bodyMargin
     ) {
       continue;
     }
@@ -276,39 +451,62 @@ export function computeStarMapEdgeArrows<T extends StarMapEdgeTarget>(params: {
     let labelShift: number;
     let box: Box;
     if (candidate.edge === "left" || candidate.edge === "right") {
-      const centerY = clamp(
-        candidate.y,
-        rail.top + halfHeight,
-        rail.bottom - halfHeight,
-      );
-      labelShift = centerY - candidate.y;
       const inner =
         candidate.edge === "right"
           ? candidate.x - STAR_MAP_EDGE_HEAD_SPAN
           : candidate.x + STAR_MAP_EDGE_HEAD_SPAN;
+      const left = candidate.edge === "right" ? inner - width : inner;
+      const right = candidate.edge === "right" ? inner : inner + width;
+      const centerY = slideClearOfObstacles({
+        center: clamp(
+          candidate.y,
+          rail.top + halfHeight,
+          rail.bottom - halfHeight,
+        ),
+        crossMax: right,
+        crossMin: left,
+        half: halfHeight,
+        horizontal: false,
+        obstacles,
+        railMax: rail.bottom,
+        railMin: rail.top,
+      });
+      labelShift = centerY - candidate.y;
       box = {
-        left: candidate.edge === "right" ? inner - width : inner,
-        right: candidate.edge === "right" ? inner : inner + width,
+        left,
+        right,
         top: centerY - halfHeight,
         bottom: centerY + halfHeight,
       };
     } else {
-      const centerX = clamp(
-        candidate.x,
-        rail.left + halfWidth,
-        rail.right - halfWidth,
-      );
-      labelShift = centerX - candidate.x;
       const inner =
         candidate.edge === "bottom"
           ? candidate.y - STAR_MAP_EDGE_HEAD_SPAN
           : candidate.y + STAR_MAP_EDGE_HEAD_SPAN;
+      const top =
+        candidate.edge === "bottom" ? inner - STAR_MAP_EDGE_LABEL_HEIGHT : inner;
+      const bottom =
+        candidate.edge === "bottom" ? inner : inner + STAR_MAP_EDGE_LABEL_HEIGHT;
+      const centerX = slideClearOfObstacles({
+        center: clamp(
+          candidate.x,
+          rail.left + halfWidth,
+          rail.right - halfWidth,
+        ),
+        crossMax: bottom,
+        crossMin: top,
+        half: halfWidth,
+        horizontal: true,
+        obstacles,
+        railMax: rail.right,
+        railMin: rail.left,
+      });
+      labelShift = centerX - candidate.x;
       box = {
         left: centerX - halfWidth,
         right: centerX + halfWidth,
-        top: candidate.edge === "bottom" ? inner - STAR_MAP_EDGE_LABEL_HEIGHT : inner,
-        bottom:
-          candidate.edge === "bottom" ? inner : inner + STAR_MAP_EDGE_LABEL_HEIGHT,
+        top,
+        bottom,
       };
     }
     if (placed.some((other) => boxesCollide(other, box))) continue;

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-flight.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-flight.ts
@@ -72,14 +72,31 @@ export function starMapViewFocusedOn(params: {
   canvas: StarMapViewBox;
   viewport: StarMapViewBox;
   scale: number;
+  /**
+   * A column lens, whose canvas hangs from a fixed top edge.
+   *
+   * Centring the y of something near the TOP of such a canvas puts the
+   * canvas origin below the window's, i.e. opens a band of empty sky
+   * above the lane headers with the columns shoved down — the state
+   * `placeStarMapView`'s own `topAnchored` exists to prevent. Lanes seats
+   * every instance body on one fixed row at y=190, so flying to a body
+   * there hits it every single time: ~210px of sky at 1:1, more as the
+   * zoom drops, recoverable only through "Reset view".
+   *
+   * A cap rather than a pin, unlike placement: a flight to a card deep in
+   * a column legitimately wants a negative y, and forcing zero would
+   * simply not travel there.
+   */
+  topAnchored?: boolean;
 }): StarMapView {
   const scale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, params.scale));
   const centerX = params.rect.x + params.rect.width / 2;
   const centerY = params.rect.y + params.rect.height / 2;
+  const y = params.viewport.height / 2 - centerY * scale;
   return clampStarMapView({
     view: {
       x: params.viewport.width / 2 - centerX * scale,
-      y: params.viewport.height / 2 - centerY * scale,
+      y: params.topAnchored ? Math.min(0, y) : y,
       scale,
     },
     canvas: params.canvas,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -351,6 +351,11 @@ describe("Tangerine Terminal theme contract", () => {
       // Geometry, not theme.
       "star-map-sky-x",
       "star-map-sky-y",
+      // Star Map edge arrows — the ray's bearing and the pill's slide along
+      // its edge, registered with `@property` and written inline per arrow
+      // by the overlay on every painted frame. Geometry, not theme.
+      "star-map-edge-angle",
+      "star-map-edge-shift",
     ]);
     const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
       ([, token]) => token

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12265,6 +12265,189 @@ textarea,
   letter-spacing: 0.04em;
 }
 
+/* Edge arrows: pointers on the window edge to every body the window is
+   not showing, turned to the bearing of the body and clickable to fly
+   there. Screen-space, so they sit beside the viewport rather than in the
+   canvas; the geometry (which edge, where on it, the angle) is
+   `star-map-edge-arrows.ts`, and the overlay re-renders on every painted
+   frame of a gesture so the arrows slide with the map.
+
+   Layered at 3: above the window's glass drag strip (2) so an arrow near
+   the top paints crisp, below the top band (4) and every readout (8+) so
+   chrome always wins a collision — the arrows are wayfinding, the chrome
+   is the controls. The rail insets in the geometry keep them out of the
+   band in the first place. */
+.star-map__edge-arrows {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+/* Per-arrow geometry, written inline on each button by the overlay: the
+   ray's bearing and the pill's slide along its edge. Registered so an
+   arrow always has a typed, valid value to transform by, and — unlike the
+   sky's parallax offset — INHERITED on purpose: the button sets them and
+   the head inside it reads them, and a non-inherited property would hand
+   the head the initial value instead. A button has a handful of
+   descendants, so the inheritance costs nothing worth avoiding. */
+@property --star-map-edge-angle {
+  syntax: "<angle>";
+  inherits: true;
+  initial-value: 0deg;
+}
+
+@property --star-map-edge-shift {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+/* The button IS the label pill — the `.star-map__filter-chip` tokens, so
+   the edge reads as one family with the top band — and the head hangs
+   off it, back at the rail point. `left`/`top` are the TIP of the head;
+   the per-edge transforms below pull the pill inward by the head span
+   (18px glyph + 4px gap, `STAR_MAP_EDGE_HEAD_SPAN`) and slide it along
+   the edge by `--star-map-edge-shift`, which the geometry sets only when
+   a pill centred on the head would hang out of a corner. */
+.star-map__edge-arrow {
+  display: inline-flex;
+  position: absolute;
+  align-items: center;
+  gap: 6px;
+  max-width: 180px;
+  height: 25px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-panel) 82%, transparent);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+  transition: border-color 90ms ease, color 90ms ease, background 90ms ease;
+}
+
+.star-map__edge-arrow--right {
+  transform: translate(calc(-100% - 22px), calc(-50% + var(--star-map-edge-shift)));
+}
+
+.star-map__edge-arrow--left {
+  transform: translate(22px, calc(-50% + var(--star-map-edge-shift)));
+}
+
+.star-map__edge-arrow--top {
+  transform: translate(calc(-50% + var(--star-map-edge-shift)), 22px);
+}
+
+.star-map__edge-arrow--bottom {
+  transform: translate(calc(-50% + var(--star-map-edge-shift)), calc(-100% - 22px));
+}
+
+.star-map__edge-arrow:hover {
+  border-color: var(--accent-border);
+  background: color-mix(in srgb, var(--bg-panel) 94%, transparent);
+  color: var(--text-primary);
+}
+
+.star-map__edge-arrow:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+/* The dart. Centred on the rail point (it undoes the pill's corner slide)
+   and turned along the ray, so its tip touches the rail and its tail
+   points back toward the middle of the window. The glow is what makes it
+   read as a signal on the sky rather than a chip's corner. */
+.star-map__edge-arrow-head {
+  display: block;
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  color: var(--accent);
+  filter: drop-shadow(0 0 4px var(--accent-shadow));
+  transition: color 90ms ease;
+}
+
+.star-map__edge-arrow-head svg {
+  display: block;
+  fill: currentColor;
+}
+
+.star-map__edge-arrow--right .star-map__edge-arrow-head {
+  top: 50%;
+  left: calc(100% + 4px);
+  transform: translate(0, calc(-50% - var(--star-map-edge-shift))) rotate(var(--star-map-edge-angle));
+}
+
+.star-map__edge-arrow--left .star-map__edge-arrow-head {
+  top: 50%;
+  right: calc(100% + 4px);
+  transform: translate(0, calc(-50% - var(--star-map-edge-shift))) rotate(var(--star-map-edge-angle));
+}
+
+.star-map__edge-arrow--top .star-map__edge-arrow-head {
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translate(calc(-50% - var(--star-map-edge-shift)), 0) rotate(var(--star-map-edge-angle));
+}
+
+.star-map__edge-arrow--bottom .star-map__edge-arrow-head {
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translate(calc(-50% - var(--star-map-edge-shift)), 0) rotate(var(--star-map-edge-angle));
+}
+
+.star-map__edge-arrow:hover .star-map__edge-arrow-head {
+  color: var(--accent-bright);
+}
+
+.star-map__edge-arrow-icon {
+  flex: none;
+  color: var(--text-primary);
+}
+
+/* A project has no celestial icon; its sun's core stands in, at pill
+   scale — the same fill and ring as `.star-map-project__core`. */
+.star-map__edge-arrow-core {
+  flex: none;
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--accent-border);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.star-map__edge-arrow-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* An arrow arrives as its body leaves the window. A short fade, and only
+   a fade: the pill already carries a transform, and a body crossing the
+   edge mid-pan is not an event worth more than a blink. */
+@media (prefers-reduced-motion: no-preference) {
+  .star-map__edge-arrow {
+    animation: star-map-edge-arrow-in 160ms ease-out;
+  }
+}
+
+@keyframes star-map-edge-arrow-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 /* Alignment guides, drawn only while a card is being dragged. They exist
    so a snap is explainable: without the line, a card latching reads as the
    drag sticking for no reason. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12304,13 +12304,21 @@ textarea,
   initial-value: 0px;
 }
 
-/* The button IS the label pill — the `.star-map__filter-chip` tokens, so
-   the edge reads as one family with the top band — and the head hangs
-   off it, back at the rail point. `left`/`top` are the TIP of the head;
-   the per-edge transforms below pull the pill inward by the head span
-   (18px glyph + 4px gap, `STAR_MAP_EDGE_HEAD_SPAN`) and slide it along
-   the edge by `--star-map-edge-shift`, which the geometry sets only when
-   a pill centred on the head would hang out of a corner. */
+/* The button IS the label pill, built on `.star-map__filter-chip`'s shape
+   and tokens so the edge reads as one family with the top band, with two
+   deliberate departures: the surface is mixed at 82% rather than 75% and
+   the text is `--text-secondary` rather than `--text-muted`. A chip sits
+   inside the band, on the band's own ground; a pill sits alone on bare
+   sky, where the chip's values read as a smudge. Anything else here that
+   differs from the chip is drift, not intent — fix it toward the chip.
+
+   The head hangs off the pill, back at the rail point. `left`/`top` are
+   the arrow's point ON the rail; the per-edge transforms below pull the
+   pill inward by the head span (18px glyph + 4px gap,
+   `STAR_MAP_EDGE_HEAD_SPAN`) and slide it along the edge by
+   `--star-map-edge-shift`, which the geometry sets when a pill centred on
+   the head would hang out of a corner or land on one of the map's own
+   readouts. */
 .star-map__edge-arrow {
   display: inline-flex;
   position: absolute;
@@ -12383,25 +12391,33 @@ textarea,
 .star-map__edge-arrow--right .star-map__edge-arrow-head {
   top: 50%;
   left: calc(100% + 4px);
-  transform: translate(0, calc(-50% - var(--star-map-edge-shift))) rotate(var(--star-map-edge-angle));
+  transform:
+    translate(0, calc(-50% - var(--star-map-edge-shift)))
+    rotate(var(--star-map-edge-angle));
 }
 
 .star-map__edge-arrow--left .star-map__edge-arrow-head {
   top: 50%;
   right: calc(100% + 4px);
-  transform: translate(0, calc(-50% - var(--star-map-edge-shift))) rotate(var(--star-map-edge-angle));
+  transform:
+    translate(0, calc(-50% - var(--star-map-edge-shift)))
+    rotate(var(--star-map-edge-angle));
 }
 
 .star-map__edge-arrow--top .star-map__edge-arrow-head {
   bottom: calc(100% + 4px);
   left: 50%;
-  transform: translate(calc(-50% - var(--star-map-edge-shift)), 0) rotate(var(--star-map-edge-angle));
+  transform:
+    translate(calc(-50% - var(--star-map-edge-shift)), 0)
+    rotate(var(--star-map-edge-angle));
 }
 
 .star-map__edge-arrow--bottom .star-map__edge-arrow-head {
   top: calc(100% + 4px);
   left: 50%;
-  transform: translate(calc(-50% - var(--star-map-edge-shift)), 0) rotate(var(--star-map-edge-angle));
+  transform:
+    translate(calc(-50% - var(--star-map-edge-shift)), 0)
+    rotate(var(--star-map-edge-angle));
 }
 
 .star-map__edge-arrow:hover .star-map__edge-arrow-head {


### PR DESCRIPTION
## Summary

The Star Map lets you pan the fleet mostly off the window (the clamp keeps a 15% strip of canvas in view), but a strip of canvas is not a body — parked on empty sky between two clouds, nothing said which way anything was. This adds **edge arrows**: for every body the window is not showing, a pointer sits on the edge of the window where a line from the middle of the window to that body would leave it, turned to the bearing of that line. Pan and the arrows slide round the edge with the bodies; pan toward one and it walks inward until the body comes on and the arrow goes away. Click an arrow and the camera flies to the body.

- **Instances / Lanes lenses:** one arrow per off-screen instance body (celestial icon + disambiguated name).
- **Projects lens:** one arrow per off-screen project sun (sun core dot + project name).
- **Click:** flies there at the operator's *current* zoom (not the ⌘K 1:1 landing — a body is legible at every zoom, and someone zoomed out asked to be taken there, not zoomed in).

## How it works

- `star-map-edge-arrows.ts` — pure geometry, fully unit-tested. Maps each body through the view, skips anything inside the window, casts a ray from the viewport centre, intersects an inset **rail** (56px at the top to clear the band and the macOS glass drag strip; 16/18px elsewhere, so the bottom lines up with the key hint), and returns `{edge, x, y, angle, distance, labelShift}`. Placement is **nearest-first with estimated pill boxes**: two bodies in nearly the same direction share the nearer one's arrow rather than two unreadable ones, and a pill that would hang out of a corner slides along its edge (the dart stays on the ray) — including across the corner, so a top-rail pill can't cover a right-rail pill.
- `StarMapEdgeArrows.tsx` — the overlay. Drags, keyboard flights and ⌘K flights all paint the canvas transform by hand and commit to React only on landing, so an overlay fed from state would freeze through every gesture. The component reads the **live view** via `useSyncExternalStore`; `paintView` pings the subscribers on every frame, so the arrows and the canvas land in the same frame while only this dozen-node component re-renders.
- `StarMapScreen.tsx` — the listener set in `paintView`, a per-lens projection of bodies → targets, and the click flight (clears any pending ⌘K flight, claims the view for the operator, `flight.flyTo(starMapViewFocusedOn(...))`, so a mid-flight canvas re-base still corrects it like any other leg).
- `app.css` — the button *is* the label pill (filter-chip tokens, so the edge reads as one family with the top band); the dart is an accent-coloured glyph with a soft glow, rotated by `--star-map-edge-angle`; per-edge transforms pull the pill inward by the head span and slide it by `--star-map-edge-shift`. Both custom properties are `@property`-registered (inherited, since the head reads them). Layer 3: above the glass strip, below the band and every readout, so chrome always wins a collision. Entrance is a 160ms fade only, off under reduced motion.

## Test plan

- [x] `star-map-edge-arrows.test.ts` — 12 geometry tests: inside-window exclusion (inclusive edge), side selection + exit point + bearing, rail insets, view mapping (pan/zoom), nearest-first ordering, pill-box culling (incl. narrow-pill packing and the cross-edge corner case), corner slide, tie-break, unmeasured/too-small windows, label width estimate.
- [x] `star-map-edge-arrows.test.tsx` — 5 screen tests: a panned-out body gets an arrow on the side it left by at the geometry's exact position/angle; the arrow **moves on a held drag frame before pointerup** (live-view subscription); clicking flies to the body at the current zoom and the arrow disappears; Projects lens names suns with the core glyph and ignores instances; the overlay leaves the tree when everything is in view.
- [x] Two existing tests (`StarMapScreen.test.tsx` "hides offline instances", `star-map-view-stability.test.tsx` "archiving empties a project") used single-element `getByText` on a body name that the off-screen body's arrow now also carries → `getAllByText`.
- [x] Full `features/star-map/__tests__` directory: 41 files / 625 tests green. `styles/__tests__` (theme-contract incl. the new `localTokens` entries): green.
- [x] `typecheck`, `lint:eslint` (default + typed config) on the changed files, `lint:colors`: clean.
- [x] Headless-Chromium harness against the real `app.css` with arrows computed by the real geometry module at 1280×800 and 900×600 (spread fleet, corner crowd, corner slide): every pill inside the window and below the band, dart and pill both hit-test to their button, hover state reads; screenshots reviewed.
- [ ] Not run: the lab E2E / a11y gate (no local Electron suite per project rules). The a11y fixture audits the map at its opening view, where its single local body is on screen, so no arrows render in that scan; the arrows are 25px-tall `<button>`s with `aria-label="Fly to <name>"` inside a named `role="group"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
