### PR TITLE
fix(desktop): route remote PR refreshes to owner

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -73,6 +73,13 @@ const federationMock = vi.hoisted(() => {
       threadId: request.threadId,
       renamedAt: 6_000,
     })),
+    refreshThreadPullRequests: vi.fn(async (request: RefreshThreadPullRequestsRequest) => ({
+      backend: request.backend ?? "codex",
+      threadId: request.threadId,
+      provider: request.provider ?? "github.com",
+      ghAvailable: true,
+      prs: [],
+    })),
     refreshDirectoryGitStatuses: vi.fn(async () => ({ scheduledCount: 1 })),
     ensureDirectoryLaunchpad: vi.fn(),
     listRecentFileReferences: vi.fn(async () => ({
@@ -496,6 +503,7 @@ const setLocalPullRequestAuthorityResolver = vi.fn();
 const setThreadPullRequestWatchToolHandler = vi.fn();
 const setThreadPrAutoDispatchHandler = vi.fn();
 const setThreadPullRequestDetachHandler = vi.fn();
+const setThreadPullRequestRefreshHandler = vi.fn();
 const setDirectoryGitStatusWriter = vi.fn();
 const setThreadPrAutoDispatchBatch = vi.fn(async () => undefined);
 const ensureDirectoryLaunchpad = vi.fn(async (request: {
@@ -913,6 +921,7 @@ vi.mock("../app-server/backend-registry", () => {
     setThreadPullRequestWatchToolHandler,
     setThreadPrAutoDispatchHandler,
     setThreadPullRequestDetachHandler,
+    setThreadPullRequestRefreshHandler,
     setDirectoryGitStatusWriter,
     setThreadPrAutoDispatchBatch,
     ensureDirectoryLaunchpad,
@@ -999,6 +1008,7 @@ describe("app server ipc", () => {
     federationMock.remoteBackend.markThreadSeen.mockClear();
     federationMock.remoteBackend.setThreadReaction.mockClear();
     federationMock.remoteBackend.setThreadParent.mockClear();
+    federationMock.remoteBackend.refreshThreadPullRequests.mockClear();
     federationMock.remoteBackend.refreshDirectoryGitStatuses.mockClear();
     federationMock.remoteBackend.ensureDirectoryLaunchpad.mockReset();
     federationMock.remoteBackend.listRecentFileReferences.mockReset();
@@ -1048,6 +1058,7 @@ describe("app server ipc", () => {
     setThreadPullRequestWatchToolHandler.mockClear();
     setThreadPrAutoDispatchHandler.mockClear();
     setThreadPullRequestDetachHandler.mockClear();
+    setThreadPullRequestRefreshHandler.mockClear();
     setDirectoryGitStatusWriter.mockClear();
     setThreadPrAutoDispatchBatch.mockClear();
     ensureDirectoryLaunchpad.mockClear();
@@ -4170,6 +4181,48 @@ describe("app server ipc", () => {
           reactions: ["👀"],
         },
       },
+    });
+  });
+
+  it("routes remote-window PR refreshes to the thread-owning instance", async () => {
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "pwr_owner",
+    };
+    const request = {
+      backend: "codex",
+      threadId: "thread-remote",
+      trigger: "user" as const,
+      branch: "fix/remote-pr-hover",
+      directoryPaths: ["/remote/repo"],
+      federationTarget,
+    };
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      { sender: { id: 999 } },
+      request,
+    );
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(
+      federationMock.remoteBackend.refreshThreadPullRequests,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-remote",
+      trigger: "user",
+      branch: "fix/remote-pr-hover",
+      directoryPaths: ["/remote/repo"],
+    });
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-remote",
+      provider: "github.com",
+      ghAvailable: true,
+      prs: [],
     });
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4214,8 +4214,6 @@ describe("app server ipc", () => {
       backend: "codex",
       threadId: "thread-remote",
       trigger: "user",
-      branch: "fix/remote-pr-hover",
-      directoryPaths: ["/remote/repo"],
     });
     expect(response).toEqual({
       backend: "codex",
@@ -4223,6 +4221,50 @@ describe("app server ipc", () => {
       provider: "github.com",
       ghAvailable: true,
       prs: [],
+    });
+  });
+
+  it("resolves federated PR refresh inputs from the owner's thread state", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-owner",
+        title: "Owner thread",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [
+          {
+            id: "directory:/owner/repo",
+            kind: "local",
+            label: "repo",
+            path: "/owner/repo",
+          },
+        ],
+        gitBranch: "owner/authoritative-branch",
+        updatedAt: 2_000,
+      },
+    ] as never);
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    detectPullRequestsForThread.mockClear();
+
+    const refreshFromOwnerState =
+      setThreadPullRequestRefreshHandler.mock.calls.at(-1)?.[0];
+    await refreshFromOwnerState({
+      backend: "codex",
+      threadId: "thread-owner",
+      trigger: "user",
+      branch: "viewer/stale-branch",
+      directoryPaths: ["/viewer/unrelated-repo"],
+    });
+
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "owner/authoritative-branch",
+        directoryPaths: ["/owner/repo"],
+        allowPrimedBranchLookup: false,
+      });
     });
   });
 

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1987,6 +1987,47 @@ describe("federation backend bridge", () => {
     });
     await expect(refreshPending).resolves.toEqual({ scheduledCount: 1 });
 
