### PR TITLE
fix(desktop): hide managed monitor threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20706,6 +20706,7 @@ command = "pnpm dev"
       reasoningEffort: "high",
       sandbox: "danger-full-access",
       serviceTier: "priority",
+      threadSource: "subagent",
     });
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "managed-review-child",
@@ -35678,7 +35679,7 @@ script = "printf setup"
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
     });
-    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
+    expect(codexClient.lastStartThreadParams?.threadSource).toBe("subagent");
     expect(pwragentDynamicTools(codexClient.lastStartThreadParams?.dynamicTools)
       .map((tool) => tool.name)).toEqual(["inject_progress", "complete_monitoring"]);
     expect(codexClient.startTurnCallCount).toBe(1);
@@ -35918,7 +35919,7 @@ script = "printf setup"
       ephemeral: false,
       model: "gpt-5.6-luna",
     });
-    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
+    expect(codexClient.lastStartThreadParams?.threadSource).toBe("subagent");
     expect(codexClient.startTurnCallCount).toBe(1);
 
     await registry.close();
@@ -35995,7 +35996,7 @@ script = "printf setup"
       ephemeral: false,
       sandbox: "danger-full-access",
     });
-    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
+    expect(codexClient.lastStartThreadParams?.threadSource).toBe("subagent");
     expect(codexClient.lastStartTurnParams).toMatchObject({
       approvalPolicy: "never",
       codexEnvironmentRuntime,

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1507,6 +1507,13 @@ describe("CodexAppServerClient", () => {
         updatedAt: 1_777_500_200,
         cwd: "/repo/app",
       },
+      {
+        id: "thread-managed-monitor",
+        preview: "You are a lightweight PwrAgent monitor subagent",
+        threadSource: "subagent",
+        updatedAt: 1_777_500_300,
+        cwd: "/repo/app",
+      },
     ]);
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const client = new CodexAppServerClient({

--- a/apps/desktop/src/main/__tests__/overlay-store-partial-navigation.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-partial-navigation.test.ts
@@ -136,4 +136,54 @@ describe("SqliteOverlayStore partial navigation snapshots", () => {
       threadId: olderThread.id,
     })).resolves.toBeDefined();
   });
