### PR TITLE
ci(deps): regenerate THIRD_PARTY_LICENSES on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-licenses.yml
+++ b/.github/workflows/dependabot-licenses.yml
@@ -1,0 +1,393 @@
+name: Dependabot Licenses
+
+# Regenerate THIRD_PARTY_LICENSES on a Dependabot PR and push the result.
+#
+# WHY THIS EXISTS
+#
+# `pnpm licenses:check` compares the committed notice against one generated
+# from the installed tree, so ANY dependency change makes the committed notice
+# stale. Dependabot only edits package.json and pnpm-lock.yaml — it cannot run
+# `pnpm licenses:generate` — so every Dependabot PR arrives with `Lint` red on
+# that one line and nothing else, and cannot merge until a human checks the
+# branch out and pushes the regenerated notice by hand.
+#
+# WHY IT IS SAFE TO AUTOMATE *NOW* AND WAS NOT BEFORE
+#
+# `generate-third-party-licenses.mjs` is a transcriber: it writes whatever
+# license string pnpm reports into the notice and judges none of it. Before
+# scripts/check-third-party-license-allowlist.mjs existed, an unattended
+# regeneration would have silently laundered a dependency that flipped to
+# GPL — the notice would gain a "GPL-3.0" section, `licenses:check` would then
+# pass because committed matched generated, and CI would go green. The only
+# safety was a human maybe noticing a new license heading in the diff, which is
+# exactly what this workflow removes.
+#
+# So this job runs the allowlist gate FIRST and pushes nothing if it fails. A
+# bad license stops here, loudly, instead of being committed by a bot.
+#
+# SECURITY NOTES — read before editing
+#
+# `pull_request_target` runs the BASE branch's copy of this file with a
+# privileged token. That is what makes the Actions secret store and a
+# write-capable token reachable at all (a Dependabot-triggered `pull_request`
+# run gets a read-only token and Dependabot secrets instead). It also means
+# every guard below must live here, in the base copy, because nothing the PR
+# head contains can change the file that judges it.
+#
+# Four controls, all load-bearing:
+#
+#   1. The `guard` job pins the actor to dependabot[bot] and the head to this
+#      repo, so a fork PR can never reach the privileged path.
+#   2. "Verify the pull request only touches dependency manifests" refuses to
+#      continue if the branch changes anything but package.json / the lockfile
+#      / the notice. A Dependabot branch that somehow carried a script or
+#      workflow edit does not get an install. It fails CLOSED — an unreadable
+#      file list is an error, not an empty list of violations.
+#   3. Only the `regenerate` job holds `contents: write`, and it is reachable
+#      only through `needs: guard`. The guard itself runs unprivileged.
+#   4. `pnpm install --ignore-scripts`. A dependency bump is by definition
+#      new third-party code, and a normal install would run its lifecycle
+#      scripts with a token that can push to this repo. Measured on this
+#      repository: a normal install and an `--ignore-scripts` install produce a
+#      BYTE-IDENTICAL notice (412 packages, sha256 13d4ba8f…), and the full
+#      `licenses:check` passes on the scripts-free tree. Nothing is traded away
+#      by skipping them. Re-measure if the generator ever starts reading
+#      anything a lifecycle script produces.
+#
+# TOKEN
+#
+# A push made with the default GITHUB_TOKEN does NOT trigger new workflow runs
+# ("events triggered by the GITHUB_TOKEN will not create a new workflow run").
+# Pushing with it still lands the commit — the PR just keeps showing its stale
+# red checks until someone nudges it. So this prefers a GitHub App token, then
+# RELEASES_PAT, and warns after the fact if it had to fall back.
+#
+# RELEASES_PAT already exists in this repository (release.yml uses it) and a
+# PAT push DOES re-trigger CI, so the fallback works with no provisioning. That
+# is convenience, not the recommendation: RELEASES_PAT is a broadly-scoped
+# personal token, and this is a `pull_request_target` job that installs
+# PR-controlled dependency versions. Prefer a GitHub App scoped to
+# `contents: write` on this repository alone — set repository variable
+# LICENSES_BOT_APP_CLIENT_ID AND secret LICENSES_BOT_APP_PRIVATE_KEY. Both are
+# required; setting only one falls back and warns rather than hard-failing the
+# mint step.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    # Mirrors the `packages:` globs in pnpm-workspace.yaml. Keep the two in
+    # sync: a workspace directory that is not listed here gets no run at all.
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "apps/*/package.json"
+      - "packages/*/package.json"
+      - "packages/messaging/*/package.json"
+      - "packages/messaging/providers/*/package.json"
+  workflow_dispatch:
+    inputs:
+      pull-request:
+        description: "PR number to regenerate THIRD_PARTY_LICENSES for"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-licenses-${{ github.event.pull_request.number || inputs.pull-request }}
+  cancel-in-progress: true
+
+env:
+  # The subject line this workflow commits under, and the one the guard below
+  # recognizes as its own. Keeping it in one workflow-level variable is what
+  # stops the committer and the guard from drifting apart: if they ever
+  # disagree, the guard stops recognizing the bot's own push and every
+  # regeneration costs a second, pointless run of the whole job.
+  REGEN_COMMIT_SUBJECT: "chore(deps): regenerate THIRD_PARTY_LICENSES"
+
+jobs:
+  # Unprivileged half. Decides whether the privileged half may run at all, and
+  # holds no write permission and no secrets while deciding.
+  guard:
+    name: Check the pull request is eligible
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # workflow_dispatch is a human deliberately naming a PR; every automatic
+    # run must be Dependabot's own branch in this repo.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.actor == 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository)
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      proceed: ${{ steps.pr.outputs.proceed }}
+      number: ${{ steps.pr.outputs.number }}
+      head-sha: ${{ steps.pr.outputs.head-sha }}
+      head-ref: ${{ steps.pr.outputs.head-ref }}
+    steps:
+      - name: Resolve the pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # One code path for both triggers: read the head off the API rather
+          # than off the event payload, so a dispatched run behaves identically.
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull-request }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          head_ref="$(jq -r '.head.ref' <<<"$pr_json")"
+          head_repo="$(jq -r '.head.repo.full_name' <<<"$pr_json")"
+          state="$(jq -r '.state' <<<"$pr_json")"
+
+          {
+            echo "number=${PR_NUMBER}"
+            echo "head-sha=${head_sha}"
+            echo "head-ref=${head_ref}"
+          } >>"$GITHUB_OUTPUT"
+
+          if [ "$state" != "open" ]; then
+            echo "::notice::PR #${PR_NUMBER} is ${state}; nothing to do."
+            echo "proceed=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$head_repo" != "$REPO" ]; then
+            echo "::error::PR #${PR_NUMBER} head is ${head_repo}, not ${REPO}. Refusing to run a" \
+              "privileged job against a fork."
+            exit 1
+          fi
+
+          # Our own push re-triggers `synchronize`, and the PR still matches the
+          # `paths` filter because the lockfile is part of its diff — so without
+          # this every regeneration would cost a second full run that can only
+          # discover the notice is already current.
+          #
+          # Read the whole message and trim in the shell rather than piping to
+          # `head -n 1`: under `pipefail` a short-circuiting reader can leave
+          # the producer with a non-zero SIGPIPE status and fail the step.
+          message="$(gh api "repos/${REPO}/commits/${head_sha}" --jq '.commit.message')"
+          subject="${message%%$'\n'*}"
+          if [ "$subject" = "$REGEN_COMMIT_SUBJECT" ]; then
+            echo "::notice::PR #${PR_NUMBER} is already at this workflow's own regeneration commit."
+            echo "proceed=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "proceed=true" >>"$GITHUB_OUTPUT"
+
+      # The privileged job installs third-party code, so it may only ever see a
+      # branch that changes dependency manifests. A Dependabot branch never
+      # legitimately touches anything else; one that does is either a bug or an
+      # attempt to get code onto that path.
+      - name: Verify the pull request only touches dependency manifests
+        if: steps.pr.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # One alternative per `packages:` glob in pnpm-workspace.yaml. `[^/]+`
+          # is load-bearing: it keeps a nested, non-workspace manifest such as
+          # apps/desktop/src/vendor/package.json out of the allowed set.
+          # pnpm-workspace.yaml is deliberately NOT allowed — it carries
+          # onlyBuiltDependencies, which decides whose install scripts may run.
+          allowed='^(package\.json|pnpm-lock\.yaml|THIRD_PARTY_LICENSES|apps/[^/]+/package\.json|packages/[^/]+/package\.json|packages/messaging/[^/]+/package\.json|packages/messaging/providers/[^/]+/package\.json)$'
+
+          # Fetch first so `set -e` catches an API failure. Folding this into a
+          # pipeline with grep would let grep's exit status stand in for the
+          # API's, which is how a guard like this fails open.
+          files="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          if [ -z "$files" ]; then
+            echo "::error::Could not read the changed-file list for PR #${PR_NUMBER}. Refusing to" \
+              "continue: an empty list is indistinguishable from a guard that did not run."
+            exit 1
+          fi
+
+          # grep exits 1 for "no matches" (every file allowed) and 2 for a real
+          # error. `|| true` alone would conflate them and report a clean guard.
+          set +e
+          unexpected="$(printf '%s\n' "$files" | grep -Ev "$allowed")"
+          grep_status=$?
+          set -e
+          if [ "$grep_status" -gt 1 ]; then
+            echo "::error::Could not evaluate the changed-file list (grep exit ${grep_status})."
+            exit 1
+          fi
+
+          if [ -n "$unexpected" ]; then
+            echo "::error::PR #${PR_NUMBER} changes files outside the dependency manifests, so it" \
+              "will not be given a privileged install. Unexpected:"
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
+          echo "Only dependency manifests changed."
+
+  regenerate:
+    name: Regenerate THIRD_PARTY_LICENSES
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # The only place in this workflow that can write. Reachable only through
+    # `needs: guard`, so every check above has already passed.
+    #
+    # This must be `write` even though the push normally uses the App token or
+    # RELEASES_PAT: when neither is provisioned the checkout persists
+    # GITHUB_TOKEN, and with `contents: read` that push is rejected 403 — the
+    # fallback path would regenerate the notice and then fail at the last step.
+    permissions:
+      contents: write
+      pull-requests: read
+    # The `secrets` context is NOT available in a step-level `if` (only
+    # github/needs/strategy/matrix/job/runner/env/vars/steps/inputs are), and an
+    # unavailable context reads as empty — so `if: secrets.RELEASES_PAT == ''`
+    # silently evaluates true even when the secret IS set. Job-level `env` CAN
+    # read secrets, so the presence tests happen here.
+    env:
+      # BOTH halves, deliberately: gating the mint step on the variable alone
+      # means an operator who sets the variable before the secret gets a hard
+      # failure inside create-github-app-token on every Dependabot PR, instead
+      # of the fallback this workflow is built around.
+      HAS_APP_TOKEN: >-
+        ${{ vars.LICENSES_BOT_APP_CLIENT_ID != ''
+        && secrets.LICENSES_BOT_APP_PRIVATE_KEY != '' }}
+      APP_PARTIALLY_CONFIGURED: >-
+        ${{ (vars.LICENSES_BOT_APP_CLIENT_ID != '')
+        != (secrets.LICENSES_BOT_APP_PRIVATE_KEY != '') }}
+      HAS_RELEASES_PAT: ${{ secrets.RELEASES_PAT != '' }}
+    steps:
+      - name: Warn about a half-provisioned GitHub App
+        if: env.APP_PARTIALLY_CONFIGURED == 'true'
+        run: |
+          echo "::warning::Exactly one of LICENSES_BOT_APP_CLIENT_ID (a repository variable) and" \
+            "LICENSES_BOT_APP_PRIVATE_KEY (a repository secret) is set. Both are required; falling" \
+            "back to RELEASES_PAT or GITHUB_TOKEN for this run."
+
+      - name: Mint a push token
+        id: app-token
+        if: env.HAS_APP_TOKEN == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.LICENSES_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LICENSES_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: Check out the pull request branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.guard.outputs.head-ref }}
+          token: ${{ steps.app-token.outputs.token || secrets.RELEASES_PAT || github.token }}
+          persist-credentials: true
+
+      - name: Confirm the branch still points at the reviewed commit
+        id: race
+        env:
+          EXPECTED: ${{ needs.guard.outputs.head-sha }}
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          if [ "$actual" != "$EXPECTED" ]; then
+            # Dependabot force-pushed while we were setting up. The guard job
+            # judged $EXPECTED, so working on $actual would install code nothing
+            # checked. A newer run is already queued for it.
+            echo "::notice::Branch moved from ${EXPECTED} to ${actual}; leaving it to the newer run."
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node.js
+        if: steps.race.outputs.skip != 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      # Deliberate divergence from pwrdrvr/configure-nodejs, which the rest of
+      # CI uses: it always runs a full `pnpm install` and exposes no input for
+      # --ignore-scripts (its inputs are node-version, package-manager,
+      # working-directory, cache-key-suffix, cache-electron, lookup-only). This
+      # job installs third-party code with a token that can write to the repo,
+      # so skipping lifecycle scripts is worth losing the shared pnpm cache for.
+      #
+      # No store cache here either, and that is also deliberate: this is a
+      # privileged `pull_request_target` job installing PR-controlled dependency
+      # versions, and a cache it writes is readable by other workflows on this
+      # repo. A cold install is the cheaper side of that trade.
+      #
+      # ⚠️  The resulting tree can ONLY be used for reading package metadata.
+      # Skipping scripts means electron's postinstall never downloads its
+      # binary and better-sqlite3 is never rebuilt, so anything that
+      # require()s electron or the native addon fails. Do NOT add a build,
+      # test, or typecheck step to this job; the PR's own CI run covers those,
+      # on a normal install, with no privileged token.
+      - name: Install dependencies without lifecycle scripts
+        if: steps.race.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          corepack enable
+          pnpm install --frozen-lockfile --ignore-scripts
+
+      # Runs BEFORE regeneration and gates it. If the bump dragged in a license
+      # we do not ship, the right outcome is a red PR a human reads — not a bot
+      # committing a notice that makes the new license look reviewed.
+      - name: Gate the new dependency tree against the license allowlist
+        if: steps.race.outputs.skip != 'true'
+        run: pnpm licenses:allowlist
+
+      - name: Regenerate THIRD_PARTY_LICENSES
+        if: steps.race.outputs.skip != 'true'
+        run: pnpm licenses:generate
+
+      - name: Commit and push if the notice changed
+        if: steps.race.outputs.skip != 'true'
+        env:
+          HEAD_REF: ${{ needs.guard.outputs.head-ref }}
+          PR_NUMBER: ${{ needs.guard.outputs.number }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- THIRD_PARTY_LICENSES; then
+            echo "THIRD_PARTY_LICENSES is already current; nothing to push."
+            echo "\`THIRD_PARTY_LICENSES\` was already current." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add THIRD_PARTY_LICENSES
+          # Single-line body on purpose: a `-m` argument continued onto a second
+          # source line inside a `run: |` block only produces the intended text
+          # while that line keeps exactly the block's indentation, so any
+          # reformatting would silently reshape the published commit message.
+          git commit -m "$REGEN_COMMIT_SUBJECT" \
+            -m "Dependabot cannot run 'pnpm licenses:generate', so 'licenses:check' fails on every dependency PR. Regenerated automatically for #${PR_NUMBER}."
+
+          # Plain push: if the branch moved since the race check, this is
+          # rejected and the newer run handles it. Never force-push a branch
+          # somebody else owns.
+          git push origin "HEAD:${HEAD_REF}"
+          echo "Pushed a regenerated \`THIRD_PARTY_LICENSES\` to \`${HEAD_REF}\`." \
+            >>"$GITHUB_STEP_SUMMARY"
+
+          # Warn only now that something was actually pushed. Warning earlier
+          # fired on every run, including the ones that push nothing.
+          if [ "$HAS_APP_TOKEN" != "true" ] && [ "$HAS_RELEASES_PAT" != "true" ]; then
+            echo "::warning::Pushed with GITHUB_TOKEN, which does not trigger new workflow runs." \
+              "PR #${PR_NUMBER} will keep showing its stale failing checks until someone pushes to" \
+              "it or closes and reopens it. Provision LICENSES_BOT_APP_CLIENT_ID +" \
+              "LICENSES_BOT_APP_PRIVATE_KEY to fix this."
+            {
+              echo "### :warning: Pushed without a re-triggering token"
+              echo
+              echo "CI will not re-run on the regenerated commit. See the workflow header for setup."
+            } >>"$GITHUB_STEP_SUMMARY"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,56 @@
 - `BlueOak-1.0.0` and `Python-2.0` were already in the shipped tree and documented nowhere.
 - `0BSD`, `CC0-1.0`, `MPL-2.0`, and `Unlicense` are approved ids that the production tree does not use today.
 
+#### Dependabot PRs regenerate the notice automatically
+
+- `licenses:check` compares the committed notice against the installed tree.
+- Any dependency change therefore makes the committed notice stale.
+- Dependabot cannot run `pnpm licenses:generate` itself.
+- Every Dependabot PR used to land with `Lint` red on that one line.
+- Each one needed a hand-pushed follow-up commit.
+- [dependabot-licenses.yml](.github/workflows/dependabot-licenses.yml) pushes that commit.
+- Read its header before you edit it.
+- Four controls keep a dependency bump from running its install scripts with a
+  token that can write to this repository:
+  - The `guard` job pins the actor to `dependabot[bot]` and the head to this repo.
+  - A file guard refuses any PR that touches more than dependency manifests.
+  - Only the `regenerate` job holds `contents: write`, reached through `needs: guard`.
+  - The install runs `--ignore-scripts`.
+- The workflow runs the allowlist gate first and pushes nothing if it fails.
+- That ordering is the reason unattended regeneration is safe.
+- A bad license stops the job instead of arriving as a bot commit with green CI.
+
+##### Editing the workflow
+
+- Keep the file guard's `allowed` regex in sync with `packages:` in `pnpm-workspace.yaml`.
+- A workspace directory missing from that regex blocks its own Dependabot PRs.
+- `packages/messaging/providers/*` is three levels deep, so a two-level regex is wrong here.
+- Keep the `paths:` trigger filter in sync with the same globs.
+- `pnpm-workspace.yaml` is deliberately absent from the allowed set.
+- It carries `onlyBuiltDependencies`, which decides whose install scripts may run.
+- The file guard fails closed. An unreadable file list is an error, not an empty violation list.
+- Do not fold the `gh api` call into a pipeline with `grep`.
+- That substitution lets `grep`'s exit status stand in for the API's and fails open.
+- Do not add a build, test, or typecheck step to the `regenerate` job.
+- The `--ignore-scripts` tree has no Electron binary and no rebuilt native addon.
+- The PR's own CI run covers those checks on a normal install with no privileged token.
+- The `secrets` context is not available in a step-level `if`.
+- An unavailable context reads as empty, so `if: secrets.FOO == ''` is true even when `FOO` is set.
+- Do the presence tests in job-level `env`, which can read secrets.
+
+##### Token
+
+- A push made with the default `GITHUB_TOKEN` does not trigger new workflow runs.
+- Without a different token the PR keeps showing its stale red checks.
+- The workflow prefers a GitHub App token, then `RELEASES_PAT`, then `GITHUB_TOKEN`.
+- `RELEASES_PAT` already exists here, so the fallback works with no provisioning.
+- Prefer a narrowly-scoped App anyway.
+- `RELEASES_PAT` is broad, and this job installs PR-controlled dependencies under `pull_request_target`.
+- To use the App path, set repository variable `LICENSES_BOT_APP_CLIENT_ID`.
+- Also set repository secret `LICENSES_BOT_APP_PRIVATE_KEY`.
+- Install that App on this repository with `contents: write`.
+- Both are required. Setting one alone falls back and warns.
+
 ## Runtime Configuration
 
 - Store all desktop configuration and state under `~/.pwragent/`.


### PR DESCRIPTION
Ports pwrdrvr/PwrSnap#528 to this repository, mirroring its post-review final state.

## Why

`licenses:check` compares the committed `THIRD_PARTY_LICENSES` against one generated from the installed tree, so **any** dependency change makes it stale — and Dependabot only edits `package.json` and `pnpm-lock.yaml`, it cannot run `pnpm licenses:generate`. `package.json`'s `lint` script chains `licenses:check`, so every Dependabot PR arrives with `Lint` red on that one line and nothing else.

That is the live state right now. Of the five open Dependabot PRs, #1872, #1871 and #1870 are red, and the log is this and nothing more:

```
package license check passed
third-party license allowlist check passed (401 production packages, 1 shipped devDependencies)
THIRD_PARTY_LICENSES is out of date. Run `pnpm licenses:generate` and commit the result.
```

This workflow pushes that commit.

## Its prerequisite is already in place

#528 depends on PwrSnap's allowlist gate (pwrdrvr/PwrSnap#527) because the workflow runs that gate before regenerating and pushes nothing if it fails. **That gate has already landed here** — `scripts/check-third-party-license-allowlist.mjs` exists and `licenses:check` invokes it between the package check and the notice check. Nothing was deferred; this ships with its dependency satisfied.

That ordering is the whole reason unattended regeneration is safe. `generate-third-party-licenses.mjs` is a transcriber: it writes whatever license string pnpm reports and judges none of it. Without the gate, a dependency that flipped to GPL would gain a `GPL-3.0` section in the notice, `licenses:check` would then pass because committed matched generated, and CI would go green — with a bot commit making it look reviewed. The gate runs first, so a bad license stops the job loudly instead.

## Adapted for this repo, not copied

Three changes were required, each verified against real data rather than assumed:

1. **The file-guard regex covers all four workspace globs.** PwrSnap's `(apps|packages)/[^/]+/package\.json` is two levels deep. This workspace is four globs deep (`apps/*`, `packages/*`, `packages/messaging/*`, `packages/messaging/providers/*`), and the changed file in **two of the five open Dependabot PRs** (#1707, #1452) is `packages/messaging/providers/slack/package.json`. PwrSnap's regex would have blocked them. The `paths:` trigger filter was widened to match.
2. **`pnpm-workspace.yaml` is deliberately *not* allowed.** It carries `onlyBuiltDependencies`, which decides whose install scripts may run. If a future pnpm catalog migration makes Dependabot touch it, the guard fails closed and a human adds it on purpose.
3. **The self-retrigger guard reads the commit subject without `| head -n 1`.** Under `set -o pipefail` a short-circuiting reader can leave `gh` with a non-zero SIGPIPE status and fail the step; bash parameter expansion has no such hazard.

Action majors also follow this repo (`checkout@v7`, `setup-node@v7`) rather than PwrSnap's.

## Token — please read, this is the one decision left

`RELEASES_PAT` already exists here (`release.yml` uses it), and unlike `GITHUB_TOKEN` a PAT push *does* re-trigger workflow runs. So the fallback chain works out of the box with no provisioning — which is convenient but is **not** what I'd recommend.

`RELEASES_PAT` is presumably broadly scoped, and this is a `pull_request_target` job that installs PR-controlled dependency versions. **I recommend provisioning a GitHub App scoped to `contents: write` on this repository alone** and leaving `RELEASES_PAT` as the fallback, exactly as #528 does:

- repository **variable** `LICENSES_BOT_APP_CLIENT_ID`
- repository **secret** `LICENSES_BOT_APP_PRIVATE_KEY`

Both are required — gating on the variable alone would hard-fail inside `create-github-app-token` for an operator who set one first. Until an App exists the workflow still runs and still catches bad licenses; it just pushes with the PAT. Your call.

## What I verified

- **`--ignore-scripts` parity, measured not assumed.** This repo has `ensure-electron-runtime && rebuild-native-for-electron` in `apps/desktop` postinstall, so this needed checking. Wiped `node_modules`, ran a normal install (postinstall chain ran to completion), regenerated; wiped again, ran `pnpm install --frozen-lockfile --ignore-scripts`, regenerated. **Byte-identical**: 412 packages both ways, `sha256 13d4ba8f4f24af47597375f33900a22bf229fd0d5330ed460ecc2b57b86302d6`, 348363 bytes. The full `pnpm licenses:check` also passes on the scripts-free tree. No narrowing needed, so `--ignore-scripts` ships intact.
- **The file guard, against 28 cases.** The harness extracts the guard's shell body out of the YAML at run time, so the test cannot drift from what ships. It covers the real file lists of all five open Dependabot PRs, every legitimate workspace manifest shape, and hostile inputs: workflow edits, edits to this workflow, edits to the generator and to the allowlist gate, nested non-workspace manifests, `pnpm-workspace.yaml`, `.npmrc`, unanchored near-misses (`evil/package.json`, `package.json.bak`), one bad file among benign ones, and the fail-closed cases (empty list, `gh api` failure). 28/28.
- **That the harness has teeth.** Two negative controls: swapping in PwrSnap's original regex fails exactly the 4 deep-path cases, and rewriting the guard to the naive `gh api ... | grep -Ev ... || true` form fails exactly the 3 fail-closed cases. So both adaptations are load-bearing, not cosmetic.
- **No script-injection surface.** No `${{ }}` is interpolated directly into any `run:` block; every value, including the `workflow_dispatch` PR number, reaches the shell through `env`.
- **`actionlint`** reports only the known stale-metadata false positive about `client-id` on `actions/create-github-app-token`. Confirmed against the action's own `action.yml`: `client-id` is the current input and `app-id` carries `deprecationMessage: "Use 'client-id' instead."` No `shellcheck` findings on the new file (the existing `release.yml` and `preview-build.yml` each have one).
- **`pnpm lint` green** (licenses, eslint, typecheck, boundaries).

## What could not be verified without a live Dependabot PR

Everything above is static analysis and local measurement. Unexercised until this merges and a Dependabot PR triggers it:

- the `pull_request_target` trigger and `paths` filter actually firing;
- the token fallback chain and whether the push re-triggers `Lint`;
- the self-retrigger guard suppressing the second run — the logic is unit-tested against real and near-miss subjects, and the guard and the committer both read one workflow-level `env` var so they cannot drift, but the round trip is untested;
- the force-push race check.

The workflow carries a `workflow_dispatch` input taking a PR number so it can be exercised on demand against any of the five open PRs once merged. That is the fastest way to close these out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