+    const refreshPrPending = client.refreshThreadPullRequests({
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "fix/remote-pr-hover",
+      directoryPaths: ["/remote/repo"],
+    });
+    const refreshPrRequest = sent.at(-1)!;
+    expect(refreshPrRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.refreshThreadPullRequests,
+      params: {
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "fix/remote-pr-hover",
+        directoryPaths: ["/remote/repo"],
+      },
+    });
+    rpc.receiveEnvelope({
+      id: "response-pr-refresh",
+      kind: "response",
+      requestId: refreshPrRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_350,
+      result: {
+        backend: "codex",
+        threadId: "thread-1",
+        provider: "github.com",
+        ghAvailable: true,
+        prs: [],
+      },
+    });
+    await expect(refreshPrPending).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      prs: [],
+    });
+
     const cancelPending = client.cancelQueuedTurn({ queueEntryId: "queue-1" });
     const cancelRequest = sent.at(-1)!;
     expect(cancelRequest).toMatchObject({
@@ -2165,6 +2206,75 @@ describe("federation backend bridge", () => {
         kind: "response",
         requestId: "refresh-request",
         result: { scheduledCount: 1 },
+      },
+    ]);
+  });
+
+  it("executes pull-request refreshes on the target instance", async () => {
+    const refreshThreadPullRequests = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      provider: "github.com" as const,
+      ghAvailable: true,
+      prs: [],
+    }));
+    const backend = {
+      refreshThreadPullRequests,
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "refresh-pr-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.refreshThreadPullRequests,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          trigger: "user",
+          branch: "fix/remote-pr-hover",
+          directoryPaths: ["/remote/repo"],
+          federationTarget: {
+            scope: "remote",
+            instanceId: "untrusted-relay-target",
+          },
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(refreshThreadPullRequests).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "fix/remote-pr-hover",
+      directoryPaths: ["/remote/repo"],
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "refresh-pr-request",
+        result: {
+          backend: "codex",
+          threadId: "thread-1",
+          provider: "github.com",
+          ghAvailable: true,
+          prs: [],
+        },
       },
     ]);
   });
@@ -2702,6 +2812,7 @@ describe("federation backend bridge", () => {
       })),
       stopCodexEnvironmentAction: vi.fn(),
       setCodexThreadEnvironment: vi.fn(),
+      refreshThreadPullRequests: vi.fn(),
       materializeDirectoryLaunchpad: vi.fn(),
       refreshDirectoryGitStatuses: vi.fn(),
       ensureDirectoryLaunchpad: vi.fn(),
