### PR TITLE
fix(desktop): stop the Windows ARP name from carrying the version

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -167,6 +167,14 @@ nsis:
   perMachine: false
   allowToChangeInstallationDirectory: true
   shortcutName: PwrAgent
+  # Without this, electron-builder defaults uninstallDisplayName to
+  # "${productName} ${version}", so Add or Remove Programs shows
+  # "PwrAgent 1.2.3" next to a Version column that already says 1.2.3.
+  # Safe to change: the installer rewrites DisplayName on every install
+  # and the upgrade path uninstalls the prior version first, so existing
+  # installs self-heal. Upgrade and uninstall detection are unaffected --
+  # both registry keys are derived from appId, not from this string.
+  uninstallDisplayName: PwrAgent
   artifactName: "${productName}-${version}-windows-${arch}-setup.${ext}"
 
 dmg:

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -210,6 +210,10 @@ for (const expected of [
   "target: deb",
   "arch: [x64, arm64]",
   "artifactName: \"${productName}-${version}-linux-${arch}.${ext}\"",
+  // Pins the Windows Add or Remove Programs name. Without an explicit value
+  // electron-builder falls back to "${productName} ${version}", which repeats
+  // the version next to the ARP Version column.
+  "uninstallDisplayName: PwrAgent",
   "desktop:",
   "entry:",
   "StartupWMClass: PwrAgent",


### PR DESCRIPTION
Ports the Windows installer naming fix from pwrdrvr/PwrSnap#468.

## Problem

`apps/desktop/electron-builder.yml`'s `nsis:` block did not set `uninstallDisplayName`. electron-builder defaults the NSIS `UNINSTALL_DISPLAY_NAME` define to `"${productName} ${version}"` when the option is unset — `NsisTarget.js:478` in app-builder-lib:

```js
defines.UNINSTALL_DISPLAY_NAME = packager.expandMacro(options.uninstallDisplayName || "${productName} ${version}", null, {}, false);
```

`productName` is `PwrAgent`, so Add or Remove Programs showed `PwrAgent <version>` next to a Version column that already displays the version. This repo pins electron-builder `26.15.7`, the same version PwrSnap verified against.

## Fix

Add `uninstallDisplayName: PwrAgent` to the `nsis:` block, with a comment explaining the default and why overriding it is safe. Nothing else in the block changed — `productName`, `shortcutName`, `appId`, and `artifactName` are untouched. Verified by parsing the YAML before and after: the only key added is `uninstallDisplayName`.

## Why it is safe

Confirmed against the NSIS templates in this tree (`node_modules/.pnpm/app-builder-lib@26.15.7_.../templates/nsis/`):

- `multiUser.nsh:8-9` defines `INSTALL_REGISTRY_KEY "Software\${APP_GUID}"` and `UNINSTALL_REGISTRY_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${UNINSTALL_APP_KEY}"`. `NsisTarget.js:162-168` computes `APP_GUID` as `UUID.v5(appInfo.id, ELECTRON_BUILDER_NS_UUID)` and `UNINSTALL_APP_KEY` from that GUID — both derive from `appId` (`com.pwrdrvr.pwragent`), never from the display name. Upgrade and uninstall detection are unaffected.
- `include/installer.nsh:119` writes `DisplayName` unconditionally on every install (`WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" DisplayName "${UNINSTALL_DISPLAY_NAME}$1"`), and the upgrade path uninstalls the prior version first — so existing installs self-heal rather than keeping a stale entry.

## Release-config test

PwrAgent has no `apps/desktop/scripts/windows-release-config.test.mjs`. The analogous guard is `scripts/check-desktop-release-metadata.mjs` (`pnpm release:check`, run by CI/release), which already asserts a list of required substrings in `electron-builder.yml`. Added `uninstallDisplayName: PwrAgent` to that list rather than inventing a new harness.

Verified load-bearing: deleting the config line makes the check fail with

```
release metadata check failed: apps/desktop/electron-builder.yml must contain "uninstallDisplayName: PwrAgent"
```

and it passes again with the line restored (`RELEASE_TAG=v1.1.0-alpha.1 pnpm release:check` → exit 0).

## Winget / other DisplayName mirrors

PwrAgent has none. There is no `docs/windows/winget/` directory and no winget manifest anywhere in the tree; a repo-wide search for winget manifests and ARP `DisplayName` references turned up only the two files this PR touches. Nothing else mirrors the Add or Remove Programs name, so no follow-up manifest edit is needed — already-published installers are immutable and keep their version-suffixed name; only future builds get the clean one.

Reference: pwrdrvr/PwrSnap#468

🤖 Generated with [Claude Code](https://claude.com/claude-code)