### PR TITLE
fix(desktop): clarify federation endpoint setup

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -609,14 +609,24 @@ export function FederationSettings(props: FederationSettingsProps) {
             label="Gateway endpoints"
             sub={
               dialsGateway
-                ? "Endpoints for one pinned gateway, one per line in fallback order. Startup and reconnects always try endpoints in this order. ws://, wss://, and ssh:// (user@host, optional ?forward=host:port) are supported."
-                : "Only used when Mode is client or dual."
+                ? "Connection paths on this client, one per line. Add or reorder them after enrollment without re-inviting. Startup and reconnects always try endpoints in this order. ws://, wss://, and ssh:// (user@host, optional ?forward=host:port) are supported."
+                : "Edit these connection paths on the enrolled client, where Mode is client or dual."
+            }
+            help={
+              <>
+                Direct Tailscale example: {" "}
+                <code>ws://gateway.tailnet.ts.net:47830</code>. Include the
+                listener port and bind the gateway to <code>0.0.0.0</code>.
+                Tailscale Serve instead uses {" "}
+                <code>wss://gateway.tailnet.ts.net/pwragent-federation</code>.
+              </>
             }
             control={
               <textarea
                 aria-label="Gateway endpoints"
                 rows={3}
                 value={gatewayEndpointsText}
+                placeholder="ws://gateway.tailnet.ts.net:47830"
                 disabled={props.saving || !dialsGateway}
                 onChange={(event) => setGatewayEndpointsText(event.target.value)}
               />
@@ -624,12 +634,23 @@ export function FederationSettings(props: FederationSettingsProps) {
           />
           <SettingsField
             label="Advertised endpoints"
-            sub="Gateway mode: endpoints written into new enrollment invites, one per line. Leave empty to advertise this machine's name, its tailnet name, and its current addresses — names keep working after the address changes."
+            sub="Gateway mode: endpoints written into new enrollment invites, one per line. Existing clients keep their current list."
+            help={
+              <>
+                Direct Tailscale example: {" "}
+                <code>ws://gateway.tailnet.ts.net:47830</code>. Include {" "}
+                <code>ws://</code> and the listener port. Leave empty to
+                advertise this machine&apos;s name, tailnet name, and current
+                addresses. To update an enrolled client, add the URL to Gateway
+                endpoints on that client.
+              </>
+            }
             control={
               <textarea
                 aria-label="Advertised endpoints"
                 rows={3}
                 value={advertisedEndpointsText}
+                placeholder="ws://gateway.tailnet.ts.net:47830"
                 disabled={props.saving}
                 onChange={(event) =>
                   setAdvertisedEndpointsText(event.target.value)

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -901,6 +901,13 @@ describe("FederationSettings", () => {
     expect(screen.getByLabelText("Listen port")).toBeEnabled();
     expect(screen.getByLabelText("Public URL")).toBeEnabled();
     expect(screen.getByLabelText("Gateway endpoints")).toBeDisabled();
+    expect(screen.getByLabelText("Advertised endpoints")).toHaveAttribute(
+      "placeholder",
+      "ws://gateway.tailnet.ts.net:47830",
+    );
+    expect(screen.getByText(
+      /Existing clients keep their current list/,
+    )).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Generate invite" }),
     ).toBeEnabled();
@@ -939,6 +946,13 @@ describe("FederationSettings", () => {
     expect(screen.getByLabelText("Listen port")).toBeDisabled();
     expect(screen.getByLabelText("Public URL")).toBeDisabled();
     expect(screen.getByLabelText("Gateway endpoints")).toBeEnabled();
+    expect(screen.getByLabelText("Gateway endpoints")).toHaveAttribute(
+      "placeholder",
+      "ws://gateway.tailnet.ts.net:47830",
+    );
+    expect(screen.getByText(
+      /Add or reorder them after enrollment without re-inviting/,
+    )).toBeInTheDocument();
     // Only the listening side issues invites.
     expect(
       screen.getByRole("button", { name: "Generate invite" }),

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -205,9 +205,12 @@ first, then a Tailscale Serve URL, then a Cloudflare Tunnel hostname. The
 reconnect loop tries the endpoints in order, starts each cycle with the last
 endpoint that carried a fully authenticated session, and applies reconnect
 backoff per full cycle through the list. Settings → Federation shows each
-endpoint's live status and lets the operator edit the ordered list; gateways
-can advertise multiple endpoints in enrollment invites via
-`[federation] advertised_endpoints`.
+endpoint's live status and lets the operator edit the ordered list without
+re-enrolling or changing the pinned gateway identity. Make that change on the
+client instance: **Gateway endpoints** is enabled in client or dual mode.
+Gateways can advertise multiple endpoints in new enrollment invites via
+`[federation] advertised_endpoints`, but changing that advertised list does not
+rewrite the lists already stored by enrolled clients.
 
 Endpoint fallback cannot redirect a client to a different gateway identity:
 
@@ -249,6 +252,20 @@ PwrAgent scopes those credentials to a single host:
 
 PwrAgent can use a Tailscale-provided URL or route without treating Tailscale
 identity as PwrAgent identity.
+
+A direct MagicDNS route is a complete WebSocket URL, including the PwrAgent
+listener port:
+
+```text
+ws://<device>.<tailnet>.ts.net:47830
+```
+
+For this direct route, the gateway listener must bind an address that includes
+the Tailscale interface, normally `0.0.0.0`. Binding only a LAN address does not
+also bind the Tailscale address. A Tailscale Serve route is different: its
+`wss://<device>.<tailnet>.ts.net/pwragent-federation` URL uses HTTPS port 443
+implicitly, so it has no visible port and the PwrAgent listener remains on
+loopback behind Serve.
 
 ### Tailscale Serve
 


### PR DESCRIPTION
## Summary

- show complete direct MagicDNS and Tailscale Serve endpoint examples in Federation settings
- explain that direct MagicDNS needs the listener port and a bind covering the Tailscale interface
- clarify that existing clients can edit Gateway endpoints without re-enrollment, while Advertised endpoints only affect new invites
- document the same behavior in the federation connectivity reference

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx`
- `pnpm lint:eslint` (passes with 43 existing warnings)
- `pnpm typecheck`