### PR TITLE
fix(messaging): avoid duplicate terminal replies

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -16160,6 +16160,51 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("preserves every text fragment from a completion-only response", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: "First final fragment.",
+              },
+              {
+                type: "text",
+                text: "Second final fragment.",
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "message" && intent.role === "assistant",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        parts: [
+          expect.objectContaining({
+            text: "First final fragment.\n\nSecond final fragment.",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("posts one assistant message when final image resolution overlaps terminal idle", async () => {
     let releaseImageResolution: (() => void) | undefined;
     let markImageResolutionStarted: (() => void) | undefined;

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -16099,6 +16099,67 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("posts one final response when turn completion repeats it with commentary", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-message-1",
+            type: "agentMessage",
+            phase: "final",
+            text: "Fixed and pushed in commit abc123.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: "I’ll update the Datadog schema and validate it.",
+              },
+              {
+                type: "text",
+                text: "Fixed and pushed in commit abc123.",
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "message" && intent.role === "assistant",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        parts: [
+          expect.objectContaining({
+            text: "Fixed and pushed in commit abc123.",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("posts one assistant message when final image resolution overlaps terminal idle", async () => {
     let releaseImageResolution: (() => void) | undefined;
     let markImageResolutionStarted: (() => void) | undefined;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -20704,16 +20704,22 @@ function assistantTextForBackendEvent(event: AgentEvent): string | undefined {
     if (!Array.isArray(params.turn?.output)) {
       return undefined;
     }
-    const text = params.turn.output
-      .map((item) =>
+    // A completed turn's output is an ordered list of transcript items, not
+    // one assistant message split into content parts. Earlier entries can be
+    // commentary that already flowed through Working Updates. Joining every
+    // text entry turns that commentary plus the final answer into a second,
+    // slightly different assistant response that escapes content deduplication.
+    for (let index = params.turn.output.length - 1; index >= 0; index -= 1) {
+      const item = params.turn.output[index];
+      const text =
         item && typeof item === "object" && "text" in item
           ? (item as { text?: unknown }).text
-          : undefined,
-      )
-      .filter((value): value is string => typeof value === "string")
-      .join("\n\n")
-      .trim();
-    return text || undefined;
+          : undefined;
+      if (typeof text === "string" && text.trim()) {
+        return text.trim();
+      }
+    }
+    return undefined;
   }
 
   return undefined;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -20696,33 +20696,38 @@ function assistantTextForBackendEvent(event: AgentEvent): string | undefined {
   }
 
   if (event.notification.method === "turn/completed") {
-    const params = event.notification.params as {
-      turn?: {
-        output?: unknown;
-      };
-    };
-    if (!Array.isArray(params.turn?.output)) {
-      return undefined;
-    }
-    // A completed turn's output is an ordered list of transcript items, not
-    // one assistant message split into content parts. Earlier entries can be
-    // commentary that already flowed through Working Updates. Joining every
-    // text entry turns that commentary plus the final answer into a second,
-    // slightly different assistant response that escapes content deduplication.
-    for (let index = params.turn.output.length - 1; index >= 0; index -= 1) {
-      const item = params.turn.output[index];
-      const text =
-        item && typeof item === "object" && "text" in item
-          ? (item as { text?: unknown }).text
-          : undefined;
-      if (typeof text === "string" && text.trim()) {
-        return text.trim();
-      }
-    }
-    return undefined;
+    const text = assistantOutputTextFragmentsForBackendEvent(event)
+      .join("\n\n")
+      .trim();
+    return text || undefined;
   }
 
   return undefined;
+}
+
+function assistantOutputTextFragmentsForBackendEvent(
+  event: AgentEvent,
+): string[] {
+  if (event.notification.method !== "turn/completed") {
+    return [];
+  }
+  const params = event.notification.params as {
+    turn?: {
+      output?: unknown;
+    };
+  };
+  if (!Array.isArray(params.turn?.output)) {
+    return [];
+  }
+  return params.turn.output
+    .map((item) =>
+      item && typeof item === "object" && "text" in item
+        ? (item as { text?: unknown }).text
+        : undefined,
+    )
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.trim())
+    .filter(Boolean);
 }
 
 /**
@@ -20956,9 +20961,20 @@ function assistantMessageDeliveryKeys(
     text,
     identity,
   );
+  // A terminal aggregate can contain earlier commentary followed by a final
+  // assistant item that was already delivered. Include each output fragment's
+  // content key in the same claim so that prior final-item delivery suppresses
+  // the repeated aggregate without changing completion-only aggregation.
+  const contentKeys = [
+    contentKey,
+    ...assistantOutputTextFragmentsForBackendEvent(event).map((fragment) =>
+      assistantMessageContentDeliveryKey(event, binding, fragment, identity)
+    ),
+  ];
+  const uniqueContentKeys = [...new Set(contentKeys)];
   const itemId = identity?.itemId ?? assistantItemIdForBackendEvent(event);
   if (!itemId) {
-    return [contentKey];
+    return uniqueContentKeys;
   }
   // Backend item identity is authoritative and intentionally independent of
   // turn/text: replaying one item with changed metadata must never post it
@@ -20971,7 +20987,7 @@ function assistantMessageDeliveryKeys(
       assistantMessageThreadId(event, identity),
       `item:${itemId}`,
     ].join("\0"),
-    contentKey,
+    ...uniqueContentKeys,
   ];
 }
 


### PR DESCRIPTION
## Summary

- preserve every text fragment in completion-only terminal responses
- deduplicate cumulative turn-completed output against previously delivered assistant items using per-fragment delivery keys
- add regression coverage for both the reported commentary-plus-final duplicate and multi-fragment completion-only output

## Root cause

Codex emitted one final assistant item and one completed-turn notification. The terminal notification contained earlier commentary followed by the same final answer. Messaging joined every text entry, producing a slightly different aggregate that bypassed item/content deduplication and was delivered as a second ordinary assistant response. This was one backend turn, not two dispatched requests.

The fix keeps terminal aggregation intact. A terminal delivery claim now includes the aggregate content key and each component output key. If the final component was already delivered through item/completed, the cumulative terminal output is suppressed. If turn/completed is the only response event, every output fragment is preserved and delivered together.

## Validation

- pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts (411 passed)
- pnpm typecheck
- pnpm lint:eslint (0 errors; existing warnings only)
- pnpm lint:boundaries
- git diff --check