### PR TITLE
fix(desktop): name concurrently launched threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18466,6 +18466,74 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("starts one Codex title helper for every concurrent explicit placeholder", async () => {
+    const titleGenerationRelease = createDeferred<void>();
+    const titleService = {
+      generateTitle: vi.fn(async ({ threadId }: { threadId: string }) => {
+        await titleGenerationRelease.promise;
+        return {
+          status: "generated" as const,
+          title: `Title for ${threadId}`,
+        };
+      }),
+    };
+    const threadIds = [
+      "thread-parallel-1",
+      "thread-parallel-2",
+      "thread-parallel-3",
+    ];
+    const overlayStore = createOverlayStoreMock();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: threadIds.map((threadId) => ({
+        id: threadId,
+        // Codex reports PwrAgent's initial placeholder rename as explicit. If
+        // the prompt-derived rename then loses a parallel session-metadata
+        // race, this is the title state the helper eligibility check sees.
+        title: "Untitled thread",
+        titleSource: "explicit",
+        linkedDirectories: [],
+        source: "codex",
+      })),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      threadTitleGenerationService: titleService,
+    });
+
+    const starts = threadIds.map((threadId) =>
+      registry.startTurn({
+        backend: "codex",
+        threadId,
+        input: [{ type: "text", text: `Prompt for ${threadId}` }],
+      }),
+    );
+
+    await waitForCondition(
+      () => titleService.generateTitle.mock.calls.length === threadIds.length,
+    );
+    for (const threadId of threadIds) {
+      await expect(
+        overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId,
+        }),
+      ).resolves.toMatchObject({
+        subAgents: [
+          expect.objectContaining({
+            monitorId: `system:title-helper:codex:${threadId}`,
+            status: "running",
+          }),
+        ],
+      });
+    }
+
+    titleGenerationRelease.resolve();
+    await Promise.all(starts);
+    await registry.close();
+  });
+
   it("logs Codex title generation failures to the main log", async () => {
     mainLoggerMock.warn.mockClear();
     const titleService = {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18469,11 +18469,11 @@ command = "pnpm dev"
   it("starts one Codex title helper for every concurrent explicit placeholder", async () => {
     const titleGenerationRelease = createDeferred<void>();
     const titleService = {
-      generateTitle: vi.fn(async ({ threadId }: { threadId: string }) => {
+      generateTitle: vi.fn(async ({ threadId }: { threadId?: string }) => {
         await titleGenerationRelease.promise;
         return {
           status: "generated" as const,
-          title: `Title for ${threadId}`,
+          title: `Title for ${threadId ?? "thread"}`,
         };
       }),
     };

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18496,12 +18496,24 @@ command = "pnpm dev"
         source: "codex",
       })),
     });
+    const pendingThreadIds = [...threadIds];
+    vi.spyOn(codexClient, "startThread").mockImplementation(async () => ({
+      threadId: pendingThreadIds.shift() ?? "unexpected-thread",
+    }));
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
       threadTitleGenerationService: titleService,
     });
 
