### PR TITLE
fix(desktop): route mounted quit blockers

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -211,6 +211,24 @@ async function restoreE2eFederationIdentity(params: {
   );
 }
 
+async function setQuitConfirmation(page: Page, enabled: boolean): Promise<void> {
+  await page.evaluate(async (nextEnabled) => {
+    const api = (window as typeof window & {
+      pwragent?: {
+        writeSettingsConfig?: (request: unknown) => Promise<unknown>;
+      };
+    }).pwragent;
+    if (!api?.writeSettingsConfig) {
+      throw new Error("writeSettingsConfig API is unavailable");
+    }
+    await api.writeSettingsConfig({
+      patch: {
+        general: { confirmQuitWithInProgressThreads: nextEnabled },
+      },
+    });
+  }, enabled);
+}
+
 function disableE2eFederationBeforeRelaunch(homeRoot: string): void {
   applyDesktopSettingsPatch(
     path.join(
@@ -625,7 +643,7 @@ test.describe("federation remote window", () => {
     }
   });
 
-  test("enrolls, browses remote threads, pins on the owner, and hides local-only chrome", async () => {
+  test("enrolls, browses remote threads, routes mounted quit blockers, and hides local-only chrome", async () => {
     test.setTimeout(300_000);
 
     let gateway: InProcessFederationGateway | undefined;
@@ -873,6 +891,61 @@ test.describe("federation remote window", () => {
       await expect(
         window.getByText(/Remote transcript for Remote gateway thread one/),
       ).toBeVisible({ timeout: 30_000 });
+
+      // A mounted remote thread can own a remote PTY inside the LOCAL viewer.
+      // That is distinct from the dedicated remote window below: the quit
+      // dialog must route both the terminal reveal and the thread selection
+      // back to this viewer, with the owning federation instance preserved.
+      const mountedTerminalToggle = window.locator(
+        ".thread-header__terminal-toggle",
+      );
+      await mountedTerminalToggle.click();
+      await expect(
+        window.getByLabel("Integrated terminal", { exact: true }),
+      ).toBeVisible();
+      await expect(window.locator(".integrated-terminal__status")).toHaveText(
+        ownerPtyCwd,
+        { timeout: 30_000 },
+      );
+
+      // Leave the shell running while viewing a local thread, matching the
+      // operator repro. If the quit row loses its federation target, the
+      // renderer cannot match the mounted remote row and stays here.
+      await window
+        .getByRole("button", { name: "Local control thread" })
+        .click();
+      await expect(window.getByText("Local thread is ready.")).toBeVisible();
+      await setQuitConfirmation(window, true);
+
+      const quitDialogPromise = electronApp.waitForEvent("window");
+      void electronApp
+        .evaluate(({ app: electronApp }) => electronApp.quit())
+        .catch(() => undefined);
+      const quitDialog = await quitDialogPromise;
+      await expect(
+        quitDialog.getByRole("heading", { name: "Quit PwrAgent?" }),
+      ).toBeVisible();
+      const mountedRemoteQuitRow = quitDialog.locator("a.row", {
+        hasText: "Remote gateway thread one",
+      });
+      await expect(mountedRemoteQuitRow).toHaveCount(1);
+      await mountedRemoteQuitRow.dispatchEvent("click");
+      await quitDialog.waitForEvent("close");
+
+      await expect(
+        window.getByText(/Remote transcript for Remote gateway thread one/),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(
+        window.getByLabel("Integrated terminal", { exact: true }),
+      ).toBeVisible();
+
+      // Disarm the quit guard before releasing the mounted session and moving
+      // on to the dedicated-remote-window coverage below.
+      await setQuitConfirmation(window, false);
+      await window.getByRole("button", { name: "Close terminal" }).click();
+      await expect(
+        window.getByLabel("Integrated terminal", { exact: true }),
+      ).toHaveCount(0);
 
       // Local-only chrome stays hidden in the remote window.
       await expect(

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -485,7 +485,11 @@ describe("clicking a quit dialog row", () => {
     // back to whichever window subscribed first — for a peer's terminal that
     // is a window with no such thread.
     expect(requestShowThread).toHaveBeenCalledWith(
-      { backend: "codex", threadId: "0f9c2b7a-remote" },
+      {
+        backend: "codex",
+        federationTarget: { scope: "remote", instanceId: "peer-a" },
+        threadId: "0f9c2b7a-remote",
+      },
       { preferWebContents: owner },
     );
     await expect(pending).resolves.toBe("manual-cancel");

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -370,7 +370,20 @@ export async function showQuitConfirmationDialog(
                     : {}),
                 })
               : undefined;
-          requestShowThread(parsed, { preferWebContents: revealed?.owner });
+          requestShowThread(
+            {
+              ...parsed,
+              ...(target.instanceId
+                ? {
+                    federationTarget: {
+                      scope: "remote" as const,
+                      instanceId: target.instanceId,
+                    },
+                  }
+                : {}),
+            },
+            { preferWebContents: revealed?.owner },
+          );
         }
         finish("manual-cancel");
         return;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -479,9 +479,9 @@ export function ToolOutputIncidentExplorerWindow() {
               title: route.title,
             }}
             onOpen={() => {
-              /* No federation target: `WindowShowThreadRequest` has none, and
-                 the main-process handler routes to this window's own owner.
-                 Passing one would be silently dropped by the spread. */
+              /* No federation target: this explorer is opened for a local
+                 thread, and the main-process handler routes back to its
+                 owning main window. */
               void desktopApi?.showThreadFromToolOutputIncidentExplorer?.({
                 backend: route.backend,
                 threadId: route.threadId,

--- a/apps/desktop/src/shared/window-show-thread.ts
+++ b/apps/desktop/src/shared/window-show-thread.ts
@@ -1,7 +1,12 @@
-import type { AppServerBackendKind } from "@pwragent/shared";
+import type {
+  AppServerBackendKind,
+  FederationRemoteTarget,
+} from "@pwragent/shared";
 
 export type WindowShowThreadRequest = {
   backend: AppServerBackendKind;
+  /** Owning peer when the thread is mounted into a local viewer. */
+  federationTarget?: FederationRemoteTarget;
   /** Transcript message to reveal after selecting the thread. */
   messageId?: string;
   threadId: string;


### PR DESCRIPTION
## Summary

- preserve the federation owner when a quit-dialog blocker selects a mounted remote thread
- route the terminal reveal and thread selection back to the local viewer that owns the remote PTY session
- cover the operator repro through the real federation transport and owner-side remote PTY E2E

## Validation

- `pnpm test apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts apps/desktop/src/main/__tests__/window-show-thread.test.ts`
- `pnpm --filter @pwragent/desktop test:e2e e2e/federation-remote-window.spec.ts --grep "routes mounted quit blockers"`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`