### PR TITLE
feat(messaging): attach PwrAgent threads as Discord replies

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4208,6 +4208,10 @@ describe("MessagingController", () => {
     const event = buildTextEvent("attach it here", {
       channel: channelEvent.channel,
       routingState: channelEvent.routingState,
+      sourceSurface: {
+        channel: "telegram",
+        id: "source-message-1",
+      },
     });
     await harness.store.upsertBinding({
       id: "binding:telegram:channel::-1001:codex:thread-1",
@@ -4631,6 +4635,7 @@ describe("MessagingController", () => {
         actor: event.actor,
         parent: event.channel,
         routingState: event.routingState,
+        sourceSurface: event.sourceSurface,
         title: "Telegram thread naming issue",
       }),
     );
@@ -9194,6 +9199,60 @@ describe("MessagingController", () => {
         },
       },
     });
+  });
+
+  it("does not persist an ephemeral inbound source surface during binding refresh", async () => {
+    const harness = await createHarness();
+    const channel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "1480556454498009352",
+        kind: "channel" as const,
+        workspaceId: "1480556454498009353",
+      },
+    };
+    const routingState = {
+      opaque: {
+        channelId: "1480556454498009352",
+        guildId: "1480556454498009353",
+        isThread: false,
+      },
+    };
+    await harness.store.upsertBinding({
+      id: "binding:discord:channel::1480556454498009352:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      routingState,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+    const upsertBinding = vi.spyOn(harness.store, "upsertBinding");
+    const event = buildTextEvent("attach this thread", {
+      channel,
+      routingState,
+      sourceSurface: {
+        channel: "discord",
+        id: "1480556454498009354",
+        state: {
+          opaque: {
+            channelId: "1480556454498009352",
+            guildId: "1480556454498009353",
+            messageId: "1480556454498009354",
+          },
+        },
+      },
+    });
+
+    await (
+      harness.controller as unknown as {
+        refreshBindingFromInbound(event: MessagingInboundEvent): Promise<void>;
+      }
+    ).refreshBindingFromInbound(event);
+
+    expect(upsertBinding).not.toHaveBeenCalled();
   });
 
   it("drops typing activity during provider cool-off without spending write budget", async () => {
@@ -24185,6 +24244,7 @@ function buildTextEvent(
     botMention?: boolean;
     channel?: MessagingInboundTextEvent["channel"];
     routingState?: MessagingInboundTextEvent["routingState"];
+    sourceSurface?: MessagingInboundTextEvent["sourceSurface"];
   } = {},
 ): MessagingInboundTextEvent {
   return {
@@ -24203,6 +24263,7 @@ function buildTextEvent(
     receivedAt: 1000,
     ...(params.botMention ? { botMention: true } : {}),
     routingState: params.routingState,
+    sourceSurface: params.sourceSurface,
     text,
   };
 }

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -756,6 +756,48 @@ describe("messaging status ipc", () => {
     });
   });
 
