### PR TITLE
fix(desktop): require deferred Token Miser capabilities

### DIFF
--- a/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
+++ b/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
@@ -80,6 +80,17 @@ test("keeps running work reachable after cancelling and following a blocker", as
     await expect(
       app.window.locator(".integrated-terminal .xterm-rows"),
     ).toContainText("PWRAGENT_QUIT_BLOCKER_READY");
+    // Seeing the marker only proves that the shell completed `echo`. On a
+    // loaded guest, node-pty can still report the shell as the foreground
+    // process for the brief interval before `sleep` takes the terminal. Quit
+    // during that interval correctly sees no blocker and exits without a
+    // prompt. Wait on the exact main-process snapshot used by QuitManager so
+    // this test asks for quit only after the condition it intends to exercise.
+    await expect
+      .poll(async () =>
+        (await app.getIntegratedTerminalQuitSnapshot())?.count ?? 0
+      )
+      .toBe(1);
 
     const dialogPromise = app.electronApp.waitForEvent("window");
     // Not awaited: the modal holds the main process, so this round trip does

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3838,8 +3838,17 @@ describe("DesktopBackendRegistry", () => {
           descriptorEnvironmentVariable:
             "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
           descriptorVersion: 1,
+          codeModeNestedPostToolUse: false,
         },
         codeModeOutputReducer: {
+          deferredCompletion: {
+            version: 1,
+            terminalOnly: true,
+            preservesOriginalCallId: true,
+            preservesCellId: true,
+            waitToolName: "wait",
+          },
+          intentContextVersion: 1,
           modelGuidance: {
             version: 1,
             toolDescriptionConfigKey:
@@ -3849,7 +3858,9 @@ describe("DesktopBackendRegistry", () => {
             modelVisibleOverheadRequestField:
               "model_visible_overhead_characters",
           },
+          postToolUseField: "parent_intent",
           protocolVersion: 1,
+          reducerRequestField: "parent_intent",
         },
       },
     });
@@ -3911,8 +3922,17 @@ describe("DesktopBackendRegistry", () => {
           descriptorEnvironmentVariable:
             "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
           descriptorVersion: 1,
+          codeModeNestedPostToolUse: false,
         },
         codeModeOutputReducer: {
+          deferredCompletion: {
+            version: 1,
+            terminalOnly: true,
+            preservesOriginalCallId: true,
+            preservesCellId: true,
+            waitToolName: "wait",
+          },
+          intentContextVersion: 1,
           modelGuidance: {
             version: 1,
             toolDescriptionConfigKey:
@@ -3922,7 +3942,9 @@ describe("DesktopBackendRegistry", () => {
             modelVisibleOverheadRequestField:
               "model_visible_overhead_characters",
           },
+          postToolUseField: "parent_intent",
           protocolVersion: 1,
+          reducerRequestField: "parent_intent",
         },
       },
     });
@@ -3971,11 +3993,23 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
-  it("rejects managed runtimes that omit native Token Miser activation", async () => {
+  it("rejects managed runtimes that omit deferred Token Miser completion", async () => {
     const codexClient = new MockBackendClient({
       threads: [],
       serverCapabilities: {
+        pwrdrvrTokenMiser: {
+          version: 1,
+          identity: "pwrdrvr.pwragent.token-miser",
+          initializeCapabilityField: "pwrdrvrTokenMiser",
+          threadStartField: "pwrdrvrTokenMiser",
+          threadResumeField: "pwrdrvrTokenMiser",
+          descriptorEnvironmentVariable:
+            "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+          descriptorVersion: 1,
+          codeModeNestedPostToolUse: false,
+        },
         codeModeOutputReducer: {
+          intentContextVersion: 1,
           modelGuidance: {
             version: 1,
             toolDescriptionConfigKey:
@@ -3985,7 +4019,9 @@ describe("DesktopBackendRegistry", () => {
             modelVisibleOverheadRequestField:
               "model_visible_overhead_characters",
           },
+          postToolUseField: "parent_intent",
           protocolVersion: 1,
+          reducerRequestField: "parent_intent",
         },
       },
     });
@@ -4026,7 +4062,7 @@ describe("DesktopBackendRegistry", () => {
       await internals.prepareTokenMiserRuntime();
 
       expect(internals.tokenMiserRuntimePreparationFailure).toBe(
-        "Managed Codex runtime lacks native Token Miser activation capability v1.",
+        "Managed Codex runtime lacks the complete Token Miser activation and deferred-completion capability contract.",
       );
       expect(resolveRuntime).not.toHaveBeenCalled();
       expect(ensureInstalled).not.toHaveBeenCalled();
@@ -4118,22 +4154,9 @@ describe("DesktopBackendRegistry", () => {
 
   it("records truthful Token Miser activation from reducer capability", async () => {
     const readActivation = async (params: {
+      managedContractRequired?: boolean;
       runtimeFailure?: string;
-      serverCapabilities: {
-        codeModeOutputReducer?: {
-          dynamicToolsResumeField?: "dynamicTools";
-          modelGuidance?: {
-            version: 1;
-            toolDescriptionConfigKey:
-              "features.code_mode.output_reducer.tool_description_guidance";
-            continuationConfigKey:
-              "features.code_mode.output_reducer.continuation_guidance";
-            modelVisibleOverheadRequestField:
-              "model_visible_overhead_characters";
-          };
-          protocolVersion?: number;
-        };
-      };
+      serverCapabilities: CodexServerCapabilities;
     }) => {
       const tokenMiserStateDir = await mkdtemp(
         path.join(os.tmpdir(), "pwragent-token-miser-activation-"),
@@ -4145,6 +4168,8 @@ describe("DesktopBackendRegistry", () => {
       const registry = new DesktopBackendRegistry({
         codexClient,
         overlayStore: createOverlayStoreMock(),
+        resolveManagedTokenMiserActivationRequired: () =>
+          params.managedContractRequired ?? false,
       });
       const internals = registry as unknown as {
         prepareTokenMiserRuntime: (
@@ -4198,6 +4223,79 @@ describe("DesktopBackendRegistry", () => {
         },
       },
     })).resolves.toMatchObject({ state: "active" });
+    await expect(readActivation({
+      managedContractRequired: true,
+      serverCapabilities: {
+        pwrdrvrTokenMiser: {
+          version: 1,
+          identity: "pwrdrvr.pwragent.token-miser",
+          initializeCapabilityField: "pwrdrvrTokenMiser",
+          threadStartField: "pwrdrvrTokenMiser",
+          threadResumeField: "pwrdrvrTokenMiser",
+          descriptorEnvironmentVariable:
+            "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+          descriptorVersion: 1,
+          codeModeNestedPostToolUse: false,
+        },
+        codeModeOutputReducer: {
+          deferredCompletion: {
+            version: 1,
+            terminalOnly: true,
+            preservesOriginalCallId: true,
+            preservesCellId: true,
+            waitToolName: "wait",
+          },
+          intentContextVersion: 1,
+          modelGuidance: {
+            version: 1,
+            toolDescriptionConfigKey:
+              "features.code_mode.output_reducer.tool_description_guidance",
+            continuationConfigKey:
+              "features.code_mode.output_reducer.continuation_guidance",
+            modelVisibleOverheadRequestField:
+              "model_visible_overhead_characters",
+          },
+          postToolUseField: "parent_intent",
+          protocolVersion: 1,
+          reducerRequestField: "parent_intent",
+        },
+      },
+    })).resolves.toMatchObject({ state: "active" });
+    await expect(readActivation({
+      managedContractRequired: true,
+      serverCapabilities: {
+        pwrdrvrTokenMiser: {
+          version: 1,
+          identity: "pwrdrvr.pwragent.token-miser",
+          initializeCapabilityField: "pwrdrvrTokenMiser",
+          threadStartField: "pwrdrvrTokenMiser",
+          threadResumeField: "pwrdrvrTokenMiser",
+          descriptorEnvironmentVariable:
+            "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+          descriptorVersion: 1,
+          codeModeNestedPostToolUse: false,
+        },
+        codeModeOutputReducer: {
+          intentContextVersion: 1,
+          modelGuidance: {
+            version: 1,
+            toolDescriptionConfigKey:
+              "features.code_mode.output_reducer.tool_description_guidance",
+            continuationConfigKey:
+              "features.code_mode.output_reducer.continuation_guidance",
+            modelVisibleOverheadRequestField:
+              "model_visible_overhead_characters",
+          },
+          postToolUseField: "parent_intent",
+          protocolVersion: 1,
+          reducerRequestField: "parent_intent",
+        },
+      },
+    })).resolves.toMatchObject({
+      reason:
+        "Managed Codex runtime lacks the complete Token Miser activation and deferred-completion capability contract.",
+      state: "unavailable",
+    });
     await expect(readActivation({
       serverCapabilities: {
         codeModeOutputReducer: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3909,6 +3909,76 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("preserves explicit disable for incomplete native Token Miser runtimes", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [],
+      serverCapabilities: {
+        pwrdrvrTokenMiser: {
+          version: 1,
+          identity: "pwrdrvr.pwragent.token-miser",
+          initializeCapabilityField: "pwrdrvrTokenMiser",
+          threadStartField: "pwrdrvrTokenMiser",
+          threadResumeField: "pwrdrvrTokenMiser",
+          descriptorEnvironmentVariable:
+            "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+          descriptorVersion: 1,
+        },
+        codeModeOutputReducer: {
+          intentContextVersion: 1,
+          modelGuidance: {
+            version: 1,
+            toolDescriptionConfigKey:
+              "features.code_mode.output_reducer.tool_description_guidance",
+            continuationConfigKey:
+              "features.code_mode.output_reducer.continuation_guidance",
+            modelVisibleOverheadRequestField:
+              "model_visible_overhead_characters",
+          },
+          postToolUseField: "parent_intent",
+          protocolVersion: 1,
+          reducerRequestField: "parent_intent",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-off": {
+            backend: "codex",
+            threadId: "thread-off",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            tokenMiserEnabled: false,
+          },
+        },
+      }),
+      resolveManagedTokenMiserActivationRequired: () => true,
+    });
+    const internals = registry as unknown as {
+      prepareTokenMiserRuntime: () => Promise<void>;
+      resolveTokenMiserEnabledFn: () => boolean;
+    };
+    internals.resolveTokenMiserEnabledFn = () => true;
+    vi.spyOn(internals, "prepareTokenMiserRuntime").mockResolvedValue(undefined);
+
+    try {
+      await registry.startThread({ backend: "codex", cwd: process.cwd() });
+      expect(
+        codexClient.lastStartThreadParams?.pwrdrvrTokenMiser,
+      ).toBeUndefined();
+
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-off",
+        input: [{ type: "text", text: "Keep this thread opted out." }],
+      });
+      expect(codexClient.lastStartTurnParams?.pwrdrvrTokenMiser).toBeNull();
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("does not install the legacy plugin when native activation is negotiated", async () => {
     const codexClient = new MockBackendClient({
       threads: [],

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -36409,6 +36409,12 @@ script = "printf setup"
       codexClient,
       overlayStore: createOverlayStoreMock(),
     });
+    const internals = registry as unknown as {
+      resolveTokenMiserDefaultEnabledFn: () => boolean;
+      resolveTokenMiserEnabledFn: () => boolean;
+    };
+    internals.resolveTokenMiserEnabledFn = () => true;
+    internals.resolveTokenMiserDefaultEnabledFn = () => true;
     await registry.publishLocalEvent({
       backend: "codex",
       notification: {
@@ -36447,6 +36453,7 @@ script = "printf setup"
       read: {
         backend: "codex",
         threadId: "target-thread",
+        tokenMiserEnabled: true,
         limit: 5,
         maxCharsPerEntry: 200,
         threadUrl: "pwragent://thread/target-thread?backend=codex",

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1483,7 +1483,6 @@ describe("CodexAppServerClient", () => {
         descriptorEnvironmentVariable:
           "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
         descriptorVersion: 1,
-        codeModeNestedPostToolUse: true,
       },
       codeModeOutputReducer: {
         deferredCompletion: {
@@ -1497,6 +1496,16 @@ describe("CodexAppServerClient", () => {
       },
     };
     await expect(client.readServerCapabilities()).resolves.toEqual({
+      pwrdrvrTokenMiser: {
+        version: 1,
+        identity: "pwrdrvr.pwragent.token-miser",
+        initializeCapabilityField: "pwrdrvrTokenMiser",
+        threadStartField: "pwrdrvrTokenMiser",
+        threadResumeField: "pwrdrvrTokenMiser",
+        descriptorEnvironmentVariable:
+          "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+        descriptorVersion: 1,
+      },
       codeModeOutputReducer: {
         deferredCompletion: {
           version: 1,

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1349,6 +1349,7 @@ describe("CodexAppServerClient", () => {
         descriptorEnvironmentVariable:
           "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
         descriptorVersion: 1,
+        codeModeNestedPostToolUse: false,
       },
       codeModeOutputReducer: {
         actionableState: {
@@ -1358,6 +1359,13 @@ describe("CodexAppServerClient", () => {
           modelOutputTag: "codex_actionable_state",
         },
         continuationGuidanceVersion: 1,
+        deferredCompletion: {
+          version: 1,
+          terminalOnly: true,
+          preservesOriginalCallId: true,
+          preservesCellId: true,
+          waitToolName: "wait",
+        },
         dynamicToolsResumeField: "dynamicTools",
         intentContextVersion: 1,
         modelGuidance: {
@@ -1398,6 +1406,7 @@ describe("CodexAppServerClient", () => {
         descriptorEnvironmentVariable:
           "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
         descriptorVersion: 1,
+        codeModeNestedPostToolUse: false,
       },
       codeModeOutputReducer: {
         actionableState: {
@@ -1407,6 +1416,13 @@ describe("CodexAppServerClient", () => {
           modelOutputTag: "codex_actionable_state",
         },
         continuationGuidanceVersion: 1,
+        deferredCompletion: {
+          version: 1,
+          terminalOnly: true,
+          preservesOriginalCallId: true,
+          preservesCellId: true,
+          waitToolName: "wait",
+        },
         dynamicToolsResumeField: "dynamicTools",
         intentContextVersion: 1,
         modelGuidance: {
@@ -1452,6 +1468,82 @@ describe("CodexAppServerClient", () => {
       },
     };
     await expect(client.readServerCapabilities()).resolves.toEqual({
+      codeModeOutputReducer: {
+        protocolVersion: 1,
+      },
+    });
+
+    MockTransport.serverCapabilitiesResult = {
+      pwrdrvrTokenMiser: {
+        version: 1,
+        identity: "pwrdrvr.pwragent.token-miser",
+        initializeCapabilityField: "pwrdrvrTokenMiser",
+        threadStartField: "pwrdrvrTokenMiser",
+        threadResumeField: "pwrdrvrTokenMiser",
+        descriptorEnvironmentVariable:
+          "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+        descriptorVersion: 1,
+        codeModeNestedPostToolUse: true,
+      },
+      codeModeOutputReducer: {
+        deferredCompletion: {
+          version: 1,
+          terminalOnly: true,
+          preservesOriginalCallId: true,
+          preservesCellId: true,
+          waitToolName: "wait",
+        },
+        protocolVersion: 1,
+      },
+    };
+    await expect(client.readServerCapabilities()).resolves.toEqual({
+      codeModeOutputReducer: {
+        deferredCompletion: {
+          version: 1,
+          terminalOnly: true,
+          preservesOriginalCallId: true,
+          preservesCellId: true,
+          waitToolName: "wait",
+        },
+        protocolVersion: 1,
+      },
+    });
+
+    MockTransport.serverCapabilitiesResult = {
+      pwrdrvrTokenMiser: {
+        version: 1,
+        identity: "pwrdrvr.pwragent.token-miser",
+        initializeCapabilityField: "pwrdrvrTokenMiser",
+        threadStartField: "pwrdrvrTokenMiser",
+        threadResumeField: "pwrdrvrTokenMiser",
+        descriptorEnvironmentVariable:
+          "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+        descriptorVersion: 1,
+        codeModeNestedPostToolUse: false,
+      },
+      codeModeOutputReducer: {
+        deferredCompletion: {
+          version: 1,
+          terminalOnly: false,
+          preservesOriginalCallId: true,
+          preservesCellId: true,
+          waitToolName: "wait",
+        },
+        protocolVersion: 1,
+      },
+    };
+    await expect(client.readServerCapabilities()).resolves.toEqual({
+      pwrdrvrTokenMiser: {
+        version: 1,
+        identity: "pwrdrvr.pwragent.token-miser",
+        initializeCapabilityField: "pwrdrvrTokenMiser",
+        threadStartField: "pwrdrvrTokenMiser",
+        threadResumeField: "pwrdrvrTokenMiser",
+        descriptorEnvironmentVariable:
+          "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH",
+        descriptorVersion: 1,
+        codeModeNestedPostToolUse: false,
+      },
       codeModeOutputReducer: {
         protocolVersion: 1,
       },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11923,15 +11923,16 @@ export class DesktopBackendRegistry {
       backend,
       threadId: request.threadId,
     });
+    const tokenMiserEnabled = this.resolveTokenMiserEnabledForOverride(
+      overlay?.tokenMiserEnabled,
+    );
 
     return {
       backend,
       fetchedAt: Date.now(),
       readDurationMs: Math.max(0, Math.round(performance.now() - readStartedAt)),
       threadId: request.threadId,
-      ...(overlay?.tokenMiserEnabled !== undefined
-        ? { tokenMiserEnabled: overlay.tokenMiserEnabled }
-        : {}),
+      tokenMiserEnabled,
       pricing,
       ...(toolAccounting ? { toolAccounting } : {}),
       ...(pendingRequest ? { pendingRequest } : {}),
@@ -33608,6 +33609,9 @@ export class DesktopBackendRegistry {
           read: {
             backend: args.backend,
             threadId,
+            ...(response.tokenMiserEnabled !== undefined
+              ? { tokenMiserEnabled: response.tokenMiserEnabled }
+              : {}),
             ...(remote
               ? {
                   instanceId: remote.instanceId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6772,6 +6772,12 @@ function hasTokenMiserModelGuidance(
 const TOKEN_MISER_MANAGED_CAPABILITY_REASON =
   "Managed Codex runtime lacks the complete Token Miser activation and deferred-completion capability contract.";
 
+function hasTokenMiserActivationTransport(
+  capabilities: CodexServerCapabilities | undefined,
+): boolean {
+  return capabilities?.pwrdrvrTokenMiser?.version === 1;
+}
+
 function hasManagedTokenMiserCapabilityContract(
   capabilities: CodexServerCapabilities | undefined,
 ): boolean {
@@ -19898,10 +19904,15 @@ export class DesktopBackendRegistry {
     const capabilities = await this.readTokenMiserServerCapabilities(
       params.client,
     );
-    if (!hasManagedTokenMiserCapabilityContract(capabilities)) {
+    if (!hasTokenMiserActivationTransport(capabilities)) {
       return undefined;
     }
-    return params.enabled ? { version: 1, enabled: true } : null;
+    if (!params.enabled) {
+      return null;
+    }
+    return hasManagedTokenMiserCapabilityContract(capabilities)
+      ? { version: 1, enabled: true }
+      : undefined;
   }
 
   private buildCodexParentDynamicTools(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6769,6 +6769,31 @@ function hasTokenMiserModelGuidance(
   );
 }
 
+const TOKEN_MISER_MANAGED_CAPABILITY_REASON =
+  "Managed Codex runtime lacks the complete Token Miser activation and deferred-completion capability contract.";
+
+function hasManagedTokenMiserCapabilityContract(
+  capabilities: CodexServerCapabilities | undefined,
+): boolean {
+  const deferredCompletion =
+    capabilities?.codeModeOutputReducer?.deferredCompletion;
+  return (
+    capabilities?.pwrdrvrTokenMiser?.version === 1
+    && capabilities.pwrdrvrTokenMiser.codeModeNestedPostToolUse === false
+    && capabilities.codeModeOutputReducer?.protocolVersion === 1
+    && capabilities.codeModeOutputReducer.intentContextVersion === 1
+    && capabilities.codeModeOutputReducer.reducerRequestField
+      === "parent_intent"
+    && capabilities.codeModeOutputReducer.postToolUseField === "parent_intent"
+    && hasTokenMiserModelGuidance(capabilities.codeModeOutputReducer)
+    && deferredCompletion?.version === 1
+    && deferredCompletion.terminalOnly === true
+    && deferredCompletion.preservesOriginalCallId === true
+    && deferredCompletion.preservesCellId === true
+    && deferredCompletion.waitToolName === "wait"
+  );
+}
+
 function buildCodexTokenMiserConfig(
   reducerDescriptorPath: string,
 ): CodexThreadStartParams["config"] {
@@ -19761,9 +19786,20 @@ export class DesktopBackendRegistry {
       try {
         const capabilities = await client.readServerCapabilities();
         const reducerCapability = capabilities.codeModeOutputReducer;
-        const supported =
+        const reducerSupported =
           reducerCapability?.protocolVersion === 1
           && hasTokenMiserModelGuidance(reducerCapability);
+        const managedContractRequired =
+          this.resolveManagedTokenMiserActivationRequiredFn();
+        const managedContractSupported =
+          hasManagedTokenMiserCapabilityContract(capabilities);
+        const supported =
+          reducerSupported
+          && (!managedContractRequired || managedContractSupported);
+        const unsupportedReason =
+          managedContractRequired && !managedContractSupported
+            ? TOKEN_MISER_MANAGED_CAPABILITY_REASON
+            : "Codex runtime lacks Token Miser reducer model-guidance v1.";
         const grouping = capabilities.codeModeOutputReducer?.postToolUseGrouping;
         this.tokenMiserCodeModeGroupingVersion =
           supported
@@ -19792,7 +19828,7 @@ export class DesktopBackendRegistry {
             : {
                 reason:
                   this.tokenMiserRuntimePreparationFailure
-                  ?? "Codex runtime lacks Token Miser reducer model-guidance v1.",
+                  ?? unsupportedReason,
                 state: "unavailable",
               },
         );
@@ -19837,10 +19873,11 @@ export class DesktopBackendRegistry {
     client: BackendClient,
   ): Promise<boolean> {
     const capabilities = await this.readTokenMiserServerCapabilities(client);
-    return (
-      capabilities?.codeModeOutputReducer?.protocolVersion === 1
-      && hasTokenMiserModelGuidance(capabilities.codeModeOutputReducer)
-    );
+    if (this.resolveManagedTokenMiserActivationRequiredFn()) {
+      return hasManagedTokenMiserCapabilityContract(capabilities);
+    }
+    return capabilities?.codeModeOutputReducer?.protocolVersion === 1
+      && hasTokenMiserModelGuidance(capabilities.codeModeOutputReducer);
   }
 
   private async supportsTokenMiserDynamicToolsResume(
@@ -19861,7 +19898,7 @@ export class DesktopBackendRegistry {
     const capabilities = await this.readTokenMiserServerCapabilities(
       params.client,
     );
-    if (capabilities?.pwrdrvrTokenMiser?.version !== 1) {
+    if (!hasManagedTokenMiserCapabilityContract(capabilities)) {
       return undefined;
     }
     return params.enabled ? { version: 1, enabled: true } : null;
@@ -19940,13 +19977,13 @@ export class DesktopBackendRegistry {
         this.codexClient,
       );
       const managedActivation =
-        capabilities?.pwrdrvrTokenMiser?.version === 1;
+        hasManagedTokenMiserCapabilityContract(capabilities);
       if (
         this.resolveManagedTokenMiserActivationRequiredFn()
         && !managedActivation
       ) {
         throw new Error(
-          "Managed Codex runtime lacks native Token Miser activation capability v1.",
+          TOKEN_MISER_MANAGED_CAPABILITY_REASON,
         );
       }
       const codexRuntime = managedActivation
@@ -19971,7 +20008,9 @@ export class DesktopBackendRegistry {
           ? { state: "active" }
           : {
               reason: this.tokenMiserReducerCapabilityState === "unsupported"
-                ? "Codex runtime lacks Token Miser reducer model-guidance v1."
+                ? this.resolveManagedTokenMiserActivationRequiredFn()
+                  ? TOKEN_MISER_MANAGED_CAPABILITY_REASON
+                  : "Codex runtime lacks Token Miser reducer model-guidance v1."
                 : "Waiting for Codex to report Token Miser output reducer support.",
               state: "unavailable",
             },

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -298,7 +298,7 @@ export type CodexServerCapabilities = {
     descriptorEnvironmentVariable:
       "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH";
     descriptorVersion: 1;
-    codeModeNestedPostToolUse: false;
+    codeModeNestedPostToolUse?: false;
   };
   codeModeOutputReducer?: {
     actionableState?: {
@@ -7343,7 +7343,7 @@ export class CodexAppServerClient {
     const exactOutput = asRecord(outputReducer?.postToolUseExactOutput);
     const deferredCompletion = asRecord(outputReducer?.deferredCompletion);
     const managedTokenMiser = asRecord(result?.pwrdrvrTokenMiser);
-    const hasManagedTokenMiserContract =
+    const hasManagedTokenMiserActivationTransport =
       managedTokenMiser?.version === 1
       && managedTokenMiser.identity === "pwrdrvr.pwragent.token-miser"
       && managedTokenMiser.initializeCapabilityField === "pwrdrvrTokenMiser"
@@ -7351,14 +7351,13 @@ export class CodexAppServerClient {
       && managedTokenMiser.threadResumeField === "pwrdrvrTokenMiser"
       && managedTokenMiser.descriptorEnvironmentVariable
         === "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH"
-      && managedTokenMiser.descriptorVersion === 1
-      && managedTokenMiser.codeModeNestedPostToolUse === false;
+      && managedTokenMiser.descriptorVersion === 1;
     const dynamicToolsResumeField =
       outputReducer?.dynamicToolsResumeField === "dynamicTools"
         ? "dynamicTools"
         : undefined;
 
-    const managedCapability = hasManagedTokenMiserContract
+    const managedCapability = hasManagedTokenMiserActivationTransport
       ? {
           pwrdrvrTokenMiser: {
             version: 1 as const,
@@ -7369,7 +7368,9 @@ export class CodexAppServerClient {
             descriptorEnvironmentVariable:
               "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH" as const,
             descriptorVersion: 1 as const,
-            codeModeNestedPostToolUse: false as const,
+            ...(managedTokenMiser.codeModeNestedPostToolUse === false
+              ? { codeModeNestedPostToolUse: false as const }
+              : {}),
           },
         }
       : {};

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -298,6 +298,7 @@ export type CodexServerCapabilities = {
     descriptorEnvironmentVariable:
       "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH";
     descriptorVersion: 1;
+    codeModeNestedPostToolUse: false;
   };
   codeModeOutputReducer?: {
     actionableState?: {
@@ -307,6 +308,13 @@ export type CodexServerCapabilities = {
       modelOutputTag: "codex_actionable_state";
     };
     continuationGuidanceVersion?: number;
+    deferredCompletion?: {
+      version: 1;
+      terminalOnly: true;
+      preservesOriginalCallId: true;
+      preservesCellId: true;
+      waitToolName: "wait";
+    };
     dynamicToolsResumeField?: "dynamicTools";
     intentContextVersion?: 1;
     modelGuidance?: {
@@ -7333,6 +7341,7 @@ export class CodexAppServerClient {
     const grouping = asRecord(outputReducer?.postToolUseGrouping);
     const modelGuidance = asRecord(outputReducer?.modelGuidance);
     const exactOutput = asRecord(outputReducer?.postToolUseExactOutput);
+    const deferredCompletion = asRecord(outputReducer?.deferredCompletion);
     const managedTokenMiser = asRecord(result?.pwrdrvrTokenMiser);
     const hasManagedTokenMiserContract =
       managedTokenMiser?.version === 1
@@ -7342,7 +7351,8 @@ export class CodexAppServerClient {
       && managedTokenMiser.threadResumeField === "pwrdrvrTokenMiser"
       && managedTokenMiser.descriptorEnvironmentVariable
         === "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH"
-      && managedTokenMiser.descriptorVersion === 1;
+      && managedTokenMiser.descriptorVersion === 1
+      && managedTokenMiser.codeModeNestedPostToolUse === false;
     const dynamicToolsResumeField =
       outputReducer?.dynamicToolsResumeField === "dynamicTools"
         ? "dynamicTools"
@@ -7359,6 +7369,7 @@ export class CodexAppServerClient {
             descriptorEnvironmentVariable:
               "PWRAGENT_TOKEN_MISER_BRIDGE_DESCRIPTOR_PATH" as const,
             descriptorVersion: 1 as const,
+            codeModeNestedPostToolUse: false as const,
           },
         }
       : {};
@@ -7382,6 +7393,21 @@ export class CodexAppServerClient {
               : {}),
             ...(typeof continuationGuidanceVersion === "number"
               ? { continuationGuidanceVersion }
+              : {}),
+            ...(deferredCompletion?.version === 1
+              && deferredCompletion.terminalOnly === true
+              && deferredCompletion.preservesOriginalCallId === true
+              && deferredCompletion.preservesCellId === true
+              && deferredCompletion.waitToolName === "wait"
+              ? {
+                  deferredCompletion: {
+                    version: 1 as const,
+                    terminalOnly: true as const,
+                    preservesOriginalCallId: true as const,
+                    preservesCellId: true as const,
+                    waitToolName: "wait" as const,
+                  },
+                }
               : {}),
             ...(dynamicToolsResumeField
               ? { dynamicToolsResumeField }

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -920,7 +920,7 @@ export type AppServerReadThreadResponse = {
    */
   readDurationMs?: number;
   threadId: ThreadIdentifier;
-  /** Persisted per-thread Token Miser override; absent follows the default. */
+  /** Effective Token Miser state for this thread. */
   tokenMiserEnabled?: boolean;
   replay: AppServerThreadReplay;
   /**

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -508,6 +508,8 @@ export type ThreadReadEntrySummary =
 export type ThreadReadResult = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  /** Effective Token Miser state when the owning backend is Codex. */
+  tokenMiserEnabled?: boolean;
   instanceId?: FederationInstanceId;
   instanceLabel?: string;
   title?: string;


### PR DESCRIPTION
## Summary

- I parse the deferred Code Mode completion capability and native nested-hook policy added by pwrdrvr/codex#13.
- I require the complete managed Token Miser contract before sending native activation, configuring a managed reducer, or reporting the runtime as active.
- I keep incomplete managed runtimes unavailable instead of silently falling back to the legacy hook path.
- I preserve the older native activation transport for explicit `null` disable signals, so an incomplete runtime cannot remain enabled after an opt-out.
- I added positive and negative coverage for deferred completion, parent-intent preservation, cell/call identity claims, and nested PostToolUse disablement.
- I fixed the macOS quit-confirmation E2E race exposed by CI by waiting for the authoritative main-process blocker snapshot before requesting quit.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` (735 tests passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/quit-confirmation-dialog.spec.ts --list`
- `git diff --check`

## Notes

- This branches from fetched `origin/main` at the squash merge of #1859 (`983ecfccb872b218f90fd2fba8bdc5af8b6531da`).
- The server-side capability fields are owned by pwrdrvr/codex#13. Token Miser remains not evaluation-ready until an immutable managed runtime at or above `.2` passes the separate artifact, entitlement, ARM64 Electron, deferred-result, telemetry, and correctness acceptance checks.
