### PR TITLE
fix(desktop): preserve MCP images in final responses

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4034,8 +4034,8 @@ describe("CodexAppServerClient", () => {
               {
                 type: "mcpToolCall",
                 id: "mcp-direct-image",
-                server: "giphy-dev",
-                tool: "giphy_get_image",
+                server: "image-tools",
+                tool: "fetch_image",
                 status: "completed",
                 result: {
                   content: [
@@ -4079,7 +4079,7 @@ describe("CodexAppServerClient", () => {
             {
               type: "image",
               url: imageUrl,
-              alt: "giphy-dev/giphy_get_image result",
+              alt: "image-tools/fetch_image result",
             },
           ],
         }),
@@ -4094,7 +4094,7 @@ describe("CodexAppServerClient", () => {
         {
           type: "image",
           url: imageUrl,
-          alt: "giphy-dev/giphy_get_image result",
+          alt: "image-tools/fetch_image result",
         },
       ],
     });
@@ -4115,8 +4115,8 @@ describe("CodexAppServerClient", () => {
               {
                 type: "mcpToolCall",
                 id: "mcp-wrapped-image",
-                server: "giphy-dev",
-                tool: "giphy_get_image",
+                server: "image-tools",
+                tool: "fetch_image",
                 status: "completed",
                 result: {
                   content: [

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4021,6 +4021,166 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("attaches direct MCP image content to the final assistant message", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const imageUrl = "data:image/webp;base64,AQID";
+    MockTransport.readThreadResultByThreadId.set("thread-direct-mcp-image", {
+      thread: {
+        turns: [
+          {
+            id: "turn-direct-mcp-image",
+            startedAt: 1_763_500_150,
+            items: [
+              {
+                type: "mcpToolCall",
+                id: "mcp-direct-image",
+                server: "giphy-dev",
+                tool: "giphy_get_image",
+                status: "completed",
+                result: {
+                  content: [
+                    {
+                      type: "image",
+                      mimeType: "image/webp",
+                      data: "AQID",
+                    },
+                  ],
+                },
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-final",
+                phase: "final_answer",
+                text: "Here is the image.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId: "thread-direct-mcp-image" });
+    const activity = replay.entries.find((entry) => entry.type === "activity");
+    const finalEntry = replay.entries.find(
+      (entry) => entry.type === "message" && entry.id === "assistant-final",
+    );
+
+    expect(activity).toMatchObject({
+      type: "activity",
+      details: [
+        expect.objectContaining({
+          id: "mcp-direct-image",
+          images: [
+            {
+              type: "image",
+              url: imageUrl,
+              alt: "giphy-dev/giphy_get_image result",
+            },
+          ],
+        }),
+      ],
+    });
+    expect(finalEntry).toMatchObject({
+      type: "message",
+      role: "assistant",
+      text: "Here is the image.",
+      parts: [
+        { type: "text", text: "Here is the image." },
+        {
+          type: "image",
+          url: imageUrl,
+          alt: "giphy-dev/giphy_get_image result",
+        },
+      ],
+    });
+
+    await client.close();
+  });
+
+  it("renders JSON-wrapped MCP image results and attaches them to the final message", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const imageUrl = "data:image/webp;base64,AQID";
+    MockTransport.readThreadResultByThreadId.set("thread-wrapped-mcp-image", {
+      thread: {
+        turns: [
+          {
+            id: "turn-wrapped-mcp-image",
+            startedAt: 1_763_500_150,
+            items: [
+              {
+                type: "mcpToolCall",
+                id: "mcp-wrapped-image",
+                server: "giphy-dev",
+                tool: "giphy_get_image",
+                status: "completed",
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        content: [
+                          {
+                            type: "image",
+                            mimeType: "image/webp",
+                            data: "AQID",
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-final",
+                phase: "final_answer",
+                text: "Here is the image.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId: "thread-wrapped-mcp-image" });
+    const activity = replay.entries.find((entry) => entry.type === "activity");
+    const finalEntry = replay.entries.find(
+      (entry) => entry.type === "message" && entry.id === "assistant-final",
+    );
+
+    expect(activity).toMatchObject({
+      type: "activity",
+      details: [
+        expect.objectContaining({
+          id: "mcp-wrapped-image",
+          images: [
+            expect.objectContaining({ type: "image", url: imageUrl }),
+          ],
+        }),
+      ],
+    });
+    expect(finalEntry).toMatchObject({
+      type: "message",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Here is the image." },
+        { type: "image", url: imageUrl },
+      ],
+    });
+
+    await client.close();
+  });
+
   it("attaches loopback image exports from MCP results to the final assistant message", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const imageUrl =
@@ -5492,6 +5652,17 @@ describe("CodexAppServerClient", () => {
               },
             ],
           }),
+        ],
+      }),
+      expect.objectContaining({
+        type: "message",
+        role: "assistant",
+        parts: [
+          {
+            type: "image",
+            url: "data:image/png;base64,AQID",
+            alt: "node_repl/js result",
+          },
         ],
       }),
     ]);

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3792,10 +3792,15 @@ function extractMcpToolResultImagePartsFromReplayItem(
       const signedImagePart = structuredContent
         ? buildMcpSignedImagePart(structuredContent)
         : undefined;
+      const toolName =
+        pickString(candidate, ["tool", "toolName", "tool_name"])
+        ?? "Tool";
+      const contentImageParts = extractMcpToolResultContentImageParts(candidate, toolName);
       const resourceLinkImageParts = extractMcpResourceLinkImageParts(result?.content);
       const resourceImageParts = extractMcpResourceImageParts(result?.content);
       return [
         ...structuredImageParts,
+        ...contentImageParts,
         ...resourceLinkImageParts,
         ...(signedImagePart ? [signedImagePart] : []),
         ...resourceImageParts,
@@ -3804,7 +3809,7 @@ function extractMcpToolResultImagePartsFromReplayItem(
   );
 }
 
-function extractDirectMcpToolResultImageParts(
+function extractMcpToolResultContentImageParts(
   item: Record<string, unknown>,
   toolName: string,
 ): AppServerThreadImagePart[] {
@@ -3815,29 +3820,57 @@ function extractDirectMcpToolResultImageParts(
     toolName,
   );
   return dedupeImageParts(content.flatMap((value): AppServerThreadImagePart[] => {
-    const block = asRecord(value);
-    const type = normalizeItemType(pickString(block ?? {}, ["type"]));
-    const mimeType = pickString(block ?? {}, ["mimeType", "mime_type"])
-      ?.trim()
-      .toLowerCase();
-    const data = pickString(block ?? {}, ["data"]);
-    if (
-      type !== "image"
-      || !mimeType
-      || !MCP_RESOURCE_IMAGE_MIME_TYPES.has(mimeType)
-      || !data
-      || data.length > MAX_MCP_RESOURCE_IMAGE_BASE64_CHARS
-      || data.length % 4 === 1
-      || !BASE64_IMAGE_BLOB_PATTERN.test(data)
-    ) {
-      return [];
-    }
-    return [{
-      type: "image",
-      url: `data:${mimeType};base64,${data}`,
-      alt: `${identifier} result`,
-    }];
+    const directImagePart = buildMcpContentImagePart(asRecord(value) ?? undefined, identifier);
+    const contentRecord = asRecord(value);
+    // Some MCP adapters accidentally serialize a complete CallToolResult into
+    // one text block. Accept one wrapper layer while retaining the normal
+    // MIME, size, and base64 validation for the nested image content.
+    const parsedText = parseStructuredValue(
+      typeof value === "string"
+        ? value
+        : pickString(contentRecord ?? {}, ["text"]),
+    );
+    const nestedResult = asRecord(parsedText);
+    const nestedContent = Array.isArray(nestedResult?.content)
+      ? nestedResult.content
+      : [];
+    const nestedImageParts = nestedContent.flatMap((nestedValue) => {
+      const imagePart = buildMcpContentImagePart(asRecord(nestedValue) ?? undefined, identifier);
+      return imagePart ? [imagePart] : [];
+    });
+    return [
+      ...(directImagePart ? [directImagePart] : []),
+      ...nestedImageParts,
+    ];
   }));
+}
+
+function buildMcpContentImagePart(
+  block: Record<string, unknown> | undefined,
+  identifier: string,
+): AppServerThreadImagePart | undefined {
+  const type = normalizeItemType(pickString(block ?? {}, ["type"]));
+  const mimeType = pickString(block ?? {}, ["mimeType", "mime_type"])
+    ?.trim()
+    .toLowerCase();
+  const data = pickString(block ?? {}, ["data"]);
+  if (
+    type !== "image"
+    || !mimeType
+    || !MCP_RESOURCE_IMAGE_MIME_TYPES.has(mimeType)
+    || !data
+    || data.length > MAX_MCP_RESOURCE_IMAGE_BASE64_CHARS
+    || data.length % 4 === 1
+    || !BASE64_IMAGE_BLOB_PATTERN.test(data)
+  ) {
+    return undefined;
+  }
+
+  return {
+    type: "image",
+    url: `data:${mimeType};base64,${data}`,
+    alt: `${identifier} result`,
+  };
 }
 
 function buildMcpSignedImagePart(
@@ -4459,7 +4492,7 @@ function summarizeActivityItems(
         normalizedItemType === "dynamictoolcall"
           ? extractDynamicToolCallImageParts(item, toolName ?? "Tool")
           : normalizedItemType === "mcptoolcall"
-            ? extractDirectMcpToolResultImageParts(item, toolName ?? "Tool")
+            ? extractMcpToolResultContentImageParts(item, toolName ?? "Tool")
           : [];
       const label =
         (normalizedItemType === "mcptoolcall" || normalizedItemType === "dynamictoolcall")


### PR DESCRIPTION
## Summary

- promote native MCP image content into the final assistant transcript message so it remains visible when completed tool activity collapses
- recognize one JSON-serialized CallToolResult wrapper inside MCP text content while retaining the existing MIME, base64, and 16 MiB validation
- cover native WebP images, wrapped WebP images, activity rendering, final-message promotion, and the no-final fallback

## Validation

- pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts (153 passed)
- pnpm lint:eslint (0 errors; existing warnings only)
- pnpm typecheck
- pnpm lint:codex-storage
- pnpm lint:boundaries