### PR TITLE
fix(desktop): coalesce thread cost notices

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -129,6 +129,7 @@ import {
   buildToolAccountingNotice,
 } from "./features/notifications/tool-accounting-notice";
 import { buildSpendAlertNotice } from "./features/notifications/spend-alert-notice";
+import { scopeThreadCostNoticeId } from "./features/notifications/thread-cost-notice";
 import {
   buildThreadIncidentSummary,
   threadIncidentNoticeId,
@@ -836,9 +837,12 @@ function DesktopAppShell(props: {
            incident. The fold still summarizes the whole thread once a new
            alert makes it worth showing. */
         if (!params.triggeredAlerts?.length) return;
-        const noticeId = threadIncidentNoticeId({
-          backend: event.backend,
-          threadId: params.threadId,
+        const noticeId = scopeThreadCostNoticeId({
+          id: threadIncidentNoticeId({
+            backend: event.backend,
+            threadId: params.threadId,
+          }),
+          ...(instanceId ? { instanceId } : {}),
         });
         /* Persisted disposition wins over anything this session inferred: it
            may predate this renderer entirely. Only for a local thread, though:
@@ -909,14 +913,19 @@ function DesktopAppShell(props: {
             ...(patch.mutedSeverity ? { mutedSeverity: patch.mutedSeverity } : {}),
           };
           toolIncidentStateRef.current.set(noticeId, next);
-          void desktopApi?.setThreadToolIncidentNotice?.({
-            backend: event.backend,
-            ...(summary.firstWarningAt !== undefined
-              ? { firstWarningAt: summary.firstWarningAt }
-              : {}),
-            ...patch,
-            threadId: params.threadId,
-          }).catch(() => undefined);
+          /* A remote dismissal belongs to this viewer session. The peer does
+             not own that preference, and an unscoped write here could mutate
+             a local thread that happens to share its backend/thread id. */
+          if (!event.federationTarget) {
+            void desktopApi?.setThreadToolIncidentNotice?.({
+              backend: event.backend,
+              ...(summary.firstWarningAt !== undefined
+                ? { firstWarningAt: summary.firstWarningAt }
+                : {}),
+              ...patch,
+              threadId: params.threadId,
+            }).catch(() => undefined);
+          }
         };
         const dismiss = (): void => {
           persistIncident({ dismissedSeverity: summary.severity });

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -804,6 +804,8 @@ function DesktopAppShell(props: {
               type: "show",
               notice: buildSpendAlertNotice({
                 alert,
+                backend: event.backend,
+                ...(instanceId ? { instanceId } : {}),
                 ...(threadLink ? { threadLink } : {}),
               }),
             });
@@ -971,6 +973,7 @@ function DesktopAppShell(props: {
         dispatchAppNotice({
           type: "show",
           notice: buildToolAccountingNotice({
+            ...(instanceId ? { instanceId } : {}),
             onDismiss: dismiss,
             onExamine: examine,
             onMute: mute,
@@ -1227,6 +1230,7 @@ function DesktopAppShell(props: {
         type: "show",
         notice: buildSpendAlertNotice({
           alert,
+          backend: thread.source,
           threadLink: {
             backend: thread.source,
             inThreadList: true,

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
@@ -22,6 +22,12 @@ export function AppNoticeStack(props: {
     durableNotices.findIndex((notice) => notice.id === activeId),
   );
   const activeNotice = durableNotices[activeIndex];
+  const activeDismissGroup = activeNotice?.dismissGroup;
+  const groupedNotices = activeDismissGroup
+    ? durableNotices.filter(
+        (notice) => notice.dismissGroup?.key === activeDismissGroup.key,
+      )
+    : [];
 
   useEffect(() => {
     if (durableNotices.length === 0) {
@@ -67,6 +73,22 @@ export function AppNoticeStack(props: {
           ? {
               current: activeIndex + 1,
               total: durableNotices.length,
+              ...(activeDismissGroup && groupedNotices.length > 1
+                ? {
+                    dismissAll: {
+                      label: activeDismissGroup.label,
+                      onDismiss: () => {
+                        for (const notice of groupedNotices) {
+                          if (notice.onDismiss) {
+                            notice.onDismiss();
+                          } else {
+                            props.onDismissDurable(notice.id);
+                          }
+                        }
+                      },
+                    },
+                  }
+                : {}),
               onPrevious: activeIndex > 0
                 ? () => selectIndex(activeIndex - 1)
                 : undefined,

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -19,6 +19,16 @@ export type AppNoticeToastNotice = {
     tone?: "primary" | "secondary";
   }[];
   autoDismiss?: boolean;
+  /** Retain only the highest-priority durable notice in this logical slot. */
+  coalescing?: {
+    key: string;
+    priority: number;
+  };
+  /** Offers one action that dismisses every durable notice in this group. */
+  dismissGroup?: {
+    key: string;
+    label: string;
+  };
   id: string;
   title: string;
   message: string;
@@ -41,6 +51,10 @@ export function AppNoticeToast(props: {
   navigation?: {
     current: number;
     total: number;
+    dismissAll?: {
+      label: string;
+      onDismiss: () => void;
+    };
     onPrevious?: () => void;
     onNext?: () => void;
   };
@@ -100,6 +114,8 @@ export function AppNoticeToast(props: {
       .filter(Boolean)
       .join("\n");
   const customActions = props.notice.actions ?? [];
+  const hasFooterActions = customActions.length > 0
+    || props.navigation?.dismissAll !== undefined;
   const statusDotClass =
     props.notice.status?.state === "progress"
       ? "status-dot status-dot--warning status-dot--blink"
@@ -110,6 +126,7 @@ export function AppNoticeToast(props: {
   return (
     <aside
       className="app-notice-toast"
+      data-navigable={props.navigation ? "true" : undefined}
       data-tone={props.notice.tone ?? "neutral"}
       role="status"
       aria-live="polite"
@@ -190,7 +207,7 @@ export function AppNoticeToast(props: {
           <span className="app-notice-toast__position">
             {props.navigation.current} of {props.navigation.total}
           </span>
-          {customActions.length > 0 ? (
+          {hasFooterActions ? (
             <div className="app-notice-toast__custom-actions">
               {customActions.map((action) => (
                 <button
@@ -202,6 +219,17 @@ export function AppNoticeToast(props: {
                   {action.label}
                 </button>
               ))}
+              {props.navigation.dismissAll ? (
+                <button
+                  className="button button--secondary app-notice-toast__dismiss-all"
+                  type="button"
+                  aria-label={`Dismiss all ${props.navigation.dismissAll.label}`}
+                  title={`Dismiss all ${props.navigation.dismissAll.label}`}
+                  onClick={props.navigation.dismissAll.onDismiss}
+                >
+                  Dismiss all
+                </button>
+              ) : null}
             </div>
           ) : null}
           <nav

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
@@ -55,4 +55,56 @@ describe("AppNoticeStack", () => {
     expect(screen.getByRole("button", { name: "Next notice" }))
       .toBeDisabled();
   });
+
+  it("dismisses every notice in the active notice group", async () => {
+    const costGroup = {
+      key: "thread-cost",
+      label: "cost notices",
+    };
+    const initial = [
+      {
+        autoDismiss: false,
+        dismissGroup: costGroup,
+        id: "cost-a",
+        message: "One",
+        title: "Cost A",
+      },
+      {
+        autoDismiss: false,
+        dismissGroup: costGroup,
+        id: "cost-b",
+        message: "Two",
+        title: "Cost B",
+      },
+      {
+        autoDismiss: false,
+        id: "failure",
+        message: "Three",
+        title: "Turn failed",
+      },
+    ] as AppNoticeToastNotice[];
+
+    function Harness() {
+      const [notices, setNotices] = useState(initial);
+      return (
+        <AppNoticeStack
+          durableNotices={notices}
+          onDismissDurable={(id) => {
+            setNotices((current) => current.filter((notice) => notice.id !== id));
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Dismiss all cost notices",
+    }));
+
+    expect(await screen.findByText("Turn failed")).toBeInTheDocument();
+    expect(screen.getByText("1 of 1")).toBeInTheDocument();
+    expect(screen.queryByText("Cost A")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cost B")).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { AppNoticeStack } from "../AppNoticeStack";
 import type { AppNoticeToastNotice } from "../AppNoticeToast";
+import { buildSpendAlertNotice } from "../spend-alert-notice";
 
 afterEach(cleanup);
 
@@ -106,5 +107,58 @@ describe("AppNoticeStack", () => {
     expect(screen.getByText("1 of 1")).toBeInTheDocument();
     expect(screen.queryByText("Cost A")).not.toBeInTheDocument();
     expect(screen.queryByText("Cost B")).not.toBeInTheDocument();
+  });
+
+  it("navigates and dismisses matching thread ids from separate peers independently", async () => {
+    const alert = {
+      alertId: "spend-alert:thread:codex:thread-a:25000000",
+      createdAt: 1_800_000_000_000,
+      currency: "USD" as const,
+      kind: "thread-spend" as const,
+      spendMicros: 31_000_000,
+      threadId: "thread-a",
+      thresholdMicros: 25_000_000,
+    };
+    const initial = [
+      {
+        ...buildSpendAlertNotice({
+          alert,
+          backend: "codex",
+          instanceId: "peer-a",
+        }),
+        title: "Peer A spend",
+      },
+      {
+        ...buildSpendAlertNotice({
+          alert,
+          backend: "codex",
+          instanceId: "peer-b",
+        }),
+        title: "Peer B spend",
+      },
+    ];
+    expect(initial[0]?.id).not.toBe(initial[1]?.id);
+
+    function Harness() {
+      const [notices, setNotices] = useState(initial);
+      return (
+        <AppNoticeStack
+          durableNotices={notices}
+          onDismissDurable={(id) => {
+            setNotices((current) => current.filter((notice) => notice.id !== id));
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByText("Peer A spend")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Next notice" }));
+    expect(screen.getByText("Peer B spend")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(await screen.findByText("Peer A spend")).toBeInTheDocument();
+    expect(screen.getByText("1 of 1")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
@@ -301,7 +301,7 @@ describe("appNoticeReducer", () => {
     let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
       type: "show",
       notice: costNotice({
-        id: "spend-alert:thread:codex:thread-a:25000000",
+        id: "thread-cost-notice:remote:remote-a:spend-alert:thread:codex:thread-a:25000000",
         priority: 2,
         threadKey: "remote-a:codex:thread-a",
         title: "Thread spend threshold reached",
@@ -310,7 +310,7 @@ describe("appNoticeReducer", () => {
     state = appNoticeReducer(state, {
       type: "show",
       notice: costNotice({
-        id: "tool-accounting:codex:thread-a",
+        id: "thread-cost-notice:remote:remote-a:tool-accounting:codex:thread-a",
         priority: 0,
         threadKey: "remote-a:codex:thread-a",
         title: "Tool output hit the cap",
@@ -326,7 +326,7 @@ describe("appNoticeReducer", () => {
     let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
       type: "show",
       notice: costNotice({
-        id: "spend-alert:active-turn:codex:thread-a:turn-1:5000000",
+        id: "thread-cost-notice:remote:remote-a:spend-alert:active-turn:codex:thread-a:turn-1:5000000",
         priority: 1,
         threadKey: "remote-a:codex:thread-a",
         title: "First active turn",
@@ -335,7 +335,7 @@ describe("appNoticeReducer", () => {
     state = appNoticeReducer(state, {
       type: "show",
       notice: costNotice({
-        id: "spend-alert:active-turn:codex:thread-a:turn-2:5000000",
+        id: "thread-cost-notice:remote:remote-a:spend-alert:active-turn:codex:thread-a:turn-2:5000000",
         priority: 1,
         threadKey: "remote-a:codex:thread-a",
         title: "Second active turn",
@@ -351,7 +351,7 @@ describe("appNoticeReducer", () => {
     let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
       type: "show",
       notice: costNotice({
-        id: "tool-accounting:codex:thread-a",
+        id: "thread-cost-notice:remote:remote-a:tool-accounting:codex:thread-a",
         priority: 0,
         threadKey: "remote-a:codex:thread-a",
         title: "Remote A tool output",
@@ -360,7 +360,7 @@ describe("appNoticeReducer", () => {
     state = appNoticeReducer(state, {
       type: "show",
       notice: costNotice({
-        id: "spend-alert:active-turn:codex:thread-a:turn-1:5000000",
+        id: "thread-cost-notice:remote:remote-a:spend-alert:active-turn:codex:thread-a:turn-1:5000000",
         priority: 1,
         threadKey: "remote-a:codex:thread-a",
         title: "Remote A turn spend",
@@ -369,7 +369,7 @@ describe("appNoticeReducer", () => {
     state = appNoticeReducer(state, {
       type: "show",
       notice: costNotice({
-        id: "tool-accounting:codex:thread-a",
+        id: "thread-cost-notice:remote:remote-b:tool-accounting:codex:thread-a",
         priority: 0,
         threadKey: "remote-b:codex:thread-a",
         title: "Remote B tool output",
@@ -380,6 +380,7 @@ describe("appNoticeReducer", () => {
       "Remote A turn spend",
       "Remote B tool output",
     ]);
+    expect(new Set(state.durable.map((notice) => notice.id))).toHaveLength(2);
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
@@ -4,6 +4,7 @@ import {
   INITIAL_APP_NOTICE_STATE,
   type AppNoticeState,
 } from "../app-notice-state";
+import type { AppNoticeToastNotice } from "../AppNoticeToast";
 
 describe("appNoticeReducer", () => {
   it("keeps failed turns in arrival order instead of overwriting them", () => {
@@ -259,4 +260,147 @@ describe("appNoticeReducer", () => {
 
     expect(state.durable.map((notice) => notice.id)).toEqual(["second"]);
   });
+
+  it("keeps only the highest-priority cost notice for each thread", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "show",
+      notice: costNotice({
+        id: "tool-accounting:codex:thread-a",
+        priority: 0,
+        threadKey: "local:codex:thread-a",
+        title: "Tool output hit the cap",
+      }),
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: costNotice({
+        id: "spend-alert:active-turn:codex:thread-a:turn-1:5000000",
+        priority: 1,
+        threadKey: "local:codex:thread-a",
+        title: "Active turn spend threshold reached",
+      }),
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: costNotice({
+        id: "spend-alert:thread:codex:thread-a:25000000",
+        priority: 2,
+        threadKey: "local:codex:thread-a",
+        title: "Thread spend threshold reached",
+      }),
+    });
+
+    expect(state.durable).toEqual([
+      expect.objectContaining({
+        id: "spend-alert:thread:codex:thread-a:25000000",
+      }),
+    ]);
+  });
+
+  it("does not let a late lower-priority event replace a worse cost notice", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "show",
+      notice: costNotice({
+        id: "spend-alert:thread:codex:thread-a:25000000",
+        priority: 2,
+        threadKey: "remote-a:codex:thread-a",
+        title: "Thread spend threshold reached",
+      }),
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: costNotice({
+        id: "tool-accounting:codex:thread-a",
+        priority: 0,
+        threadKey: "remote-a:codex:thread-a",
+        title: "Tool output hit the cap",
+      }),
+    });
+
+    expect(state.durable.map((notice) => notice.title)).toEqual([
+      "Thread spend threshold reached",
+    ]);
+  });
+
+  it("replaces an earlier active-turn cost notice from the same thread", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "show",
+      notice: costNotice({
+        id: "spend-alert:active-turn:codex:thread-a:turn-1:5000000",
+        priority: 1,
+        threadKey: "remote-a:codex:thread-a",
+        title: "First active turn",
+      }),
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: costNotice({
+        id: "spend-alert:active-turn:codex:thread-a:turn-2:5000000",
+        priority: 1,
+        threadKey: "remote-a:codex:thread-a",
+        title: "Second active turn",
+      }),
+    });
+
+    expect(state.durable.map((notice) => notice.title)).toEqual([
+      "Second active turn",
+    ]);
+  });
+
+  it("coalesces a remote viewer per owning instance without merging peers", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "show",
+      notice: costNotice({
+        id: "tool-accounting:codex:thread-a",
+        priority: 0,
+        threadKey: "remote-a:codex:thread-a",
+        title: "Remote A tool output",
+      }),
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: costNotice({
+        id: "spend-alert:active-turn:codex:thread-a:turn-1:5000000",
+        priority: 1,
+        threadKey: "remote-a:codex:thread-a",
+        title: "Remote A turn spend",
+      }),
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: costNotice({
+        id: "tool-accounting:codex:thread-a",
+        priority: 0,
+        threadKey: "remote-b:codex:thread-a",
+        title: "Remote B tool output",
+      }),
+    });
+
+    expect(state.durable.map((notice) => notice.title)).toEqual([
+      "Remote A turn spend",
+      "Remote B tool output",
+    ]);
+  });
 });
+
+function costNotice(params: {
+  id: string;
+  priority: number;
+  threadKey: string;
+  title: string;
+}): AppNoticeToastNotice {
+  return {
+    autoDismiss: false,
+    coalescing: {
+      key: `thread-cost:${params.threadKey}`,
+      priority: params.priority,
+    },
+    dismissGroup: {
+      key: "thread-cost",
+      label: "cost notices",
+    },
+    id: params.id,
+    message: params.title,
+    title: params.title,
+  } as AppNoticeToastNotice;
+}

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/spend-alert-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/spend-alert-notice.test.ts
@@ -14,10 +14,19 @@ describe("spend alert notice", () => {
         thresholdMicros: 5_000_000,
         turnId: "turn-2",
       },
+      backend: "codex",
     });
 
     expect(notice).toMatchObject({
       autoDismiss: false,
+      coalescing: {
+        key: "thread-cost:local:codex:thread-1",
+        priority: 1,
+      },
+      dismissGroup: {
+        key: "thread-cost",
+        label: "cost notices",
+      },
       message: expect.stringContaining("$5.25"),
       title: "Active turn spend threshold reached",
       tone: "warning",
@@ -36,9 +45,15 @@ describe("spend alert notice", () => {
         threadId: "thread-1",
         thresholdMicros: 25_000_000,
       },
+      backend: "codex",
+      instanceId: "peer-a",
     });
 
     expect(notice).toMatchObject({
+      coalescing: {
+        key: "thread-cost:remote:peer-a:codex:thread-1",
+        priority: 2,
+      },
       message: expect.stringContaining("$31.00"),
       title: "Thread spend threshold reached",
     });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/spend-alert-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/spend-alert-notice.test.ts
@@ -54,6 +54,7 @@ describe("spend alert notice", () => {
         key: "thread-cost:remote:peer-a:codex:thread-1",
         priority: 2,
       },
+      id: "thread-cost-notice:remote:peer-a:spend-alert:thread:codex:thread-1:25000000",
       message: expect.stringContaining("$31.00"),
       title: "Thread spend threshold reached",
     });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -201,6 +201,14 @@ describe("buildToolAccountingNotice", () => {
     });
 
     expect(notice.id).toBe("tool-accounting:codex:thread-1");
+    expect(notice.coalescing).toEqual({
+      key: "thread-cost:local:codex:thread-1",
+      priority: 0,
+    });
+    expect(notice.dismissGroup).toEqual({
+      key: "thread-cost",
+      label: "cost notices",
+    });
     expect(notice.message).toContain("3 tool calls flagged across 2 turns");
     expect(notice.actions?.map((action) => action.label)).not.toContain(
       "Dismiss",

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/tool-accounting-notice.test.ts
@@ -217,6 +217,20 @@ describe("buildToolAccountingNotice", () => {
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
+  it("qualifies a remote viewer notice id by owning instance", () => {
+    const notice = buildToolAccountingNotice({
+      instanceId: "peer-a",
+      onDismiss: vi.fn(),
+      onExamine: vi.fn(),
+      showCost: false,
+      summary: summaryFor(),
+    });
+
+    expect(notice.id).toBe(
+      "thread-cost-notice:remote:peer-a:tool-accounting:codex:thread-1",
+    );
+  });
+
   it("offers a mute for a warning but not for a cap hit", () => {
     const warning = buildToolAccountingNotice({
       onDismiss: vi.fn(),

--- a/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
@@ -127,7 +127,19 @@ function upsertNotice(
   notices: readonly AppNoticeToastNotice[],
   notice: AppNoticeToastNotice,
 ): AppNoticeToastNotice[] {
-  const index = notices.findIndex((entry) => entry.id === notice.id);
+  const index = notice.coalescing
+    ? notices.findIndex(
+        (entry) => entry.coalescing?.key === notice.coalescing?.key,
+      )
+    : notices.findIndex((entry) => entry.id === notice.id);
+  const current = notices[index];
+  if (
+    current?.coalescing
+    && notice.coalescing
+    && current.coalescing.priority > notice.coalescing.priority
+  ) {
+    return [...notices];
+  }
   return index >= 0
     ? notices.map((entry, entryIndex) =>
         entryIndex === index ? notice : entry

--- a/apps/desktop/src/renderer/src/features/notifications/spend-alert-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/spend-alert-notice.ts
@@ -1,9 +1,16 @@
-import type { ThreadSpendAlert } from "@pwragent/shared";
+import type {
+  AppServerBackendKind,
+  FederationInstanceId,
+  ThreadSpendAlert,
+} from "@pwragent/shared";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
+import { buildThreadCostNoticeMetadata } from "./thread-cost-notice";
 
 export function buildSpendAlertNotice(params: {
   alert: ThreadSpendAlert;
+  backend: AppServerBackendKind;
+  instanceId?: FederationInstanceId;
   threadLink?: ResolvedThreadLink;
 }): AppNoticeToastNotice {
   const alert = params.alert;
@@ -11,6 +18,12 @@ export function buildSpendAlertNotice(params: {
   const threshold = formatUsdMicros(alert.thresholdMicros);
   const activeTurn = alert.kind === "active-turn-spend";
   return {
+    ...buildThreadCostNoticeMetadata({
+      backend: params.backend,
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
+      kind: alert.kind,
+      threadId: alert.threadId,
+    }),
     autoDismiss: false,
     id: alert.alertId,
     message: activeTurn

--- a/apps/desktop/src/renderer/src/features/notifications/spend-alert-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/spend-alert-notice.ts
@@ -5,7 +5,10 @@ import type {
 } from "@pwragent/shared";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
-import { buildThreadCostNoticeMetadata } from "./thread-cost-notice";
+import {
+  buildThreadCostNoticeMetadata,
+  scopeThreadCostNoticeId,
+} from "./thread-cost-notice";
 
 export function buildSpendAlertNotice(params: {
   alert: ThreadSpendAlert;
@@ -25,7 +28,10 @@ export function buildSpendAlertNotice(params: {
       threadId: alert.threadId,
     }),
     autoDismiss: false,
-    id: alert.alertId,
+    id: scopeThreadCostNoticeId({
+      id: alert.alertId,
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
+    }),
     message: activeTurn
       ? `This active turn has reached ${spend} in estimated list-price spend, crossing the configured ${threshold} threshold.`
       : `This thread has reached ${spend} in estimated list-price spend, crossing the configured ${threshold} threshold.`,

--- a/apps/desktop/src/renderer/src/features/notifications/thread-cost-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-cost-notice.ts
@@ -44,3 +44,22 @@ export function buildThreadCostNoticeMetadata(params: {
     dismissGroup: THREAD_COST_DISMISS_GROUP,
   };
 }
+
+/**
+ * Notice-stack navigation and dismissal use `id` as the UI identity. Keep the
+ * local id unchanged for compatibility, but qualify a peer-owned notice so
+ * equal backend/thread ids on separate instances remain independently usable.
+ */
+export function scopeThreadCostNoticeId(params: {
+  id: string;
+  instanceId?: string;
+}): string {
+  return params.instanceId
+    ? [
+        "thread-cost-notice",
+        "remote",
+        encodeURIComponent(params.instanceId),
+        params.id,
+      ].join(":")
+    : params.id;
+}

--- a/apps/desktop/src/renderer/src/features/notifications/thread-cost-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/thread-cost-notice.ts
@@ -1,0 +1,46 @@
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export type ThreadCostNoticeKind =
+  | "tool-output"
+  | "active-turn-spend"
+  | "thread-spend";
+
+const THREAD_COST_NOTICE_PRIORITY: Record<ThreadCostNoticeKind, number> = {
+  "tool-output": 0,
+  "active-turn-spend": 1,
+  "thread-spend": 2,
+};
+
+const THREAD_COST_DISMISS_GROUP = {
+  key: "thread-cost",
+  label: "cost notices",
+} as const;
+
+/**
+ * Cost warnings share one renderer slot per owning instance and thread. The
+ * instance segment matters for federation viewers: identical backend/thread
+ * ids on two peers are different threads, even when one window normally
+ * fronts only one peer at a time.
+ */
+export function buildThreadCostNoticeMetadata(params: {
+  backend: string;
+  instanceId?: string;
+  kind: ThreadCostNoticeKind;
+  threadId: string;
+}): Pick<AppNoticeToastNotice, "coalescing" | "dismissGroup"> {
+  const source = params.instanceId
+    ? `remote:${encodeURIComponent(params.instanceId)}`
+    : "local";
+  return {
+    coalescing: {
+      key: [
+        "thread-cost",
+        source,
+        encodeURIComponent(params.backend),
+        encodeURIComponent(params.threadId),
+      ].join(":"),
+      priority: THREAD_COST_NOTICE_PRIORITY[params.kind],
+    },
+    dismissGroup: THREAD_COST_DISMISS_GROUP,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -6,7 +6,10 @@ import {
   formatIncidentMicros,
   threadIncidentNoticeId,
 } from "./thread-incident-summary";
-import { buildThreadCostNoticeMetadata } from "./thread-cost-notice";
+import {
+  buildThreadCostNoticeMetadata,
+  scopeThreadCostNoticeId,
+} from "./thread-cost-notice";
 
 export function buildToolAccountingNotice(params: {
   instanceId?: string;
@@ -45,7 +48,10 @@ export function buildToolAccountingNotice(params: {
     ],
     autoDismiss: false,
     copyText: describeToolAccountingIncident({ showCost: true, summary }),
-    id: threadIncidentNoticeId(summary),
+    id: scopeThreadCostNoticeId({
+      id: threadIncidentNoticeId(summary),
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
+    }),
     message: describeToolAccountingIncident({
       showCost: params.showCost,
       summary,

--- a/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/tool-accounting-notice.ts
@@ -6,8 +6,10 @@ import {
   formatIncidentMicros,
   threadIncidentNoticeId,
 } from "./thread-incident-summary";
+import { buildThreadCostNoticeMetadata } from "./thread-cost-notice";
 
 export function buildToolAccountingNotice(params: {
+  instanceId?: string;
   onExamine: () => void;
   onDismiss: () => void;
   onMute?: () => void;
@@ -18,6 +20,12 @@ export function buildToolAccountingNotice(params: {
   const summary = params.summary;
   const critical = summary.severity === "critical";
   return {
+    ...buildThreadCostNoticeMetadata({
+      backend: summary.backend,
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
+      kind: "tool-output",
+      threadId: summary.threadId,
+    }),
     actions: [
       {
         label: `Examine ${summary.flaggedInvocationCount.toLocaleString()} case${summary.flaggedInvocationCount === 1 ? "" : "s"}`,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -501,6 +501,10 @@ describe("Tangerine Terminal theme contract", () => {
   });
 
   it("lets long durable toast actions wrap without compressing labels", () => {
+    const durableToastRule = extractRuleBody(
+      css,
+      '.app-notice-toast[data-navigable="true"]',
+    );
     const footerRule = extractRuleBody(
       css,
       ".app-notice-toast__footer",
@@ -513,13 +517,22 @@ describe("Tangerine Terminal theme contract", () => {
       css,
       ".app-notice-toast__footer .app-notice-toast__custom-actions .button",
     );
+    const navigationRule = extractRuleBody(
+      css,
+      ".app-notice-toast__navigation",
+    );
 
+    expect(durableToastRule).toContain(
+      "height: min(208px, calc(100vh - 32px));",
+    );
     expect(footerRule).toContain(
       "grid-template-columns: auto minmax(0, 1fr) auto;",
     );
     expect(customActionsRule).toContain("min-width: 0;");
     expect(customActionsRule).toContain("flex-wrap: wrap;");
+    expect(customActionsRule).toContain("grid-column: 2;");
     expect(actionButtonRule).toContain("white-space: nowrap;");
+    expect(navigationRule).toContain("grid-column: 3;");
   });
 
   it("lets transcript scroll restoration own scroll anchoring", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7056,6 +7056,16 @@ textarea,
   background: color-mix(in srgb, var(--bg-panel-elevated) 96%, var(--text-muted) 4%);
 }
 
+.app-notice-toast[data-navigable="true"] {
+  height: min(208px, calc(100vh - 32px));
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.app-notice-toast[data-navigable="true"] .app-notice-toast__content {
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .app-notice-toast[data-tone="warning"] {
   border-color: color-mix(in srgb, var(--status-warning) 52%, var(--border-subtle));
   background: color-mix(in srgb, var(--bg-panel-elevated) 92%, var(--status-warning) 8%);
@@ -7190,6 +7200,7 @@ textarea,
 }
 
 .app-notice-toast__footer .app-notice-toast__custom-actions {
+  grid-column: 2;
   min-width: 0;
   flex-wrap: wrap;
   justify-content: flex-end;
@@ -7201,7 +7212,9 @@ textarea,
 
 .app-notice-toast__navigation {
   display: flex;
+  grid-column: 3;
   align-items: center;
+  justify-self: end;
   gap: 6px;
 }
 


### PR DESCRIPTION
## Summary

- retain only the highest-priority cost notice per federation instance, backend, and thread
- add group-aware dismissal while preserving notice-specific persistence hooks
- stabilize durable notice height and pin navigation controls to the bottom-right
- cover local and remote-viewer replacement, downgrade prevention, and dismiss-all behavior

## Verification

- pnpm test apps/desktop/src/renderer/src — 217 files, 3,404 tests passed
- pnpm typecheck
- pnpm lint:eslint
- pnpm lint:colors
- pnpm lint:boundaries