### PR TITLE
feat(release): publish a stable-name Windows installer alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,6 +335,33 @@ jobs:
           node apps/desktop/scripts/release.mjs
           --win --sign-stage-only --no-publish --require-signing
 
+      # `/releases/latest/download/<name>` only resolves for a version-independent
+      # asset name. macOS publishes `PwrAgent.dmg` and Linux publishes
+      # `PwrAgent-linux-<arch>.deb`; this is the Windows equivalent. The copy has
+      # to happen after the packaging step above so the alias carries the same
+      # Authenticode signature as the installer it copies.
+      - name: Prepare stable-name Windows installer alias
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dist = "apps/desktop/release-stage/dist"
+          $versioned = Get-ChildItem -Path $dist -File -Filter "PwrAgent-*-windows-x64-setup.exe" |
+            Sort-Object -Property Name |
+            Select-Object -First 1
+          if (-not $versioned) {
+            throw "No versioned Windows installer found under $dist."
+          }
+          $aliasName = "PwrAgent-windows-x64-setup.exe"
+          $aliasPath = Join-Path $dist $aliasName
+          Copy-Item -LiteralPath $versioned.FullName -Destination $aliasPath -Force
+          # release.mjs wrote SHA256SUMS before this copy existed. Append the alias
+          # so the manifest names every published installer, the way the Linux
+          # manifest covers both the versioned package and its stable-name alias.
+          $digest = (Get-FileHash -Algorithm SHA256 -LiteralPath $aliasPath).Hash.ToLowerInvariant()
+          $manifest = Join-Path $dist "SHA256SUMS"
+          Add-Content -LiteralPath $manifest -Value "$digest  $aliasName`n" -NoNewline -Encoding ascii
+          Write-Host "alias: $aliasPath"
+
       - name: Upload Windows installer artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -178,7 +178,9 @@ seven job definitions (the Linux package job fans out across two architectures):
    --sign-stage-only --no-publish --require-signing`. The post-package ASAR
    verifier resolves from the staged toolchain, not the workspace. The Azure
    service-principal secrets are injected only into this signing-aware packaging
-   step.
+   step. After packaging it copies the signed installer to the stable name
+   `PwrAgent-windows-x64-setup.exe` and appends that copy to the Windows
+   `SHA256SUMS` manifest.
 6. `Publish release assets`, which waits for successful macOS signing, both
    Linux packages, and the signed Windows installer. Only then does it create
    the GitHub Release — always as a `Pre-release`, whatever the tag suffix —
@@ -284,6 +286,13 @@ Stable landing-page URL:
 https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg
 ```
 
+Stable Windows download URLs:
+
+```text
+https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent-windows-x64-setup.exe
+https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent-windows-SHA256SUMS
+```
+
 Stable Linux download URLs:
 
 ```text
@@ -291,6 +300,12 @@ https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent-linux-x64.
 https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent-linux-arm64.deb
 https://github.com/pwrdrvr/PwrAgent/releases/latest/download/SHA256SUMS
 ```
+
+Each stable name is a byte-identical copy of the versioned asset from the same
+release, so `pwragent.ai` can link these URLs directly instead of resolving the
+versioned asset name through the GitHub Releases API. GitHub serves
+`/releases/latest/download/` only from a release promoted to Latest, so these
+URLs keep serving the previous release until the promotion step below runs.
 
 For the current arm64-only beta, backfill the stable alias:
 

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -368,6 +368,8 @@ for (const expected of [
   "scripts/release/install-trusted-signing.ps1",
   "secrets.AZURE_CLIENT_SECRET",
   "--win --sign-stage-only --no-publish --require-signing",
+  "Prepare stable-name Windows installer alias",
+  "PwrAgent-windows-x64-setup.exe",
 ]) {
   assertWorkflowJobContainsText(
     releaseWorkflow,
@@ -376,6 +378,23 @@ for (const expected of [
     expected,
   );
 }
+// The alias is a copy of an already-signed installer, so it must be made after
+// packaging and before the upload that feeds publish-release-assets. Copying
+// earlier would publish a stable-name .exe without an Authenticode signature.
+assertWorkflowJobOrdersText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "windows-sign",
+  "--win --sign-stage-only --no-publish --require-signing",
+  "Prepare stable-name Windows installer alias",
+);
+assertWorkflowJobOrdersText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "windows-sign",
+  "Prepare stable-name Windows installer alias",
+  "Upload Windows installer artifact",
+);
 for (const expected of [
   "--sign-stage-only --no-publish",
   "Upload macOS release assets",
@@ -544,6 +563,7 @@ for (const stepName of [
 for (const expected of [
   "PwrAgent-linux-x64.deb",
   "PwrAgent-linux-arm64.deb",
+  "PwrAgent-windows-x64-setup.exe",
   "SHA256SUMS",
   "born as a GitHub `Pre-release`",
   "--latest --prerelease=false",


### PR DESCRIPTION
## Problem

`https://github.com/pwrdrvr/PwrAgent/releases/latest/download/<NAME>` only resolves for a version-independent asset name. macOS publishes `PwrAgent.dmg` and Linux publishes `PwrAgent-linux-x64.deb` / `PwrAgent-linux-arm64.deb`, but Windows shipped only `PwrAgent-<version>-windows-x64-setup.exe`.

Because of that gap, pwragent.ai server-renders a link to the latest-release *page* and rewrites the href at runtime by querying the Releases API and matching the `-windows-x64-setup.exe` suffix — an anonymous, rate-limited call whose no-JavaScript path drops visitors on a release page instead of starting a download.

## Change

- `windows-sign` copies the packaged installer to `PwrAgent-windows-x64-setup.exe`. The copy runs **after** the signing-aware packaging step, so the alias carries the same Authenticode signature, and **before** the upload that feeds `publish-release-assets`.
- The step appends the alias to the Windows `SHA256SUMS`. `release.mjs` writes that manifest before the copy exists, and the Linux manifest already names both the versioned package and its alias.
- `release:check` pins the step's presence and its position between packaging and upload, and requires the runbook to document the name.
- Runbook: documents the stable Windows download URLs alongside the macOS and Linux ones.

No change was needed to the upload or publish paths — `apps/desktop/release-stage/dist/*.exe` and `windows-dist/*` already carry the alias.

## Verification

Done here:

- `pnpm release:check` passes; each new assertion was negative-tested — it fails when the step is removed **and** when the step is moved before the signing step.
- Simulated a Windows `dist/` and confirmed the alias semantics: the versioned glob `PwrAgent-*-windows-x64-setup.exe` does not match the alias, the appended manifest verifies clean under `sha256sum -c`, and the upload globs pick the alias up.
- No collision: `v1.0.3` has no asset named `PwrAgent-windows-x64-setup.exe`.
- electron-updater is unaffected. Windows `latest.yml` is not uploaded by this workflow and is absent from `v1.0.3`'s assets; the `generic` provider in `auto-updater.ts` fetches only the filenames named inside the channel manifest, so an extra copy is never referenced. No `.blockmap` sibling is created for the alias, matching `PwrAgent.dmg`.

Not done here — needs a Windows host:

- Executing the step's PowerShell. There is no `pwsh` on the authoring machine, so the block was verified by reading and by porting its semantics, not by running it.
- Confirming `https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent-windows-x64-setup.exe` resolves on a real release.

## Downstream

Once this ships, pwragent.ai can put the direct URL under `download:` in `_config.yml`, point the Windows control at it so it works without JavaScript, and reduce `assets/js/site.js` to the version/size badges. pwrsnap.com has the identical gap and is worth the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)