+  it("labels an approved Discord guild with the server name, not the channel", async () => {
+    const { MESSAGING_APPROVE_PAIRING_CHANNEL } = await import("../../shared/ipc");
+    const entry = {
+      id: "pairing-discord-guild",
+      platform: "discord",
+      instanceId: "default",
+      scope: "bucket",
+      status: "observed",
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+      observedActor: { id: "1480556454498009351", displayName: "Harold" },
+      observedChat: {
+        id: "1480556454498009352",
+        kind: "channel",
+        title: "general",
+        parentTitle: "huntharo-claw",
+        bucketId: "1480556454498009353",
+      },
+    };
+    const consumed = { ...entry, status: "consumed" };
+    runtimeMock.listPairingRequests.mockReturnValue({ entries: [entry] });
+    settingsServiceMock.readSettings.mockResolvedValue(discordSettingsSnapshot());
+    pairingStoreMock.markStatus.mockReturnValue(consumed);
+
+    registerMessagingStatusIpcHandlers();
+
+    await handlers.get(MESSAGING_APPROVE_PAIRING_CHANNEL)?.(
+      {},
+      { entryId: entry.id },
+    );
+
+    expect(settingsServiceMock.writeConfigPatch).toHaveBeenCalledWith({
+      messaging: {
+        discord: {
+          authorizedGuilds: [
+            { id: "1480556454498009353", displayName: "huntharo-claw" },
+          ],
+        },
+      },
+    });
+  });
+
   it("maps a Slack channel-level pairing (no thread) to the channel name", async () => {
     const { MESSAGING_APPROVE_PAIRING_CHANNEL } = await import("../../shared/ipc");
     // Pairing sent directly in #signals-chat (not a thread): the channel name
@@ -1033,6 +1075,17 @@ function feishuSettingsSnapshot() {
         authorizedUserIds: { value: [], source: "default" },
         authorizedChats: { value: [], source: "default" },
         authorizedTenants: { value: [], source: "default" },
+      },
+    },
+  };
+}
+
+function discordSettingsSnapshot() {
+  return {
+    messaging: {
+      discord: {
+        authorizedUserIds: { value: [], source: "default" },
+        authorizedGuilds: { value: [], source: "default" },
       },
     },
   };

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -771,7 +771,8 @@ describe("messaging status ipc", () => {
         id: "1480556454498009352",
         kind: "channel",
         title: "general",
-        parentTitle: "huntharo-claw",
+        parentTitle: "Text Channels",
+        ancestorTitle: "huntharo-claw",
         bucketId: "1480556454498009353",
       },
     };

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -31,6 +31,10 @@ const electronMocks = vi.hoisted(() => ({
 const providerMocks = vi.hoisted(() => ({
   resolveTelegramContact: vi.fn(),
   resolveDiscordContact: vi.fn(),
+  inspectDiscordThreadPermissions: vi.fn(),
+  buildDiscordThreadPermissionRequestUrl: vi.fn(
+    () => "https://discord.com/oauth2/authorize?client_id=1480556454498009351",
+  ),
   resolveMattermostContact: vi.fn(),
   resolveSlackContact: vi.fn(),
   buildSlackCreateAppUrl: vi.fn(() => ({
@@ -167,6 +171,9 @@ vi.mock("@pwragent/messaging-provider-telegram", () => ({
 
 vi.mock("@pwragent/messaging-provider-discord", () => ({
   resolveContact: providerMocks.resolveDiscordContact,
+  inspectDiscordThreadPermissions: providerMocks.inspectDiscordThreadPermissions,
+  buildDiscordThreadPermissionRequestUrl:
+    providerMocks.buildDiscordThreadPermissionRequestUrl,
 }));
 
 vi.mock("@pwragent/messaging-provider-mattermost", () => ({
@@ -196,6 +203,8 @@ describe("settings ipc", () => {
     getDesktopBackendRegistryMock.mockClear();
     providerMocks.resolveTelegramContact.mockReset();
     providerMocks.resolveDiscordContact.mockReset();
+    providerMocks.inspectDiscordThreadPermissions.mockReset();
+    providerMocks.buildDiscordThreadPermissionRequestUrl.mockClear();
     providerMocks.resolveMattermostContact.mockReset();
     providerMocks.resolveSlackContact.mockReset();
     providerMocks.buildSlackCreateAppUrl.mockClear();
@@ -493,6 +502,74 @@ describe("settings ipc", () => {
     expect(providerMocks.buildSlackCreateAppUrl).toHaveBeenCalledTimes(1);
     expect(electronMocks.openExternal).toHaveBeenCalledExactlyOnceWith(
       "https://api.slack.com/apps?new_app=1&manifest_json=%7B%7D",
+    );
+
+    disposeSettingsIpcHandlers();
+  });
+
+  it("checks and opens Discord's suggested thread-reply permission request", async () => {
+    const service = {
+      readSettings: vi.fn(),
+    } as unknown as DesktopSettingsService;
+    messagingConfigMocks.loadDesktopMessagingConfigFromSettings
+      .mockResolvedValueOnce({
+        discord: {
+          applicationId: "1480556454498009351",
+          botToken: "discord-token",
+        },
+      })
+      .mockResolvedValueOnce({
+        discord: {
+          applicationId: "1480556454498009351",
+          botToken: "discord-token",
+        },
+      });
+    providerMocks.inspectDiscordThreadPermissions.mockResolvedValue({
+      channelId: "1480556454498009352",
+      checkedAt: 1,
+      durationMs: 1,
+      guildId: "1480556454498009353",
+      permissions: [],
+      status: "ok",
+    });
+    const { registerSettingsIpcHandlers, disposeSettingsIpcHandlers } = await import(
+      "../ipc/settings"
+    );
+    const {
+      SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+      SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
+    } = await import("../../shared/ipc");
+
+    disposeSettingsIpcHandlers();
+    registerSettingsIpcHandlers(service);
+
+    await expect(
+      handlers.get(SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL)?.(
+        {},
+        {
+          channelId: "1480556454498009352",
+          guildId: "1480556454498009353",
+        },
+      ),
+    ).resolves.toMatchObject({ status: "ok" });
+    expect(providerMocks.inspectDiscordThreadPermissions).toHaveBeenCalledWith({
+      botToken: "discord-token",
+      channelId: "1480556454498009352",
+      guildId: "1480556454498009353",
+    });
+
+    await expect(
+      handlers.get(SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL)?.(
+        {},
+        { guildId: "1480556454498009353", open: true },
+      ),
+    ).resolves.toMatchObject({ opened: true });
+    expect(providerMocks.buildDiscordThreadPermissionRequestUrl).toHaveBeenCalledWith({
+      applicationId: "1480556454498009351",
+      guildId: "1480556454498009353",
+    });
+    expect(electronMocks.openExternal).toHaveBeenCalledWith(
+      "https://discord.com/oauth2/authorize?client_id=1480556454498009351",
     );
 
     disposeSettingsIpcHandlers();

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -32,6 +32,7 @@ const providerMocks = vi.hoisted(() => ({
   resolveTelegramContact: vi.fn(),
   resolveDiscordContact: vi.fn(),
   inspectDiscordThreadPermissions: vi.fn(),
+  listDiscordThreadPermissionChannels: vi.fn(),
   buildDiscordThreadPermissionRequestUrl: vi.fn(
     () => "https://discord.com/oauth2/authorize?client_id=1480556454498009351",
   ),
@@ -172,6 +173,8 @@ vi.mock("@pwragent/messaging-provider-telegram", () => ({
 vi.mock("@pwragent/messaging-provider-discord", () => ({
   resolveContact: providerMocks.resolveDiscordContact,
   inspectDiscordThreadPermissions: providerMocks.inspectDiscordThreadPermissions,
+  listDiscordThreadPermissionChannels:
+    providerMocks.listDiscordThreadPermissionChannels,
   buildDiscordThreadPermissionRequestUrl:
     providerMocks.buildDiscordThreadPermissionRequestUrl,
 }));
@@ -204,6 +207,7 @@ describe("settings ipc", () => {
     providerMocks.resolveTelegramContact.mockReset();
     providerMocks.resolveDiscordContact.mockReset();
     providerMocks.inspectDiscordThreadPermissions.mockReset();
+    providerMocks.listDiscordThreadPermissionChannels.mockReset();
     providerMocks.buildDiscordThreadPermissionRequestUrl.mockClear();
     providerMocks.resolveMattermostContact.mockReset();
     providerMocks.resolveSlackContact.mockReset();
@@ -511,19 +515,28 @@ describe("settings ipc", () => {
     const service = {
       readSettings: vi.fn(),
     } as unknown as DesktopSettingsService;
+    const discordConfig = {
+      discord: {
+        applicationId: "1480556454498009351",
+        botToken: "discord-token",
+      },
+    };
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings
-      .mockResolvedValueOnce({
-        discord: {
-          applicationId: "1480556454498009351",
-          botToken: "discord-token",
+      .mockResolvedValueOnce(discordConfig)
+      .mockResolvedValueOnce(discordConfig)
+      .mockResolvedValueOnce(discordConfig);
+    providerMocks.listDiscordThreadPermissionChannels.mockResolvedValue({
+      channels: [
+        {
+          id: "1480556454498009352",
+          kind: "text",
+          name: "general",
         },
-      })
-      .mockResolvedValueOnce({
-        discord: {
-          applicationId: "1480556454498009351",
-          botToken: "discord-token",
-        },
-      });
+      ],
+      guildId: "1480556454498009353",
+      guildName: "PwrAgent test guild",
+      status: "ok",
+    });
     providerMocks.inspectDiscordThreadPermissions.mockResolvedValue({
       channelId: "1480556454498009352",
       checkedAt: 1,
@@ -537,11 +550,26 @@ describe("settings ipc", () => {
     );
     const {
       SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+      SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL,
       SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
     } = await import("../../shared/ipc");
 
     disposeSettingsIpcHandlers();
     registerSettingsIpcHandlers(service);
+
+    await expect(
+      handlers.get(SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL)?.(
+        {},
+        { guildId: "1480556454498009353" },
+      ),
+    ).resolves.toMatchObject({
+      channels: [expect.objectContaining({ name: "general" })],
+      status: "ok",
+    });
+    expect(providerMocks.listDiscordThreadPermissionChannels).toHaveBeenCalledWith({
+      botToken: "discord-token",
+      guildId: "1480556454498009353",
+    });
 
     await expect(
       handlers.get(SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL)?.(

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -356,9 +356,12 @@ function contactForPairing(
       return { id, displayName: slackChannelDisplayName(entry.observedChat) };
     }
     const id = entry.observedChat.bucketId ?? entry.observedChat.parentId ?? entry.observedChat.id;
+    const displayName = entry.platform === "discord"
+      ? entry.observedChat.ancestorTitle ?? entry.observedChat.parentTitle ?? ""
+      : entry.observedChat.title ?? entry.observedChat.parentTitle ?? "";
     return {
       id,
-      displayName: entry.observedChat.title ?? entry.observedChat.parentTitle ?? "",
+      displayName,
     };
   }
   if (isSlack && !validateSlackUserId(entry.observedActor.id).ok) {

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -21,6 +21,8 @@ import type {
   DesktopSettingsSnapshot,
   InspectDiscordThreadPermissionsRequest,
   InspectDiscordThreadPermissionsResponse,
+  ListDiscordThreadPermissionChannelsRequest,
+  ListDiscordThreadPermissionChannelsResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
   ReadDesktopSettingsRequest,
@@ -54,6 +56,7 @@ import {
   SETTINGS_CREATE_CODEX_AUTH_PROFILE_CHANNEL,
   SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL,
   SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+  SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL,
   SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
   SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL,
   SETTINGS_PICK_GH_COMMAND_CHANNEL,
@@ -1418,6 +1421,25 @@ export function registerSettingsIpcHandlers(
     },
   );
 
+  ipcMain.removeHandler(SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL);
+  ipcMain.handle(
+    SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL,
+    async (
+      _event,
+      request: ListDiscordThreadPermissionChannelsRequest,
+    ): Promise<ListDiscordThreadPermissionChannelsResponse> => {
+      const config = await loadDesktopMessagingConfigFromSettings(
+        getService(service),
+        process.env,
+      );
+      const discordProvider = await import("@pwragent/messaging-provider-discord");
+      return await discordProvider.listDiscordThreadPermissionChannels({
+        botToken: config.discord?.botToken ?? "",
+        guildId: request.guildId,
+      });
+    },
+  );
+
   ipcMain.removeHandler(SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL);
   ipcMain.handle(
     SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
@@ -1546,6 +1568,7 @@ export function disposeSettingsIpcHandlers(): void {
   ipcMain.removeHandler(SETTINGS_TEST_CREDENTIALS_CHANNEL);
   ipcMain.removeHandler(SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL);
   ipcMain.removeHandler(SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL);
+  ipcMain.removeHandler(SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL);
   ipcMain.removeHandler(SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL);
   ipcMain.removeHandler(SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL);
   ipcMain.removeHandler(SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL);

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -19,6 +19,8 @@ import type {
   DesktopSettingsSecretName,
   DesktopSettingsWriteResponse,
   DesktopSettingsSnapshot,
+  InspectDiscordThreadPermissionsRequest,
+  InspectDiscordThreadPermissionsResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
   ReadDesktopSettingsRequest,
@@ -29,6 +31,8 @@ import type {
   SettingsCredentialTestKind,
   SettingsCredentialTestRequest,
   SettingsCredentialTestResult,
+  OpenDiscordThreadPermissionRequest,
+  OpenDiscordThreadPermissionResponse,
   SlackCreateAppRequest,
   SlackCreateAppResponse,
   StartDesktopCodexAuthProfileLoginRequest,
@@ -49,6 +53,8 @@ import {
   SETTINGS_CLEAR_SECRET_CHANNEL,
   SETTINGS_CREATE_CODEX_AUTH_PROFILE_CHANNEL,
   SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL,
+  SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+  SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
   SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL,
   SETTINGS_PICK_GH_COMMAND_CHANNEL,
   SETTINGS_READ_CHANNEL,
@@ -1412,6 +1418,59 @@ export function registerSettingsIpcHandlers(
     },
   );
 
+  ipcMain.removeHandler(SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL);
+  ipcMain.handle(
+    SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+    async (
+      _event,
+      request: InspectDiscordThreadPermissionsRequest,
+    ): Promise<InspectDiscordThreadPermissionsResponse> => {
+      const config = await loadDesktopMessagingConfigFromSettings(
+        getService(service),
+        process.env,
+      );
+      const discordProvider = await import("@pwragent/messaging-provider-discord");
+      return await discordProvider.inspectDiscordThreadPermissions({
+        botToken: config.discord?.botToken ?? "",
+        channelId: request.channelId,
+        guildId: request.guildId,
+      });
+    },
+  );
+
+  ipcMain.removeHandler(SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL);
+  ipcMain.handle(
+    SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
+    async (
+      _event,
+      request: OpenDiscordThreadPermissionRequest = {},
+    ): Promise<OpenDiscordThreadPermissionResponse> => {
+      const config = await loadDesktopMessagingConfigFromSettings(
+        getService(service),
+        process.env,
+      );
+      const applicationId = config.discord?.applicationId;
+      if (!applicationId) {
+        throw new Error("Configure the Discord application ID before requesting permissions.");
+      }
+      const discordProvider = await import("@pwragent/messaging-provider-discord");
+      const url = discordProvider.buildDiscordThreadPermissionRequestUrl({
+        applicationId,
+        ...(request.guildId ? { guildId: request.guildId } : {}),
+      });
+      const shouldOpen = request.open !== false;
+      let opened = false;
+      if (shouldOpen) {
+        if (!isSafeExternalOpenUrl(url)) {
+          throw new Error("Refused to open an unsafe Discord permission URL.");
+        }
+        await shell.openExternal(url);
+        opened = true;
+      }
+      return { opened, url };
+    },
+  );
+
   ipcMain.removeHandler(SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL);
   ipcMain.handle(
     SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL,
@@ -1487,6 +1546,8 @@ export function disposeSettingsIpcHandlers(): void {
   ipcMain.removeHandler(SETTINGS_TEST_CREDENTIALS_CHANNEL);
   ipcMain.removeHandler(SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL);
   ipcMain.removeHandler(SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL);
+  ipcMain.removeHandler(SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL);
+  ipcMain.removeHandler(SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL);
   ipcMain.removeHandler(SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL);
   ipcMain.removeHandler(ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL);
   disposeCredentialTester();

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -16380,6 +16380,7 @@ export class MessagingController {
         actor: origin.origin.event.actor,
         parent: origin.origin.event.channel,
         routingState: origin.origin.event.routingState,
+        sourceSurface: origin.origin.event.sourceSurface,
         title: sanitizeMessagingChildTitle(args.title),
       });
       if (createResult.outcome !== "created" || !createResult.conversation) {
@@ -17487,6 +17488,7 @@ export class MessagingController {
       actor: origin.event.actor,
       channel: origin.event.channel,
       routingState: origin.event.routingState,
+      sourceSurface: origin.event.sourceSurface,
     });
     const operation = rights.operations.find(
       (candidate) => candidate.operation === "create_child",

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -3024,6 +3024,7 @@ function observedChatFromEvent(event: MessagingInboundEvent): MessagingPairingOb
     title: conversation.title,
     parentId: conversation.parentId,
     parentTitle: conversation.parentTitle,
+    ancestorTitle: conversation.ancestorTitle,
     bucketId: bucketIdFromEvent(event),
   };
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -373,6 +373,8 @@ import type {
   SettingsCredentialTestResult,
   InspectDiscordThreadPermissionsRequest,
   InspectDiscordThreadPermissionsResponse,
+  ListDiscordThreadPermissionChannelsRequest,
+  ListDiscordThreadPermissionChannelsResponse,
   OpenDiscordThreadPermissionRequest,
   OpenDiscordThreadPermissionResponse,
   SlackCreateAppRequest,
@@ -708,6 +710,7 @@ import {
   SETTINGS_CREATE_CODEX_AUTH_PROFILE_CHANNEL,
   SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL,
   SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+  SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL,
   SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
   SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL,
   SETTINGS_PICK_GH_COMMAND_CHANNEL,
@@ -1220,6 +1223,13 @@ const desktopApi = Object.freeze({
     request?: SlackCreateAppRequest,
   ): Promise<SlackCreateAppResponse> =>
     await ipcRenderer.invoke(SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL, request),
+  listDiscordThreadPermissionChannels: async (
+    request: ListDiscordThreadPermissionChannelsRequest,
+  ): Promise<ListDiscordThreadPermissionChannelsResponse> =>
+    await ipcRenderer.invoke(
+      SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL,
+      request,
+    ),
   inspectDiscordThreadPermissions: async (
     request: InspectDiscordThreadPermissionsRequest,
   ): Promise<InspectDiscordThreadPermissionsResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -371,6 +371,10 @@ import type {
   SettingsCredentialTestKind,
   SettingsCredentialTestRequest,
   SettingsCredentialTestResult,
+  InspectDiscordThreadPermissionsRequest,
+  InspectDiscordThreadPermissionsResponse,
+  OpenDiscordThreadPermissionRequest,
+  OpenDiscordThreadPermissionResponse,
   SlackCreateAppRequest,
   SlackCreateAppResponse,
   DesktopBootInfo,
@@ -703,6 +707,8 @@ import {
   SETTINGS_CLEAR_SECRET_CHANNEL,
   SETTINGS_CREATE_CODEX_AUTH_PROFILE_CHANNEL,
   SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL,
+  SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+  SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
   SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL,
   SETTINGS_PICK_GH_COMMAND_CHANNEL,
   SETTINGS_READ_CHANNEL,
@@ -1214,6 +1220,20 @@ const desktopApi = Object.freeze({
     request?: SlackCreateAppRequest,
   ): Promise<SlackCreateAppResponse> =>
     await ipcRenderer.invoke(SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL, request),
+  inspectDiscordThreadPermissions: async (
+    request: InspectDiscordThreadPermissionsRequest,
+  ): Promise<InspectDiscordThreadPermissionsResponse> =>
+    await ipcRenderer.invoke(
+      SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL,
+      request,
+    ),
+  openDiscordThreadPermissionRequest: async (
+    request?: OpenDiscordThreadPermissionRequest,
+  ): Promise<OpenDiscordThreadPermissionResponse> =>
+    await ipcRenderer.invoke(
+      SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL,
+      request,
+    ),
   readLastSettingsCredentialTest: async (
     request: { kind: SettingsCredentialTestKind },
   ): Promise<SettingsCredentialTestResult | undefined> =>

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -1900,8 +1900,25 @@ function DiscordThreadPermissionsField(props: {
   const [requesting, setRequesting] = useState(false);
   const [result, setResult] = useState<InspectDiscordThreadPermissionsResponse>();
   const [notice, setNotice] = useState<string>();
-  const validGuild = validateDiscordSnowflake(guildId).ok;
-  const validChannel = validateDiscordSnowflake(channelId.trim()).ok;
+  const selectedGuildId = props.authorizedGuilds.some((guild) => guild.id === guildId)
+    ? guildId
+    : (props.authorizedGuilds[0]?.id ?? "");
+  const selectedChannelId = channelId.trim();
+  const permissionSelectionRef = useRef({
+    channelId: selectedChannelId,
+    guildId: selectedGuildId,
+  });
+  permissionSelectionRef.current = {
+    channelId: selectedChannelId,
+    guildId: selectedGuildId,
+  };
+  const visibleResult =
+    result?.guildId === selectedGuildId
+    && result.channelId === selectedChannelId
+      ? result
+      : undefined;
+  const validGuild = validateDiscordSnowflake(selectedGuildId).ok;
+  const validChannel = validateDiscordSnowflake(selectedChannelId).ok;
   const canCheck =
     Boolean(props.desktopApi?.inspectDiscordThreadPermissions)
     && validGuild
@@ -1916,16 +1933,28 @@ function DiscordThreadPermissionsField(props: {
 
   const checkPermissions = async () => {
     if (!canCheck || !props.desktopApi?.inspectDiscordThreadPermissions) return;
+    const request = {
+      channelId: selectedChannelId,
+      guildId: selectedGuildId,
+    };
     setChecking(true);
     setNotice(undefined);
     try {
-      setResult(await props.desktopApi.inspectDiscordThreadPermissions({
-        channelId: channelId.trim(),
-        guildId,
-      }));
+      const nextResult = await props.desktopApi.inspectDiscordThreadPermissions(request);
+      if (
+        permissionSelectionRef.current.channelId === request.channelId
+        && permissionSelectionRef.current.guildId === request.guildId
+      ) {
+        setResult(nextResult);
+      }
     } catch (error) {
-      setResult(undefined);
-      setNotice(error instanceof Error ? error.message : String(error));
+      if (
+        permissionSelectionRef.current.channelId === request.channelId
+        && permissionSelectionRef.current.guildId === request.guildId
+      ) {
+        setResult(undefined);
+        setNotice(error instanceof Error ? error.message : String(error));
+      }
     } finally {
       setChecking(false);
     }
@@ -1937,7 +1966,7 @@ function DiscordThreadPermissionsField(props: {
     setNotice(undefined);
     try {
       const opened = await props.desktopApi.openDiscordThreadPermissionRequest({
-        ...(validGuild ? { guildId } : {}),
+        ...(validGuild ? { guildId: selectedGuildId } : {}),
       });
       setNotice(
         opened.opened
@@ -1963,7 +1992,7 @@ function DiscordThreadPermissionsField(props: {
               aria-label="Discord server for thread reply permissions"
               className="settings-input"
               disabled={props.disabled || props.authorizedGuilds.length === 0}
-              value={guildId}
+              value={selectedGuildId}
               onChange={(event) => {
                 setGuildId(event.currentTarget.value);
                 setResult(undefined);
@@ -2010,9 +2039,9 @@ function DiscordThreadPermissionsField(props: {
               {requesting ? "Opening…" : "Request suggested permissions"}
             </button>
           </div>
-          {result?.status === "ok" ? (
+          {visibleResult?.status === "ok" ? (
             <div className="settings-field__help" role="status">
-              {result.permissions.map((permission) => (
+              {visibleResult.permissions.map((permission) => (
                 <span key={permission.id}>
                   {permission.granted ? "Granted" : "Missing"}: {permission.label}
                   {" · "}
@@ -2020,12 +2049,13 @@ function DiscordThreadPermissionsField(props: {
               ))}
             </div>
           ) : null}
-          {result?.status === "failed" ? (
+          {visibleResult?.status === "failed" ? (
             <div className="settings-field__help" role="alert">
-              {result.errorMessage ?? "Discord could not check these permissions."}
+              {visibleResult.errorMessage
+                ?? "Discord could not check these permissions."}
             </div>
           ) : null}
-          {result?.status === "unset" ? (
+          {visibleResult?.status === "unset" ? (
             <div className="settings-field__help" role="status">
               Configure a Discord bot token before checking permissions.
             </div>

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -48,7 +48,16 @@ import {
   type InspectDiscordThreadPermissionsResponse,
   type ListDiscordThreadPermissionChannelsResponse,
 } from "@pwragent/shared";
-import { DiscordIcon, FeishuIcon, LineIcon, MattermostIcon, SlackIcon, TelegramIcon } from "../../icons";
+import {
+  CheckIcon,
+  CloseIcon,
+  DiscordIcon,
+  FeishuIcon,
+  LineIcon,
+  MattermostIcon,
+  SlackIcon,
+  TelegramIcon,
+} from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import {
   SLACK_APPROVAL_TARGET_LABELS,
@@ -1932,6 +1941,15 @@ function DiscordThreadPermissionsField(props: {
     && result.channelId === selectedChannelId
       ? result
       : undefined;
+  const checkedPermissions = visibleResult?.status === "ok"
+    ? [
+        ...visibleResult.permissions.filter((permission) => !permission.granted),
+        ...visibleResult.permissions.filter((permission) => permission.granted),
+      ]
+    : [];
+  const missingPermissionCount = checkedPermissions.filter(
+    (permission) => !permission.granted,
+  ).length;
   const validChannel = validateDiscordSnowflake(selectedChannelId).ok;
   const canCheck =
     Boolean(props.desktopApi?.inspectDiscordThreadPermissions)
@@ -2043,7 +2061,7 @@ function DiscordThreadPermissionsField(props: {
     <SettingsField
       label="Thread replies"
       sub="Create a public Discord thread from a selected message, then attach the PwrAgent thread to it."
-      help="Suggested: View Channel, Send Messages, Embed Links, Attach Files, Read Message History, Create Public Threads, and Send Messages in Threads. The check includes category and channel overrides. The authorization request does not request Administrator or Manage Threads."
+      help="Checks PwrAgent’s suggested permissions, including category and channel overrides. The authorization request does not request Administrator or Manage Threads."
       control={
         <>
           <div className="settings-inline-actions">
@@ -2151,13 +2169,55 @@ function DiscordThreadPermissionsField(props: {
             </div>
           ) : null}
           {visibleResult?.status === "ok" ? (
-            <div className="settings-field__help" role="status">
-              {visibleResult.permissions.map((permission) => (
-                <span key={permission.id}>
-                  {permission.granted ? "Granted" : "Missing"}: {permission.label}
-                  {" · "}
-                </span>
-              ))}
+            <div
+              aria-label="Discord permission check result"
+              className="discord-permission-result"
+              role={missingPermissionCount > 0 ? "alert" : "status"}
+            >
+              <div className="discord-permission-result__summary">
+                <strong>
+                  {missingPermissionCount === 0
+                    ? `All ${checkedPermissions.length} suggested permissions are granted.`
+                    : `${missingPermissionCount} of ${checkedPermissions.length} suggested ${
+                        checkedPermissions.length === 1 ? "permission" : "permissions"
+                      } ${missingPermissionCount === 1 ? "is" : "are"} missing.`}
+                </strong>
+                {missingPermissionCount > 0 ? (
+                  <span>Missing permissions are listed first.</span>
+                ) : null}
+              </div>
+              <ul
+                aria-label="Discord permission check details"
+                className="discord-permission-result__list"
+              >
+                {checkedPermissions.map((permission) => (
+                  <li
+                    className={`discord-permission-result__item ${
+                      permission.granted
+                        ? "discord-permission-result__item--granted"
+                        : "discord-permission-result__item--missing"
+                    }`}
+                    key={permission.id}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="discord-permission-result__icon"
+                    >
+                      {permission.granted ? (
+                        <CheckIcon size={14} />
+                      ) : (
+                        <CloseIcon size={14} />
+                      )}
+                    </span>
+                    <span className="discord-permission-result__label">
+                      {permission.label}
+                    </span>
+                    <span className="discord-permission-result__state">
+                      {permission.granted ? "Granted" : "Missing"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             </div>
           ) : null}
           {visibleResult?.status === "failed" ? (

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -45,6 +45,7 @@ import {
   type MessagingPairingEntry,
   type MessagingPairingScope,
   type MessagingToolUpdateMode,
+  type InspectDiscordThreadPermissionsResponse,
 } from "@pwragent/shared";
 import { DiscordIcon, FeishuIcon, LineIcon, MattermostIcon, SlackIcon, TelegramIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
@@ -699,6 +700,12 @@ export function MessagingSettings(props: {
                 defaultSub="discord.com/api/v10"
               />
             }
+          />
+          <DiscordThreadPermissionsField
+            applicationId={discord.applicationId.value}
+            authorizedGuilds={discord.authorizedGuilds.value}
+            desktopApi={props.desktopApi}
+            disabled={props.saving}
           />
           <PairingTokenField
             desktopApi={props.desktopApi}
@@ -1879,6 +1886,157 @@ function configuredMessagingRoutePlatforms(
     messaging.feishu.appSecret.configured ? "feishu" : undefined,
     messaging.line.channelAccessToken.configured ? "line" : undefined,
   ].filter((platform): platform is MessagingChannelKind => Boolean(platform));
+}
+
+function DiscordThreadPermissionsField(props: {
+  applicationId: string;
+  authorizedGuilds: DesktopAuthorizedContact[];
+  desktopApi?: DesktopApi;
+  disabled: boolean;
+}) {
+  const [guildId, setGuildId] = useState(props.authorizedGuilds[0]?.id ?? "");
+  const [channelId, setChannelId] = useState("");
+  const [checking, setChecking] = useState(false);
+  const [requesting, setRequesting] = useState(false);
+  const [result, setResult] = useState<InspectDiscordThreadPermissionsResponse>();
+  const [notice, setNotice] = useState<string>();
+  const validGuild = validateDiscordSnowflake(guildId).ok;
+  const validChannel = validateDiscordSnowflake(channelId.trim()).ok;
+  const canCheck =
+    Boolean(props.desktopApi?.inspectDiscordThreadPermissions)
+    && validGuild
+    && validChannel
+    && !props.disabled
+    && !checking;
+  const canRequest =
+    Boolean(props.desktopApi?.openDiscordThreadPermissionRequest)
+    && validateDiscordSnowflake(props.applicationId).ok
+    && !props.disabled
+    && !requesting;
+
+  const checkPermissions = async () => {
+    if (!canCheck || !props.desktopApi?.inspectDiscordThreadPermissions) return;
+    setChecking(true);
+    setNotice(undefined);
+    try {
+      setResult(await props.desktopApi.inspectDiscordThreadPermissions({
+        channelId: channelId.trim(),
+        guildId,
+      }));
+    } catch (error) {
+      setResult(undefined);
+      setNotice(error instanceof Error ? error.message : String(error));
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const requestPermissions = async () => {
+    if (!canRequest || !props.desktopApi?.openDiscordThreadPermissionRequest) return;
+    setRequesting(true);
+    setNotice(undefined);
+    try {
+      const opened = await props.desktopApi.openDiscordThreadPermissionRequest({
+        ...(validGuild ? { guildId } : {}),
+      });
+      setNotice(
+        opened.opened
+          ? "Opened Discord’s administrator authorization request."
+          : "Prepared the Discord administrator authorization request.",
+      );
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : String(error));
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  return (
+    <SettingsField
+      label="Thread replies"
+      sub="Create a public Discord thread from a selected message, then attach the PwrAgent thread to it."
+      help="Suggested: View Channel, Send Messages, Embed Links, Attach Files, Read Message History, Create Public Threads, and Send Messages in Threads. The check includes category and channel overrides. The authorization request does not request Administrator or Manage Threads."
+      control={
+        <>
+          <div className="settings-inline-actions">
+            <select
+              aria-label="Discord server for thread reply permissions"
+              className="settings-input"
+              disabled={props.disabled || props.authorizedGuilds.length === 0}
+              value={guildId}
+              onChange={(event) => {
+                setGuildId(event.currentTarget.value);
+                setResult(undefined);
+                setNotice(undefined);
+              }}
+            >
+              {props.authorizedGuilds.length === 0 ? (
+                <option value="">Add an authorized server first</option>
+              ) : null}
+              {props.authorizedGuilds.map((guild) => (
+                <option key={guild.id} value={guild.id}>
+                  {guild.displayName || guild.id}
+                </option>
+              ))}
+            </select>
+            <input
+              aria-label="Discord channel ID for thread reply permissions"
+              className="settings-input"
+              disabled={props.disabled}
+              placeholder="Channel ID"
+              value={channelId}
+              onChange={(event) => {
+                setChannelId(event.currentTarget.value);
+                setResult(undefined);
+                setNotice(undefined);
+              }}
+            />
+          </div>
+          <div className="settings-inline-actions">
+            <button
+              className="button button--secondary"
+              disabled={!canCheck}
+              type="button"
+              onClick={() => void checkPermissions()}
+            >
+              {checking ? "Checking…" : "Check permissions"}
+            </button>
+            <button
+              className="button button--secondary"
+              disabled={!canRequest}
+              type="button"
+              onClick={() => void requestPermissions()}
+            >
+              {requesting ? "Opening…" : "Request suggested permissions"}
+            </button>
+          </div>
+          {result?.status === "ok" ? (
+            <div className="settings-field__help" role="status">
+              {result.permissions.map((permission) => (
+                <span key={permission.id}>
+                  {permission.granted ? "Granted" : "Missing"}: {permission.label}
+                  {" · "}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {result?.status === "failed" ? (
+            <div className="settings-field__help" role="alert">
+              {result.errorMessage ?? "Discord could not check these permissions."}
+            </div>
+          ) : null}
+          {result?.status === "unset" ? (
+            <div className="settings-field__help" role="status">
+              Configure a Discord bot token before checking permissions.
+            </div>
+          ) : null}
+          {notice ? (
+            <div className="settings-field__help" role="status">{notice}</div>
+          ) : null}
+        </>
+      }
+    />
+  );
 }
 
 const TOOL_UPDATE_MODE_OPTIONS: Array<{

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -46,6 +46,7 @@ import {
   type MessagingPairingScope,
   type MessagingToolUpdateMode,
   type InspectDiscordThreadPermissionsResponse,
+  type ListDiscordThreadPermissionChannelsResponse,
 } from "@pwragent/shared";
 import { DiscordIcon, FeishuIcon, LineIcon, MattermostIcon, SlackIcon, TelegramIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
@@ -1896,6 +1897,11 @@ function DiscordThreadPermissionsField(props: {
 }) {
   const [guildId, setGuildId] = useState(props.authorizedGuilds[0]?.id ?? "");
   const [channelId, setChannelId] = useState("");
+  const [channelList, setChannelList] =
+    useState<ListDiscordThreadPermissionChannelsResponse>();
+  const [channelListRevision, setChannelListRevision] = useState(0);
+  const [guildNames, setGuildNames] = useState<Record<string, string>>({});
+  const [loadingChannels, setLoadingChannels] = useState(false);
   const [checking, setChecking] = useState(false);
   const [requesting, setRequesting] = useState(false);
   const [result, setResult] = useState<InspectDiscordThreadPermissionsResponse>();
@@ -1903,7 +1909,16 @@ function DiscordThreadPermissionsField(props: {
   const selectedGuildId = props.authorizedGuilds.some((guild) => guild.id === guildId)
     ? guildId
     : (props.authorizedGuilds[0]?.id ?? "");
-  const selectedChannelId = channelId.trim();
+  const validGuild = validateDiscordSnowflake(selectedGuildId).ok;
+  const visibleChannelList = channelList?.guildId === selectedGuildId
+    ? channelList
+    : undefined;
+  const channels = visibleChannelList?.status === "ok"
+    ? visibleChannelList.channels
+    : [];
+  const selectedChannelId = channels.some((channel) => channel.id === channelId)
+    ? channelId
+    : (channels[0]?.id ?? "");
   const permissionSelectionRef = useRef({
     channelId: selectedChannelId,
     guildId: selectedGuildId,
@@ -1917,7 +1932,6 @@ function DiscordThreadPermissionsField(props: {
     && result.channelId === selectedChannelId
       ? result
       : undefined;
-  const validGuild = validateDiscordSnowflake(selectedGuildId).ok;
   const validChannel = validateDiscordSnowflake(selectedChannelId).ok;
   const canCheck =
     Boolean(props.desktopApi?.inspectDiscordThreadPermissions)
@@ -1930,6 +1944,51 @@ function DiscordThreadPermissionsField(props: {
     && validateDiscordSnowflake(props.applicationId).ok
     && !props.disabled
     && !requesting;
+
+  useEffect(() => {
+    const listChannels = props.desktopApi?.listDiscordThreadPermissionChannels;
+    if (!validGuild || !listChannels) {
+      setChannelList(undefined);
+      setLoadingChannels(false);
+      return;
+    }
+    let cancelled = false;
+    setLoadingChannels(true);
+    setChannelList(undefined);
+    setResult(undefined);
+    setNotice(undefined);
+    void listChannels({ guildId: selectedGuildId })
+      .then((nextList) => {
+        if (cancelled) return;
+        setChannelList(nextList);
+        if (nextList.guildId === selectedGuildId && nextList.guildName) {
+          setGuildNames((current) => ({
+            ...current,
+            [selectedGuildId]: nextList.guildName ?? "",
+          }));
+        }
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setChannelList({
+          channels: [],
+          errorMessage: error instanceof Error ? error.message : String(error),
+          guildId: selectedGuildId,
+          status: "failed",
+        });
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingChannels(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    channelListRevision,
+    props.desktopApi,
+    selectedGuildId,
+    validGuild,
+  ]);
 
   const checkPermissions = async () => {
     if (!canCheck || !props.desktopApi?.inspectDiscordThreadPermissions) return;
@@ -1990,11 +2049,13 @@ function DiscordThreadPermissionsField(props: {
           <div className="settings-inline-actions">
             <select
               aria-label="Discord server for thread reply permissions"
-              className="settings-input"
+              className="settings-select"
               disabled={props.disabled || props.authorizedGuilds.length === 0}
               value={selectedGuildId}
               onChange={(event) => {
                 setGuildId(event.currentTarget.value);
+                setChannelId("");
+                setChannelList(undefined);
                 setResult(undefined);
                 setNotice(undefined);
               }}
@@ -2004,22 +2065,44 @@ function DiscordThreadPermissionsField(props: {
               ) : null}
               {props.authorizedGuilds.map((guild) => (
                 <option key={guild.id} value={guild.id}>
-                  {guild.displayName || guild.id}
+                  {guildNames[guild.id] || guild.displayName || guild.id}
                 </option>
               ))}
             </select>
-            <input
-              aria-label="Discord channel ID for thread reply permissions"
-              className="settings-input"
-              disabled={props.disabled}
-              placeholder="Channel ID"
-              value={channelId}
+            <select
+              aria-label="Discord channel for thread reply permissions"
+              className="settings-select"
+              disabled={props.disabled || loadingChannels || channels.length === 0}
+              value={selectedChannelId}
               onChange={(event) => {
                 setChannelId(event.currentTarget.value);
                 setResult(undefined);
                 setNotice(undefined);
               }}
-            />
+            >
+              {channels.length === 0 ? (
+                <option value="">
+                  {!validGuild
+                    ? "Select an authorized server first"
+                    : loadingChannels
+                      ? "Loading channels…"
+                      : !props.desktopApi?.listDiscordThreadPermissionChannels
+                        ? "Channel discovery unavailable"
+                        : visibleChannelList?.status === "unset"
+                          ? "Configure the bot token first"
+                          : visibleChannelList?.status === "failed"
+                            ? "Could not load channels"
+                            : "No text channels available"}
+                </option>
+              ) : null}
+              {channels.map((channel) => (
+                <option key={channel.id} value={channel.id}>
+                  {channel.categoryName ? `${channel.categoryName} / ` : ""}
+                  {`#${channel.name}`}
+                  {channel.kind === "announcement" ? " (announcement)" : ""}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="settings-inline-actions">
             <button
@@ -2032,6 +2115,19 @@ function DiscordThreadPermissionsField(props: {
             </button>
             <button
               className="button button--secondary"
+              disabled={
+                props.disabled
+                || !validGuild
+                || loadingChannels
+                || !props.desktopApi?.listDiscordThreadPermissionChannels
+              }
+              type="button"
+              onClick={() => setChannelListRevision((revision) => revision + 1)}
+            >
+              {loadingChannels ? "Loading channels…" : "Reload channels"}
+            </button>
+            <button
+              className="button button--secondary"
               disabled={!canRequest}
               type="button"
               onClick={() => void requestPermissions()}
@@ -2039,6 +2135,21 @@ function DiscordThreadPermissionsField(props: {
               {requesting ? "Opening…" : "Request suggested permissions"}
             </button>
           </div>
+          {visibleChannelList?.status === "failed" ? (
+            <div className="settings-field__help" role="alert">
+              {visibleChannelList.errorMessage ?? "Discord could not list this server’s channels."}
+            </div>
+          ) : null}
+          {visibleChannelList?.status === "unset" ? (
+            <div className="settings-field__help" role="status">
+              Configure a Discord bot token to load this server’s channels.
+            </div>
+          ) : null}
+          {visibleChannelList?.status === "ok" && channels.length === 0 ? (
+            <div className="settings-field__help" role="status">
+              This server has no text or announcement channels available to the bot.
+            </div>
+          ) : null}
           {visibleResult?.status === "ok" ? (
             <div className="settings-field__help" role="status">
               {visibleResult.permissions.map((permission) => (

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -2048,7 +2048,7 @@ function DiscordThreadPermissionsField(props: {
         <>
           <div className="settings-inline-actions">
             <select
-              aria-label="Discord server for thread reply permissions"
+              aria-label="Discord server for permission check"
               className="settings-select"
               disabled={props.disabled || props.authorizedGuilds.length === 0}
               value={selectedGuildId}
@@ -2070,7 +2070,7 @@ function DiscordThreadPermissionsField(props: {
               ))}
             </select>
             <select
-              aria-label="Discord channel for thread reply permissions"
+              aria-label="Discord channel for permission check"
               className="settings-select"
               disabled={props.disabled || loadingChannels || channels.length === 0}
               value={selectedChannelId}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -17,6 +17,7 @@ import type {
   AppServerThreadSummary,
   BackendSummary,
   DesktopSettingsSnapshot,
+  InspectDiscordThreadPermissionsResponse,
   ListMessagingRoutesResponse,
   MessagingPairingEntry,
   WorktreeSnapshotSummary,
@@ -4455,6 +4456,130 @@ describe("SettingsScreen", () => {
         guildId: "1480556454498009353",
       });
     });
+  });
+
+  it("reconciles the Discord permission server after authorized guilds change", () => {
+    const applicationId = "1480556454498009351";
+    const firstGuildId = "1480556454498009353";
+    const replacementGuildId = "1480556454498009354";
+    const initialSnapshot = createSnapshot();
+    initialSnapshot.messaging.discord.applicationId.value = applicationId;
+    const openDiscordThreadPermissionRequest = vi.fn(async () => ({
+      opened: true,
+      url: "https://discord.com/oauth2/authorize",
+    }));
+    const view = render(
+      <SettingsScreen
+        settings={createSettingsState(initialSnapshot)}
+        desktopApi={{ openDiscordThreadPermissionRequest }}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("combobox", {
+        name: "Discord server for thread reply permissions",
+      }),
+    ).toHaveValue("");
+
+    const firstSnapshot = createSnapshot();
+    firstSnapshot.messaging.discord.applicationId.value = applicationId;
+    firstSnapshot.messaging.discord.authorizedGuilds.value = [
+      { id: firstGuildId, displayName: "First guild" },
+    ];
+    view.rerender(
+      <SettingsScreen
+        settings={createSettingsState(firstSnapshot)}
+        desktopApi={{ openDiscordThreadPermissionRequest }}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", {
+        name: "Discord server for thread reply permissions",
+      }),
+    ).toHaveValue(firstGuildId);
+
+    const replacementSnapshot = createSnapshot();
+    replacementSnapshot.messaging.discord.applicationId.value = applicationId;
+    replacementSnapshot.messaging.discord.authorizedGuilds.value = [
+      { id: replacementGuildId, displayName: "Replacement guild" },
+    ];
+    view.rerender(
+      <SettingsScreen
+        settings={createSettingsState(replacementSnapshot)}
+        desktopApi={{ openDiscordThreadPermissionRequest }}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", {
+        name: "Discord server for thread reply permissions",
+      }),
+    ).toHaveValue(replacementGuildId);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Request suggested permissions" }),
+    );
+    expect(openDiscordThreadPermissionRequest).toHaveBeenCalledWith({
+      guildId: replacementGuildId,
+    });
+  });
+
+  it("discards a Discord permission result after the channel selection changes", async () => {
+    const firstChannelId = "1480556454498009352";
+    const secondChannelId = "1480556454498009355";
+    const guildId = "1480556454498009353";
+    let resolveInspection!: (
+      value: InspectDiscordThreadPermissionsResponse,
+    ) => void;
+    const inspectDiscordThreadPermissions = vi.fn(
+      async (): Promise<InspectDiscordThreadPermissionsResponse> =>
+        await new Promise<InspectDiscordThreadPermissionsResponse>((resolve) => {
+          resolveInspection = resolve;
+        }),
+    );
+    const snapshot = createSnapshot();
+    snapshot.messaging.discord.authorizedGuilds.value = [
+      { id: guildId, displayName: "PwrAgent test guild" },
+    ];
+    render(
+      <SettingsScreen
+        settings={createSettingsState(snapshot)}
+        desktopApi={{ inspectDiscordThreadPermissions }}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+    const channelInput = screen.getByRole("textbox", {
+      name: "Discord channel ID for thread reply permissions",
+    });
+
+    fireEvent.change(channelInput, { target: { value: firstChannelId } });
+    fireEvent.click(screen.getByRole("button", { name: "Check permissions" }));
+    fireEvent.change(channelInput, { target: { value: secondChannelId } });
+    await act(async () => {
+      resolveInspection({
+        channelId: firstChannelId,
+        checkedAt: 1,
+        durationMs: 1,
+        guildId,
+        permissions: [
+          {
+            granted: false,
+            id: "create_public_threads",
+            label: "Create Public Threads",
+          },
+        ],
+        status: "ok",
+      });
+    });
+    fireEvent.change(channelInput, { target: { value: firstChannelId } });
+
+    expect(screen.queryByText(/Missing: Create Public Threads/)).not.toBeInTheDocument();
   });
 
   it("shows a leftover Events API notice and persists Socket Mode", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4470,7 +4470,41 @@ describe("SettingsScreen", () => {
         guildId: "1480556454498009353",
       });
     });
-    expect(screen.getByText("Missing: Send Messages in Threads ·")).toBeInTheDocument();
+    const permissionResult = screen.getByRole("alert", {
+      name: "Discord permission check result",
+    });
+    expect(permissionResult).toHaveTextContent(
+      "1 of 2 suggested permissions is missing.",
+    );
+    const permissionRows = within(permissionResult).getAllByRole("listitem");
+    expect(permissionRows).toHaveLength(2);
+    expect(permissionRows[0]).toHaveTextContent("Send Messages in ThreadsMissing");
+    expect(permissionRows[1]).toHaveTextContent("Create Public ThreadsGranted");
+
+    inspectDiscordThreadPermissions.mockResolvedValueOnce({
+      botId: "1480556454498009351",
+      channelId: "1480556454498009352",
+      checkedAt: 2,
+      durationMs: 1,
+      guildId: "1480556454498009353",
+      permissions: [
+        {
+          granted: true,
+          id: "create_public_threads",
+          label: "Create Public Threads",
+        },
+        {
+          granted: true,
+          id: "send_messages_in_threads",
+          label: "Send Messages in Threads",
+        },
+      ],
+      status: "ok",
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Check permissions" }));
+    expect(
+      await screen.findByRole("status", { name: "Discord permission check result" }),
+    ).toHaveTextContent("All 2 suggested permissions are granted.");
 
     fireEvent.click(
       screen.getByRole("button", { name: "Request suggested permissions" }),
@@ -4623,7 +4657,9 @@ describe("SettingsScreen", () => {
     });
     fireEvent.change(channelSelect, { target: { value: firstChannelId } });
 
-    expect(screen.queryByText(/Missing: Create Public Threads/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("alert", { name: "Discord permission check result" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a leftover Events API notice and persists Socket Mode", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4388,6 +4388,75 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("checks and requests the suggested Discord thread-reply permissions", async () => {
+    const snapshot = createSnapshot();
+    snapshot.messaging.discord.applicationId.value = "1480556454498009351";
+    snapshot.messaging.discord.authorizedGuilds.value = [
+      { id: "1480556454498009353", displayName: "PwrAgent test guild" },
+    ];
+    const inspectDiscordThreadPermissions = vi.fn(async () => ({
+      botId: "1480556454498009351",
+      channelId: "1480556454498009352",
+      checkedAt: 1,
+      durationMs: 1,
+      guildId: "1480556454498009353",
+      permissions: [
+        {
+          granted: true,
+          id: "create_public_threads" as const,
+          label: "Create Public Threads",
+        },
+        {
+          granted: false,
+          id: "send_messages_in_threads" as const,
+          label: "Send Messages in Threads",
+        },
+      ],
+      status: "ok" as const,
+    }));
+    const openDiscordThreadPermissionRequest = vi.fn(async () => ({
+      opened: true,
+      url: "https://discord.com/oauth2/authorize",
+    }));
+    const settings = createSettingsState(snapshot);
+
+    render(
+      <SettingsScreen
+        settings={settings}
+        desktopApi={{
+          inspectDiscordThreadPermissions,
+          openDiscordThreadPermissionRequest,
+        }}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByRole("textbox", {
+        name: "Discord channel ID for thread reply permissions",
+      }),
+      { target: { value: "1480556454498009352" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Check permissions" }));
+    await waitFor(() => {
+      expect(inspectDiscordThreadPermissions).toHaveBeenCalledWith({
+        channelId: "1480556454498009352",
+        guildId: "1480556454498009353",
+      });
+    });
+    expect(screen.getByText("Missing: Send Messages in Threads ·")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Request suggested permissions" }),
+    );
+    await waitFor(() => {
+      expect(openDiscordThreadPermissionRequest).toHaveBeenCalledWith({
+        guildId: "1480556454498009353",
+      });
+    });
+  });
+
   it("shows a leftover Events API notice and persists Socket Mode", async () => {
     const snapshot = createSnapshot();
     snapshot.messaging.slack.inboundMode = { value: "events", source: "config" };

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4448,11 +4448,16 @@ describe("SettingsScreen", () => {
     );
 
     const channelSelect = await screen.findByRole("combobox", {
-      name: "Discord channel for thread reply permissions",
+      name: "Discord channel for permission check",
     });
     await waitFor(() => {
       expect(channelSelect).toHaveValue("1480556454498009352");
     });
+    const serverSelect = screen.getByRole("combobox", {
+      name: "Discord server for permission check",
+    });
+    expect(serverSelect).not.toHaveAccessibleName(/reply/i);
+    expect(channelSelect).not.toHaveAccessibleName(/reply/i);
     expect(screen.getByRole("option", { name: "huntharo-claw" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Chat / #general" })).toBeInTheDocument();
     expect(listDiscordThreadPermissionChannels).toHaveBeenCalledWith({
@@ -4498,7 +4503,7 @@ describe("SettingsScreen", () => {
 
     expect(
       screen.getByRole("combobox", {
-        name: "Discord server for thread reply permissions",
+        name: "Discord server for permission check",
       }),
     ).toHaveValue("");
 
@@ -4517,7 +4522,7 @@ describe("SettingsScreen", () => {
     );
     expect(
       screen.getByRole("combobox", {
-        name: "Discord server for thread reply permissions",
+        name: "Discord server for permission check",
       }),
     ).toHaveValue(firstGuildId);
 
@@ -4536,7 +4541,7 @@ describe("SettingsScreen", () => {
     );
     expect(
       screen.getByRole("combobox", {
-        name: "Discord server for thread reply permissions",
+        name: "Discord server for permission check",
       }),
     ).toHaveValue(replacementGuildId);
 
@@ -4594,7 +4599,7 @@ describe("SettingsScreen", () => {
       />,
     );
     const channelSelect = await screen.findByRole("combobox", {
-      name: "Discord channel for thread reply permissions",
+      name: "Discord channel for permission check",
     });
 
     await waitFor(() => expect(channelSelect).toHaveValue(firstChannelId));

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4393,8 +4393,21 @@ describe("SettingsScreen", () => {
     const snapshot = createSnapshot();
     snapshot.messaging.discord.applicationId.value = "1480556454498009351";
     snapshot.messaging.discord.authorizedGuilds.value = [
-      { id: "1480556454498009353", displayName: "PwrAgent test guild" },
+      { id: "1480556454498009353", displayName: "general" },
     ];
+    const listDiscordThreadPermissionChannels = vi.fn(async () => ({
+      channels: [
+        {
+          categoryName: "Chat",
+          id: "1480556454498009352",
+          kind: "text" as const,
+          name: "general",
+        },
+      ],
+      guildId: "1480556454498009353",
+      guildName: "huntharo-claw",
+      status: "ok" as const,
+    }));
     const inspectDiscordThreadPermissions = vi.fn(async () => ({
       botId: "1480556454498009351",
       channelId: "1480556454498009352",
@@ -4426,6 +4439,7 @@ describe("SettingsScreen", () => {
         settings={settings}
         desktopApi={{
           inspectDiscordThreadPermissions,
+          listDiscordThreadPermissionChannels,
           openDiscordThreadPermissionRequest,
         }}
         initialSection="messaging"
@@ -4433,12 +4447,17 @@ describe("SettingsScreen", () => {
       />,
     );
 
-    fireEvent.change(
-      screen.getByRole("textbox", {
-        name: "Discord channel ID for thread reply permissions",
-      }),
-      { target: { value: "1480556454498009352" } },
-    );
+    const channelSelect = await screen.findByRole("combobox", {
+      name: "Discord channel for thread reply permissions",
+    });
+    await waitFor(() => {
+      expect(channelSelect).toHaveValue("1480556454498009352");
+    });
+    expect(screen.getByRole("option", { name: "huntharo-claw" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Chat / #general" })).toBeInTheDocument();
+    expect(listDiscordThreadPermissionChannels).toHaveBeenCalledWith({
+      guildId: "1480556454498009353",
+    });
     fireEvent.click(screen.getByRole("button", { name: "Check permissions" }));
     await waitFor(() => {
       expect(inspectDiscordThreadPermissions).toHaveBeenCalledWith({
@@ -4542,6 +4561,23 @@ describe("SettingsScreen", () => {
           resolveInspection = resolve;
         }),
     );
+    const listDiscordThreadPermissionChannels = vi.fn(async () => ({
+      channels: [
+        {
+          id: firstChannelId,
+          kind: "text" as const,
+          name: "general",
+        },
+        {
+          id: secondChannelId,
+          kind: "text" as const,
+          name: "coding",
+        },
+      ],
+      guildId,
+      guildName: "PwrAgent test guild",
+      status: "ok" as const,
+    }));
     const snapshot = createSnapshot();
     snapshot.messaging.discord.authorizedGuilds.value = [
       { id: guildId, displayName: "PwrAgent test guild" },
@@ -4549,18 +4585,21 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         settings={createSettingsState(snapshot)}
-        desktopApi={{ inspectDiscordThreadPermissions }}
+        desktopApi={{
+          inspectDiscordThreadPermissions,
+          listDiscordThreadPermissionChannels,
+        }}
         initialSection="messaging"
         onClose={() => undefined}
       />,
     );
-    const channelInput = screen.getByRole("textbox", {
-      name: "Discord channel ID for thread reply permissions",
+    const channelSelect = await screen.findByRole("combobox", {
+      name: "Discord channel for thread reply permissions",
     });
 
-    fireEvent.change(channelInput, { target: { value: firstChannelId } });
+    await waitFor(() => expect(channelSelect).toHaveValue(firstChannelId));
     fireEvent.click(screen.getByRole("button", { name: "Check permissions" }));
-    fireEvent.change(channelInput, { target: { value: secondChannelId } });
+    fireEvent.change(channelSelect, { target: { value: secondChannelId } });
     await act(async () => {
       resolveInspection({
         channelId: firstChannelId,
@@ -4577,7 +4616,7 @@ describe("SettingsScreen", () => {
         status: "ok",
       });
     });
-    fireEvent.change(channelInput, { target: { value: firstChannelId } });
+    fireEvent.change(channelSelect, { target: { value: firstChannelId } });
 
     expect(screen.queryByText(/Missing: Create Public Threads/)).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -400,6 +400,10 @@ import type {
   SettingsCredentialTestKind,
   SettingsCredentialTestRequest,
   SettingsCredentialTestResult,
+  InspectDiscordThreadPermissionsRequest,
+  InspectDiscordThreadPermissionsResponse,
+  OpenDiscordThreadPermissionRequest,
+  OpenDiscordThreadPermissionResponse,
   SlackCreateAppRequest,
   SlackCreateAppResponse,
   DesktopBootInfo,
@@ -859,6 +863,12 @@ export type DesktopApi = {
   openSlackCreateApp?: (
     request?: SlackCreateAppRequest,
   ) => Promise<SlackCreateAppResponse>;
+  inspectDiscordThreadPermissions?: (
+    request: InspectDiscordThreadPermissionsRequest,
+  ) => Promise<InspectDiscordThreadPermissionsResponse>;
+  openDiscordThreadPermissionRequest?: (
+    request?: OpenDiscordThreadPermissionRequest,
+  ) => Promise<OpenDiscordThreadPermissionResponse>;
   /** Read the last-known credential-test result without firing a new
    *  probe. Used by the test-block primitive to render the previous
    *  status on settings-pane mount. */

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -402,6 +402,8 @@ import type {
   SettingsCredentialTestResult,
   InspectDiscordThreadPermissionsRequest,
   InspectDiscordThreadPermissionsResponse,
+  ListDiscordThreadPermissionChannelsRequest,
+  ListDiscordThreadPermissionChannelsResponse,
   OpenDiscordThreadPermissionRequest,
   OpenDiscordThreadPermissionResponse,
   SlackCreateAppRequest,
@@ -863,6 +865,9 @@ export type DesktopApi = {
   openSlackCreateApp?: (
     request?: SlackCreateAppRequest,
   ) => Promise<SlackCreateAppResponse>;
+  listDiscordThreadPermissionChannels?: (
+    request: ListDiscordThreadPermissionChannelsRequest,
+  ) => Promise<ListDiscordThreadPermissionChannelsResponse>;
   inspectDiscordThreadPermissions?: (
     request: InspectDiscordThreadPermissionsRequest,
   ) => Promise<InspectDiscordThreadPermissionsResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8593,6 +8593,91 @@ textarea,
   line-height: 1.45;
 }
 
+.discord-permission-result {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.discord-permission-result__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.discord-permission-result__summary strong {
+  color: var(--text-primary);
+  font-weight: 650;
+}
+
+.discord-permission-result__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.discord-permission-result__item {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  min-height: 32px;
+  padding: 5px 8px;
+  border: 1px solid var(--success-border);
+  border-radius: 6px;
+  background: var(--success-soft);
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+
+.discord-permission-result__item--missing {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+}
+
+.discord-permission-result__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--success-border);
+  border-radius: 50%;
+  color: var(--success-text);
+}
+
+.discord-permission-result__item--missing .discord-permission-result__icon {
+  border-color: var(--danger-border);
+  border-radius: 4px;
+  color: var(--danger-text);
+}
+
+.discord-permission-result__label {
+  min-width: 0;
+  color: var(--text-primary);
+}
+
+.discord-permission-result__state {
+  color: var(--success-text);
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.discord-permission-result__item--missing .discord-permission-result__state {
+  color: var(--danger-text);
+}
+
 .settings-inline-notice {
   margin: 0 18px 8px;
   padding: 8px 10px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -335,6 +335,13 @@ export const SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL =
 export const SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL =
   "settings:open-slack-create-app";
 /**
+ * List Discord text channels available for the selected authorized server.
+ * The main process owns the bot token; the renderer receives display labels
+ * and validated channel IDs only.
+ */
+export const SETTINGS_LIST_DISCORD_THREAD_PERMISSION_CHANNELS_CHANNEL =
+  "settings:list-discord-thread-permission-channels";
+/**
  * Inspect the Discord bot's effective permissions for a selected guild channel.
  * The main process reads the bot token and returns only permission booleans.
  */

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -335,6 +335,18 @@ export const SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL =
 export const SETTINGS_OPEN_SLACK_CREATE_APP_CHANNEL =
   "settings:open-slack-create-app";
 /**
+ * Inspect the Discord bot's effective permissions for a selected guild channel.
+ * The main process reads the bot token and returns only permission booleans.
+ */
+export const SETTINGS_INSPECT_DISCORD_THREAD_PERMISSIONS_CHANNEL =
+  "settings:inspect-discord-thread-permissions";
+/**
+ * Build the Discord OAuth authorization request containing PwrAgent's
+ * suggested thread-reply permissions and optionally open it in the OS browser.
+ */
+export const SETTINGS_OPEN_DISCORD_THREAD_PERMISSION_CHANNEL =
+  "settings:open-discord-thread-permission";
+/**
  * Fired main → renderer whenever the messaging store has had bindings or
  * default Agent assignments created, changed, or revoked. The
  * payload is intentionally minimal — receivers should refetch the

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -344,7 +344,8 @@ export type MessagingConversationRef = {
    */
   parentTitle?: string;
   /**
-   * Two levels up. Today: Discord threads — the guild name.
+   * Two levels up. Today: Discord threads and categorized channels — the
+   * guild name.
    */
   ancestorTitle?: string;
 };

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -434,6 +434,11 @@ export type MessagingManagedConversationRightsRequest = {
   actor?: MessagingActorIdentity;
   channel: MessagingChannelRef;
   routingState?: MessagingAdapterState;
+  /**
+   * Ephemeral platform surface that triggered the request. Unlike routing
+   * state, hosts do not persist this reference on conversation bindings.
+   */
+  sourceSurface?: MessagingSurfaceRef;
 };
 
 export type MessagingManagedConversationRightsResult = {
@@ -449,6 +454,8 @@ export type MessagingManagedConversationCreateRequest = {
   actor?: MessagingActorIdentity;
   parent: MessagingChannelRef;
   routingState?: MessagingAdapterState;
+  /** Ephemeral source message used when the child must be created from it. */
+  sourceSurface?: MessagingSurfaceRef;
   title: string;
 };
 
@@ -1371,6 +1378,12 @@ export type MessagingInboundBaseEvent = {
    */
   botMention?: boolean;
   routingState?: MessagingAdapterState;
+  /**
+   * The platform message that produced this inbound event. This is distinct
+   * from stable conversation routing state and must not be persisted as part
+   * of a binding refresh.
+   */
+  sourceSurface?: MessagingSurfaceRef;
 };
 
 export type MessagingInboundRejectionReason =
@@ -1426,12 +1439,6 @@ export type MessagingInboundCommandEvent = MessagingInboundBaseEvent & {
 export type MessagingInboundCallbackEvent = MessagingInboundBaseEvent & {
   kind: "callback";
   interaction: MessagingInteractionRef;
-  /**
-   * The message surface that contained the clicked control, when the provider
-   * supplies an editable message reference. This is distinct from
-   * `interaction`, whose id/state identify the callback itself.
-   */
-  sourceSurface?: MessagingSurfaceRef;
   actionId?: string;
   value?: MessagingJsonValue;
 };

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -441,6 +441,7 @@ describe("discord adapter", () => {
     const createThreadFromMessage = vi.fn(async () => ({
       id: "1480556454498009358",
       name: "Investigate reply support",
+      parent_id: TEST_CHANNEL_ID,
     }));
     const getThreadPermissions = vi.fn(async () => ({
       botId: "1480556454498009351",
@@ -494,13 +495,24 @@ describe("discord adapter", () => {
         channelId: TEST_CHANNEL_ID,
         guildId: TEST_GUILD_ID,
         isThread: false,
-        messageId: TEST_MESSAGE_ID,
+      },
+    };
+    const sourceSurface = {
+      channel: "discord" as const,
+      id: TEST_MESSAGE_ID,
+      state: {
+        opaque: {
+          channelId: TEST_CHANNEL_ID,
+          guildId: TEST_GUILD_ID,
+          messageId: TEST_MESSAGE_ID,
+        },
       },
     };
 
     await expect(adapter.getManagedConversationRights({
       channel: parent,
       routingState,
+      sourceSurface,
     })).resolves.toMatchObject({
       operations: [{ operation: "create_child", supported: true }],
       outcome: "ok",
@@ -508,6 +520,7 @@ describe("discord adapter", () => {
     await expect(adapter.createManagedConversation({
       parent,
       routingState,
+      sourceSurface,
       title: "Investigate reply support",
     })).resolves.toMatchObject({
       conversation: {
@@ -531,6 +544,83 @@ describe("discord adapter", () => {
       TEST_MESSAGE_ID,
       { name: "Investigate reply support" },
     );
+  });
+
+  it.each([
+    {
+      errorMessage: "Discord returned an invalid created thread.",
+      name: "malformed thread ID",
+      thread: {
+        id: "not-a-snowflake",
+        parent_id: TEST_CHANNEL_ID,
+      },
+    },
+    {
+      errorMessage: "Discord returned a thread for an unexpected parent channel.",
+      name: "mismatched parent channel",
+      thread: {
+        id: "1480556454498009358",
+        parent_id: "1480556454498009359",
+      },
+    },
+    {
+      errorMessage: "Discord returned an invalid created thread parent.",
+      name: "malformed parent channel ID",
+      thread: {
+        id: "1480556454498009358",
+        parent_id: "not-a-snowflake",
+      },
+    },
+  ])("rejects a created Discord thread with a $name", async ({
+    errorMessage: expectedError,
+    thread,
+  }) => {
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+    const adapter = new DiscordAdapter({
+      api: createApi({
+        createThreadFromMessage: async () => thread,
+      }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      logger,
+      now: () => 1234,
+    });
+
+    await expect(adapter.createManagedConversation({
+      parent: {
+        channel: "discord",
+        conversation: {
+          id: TEST_CHANNEL_ID,
+          kind: "channel",
+          workspaceId: TEST_GUILD_ID,
+        },
+      },
+      routingState: {
+        opaque: {
+          channelId: TEST_CHANNEL_ID,
+          guildId: TEST_GUILD_ID,
+        },
+      },
+      sourceSurface: {
+        channel: "discord",
+        id: TEST_MESSAGE_ID,
+        state: {
+          opaque: {
+            channelId: TEST_CHANNEL_ID,
+            guildId: TEST_GUILD_ID,
+            messageId: TEST_MESSAGE_ID,
+          },
+        },
+      },
+      title: "Investigate reply support",
+    })).resolves.toMatchObject({
+      errorMessage: expectedError,
+      outcome: "failed",
+    });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
   it("reports the missing Discord thread permission before creating a thread", async () => {
@@ -589,7 +679,17 @@ describe("discord adapter", () => {
         opaque: {
           channelId: TEST_CHANNEL_ID,
           guildId: TEST_GUILD_ID,
-          messageId: TEST_MESSAGE_ID,
+        },
+      },
+      sourceSurface: {
+        channel: "discord",
+        id: TEST_MESSAGE_ID,
+        state: {
+          opaque: {
+            channelId: TEST_CHANNEL_ID,
+            guildId: TEST_GUILD_ID,
+            messageId: TEST_MESSAGE_ID,
+          },
         },
       },
       title: "Investigate reply support",
@@ -1331,12 +1431,25 @@ describe("discord adapter", () => {
           kind: "text",
           routingState: expect.objectContaining({
             opaque: expect.objectContaining({
-              messageId: inboundMessage.id,
+              channelId: TEST_CHANNEL_ID,
+              guildId: TEST_GUILD_ID,
             }),
           }),
+          sourceSurface: {
+            channel: "discord",
+            id: inboundMessage.id,
+            state: {
+              opaque: {
+                channelId: TEST_CHANNEL_ID,
+                guildId: TEST_GUILD_ID,
+                messageId: inboundMessage.id,
+              },
+            },
+          },
           text: "pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
         }),
       ]);
+      expect(events[0]?.routingState?.opaque).not.toHaveProperty("messageId");
       expect(rejectedEvents).toEqual([]);
       expect(logger.warn).not.toHaveBeenCalledWith(
         "discord inbound ignored unauthorized guild",
@@ -2216,8 +2329,9 @@ function createApi(overrides: Partial<DiscordApi> = {}): DiscordApi {
       channel_id: channelId,
       id: "message-2",
     }),
-    createThreadFromMessage: async () => ({
-      id: "thread-1",
+    createThreadFromMessage: async (channelId) => ({
+      id: "1480556454498009358",
+      parent_id: channelId,
     }),
     deleteApplicationCommand: async () => {},
     getChannel: async (id: string) => ({ id }),

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -1890,6 +1890,72 @@ describe("discord adapter", () => {
       await adapter.stop();
     });
 
+    it("keeps the guild name above a categorized Discord channel", async () => {
+      const BOT_ID = "1480556454498009352";
+      const categoryId = "1480556454498009357";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi({
+          getChannel: async (id) => id === TEST_CHANNEL_ID
+            ? {
+                id,
+                name: "general",
+                parentId: categoryId,
+              }
+            : {
+                id,
+                name: "Text Channels",
+              },
+          getGuild: async (id) => ({
+            id,
+            name: "PwrDrvr",
+          }),
+        }),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: TEST_AUTHORIZED_GUILD_IDS,
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: {
+          ...messageDispatch({
+            authorBot: false,
+            content: `<@${BOT_ID}> investigate this`,
+            id: "categorized-channel-message",
+          }),
+          channel_type: 0,
+          is_thread: false,
+        },
+      });
+
+      expect(events[0]).toMatchObject({
+        channel: {
+          channel: "discord",
+          conversation: {
+            ancestorTitle: "PwrDrvr",
+            id: TEST_CHANNEL_ID,
+            kind: "channel",
+            parentTitle: "Text Channels",
+            title: "general",
+            workspaceId: TEST_GUILD_ID,
+          },
+        },
+      });
+      await adapter.stop();
+    });
+
     it("normalizes addressed Discord threads as bindable child conversations", async () => {
       const BOT_ID = "1480556454498009352";
       const parentChannelId = "1480556454498009357";

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -437,6 +437,169 @@ describe("discord adapter", () => {
     expect(updateChannelName).toHaveBeenCalledTimes(1);
   });
 
+  it("creates a public Discord thread from the inbound source message", async () => {
+    const createThreadFromMessage = vi.fn(async () => ({
+      id: "1480556454498009358",
+      name: "Investigate reply support",
+    }));
+    const getThreadPermissions = vi.fn(async () => ({
+      botId: "1480556454498009351",
+      channelId: TEST_CHANNEL_ID,
+      checkedAt: 0,
+      durationMs: 0,
+      guildId: TEST_GUILD_ID,
+      permissions: [
+        {
+          granted: true,
+          id: "view_channel" as const,
+          label: "View Channel",
+        },
+        {
+          granted: true,
+          id: "send_messages" as const,
+          label: "Send Messages",
+        },
+        {
+          granted: true,
+          id: "create_public_threads" as const,
+          label: "Create Public Threads",
+        },
+        {
+          granted: true,
+          id: "send_messages_in_threads" as const,
+          label: "Send Messages in Threads",
+        },
+      ],
+      status: "ok" as const,
+    }));
+    const adapter = new DiscordAdapter({
+      api: createApi({ createThreadFromMessage, getThreadPermissions }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+    const parent = {
+      channel: "discord" as const,
+      conversation: {
+        id: TEST_CHANNEL_ID,
+        kind: "channel" as const,
+        workspaceId: TEST_GUILD_ID,
+      },
+    };
+    const routingState = {
+      opaque: {
+        channelId: TEST_CHANNEL_ID,
+        guildId: TEST_GUILD_ID,
+        isThread: false,
+        messageId: TEST_MESSAGE_ID,
+      },
+    };
+
+    await expect(adapter.getManagedConversationRights({
+      channel: parent,
+      routingState,
+    })).resolves.toMatchObject({
+      operations: [{ operation: "create_child", supported: true }],
+      outcome: "ok",
+    });
+    await expect(adapter.createManagedConversation({
+      parent,
+      routingState,
+      title: "Investigate reply support",
+    })).resolves.toMatchObject({
+      conversation: {
+        id: "1480556454498009358",
+        kind: "thread",
+        parentConversationId: TEST_CHANNEL_ID,
+      },
+      outcome: "created",
+      routingState: {
+        opaque: {
+          channelId: "1480556454498009358",
+          guildId: TEST_GUILD_ID,
+          isThread: true,
+          parentChannelId: TEST_CHANNEL_ID,
+          parentMessageId: TEST_MESSAGE_ID,
+        },
+      },
+    });
+    expect(createThreadFromMessage).toHaveBeenCalledWith(
+      TEST_CHANNEL_ID,
+      TEST_MESSAGE_ID,
+      { name: "Investigate reply support" },
+    );
+  });
+
+  it("reports the missing Discord thread permission before creating a thread", async () => {
+    const createThreadFromMessage = vi.fn();
+    const adapter = new DiscordAdapter({
+      api: createApi({
+        createThreadFromMessage,
+        getThreadPermissions: async ({ channelId, guildId }) => ({
+          channelId,
+          checkedAt: 0,
+          durationMs: 0,
+          guildId,
+          permissions: [
+            {
+              granted: true,
+              id: "view_channel",
+              label: "View Channel",
+            },
+            {
+              granted: true,
+              id: "send_messages",
+              label: "Send Messages",
+            },
+            {
+              granted: false,
+              id: "create_public_threads",
+              label: "Create Public Threads",
+            },
+            {
+              granted: true,
+              id: "send_messages_in_threads",
+              label: "Send Messages in Threads",
+            },
+          ],
+          status: "ok",
+        }),
+      }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+
+    await expect(adapter.createManagedConversation({
+      parent: {
+        channel: "discord",
+        conversation: {
+          id: TEST_CHANNEL_ID,
+          kind: "channel",
+          workspaceId: TEST_GUILD_ID,
+        },
+      },
+      routingState: {
+        opaque: {
+          channelId: TEST_CHANNEL_ID,
+          guildId: TEST_GUILD_ID,
+          messageId: TEST_MESSAGE_ID,
+        },
+      },
+      title: "Investigate reply support",
+    })).resolves.toMatchObject({
+      errorMessage: "Discord bot is missing Create Public Threads in this channel.",
+      outcome: "failed",
+    });
+    expect(createThreadFromMessage).not.toHaveBeenCalled();
+  });
+
   it("sends file message intents as Discord upload files", async () => {
     const createMessage = vi.fn(async (channelId: string) => ({
       channel_id: channelId,
@@ -1145,14 +1308,15 @@ describe("discord adapter", () => {
       adapter.onInboundRejected((event) => {
         rejectedEvents.push(event);
       });
+      const inboundMessage = messageDispatch({
+        authorBot: false,
+        content: "pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
+        id: "pairing-msg",
+      });
       await gateway.emit({
         op: 0,
         t: "MESSAGE_CREATE",
-        d: messageDispatch({
-          authorBot: false,
-          content: "pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
-          id: "pairing-msg",
-        }),
+        d: inboundMessage,
       });
 
       expect(events).toEqual([
@@ -1165,6 +1329,11 @@ describe("discord adapter", () => {
             }),
           }),
           kind: "text",
+          routingState: expect.objectContaining({
+            opaque: expect.objectContaining({
+              messageId: inboundMessage.id,
+            }),
+          }),
           text: "pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
         }),
       ]);
@@ -2047,9 +2216,42 @@ function createApi(overrides: Partial<DiscordApi> = {}): DiscordApi {
       channel_id: channelId,
       id: "message-2",
     }),
+    createThreadFromMessage: async () => ({
+      id: "thread-1",
+    }),
     deleteApplicationCommand: async () => {},
     getChannel: async (id: string) => ({ id }),
     getGuild: async (id: string) => ({ id }),
+    getThreadPermissions: async ({ channelId, guildId }) => ({
+      botId: "123456789012345678",
+      channelId,
+      checkedAt: 0,
+      durationMs: 0,
+      guildId,
+      permissions: [
+        {
+          granted: true,
+          id: "view_channel",
+          label: "View Channel",
+        },
+        {
+          granted: true,
+          id: "send_messages",
+          label: "Send Messages",
+        },
+        {
+          granted: true,
+          id: "create_public_threads",
+          label: "Create Public Threads",
+        },
+        {
+          granted: true,
+          id: "send_messages_in_threads",
+          label: "Send Messages in Threads",
+        },
+      ],
+      status: "ok",
+    }),
     listApplicationCommands: async () => [],
     pinMessage: async () => {},
     sendTyping: async () => {},

--- a/packages/messaging/providers/discord/src/__tests__/thread-permissions.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/thread-permissions.test.ts
@@ -104,4 +104,28 @@ describe("Discord thread permissions", () => {
     expect(url.searchParams.get("guild_id")).toBe(GUILD_ID);
     expect(url.searchParams.get("disable_guild_select")).toBe("true");
   });
+
+  it("rejects a DM channel that has no selected guild", async () => {
+    const permissions = await inspectDiscordThreadPermissionsWithRest({
+      channelId: CHANNEL_ID,
+      guildId: GUILD_ID,
+      rest: {
+        get: async (route) => {
+          if (route === "/users/%40me") return { id: BOT_ID };
+          if (route === `/guilds/${GUILD_ID}`) return {};
+          if (route === `/channels/${CHANNEL_ID}`) return {};
+          if (route === `/guilds/${GUILD_ID}/members/${BOT_ID}`) {
+            return { roles: [] };
+          }
+          if (route === `/guilds/${GUILD_ID}/roles`) return [];
+          throw new Error(`unexpected route: ${route}`);
+        },
+      },
+    });
+
+    expect(permissions).toMatchObject({
+      errorMessage: "The selected Discord channel is not in the selected server.",
+      status: "failed",
+    });
+  });
 });

--- a/packages/messaging/providers/discord/src/__tests__/thread-permissions.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/thread-permissions.test.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   buildDiscordThreadPermissionRequestUrl,
   inspectDiscordThreadPermissionsWithRest,
+  listDiscordThreadPermissionChannelsWithRest,
 } from "../thread-permissions.ts";
 
 const BOT_ID = "1480556454498009351";
 const CHANNEL_ID = "1480556454498009352";
 const GUILD_ID = "1480556454498009353";
 const BOT_ROLE_ID = "1480556454498009354";
+const ANNOUNCEMENT_CHANNEL_ID = "1480556454498009355";
+const CATEGORY_ID = "1480556454498009356";
 
 describe("Discord thread permissions", () => {
   it("applies role and member channel overwrites before reporting effective permissions", async () => {
@@ -125,6 +128,110 @@ describe("Discord thread permissions", () => {
 
     expect(permissions).toMatchObject({
       errorMessage: "The selected Discord channel is not in the selected server.",
+      status: "failed",
+    });
+  });
+
+  it("lists named text channels and their categories for the selected server", async () => {
+    const listing = await listDiscordThreadPermissionChannelsWithRest({
+      guildId: GUILD_ID,
+      rest: {
+        get: async (route) => {
+          if (route === `/guilds/${GUILD_ID}`) {
+            return { id: GUILD_ID, name: "huntharo-claw" };
+          }
+          if (route === `/guilds/${GUILD_ID}/channels`) {
+            return [
+              {
+                guild_id: GUILD_ID,
+                id: CATEGORY_ID,
+                name: "Chat",
+                position: 1,
+                type: 4,
+              },
+              {
+                guild_id: GUILD_ID,
+                id: CHANNEL_ID,
+                name: "general",
+                parent_id: CATEGORY_ID,
+                position: 2,
+                type: 0,
+              },
+              {
+                guild_id: GUILD_ID,
+                id: ANNOUNCEMENT_CHANNEL_ID,
+                name: "announcements",
+                parent_id: CATEGORY_ID,
+                position: 3,
+                type: 5,
+              },
+              {
+                guild_id: GUILD_ID,
+                id: "1480556454498009357",
+                name: "Voice",
+                position: 4,
+                type: 2,
+              },
+              {
+                guild_id: "1480556454498009358",
+                id: "1480556454498009359",
+                name: "wrong-server",
+                position: 5,
+                type: 0,
+              },
+              {
+                guild_id: GUILD_ID,
+                id: "not-a-snowflake",
+                name: "invalid",
+                position: 6,
+                type: 0,
+              },
+            ];
+          }
+          throw new Error(`unexpected route: ${route}`);
+        },
+      },
+    });
+
+    expect(listing).toEqual({
+      channels: [
+        {
+          categoryName: "Chat",
+          id: CHANNEL_ID,
+          kind: "text",
+          name: "general",
+        },
+        {
+          categoryName: "Chat",
+          id: ANNOUNCEMENT_CHANNEL_ID,
+          kind: "announcement",
+          name: "announcements",
+        },
+      ],
+      guildId: GUILD_ID,
+      guildName: "huntharo-claw",
+      status: "ok",
+    });
+  });
+
+  it("rejects a malformed server response when listing channels", async () => {
+    const listing = await listDiscordThreadPermissionChannelsWithRest({
+      guildId: GUILD_ID,
+      rest: {
+        get: async (route) => {
+          if (route === `/guilds/${GUILD_ID}`) {
+            return { id: "1480556454498009358", name: "Another server" };
+          }
+          if (route === `/guilds/${GUILD_ID}/channels`) return [];
+          throw new Error(`unexpected route: ${route}`);
+        },
+      },
+    });
+
+    expect(listing).toMatchObject({
+      channels: [],
+      errorMessage: "Discord returned an unexpected server.",
+      guildId: GUILD_ID,
       status: "failed",
     });
   });

--- a/packages/messaging/providers/discord/src/__tests__/thread-permissions.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/thread-permissions.test.ts
@@ -1,0 +1,107 @@
+import { PermissionFlagsBits } from "discord.js";
+import { describe, expect, it } from "vitest";
+import {
+  buildDiscordThreadPermissionRequestUrl,
+  inspectDiscordThreadPermissionsWithRest,
+} from "../thread-permissions.ts";
+
+const BOT_ID = "1480556454498009351";
+const CHANNEL_ID = "1480556454498009352";
+const GUILD_ID = "1480556454498009353";
+const BOT_ROLE_ID = "1480556454498009354";
+
+describe("Discord thread permissions", () => {
+  it("applies role and member channel overwrites before reporting effective permissions", async () => {
+    const permissions = await inspectDiscordThreadPermissionsWithRest({
+      channelId: CHANNEL_ID,
+      guildId: GUILD_ID,
+      rest: {
+        get: async (route) => {
+          if (route === "/users/%40me") return { id: BOT_ID };
+          if (route === `/guilds/${GUILD_ID}`) return {};
+          if (route === `/channels/${CHANNEL_ID}`) {
+            return {
+              guild_id: GUILD_ID,
+              permission_overwrites: [
+                {
+                  allow: "0",
+                  deny: PermissionFlagsBits.SendMessages.toString(),
+                  id: BOT_ROLE_ID,
+                  type: 0,
+                },
+                {
+                  allow: PermissionFlagsBits.EmbedLinks.toString(),
+                  deny: PermissionFlagsBits.CreatePublicThreads.toString(),
+                  id: BOT_ID,
+                  type: 1,
+                },
+              ],
+            };
+          }
+          if (route === `/guilds/${GUILD_ID}/members/${BOT_ID}`) {
+            return { roles: [BOT_ROLE_ID] };
+          }
+          if (route === `/guilds/${GUILD_ID}/roles`) {
+            return [
+              {
+                id: GUILD_ID,
+                permissions: (
+                  PermissionFlagsBits.ViewChannel
+                  | PermissionFlagsBits.SendMessages
+                ).toString(),
+              },
+              {
+                id: BOT_ROLE_ID,
+                permissions: (
+                  PermissionFlagsBits.AttachFiles
+                  | PermissionFlagsBits.CreatePublicThreads
+                  | PermissionFlagsBits.ReadMessageHistory
+                  | PermissionFlagsBits.SendMessagesInThreads
+                ).toString(),
+              },
+            ];
+          }
+          throw new Error(`unexpected route: ${route}`);
+        },
+      },
+    });
+
+    expect(permissions.status).toBe("ok");
+    expect(permissions.permissions).toEqual([
+      { granted: true, id: "view_channel", label: "View Channel" },
+      { granted: false, id: "send_messages", label: "Send Messages" },
+      { granted: true, id: "embed_links", label: "Embed Links" },
+      { granted: true, id: "attach_files", label: "Attach Files" },
+      {
+        granted: true,
+        id: "read_message_history",
+        label: "Read Message History",
+      },
+      {
+        granted: false,
+        id: "create_public_threads",
+        label: "Create Public Threads",
+      },
+      {
+        granted: true,
+        id: "send_messages_in_threads",
+        label: "Send Messages in Threads",
+      },
+    ]);
+  });
+
+  it("builds a guild-targeted least-privilege Discord authorization request", () => {
+    const url = new URL(buildDiscordThreadPermissionRequestUrl({
+      applicationId: BOT_ID,
+      guildId: GUILD_ID,
+    }));
+
+    expect(url.origin).toBe("https://discord.com");
+    expect(url.pathname).toBe("/oauth2/authorize");
+    expect(url.searchParams.get("client_id")).toBe(BOT_ID);
+    expect(url.searchParams.get("scope")).toBe("bot applications.commands");
+    expect(url.searchParams.get("permissions")).toBe("309237763072");
+    expect(url.searchParams.get("guild_id")).toBe(GUILD_ID);
+    expect(url.searchParams.get("disable_guild_select")).toBe("true");
+  });
+});

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -28,8 +28,13 @@ import type {
   MessagingImagePart,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
+  MessagingManagedConversationCreateRequest,
+  MessagingManagedConversationCreateResult,
+  MessagingManagedConversationRightsRequest,
+  MessagingManagedConversationRightsResult,
   MessagingRateLimitInfo,
   MessagingCallbackHandleStore,
+  MessagingChannelRef,
   MessagingRejectedInboundEvent,
   MessagingClientRateLimitStrategy,
   MessagingSurfaceAction,
@@ -64,6 +69,10 @@ import {
   validateDiscordSnowflake,
   type DiscordIdentifierField,
 } from "./validate-ids.ts";
+import {
+  inspectDiscordThreadPermissionsWithRest,
+  type DiscordThreadPermissionInspection,
+} from "./thread-permissions.ts";
 
 const DISCORD_DEFAULT_TYPING_SIGNAL_LEASE_MS = 15_000;
 const DISCORD_TYPING_SIGNAL_INTERVAL_MS = 4_000;
@@ -124,6 +133,12 @@ export type DiscordMessage = {
   content?: string;
   guild_id?: string;
   id: string;
+};
+
+export type DiscordThreadChannel = {
+  id: string;
+  name?: string;
+  parent_id?: string;
 };
 
 export type DiscordUser = {
@@ -209,8 +224,17 @@ export type DiscordGuildInfo = {
 };
 
 export type DiscordApi = DiscordApplicationCommandApi & {
+  createThreadFromMessage(
+    channelId: string,
+    messageId: string,
+    request: { name: string },
+  ): Promise<DiscordThreadChannel>;
   getChannel(channelId: string): Promise<DiscordChannelInfo>;
   getGuild(guildId: string): Promise<DiscordGuildInfo>;
+  getThreadPermissions(request: {
+    channelId: string;
+    guildId: string;
+  }): Promise<DiscordThreadPermissionInspection>;
   updateChannelName(channelId: string, request: { name: string }): Promise<void>;
   createInteractionResponse(
     interactionId: string,
@@ -264,6 +288,12 @@ export type DiscordProviderAdapter = {
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
+  getManagedConversationRights?(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult>;
+  createManagedConversation?(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult>;
   onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
@@ -783,6 +813,167 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     }
   }
 
+  async getManagedConversationRights(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult> {
+    const conversation = request.channel.conversation;
+    const target = discordManagedThreadTarget(request.channel, request.routingState);
+    if (!target) {
+      return {
+        channel: this.channel,
+        conversation,
+        operations: [
+          {
+            operation: "create_child",
+            reason: discordManagedThreadUnsupportedReason(request.channel),
+            supported: false,
+          },
+        ],
+        outcome: "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+
+    try {
+      const inspection = await this.api.getThreadPermissions(target);
+      if (inspection.status !== "ok") {
+        return {
+          channel: this.channel,
+          conversation,
+          errorMessage: inspection.errorMessage
+            ?? "Discord could not inspect the bot's channel permissions.",
+          operations: [
+            {
+              operation: "create_child",
+              reason: inspection.errorMessage
+                ?? "Discord could not inspect the bot's channel permissions.",
+              supported: false,
+            },
+          ],
+          outcome: "failed",
+          updatedAt: this.now(),
+        };
+      }
+      const missingPermission = inspection.permissions.find(
+        (permission) =>
+          !permission.granted
+          && (
+            permission.id === "create_public_threads"
+            || permission.id === "send_messages"
+            || permission.id === "send_messages_in_threads"
+            || permission.id === "view_channel"
+          ),
+      );
+      return {
+        channel: this.channel,
+        conversation,
+        operations: [
+          {
+            operation: "create_child",
+            ...(missingPermission
+              ? { missingPermission: missingPermission.label }
+              : {}),
+            supported: !missingPermission,
+          },
+        ],
+        outcome: "ok",
+        updatedAt: this.now(),
+      };
+    } catch (error) {
+      const message = errorMessage(error);
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: message,
+        operations: [
+          {
+            operation: "create_child",
+            reason: message,
+            supported: false,
+          },
+        ],
+        outcome: "failed",
+        updatedAt: this.now(),
+      };
+    }
+  }
+
+  async createManagedConversation(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult> {
+    const target = discordManagedThreadTarget(request.parent, request.routingState);
+    if (!target) {
+      return {
+        channel: this.channel,
+        errorMessage: discordManagedThreadUnsupportedReason(request.parent),
+        outcome: "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+
+    const rights = await this.getManagedConversationRights({
+      actor: request.actor,
+      channel: request.parent,
+      routingState: request.routingState,
+    });
+    const createChild = rights.operations.find(
+      (operation) => operation.operation === "create_child",
+    );
+    if (!createChild?.supported) {
+      return {
+        channel: this.channel,
+        errorMessage: createChild?.missingPermission
+          ? `Discord bot is missing ${createChild.missingPermission} in this channel.`
+          : (rights.errorMessage ?? createChild?.reason ?? "Discord thread creation is unavailable."),
+        outcome: createChild?.missingPermission || rights.outcome === "failed"
+          ? "failed"
+          : "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+
+    try {
+      const thread = await this.api.createThreadFromMessage(target.channelId, target.messageId, {
+        name: sanitizeDiscordThreadName(request.title),
+      });
+      return {
+        channel: this.channel,
+        conversation: {
+          id: thread.id,
+          kind: "thread",
+          parentId: target.guildId,
+          parentConversationId: request.parent.conversation.id,
+          parentConversationParentId: target.guildId,
+          ...(request.parent.conversation.workspaceId
+            ? { workspaceId: request.parent.conversation.workspaceId }
+            : {}),
+          ...(request.parent.conversation.title
+            ? { parentTitle: request.parent.conversation.title }
+            : {}),
+          title: thread.name ?? sanitizeDiscordThreadName(request.title),
+        },
+        outcome: "created",
+        routingState: {
+          opaque: {
+            channelId: thread.id,
+            guildId: target.guildId,
+            isThread: true,
+            parentChannelId: target.channelId,
+            parentMessageId: target.messageId,
+          },
+        },
+        updatedAt: this.now(),
+      };
+    } catch (error) {
+      return {
+        channel: this.channel,
+        errorMessage: errorMessage(error),
+        outcome: "failed",
+        updatedAt: this.now(),
+      };
+    }
+  }
+
   async handleGatewayEvent(event: DiscordGatewayEvent): Promise<void> {
     if (event.t === "MESSAGE_CREATE") {
       await this.handleMessageCreate(event.d);
@@ -840,6 +1031,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id, {
       channelType: message.channel_type,
       isThread: message.is_thread,
+      messageId: message.id,
     });
     const sourceUrl = discordConversationUrl({
       channelId: message.channel_id,
@@ -1827,6 +2019,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       channelType?: number;
       interactionToken?: string;
       isThread?: boolean;
+      messageId?: string;
     },
   ): MessagingAdapterState {
     return {
@@ -1839,6 +2032,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         guildId: guildId ?? null,
         interactionToken: options?.interactionToken ?? null,
         isThread: options?.isThread ?? null,
+        messageId: options?.messageId ?? null,
       },
     };
   }
@@ -2087,6 +2281,17 @@ class DiscordRestApi implements DiscordApi {
     return { id: raw.id, name: raw.name ?? undefined };
   }
 
+  async getThreadPermissions(request: {
+    channelId: string;
+    guildId: string;
+  }): Promise<DiscordThreadPermissionInspection> {
+    return inspectDiscordThreadPermissionsWithRest({
+      channelId: request.channelId,
+      guildId: request.guildId,
+      rest: this.rest,
+    });
+  }
+
   async createMessage(
     channelId: string,
     request: DiscordCreateMessageRequest,
@@ -2099,6 +2304,17 @@ class DiscordRestApi implements DiscordApi {
         name: file.name,
       })),
     })) as DiscordMessage;
+  }
+
+  async createThreadFromMessage(
+    channelId: string,
+    messageId: string,
+    request: { name: string },
+  ): Promise<DiscordThreadChannel> {
+    return (await this.rest.post(
+      `/channels/${channelId}/messages/${messageId}/threads`,
+      { body: request },
+    )) as DiscordThreadChannel;
   }
 
   async updateChannelName(
@@ -2460,24 +2676,63 @@ function discordConversationUrl(params: {
 function isDiscordThreadConversation(
   request: MessagingConversationTitleUpdateRequest,
 ): boolean {
-  if (request.channel.conversation.kind === "thread") {
+  return isDiscordThreadChannel(request.channel, request.routingState);
+}
+
+function discordManagedThreadTarget(
+  channel: MessagingChannelRef,
+  routingState: MessagingAdapterState | undefined,
+): { channelId: string; guildId: string; messageId: string } | undefined {
+  if (isDiscordThreadChannel(channel, routingState)) {
+    return undefined;
+  }
+  const opaque = discordRoutingOpaque(routingState);
+  const channelId = channel.conversation.id;
+  const guildId = channel.conversation.workspaceId;
+  const messageId = opaque?.messageId;
+  if (
+    typeof guildId !== "string"
+    || typeof messageId !== "string"
+    || !validateDiscordSnowflake(channelId).ok
+    || !validateDiscordSnowflake(guildId).ok
+    || !validateDiscordSnowflake(messageId).ok
+    || (typeof opaque?.channelId === "string" && opaque.channelId !== channelId)
+    || (typeof opaque?.guildId === "string" && opaque.guildId !== guildId)
+  ) {
+    return undefined;
+  }
+  return { channelId, guildId, messageId };
+}
+
+function discordManagedThreadUnsupportedReason(channel: MessagingChannelRef): string {
+  return channel.conversation.kind === "thread"
+    ? "Discord does not support nested threads."
+    : "Discord thread creation needs the source message in a guild text channel.";
+}
+
+function isDiscordThreadChannel(
+  channel: MessagingChannelRef,
+  routingState: MessagingAdapterState | undefined,
+): boolean {
+  if (channel.conversation.kind === "thread") {
     return true;
   }
-
-  const opaque = request.routingState?.opaque;
-  if (!opaque || typeof opaque !== "object" || Array.isArray(opaque)) {
-    return false;
-  }
-
-  if (opaque.isThread === true) {
-    return true;
-  }
-
+  const opaque = discordRoutingOpaque(routingState);
   return (
-    opaque.channelType === 10 ||
-    opaque.channelType === 11 ||
-    opaque.channelType === 12
+    opaque?.isThread === true
+    || opaque?.channelType === 10
+    || opaque?.channelType === 11
+    || opaque?.channelType === 12
   );
+}
+
+function discordRoutingOpaque(
+  routingState: MessagingAdapterState | undefined,
+): Record<string, unknown> | undefined {
+  const opaque = routingState?.opaque;
+  return opaque && typeof opaque === "object" && !Array.isArray(opaque)
+    ? opaque
+    : undefined;
 }
 
 function sanitizeDiscordThreadName(title: string): string {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -1896,7 +1896,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           : {}),
         title: breadcrumbs.channelName,
         parentTitle: breadcrumbs.parentChannelName ?? breadcrumbs.guildName,
-        ancestorTitle: options?.isThread && breadcrumbs.parentChannelName
+        ancestorTitle: breadcrumbs.parentChannelName
           ? breadcrumbs.guildName
           : undefined,
       },

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -39,6 +39,7 @@ import type {
   MessagingClientRateLimitStrategy,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
+  MessagingSurfaceRef,
 } from "@pwragent/messaging-interface";
 import {
   evictStaleStreamAnchors,
@@ -138,7 +139,7 @@ export type DiscordMessage = {
 export type DiscordThreadChannel = {
   id: string;
   name?: string;
-  parent_id?: string;
+  parent_id: string;
 };
 
 export type DiscordUser = {
@@ -817,7 +818,11 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     request: MessagingManagedConversationRightsRequest,
   ): Promise<MessagingManagedConversationRightsResult> {
     const conversation = request.channel.conversation;
-    const target = discordManagedThreadTarget(request.channel, request.routingState);
+    const target = discordManagedThreadTarget(
+      request.channel,
+      request.routingState,
+      request.sourceSurface,
+    );
     if (!target) {
       return {
         channel: this.channel,
@@ -901,7 +906,11 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   async createManagedConversation(
     request: MessagingManagedConversationCreateRequest,
   ): Promise<MessagingManagedConversationCreateResult> {
-    const target = discordManagedThreadTarget(request.parent, request.routingState);
+    const target = discordManagedThreadTarget(
+      request.parent,
+      request.routingState,
+      request.sourceSurface,
+    );
     if (!target) {
       return {
         channel: this.channel,
@@ -915,6 +924,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       actor: request.actor,
       channel: request.parent,
       routingState: request.routingState,
+      sourceSurface: request.sourceSurface,
     });
     const createChild = rights.operations.find(
       (operation) => operation.operation === "create_child",
@@ -936,6 +946,48 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       const thread = await this.api.createThreadFromMessage(target.channelId, target.messageId, {
         name: sanitizeDiscordThreadName(request.title),
       });
+      const threadIdValidation = validateDiscordSnowflake(thread.id);
+      if (!threadIdValidation.ok) {
+        logDiscordInvalidIdentifier({
+          field: "channel_id",
+          logger: this.options.logger,
+          reason: threadIdValidation.reason,
+          value: thread.id,
+        });
+        return {
+          channel: this.channel,
+          errorMessage: "Discord returned an invalid created thread.",
+          outcome: "failed",
+          updatedAt: this.now(),
+        };
+      }
+      const parentIdValidation = validateDiscordSnowflake(thread.parent_id);
+      if (!parentIdValidation.ok) {
+        logDiscordInvalidIdentifier({
+          field: "channel_id",
+          logger: this.options.logger,
+          reason: parentIdValidation.reason,
+          value: thread.parent_id,
+        });
+        return {
+          channel: this.channel,
+          errorMessage: "Discord returned an invalid created thread parent.",
+          outcome: "failed",
+          updatedAt: this.now(),
+        };
+      }
+      if (thread.parent_id !== target.channelId) {
+        this.options.logger?.warn?.("discord created thread response rejected", {
+          platform: this.channel,
+          reason: "parent_channel_mismatch",
+        });
+        return {
+          channel: this.channel,
+          errorMessage: "Discord returned a thread for an unexpected parent channel.",
+          outcome: "failed",
+          updatedAt: this.now(),
+        };
+      }
       return {
         channel: this.channel,
         conversation: {
@@ -1031,8 +1083,18 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id, {
       channelType: message.channel_type,
       isThread: message.is_thread,
-      messageId: message.id,
     });
+    const sourceSurface: MessagingSurfaceRef = {
+      channel: this.channel,
+      id: message.id,
+      state: {
+        opaque: {
+          channelId: message.channel_id,
+          guildId: message.guild_id ?? null,
+          messageId: message.id,
+        },
+      },
+    };
     const sourceUrl = discordConversationUrl({
       channelId: message.channel_id,
       guildId: message.guild_id,
@@ -1064,6 +1126,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         },
         receivedAt,
         routingState,
+        sourceSurface,
         sourceUrl,
         text: normalizedContent,
         ...(mentionRemainder !== undefined ? { botMention: true } : {}),
@@ -1097,6 +1160,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           }),
       receivedAt,
       routingState,
+      sourceSurface,
       sourceUrl,
     } as MessagingInboundEvent);
   }
@@ -2019,7 +2083,6 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       channelType?: number;
       interactionToken?: string;
       isThread?: boolean;
-      messageId?: string;
     },
   ): MessagingAdapterState {
     return {
@@ -2032,7 +2095,6 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         guildId: guildId ?? null,
         interactionToken: options?.interactionToken ?? null,
         isThread: options?.isThread ?? null,
-        messageId: options?.messageId ?? null,
       },
     };
   }
@@ -2682,22 +2744,28 @@ function isDiscordThreadConversation(
 function discordManagedThreadTarget(
   channel: MessagingChannelRef,
   routingState: MessagingAdapterState | undefined,
+  sourceSurface: MessagingSurfaceRef | undefined,
 ): { channelId: string; guildId: string; messageId: string } | undefined {
   if (isDiscordThreadChannel(channel, routingState)) {
     return undefined;
   }
   const opaque = discordRoutingOpaque(routingState);
+  const sourceOpaque = discordRoutingOpaque(sourceSurface?.state);
   const channelId = channel.conversation.id;
   const guildId = channel.conversation.workspaceId;
-  const messageId = opaque?.messageId;
+  const messageId = sourceSurface?.id;
   if (
-    typeof guildId !== "string"
+    sourceSurface?.channel !== "discord"
+    || typeof guildId !== "string"
     || typeof messageId !== "string"
     || !validateDiscordSnowflake(channelId).ok
     || !validateDiscordSnowflake(guildId).ok
     || !validateDiscordSnowflake(messageId).ok
     || (typeof opaque?.channelId === "string" && opaque.channelId !== channelId)
     || (typeof opaque?.guildId === "string" && opaque.guildId !== guildId)
+    || sourceOpaque?.channelId !== channelId
+    || sourceOpaque?.guildId !== guildId
+    || sourceOpaque?.messageId !== messageId
   ) {
     return undefined;
   }

--- a/packages/messaging/providers/discord/src/index.ts
+++ b/packages/messaging/providers/discord/src/index.ts
@@ -7,6 +7,7 @@ export type {
   DiscordInteractionResponseRequest,
   DiscordMessage,
   DiscordProviderLogger,
+  DiscordThreadChannel,
 } from "./discord-adapter.ts";
 export type {
   DiscordApplicationCommand,
@@ -24,3 +25,12 @@ export {
 } from "./discord-formatting.ts";
 export type { DiscordMessagingConfig } from "./discord-config.ts";
 export { validateCredentials } from "./validate-credentials.ts";
+export {
+  buildDiscordThreadPermissionRequestUrl,
+  DISCORD_THREAD_REPLY_PERMISSIONS,
+  inspectDiscordThreadPermissions,
+} from "./thread-permissions.ts";
+export type {
+  DiscordThreadPermissionInspection,
+  DiscordThreadReplyPermissionId,
+} from "./thread-permissions.ts";

--- a/packages/messaging/providers/discord/src/index.ts
+++ b/packages/messaging/providers/discord/src/index.ts
@@ -29,8 +29,10 @@ export {
   buildDiscordThreadPermissionRequestUrl,
   DISCORD_THREAD_REPLY_PERMISSIONS,
   inspectDiscordThreadPermissions,
+  listDiscordThreadPermissionChannels,
 } from "./thread-permissions.ts";
 export type {
+  DiscordThreadPermissionChannelListing,
   DiscordThreadPermissionInspection,
   DiscordThreadReplyPermissionId,
 } from "./thread-permissions.ts";

--- a/packages/messaging/providers/discord/src/thread-permissions.ts
+++ b/packages/messaging/providers/discord/src/thread-permissions.ts
@@ -1,0 +1,311 @@
+import { PermissionFlagsBits, REST, Routes } from "discord.js";
+import { clipMessagingValidationError } from "@pwragent/messaging-interface";
+import { validateDiscordSnowflake } from "./validate-ids.ts";
+
+export const DISCORD_THREAD_REPLY_PERMISSIONS = [
+  {
+    bit: PermissionFlagsBits.ViewChannel,
+    id: "view_channel",
+    label: "View Channel",
+  },
+  {
+    bit: PermissionFlagsBits.SendMessages,
+    id: "send_messages",
+    label: "Send Messages",
+  },
+  {
+    bit: PermissionFlagsBits.EmbedLinks,
+    id: "embed_links",
+    label: "Embed Links",
+  },
+  {
+    bit: PermissionFlagsBits.AttachFiles,
+    id: "attach_files",
+    label: "Attach Files",
+  },
+  {
+    bit: PermissionFlagsBits.ReadMessageHistory,
+    id: "read_message_history",
+    label: "Read Message History",
+  },
+  {
+    bit: PermissionFlagsBits.CreatePublicThreads,
+    id: "create_public_threads",
+    label: "Create Public Threads",
+  },
+  {
+    bit: PermissionFlagsBits.SendMessagesInThreads,
+    id: "send_messages_in_threads",
+    label: "Send Messages in Threads",
+  },
+] as const;
+
+export type DiscordThreadReplyPermissionId =
+  (typeof DISCORD_THREAD_REPLY_PERMISSIONS)[number]["id"];
+
+export type DiscordThreadPermissionInspection = {
+  botId?: string;
+  channelId: string;
+  checkedAt: number;
+  durationMs: number;
+  errorMessage?: string;
+  guildId: string;
+  permissions: Array<{
+    granted: boolean;
+    id: DiscordThreadReplyPermissionId;
+    label: string;
+  }>;
+  status: "ok" | "failed" | "unset";
+};
+
+export type DiscordPermissionRest = {
+  get(route: string): Promise<unknown>;
+};
+
+type DiscordUserPayload = {
+  id?: string;
+};
+
+type DiscordGuildPayload = {
+  owner_id?: string;
+};
+
+type DiscordGuildMemberPayload = {
+  roles?: string[];
+};
+
+type DiscordRolePayload = {
+  id?: string;
+  permissions?: string;
+};
+
+type DiscordPermissionOverwritePayload = {
+  allow?: string;
+  deny?: string;
+  id?: string;
+  type?: number;
+};
+
+type DiscordChannelPayload = {
+  guild_id?: string;
+  permission_overwrites?: DiscordPermissionOverwritePayload[];
+};
+
+const DISCORD_ADMINISTRATOR = PermissionFlagsBits.Administrator;
+const DISCORD_THREAD_REPLY_PERMISSION_BITS = DISCORD_THREAD_REPLY_PERMISSIONS
+  .reduce((bits, permission) => bits | permission.bit, 0n);
+
+/**
+ * Inspect the bot's effective permissions in one guild text channel. Discord
+ * applies @everyone, roles, and channel overwrites in that order; this mirrors
+ * that precedence for the permissions PwrAgent exposes in Settings.
+ */
+export async function inspectDiscordThreadPermissions(
+  request: {
+    botToken: string;
+    channelId: string;
+    guildId: string;
+  },
+): Promise<DiscordThreadPermissionInspection> {
+  const startedAt = Date.now();
+  if (!request.botToken) {
+    return {
+      channelId: request.channelId,
+      checkedAt: startedAt,
+      durationMs: 0,
+      guildId: request.guildId,
+      permissions: [],
+      status: "unset",
+    };
+  }
+  const rest = new REST({ version: "10" }).setToken(request.botToken);
+  return inspectDiscordThreadPermissionsWithRest({
+    channelId: request.channelId,
+    guildId: request.guildId,
+    rest,
+    startedAt,
+  });
+}
+
+export async function inspectDiscordThreadPermissionsWithRest(
+  request: {
+    channelId: string;
+    guildId: string;
+    rest: DiscordPermissionRest;
+    startedAt?: number;
+  },
+): Promise<DiscordThreadPermissionInspection> {
+  const startedAt = request.startedAt ?? Date.now();
+  const invalidIdentifier = invalidThreadPermissionIdentifier(request);
+  if (invalidIdentifier) {
+    return {
+      channelId: request.channelId,
+      checkedAt: startedAt,
+      durationMs: 0,
+      errorMessage: invalidIdentifier,
+      guildId: request.guildId,
+      permissions: [],
+      status: "failed",
+    };
+  }
+
+  try {
+    const me = (await request.rest.get(Routes.user("@me"))) as DiscordUserPayload;
+    if (!me.id || !validateDiscordSnowflake(me.id).ok) {
+      throw new Error("Discord did not return a valid bot identity.");
+    }
+    const [guild, channel, member, roles] = await Promise.all([
+      request.rest.get(Routes.guild(request.guildId)) as Promise<DiscordGuildPayload>,
+      request.rest.get(Routes.channel(request.channelId)) as Promise<DiscordChannelPayload>,
+      request.rest.get(
+        `/guilds/${request.guildId}/members/${me.id}`,
+      ) as Promise<DiscordGuildMemberPayload>,
+      request.rest.get(`/guilds/${request.guildId}/roles`) as Promise<DiscordRolePayload[]>,
+    ]);
+    if (channel.guild_id && channel.guild_id !== request.guildId) {
+      throw new Error("The selected Discord channel is not in the selected server.");
+    }
+
+    const effectivePermissions = calculateDiscordChannelPermissions({
+      botId: me.id,
+      channel,
+      guild,
+      guildId: request.guildId,
+      member,
+      roles,
+    });
+    return {
+      botId: me.id,
+      channelId: request.channelId,
+      checkedAt: Date.now(),
+      durationMs: Date.now() - startedAt,
+      guildId: request.guildId,
+      permissions: DISCORD_THREAD_REPLY_PERMISSIONS.map((permission) => ({
+        granted: hasDiscordPermission(effectivePermissions, permission.bit),
+        id: permission.id,
+        label: permission.label,
+      })),
+      status: "ok",
+    };
+  } catch (error) {
+    return {
+      channelId: request.channelId,
+      checkedAt: Date.now(),
+      durationMs: Date.now() - startedAt,
+      errorMessage: clipMessagingValidationError(
+        error instanceof Error ? error.message : String(error),
+      ),
+      guildId: request.guildId,
+      permissions: [],
+      status: "failed",
+    };
+  }
+}
+
+export function buildDiscordThreadPermissionRequestUrl(request: {
+  applicationId: string;
+  guildId?: string;
+}): string {
+  if (!validateDiscordSnowflake(request.applicationId).ok) {
+    throw new Error("A valid Discord application ID is required.");
+  }
+  if (request.guildId && !validateDiscordSnowflake(request.guildId).ok) {
+    throw new Error("The Discord server ID is invalid.");
+  }
+
+  const url = new URL("https://discord.com/oauth2/authorize");
+  url.searchParams.set("client_id", request.applicationId);
+  url.searchParams.set("scope", "bot applications.commands");
+  url.searchParams.set(
+    "permissions",
+    DISCORD_THREAD_REPLY_PERMISSION_BITS.toString(),
+  );
+  if (request.guildId) {
+    url.searchParams.set("guild_id", request.guildId);
+    url.searchParams.set("disable_guild_select", "true");
+  }
+  return url.toString();
+}
+
+function calculateDiscordChannelPermissions(input: {
+  botId: string;
+  channel: DiscordChannelPayload;
+  guild: DiscordGuildPayload;
+  guildId: string;
+  member: DiscordGuildMemberPayload;
+  roles: DiscordRolePayload[];
+}): bigint {
+  if (input.guild.owner_id === input.botId) {
+    return DISCORD_THREAD_REPLY_PERMISSION_BITS;
+  }
+
+  const roleIds = new Set([input.guildId, ...(input.member.roles ?? [])]);
+  let permissions = input.roles
+    .filter((role) => role.id && roleIds.has(role.id))
+    .reduce((bits, role) => bits | permissionBits(role.permissions), 0n);
+  if ((permissions & DISCORD_ADMINISTRATOR) === DISCORD_ADMINISTRATOR) {
+    return permissions;
+  }
+  const overwrites = input.channel.permission_overwrites ?? [];
+  const everyoneOverwrite = overwrites.find(
+    (overwrite) => overwrite.type === 0 && overwrite.id === input.guildId,
+  );
+  permissions = applyDiscordPermissionOverwrite(permissions, everyoneOverwrite);
+
+  let roleAllow = 0n;
+  let roleDeny = 0n;
+  for (const overwrite of overwrites) {
+    if (
+      overwrite.type === 0
+      && overwrite.id
+      && overwrite.id !== input.guildId
+      && roleIds.has(overwrite.id)
+    ) {
+      roleAllow |= permissionBits(overwrite.allow);
+      roleDeny |= permissionBits(overwrite.deny);
+    }
+  }
+  permissions = (permissions & ~roleDeny) | roleAllow;
+
+  const memberOverwrite = overwrites.find(
+    (overwrite) => overwrite.type === 1 && overwrite.id === input.botId,
+  );
+  return applyDiscordPermissionOverwrite(permissions, memberOverwrite);
+}
+
+function applyDiscordPermissionOverwrite(
+  permissions: bigint,
+  overwrite: DiscordPermissionOverwritePayload | undefined,
+): bigint {
+  if (!overwrite) {
+    return permissions;
+  }
+  return (permissions & ~permissionBits(overwrite.deny)) | permissionBits(overwrite.allow);
+}
+
+function hasDiscordPermission(permissions: bigint, permission: bigint): boolean {
+  return (
+    (permissions & DISCORD_ADMINISTRATOR) === DISCORD_ADMINISTRATOR
+    || (permissions & permission) === permission
+  );
+}
+
+function invalidThreadPermissionIdentifier(request: {
+  channelId: string;
+  guildId: string;
+}): string | undefined {
+  if (!validateDiscordSnowflake(request.channelId).ok) {
+    return "The Discord channel ID is invalid.";
+  }
+  if (!validateDiscordSnowflake(request.guildId).ok) {
+    return "The Discord server ID is invalid.";
+  }
+  return undefined;
+}
+
+function permissionBits(value: string | undefined): bigint {
+  if (!value || !/^[0-9]+$/.test(value)) {
+    return 0n;
+  }
+  return BigInt(value);
+}

--- a/packages/messaging/providers/discord/src/thread-permissions.ts
+++ b/packages/messaging/providers/discord/src/thread-permissions.ts
@@ -1,5 +1,8 @@
 import { PermissionFlagsBits, REST, Routes } from "discord.js";
-import { clipMessagingValidationError } from "@pwragent/messaging-interface";
+import {
+  clipMessagingValidationError,
+  sanitizeMessagingContactLabel,
+} from "@pwragent/messaging-interface";
 import { validateDiscordSnowflake } from "./validate-ids.ts";
 
 export const DISCORD_THREAD_REPLY_PERMISSIONS = [
@@ -58,6 +61,19 @@ export type DiscordThreadPermissionInspection = {
   status: "ok" | "failed" | "unset";
 };
 
+export type DiscordThreadPermissionChannelListing = {
+  channels: Array<{
+    categoryName?: string;
+    id: string;
+    kind: "announcement" | "text";
+    name: string;
+  }>;
+  errorMessage?: string;
+  guildId: string;
+  guildName?: string;
+  status: "ok" | "failed" | "unset";
+};
+
 export type DiscordPermissionRest = {
   get(route: string): Promise<unknown>;
 };
@@ -67,6 +83,8 @@ type DiscordUserPayload = {
 };
 
 type DiscordGuildPayload = {
+  id?: unknown;
+  name?: unknown;
   owner_id?: string;
 };
 
@@ -90,6 +108,19 @@ type DiscordChannelPayload = {
   guild_id?: string;
   permission_overwrites?: DiscordPermissionOverwritePayload[];
 };
+
+type DiscordListedChannelPayload = {
+  guild_id?: unknown;
+  id?: unknown;
+  name?: unknown;
+  parent_id?: unknown;
+  position?: unknown;
+  type?: unknown;
+};
+
+const DISCORD_GUILD_TEXT_CHANNEL = 0;
+const DISCORD_GUILD_CATEGORY_CHANNEL = 4;
+const DISCORD_GUILD_ANNOUNCEMENT_CHANNEL = 5;
 
 const DISCORD_ADMINISTRATOR = PermissionFlagsBits.Administrator;
 const DISCORD_THREAD_REPLY_PERMISSION_BITS = DISCORD_THREAD_REPLY_PERMISSIONS
@@ -125,6 +156,135 @@ export async function inspectDiscordThreadPermissions(
     rest,
     startedAt,
   });
+}
+
+/**
+ * List the named guild channels where Discord can create a thread from an
+ * existing message. This keeps platform snowflakes out of the Settings UI.
+ */
+export async function listDiscordThreadPermissionChannels(
+  request: {
+    botToken: string;
+    guildId: string;
+  },
+): Promise<DiscordThreadPermissionChannelListing> {
+  if (!request.botToken) {
+    return {
+      channels: [],
+      guildId: request.guildId,
+      status: "unset",
+    };
+  }
+  const rest = new REST({ version: "10" }).setToken(request.botToken);
+  return listDiscordThreadPermissionChannelsWithRest({
+    guildId: request.guildId,
+    rest,
+  });
+}
+
+export async function listDiscordThreadPermissionChannelsWithRest(
+  request: {
+    guildId: string;
+    rest: DiscordPermissionRest;
+  },
+): Promise<DiscordThreadPermissionChannelListing> {
+  if (!validateDiscordSnowflake(request.guildId).ok) {
+    return {
+      channels: [],
+      errorMessage: "The Discord server ID is invalid.",
+      guildId: request.guildId,
+      status: "failed",
+    };
+  }
+
+  try {
+    const [guild, rawChannels] = await Promise.all([
+      request.rest.get(Routes.guild(request.guildId)) as Promise<DiscordGuildPayload>,
+      request.rest.get(`/guilds/${request.guildId}/channels`) as Promise<unknown>,
+    ]);
+    if (guild.id !== request.guildId) {
+      throw new Error("Discord returned an unexpected server.");
+    }
+    if (!Array.isArray(rawChannels)) {
+      throw new Error("Discord did not return a channel list.");
+    }
+
+    const listedChannels = rawChannels as DiscordListedChannelPayload[];
+    const categories = new Map<string, { name: string; position: number }>();
+    for (const channel of listedChannels) {
+      const name = sanitizeMessagingContactLabel(channel.name);
+      if (
+        channel.type === DISCORD_GUILD_CATEGORY_CHANNEL
+        && channel.guild_id === request.guildId
+        && typeof channel.id === "string"
+        && validateDiscordSnowflake(channel.id).ok
+        && name
+      ) {
+        categories.set(channel.id, {
+          name,
+          position: validDiscordChannelPosition(channel.position),
+        });
+      }
+    }
+
+    const channels = listedChannels.flatMap((channel) => {
+      const name = sanitizeMessagingContactLabel(channel.name);
+      const validKind =
+        channel.type === DISCORD_GUILD_TEXT_CHANNEL
+        || channel.type === DISCORD_GUILD_ANNOUNCEMENT_CHANNEL;
+      if (
+        !validKind
+        || channel.guild_id !== request.guildId
+        || typeof channel.id !== "string"
+        || !validateDiscordSnowflake(channel.id).ok
+        || !name
+      ) {
+        return [];
+      }
+      const category =
+        typeof channel.parent_id === "string"
+        && validateDiscordSnowflake(channel.parent_id).ok
+          ? categories.get(channel.parent_id)
+          : undefined;
+      return [{
+        categoryName: category?.name,
+        categoryPosition: category?.position ?? -1,
+        id: channel.id,
+        kind: channel.type === DISCORD_GUILD_ANNOUNCEMENT_CHANNEL
+          ? "announcement" as const
+          : "text" as const,
+        name,
+        position: validDiscordChannelPosition(channel.position),
+      }];
+    });
+    channels.sort((left, right) =>
+      left.categoryPosition - right.categoryPosition
+      || left.position - right.position
+      || left.name.localeCompare(right.name)
+      || left.id.localeCompare(right.id),
+    );
+
+    const guildName = sanitizeMessagingContactLabel(guild.name);
+    return {
+      channels: channels.map(({
+        categoryPosition: _categoryPosition,
+        position: _position,
+        ...channel
+      }) => channel),
+      guildId: request.guildId,
+      guildName: guildName || undefined,
+      status: "ok",
+    };
+  } catch (error) {
+    return {
+      channels: [],
+      errorMessage: clipMessagingValidationError(
+        error instanceof Error ? error.message : String(error),
+      ),
+      guildId: request.guildId,
+      status: "failed",
+    };
+  }
 }
 
 export async function inspectDiscordThreadPermissionsWithRest(
@@ -301,6 +461,13 @@ function invalidThreadPermissionIdentifier(request: {
     return "The Discord server ID is invalid.";
   }
   return undefined;
+}
+
+function validDiscordChannelPosition(value: unknown): number {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  return Number.MAX_SAFE_INTEGER;
 }
 
 function permissionBits(value: string | undefined): bigint {

--- a/packages/messaging/providers/discord/src/thread-permissions.ts
+++ b/packages/messaging/providers/discord/src/thread-permissions.ts
@@ -162,7 +162,7 @@ export async function inspectDiscordThreadPermissionsWithRest(
       ) as Promise<DiscordGuildMemberPayload>,
       request.rest.get(`/guilds/${request.guildId}/roles`) as Promise<DiscordRolePayload[]>,
     ]);
-    if (channel.guild_id && channel.guild_id !== request.guildId) {
+    if (channel.guild_id !== request.guildId) {
       throw new Error("The selected Discord channel is not in the selected server.");
     }
 

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -474,6 +474,7 @@ export type MessagingPairingObservedChat = {
   title?: string;
   parentId?: string;
   parentTitle?: string;
+  ancestorTitle?: string;
   bucketId?: string;
 };
 

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -370,7 +370,8 @@ export type MessagingThreadBindingSummary = {
    */
   parentTitle?: string;
   /**
-   * Two levels up. Today: Discord threads — the guild name.
+   * Two levels up. Today: Discord threads and categorized channels — the
+   * guild name.
    */
   ancestorTitle?: string;
   /** Wall-clock ms when the binding last had inbound or outbound activity. */

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1860,3 +1860,79 @@ export type SlackCreateAppResponse = {
   manifestJson: string;
   opened: boolean;
 };
+
+/**
+ * Permissions PwrAgent commonly needs to post rich replies and turn a
+ * user-selected Discord message into a public thread.
+ */
+export const DISCORD_THREAD_REPLY_PERMISSIONS = [
+  {
+    id: "view_channel",
+    label: "View Channel",
+  },
+  {
+    id: "send_messages",
+    label: "Send Messages",
+  },
+  {
+    id: "embed_links",
+    label: "Embed Links",
+  },
+  {
+    id: "attach_files",
+    label: "Attach Files",
+  },
+  {
+    id: "read_message_history",
+    label: "Read Message History",
+  },
+  {
+    id: "create_public_threads",
+    label: "Create Public Threads",
+  },
+  {
+    id: "send_messages_in_threads",
+    label: "Send Messages in Threads",
+  },
+] as const;
+
+export type DiscordThreadReplyPermissionId =
+  (typeof DISCORD_THREAD_REPLY_PERMISSIONS)[number]["id"];
+
+export type DiscordThreadPermissionStatus = "ok" | "failed" | "unset";
+
+export type InspectDiscordThreadPermissionsRequest = {
+  channelId: string;
+  guildId: string;
+};
+
+export type InspectDiscordThreadPermissionsResponse = {
+  botId?: string;
+  channelId: string;
+  checkedAt: number;
+  durationMs: number;
+  errorMessage?: string;
+  guildId: string;
+  permissions: Array<{
+    granted: boolean;
+    id: DiscordThreadReplyPermissionId;
+    label: string;
+  }>;
+  status: DiscordThreadPermissionStatus;
+};
+
+/**
+ * Open an OAuth authorization request that includes PwrAgent's suggested
+ * least-privilege Discord permissions. Discord still requires an administrator
+ * to approve the request.
+ */
+export type OpenDiscordThreadPermissionRequest = {
+  guildId?: string;
+  /** When false, return the URL without opening it. */
+  open?: boolean;
+};
+
+export type OpenDiscordThreadPermissionResponse = {
+  opened: boolean;
+  url: string;
+};

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1901,6 +1901,23 @@ export type DiscordThreadReplyPermissionId =
 
 export type DiscordThreadPermissionStatus = "ok" | "failed" | "unset";
 
+export type ListDiscordThreadPermissionChannelsRequest = {
+  guildId: string;
+};
+
+export type ListDiscordThreadPermissionChannelsResponse = {
+  channels: Array<{
+    categoryName?: string;
+    id: string;
+    kind: "announcement" | "text";
+    name: string;
+  }>;
+  errorMessage?: string;
+  guildId: string;
+  guildName?: string;
+  status: DiscordThreadPermissionStatus;
+};
+
 export type InspectDiscordThreadPermissionsRequest = {
   channelId: string;
   guildId: string;


### PR DESCRIPTION
## Summary

- I implemented native Discord public-thread creation from the selected source message, so attaching a PwrAgent thread can now create and bind a real Discord reply thread.
- I added an effective channel-permission preflight for the required Discord thread-reply permissions.
- I replaced the raw channel-ID field with server and channel selectors populated from Discord, including category names and announcement-channel labels.
- I corrected Discord pairing labels so an authorized server displays its server name instead of the channel where pairing occurred.
- I added Settings → Messaging → Discord controls that check the selected channel, put missing permissions first in a clear granted/missing checklist, refresh the available channels, and open Discord's least-privilege administrator authorization request.
- I kept source-message IDs ephemeral so ordinary inbound Discord messages do not rewrite persistent bindings, and I validate Discord's created-thread response before persisting its route.

## Verification

- I ran `pnpm test packages/messaging/providers/discord/src/__tests__/thread-permissions.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (133 passing tests).
- I ran the earlier Discord adapter, permission, Settings, and controller focused suite (546 passing tests).
- I ran `pnpm typecheck`, `pnpm lint:boundaries`, `pnpm lint:sql`, `pnpm lint:colors`, `pnpm lint:codex-storage`, and `pnpm licenses:check`.
- I ran `pnpm lint:eslint`; it completed without errors and reported only pre-existing warnings in unrelated files.
- I launched this checkout with the isolated `dev` profile and verified Settings resolved the live Discord selection as `huntharo-claw` → `Text Channels / #general`; the raw ID field was absent.
- I reran the 84 Settings screen tests after adding the permission-result checklist, then visually verified the live seven-permission all-granted result at the desktop window size. The mixed granted/missing test verifies the missing permission is listed first with an explicit summary.

## Notes

- The authorization request asks for View Channel, Send Messages, Embed Links, Attach Files, Read Message History, Create Public Threads, and Send Messages in Threads. It does not request Administrator or Manage Threads.
