### PR TITLE
fix(desktop): scope review provenance to selected repo

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4325,6 +4325,50 @@ describe("app server ipc", () => {
     });
   });
 
+  it("does not associate a discovered PR with sibling repositories", async () => {
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-multi-repository-pr",
+      trigger: "user",
+      branch: "fix/shared-branch-name",
+      directoryPaths: ["/repo/catalog-service", "/repo/deployment-fixtures"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: request.backend,
+      threadId: request.threadId,
+      branch: request.branch,
+      directoryPaths: request.directoryPaths,
+    });
+    const discoveredPr = githubPr({
+      number: 1854,
+      org: "ExampleOrg",
+      repo: "catalog-service",
+      state: "passing",
+      headSha: "b".repeat(40),
+      linkedDirectoryPaths: [request.directoryPaths[0]!],
+      url: "https://github.com/ExampleOrg/catalog-service/pull/1854",
+    });
+    getThreadOverlayState.mockResolvedValueOnce(undefined);
+    detectPullRequestsForThread.mockResolvedValueOnce([discoveredPr]);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: request.threadId,
+        prs: [{
+          ...discoveredPr,
+          commitShas: undefined,
+        }],
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
+    });
+  });
+
   it("logs user-triggered PR refresh decisions and background completion with PR ids", async () => {
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
     const request = {

--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -118,7 +118,10 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(prs).toEqual([expectedPr]);
+    expect(prs).toEqual([{
+      ...expectedPr,
+      linkedDirectoryPaths: [repo],
+    }]);
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
       cwd: repo,
@@ -152,7 +155,10 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(prs).toEqual([expectedPr]);
+    expect(prs).toEqual([{
+      ...expectedPr,
+      linkedDirectoryPaths: [repo],
+    }]);
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
       cwd: repo,
@@ -184,7 +190,10 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(prs).toEqual([expectedPr]);
+    expect(prs).toEqual([{
+      ...expectedPr,
+      linkedDirectoryPaths: [repo],
+    }]);
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
       cwd: repo,
@@ -224,7 +233,10 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(prs).toEqual([expectedPr]);
+    expect(prs).toEqual([{
+      ...expectedPr,
+      linkedDirectoryPaths: [repo],
+    }]);
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
       cwd: repo,
@@ -256,7 +268,10 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(prs).toEqual([expectedPr]);
+    expect(prs).toEqual([{
+      ...expectedPr,
+      linkedDirectoryPaths: [repo],
+    }]);
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
       cwd: repo,
@@ -286,12 +301,46 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(prs).toEqual([expectedPr]);
+    expect(prs).toEqual([{
+      ...expectedPr,
+      linkedDirectoryPaths: [repo],
+    }]);
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
     expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
       cwd: repo,
       branch,
     });
+  });
+
+  it("records only the repository that discovered a PR in a multi-repository lookup", async () => {
+    const branch = "fix/shared-branch-name";
+    const firstRepo = await createRepoWithBranch(branch);
+    const secondRepo = await createRepoWithBranch(branch);
+    await addGitHubRemote(firstRepo);
+    await addGitHubRemote(secondRepo);
+    const expectedPr = {
+      number: 13273,
+      org: "ExampleOrg",
+      repo: "catalog-service",
+      state: "pending" as const,
+      url: "https://github.com/ExampleOrg/catalog-service/pull/13273",
+    };
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ cwd }) =>
+        cwd === firstRepo ? [expectedPr] : [],
+      ),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch,
+      directoryPaths: [firstRepo, secondRepo],
+    });
+
+    expect(prs).toEqual([{
+      ...expectedPr,
+      linkedDirectoryPaths: [firstRepo],
+    }]);
   });
 
   it("forwards authoritative lookup intent so user refreshes bypass discovery primes", async () => {

--- a/apps/desktop/src/main/__tests__/review-workspace-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/review-workspace-guard.test.ts
@@ -115,6 +115,38 @@ describe("assertReviewWorkspaceMatchesAttachedPullRequest", () => {
     expect(runGit).not.toHaveBeenCalled();
   });
 
+  it("ignores a polluted path association when the selected repository differs", async () => {
+    const runGit = vi.fn(async (_cwd: string, args: string[]) => {
+      if (args[0] === "merge-base") {
+        throw new Error("not an ancestor");
+      }
+      if (args[0] === "rev-parse" && args[1] === "HEAD") {
+        return { stdout: CURRENT_HEAD };
+      }
+      return { stdout: "refs/remotes/origin/pwragent" };
+    });
+    const resolveGitHubRepos = vi.fn(async () => [{
+      host: "github.com",
+      owner: "pwrdrvr",
+      repo: "other-repository",
+    }]);
+    const params = {
+      cwd: "/other-repository",
+      prs: [pullRequest({
+        linkedDirectoryPaths: ["/worktree", "/other-repository"],
+      })],
+      resolveGitHubRepos,
+      runGit,
+      target: { type: "baseBranch" as const, branch: "pwragent" },
+    };
+
+    await expect(
+      assertReviewWorkspaceMatchesAttachedPullRequest(params),
+    ).resolves.toBeUndefined();
+    expect(resolveGitHubRepos).toHaveBeenCalledWith("/other-repository");
+    expect(runGit).not.toHaveBeenCalled();
+  });
+
   it("fails closed without running local Git for a remote workspace", async () => {
     const runGit = vi.fn();
 

--- a/apps/desktop/src/main/app-server/review-workspace-guard.ts
+++ b/apps/desktop/src/main/app-server/review-workspace-guard.ts
@@ -1,5 +1,9 @@
 import type { AppServerReviewTarget, PrSummary } from "@pwragent/shared";
 import { runGitCommand } from "./git-executable";
+import {
+  resolveGitHubReposForDirectory,
+  type GitHubRepoRef,
+} from "../pr-status/git-remote";
 
 type ReviewGitRunner = (
   cwd: string,
@@ -16,6 +20,12 @@ function prBelongsToWorkspace(pr: PrSummary, cwd: string): boolean {
   return (pr.linkedDirectoryPaths ?? []).some(
     (directoryPath) => normalizeWorkspacePath(directoryPath) === selectedWorkspace,
   );
+}
+
+function prMatchesRepository(pr: PrSummary, repo: GitHubRepoRef): boolean {
+  return pr.provider.trim().toLowerCase() === repo.host.toLowerCase()
+    && pr.org.trim().toLowerCase() === repo.owner.toLowerCase()
+    && pr.repo.trim().toLowerCase() === repo.repo.toLowerCase();
 }
 
 function normalizeFullRef(ref: string): string {
@@ -91,6 +101,7 @@ export async function assertReviewWorkspaceMatchesAttachedPullRequest(params: {
   cwd?: string;
   executionTarget?: "local" | "remote";
   prs?: PrSummary[];
+  resolveGitHubRepos?: (cwd: string) => Promise<GitHubRepoRef[]>;
   runGit?: ReviewGitRunner;
   target: AppServerReviewTarget;
 }): Promise<void> {
@@ -117,11 +128,23 @@ export async function assertReviewWorkspaceMatchesAttachedPullRequest(params: {
     );
   }
 
-  const workspacePullRequests = reviewablePullRequests.filter((pr) =>
+  let workspacePullRequests = reviewablePullRequests.filter((pr) =>
     prBelongsToWorkspace(pr, cwd)
   );
   if (workspacePullRequests.length === 0) {
     return;
+  }
+
+  const resolveGitHubRepos =
+    params.resolveGitHubRepos ?? resolveGitHubReposForDirectory;
+  const workspaceRepositories = await resolveGitHubRepos(cwd);
+  if (workspaceRepositories.length > 0) {
+    workspacePullRequests = workspacePullRequests.filter((pr) =>
+      workspaceRepositories.some((repo) => prMatchesRepository(pr, repo))
+    );
+    if (workspacePullRequests.length === 0) {
+      return;
+    }
   }
 
   const runGit = params.runGit ?? runGitCommand;

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1122,12 +1122,20 @@ function associatePrsWithLinkedDirectories(
     if (!pr.headSha?.trim()) {
       return pr;
     }
+    const discoveredDirectoryPaths = normalizePrLookupDirectoryPaths(
+      pr.linkedDirectoryPaths ?? [],
+    );
+    // Discovery records which checkout returned each PR. A multi-repository
+    // lookup cannot safely use every requested path as a fallback: doing so
+    // makes a PR from one repository appear to constrain all sibling repos.
+    const associatedDirectoryPaths = discoveredDirectoryPaths.length > 0
+      ? discoveredDirectoryPaths
+      : linkedDirectoryPaths.length === 1
+        ? linkedDirectoryPaths
+        : [];
     return normalizePrSummary({
       ...pr,
-      linkedDirectoryPaths: mergeLinkedDirectoryPaths(
-        pr.linkedDirectoryPaths,
-        linkedDirectoryPaths,
-      ),
+      linkedDirectoryPaths: associatedDirectoryPaths,
     });
   });
 }

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -71,16 +71,29 @@ export async function detectPullRequestsForThread(params: {
             .catch(() => []),
         ),
       );
-      return prsByBranch.flat();
+      return prsByBranch.flat().map((pr) => ({
+        ...pr,
+        linkedDirectoryPaths: uniqueNonEmpty([
+          ...(pr.linkedDirectoryPaths ?? []),
+          cwd,
+        ]),
+      }));
     }),
   );
 
   const seenByUrl = new Map<string, PrSummary>();
   for (const prs of results) {
     for (const pr of prs) {
-      if (!seenByUrl.has(pr.url)) {
-        seenByUrl.set(pr.url, pr);
-      }
+      const existing = seenByUrl.get(pr.url);
+      seenByUrl.set(pr.url, existing
+        ? {
+            ...pr,
+            linkedDirectoryPaths: uniqueNonEmpty([
+              ...(existing.linkedDirectoryPaths ?? []),
+              ...(pr.linkedDirectoryPaths ?? []),
+            ]),
+          }
+        : pr);
     }
   }
   return [...seenByUrl.values()];


### PR DESCRIPTION
## Summary

- record the exact linked checkout that discovers each pull request
- avoid broadening PR provenance across sibling repositories in multi-project threads
- cross-check the selected local checkout repository before enforcing stored PR ancestry, which safely handles existing polluted associations

## Regression

Selecting a secondary repository in the review dialog could be rejected against a PR attached to the thread's primary repository. The failed request then restored the `/review` draft, making the dialog appear to close into a normal slash command.

## Validation

- `pnpm test` (622 files, 8,968 passed, 6 skipped)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:eslint:typed`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`