### PR TITLE
fix(desktop): bundle ripgrep for agent runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ apps/desktop/dist/
 # pnpm deploy stage (release.mjs materializes a flat node_modules tree here)
 apps/desktop/release-stage/
 apps/desktop/build/bundled-agents/grok/
+apps/desktop/build/bundled-tools/ripgrep/
 apps/desktop/build/native/
 
 # Release-time secrets — must never land in the repo

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -81,6 +81,8 @@ extraResources:
     to: pwrsnap-app-icon.png
   - from: build/bundled-agents
     to: agents
+  - from: build/bundled-tools/ripgrep
+    to: tools
 
 # Electron fuses — ASAR integrity is NOT on by default in electron-builder.
 # Enable it explicitly so the runtime aborts if the .asar is tampered with.

--- a/apps/desktop/ripgrep-bundle.json
+++ b/apps/desktop/ripgrep-bundle.json
@@ -1,0 +1,11 @@
+{
+  "repository": "BurntSushi/ripgrep",
+  "tag": "15.2.0",
+  "assets": {
+    "macos-arm64": "ripgrep-15.2.0-aarch64-apple-darwin.tar.gz",
+    "macos-x86_64": "ripgrep-15.2.0-x86_64-apple-darwin.tar.gz",
+    "linux-aarch64": "ripgrep-15.2.0-aarch64-unknown-linux-musl.tar.gz",
+    "linux-x86_64": "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz",
+    "windows-x86_64": "ripgrep-15.2.0-x86_64-pc-windows-msvc.zip"
+  }
+}

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -17,6 +17,7 @@ export const ELECTRON_DEV_ENV_KEYS = [
 
 const TERMINAL_SHUTDOWN_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"];
 export const DEV_SETUP_SCRIPTS = [
+  ["./scripts/stage-ripgrep-bundle.mjs", "--platform", "current"],
   "./scripts/ensure-electron-runtime.mjs",
   "./scripts/rebuild-native-for-electron.mjs"
 ];
@@ -53,7 +54,8 @@ function run(command, args, env) {
 
 export function runDevSetup(node, env, runCommand = run) {
   for (const script of DEV_SETUP_SCRIPTS) {
-    const status = runCommand(node, [script], env);
+    const args = Array.isArray(script) ? script : [script];
+    const status = runCommand(node, args, env);
     if (status !== 0) return status;
   }
   return 0;

--- a/apps/desktop/scripts/dev.test.mjs
+++ b/apps/desktop/scripts/dev.test.mjs
@@ -54,7 +54,11 @@ describe("dev launch wrapper", () => {
 
     expect(status).toBe(0);
     expect(calls).toEqual(
-      DEV_SETUP_SCRIPTS.map((script) => ["node", [script], env])
+      DEV_SETUP_SCRIPTS.map((script) => [
+        "node",
+        Array.isArray(script) ? script : [script],
+        env,
+      ])
     );
   });
 
@@ -63,12 +67,16 @@ describe("dev launch wrapper", () => {
     const calls = [];
 
     const status = runDevSetup("node", {}, (_command, args) => {
-      calls.push(args[0]);
+      calls.push(args);
       return statuses.shift();
     });
 
     expect(status).toBe(1);
-    expect(calls).toEqual(DEV_SETUP_SCRIPTS);
+    expect(calls).toEqual(
+      DEV_SETUP_SCRIPTS.slice(0, 2).map((script) =>
+        Array.isArray(script) ? script : [script]
+      ),
+    );
   });
 
   it("scrubs inherited Electron and module-resolution variables", () => {

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -516,6 +516,33 @@ function assertRequiredGrokBundle() {
   console.log(`  verified bundled Grok runtime: ${bundledExecutable}`);
 }
 
+function ripgrepBundlePlatform() {
+  if (win) return "windows-x86_64";
+  if (linux) {
+    return currentLinuxBuilderArch() === "arm64"
+      ? "linux-aarch64"
+      : "linux-x86_64";
+  }
+  return "macos-universal";
+}
+
+function assertRequiredRipgrepBundle() {
+  const executable = process.platform === "win32" ? "rg.exe" : "rg";
+  const bundledExecutable = join(
+    stageDir,
+    "build",
+    "bundled-tools",
+    "ripgrep",
+    executable,
+  );
+  if (!existsSync(bundledExecutable)) {
+    throw new Error(
+      `The staged ripgrep executable is missing at ${bundledExecutable}`,
+    );
+  }
+  console.log(`  verified staged ripgrep: ${bundledExecutable}`);
+}
+
 // Windows PowerShell 5.1 inherits this process's PSModulePath, and the hosted
 // runner's value is PowerShell 7-oriented. Autoloading Windows PowerShell's own
 // Microsoft.PowerShell.Security then fails ("the module could not be loaded"),
@@ -588,6 +615,49 @@ function verifyPackagedGrok(resourcesDirectory) {
           "$signature = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE",
           "if ($signature.Status -ne 'Valid') { throw \"Bundled Grok Authenticode signature is $($signature.Status): $($signature.StatusMessage)\" }",
           "if ($signature.SignerCertificate.Subject -notmatch '(^|,\\s*)CN=PwrDrvr LLC(,|$)') { throw \"Bundled Grok signer is not PwrDrvr LLC: $($signature.SignerCertificate.Subject)\" }",
+        ].join("; "),
+      ],
+      { env: { PWRAGENT_VERIFY_EXECUTABLE: bundledExecutable } },
+    );
+  }
+  return bundledExecutable;
+}
+
+function verifyPackagedRipgrep(resourcesDirectory) {
+  const executable = process.platform === "win32" ? "rg.exe" : "rg";
+  const bundledExecutable = join(resourcesDirectory, "tools", executable);
+  if (!existsSync(bundledExecutable)) {
+    throw new Error(`Packaged ripgrep is missing at ${bundledExecutable}`);
+  }
+  runChecked(bundledExecutable, ["--version"], {
+    cwd: dirname(bundledExecutable),
+  });
+  if (process.platform === "darwin") {
+    const codesignArgs = [
+      "--verify",
+      "--strict",
+      "--verbose=2",
+    ];
+    if (!dryrun) {
+      codesignArgs.push(
+        "--test-requirement",
+        '=anchor apple generic and certificate leaf[subject.OU] = "T44CNHC4UH"',
+      );
+    }
+    codesignArgs.push(bundledExecutable);
+    runChecked("codesign", codesignArgs);
+  } else if (process.platform === "win32" && requireSigning) {
+    runChecked(
+      windowsPowerShellCommand(),
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        [
+          ...WINDOWS_SIGNATURE_PRELUDE,
+          "$signature = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE",
+          "if ($signature.Status -ne 'Valid') { throw \"Bundled ripgrep Authenticode signature is $($signature.Status): $($signature.StatusMessage)\" }",
+          "if ($signature.SignerCertificate.Subject -notmatch '(^|,\\s*)CN=PwrDrvr LLC(,|$)') { throw \"Bundled ripgrep signer is not PwrDrvr LLC: $($signature.SignerCertificate.Subject)\" }",
         ].join("; "),
       ],
       { env: { PWRAGENT_VERIFY_EXECUTABLE: bundledExecutable } },
@@ -739,6 +809,13 @@ function maybePrepareCodesignKeychain() {
 
 if (!signStageOnly) {
   // 2. Build (electron-vite -> apps/desktop/out/).
+  step("stage pinned ripgrep");
+  runChecked(process.execPath, [
+    join(desktopRoot, "scripts", "stage-ripgrep-bundle.mjs"),
+    "--platform",
+    ripgrepBundlePlatform(),
+  ]);
+
   step("license notices check");
   runChecked("pnpm", ["licenses:check"], { cwd: repoRoot });
 
@@ -812,6 +889,7 @@ if (!signStageOnly) {
     copyFileSync(join(repoRoot, file), join(stageDir, file));
   }
   assertRequiredGrokBundle();
+  assertRequiredRipgrepBundle();
 
   if (prepareOnly) {
     step("prepared release-stage");
@@ -823,6 +901,7 @@ if (!signStageOnly) {
     throw new Error(`release-stage is missing at ${stageDir}`);
   }
   assertRequiredGrokBundle();
+  assertRequiredRipgrepBundle();
 }
 
 // 5. electron-builder.
@@ -895,6 +974,9 @@ const dist = join(stageDir, "dist");
 if (win) {
   const builtApp = findWindowsUnpackedDir(dist);
 
+  step("verify packaged ripgrep");
+  verifyPackagedRipgrep(join(builtApp, "resources"));
+
   step("verify packaged Grok runtime");
   verifyPackagedGrok(join(builtApp, "resources"));
 
@@ -916,6 +998,9 @@ if (win) {
 
 if (linux) {
   const builtApp = findLinuxUnpackedDir(dist);
+
+  step("verify packaged ripgrep");
+  verifyPackagedRipgrep(join(builtApp, "resources"));
 
   step("verify packaged Grok runtime");
   verifyPackagedGrok(join(builtApp, "resources"));
@@ -1024,6 +1109,16 @@ if (bundledGrokExecutable) {
     "arm64",
   ]);
 }
+
+const bundledRipgrepExecutable = verifyPackagedRipgrep(
+  join(builtApp, "Contents", "Resources"),
+);
+runChecked("lipo", [
+  bundledRipgrepExecutable,
+  "-verify_arch",
+  "x86_64",
+  "arm64",
+]);
 
 step("verify packaged asar contents");
 runChecked("node", [join(desktopRoot, "scripts", "verify-asar-contents.mjs"), builtApp]);

--- a/apps/desktop/scripts/stage-ripgrep-bundle.mjs
+++ b/apps/desktop/scripts/stage-ripgrep-bundle.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const desktopRoot = resolve(dirname(scriptPath), "..");
+const manifestPath = join(desktopRoot, "ripgrep-bundle.json");
+const outputRoot = join(desktopRoot, "build", "bundled-tools", "ripgrep");
+
+function readManifest() {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (
+    typeof manifest.repository !== "string"
+    || typeof manifest.tag !== "string"
+    || !manifest.assets
+    || typeof manifest.assets !== "object"
+  ) {
+    throw new Error(`Invalid ripgrep bundle manifest: ${manifestPath}`);
+  }
+  return manifest;
+}
+
+export function resolveCurrentRipgrepPlatform(platform, arch) {
+  if (platform === "darwin" && arch === "arm64") return "macos-arm64";
+  if (platform === "darwin" && arch === "x64") return "macos-x86_64";
+  if (platform === "linux" && arch === "arm64") return "linux-aarch64";
+  if (platform === "linux" && arch === "x64") return "linux-x86_64";
+  if (platform === "win32" && arch === "x64") return "windows-x86_64";
+  throw new Error(`Unsupported ripgrep bundle platform: ${platform}-${arch}`);
+}
+
+export function resolveRipgrepAssetPlatforms(platform, hostPlatform, hostArch) {
+  const resolvedPlatform = platform === "current"
+    ? resolveCurrentRipgrepPlatform(hostPlatform, hostArch)
+    : platform;
+  return resolvedPlatform === "macos-universal"
+    ? ["macos-arm64", "macos-x86_64"]
+    : [resolvedPlatform];
+}
+
+async function download(url, targetPath) {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/octet-stream",
+      "User-Agent": "PwrAgent-release-packager",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    redirect: "follow",
+  });
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed (${response.status}) for ${url}`);
+  }
+  await pipeline(response.body, createWriteStream(targetPath));
+}
+
+export function expectedChecksum(checksumText, assetName) {
+  const match = /^([0-9a-fA-F]{64})\s+\*?(.+)$/u.exec(checksumText.trim());
+  if (!match || basename(match[2]) !== assetName) {
+    throw new Error(`Invalid checksum for ${assetName}`);
+  }
+  return match[1].toLowerCase();
+}
+
+async function sha256(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+function runChecked(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with status ${result.status}`);
+  }
+}
+
+function extractArchive(archivePath, targetDir) {
+  mkdirSync(targetDir, { recursive: true });
+  const tar = process.platform === "win32" ? "tar.exe" : "tar";
+  runChecked(tar, ["-xf", archivePath, "-C", targetDir]);
+}
+
+function extractedBundleDirectory(extractedRoot) {
+  const directories = readdirSync(extractedRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(extractedRoot, entry.name));
+  if (directories.length !== 1) {
+    throw new Error(
+      `Expected one ripgrep archive directory under ${extractedRoot}; found ${directories.length}`,
+    );
+  }
+  return directories[0];
+}
+
+function validateExtractedBundle(directory, platform) {
+  const executable = platform.startsWith("windows-") ? "rg.exe" : "rg";
+  const requiredFiles = [
+    join(directory, executable),
+    join(directory, "LICENSE-MIT"),
+    join(directory, "UNLICENSE"),
+  ];
+  for (const requiredFile of requiredFiles) {
+    if (!existsSync(requiredFile) || !statSync(requiredFile).isFile()) {
+      throw new Error(`ripgrep bundle is missing ${requiredFile}`);
+    }
+  }
+  return {
+    directory,
+    executable: join(directory, executable),
+  };
+}
+
+function stagedExecutable() {
+  return join(outputRoot, process.platform === "win32" ? "rg.exe" : "rg");
+}
+
+function cachedBundleMatches(manifest, requestedPlatform, assetPlatforms) {
+  const metadataPath = join(outputRoot, "PWRAGENT-BUNDLE.json");
+  if (!existsSync(metadataPath)) return false;
+  try {
+    const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+    const platformMatches = metadata.platform === requestedPlatform
+      || (
+        requestedPlatform.startsWith("macos-")
+        && requestedPlatform !== "macos-universal"
+        && metadata.platform === "macos-universal"
+      );
+    const expectedAssets = assetPlatforms.map((platform) => manifest.assets[platform]);
+    const cachedAssets = metadata.assets?.map(({ asset }) => asset);
+    const assetsMatch = metadata.platform === "macos-universal"
+      && requestedPlatform.startsWith("macos-")
+      && requestedPlatform !== "macos-universal"
+      ? expectedAssets.every((asset) => cachedAssets?.includes(asset))
+      : JSON.stringify(cachedAssets) === JSON.stringify(expectedAssets);
+    if (
+      metadata.repository !== manifest.repository
+      || metadata.tag !== manifest.tag
+      || !platformMatches
+      || !assetsMatch
+      || !existsSync(join(outputRoot, "LICENSE-MIT"))
+      || !existsSync(join(outputRoot, "UNLICENSE"))
+      || !existsSync(stagedExecutable())
+    ) {
+      return false;
+    }
+    const probe = spawnSync(stagedExecutable(), ["--version"], {
+      encoding: "utf8",
+    });
+    return probe.status === 0 && probe.stdout.startsWith(`ripgrep ${manifest.tag}`);
+  } catch {
+    return false;
+  }
+}
+
+async function downloadAndExtractAsset({ assetName, platform, releaseBase, tempRoot }) {
+  const archivePath = join(tempRoot, assetName);
+  const checksumPath = `${archivePath}.sha256`;
+  await Promise.all([
+    download(`${releaseBase}/${assetName}`, archivePath),
+    download(`${releaseBase}/${assetName}.sha256`, checksumPath),
+  ]);
+  const expected = expectedChecksum(readFileSync(checksumPath, "utf8"), assetName);
+  const actual = await sha256(archivePath);
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch for ${assetName}: expected ${expected}, got ${actual}`,
+    );
+  }
+
+  const extractedRoot = join(tempRoot, `extracted-${platform}`);
+  extractArchive(archivePath, extractedRoot);
+  const bundle = validateExtractedBundle(
+    extractedBundleDirectory(extractedRoot),
+    platform,
+  );
+  return { ...bundle, asset: assetName, platform, sha256: actual };
+}
+
+function assembleBundle(bundles, requestedPlatform) {
+  rmSync(outputRoot, { recursive: true, force: true });
+  mkdirSync(outputRoot, { recursive: true });
+  copyFileSync(join(bundles[0].directory, "LICENSE-MIT"), join(outputRoot, "LICENSE-MIT"));
+  copyFileSync(join(bundles[0].directory, "UNLICENSE"), join(outputRoot, "UNLICENSE"));
+  const executable = stagedExecutable();
+  if (requestedPlatform === "macos-universal") {
+    const arm64 = bundles.find(({ platform }) => platform === "macos-arm64");
+    const x86_64 = bundles.find(({ platform }) => platform === "macos-x86_64");
+    if (!arm64 || !x86_64) {
+      throw new Error("macos-universal ripgrep requires arm64 and x86_64 archives");
+    }
+    runChecked("lipo", ["-create", arm64.executable, x86_64.executable, "-output", executable]);
+    runChecked("lipo", [executable, "-verify_arch", "arm64", "x86_64"]);
+  } else {
+    copyFileSync(bundles[0].executable, executable);
+  }
+  if (process.platform !== "win32") {
+    chmodSync(executable, 0o755);
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const platformIndex = argv.indexOf("--platform");
+  const platform = platformIndex === -1 ? undefined : argv[platformIndex + 1];
+  if (!platform) {
+    throw new Error(
+      "Usage: stage-ripgrep-bundle.mjs --platform <current|macos-universal|asset-platform>",
+    );
+  }
+
+  const manifest = readManifest();
+  const assetPlatforms = resolveRipgrepAssetPlatforms(
+    platform,
+    process.platform,
+    process.arch,
+  );
+  const requestedPlatform = platform === "current"
+    ? resolveCurrentRipgrepPlatform(process.platform, process.arch)
+    : platform;
+  for (const assetPlatform of assetPlatforms) {
+    if (typeof manifest.assets[assetPlatform] !== "string") {
+      throw new Error(`No ripgrep bundle asset is configured for ${assetPlatform}`);
+    }
+  }
+  if (!argv.includes("--force") && cachedBundleMatches(
+    manifest,
+    requestedPlatform,
+    assetPlatforms,
+  )) {
+    console.log(`Using staged ripgrep ${manifest.tag} at ${outputRoot}`);
+    return;
+  }
+
+  const releaseBase =
+    `https://github.com/${manifest.repository}/releases/download/${manifest.tag}`;
+  const tempRoot = mkdtempSync(join(tmpdir(), "pwragent-ripgrep-bundle-"));
+  try {
+    const bundles = await Promise.all(assetPlatforms.map(async (assetPlatform) =>
+      await downloadAndExtractAsset({
+        assetName: manifest.assets[assetPlatform],
+        platform: assetPlatform,
+        releaseBase,
+        tempRoot,
+      })));
+    assembleBundle(bundles, requestedPlatform);
+    writeFileSync(
+      join(outputRoot, "PWRAGENT-BUNDLE.json"),
+      `${JSON.stringify(
+        {
+          repository: manifest.repository,
+          tag: manifest.tag,
+          platform: requestedPlatform,
+          assets: bundles.map(({ asset, platform: assetPlatform, sha256: digest }) => ({
+            platform: assetPlatform,
+            asset,
+            sha256: digest,
+          })),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    runChecked(stagedExecutable(), ["--version"]);
+    console.log(`Staged ripgrep ${manifest.tag} at ${outputRoot}`);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  await main();
+}

--- a/apps/desktop/scripts/stage-ripgrep-bundle.test.mjs
+++ b/apps/desktop/scripts/stage-ripgrep-bundle.test.mjs
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  expectedChecksum,
+  resolveCurrentRipgrepPlatform,
+  resolveRipgrepAssetPlatforms,
+} from "./stage-ripgrep-bundle.mjs";
+
+describe("ripgrep bundle staging", () => {
+  it("maps supported host architectures to pinned asset platforms", () => {
+    expect(resolveCurrentRipgrepPlatform("darwin", "arm64")).toBe("macos-arm64");
+    expect(resolveCurrentRipgrepPlatform("darwin", "x64")).toBe("macos-x86_64");
+    expect(resolveCurrentRipgrepPlatform("linux", "arm64")).toBe("linux-aarch64");
+    expect(resolveCurrentRipgrepPlatform("linux", "x64")).toBe("linux-x86_64");
+    expect(resolveCurrentRipgrepPlatform("win32", "x64")).toBe("windows-x86_64");
+  });
+
+  it("stages both macOS architectures for a universal package", () => {
+    expect(resolveRipgrepAssetPlatforms(
+      "macos-universal",
+      "darwin",
+      "arm64",
+    )).toEqual(["macos-arm64", "macos-x86_64"]);
+  });
+
+  it("validates official per-archive checksum files", () => {
+    const digest = "a".repeat(64);
+    expect(expectedChecksum(
+      `${digest}  ripgrep-15.2.0-aarch64-apple-darwin.tar.gz\n`,
+      "ripgrep-15.2.0-aarch64-apple-darwin.tar.gz",
+    )).toBe(digest);
+    expect(() => expectedChecksum(
+      `${digest}  another-asset.tar.gz\n`,
+      "ripgrep.tar.gz",
+    )).toThrow("Invalid checksum");
+  });
+});

--- a/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
@@ -1,4 +1,12 @@
 import { EventEmitter } from "node:events";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { PassThrough, Writable } from "node:stream";
 import type { AcpBackendId } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
@@ -43,7 +51,55 @@ function createDescriptor(overrides: Partial<AcpLaunchDescriptor> = {}): AcpLaun
   };
 }
 
+function createBundledToolsDirectory(): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "pwragent-bundled-tools-"));
+  const executable = path.join(
+    directory,
+    process.platform === "win32" ? "rg.exe" : "rg",
+  );
+  writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+  if (process.platform !== "win32") {
+    chmodSync(executable, 0o755);
+  }
+  return directory;
+}
+
 describe("AcpStdioJsonRpcTransport", () => {
+  it("prepends PwrAgent's bundled ripgrep for external ACP runtimes", async () => {
+    const child = new MockAcpChildProcess();
+    const spawnCalls: Array<Parameters<AcpStdioSpawn>> = [];
+    const bundledToolsDirectory = createBundledToolsDirectory();
+    const externalRuntimeDirectory = path.join(os.tmpdir(), "custom-acp-runtime");
+    const originalPath = [externalRuntimeDirectory, "/usr/bin"].join(path.delimiter);
+    const spawn: AcpStdioSpawn = (command, args, options) => {
+      spawnCalls.push([command, args, options]);
+      return child;
+    };
+    try {
+      const transport = new AcpStdioJsonRpcTransport({
+        bundledToolsDirectory,
+        launchDescriptor: createDescriptor({
+          command: path.join(externalRuntimeDirectory, "agent"),
+          distributionKind: "local",
+          env: { PATH: originalPath },
+        }),
+        spawn,
+      });
+
+      await transport.connect();
+
+      expect(spawnCalls[0]?.[0]).toBe(path.join(externalRuntimeDirectory, "agent"));
+      expect(String(spawnCalls[0]?.[2].env?.PATH).split(path.delimiter)[0]).toBe(
+        bundledToolsDirectory,
+      );
+      expect(String(spawnCalls[0]?.[2].env?.PATH)).toContain(originalPath);
+
+      await transport.close();
+    } finally {
+      rmSync(bundledToolsDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("launches the descriptor command directly and writes newline JSON-RPC", async () => {
     const child = new MockAcpChildProcess();
     const spawnCalls: Array<Parameters<AcpStdioSpawn>> = [];

--- a/apps/desktop/src/main/__tests__/bundled-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/bundled-tools.test.ts
@@ -13,7 +13,10 @@ import {
   resolveBundledToolsDirectory,
 } from "../bundled-tools";
 
-function writeRipgrep(directory: string, executable = "rg"): void {
+function writeRipgrep(
+  directory: string,
+  executable = process.platform === "win32" ? "rg.exe" : "rg",
+): void {
   mkdirSync(directory, { recursive: true });
   const executablePath = path.join(directory, executable);
   writeFileSync(executablePath, "#!/bin/sh\nexit 0\n");

--- a/apps/desktop/src/main/__tests__/bundled-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/bundled-tools.test.ts
@@ -1,0 +1,119 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  prependBundledToolsToPath,
+  resolveBundledToolsDirectory,
+} from "../bundled-tools";
+
+function writeRipgrep(directory: string, executable = "rg"): void {
+  mkdirSync(directory, { recursive: true });
+  const executablePath = path.join(directory, executable);
+  writeFileSync(executablePath, "#!/bin/sh\nexit 0\n");
+  if (executable !== "rg.exe") {
+    chmodSync(executablePath, 0o755);
+  }
+}
+
+describe("bundled tools", () => {
+  it("prefers the packaged resources directory", () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "pwragent-tools-"));
+    try {
+      const packagedDirectory = path.join(tempRoot, "resources", "tools");
+      const developmentDirectory = path.join(
+        tempRoot,
+        "build",
+        "bundled-tools",
+        "ripgrep",
+      );
+      writeRipgrep(packagedDirectory);
+      writeRipgrep(developmentDirectory);
+
+      expect(resolveBundledToolsDirectory({
+        developmentMode: true,
+        developmentRoot: tempRoot,
+        resourcesPath: path.join(tempRoot, "resources"),
+      })).toBe(packagedDirectory);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the staged development bundle when packaged resources have no ripgrep", () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "pwragent-tools-"));
+    try {
+      const developmentDirectory = path.join(
+        tempRoot,
+        "apps",
+        "desktop",
+        "build",
+        "bundled-tools",
+        "ripgrep",
+      );
+      writeRipgrep(developmentDirectory);
+
+      expect(resolveBundledToolsDirectory({
+        developmentMode: true,
+        developmentRoot: tempRoot,
+        resourcesPath: path.join(tempRoot, "electron-resources"),
+      })).toBe(developmentDirectory);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves PATH unchanged when the bundle is missing", () => {
+    const env = { PATH: "/usr/bin:/bin" };
+
+    expect(prependBundledToolsToPath(env, {
+      directory: "/missing/pwragent/tools",
+    })).toBe(env);
+  });
+
+  it("does not trust a working-directory tool in a packaged process", () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "pwragent-tools-"));
+    try {
+      const developmentDirectory = path.join(
+        tempRoot,
+        "build",
+        "bundled-tools",
+        "ripgrep",
+      );
+      writeRipgrep(developmentDirectory);
+
+      expect(resolveBundledToolsDirectory({
+        developmentMode: false,
+        developmentRoot: tempRoot,
+        resourcesPath: path.join(tempRoot, "missing-resources"),
+      })).toBeUndefined();
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("deduplicates Windows PATH entries case-insensitively", () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "pwragent-tools-"));
+    try {
+      writeRipgrep(tempRoot, "rg.exe");
+      const env = {
+        Path: `C:\\Windows;${tempRoot.toUpperCase()};C:\\Tools`,
+      };
+
+      expect(prependBundledToolsToPath(env, {
+        directory: tempRoot,
+        platform: "win32",
+      })).toEqual({
+        Path: `${tempRoot};C:\\Windows;C:\\Tools`,
+      });
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -21,6 +21,21 @@ const codexClientLogDebug = vi.hoisted(() => vi.fn());
 const codexClientLogInfo = vi.hoisted(() => vi.fn());
 const codexClientLogWarn = vi.hoisted(() => vi.fn());
 
+async function createBundledToolsDirectory(): Promise<string> {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "pwragent-codex-bundled-tools-"),
+  );
+  const executable = path.join(
+    directory,
+    process.platform === "win32" ? "rg.exe" : "rg",
+  );
+  await fs.writeFile(executable, "#!/bin/sh\nexit 0\n");
+  if (process.platform !== "win32") {
+    await fs.chmod(executable, 0o755);
+  }
+  return directory;
+}
+
 vi.mock("../log", () => ({
   getMainLogger: vi.fn(() => ({
     debug: codexClientLogDebug,
@@ -7408,6 +7423,77 @@ describe("CodexAppServerClient", () => {
     ).toBeUndefined();
 
     await client.close();
+  });
+
+  it("preserves bundled tools in a hydrated Codex thread/start PATH", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const bundledToolsDirectory = await createBundledToolsDirectory();
+    const capturedPath = "/Users/fixture-user/.nvm/versions/node/v26.0.0/bin:/usr/bin";
+    const client = new CodexAppServerClient({
+      bundledToolsDirectory,
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    try {
+      await client.startThread({
+        cwd: "/Users/fixture-user/pwrdrvr/PwrAgent",
+        codexEnvironmentRuntime: {
+          environmentId: "env",
+          environmentName: "Env",
+          executionTarget: "local",
+          shellEnvironment: { PATH: capturedPath },
+        },
+      });
+
+      const startPayload = MockTransport.instances.at(-1)?.sentMessages
+        .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+        .find((payload) => payload.method === "thread/start");
+      expect(startPayload?.params).toMatchObject({
+        config: {
+          "shell_environment_policy.set.PATH":
+            `${bundledToolsDirectory}${path.delimiter}${capturedPath}`,
+        },
+      });
+    } finally {
+      await client.close();
+      await fs.rm(bundledToolsDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves bundled tools in a hydrated Codex thread/resume PATH", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const bundledToolsDirectory = await createBundledToolsDirectory();
+    const capturedPath = "/Users/fixture-user/project/.venv/bin:/usr/bin";
+    const client = new CodexAppServerClient({
+      bundledToolsDirectory,
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    try {
+      await client.startTurn({
+        threadId: "thread-2",
+        input: [{ type: "text", text: "Continue" }],
+        codexEnvironmentRuntime: {
+          environmentId: "env",
+          environmentName: "Env",
+          executionTarget: "local",
+          shellEnvironment: { PATH: capturedPath },
+        },
+      });
+
+      const resumePayload = MockTransport.instances.at(-1)?.sentMessages
+        .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+        .find((payload) => payload.method === "thread/resume");
+      expect(resumePayload?.params).toMatchObject({
+        config: {
+          "shell_environment_policy.set.PATH":
+            `${bundledToolsDirectory}${path.delimiter}${capturedPath}`,
+        },
+      });
+    } finally {
+      await client.close();
+      await fs.rm(bundledToolsDirectory, { recursive: true, force: true });
+    }
   });
 
   it("enables default-mode request_user_input in Codex thread/start config", async () => {

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -1,4 +1,12 @@
 import { EventEmitter } from "node:events";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { PassThrough, Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { compareCodexCliVersions } from "@pwrdrvr/codex-discovery";
@@ -55,6 +63,19 @@ class MockCodexChildProcess extends EventEmitter {
   }
 }
 
+function createBundledToolsDirectory(): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "pwragent-bundled-tools-"));
+  const executable = path.join(
+    directory,
+    process.platform === "win32" ? "rg.exe" : "rg",
+  );
+  writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+  if (process.platform !== "win32") {
+    chmodSync(executable, 0o755);
+  }
+  return directory;
+}
+
 beforeEach(() => {
   resolveCodexCommandMock.mockClear();
   spawnMock.mockReset();
@@ -72,6 +93,51 @@ describe("stdio transport Codex CLI resolution", () => {
 });
 
 describe("StdioJsonRpcTransport", () => {
+  it("prepends PwrAgent's bundled ripgrep for an external Codex runtime and its shell policy", async () => {
+    const child = new MockCodexChildProcess();
+    const bundledToolsDirectory = createBundledToolsDirectory();
+    const externalRuntimeDirectory = path.join(os.tmpdir(), "custom-codex-runtime");
+    const originalPath = [externalRuntimeDirectory, "/usr/bin"].join(path.delimiter);
+    const resolveArgs = vi.fn((env: NodeJS.ProcessEnv) => [
+      "-c",
+      `shell_environment_policy.set.PATH=${JSON.stringify(env.PATH)}`,
+    ]);
+    spawnMock.mockReturnValue(child);
+    try {
+      const transport = new StdioJsonRpcTransport({
+        command: "codex",
+        bundledToolsDirectory,
+        env: { PATH: originalPath },
+        resolveArgs,
+        resolveCommand: async () => ({
+          command: path.join(externalRuntimeDirectory, "codex"),
+          source: "path",
+          version: "0.144.0",
+        }),
+      });
+
+      await transport.connect();
+
+      const expectedPath = [bundledToolsDirectory, originalPath].join(path.delimiter);
+      expect(resolveArgs).toHaveBeenCalledWith({ PATH: expectedPath });
+      expect(spawnMock).toHaveBeenCalledWith(
+        path.join(externalRuntimeDirectory, "codex"),
+        [
+          "app-server",
+          "-c",
+          `shell_environment_policy.set.PATH=${JSON.stringify(expectedPath)}`,
+        ],
+        expect.objectContaining({
+          env: expect.objectContaining({ PATH: expectedPath }),
+        }),
+      );
+
+      await transport.close();
+    } finally {
+      rmSync(bundledToolsDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("does not pass PwrAgent's renderer URL to the Codex app server", async () => {
     const child = new MockCodexChildProcess();
     spawnMock.mockReturnValue(child);

--- a/apps/desktop/src/main/acp/acp-stdio-transport.ts
+++ b/apps/desktop/src/main/acp/acp-stdio-transport.ts
@@ -15,6 +15,7 @@ import {
   type JsonRpcTransport,
 } from "@pwrdrvr/agent-transport";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
+import { prependBundledToolsToPath } from "../bundled-tools.js";
 import { getMainLogger } from "../log.js";
 import {
   terminateOwnedProcessTree,
@@ -46,6 +47,8 @@ export type AcpStdioJsonRpcTransportOptions = {
   observer?: JsonRpcObserver;
   spawn?: AcpStdioSpawn;
   platform?: NodeJS.Platform;
+  /** Test seam for the packaged or development bundled-tools directory. */
+  bundledToolsDirectory?: string;
 };
 
 function appendExecutableSearchPaths(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -94,6 +97,7 @@ export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
       launchDescriptor: options.launchDescriptor,
       spawn: options.spawn,
       platform: options.platform,
+      bundledToolsDirectory: options.bundledToolsDirectory,
     });
     this.connection = new JsonRpcConnection(
       this.lineTransport,
@@ -189,6 +193,7 @@ class AcpLineStdioTransport implements JsonRpcTransport {
       launchDescriptor: AcpLaunchDescriptor;
       spawn?: AcpStdioSpawn;
       platform?: NodeJS.Platform;
+      bundledToolsDirectory?: string;
     },
   ) {}
 
@@ -211,10 +216,18 @@ class AcpLineStdioTransport implements JsonRpcTransport {
     this.stderrPreview = "";
 
     const descriptor = normalizeAcpLaunchDescriptor(this.options.launchDescriptor);
-    const env = buildPwrAgentChildProcessEnv(
-      appendExecutableSearchPaths(
-        buildPwrAgentChildProcessEnv(process.env, descriptor.env),
+    const env = prependBundledToolsToPath(
+      buildPwrAgentChildProcessEnv(
+        appendExecutableSearchPaths(
+          buildPwrAgentChildProcessEnv(process.env, descriptor.env),
+        ),
       ),
+      {
+        ...(this.options.bundledToolsDirectory
+          ? { directory: this.options.bundledToolsDirectory }
+          : {}),
+        ...(this.options.platform ? { platform: this.options.platform } : {}),
+      },
     );
     const invocation = createCommandInvocation({
       command: descriptor.command,

--- a/apps/desktop/src/main/bundled-tools.ts
+++ b/apps/desktop/src/main/bundled-tools.ts
@@ -1,0 +1,111 @@
+import { accessSync, constants as fsConstants, statSync } from "node:fs";
+import path from "node:path";
+
+export const BUNDLED_TOOLS_RESOURCE_DIRECTORY = "tools";
+export const DEVELOPMENT_RIPGREP_DIRECTORY = [
+  "build",
+  "bundled-tools",
+  "ripgrep",
+] as const;
+
+type BundledToolsOptions = {
+  directory?: string;
+  developmentMode?: boolean;
+  developmentRoot?: string;
+  platform?: NodeJS.Platform;
+  resourcesPath?: string;
+};
+
+export function prependBundledToolsToPath(
+  env: NodeJS.ProcessEnv,
+  options: BundledToolsOptions = {},
+): NodeJS.ProcessEnv {
+  const platform = options.platform ?? process.platform;
+  const toolDirectory = resolveBundledToolsDirectory(options);
+  if (!toolDirectory) {
+    return env;
+  }
+
+  const pathKey = resolvePathEnvKey(env, platform);
+  const delimiter = platform === "win32" ? ";" : path.delimiter;
+  const currentEntries = (env[pathKey] ?? "").split(delimiter).filter(Boolean);
+  const normalizedToolDirectory = normalizePathEntry(toolDirectory, platform);
+  const nextEntries = [
+    toolDirectory,
+    ...currentEntries.filter(
+      (entry) => normalizePathEntry(entry, platform) !== normalizedToolDirectory,
+    ),
+  ];
+  if (
+    nextEntries.length === currentEntries.length
+    && nextEntries.every((entry, index) => entry === currentEntries[index])
+  ) {
+    return env;
+  }
+  return {
+    ...env,
+    [pathKey]: nextEntries.join(delimiter),
+  };
+}
+
+export function resolveBundledToolsDirectory(
+  options: BundledToolsOptions = {},
+): string | undefined {
+  const platform = options.platform ?? process.platform;
+  const resourcesPath = options.resourcesPath ?? process.resourcesPath;
+  const developmentRoot = options.developmentRoot ?? process.cwd();
+  const developmentMode = options.developmentMode ?? process.defaultApp === true;
+  const candidates = options.directory
+    ? [options.directory]
+    : [
+        resourcesPath
+          ? path.resolve(resourcesPath, BUNDLED_TOOLS_RESOURCE_DIRECTORY)
+          : undefined,
+        ...(developmentMode
+          ? [
+              path.resolve(developmentRoot, ...DEVELOPMENT_RIPGREP_DIRECTORY),
+              path.resolve(
+                developmentRoot,
+                "apps",
+                "desktop",
+                ...DEVELOPMENT_RIPGREP_DIRECTORY,
+              ),
+            ]
+          : []),
+      ];
+  const executable = platform === "win32" ? "rg.exe" : "rg";
+  for (const candidate of candidates) {
+    if (candidate && isExecutableFile(path.join(candidate, executable), platform)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function isExecutableFile(candidate: string, platform: NodeJS.Platform): boolean {
+  try {
+    if (!statSync(candidate).isFile()) {
+      return false;
+    }
+    if (platform !== "win32") {
+      accessSync(candidate, fsConstants.X_OK);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizePathEntry(entry: string, platform: NodeJS.Platform): string {
+  return platform === "win32" ? entry.toLowerCase() : entry;
+}
+
+function resolvePathEnvKey(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string {
+  if (platform !== "win32") {
+    return "PATH";
+  }
+  return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -53,12 +53,13 @@ import type {
   CodexMcpServerSummary,
   LinkedDirectorySummary,
 } from "@pwragent/shared";
-import { getMainLogger } from "../log";
-import { isPwrSnapSignedMediaUrl } from "../pwrsnap-media-url";
+import { prependBundledToolsToPath } from "../bundled-tools";
 import {
   buildPwrAgentChildProcessEnv,
   ELECTRON_RENDERER_URL_ENV,
 } from "../child-process-env";
+import { getMainLogger } from "../log";
+import { isPwrSnapSignedMediaUrl } from "../pwrsnap-media-url";
 import type {
   ClientRequest as CodexClientRequest,
   InitializeParams as CodexInitializeParams,
@@ -246,6 +247,7 @@ type CodexClientOptions = {
   resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
   resolveCommand?: StdioJsonRpcTransportOptions["resolveCommand"];
   resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
+  bundledToolsDirectory?: StdioJsonRpcTransportOptions["bundledToolsDirectory"];
   directoryResolver?: (
     projectKey?: string
   ) => Promise<LinkedDirectorySummary[]>;
@@ -6200,6 +6202,7 @@ function buildThreadStartPayload(params: {
   defaultModeRequestUserInput?: boolean;
   dynamicTools?: CodexDynamicToolSpec[];
   threadSource?: CodexThreadStartParams["threadSource"];
+  bundledToolsDirectory?: string;
 }, compatibility: CodexProtocolCompatibility): CodexThreadStartPayload {
   const base: CodexThreadStartPayload = {
     experimentalRawEvents: false,
@@ -6253,6 +6256,7 @@ function buildThreadStartPayload(params: {
       params.defaultModeRequestUserInput,
     ),
     params.codexEnvironmentRuntime,
+    params.bundledToolsDirectory,
   );
   if (config) {
     base.config = config;
@@ -6283,13 +6287,18 @@ function buildThreadStartPayload(params: {
 function mergeCodexShellEnvironmentPolicyConfig(
   config: CodexThreadStartParams["config"] | undefined,
   runtime: CodexThreadEnvironmentRuntime | undefined,
+  bundledToolsDirectory?: string,
 ): CodexThreadStartParams["config"] | undefined {
   const sanitizedConfig = sanitizeCodexShellEnvironmentPolicyConfig(config);
   if (runtime?.executionTarget !== "local" || !runtime.shellEnvironment) {
     return sanitizedConfig;
   }
+  const hydratedEnvironment = prependBundledToolsToPath(
+    buildPwrAgentChildProcessEnv(runtime.shellEnvironment),
+    bundledToolsDirectory ? { directory: bundledToolsDirectory } : {},
+  );
   const shellEnvironment = Object.fromEntries(
-    Object.entries(buildPwrAgentChildProcessEnv(runtime.shellEnvironment)).filter(
+    Object.entries(hydratedEnvironment).filter(
       (entry): entry is [string, string] =>
         typeof entry[0] === "string" &&
         entry[0].length > 0 &&
@@ -6376,6 +6385,7 @@ function buildThreadForkPayload(params: {
   fastMode?: boolean;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   config?: CodexThreadForkParams["config"];
+  bundledToolsDirectory?: string;
 }, compatibility: CodexProtocolCompatibility): CodexThreadForkPayload {
   const base: CodexThreadForkPayload = {
     threadId: params.threadId,
@@ -6419,6 +6429,7 @@ function buildThreadForkPayload(params: {
   const config = mergeCodexShellEnvironmentPolicyConfig(
     mergeCodexFastModeConfig(params.config, params.fastMode),
     params.codexEnvironmentRuntime,
+    params.bundledToolsDirectory,
   );
   if (config) {
     base.config = config;
@@ -6439,6 +6450,7 @@ function buildThreadResumePayloads(params: {
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   config?: CodexThreadResumeParams["config"];
   defaultModeRequestUserInput?: boolean;
+  bundledToolsDirectory?: string;
 }, compatibility: CodexProtocolCompatibility): CodexThreadResumePayload[] {
   const base: CodexThreadResumePayload = {
     threadId: params.threadId,
@@ -6478,6 +6490,7 @@ function buildThreadResumePayloads(params: {
       params.defaultModeRequestUserInput,
     ),
     params.codexEnvironmentRuntime,
+    params.bundledToolsDirectory,
   );
   if (config) {
     base.config = config;
@@ -6983,6 +6996,7 @@ export class CodexAppServerClient {
         resolveArgs: options.resolveArgs,
         resolveCommand: options.resolveCommand,
         resolveEnv: options.resolveEnv,
+        bundledToolsDirectory: options.bundledToolsDirectory,
       }),
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
       createCodexObserverWithConfigReadRedaction(options.connectionObserver),
@@ -8045,7 +8059,13 @@ export class CodexAppServerClient {
       client: this.connection,
       methods: ["thread/start"],
       payloads: [
-        buildThreadStartPayload(params, this.getProtocolCompatibility()),
+        buildThreadStartPayload(
+          {
+            ...params,
+            bundledToolsDirectory: this.options.bundledToolsDirectory,
+          },
+          this.getProtocolCompatibility(),
+        ),
       ],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
@@ -8081,7 +8101,13 @@ export class CodexAppServerClient {
       client: this.connection,
       methods: ["thread/fork"],
       payloads: [
-        buildThreadForkPayload(params, this.getProtocolCompatibility()),
+        buildThreadForkPayload(
+          {
+            ...params,
+            bundledToolsDirectory: this.options.bundledToolsDirectory,
+          },
+          this.getProtocolCompatibility(),
+        ),
       ],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
@@ -8144,6 +8170,7 @@ export class CodexAppServerClient {
             codexEnvironmentRuntime: params.codexEnvironmentRuntime,
             config: params.config,
             defaultModeRequestUserInput: params.defaultModeRequestUserInput,
+            bundledToolsDirectory: this.options.bundledToolsDirectory,
           },
           this.getProtocolCompatibility(),
         ),
@@ -8530,6 +8557,7 @@ export class CodexAppServerClient {
             reasoningEffort: params.reasoningEffort,
             fastMode: params.fastMode,
             codexEnvironmentRuntime: params.codexEnvironmentRuntime,
+            bundledToolsDirectory: this.options.bundledToolsDirectory,
           },
           this.getProtocolCompatibility(),
         ),

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -8,6 +8,7 @@ import {
   type JsonRpcTransport,
 } from "@pwrdrvr/agent-transport";
 import { getMainLogger } from "../log";
+import { prependBundledToolsToPath } from "../bundled-tools";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { terminateOwnedProcessTree } from "../process-tree";
 import {
@@ -43,6 +44,8 @@ export type StdioJsonRpcTransportOptions = {
   platform?: NodeJS.Platform;
   /** Test seam for the Windows shim-sibling lookup. */
   commandExists?: (candidate: string) => boolean;
+  /** Test seam for the packaged or development bundled-tools directory. */
+  bundledToolsDirectory?: string;
 };
 
 export { compareCodexCliVersions };
@@ -117,7 +120,15 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       ? await this.options.resolveEnv()
       : this.options.env ?? process.env;
     this.assertCurrentGeneration(generation);
-    const env = buildPwrAgentChildProcessEnv(resolvedEnv);
+    const env = prependBundledToolsToPath(
+      buildPwrAgentChildProcessEnv(resolvedEnv),
+      {
+        ...(this.options.bundledToolsDirectory
+          ? { directory: this.options.bundledToolsDirectory }
+          : {}),
+        ...(this.options.platform ? { platform: this.options.platform } : {}),
+      },
+    );
     const args = this.options.resolveArgs
       ? await this.options.resolveArgs(env)
       : this.options.args ?? [];


### PR DESCRIPTION
## Summary

- I pin and checksum-verify official ripgrep 15.2.0 archives, assemble a universal macOS binary, and package the native executable plus its MIT/Unlicense notices at a stable `Resources/tools` location.
- I stage ripgrep automatically for development and every desktop package, and I verify its version, architecture slices, and platform signature in the release pipeline.
- I prepend the bundled tools directory to Codex App Server and ACP environments. Codex receives it before launch arguments are built, so Code Mode's `shell_environment_policy.set.PATH` includes ripgrep even when the selected external Codex runtime has no sibling `rg`.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/bundled-tools.test.ts apps/desktop/src/main/__tests__/stdio-transport.test.ts apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts apps/desktop/scripts/stage-ripgrep-bundle.test.mjs apps/desktop/scripts/dev.test.mjs` (45 tests passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `node apps/desktop/scripts/stage-ripgrep-bundle.mjs --platform macos-universal --force`
- `pnpm --filter @pwragent/desktop package:dryrun` (final packaged `Resources/tools/rg` executed as 15.2.0, passed arm64/x86_64 and code-signature verification, and passed the ASAR audit)

## Notes

- I recovered the intent of the original closed draft, but replaced its Codex-sibling lookup with an app-owned distribution so custom Codex runtimes and all ACP providers share the same reliable tool path.
- The package adds about 8.1 MB uncompressed to the universal macOS app. Linux and Windows stage a single native archive.
- Windows signing and Linux package execution remain covered by the release pipeline but were not executable on this macOS worktree.
