### PR TITLE
fix(desktop): keep quit blockers reachable

### DIFF
--- a/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
+++ b/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
@@ -194,7 +194,10 @@ test("keeps running work reachable after cancelling and following a blocker", as
     await expect(queue.locator(".quit-blocker-queue__row")).toHaveCount(0, {
       timeout: 15_000,
     });
-    await expect(queue).toContainText("No running work.");
+    const queueToast = app.window.locator(".app-notice-toast").filter({
+      has: queue,
+    });
+    await expect(queueToast).toContainText("No running work.");
     await expect(queue).toContainText(
       "PwrAgent can quit without interrupting work.",
     );

--- a/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
+++ b/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
@@ -54,7 +54,7 @@ async function openIntegratedTerminal(page: Page) {
  * listeners are bound to, so the fake-scheme round trip is still exercised
  * end to end — which is the part that actually breaks.
  */
-test("lists running terminals, cancels auto-quit, and stays open", async () => {
+test("keeps running work reachable after cancelling and following a blocker", async () => {
   // Spawning a real login shell, then standing up a second BrowserWindow, is
   // slower than the 30s default.
   test.setTimeout(90_000);
@@ -144,10 +144,50 @@ test("lists running terminals, cancels auto-quit, and stays open", async () => {
     await expect(
       app.window.getByLabel("Integrated terminal", { exact: true }),
     ).toBeVisible();
+
+    // Ask again, then follow the blocker instead of merely cancelling. The
+    // standalone dialog closes, but its live queue must remain in this viewer
+    // so the operator can work through every remaining item.
+    const followUpDialogPromise = app.electronApp.waitForEvent("window");
+    void app.electronApp
+      .evaluate(({ app: electronApp }) => {
+        electronApp.quit();
+      })
+      .catch(() => undefined);
+    const followUpDialog = await followUpDialogPromise;
+    await expect(
+      followUpDialog.getByRole("heading", { name: "Quit PwrAgent?" }),
+    ).toBeVisible();
+    await followUpDialog.evaluate(() => {
+      (document.querySelector("a.row") as HTMLAnchorElement | null)?.click();
+    });
+    await followUpDialog.waitForEvent("close");
+
+    const queue = app.window.getByTestId("quit-blocker-queue");
+    await expect(queue).toBeVisible();
+    await expect(queue).toContainText("Integrated terminals");
+    await expect(queue.locator(".quit-blocker-queue__row")).toHaveCount(1);
+    expect(
+      await queue.locator(".quit-blocker-queue__list").evaluate(
+        (element) => getComputedStyle(element).overflowY,
+      ),
+    ).toBe("auto");
+
+    // Resolve the foreground command. The authoritative blocker snapshot must
+    // remove its row while keeping the queue visible long enough to show that
+    // it is empty.
+    await app.window.locator(".integrated-terminal__viewport").click();
+    await app.window.keyboard.press("Control+C");
+    await expect(queue.locator(".quit-blocker-queue__row")).toHaveCount(0, {
+      timeout: 15_000,
+    });
+    await expect(queue).toContainText("No running work.");
+    await expect(queue).toContainText(
+      "PwrAgent can quit without interrupting work.",
+    );
   } finally {
-    // Disarm the confirmation before teardown. The terminal is still running,
-    // so `app.close()` would trip the quit path again and hang on a second
-    // dialog that nobody is there to answer.
+    // Disarm before teardown so an assertion failure while the command is
+    // still active cannot open a dialog that nobody is there to answer.
     await setQuitConfirmation(app.window, false).catch(() => undefined);
     await app.close();
   }

--- a/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
+++ b/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
@@ -176,8 +176,21 @@ test("keeps running work reachable after cancelling and following a blocker", as
     // Resolve the foreground command. The authoritative blocker snapshot must
     // remove its row while keeping the queue visible long enough to show that
     // it is empty.
-    await app.window.locator(".integrated-terminal__viewport").click();
-    await app.window.keyboard.press("Control+C");
+    const activeTerminal = await app.getIntegratedTerminalQuitSnapshot();
+    const sessionId = activeTerminal?.sessionIds[0];
+    expect(sessionId).toBeTruthy();
+    if (!sessionId) {
+      throw new Error("Expected an active terminal session");
+    }
+    await app.window.evaluate(async (request) => {
+      await (
+        window as unknown as {
+          pwragent: {
+            writeIntegratedTerminal: (value: typeof request) => Promise<void>;
+          };
+        }
+      ).pwragent.writeIntegratedTerminal(request);
+    }, { sessionId, data: "\u0003" });
     await expect(queue.locator(".quit-blocker-queue__row")).toHaveCount(0, {
       timeout: 15_000,
     });

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -53,6 +53,8 @@ const openDesktopPwrAgentProfileMock = vi.fn();
 const registerRendererErrorIpcHandlersMock = vi.fn();
 const registerBootInfoIpcHandlersMock = vi.fn();
 const disposeBootInfoIpcHandlersMock = vi.fn();
+const registerQuitBlockerIpcHandlersMock = vi.fn();
+const disposeQuitBlockerIpcHandlersMock = vi.fn();
 const registerRuntimeIdentityIpcHandlersMock = vi.fn();
 const disposeRuntimeIdentityIpcHandlersMock = vi.fn();
 const registerSettingsIpcHandlersMock = vi.fn();
@@ -422,6 +424,11 @@ vi.mock("../ipc/boot-info", () => ({
   disposeBootInfoIpcHandlers: disposeBootInfoIpcHandlersMock,
 }));
 
+vi.mock("../ipc/quit-blockers", () => ({
+  registerQuitBlockerIpcHandlers: registerQuitBlockerIpcHandlersMock,
+  disposeQuitBlockerIpcHandlers: disposeQuitBlockerIpcHandlersMock,
+}));
+
 vi.mock("../ipc/runtime-identity", () => ({
   registerRuntimeIdentityIpcHandlers: registerRuntimeIdentityIpcHandlersMock,
   disposeRuntimeIdentityIpcHandlers: disposeRuntimeIdentityIpcHandlersMock,
@@ -661,6 +668,8 @@ describe("bootstrapApp", () => {
     registerRendererErrorIpcHandlersMock.mockReset();
     registerBootInfoIpcHandlersMock.mockReset();
     disposeBootInfoIpcHandlersMock.mockReset();
+    registerQuitBlockerIpcHandlersMock.mockReset();
+    disposeQuitBlockerIpcHandlersMock.mockReset();
     registerRuntimeIdentityIpcHandlersMock.mockReset();
     disposeRuntimeIdentityIpcHandlersMock.mockReset();
     registerSettingsIpcHandlersMock.mockReset();

--- a/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+}));
+
+vi.mock("../quit-manager", () => ({
+  getCurrentQuitBlockers: vi.fn(),
+  readQuitBlockerQueueSnapshot: vi.fn(),
+}));
+
+vi.mock("../ipc/integrated-terminal", () => ({
+  revealIntegratedTerminal: vi.fn(),
+}));
+
+vi.mock("../window-show-thread", () => ({
+  requestShowThread: vi.fn(),
+}));
+
+import type { WebContents } from "electron";
+import { getCurrentQuitBlockers } from "../quit-manager";
+import { revealIntegratedTerminal } from "../ipc/integrated-terminal";
+import { requestShowThread } from "../window-show-thread";
+import { revealCurrentQuitBlocker } from "../ipc/quit-blockers";
+
+describe("quit blocker IPC", () => {
+  const sender = { id: 10 } as unknown as WebContents;
+  const owner = { id: 11 } as unknown as WebContents;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reveals the authoritative remote item and keeps its mounted viewer route", () => {
+    vi.mocked(getCurrentQuitBlockers).mockReturnValue({
+      count: 2,
+      terminalSessionCount: 2,
+      terminalThreadKeys: ["codex:shared", "codex:shared"],
+      threadIds: [],
+      actionRunCount: 0,
+      automationRunCount: 0,
+      items: [
+        {
+          kind: "terminal",
+          backend: "codex",
+          threadId: "shared",
+          threadKey: "codex:shared",
+        },
+        {
+          kind: "terminal",
+          backend: "codex",
+          threadId: "shared",
+          threadKey: "codex:shared",
+          target: { scope: "remote", instanceId: "peer-a" },
+        },
+      ],
+    });
+    vi.mocked(revealIntegratedTerminal).mockReturnValue({
+      revealed: true,
+      owner,
+    });
+
+    expect(
+      revealCurrentQuitBlocker(
+        {
+          kind: "terminal",
+          threadKey: "codex:shared",
+          target: { scope: "remote", instanceId: "peer-a" },
+        },
+        sender,
+      ),
+    ).toEqual({ revealed: true });
+    expect(revealIntegratedTerminal).toHaveBeenCalledWith("codex:shared", {
+      instanceId: "peer-a",
+    });
+    expect(requestShowThread).toHaveBeenCalledWith(
+      { backend: "codex", threadId: "shared" },
+      { preferWebContents: owner },
+    );
+  });
+
+  it("does not navigate after the requested blocker has resolved", () => {
+    vi.mocked(getCurrentQuitBlockers).mockReturnValue({
+      count: 0,
+      terminalSessionCount: 0,
+      terminalThreadKeys: [],
+      threadIds: [],
+      actionRunCount: 0,
+      automationRunCount: 0,
+      items: [],
+    });
+
+    expect(
+      revealCurrentQuitBlocker(
+        { kind: "turn", threadKey: "codex:finished" },
+        sender,
+      ),
+    ).toEqual({ revealed: false });
+    expect(revealIntegratedTerminal).not.toHaveBeenCalled();
+    expect(requestShowThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
@@ -20,18 +20,31 @@ vi.mock("../window-show-thread", () => ({
   requestShowThread: vi.fn(),
 }));
 
+vi.mock("../window-channels", () => ({
+  subscribersForChannel: vi.fn(),
+}));
+
+vi.mock("../window", () => ({
+  isFederationWindowWebContents: vi.fn(),
+}));
+
 import type { WebContents } from "electron";
 import { getCurrentQuitBlockers } from "../quit-manager";
 import { revealIntegratedTerminal } from "../ipc/integrated-terminal";
 import { requestShowThread } from "../window-show-thread";
+import { subscribersForChannel } from "../window-channels";
+import { isFederationWindowWebContents } from "../window";
 import { revealCurrentQuitBlocker } from "../ipc/quit-blockers";
 
 describe("quit blocker IPC", () => {
   const sender = { id: 10 } as unknown as WebContents;
   const owner = { id: 11 } as unknown as WebContents;
+  const localViewer = { id: 12 } as unknown as WebContents;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(isFederationWindowWebContents).mockReturnValue(false);
+    vi.mocked(subscribersForChannel).mockReturnValue([]);
   });
 
   it("reveals the authoritative remote item and keeps its mounted viewer route", () => {
@@ -79,6 +92,40 @@ describe("quit blocker IPC", () => {
     expect(requestShowThread).toHaveBeenCalledWith(
       { backend: "codex", threadId: "shared" },
       { preferWebContents: owner },
+    );
+  });
+
+  it("routes a local blocker from a federation queue to a local viewer", () => {
+    vi.mocked(getCurrentQuitBlockers).mockReturnValue({
+      count: 1,
+      terminalSessionCount: 0,
+      terminalThreadKeys: [],
+      threadIds: ["local-thread"],
+      actionRunCount: 0,
+      automationRunCount: 0,
+      items: [
+        {
+          kind: "turn",
+          backend: "codex",
+          threadId: "local-thread",
+          threadKey: "codex:local-thread",
+        },
+      ],
+    });
+    vi.mocked(isFederationWindowWebContents).mockImplementation(
+      (webContents) => webContents === sender,
+    );
+    vi.mocked(subscribersForChannel).mockReturnValue([sender, localViewer]);
+
+    expect(
+      revealCurrentQuitBlocker(
+        { kind: "turn", threadKey: "codex:local-thread" },
+        sender,
+      ),
+    ).toEqual({ revealed: true });
+    expect(requestShowThread).toHaveBeenCalledWith(
+      { backend: "codex", threadId: "local-thread" },
+      { preferWebContents: localViewer },
     );
   });
 

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -113,6 +113,10 @@ vi.mock("../window-show-thread", () => ({
   requestShowThread: vi.fn(),
 }));
 
+vi.mock("../window-show-quit-blockers", () => ({
+  requestShowQuitBlockers: vi.fn(),
+}));
+
 vi.mock("../settings/appearance-bootstrap", () => ({
   readBootstrapAppearance: () => ({ theme: "dark" }),
 }));
@@ -121,6 +125,7 @@ import type { WebContents } from "electron";
 import { parseThreadIdentityKey } from "@pwragent/shared";
 import { revealIntegratedTerminal } from "../ipc/integrated-terminal";
 import { requestShowThread } from "../window-show-thread";
+import { requestShowQuitBlockers } from "../window-show-quit-blockers";
 import {
   focusActiveQuitConfirmationDialog,
   formatQuitItemAction,
@@ -443,6 +448,8 @@ describe("clicking a quit dialog row", () => {
     await Promise.resolve();
     dialogWindows.length = 0;
     vi.mocked(revealIntegratedTerminal).mockReset();
+    vi.mocked(requestShowThread).mockReset();
+    vi.mocked(requestShowQuitBlockers).mockReset();
   });
 
   /**
@@ -459,6 +466,7 @@ describe("clicking a quit dialog row", () => {
       revealed: true,
       owner,
     });
+    vi.mocked(requestShowThread).mockReturnValue(owner);
     const item: QuitBlockerItem = {
       kind: "terminal",
       backend: "codex",
@@ -492,6 +500,13 @@ describe("clicking a quit dialog row", () => {
       },
       { preferWebContents: owner },
     );
+    expect(requestShowQuitBlockers).toHaveBeenCalledWith(owner, {
+      inProgressThreadCount: 0,
+      automationRunCount: 0,
+      terminalSessionCount: 1,
+      actionRunCount: 0,
+      items: [item],
+    });
     await expect(pending).resolves.toBe("manual-cancel");
   });
 
@@ -522,6 +537,7 @@ describe("clicking a quit dialog row", () => {
       { backend: "codex", threadId: "local-thread" },
       { preferWebContents: undefined },
     );
+    expect(requestShowQuitBlockers).not.toHaveBeenCalled();
     await expect(pending).resolves.toBe("manual-cancel");
   });
 });

--- a/apps/desktop/src/main/__tests__/window-show-thread.test.ts
+++ b/apps/desktop/src/main/__tests__/window-show-thread.test.ts
@@ -46,7 +46,7 @@ describe("requestShowThread", () => {
     getFocusedWindowMock.mockReturnValue(focusedWindow);
     vi.mocked(subscribersForChannel).mockReturnValue([focusedWindow.webContents]);
 
-    requestShowThread(request);
+    expect(requestShowThread(request)).toBe(focusedWebContents);
 
     expect(subscribersForChannel).toHaveBeenCalledWith(WINDOW_SHOW_THREAD_CHANNEL);
     expect(focusedWindow.show).toHaveBeenCalledOnce();
@@ -70,7 +70,7 @@ describe("requestShowThread", () => {
     vi.mocked(subscribersForChannel).mockReturnValue([fallbackContents]);
     fromWebContentsMock.mockReturnValue(fallbackWindow);
 
-    requestShowThread(request);
+    expect(requestShowThread(request)).toBe(fallbackContents);
 
     expect(fallbackWindow.restore).toHaveBeenCalledOnce();
     expect(fallbackWindow.show).toHaveBeenCalledOnce();
@@ -82,9 +82,9 @@ describe("requestShowThread", () => {
     getFocusedWindowMock.mockReturnValue(null);
     vi.mocked(subscribersForChannel).mockReturnValue([]);
 
-    expect(() =>
+    expect(
       requestShowThread({ backend: "codex", threadId: "thread-3" }),
-    ).not.toThrow();
+    ).toBeUndefined();
     expect(fromWebContentsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -102,6 +102,10 @@ import {
   registerBootInfoIpcHandlers,
 } from "./ipc/boot-info";
 import {
+  disposeQuitBlockerIpcHandlers,
+  registerQuitBlockerIpcHandlers,
+} from "./ipc/quit-blockers";
+import {
   disposeProfilesIpcHandlers,
   listDesktopPwrAgentProfiles,
   openDesktopPwrAgentProfile,
@@ -528,6 +532,7 @@ function disposeMainProcessResourcesSync(options?: {
   }
   disposePreloadLogIpcHandlers();
   disposeBootInfoIpcHandlers();
+  disposeQuitBlockerIpcHandlers();
   disposeProfilesIpcHandlers();
   disposeSettingsIpcHandlers();
   disposeWindowPointerIpcHandlers();
@@ -1299,6 +1304,7 @@ export function bootstrapApp(): void {
         await requestQuit({ source: "ipc" });
       },
     });
+    registerQuitBlockerIpcHandlers();
     registerSettingsIpcHandlers(undefined, {
       onConfigPatchWritten: async (patch) => {
         if (patch.federation !== undefined) {

--- a/apps/desktop/src/main/ipc/quit-blockers.ts
+++ b/apps/desktop/src/main/ipc/quit-blockers.ts
@@ -3,6 +3,7 @@ import { parseThreadIdentityKey } from "@pwragent/shared";
 import {
   QUIT_BLOCKERS_READ_CHANNEL,
   QUIT_BLOCKER_REVEAL_CHANNEL,
+  WINDOW_SHOW_THREAD_CHANNEL,
 } from "../../shared/ipc";
 import {
   quitBlockerItemKey,
@@ -14,6 +15,8 @@ import {
   readQuitBlockerQueueSnapshot,
 } from "../quit-manager";
 import { revealIntegratedTerminal } from "./integrated-terminal";
+import { subscribersForChannel } from "../window-channels";
+import { isFederationWindowWebContents } from "../window";
 import { requestShowThread } from "../window-show-thread";
 
 export function registerQuitBlockerIpcHandlers(): void {
@@ -55,8 +58,21 @@ export function revealCurrentQuitBlocker(
           : {}),
       })
     : undefined;
+  const senderIsFederationWindow = isFederationWindowWebContents(sender);
+  const localViewer = !item.target && senderIsFederationWindow
+    ? subscribersForChannel(WINDOW_SHOW_THREAD_CHANNEL).find(
+        (subscriber) => !isFederationWindowWebContents(subscriber),
+      )
+    : undefined;
+  const viewer = terminal?.owner
+    ?? (senderIsFederationWindow && !item.target
+      ? localViewer
+      : sender);
+  if (!viewer) {
+    return { revealed: false };
+  }
   requestShowThread(parsed, {
-    preferWebContents: terminal?.owner ?? sender,
+    preferWebContents: viewer,
   });
   return { revealed: true };
 }

--- a/apps/desktop/src/main/ipc/quit-blockers.ts
+++ b/apps/desktop/src/main/ipc/quit-blockers.ts
@@ -1,0 +1,62 @@
+import { ipcMain, type WebContents } from "electron";
+import { parseThreadIdentityKey } from "@pwragent/shared";
+import {
+  QUIT_BLOCKERS_READ_CHANNEL,
+  QUIT_BLOCKER_REVEAL_CHANNEL,
+} from "../../shared/ipc";
+import {
+  quitBlockerItemKey,
+  type RevealQuitBlockerRequest,
+  type RevealQuitBlockerResponse,
+} from "../../shared/quit-blockers";
+import {
+  getCurrentQuitBlockers,
+  readQuitBlockerQueueSnapshot,
+} from "../quit-manager";
+import { revealIntegratedTerminal } from "./integrated-terminal";
+import { requestShowThread } from "../window-show-thread";
+
+export function registerQuitBlockerIpcHandlers(): void {
+  ipcMain.removeHandler(QUIT_BLOCKERS_READ_CHANNEL);
+  ipcMain.handle(QUIT_BLOCKERS_READ_CHANNEL, readQuitBlockerQueueSnapshot);
+
+  ipcMain.removeHandler(QUIT_BLOCKER_REVEAL_CHANNEL);
+  ipcMain.handle(
+    QUIT_BLOCKER_REVEAL_CHANNEL,
+    async (event, request: RevealQuitBlockerRequest): Promise<RevealQuitBlockerResponse> =>
+      revealCurrentQuitBlocker(request, event.sender),
+  );
+}
+
+export function disposeQuitBlockerIpcHandlers(): void {
+  ipcMain.removeHandler(QUIT_BLOCKERS_READ_CHANNEL);
+  ipcMain.removeHandler(QUIT_BLOCKER_REVEAL_CHANNEL);
+}
+
+export function revealCurrentQuitBlocker(
+  request: RevealQuitBlockerRequest,
+  sender: WebContents,
+): RevealQuitBlockerResponse {
+  const requestKey = quitBlockerItemKey(request);
+  const item = getCurrentQuitBlockers().items.find(
+    (candidate) => quitBlockerItemKey(candidate) === requestKey,
+  );
+  if (!item) {
+    return { revealed: false };
+  }
+  const parsed = parseThreadIdentityKey(item.threadKey);
+  if (!parsed) {
+    return { revealed: false };
+  }
+  const terminal = item.kind === "terminal"
+    ? revealIntegratedTerminal(item.threadKey, {
+        ...(item.target
+          ? { instanceId: item.target.instanceId }
+          : {}),
+      })
+    : undefined;
+  requestShowThread(parsed, {
+    preferWebContents: terminal?.owner ?? sender,
+  });
+  return { revealed: true };
+}

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -1,9 +1,13 @@
 import { BrowserWindow, nativeTheme } from "electron";
-import type { FederationRemoteTarget } from "@pwragent/shared";
 import { parseThreadIdentityKey } from "@pwragent/shared";
+import type {
+  QuitBlockerItem,
+  QuitBlockerQueueSnapshot,
+} from "../shared/quit-blockers";
 import { revealIntegratedTerminal } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
 import { readBootstrapAppearance } from "./settings/appearance-bootstrap";
+import { requestShowQuitBlockers } from "./window-show-quit-blockers";
 import { requestShowThread } from "./window-show-thread";
 
 const quitDialogLog = getMainLogger("pwragent:quit-dialog");
@@ -14,32 +18,8 @@ export type QuitConfirmationDialogResult =
   | "countdown-expired"
   | "work-completed";
 
-/**
- * One row in the dialog's "still running" list. Declared here rather than in
- * `quit-manager` because quit-manager imports this module — the reverse would
- * be a dependency cycle.
- */
-export type QuitBlockerItem = {
-  kind: "turn" | "automation" | "terminal" | "action";
-  backend: string;
-  threadId: string;
-  threadKey: string;
-  /**
-   * Peer that owns this work, when it does not run on this machine. Both the
-   * title lookup and the row's navigation need it: a remote thread is absent
-   * from this instance's thread list and from every window but the one
-   * fronting that peer.
-   */
-  target?: FederationRemoteTarget;
-  /** Resolved just before the dialog opens; falls back to the thread id. */
-  title?: string;
-  /** The active turn belongs to a worker owned by this thread. */
-  isSubAgent?: boolean;
-  /** Secondary line — the owning peer, or an action's command and pid. */
-  detail?: string;
-  /** Start time for live elapsed/completion reporting in the quit prompt. */
-  startedAt?: number;
-};
+/** One row in the dialog's "still running" list. */
+export type { QuitBlockerItem } from "../shared/quit-blockers";
 
 export type QuitConfirmationDialogOptions = {
   countdownSeconds: number;
@@ -52,13 +32,7 @@ export type QuitConfirmationDialogOptions = {
   refresh?: () => Promise<QuitConfirmationDialogSnapshot>;
 };
 
-export type QuitConfirmationDialogSnapshot = {
-  inProgressThreadCount: number;
-  automationRunCount: number;
-  terminalSessionCount: number;
-  actionRunCount: number;
-  items: QuitBlockerItem[];
-};
+export type QuitConfirmationDialogSnapshot = QuitBlockerQueueSnapshot;
 
 /**
  * Quit-dialog theme palette. The dialog is a standalone `data:` HTML window
@@ -253,6 +227,13 @@ export async function showQuitConfirmationDialog(
       actionRunCount: options.actionRunCount ?? 0,
       items,
     });
+    let latestSnapshot: QuitConfirmationDialogSnapshot = {
+      inProgressThreadCount: options.inProgressThreadCount,
+      automationRunCount: options.automationRunCount ?? 0,
+      terminalSessionCount: options.terminalSessionCount,
+      actionRunCount: options.actionRunCount ?? 0,
+      items,
+    };
 
     const finish = (result: QuitConfirmationDialogResult): void => {
       if (settled) return;
@@ -287,6 +268,7 @@ export async function showQuitConfirmationDialog(
       refreshInFlight = true;
       try {
         const snapshot = await options.refresh();
+        latestSnapshot = snapshot;
         const signature = JSON.stringify(snapshot);
         const payload = buildQuitDialogUpdatePayload(snapshot, navigationPrefix);
         lastTotalCount = payload.totalCount;
@@ -370,7 +352,7 @@ export async function showQuitConfirmationDialog(
                     : {}),
                 })
               : undefined;
-          requestShowThread(
+          const viewer = requestShowThread(
             {
               ...parsed,
               ...(target.instanceId
@@ -384,6 +366,9 @@ export async function showQuitConfirmationDialog(
             },
             { preferWebContents: revealed?.owner },
           );
+          if (viewer) {
+            requestShowQuitBlockers(viewer, latestSnapshot);
+          }
         }
         finish("manual-cancel");
         return;

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -26,10 +26,13 @@ import { getDesktopSettingsService } from "./settings/desktop-settings-singleton
 import {
   focusActiveQuitConfirmationDialog,
   showQuitConfirmationDialog,
-  type QuitBlockerItem,
   type QuitConfirmationDialogResult,
   type QuitConfirmationDialogSnapshot,
 } from "./quit-confirmation-dialog";
+import type {
+  QuitBlockerItem,
+  QuitBlockerQueueSnapshot,
+} from "../shared/quit-blockers";
 
 export type { QuitBlockerItem };
 
@@ -274,7 +277,7 @@ export function createQuitManager(
   };
 }
 
-async function buildQuitConfirmationSnapshot(
+export async function buildQuitConfirmationSnapshot(
   snapshot: QuitBlockerSnapshot,
   resolveThreadTitles: QuitManagerDependencies["resolveThreadTitles"],
   log: QuitManagerDependencies["log"],
@@ -601,36 +604,53 @@ function splitQuitThreadKey(threadKey: string): {
 
 const quitLog = getMainLogger("pwragent:quit");
 
+export function getCurrentQuitBlockers(): QuitBlockerSnapshot {
+  return buildQuitBlockerSnapshot({
+    inProgressThreads:
+      getDesktopBackendRegistry().getInProgressThreadSnapshotForQuit(),
+    terminalSessions: getIntegratedTerminalQuitSnapshot(),
+    actionRuns: listRunningDetachedCommands(),
+  });
+}
+
+async function resolveCurrentQuitBlockerTitles(
+  items: QuitBlockerItem[],
+): Promise<Map<string, string>> {
+  return await resolveQuitBlockerThreadTitles(items, {
+    listLocalThreads: async () =>
+      await getDesktopBackendRegistry().listThreads({
+        callerReason: "quit-confirmation",
+      }),
+    cachedRemoteThreadName: (params) =>
+      getDesktopFederationRuntime()
+        .remoteThreadSummaries()
+        .cachedThreadNameFromPeer(params),
+    listRemoteThreadPins: async () =>
+      await getDesktopOverlayStore().listRemoteThreadPins(),
+  });
+}
+
+export async function readQuitBlockerQueueSnapshot(): Promise<
+  QuitBlockerQueueSnapshot
+> {
+  return await buildQuitConfirmationSnapshot(
+    getCurrentQuitBlockers(),
+    resolveCurrentQuitBlockerTitles,
+    quitLog,
+  );
+}
+
 export const appQuitManager = createQuitManager({
   focusPendingConfirmation: () => focusActiveQuitConfirmationDialog(),
   getConfirmationEnabled: () =>
     getDesktopSettingsService().resolveConfirmQuitWithInProgressThreads(),
   getFocusedWindow: () => BrowserWindow.getFocusedWindow(),
-  getQuitBlockers: () =>
-    buildQuitBlockerSnapshot({
-      inProgressThreads:
-        getDesktopBackendRegistry().getInProgressThreadSnapshotForQuit(),
-      terminalSessions: getIntegratedTerminalQuitSnapshot(),
-      actionRuns: listRunningDetachedCommands(),
-    }),
+  getQuitBlockers: getCurrentQuitBlockers,
   quiesceAutomationDispatch: () =>
     getDesktopAutomationService().quiesceDispatch(),
-  resolveThreadTitles: async (items) =>
-    await resolveQuitBlockerThreadTitles(items, {
-      listLocalThreads: async () =>
-        await getDesktopBackendRegistry().listThreads({
-          callerReason: "quit-confirmation",
-        }),
-      // Map read, no peer round trip: names remembered from every peer
-      // snapshot this instance has seen, which is why the name is normally
-      // in hand for anything that could be blocking the quit.
-      cachedRemoteThreadName: (params) =>
-        getDesktopFederationRuntime()
-          .remoteThreadSummaries()
-          .cachedThreadNameFromPeer(params),
-      listRemoteThreadPins: async () =>
-        await getDesktopOverlayStore().listRemoteThreadPins(),
-    }),
+  // Map/store reads only, no peer round trip. Names remembered from peer
+  // snapshots keep remote blockers readable without delaying shutdown.
+  resolveThreadTitles: resolveCurrentQuitBlockerTitles,
   log: quitLog,
   performQuit: () => {
     app.quit();

--- a/apps/desktop/src/main/window-show-quit-blockers.ts
+++ b/apps/desktop/src/main/window-show-quit-blockers.ts
@@ -1,0 +1,11 @@
+import type { WebContents } from "electron";
+import { WINDOW_SHOW_QUIT_BLOCKERS_CHANNEL } from "../shared/ipc";
+import type { QuitBlockerQueueSnapshot } from "../shared/quit-blockers";
+
+export function requestShowQuitBlockers(
+  webContents: WebContents,
+  snapshot: QuitBlockerQueueSnapshot,
+): void {
+  if (webContents.isDestroyed()) return;
+  webContents.send(WINDOW_SHOW_QUIT_BLOCKERS_CHANNEL, snapshot);
+}

--- a/apps/desktop/src/main/window-show-thread.ts
+++ b/apps/desktop/src/main/window-show-thread.ts
@@ -17,7 +17,7 @@ export type RequestShowThreadOptions = {
 export function requestShowThread(
   request: WindowShowThreadRequest,
   options: RequestShowThreadOptions = {},
-): void {
+): WebContents | undefined {
   const focused = BrowserWindow.getFocusedWindow();
   const subscribers = subscribersForChannel(WINDOW_SHOW_THREAD_CHANNEL);
 
@@ -28,7 +28,7 @@ export function requestShowThread(
       showWindow(preferredWindow);
     }
     preferred.send(WINDOW_SHOW_THREAD_CHANNEL, request);
-    return;
+    return preferred;
   }
 
   if (focused && !focused.isDestroyed()) {
@@ -38,19 +38,20 @@ export function requestShowThread(
     if (focusedSubscriber) {
       showWindow(focused);
       focusedSubscriber.send(WINDOW_SHOW_THREAD_CHANNEL, request);
-      return;
+      return focusedSubscriber;
     }
   }
 
   const fallback = subscribers[0];
   if (!fallback) {
-    return;
+    return undefined;
   }
   const fallbackWindow = BrowserWindow.fromWebContents(fallback);
   if (fallbackWindow && !fallbackWindow.isDestroyed()) {
     showWindow(fallbackWindow);
   }
   fallback.send(WINDOW_SHOW_THREAD_CHANNEL, request);
+  return fallback;
 }
 
 function showWindow(window: BrowserWindow): void {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -435,6 +435,11 @@ import type {
   IntegratedTerminalSetPanelHiddenRequest,
   IntegratedTerminalWriteRequest,
 } from "../shared/integrated-terminal";
+import type {
+  QuitBlockerQueueSnapshot,
+  RevealQuitBlockerRequest,
+  RevealQuitBlockerResponse,
+} from "../shared/quit-blockers";
 import {
   AGENT_CANCEL_QUEUED_TURN_CHANNEL,
   SCHEDULED_ACTIONS_CANCEL_CHANNEL,
@@ -682,6 +687,8 @@ import {
   APP_GET_BOOT_INFO_CHANNEL,
   APP_QUIT_CHANNEL,
   APP_WAIT_FOR_PROFILE_ALIVE_CHANNEL,
+  QUIT_BLOCKERS_READ_CHANNEL,
+  QUIT_BLOCKER_REVEAL_CHANNEL,
   PROFILES_DELETE_CHANNEL,
   PROFILES_GRADUATE_BOOTSTRAP_CONFIG_CHANNEL,
   PROFILES_LIST_CHANNEL,
@@ -716,6 +723,7 @@ import {
   WINDOW_REPLAY_ONBOARDING_CHANNEL,
   WINDOW_COPY_LOCAL_DIAGNOSTICS_INFO_CHANNEL,
   WINDOW_SHOW_THREAD_CHANNEL,
+  WINDOW_SHOW_QUIT_BLOCKERS_CHANNEL,
   APP_MENU_MODEL_CHANNEL,
   APP_MENU_POPUP_CHANNEL,
 } from "../shared/ipc";
@@ -1014,6 +1022,12 @@ const desktopApi = Object.freeze({
       APP_GET_BOOT_INFO_CHANNEL,
     ),
   quitApp: async (): Promise<void> => await ipcRenderer.invoke(APP_QUIT_CHANNEL),
+  readQuitBlockerQueue: async (): Promise<QuitBlockerQueueSnapshot> =>
+    await ipcRenderer.invoke(QUIT_BLOCKERS_READ_CHANNEL),
+  revealQuitBlocker: async (
+    request: RevealQuitBlockerRequest,
+  ): Promise<RevealQuitBlockerResponse> =>
+    await ipcRenderer.invoke(QUIT_BLOCKER_REVEAL_CHANNEL, request),
   waitForProfileAlive: async (
     request: WaitForDesktopProfileAliveRequest,
   ): Promise<WaitForDesktopProfileAliveResponse> =>
@@ -2057,6 +2071,18 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(WINDOW_SHOW_THREAD_CHANNEL, listener);
     return () => {
       ipcRenderer.off(WINDOW_SHOW_THREAD_CHANNEL, listener);
+    };
+  },
+  onShowQuitBlockersRequested: (
+    callback: (snapshot: QuitBlockerQueueSnapshot) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      snapshot: QuitBlockerQueueSnapshot,
+    ) => callback(snapshot);
+    ipcRenderer.on(WINDOW_SHOW_QUIT_BLOCKERS_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(WINDOW_SHOW_QUIT_BLOCKERS_CHANNEL, listener);
     };
   },
   onReplayOnboardingRequested: (callback: () => void): (() => void) => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -108,6 +108,7 @@ import { resolveThreadWorkingStatePath } from "./lib/thread-working-state-path";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
 import { AppNoticeStack } from "./features/notifications/AppNoticeStack";
+import { QuitBlockerQueueToast } from "./features/notifications/QuitBlockerQueueToast";
 import {
   appNoticeReducer,
   INITIAL_APP_NOTICE_STATE,
@@ -2923,6 +2924,7 @@ function DesktopAppShell(props: {
             })),
           ]}
         >
+          <QuitBlockerQueueToast desktopApi={desktopApi} />
           <AppUpdateBanner desktopApi={desktopApi} />
         </AppNoticeStack>
       </div>

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -47,6 +47,7 @@ export type AppNoticeToastNotice = {
 };
 
 export function AppNoticeToast(props: {
+  children?: ReactNode;
   desktopApi?: Pick<DesktopApi, "copyText">;
   navigation?: {
     current: number;
@@ -188,6 +189,9 @@ export function AppNoticeToast(props: {
           <CloseIcon size={14} aria-hidden="true" />
         </button>
       </div>
+      {props.children ? (
+        <div className="app-notice-toast__body">{props.children}</div>
+      ) : null}
       {customActions.length > 0 && !props.navigation ? (
         <div className="app-notice-toast__custom-actions">
           {customActions.map((action) => (

--- a/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react";
+import {
+  quitBlockerItemKey,
+  type QuitBlockerItem,
+  type QuitBlockerKind,
+  type QuitBlockerQueueSnapshot,
+} from "../../../../shared/quit-blockers";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { AppNoticeToast } from "./AppNoticeToast";
+
+const REFRESH_INTERVAL_MS = 500;
+
+const GROUPS: ReadonlyArray<{
+  kind: QuitBlockerKind;
+  heading: string;
+}> = [
+  { kind: "turn", heading: "Agent turns in progress" },
+  { kind: "automation", heading: "Automations in progress" },
+  { kind: "terminal", heading: "Integrated terminals" },
+  { kind: "action", heading: "Environment actions" },
+];
+
+type QuitBlockerQueueApi = Pick<
+  DesktopApi,
+  | "copyText"
+  | "onShowQuitBlockersRequested"
+  | "readQuitBlockerQueue"
+  | "revealQuitBlocker"
+>;
+
+export function QuitBlockerQueueToast(props: {
+  desktopApi?: QuitBlockerQueueApi;
+}) {
+  const [snapshot, setSnapshot] = useState<QuitBlockerQueueSnapshot>();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    return props.desktopApi?.onShowQuitBlockersRequested?.((nextSnapshot) => {
+      setSnapshot(nextSnapshot);
+      setVisible(true);
+    });
+  }, [props.desktopApi]);
+
+  useEffect(() => {
+    if (!visible || !props.desktopApi?.readQuitBlockerQueue) return;
+    const readQuitBlockerQueue = props.desktopApi.readQuitBlockerQueue;
+    let disposed = false;
+    let inFlight = false;
+    const refresh = async (): Promise<void> => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const nextSnapshot = await readQuitBlockerQueue();
+        if (!disposed) {
+          setSnapshot(nextSnapshot);
+        }
+      } catch {
+        // Keep the last authoritative snapshot visible. The next interval can
+        // recover without making a transient IPC failure dismiss the queue.
+      } finally {
+        inFlight = false;
+      }
+    };
+    void refresh();
+    const interval = window.setInterval(
+      () => void refresh(),
+      REFRESH_INTERVAL_MS,
+    );
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+    };
+  }, [props.desktopApi, visible]);
+
+  if (!visible || !snapshot) return null;
+
+  const total =
+    snapshot.inProgressThreadCount
+    + snapshot.automationRunCount
+    + snapshot.terminalSessionCount
+    + snapshot.actionRunCount;
+  const message = total === 0
+    ? "No running work."
+    : `${total} ${total === 1 ? "item is" : "items are"} still running.`;
+  const copyText = [
+    "Running work",
+    message,
+    ...snapshot.items.map((item) =>
+      [item.title?.trim() || item.threadId, item.detail]
+        .filter(Boolean)
+        .join(" — ")
+    ),
+  ].join("\n");
+
+  return (
+    <AppNoticeToast
+      desktopApi={props.desktopApi}
+      notice={{
+        id: "quit-blocker-queue",
+        title: "Running work",
+        message,
+        copyText,
+        tone: total === 0 ? "success" : "warning",
+        autoDismiss: false,
+      }}
+      onDismiss={() => setVisible(false)}
+    >
+      <div className="quit-blocker-queue" data-testid="quit-blocker-queue">
+        {total === 0 ? (
+          <p className="quit-blocker-queue__empty">
+            PwrAgent can quit without interrupting work.
+          </p>
+        ) : (
+          <div className="quit-blocker-queue__list">
+            {GROUPS.map((group) => {
+              const items = snapshot.items.filter(
+                (item) => item.kind === group.kind,
+              );
+              if (items.length === 0) return null;
+              return (
+                <section
+                  className="quit-blocker-queue__group"
+                  key={group.kind}
+                >
+                  <p className="quit-blocker-queue__heading">
+                    {group.heading}
+                  </p>
+                  {items.map((item) => (
+                    <QuitBlockerRow
+                      item={item}
+                      key={quitBlockerItemKey(item)}
+                      onReveal={(selected) => {
+                        void props.desktopApi?.revealQuitBlocker?.({
+                          kind: selected.kind,
+                          threadKey: selected.threadKey,
+                          ...(selected.target
+                            ? { target: selected.target }
+                            : {}),
+                        });
+                      }}
+                    />
+                  ))}
+                </section>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </AppNoticeToast>
+  );
+}
+
+function QuitBlockerRow(props: {
+  item: QuitBlockerItem;
+  onReveal: (item: QuitBlockerItem) => void;
+}) {
+  const label = props.item.title?.trim() || props.item.threadId;
+  return (
+    <button
+      className="quit-blocker-queue__row"
+      type="button"
+      onClick={() => props.onReveal(props.item)}
+    >
+      <span className="quit-blocker-queue__row-heading">
+        <span className="quit-blocker-queue__label">{label}</span>
+        {props.item.isSubAgent ? (
+          <span className="quit-blocker-queue__chip">Sub-agent</span>
+        ) : null}
+      </span>
+      {props.item.detail ? (
+        <span className="quit-blocker-queue__detail">{props.item.detail}</span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
@@ -1,0 +1,113 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { QuitBlockerQueueSnapshot } from "../../../../../shared/quit-blockers";
+import { QuitBlockerQueueToast } from "../QuitBlockerQueueToast";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function snapshot(
+  items: QuitBlockerQueueSnapshot["items"],
+): QuitBlockerQueueSnapshot {
+  return {
+    inProgressThreadCount: items.filter((item) => item.kind === "turn").length,
+    automationRunCount: items.filter((item) => item.kind === "automation").length,
+    terminalSessionCount: items.filter((item) => item.kind === "terminal").length,
+    actionRunCount: items.filter((item) => item.kind === "action").length,
+    items,
+  };
+}
+
+describe("QuitBlockerQueueToast", () => {
+  it("keeps the live queue reachable while authoritative refreshes remove resolved work", async () => {
+    vi.useFakeTimers();
+    let showQueue!: (snapshot: QuitBlockerQueueSnapshot) => void;
+    let resolveFirstRead!: (snapshot: QuitBlockerQueueSnapshot) => void;
+    const firstRead = new Promise<QuitBlockerQueueSnapshot>((resolve) => {
+      resolveFirstRead = resolve;
+    });
+    const initial = snapshot([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "thread-a",
+        threadKey: "codex:thread-a",
+        title: "Turn A",
+      },
+      {
+        kind: "terminal",
+        backend: "codex",
+        threadId: "thread-b",
+        threadKey: "codex:thread-b",
+        title: "Terminal B",
+        target: { scope: "remote", instanceId: "peer-a" },
+        detail: "Build Mac",
+      },
+    ]);
+    const oneRemaining = snapshot([initial.items[1]]);
+    const empty = snapshot([]);
+    const readQuitBlockerQueue = vi.fn()
+      .mockReturnValueOnce(firstRead)
+      .mockResolvedValue(empty);
+    const revealQuitBlocker = vi.fn(async () => ({ revealed: true }));
+
+    render(
+      <QuitBlockerQueueToast
+        desktopApi={{
+          onShowQuitBlockersRequested: (callback) => {
+            showQueue = callback;
+            return () => undefined;
+          },
+          readQuitBlockerQueue,
+          revealQuitBlocker,
+        }}
+      />,
+    );
+
+    act(() => showQueue(initial));
+    expect(screen.getByText("2 items are still running.")).toBeInTheDocument();
+    expect(screen.getByText("Turn A")).toBeInTheDocument();
+    expect(screen.getByText("Terminal B")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Terminal B"));
+    expect(revealQuitBlocker).toHaveBeenCalledWith({
+      kind: "terminal",
+      threadKey: "codex:thread-b",
+      target: { scope: "remote", instanceId: "peer-a" },
+    });
+
+    await act(async () => resolveFirstRead(oneRemaining));
+    expect(screen.queryByText("Turn A")).not.toBeInTheDocument();
+    expect(screen.getByText("1 item is still running.")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(screen.queryByText("Terminal B")).not.toBeInTheDocument();
+    expect(screen.getByText("No running work.")).toBeInTheDocument();
+    expect(
+      screen.getByText("PwrAgent can quit without interrupting work."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("quit-blocker-queue")).toBeInTheDocument();
+  });
+
+  it("stays hidden until a quit-dialog row hands the queue to this viewer", () => {
+    const readQuitBlockerQueue = vi.fn(async () => snapshot([]));
+
+    render(
+      <QuitBlockerQueueToast
+        desktopApi={{
+          onShowQuitBlockersRequested: () => () => undefined,
+          readQuitBlockerQueue,
+          revealQuitBlocker: vi.fn(async () => ({ revealed: false })),
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId("quit-blocker-queue")).not.toBeInTheDocument();
+    expect(readQuitBlockerQueue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -35,6 +35,11 @@ import type {
   IntegratedTerminalWriteRequest,
 } from "../../../shared/integrated-terminal";
 import type {
+  QuitBlockerQueueSnapshot,
+  RevealQuitBlockerRequest,
+  RevealQuitBlockerResponse,
+} from "../../../shared/quit-blockers";
+import type {
   AgentEvent,
   AutomationIdRequest,
   AutomationMutationResponse,
@@ -555,6 +560,10 @@ export type DesktopApi = {
    *  confirmation step when the operator declines to set up the
    *  requested profile. */
   quitApp?: () => Promise<void>;
+  readQuitBlockerQueue?: () => Promise<QuitBlockerQueueSnapshot>;
+  revealQuitBlocker?: (
+    request: RevealQuitBlockerRequest,
+  ) => Promise<RevealQuitBlockerResponse>;
   /** Wait for another PwrAgent process to be alive on a target
    *  profile. The wizard's graduation path uses this to delay its
    *  own quit until the new profile's window has fully loaded —
@@ -1301,6 +1310,9 @@ export type DesktopApi = {
    */
   onShowThreadRequested?: (
     callback: (request: WindowShowThreadRequest) => void,
+  ) => () => void;
+  onShowQuitBlockersRequested?: (
+    callback: (snapshot: QuitBlockerQueueSnapshot) => void,
   ) => () => void;
   /**
    * Main → renderer push: fires when the user invokes Help →

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7153,6 +7153,104 @@ textarea,
   z-index: 150;
 }
 
+.app-notice-toast__body {
+  min-width: 0;
+  grid-column: 1 / -1;
+}
+
+.quit-blocker-queue__list {
+  max-height: min(240px, 40vh);
+  overflow-y: auto;
+  margin: 0 -4px;
+  padding: 0 4px;
+}
+
+.quit-blocker-queue__group + .quit-blocker-queue__group {
+  margin-top: 10px;
+}
+
+.quit-blocker-queue__heading {
+  margin: 0 0 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.quit-blocker-queue__row {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+}
+
+.quit-blocker-queue__row:hover {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+}
+
+.quit-blocker-queue__row:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.quit-blocker-queue__row-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.quit-blocker-queue__label {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.quit-blocker-queue__chip {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.quit-blocker-queue__detail,
+.quit-blocker-queue__empty {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.quit-blocker-queue__detail {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.quit-blocker-queue__empty {
+  margin: 0;
+}
+
 .app-notice-toast__status {
   display: flex;
   align-items: flex-start;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -563,6 +563,9 @@ export const PROFILES_GRADUATE_BOOTSTRAP_CONFIG_CHANNEL =
   "profiles:graduate-bootstrap-config";
 export const APP_GET_BOOT_INFO_CHANNEL = "app:get-boot-info";
 export const APP_QUIT_CHANNEL = "app:quit";
+export const QUIT_BLOCKERS_READ_CHANNEL = "quit-blockers:read";
+export const QUIT_BLOCKER_REVEAL_CHANNEL = "quit-blockers:reveal";
+export const WINDOW_SHOW_QUIT_BLOCKERS_CHANNEL = "window:show-quit-blockers";
 export const APP_WAIT_FOR_PROFILE_ALIVE_CHANNEL = "app:wait-for-profile-alive";
 export const PROFILES_WRITE_SECRETS_CHANNEL = "profiles:write-secrets";
 // Windows custom title-bar menu bar (see shared/app-menu.ts). `model` returns

--- a/apps/desktop/src/shared/quit-blockers.ts
+++ b/apps/desktop/src/shared/quit-blockers.ts
@@ -1,0 +1,45 @@
+import type { FederationRemoteTarget } from "@pwragent/shared";
+
+export type QuitBlockerKind = "turn" | "automation" | "terminal" | "action";
+
+export type QuitBlockerItem = {
+  kind: QuitBlockerKind;
+  backend: string;
+  threadId: string;
+  threadKey: string;
+  /** Owning peer when the work is mounted from another PwrAgent instance. */
+  target?: FederationRemoteTarget;
+  /** Resolved before presentation; falls back to the opaque thread id. */
+  title?: string;
+  /** The active turn belongs to a worker owned by this thread. */
+  isSubAgent?: boolean;
+  /** Secondary line, such as a peer label or an action command and pid. */
+  detail?: string;
+  /** Start time used for elapsed or completion reporting. */
+  startedAt?: number;
+};
+
+export type QuitBlockerQueueSnapshot = {
+  inProgressThreadCount: number;
+  automationRunCount: number;
+  terminalSessionCount: number;
+  actionRunCount: number;
+  items: QuitBlockerItem[];
+};
+
+export type RevealQuitBlockerRequest = Pick<
+  QuitBlockerItem,
+  "kind" | "threadKey" | "target"
+>;
+
+export type RevealQuitBlockerResponse = {
+  revealed: boolean;
+};
+
+export function quitBlockerItemKey(
+  item: Pick<QuitBlockerItem, "kind" | "threadKey" | "target">,
+): string {
+  return [item.target?.instanceId ?? "local", item.kind, item.threadKey].join(
+    "::",
+  );
+}


### PR DESCRIPTION
## Summary

- hand the live blocker snapshot from the quit dialog to the exact renderer viewer selected for navigation
- keep a scrollable, durable running-work queue refreshed from authoritative main-process blocker state
- remove resolved items in place, retain the empty state, and validate instance-qualified local/remote reveal routing

## Verification

- `pnpm test apps/desktop/src/main/__tests__/quit-manager.test.ts apps/desktop/src/main/__tests__/quit-dialog-render.test.ts apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts apps/desktop/src/main/__tests__/window-show-thread.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm --filter @pwragent/desktop build`
- added focused Electron coverage in `e2e/quit-confirmation-dialog.spec.ts`; not run locally because no off-desktop headed-E2E lab was available

## Notes

- This is the follow-up UX PR. The separate mounted-remote-thread navigation fix may overlap `quit-confirmation-dialog.ts`; this change deliberately reuses the viewer returned by the navigation route and keeps blocker identity instance-qualified.