### PR TITLE
fix(messaging): ignore Discord messages addressed elsewhere

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7610,6 +7610,32 @@ describe("MessagingController", () => {
     );
   });
 
+  it("ignores shared messages explicitly addressed to another participant", async () => {
+    const harness = await createHarness({
+      responseModeForConversation: () => "every_message",
+    });
+    const channel = buildTopicChannel("500");
+    await harness.store.upsertBinding({
+      id: "binding:telegram:topic:-1001:500:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("please handle this", {
+        addressedToOtherParticipant: true,
+        channel,
+      }),
+    );
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+  });
+
   it("ignores response modes when the provider cannot report bot mentions", async () => {
     const harness = await createHarness({
       capabilityProfile: {
@@ -24182,6 +24208,7 @@ async function seedConversationDefaultAgent(
 function buildTextEvent(
   text: string,
   params: {
+    addressedToOtherParticipant?: boolean;
     botMention?: boolean;
     channel?: MessagingInboundTextEvent["channel"];
     routingState?: MessagingInboundTextEvent["routingState"];
@@ -24201,6 +24228,9 @@ function buildTextEvent(
       },
     },
     receivedAt: 1000,
+    ...(params.addressedToOtherParticipant
+      ? { addressedToOtherParticipant: true }
+      : {}),
     ...(params.botMention ? { botMention: true } : {}),
     routingState: params.routingState,
     text,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3166,6 +3166,9 @@ export class MessagingController {
   }
 
   private async handleText(event: MessagingInboundTextEvent): Promise<void> {
+    if (this.isSharedMessageAddressedElsewhere(event)) {
+      return;
+    }
     const command = parseTextCommand(event.text);
     if (command) {
       await this.handleCommand({
@@ -3448,6 +3451,9 @@ export class MessagingController {
   }
 
   private async handleMedia(event: MessagingInboundMediaEvent): Promise<void> {
+    if (this.isSharedMessageAddressedElsewhere(event)) {
+      return;
+    }
     const command = event.text ? parseTextCommand(event.text) : undefined;
     if (command) {
       await this.handleCommand({
@@ -3542,6 +3548,9 @@ export class MessagingController {
     ) {
       return true;
     }
+    if (this.isSharedMessageAddressedElsewhere(event)) {
+      return false;
+    }
     if (
       this.capabilityProfile.conversationInput?.reportsBotMention !== true
     ) {
@@ -3552,6 +3561,16 @@ export class MessagingController {
       await this.responseModeForConversation(event.channel),
     );
     return responseMode === "every_message" || event.botMention === true;
+  }
+
+  private isSharedMessageAddressedElsewhere(
+    event: MessagingInboundTextEvent | MessagingInboundMediaEvent,
+  ): boolean {
+    return (
+      event.addressedToOtherParticipant === true
+      && event.channel.conversation.kind !== "dm"
+      && event.channel.conversation.isDirectMessage !== true
+    );
   }
 
   private async responseModeForConversation(

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -49,6 +49,13 @@ turn admission policy that coalesces split input, prevents overlapping
 `turn/start` calls, queues follow-ups during active turns, and maps queued
 input to `turn/steer` or a later `turn/start`.
 
+When a shared-conversation message begins with a platform-native mention of a
+different participant, adapters that can identify that target should set
+`addressedToOtherParticipant: true`. Desktop routing then treats the message as
+explicitly addressed elsewhere instead of ambient input, including when the
+conversation's response mode is `every_message`. Compare stable platform IDs;
+never infer this signal from display-name text.
+
 The `actor.platformUserId` must be the stable platform ID used for
 authorization. Mutable usernames and display names may be included for audit or
 operator visibility only.

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1370,6 +1370,12 @@ export type MessagingInboundBaseEvent = {
    * explicit event kinds and do not need this marker.
    */
   botMention?: boolean;
+  /**
+   * True when the original platform message explicitly addressed a different
+   * participant. Shared-conversation routing must not treat these messages as
+   * ambient input, even when the conversation accepts every other message.
+   */
+  addressedToOtherParticipant?: boolean;
   routingState?: MessagingAdapterState;
 };
 

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -1939,6 +1939,48 @@ describe("discord adapter", () => {
       });
       await adapter.stop();
     });
+
+    it("marks a leading mention of another user as addressed elsewhere", async () => {
+      const BOT_ID = "1480556454498009352";
+      const OTHER_USER_ID = "1490699645528309951";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: TEST_AUTHORIZED_GUILD_IDS,
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: messageDispatch({
+          authorBot: false,
+          content: `<@${OTHER_USER_ID}> please handle this`,
+          id: "msg-addressed-elsewhere",
+        }),
+      });
+
+      expect(events).toEqual([
+        expect.objectContaining({
+          addressedToOtherParticipant: true,
+          kind: "text",
+          text: `<@${OTHER_USER_ID}> please handle this`,
+        }),
+      ]);
+      expect(events[0]).not.toHaveProperty("botMention");
+      await adapter.stop();
+    });
   });
 });
 

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -812,6 +812,12 @@ export class DiscordAdapter implements DiscordProviderAdapter {
             this.options.config.applicationId,
           )
         : undefined;
+    const addressedToOtherParticipant =
+      message.content !== undefined
+      && isDiscordMessageAddressedToOtherParticipant(
+        message.content,
+        this.options.config.applicationId,
+      );
     const isPairingMessage = message.content !== undefined
       ? Boolean(extractMessagingPairingToken(message.content))
       : false;
@@ -874,6 +880,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         routingState,
         sourceUrl,
         text: normalizedContent,
+        ...(addressedToOtherParticipant
+          ? { addressedToOtherParticipant: true }
+          : {}),
         ...(mentionRemainder !== undefined ? { botMention: true } : {}),
       });
       return;
@@ -901,6 +910,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           }
         : {
             text: normalizedContent ?? "",
+            ...(addressedToOtherParticipant
+              ? { addressedToOtherParticipant: true }
+              : {}),
             ...(mentionRemainder !== undefined ? { botMention: true } : {}),
           }),
       receivedAt,
@@ -2339,6 +2351,22 @@ export function stripDiscordBotMention(
   }
   const remainder = trimmedStart.slice(mention.length).trim();
   return remainder;
+}
+
+/**
+ * Return true when a message begins with a Discord user mention whose exact
+ * snowflake differs from the configured bot identity. This lets shared-channel
+ * routing distinguish ambient chatter from a message explicitly addressed to
+ * someone else, including when the channel accepts every ambient message.
+ */
+export function isDiscordMessageAddressedToOtherParticipant(
+  text: string,
+  botUserId: string | undefined,
+): boolean {
+  const trimmedStart = text.replace(/^\s+/, "");
+  const match = /^<@!?([0-9]{1,20})>/.exec(trimmedStart);
+  const mentionedUserId = match?.[1];
+  return mentionedUserId !== undefined && mentionedUserId !== botUserId;
 }
 
 function messageToDispatch(message: Message): DiscordMessageCreateDispatch {


### PR DESCRIPTION
## Summary

- I prevent PwrAgent from starting a turn for a shared Discord message that begins with an exact user-ID mention of someone else, even when the conversation accepts every ambient message.
- I carry the provider-neutral `addressedToOtherParticipant` signal from the Discord adapter into shared-conversation routing and apply it before pending replies or turn admission.
- I added adapter and controller regressions using the incident's foreign Discord user ID.

## Verification

- `pnpm test packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts` (455 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (no errors; existing unrelated warnings remain)
- `pnpm lint:boundaries`

## Notes

- I confirmed the current adapter already matches the configured bot ID exactly; it was not doing a display-name prefix match. The bug was that a foreign mention remained ordinary ambient text, which `every_message` mode then admitted.
- Direct messages retain their existing behavior. The new suppression applies only to shared conversations that a provider positively identifies as addressed to another participant.
