### PR TITLE
fix(desktop): preserve rich paste with inline code

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -585,6 +585,29 @@ function getHtmlInlineMark(tagName: string): { type: string } | undefined {
   return undefined;
 }
 
+function mergeHtmlInlineMarks(
+  inheritedMarks: { type: string }[],
+  mark: { type: string } | undefined,
+): { type: string }[] {
+  if (!mark || inheritedMarks.some((inheritedMark) => inheritedMark.type === mark.type)) {
+    return inheritedMarks;
+  }
+
+  // ProseMirror's inline code mark excludes every other mark. Transcript
+  // clipboard HTML can legitimately nest it inside <strong>, for example for
+  // Markdown like **10 `Promise.all` cells**. Keep the code mark and split the
+  // surrounding emphasis around it instead of constructing an invalid mark set
+  // that aborts the whole paste.
+  if (mark.type === "code") {
+    return [mark];
+  }
+  if (inheritedMarks.some((inheritedMark) => inheritedMark.type === "code")) {
+    return inheritedMarks;
+  }
+
+  return [...inheritedMarks, mark];
+}
+
 function parseHtmlInlineContent(
   node: Node,
   inheritedMarks: { type: string }[] = [],
@@ -612,7 +635,7 @@ function parseHtmlInlineContent(
   }
 
   const mark = getHtmlInlineMark(node.tagName.toLowerCase());
-  const nextMarks = mark ? [...inheritedMarks, mark] : inheritedMarks;
+  const nextMarks = mergeHtmlInlineMarks(inheritedMarks, mark);
   return Array.from(node.childNodes).flatMap((child) =>
     parseHtmlInlineContent(child, nextMarks),
   );

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -231,6 +231,64 @@ describe("ComposerTiptapInput", () => {
     expect(container.querySelector("a")).not.toBeInTheDocument();
   });
 
+  it("pastes copied transcript text that nests code inside bold text", async () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ComposerTiptapInput
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "blockquote",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Context:" }],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="> Context:"
+      />,
+    );
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    setComposerSelection(textbox, "Context:".length);
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return "<p><strong>10 <code>Promise.all</code> cells</strong></p>";
+          }
+          return type === "text/plain" ? "10 Promise.all cells" : "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        [
+          "> Context:",
+          "> ",
+          "> **10** `Promise.all` **cells**",
+        ].join("\n"),
+        [],
+        expect.any(Object),
+      );
+    });
+    expect(container.querySelector("code")).toHaveTextContent("Promise.all");
+  });
+
   it("pastes copied handoff markdown as fences and lists without extra blank lines", async () => {
     const { container, onChange } = renderTiptapInput();
     const textbox = await screen.findByRole("textbox", { name: "Reply" });


### PR DESCRIPTION
## Summary

- I fixed the Composer rich-HTML paste path so inline code copied inside bold text no longer produces ProseMirror's invalid `bold,code` mark collection.
- I added a regression test that pastes a copied transcript selection into a blockquote, matching the renderer exception recorded in the default-profile log.

## Verification

- I verified the focused Composer Tiptap test suite: `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`.
- I verified `pnpm typecheck`, `pnpm lint:eslint`, and `pnpm lint:boundaries`.

## Notes

- The change keeps the inline-code mark and separates surrounding emphasis so the composed Markdown remains valid.
