### PR TITLE
fix(desktop): retry remote thread after reconnect

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -513,6 +513,118 @@ test.describe("federation remote window", () => {
     }
   });
 
+  test("retries an offline mounted thread after the peer reconnects and the row is reselected", async () => {
+    test.setTimeout(180_000);
+
+    const fixture = await createLocalControlFixture();
+    let gateway: InProcessFederationGateway | undefined;
+    let app: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+
+    try {
+      gateway = await startInProcessFederationGateway({
+        instanceLabel: "Remote reconnect owner",
+        threads: [{
+          id: "remote-reconnect-thread",
+          title: "Remote reconnect thread",
+          updatedAt: 2_000,
+        }],
+      });
+      app = await launchElectronApp({
+        fixturePath: fixture.fixturePath,
+        secretStorage: "memory",
+      });
+      const { window } = app;
+
+      const localRow = window.getByRole("button", {
+        name: "Local control thread",
+      });
+      await expect(localRow).toBeVisible({ timeout: 30_000 });
+      await localRow.click();
+      await expect(window.getByText("Local thread is ready.")).toBeVisible();
+
+      await window.getByRole("button", { name: "Open settings" }).click();
+      await window
+        .getByRole("navigation", { name: "Settings sections" })
+        .getByRole("button", { name: "Federation" })
+        .click();
+      await window.getByLabel("Import invite").fill(gateway.invite);
+      await window.getByRole("button", { name: "Import invite" }).click();
+      await gateway.waitForConnection(30_000);
+
+      await window.evaluate(async ({ instanceId }) => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            addRemoteThreadPin?: (request: unknown) => Promise<unknown>;
+          };
+        }).pwragent;
+        if (!api?.addRemoteThreadPin) {
+          throw new Error("addRemoteThreadPin API is unavailable");
+        }
+        await api.addRemoteThreadPin({
+          ref: {
+            backend: "codex",
+            target: { scope: "remote", instanceId },
+            threadId: "remote-reconnect-thread",
+          },
+          instanceLabel: "Remote reconnect owner",
+          summary: {
+            source: "codex",
+            id: "remote-reconnect-thread",
+            title: "Remote reconnect thread",
+            titleSource: "explicit",
+            linkedDirectories: [],
+            inbox: { inInbox: true },
+            updatedAt: 2_000,
+            federation: {
+              ref: {
+                backend: "codex",
+                target: { scope: "remote", instanceId },
+                threadId: "remote-reconnect-thread",
+              },
+              instanceLabel: "Remote reconnect owner",
+              peerStatus: "connected",
+            },
+          },
+        });
+      }, { instanceId: gateway.instanceId });
+      await window.getByRole("button", { name: /Exit Settings/i }).click();
+
+      const remoteRow = window.getByRole("button", {
+        name: "Remote reconnect thread",
+      });
+      await expect(remoteRow).toBeVisible({ timeout: 30_000 });
+
+      await gateway.stop();
+      await remoteRow.click();
+      await expect(
+        window.locator(".federation-disconnected-banner"),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(window.locator(".transcript-error")).toContainText(
+        "not connected",
+        { timeout: 30_000 },
+      );
+
+      await localRow.click();
+      await expect(window.getByText("Local thread is ready.")).toBeVisible();
+
+      await gateway.restart();
+      await gateway.waitForNextConnection(90_000);
+      await expect(
+        window.locator(".federation-disconnected-banner"),
+      ).toHaveCount(0, { timeout: 60_000 });
+
+      await remoteRow.click();
+      await expect(
+        window.getByText("Remote transcript for Remote reconnect thread."),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(window.locator(".transcript-error")).toHaveCount(0);
+    } finally {
+      await app?.close();
+      await gateway?.close();
+      await fixture.cleanup();
+    }
+  });
+
   test("enrolls, browses remote threads, pins on the owner, and hides local-only chrome", async () => {
     test.setTimeout(300_000);
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1592,6 +1592,87 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("contains a failed remote seen write and retries it on reselection", async () => {
+    const federationTarget: FederationRemoteTarget = {
+      scope: "remote",
+      instanceId: "remote-owner",
+    };
+    const markThreadSeen = vi
+      .fn<NonNullable<DesktopApi["markThreadSeen"]>>()
+      .mockRejectedValueOnce(new Error("Federation peer is not connected"))
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: "remote-thread",
+        seenAt: 2_000,
+        seenUpdatedAt: 1_000,
+      });
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:remote-thread"],
+      threads: [{
+        id: "remote-thread",
+        title: "Remote thread",
+        titleSource: "explicit" as const,
+        summary: "Remote thread summary",
+        source: "codex" as const,
+        linkedDirectories: [],
+        inbox: {
+          inInbox: true,
+          reason: "updated-since-seen" as const,
+          lastSeenUpdatedAt: 900,
+        },
+        updatedAt: 1_000,
+        federation: {
+          ref: {
+            backend: "codex" as const,
+            target: federationTarget,
+            threadId: "remote-thread",
+          },
+          instanceLabel: "Remote owner",
+          peerStatus: "connected" as const,
+        },
+      }],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("remote-thread");
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.threads[0]?.inbox.inInbox).toBe(true);
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledTimes(2);
+    });
+    expect(markThreadSeen).toHaveBeenLastCalledWith({
+      backend: "codex",
+      federationTarget,
+      threadId: "remote-thread",
+      seenUpdatedAt: 1_000,
+    });
+  });
+
   it("clears a selected-thread unread update when the seen write resolves after selecting away", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const delayedSeen = createDeferred<{

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -7914,6 +7914,59 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("retries a failed transcript read after the thread is reselected", async () => {
+    const thread = buildThread({ id: "thread-1", updatedAt: 1_000 });
+    const readThread = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Federation peer is not connected"))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [messageEntry({
+          createdAt: 1_000,
+          id: "recovered-message",
+          text: "Remote thread recovered.",
+        })],
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: thread as NavigationThreadSummary | undefined,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Federation peer is not connected");
+    });
+    expect(readThread).toHaveBeenCalledTimes(1);
+
+    rerender({ currentThread: undefined });
+    rerender({ currentThread: thread });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.messages).toEqual([
+        expect.objectContaining({
+          id: "recovered-message",
+          text: "Remote thread recovered.",
+        }),
+      ]);
+    });
+  });
+
   it("keeps thinking visible during metadata notifications for an active turn", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5126,6 +5126,10 @@ export function useThreadNavigation(
             }));
           }
         }