+
+  it("keeps durable managed sub-agent workers out of navigation", async () => {
+    const parentThread = buildThread({
+      id: "thread-parent",
+      path: "/repo/parent",
+      updatedAt: 2_000,
+    });
+    const monitorThread = buildThread({
+      id: "thread-monitor",
+      path: "/repo/monitor",
+      updatedAt: 3_000,
+    });
+    await store.upsertThreadSubAgent({
+      backend: "codex",
+      threadId: parentThread.id,
+      subAgent: {
+        backend: "codex",
+        createdAt: 1_500,
+        monitorId: "monitor-1",
+        monitorThreadId: monitorThread.id,
+        status: "success",
+        task: "Watch a release workflow.",
+        updatedAt: 2_500,
+      },
+    });
+
+    const full = await store.reconcileNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 3_100,
+      threads: [monitorThread, parentThread],
+    });
+
+    expect(full.threads.map((thread) => thread.id)).toEqual([parentThread.id]);
+    expect(full.directories.map((directory) => directory.path)).toEqual([
+      "/repo/parent",
+    ]);
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: monitorThread.id,
+    })).resolves.toBeUndefined();
+
+    const partial = await store.reconcileNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 3_200,
+      partial: true,
+      threads: [monitorThread],
+    });
+    expect(partial.threads).toEqual([]);
+    expect(partial.directories).toEqual([]);
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13909,10 +13909,11 @@ export class DesktopBackendRegistry {
     const thread = await client.startThread({
       ...(params.cwd ? { cwd: params.cwd } : {}),
       approvalPolicy: modeSettings.approvalPolicy,
-      // App-server threads are excluded from the default interactive thread
-      // listing by source kind. Keep review children durable so their
-      // inspection-only transcript can use thread/read with includeTurns.
+      // Keep review children durable so their inspection-only transcript can
+      // use thread/read with includeTurns, and mark them as subagents so Codex
+      // and PwrAgent both exclude them from ordinary navigation.
       ephemeral: false,
+      threadSource: "subagent" as CodexThreadSource,
       sandbox: modeSettings.sandbox,
       ...params.modelSettings,
       ...(params.codexEnvironmentRuntime
@@ -29077,13 +29078,14 @@ export class DesktopBackendRegistry {
       ...(cwd ? { cwd } : {}),
       approvalPolicy: modeSettings.approvalPolicy,
       dynamicTools,
-      // App-server threads are excluded from the default interactive thread
-      // listing by source kind. Keep monitor children durable so their
-      // inspection-only transcript can use thread/read with includeTurns.
+      // Keep monitor children durable so their inspection-only transcript can
+      // use thread/read with includeTurns, and mark them as subagents so Codex
+      // and PwrAgent both exclude them from ordinary navigation.
       ephemeral: false,
       model: params.preferredModel,
       reasoningEffort: params.preferredReasoningEffort,
       sandbox: modeSettings.sandbox,
+      threadSource: "subagent" as CodexThreadSource,
       ...(sourceOverlay?.codexEnvironmentRuntime
         ? { codexEnvironmentRuntime: sourceOverlay.codexEnvironmentRuntime }
         : {}),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13910,8 +13910,10 @@ export class DesktopBackendRegistry {
       ...(params.cwd ? { cwd: params.cwd } : {}),
       approvalPolicy: modeSettings.approvalPolicy,
       // Keep review children durable so their inspection-only transcript can
-      // use thread/read with includeTurns, and mark them as subagents so Codex
-      // and PwrAgent both exclude them from ordinary navigation.
+      // use thread/read with includeTurns, and mark them as subagents so
+      // PwrAgent excludes them from ordinary navigation. This classification
+      // does not claim Codex-native ThreadSpawn parentage, which Codex reserves
+      // for workers created by spawn_agent.
       ephemeral: false,
       threadSource: "subagent" as CodexThreadSource,
       sandbox: modeSettings.sandbox,
@@ -29079,8 +29081,10 @@ export class DesktopBackendRegistry {
       approvalPolicy: modeSettings.approvalPolicy,
       dynamicTools,
       // Keep monitor children durable so their inspection-only transcript can
-      // use thread/read with includeTurns, and mark them as subagents so Codex
-      // and PwrAgent both exclude them from ordinary navigation.
+      // use thread/read with includeTurns, and mark them as subagents so
+      // PwrAgent excludes them from ordinary navigation. This classification
+      // does not claim Codex-native ThreadSpawn parentage, which Codex reserves
+      // for workers created by spawn_agent.
       ephemeral: false,
       model: params.preferredModel,
       reasoningEffort: params.preferredReasoningEffort,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1714,10 +1714,12 @@ function isKnownCompanionAppCodexThread(thread: RawCodexThreadSummary): boolean 
 }
 
 function isVisibleCodexThreadSource(thread: RawCodexThreadSummary): boolean {
-  const sourceKind = thread.codexThreadSourceKind?.trim();
+  const sourceKind = thread.codexThreadSourceKind?.trim().toLowerCase();
   // Native Codex subagents appear on their originating thread as activity and
-  // have an inspection-only transcript. They are not durable navigation threads.
-  return !sourceKind?.startsWith("subAgent");
+  // PwrAgent-managed workers have an inspection-only transcript. Neither is a
+  // durable navigation thread. Codex source-kind variants use camelCase while
+  // the durable ThreadSource marker is the lowercase string "subagent".
+  return !sourceKind?.startsWith("subagent");
 }
 
 function filterVisibleCodexThreads(

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -729,9 +729,19 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     const backendState = this.getBackend(params.backend);
     const firstSnapshot = !backendState?.lastSnapshotHash;
     const persistReconciliation = params.partial !== true;
+    const managedSubAgentThreadKeys = this.listManagedSubAgentThreadKeys();
+    // Parent overlays are the durable source of truth for PwrAgent-managed
+    // workers. Filter by that relationship as well as provider metadata so
+    // children created by older builds cannot leak into local or federated
+    // navigation after managed transcripts became durable.
+    const threads = params.threads.filter(
+      (thread) => !managedSubAgentThreadKeys.has(
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+    );
 
     if (persistReconciliation && firstSnapshot) {
-      for (const thread of params.threads) {
+      for (const thread of threads) {
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const current = this.getThread(threadKey);
         const applyAcpExecutionModeSnapshot =
@@ -784,7 +794,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       }
     }
 
-    for (const thread of persistReconciliation ? params.threads : []) {
+    for (const thread of persistReconciliation ? threads : []) {
       if (!isAcpBackendId(thread.source) || !thread.executionMode) {
         continue;
       }
@@ -809,7 +819,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     // Agent names originate from the thread title when a thread is promoted
     // or created as an Agent. Keep that invariant across older builds that
     // renamed only the provider thread and left the overlay name stale.
-    for (const thread of persistReconciliation ? params.threads : []) {
+    for (const thread of persistReconciliation ? threads : []) {
       const threadTitle = thread.title.trim();
       if (!threadTitle) {
         continue;
@@ -829,7 +839,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     }
 
     const overlayByThreadKey = Object.fromEntries(
-      params.threads.map((thread) => {
+      threads.map((thread) => {
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const overlay = this.getThread(threadKey);
         const queue = params.queuedExecutionModesByThreadKey?.[threadKey];
@@ -877,7 +887,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       messagingBindingsByThreadKey: params.messagingBindingsByThreadKey,
       overlayByThreadKey,
       previousKnownThreadKeys: backendState?.knownThreadKeys ?? [],
-      threads: params.threads,
+      threads,
       unchanged: false,
       workspaceRoots: params.workspaceRoots,
     });
@@ -905,7 +915,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
 
     if (persistReconciliation) {
       this.putBackend(params.backend, {
-        knownThreadKeys: params.threads.map((thread) =>
+        knownThreadKeys: threads.map((thread) =>
           buildThreadIdentityKey(thread.source, thread.id),
         ),
         lastSnapshotHash: nextHash,
@@ -5963,6 +5973,37 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return pending
       ? { ...overlay, prAutoDispatchPending: pending.pending }
       : overlay;
+  }
+
+  private listManagedSubAgentThreadKeys(): Set<string> {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT payload FROM threads
+         WHERE payload LIKE '%"monitorThreadId"%'`,
+      )
+      .all() as Array<{ payload: string }>;
+    const threadKeys = new Set<string>();
+    for (const row of rows) {
+      try {
+        const overlay = normalizeThreadOverlayState(
+          JSON.parse(row.payload) as ThreadOverlayState,
+        );
+        for (const subAgent of overlay.subAgents ?? []) {
+          const threadId = subAgent.monitorThreadId?.trim();
+          const backend = subAgent.backend ?? overlay.backend;
+          if (
+            !threadId
+            || (backend === overlay.backend && threadId === overlay.threadId)
+          ) {
+            continue;
+          }
+          threadKeys.add(buildThreadIdentityKey(backend, threadId));
+        }
+      } catch {
+        // A malformed unrelated overlay must not block navigation.
+      }
+    }
+    return threadKeys;
   }
 
   /**


### PR DESCRIPTION
## Summary

- classify durable managed monitor and review threads as subagents when starting them through the Codex App Server
- filter Codex subagent source kinds case-insensitively
- keep already-created managed children out of navigation by deriving their identities from PwrAgent-owned parent overlays
- add regression coverage for both newly classified and legacy durable children

## Root cause

Commit bda32eecb0 made managed monitor and review transcripts durable, but their thread/start calls omitted threadSource. Because App Server sessions use an interactive session source, ordinary navigation treated those child transcripts as top-level threads.

The owner-local M4 profile log confirmed the reported thread was created through create_monitor_delegation and completed as a managed monitor.

## Codex provenance

Native spawn_agent workers use a Codex SessionSource::SubAgent ThreadSpawn value with parent, depth, and agent identity metadata. PwrAgent-managed monitors are orchestrator-owned workers and use the durable threadSource subagent classification instead; they deliberately do not claim native ThreadSpawn parentage. Both remain readable while staying out of top-level PwrAgent navigation.

## Live App Server verification

Tested with the ChatGPT-bundled Codex App Server 0.148.0-alpha.9:

- created a durable managed-classified thread in an isolated Codex home, injected transcript history, closed and reopened App Server, and confirmed thread/read still succeeded
- confirmed that managed thread was absent from top-level PwrAgent listThreads and absent from listNativeSubAgentThreads
- queried the real profile read-only and found 14 native spawn_agent workers; a sampled child exposed parent ID, depth, and nickname metadata, had a readable five-message transcript, and was absent from the top-level list

## Testing

- pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/overlay-store-partial-navigation.test.ts
- pnpm typecheck
- pnpm lint:sql
- pnpm lint:eslint
- pnpm lint:boundaries
- pnpm lint:codex-storage
- git diff --check