### PR TITLE
feat(desktop): price GPT-5.6 Sol at August 21 rates

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -23528,7 +23528,7 @@ command = "pnpm dev"
       inputTokens: 10_254_903,
       outputTokens: 10_356,
       reasoningOutputTokens: 3_023,
-      totalCostMicros: 6_699_501,
+      totalCostMicros: 5_306_085,
       totalTokens: 10_265_259,
       turnUsageAttributed: true,
       uncachedInputTokens: 260_151,

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -298,6 +298,45 @@ describe("token usage pricing", () => {
     });
   });
 
+  it("prices current GPT-5.6 Sol, Terra, and Luna at the published list rates", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, "2026-08-21", 24_400_000, 4, 0.4, 20],
+      ["gpt-5.6-sol", true, "2026-08-21", 48_800_000, 8, 0.8, 40],
+      ["gpt-5.6-terra", false, "2026-07-30", 14_200_000, 2, 0.2, 12],
+      ["gpt-5.6-terra", true, "2026-07-30", 28_400_000, 4, 0.4, 24],
+      ["gpt-5.6-luna", false, "2026-07-30", 1_420_000, 0.2, 0.02, 1.2],
+      ["gpt-5.6-luna", true, "2026-07-30", 2_840_000, 0.4, 0.04, 2.4],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      catalogVersion,
+      totalCostMicros,
+      inputUsdPerMillion,
+      cachedInputUsdPerMillion,
+      outputUsdPerMillion,
+    ] of cases) {
+      const cost = estimateOpenAiTokenUsageCost({
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(cost).toMatchObject({
+        catalogVersion,
+        cachedInputUsdPerMillion,
+        inputUsdPerMillion,
+        outputUsdPerMillion,
+        rateId: `openai:${catalogVersion}:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
+        totalCostMicros,
+      });
+    }
+  });
+
   it("does not price GPT-5.6 usage before its catalog effective date", () => {
     expect(
       estimateOpenAiTokenUsageCost({
@@ -544,6 +583,21 @@ describe("token usage pricing", () => {
     expect(listOpenAiTokenUsagePricingRates()).toContainEqual(
       expect.objectContaining({
         catalogId: "openai-api",
+        catalogVersion: "2026-07-30",
+        currency: "USD",
+        displayName: "GPT-5.6 Terra Standard",
+        inputMicrosPerMillion: 2_000_000,
+        cachedInputMicrosPerMillion: 200_000,
+        outputMicrosPerMillion: 12_000_000,
+        model: "gpt-5.6-terra",
+        provider: "openai",
+        rateId: "openai:2026-07-30:gpt-5.6-terra:standard",
+        serviceTier: "standard",
+      }),
+    );
+    expect(listOpenAiTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        catalogId: "openai-api",
         catalogVersion: "2026-08-21",
         currency: "USD",
         displayName: "GPT-5.6 Sol Standard",
@@ -766,6 +820,50 @@ describe("token usage pricing", () => {
         outputCreditsPerMillion,
         provider: "openai",
         rateId: `openai:2026-08-21:codex-credits:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
+        totalCreditMicros,
+        totalCredits: totalCreditMicros / 1_000_000,
+      });
+    }
+  });
+
+  it("estimates current GPT-5.6 Codex Credits at the published list rates", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, "2026-08-21", "GPT-5.6 Sol Standard", 100, 10, 500, 610_000_000],
+      ["gpt-5.6-sol", true, "2026-08-21", "GPT-5.6 Sol Fast", 250, 25, 1250, 1_525_000_000],
+      ["gpt-5.6-terra", false, "2026-07-30", "GPT-5.6 Terra Standard", 50, 5, 300, 355_000_000],
+      ["gpt-5.6-terra", true, "2026-07-30", "GPT-5.6 Terra Fast", 125, 12.5, 750, 887_500_000],
+      ["gpt-5.6-luna", false, "2026-07-30", "GPT-5.6 Luna Standard", 5, 0.5, 30, 35_500_000],
+      ["gpt-5.6-luna", true, "2026-07-30", "GPT-5.6 Luna Fast", 12.5, 1.25, 75, 88_750_000],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      catalogVersion,
+      displayName,
+      inputCreditsPerMillion,
+      cachedInputCreditsPerMillion,
+      outputCreditsPerMillion,
+      totalCreditMicros,
+    ] of cases) {
+      const credits = estimateOpenAiCodexCreditUsage({
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(credits).toMatchObject({
+        catalogId: "openai-codex-credits",
+        catalogVersion,
+        displayName,
+        inputCreditsPerMillion,
+        cachedInputCreditsPerMillion,
+        outputCreditsPerMillion,
+        provider: "openai",
+        rateId: `openai:${catalogVersion}:codex-credits:${model}:${fastMode ? "priority" : "standard"}`,
         serviceTier: fastMode ? "priority" : "standard",
         totalCreditMicros,
         totalCredits: totalCreditMicros / 1_000_000,

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -244,6 +244,60 @@ describe("token usage pricing", () => {
     }
   });
 
+  it("prices GPT-5.6 Sol at the reduced August 21 rates", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, 24_400_000, 4, 0.4, 20],
+      ["gpt-5.6-sol", true, 48_800_000, 8, 0.8, 40],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      totalCostMicros,
+      inputUsdPerMillion,
+      cachedInputUsdPerMillion,
+      outputUsdPerMillion,
+    ] of cases) {
+      const cost = estimateOpenAiTokenUsageCost({
+        at: Date.UTC(2026, 7, 21),
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(cost).toMatchObject({
+        catalogVersion: "2026-08-21",
+        cachedInputUsdPerMillion,
+        inputUsdPerMillion,
+        outputUsdPerMillion,
+        rateId: `openai:2026-08-21:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
+        totalCostMicros,
+      });
+    }
+  });
+
+  it("keeps GPT-5.6 Sol on the July 9 rates until August 21", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 7, 20, 23, 59, 59),
+      cachedInputTokens: 1_000_000,
+      model: "gpt-5.6-sol",
+      outputTokens: 1_000_000,
+      uncachedInputTokens: 1_000_000,
+    });
+
+    expect(cost).toMatchObject({
+      catalogVersion: "2026-07-09",
+      inputUsdPerMillion: 5,
+      cachedInputUsdPerMillion: 0.5,
+      outputUsdPerMillion: 30,
+      rateId: "openai:2026-07-09:gpt-5.6-sol:standard",
+      totalCostMicros: 35_500_000,
+    });
+  });
+
   it("does not price GPT-5.6 usage before its catalog effective date", () => {
     expect(
       estimateOpenAiTokenUsageCost({
@@ -487,6 +541,21 @@ describe("token usage pricing", () => {
         serviceTier: "priority",
       }),
     );
+    expect(listOpenAiTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        catalogId: "openai-api",
+        catalogVersion: "2026-08-21",
+        currency: "USD",
+        displayName: "GPT-5.6 Sol Standard",
+        inputMicrosPerMillion: 4_000_000,
+        cachedInputMicrosPerMillion: 400_000,
+        outputMicrosPerMillion: 20_000_000,
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        rateId: "openai:2026-08-21:gpt-5.6-sol:standard",
+        serviceTier: "standard",
+      }),
+    );
     expect(listTokenUsagePricingRates()).toContainEqual(
       expect.objectContaining({
         cachedInputUsdPerMillion: 0.5,
@@ -658,6 +727,46 @@ describe("token usage pricing", () => {
         provider: "openai",
         rateId: `openai:2026-07-30:codex-credits:${model}:priority`,
         serviceTier: "priority",
+        totalCreditMicros,
+        totalCredits: totalCreditMicros / 1_000_000,
+      });
+    }
+  });
+
+  it("estimates reduced GPT-5.6 Sol Codex Credits from August 21", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, "GPT-5.6 Sol Standard", 100, 10, 500, 610_000_000],
+      ["gpt-5.6-sol", true, "GPT-5.6 Sol Fast", 250, 25, 1250, 1_525_000_000],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      displayName,
+      inputCreditsPerMillion,
+      cachedInputCreditsPerMillion,
+      outputCreditsPerMillion,
+      totalCreditMicros,
+    ] of cases) {
+      const credits = estimateOpenAiCodexCreditUsage({
+        at: Date.UTC(2026, 7, 21),
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(credits).toMatchObject({
+        catalogId: "openai-codex-credits",
+        catalogVersion: "2026-08-21",
+        displayName,
+        inputCreditsPerMillion,
+        cachedInputCreditsPerMillion,
+        outputCreditsPerMillion,
+        provider: "openai",
+        rateId: `openai:2026-08-21:codex-credits:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
         totalCreditMicros,
         totalCredits: totalCreditMicros / 1_000_000,
       });

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -265,6 +265,9 @@ const OPENAI_GPT56_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 9);
 // https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/
 const OPENAI_GPT56_REPRICING_CATALOG_VERSION = "2026-07-30";
 const OPENAI_GPT56_REPRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 30);
+// https://developers.openai.com/api/docs/models/gpt-5.6-sol
+const OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION = "2026-08-21";
+const OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM = Date.UTC(2026, 7, 21);
 const OPENAI_CODEX_CREDITS_CATALOG_ID = "openai-codex-credits";
 const OPENAI_CODEX_CREDITS_CATALOG_VERSION = "2026-06-16";
 const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-27";
@@ -292,6 +295,32 @@ const QWEN_PRICING_CATALOG_VERSION = "2026-07-15";
 const QWEN37_PLUS_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 4, 26);
 
 const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION,
+    model: "gpt-5.6-sol",
+    displayModel: "GPT-5.6 Sol",
+    displayTier: "Standard",
+    effectiveFrom: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "standard",
+    inputUsdPerMillion: 4,
+    cachedInputUsdPerMillion: 0.4,
+    outputUsdPerMillion: 20,
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION,
+    model: "gpt-5.6-sol",
+    displayModel: "GPT-5.6 Sol",
+    displayTier: "Fast",
+    effectiveFrom: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "priority",
+    inputUsdPerMillion: 8,
+    cachedInputUsdPerMillion: 0.8,
+    outputUsdPerMillion: 40,
+  },
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT56_REPRICING_CATALOG_VERSION,
@@ -351,6 +380,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.6 Sol",
     displayTier: "Standard",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
+    effectiveTo: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "standard",
     inputUsdPerMillion: 5,
@@ -364,6 +394,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.6 Sol",
     displayTier: "Fast (Priority)",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
+    effectiveTo: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "priority",
     inputUsdPerMillion: 10,
@@ -627,10 +658,23 @@ function buildCodexCreditsCatalogEntries(params: {
 
 const OPENAI_CODEX_CREDITS_CATALOG: readonly CodexCreditsCatalogEntry[] = [
   ...buildCodexCreditsCatalogEntries({
+    catalogVersion: OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION,
+    model: "gpt-5.6-sol",
+    displayModel: "GPT-5.6 Sol",
+    effectiveFrom: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
+    fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.6"],
+    standardRates: {
+      inputCreditsPerMillion: 100,
+      cachedInputCreditsPerMillion: 10,
+      outputCreditsPerMillion: 500,
+    },
+  }),
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.6-sol",
     displayModel: "GPT-5.6 Sol",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
+    effectiveTo: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
     fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.6"],
     standardRates: {
       inputCreditsPerMillion: 125,


### PR DESCRIPTION
## Summary

GPT-5.6 Sol's published API list rate became **$4 input / $20 output per 1M tokens** on **2026-08-21**.

OpenAI announced the cut that day as "starting today" and a >20% drop for the next 3 months:

- [@OpenAI, 2026-08-21 19:34 GMT](https://x.com/OpenAI/status/2090885187634905500)
- [OpenAI Developer Community announcement](https://community.openai.com/t/20-price-reduction-for-gpt-5-6-sol-api-codex-credits-and-chatgpt-work/1391726)
- Current list on [GPT-5.6 Sol model docs](https://developers.openai.com/api/docs/models/gpt-5.6-sol) and the [API pricing page](https://developers.openai.com/api/docs/pricing)

Checked the same live pricing page for Terra and Luna. Those Standard and Fast short-context rates did **not** move on August 21; they still match the July 30 cut already in the catalog.

| Model | Current Standard | Current Fast (2x API) | Current since |
| --- | --- | --- | --- |
| GPT-5.6 Sol | $4 / $0.40 / $20 | $8 / $0.80 / $40 | 2026-08-21 |
| GPT-5.6 Terra | $2 / $0.20 / $12 | $4 / $0.40 / $24 | 2026-07-30 |
| GPT-5.6 Luna | $0.20 / $0.02 / $1.20 | $0.40 / $0.04 / $2.40 | 2026-07-30 |

Sol before August 21 stays on the July 9 launch rates ($5 / $0.50 / $30). Codex credits follow the same 25 credits-per-dollar mapping.

OpenAI still describes the Sol $4/$20 rates as promotional and available at least through 2026-11-21. This catalog treats the published list as current and does not invent a revert date.

Not modeled here (unchanged from the existing catalog): cache writes (1.25x uncached input) and long-context requests (>272K, 2x input / 1.5x output).

## Test plan

- [x] `pnpm test packages/shared/src/__tests__/token-usage-pricing.test.ts`
- [x] Confirmed live OpenAI Standard/Fast short-context rates for Terra and Luna
- [ ] Confirm a Sol turn dated before 2026-08-21 still estimates at $5/$30
- [ ] Confirm a current Sol turn estimates at $4/$20
- [ ] Confirm current Terra/Luna turns estimate at $2/$12 and $0.20/$1.20