### PR TITLE
fix(desktop): run inline reviews on parent threads

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -2000,25 +2000,33 @@ test.describe("federation remote window", () => {
       const setupMtimeMs = statSync(setupMarkerPath).mtimeMs;
       expect(setupMtimeMs).toBeLessThanOrEqual(threadStart!.at + 5_000);
 
-      // Starting a native review continues asynchronously after child
+      // Starting the inline review turn continues asynchronously after child
       // materialization. Wait for the durable request instead of assuming it
       // has arrived as soon as thread/start is observable on a slower VM.
       await expect
         .poll(async () => {
           const entries = await readFakeCodexRequestLog(requestLogPath);
-          return findAllFakeCodexRequests(entries, "review/start").length;
+          return findAllFakeCodexRequests(entries, "turn/start").length;
         }, { timeout: 30_000 })
         .toBeGreaterThan(0);
 
       protocol = await readFakeCodexRequestLog(requestLogPath);
       const initialize = findFakeCodexRequest(protocol, "initialize");
       threadStart = findFakeCodexRequest(protocol, "thread/start");
-      const reviewStart = findFakeCodexRequest(protocol, "review/start");
+      const reviewTurnStart = findFakeCodexRequest(protocol, "turn/start");
       expect(initialize).toBeTruthy();
       expect(threadStart).toBeTruthy();
-      expect(reviewStart).toBeTruthy();
+      expect(reviewTurnStart).toBeTruthy();
+      expect(reviewTurnStart!.params).toMatchObject({
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
+      });
       expect(initialize!.at).toBeLessThanOrEqual(threadStart!.at);
-      expect(threadStart!.at).toBeLessThanOrEqual(reviewStart!.at);
+      expect(threadStart!.at).toBeLessThanOrEqual(reviewTurnStart!.at);
     } finally {
       if (testInfo.status !== testInfo.expectedStatus) await testInfo.attach("navigation-diagnostics", {
         body: navigationDiagnostics.join("\n"), contentType: "text/plain",

--- a/apps/desktop/e2e/fixtures/review-command-flow/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-command-flow/replay.fixture.json
@@ -19,8 +19,7 @@
           "thread/list",
           "thread/read",
           "skills/list",
-          "turn/start",
-          "review/start"
+          "turn/start"
         ]
       }
     },
@@ -86,12 +85,11 @@
       }
     },
     {
-      "id": "review-start-1",
+      "id": "review-turn-start-1",
       "kind": "response",
-      "method": "review/start",
+      "method": "turn/start",
       "result": {
         "threadId": "thread-review-command",
-        "reviewThreadId": "thread-review-command",
         "turnId": "turn-review-1"
       }
     },

--- a/apps/desktop/e2e/fixtures/review-multiple-findings/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-multiple-findings/replay.fixture.json
@@ -19,7 +19,7 @@
           "thread/list",
           "thread/read",
           "skills/list",
-          "review/start"
+          "turn/start"
         ]
       }
     },
@@ -73,12 +73,11 @@
       }
     },
     {
-      "id": "review-start-1",
+      "id": "review-turn-start-1",
       "kind": "response",
-      "method": "review/start",
+      "method": "turn/start",
       "result": {
         "threadId": "019dd4ce-4fec-76c0-8ede-5e65d7377417",
-        "reviewThreadId": "019dd4ce-4fec-76c0-8ede-5e65d7377417",
         "turnId": "019dd6fe-485f-7f73-bf6e-16ff7911fadb"
       }
     },

--- a/apps/desktop/e2e/fixtures/review-output-rendering/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-output-rendering/replay.fixture.json
@@ -19,7 +19,7 @@
           "thread/list",
           "thread/read",
           "skills/list",
-          "review/start"
+          "turn/start"
         ]
       }
     },
@@ -81,12 +81,11 @@
       }
     },
     {
-      "id": "review-start-1",
+      "id": "review-turn-start-1",
       "kind": "response",
-      "method": "review/start",
+      "method": "turn/start",
       "result": {
         "threadId": "019dd682-56d6-7601-8634-fc3a49e67554",
-        "reviewThreadId": "019dd682-56d6-7601-8634-fc3a49e67554",
         "turnId": "019dd6d5-91fa-7820-acb5-8ebd37da76e4"
       }
     },

--- a/apps/desktop/e2e/queued-review-release.spec.ts
+++ b/apps/desktop/e2e/queued-review-release.spec.ts
@@ -68,7 +68,6 @@ async function createQueuedReviewReleaseFixture(): Promise<{
                 "thread/list",
                 "thread/read",
                 "turn/start",
-                "review/start",
               ],
             },
           },
@@ -147,12 +146,11 @@ async function createQueuedReviewReleaseFixture(): Promise<{
             },
           },
           {
-            id: "review-start-1",
+            id: "review-turn-start-1",
             kind: "response",
-            method: "review/start",
+            method: "turn/start",
             result: {
               threadId: "thread-active",
-              reviewThreadId: "thread-active",
               turnId: "turn-review",
             },
           },