+      } catch {
+        // A selected remote thread can become unreachable between the
+        // navigation snapshot and this write. Keep its unread state intact;
+        // selecting it again will submit a fresh attempt.
       } finally {
         if (mountedRef.current) {
           setPendingSeenThreadKey((current) =>

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4679,6 +4679,11 @@ export function useThreadSessionState(params: {
 
     updateSession(threadKey, (current) => ({
       ...current,
+      // A failed hydration is suppressed while the operator remains on the
+      // same thread/version so a dead backend cannot create a retry loop.
+      // Selecting the thread again is an explicit retry after conditions may
+      // have changed, such as a Federation peer reconnecting.
+      failedHydrationVersion: undefined,
       lastTouchedAt: Date.now(),
     }));
   }, [threadKey, updateSession]);


### PR DESCRIPTION
## Summary

- I clear a failed transcript hydration when the operator reselects the thread, while preserving the existing retry-loop guard during a continuous selection.
- I contain transient remote `markThreadSeen` failures so a disconnected peer does not produce an unhandled renderer rejection or incorrectly clear the unread state.
- I added unit regressions and a real Noise/WebSocket Federation gateway E2E that selects a mounted thread while offline, reconnects the peer, and verifies reselection loads the transcript.

## Verification

- I verified both new renderer regressions fail before their fixes and pass afterward.
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (277 tests)
- `pnpm test:desktop-e2e apps/desktop/e2e/federation-remote-window.spec.ts --grep 'retries an offline mounted thread'`
- `pnpm lint:eslint`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `pnpm licenses:check`
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Notes

- I traced the reported disconnect in the viewer log to the Federation transport failing its peer keepalive and terminating the socket. Determining why the owning machine stopped answering that keepalive still requires its owner-local log.
