### PR TITLE
fix(desktop): propagate selected Codex home

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
@@ -222,6 +222,12 @@ describe("DesktopBackendRegistry replay isolation", () => {
     await expect(constructorState.codexResolveEnvs[0]?.()).resolves.toMatchObject({
       CODEX_HOME: codexHome,
     });
+    const resolvedArgs = await constructorState.codexResolveArgs[0]?.({
+      CODEX_HOME: codexHome,
+    });
+    expect(resolvedArgs).toContain(
+      `shell_environment_policy.set.CODEX_HOME=${JSON.stringify(codexHome)}`,
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1738,6 +1738,31 @@ describe("DesktopSettingsService", () => {
     );
   });
 
+  it("sets the selected Codex auth profile on integrated terminal shells", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const codexRoot = path.join(root, "codex");
+    fs.writeFileSync(
+      configPath,
+      ["[models.codex]", 'profile = "work"'].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      env: { CODEX_HOME: codexRoot } as NodeJS.ProcessEnv,
+      secretStore: new MemoryDesktopSecretStore(),
+      resolveCodexShellEnv: () => ({
+        CODEX_HOME: path.join(root, "login-shell-default"),
+        PATH: "/opt/homebrew/bin:/usr/bin",
+      }),
+    });
+
+    await expect(service.resolveTerminalSpawnEnvAsync()).resolves.toMatchObject({
+      CODEX_HOME: path.join(codexRoot, "profiles", "work"),
+      PATH: "/opt/homebrew/bin:/usr/bin",
+    });
+  });
+
   it("keeps CODEX_HOME fixed to the startup Codex auth profile", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2122,6 +2122,13 @@ export function buildCodexClientArgs(env?: NodeJS.ProcessEnv): string[] {
       `shell_environment_policy.set.PATH=${formatTomlString(pathValue)}`,
     );
   }
+  const codexHome = env?.CODEX_HOME?.trim();
+  if (codexHome) {
+    args.push(
+      "-c",
+      `shell_environment_policy.set.CODEX_HOME=${formatTomlString(codexHome)}`,
+    );
+  }
   return args;
 }
 

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1849,11 +1849,13 @@ export class DesktopSettingsService {
 
   async resolveTerminalSpawnEnvAsync(): Promise<NodeJS.ProcessEnv> {
     if (this.options.resolveCodexShellEnv) {
-      return buildPwrAgentChildProcessEnv(
-        mergeLoginShellEnvIntoEnv(buildPwrAgentChildProcessEnv(this.env), {
-          resolveShellEnv: this.options.resolveCodexShellEnv,
-          logger: getMainLogger("pwragent:shell-environment"),
-        }),
+      return this.withStartupCodexHome(
+        buildPwrAgentChildProcessEnv(
+          mergeLoginShellEnvIntoEnv(buildPwrAgentChildProcessEnv(this.env), {
+            resolveShellEnv: this.options.resolveCodexShellEnv,
+            logger: getMainLogger("pwragent:shell-environment"),
+          }),
+        ),
       );
     }
 
@@ -1883,6 +1885,9 @@ export class DesktopSettingsService {
         hadHomebrewPrefix: Boolean(shellEnv.HOMEBREW_PREFIX),
       });
       mergePwrAgentChildProcessEnv(targetEnv, shellEnv);
+      if (this.startupCodexHome) {
+        targetEnv.CODEX_HOME = this.startupCodexHome;
+      }
       return targetEnv;
     });
 
@@ -1907,7 +1912,9 @@ export class DesktopSettingsService {
   }
 
   private ensureBaseTerminalSpawnEnv(): NodeJS.ProcessEnv {
-    this.terminalSpawnEnv ??= buildPwrAgentChildProcessEnv(this.env);
+    this.terminalSpawnEnv ??= this.withStartupCodexHome(
+      buildPwrAgentChildProcessEnv(this.env),
+    );
     return this.terminalSpawnEnv;
   }
 


### PR DESCRIPTION
## Summary

- I propagate the resolved startup `CODEX_HOME` into integrated terminal shells, including after login-shell environment hydration.
- I pin the same `CODEX_HOME` in Codex's shell environment policy so commands and tools launched by the App Server use the active profile.
- I added regression coverage for terminal profile selection and Codex child-tool configuration.

## Verification

- `pnpm test` (618 files passed; 8,920 tests passed; 6 skipped)
- `pnpm lint:eslint` (0 errors; 43 existing warnings)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- I verified the new tests fail before the implementation and pass after it.

## Notes

- Official Codex documentation defines `CODEX_HOME` as the state root used by the CLI and App Server, so child Codex invocations now stay on the same config/auth/profile state as PwrAgent's App Server.
