### PR TITLE
fix(desktop): honor thread list actions during hover

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -106,6 +106,7 @@ type HoverStableSidebarSnapshot = {
 function hydrateHoverStableSidebarSnapshot(
   frozen: HoverStableSidebarSnapshot,
   latest: HoverStableSidebarSnapshot,
+  options?: { removeMissingThreads?: boolean },
 ): HoverStableSidebarSnapshot {
   const latestDirectoriesByKey = new Map(
     latest.directories.map((directory) => [directory.key, directory]),
@@ -147,23 +148,26 @@ function hydrateHoverStableSidebarSnapshot(
         .map((directory) => ({ ...directory, pinnedRank: undefined })),
     ],
     threads: [
-      ...frozen.threads.map((thread) => {
+      ...frozen.threads.flatMap((thread) => {
         const latestThread = latestThreadsByKey.get(
           threadSummaryIdentityKey(thread),
         );
-        return latestThread
-          ? {
-              ...latestThread,
-              createdAt: thread.createdAt,
-              parentThreadBackend: thread.parentThreadBackend,
-              parentThreadId: thread.parentThreadId,
-              parentThreadInstanceId: thread.parentThreadInstanceId,
-              pinnedRank: thread.pinnedRank,
-              codexNativeSubAgents: thread.codexNativeSubAgents,
-              subthreadsCollapsed: thread.subthreadsCollapsed,
-              subthreadOrder: thread.subthreadOrder,
-            }
-          : thread;
+        if (!latestThread) {
+          return options?.removeMissingThreads ? [] : [thread];
+        }
+        return [
+          {
+            ...latestThread,
+            createdAt: thread.createdAt,
+            parentThreadBackend: thread.parentThreadBackend,
+            parentThreadId: thread.parentThreadId,
+            parentThreadInstanceId: thread.parentThreadInstanceId,
+            pinnedRank: thread.pinnedRank,
+            codexNativeSubAgents: thread.codexNativeSubAgents,
+            subthreadsCollapsed: thread.subthreadsCollapsed,
+            subthreadOrder: thread.subthreadOrder,
+          },
+        ];
       }),
       ...latest.threads
         .filter((thread) => !frozenThreadKeys.has(
@@ -178,6 +182,16 @@ function hydrateHoverStableSidebarSnapshot(
           pinnedRank: undefined,
         })),
     ],
+  };
+}
+
+function releaseBeforeListChange<Args extends unknown[], Result>(
+  release: () => void,
+  operation: (...args: Args) => Result,
+): (...args: Args) => Result {
+  return (...args) => {
+    release();
+    return operation(...args);
   };
 }
 
@@ -586,7 +600,10 @@ export function Sidebar(props: SidebarProps) {
           ? props.recentThreads ?? props.threads
           : updatedOrderThreads;
   const hoverStableSnapshot = useHoverStableSnapshot({
-    hydrateFrozenValue: hydrateHoverStableSidebarSnapshot,
+    hydrateFrozenValue: (frozen, latest) =>
+      hydrateHoverStableSidebarSnapshot(frozen, latest, {
+        removeMissingThreads: props.browseMode === "attention",
+      }),
     scope: props.browseMode,
     value: {
       directories: props.directories,
@@ -596,6 +613,72 @@ export function Sidebar(props: SidebarProps) {
   });
   const renderedDirectories = hoverStableSnapshot.value.directories;
   const renderedThreads = hoverStableSnapshot.value.threads;
+  /**
+   * Hover stability protects a target from background list churn. A command
+   * the operator chose must instead reveal its resulting snapshot immediately.
+   */
+  const releaseHoverStableSnapshot = hoverStableSnapshot.release;
+  const hoverReleasedListHandlers = useMemo(
+    () => ({
+      openLaunchpad: releaseBeforeListChange(
+        releaseHoverStableSnapshot,
+        props.onOpenLaunchpad,
+      ),
+      reorderDirectoryPins: props.onReorderDirectoryPins
+        ? releaseBeforeListChange(
+            releaseHoverStableSnapshot,
+            props.onReorderDirectoryPins,
+          )
+        : undefined,
+      reorderThreadPins: props.onReorderThreadPins
+        ? releaseBeforeListChange(
+            releaseHoverStableSnapshot,
+            props.onReorderThreadPins,
+          )
+        : undefined,
+      setDirectoryPin: props.onSetDirectoryPin
+        ? releaseBeforeListChange(
+            releaseHoverStableSnapshot,
+            props.onSetDirectoryPin,
+          )
+        : undefined,
+      setDirectoryThreadsCollapsed: props.onSetDirectoryThreadsCollapsed
+        ? releaseBeforeListChange(
+            releaseHoverStableSnapshot,
+            props.onSetDirectoryThreadsCollapsed,
+          )
+        : undefined,
+      setSubthreadsCollapsed: props.onSetSubthreadsCollapsed
+        ? releaseBeforeListChange(
+            releaseHoverStableSnapshot,
+            props.onSetSubthreadsCollapsed,
+          )
+        : undefined,
+      setThreadPin: props.onSetThreadPin
+        ? releaseBeforeListChange(
+            releaseHoverStableSnapshot,
+            props.onSetThreadPin,
+          )
+        : undefined,
+      updateSubthreadOrder: props.onUpdateSubthreadOrder
+        ? releaseBeforeListChange(
+            releaseHoverStableSnapshot,
+            props.onUpdateSubthreadOrder,
+          )
+        : undefined,
+    }),
+    [
+      props.onOpenLaunchpad,
+      props.onReorderDirectoryPins,
+      props.onReorderThreadPins,
+      props.onSetDirectoryPin,
+      props.onSetDirectoryThreadsCollapsed,
+      props.onSetSubthreadsCollapsed,
+      props.onSetThreadPin,
+      props.onUpdateSubthreadOrder,
+      releaseHoverStableSnapshot,
+    ],
+  );
   /**
    * The numbers on the Attention tab. Counted over the very rows the lens
    * renders, not over `props.threads`, so the tab and the list cannot report
@@ -1204,6 +1287,7 @@ export function Sidebar(props: SidebarProps) {
     options?: ArchiveThreadOptions,
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     if (options) {
       void onArchiveThread(thread, options);
       return;
@@ -1216,6 +1300,7 @@ export function Sidebar(props: SidebarProps) {
     mode: ThreadWorkspaceMode,
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     void props.onCreateSubthread?.(thread, mode);
   };
 
@@ -1224,11 +1309,13 @@ export function Sidebar(props: SidebarProps) {
     mode: ThreadWorkspaceMode,
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     void props.onForkThread?.(thread, mode);
   };
 
   const unlinkSubthreadFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     if (props.onUnlinkThreads) {
       void props.onUnlinkThreads([thread]);
       return;
@@ -1238,16 +1325,18 @@ export function Sidebar(props: SidebarProps) {
 
   const togglePinFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
-    void props.onSetThreadPin?.(thread, !thread.pinnedRank);
+    void hoverReleasedListHandlers.setThreadPin?.(thread, !thread.pinnedRank);
   };
 
   const markUnreadFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     void props.onMarkThreadUnread?.(thread);
   };
 
   const markReadFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     void props.onMarkThreadsSeen?.([thread]);
   };
 
@@ -1255,6 +1344,7 @@ export function Sidebar(props: SidebarProps) {
     thread: NavigationThreadSummary,
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     // Viewer-side delete only: works while the owner is unreachable and
     // never archives the owner's thread.
     void props.onRemoveRemoteThreadPin?.(thread);
@@ -1292,13 +1382,17 @@ export function Sidebar(props: SidebarProps) {
     directory: NavigationDirectorySummary,
   ): void => {
     setDirectoryContextMenu(undefined);
-    void props.onSetDirectoryPin?.(directory, !directory.pinnedRank);
+    void hoverReleasedListHandlers.setDirectoryPin?.(
+      directory,
+      !directory.pinnedRank,
+    );
   };
 
   const removeDirectoryFromContextMenu = (
     directory: NavigationDirectorySummary,
   ): void => {
     setDirectoryContextMenu(undefined);
+    hoverStableSnapshot.release();
     props.onRemoveDirectory?.(directory);
   };
 
@@ -1319,6 +1413,7 @@ export function Sidebar(props: SidebarProps) {
         ) && thread.inbox.inInbox,
     );
     setDirectoryContextMenu(undefined);
+    hoverStableSnapshot.release();
     void props.onMarkThreadsSeen?.(unreadThreads);
   };
 
@@ -1377,7 +1472,7 @@ export function Sidebar(props: SidebarProps) {
     // tick, so subsequent Move clicks see updated adjacency.
     // Pin / Unpin / Rename / Archive are terminal actions and
     // still dismiss the menu.
-    void props.onReorderThreadPins?.(nextKeys);
+    void hoverReleasedListHandlers.reorderThreadPins?.(nextKeys);
   };
 
   const moveDirectoryFromContextMenu = (
@@ -1399,13 +1494,14 @@ export function Sidebar(props: SidebarProps) {
     );
     // See `moveThreadFromContextMenu` for why we don't dismiss
     // the menu here.
-    void props.onReorderDirectoryPins?.(nextKeys);
+    void hoverReleasedListHandlers.reorderDirectoryPins?.(nextKeys);
   };
 
   const archiveThreadsFromContextMenu = (
     threads: NavigationThreadSummary[],
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     void Promise.all(threads.map((thread) => onArchiveThread(thread)));
   };
 
@@ -1413,6 +1509,7 @@ export function Sidebar(props: SidebarProps) {
     threads: NavigationThreadSummary[],
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     if (props.onUnlinkThreads) {
       void props.onUnlinkThreads(threads);
       return;
@@ -1428,6 +1525,7 @@ export function Sidebar(props: SidebarProps) {
     threads: NavigationThreadSummary[],
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     const threadKeys = threads.map((thread) =>
       threadSummaryIdentityKey(thread),
     );
@@ -1449,6 +1547,7 @@ export function Sidebar(props: SidebarProps) {
     threads: NavigationThreadSummary[],
   ): void => {
     setContextMenu(undefined);
+    hoverStableSnapshot.release();
     void Promise.all(
       threads.map((thread) => props.onSetThreadPin?.(thread, false)),
     );
@@ -1997,7 +2096,7 @@ export function Sidebar(props: SidebarProps) {
               thinkingThreadKeys={props.thinkingThreadKeys}
               threads={renderedThreads}
               onOpenThreadContextMenu={openThreadContextMenu}
-              onOpenLaunchpad={props.onOpenLaunchpad}
+              onOpenLaunchpad={hoverReleasedListHandlers.openLaunchpad}
               onOpenFederationTargetMenu={
                 federationThreadTargets.length > 0
                   ? openDirectoryTargetMenu
@@ -2012,13 +2111,21 @@ export function Sidebar(props: SidebarProps) {
                 props.onRevealSelectedThreadComplete
               }
               onDetachPullRequest={detachPullRequest}
-              onReorderThreadPins={props.onReorderThreadPins}
-              onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
-              onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
-              onSetDirectoryPin={props.onSetDirectoryPin}
-              onReorderDirectoryPins={props.onReorderDirectoryPins}
+              onReorderThreadPins={
+                hoverReleasedListHandlers.reorderThreadPins
+              }
+              onUpdateSubthreadOrder={
+                hoverReleasedListHandlers.updateSubthreadOrder
+              }
+              onSetSubthreadsCollapsed={
+                hoverReleasedListHandlers.setSubthreadsCollapsed
+              }
+              onSetDirectoryPin={hoverReleasedListHandlers.setDirectoryPin}
+              onReorderDirectoryPins={
+                hoverReleasedListHandlers.reorderDirectoryPins
+              }
               onSetDirectoryThreadsCollapsed={
-                props.onSetDirectoryThreadsCollapsed
+                hoverReleasedListHandlers.setDirectoryThreadsCollapsed
               }
               onOpenDirectoryContextMenu={
                 props.onSetDirectoryPin || props.onMarkThreadsSeen
@@ -2029,7 +2136,7 @@ export function Sidebar(props: SidebarProps) {
               onSelectDirectory={selectDirectoryFromList}
               onSelectThread={selectThreadFromList}
               onSetReaction={props.onSetThreadReaction}
-              onSetThreadPin={props.onSetThreadPin}
+              onSetThreadPin={hoverReleasedListHandlers.setThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : (
@@ -2066,11 +2173,15 @@ export function Sidebar(props: SidebarProps) {
                   props.onRevealSelectedThreadComplete
                 }
                 onDetachPullRequest={detachPullRequest}
-                onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
-                onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
+                onUpdateSubthreadOrder={
+                  hoverReleasedListHandlers.updateSubthreadOrder
+                }
+                onSetSubthreadsCollapsed={
+                  hoverReleasedListHandlers.setSubthreadsCollapsed
+                }
                 onSelectThread={selectThreadFromList}
                 onSetReaction={props.onSetThreadReaction}
-                onSetThreadPin={props.onSetThreadPin}
+                onSetThreadPin={hoverReleasedListHandlers.setThreadPin}
                 onUnbindMessagingBinding={props.onUnbindMessagingBinding}
               />
             )

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -106,7 +106,10 @@ type HoverStableSidebarSnapshot = {
 function hydrateHoverStableSidebarSnapshot(
   frozen: HoverStableSidebarSnapshot,
   latest: HoverStableSidebarSnapshot,
-  options?: { removeMissingThreads?: boolean },
+  options?: {
+    refreshThreadPinRanks?: boolean;
+    removeMissingThreads?: boolean;
+  },
 ): HoverStableSidebarSnapshot {
   const latestDirectoriesByKey = new Map(
     latest.directories.map((directory) => [directory.key, directory]),
@@ -162,7 +165,9 @@ function hydrateHoverStableSidebarSnapshot(
             parentThreadBackend: thread.parentThreadBackend,
             parentThreadId: thread.parentThreadId,
             parentThreadInstanceId: thread.parentThreadInstanceId,
-            pinnedRank: thread.pinnedRank,
+            pinnedRank: options?.refreshThreadPinRanks
+              ? latestThread.pinnedRank
+              : thread.pinnedRank,
             codexNativeSubAgents: thread.codexNativeSubAgents,
             subthreadsCollapsed: thread.subthreadsCollapsed,
             subthreadOrder: thread.subthreadOrder,
@@ -179,7 +184,9 @@ function hydrateHoverStableSidebarSnapshot(
           parentThreadBackend: undefined,
           parentThreadId: undefined,
           parentThreadInstanceId: undefined,
-          pinnedRank: undefined,
+          pinnedRank: options?.refreshThreadPinRanks
+            ? thread.pinnedRank
+            : undefined,
         })),
     ],
   };
@@ -602,6 +609,7 @@ export function Sidebar(props: SidebarProps) {
   const hoverStableSnapshot = useHoverStableSnapshot({
     hydrateFrozenValue: (frozen, latest) =>
       hydrateHoverStableSidebarSnapshot(frozen, latest, {
+        refreshThreadPinRanks: props.browseMode !== "directories",
         removeMissingThreads: props.browseMode === "attention",
       }),
     scope: props.browseMode,
@@ -654,12 +662,13 @@ export function Sidebar(props: SidebarProps) {
             props.onSetSubthreadsCollapsed,
           )
         : undefined,
-      setThreadPin: props.onSetThreadPin
-        ? releaseBeforeListChange(
-            releaseHoverStableSnapshot,
-            props.onSetThreadPin,
-          )
-        : undefined,
+      setThreadPin:
+        props.onSetThreadPin && props.browseMode === "directories"
+          ? releaseBeforeListChange(
+              releaseHoverStableSnapshot,
+              props.onSetThreadPin,
+            )
+          : props.onSetThreadPin,
       updateSubthreadOrder: props.onUpdateSubthreadOrder
         ? releaseBeforeListChange(
             releaseHoverStableSnapshot,
@@ -676,6 +685,7 @@ export function Sidebar(props: SidebarProps) {
       props.onSetSubthreadsCollapsed,
       props.onSetThreadPin,
       props.onUpdateSubthreadOrder,
+      props.browseMode,
       releaseHoverStableSnapshot,
     ],
   );
@@ -1525,7 +1535,9 @@ export function Sidebar(props: SidebarProps) {
     threads: NavigationThreadSummary[],
   ): void => {
     setContextMenu(undefined);
-    hoverStableSnapshot.release();
+    if (props.browseMode === "directories") {
+      hoverStableSnapshot.release();
+    }
     const threadKeys = threads.map((thread) =>
       threadSummaryIdentityKey(thread),
     );
@@ -1547,7 +1559,9 @@ export function Sidebar(props: SidebarProps) {
     threads: NavigationThreadSummary[],
   ): void => {
     setContextMenu(undefined);
-    hoverStableSnapshot.release();
+    if (props.browseMode === "directories") {
+      hoverStableSnapshot.release();
+    }
     void Promise.all(
       threads.map((thread) => props.onSetThreadPin?.(thread, false)),
     );

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type {
   NavigationDirectorySummary,
@@ -66,7 +72,15 @@ function renderSidebar(params: {
   directories?: NavigationDirectorySummary[];
   draftThreadKeys?: Record<string, boolean>;
   inboxThreads?: NavigationThreadSummary[];
+  onOpenLaunchpad?: (
+    directory: NavigationDirectorySummary,
+  ) => Promise<void>;
+  onReorderThreadPins?: (orderedThreadKeys: string[]) => Promise<void>;
   onSelectThread?: (thread: NavigationThreadSummary) => void;
+  onSetThreadPin?: (
+    thread: NavigationThreadSummary,
+    pinned: boolean,
+  ) => Promise<void>;
   onSetSubthreadsCollapsed?: (
     parent: NavigationThreadSummary,
     collapsed: boolean,
@@ -88,8 +102,10 @@ function renderSidebar(params: {
       threads={params.threads}
       onBrowseModeChange={() => undefined}
       onCreateThread={async () => undefined}
-      onOpenLaunchpad={async () => undefined}
+      onOpenLaunchpad={params.onOpenLaunchpad ?? (async () => undefined)}
+      onReorderThreadPins={params.onReorderThreadPins}
       onSelectThread={params.onSelectThread ?? (() => undefined)}
+      onSetThreadPin={params.onSetThreadPin}
       onSetSubthreadsCollapsed={params.onSetSubthreadsCollapsed}
     />
   );
@@ -114,6 +130,15 @@ function leaveThreadBrowser(): void {
     throw new Error("Expected the sidebar scroll region");
   }
   fireEvent.pointerLeave(scrollRegion, { pointerType: "mouse" });
+}
+
+function threadRow(title: string): HTMLElement {
+  const row = screen.getByRole("button", { name: new RegExp(`^${title}`) })
+    .closest<HTMLElement>("[data-hover-stable-row]");
+  if (!row) {
+    throw new Error(`Expected a hover-stable row for ${title}`);
+  }
+  return row;
 }
 
 describe("Sidebar hover-stable thread ordering", () => {
@@ -221,6 +246,40 @@ describe("Sidebar hover-stable thread ordering", () => {
       "Alpha thread",
       "Bravo thread",
     ]);
+  });
+
+  it("removes an archived Attention row without resorting the survivors", () => {
+    const activeAlpha = { ...alpha, threadStatus: "active" as const };
+    const unreadBravo = {
+      ...bravo,
+      inbox: {
+        inInbox: true,
+        reason: "updated-since-seen" as const,
+        lastSeenUpdatedAt: 0,
+      },
+    };
+    const unreadCharlie = {
+      ...charlie,
+      inbox: {
+        inInbox: true,
+        reason: "updated-since-seen" as const,
+        lastSeenUpdatedAt: 0,
+      },
+    };
+    const view = render(renderSidebar({
+      browseMode: "attention",
+      threads: [activeAlpha, unreadBravo, unreadCharlie],
+    }));
+    hoverFirstThread();
+
+    view.rerender(renderSidebar({
+      browseMode: "attention",
+      threads: [unreadCharlie, unreadBravo],
+    }));
+
+    expect(threadTitles()).toEqual(["Bravo thread", "Charlie thread"]);
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual(["Bravo thread", "Charlie thread"]);
   });
 
   it("freezes fields that add or remove subthread rows while hovered", () => {
@@ -347,37 +406,192 @@ describe("Sidebar hover-stable thread ordering", () => {
     expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
   });
 
-  it("defers a Directories pin promotion until hover ends", () => {
+  it("applies a user-requested pin immediately while hovered", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
     const view = render(renderSidebar({
       browseMode: "directories",
       directories: [directory],
       selectedItemKey: "codex:alpha",
       threads: [alpha, bravo],
+      onSetThreadPin,
     }));
-    hoverFirstThread();
+    const bravoRow = threadRow("Bravo thread");
+    fireEvent.pointerOver(bravoRow, { pointerType: "mouse" });
+    fireEvent.click(
+      within(bravoRow).getByRole("button", { name: "Pin thread" }),
+    );
+    expect(onSetThreadPin).toHaveBeenCalledWith(bravo, true);
 
     const pinnedBravo = { ...bravo, pinnedRank: "1024" };
-    const expandedDirectory = {
+    view.rerender(renderSidebar({
+      browseMode: "directories",
+      directories: [directory],
+      selectedItemKey: "codex:alpha",
+      threads: [alpha, pinnedBravo],
+      onSetThreadPin,
+    }));
+
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+  });
+
+  it("removes a user-unpinned row from collapsed Directory threads immediately", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    const pinnedAlpha = { ...alpha, pinnedRank: "1024" };
+    const pinnedBravo = { ...bravo, pinnedRank: "2048" };
+    const collapsedDirectory = {
       ...directory,
-      threadKeys: ["codex:charlie", ...directory.threadKeys],
+      directoryThreadsCollapsed: true,
+    };
+    const view = render(renderSidebar({
+      browseMode: "directories",
+      directories: [collapsedDirectory],
+      selectedItemKey: "codex:alpha",
+      threads: [pinnedAlpha, pinnedBravo],
+      onSetThreadPin,
+    }));
+    const alphaRow = threadRow("Alpha thread");
+    fireEvent.pointerOver(alphaRow, { pointerType: "mouse" });
+    fireEvent.click(
+      within(alphaRow).getByRole("button", { name: "Unpin thread" }),
+    );
+    expect(onSetThreadPin).toHaveBeenCalledWith(pinnedAlpha, false);
+
+    view.rerender(renderSidebar({
+      browseMode: "directories",
+      directories: [collapsedDirectory],
+      selectedItemKey: "codex:alpha",
+      threads: [{ ...alpha, pinnedRank: undefined }, pinnedBravo],
+      onSetThreadPin,
+    }));
+
+    expect(threadTitles()).toEqual(["Bravo thread"]);
+  });
+
+  it("applies a pointer drag pin reorder immediately while hovered", async () => {
+    const onReorderThreadPins = vi.fn(async () => undefined);
+    const pinnedAlpha = { ...alpha, pinnedRank: "1024" };
+    const pinnedBravo = { ...bravo, pinnedRank: "2048" };
+    const view = render(renderSidebar({
+      browseMode: "directories",
+      directories: [directory],
+      selectedItemKey: "codex:alpha",
+      threads: [pinnedAlpha, pinnedBravo],
+      onReorderThreadPins,
+    }));
+    const alphaRow = threadRow("Alpha thread");
+    const bravoRow = threadRow("Bravo thread");
+    fireEvent.pointerOver(alphaRow, { pointerType: "mouse" });
+    vi.spyOn(alphaRow, "getBoundingClientRect").mockReturnValue({
+      bottom: 200,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 100,
+      width: 300,
+      x: 0,
+      y: 100,
+    });
+    vi.spyOn(bravoRow, "getBoundingClientRect").mockReturnValue({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 0,
+      width: 300,
+      x: 0,
+      y: 0,
+    });
+    const elementFromPoint = document.elementFromPoint;
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: () => bravoRow,
+    });
+    try {
+      fireEvent.pointerDown(alphaRow, {
+        button: 0,
+        clientX: 50,
+        clientY: 150,
+        pointerId: 41,
+      });
+      fireEvent.pointerMove(window, {
+        buttons: 1,
+        clientX: 50,
+        clientY: 75,
+        pointerId: 41,
+      });
+      await waitFor(() => {
+        expect(bravoRow).toHaveClass("is-drop-target-after");
+      });
+      fireEvent.pointerUp(window, {
+        button: 0,
+        clientX: 50,
+        clientY: 75,
+        pointerId: 41,
+      });
+    } finally {
+      if (elementFromPoint) {
+        Object.defineProperty(document, "elementFromPoint", {
+          configurable: true,
+          value: elementFromPoint,
+        });
+      } else {
+        Reflect.deleteProperty(document, "elementFromPoint");
+      }
+    }
+    expect(onReorderThreadPins).toHaveBeenCalledWith([
+      "codex:bravo",
+      "codex:alpha",
+    ]);
+
+    view.rerender(renderSidebar({
+      browseMode: "directories",
+      directories: [directory],
+      selectedItemKey: "codex:alpha",
+      threads: [
+        { ...pinnedAlpha, pinnedRank: "2048" },
+        { ...pinnedBravo, pinnedRank: "1024" },
+      ],
+      onReorderThreadPins,
+    }));
+
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+  });
+
+  it("shows a newly created pinned thread while Directory threads are collapsed", () => {
+    const onOpenLaunchpad = vi.fn(async () => undefined);
+    const pinnedAlpha = { ...alpha, pinnedRank: "1024" };
+    const collapsedDirectory = {
+      ...directory,
+      directoryThreadsCollapsed: true,
+    };
+    const view = render(renderSidebar({
+      browseMode: "directories",
+      directories: [collapsedDirectory],
+      selectedItemKey: "codex:alpha",
+      threads: [pinnedAlpha, bravo],
+      onOpenLaunchpad,
+    }));
+    const launchpadButton = screen.getByRole("button", {
+      name: "Open new thread launchpad for Repo",
+    });
+    fireEvent.pointerOver(launchpadButton, { pointerType: "mouse" });
+    fireEvent.click(launchpadButton);
+    expect(onOpenLaunchpad).toHaveBeenCalledWith(collapsedDirectory, undefined);
+
+    const expandedDirectory = {
+      ...collapsedDirectory,
+      threadKeys: ["codex:charlie", ...collapsedDirectory.threadKeys],
     };
     view.rerender(renderSidebar({
       browseMode: "directories",
       directories: [expandedDirectory],
       selectedItemKey: "codex:alpha",
-      threads: [charlie, alpha, pinnedBravo],
+      threads: [{ ...charlie, pinnedRank: "512" }, pinnedAlpha, bravo],
+      onOpenLaunchpad,
     }));
 
-    expect(threadTitles()).toEqual([
-      "Alpha thread",
-      "Bravo thread",
-      "Charlie thread",
-    ]);
-    leaveThreadBrowser();
-    expect(threadTitles()).toEqual([
-      "Bravo thread",
-      "Charlie thread",
-      "Alpha thread",
-    ]);
+    expect(threadTitles()).toEqual(["Charlie thread", "Alpha thread"]);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -248,6 +248,78 @@ describe("Sidebar hover-stable thread ordering", () => {
     ]);
   });
 
+  it("updates an inline Inbox pin without releasing deferred ordering", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    const view = render(renderSidebar({
+      browseMode: "inbox",
+      threads: [alpha, bravo],
+      onSetThreadPin,
+    }));
+    const alphaRow = threadRow("Alpha thread");
+    fireEvent.pointerOver(alphaRow, { pointerType: "mouse" });
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      threads: [bravo, alpha],
+      onSetThreadPin,
+    }));
+
+    fireEvent.click(
+      within(alphaRow).getByRole("button", { name: "Pin thread" }),
+    );
+    expect(onSetThreadPin).toHaveBeenCalledWith(alpha, true);
+
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      threads: [bravo, { ...alpha, pinnedRank: "1024" }],
+      onSetThreadPin,
+    }));
+
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    expect(
+      within(threadRow("Alpha thread")).getByRole("button", {
+        name: "Unpin thread",
+      }),
+    ).toBeInTheDocument();
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+  });
+
+  it("updates a context-menu Inbox unpin without releasing deferred ordering", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    const pinnedAlpha = { ...alpha, pinnedRank: "1024" };
+    const view = render(renderSidebar({
+      browseMode: "inbox",
+      threads: [pinnedAlpha, bravo],
+      onSetThreadPin,
+    }));
+    const alphaRow = threadRow("Alpha thread");
+    fireEvent.pointerOver(alphaRow, { pointerType: "mouse" });
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      threads: [bravo, pinnedAlpha],
+      onSetThreadPin,
+    }));
+
+    fireEvent.contextMenu(
+      within(alphaRow).getByRole("button", { name: /^Alpha thread/ }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Unpin Thread" }));
+    expect(onSetThreadPin).toHaveBeenCalledWith(pinnedAlpha, false);
+
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      threads: [bravo, alpha],
+      onSetThreadPin,
+    }));
+
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+    expect(
+      within(threadRow("Alpha thread")).getByRole("button", {
+        name: "Pin thread",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("removes an archived Attention row without resorting the survivors", () => {
     const activeAlpha = { ...alpha, threadStatus: "active" as const };
     const unreadBravo = {

--- a/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useHoverStableSnapshot.ts
@@ -36,6 +36,7 @@ export function useHoverStableSnapshot<T>(params: {
   onPointerLeave: PointerEventHandler<HTMLDivElement>;
   onPointerOut: PointerEventHandler<HTMLDivElement>;
   onPointerOver: PointerEventHandler<HTMLDivElement>;
+  release: () => void;
   value: T;
 } {
   const latestValueRef = useRef(params.value);
@@ -101,6 +102,7 @@ export function useHoverStableSnapshot<T>(params: {
     onPointerLeave: release,
     onPointerOut,
     onPointerOver,
+    release,
     value: hoveringRowRef.current
       ? params.hydrateFrozenValue?.(frozenValueRef.current, params.value)
         ?? frozenValueRef.current


### PR DESCRIPTION
## Summary

- keep background thread-list reordering and top insertion deferred while the pointer rests on the list
- release the held snapshot for structural Directories actions such as pin, unpin, reorder, create, collapse, and removal
- update pin state immediately in Inbox, Recents, Attention, and Drafts without releasing their deferred row order
- remove departed Attention rows immediately while preserving the relative order of surviving rows
- add regressions for pinning, unpinning, pointer drag reorder, newly created pinned threads, Attention removals, and non-Directories pin actions during deferred reordering

## Tests

- pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
- pnpm typecheck
- pnpm --filter @pwragent/desktop typecheck
- pnpm lint:eslint
- pnpm lint:boundaries