+    await Promise.all(
+      threadIds.map((threadId) =>
+        registry.startThread({
+          backend: "codex",
+          cwd: `/repo/${threadId}`,
+        }),
+      ),
+    );
     const starts = threadIds.map((threadId) =>
       registry.startTurn({
         backend: "codex",
@@ -18531,6 +18543,72 @@ command = "pnpm dev"
 
     titleGenerationRelease.resolve();
     await Promise.all(starts);
+    await registry.close();
+  });
+
+  it("preserves an explicit Untitled thread rename while its title helper finishes", async () => {
+    const titleGenerationRelease = createDeferred<void>();
+    const titleService = {
+      generateTitle: vi.fn(async () => {
+        await titleGenerationRelease.promise;
+        return {
+          status: "generated" as const,
+          title: "Generated replacement",
+        };
+      }),
+    };
+    const threadId = "thread-explicit-placeholder";
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgent = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      startThreadResult: { threadId },
+      threads: [
+        {
+          id: threadId,
+          title: "Untitled thread",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const renameThread = vi.spyOn(codexClient, "renameThread");
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startThread({
+      backend: "codex",
+      cwd: "/repo/explicit-placeholder",
+    });
+    await registry.startTurn({
+      backend: "codex",
+      threadId,
+      input: [{ type: "text", text: "Name this work" }],
+    });
+    await waitForCondition(() => titleService.generateTitle.mock.calls.length === 1);
+
+    await registry.renameThread({
+      backend: "codex",
+      threadId,
+      name: "Untitled thread",
+    });
+    titleGenerationRelease.resolve();
+    await waitForCondition(() =>
+      upsertSubAgent.mock.calls.some(
+        ([params]) => params.subAgent.status === "success",
+      ),
+    );
+
+    expect(renameThread).toHaveBeenCalledTimes(1);
+    expect(renameThread).toHaveBeenCalledWith({
+      threadId,
+      name: "Untitled thread",
+    });
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6065,6 +6065,7 @@ function buildPromptHash(prompt: string): string {
 function isEligibleForGeneratedTitle(
   thread: AppServerThreadSummary | undefined,
   prompt: string,
+  options?: { systemPlaceholder?: boolean },
 ): boolean {
   if (!thread) {
     return true;
@@ -6072,11 +6073,11 @@ function isEligibleForGeneratedTitle(
   if (isPromptPlaceholderTitle(thread.title, prompt)) {
     return true;
   }
-  if (isGenericPlaceholderTitle(thread.title)) {
-    return true;
-  }
   if (thread.titleSource === "explicit") {
-    return false;
+    return Boolean(
+      options?.systemPlaceholder
+      && isGenericPlaceholderTitle(thread.title),
+    );
   }
   if (isInjectedContextPlaceholderTitle(thread.title)) {
     return true;
@@ -7717,6 +7718,8 @@ export class DesktopBackendRegistry {
    */
   private readonly codexEnvironmentRuntimeLocks = new PerKeyAsyncLock();
   private readonly attemptedTitleGenerations = new Set<string>();
+  /** Launch placeholders stay helper-eligible until renamed or attempted. */
+  private readonly systemPlaceholderTitleThreadKeys = new Set<string>();
   private readonly repairedDirectoryThreadKeys = new Set<string>();
   private readonly failedDirectoryRelationshipLogKeys = new Set<string>();
   private readonly pendingCodexWorkspaceCwdSyncs = new Map<
@@ -11288,6 +11291,12 @@ export class DesktopBackendRegistry {
     request: RenameThreadRequest,
   ): Promise<RenameThreadResponse> {
     const backend = request.backend ?? "codex";
+    // A rename supersedes PwrAgent's launch placeholder. Clear this before the
+    // provider round trip so an in-flight title helper's late eligibility
+    // check cannot overwrite an operator rename that is still being accepted.
+    this.systemPlaceholderTitleThreadKeys.delete(
+      buildThreadIdentityKey(backend, request.threadId),
+    );
     let result: { threadId: string };
     if (isAcpBackendId(backend)) {
       result = await this.renameAcpSession(backend, request.threadId, request.name);
@@ -12759,6 +12768,9 @@ export class DesktopBackendRegistry {
           : {}),
       },
     );
+    if (!agentName) {
+      this.systemPlaceholderTitleThreadKeys.add(pendingThreadKey);
+    }
     if (effectiveWorkMode === "worktree") {
       await this.recordCodexWorktreeOwnerThread({
         backend,
@@ -26344,7 +26356,11 @@ export class DesktopBackendRegistry {
         callerReason: "title-generation",
         threadId: params.threadId,
       });
-      if (!isEligibleForGeneratedTitle(currentThread, params.prompt)) {
+      if (
+        !isEligibleForGeneratedTitle(currentThread, params.prompt, {
+          systemPlaceholder: this.systemPlaceholderTitleThreadKeys.has(params.key),
+        })
+      ) {
         this.logThreadTitleGeneration(
           "skipped",
           params,
@@ -26429,7 +26445,12 @@ export class DesktopBackendRegistry {
         callerReason: "title-generation",
         threadId: params.threadId,
       });
-      if (latestThread && !isEligibleForGeneratedTitle(latestThread, params.prompt)) {
+      if (
+        latestThread
+        && !isEligibleForGeneratedTitle(latestThread, params.prompt, {
+          systemPlaceholder: this.systemPlaceholderTitleThreadKeys.has(params.key),
+        })
+      ) {
         this.logThreadTitleGeneration(
           "skipped",
           params,
@@ -26491,6 +26512,7 @@ export class DesktopBackendRegistry {
       if (pending?.token === params.token) {
         this.pendingTitleGenerations.delete(params.key);
       }
+      this.systemPlaceholderTitleThreadKeys.delete(params.key);
     }
   }
 
@@ -26561,7 +26583,14 @@ export class DesktopBackendRegistry {
       callerReason: "title-generation",
       threadId: params.threadId,
     });
-    if (latestThread && !isEligibleForGeneratedTitle(latestThread, params.prompt)) {
+    if (
+      latestThread
+      && !isEligibleForGeneratedTitle(latestThread, params.prompt, {
+        systemPlaceholder: this.systemPlaceholderTitleThreadKeys.has(
+          buildTitleGenerationKey(params.backend, params.threadId),
+        ),
+      })
+    ) {
       return;
     }
     await this.renameAcpSession(params.backend, params.threadId, title, {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6072,6 +6072,9 @@ function isEligibleForGeneratedTitle(
   if (isPromptPlaceholderTitle(thread.title, prompt)) {
     return true;
   }
+  if (isGenericPlaceholderTitle(thread.title)) {
+    return true;
+  }
   if (thread.titleSource === "explicit") {
     return false;
   }
@@ -6084,10 +6087,6 @@ function isEligibleForGeneratedTitle(
       isAcpFallbackPlaceholderTitle(thread.title)
     );
   }
-  if (isGenericPlaceholderTitle(thread.title)) {
-    return true;
-  }
-
   const derivedTitle = shortenDerivedThreadTitle(prompt) ?? prompt;
   return normalizeTitleForComparison(thread.title) === normalizeTitleForComparison(derivedTitle);
 }


### PR DESCRIPTION
## Summary

- I keep PwrAgent's system-created `Untitled thread` launch placeholder eligible for generated titles while preserving an operator's explicit rename to the same text.
- I added regressions that start three first turns concurrently and that rename an in-flight helper's parent to `Untitled thread`, verifying both helper creation and operator-title preservation.
- I traced the production failure to parallel prompt-derived rename errors leaving the initial placeholder classified as explicit; the title-helper maps themselves are already keyed per thread.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (574 tests)
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t 'title helper|title generation|generated Codex thread titles'` (13 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Notes

- I diagnosed this from the supplied PwrAgent main-process log without controlling, restarting, signaling, or mutating the running eval instance or its profiles.
- The log showed the affected thread and seven sibling launches failing their prompt-derived Codex rename with a session-metadata read error. That left `Untitled thread` as the last observed explicit name, which previously suppressed title-helper creation.
