### PR TITLE
fix(desktop): distinguish colliding federated threads

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -5,9 +5,12 @@ import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
+import type { ThreadPrAutoDispatchPending } from "@pwragent/shared";
 import { generateFederationIdentityKeyPair } from "../src/main/federation/federation-identity";
 import { generateFederationNoiseStaticKeyPair } from "../src/main/federation/federation-noise";
 import { applyDesktopSettingsPatch } from "../src/main/settings/desktop-config";
+import { SqliteOverlayStore } from "../src/main/state/overlay-store-sqlite";
+import { StateDb } from "../src/main/state/state-db";
 import { launchElectronApp, rightClickThreadRow } from "./fixtures/electron-app";
 import {
   buildFakeAgentConfigToml,
@@ -37,7 +40,10 @@ import {
  * with executable-backed Kimi + Codex fakes (no Codex replay fixture).
  */
 
-async function createLocalControlFixture(): Promise<{
+async function createLocalControlFixture(options?: {
+  threadId?: string;
+  threadTitle?: string;
+}): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
 }> {
@@ -45,6 +51,8 @@ async function createLocalControlFixture(): Promise<{
     path.join(os.tmpdir(), "pwragent-federation-e2e-"),
   );
   const fixturePath = path.join(rootDir, "federation-local.fixture.json");
+  const threadId = options?.threadId ?? "local-thread-1";
+  const threadTitle = options?.threadTitle ?? "Local control thread";
   await writeFile(
     fixturePath,
     JSON.stringify({
@@ -75,8 +83,8 @@ async function createLocalControlFixture(): Promise<{
           method: "thread/list",
           result: [
             {
-              id: "local-thread-1",
-              title: "Local control thread",
+              id: threadId,
+              title: threadTitle,
               titleSource: "explicit",
               source: "codex",
               executionMode: "default",
@@ -268,6 +276,243 @@ async function seedFixtureGitRepo(params: {
 }
 
 test.describe("federation remote window", () => {
+  test("cancels a colliding remote auto-fix without changing the local thread", async () => {
+    test.setTimeout(180_000);
+
+    const threadId = "colliding-thread-id";
+    const now = Date.now();
+    const localPending: ThreadPrAutoDispatchPending = {
+      fingerprint: "local-auto-fix",
+      prKey: "github.com/local/repo#41",
+      prNumber: 41,
+      prTitle: "Keep the local pending repair",
+      prUrl: "https://github.com/local/repo/pull/41",
+      headSha: "local-head",
+      eventKinds: ["ci-failure"],
+      createdAt: now,
+      scheduledAt: now + 120_000,
+    };
+    const remotePending: ThreadPrAutoDispatchPending = {
+      fingerprint: "remote-auto-fix",
+      prKey: "github.com/remote/repo#42",
+      prNumber: 42,
+      prTitle: "Cancel the remote pending repair",
+      prUrl: "https://github.com/remote/repo/pull/42",
+      headSha: "remote-head",
+      eventKinds: ["ci-failure"],
+      createdAt: now,
+      scheduledAt: now + 120_000,
+    };
+    const fixture = await createLocalControlFixture({
+      threadId,
+      threadTitle: "Local colliding thread",
+    });
+    let gateway: InProcessFederationGateway | undefined;
+    let app: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+
+    try {
+      gateway = await startInProcessFederationGateway({
+        instanceLabel: "Remote collision owner",
+        threads: [{
+          id: threadId,
+          title: "Remote colliding thread",
+          updatedAt: 2_000,
+          prAutoDispatchPending: remotePending,
+        }],
+      });
+      app = await launchElectronApp({
+        fixturePath: fixture.fixturePath,
+        secretStorage: "memory",
+        preLaunchHook: async (homeRoot) => {
+          const statePath = path.join(
+            homeRoot,
+            ".pwragent",
+            "profiles",
+            "default",
+            "state",
+            "state.db",
+          );
+          await mkdir(path.dirname(statePath), { recursive: true });
+          const stateDb = StateDb.open(statePath);
+          try {
+            const store = new SqliteOverlayStore(stateDb);
+            await store.setThreadPrAutoDispatchEnabled({
+              backend: "codex",
+              threadId,
+              enabled: true,
+            });
+            const scheduled = await store.scheduleThreadPrAutoDispatch({
+              backend: "codex",
+              threadId,
+              pending: localPending,
+              prompt: "Repair the local PR",
+              maxAttempts: 2,
+            });
+            if (scheduled.status !== "scheduled") {
+              throw new Error(
+                `Failed to seed local auto-fix: ${scheduled.status}`,
+              );
+            }
+          } finally {
+            stateDb.close();
+          }
+        },
+      });
+      const { window } = app;
+
+      const localRow = window.getByRole("button", {
+        name: "Local colliding thread",
+      });
+      await expect(localRow).toBeVisible({ timeout: 30_000 });
+      await localRow.click();
+      await expect(window.getByText("Local thread is ready.")).toBeVisible();
+      await expect(window.getByText("#41 · CI failed")).toBeVisible();
+
+      await window.getByRole("button", { name: "Open settings" }).click();
+      await window
+        .getByRole("navigation", { name: "Settings sections" })
+        .getByRole("button", { name: "Federation" })
+        .click();
+      await window.getByLabel("Import invite").fill(gateway.invite);
+      await window.getByRole("button", { name: "Import invite" }).click();
+      await gateway.waitForConnection(30_000);
+
+      await window.evaluate(async ({ instanceId, pending, threadId: remoteThreadId }) => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            addRemoteThreadPin?: (request: unknown) => Promise<unknown>;
+          };
+        }).pwragent;
+        if (!api?.addRemoteThreadPin) {
+          throw new Error("addRemoteThreadPin API is unavailable");
+        }
+        await api.addRemoteThreadPin({
+          ref: {
+            backend: "codex",
+            target: { scope: "remote", instanceId },
+            threadId: remoteThreadId,
+          },
+          instanceLabel: "Remote collision owner",
+          summary: {
+            source: "codex",
+            id: remoteThreadId,
+            title: "Remote colliding thread",
+            titleSource: "explicit",
+            linkedDirectories: [],
+            inbox: { inInbox: true },
+            updatedAt: 2_000,
+            prAutoDispatchPending: pending,
+            federation: {
+              ref: {
+                backend: "codex",
+                target: { scope: "remote", instanceId },
+                threadId: remoteThreadId,
+              },
+              instanceLabel: "Remote collision owner",
+              peerStatus: "connected",
+            },
+          },
+        });
+      }, {
+        instanceId: gateway.instanceId,
+        pending: remotePending,
+        threadId,
+      });
+      await window.getByRole("button", { name: /Exit Settings/i }).click();
+      const collidingSnapshotThreads = await window.evaluate(
+        async (collidingThreadId) => {
+          const api = (window as typeof window & {
+            pwragent?: {
+              getNavigationSnapshot?: () => Promise<{
+                threads: Array<{
+                  id: string;
+                  title: string;
+                  federation?: { ref?: { target?: { instanceId?: string } } };
+                }>;
+              }>;
+            };
+          }).pwragent;
+          if (!api?.getNavigationSnapshot) {
+            throw new Error("getNavigationSnapshot API is unavailable");
+          }
+          const snapshot = await api.getNavigationSnapshot();
+          return snapshot.threads
+            .filter((thread) => thread.id === collidingThreadId)
+            .map((thread) => ({
+              instanceId: thread.federation?.ref?.target?.instanceId,
+              title: thread.title,
+            }));
+        },
+        threadId,
+      );
+      expect(collidingSnapshotThreads).toEqual(expect.arrayContaining([
+        { instanceId: undefined, title: "Local colliding thread" },
+        {
+          instanceId: gateway.instanceId,
+          title: "Remote colliding thread",
+        },
+      ]));
+      await expect.poll(async () =>
+        await window.locator(".thread-row__open").evaluateAll((buttons) =>
+          buttons.map((button) => button.getAttribute("aria-label"))
+        )
+      ).toEqual(expect.arrayContaining([
+        "Local colliding thread",
+        "Remote colliding thread",
+      ]));
+
+      const remoteRow = window.getByRole("button", {
+        name: "Remote colliding thread",
+      }).first();
+      await expect(remoteRow).toBeVisible({ timeout: 30_000 });
+      await remoteRow.click();
+      await expect(
+        window.getByText("Remote transcript for Remote colliding thread."),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(window.getByText("#42 · CI failed")).toBeVisible();
+
+      await window.getByRole("button", { name: "Cancel", exact: true }).click();
+      await expect.poll(() =>
+        gateway!.calls.find((call) =>
+          call.method === "cancelThreadPrAutoDispatch"
+        )
+      ).toMatchObject({
+        method: "cancelThreadPrAutoDispatch",
+        params: {
+          backend: "codex",
+          threadId,
+          fingerprint: remotePending.fingerprint,
+        },
+      });
+
+      gateway.deliverBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "thread/prAutoDispatch/pendingUpdated",
+          params: { threadId, pending: null },
+        },
+      });
+      await expect(window.getByText("#42 · CI failed")).toHaveCount(0);
+
+      await localRow.click();
+      await expect(window.getByText("Local thread is ready.")).toBeVisible();
+      await expect(window.getByText("#41 · CI failed")).toBeVisible();
+      await expect(
+        window.getByRole("button", { name: "Remote colliding thread" }),
+      ).toHaveCount(1);
+      await expect(
+        window.getByRole("button", { name: "Local colliding thread" }),
+      ).toHaveCount(1);
+      await expect(
+        window.locator(".thread-row__open[aria-pressed=\"true\"]"),
+      ).toHaveCount(1);
+    } finally {
+      await app?.close();
+      await gateway?.close();
+      await fixture.cleanup();
+    }
+  });
+
   test("enrolls, browses remote threads, pins on the owner, and hides local-only chrome", async () => {
     test.setTimeout(300_000);
 

--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -3,10 +3,13 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type {
+  AppServerNotification,
   AppServerBackendKind,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
+  CancelThreadPrAutoDispatchRequest,
+  CancelThreadPrAutoDispatchResponse,
   CodexEnvironmentOption,
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
@@ -15,6 +18,7 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  NavigationThreadSummary,
   SetThreadPinRequest,
   SetThreadPinResponse,
 } from "@pwragent/shared";
@@ -29,6 +33,7 @@ import {
   encodeFederationInvite,
 } from "../../src/main/federation/federation-enrollment";
 import {
+  FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
   additionalFederationBackendCapabilities,
   registerFederationBackendHandlers,
@@ -54,6 +59,7 @@ export type GatewayThreadSeed = {
   source?: AppServerBackendKind;
   executionMode?: AppServerThreadSummary["executionMode"];
   linkedDirectories?: LinkedDirectorySummary[];
+  prAutoDispatchPending?: NavigationThreadSummary["prAutoDispatchPending"];
   /**
    * Needed to reach a Star Map lane: a thread with no attention category
    * is not on the map at all, and an idle thread with no PR and no
@@ -112,6 +118,11 @@ export type InProcessFederationGateway = {
   };
   /** Current pin rank per thread id (mutated by backend.setThreadPin). */
   pinnedRankByThreadId: Map<string, string | undefined>;
+  /** Deliver an owner-side backend update to every connected viewer. */
+  deliverBackendEvent: (params: {
+    backend: AppServerBackendKind;
+    notification: AppServerNotification;
+  }) => void;
   /** Resolves when a client connection has completed enrollment/auth. */
   waitForConnection: (timeoutMs?: number) => Promise<void>;
   /** Resolves when a connection completes AFTER this call (reconnects). */
@@ -244,6 +255,9 @@ export async function startInProcessFederationGateway(params: {
       updatedAt: thread.updatedAt,
       createdAt: thread.updatedAt,
       ...(thread.threadStatus ? { threadStatus: thread.threadStatus } : {}),
+      ...(thread.prAutoDispatchPending
+        ? { prAutoDispatchPending: thread.prAutoDispatchPending }
+        : {}),
       ...(pinnedRankByThreadId.get(thread.id) !== undefined
         ? { pinnedRank: pinnedRankByThreadId.get(thread.id) }
         : {}),
@@ -423,6 +437,12 @@ export async function startInProcessFederationGateway(params: {
       calls.push({ method: "listScheduledThreadActions", params: {} });
       return { actions: [] };
     },
+    async cancelThreadPrAutoDispatch(
+      request: CancelThreadPrAutoDispatchRequest,
+    ): Promise<CancelThreadPrAutoDispatchResponse> {
+      calls.push({ method: "cancelThreadPrAutoDispatch", params: request });
+      return { ...request, cancelled: true };
+    },
     async ensureDirectoryLaunchpad(
       request: EnsureDirectoryLaunchpadRequest,
     ): Promise<EnsureDirectoryLaunchpadResponse> {
@@ -534,6 +554,7 @@ export async function startInProcessFederationGateway(params: {
   }
 
   let connectionCount = 0;
+  const connectedPeerIds = new Set<string>();
   const connectionWaiters: (() => void)[] = [];
   const buildServer = (port: number) =>
     new FederationGatewayWebSocketServer({
@@ -545,6 +566,7 @@ export async function startInProcessFederationGateway(params: {
       store,
       noiseStatic,
       onConnection: (connection) => {
+        connectedPeerIds.add(connection.peerId);
         router.registerConnection({
           peerId: connection.peerId,
           capabilities: connection.capabilities,
@@ -557,6 +579,7 @@ export async function startInProcessFederationGateway(params: {
         }
       },
       onDisconnect: (connection) => {
+        connectedPeerIds.delete(connection.peerId);
         router.unregisterConnection(connection.peerId);
         ptyService?.notifyPeerDisconnected(connection.peerId);
       },
@@ -623,6 +646,26 @@ export async function startInProcessFederationGateway(params: {
     calls,
     transcriptStats,
     pinnedRankByThreadId,
+    deliverBackendEvent: ({ backend: eventBackend, notification }) => {
+      for (const peerId of connectedPeerIds) {
+        const delivered = router.sendToPeer(peerId, {
+          id: `federation-backend-event:${randomBytes(8).toString("hex")}`,
+          kind: "notification",
+          method: FEDERATION_BACKEND_EVENT_METHOD,
+          params: {
+            backend: eventBackend,
+            notification,
+          },
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: gatewayInstanceId,
+          targetInstanceId: peerId,
+          createdAt: Date.now(),
+        });
+        if (!delivered) {
+          throw new Error(`Failed to deliver backend event to ${peerId}`);
+        }
+      }
+    },
     waitForConnection: async (timeoutMs = 15_000) => {
       await waitForConnectionCount(1, timeoutMs);
     },

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2792,6 +2792,90 @@ describe("app server ipc", () => {
     expect(row?.pinnedRank).toBe("3072");
   });
 
+  it("keeps viewer pin ranks separate across colliding remote owners", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+    const firstRef = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-first",
+      threadId: "shared-thread",
+    });
+    const secondRef = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-second",
+      threadId: "shared-thread",
+    });
+    listRemoteThreadPins.mockResolvedValueOnce([
+      {
+        ref: firstRef,
+        addedAt: 1_000,
+        instanceLabel: "First",
+        localPinnedRank: "1024",
+      },
+      {
+        ref: secondRef,
+        addedAt: 2_000,
+        instanceLabel: "Second",
+        localPinnedRank: "2048",
+      },
+    ]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          source: "codex" as const,
+          id: "shared-thread",
+          title: "First owner",
+          titleSource: "derived" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          federation: {
+            ref: firstRef,
+            instanceLabel: "First",
+            peerStatus: "connected" as const,
+            capabilities: [],
+          },
+        },
+        {
+          source: "codex" as const,
+          id: "shared-thread",
+          title: "Second owner",
+          titleSource: "derived" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          federation: {
+            ref: secondRef,
+            instanceLabel: "Second",
+            peerStatus: "connected" as const,
+            capabilities: [],
+          },
+        },
+      ],
+      refreshed: [],
+      archived: [],
+    });
+
+    registerAppServerIpcHandlers();
+    const response = (await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    )) as {
+      threads: Array<{
+        federation?: { ref: { target: { instanceId?: string } } };
+        pinnedRank?: string;
+      }>;
+    };
+
+    expect(response.threads
+      .filter((thread) => thread.federation)
+      .map((thread) => ({
+        instanceId: thread.federation?.ref.target.instanceId,
+        pinnedRank: thread.pinnedRank,
+      }))).toEqual([
+      { instanceId: "peer-first", pinnedRank: "1024" },
+      { instanceId: "peer-second", pinnedRank: "2048" },
+    ]);
+  });
+
   it("routes pin reorders per key: viewer rank for remote pins, overlay for local", async () => {
     const { NAVIGATION_REORDER_THREAD_PINS_CHANNEL } = await import(
       "../../shared/ipc"

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2231,7 +2231,9 @@ describe("app server ipc", () => {
     const appDirectory = response.directories.find(
       (directory) => directory.key === "directory:/repo/app",
     );
-    expect(appDirectory?.threadKeys).toContain("codex:remote-1");
+    expect(appDirectory?.threadKeys).toContain(
+      "remote:peer-laptop:codex:remote-1",
+    );
     // The unread remote row bumps the group's "N to review" badge past the
     // reconcile-computed local count.
     expect(appDirectory?.needsAttentionCount).toBe(2);
@@ -2332,7 +2334,7 @@ describe("app server ipc", () => {
       kind: "directory",
       label: "grok-build",
       localAvailability: "unconfigured",
-      threadKeys: ["codex:remote-grok-build"],
+      threadKeys: ["remote:peer-laptop:codex:remote-grok-build"],
       needsAttentionCount: 1,
     });
 
@@ -2346,7 +2348,7 @@ describe("app server ipc", () => {
     expect(second.directories).toContainEqual(expect.objectContaining({
       key: "directory:/viewer/repos/grok-build",
       label: "grok-build",
-      threadKeys: ["codex:remote-grok-build"],
+      threadKeys: ["remote:peer-laptop:codex:remote-grok-build"],
     }));
     expect(second.directories).not.toContainEqual(expect.objectContaining({
       localAvailability: "unconfigured",
@@ -2586,10 +2588,10 @@ describe("app server ipc", () => {
       response.directories.map((directory) => [directory.key, directory]),
     );
     expect(byKey.get("directory:/repo/PwrAgent")?.threadKeys).toContain(
-      "codex:remote-multi",
+      "remote:peer-laptop:codex:remote-multi",
     );
     expect(byKey.get("directory:/repo/agent-kit")?.threadKeys).not.toContain(
-      "codex:remote-multi",
+      "remote:peer-laptop:codex:remote-multi",
     );
   });
 
@@ -2692,10 +2694,10 @@ describe("app server ipc", () => {
       response.directories.map((directory) => [directory.key, directory]),
     );
     expect(byKey.get("directory:/repo/PwrAgent")?.threadKeys).toContain(
-      "codex:remote-primary-project",
+      "remote:peer-laptop:codex:remote-primary-project",
     );
     expect(byKey.get("directory:/repo/PwrSuiteLab")?.threadKeys).not.toContain(
-      "codex:remote-primary-project",
+      "remote:peer-laptop:codex:remote-primary-project",
     );
   });
 
@@ -2810,17 +2812,27 @@ describe("app server ipc", () => {
 
     const response = (await handlers.get(NAVIGATION_REORDER_THREAD_PINS_CHANNEL)?.(
       {},
-      { threadKeys: ["codex:remote-pin", "codex:local-pin"] },
+      {
+        threadKeys: [
+          "remote:peer-laptop:codex:remote-pin",
+          "codex:local-pin",
+        ],
+      },
     )) as { pinnedRanks: Record<string, string> };
 
     // The store gets the FULL order plus the remote-key routing map so both
     // kinds interleave in one atomic write.
     expect(reorderThreadPinsStore).toHaveBeenCalledWith({
-      threadKeys: ["codex:remote-pin", "codex:local-pin"],
-      remoteRefsByKey: { "codex:remote-pin": remoteRef },
+      threadKeys: [
+        "remote:peer-laptop:codex:remote-pin",
+        "codex:local-pin",
+      ],
+      remoteRefsByKey: {
+        "remote:peer-laptop:codex:remote-pin": remoteRef,
+      },
     });
     expect(response.pinnedRanks).toEqual({
-      "codex:remote-pin": "1024",
+      "remote:peer-laptop:codex:remote-pin": "1024",
       "codex:local-pin": "2048",
     });
   });

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -387,7 +387,9 @@ describe("DesktopFederationRuntime", () => {
       },
     });
     expect(snapshot.inboxThreadKeys).toEqual([]);
-    expect(snapshot.directories[0]?.threadKeys).toEqual(["codex:thread-1"]);
+    expect(snapshot.directories[0]?.threadKeys).toEqual([
+      "remote:client_one:codex:thread-1",
+    ]);
     expect(snapshot.threads[0]?.gitWorkingState).toEqual(gitWorkingState);
     expect(snapshot.threads[0]?.federation?.capabilities).toContain("remote_pty");
     expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
@@ -487,7 +489,9 @@ describe("DesktopFederationRuntime", () => {
     expect(changed.threads.map((thread) => thread.title)).toEqual([
       "Remote one updated",
     ]);
-    expect(changed.inboxThreadKeys).toEqual(["codex:thread-1"]);
+    expect(changed.inboxThreadKeys).toEqual([
+      "remote:client_one:codex:thread-1",
+    ]);
     expect(unchanged.threads.map((thread) => thread.title)).toEqual([
       "Remote one updated",
     ]);

--- a/apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts
@@ -3,7 +3,10 @@ import type {
   NavigationSnapshot,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  applyNavigationSnapshotTransportResponse,
+  buildThreadIdentityKey,
+} from "@pwragent/shared";
 import { NavigationSnapshotTransport } from "../navigation-snapshot-transport";
 
 function buildThread(index: number): NavigationThreadSummary {
@@ -124,6 +127,57 @@ describe("NavigationSnapshotTransport", () => {
       removed.removedThreadKeys,
     );
     expect(removed.inboxThreadKeys).toBeUndefined();
+  });
+
+  it("keeps colliding local and remote identities distinct across a delta", () => {
+    const transport = new NavigationSnapshotTransport();
+    const local = {
+      ...buildThread(1),
+      title: "Local collision",
+    };
+    const full = transport.encode({
+      request: {},
+      snapshot: buildSnapshot([local]),
+    });
+    if (full.kind !== "full") {
+      throw new Error("Expected initial full snapshot");
+    }
+    const remote = {
+      ...buildThread(1),
+      title: "Remote collision",
+      federation: {
+        ref: {
+          backend: "codex" as const,
+          target: {
+            scope: "remote" as const,
+            instanceId: "remote-owner",
+          },
+          threadId: local.id,
+        },
+        instanceLabel: "Remote owner",
+      },
+    };
+    const delta = transport.encode({
+      baseRevision: full.revision,
+      request: {},
+      snapshot: buildSnapshot([local, remote], 2),
+    });
+    if (delta.kind !== "delta") {
+      throw new Error("Expected collision delta");
+    }
+
+    expect(delta.upsertedThreads).toEqual([remote]);
+    const baseline = applyNavigationSnapshotTransportResponse(undefined, full);
+    const applied = applyNavigationSnapshotTransportResponse(baseline, delta);
+    expect(applied?.snapshot.threads.map((thread) => ({
+      instanceId: thread.federation?.ref.target.scope === "remote"
+        ? thread.federation.ref.target.instanceId
+        : undefined,
+      title: thread.title,
+    }))).toEqual([
+      { instanceId: undefined, title: "Local collision" },
+      { instanceId: "remote-owner", title: "Remote collision" },
+    ]);
   });
 
   it("sends a full baseline for a stale revision", () => {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -86,6 +86,7 @@ import {
   buildFederatedThreadRef,
   buildThreadIdentityKey,
   encodeLegacyThreadIdentityKey,
+  federatedThreadIdentityKey,
   federationEndpointAcceptsCloudflareCredentials,
   isCelestialIconAssignment,
   isCelestialIconId,
@@ -1984,7 +1985,11 @@ export class DesktopFederationRuntime {
       visiblePeer,
     );
     const peerStatus = visiblePeer?.status ?? peer?.status;
+    const stampedThreadKeyBySourceKey = new Map<string, string>();
     const threads = response.threads.map((thread) => {
+      const sourceKey = thread.federation?.ref
+        ? federatedThreadIdentityKey(thread.federation.ref)
+        : buildThreadIdentityKey(thread.source, thread.id);
       const existingOwner = thread.federation?.ref.target;
       const ownerInstanceId = existingOwner
         && isRemoteFederationTarget(existingOwner)
@@ -2005,6 +2010,10 @@ export class DesktopFederationRuntime {
         instanceId: ownerInstanceId,
         threadId: thread.id,
       });
+      stampedThreadKeyBySourceKey.set(
+        sourceKey,
+        federatedThreadIdentityKey(ref),
+      );
       return {
         ...thread,
         federation: {
@@ -2027,6 +2036,15 @@ export class DesktopFederationRuntime {
       federationTarget: target,
       unchanged: false,
       threads,
+      inboxThreadKeys: response.inboxThreadKeys.map(
+        (threadKey) => stampedThreadKeyBySourceKey.get(threadKey) ?? threadKey,
+      ),
+      directories: response.directories.map((directory) => ({
+        ...directory,
+        threadKeys: directory.threadKeys.map(
+          (threadKey) => stampedThreadKeyBySourceKey.get(threadKey) ?? threadKey,
+        ),
+      })),
     };
   }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2343,7 +2343,7 @@ class DesktopAppServerService {
         // window path is untouched — owner semantics are correct there.
         const localRankByKey = new Map(
           pins.map((pin) => [
-            buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId),
+            federatedThreadIdentityKey(pin.ref),
             pin.localPinnedRank,
           ]),
         );
@@ -2352,7 +2352,9 @@ class DesktopAppServerService {
           threads: resolution.threads.map(
             ({ pinnedRank: _pinnedRank, ...thread }) => {
               const localRank = localRankByKey.get(
-                buildThreadIdentityKey(thread.source, thread.id),
+                thread.federation?.ref
+                  ? federatedThreadIdentityKey(thread.federation.ref)
+                  : buildThreadIdentityKey(thread.source, thread.id),
               );
               return localRank ? { ...thread, pinnedRank: localRank } : thread;
             },

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -686,7 +686,9 @@ function attachRemoteThreadsToLocalDirectories(
     Array<{ threadKey: string; inInbox: boolean }>
   >();
   for (const thread of remoteThreads) {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = thread.federation?.ref
+      ? federatedThreadIdentityKey(thread.federation.ref)
+      : buildThreadIdentityKey(thread.source, thread.id);
     let homeIndex = findRemoteHomeDirectoryIndex(
       mergedDirectories,
       thread,
@@ -6043,7 +6045,7 @@ class DesktopAppServerService {
         : [];
     const remoteRefsByKey = Object.fromEntries(
       remotePins.map((pin) => [
-        buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId),
+        federatedThreadIdentityKey(pin.ref),
         pin.ref,
       ]),
     );

--- a/apps/desktop/src/main/navigation-snapshot-transport.ts
+++ b/apps/desktop/src/main/navigation-snapshot-transport.ts
@@ -11,6 +11,7 @@ import type {
 import {
   buildNavigationSnapshotTransportScopeKey,
   buildThreadIdentityKey,
+  federatedThreadIdentityKey,
   normalizeThreadIdentityKey,
 } from "@pwragent/shared";
 
@@ -42,7 +43,9 @@ function positiveIntegerOrDefault(
 }
 
 function threadKey(thread: NavigationThreadSummary): string {
-  return buildThreadIdentityKey(thread.source, thread.id);
+  return thread.federation?.ref
+    ? federatedThreadIdentityKey(thread.federation.ref)
+    : buildThreadIdentityKey(thread.source, thread.id);
 }
 
 function selectionHasKey(selected: ReadonlySet<string>, key: string): boolean {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -13,11 +13,11 @@ import {
 } from "react";
 import {
   buildThreadIdentityKey,
+  federatedThreadIdentityKey,
   DEFAULT_BACKGROUND_PR_POLLING,
   DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
   DESKTOP_TOOL_OUTPUT_ALERT_POLICY_DEFAULT,
   isRemoteFederationTarget,
-  parseThreadIdentityKey,
   resolveNewThreadBackend,
   type AppServerBackendKind,
   type DesktopBootInfo,
@@ -78,7 +78,10 @@ import { useFederationPeerConnectivity } from "./lib/useFederationPeerConnectivi
 import { useFederationHealth } from "./lib/useFederationHealth";
 import { useFederationThreadEventSubscriptions } from "./lib/useFederationThreadEventSubscriptions";
 import { scopeDesktopApiToFederationTarget } from "./lib/federation-desktop-api";
-import { federationTargetsEqual } from "./lib/federated-thread-events";
+import {
+  federationTargetsEqual,
+  threadSummaryIdentityKey,
+} from "./lib/federated-thread-events";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
 import {
   useNavigationHistory,
@@ -1434,6 +1437,7 @@ function DesktopAppShell(props: {
   const openWorkspaceLaunchpad = navigation.openWorkspaceLaunchpad;
   const queueMessageLinkRequest = useCallback((request: {
     backend: AppServerBackendKind;
+    instanceId?: FederationInstanceId;
     messageId?: string;
     threadId: string;
   }): void => {
@@ -1441,7 +1445,16 @@ function DesktopAppShell(props: {
       ? {
           messageId: request.messageId,
           nonce: ++messageLinkNonceRef.current,
-          threadKey: buildThreadIdentityKey(request.backend, request.threadId),
+          threadKey: request.instanceId
+            ? federatedThreadIdentityKey({
+                backend: request.backend,
+                target: {
+                  scope: "remote",
+                  instanceId: request.instanceId,
+                },
+                threadId: request.threadId,
+              })
+            : buildThreadIdentityKey(request.backend, request.threadId),
         }
       : undefined);
   }, []);
@@ -1460,14 +1473,14 @@ function DesktopAppShell(props: {
       if (request.instanceId) {
         const windowTarget = readRendererFederationTarget();
         if (windowTarget?.instanceId !== request.instanceId) {
+          const target = {
+            scope: "remote" as const,
+            instanceId: request.instanceId,
+          };
           // A remote viewer is already scoped to another owner. Keep its
           // cross-instance navigation window-scoped; viewer-owned local pins
           // belong to the unscoped main window only.
           if (windowTarget) {
-            const target = {
-              scope: "remote" as const,
-              instanceId: request.instanceId,
-            };
             void desktopApi?.openFederationWindow?.({
               target,
               initialThread: {
@@ -1484,14 +1497,11 @@ function DesktopAppShell(props: {
             setMainView("thread");
             void showThread({
               backend: request.backend,
+              federationTarget: target,
               threadId: request.threadId,
             });
             return;
           }
-          const target = {
-            scope: "remote" as const,
-            instanceId: request.instanceId,
-          };
           void (async () => {
             try {
               await desktopApi?.addRemoteThreadPin?.({
@@ -1509,6 +1519,7 @@ function DesktopAppShell(props: {
             setMainView("thread");
             await showThread({
               backend: request.backend,
+              federationTarget: target,
               threadId: request.threadId,
             });
           })();
@@ -1517,7 +1528,18 @@ function DesktopAppShell(props: {
       }
       queueMessageLinkRequest(request);
       setMainView("thread");
-      void showThread({ backend: request.backend, threadId: request.threadId });
+      void showThread({
+        backend: request.backend,
+        ...(request.instanceId
+          ? {
+              federationTarget: {
+                scope: "remote" as const,
+                instanceId: request.instanceId,
+              },
+            }
+          : {}),
+        threadId: request.threadId,
+      });
     },
     [desktopApi, queueMessageLinkRequest, showThread],
   );
@@ -1555,12 +1577,14 @@ function DesktopAppShell(props: {
         selectDirectoryLaunchpad(location.directoryKey);
         return;
       }
-      const parts = parseThreadIdentityKey(location.threadKey);
-      if (parts) {
-        void showThread(parts);
+      const thread = navigation.threads.find(
+        (candidate) => threadSummaryIdentityKey(candidate) === location.threadKey,
+      );
+      if (thread) {
+        navigation.selectThread(thread);
       }
     },
-    [selectDirectoryLaunchpad, showThread],
+    [navigation, selectDirectoryLaunchpad],
   );
   // Undefined while the snapshot is empty/loading so a transient blank
   // thread list can't wipe the stacks; otherwise dead threads (archived,
@@ -1570,7 +1594,7 @@ function DesktopAppShell(props: {
       navigation.threads.length > 0
         ? new Set(
             navigation.threads.map((thread) =>
-              buildThreadIdentityKey(thread.source, thread.id),
+              threadSummaryIdentityKey(thread),
             ),
           )
         : undefined,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -378,6 +378,7 @@ describe("App", () => {
 
   it("starts a new thread on a selected federation machine and profile", async () => {
     const federationListeners = new Set<(event: AgentEvent) => void>();
+    const threadViewImported = createDeferred<void>();
     const remoteTarget = { scope: "remote" as const, instanceId: "studio-work" };
     const remoteWorkspace = {
       key: "workspace:new-thread",
@@ -480,6 +481,11 @@ describe("App", () => {
         },
         onWindowFocus: () => () => undefined,
         readFederationHealth,
+        recordStartupProfileEvent: (event: string) => {
+          if (event === "thread-view-import:end") {
+            threadViewImported.resolve(undefined);
+          }
+        },
       },
     });
 
@@ -509,6 +515,13 @@ describe("App", () => {
       federationTarget: remoteTarget,
       preferredBackend: undefined,
     }));
+    // The menu intentionally fire-and-forgets its async target callback, and
+    // thread detail is loaded after two animation frames. The bridge call can
+    // therefore finish before the composer module is ready on a loaded CI
+    // runner. Synchronize on the app's startup-profile readiness event rather
+    // than extending the query timeout.
+    await threadViewImported.promise;
+    await flushReactUpdates();
     expect(await screen.findByRole("textbox", { name: "New thread" }))
       .toBeInTheDocument();
 

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -16,7 +16,6 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import {
-  buildThreadIdentityKey,
   comparePinnedDirectories,
   comparePinnedThreads,
   isPinnedDirectory,
@@ -39,7 +38,10 @@ import {
   useDropIndicatorController,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
-import { threadSupportsFederationCapability } from "../../lib/federated-thread-events";
+import {
+  threadSummaryIdentityKey,
+  threadSupportsFederationCapability,
+} from "../../lib/federated-thread-events";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   beginNativeDragInteraction,
@@ -770,7 +772,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
     () =>
       new Map(
         props.threads.map((thread) => [
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
           thread,
         ]),
       ),
@@ -786,7 +788,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const pinnedThreadKeys = useMemo(
     () =>
       pinnedThreads.map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id),
+        threadSummaryIdentityKey(thread),
       ),
     [pinnedThreads],
   );
@@ -932,7 +934,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
     thread: NavigationThreadSummary,
     direction: "up" | "down",
   ): void => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
     const directoryPinnedThreadKeys = buildDirectoryPinnedKeys(directory);
     const currentIndex = directoryPinnedThreadKeys.indexOf(threadKey);
     if (currentIndex === -1) return;
@@ -1061,15 +1063,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
         return !parentKey || !directoryThreadKeys.has(parentKey);
       })
       .filter((thread) => !isPinnedThread(thread));
-    const topLevelThreadKey = buildThreadIdentityKey(
-      topLevelThread.source,
-      topLevelThread.id,
-    );
+    const topLevelThreadKey = threadSummaryIdentityKey(topLevelThread);
     if (
       topLevelUnpinnedThreads.findIndex(
-        (thread) =>
-          buildThreadIdentityKey(thread.source, thread.id) ===
-          topLevelThreadKey,
+        (thread) => threadSummaryIdentityKey(thread) === topLevelThreadKey,
       ) >= DIRECTORY_UNPINNED_THREAD_CAP
     ) {
       setUnpinnedExpandedByKey((current) => ({
@@ -1147,7 +1144,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       threadModel.expanded ?? EMPTY_EXPANDED_DIRECTORY_THREAD_MODEL;
     const { childThreadsByParentKey } = expandedThreadModel;
     const renderStaticSubthreads = (parent: NavigationThreadSummary): ReactElement | null => {
-      const parentKey = buildThreadIdentityKey(parent.source, parent.id);
+      const parentKey = threadSummaryIdentityKey(parent);
       const children = sortSubthreadSummaries(parent, childThreadsByParentKey.get(parentKey) ?? []);
       const nativeSubAgentCount = parent.codexNativeSubAgents?.length ?? 0;
       const subthreadsCollapsed = isSubthreadSectionCollapsed(parent);
@@ -1162,7 +1159,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       // `draggedSubthreadKey` state for why it stays isolated from the
       // directory / pinned-thread drag.
       const childOrderKeys = children.map((child) =>
-        buildThreadIdentityKey(child.source, child.id),
+        threadSummaryIdentityKey(child),
       );
       const reorderable =
         threadSupportsFederationCapability(parent, "thread_grouping")
@@ -1171,7 +1168,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       return (
         <div className="subthread-list subthread-list--compact" role="list" aria-label={`Sub-threads of ${parent.title}`}>
           {children.map((child) => {
-            const childKey = buildThreadIdentityKey(child.source, child.id);
+            const childKey = threadSummaryIdentityKey(child);
             const rowDropKey = `subthread:${parentKey}:${childKey}`;
             return (
             <ThreadRow
@@ -1304,7 +1301,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const renderUnpinnedRow = (
       thread: NavigationThreadSummary,
     ): ReactElement => {
-      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const threadKey = threadSummaryIdentityKey(thread);
       const ordinarySubthreadCount =
         childThreadsByParentKey.get(threadKey)?.length ?? 0;
       const subthreadCount = getSubthreadDisclosureCount(
@@ -1734,7 +1731,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 {visibleThreadCount > 0 ? (
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
                     {directoryPinnedThreads.map((thread) => {
-	                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+	                      const threadKey = threadSummaryIdentityKey(thread);
                           const ordinarySubthreadCount =
                             childThreadsByParentKey.get(threadKey)?.length ?? 0;
                           const subthreadCount = getSubthreadDisclosureCount(

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -23,7 +23,6 @@ import {
   isSubthreadLaunchpadKey,
   moveDirectoryKey,
   moveThreadKey,
-  parseThreadIdentityKey,
   resolveThreadParentKey,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
@@ -1253,7 +1252,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 void props.onUpdateSubthreadOrder?.(
                   parent,
                   nextKeys
-                    .map((key) => parseThreadIdentityKey(key)?.threadId)
+                    .map((key) => threadsByKey.get(key)?.id)
                     .filter((threadId): threadId is string => Boolean(threadId)),
                 );
               }}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -6,7 +6,6 @@ import type {
 } from "@pwragent/shared";
 import {
   moveThreadKey,
-  parseThreadIdentityKey,
   resolveThreadParentKey,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
@@ -213,8 +212,6 @@ export function RecentsList(props: RecentsListProps) {
                 ) {
                   return;
                 }
-                const draggedId = parseThreadIdentityKey(draggedKey)?.threadId;
-                if (!draggedId) return;
                 const nextKeys = moveThreadKey(
                   childKeys,
                   draggedKey,
@@ -224,7 +221,7 @@ export function RecentsList(props: RecentsListProps) {
                 void props.onUpdateSubthreadOrder?.(
                   parent,
                   nextKeys
-                    .map((threadKey) => parseThreadIdentityKey(threadKey)?.threadId)
+                    .map((threadKey) => threadByKey.get(threadKey)?.id)
                     .filter((threadId): threadId is string => Boolean(threadId)),
                 );
               }}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -5,7 +5,6 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import {
-  buildThreadIdentityKey,
   moveThreadKey,
   parseThreadIdentityKey,
   resolveThreadParentKey,
@@ -17,7 +16,10 @@ import {
   useDropIndicatorController,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
-import { threadSupportsFederationCapability } from "../../lib/federated-thread-events";
+import {
+  threadSummaryIdentityKey,
+  threadSupportsFederationCapability,
+} from "../../lib/federated-thread-events";
 import {
   getSubthreadDisclosureCount,
   isSubthreadSectionCollapsed,
@@ -100,7 +102,7 @@ export function RecentsList(props: RecentsListProps) {
   );
   const threadByKey = new Map(
     props.threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread,
     ]),
   );
@@ -119,7 +121,7 @@ export function RecentsList(props: RecentsListProps) {
     childrenByParentKey.set(parentKey, children);
   }
   const renderSubthreads = (parent: NavigationThreadSummary) => {
-    const parentKey = buildThreadIdentityKey(parent.source, parent.id);
+    const parentKey = threadSummaryIdentityKey(parent);
     const children = sortSubthreadSummaries(parent, childrenByParentKey.get(parentKey) ?? []);
     const nativeSubAgentCount = parent.codexNativeSubAgents?.length ?? 0;
     const subthreadsCollapsed = isSubthreadSectionCollapsed(parent);
@@ -135,12 +137,12 @@ export function RecentsList(props: RecentsListProps) {
     }
 
     const childKeys = children.map((child) =>
-      buildThreadIdentityKey(child.source, child.id),
+      threadSummaryIdentityKey(child),
     );
     return (
       <div className="subthread-list" role="list" aria-label={`Sub-threads of ${parent.title}`}>
         {children.map((child) => {
-          const childKey = buildThreadIdentityKey(child.source, child.id);
+          const childKey = threadSummaryIdentityKey(child);
           const rowDropKey = `${parentKey}:${childKey}`;
           return (
             <ThreadRow
@@ -255,7 +257,7 @@ export function RecentsList(props: RecentsListProps) {
   // deliberately absent, just like Finder ranges do not reach into a closed
   // disclosure.
   const selectionOrder = topLevelThreads.flatMap((thread) => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
     const children = sortSubthreadSummaries(
       thread,
       childrenByParentKey.get(threadKey) ?? [],
@@ -265,13 +267,13 @@ export function RecentsList(props: RecentsListProps) {
       ...(isSubthreadSectionCollapsed(thread)
         ? []
         : children.map((child) =>
-            buildThreadIdentityKey(child.source, child.id),
+            threadSummaryIdentityKey(child),
           )),
     ];
   });
 
   const renderThreadGroup = (thread: NavigationThreadSummary) => {
-    const key = buildThreadIdentityKey(thread.source, thread.id);
+    const key = threadSummaryIdentityKey(thread);
     const children = sortSubthreadSummaries(thread, childrenByParentKey.get(key) ?? []);
     const subthreadCount = getSubthreadDisclosureCount(thread, children.length);
     const subthreadsCollapsed = isSubthreadSectionCollapsed(thread);

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -17,7 +17,6 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
-  buildThreadIdentityKey,
   buildThreadUrl,
   comparePinnedDirectories,
   comparePinnedThreads,
@@ -31,6 +30,7 @@ import {
   readRendererFederationLabel,
   readRendererFederationTarget,
 } from "../../lib/federation-window";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import {
@@ -112,7 +112,7 @@ function hydrateHoverStableSidebarSnapshot(
   );
   const latestThreadsByKey = new Map(
     latest.threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread,
     ]),
   );
@@ -121,7 +121,7 @@ function hydrateHoverStableSidebarSnapshot(
   );
   const frozenThreadKeys = new Set(
     frozen.threads.map((thread) =>
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
     ),
   );
 
@@ -149,7 +149,7 @@ function hydrateHoverStableSidebarSnapshot(
     threads: [
       ...frozen.threads.map((thread) => {
         const latestThread = latestThreadsByKey.get(
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
         );
         return latestThread
           ? {
@@ -167,7 +167,7 @@ function hydrateHoverStableSidebarSnapshot(
       }),
       ...latest.threads
         .filter((thread) => !frozenThreadKeys.has(
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
         ))
         .map((thread) => ({
           ...thread,
@@ -640,7 +640,7 @@ export function Sidebar(props: SidebarProps) {
   const navigationThreadByKey = useMemo(
     () => new Map(
       navigationThreads.map((thread) => [
-        buildThreadIdentityKey(thread.source, thread.id),
+        threadSummaryIdentityKey(thread),
         thread,
       ]),
     ),
@@ -676,7 +676,7 @@ export function Sidebar(props: SidebarProps) {
   useEffect(() => {
     const availableThreadKeys = new Set(
       navigationThreads.map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id),
+        threadSummaryIdentityKey(thread),
       ),
     );
     if (!availableThreadKeys.has(selectionAnchorKeyRef.current ?? "")) {
@@ -731,7 +731,7 @@ export function Sidebar(props: SidebarProps) {
     event: ReactMouseEvent<HTMLElement>,
     selectionOrder: string[],
   ): void => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
 
     if (!event.metaKey && !event.shiftKey) {
       selectionAnchorKeyRef.current = threadKey;
@@ -1126,7 +1126,7 @@ export function Sidebar(props: SidebarProps) {
   const resolveContextMenuThreads = (
     thread: NavigationThreadSummary,
   ): NavigationThreadSummary[] => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
     if (!selectedThreadKeys.has(threadKey)) {
       selectionAnchorKeyRef.current = threadKey;
       setSelectedThreadKeys(new Set([threadKey]));
@@ -1135,7 +1135,7 @@ export function Sidebar(props: SidebarProps) {
 
     const selectedThreads = props.threads.filter((candidate) =>
       selectedThreadKeys.has(
-        buildThreadIdentityKey(candidate.source, candidate.id),
+        threadSummaryIdentityKey(candidate),
       ),
     );
 
@@ -1315,7 +1315,7 @@ export function Sidebar(props: SidebarProps) {
     const unreadThreads = props.threads.filter(
       (thread) =>
         directoryThreadKeys.has(
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
         ) && thread.inbox.inInbox,
     );
     setDirectoryContextMenu(undefined);
@@ -1332,7 +1332,7 @@ export function Sidebar(props: SidebarProps) {
       [...props.threads]
         .filter(isPinnedThread)
         .sort(comparePinnedThreads)
-        .map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
+        .map((thread) => threadSummaryIdentityKey(thread)),
     [props.threads],
   );
 
@@ -1356,7 +1356,7 @@ export function Sidebar(props: SidebarProps) {
     direction: "up" | "down",
   ): void => {
     const ordered = pinnedThreadKeysInOrder;
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
     const currentIndex = ordered.indexOf(threadKey);
     if (currentIndex === -1) return;
     const targetIndex =
@@ -1429,7 +1429,7 @@ export function Sidebar(props: SidebarProps) {
   ): void => {
     setContextMenu(undefined);
     const threadKeys = threads.map((thread) =>
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
     );
     if (props.onReorderThreadPins) {
       const nextKeys = [
@@ -1544,10 +1544,7 @@ export function Sidebar(props: SidebarProps) {
     ? props.threads.filter(
         (thread) =>
           resolveThreadParentKey(thread, navigationThreadByKey)
-          === buildThreadIdentityKey(
-            contextMenu.thread.source,
-            contextMenu.thread.id,
-          ),
+          === threadSummaryIdentityKey(contextMenu.thread),
       ).length
     : 0;
   const contextMenuHasChildThreads = contextMenuChildThreadCount > 0;
@@ -1622,7 +1619,7 @@ export function Sidebar(props: SidebarProps) {
   );
   const contextMenuPinnedThreadIndex = contextMenu
     ? pinnedThreadKeysInOrder.indexOf(
-        buildThreadIdentityKey(contextMenu.thread.source, contextMenu.thread.id),
+        threadSummaryIdentityKey(contextMenu.thread),
       )
     : -1;
   const contextMenuPinnedThreadCount = pinnedThreadKeysInOrder.length;
@@ -1710,7 +1707,7 @@ export function Sidebar(props: SidebarProps) {
   const directoryMenuUnreadThreads = props.threads.filter(
     (thread) =>
       directoryMenuThreadKeys.has(
-        buildThreadIdentityKey(thread.source, thread.id),
+        threadSummaryIdentityKey(thread),
       ) && thread.inbox.inInbox,
   );
   const directoryMenuCanMarkRead = Boolean(

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -13,13 +13,12 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import {
-  buildThreadIdentityKey,
-  federatedThreadIdentityKey,
   threadHasExactPrNumberMatch,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { SearchIcon } from "../../icons";
 import { getDesktopApi } from "../../lib/desktop-api";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import {
   FEDERATED_THREAD_SEARCH_LIMIT,
   useFederatedThreadSearch,
@@ -111,11 +110,11 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
   const remoteRows = useMemo(() => {
     const localKeys = new Set(
       props.threads.map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id),
+        threadSummaryIdentityKey(thread),
       ),
     );
     return remoteResults.filter(
-      (thread) => !localKeys.has(buildThreadIdentityKey(thread.source, thread.id)),
+      (thread) => !localKeys.has(threadSummaryIdentityKey(thread)),
     );
   }, [remoteResults, props.threads]);
 
@@ -238,9 +237,7 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     const prStripResetKey = `${exactPrQuery}|${prs
       .map((pr) => pr.url)
       .join("|")}`;
-    const key = thread.federation
-      ? federatedThreadIdentityKey(thread.federation.ref)
-      : buildThreadIdentityKey(thread.source, thread.id);
+    const key = threadSummaryIdentityKey(thread);
     return (
       <li
         key={key}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -12,8 +12,8 @@ import type {
   NavigationThreadSummary,
   PrSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
 import { MoreVerticalIcon, PinIcon, SmileyIcon } from "../../icons";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
@@ -138,7 +138,7 @@ type ThreadRowProps = {
 };
 
 export function ThreadRow(props: ThreadRowProps) {
-  const threadKey = buildThreadIdentityKey(props.thread.source, props.thread.id);
+  const threadKey = threadSummaryIdentityKey(props.thread);
   const selected = props.selectedThreadKeys
     ? props.selectedThreadKeys.has(threadKey)
     : threadKey === props.selectedThreadKey;

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -343,6 +343,30 @@ describe("SidebarSearchPopup", () => {
     expect(onJumpToRemoteThread.mock.calls[0][0].id).toBe("r1");
   });
 
+  it("keeps a remote result when its backend and id collide locally", async () => {
+    jumpSearchRemoteThreads.mockResolvedValue({
+      results: [remoteThread({ threadId: "shared", title: "Remote fix" })],
+    });
+
+    render(
+      <SidebarSearchPopup
+        threads={[localThread({ id: "shared", title: "Local fix" })]}
+        onJumpToThread={vi.fn()}
+        onJumpToRemoteThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "fix" },
+    });
+    await settleRemoteSearch();
+
+    expect(screen.getByText("Local fix")).toBeInTheDocument();
+    expect(screen.getByText("Remote fix")).toBeInTheDocument();
+    expect(screen.getByText("Other instances")).toBeInTheDocument();
+  });
+
   it("hides remote hits that are already pinned into the local list", async () => {
     const pinnedLocally = remoteThread({ threadId: "r1", title: "Remote fix" });
     jumpSearchRemoteThreads.mockResolvedValue({ results: [pinnedLocally] });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/directory-thread-render-model.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/directory-thread-render-model.test.ts
@@ -1,8 +1,68 @@
 import { describe, expect, it } from "vitest";
+import {
+  buildFederatedThreadRef,
+  federatedThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
 import { buildDirectoryThreadRenderModel } from "../directory-thread-render-model";
 import { buildLargeDirectoryFixture } from "./fixtures/directory-performance";
 
 describe("large directory thread render model", () => {
+  it("groups same-owner remote children under their scoped parent", () => {
+    const parentRef = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "remote-owner",
+      threadId: "parent",
+    });
+    const childRef = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "remote-owner",
+      threadId: "child",
+    });
+    const parent = {
+      id: "parent",
+      title: "Remote parent",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      federation: { ref: parentRef, instanceLabel: "Remote owner" },
+    } as NavigationThreadSummary;
+    const child = {
+      id: "child",
+      title: "Remote child",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      parentThreadBackend: "codex",
+      parentThreadId: "parent",
+      federation: { ref: childRef, instanceLabel: "Remote owner" },
+    } as NavigationThreadSummary;
+    const parentKey = federatedThreadIdentityKey(parentRef);
+    const childKey = federatedThreadIdentityKey(childRef);
+    const model = buildDirectoryThreadRenderModel({
+      directory: {
+        key: "directory:/remote/repo",
+        kind: "directory",
+        label: "Remote repo",
+        path: "/remote/repo",
+        threadKeys: [parentKey, childKey],
+        needsAttentionCount: 0,
+      },
+      expanded: true,
+      threadsByKey: new Map([
+        [parentKey, parent],
+        [childKey, child],
+      ]),
+    });
+
+    expect(model.expanded?.childThreadsByParentKey.get(parentKey)).toEqual([
+      child,
+    ]);
+    expect(model.expanded?.selectionOrder).toEqual([parentKey, childKey]);
+  });
+
   it("does not prepare hidden thread structure for collapsed project folders", () => {
     const fixture = buildLargeDirectoryFixture({
       directoryCount: 12,

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -117,7 +117,7 @@ function leaveThreadBrowser(): void {
 }
 
 describe("Sidebar hover-stable thread ordering", () => {
-  it("keeps an Inbox click aimed at the row that was under the pointer", () => {
+  it("keeps an Inbox click aimed at a local row when a remote collision appears", () => {
     const onSelectThread = vi.fn<(thread: NavigationThreadSummary) => void>();
     const initial = [alpha, bravo];
     const view = render(renderSidebar({
@@ -150,8 +150,9 @@ describe("Sidebar hover-stable thread ordering", () => {
     expect(threadTitles()).toEqual([
       "Alpha thread",
       "Bravo thread refreshed",
+      "Alpha thread",
     ]);
-    expect(firstRow.querySelector(".thread-row")).toHaveClass(
+    expect(firstRow.querySelector(".thread-row")).not.toHaveClass(
       "is-remote-offline",
     );
     fireEvent.click(within(firstRow).getByRole("button", { name: /^Alpha thread/ }));

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -6752,7 +6752,7 @@ describe("Sidebar thread pinning Move items", () => {
         directories={[
           pinnedThreadsDirectory([
             "codex:codex-top",
-            "acp:grok:grok-middle",
+            "remote:peer-laptop:acp:grok:grok-middle",
             "acp:grok:grok-bottom",
           ]),
         ]}
@@ -6786,7 +6786,7 @@ describe("Sidebar thread pinning Move items", () => {
 
     fireEvent.click(moveUp);
     expect(onReorderThreadPins).toHaveBeenCalledWith([
-      "acp:grok:grok-middle",
+      "remote:peer-laptop:acp:grok:grok-middle",
       "codex:codex-top",
       "acp:grok:grok-bottom",
     ]);

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -970,6 +970,106 @@ describe("Sidebar", () => {
     expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(sharedThread, true);
   });
 
+  it("groups same-owner remote sub-threads and submits their drag order", () => {
+    const target = { scope: "remote" as const, instanceId: "remote-owner" };
+    const remoteParent: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "remote-parent",
+      title: "Remote parent",
+      subthreadOrder: ["remote-child-a", "remote-child-b"],
+      federation: {
+        capabilities: ["thread_grouping"],
+        instanceLabel: "Remote owner",
+        ref: {
+          backend: "codex",
+          target,
+          threadId: "remote-parent",
+        },
+      },
+    };
+    const remoteChildA: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "remote-child-a",
+      title: "Remote child A",
+      parentThreadBackend: "codex",
+      parentThreadId: remoteParent.id,
+      federation: {
+        instanceLabel: "Remote owner",
+        ref: {
+          backend: "codex",
+          target,
+          threadId: "remote-child-a",
+        },
+      },
+    };
+    const remoteChildB: NavigationThreadSummary = {
+      ...remoteChildA,
+      id: "remote-child-b",
+      title: "Remote child B",
+      federation: {
+        instanceLabel: "Remote owner",
+        ref: {
+          backend: "codex",
+          target,
+          threadId: "remote-child-b",
+        },
+      },
+    };
+    const onUpdateSubthreadOrder = vi.fn(async () => undefined);
+
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        directories={[]}
+        inboxThreads={[remoteChildA, remoteChildB, remoteParent]}
+        loading={false}
+        selectedItemKey="remote:remote-owner:codex:remote-parent"
+        threads={[remoteChildA, remoteChildB, remoteParent]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onUpdateSubthreadOrder={onUpdateSubthreadOrder}
+      />,
+    );
+
+    expect(container.querySelector(".subthread-list")).toContainElement(
+      threadCard(screen.getByRole("button", { name: "Remote child A" })),
+    );
+    const source = screen.getByRole("button", { name: "Remote child A" })
+      .closest<HTMLElement>(".thread-row-shell")!;
+    const targetRow = screen.getByRole("button", { name: "Remote child B" })
+      .closest<HTMLElement>(".thread-row-shell")!;
+    vi.spyOn(targetRow, "getBoundingClientRect").mockReturnValue({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 0,
+      width: 300,
+      x: 0,
+      y: 0,
+    });
+    const values = new Map<string, string>();
+    const dataTransfer = {
+      dropEffect: "move",
+      effectAllowed: "move",
+      getData: vi.fn((type: string) => values.get(type) ?? ""),
+      setData: vi.fn((type: string, value: string) => values.set(type, value)),
+      setDragImage: vi.fn(),
+    };
+    fireEvent.dragStart(source, { dataTransfer });
+    fireEvent.dragOver(targetRow, { clientY: 75, dataTransfer });
+    fireEvent.drop(targetRow, { clientY: 75, dataTransfer });
+
+    expect(onUpdateSubthreadOrder).toHaveBeenCalledWith(remoteParent, [
+      "remote-child-a",
+      "remote-child-b",
+    ]);
+  });
+
   it("does not expose sub-thread disclosure controls for an older remote peer", () => {
     const remoteParent: NavigationThreadSummary = {
       ...sharedThread,

--- a/apps/desktop/src/renderer/src/features/navigation/directory-thread-render-model.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/directory-thread-render-model.ts
@@ -3,12 +3,12 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import {
-  buildThreadIdentityKey,
   comparePinnedThreads,
   isPinnedThread,
   resolveThreadParentKey,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import {
   isThreadActive,
   isThreadAwaitingReview,
@@ -118,7 +118,7 @@ export function buildDirectoryThreadRenderModel(params: {
     : overflowUnpinnedThreads.length;
   const selectedUnpinnedInOverflow = overflowUnpinnedThreads.some(
     (thread) =>
-      buildThreadIdentityKey(thread.source, thread.id) ===
+      threadSummaryIdentityKey(thread) ===
       params.selectedItemKey,
   );
   const unpinnedExpanded =
@@ -131,7 +131,7 @@ export function buildDirectoryThreadRenderModel(params: {
       ];
   const renderedParentKeys = new Set(
     [...directoryPinnedThreads, ...visibleUnpinnedThreads].map((thread) =>
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
     ),
   );
   const childThreadsByParentKey = new Map<
@@ -149,7 +149,7 @@ export function buildDirectoryThreadRenderModel(params: {
     ...directoryPinnedThreads,
     ...visibleUnpinnedThreads,
   ].flatMap((thread) => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
     const children = sortSubthreadSummaries(
       thread,
       childThreadsByParentKey.get(threadKey) ?? [],
@@ -159,7 +159,7 @@ export function buildDirectoryThreadRenderModel(params: {
       ...(thread.subthreadsCollapsed
         ? []
         : children.map((child) =>
-            buildThreadIdentityKey(child.source, child.id),
+            threadSummaryIdentityKey(child),
           )),
     ];
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -121,6 +121,9 @@ export function ThreadHeader(props: ThreadHeaderProps) {
   // under a resting pointer and releases on unmount.
   const titleHover = useThreadLinkHoverSource({
     backend: props.thread.source,
+    ...(props.thread.federation?.ref.target.scope === "remote"
+      ? { instanceId: props.thread.federation.ref.target.instanceId }
+      : {}),
     threadId: props.thread.id,
   });
   const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx
@@ -46,7 +46,9 @@ const otherThread = threadSummary({
 const remoteThread = threadSummary({
   federation: {
     ref: {
+      backend: "codex",
       target: { scope: "remote", instanceId: REMOTE_INSTANCE_ID },
+      threadId: TARGET_THREAD_ID,
     },
     instanceLabel: "Peer",
   } as NavigationThreadSummary["federation"],

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1258,6 +1258,105 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("releases retained remote unread state without clearing a local collision", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const markThreadSeen = vi.fn(
+      async (
+        request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0],
+      ) => ({
+        backend: request.backend ?? "codex",
+        threadId: request.threadId,
+        seenAt: Date.now(),
+        seenUpdatedAt: request.seenUpdatedAt,
+      }),
+    );
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["remote:remote-instance:codex:shared-thread"],
+      threads: [
+        {
+          id: "shared-thread",
+          title: "Local collision",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          updatedAt: 1_500,
+        },
+        {
+          id: "shared-thread",
+          title: "Remote unread collision",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "shared-thread",
+            },
+          },
+          inbox: {
+            inInbox: true,
+            reason: "updated-since-seen" as const,
+            lastSeenUpdatedAt: 1_000,
+          },
+          updatedAt: 2_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(2);
+    });
+    act(() => {
+      result.current.selectThread(
+        result.current.threads.find((thread) => thread.federation)!,
+      );
+    });
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        federationTarget,
+        threadId: "shared-thread",
+        seenUpdatedAt: 2_000,
+      });
+    });
+    expect(result.current.threads.find((thread) => thread.federation)?.inbox.inInbox)
+      .toBe(true);
+
+    act(() => {
+      result.current.selectThread(
+        result.current.threads.find((thread) => !thread.federation)!,
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.threads.find(
+        (thread) => thread.federation,
+      )?.inbox.inInbox).toBe(false);
+    });
+    expect(result.current.threads.find((thread) => !thread.federation)?.inbox.inInbox)
+      .toBe(false);
+    expect(result.current.snapshot?.inboxThreadKeys).toEqual([]);
+  });
+
   it("marks a remote read thread unread until the user returns to it", async () => {
     const federationTarget = {
       scope: "remote" as const,
@@ -1347,7 +1446,7 @@ describe("useThreadNavigation", () => {
       lastSeenUpdatedAt: 1_999,
     });
     expect(result.current.snapshot?.inboxThreadKeys).toEqual([
-      "codex:thread-read",
+      "remote:remote-instance:codex:thread-read",
     ]);
 
     act(() => {
@@ -2913,6 +3012,91 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("keeps a colliding local row visible while suppressing a remote archive", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const remoteKey = "remote:remote-instance:codex:shared-thread";
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:shared-thread", remoteKey],
+      threads: [
+        {
+          id: "shared-thread",
+          title: "Local collision",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+        },
+        {
+          id: "shared-thread",
+          title: "Remote collision",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "shared-thread",
+            },
+          },
+        },
+      ],
+      directories: [{
+        key: "directory:/repo",
+        kind: "directory" as const,
+        label: "Repo",
+        path: "/repo",
+        threadKeys: ["codex:shared-thread", remoteKey],
+        needsAttentionCount: 2,
+      }],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const archiveThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "shared-thread",
+      archivedAt: 2_000,
+      cleanup: [],
+    }));
+    const desktopApi: DesktopApi = {
+      archiveThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      removeRemoteThreadPin: vi.fn(async () => ({ removed: true })),
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(2);
+    });
+    const remoteThread = result.current.threads.find(
+      (thread) => thread.federation,
+    )!;
+    await act(async () => {
+      await result.current.archiveThread(remoteThread);
+    });
+
+    expect(result.current.threads.map((thread) => thread.title)).toEqual([
+      "Local collision",
+    ]);
+    expect(result.current.snapshot?.inboxThreadKeys).toEqual([
+      "codex:shared-thread",
+    ]);
+    expect(result.current.directories[0]?.threadKeys).toEqual([
+      "codex:shared-thread",
+    ]);
+  });
+
   it("pins a main-window remote row through the viewer-owned local pin API", async () => {
     const federationTarget = {
       scope: "remote" as const,
@@ -2929,6 +3113,14 @@ describe("useThreadNavigation", () => {
       unchanged: false,
       inboxThreadKeys: [],
       threads: [
+        {
+          id: "thread-remote",
+          title: "Local collision",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
         {
           id: "thread-remote",
           title: "Remote thread",
@@ -2966,10 +3158,13 @@ describe("useThreadNavigation", () => {
     const { result } = renderHook(() => useThreadNavigation(desktopApi));
 
     await waitFor(() => {
-      expect(result.current.threads[0]?.id).toBe("thread-remote");
+      expect(result.current.threads).toHaveLength(2);
     });
+    const remoteThread = result.current.threads.find(
+      (thread) => thread.federation,
+    )!;
     await act(async () => {
-      await result.current.setThreadPin(result.current.threads[0]!, true);
+      await result.current.setThreadPin(remoteThread, true);
     });
 
     // Main window, remote row: the rank is VIEWER-owned — the owner-routing
@@ -2979,7 +3174,10 @@ describe("useThreadNavigation", () => {
       pinnedRank: expect.any(String),
     });
     expect(setThreadPin).not.toHaveBeenCalled();
-    expect(result.current.threads[0]?.pinnedRank).toBe("1024");
+    expect(result.current.threads.find((thread) => !thread.federation)?.pinnedRank)
+      .toBeUndefined();
+    expect(result.current.threads.find((thread) => thread.federation)?.pinnedRank)
+      .toBe("1024");
   });
 
   it("pins through the owner in a remote-viewer window", async () => {
@@ -4213,7 +4411,7 @@ describe("useThreadNavigation", () => {
         "codex:thread-before",
         "codex:thread-child-a",
         "codex:thread-child-b",
-        "codex:thread-parent",
+        "remote:parent-owner:codex:thread-parent",
       ],
     });
   });
@@ -4300,7 +4498,10 @@ describe("useThreadNavigation", () => {
     );
     expect(reorderThreadPins).toHaveBeenCalledWith({
       federationTarget: undefined,
-      threadKeys: ["codex:thread-child", "codex:thread-parent"],
+      threadKeys: [
+        "remote:child-owner:codex:thread-child",
+        "codex:thread-parent",
+      ],
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -1,5 +1,6 @@
 import {
   buildThreadIdentityKey,
+  federatedThreadIdentityKey,
   isThreadLinkId,
   parseThreadUrl,
   type AppServerBackendKind,
@@ -59,16 +60,24 @@ export type ThreadLinkContextValue = {
   hoverTarget: ThreadLinkHoverStore;
 };
 
-export type ThreadLinkHoverTarget = Pick<ResolvedThreadLink, "backend" | "threadId">;
+export type ThreadLinkHoverTarget = Pick<
+  ResolvedThreadLink,
+  "backend" | "instanceId" | "threadId"
+>;
 
 /**
  * The key a hovered link is matched against a sidebar card by. Same shape as
- * the row's own identity key (`buildThreadIdentityKey(source, id)`) and as
- * `composerSourceThreadKey`, so a link to a pinned remote thread lights up
- * that row too — the instance is deliberately not part of the match.
+ * the row's own identity key, including its federation owner when remote, so
+ * a link cannot light up a colliding local or sibling-instance row.
  */
 function threadLinkHoverKey(link: ThreadLinkHoverTarget): string {
-  return buildThreadIdentityKey(link.backend, link.threadId);
+  return link.instanceId
+    ? federatedThreadIdentityKey({
+        backend: link.backend,
+        target: { scope: "remote", instanceId: link.instanceId },
+        threadId: link.threadId,
+      })
+    : buildThreadIdentityKey(link.backend, link.threadId);
 }
 
 /**
@@ -316,9 +325,9 @@ export function useLiveThreadLink(link: ResolvedThreadLink): ResolvedThreadLink 
 }
 
 /**
- * Whether a hovered or focused thread link currently points at `threadKey`
- * (a `buildThreadIdentityKey` value). Subscribes per row, so only the rows
- * whose answer flips re-render. Always false outside a `ThreadLinkProvider`.
+ * Whether a hovered or focused thread link currently points at `threadKey`.
+ * Subscribes per row, so only the rows whose answer flips re-render. Always
+ * false outside a `ThreadLinkProvider`.
  */
 export function useThreadLinkHoverTarget(threadKey: string): boolean {
   // The store is a stable per-provider instance, so these deps do not churn
@@ -534,14 +543,16 @@ export function ThreadLinkProvider(props: {
 
     for (const thread of threadsRef.current) {
       const link = threadSummaryLink(thread);
-      byIdentity.set(buildThreadIdentityKey(thread.source, thread.id), link);
       if (link.instanceId) {
         byFederatedIdentity.set(threadLinkKey(link), link);
+      } else {
+        byIdentity.set(buildThreadIdentityKey(thread.source, thread.id), link);
       }
       // Thread ids are backend-generated and effectively unique, so a bare
       // `pwragent://thread/<id>` resolves without a backend hint. If two
       // backends ever collide on an id, the explicit `?backend=` form wins.
-      if (!byThreadId.has(thread.id)) {
+      const existingByThreadId = byThreadId.get(thread.id);
+      if (!existingByThreadId || (!link.instanceId && existingByThreadId.instanceId)) {
         byThreadId.set(thread.id, link);
       }
     }

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1236,6 +1236,7 @@ function updateThreadPinInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     pinnedRank?: string;
   },
@@ -1244,9 +1245,17 @@ function updateThreadPinInSnapshot(
     return snapshot;
   }
 
+  const threadKey = params.federationTarget
+    && isRemoteFederationTarget(params.federationTarget)
+    ? federatedThreadIdentityKey({
+        backend: params.backend,
+        target: params.federationTarget,
+        threadId: params.threadId,
+      })
+    : buildThreadIdentityKey(params.backend, params.threadId);
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (thread.source !== params.backend || thread.id !== params.threadId) {
+    if (threadSummaryIdentityKey(thread) !== threadKey) {
       return thread;
     }
     if (thread.pinnedRank === params.pinnedRank) {
@@ -1368,8 +1377,7 @@ function updateThreadParentInSnapshot(
 function ungroupChildThreadsInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
-    backend: AppServerBackendKind;
-    parentThreadId: string;
+    parent: NavigationThreadSummary;
   },
 ): NavigationSnapshot | undefined {
   if (!snapshot) {
@@ -1379,14 +1387,11 @@ function ungroupChildThreadsInSnapshot(
   let changed = false;
   const threadByKey = new Map(
     snapshot.threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread,
     ]),
   );
-  const parentKey = buildThreadIdentityKey(
-    params.backend,
-    params.parentThreadId,
-  );
+  const parentKey = threadSummaryIdentityKey(params.parent);
   const threads = snapshot.threads.map((thread) => {
     if (resolveThreadParentKey(thread, threadByKey) !== parentKey) {
       return thread;
@@ -1410,11 +1415,11 @@ function collectDescendantThreads(
   const descendants: NavigationThreadSummary[] = [];
   const threadByKey = new Map(
     threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread,
     ]),
   );
-  const parentKey = buildThreadIdentityKey(parent.source, parent.id);
+  const parentKey = threadSummaryIdentityKey(parent);
   const queue = threads.filter(
     (thread) => resolveThreadParentKey(thread, threadByKey) === parentKey,
   );
@@ -1422,13 +1427,13 @@ function collectDescendantThreads(
 
   while (queue.length > 0) {
     const thread = queue.shift()!;
-    const key = buildThreadIdentityKey(thread.source, thread.id);
+    const key = threadSummaryIdentityKey(thread);
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
     descendants.push(thread);
-    const currentKey = buildThreadIdentityKey(thread.source, thread.id);
+    const currentKey = threadSummaryIdentityKey(thread);
     queue.push(
       ...threads.filter(
         (candidate) =>
@@ -1780,14 +1785,9 @@ function markThreadUnreadInSnapshot(
         0,
       ),
     })),
-    inboxThreadKeys: snapshot.inboxThreadKeys.includes(
-      buildThreadIdentityKey(params.backend, params.threadId),
-    )
+    inboxThreadKeys: snapshot.inboxThreadKeys.includes(threadKey)
       ? snapshot.inboxThreadKeys
-      : [
-          buildThreadIdentityKey(params.backend, params.threadId),
-          ...snapshot.inboxThreadKeys,
-        ],
+      : [threadKey, ...snapshot.inboxThreadKeys],
     threads,
   };
 }
@@ -1796,6 +1796,7 @@ function removeThreadFromSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }
 ): NavigationSnapshot | undefined {
@@ -1803,9 +1804,16 @@ function removeThreadFromSnapshot(
     return snapshot;
   }
 
-  const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+  const threadKey = params.federationTarget
+    && isRemoteFederationTarget(params.federationTarget)
+    ? federatedThreadIdentityKey({
+        backend: params.backend,
+        target: params.federationTarget,
+        threadId: params.threadId,
+      })
+    : buildThreadIdentityKey(params.backend, params.threadId);
   const threads = snapshot.threads.filter(
-    (thread) => buildThreadIdentityKey(thread.source, thread.id) !== threadKey
+    (thread) => threadSummaryIdentityKey(thread) !== threadKey
   );
   if (threads.length === snapshot.threads.length) {
     return snapshot;
@@ -1813,7 +1821,7 @@ function removeThreadFromSnapshot(
 
   const threadInboxByKey = new Map(
     threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread.inbox.inInbox,
     ])
   );
@@ -1845,7 +1853,7 @@ function removeThreadKeysFromSnapshot(
   }
 
   const threads = snapshot.threads.filter(
-    (thread) => !threadKeysToRemove.has(buildThreadIdentityKey(thread.source, thread.id))
+    (thread) => !threadKeysToRemove.has(threadSummaryIdentityKey(thread))
   );
   if (threads.length === snapshot.threads.length) {
     return snapshot;
@@ -1853,7 +1861,7 @@ function removeThreadKeysFromSnapshot(
 
   const threadInboxByKey = new Map(
     threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread.inbox.inInbox,
     ])
   );
@@ -1884,6 +1892,7 @@ function getFallbackSelectionAfterRemoval(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     optimisticThreadKey?: string;
   }
@@ -3350,10 +3359,7 @@ export function useThreadNavigation(
       return;
     }
 
-    const retainedThreadKey = buildThreadIdentityKey(
-      retainedThread.source,
-      retainedThread.id
-    );
+    const retainedThreadKey = threadSummaryIdentityKey(retainedThread);
     if (nextSelectionKey === retainedThreadKey) {
       return;
     }
@@ -3362,6 +3368,7 @@ export function useThreadNavigation(
       ...current,
       response: markThreadSeenInSnapshot(current.response, {
         backend: retainedThread.source,
+        federationTarget: retainedThread.federation?.ref.target,
         threadId: retainedThread.id,
         seenUpdatedAt: retainedThread.updatedAt,
       }),
@@ -4354,6 +4361,7 @@ export function useThreadNavigation(
           ...current,
           response: removeThreadFromSnapshot(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
           }),
         }));
@@ -4361,21 +4369,23 @@ export function useThreadNavigation(
           current === threadKey
             ? getFallbackSelectionAfterRemoval(state.response, {
                 backend: event.backend,
+                federationTarget: event.federationTarget,
                 threadId,
                 optimisticThreadKey: optimisticThreadRef.current
-                  ? buildThreadIdentityKey(
-                      optimisticThreadRef.current.source,
-                      optimisticThreadRef.current.id
-                    )
+                  ? threadSummaryIdentityKey(optimisticThreadRef.current)
                   : undefined,
               })
             : current
         );
         setRetainedUnreadThread((current) =>
-          current?.source === event.backend && current.id === threadId ? undefined : current
+          current && agentEventMatchesThread(event, current, threadId)
+            ? undefined
+            : current
         );
         setOptimisticThread((current) =>
-          current?.source === event.backend && current.id === threadId ? undefined : current
+          current && agentEventMatchesThread(event, current, threadId)
+            ? undefined
+            : current
         );
         return;
       }
@@ -4640,6 +4650,7 @@ export function useThreadNavigation(
           ...current,
           response: updateThreadPinInSnapshot(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
             pinnedRank,
           }),
@@ -4655,6 +4666,7 @@ export function useThreadNavigation(
           ...current,
           response: updateThreadPinInSnapshot(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
             pinnedRank: undefined,
           }),
@@ -5534,7 +5546,7 @@ export function useThreadNavigation(
       const threads = stateRef.current.response?.threads ?? [];
       const threadByKey = new Map(
         threads.map((thread) => [
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
           thread,
         ]),
       );
@@ -5566,11 +5578,18 @@ export function useThreadNavigation(
       }
       const threadByKey = new Map(
         snapshot.threads.map((thread) => [
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
           thread,
         ]),
       );
-      const rootKey = buildThreadIdentityKey(parentBackend, rootThreadId);
+      const rootKey = federationTarget
+        && isRemoteFederationTarget(federationTarget)
+        ? federatedThreadIdentityKey({
+            backend: parentBackend,
+            target: federationTarget,
+            threadId: rootThreadId,
+          })
+        : buildThreadIdentityKey(parentBackend, rootThreadId);
       const root = threadByKey.get(rootKey);
       if (
         federationTarget
@@ -5624,7 +5643,7 @@ export function useThreadNavigation(
             }),
           }));
         } catch {
-          await refresh(buildThreadIdentityKey(parentBackend, rootThreadId));
+          await refresh(rootKey);
         }
       }
 
@@ -7238,16 +7257,16 @@ export function useThreadNavigation(
         return;
       }
 
-      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const threadKey = threadSummaryIdentityKey(thread);
       const optimisticThreadKey = optimisticThread
-        ? buildThreadIdentityKey(optimisticThread.source, optimisticThread.id)
+        ? threadSummaryIdentityKey(optimisticThread)
         : undefined;
       const targetThreads = options?.includeSubthreads
         ? [...collectDescendantThreads(threads, thread).reverse(), thread]
         : [thread];
       const targetThreadKeys = new Set(
         targetThreads.map((target) =>
-          buildThreadIdentityKey(target.source, target.id)
+          threadSummaryIdentityKey(target)
         )
       );
 
@@ -7266,13 +7285,14 @@ export function useThreadNavigation(
           (snapshot, target) =>
             removeThreadFromSnapshot(snapshot, {
               backend: target.source,
+              federationTarget: target.federation?.ref.target
+                ?? readRendererFederationTarget(),
               threadId: target.id,
             }),
           options?.includeSubthreads
             ? current.response
             : ungroupChildThreadsInSnapshot(current.response, {
-                backend: thread.source,
-                parentThreadId: thread.id,
+                parent: thread,
               })
         ),
       }));
@@ -7280,18 +7300,20 @@ export function useThreadNavigation(
         current && targetThreadKeys.has(current)
           ? getFallbackSelectionAfterRemoval(state.response, {
               backend: thread.source,
+              federationTarget: thread.federation?.ref.target
+                ?? readRendererFederationTarget(),
               threadId: thread.id,
               optimisticThreadKey,
             })
           : current
       );
       setRetainedUnreadThread((current) =>
-        current && targetThreadKeys.has(buildThreadIdentityKey(current.source, current.id))
+        current && targetThreadKeys.has(threadSummaryIdentityKey(current))
           ? undefined
           : current
       );
       setOptimisticThread((current) =>
-        current && targetThreadKeys.has(buildThreadIdentityKey(current.source, current.id))
+        current && targetThreadKeys.has(threadSummaryIdentityKey(current))
           ? undefined
           : current
       );
@@ -7358,7 +7380,7 @@ export function useThreadNavigation(
           repositoryPath: directory.path,
           worktreePath,
         });
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       } catch (error) {
         setWorktreeArchiveError(error instanceof Error ? error.message : String(error));
       }
@@ -7387,7 +7409,7 @@ export function useThreadNavigation(
           snapshotRef,
           worktreePath,
         });
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       } catch (error) {
         setWorktreeArchiveError(error instanceof Error ? error.message : String(error));
       }
@@ -7417,7 +7439,7 @@ export function useThreadNavigation(
             readRendererFederationTarget(),
           threadId: thread.id,
         });
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         setWorktreeArchiveError(message);
@@ -7430,7 +7452,7 @@ export function useThreadNavigation(
   const renameThread = useCallback(
     async (thread: NavigationThreadSummary, name: string): Promise<void> => {
       const nextName = name.trim();
-      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const threadKey = threadSummaryIdentityKey(thread);
 
       if (!nextName) {
         setRenameThreadError("Thread name cannot be blank.");
@@ -7579,11 +7601,14 @@ export function useThreadNavigation(
             ),
           )
         : undefined;
+      const federationTarget = thread.federation?.ref.target
+        ?? readRendererFederationTarget();
 
       setState((current) => ({
         ...current,
         response: updateThreadPinInSnapshot(current.response, {
           backend: thread.source,
+          federationTarget,
           threadId: thread.id,
           pinnedRank,
         }),
@@ -7609,6 +7634,7 @@ export function useThreadNavigation(
             ...current,
             response: updateThreadPinInSnapshot(current.response, {
               backend: thread.source,
+              federationTarget,
               threadId: thread.id,
               pinnedRank: result.pinnedRank,
             }),
@@ -7617,8 +7643,7 @@ export function useThreadNavigation(
         }
         const result = await setThreadPinRequest({
           backend: thread.source,
-          federationTarget:
-            thread.federation?.ref.target ?? readRendererFederationTarget(),
+          federationTarget,
           threadId: thread.id,
           pinnedRank,
         });
@@ -7626,12 +7651,13 @@ export function useThreadNavigation(
           ...current,
           response: updateThreadPinInSnapshot(current.response, {
             backend: result.backend,
+            federationTarget,
             threadId: result.threadId,
             pinnedRank: result.pinnedRank,
           }),
         }));
       } catch {
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       }
     },
     [
@@ -7718,7 +7744,7 @@ export function useThreadNavigation(
           }),
         }));
       } catch {
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       }
     },
     [refresh, setThreadParentRequest],
@@ -7735,7 +7761,7 @@ export function useThreadNavigation(
       }
       const threadByKey = new Map(
         snapshot.threads.map((thread) => [
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
           thread,
         ]),
       );
@@ -7747,7 +7773,7 @@ export function useThreadNavigation(
           continue;
         }
         const childKeys = childKeysByPinnedParent.get(parentKey) ?? [];
-        childKeys.push(buildThreadIdentityKey(thread.source, thread.id));
+        childKeys.push(threadSummaryIdentityKey(thread));
         childKeysByPinnedParent.set(parentKey, childKeys);
       }
       for (const [parentKey, childKeys] of childKeysByPinnedParent) {
@@ -7761,22 +7787,22 @@ export function useThreadNavigation(
           childKeysByPinnedParent.set(
             parentKey,
             sortSubthreadSummaries(parent, selectedChildren).map((thread) =>
-              buildThreadIdentityKey(thread.source, thread.id)
+              threadSummaryIdentityKey(thread)
             ),
           );
         }
       }
       const selectedKeys = new Set(
         threadsToUnlink.map((thread) =>
-          buildThreadIdentityKey(thread.source, thread.id)
+          threadSummaryIdentityKey(thread)
         ),
       );
       const currentPinnedKeys = snapshot.threads
         .filter((thread) => thread.pinnedRank && !selectedKeys.has(
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
         ))
         .sort(comparePinnedThreads)
-        .map((thread) => buildThreadIdentityKey(thread.source, thread.id));
+        .map((thread) => threadSummaryIdentityKey(thread));
       const nextPinnedKeys = currentPinnedKeys.flatMap((threadKey) => [
         ...(childKeysByPinnedParent.get(threadKey) ?? []),
         threadKey,
@@ -7827,7 +7853,7 @@ export function useThreadNavigation(
               readRendererFederationTarget(),
             threadId: thread.id,
           });
-          const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+          const threadKey = threadSummaryIdentityKey(thread);
           const parentKey = resolveThreadParentKey(thread, threadByKey);
           if (parentKey && childKeysByPinnedParent.has(parentKey)) {
             successfullyUnlinkedPinnedKeys.add(threadKey);
@@ -7903,7 +7929,7 @@ export function useThreadNavigation(
           }),
         }));
       } catch {
-        await refresh(buildThreadIdentityKey(parent.source, parent.id));
+        await refresh(threadSummaryIdentityKey(parent));
       }
     },
     [refresh, updateSubthreadOrderRequest],
@@ -7950,7 +7976,7 @@ export function useThreadNavigation(
           }),
         }));
       } catch {
-        await refresh(buildThreadIdentityKey(parent.source, parent.id));
+        await refresh(threadSummaryIdentityKey(parent));
       }
     },
     [refresh, setSubthreadsCollapsedRequest],
@@ -7980,7 +8006,7 @@ export function useThreadNavigation(
           }),
         }));
       } catch {
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       }
     },
     [refresh, setThreadAgentRequest],
@@ -8169,10 +8195,10 @@ export function useThreadNavigation(
           threadId: thread.id,
           executionMode,
         });
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       } catch (error) {
         setSetThreadExecutionModeError(error instanceof Error ? error.message : String(error));
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       } finally {
         setUpdatingThreadExecutionMode(undefined);
       }
@@ -8196,12 +8222,12 @@ export function useThreadNavigation(
             readRendererFederationTarget(),
           threadId: thread.id,
         });
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       } catch (error) {
         setSetThreadExecutionModeError(
           error instanceof Error ? error.message : String(error)
         );
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       }
     },
     [cancelThreadExecutionModeQueueRequest, refresh]
@@ -8266,7 +8292,7 @@ export function useThreadNavigation(
         setSetThreadModelSettingsError(
           error instanceof Error ? error.message : String(error)
         );
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       }
     },
     [refresh, setThreadModelSettings]
@@ -8314,7 +8340,7 @@ export function useThreadNavigation(
         setSetThreadModelSettingsError(
           error instanceof Error ? error.message : String(error),
         );
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       }
     },
     [refresh, setThreadPrAutoDispatchRequest],
@@ -8411,12 +8437,12 @@ export function useThreadNavigation(
           threadId: thread.id,
           ...params,
         });
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       } catch (error) {
         setSetThreadExecutionModeError(
           error instanceof Error ? error.message : String(error)
         );
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        await refresh(threadSummaryIdentityKey(thread));
       }
     },
     [refresh, setAcpSessionRuntimeOption]

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1301,7 +1301,7 @@ function updateThreadPinsInSnapshot(
   const threads = snapshot.threads.map((thread) => {
     const pinnedRank =
       params.pinnedRanksByThreadKey[
-        buildThreadIdentityKey(thread.source, thread.id)
+        threadSummaryIdentityKey(thread)
       ];
     if (!pinnedRank || thread.pinnedRank === pinnedRank) {
       return thread;
@@ -3073,6 +3073,7 @@ export function useThreadNavigation(
   markThreadUnread: (thread: NavigationThreadSummary) => Promise<void>;
   showThread: (params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }) => Promise<void>;
   archiveThread: (
@@ -5355,12 +5356,25 @@ export function useThreadNavigation(
   const showThread = useCallback(
     async (params: {
       backend: AppServerBackendKind;
+      federationTarget?: FederationTarget;
       threadId: string;
     }): Promise<void> => {
-      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const threadKey = params.federationTarget
+        && isRemoteFederationTarget(params.federationTarget)
+        ? federatedThreadIdentityKey({
+            backend: params.backend,
+            target: params.federationTarget,
+            threadId: params.threadId,
+          })
+        : buildThreadIdentityKey(params.backend, params.threadId);
       const thread = state.response?.threads.find(
         (candidate) =>
-          candidate.source === params.backend && candidate.id === params.threadId,
+          candidate.source === params.backend
+          && candidate.id === params.threadId
+          && federationTargetsEqual(
+            candidate.federation?.ref.target,
+            params.federationTarget,
+          ),
       );
       if (thread) {
         selectThread(thread);

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -935,7 +935,7 @@ function reconcileNavigationSnapshot(
 
   const previousByThreadKey = new Map(
     previous.threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread,
     ])
   );
@@ -958,7 +958,7 @@ function reconcileNavigationSnapshot(
     directories: sortNavigationDirectories(reconciledDirectories),
     threads: next.threads.map((thread) => {
       const previousThread = previousByThreadKey.get(
-        buildThreadIdentityKey(thread.source, thread.id)
+        threadSummaryIdentityKey(thread)
       );
       return previousThread && threadSummariesEqual(previousThread, thread)
         ? previousThread
@@ -977,7 +977,7 @@ function preserveNavigationPinState(
 
   const currentThreads = new Map(
     current.threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread,
     ]),
   );
@@ -988,7 +988,7 @@ function preserveNavigationPinState(
     ...next,
     threads: next.threads.map((thread) => {
       const currentThread = currentThreads.get(
-        buildThreadIdentityKey(thread.source, thread.id),
+        threadSummaryIdentityKey(thread),
       );
       if (!currentThread || currentThread.pinnedRank === thread.pinnedRank) {
         return thread;
@@ -1624,6 +1624,7 @@ function markThreadsSeenInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: Array<{
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     seenUpdatedAt?: number;
   }>,
@@ -1634,14 +1635,20 @@ function markThreadsSeenInSnapshot(
 
   const seenUpdatedAtByThreadKey = new Map(
     params.map((entry) => [
-      buildThreadIdentityKey(entry.backend, entry.threadId),
+      entry.federationTarget && isRemoteFederationTarget(entry.federationTarget)
+        ? federatedThreadIdentityKey({
+            backend: entry.backend,
+            target: entry.federationTarget,
+            threadId: entry.threadId,
+          })
+        : buildThreadIdentityKey(entry.backend, entry.threadId),
       entry.seenUpdatedAt,
     ]),
   );
   const markedThreadKeys = new Set<string>();
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
     if (!seenUpdatedAtByThreadKey.has(threadKey)) {
       return thread;
     }
@@ -1680,7 +1687,7 @@ function markThreadsSeenInSnapshot(
   const directories = snapshot.directories ?? [];
   const threadInboxByKey = new Map(
     threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread.inbox.inInbox,
     ])
   );
@@ -1705,6 +1712,7 @@ function markThreadSeenInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     seenUpdatedAt?: number;
   },
@@ -1716,6 +1724,7 @@ function markThreadUnreadInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     seenUpdatedAt: number;
   },
@@ -1724,10 +1733,17 @@ function markThreadUnreadInSnapshot(
     return snapshot;
   }
 
-  const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+  const threadKey = params.federationTarget
+    && isRemoteFederationTarget(params.federationTarget)
+    ? federatedThreadIdentityKey({
+        backend: params.backend,
+        target: params.federationTarget,
+        threadId: params.threadId,
+      })
+    : buildThreadIdentityKey(params.backend, params.threadId);
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (buildThreadIdentityKey(thread.source, thread.id) !== threadKey) {
+    if (threadSummaryIdentityKey(thread) !== threadKey) {
       return thread;
     }
 
@@ -1749,7 +1765,7 @@ function markThreadUnreadInSnapshot(
 
   const threadInboxByKey = new Map(
     threads.map((thread) => [
-      buildThreadIdentityKey(thread.source, thread.id),
+      threadSummaryIdentityKey(thread),
       thread.inbox.inInbox,
     ]),
   );
@@ -1764,9 +1780,14 @@ function markThreadUnreadInSnapshot(
         0,
       ),
     })),
-    inboxThreadKeys: snapshot.inboxThreadKeys.includes(threadKey)
+    inboxThreadKeys: snapshot.inboxThreadKeys.includes(
+      buildThreadIdentityKey(params.backend, params.threadId),
+    )
       ? snapshot.inboxThreadKeys
-      : [threadKey, ...snapshot.inboxThreadKeys],
+      : [
+          buildThreadIdentityKey(params.backend, params.threadId),
+          ...snapshot.inboxThreadKeys,
+        ],
     threads,
   };
 }
@@ -2568,7 +2589,7 @@ function projectOptimisticThreadIntoDirectories(
     return directories;
   }
 
-  const threadKey = buildThreadIdentityKey(optimisticThread.source, optimisticThread.id);
+  const threadKey = threadSummaryIdentityKey(optimisticThread);
   let changed = false;
   const nextDirectories = [...directories];
 
@@ -2635,7 +2656,7 @@ function hasSelectionKey(
 
   return (
     response.threads.some(
-      (thread) => buildThreadIdentityKey(thread.source, thread.id) === selectionKey
+      (thread) => threadSummaryIdentityKey(thread) === selectionKey
     ) || selectionKey === optimisticThreadKey
   );
 }
@@ -2649,7 +2670,7 @@ function getFallbackSelectionKey(
   }
 
   if (response.threads[0]) {
-    return buildThreadIdentityKey(response.threads[0].source, response.threads[0].id);
+    return threadSummaryIdentityKey(response.threads[0]);
   }
 
   const firstLaunchpadDirectory = response.directories.find((directory) => directory.launchpad);
@@ -3521,7 +3542,7 @@ export function useThreadNavigation(
           : filteredResponse;
         const optimisticSelection = preferredOptimisticThread ?? optimisticThreadRef.current;
         const optimisticThreadKey = optimisticSelection
-          ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
+          ? threadSummaryIdentityKey(optimisticSelection)
           : undefined;
         const responseWithObservedThreadNames = applyObservedThreadNames(
           response,
@@ -3569,11 +3590,11 @@ export function useThreadNavigation(
         if (
           optimisticThreadKey &&
           response.threads.some(
-            (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+            (thread) => threadSummaryIdentityKey(thread) === optimisticThreadKey
           )
         ) {
           const hydratedOptimisticThread = response.threads.find(
-            (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+            (thread) => threadSummaryIdentityKey(thread) === optimisticThreadKey
           );
 
           setOptimisticThread((current) => {
@@ -4847,17 +4868,14 @@ export function useThreadNavigation(
       return currentThreads;
     }
 
-    const optimisticThreadKey = buildThreadIdentityKey(
-      optimisticThread.source,
-      optimisticThread.id
-    );
+    const optimisticThreadKey = threadSummaryIdentityKey(optimisticThread);
 
     const hasHydratedThread = currentThreads.some(
-      (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+      (thread) => threadSummaryIdentityKey(thread) === optimisticThreadKey
     );
     if (hasHydratedThread) {
       return currentThreads.map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+        threadSummaryIdentityKey(thread) === optimisticThreadKey
           ? {
               ...mergeHydratedThreadWithOptimisticTitle(thread, optimisticThread),
               optimisticActiveTurn:
@@ -4887,12 +4905,9 @@ export function useThreadNavigation(
         return currentDirectories;
       }
 
-      const optimisticThreadKey = buildThreadIdentityKey(
-        optimisticThread.source,
-        optimisticThread.id
-      );
+      const optimisticThreadKey = threadSummaryIdentityKey(optimisticThread);
       const hasHydratedThread = state.response?.threads.some(
-        (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+        (thread) => threadSummaryIdentityKey(thread) === optimisticThreadKey
       );
 
       return projectOptimisticThreadIntoDirectories(
@@ -4983,8 +4998,7 @@ export function useThreadNavigation(
     () =>
       selectedThreadKey
         ? threads.find(
-            (thread) =>
-              buildThreadIdentityKey(thread.source, thread.id) === selectedThreadKey
+            (thread) => threadSummaryIdentityKey(thread) === selectedThreadKey
           )
         : undefined,
     [selectedThreadKey, threads]
@@ -5057,8 +5071,7 @@ export function useThreadNavigation(
     if (
       !pendingSeenThreadKey ||
       !selectedThread ||
-      pendingSeenThreadKey !==
-        buildThreadIdentityKey(selectedThread.source, selectedThread.id) ||
+      pendingSeenThreadKey !== threadSummaryIdentityKey(selectedThread) ||
       !submitMarkThreadSeen
     ) {
       return;
@@ -5068,10 +5081,7 @@ export function useThreadNavigation(
     const threadToMarkSeen = selectedThread;
 
     async function markSeen(): Promise<void> {
-      const threadKey = buildThreadIdentityKey(
-        threadToMarkSeen.source,
-        threadToMarkSeen.id
-      );
+      const threadKey = threadSummaryIdentityKey(threadToMarkSeen);
       submittedSeenUpdatedAtByThreadKeyRef.current.set(
         threadKey,
         threadToMarkSeen.updatedAt
@@ -5090,13 +5100,13 @@ export function useThreadNavigation(
           const retainedThread = retainedUnreadThreadRef.current;
           if (
             !retainedThread ||
-            buildThreadIdentityKey(retainedThread.source, retainedThread.id) !==
-              threadKey
+            threadSummaryIdentityKey(retainedThread) !== threadKey
           ) {
             setState((current) => ({
               ...current,
               response: markThreadSeenInSnapshot(current.response, {
                 backend: threadToMarkSeen.source,
+                federationTarget: threadToMarkSeen.federation?.ref.target,
                 threadId: threadToMarkSeen.id,
                 seenUpdatedAt: threadToMarkSeen.updatedAt,
               }),
@@ -5153,15 +5163,12 @@ export function useThreadNavigation(
       return;
     }
 
-    const threadKey = buildThreadIdentityKey(
-      selectedThread.source,
-      selectedThread.id
-    );
+    const threadKey = threadSummaryIdentityKey(selectedThread);
     if (!manuallySelectedThreadKeysRef.current.has(threadKey)) {
       return;
     }
     const retainedThreadKey = retainedUnreadThread
-      ? buildThreadIdentityKey(retainedUnreadThread.source, retainedUnreadThread.id)
+      ? threadSummaryIdentityKey(retainedUnreadThread)
       : undefined;
 
     if (
@@ -5191,7 +5198,7 @@ export function useThreadNavigation(
   ]);
 
   const selectThread = useCallback((thread: NavigationThreadSummary): void => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const threadKey = threadSummaryIdentityKey(thread);
     manuallySelectedThreadKeysRef.current.add(threadKey);
     releaseRetainedUnreadThread(threadKey);
     refreshThreadDirectoryGitStatuses(threadKey);
@@ -5233,7 +5240,7 @@ export function useThreadNavigation(
           continue;
         }
         unreadThreadsByKey.set(
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
           thread,
         );
       }
@@ -5244,7 +5251,7 @@ export function useThreadNavigation(
 
       for (const thread of unreadThreads) {
         submittedSeenUpdatedAtByThreadKeyRef.current.set(
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
           thread.updatedAt,
         );
       }
@@ -5271,11 +5278,12 @@ export function useThreadNavigation(
 
       const markedThreadKeys = new Set(
         markedThreads.map((thread) =>
-          buildThreadIdentityKey(thread.source, thread.id),
+          threadSummaryIdentityKey(thread),
         ),
       );
       const seenThreads = markedThreads.map((thread) => ({
         backend: thread.source,
+        federationTarget: thread.federation?.ref.target,
         threadId: thread.id,
         seenUpdatedAt: thread.updatedAt,
       }));
@@ -5287,7 +5295,7 @@ export function useThreadNavigation(
         if (
           current
           && markedThreadKeys.has(
-            buildThreadIdentityKey(current.source, current.id),
+            threadSummaryIdentityKey(current),
           )
         ) {
           return undefined;
@@ -5307,7 +5315,7 @@ export function useThreadNavigation(
         return;
       }
 
-      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const threadKey = threadSummaryIdentityKey(thread);
       const seenUpdatedAt = Math.max(0, thread.updatedAt - 1);
       await markThreadSeen({
         backend: thread.source,
@@ -5327,7 +5335,7 @@ export function useThreadNavigation(
         current === threadKey ? undefined : current,
       );
       setRetainedUnreadThread((current) =>
-        current && buildThreadIdentityKey(current.source, current.id) === threadKey
+        current && threadSummaryIdentityKey(current) === threadKey
           ? undefined
           : current,
       );
@@ -5335,6 +5343,7 @@ export function useThreadNavigation(
         ...current,
         response: markThreadUnreadInSnapshot(current.response, {
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target,
           threadId: thread.id,
           seenUpdatedAt,
         }),
@@ -6966,7 +6975,9 @@ export function useThreadNavigation(
           console.warn("Could not add the remote thread to this thread list:", error);
         }
       }
-      const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+      const nextThreadKey = threadSummaryIdentityKey(
+        namedOptimisticMaterializedThread,
+      );
       // Sub-thread launchpads drop the new child directly below their source
       // card. Plain new-thread launchpads have no parent and skip this. Await
       // so the order write commits before the refresh below reads it back.

--- a/packages/shared/src/__tests__/subthreads.test.ts
+++ b/packages/shared/src/__tests__/subthreads.test.ts
@@ -1,8 +1,46 @@
 import { describe, expect, it } from "vitest";
 import {
   insertSubthreadIdAfter,
+  resolveThreadParentKey,
   sortSubthreadSummaries,
 } from "../subthreads";
+import type { NavigationThreadSummary } from "../contracts/navigation";
+import {
+  buildThreadIdentityKey,
+} from "../contracts/navigation";
+import { federatedThreadIdentityKey } from "../contracts/federation";
+
+type ParentLinkedThread = Pick<
+  NavigationThreadSummary,
+  | "id"
+  | "parentThreadBackend"
+  | "parentThreadId"
+  | "parentThreadInstanceId"
+  | "source"
+>;
+
+describe("resolveThreadParentKey", () => {
+  it("uses the remote owner identity when a local thread id collides", () => {
+    const localParentKey = buildThreadIdentityKey("codex", "parent");
+    const remoteParentKey = federatedThreadIdentityKey({
+      backend: "codex",
+      target: { scope: "remote", instanceId: "remote-owner" },
+      threadId: "parent",
+    });
+    const parents = new Map<string, ParentLinkedThread>([
+      [localParentKey, { id: "parent", source: "codex" }],
+      [remoteParentKey, { id: "parent", source: "codex" }],
+    ]);
+
+    expect(resolveThreadParentKey({
+      id: "child",
+      source: "codex",
+      parentThreadBackend: "codex",
+      parentThreadId: "parent",
+      parentThreadInstanceId: "remote-owner",
+    }, parents)).toBe(remoteParentKey);
+  });
+});
 
 describe("sortSubthreadSummaries", () => {
   it("orders explicitly-ranked children by subthreadOrder", () => {

--- a/packages/shared/src/__tests__/subthreads.test.ts
+++ b/packages/shared/src/__tests__/subthreads.test.ts
@@ -12,6 +12,7 @@ import { federatedThreadIdentityKey } from "../contracts/federation";
 
 type ParentLinkedThread = Pick<
   NavigationThreadSummary,
+  | "federation"
   | "id"
   | "parentThreadBackend"
   | "parentThreadId"
@@ -38,6 +39,32 @@ describe("resolveThreadParentKey", () => {
       parentThreadBackend: "codex",
       parentThreadId: "parent",
       parentThreadInstanceId: "remote-owner",
+    }, parents)).toBe(remoteParentKey);
+  });
+
+  it("inherits the remote owner when a same-owner link omits the instance", () => {
+    const remoteParentKey = federatedThreadIdentityKey({
+      backend: "codex",
+      target: { scope: "remote", instanceId: "remote-owner" },
+      threadId: "parent",
+    });
+    const parents = new Map<string, ParentLinkedThread>([
+      [remoteParentKey, { id: "parent", source: "codex" }],
+    ]);
+
+    expect(resolveThreadParentKey({
+      id: "child",
+      source: "codex",
+      parentThreadBackend: "codex",
+      parentThreadId: "parent",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "remote-owner" },
+          threadId: "child",
+        },
+        instanceLabel: "Remote owner",
+      },
     }, parents)).toBe(remoteParentKey);
   });
 });

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1512,9 +1512,10 @@ export type ReorderThreadPinsRequest = {
   federationTarget?: FederationTarget;
   /**
    * Complete pinned order across ALL backends, first item at the top.
-   * Entries are thread identity keys (`buildThreadIdentityKey`), so a Codex
-   * pin and an ACP pin can be interleaved in any order — pin order is global,
-   * not per-backend (mirrors directory pinning).
+   * Entries are local (`buildThreadIdentityKey`) or federated
+   * (`federatedThreadIdentityKey`) thread identity keys, so local and remote
+   * pins can be interleaved without collapsing an owner collision. Pin order
+   * is global, not per-backend (mirrors directory pinning).
    */
   threadKeys: string[];
 };

--- a/packages/shared/src/navigation-snapshot-transport.ts
+++ b/packages/shared/src/navigation-snapshot-transport.ts
@@ -5,12 +5,19 @@ import type {
   NavigationSnapshotTransportResponse,
   NavigationThreadSummary,
 } from "./contracts/navigation";
+import { federatedThreadIdentityKey } from "./contracts/federation";
 import { buildThreadIdentityKey } from "./contracts/navigation";
 
 export type NavigationSnapshotTransportState = {
   revision: string;
   snapshot: NavigationSnapshot;
 };
+
+function threadKey(thread: NavigationThreadSummary): string {
+  return thread.federation?.ref
+    ? federatedThreadIdentityKey(thread.federation.ref)
+    : buildThreadIdentityKey(thread.source, thread.id);
+}
 
 function applyKeyedDelta<T>(params: {
   current: T[];
@@ -63,7 +70,7 @@ function applyDelta(
   }
   const threads = applyKeyedDelta<NavigationThreadSummary>({
     current: previous.snapshot.threads,
-    key: (thread) => buildThreadIdentityKey(thread.source, thread.id),
+    key: threadKey,
     order: delta.threadKeys,
     removedKeys: delta.removedThreadKeys,
     upserted: delta.upsertedThreads,

--- a/packages/shared/src/subthreads.ts
+++ b/packages/shared/src/subthreads.ts
@@ -2,12 +2,17 @@ import {
   buildThreadIdentityKey,
   type NavigationThreadSummary,
 } from "./contracts/navigation";
+import { federatedThreadIdentityKey } from "./contracts/federation";
 
 type SubthreadParent = Pick<NavigationThreadSummary, "subthreadOrder">;
 type SubthreadChild = Pick<NavigationThreadSummary, "id" | "createdAt">;
 type ParentLinkedThread = Pick<
   NavigationThreadSummary,
-  "id" | "parentThreadBackend" | "parentThreadId" | "source"
+  | "id"
+  | "parentThreadBackend"
+  | "parentThreadId"
+  | "parentThreadInstanceId"
+  | "source"
 >;
 
 /**
@@ -26,10 +31,22 @@ export function resolveThreadParentKey<T extends ParentLinkedThread>(
     return undefined;
   }
 
-  const explicitKey = buildThreadIdentityKey(
-    thread.parentThreadBackend ?? thread.source,
-    parentThreadId,
-  );
+  const parentBackend = thread.parentThreadBackend ?? thread.source;
+  if (thread.parentThreadInstanceId) {
+    const federatedKey = federatedThreadIdentityKey({
+      backend: parentBackend,
+      target: {
+        scope: "remote",
+        instanceId: thread.parentThreadInstanceId,
+      },
+      threadId: parentThreadId,
+    });
+    if (threadsByKey.has(federatedKey)) {
+      return federatedKey;
+    }
+  }
+
+  const explicitKey = buildThreadIdentityKey(parentBackend, parentThreadId);
   if (threadsByKey.has(explicitKey) || thread.parentThreadBackend) {
     return explicitKey;
   }

--- a/packages/shared/src/subthreads.ts
+++ b/packages/shared/src/subthreads.ts
@@ -8,6 +8,7 @@ type SubthreadParent = Pick<NavigationThreadSummary, "subthreadOrder">;
 type SubthreadChild = Pick<NavigationThreadSummary, "id" | "createdAt">;
 type ParentLinkedThread = Pick<
   NavigationThreadSummary,
+  | "federation"
   | "id"
   | "parentThreadBackend"
   | "parentThreadId"
@@ -32,13 +33,16 @@ export function resolveThreadParentKey<T extends ParentLinkedThread>(
   }
 
   const parentBackend = thread.parentThreadBackend ?? thread.source;
-  if (thread.parentThreadInstanceId) {
+  const parentTarget = thread.parentThreadInstanceId
+    ? {
+        scope: "remote" as const,
+        instanceId: thread.parentThreadInstanceId,
+      }
+    : thread.federation?.ref.target;
+  if (parentTarget) {
     const federatedKey = federatedThreadIdentityKey({
       backend: parentBackend,
-      target: {
-        scope: "remote",
-        instanceId: thread.parentThreadInstanceId,
-      },
+      target: parentTarget,
       threadId: parentThreadId,
     });
     if (threadsByKey.has(federatedKey)) {


### PR DESCRIPTION
## Summary

- I ported the broader federated-thread collision fix onto current `main` while preserving the existing remote auto-fix synchronization fix.
- I use federation-scoped identities across snapshot deltas, renderer reconciliation, selection, unread state, pin ordering, directory membership, link navigation, hover targeting, and navigation history so local and remote threads with the same backend/thread ID remain distinct.
- I added transport and Electron E2E coverage proving that cancelling a colliding remote auto-fix leaves the local pending repair unchanged.

## Verification

- `pnpm test` — 618 files passed; 8,920 tests passed; 6 skipped.
- `pnpm test apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` — 148 tests passed.
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-link-hover-target.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/main/__tests__/app-server-ipc.test.ts` — 467 tests passed.
- `pnpm test:desktop-e2e e2e/federation-remote-window.spec.ts --grep "cancels a colliding remote auto-fix"` — 1 test passed.
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; 43 existing warnings.
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Notes

- I treated the source worktree as read-only; it remains detached at its original commit with its original ten uncommitted files.
- Both commits in this PR are SSH-signed.