@@ -3043,6 +3154,7 @@ describe("federation backend bridge", () => {
         runCodexEnvironmentAction: vi.fn(),
         stopCodexEnvironmentAction: vi.fn(),
         setCodexThreadEnvironment: vi.fn(),
+        refreshThreadPullRequests: vi.fn(),
         refreshDirectoryGitStatuses: vi.fn(),
         ensureDirectoryLaunchpad: vi.fn(),
         listRecentFileReferences: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1991,8 +1991,6 @@ describe("federation backend bridge", () => {
       backend: "codex",
       threadId: "thread-1",
       trigger: "user",
-      branch: "fix/remote-pr-hover",
-      directoryPaths: ["/remote/repo"],
     });
     const refreshPrRequest = sent.at(-1)!;
     expect(refreshPrRequest).toMatchObject({
@@ -2002,8 +2000,6 @@ describe("federation backend bridge", () => {
         backend: "codex",
         threadId: "thread-1",
         trigger: "user",
-        branch: "fix/remote-pr-hover",
-        directoryPaths: ["/remote/repo"],
       },
     });
     rpc.receiveEnvelope({
@@ -2261,8 +2257,6 @@ describe("federation backend bridge", () => {
       backend: "codex",
       threadId: "thread-1",
       trigger: "user",
-      branch: "fix/remote-pr-hover",
-      directoryPaths: ["/remote/repo"],
     });
     expect(replies).toMatchObject([
       {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -202,7 +202,7 @@ import {
   type QueueThreadExecutionModeResponse,
   type RefreshDirectoryGitStatusesRequest,
   type RefreshDirectoryGitStatusesResponse,
-  type RefreshThreadPullRequestsRequest,
+  type RefreshOwnedThreadPullRequestsRequest,
   type RefreshThreadPullRequestsResponse,
   type NavigationDirectoryGitStatusUpdatedNotification,
   type CancelThreadExecutionModeQueueRequest,
@@ -1752,7 +1752,7 @@ type ThreadPullRequestDetachHandler = (
 ) => Promise<DetachThreadPullRequestResponse>;
 
 type ThreadPullRequestRefreshHandler = (
-  request: RefreshThreadPullRequestsRequest,
+  request: RefreshOwnedThreadPullRequestsRequest,
 ) => Promise<RefreshThreadPullRequestsResponse>;
 
 type ThreadPrAutoDispatchHandler = {
@@ -8081,8 +8081,8 @@ export class DesktopBackendRegistry {
    * Refresh PR state through the desktop app-server service. Federation uses
    * this mediator so its backend bridge does not import the IPC module.
    */
-  async refreshThreadPullRequests(
-    request: RefreshThreadPullRequestsRequest,
+  async refreshOwnedThreadPullRequests(
+    request: RefreshOwnedThreadPullRequestsRequest,
   ): Promise<RefreshThreadPullRequestsResponse> {
     const handler = this.threadPullRequestRefreshHandler;
     if (!handler) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -202,6 +202,8 @@ import {
   type QueueThreadExecutionModeResponse,
   type RefreshDirectoryGitStatusesRequest,
   type RefreshDirectoryGitStatusesResponse,
+  type RefreshThreadPullRequestsRequest,
+  type RefreshThreadPullRequestsResponse,
   type NavigationDirectoryGitStatusUpdatedNotification,
   type CancelThreadExecutionModeQueueRequest,
   type CancelThreadExecutionModeQueueResponse,
@@ -1748,6 +1750,10 @@ type DirectoryGitStatusWriter = (params: {
 type ThreadPullRequestDetachHandler = (
   request: DetachThreadPullRequestRequest,
 ) => Promise<DetachThreadPullRequestResponse>;
+
+type ThreadPullRequestRefreshHandler = (
+  request: RefreshThreadPullRequestsRequest,
+) => Promise<RefreshThreadPullRequestsResponse>;
 
 type ThreadPrAutoDispatchHandler = {
   preferenceChanged: (request: SetThreadPrAutoDispatchRequest) => Promise<void>;
@@ -7120,6 +7126,9 @@ export class DesktopBackendRegistry {
   private threadPullRequestDetachHandler:
     | ThreadPullRequestDetachHandler
     | undefined;
+  private threadPullRequestRefreshHandler:
+    | ThreadPullRequestRefreshHandler
+    | undefined;
   private threadPullRequestCanonicalizer:
     | ThreadPullRequestCanonicalizer
     | undefined;
@@ -8060,6 +8069,26 @@ export class DesktopBackendRegistry {
     handler: ThreadPullRequestDetachHandler | null | undefined,
   ): void {
     this.threadPullRequestDetachHandler = handler ?? undefined;
+  }
+
+  setThreadPullRequestRefreshHandler(
+    handler: ThreadPullRequestRefreshHandler | null | undefined,
+  ): void {
+    this.threadPullRequestRefreshHandler = handler ?? undefined;
+  }
+
+  /**
+   * Refresh PR state through the desktop app-server service. Federation uses
+   * this mediator so its backend bridge does not import the IPC module.
+   */
+  async refreshThreadPullRequests(
+    request: RefreshThreadPullRequestsRequest,
+  ): Promise<RefreshThreadPullRequestsResponse> {
+    const handler = this.threadPullRequestRefreshHandler;
+    if (!handler) {
+      throw new Error("Pull-request refresh service is not available yet.");
+    }
+    return await handler(request);
   }
 
   /**

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -86,7 +86,7 @@ import type {
   QueueThreadExecutionModeResponse,
   RefreshDirectoryGitStatusesRequest,
   RefreshDirectoryGitStatusesResponse,
-  RefreshThreadPullRequestsRequest,
+  RefreshOwnedThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   RecordModelSettingsRecentRequest,
   RecordRecentFileReferencesRequest,
@@ -179,16 +179,18 @@ export type FederationStartTurnRequest = StartTurnRequest & {
   messageOrigin?: AppServerThreadMessageOrigin;
 };
 
-export type FederationRefreshThreadPullRequestsRequest = Omit<
-  RefreshThreadPullRequestsRequest,
-  "federationTarget"
->;
+export type FederationRefreshThreadPullRequestsRequest =
+  RefreshOwnedThreadPullRequestsRequest;
 
 function localizeRefreshThreadPullRequestsRequest(
-  request: RefreshThreadPullRequestsRequest,
+  request: RefreshOwnedThreadPullRequestsRequest,
 ): FederationRefreshThreadPullRequestsRequest {
-  const { federationTarget: _federationTarget, ...localRequest } = request;
-  return localRequest;
+  return {
+    backend: request.backend,
+    threadId: request.threadId,
+    ...(request.provider ? { provider: request.provider } : {}),
+    ...(request.trigger ? { trigger: request.trigger } : {}),
+  };
 }
 
 type FederationMaterializeDirectoryLaunchpadRequest =
@@ -1160,7 +1162,7 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.refreshThreadPullRequests(
         localizeRefreshThreadPullRequestsRequest(
-          envelope.params as RefreshThreadPullRequestsRequest,
+          envelope.params as RefreshOwnedThreadPullRequestsRequest,
         ),
       ),
   );

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -86,6 +86,8 @@ import type {
   QueueThreadExecutionModeResponse,
   RefreshDirectoryGitStatusesRequest,
   RefreshDirectoryGitStatusesResponse,
+  RefreshThreadPullRequestsRequest,
+  RefreshThreadPullRequestsResponse,
   RecordModelSettingsRecentRequest,
   RecordRecentFileReferencesRequest,
   ResolveThreadRequest,
@@ -176,6 +178,18 @@ export type FederatedTranscriptImageResponse = {
 export type FederationStartTurnRequest = StartTurnRequest & {
   messageOrigin?: AppServerThreadMessageOrigin;
 };
+
+export type FederationRefreshThreadPullRequestsRequest = Omit<
+  RefreshThreadPullRequestsRequest,
+  "federationTarget"
+>;
+
+function localizeRefreshThreadPullRequestsRequest(
+  request: RefreshThreadPullRequestsRequest,
+): FederationRefreshThreadPullRequestsRequest {
+  const { federationTarget: _federationTarget, ...localRequest } = request;
+  return localRequest;
+}
 
 type FederationMaterializeDirectoryLaunchpadRequest =
   MaterializeDirectoryLaunchpadRequest & {
@@ -314,6 +328,7 @@ export const FEDERATION_BACKEND_METHODS = {
   runCodexEnvironmentAction: "backend.runCodexEnvironmentAction",
   stopCodexEnvironmentAction: "backend.stopCodexEnvironmentAction",
   setCodexThreadEnvironment: "backend.setCodexThreadEnvironment",
+  refreshThreadPullRequests: "backend.refreshThreadPullRequests",
   refreshDirectoryGitStatuses: "backend.refreshDirectoryGitStatuses",
   ensureDirectoryLaunchpad: "backend.ensureDirectoryLaunchpad",
   listRecentFileReferences: "backend.listRecentFileReferences",
@@ -412,6 +427,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment]: "environment_actions",
+  [FEDERATION_BACKEND_METHODS.refreshThreadPullRequests]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.ensureDirectoryLaunchpad]: "launchpad_metadata",
   [FEDERATION_BACKEND_METHODS.listRecentFileReferences]: "remote_window",
@@ -592,6 +608,9 @@ export type FederationBackendOperations = {
   setCodexThreadEnvironment(
     request: SetCodexThreadEnvironmentRequest,
   ): Promise<SetCodexThreadEnvironmentResponse>;
+  refreshThreadPullRequests(
+    request: FederationRefreshThreadPullRequestsRequest,
+  ): Promise<RefreshThreadPullRequestsResponse>;
   refreshDirectoryGitStatuses(
     request: RefreshDirectoryGitStatusesRequest,
   ): Promise<RefreshDirectoryGitStatusesResponse>;
@@ -1134,6 +1153,15 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.setCodexThreadEnvironment(
         envelope.params as SetCodexThreadEnvironmentRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.refreshThreadPullRequests,
+    async (envelope) =>
+      await params.backend.refreshThreadPullRequests(
+        localizeRefreshThreadPullRequestsRequest(
+          envelope.params as RefreshThreadPullRequestsRequest,
+        ),
       ),
   );
   params.router.registerHandler(
@@ -1764,6 +1792,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<RefreshDirectoryGitStatusesResponse> {
     return await this.rpc.request<RefreshDirectoryGitStatusesResponse>({
       method: FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses,
+      params: request,
+    });
+  }
+
+  async refreshThreadPullRequests(
+    request: FederationRefreshThreadPullRequestsRequest,
+  ): Promise<RefreshThreadPullRequestsResponse> {
+    return await this.rpc.request<RefreshThreadPullRequestsResponse>({
+      method: FEDERATION_BACKEND_METHODS.refreshThreadPullRequests,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -55,6 +55,7 @@ import type {
   ReadFederationPinImpactRequest,
   ReadFederationPinImpactResponse,
   RefreshDirectoryGitStatusesResponse,
+  RefreshThreadPullRequestsResponse,
   ResetFederationEnrollmentRequest,
   RetainThreadBranchDriftResponse,
   RenameThreadResponse,
@@ -239,6 +240,7 @@ import {
   type FederationBackendEventNotification,
   type FederationBackendOperations,
   type FederationEnvironmentSetupProgressNotification,
+  type FederationRefreshThreadPullRequestsRequest,
   type FederationStartTurnRequest,
 } from "./federation-backend-bridge";
 import {
@@ -5196,6 +5198,11 @@ function localBackendOperations(): FederationBackendOperations {
       request: RefreshDirectoryGitStatusesRequest,
     ): Promise<RefreshDirectoryGitStatusesResponse> {
       return await getDesktopBackendRegistry().refreshDirectoryGitStatuses(request);
+    },
+    async refreshThreadPullRequests(
+      request: FederationRefreshThreadPullRequestsRequest,
+    ): Promise<RefreshThreadPullRequestsResponse> {
+      return await getDesktopBackendRegistry().refreshThreadPullRequests(request);
     },
     async ensureDirectoryLaunchpad(request: EnsureDirectoryLaunchpadRequest) {
       return await new DesktopMessagingBackendBridge()

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -5202,7 +5202,7 @@ function localBackendOperations(): FederationBackendOperations {
     async refreshThreadPullRequests(
       request: FederationRefreshThreadPullRequestsRequest,
     ): Promise<RefreshThreadPullRequestsResponse> {
-      return await getDesktopBackendRegistry().refreshThreadPullRequests(request);
+      return await getDesktopBackendRegistry().refreshOwnedThreadPullRequests(request);
     },
     async ensureDirectoryLaunchpad(request: EnsureDirectoryLaunchpadRequest) {
       return await new DesktopMessagingBackendBridge()

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -80,6 +80,7 @@ import {
   type RefreshDirectoryGitStatusesResponse,
   type RefreshThreadGitWorkingStateRequest,
   type RefreshThreadGitWorkingStateResponse,
+  type RefreshOwnedThreadPullRequestsRequest,
   type RefreshThreadPullRequestsRequest,
   type SetPullRequestPollingFocusRequest,
   type RefreshThreadPullRequestsResponse,
@@ -3593,10 +3594,14 @@ class DesktopAppServerService {
       request.federationTarget
       && isRemoteFederationTarget(request.federationTarget)
     ) {
-      const { federationTarget, ...remoteRequest } = request;
       return await getDesktopFederationRuntime()
-        .remoteBackend(federationTarget)
-        .refreshThreadPullRequests(remoteRequest);
+        .remoteBackend(request.federationTarget)
+        .refreshThreadPullRequests({
+          backend: request.backend,
+          threadId: request.threadId,
+          ...(request.provider ? { provider: request.provider } : {}),
+          ...(request.trigger ? { trigger: request.trigger } : {}),
+        });
     }
     const backend = request.backend ?? "codex";
     const requestKey = getThreadPullRequestsRequestKey(backend, request);
@@ -3626,6 +3631,36 @@ class DesktopAppServerService {
     } finally {
       this.pendingThreadPullRequestRefreshes.delete(requestKey);
     }
+  }
+
+  async refreshOwnedThreadPullRequests(
+    request: RefreshOwnedThreadPullRequestsRequest,
+  ): Promise<RefreshThreadPullRequestsResponse> {
+    const backend = request.backend ?? "codex";
+    const threadKey = buildThreadIdentityKey(backend, request.threadId);
+    const [firstContext, ...remainingContexts] =
+      this.prRefreshContextByThreadKey.get(threadKey) ?? [];
+    if (!firstContext) {
+      throw new Error(
+        `No owner PR refresh context is available for ${threadKey}.`,
+      );
+    }
+    const refreshContext = async (
+      context: ThreadPrRefreshContext,
+    ): Promise<RefreshThreadPullRequestsResponse> => {
+      const { branchScoped: _branchScoped, ...lookupRequest } = context;
+      return await this.refreshThreadPullRequests({
+        ...lookupRequest,
+        ...(request.provider ? { provider: request.provider } : {}),
+        ...(request.trigger ? { trigger: request.trigger } : {}),
+      });
+    };
+
+    let response = await refreshContext(firstContext);
+    for (const context of remainingContexts) {
+      response = await refreshContext(context);
+    }
+    return response;
   }
 
   async checkThreadPullRequestStatusForTool(
@@ -7572,7 +7607,8 @@ export function registerAppServerIpcHandlers(): void {
     async (request) => await appServerService.detachThreadPullRequest(request),
   );
   getDesktopBackendRegistry().setThreadPullRequestRefreshHandler(
-    async (request) => await appServerService.refreshThreadPullRequests(request),
+    async (request) =>
+      await appServerService.refreshOwnedThreadPullRequests(request),
   );
   getDesktopBackendRegistry().setThreadPrAutoDispatchHandler({
     preferenceChanged: async (request) =>

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -3589,6 +3589,15 @@ class DesktopAppServerService {
   async refreshThreadPullRequests(
     request: RefreshThreadPullRequestsRequest,
   ): Promise<RefreshThreadPullRequestsResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...remoteRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .refreshThreadPullRequests(remoteRequest);
+    }
     const backend = request.backend ?? "codex";
     const requestKey = getThreadPullRequestsRequestKey(backend, request);
     const pending = this.pendingThreadPullRequestRefreshes.get(requestKey);
@@ -7562,6 +7571,9 @@ export function registerAppServerIpcHandlers(): void {
   getDesktopBackendRegistry().setThreadPullRequestDetachHandler(
     async (request) => await appServerService.detachThreadPullRequest(request),
   );
+  getDesktopBackendRegistry().setThreadPullRequestRefreshHandler(
+    async (request) => await appServerService.refreshThreadPullRequests(request),
+  );
   getDesktopBackendRegistry().setThreadPrAutoDispatchHandler({
     preferenceChanged: async (request) =>
       await appServerService.handleThreadPrAutoDispatchPreference(request),
@@ -8017,15 +8029,18 @@ export function registerAppServerIpcHandlers(): void {
       event,
       request: RefreshThreadPullRequestsRequest,
     ): Promise<RefreshThreadPullRequestsResponse> => {
-      // Defense in depth behind the renderer-side guard: a remote
-      // federation window's PR lookups belong to the owning instance.
-      // Running them here would use THIS machine's paths and GitHub
-      // credentials against a remote thread id. Throw (renderer refresh
-      // paths swallow errors) rather than return an empty result a
-      // caller might diff against snapshot PRs and loop on.
-      if (isFederationWindowWebContents(event?.sender)) {
+      // Defense in depth behind renderer target stamping: a remote window's
+      // lookup must be routed to the owning instance. Running an untargeted
+      // lookup here would use this machine's checkout and GitHub credentials.
+      if (
+        isFederationWindowWebContents(event?.sender)
+        && !(
+          request.federationTarget
+          && isRemoteFederationTarget(request.federationTarget)
+        )
+      ) {
         throw new Error(
-          "PR lookups for remote threads run on the owning instance.",
+          "PR lookups for remote threads must target the owning instance.",
         );
       }
       return await timeStartupProfileOperation({
@@ -8516,6 +8531,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   registry?.setDirectoryGitStatusWriter(undefined);
   registry?.setThreadPrAutoDispatchHandler(undefined);
   registry?.setThreadPullRequestDetachHandler(undefined);
+  registry?.setThreadPullRequestRefreshHandler(undefined);
   await appServerService.close();
 }
 

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -84,7 +84,7 @@ describe("usePullRequestRefresh", () => {
     });
   });
 
-  it("refreshes a remote thread through the caller-provided scoped API", async () => {
+  it("routes a remote hover refresh to the thread owner", async () => {
     const onRefreshNavigation = vi.fn(async () => undefined);
     const refreshThreadPullRequests = vi.fn(async () => buildResponse());
     const desktopApi = {
@@ -124,6 +124,50 @@ describe("usePullRequestRefresh", () => {
     });
     await waitFor(() => {
       expect(onRefreshNavigation).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("clears local polling focus when selection moves to a remote thread", async () => {
+    const refreshThreadPullRequests = vi.fn(async () => buildResponse({ prs: [] }));
+    const setPullRequestPollingFocus = vi.fn(async () => undefined);
+    const desktopApi = {
+      refreshThreadPullRequests,
+      setPullRequestPollingFocus,
+    } satisfies DesktopApi;
+    const { rerender } = renderHook(
+      ({ selectedThread }: { selectedThread: NavigationThreadSummary }) =>
+        usePullRequestRefresh({ desktopApi, selectedThread }),
+      {
+        initialProps: { selectedThread: buildThread({ prs: [] }) },
+      },
+    );
+
+    await waitFor(() => {
+      expect(setPullRequestPollingFocus).toHaveBeenCalledWith({
+        threadKeys: ["codex:thread-1"],
+      });
+    });
+
+    rerender({
+      selectedThread: buildThread({
+        id: "remote-thread",
+        prs: [],
+        federation: {
+          ref: buildFederatedThreadRef({
+            backend: "codex",
+            instanceId: "peer-laptop",
+            threadId: "remote-thread",
+          }),
+          instanceLabel: "Laptop",
+          peerStatus: "connected",
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(setPullRequestPollingFocus).toHaveBeenLastCalledWith({
+        threadKeys: [],
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -84,37 +84,47 @@ describe("usePullRequestRefresh", () => {
     });
   });
 
-  it("never drives local PR lookups for a remote thread pinned into the main window", async () => {
+  it("refreshes a remote thread through the caller-provided scoped API", async () => {
     const onRefreshNavigation = vi.fn(async () => undefined);
     const refreshThreadPullRequests = vi.fn(async () => buildResponse());
     const desktopApi = {
       refreshThreadPullRequests,
     } satisfies DesktopApi;
 
-    // Main window (no window-level federation target), but the selected
-    // thread is remote-owned: the per-thread guard must hold — its branch
-    // and paths belong to the peer machine.
-    renderHook(() =>
+    const { result } = renderHook(() =>
       usePullRequestRefresh({
         desktopApi,
         onRefreshNavigation,
-        selectedThread: buildThread({
-          federation: {
-            ref: buildFederatedThreadRef({
-              backend: "codex",
-              instanceId: "peer-laptop",
-              threadId: "thread-1",
-            }),
-            instanceLabel: "Laptop",
-            peerStatus: "connected",
-          },
-        }),
       }),
     );
+    result.current.prefetch(buildThread({
+      federation: {
+        ref: buildFederatedThreadRef({
+          backend: "codex",
+          instanceId: "peer-laptop",
+          threadId: "thread-1",
+        }),
+        instanceLabel: "Laptop",
+        peerStatus: "connected",
+      },
+    }));
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(refreshThreadPullRequests).not.toHaveBeenCalled();
-    expect(onRefreshNavigation).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "feat/pr-chip",
+        directoryPaths: ["/repo"],
+        federationTarget: {
+          scope: "remote",
+          instanceId: "peer-laptop",
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(onRefreshNavigation).toHaveBeenCalledOnce();
+    });
   });
 
   it("does not refresh navigation when the PR probe matches current PRs", async () => {

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -144,10 +144,14 @@ export function usePullRequestRefresh(params: {
   useEffect(() => {
     const setFocus = desktopApi?.setPullRequestPollingFocus;
     if (!setFocus) return;
-    if (federationWindowInstanceId || selectedIsRemoteFederated) {
-      return;
-    }
-    const threadKeys = selectedThreadKey ? [selectedThreadKey] : [];
+    // Focus is sender-scoped in main. A remote selection must actively clear
+    // this window's prior local key so it stops consuming the fast tier.
+    const threadKeys =
+      federationWindowInstanceId || selectedIsRemoteFederated
+        ? []
+        : selectedThreadKey
+          ? [selectedThreadKey]
+          : [];
     const timeoutId = window.setTimeout(() => {
       void setFocus({ threadKeys }).catch(() => {
         // Logged in main — keep the renderer silent.

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
+import type {
+  FederationRemoteTarget,
+  NavigationThreadSummary,
+  PrSummary,
+} from "@pwragent/shared";
 import {
   buildThreadIdentityKey,
   isRemoteFederationTarget,
@@ -41,14 +45,9 @@ export function usePullRequestRefresh(params: {
   onRefreshNavigation?: () => Promise<void>;
   selectedThread?: NavigationThreadSummary;
 }): { prefetch: (thread: NavigationThreadSummary) => void } {
-  // PR polling is owned by the instance that owns the thread. A remote
-  // federation window must never drive local `gh` lookups: the paths and
-  // branch belong to the peer machine, so a local lookup either wastes a
-  // subprocess or — worse, with the same repo checked out locally —
-  // records wrong PR data under the remote thread id. Remote windows get
-  // PR state from the remote snapshot and relayed backend events.
-  const isFederationWindow = Boolean(readRendererFederationTarget());
   const desktopApi = params.desktopApi;
+  const federationWindowInstanceId =
+    readRendererFederationTarget()?.instanceId;
   const onRefreshNavigation = params.onRefreshNavigation;
   const onRefreshNavigationRef = useRef(onRefreshNavigation);
   useEffect(() => {
@@ -61,9 +60,12 @@ export function usePullRequestRefresh(params: {
       trigger: "scheduled" | "user" = "scheduled",
     ): void => {
       if (!desktopApi?.refreshThreadPullRequests) return;
-      if (isFederationWindow || isRemoteFederatedThread(thread)) return;
       const target = resolvePullRequestLookupTarget(thread);
       if (!target) return;
+      const federationTarget = resolvePullRequestFederationTarget(
+        thread,
+        federationWindowInstanceId,
+      );
       void desktopApi
         .refreshThreadPullRequests({
           backend: thread.source,
@@ -71,6 +73,7 @@ export function usePullRequestRefresh(params: {
           trigger,
           branch: target.branch,
           directoryPaths: target.directoryPaths,
+          ...(federationTarget ? { federationTarget } : {}),
         })
         .then((response) => {
           if (prSummariesEqual(thread.prs, response.prs)) {
@@ -82,14 +85,16 @@ export function usePullRequestRefresh(params: {
           // Logged in main — keep the renderer silent.
         });
     },
-    [desktopApi, isFederationWindow],
+    [desktopApi, federationWindowInstanceId],
   );
 
   const selected = params.selectedThread;
   const selectedRef = useRef<NavigationThreadSummary | undefined>(selected);
   const selectedRefreshKey = useMemo(
-    () => selected ? buildRefreshRequestKey(selected) : undefined,
-    [selected],
+    () => selected
+      ? buildRefreshRequestKey(selected, federationWindowInstanceId)
+      : undefined,
+    [federationWindowInstanceId, selected],
   );
 
   useEffect(() => {
@@ -106,7 +111,10 @@ export function usePullRequestRefresh(params: {
     const refreshSelected = (): void => {
       const currentSelected = selectedRef.current;
       if (!currentSelected) return;
-      if (buildRefreshRequestKey(currentSelected) !== selectedRefreshKey) return;
+      if (
+        buildRefreshRequestKey(currentSelected, federationWindowInstanceId)
+        !== selectedRefreshKey
+      ) return;
       refresh(currentSelected, "scheduled");
     };
 
@@ -117,7 +125,7 @@ export function usePullRequestRefresh(params: {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [selectedRefreshKey, refresh]);
+  }, [federationWindowInstanceId, selectedRefreshKey, refresh]);
 
   // Tell main's background PR poller which thread the operator is actually
   // looking at, so its PRs land on the fast tier while the other 20-30 open
@@ -130,13 +138,15 @@ export function usePullRequestRefresh(params: {
   const selectedThreadKey = selected
     ? buildThreadIdentityKey(selected.source, selected.id)
     : undefined;
+  const selectedIsRemoteFederated = Boolean(
+    selected && resolvePullRequestFederationTarget(selected),
+  );
   useEffect(() => {
     const setFocus = desktopApi?.setPullRequestPollingFocus;
     if (!setFocus) return;
-    // A federation window's selection is a remote thread key — pushing it
-    // into the LOCAL poller's focus set would clobber the local window's
-    // fast tier while matching nothing.
-    if (isFederationWindow) return;
+    if (federationWindowInstanceId || selectedIsRemoteFederated) {
+      return;
+    }
     const threadKeys = selectedThreadKey ? [selectedThreadKey] : [];
     const timeoutId = window.setTimeout(() => {
       void setFocus({ threadKeys }).catch(() => {
@@ -146,7 +156,12 @@ export function usePullRequestRefresh(params: {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [desktopApi, isFederationWindow, selectedThreadKey]);
+  }, [
+    desktopApi,
+    federationWindowInstanceId,
+    selectedIsRemoteFederated,
+    selectedThreadKey,
+  ]);
 
   // Hover prefetch: dedupe so a flood of mouseenter events for the same
   // thread doesn't trigger a flood of gh subprocesses. User-triggered
@@ -154,7 +169,10 @@ export function usePullRequestRefresh(params: {
   const inflightKeysRef = useRef<Set<string>>(new Set());
   const prefetch = useCallback(
     (thread: NavigationThreadSummary): void => {
-      const key = buildThreadIdentityKey(thread.source, thread.id);
+      const key = buildPullRequestThreadKey(
+        thread,
+        federationWindowInstanceId,
+      );
       if (inflightKeysRef.current.has(key)) return;
       inflightKeysRef.current.add(key);
       try {
@@ -169,25 +187,50 @@ export function usePullRequestRefresh(params: {
         }, 10_000);
       }
     },
-    [refresh],
+    [federationWindowInstanceId, refresh],
   );
 
   return { prefetch };
 }
 
-function isRemoteFederatedThread(thread: NavigationThreadSummary): boolean {
-  const target = thread.federation?.ref.target;
-  return Boolean(target && isRemoteFederationTarget(target));
-}
-
-function buildRefreshRequestKey(thread: NavigationThreadSummary): string | undefined {
+function buildRefreshRequestKey(
+  thread: NavigationThreadSummary,
+  federationWindowInstanceId?: string,
+): string | undefined {
   const target = resolvePullRequestLookupTarget(thread);
   if (!target) return undefined;
 
   return JSON.stringify({
-    threadKey: buildThreadIdentityKey(thread.source, thread.id),
+    threadKey: buildPullRequestThreadKey(thread, federationWindowInstanceId),
     target,
   });
+}
+
+function buildPullRequestThreadKey(
+  thread: NavigationThreadSummary,
+  federationWindowInstanceId?: string,
+): string {
+  const federationTarget = resolvePullRequestFederationTarget(
+    thread,
+    federationWindowInstanceId,
+  );
+  return `${federationTarget?.instanceId ?? "local"}:${buildThreadIdentityKey(
+    thread.source,
+    thread.id,
+  )}`;
+}
+
+function resolvePullRequestFederationTarget(
+  thread: NavigationThreadSummary,
+  federationWindowInstanceId?: string,
+): FederationRemoteTarget | undefined {
+  const threadTarget = thread.federation?.ref.target;
+  if (threadTarget && isRemoteFederationTarget(threadTarget)) {
+    return threadTarget;
+  }
+  return federationWindowInstanceId
+    ? { scope: "remote", instanceId: federationWindowInstanceId }
+    : undefined;
 }
 
 function resolvePullRequestLookupTarget(

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -55,12 +55,14 @@ surface used by desktop windows and messaging. It includes thread creation,
 fork/review, turn start/steer/interrupt/compact, pending-request submission,
 scheduled-action list/create/update/cancel/send-now, model and execution
 settings, environment actions, environment setup progress, workspace handoff,
-and explicit directory Git-status refreshes. Directory refresh requests carry
-owner-known directory keys rather than viewer-resolved paths; the target
-instance resolves those keys and runs Git locally. Scheduled operations require
-the dedicated `scheduled_actions` capability rather than inheriting broad turn
-control. Capability checks remain attached to every method, so an older or
-restricted peer fails closed instead of silently executing locally.
+and explicit directory Git-status and thread PR refreshes. Directory refresh
+requests carry owner-known directory keys rather than viewer-resolved paths.
+PR refresh requests likewise carry only owner-known backend and thread IDs plus
+refresh intent. The target instance resolves filesystem paths and branches from
+its maintained state, then runs Git or `gh` locally. Scheduled operations
+require the dedicated `scheduled_actions` capability rather than inheriting
+broad turn control. Capability checks remain attached to every method, so an
+older or restricted peer fails closed instead of silently executing locally.
 
 Transcript images stay behind the renderer-safe `pwragent-image://` protocol.
 For a remote thread, the viewer rewrites owner-local image URLs to identify the

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1633,6 +1633,8 @@ export type SetPullRequestPollingFocusRequest = {
 
 export type RefreshThreadPullRequestsRequest = {
   backend?: AppServerBackendKind;
+  /** Route the lookup to the instance that owns the thread and its checkout. */
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   /** Forge host for this lookup. Defaults to github.com while GitHub is the only provider. */
   provider?: PullRequestProvider;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1658,6 +1658,15 @@ export type RefreshThreadPullRequestsRequest = {
   includeStatusFreshness?: boolean;
 };
 
+/**
+ * Federation refresh intent. The owner resolves branch and checkout paths
+ * from its maintained thread state instead of trusting viewer filesystem data.
+ */
+export type RefreshOwnedThreadPullRequestsRequest = Pick<
+  RefreshThreadPullRequestsRequest,
+  "backend" | "provider" | "threadId" | "trigger"
+>;
+
 export type DetachThreadPullRequestRequest = {
   backend?: AppServerBackendKind;
   federationTarget?: FederationTarget;


### PR DESCRIPTION
## Summary

- route remote PR hover and selection refreshes to each thread owner
- add a capability-guarded Federation PR refresh RPC and owner-side service bridge
- preserve local polling focus and prevent nested Federation relay targets
- add renderer, IPC, and Federation regression coverage

## Testing

- pnpm test (622 test files; 8,967 passed, 6 skipped)
- pnpm lint
- focused PR refresh tests after rebasing onto origin/main (176 passed)