@@ -314,14 +312,15 @@ test("background queued review releases after active turn branch adoption", asyn
     await app.advance({ stepId: "turn-completed-1" });
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "thread-active",
-        target: {
-          type: "baseBranch",
-          branch: "main",
-        },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
   } finally {
     await app.close();

--- a/apps/desktop/e2e/review-command-flow.spec.ts
+++ b/apps/desktop/e2e/review-command-flow.spec.ts
@@ -35,7 +35,7 @@ test("review command asks for target and preserves transcript order", async () =
     const reviewTarget = app.window.getByRole("group", { name: "Review target" });
     await expect(reviewTarget).toBeVisible();
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toBeUndefined();
 
     await reviewTarget.getByRole("combobox", { name: "Base branch" }).click();
@@ -43,11 +43,15 @@ test("review command asks for target and preserves transcript order", async () =
     await reviewTarget.getByRole("button", { name: "Start review" }).click();
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "thread-review-command",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
 
     const transcript = app.window.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/e2e/review-multiple-findings.spec.ts
+++ b/apps/desktop/e2e/review-multiple-findings.spec.ts
@@ -30,11 +30,15 @@ test("renders captured Codex review findings as separate cards without duplicate
     await app.window.getByRole("button", { name: "Send" }).click();
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "019dd4ce-4fec-76c0-8ede-5e65d7377417",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
 
     const transcript = app.window.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/e2e/review-output-rendering.spec.ts
+++ b/apps/desktop/e2e/review-output-rendering.spec.ts
@@ -34,11 +34,15 @@ test("renders captured Codex review findings once in the review card", async () 
     await app.window.getByRole("button", { name: "Send" }).click();
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "019dd682-56d6-7601-8634-fc3a49e67554",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
 
     const transcript = app.window.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -27403,7 +27403,7 @@ command = "pnpm dev"
       await registry.listBackends({ includeUnavailable: true })
     ).backends.find((backend) => backend.kind === "codex");
     expect(codexBackend?.capabilities.startReview).toBe(true);
-    expect(codexBackend?.capabilities.startDetachedReview).toBe(false);
+    expect(codexBackend?.capabilities.startDetachedReview).toBe(true);
 
     const response = await registry.startReview({
       backend: "codex",
@@ -28931,7 +28931,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("persists native review provenance on the existing sub-agent write", async () => {
+  it("persists detached native review provenance on the existing sub-agent write", async () => {
     const context: AppServerReviewContext = {
       workspacePath: "/repo",
       projectLabel: "PwrAgent",
@@ -28968,7 +28968,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "origin/main" },
-      delivery: "inline",
+      delivery: "detached",
     });
 
     await expect(

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1680,6 +1680,7 @@ class MockBackendClient {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: unknown;
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   };
   interruptTurnCallCount = 0;
   lastInterruptTurnParams?: {
@@ -2129,6 +2130,7 @@ class MockBackendClient {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: unknown;
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{ threadId: string; turnId: string }> {
     this.startTurnCallCount += 1;
     await this.options.startTurnDelay;
@@ -17944,10 +17946,9 @@ command = "pnpm grok"
   });
 
   it("names a thread launched straight into a review", async () => {
-    // A /review launch never calls startTurn, so the thread was born with no
-    // user prompt for the title generator to work from and kept its fallback
-    // name forever. Synthesize a prompt from what the review already knows:
-    // the repository, the branch, and the review target.
+    // The inline turn uses an internal review prompt. Keep that prompt out of
+    // Codex's derived-name path and synthesize the public title prompt from
+    // what the review already knows: repository, branch, and review target.
     const titleService = {
       generateTitle: vi.fn(async (_params: { userPrompt: string }) => ({
         status: "generated" as const,
@@ -17956,7 +17957,7 @@ command = "pnpm grok"
     };
     const codexClient = new MockBackendClient({
       initializeResult: {
-        methods: ["thread/start", "thread/name/set", "review/start"],
+        methods: ["thread/start", "thread/name/set", "turn/start"],
       },
       threads: [],
     });
@@ -17998,6 +17999,9 @@ command = "pnpm grok"
       threadId: "thread-1",
       name: "Review app against main",
     });
+    expect(codexClient.lastStartTurnParams?.suppressThreadTitleDerivation).toBe(
+      true,
+    );
 
     await registry.close();
   });
@@ -27399,6 +27403,7 @@ command = "pnpm dev"
       await registry.listBackends({ includeUnavailable: true })
     ).backends.find((backend) => backend.kind === "codex");
     expect(codexBackend?.capabilities.startReview).toBe(true);
+    expect(codexBackend?.capabilities.startDetachedReview).toBe(false);
 
     const response = await registry.startReview({
       backend: "codex",
@@ -27436,6 +27441,116 @@ command = "pnpm dev"
           ),
         },
       ],
+    });
+
+    await registry.close();
+  });
+
+  it("does not restore an inline review as active when its terminal event precedes turn/start", async () => {
+    const startTurnDelay = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      startTurnDelay: startTurnDelay.promise,
+      startTurnResults: [{ threadId: "thread-parent", turnId: "turn-fast-review" }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const review = registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    await vi.waitFor(() => {
+      expect(codexClient.startTurnCallCount).toBe(1);
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-fast-review",
+        turn: {
+          id: "turn-fast-review",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+    startTurnDelay.resolve();
+
+    await expect(review).resolves.toMatchObject({
+      threadId: "thread-parent",
+      reviewThreadId: "thread-parent",
+      turnId: "turn-fast-review",
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
+    await expect(registry.startTurn({
+      backend: "codex",
+      threadId: "thread-parent",
+      input: [{ type: "text", text: "Continue after the fast review" }],
+    })).resolves.toMatchObject({ threadId: "thread-parent" });
+
+    await registry.close();
+  });
+
+  it("rejects detached Codex review when neither native nor managed-child support exists", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "detached",
+    })).rejects.toThrow(/detached review/i);
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("falls back to a managed child for detached Codex review without review/start", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startThreadResult: { threadId: "managed-detached-review" },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const codexBackend = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends.find((backend) => backend.kind === "codex");
+    expect(codexBackend?.capabilities.startDetachedReview).toBe(true);
+
+    const response = await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "detached",
+    });
+
+    expect(response).toMatchObject({
+      threadId: "thread-parent",
+      reviewThreadId: "managed-detached-review",
+      turnId: "turn-1",
+    });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+    expect(codexClient.lastStartThreadParams).toMatchObject({
+      ephemeral: false,
+      threadSource: "subagent",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5194,7 +5194,7 @@ describe("DesktopBackendRegistry", () => {
     });
   });
 
-  it("configures the code-mode reducer before a native Token Miser review", async () => {
+  it("configures the code-mode reducer before an inline Token Miser review", async () => {
     const codexClient = new MockBackendClient({
       threads: [],
       serverCapabilities: {
@@ -5243,7 +5243,7 @@ describe("DesktopBackendRegistry", () => {
       });
 
       expect(prepare).toHaveBeenCalledTimes(1);
-      expect(codexClient.lastStartReviewParams?.config).toMatchObject({
+      expect(codexClient.lastStartTurnParams?.config).toMatchObject({
         features: {
           code_mode: {
             output_reducer: {
@@ -5257,7 +5257,7 @@ describe("DesktopBackendRegistry", () => {
         },
       });
       const dynamicToolNames = pwragentDynamicTools(
-        codexClient.lastStartReviewParams?.dynamicTools,
+        codexClient.lastStartTurnParams?.dynamicTools,
       ).map((tool) => tool.name);
       expect(dynamicToolNames).toContain("search_threads");
       expect(dynamicToolNames).toEqual(expect.arrayContaining([
@@ -5270,7 +5270,7 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
-  it("does not pass reducer config to native review for another protocol version", async () => {
+  it("does not pass reducer config to inline review for another protocol version", async () => {
     const codexClient = new MockBackendClient({
       threads: [],
       serverCapabilities: {
@@ -5304,13 +5304,13 @@ describe("DesktopBackendRegistry", () => {
       })).resolves.toMatchObject({ threadId: "thread-1" });
 
       expect(prepare).toHaveBeenCalledTimes(1);
-      expect(codexClient.lastStartReviewParams?.config).toBeUndefined();
+      expect(codexClient.lastStartTurnParams?.config).toBeUndefined();
     } finally {
       await registry.close();
     }
   });
 
-  it("removes Token Miser tools from an opted-out native review catalog", async () => {
+  it("removes Token Miser tools from an opted-out inline review catalog", async () => {
     const codexClient = new MockBackendClient({
       threads: [],
       serverCapabilities: {
@@ -5352,13 +5352,13 @@ describe("DesktopBackendRegistry", () => {
       });
 
       const dynamicToolNames = pwragentDynamicTools(
-        codexClient.lastStartReviewParams?.dynamicTools,
+        codexClient.lastStartTurnParams?.dynamicTools,
       ).map((tool) => tool.name);
       expect(dynamicToolNames).toContain("search_threads");
       expect(dynamicToolNames).not.toContain("search_token_miser_output");
       expect(dynamicToolNames).not.toContain("read_token_miser_output");
       expect(dynamicToolNames).not.toContain("read_all_token_miser_output");
-      expect(codexClient.lastStartReviewParams?.config).toBeUndefined();
+      expect(codexClient.lastStartTurnParams?.config).toBeUndefined();
     } finally {
       await registry.close();
     }
@@ -15829,7 +15829,7 @@ script = "echo setup"
       target: { type: "baseBranch", branch: "main" },
     });
 
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",
       cwd: handoffWorktreePath,
     });
@@ -17916,10 +17916,12 @@ command = "pnpm grok"
       serviceTier: "priority",
       fastMode: true,
     });
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",
-      target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("base branch 'main'"),
+      }],
       model: "gpt-5.4",
       reasoningEffort: "high",
       serviceTier: "priority",
@@ -24974,7 +24976,7 @@ command = "pnpm dev"
       fastMode: true,
     });
 
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-env",
       cwd: "/repo/app",
       codexEnvironmentRuntime,
@@ -25018,7 +25020,7 @@ command = "pnpm dev"
     });
 
     // The review itself runs on the picked model...
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       model: "gpt-5.2",
       reasoningEffort: "high",
     });
@@ -27379,6 +27381,66 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("starts inline Codex reviews as turns on the parent thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      startReviewResult: {
+        threadId: "thread-parent",
+        reviewThreadId: "ephemeral-review-thread",
+        turnId: "native-review-turn",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const codexBackend = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends.find((backend) => backend.kind === "codex");
+    expect(codexBackend?.capabilities.startReview).toBe(true);
+
+    const response = await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "origin/main" },
+      delivery: "inline",
+    });
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-parent",
+      reviewThreadId: "thread-parent",
+      turnId: "turn-1",
+    });
+    expect(registry.getActiveTurnForThread({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual({
+      backend: "codex",
+      threadId: "thread-parent",
+      turnId: "turn-1",
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-parent"],
+    });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-parent",
+      input: [
+        {
+          type: "text",
+          text: expect.stringMatching(
+            /Review the code changes[\s\S]*origin\/main[\s\S]*prioritized findings/,
+          ),
+        },
+      ],
+    });
+
+    await registry.close();
+  });
+
   it("treats a Codex review as active until its terminal turn notification", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
@@ -27410,15 +27472,15 @@ command = "pnpm dev"
         input: [{ type: "text", text: "Follow-up while review is running" }],
       }),
     ).rejects.toThrow("A turn is already active for this thread.");
-    expect(codexClient.startTurnCallCount).toBe(0);
+    expect(codexClient.startTurnCallCount).toBe(1);
 
     await codexClient.emit({
       method: "turn/completed",
       params: {
         threadId: "thread-1",
-        turnId: "turn-review-1",
+        turnId: "turn-1",
         turn: {
-          id: "turn-review-1",
+          id: "turn-1",
           status: "completed",
           completedAt: 1_781_178_272,
           output: [],
@@ -27431,7 +27493,7 @@ command = "pnpm dev"
       threadId: "thread-1",
       input: [{ type: "text", text: "Follow-up after review" }],
     });
-    expect(codexClient.startTurnCallCount).toBe(1);
+    expect(codexClient.startTurnCallCount).toBe(2);
 
     await registry.close();
   });
@@ -28894,7 +28956,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("persists Codex reviews as sub-agent summaries on the parent thread", async () => {
+  it("persists detached Codex reviews as sub-agent summaries on the parent thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
       models: [
@@ -28922,7 +28984,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      delivery: "detached",
     });
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
@@ -29045,7 +29107,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("patches Codex review sub-agent usage when usage arrives after completion", async () => {
+  it("patches detached Codex review usage when usage arrives after completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
       startReviewResult: {
@@ -29064,7 +29126,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      delivery: "detached",
     });
 
     await codexClient.emit({
@@ -30172,7 +30234,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      delivery: "detached",
     });
     await codexClient.emit({
       method: "turn/started",
@@ -36461,10 +36523,12 @@ script = "printf setup"
       },
     });
 
-    expect(codexClient.lastStartReviewParams).toEqual({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "parent-thread",
-      target: { type: "uncommittedChanges" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("staged, unstaged, and untracked"),
+      }],
     });
 
     await registry.close();
@@ -36476,7 +36540,7 @@ script = "printf setup"
       initializeResult: {
         methods: ["turn/start", "review/start", "thread/resume"],
       },
-      startReviewDelay: startReviewDelay.promise,
+      startTurnDelay: startReviewDelay.promise,
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -36512,7 +36576,7 @@ script = "printf setup"
       },
     });
     await vi.waitFor(() => {
-      expect(codexClient.lastStartReviewParams).toBeDefined();
+      expect(codexClient.startTurnCallCount).toBe(1);
     });
 
     expect(registry.cancelPendingReview(
@@ -36530,6 +36594,10 @@ script = "printf setup"
       initializeResult: {
         methods: ["turn/start", "review/start", "thread/resume"],
       },
+      startTurnResults: [
+        { threadId: "parent-thread", turnId: "turn-review-1" },
+        { threadId: "parent-thread", turnId: "turn-review-2" },
+      ],
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -36599,10 +36667,12 @@ script = "printf setup"
       },
     });
 
-    expect(codexClient.lastStartReviewParams).toEqual({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "parent-thread",
-      target: { type: "uncommittedChanges" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("staged, unstaged, and untracked"),
+      }],
     });
     expect(events).toContainEqual({
       backend: "codex",
@@ -36644,10 +36714,12 @@ script = "printf setup"
       },
     });
 
-    expect(codexClient.lastStartReviewParams).toEqual({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "parent-thread",
-      target: { type: "baseBranch", branch: "develop" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("base branch 'develop'"),
+      }],
     });
     expect(events).toContainEqual({
       backend: "codex",
@@ -36668,7 +36740,7 @@ script = "printf setup"
       initializeResult: {
         methods: ["turn/start", "review/start", "thread/resume"],
       },
-      startReviewError: new Error("Codex disconnected"),
+      startTurnError: new Error("Codex disconnected"),
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -49902,7 +49974,7 @@ script = "printf setup"
       await registry.close();
     });
 
-    it("startReview waits for an in-flight permission queue flush before review/start", async () => {
+    it("startReview waits for an in-flight permission queue flush before the inline turn", async () => {
       const permissionFlush = createDeferred<void>();
       const codexClient = new MockBackendClient({
         initializeResult: { methods: ["turn/start", "review/start", "thread/resume"] },
@@ -49954,10 +50026,14 @@ script = "printf setup"
         approvalPolicy: "never",
         sandbox: "danger-full-access",
       });
-      expect(codexClient.lastStartReviewParams).toEqual({
+      expect(codexClient.lastStartTurnParams).toMatchObject({
         threadId: "thread-1",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringContaining("base branch 'main'"),
+        }],
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
       });
       const overlay = await overlayStore.getThreadOverlayState({
         backend: "codex",

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -9949,6 +9949,57 @@ describe("CodexAppServerClient", () => {
     }
   });
 
+  it("does not derive a Codex thread name from an internal turn prompt", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-session-index-"));
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-internal-prompt",
+        path: path.join(tempDir, "sessions/thread-internal-prompt.jsonl"),
+        cwd: "/Users/fixture-user/github/PwrAgent",
+        preview: "",
+        name: null,
+        updatedAt: 1_777_347_163,
+      },
+      model: "gpt-5.5",
+    };
+
+    try {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+      });
+
+      await client.startThread({
+        cwd: "/Users/fixture-user/github/PwrAgent",
+      });
+      await client.startTurn({
+        threadId: "thread-internal-prompt",
+        input: [{
+          type: "text",
+          text: "Review the code changes requested below. Do not modify files.",
+        }],
+        suppressThreadTitleDerivation: true,
+      });
+      await client.close();
+
+      const transport = MockTransport.instances.at(-1);
+      const nameRequests = transport?.sentMessages
+        .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+        .filter((message) => message.method === "thread/name/set");
+      expect(nameRequests).toEqual([
+        expect.objectContaining({
+          params: {
+            threadId: "thread-internal-prompt",
+            name: "Untitled thread",
+          },
+        }),
+      ]);
+    } finally {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it("does not derive a Codex thread name for resumed threads with unknown current names", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/managed-review.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-review.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildInlineReviewPrompt,
   buildManagedReviewPrompt,
   formatManagedReviewOutput,
   parseManagedReviewOutput,
@@ -7,6 +8,19 @@ import {
 import grokReviewSession from "./fixtures/grok-managed-review-session.json";
 
 describe("managed review", () => {
+  it("builds a hidden Markdown prompt for inline parent reviews", () => {
+    const prompt = buildInlineReviewPrompt({
+      type: "baseBranch",
+      branch: "origin/main",
+    });
+
+    expect(prompt).toContain("<action>review</action>");
+    expect(prompt).toContain("against base branch 'origin/main'");
+    expect(prompt).toContain("prioritized findings");
+    expect(prompt).toContain("concise Markdown review");
+    expect(prompt).not.toContain("Return only one JSON object");
+  });
+
   it.each([
     [
       { type: "uncommittedChanges" as const },

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -419,6 +419,7 @@ export function buildAcpCapabilities(
     readThread: true,
     startTurn: true,
     startReview: agentCapabilities?.managedReview === true,
+    startDetachedReview: agentCapabilities?.managedReview === true,
     reviewRunner: agentCapabilities?.managedReview === true,
     interruptTurn: true,
     steerTurn: agentCapabilities?.steerTurn === true,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -58,6 +58,7 @@ import {
   type PwrGitConnectionService,
 } from "../mcp-connections/pwrgit-connection-service";
 import {
+  buildInlineReviewPrompt,
   buildManagedReviewContextInput,
   buildManagedReviewPrompt,
   formatManagedReviewOutput,
@@ -2200,7 +2201,7 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     renameThread: supported.has("thread/name/set") || assumeCodexAppServerSurface,
     readThread: supported.has("thread/read") || assumeCodexAppServerSurface,
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
-    startReview: supported.has("review/start") || assumeCodexAppServerSurface,
+    startReview: supported.has("turn/start") || assumeCodexAppServerSurface,
     // A managed review child is an ephemeral thread plus one turn, so Codex
     // can review for another provider's thread even on builds whose native
     // review/start is absent.
@@ -17136,6 +17137,7 @@ export class DesktopBackendRegistry {
     const reviewerOverridden = Boolean(params.reviewBackend);
     const reviewBackend = params.reviewBackend ?? params.backend;
     const reviewBackendDiffers = reviewBackend !== params.backend;
+    const delivery = params.delivery ?? "inline";
     if (reviewBackendDiffers) {
       this.assertReviewBackendSupported(reviewBackend);
     }
@@ -17165,6 +17167,7 @@ export class DesktopBackendRegistry {
     let codexEnvironmentRuntime: CodexThreadEnvironmentRuntime | undefined;
     let reviewContext: AppServerReviewContext | undefined;
     let tokenMiserEnabled = false;
+    let inlineParentMode: boolean;
     try {
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
@@ -17285,7 +17288,7 @@ export class DesktopBackendRegistry {
         return await client.startReview({
           threadId: params.threadId,
           target: params.target,
-          delivery: params.delivery ?? "inline",
+          delivery,
           ...modelSettings,
           ...(cwd ? { cwd } : {}),
           ...(codexEnvironmentRuntime
@@ -17295,6 +17298,50 @@ export class DesktopBackendRegistry {
           ...(dynamicTools !== undefined ? { dynamicTools } : {}),
         });
       };
+
+      const startInlineWithClient = async (
+        client: BackendClient,
+      ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
+        const tokenMiserConfig =
+          await this.buildSupportedCodexTokenMiserConfig({
+            client,
+            enabled: tokenMiserEnabled,
+          });
+        const dynamicTools =
+          await this.buildSupportedCodexDynamicToolsRefresh({
+            client,
+            tokenMiserEnabled,
+          });
+        const executionMode =
+          overlay?.executionMode
+          ?? await this.resolveCodexThreadExecutionModeForActiveTurn(
+            params.threadId,
+          );
+        const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
+        const turn = await client.startTurn({
+          threadId: params.threadId,
+          input: [{ type: "text", text: buildInlineReviewPrompt(params.target) }],
+          approvalPolicy: modeSettings.approvalPolicy,
+          sandbox: modeSettings.sandbox,
+          ...modelSettings,
+          ...(cwd ? { cwd } : {}),
+          ...(codexEnvironmentRuntime
+            ? { codexEnvironmentRuntime }
+            : {}),
+          ...(tokenMiserConfig ? { config: tokenMiserConfig } : {}),
+          ...(dynamicTools !== undefined ? { dynamicTools } : {}),
+        });
+        return {
+          threadId: params.threadId,
+          reviewThreadId: params.threadId,
+          turnId: turn.turnId,
+        };
+      };
+
+      inlineParentMode =
+        params.backend === "codex"
+        && delivery === "inline"
+        && !managedMode;
 
       result = managedMode
         ? await this.startManagedReviewChild({
@@ -17311,9 +17358,14 @@ export class DesktopBackendRegistry {
             target: params.target,
             tokenMiserEnabled,
           })
-        : params.backend === "codex"
-          ? await this.withCodexThreadClient(params.threadId, startWithClient)
-          : await startWithClient(this.getClient(params.backend));
+        : inlineParentMode
+          ? await this.withCodexThreadClient(
+              params.threadId,
+              startInlineWithClient,
+            )
+          : params.backend === "codex"
+            ? await this.withCodexThreadClient(params.threadId, startWithClient)
+            : await startWithClient(this.getClient(params.backend));
     } catch (error) {
       if (reserveCodexReviewStart) {
         this.reservedCodexStartThreadIds.delete(params.threadId);
@@ -17352,6 +17404,26 @@ export class DesktopBackendRegistry {
       }
     } else if (acpReviewReservationKey) {
       this.reservedAcpStartThreadKeys.delete(acpReviewReservationKey);
+    }
+
+    if (inlineParentMode) {
+      backendRegistryLog.info("inline code review started", {
+        parentThreadId: result.threadId,
+        turnId: result.turnId,
+      });
+      if (!reviewerOverridden && hasExplicitModelSettings(modelSettings)) {
+        await this.overlayStore.setThreadModelSettings({
+          backend: params.backend,
+          threadId: result.threadId,
+          ...modelSettings,
+        });
+      }
+      return {
+        backend: params.backend,
+        threadId: result.threadId,
+        reviewThreadId: result.threadId,
+        turnId: result.turnId,
+      };
     }
     const reviewSubAgentRecord: ReviewSubAgentRecord = {
       backend: reviewBackend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -865,6 +865,7 @@ type BackendClient = {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{
     threadId: string;
     turnId: string;
@@ -2177,6 +2178,13 @@ function sanitizeAcpRuntimeForExecutionMode(params: {
 function buildCapabilities(methods: string[], backend: AppServerBackendKind): BackendCapabilities {
   const supported = new Set(methods);
   const assumeCodexAppServerSurface = backend === "codex" && methods.length === 0;
+  const nativeReview =
+    supported.has("review/start") || assumeCodexAppServerSurface;
+  const reviewRunner =
+    (supported.has("thread/start")
+      || supported.has("thread/new")
+      || assumeCodexAppServerSurface)
+    && (supported.has("turn/start") || assumeCodexAppServerSurface);
 
   return {
     listThreads:
@@ -2202,14 +2210,11 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     readThread: supported.has("thread/read") || assumeCodexAppServerSurface,
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
     startReview: supported.has("turn/start") || assumeCodexAppServerSurface,
+    startDetachedReview: nativeReview || reviewRunner,
     // A managed review child is an ephemeral thread plus one turn, so Codex
     // can review for another provider's thread even on builds whose native
     // review/start is absent.
-    reviewRunner:
-      (supported.has("thread/start")
-        || supported.has("thread/new")
-        || assumeCodexAppServerSurface)
-      && (supported.has("turn/start") || assumeCodexAppServerSurface),
+    reviewRunner,
     interruptTurn: supported.has("turn/interrupt"),
     steerTurn: backend === "codex" || supported.has("turn/steer"),
     transcriptPagination: false,
@@ -7965,6 +7970,8 @@ type CodexRetryableTurnStart = {
     reasoningEffort?: string;
     fastMode?: boolean;
     messageOrigin?: AppServerThreadMessageOrigin;
+    persistModelSettings?: boolean;
+    suppressThreadTitleDerivation?: boolean;
   };
   terminalObserved?: boolean;
   turnId?: string;
@@ -16283,6 +16290,9 @@ export class DesktopBackendRegistry {
     fastMode?: boolean;
     messageOrigin?: AppServerThreadMessageOrigin;
     invalidIdRecoveryAttempted?: boolean;
+    persistModelSettings?: boolean;
+    preReservedCodexStart?: boolean;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     if (!this.tokenMiserServerCapabilitiesForTurn.getStore()) {
       return await this.tokenMiserServerCapabilitiesForTurn.run(
@@ -16442,7 +16452,7 @@ export class DesktopBackendRegistry {
     let input: AppServerTurnInputItem[] = [];
     let pdfAttachments: PendingPdfAttachment[];
     const reserveCodexStart = params.backend === "codex";
-    if (reserveCodexStart) {
+    if (reserveCodexStart && !params.preReservedCodexStart) {
       if (this.threadHasActiveTurn(params.threadId)) {
         throw new Error("A turn is already active for this thread.");
       }
@@ -16577,10 +16587,13 @@ export class DesktopBackendRegistry {
       params.backend,
       params.threadId,
     );
+    const generateThreadTitle = !params.suppressThreadTitleDerivation;
     // Title generation can be scheduled from a lifecycle event before this
     // turn/start call resolves. It must receive the same prepared input that
     // goes to the agent, not raw local PDF references from the composer.
-    this.pendingTitleGenerationInputs.set(titleGenerationKey, input);
+    if (generateThreadTitle) {
+      this.pendingTitleGenerationInputs.set(titleGenerationKey, input);
+    }
     const pendingMessageContextId = await this.registerPendingThreadMessageContext({
       backend: params.backend,
       input,
@@ -16606,6 +16619,9 @@ export class DesktopBackendRegistry {
               reasoningEffort: params.reasoningEffort,
               fastMode: params.fastMode,
               messageOrigin: params.messageOrigin,
+              persistModelSettings: params.persistModelSettings,
+              suppressThreadTitleDerivation:
+                params.suppressThreadTitleDerivation,
             },
           }
         : undefined;
@@ -16663,6 +16679,8 @@ export class DesktopBackendRegistry {
             ...(pwrdrvrTokenMiser !== undefined
               ? { pwrdrvrTokenMiser }
               : {}),
+            suppressThreadTitleDerivation:
+              params.suppressThreadTitleDerivation,
           });
           activeTurnMode = effectiveMode;
           return started;
@@ -16694,7 +16712,9 @@ export class DesktopBackendRegistry {
       if (reserveCodexStart) {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
-      this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+      if (generateThreadTitle) {
+        this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+      }
       this.forgetPendingThreadMessageContext(pendingMessageContextId);
       if (
         retryableCodexTurnStart
@@ -16772,10 +16792,13 @@ export class DesktopBackendRegistry {
     }
 
     if (
-      turnParams.model !== undefined ||
-      turnParams.reasoningEffort !== undefined ||
-      turnParams.serviceTier !== undefined ||
-      turnParams.fastMode !== undefined
+      params.persistModelSettings !== false
+      && (
+        turnParams.model !== undefined
+        || turnParams.reasoningEffort !== undefined
+        || turnParams.serviceTier !== undefined
+        || turnParams.fastMode !== undefined
+      )
     ) {
       await this.overlayStore.setThreadModelSettings({
         backend: params.backend,
@@ -16807,12 +16830,14 @@ export class DesktopBackendRegistry {
       turnId: result.turnId,
     });
     if (!isAcpBackendId(params.backend)) {
-      this.pendingTitleGenerationInputs.delete(titleGenerationKey);
-      this.scheduleThreadTitleGeneration({
-        backend: params.backend,
-        threadId: result.threadId,
-        input,
-      });
+      if (generateThreadTitle) {
+        this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+        this.scheduleThreadTitleGeneration({
+          backend: params.backend,
+          threadId: result.threadId,
+          input,
+        });
+      }
     }
 
     return response;
@@ -17169,6 +17194,28 @@ export class DesktopBackendRegistry {
     let tokenMiserEnabled = false;
     let inlineParentMode: boolean;
     try {
+      if (
+        params.backend === "codex"
+        && delivery === "detached"
+        && !managedMode
+      ) {
+        const detachedSupport = await this.withCodexThreadClient(
+          params.threadId,
+          async (client) => {
+            const methods = (await client.getInitializeResult()).methods ?? [];
+            return {
+              managed: buildCapabilities(methods, "codex").reviewRunner === true,
+              native: methods.length === 0 || methods.includes("review/start"),
+            };
+          },
+        );
+        if (!detachedSupport.native && !detachedSupport.managed) {
+          throw new Error(
+            "Detached review requires Codex review/start or thread/start plus turn/start.",
+          );
+        }
+        managedMode = !detachedSupport.native;
+      }
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
       }
@@ -17182,9 +17229,6 @@ export class DesktopBackendRegistry {
         tokenMiserEnabled = this.resolveTokenMiserEnabledForOverride(
           params.backend === "codex" ? overlay?.tokenMiserEnabled : undefined,
         );
-        if (tokenMiserEnabled) {
-          await this.prepareTokenMiserRuntime();
-        }
       }
       if (params.backend === "codex") {
         codexEnvironmentRuntime = overlay?.codexEnvironmentRuntime;
@@ -17228,6 +17272,13 @@ export class DesktopBackendRegistry {
             params.threadId,
             overlay,
           );
+      }
+      inlineParentMode =
+        params.backend === "codex"
+        && delivery === "inline"
+        && !managedMode;
+      if (tokenMiserEnabled && !inlineParentMode) {
+        await this.prepareTokenMiserRuntime();
       }
       await assertReviewWorkspaceMatchesAttachedPullRequest({
         cwd,
@@ -17299,50 +17350,6 @@ export class DesktopBackendRegistry {
         });
       };
 
-      const startInlineWithClient = async (
-        client: BackendClient,
-      ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
-        const tokenMiserConfig =
-          await this.buildSupportedCodexTokenMiserConfig({
-            client,
-            enabled: tokenMiserEnabled,
-          });
-        const dynamicTools =
-          await this.buildSupportedCodexDynamicToolsRefresh({
-            client,
-            tokenMiserEnabled,
-          });
-        const executionMode =
-          overlay?.executionMode
-          ?? await this.resolveCodexThreadExecutionModeForActiveTurn(
-            params.threadId,
-          );
-        const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
-        const turn = await client.startTurn({
-          threadId: params.threadId,
-          input: [{ type: "text", text: buildInlineReviewPrompt(params.target) }],
-          approvalPolicy: modeSettings.approvalPolicy,
-          sandbox: modeSettings.sandbox,
-          ...modelSettings,
-          ...(cwd ? { cwd } : {}),
-          ...(codexEnvironmentRuntime
-            ? { codexEnvironmentRuntime }
-            : {}),
-          ...(tokenMiserConfig ? { config: tokenMiserConfig } : {}),
-          ...(dynamicTools !== undefined ? { dynamicTools } : {}),
-        });
-        return {
-          threadId: params.threadId,
-          reviewThreadId: params.threadId,
-          turnId: turn.turnId,
-        };
-      };
-
-      inlineParentMode =
-        params.backend === "codex"
-        && delivery === "inline"
-        && !managedMode;
-
       result = managedMode
         ? await this.startManagedReviewChild({
             backend: reviewBackend,
@@ -17359,10 +17366,24 @@ export class DesktopBackendRegistry {
             tokenMiserEnabled,
           })
         : inlineParentMode
-          ? await this.withCodexThreadClient(
-              params.threadId,
-              startInlineWithClient,
-            )
+          ? await this.startTurnNow({
+              backend: "codex",
+              threadId: params.threadId,
+              input: [{
+                type: "text",
+                text: buildInlineReviewPrompt(params.target),
+              }],
+              ...modelSettings,
+              persistModelSettings:
+                !reviewerOverridden
+                && hasExplicitModelSettings(modelSettings),
+              preReservedCodexStart: true,
+              suppressThreadTitleDerivation: true,
+            }).then((turn) => ({
+              threadId: turn.threadId,
+              reviewThreadId: turn.threadId,
+              turnId: turn.turnId,
+            }))
           : params.backend === "codex"
             ? await this.withCodexThreadClient(params.threadId, startWithClient)
             : await startWithClient(this.getClient(params.backend));
@@ -17377,30 +17398,44 @@ export class DesktopBackendRegistry {
     }
 
     if (params.backend === "codex") {
-      try {
-        const reviewThreadId = managedMode
-          ? result.threadId
-          : result.reviewThreadId || result.threadId;
-        // Codex review/start returns the real review turn id, but current
-        // Codex builds can also emit a lone, mismatched turn/started for the
-        // same thread. Treat the returned review turn as active so queued
-        // turns cannot release in parallel and so the matching terminal
-        // review notification clears the active state.
-        const activeTurnMode = await this.resolveCodexThreadExecutionModeForActiveTurn(
-          reviewThreadId,
+      if (inlineParentMode) {
+        const activeTurnModeKey = buildActiveTurnModeKey(
+          result.threadId,
+          result.turnId,
         );
-        this.activeTurnKeys.add(
-          buildActiveTurnKey(params.backend, reviewThreadId, result.turnId),
-        );
-        this.activeCodexTurnModes.set(
-          buildActiveTurnModeKey(reviewThreadId, result.turnId),
-          activeTurnMode,
-        );
-        this.activeCodexReviewTurnKeys.add(
-          buildActiveTurnModeKey(reviewThreadId, result.turnId),
-        );
-      } finally {
-        this.reservedCodexStartThreadIds.delete(params.threadId);
+        // startTurnNow owns the active-turn lifecycle, including the case
+        // where a terminal notification arrives before turn/start resolves.
+        // Mark it as a review only while that normal lifecycle still says the
+        // turn is active; otherwise a fast completion would be resurrected.
+        if (this.activeCodexTurnModes.has(activeTurnModeKey)) {
+          this.activeCodexReviewTurnKeys.add(activeTurnModeKey);
+        }
+      } else {
+        try {
+          const reviewThreadId = managedMode
+            ? result.threadId
+            : result.reviewThreadId || result.threadId;
+          // Codex review/start returns the real review turn id, but current
+          // Codex builds can also emit a lone, mismatched turn/started for the
+          // same thread. Treat the returned review turn as active so queued
+          // turns cannot release in parallel and so the matching terminal
+          // review notification clears the active state.
+          const activeTurnMode = await this.resolveCodexThreadExecutionModeForActiveTurn(
+            reviewThreadId,
+          );
+          this.activeTurnKeys.add(
+            buildActiveTurnKey(params.backend, reviewThreadId, result.turnId),
+          );
+          this.activeCodexTurnModes.set(
+            buildActiveTurnModeKey(reviewThreadId, result.turnId),
+            activeTurnMode,
+          );
+          this.activeCodexReviewTurnKeys.add(
+            buildActiveTurnModeKey(reviewThreadId, result.turnId),
+          );
+        } finally {
+          this.reservedCodexStartThreadIds.delete(params.threadId);
+        }
       }
     } else if (acpReviewReservationKey) {
       this.reservedAcpStartThreadKeys.delete(acpReviewReservationKey);
@@ -17411,13 +17446,6 @@ export class DesktopBackendRegistry {
         parentThreadId: result.threadId,
         turnId: result.turnId,
       });
-      if (!reviewerOverridden && hasExplicitModelSettings(modelSettings)) {
-        await this.overlayStore.setThreadModelSettings({
-          backend: params.backend,
-          threadId: result.threadId,
-          ...modelSettings,
-        });
-      }
       return {
         backend: params.backend,
         threadId: result.threadId,

--- a/apps/desktop/src/main/app-server/managed-review.ts
+++ b/apps/desktop/src/main/app-server/managed-review.ts
@@ -22,6 +22,17 @@ const REVIEW_OUTPUT_INSTRUCTIONS = [
   "Do not wrap the JSON in Markdown fences and do not include prose outside it.",
 ].join("\n");
 
+export function buildInlineReviewPrompt(
+  target: AppServerReviewTarget,
+): string {
+  return [
+    "Review the code changes requested below. Do not modify files.",
+    "<user_action><action>review</action></user_action>",
+    reviewTargetInstructions(target),
+    "Return a concise Markdown review with prioritized findings. For each finding, cite the affected file and line range, explain the concrete impact, and suggest the smallest useful remedy. If there are no actionable findings, say so directly.",
+  ].join("\n\n");
+}
+
 export function buildManagedReviewPrompt(
   target: AppServerReviewTarget,
 ): string {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -8911,6 +8911,7 @@ export class CodexAppServerClient {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{
     threadId: string;
     turnId: string;
@@ -9041,10 +9042,12 @@ export class CodexAppServerClient {
     const turnId = extractTurnIdFromValue(result) ?? `pending:${threadId}`;
     this.pendingFirstTurnThreadResults.delete(params.threadId);
     this.pendingFirstTurnShellEnvironments.delete(params.threadId);
-    await this.recordDerivedThreadNameWithCodex({
-      threadId: params.threadId,
-      input: params.input,
-    });
+    if (!params.suppressThreadTitleDerivation) {
+      await this.recordDerivedThreadNameWithCodex({
+        threadId: params.threadId,
+        input: params.input,
+      });
+    }
 
     return { threadId, turnId };
   }

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -149,6 +149,11 @@ export type BackendCapabilities = {
   startTurn: boolean;
   startReview?: boolean;
   /**
+   * This backend can honor `delivery: "detached"` either through its native
+   * review method or through a managed review child.
+   */
+  startDetachedReview?: boolean;
+  /**
    * This backend can run a PwrAgent-managed review on behalf of a thread that
    * lives on a different provider, so it can be offered as a reviewer
    * override. Doubles as the feature probe for the override itself: an


### PR DESCRIPTION
## Summary

- run inline Codex reviews as ordinary turns on the parent thread
- keep managed and explicit detached review workflows on their existing child paths
- hide the internal review instruction prompt while returning normal Markdown findings
- advertise inline review support from turn/start rather than review/start

## Why

The shipped ChatGPT client starts inline reviews with turn/start on the current conversation. PwrAgent instead called native review/start, which can return an ephemeral review thread with no durable rollout. The GUI tracked that hidden child while the bound parent appeared idle.

## Verification

- pnpm test (637 files, 9,240 passed, 6 skipped)
- pnpm typecheck
- pnpm lint:eslint
- pnpm lint:boundaries
- pnpm lint:sql
- pnpm lint:codex-storage
- pnpm lint:colors
- pnpm licenses:check