### PR TITLE
feat(desktop): add per-review location choice

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -2042,25 +2042,33 @@ test.describe("federation remote window", () => {
       const setupMtimeMs = statSync(setupMarkerPath).mtimeMs;
       expect(setupMtimeMs).toBeLessThanOrEqual(threadStart!.at + 5_000);
 
-      // Starting a native review continues asynchronously after child
+      // Starting the inline review turn continues asynchronously after child
       // materialization. Wait for the durable request instead of assuming it
       // has arrived as soon as thread/start is observable on a slower VM.
       await expect
         .poll(async () => {
           const entries = await readFakeCodexRequestLog(requestLogPath);
-          return findAllFakeCodexRequests(entries, "review/start").length;
+          return findAllFakeCodexRequests(entries, "turn/start").length;
         }, { timeout: 30_000 })
         .toBeGreaterThan(0);
 
       protocol = await readFakeCodexRequestLog(requestLogPath);
       const initialize = findFakeCodexRequest(protocol, "initialize");
       threadStart = findFakeCodexRequest(protocol, "thread/start");
-      const reviewStart = findFakeCodexRequest(protocol, "review/start");
+      const reviewTurnStart = findFakeCodexRequest(protocol, "turn/start");
       expect(initialize).toBeTruthy();
       expect(threadStart).toBeTruthy();
-      expect(reviewStart).toBeTruthy();
+      expect(reviewTurnStart).toBeTruthy();
+      expect(reviewTurnStart!.params).toMatchObject({
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
+      });
       expect(initialize!.at).toBeLessThanOrEqual(threadStart!.at);
-      expect(threadStart!.at).toBeLessThanOrEqual(reviewStart!.at);
+      expect(threadStart!.at).toBeLessThanOrEqual(reviewTurnStart!.at);
     } finally {
       if (existsSync(requestLogPath)) {
         await testInfo.attach("fake-codex-protocol", {

--- a/apps/desktop/e2e/fixtures/review-command-flow/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-command-flow/replay.fixture.json
@@ -19,8 +19,7 @@
           "thread/list",
           "thread/read",
           "skills/list",
-          "turn/start",
-          "review/start"
+          "turn/start"
         ]
       }
     },
@@ -86,12 +85,11 @@
       }
     },
     {
-      "id": "review-start-1",
+      "id": "review-turn-start-1",
       "kind": "response",
-      "method": "review/start",
+      "method": "turn/start",
       "result": {
         "threadId": "thread-review-command",
-        "reviewThreadId": "thread-review-command",
         "turnId": "turn-review-1"
       }
     },

--- a/apps/desktop/e2e/fixtures/review-multiple-findings/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-multiple-findings/replay.fixture.json
@@ -19,7 +19,7 @@
           "thread/list",
           "thread/read",
           "skills/list",
-          "review/start"
+          "turn/start"
         ]
       }
     },
@@ -73,12 +73,11 @@
       }
     },
     {
-      "id": "review-start-1",
+      "id": "review-turn-start-1",
       "kind": "response",
-      "method": "review/start",
+      "method": "turn/start",
       "result": {
         "threadId": "019dd4ce-4fec-76c0-8ede-5e65d7377417",
-        "reviewThreadId": "019dd4ce-4fec-76c0-8ede-5e65d7377417",
         "turnId": "019dd6fe-485f-7f73-bf6e-16ff7911fadb"
       }
     },

--- a/apps/desktop/e2e/fixtures/review-output-rendering/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-output-rendering/replay.fixture.json
@@ -19,7 +19,7 @@
           "thread/list",
           "thread/read",
           "skills/list",
-          "review/start"
+          "turn/start"
         ]
       }
     },
@@ -81,12 +81,11 @@
       }
     },
     {
-      "id": "review-start-1",
+      "id": "review-turn-start-1",
       "kind": "response",
-      "method": "review/start",
+      "method": "turn/start",
       "result": {
         "threadId": "019dd682-56d6-7601-8634-fc3a49e67554",
-        "reviewThreadId": "019dd682-56d6-7601-8634-fc3a49e67554",
         "turnId": "019dd6d5-91fa-7820-acb5-8ebd37da76e4"
       }
     },

--- a/apps/desktop/e2e/managed-review.spec.ts
+++ b/apps/desktop/e2e/managed-review.spec.ts
@@ -126,7 +126,7 @@ test("managed review failure leaves one start marker and clears Stop state", asy
       .getByRole("button", { name: "Review location" })
       .press("Enter");
     await fixture.app.window
-      .getByRole("option", { name: "Separate thread" })
+      .getByRole("option", { name: "Subagent" })
       .click();
     await fixture.app.window
       .getByRole("button", { name: "Start review" })

--- a/apps/desktop/e2e/managed-review.spec.ts
+++ b/apps/desktop/e2e/managed-review.spec.ts
@@ -2,7 +2,6 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
-import { applyDesktopSettingsPatch } from "../src/main/settings/desktop-config";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 async function createManagedReviewFixture(): Promise<{
@@ -104,12 +103,6 @@ async function launchManagedReviewFixture() {
   const fixture = await createManagedReviewFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
-    preLaunchHook: (homeRoot) => {
-      applyDesktopSettingsPatch(
-        path.join(homeRoot, ".pwragent/profiles/default/config.toml"),
-        { experimental: { managedReview: true } },
-      );
-    },
   });
   return {
     app,
@@ -127,8 +120,14 @@ test("managed review failure leaves one start marker and clears Stop state", asy
       .getByRole("button", { name: /Managed review failure/i })
       .first()
       .click();
-    await fixture.app.window.getByLabel("Reply").fill("/review main");
+    await fixture.app.window.getByLabel("Reply").fill("/review");
     await fixture.app.window.getByRole("button", { name: "Send" }).click();
+    await fixture.app.window
+      .getByRole("radio", { name: "Separate thread" })
+      .click();
+    await fixture.app.window
+      .getByRole("button", { name: "Start review" })
+      .click();
 
     const transcript = fixture.app.window.getByRole("region", { name: "Transcript" });
     await expect(transcript.getByText("Review changes against main")).toHaveCount(1);

--- a/apps/desktop/e2e/managed-review.spec.ts
+++ b/apps/desktop/e2e/managed-review.spec.ts
@@ -123,7 +123,10 @@ test("managed review failure leaves one start marker and clears Stop state", asy
     await fixture.app.window.getByLabel("Reply").fill("/review");
     await fixture.app.window.getByRole("button", { name: "Send" }).click();
     await fixture.app.window
-      .getByRole("radio", { name: "Separate thread" })
+      .getByRole("button", { name: "Review location" })
+      .press("Enter");
+    await fixture.app.window
+      .getByRole("option", { name: "Separate thread" })
       .click();
     await fixture.app.window
       .getByRole("button", { name: "Start review" })

--- a/apps/desktop/e2e/queued-review-release.spec.ts
+++ b/apps/desktop/e2e/queued-review-release.spec.ts
@@ -68,7 +68,6 @@ async function createQueuedReviewReleaseFixture(): Promise<{
                 "thread/list",
                 "thread/read",
                 "turn/start",
-                "review/start",
               ],
             },
           },
@@ -147,12 +146,11 @@ async function createQueuedReviewReleaseFixture(): Promise<{
             },
           },
           {
-            id: "review-start-1",
+            id: "review-turn-start-1",
             kind: "response",
-            method: "review/start",
+            method: "turn/start",
             result: {
               threadId: "thread-active",
-              reviewThreadId: "thread-active",
               turnId: "turn-review",
             },
           },
@@ -313,14 +311,15 @@ test("background queued review releases after active turn branch adoption", asyn
     await app.advance({ stepId: "turn-completed-1" });
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "thread-active",
-        target: {
-          type: "baseBranch",
-          branch: "main",
-        },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
   } finally {
     await app.close();

--- a/apps/desktop/e2e/review-command-flow.spec.ts
+++ b/apps/desktop/e2e/review-command-flow.spec.ts
@@ -35,7 +35,7 @@ test("review command asks for target and preserves transcript order", async () =
     const reviewTarget = app.window.getByRole("group", { name: "Review target" });
     await expect(reviewTarget).toBeVisible();
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toBeUndefined();
 
     await reviewTarget.getByRole("combobox", { name: "Base branch" }).click();
@@ -43,11 +43,15 @@ test("review command asks for target and preserves transcript order", async () =
     await reviewTarget.getByRole("button", { name: "Start review" }).click();
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "thread-review-command",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
 
     const transcript = app.window.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/e2e/review-multiple-findings.spec.ts
+++ b/apps/desktop/e2e/review-multiple-findings.spec.ts
@@ -30,11 +30,15 @@ test("renders captured Codex review findings as separate cards without duplicate
     await app.window.getByRole("button", { name: "Send" }).click();
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "019dd4ce-4fec-76c0-8ede-5e65d7377417",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
 
     const transcript = app.window.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/e2e/review-output-rendering.spec.ts
+++ b/apps/desktop/e2e/review-output-rendering.spec.ts
@@ -34,11 +34,15 @@ test("renders captured Codex review findings once in the review card", async () 
     await app.window.getByRole("button", { name: "Send" }).click();
 
     await expect
-      .poll(async () => await app.getLastStartReview())
+      .poll(async () => await app.getLastStartTurn())
       .toMatchObject({
         threadId: "019dd682-56d6-7601-8634-fc3a49e67554",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringMatching(
+            /<user_action><action>review<\/action><\/user_action>[\s\S]*base branch 'main'/,
+          ),
+        }],
       });
 
     const transcript = app.window.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -536,6 +536,7 @@ describe("agent ipc", () => {
     await handlers.get(AGENT_START_REVIEW_CHANNEL)?.({}, {
       backend: "codex",
       federationTarget,
+      runMode: "managed-child",
       threadId: "thread-1",
       target: { type: "uncommittedChanges" },
     });
@@ -704,6 +705,7 @@ describe("agent ipc", () => {
     expect(registry.cancelQueuedTurnWithDisposition).not.toHaveBeenCalled();
     expect(federationMock.remoteBackend.startReview).toHaveBeenCalledWith({
       backend: "codex",
+      runMode: "managed-child",
       threadId: "thread-1",
       target: { type: "uncommittedChanges" },
     });
@@ -993,6 +995,7 @@ describe("agent ipc", () => {
     expect(
       await handlers.get(AGENT_START_REVIEW_CHANNEL)?.({}, {
         backend: "acp:grok",
+        runMode: "managed-child",
         threadId: "thread-1",
         target: { type: "uncommittedChanges" },
       }),
@@ -1001,6 +1004,12 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       reviewThreadId: "thread-1",
       turnId: "turn-review-1",
+    });
+    expect(registry.startReview).toHaveBeenCalledWith({
+      backend: "acp:grok",
+      runMode: "managed-child",
+      threadId: "thread-1",
+      target: { type: "uncommittedChanges" },
     });
     expect(
       await handlers.get(AGENT_INTERRUPT_TURN_CHANNEL)?.({}, {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25412,7 +25412,7 @@ command = "pnpm dev"
       await registry.listBackends({ includeUnavailable: true })
     ).backends.find((backend) => backend.kind === "codex");
     expect(codexBackend?.capabilities.startReview).toBe(true);
-    expect(codexBackend?.capabilities.startDetachedReview).toBe(false);
+    expect(codexBackend?.capabilities.startDetachedReview).toBe(true);
 
     const response = await registry.startReview({
       backend: "codex",
@@ -26445,7 +26445,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("persists native review provenance on the existing sub-agent write", async () => {
+  it("persists detached native review provenance on the existing sub-agent write", async () => {
     const context: AppServerReviewContext = {
       workspacePath: "/repo",
       projectLabel: "PwrAgent",
@@ -26482,7 +26482,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "origin/main" },
-      delivery: "inline",
+      delivery: "detached",
     });
 
     await expect(

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5027,7 +5027,7 @@ describe("DesktopBackendRegistry", () => {
     });
   });
 
-  it("configures the code-mode reducer before a native Token Miser review", async () => {
+  it("configures the code-mode reducer before an inline Token Miser review", async () => {
     const codexClient = new MockBackendClient({
       threads: [],
       serverCapabilities: {
@@ -5076,7 +5076,7 @@ describe("DesktopBackendRegistry", () => {
       });
 
       expect(prepare).toHaveBeenCalledTimes(1);
-      expect(codexClient.lastStartReviewParams?.config).toMatchObject({
+      expect(codexClient.lastStartTurnParams?.config).toMatchObject({
         features: {
           code_mode: {
             output_reducer: {
@@ -5090,7 +5090,7 @@ describe("DesktopBackendRegistry", () => {
         },
       });
       const dynamicToolNames = pwragentDynamicTools(
-        codexClient.lastStartReviewParams?.dynamicTools,
+        codexClient.lastStartTurnParams?.dynamicTools,
       ).map((tool) => tool.name);
       expect(dynamicToolNames).toContain("search_threads");
       expect(dynamicToolNames).toEqual(expect.arrayContaining([
@@ -5103,7 +5103,7 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
-  it("does not pass reducer config to native review for another protocol version", async () => {
+  it("does not pass reducer config to inline review for another protocol version", async () => {
     const codexClient = new MockBackendClient({
       threads: [],
       serverCapabilities: {
@@ -5137,13 +5137,13 @@ describe("DesktopBackendRegistry", () => {
       })).resolves.toMatchObject({ threadId: "thread-1" });
 
       expect(prepare).toHaveBeenCalledTimes(1);
-      expect(codexClient.lastStartReviewParams?.config).toBeUndefined();
+      expect(codexClient.lastStartTurnParams?.config).toBeUndefined();
     } finally {
       await registry.close();
     }
   });
 
-  it("removes Token Miser tools from an opted-out native review catalog", async () => {
+  it("removes Token Miser tools from an opted-out inline review catalog", async () => {
     const codexClient = new MockBackendClient({
       threads: [],
       serverCapabilities: {
@@ -5185,13 +5185,13 @@ describe("DesktopBackendRegistry", () => {
       });
 
       const dynamicToolNames = pwragentDynamicTools(
-        codexClient.lastStartReviewParams?.dynamicTools,
+        codexClient.lastStartTurnParams?.dynamicTools,
       ).map((tool) => tool.name);
       expect(dynamicToolNames).toContain("search_threads");
       expect(dynamicToolNames).not.toContain("search_token_miser_output");
       expect(dynamicToolNames).not.toContain("read_token_miser_output");
       expect(dynamicToolNames).not.toContain("read_all_token_miser_output");
-      expect(codexClient.lastStartReviewParams?.config).toBeUndefined();
+      expect(codexClient.lastStartTurnParams?.config).toBeUndefined();
     } finally {
       await registry.close();
     }
@@ -13957,7 +13957,7 @@ script = "echo setup"
       target: { type: "baseBranch", branch: "main" },
     });
 
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",
       cwd: handoffWorktreePath,
     });
@@ -16044,10 +16044,12 @@ command = "pnpm grok"
       serviceTier: "priority",
       fastMode: true,
     });
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",
-      target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("base branch 'main'"),
+      }],
       model: "gpt-5.4",
       reasoningEffort: "high",
       serviceTier: "priority",
@@ -23001,7 +23003,7 @@ command = "pnpm dev"
       fastMode: true,
     });
 
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-env",
       cwd: "/repo/app",
       codexEnvironmentRuntime,
@@ -23045,7 +23047,7 @@ command = "pnpm dev"
     });
 
     // The review itself runs on the picked model...
-    expect(codexClient.lastStartReviewParams).toMatchObject({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       model: "gpt-5.2",
       reasoningEffort: "high",
     });
@@ -25388,6 +25390,66 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("starts inline Codex reviews as turns on the parent thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      startReviewResult: {
+        threadId: "thread-parent",
+        reviewThreadId: "ephemeral-review-thread",
+        turnId: "native-review-turn",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const codexBackend = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends.find((backend) => backend.kind === "codex");
+    expect(codexBackend?.capabilities.startReview).toBe(true);
+
+    const response = await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "origin/main" },
+      delivery: "inline",
+    });
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-parent",
+      reviewThreadId: "thread-parent",
+      turnId: "turn-1",
+    });
+    expect(registry.getActiveTurnForThread({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual({
+      backend: "codex",
+      threadId: "thread-parent",
+      turnId: "turn-1",
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-parent"],
+    });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-parent",
+      input: [
+        {
+          type: "text",
+          text: expect.stringMatching(
+            /Review the code changes[\s\S]*origin\/main[\s\S]*prioritized findings/,
+          ),
+        },
+      ],
+    });
+
+    await registry.close();
+  });
+
   it("treats a Codex review as active until its terminal turn notification", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
@@ -25419,15 +25481,15 @@ command = "pnpm dev"
         input: [{ type: "text", text: "Follow-up while review is running" }],
       }),
     ).rejects.toThrow("A turn is already active for this thread.");
-    expect(codexClient.startTurnCallCount).toBe(0);
+    expect(codexClient.startTurnCallCount).toBe(1);
 
     await codexClient.emit({
       method: "turn/completed",
       params: {
         threadId: "thread-1",
-        turnId: "turn-review-1",
+        turnId: "turn-1",
         turn: {
-          id: "turn-review-1",
+          id: "turn-1",
           status: "completed",
           completedAt: 1_781_178_272,
           output: [],
@@ -25440,7 +25502,7 @@ command = "pnpm dev"
       threadId: "thread-1",
       input: [{ type: "text", text: "Follow-up after review" }],
     });
-    expect(codexClient.startTurnCallCount).toBe(1);
+    expect(codexClient.startTurnCallCount).toBe(2);
 
     await registry.close();
   });
@@ -26408,7 +26470,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("persists Codex reviews as sub-agent summaries on the parent thread", async () => {
+  it("persists detached Codex reviews as sub-agent summaries on the parent thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
       models: [
@@ -26436,7 +26498,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      delivery: "detached",
     });
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
@@ -26559,7 +26621,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("patches Codex review sub-agent usage when usage arrives after completion", async () => {
+  it("patches detached Codex review usage when usage arrives after completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
       startReviewResult: {
@@ -26578,7 +26640,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      delivery: "detached",
     });
 
     await codexClient.emit({
@@ -27686,7 +27748,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
-      delivery: "inline",
+      delivery: "detached",
     });
     await codexClient.emit({
       method: "turn/started",
@@ -33946,10 +34008,12 @@ script = "printf setup"
       },
     });
 
-    expect(codexClient.lastStartReviewParams).toEqual({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "parent-thread",
-      target: { type: "uncommittedChanges" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("staged, unstaged, and untracked"),
+      }],
     });
 
     await registry.close();
@@ -33961,7 +34025,7 @@ script = "printf setup"
       initializeResult: {
         methods: ["turn/start", "review/start", "thread/resume"],
       },
-      startReviewDelay: startReviewDelay.promise,
+      startTurnDelay: startReviewDelay.promise,
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -33997,7 +34061,7 @@ script = "printf setup"
       },
     });
     await vi.waitFor(() => {
-      expect(codexClient.lastStartReviewParams).toBeDefined();
+      expect(codexClient.startTurnCallCount).toBe(1);
     });
 
     expect(registry.cancelPendingReview(
@@ -34015,6 +34079,10 @@ script = "printf setup"
       initializeResult: {
         methods: ["turn/start", "review/start", "thread/resume"],
       },
+      startTurnResults: [
+        { threadId: "parent-thread", turnId: "turn-review-1" },
+        { threadId: "parent-thread", turnId: "turn-review-2" },
+      ],
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -34084,10 +34152,12 @@ script = "printf setup"
       },
     });
 
-    expect(codexClient.lastStartReviewParams).toEqual({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "parent-thread",
-      target: { type: "uncommittedChanges" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("staged, unstaged, and untracked"),
+      }],
     });
     expect(events).toContainEqual({
       backend: "codex",
@@ -34129,10 +34199,12 @@ script = "printf setup"
       },
     });
 
-    expect(codexClient.lastStartReviewParams).toEqual({
+    expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "parent-thread",
-      target: { type: "baseBranch", branch: "develop" },
-      delivery: "inline",
+      input: [{
+        type: "text",
+        text: expect.stringContaining("base branch 'develop'"),
+      }],
     });
     expect(events).toContainEqual({
       backend: "codex",
@@ -34153,7 +34225,7 @@ script = "printf setup"
       initializeResult: {
         methods: ["turn/start", "review/start", "thread/resume"],
       },
-      startReviewError: new Error("Codex disconnected"),
+      startTurnError: new Error("Codex disconnected"),
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -47151,7 +47223,7 @@ script = "printf setup"
       await registry.close();
     });
 
-    it("startReview waits for an in-flight permission queue flush before review/start", async () => {
+    it("startReview waits for an in-flight permission queue flush before the inline turn", async () => {
       const permissionFlush = createDeferred<void>();
       const codexClient = new MockBackendClient({
         initializeResult: { methods: ["turn/start", "review/start", "thread/resume"] },
@@ -47203,10 +47275,14 @@ script = "printf setup"
         approvalPolicy: "never",
         sandbox: "danger-full-access",
       });
-      expect(codexClient.lastStartReviewParams).toEqual({
+      expect(codexClient.lastStartTurnParams).toMatchObject({
         threadId: "thread-1",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
+        input: [{
+          type: "text",
+          text: expect.stringContaining("base branch 'main'"),
+        }],
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
       });
       const overlay = await overlayStore.getThreadOverlayState({
         backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -24387,7 +24387,7 @@ command = "pnpm dev"
     expect(codexClient.lastStartThreadParams).toMatchObject({
       approvalPolicy: "never",
       cwd: "/repo/worktree",
-      ephemeral: false,
+      ephemeral: true,
       fastMode: true,
       model: "gpt-5.5",
       reasoningEffort: "high",
@@ -24796,7 +24796,7 @@ command = "pnpm dev"
     expect(codexClient.lastStartReviewParams).toBeUndefined();
     expect(codexClient.lastStartThreadParams).toMatchObject({
       cwd: "/repo/selected",
-      ephemeral: false,
+      ephemeral: true,
     });
     expect(
       codexClient.lastStartThreadParams?.codexEnvironmentRuntime,
@@ -24868,7 +24868,7 @@ command = "pnpm dev"
     expect(codexClient.lastStartThreadParams).toMatchObject({
       cwd: "/remote/selected",
       codexEnvironmentRuntime: remoteRuntime,
-      ephemeral: false,
+      ephemeral: true,
     });
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "remote-project-review",
@@ -25559,7 +25559,7 @@ command = "pnpm dev"
     });
     expect(codexClient.lastStartReviewParams).toBeUndefined();
     expect(codexClient.lastStartThreadParams).toMatchObject({
-      ephemeral: false,
+      ephemeral: true,
       threadSource: "subagent",
     });
 
@@ -34069,7 +34069,7 @@ script = "printf setup"
     expect(codexClient.lastStartReviewParams).toBeUndefined();
     expect(codexClient.lastStartThreadParams).toMatchObject({
       cwd: "/repo/pwragent",
-      ephemeral: false,
+      ephemeral: true,
     });
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5223,7 +5223,6 @@ describe("DesktopBackendRegistry", () => {
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
-      resolveManagedReviewEnabled: () => true,
     });
     const tokenMiserStateDir = path.join(
       "/tmp",
@@ -5263,6 +5262,7 @@ describe("DesktopBackendRegistry", () => {
         backend: "codex",
         threadId: "thread-1",
         target: { type: "custom", instructions: "Review the current change." },
+        runMode: "managed-child",
       });
 
       expect(prepare).toHaveBeenCalledTimes(1);
@@ -5365,7 +5365,6 @@ describe("DesktopBackendRegistry", () => {
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore: createOverlayStoreMock(),
-      resolveManagedReviewEnabled: () => true,
     });
     const tokenMiserStateDir = path.join(
       "/tmp",
@@ -5391,6 +5390,7 @@ describe("DesktopBackendRegistry", () => {
         backend: "codex",
         threadId: "thread-1",
         target: { type: "custom", instructions: "Review the current change." },
+        runMode: "managed-child",
       });
 
       expect(codexClient.lastStartThreadParams?.config).toBeUndefined();
@@ -23046,6 +23046,7 @@ command = "pnpm dev"
       threadId: "thread-parent",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "inline",
       model: "gpt-5.2",
       reasoningEffort: "high",
     });
@@ -23055,6 +23056,7 @@ command = "pnpm dev"
       model: "gpt-5.2",
       reasoningEffort: "high",
     });
+    expect(codexClient.lastStartThreadParams).toBeUndefined();
     // ...but the thread keeps answering as it did before.
     const overlay = await overlayStore.getThreadOverlayState({
       backend: "codex",
@@ -23485,13 +23487,13 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
-      resolveManagedReviewEnabled: () => true,
     });
     await registry.startReview({
       backend: "codex",
       threadId: "thread-parent",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "managed-child",
     });
 
     const events: AgentEvent[] = [];
@@ -23552,13 +23554,13 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore: overlayStore as never,
-      resolveManagedReviewEnabled: () => true,
     });
     await registry.startReview({
       backend: "codex",
       threadId: "thread-parent",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "managed-child",
     });
 
     const events: AgentEvent[] = [];
@@ -24266,13 +24268,13 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
-      resolveManagedReviewEnabled: () => true,
     });
     await registry.startReview({
       backend: "codex",
       threadId: "thread-parent",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "managed-child",
     });
 
     const events: AgentEvent[] = [];
@@ -24311,7 +24313,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("runs the managed review experiment as one child turn and attributes usage to it", async () => {
+  it("runs an explicitly selected managed review as one child turn and attributes usage to it", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
       models: [
@@ -24355,7 +24357,6 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
-      resolveManagedReviewEnabled: () => true,
     });
     const events: AgentEvent[] = [];
     registry.onEvent((event) => {
@@ -24372,6 +24373,7 @@ command = "pnpm dev"
       threadId: "thread-parent",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "managed-child",
     });
 
     expect(response).toEqual({
@@ -24579,7 +24581,6 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
-      resolveManagedReviewEnabled: () => true,
     });
 
     const response = await registry.startReview({
@@ -24587,6 +24588,7 @@ command = "pnpm dev"
       threadId: "thread-parent",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "managed-child",
     });
     expect(codexClient.lastStartThreadParams?.model).toBeUndefined();
 
@@ -24664,7 +24666,6 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({
       codexClient,
       overlayStore,
-      resolveManagedReviewEnabled: () => true,
     });
     const events: AgentEvent[] = [];
     registry.onEvent((event) => {
@@ -24676,6 +24677,7 @@ command = "pnpm dev"
       threadId: "thread-parent",
       target: { type: "uncommittedChanges" },
       delivery: "inline",
+      runMode: "managed-child",
     });
     const queuedTurn = await registry.submitTurn({
       backend: "codex",
@@ -24774,7 +24776,6 @@ command = "pnpm dev"
           },
         },
       }),
-      resolveManagedReviewEnabled: () => false,
     });
 
     const response = await registry.startReview({
@@ -24853,7 +24854,6 @@ command = "pnpm dev"
           },
         },
       }),
-      resolveManagedReviewEnabled: () => false,
     });
 
     await registry.startReview({
@@ -25394,7 +25394,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("starts inline Codex reviews as turns on the parent thread", async () => {
+  it("keeps legacy review requests without runMode inline on the parent thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
       startReviewResult: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1646,6 +1646,7 @@ class MockBackendClient {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: unknown;
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   };
   interruptTurnCallCount = 0;
   lastInterruptTurnParams?: {
@@ -2085,6 +2086,7 @@ class MockBackendClient {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: unknown;
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{ threadId: string; turnId: string }> {
     this.startTurnCallCount += 1;
     await this.options.startTurnDelay;
@@ -16072,10 +16074,9 @@ command = "pnpm grok"
   });
 
   it("names a thread launched straight into a review", async () => {
-    // A /review launch never calls startTurn, so the thread was born with no
-    // user prompt for the title generator to work from and kept its fallback
-    // name forever. Synthesize a prompt from what the review already knows:
-    // the repository, the branch, and the review target.
+    // The inline turn uses an internal review prompt. Keep that prompt out of
+    // Codex's derived-name path and synthesize the public title prompt from
+    // what the review already knows: repository, branch, and review target.
     const titleService = {
       generateTitle: vi.fn(async (_params: { userPrompt: string }) => ({
         status: "generated" as const,
@@ -16084,7 +16085,7 @@ command = "pnpm grok"
     };
     const codexClient = new MockBackendClient({
       initializeResult: {
-        methods: ["thread/start", "thread/name/set", "review/start"],
+        methods: ["thread/start", "thread/name/set", "turn/start"],
       },
       threads: [],
     });
@@ -16126,6 +16127,9 @@ command = "pnpm grok"
       threadId: "thread-1",
       name: "Review app against main",
     });
+    expect(codexClient.lastStartTurnParams?.suppressThreadTitleDerivation).toBe(
+      true,
+    );
 
     await registry.close();
   });
@@ -25408,6 +25412,7 @@ command = "pnpm dev"
       await registry.listBackends({ includeUnavailable: true })
     ).backends.find((backend) => backend.kind === "codex");
     expect(codexBackend?.capabilities.startReview).toBe(true);
+    expect(codexBackend?.capabilities.startDetachedReview).toBe(false);
 
     const response = await registry.startReview({
       backend: "codex",
@@ -25445,6 +25450,116 @@ command = "pnpm dev"
           ),
         },
       ],
+    });
+
+    await registry.close();
+  });
+
+  it("does not restore an inline review as active when its terminal event precedes turn/start", async () => {
+    const startTurnDelay = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      startTurnDelay: startTurnDelay.promise,
+      startTurnResults: [{ threadId: "thread-parent", turnId: "turn-fast-review" }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const review = registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    await vi.waitFor(() => {
+      expect(codexClient.startTurnCallCount).toBe(1);
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-fast-review",
+        turn: {
+          id: "turn-fast-review",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+    startTurnDelay.resolve();
+
+    await expect(review).resolves.toMatchObject({
+      threadId: "thread-parent",
+      reviewThreadId: "thread-parent",
+      turnId: "turn-fast-review",
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
+    await expect(registry.startTurn({
+      backend: "codex",
+      threadId: "thread-parent",
+      input: [{ type: "text", text: "Continue after the fast review" }],
+    })).resolves.toMatchObject({ threadId: "thread-parent" });
+
+    await registry.close();
+  });
+
+  it("rejects detached Codex review when neither native nor managed-child support exists", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "detached",
+    })).rejects.toThrow(/detached review/i);
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("falls back to a managed child for detached Codex review without review/start", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startThreadResult: { threadId: "managed-detached-review" },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const codexBackend = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends.find((backend) => backend.kind === "codex");
+    expect(codexBackend?.capabilities.startDetachedReview).toBe(true);
+
+    const response = await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "detached",
+    });
+
+    expect(response).toMatchObject({
+      threadId: "thread-parent",
+      reviewThreadId: "managed-detached-review",
+      turnId: "turn-1",
+    });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+    expect(codexClient.lastStartThreadParams).toMatchObject({
+      ephemeral: false,
+      threadSource: "subagent",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -23137,6 +23137,7 @@ command = "pnpm dev"
       await registry.listBackends({ includeUnavailable: true })
     ).backends.find((backend) => backend.kind === "codex");
     expect(codexBackend?.capabilities.reviewRunner).toBe(true);
+    expect(codexBackend?.capabilities.reviewRunMode).toBe(true);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -9107,6 +9107,57 @@ describe("CodexAppServerClient", () => {
     }
   });
 
+  it("does not derive a Codex thread name from an internal turn prompt", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-session-index-"));
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-internal-prompt",
+        path: path.join(tempDir, "sessions/thread-internal-prompt.jsonl"),
+        cwd: "/Users/fixture-user/github/PwrAgent",
+        preview: "",
+        name: null,
+        updatedAt: 1_777_347_163,
+      },
+      model: "gpt-5.5",
+    };
+
+    try {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+      });
+
+      await client.startThread({
+        cwd: "/Users/fixture-user/github/PwrAgent",
+      });
+      await client.startTurn({
+        threadId: "thread-internal-prompt",
+        input: [{
+          type: "text",
+          text: "Review the code changes requested below. Do not modify files.",
+        }],
+        suppressThreadTitleDerivation: true,
+      });
+      await client.close();
+
+      const transport = MockTransport.instances.at(-1);
+      const nameRequests = transport?.sentMessages
+        .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+        .filter((message) => message.method === "thread/name/set");
+      expect(nameRequests).toEqual([
+        expect.objectContaining({
+          params: {
+            threadId: "thread-internal-prompt",
+            name: "Untitled thread",
+          },
+        }),
+      ]);
+    } finally {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it("does not derive a Codex thread name for resumed threads with unknown current names", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -3726,7 +3726,7 @@ describe("DesktopSettingsService", () => {
     );
   });
 
-  it("defaults managed review to false and persists the additive flag", async () => {
+  it("keeps the retired managed-review flag readable and writable", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");
     fs.writeFileSync(configPath, [

--- a/apps/desktop/src/main/__tests__/managed-review.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-review.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildInlineReviewPrompt,
   buildManagedReviewPrompt,
   formatManagedReviewOutput,
   parseManagedReviewOutput,
@@ -7,6 +8,19 @@ import {
 import grokReviewSession from "./fixtures/grok-managed-review-session.json";
 
 describe("managed review", () => {
+  it("builds a hidden Markdown prompt for inline parent reviews", () => {
+    const prompt = buildInlineReviewPrompt({
+      type: "baseBranch",
+      branch: "origin/main",
+    });
+
+    expect(prompt).toContain("<action>review</action>");
+    expect(prompt).toContain("against base branch 'origin/main'");
+    expect(prompt).toContain("prioritized findings");
+    expect(prompt).toContain("concise Markdown review");
+    expect(prompt).not.toContain("Return only one JSON object");
+  });
+
   it.each([
     [
       { type: "uncommittedChanges" as const },

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -787,6 +787,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       target: { type: "uncommittedChanges" },
       delivery: "inline",
+      runMode: "inline",
       cwd: "/repo/pwragent",
     });
     expect(harness.delivered.at(-1)).toMatchObject({
@@ -866,6 +867,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "inline",
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
@@ -1128,6 +1130,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "inline",
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
@@ -1236,6 +1239,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "release" },
       delivery: "inline",
+      runMode: "inline",
       cwd: "/repo/pwragent/.worktrees/pwragent-feature-handoff",
     });
 
@@ -1434,6 +1438,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "origin/develop" },
       delivery: "inline",
+      runMode: "inline",
       cwd: "/worktrees/infra",
     });
   });
@@ -1476,6 +1481,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "release" },
       delivery: "inline",
+      runMode: "inline",
       cwd: "/worktrees/app",
     });
   });
@@ -1549,6 +1555,7 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "origin/develop" },
       delivery: "inline",
+      runMode: "inline",
       cwd: "/worktrees/infra",
     });
   });

--- a/apps/desktop/src/main/__tests__/scheduled-thread-action-service.test.ts
+++ b/apps/desktop/src/main/__tests__/scheduled-thread-action-service.test.ts
@@ -473,7 +473,10 @@ describe("ScheduledThreadActionService", () => {
       origin: "desktop",
       scheduledFor: 10_000,
       displayText: "/review",
-      review: { target: { type: "uncommittedChanges" } },
+      review: {
+        runMode: "managed-child",
+        target: { type: "uncommittedChanges" },
+      },
     });
 
     expect(store.get(response.action.id)).toMatchObject({
@@ -483,6 +486,7 @@ describe("ScheduledThreadActionService", () => {
     expect(harness.submitReview).toHaveBeenCalledWith(
       expect.objectContaining({
         idempotencyKey: response.action.id,
+        runMode: "managed-child",
       }),
     );
     await Promise.all([...harness.listeners].map((listener) => listener({

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -416,6 +416,7 @@ export function buildAcpCapabilities(
     readThread: true,
     startTurn: true,
     startReview: agentCapabilities?.managedReview === true,
+    startDetachedReview: agentCapabilities?.managedReview === true,
     reviewRunner: agentCapabilities?.managedReview === true,
     interruptTurn: true,
     steerTurn: agentCapabilities?.steerTurn === true,

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -418,6 +418,7 @@ export function buildAcpCapabilities(
     startReview: agentCapabilities?.managedReview === true,
     startDetachedReview: agentCapabilities?.managedReview === true,
     reviewRunner: agentCapabilities?.managedReview === true,
+    reviewRunMode: agentCapabilities?.managedReview === true,
     interruptTurn: true,
     steerTurn: agentCapabilities?.steerTurn === true,
     transcriptPagination: false,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -834,6 +834,7 @@ type BackendClient = {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{
     threadId: string;
     turnId: string;
@@ -2113,6 +2114,13 @@ function sanitizeAcpRuntimeForExecutionMode(params: {
 function buildCapabilities(methods: string[], backend: AppServerBackendKind): BackendCapabilities {
   const supported = new Set(methods);
   const assumeCodexAppServerSurface = backend === "codex" && methods.length === 0;
+  const nativeReview =
+    supported.has("review/start") || assumeCodexAppServerSurface;
+  const reviewRunner =
+    (supported.has("thread/start")
+      || supported.has("thread/new")
+      || assumeCodexAppServerSurface)
+    && (supported.has("turn/start") || assumeCodexAppServerSurface);
 
   return {
     listThreads:
@@ -2138,14 +2146,11 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     readThread: supported.has("thread/read") || assumeCodexAppServerSurface,
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
     startReview: supported.has("turn/start") || assumeCodexAppServerSurface,
+    startDetachedReview: nativeReview || reviewRunner,
     // A managed review child is an ephemeral thread plus one turn, so Codex
     // can review for another provider's thread even on builds whose native
     // review/start is absent.
-    reviewRunner:
-      (supported.has("thread/start")
-        || supported.has("thread/new")
-        || assumeCodexAppServerSurface)
-      && (supported.has("turn/start") || assumeCodexAppServerSurface),
+    reviewRunner,
     interruptTurn: supported.has("turn/interrupt"),
     steerTurn: backend === "codex" || supported.has("turn/steer"),
     transcriptPagination: false,
@@ -7527,6 +7532,8 @@ type CodexRetryableTurnStart = {
     reasoningEffort?: string;
     fastMode?: boolean;
     messageOrigin?: AppServerThreadMessageOrigin;
+    persistModelSettings?: boolean;
+    suppressThreadTitleDerivation?: boolean;
   };
   terminalObserved?: boolean;
   turnId?: string;
@@ -14938,6 +14945,9 @@ export class DesktopBackendRegistry {
     fastMode?: boolean;
     messageOrigin?: AppServerThreadMessageOrigin;
     invalidIdRecoveryAttempted?: boolean;
+    persistModelSettings?: boolean;
+    preReservedCodexStart?: boolean;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     if (!this.tokenMiserServerCapabilitiesForTurn.getStore()) {
       return await this.tokenMiserServerCapabilitiesForTurn.run(
@@ -15091,7 +15101,7 @@ export class DesktopBackendRegistry {
     let input: AppServerTurnInputItem[] = [];
     let pdfAttachments: PendingPdfAttachment[];
     const reserveCodexStart = params.backend === "codex";
-    if (reserveCodexStart) {
+    if (reserveCodexStart && !params.preReservedCodexStart) {
       if (this.threadHasActiveTurn(params.threadId)) {
         throw new Error("A turn is already active for this thread.");
       }
@@ -15226,10 +15236,13 @@ export class DesktopBackendRegistry {
       params.backend,
       params.threadId,
     );
+    const generateThreadTitle = !params.suppressThreadTitleDerivation;
     // Title generation can be scheduled from a lifecycle event before this
     // turn/start call resolves. It must receive the same prepared input that
     // goes to the agent, not raw local PDF references from the composer.
-    this.pendingTitleGenerationInputs.set(titleGenerationKey, input);
+    if (generateThreadTitle) {
+      this.pendingTitleGenerationInputs.set(titleGenerationKey, input);
+    }
     const pendingMessageContextId = await this.registerPendingThreadMessageContext({
       backend: params.backend,
       input,
@@ -15255,6 +15268,9 @@ export class DesktopBackendRegistry {
               reasoningEffort: params.reasoningEffort,
               fastMode: params.fastMode,
               messageOrigin: params.messageOrigin,
+              persistModelSettings: params.persistModelSettings,
+              suppressThreadTitleDerivation:
+                params.suppressThreadTitleDerivation,
             },
           }
         : undefined;
@@ -15312,6 +15328,8 @@ export class DesktopBackendRegistry {
             ...(pwrdrvrTokenMiser !== undefined
               ? { pwrdrvrTokenMiser }
               : {}),
+            suppressThreadTitleDerivation:
+              params.suppressThreadTitleDerivation,
           });
           activeTurnMode = effectiveMode;
           return started;
@@ -15343,7 +15361,9 @@ export class DesktopBackendRegistry {
       if (reserveCodexStart) {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
-      this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+      if (generateThreadTitle) {
+        this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+      }
       this.forgetPendingThreadMessageContext(pendingMessageContextId);
       if (
         retryableCodexTurnStart
@@ -15421,10 +15441,13 @@ export class DesktopBackendRegistry {
     }
 
     if (
-      turnParams.model !== undefined ||
-      turnParams.reasoningEffort !== undefined ||
-      turnParams.serviceTier !== undefined ||
-      turnParams.fastMode !== undefined
+      params.persistModelSettings !== false
+      && (
+        turnParams.model !== undefined
+        || turnParams.reasoningEffort !== undefined
+        || turnParams.serviceTier !== undefined
+        || turnParams.fastMode !== undefined
+      )
     ) {
       await this.overlayStore.setThreadModelSettings({
         backend: params.backend,
@@ -15456,12 +15479,14 @@ export class DesktopBackendRegistry {
       turnId: result.turnId,
     });
     if (!isAcpBackendId(params.backend)) {
-      this.pendingTitleGenerationInputs.delete(titleGenerationKey);
-      this.scheduleThreadTitleGeneration({
-        backend: params.backend,
-        threadId: result.threadId,
-        input,
-      });
+      if (generateThreadTitle) {
+        this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+        this.scheduleThreadTitleGeneration({
+          backend: params.backend,
+          threadId: result.threadId,
+          input,
+        });
+      }
     }
 
     return response;
@@ -15818,6 +15843,28 @@ export class DesktopBackendRegistry {
     let tokenMiserEnabled = false;
     let inlineParentMode: boolean;
     try {
+      if (
+        params.backend === "codex"
+        && delivery === "detached"
+        && !managedMode
+      ) {
+        const detachedSupport = await this.withCodexThreadClient(
+          params.threadId,
+          async (client) => {
+            const methods = (await client.getInitializeResult()).methods ?? [];
+            return {
+              managed: buildCapabilities(methods, "codex").reviewRunner === true,
+              native: methods.length === 0 || methods.includes("review/start"),
+            };
+          },
+        );
+        if (!detachedSupport.native && !detachedSupport.managed) {
+          throw new Error(
+            "Detached review requires Codex review/start or thread/start plus turn/start.",
+          );
+        }
+        managedMode = !detachedSupport.native;
+      }
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
       }
@@ -15831,9 +15878,6 @@ export class DesktopBackendRegistry {
         tokenMiserEnabled = this.resolveTokenMiserEnabledForOverride(
           params.backend === "codex" ? overlay?.tokenMiserEnabled : undefined,
         );
-        if (tokenMiserEnabled) {
-          await this.prepareTokenMiserRuntime();
-        }
       }
       if (params.backend === "codex") {
         codexEnvironmentRuntime = overlay?.codexEnvironmentRuntime;
@@ -15877,6 +15921,13 @@ export class DesktopBackendRegistry {
             params.threadId,
             overlay,
           );
+      }
+      inlineParentMode =
+        params.backend === "codex"
+        && delivery === "inline"
+        && !managedMode;
+      if (tokenMiserEnabled && !inlineParentMode) {
+        await this.prepareTokenMiserRuntime();
       }
       await assertReviewWorkspaceMatchesAttachedPullRequest({
         cwd,
@@ -15948,50 +15999,6 @@ export class DesktopBackendRegistry {
         });
       };
 
-      const startInlineWithClient = async (
-        client: BackendClient,
-      ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
-        const tokenMiserConfig =
-          await this.buildSupportedCodexTokenMiserConfig({
-            client,
-            enabled: tokenMiserEnabled,
-          });
-        const dynamicTools =
-          await this.buildSupportedCodexDynamicToolsRefresh({
-            client,
-            tokenMiserEnabled,
-          });
-        const executionMode =
-          overlay?.executionMode
-          ?? await this.resolveCodexThreadExecutionModeForActiveTurn(
-            params.threadId,
-          );
-        const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
-        const turn = await client.startTurn({
-          threadId: params.threadId,
-          input: [{ type: "text", text: buildInlineReviewPrompt(params.target) }],
-          approvalPolicy: modeSettings.approvalPolicy,
-          sandbox: modeSettings.sandbox,
-          ...modelSettings,
-          ...(cwd ? { cwd } : {}),
-          ...(codexEnvironmentRuntime
-            ? { codexEnvironmentRuntime }
-            : {}),
-          ...(tokenMiserConfig ? { config: tokenMiserConfig } : {}),
-          ...(dynamicTools !== undefined ? { dynamicTools } : {}),
-        });
-        return {
-          threadId: params.threadId,
-          reviewThreadId: params.threadId,
-          turnId: turn.turnId,
-        };
-      };
-
-      inlineParentMode =
-        params.backend === "codex"
-        && delivery === "inline"
-        && !managedMode;
-
       result = managedMode
         ? await this.startManagedReviewChild({
             backend: reviewBackend,
@@ -16008,10 +16015,24 @@ export class DesktopBackendRegistry {
             tokenMiserEnabled,
           })
         : inlineParentMode
-          ? await this.withCodexThreadClient(
-              params.threadId,
-              startInlineWithClient,
-            )
+          ? await this.startTurnNow({
+              backend: "codex",
+              threadId: params.threadId,
+              input: [{
+                type: "text",
+                text: buildInlineReviewPrompt(params.target),
+              }],
+              ...modelSettings,
+              persistModelSettings:
+                !reviewerOverridden
+                && hasExplicitModelSettings(modelSettings),
+              preReservedCodexStart: true,
+              suppressThreadTitleDerivation: true,
+            }).then((turn) => ({
+              threadId: turn.threadId,
+              reviewThreadId: turn.threadId,
+              turnId: turn.turnId,
+            }))
           : params.backend === "codex"
             ? await this.withCodexThreadClient(params.threadId, startWithClient)
             : await startWithClient(this.getClient(params.backend));
@@ -16026,30 +16047,44 @@ export class DesktopBackendRegistry {
     }
 
     if (params.backend === "codex") {
-      try {
-        const reviewThreadId = managedMode
-          ? result.threadId
-          : result.reviewThreadId || result.threadId;
-        // Codex review/start returns the real review turn id, but current
-        // Codex builds can also emit a lone, mismatched turn/started for the
-        // same thread. Treat the returned review turn as active so queued
-        // turns cannot release in parallel and so the matching terminal
-        // review notification clears the active state.
-        const activeTurnMode = await this.resolveCodexThreadExecutionModeForActiveTurn(
-          reviewThreadId,
+      if (inlineParentMode) {
+        const activeTurnModeKey = buildActiveTurnModeKey(
+          result.threadId,
+          result.turnId,
         );
-        this.activeTurnKeys.add(
-          buildActiveTurnKey(params.backend, reviewThreadId, result.turnId),
-        );
-        this.activeCodexTurnModes.set(
-          buildActiveTurnModeKey(reviewThreadId, result.turnId),
-          activeTurnMode,
-        );
-        this.activeCodexReviewTurnKeys.add(
-          buildActiveTurnModeKey(reviewThreadId, result.turnId),
-        );
-      } finally {
-        this.reservedCodexStartThreadIds.delete(params.threadId);
+        // startTurnNow owns the active-turn lifecycle, including the case
+        // where a terminal notification arrives before turn/start resolves.
+        // Mark it as a review only while that normal lifecycle still says the
+        // turn is active; otherwise a fast completion would be resurrected.
+        if (this.activeCodexTurnModes.has(activeTurnModeKey)) {
+          this.activeCodexReviewTurnKeys.add(activeTurnModeKey);
+        }
+      } else {
+        try {
+          const reviewThreadId = managedMode
+            ? result.threadId
+            : result.reviewThreadId || result.threadId;
+          // Codex review/start returns the real review turn id, but current
+          // Codex builds can also emit a lone, mismatched turn/started for the
+          // same thread. Treat the returned review turn as active so queued
+          // turns cannot release in parallel and so the matching terminal
+          // review notification clears the active state.
+          const activeTurnMode = await this.resolveCodexThreadExecutionModeForActiveTurn(
+            reviewThreadId,
+          );
+          this.activeTurnKeys.add(
+            buildActiveTurnKey(params.backend, reviewThreadId, result.turnId),
+          );
+          this.activeCodexTurnModes.set(
+            buildActiveTurnModeKey(reviewThreadId, result.turnId),
+            activeTurnMode,
+          );
+          this.activeCodexReviewTurnKeys.add(
+            buildActiveTurnModeKey(reviewThreadId, result.turnId),
+          );
+        } finally {
+          this.reservedCodexStartThreadIds.delete(params.threadId);
+        }
       }
     } else if (acpReviewReservationKey) {
       this.reservedAcpStartThreadKeys.delete(acpReviewReservationKey);
@@ -16060,13 +16095,6 @@ export class DesktopBackendRegistry {
         parentThreadId: result.threadId,
         turnId: result.turnId,
       });
-      if (!reviewerOverridden && hasExplicitModelSettings(modelSettings)) {
-        await this.overlayStore.setThreadModelSettings({
-          backend: params.backend,
-          threadId: result.threadId,
-          ...modelSettings,
-        });
-      }
       return {
         backend: params.backend,
         threadId: result.threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -51,6 +51,7 @@ import {
   type PwrSnapConnectionService,
 } from "../mcp-connections/pwrsnap-connection-service";
 import {
+  buildInlineReviewPrompt,
   buildManagedReviewContextInput,
   buildManagedReviewPrompt,
   formatManagedReviewOutput,
@@ -2136,7 +2137,7 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     renameThread: supported.has("thread/name/set") || assumeCodexAppServerSurface,
     readThread: supported.has("thread/read") || assumeCodexAppServerSurface,
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
-    startReview: supported.has("review/start") || assumeCodexAppServerSurface,
+    startReview: supported.has("turn/start") || assumeCodexAppServerSurface,
     // A managed review child is an ephemeral thread plus one turn, so Codex
     // can review for another provider's thread even on builds whose native
     // review/start is absent.
@@ -15785,6 +15786,7 @@ export class DesktopBackendRegistry {
     const reviewerOverridden = Boolean(params.reviewBackend);
     const reviewBackend = params.reviewBackend ?? params.backend;
     const reviewBackendDiffers = reviewBackend !== params.backend;
+    const delivery = params.delivery ?? "inline";
     if (reviewBackendDiffers) {
       this.assertReviewBackendSupported(reviewBackend);
     }
@@ -15814,6 +15816,7 @@ export class DesktopBackendRegistry {
     let codexEnvironmentRuntime: CodexThreadEnvironmentRuntime | undefined;
     let reviewContext: AppServerReviewContext | undefined;
     let tokenMiserEnabled = false;
+    let inlineParentMode: boolean;
     try {
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
@@ -15934,7 +15937,7 @@ export class DesktopBackendRegistry {
         return await client.startReview({
           threadId: params.threadId,
           target: params.target,
-          delivery: params.delivery ?? "inline",
+          delivery,
           ...modelSettings,
           ...(cwd ? { cwd } : {}),
           ...(codexEnvironmentRuntime
@@ -15944,6 +15947,50 @@ export class DesktopBackendRegistry {
           ...(dynamicTools !== undefined ? { dynamicTools } : {}),
         });
       };
+
+      const startInlineWithClient = async (
+        client: BackendClient,
+      ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
+        const tokenMiserConfig =
+          await this.buildSupportedCodexTokenMiserConfig({
+            client,
+            enabled: tokenMiserEnabled,
+          });
+        const dynamicTools =
+          await this.buildSupportedCodexDynamicToolsRefresh({
+            client,
+            tokenMiserEnabled,
+          });
+        const executionMode =
+          overlay?.executionMode
+          ?? await this.resolveCodexThreadExecutionModeForActiveTurn(
+            params.threadId,
+          );
+        const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
+        const turn = await client.startTurn({
+          threadId: params.threadId,
+          input: [{ type: "text", text: buildInlineReviewPrompt(params.target) }],
+          approvalPolicy: modeSettings.approvalPolicy,
+          sandbox: modeSettings.sandbox,
+          ...modelSettings,
+          ...(cwd ? { cwd } : {}),
+          ...(codexEnvironmentRuntime
+            ? { codexEnvironmentRuntime }
+            : {}),
+          ...(tokenMiserConfig ? { config: tokenMiserConfig } : {}),
+          ...(dynamicTools !== undefined ? { dynamicTools } : {}),
+        });
+        return {
+          threadId: params.threadId,
+          reviewThreadId: params.threadId,
+          turnId: turn.turnId,
+        };
+      };
+
+      inlineParentMode =
+        params.backend === "codex"
+        && delivery === "inline"
+        && !managedMode;
 
       result = managedMode
         ? await this.startManagedReviewChild({
@@ -15960,9 +16007,14 @@ export class DesktopBackendRegistry {
             target: params.target,
             tokenMiserEnabled,
           })
-        : params.backend === "codex"
-          ? await this.withCodexThreadClient(params.threadId, startWithClient)
-          : await startWithClient(this.getClient(params.backend));
+        : inlineParentMode
+          ? await this.withCodexThreadClient(
+              params.threadId,
+              startInlineWithClient,
+            )
+          : params.backend === "codex"
+            ? await this.withCodexThreadClient(params.threadId, startWithClient)
+            : await startWithClient(this.getClient(params.backend));
     } catch (error) {
       if (reserveCodexReviewStart) {
         this.reservedCodexStartThreadIds.delete(params.threadId);
@@ -16001,6 +16053,26 @@ export class DesktopBackendRegistry {
       }
     } else if (acpReviewReservationKey) {
       this.reservedAcpStartThreadKeys.delete(acpReviewReservationKey);
+    }
+
+    if (inlineParentMode) {
+      backendRegistryLog.info("inline code review started", {
+        parentThreadId: result.threadId,
+        turnId: result.turnId,
+      });
+      if (!reviewerOverridden && hasExplicitModelSettings(modelSettings)) {
+        await this.overlayStore.setThreadModelSettings({
+          backend: params.backend,
+          threadId: result.threadId,
+          ...modelSettings,
+        });
+      }
+      return {
+        backend: params.backend,
+        threadId: result.threadId,
+        reviewThreadId: result.threadId,
+        turnId: result.turnId,
+      };
     }
     const reviewSubAgentRecord: ReviewSubAgentRecord = {
       backend: reviewBackend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2146,6 +2146,7 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     readThread: supported.has("thread/read") || assumeCodexAppServerSurface,
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
     startReview: supported.has("turn/start") || assumeCodexAppServerSurface,
+    reviewRunMode: supported.has("turn/start") || assumeCodexAppServerSurface,
     startDetachedReview: nativeReview || reviewRunner,
     // A managed review child is a durable PwrAgent subagent thread plus one
     // turn, so Codex can review for another provider's thread even on builds

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2148,9 +2148,9 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     startReview: supported.has("turn/start") || assumeCodexAppServerSurface,
     reviewRunMode: supported.has("turn/start") || assumeCodexAppServerSurface,
     startDetachedReview: nativeReview || reviewRunner,
-    // A managed review child is a durable PwrAgent subagent thread plus one
-    // turn, so Codex can review for another provider's thread even on builds
-    // whose native review/start is absent.
+    // A managed review child is a disposable PwrAgent subagent plus one turn,
+    // so Codex can review for another provider's thread even on builds whose
+    // native review/start is absent.
     reviewRunner,
     interruptTurn: supported.has("turn/interrupt"),
     steerTurn: backend === "codex" || supported.has("turn/steer"),
@@ -16214,12 +16214,10 @@ export class DesktopBackendRegistry {
     const thread = await client.startThread({
       ...(params.cwd ? { cwd: params.cwd } : {}),
       approvalPolicy: modeSettings.approvalPolicy,
-      // Keep review children durable so their inspection-only transcript can
-      // use thread/read with includeTurns, and mark them as subagents so
-      // PwrAgent excludes them from ordinary navigation. This classification
-      // does not claim Codex-native ThreadSpawn parentage, which Codex reserves
-      // for workers created by spawn_agent.
-      ephemeral: false,
+      // The original managed-review experiment used a disposable subagent.
+      // PwrAgent mirrors its live activity and persists the review artifact on
+      // the parent, so the child itself must not become a durable thread.
+      ephemeral: true,
       threadSource: "subagent" as CodexThreadSource,
       sandbox: modeSettings.sandbox,
       ...params.modelSettings,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -23684,13 +23684,6 @@ export class DesktopBackendRegistry {
     const available = Boolean(lastKnownGood?.selectedCommand);
     const methods: string[] = [];
     const capabilities = buildCapabilities(methods, "codex");
-    if (
-      this.resolveManagedReviewEnabledFn()
-      && capabilities.createThread
-      && capabilities.startTurn
-    ) {
-      capabilities.startReview = true;
-    }
     const unavailableReason = provider?.validation.error
       ?? "Codex discovery has not completed yet.";
     return {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2147,9 +2147,9 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
     startReview: supported.has("turn/start") || assumeCodexAppServerSurface,
     startDetachedReview: nativeReview || reviewRunner,
-    // A managed review child is an ephemeral thread plus one turn, so Codex
-    // can review for another provider's thread even on builds whose native
-    // review/start is absent.
+    // A managed review child is a durable PwrAgent subagent thread plus one
+    // turn, so Codex can review for another provider's thread even on builds
+    // whose native review/start is absent.
     reviewRunner,
     interruptTurn: supported.has("turn/interrupt"),
     steerTurn: backend === "codex" || supported.has("turn/steer"),
@@ -8233,7 +8233,6 @@ export class DesktopBackendRegistry {
    */
   private readonly isCodexBootstrapDeferredFn: () => boolean;
   private readonly resolveCodexDefaultModeRequestUserInputFn: () => boolean;
-  private readonly resolveManagedReviewEnabledFn: () => boolean;
   private readonly resolveDefaultPrAutoDispatchEnabledFn: () => boolean;
   private readonly resolveProviderModelDefaultsFn: () => Record<
     string,
@@ -8343,7 +8342,6 @@ export class DesktopBackendRegistry {
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
     resolveCodexDefaultModeRequestUserInput?: () => boolean;
-    resolveManagedReviewEnabled?: () => boolean;
     resolveDefaultPrAutoDispatchEnabled?: () => boolean;
     resolveProviderModelDefaults?: () => Record<
       string,
@@ -8444,23 +8442,6 @@ export class DesktopBackendRegistry {
         } catch (error) {
           backendRegistryLog.warn(
             "failed to resolve Codex default-mode request_user_input setting",
-            {
-              error: error instanceof Error ? error.message : String(error),
-            },
-          );
-          return false;
-        }
-      });
-    this.resolveManagedReviewEnabledFn =
-      options?.resolveManagedReviewEnabled ??
-      (() => {
-        try {
-          return (
-            settingsService ?? getDesktopSettingsService()
-          ).resolveManagedReviewEnabled();
-        } catch (error) {
-          backendRegistryLog.warn(
-            "failed to resolve managed review experiment setting",
             {
               error: error instanceof Error ? error.message : String(error),
             },
@@ -15815,10 +15796,10 @@ export class DesktopBackendRegistry {
     if (reviewBackendDiffers) {
       this.assertReviewBackendSupported(reviewBackend);
     }
-    const managedReviewExperiment =
-      params.backend === "codex" && this.resolveManagedReviewEnabledFn();
     let managedMode =
-      acpManagedMode || managedReviewExperiment || reviewBackendDiffers;
+      acpManagedMode
+      || params.runMode === "managed-child"
+      || reviewBackendDiffers;
     const reserveCodexReviewStart = params.backend === "codex";
     const acpReviewReservationKey = isAcpBackendId(params.backend)
       ? buildTurnStartReservationKey(params.backend, params.threadId)
@@ -15924,7 +15905,7 @@ export class DesktopBackendRegistry {
       }
       inlineParentMode =
         params.backend === "codex"
-        && delivery === "inline"
+        && (params.runMode === "inline" || delivery === "inline")
         && !managedMode;
       if (tokenMiserEnabled && !inlineParentMode) {
         await this.prepareTokenMiserRuntime();
@@ -20723,6 +20704,7 @@ export class DesktopBackendRegistry {
                     target: request.reviewTarget,
                     draftText: formatReviewCommand(request.reviewTarget),
                     delivery: "inline" as const,
+                    runMode: "inline" as const,
                     model: launchpad.model,
                     reasoningEffort: launchpad.reasoningEffort,
                     serviceTier: launchpad.serviceTier,
@@ -20784,6 +20766,7 @@ export class DesktopBackendRegistry {
           threadId: startThreadResponse.threadId,
           target: request.reviewTarget,
           delivery: "inline",
+          runMode: "inline",
           model: launchpad.model,
           reasoningEffort: launchpad.reasoningEffort,
           serviceTier: launchpad.serviceTier,
@@ -23783,14 +23766,6 @@ export class DesktopBackendRegistry {
       );
     }
     const capabilities = buildCapabilities(methods, "codex");
-    if (
-      this.resolveManagedReviewEnabledFn()
-      && capabilities.createThread
-      && capabilities.startTurn
-    ) {
-      capabilities.startReview = true;
-    }
-
     const summary: BackendSummary = {
       kind: "codex",
       label: BACKEND_LABELS.codex,

--- a/apps/desktop/src/main/app-server/managed-review.ts
+++ b/apps/desktop/src/main/app-server/managed-review.ts
@@ -22,6 +22,17 @@ const REVIEW_OUTPUT_INSTRUCTIONS = [
   "Do not wrap the JSON in Markdown fences and do not include prose outside it.",
 ].join("\n");
 
+export function buildInlineReviewPrompt(
+  target: AppServerReviewTarget,
+): string {
+  return [
+    "Review the code changes requested below. Do not modify files.",
+    "<user_action><action>review</action></user_action>",
+    reviewTargetInstructions(target),
+    "Return a concise Markdown review with prioritized findings. For each finding, cite the affected file and line range, explain the concrete impact, and suggest the smallest useful remedy. If there are no actionable findings, say so directly.",
+  ].join("\n\n");
+}
+
 export function buildManagedReviewPrompt(
   target: AppServerReviewTarget,
 ): string {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -8613,6 +8613,7 @@ export class CodexAppServerClient {
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
     pwrdrvrTokenMiser?: CodexPwrdrvrTokenMiserActivation | null;
+    suppressThreadTitleDerivation?: boolean;
   }): Promise<{
     threadId: string;
     turnId: string;
@@ -8704,10 +8705,12 @@ export class CodexAppServerClient {
     const threadId = extractThreadIdFromValue(result) ?? params.threadId;
     const turnId = extractTurnIdFromValue(result) ?? `pending:${threadId}`;
     this.pendingFirstTurnThreadResults.delete(params.threadId);
-    await this.recordDerivedThreadNameWithCodex({
-      threadId: params.threadId,
-      input: params.input,
-    });
+    if (!params.suppressThreadTitleDerivation) {
+      await this.recordDerivedThreadNameWithCodex({
+        threadId: params.threadId,
+        input: params.input,
+      });
+    }
 
     return { threadId, turnId };
   }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -6043,6 +6043,7 @@ export class MessagingController {
         threadId: params.binding.threadId,
         target: params.target,
         delivery: "inline",
+        runMode: "inline",
         ...(params.cwd ? { cwd: params.cwd } : {}),
         // An explicit reviewer replaces the binding's inherited settings
         // wholesale — its model belongs to a different catalog.

--- a/apps/desktop/src/main/scheduled-actions/scheduled-thread-action-service.ts
+++ b/apps/desktop/src/main/scheduled-actions/scheduled-thread-action-service.ts
@@ -273,6 +273,7 @@ export class ScheduledThreadActionService {
           idempotencyKey: action.id,
           target: action.review.target,
           delivery: action.review.delivery ?? "inline",
+          runMode: action.review.runMode,
           cwd: action.review.cwd,
           reviewBackend: action.review.reviewBackend,
           model: action.review.model,

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1744,6 +1744,7 @@ export class DesktopSettingsService {
     ).value;
   }
 
+  /** Retained for configuration compatibility; review routing no longer reads it. */
   resolveManagedReviewEnabled(): boolean {
     return this.resolveConfigBoolean(
       this.readExperimentalConfig().managedReview,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3675,6 +3675,7 @@ describe("App", () => {
         },
         draftText: "/review main",
         delivery: "inline",
+        runMode: "inline",
         cwd: undefined,
         model: undefined,
         reasoningEffort: undefined,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -43,6 +43,7 @@ import type {
   NavigationThreadSummary,
   PrSummary,
   RenderComposerPdfPreviewResponse,
+  ReviewRunMode,
   ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
 } from "@pwragent/shared";
@@ -81,6 +82,7 @@ import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
 import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
+import { resolveReviewRunMode } from "../../lib/review-run-mode";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { agentEventMatchesThread } from "../../lib/federated-thread-events";
 import {
@@ -510,6 +512,7 @@ type QueuedTurnDraft = {
   reviewCommand?: {
     cwd?: string;
     displayText: string;
+    runMode?: ReviewRunMode;
     target: AppServerReviewTarget;
   };
   text: string;
@@ -601,6 +604,7 @@ type ReviewConfigState = {
    * applies to one review, never to the thread.
    */
   reviewer?: ModelSettingsRecent;
+  runMode: ReviewRunMode;
   target?: ReviewTargetChoice;
   workspaceCwd?: string;
 };
@@ -953,6 +957,7 @@ function createReviewConfig(params: {
     branchSource: "auto",
     commit: "",
     customInstructions: "",
+    runMode: "inline",
     target: "baseBranch",
     workspaceCwd: params.reviewCommand?.cwd ?? (
       preferredWorkspaceCwd ??
@@ -1086,7 +1091,12 @@ function findReviewDirectoryForWorkspace(params: {
 
 function buildConfiguredReviewCommand(
   config: ReviewConfigState | undefined
-): { cwd?: string; displayText: string; target: AppServerReviewTarget } | undefined {
+): {
+  cwd?: string;
+  displayText: string;
+  runMode: ReviewRunMode;
+  target: AppServerReviewTarget;
+} | undefined {
   if (!config?.target) {
     return undefined;
   }
@@ -1095,6 +1105,7 @@ function buildConfiguredReviewCommand(
   if (config.target === "uncommittedChanges") {
     return {
       ...(cwd ? { cwd } : {}),
+      runMode: config.runMode,
       target: { type: "uncommittedChanges" },
       displayText: "Review current changes",
     };
@@ -1105,6 +1116,7 @@ function buildConfiguredReviewCommand(
     return branch
       ? {
           ...(cwd ? { cwd } : {}),
+          runMode: config.runMode,
           target: { type: "baseBranch", branch },
           displayText: `Review changes against ${branch}`,
         }
@@ -1116,6 +1128,7 @@ function buildConfiguredReviewCommand(
     return sha
       ? {
           ...(cwd ? { cwd } : {}),
+          runMode: config.runMode,
           target: { type: "commit", sha, title: null },
           displayText: `Review commit ${sha}`,
         }
@@ -1126,6 +1139,7 @@ function buildConfiguredReviewCommand(
   return instructions
     ? {
         ...(cwd ? { cwd } : {}),
+        runMode: config.runMode,
         target: { type: "custom", instructions },
         displayText: "Review custom instructions",
       }
@@ -3134,6 +3148,7 @@ export function Composer(props: ComposerProps) {
   }>({ maxHeight: 320, placement: "above" });
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
   const [reviewConfig, setReviewConfig] = useState<ReviewConfigState>();
+  const reviewLocationHelpId = useId();
   // Tagged with the owning instance the same way recent file references are:
   // a combination remembered on another instance names models that instance
   // has, so a response that lands after the thread changed must not paint.
@@ -5499,6 +5514,7 @@ export function Composer(props: ComposerProps) {
   const submitReviewCommand = async (reviewCommand: {
     cwd?: string;
     displayText: string;
+    runMode?: ReviewRunMode;
     target: AppServerReviewTarget;
     reviewer?: ModelSettingsRecent;
   }, options?: {
@@ -5632,6 +5648,7 @@ export function Composer(props: ComposerProps) {
         threadId: props.thread.id,
         target: reviewCommand.target,
         delivery: "inline",
+        runMode: reviewCommand.runMode ?? "inline",
         ...(reviewCommand.cwd ? { cwd: reviewCommand.cwd } : {}),
         ...(submittedReviewer
           ? {
@@ -5907,21 +5924,25 @@ export function Composer(props: ComposerProps) {
     if (!configuredReviewCommand) {
       return;
     }
+    const routedReviewCommand = {
+      ...configuredReviewCommand,
+      runMode: reviewRunModeDecision.runMode,
+    };
     if (futureScheduledDraftSendAt) {
       if (props.launchpad) {
         await scheduleLaunchpadMaterialization(
           futureScheduledDraftSendAt,
-          configuredReviewCommand.target,
+          routedReviewCommand.target,
         );
         return;
       }
-      queueReviewCommand(configuredReviewCommand, {
+      queueReviewCommand(routedReviewCommand, {
         scheduledSendAt: futureScheduledDraftSendAt,
       });
       return;
     }
 
-    await submitReviewCommand(configuredReviewCommand);
+    await submitReviewCommand(routedReviewCommand);
   };
 
   const focusReviewOption = (index: number): void => {
@@ -6624,6 +6645,7 @@ export function Composer(props: ComposerProps) {
     reviewCommand: {
       cwd?: string;
       displayText: string;
+      runMode?: ReviewRunMode;
       target: AppServerReviewTarget;
     },
     options?: { scheduledSendAt?: number },
@@ -6646,6 +6668,7 @@ export function Composer(props: ComposerProps) {
           target: reviewCommand.target,
           draftText: text,
           delivery: "inline",
+          runMode: reviewCommand.runMode ?? "inline",
           cwd: reviewCommand.cwd,
           // Carry the picked reviewer through the queue so releasing it later
           // does not silently fall back to the thread's own provider.
@@ -9021,6 +9044,19 @@ export function Composer(props: ComposerProps) {
     reviewerSelection.model,
   );
   const reviewerOverridden = Boolean(reviewConfig?.reviewer);
+  const reviewRunModeDecision = props.thread
+    ? resolveReviewRunMode({
+        requestedRunMode: reviewConfig?.runMode,
+        reviewerBackend: reviewerSelection.backend,
+        reviewerSummary: reviewerSelection.summary,
+        thread: props.thread,
+        workspaceCwd: reviewConfig?.workspaceCwd,
+      })
+    : {
+        controlDisabled: false,
+        runMode: "inline" as const,
+        separateThreadDisabled: true,
+      };
   // A remembered combination is only offered while it still resolves against
   // the owner's current catalog. Recents are disposable, so a dead row is
   // noise rather than a preference worth preserving.
@@ -10722,6 +10758,91 @@ export function Composer(props: ComposerProps) {
               </label>
             ) : null}
 
+            {props.thread ? (
+              <div className="composer__review-field composer__review-location">
+                <span>Review location</span>
+                <div
+                  className={`composer__review-location-control${
+                    reviewRunModeDecision.helpText ? " tooltip-target" : ""
+                  }`}
+                  data-tooltip={reviewRunModeDecision.helpText}
+                  tabIndex={reviewRunModeDecision.helpText ? 0 : undefined}
+                >
+                  <div
+                    aria-describedby={
+                      reviewRunModeDecision.helpText
+                        ? reviewLocationHelpId
+                        : undefined
+                    }
+                    aria-disabled={reviewRunModeDecision.controlDisabled}
+                    aria-label="Review location"
+                    className="settings-segmented"
+                    role="radiogroup"
+                  >
+                    <button
+                      aria-checked={reviewRunModeDecision.runMode === "inline"}
+                      className={`settings-segmented__button${
+                        reviewRunModeDecision.runMode === "inline"
+                          ? " is-active"
+                          : ""
+                      }`}
+                      disabled={reviewRunModeDecision.controlDisabled}
+                      onClick={() => {
+                        setReviewConfig((current) => ({
+                          ...(current ?? createReviewConfig({
+                            directory: props.directory,
+                            thread: props.thread,
+                          })),
+                          runMode: "inline",
+                        }));
+                        setSendError(undefined);
+                      }}
+                      role="radio"
+                      type="button"
+                    >
+                      This thread
+                    </button>
+                    <button
+                      aria-checked={
+                        reviewRunModeDecision.runMode === "managed-child"
+                      }
+                      className={`settings-segmented__button${
+                        reviewRunModeDecision.runMode === "managed-child"
+                          ? " is-active"
+                          : ""
+                      }`}
+                      disabled={
+                        reviewRunModeDecision.controlDisabled
+                        || reviewRunModeDecision.separateThreadDisabled
+                      }
+                      onClick={() => {
+                        setReviewConfig((current) => ({
+                          ...(current ?? createReviewConfig({
+                            directory: props.directory,
+                            thread: props.thread,
+                          })),
+                          runMode: "managed-child",
+                        }));
+                        setSendError(undefined);
+                      }}
+                      role="radio"
+                      type="button"
+                    >
+                      Separate thread
+                    </button>
+                  </div>
+                  {reviewRunModeDecision.helpText ? (
+                    <small
+                      className="composer__review-location-help"
+                      id={reviewLocationHelpId}
+                    >
+                      {reviewRunModeDecision.helpText}
+                    </small>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+
             {reviewerOverridesSupported ? (
               <div className="composer__review-field composer__review-reviewer">
                 <span>Reviewer</span>
@@ -10847,7 +10968,11 @@ export function Composer(props: ComposerProps) {
                 className="composer__primary-action"
                 disabled={
                   !buildConfiguredReviewCommand(reviewConfig) ||
-                  (reviewWorkspaceSelectionRequired && !reviewConfig?.workspaceCwd)
+                  (reviewWorkspaceSelectionRequired && !reviewConfig?.workspaceCwd) ||
+                  (
+                    reviewRunModeDecision.runMode === "managed-child"
+                    && reviewRunModeDecision.separateThreadDisabled
+                  )
                 }
                 onClick={() => {
                   void submitConfiguredReviewComposer();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5927,7 +5927,7 @@ export function Composer(props: ComposerProps) {
     if (reviewSubmissionUnavailable) {
       setSendError(
         reviewRunModeDecision.helpText
-        ?? "A separate review thread is unavailable for this reviewer.",
+        ?? "A review subagent is unavailable for this reviewer.",
       );
       return;
     }
@@ -9072,11 +9072,11 @@ export function Composer(props: ComposerProps) {
         controlDisabled: false,
         explicitRunModeSupported: false,
         runMode: "inline" as const,
-        separateThreadDisabled: true,
+        subagentDisabled: true,
       };
   const reviewSubmissionUnavailable =
     reviewRunModeDecision.runMode === "managed-child"
-    && reviewRunModeDecision.separateThreadDisabled;
+    && reviewRunModeDecision.subagentDisabled;
   // A remembered combination is only offered while it still resolves against
   // the owner's current catalog. Recents are disposable, so a dead row is
   // noise rather than a preference worth preserving.

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -190,6 +190,7 @@ import {
   useDismissableMenu,
 } from "./ComposerDropdown";
 import type { ComposerDropdownIcon, ComposerDropdownOption } from "./ComposerDropdown";
+import { ReviewLocationDropdown } from "./ReviewLocationDropdown";
 import { ReferencePicker, type ReferencePickerFile } from "./ReferencePicker";
 import { REMOTE_NATIVE_PICKER_TOOLTIP } from "./native-picker-boundary";
 import { TranscriptCopyButton } from "../thread-detail/TranscriptCopyButton";
@@ -3148,7 +3149,6 @@ export function Composer(props: ComposerProps) {
   }>({ maxHeight: 320, placement: "above" });
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
   const [reviewConfig, setReviewConfig] = useState<ReviewConfigState>();
-  const reviewLocationHelpId = useId();
   // Tagged with the owning instance the same way recent file references are:
   // a combination remembered on another instance names models that instance
   // has, so a response that lands after the thread changed must not paint.
@@ -10759,198 +10759,130 @@ export function Composer(props: ComposerProps) {
             ) : null}
 
             {props.thread ? (
-              <div className="composer__review-field composer__review-location">
-                <span>Review location</span>
-                <div
-                  className={`composer__review-location-control${
-                    reviewRunModeDecision.helpText ? " tooltip-target" : ""
-                  }`}
-                  data-tooltip={reviewRunModeDecision.helpText}
-                  tabIndex={reviewRunModeDecision.helpText ? 0 : undefined}
-                >
-                  <div
-                    aria-describedby={
-                      reviewRunModeDecision.helpText
-                        ? reviewLocationHelpId
-                        : undefined
-                    }
-                    aria-disabled={reviewRunModeDecision.controlDisabled}
-                    aria-label="Review location"
-                    className="settings-segmented"
-                    role="radiogroup"
-                  >
-                    <button
-                      aria-checked={reviewRunModeDecision.runMode === "inline"}
-                      className={`settings-segmented__button${
-                        reviewRunModeDecision.runMode === "inline"
-                          ? " is-active"
-                          : ""
-                      }`}
-                      disabled={reviewRunModeDecision.controlDisabled}
-                      onClick={() => {
-                        setReviewConfig((current) => ({
-                          ...(current ?? createReviewConfig({
-                            directory: props.directory,
-                            thread: props.thread,
-                          })),
-                          runMode: "inline",
-                        }));
-                        setSendError(undefined);
-                      }}
-                      role="radio"
-                      type="button"
-                    >
-                      This thread
-                    </button>
-                    <button
-                      aria-checked={
-                        reviewRunModeDecision.runMode === "managed-child"
-                      }
-                      className={`settings-segmented__button${
-                        reviewRunModeDecision.runMode === "managed-child"
-                          ? " is-active"
-                          : ""
-                      }`}
-                      disabled={
-                        reviewRunModeDecision.controlDisabled
-                        || reviewRunModeDecision.separateThreadDisabled
-                      }
-                      onClick={() => {
-                        setReviewConfig((current) => ({
-                          ...(current ?? createReviewConfig({
-                            directory: props.directory,
-                            thread: props.thread,
-                          })),
-                          runMode: "managed-child",
-                        }));
-                        setSendError(undefined);
-                      }}
-                      role="radio"
-                      type="button"
-                    >
-                      Separate thread
-                    </button>
-                  </div>
-                  {reviewRunModeDecision.helpText ? (
-                    <small
-                      className="composer__review-location-help"
-                      id={reviewLocationHelpId}
-                    >
-                      {reviewRunModeDecision.helpText}
-                    </small>
-                  ) : null}
-                </div>
-              </div>
-            ) : null}
-
-            {reviewerOverridesSupported ? (
               <div className="composer__review-field composer__review-reviewer">
                 <span>Reviewer</span>
                 <div className="composer__review-reviewer-chips">
-                  <ComposerDropdown
-                    ariaLabel="Review provider"
-                    id="composer-review-provider"
-                    options={reviewerBackendOptions.map((candidate) => ({
-                      label: formatBackendLabel(candidate.kind, props.backends),
-                      value: candidate.kind,
-                    }))}
-                    value={reviewerSelection.backend ?? ""}
-                    onChange={(value) => {
-                      patchReviewer(() => ({
-                        backend: value as AppServerBackendKind,
+                  {reviewerOverridesSupported ? (
+                    <>
+                      <ComposerDropdown
+                        ariaLabel="Review provider"
+                        id="composer-review-provider"
+                        options={reviewerBackendOptions.map((candidate) => ({
+                          label: formatBackendLabel(candidate.kind, props.backends),
+                          value: candidate.kind,
+                        }))}
+                        value={reviewerSelection.backend ?? ""}
+                        onChange={(value) => {
+                          patchReviewer(() => ({
+                            backend: value as AppServerBackendKind,
+                          }));
+                        }}
+                      />
+                      {reviewerModelOptions.length > 0 ? (
+                        <ComposerDropdown
+                          ariaLabel="Review model"
+                          id="composer-review-model"
+                          options={reviewerModelOptions.map((option) => ({
+                            label: option.label ?? option.id,
+                            value: option.id,
+                          }))}
+                          value={reviewerSelection.model?.id ?? ""}
+                          onChange={(value) => {
+                            patchReviewer((current) => {
+                              const backend =
+                                current?.backend ?? reviewerSelection.backend;
+                              return backend ? { backend, model: value } : current;
+                            });
+                          }}
+                        />
+                      ) : null}
+                      {reviewerReasoningOptions.length > 0 ? (
+                        <ComposerDropdown
+                          ariaLabel="Review reasoning"
+                          id="composer-review-reasoning"
+                          options={reviewerReasoningOptions.map((effort) => ({
+                            label: effort,
+                            value: effort,
+                          }))}
+                          value={reviewerSelection.reasoningEffort ?? ""}
+                          onChange={(value) => {
+                            patchReviewer((current) => {
+                              const backend =
+                                current?.backend ?? reviewerSelection.backend;
+                              if (!backend) {
+                                return current;
+                              }
+                              return {
+                                backend,
+                                ...(reviewerSelection.model?.id
+                                  ? { model: reviewerSelection.model.id }
+                                  : {}),
+                                reasoningEffort: value,
+                              };
+                            });
+                          }}
+                        />
+                      ) : null}
+                      {resolvableReviewerRecents.length > 0 ? (
+                        <ComposerDropdown
+                          ariaLabel="Recent reviewer settings"
+                          id="composer-review-recents"
+                          options={[
+                            // Sentinel so the trigger reads "Recent" until a
+                            // remembered combination is actually applied; the
+                            // dropdown falls back to the first option whenever the
+                            // value matches nothing.
+                            { label: "Recent", value: "" },
+                            ...resolvableReviewerRecents.map((recent, index) => ({
+                              label: formatReviewerRecentLabel(
+                                recent,
+                                props.backends,
+                              ),
+                              value: String(index),
+                            })),
+                          ]}
+                          tooltip="Reuse a recent reviewer"
+                          value={
+                            activeReviewerRecentIndex >= 0
+                              ? String(activeReviewerRecentIndex)
+                              : ""
+                          }
+                          onChange={(value) => {
+                            const picked = resolvableReviewerRecents[Number(value)];
+                            if (picked) {
+                              patchReviewer(() => picked);
+                            }
+                          }}
+                        />
+                      ) : null}
+                      {reviewerOverridden ? (
+                        <button
+                          type="button"
+                          aria-label="Reset reviewer to thread settings"
+                          className="composer__toggle tooltip-target"
+                          data-tooltip="Reset the reviewer to this thread's provider, model, and reasoning"
+                          onClick={() => {
+                            patchReviewer(() => undefined);
+                          }}
+                        >
+                          ↺
+                        </button>
+                      ) : null}
+                    </>
+                  ) : null}
+                  <ReviewLocationDropdown
+                    decision={reviewRunModeDecision}
+                    onChange={(runMode) => {
+                      setReviewConfig((current) => ({
+                        ...(current ?? createReviewConfig({
+                          directory: props.directory,
+                          thread: props.thread,
+                        })),
+                        runMode,
                       }));
+                      setSendError(undefined);
                     }}
                   />
-                  {reviewerModelOptions.length > 0 ? (
-                    <ComposerDropdown
-                      ariaLabel="Review model"
-                      id="composer-review-model"
-                      options={reviewerModelOptions.map((option) => ({
-                        label: option.label ?? option.id,
-                        value: option.id,
-                      }))}
-                      value={reviewerSelection.model?.id ?? ""}
-                      onChange={(value) => {
-                        patchReviewer((current) => {
-                          const backend =
-                            current?.backend ?? reviewerSelection.backend;
-                          return backend ? { backend, model: value } : current;
-                        });
-                      }}
-                    />
-                  ) : null}
-                  {reviewerReasoningOptions.length > 0 ? (
-                    <ComposerDropdown
-                      ariaLabel="Review reasoning"
-                      id="composer-review-reasoning"
-                      options={reviewerReasoningOptions.map((effort) => ({
-                        label: effort,
-                        value: effort,
-                      }))}
-                      value={reviewerSelection.reasoningEffort ?? ""}
-                      onChange={(value) => {
-                        patchReviewer((current) => {
-                          const backend =
-                            current?.backend ?? reviewerSelection.backend;
-                          if (!backend) {
-                            return current;
-                          }
-                          return {
-                            backend,
-                            ...(reviewerSelection.model?.id
-                              ? { model: reviewerSelection.model.id }
-                              : {}),
-                            reasoningEffort: value,
-                          };
-                        });
-                      }}
-                    />
-                  ) : null}
-                  {resolvableReviewerRecents.length > 0 ? (
-                    <ComposerDropdown
-                      ariaLabel="Recent reviewer settings"
-                      id="composer-review-recents"
-                      options={[
-                        // Sentinel so the trigger reads "Recent" until a
-                        // remembered combination is actually applied; the
-                        // dropdown falls back to the first option whenever the
-                        // value matches nothing.
-                        { label: "Recent", value: "" },
-                        ...resolvableReviewerRecents.map((recent, index) => ({
-                          label: formatReviewerRecentLabel(
-                            recent,
-                            props.backends,
-                          ),
-                          value: String(index),
-                        })),
-                      ]}
-                      tooltip="Reuse a recent reviewer"
-                      value={
-                        activeReviewerRecentIndex >= 0
-                          ? String(activeReviewerRecentIndex)
-                          : ""
-                      }
-                      onChange={(value) => {
-                        const picked = resolvableReviewerRecents[Number(value)];
-                        if (picked) {
-                          patchReviewer(() => picked);
-                        }
-                      }}
-                    />
-                  ) : null}
-                  {reviewerOverridden ? (
-                    <button
-                      type="button"
-                      aria-label="Reset reviewer to thread settings"
-                      className="composer__toggle tooltip-target"
-                      data-tooltip="Reset the reviewer to this thread's provider, model, and reasoning"
-                      onClick={() => {
-                        patchReviewer(() => undefined);
-                      }}
-                    >
-                      ↺
-                    </button>
-                  ) : null}
                 </div>
               </div>
             ) : null}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5924,6 +5924,13 @@ export function Composer(props: ComposerProps) {
     if (!configuredReviewCommand) {
       return;
     }
+    if (reviewSubmissionUnavailable) {
+      setSendError(
+        reviewRunModeDecision.helpText
+        ?? "A separate review thread is unavailable for this reviewer.",
+      );
+      return;
+    }
     const routedReviewCommand = {
       ...configuredReviewCommand,
       runMode: reviewRunModeDecision.runMode,
@@ -6010,6 +6017,11 @@ export function Composer(props: ComposerProps) {
     event: ReactKeyboardEvent<HTMLFieldSetElement>,
   ): void => {
     if (event.key !== "Escape") {
+      return;
+    }
+    const targetElement =
+      event.target instanceof HTMLElement ? event.target : undefined;
+    if (targetElement?.closest(".composer-dropdown--open")) {
       return;
     }
     event.preventDefault();
@@ -9037,6 +9049,9 @@ export function Composer(props: ComposerProps) {
     threadModel: selectedModelOption?.id,
     threadReasoningEffort: supportsReasoning ? selectedReasoningEffort : undefined,
   });
+  const reviewOwnerSummary = props.backends?.find(
+    (candidate) => candidate.kind === props.thread?.source,
+  );
   const reviewerModelOptions =
     reviewerSelection.summary?.launchpadOptions?.models ?? [];
   const reviewerReasoningOptions = getReasoningEffortsForModel(
@@ -9046,6 +9061,7 @@ export function Composer(props: ComposerProps) {
   const reviewerOverridden = Boolean(reviewConfig?.reviewer);
   const reviewRunModeDecision = props.thread
     ? resolveReviewRunMode({
+        ownerSummary: reviewOwnerSummary,
         requestedRunMode: reviewConfig?.runMode,
         reviewerBackend: reviewerSelection.backend,
         reviewerSummary: reviewerSelection.summary,
@@ -9054,9 +9070,13 @@ export function Composer(props: ComposerProps) {
       })
     : {
         controlDisabled: false,
+        explicitRunModeSupported: false,
         runMode: "inline" as const,
         separateThreadDisabled: true,
       };
+  const reviewSubmissionUnavailable =
+    reviewRunModeDecision.runMode === "managed-child"
+    && reviewRunModeDecision.separateThreadDisabled;
   // A remembered combination is only offered while it still resolves against
   // the owner's current catalog. Recents are disposable, so a dead row is
   // noise rather than a preference worth preserving.
@@ -10901,10 +10921,7 @@ export function Composer(props: ComposerProps) {
                 disabled={
                   !buildConfiguredReviewCommand(reviewConfig) ||
                   (reviewWorkspaceSelectionRequired && !reviewConfig?.workspaceCwd) ||
-                  (
-                    reviewRunModeDecision.runMode === "managed-child"
-                    && reviewRunModeDecision.separateThreadDisabled
-                  )
+                  reviewSubmissionUnavailable
                 }
                 onClick={() => {
                   void submitConfiguredReviewComposer();

--- a/apps/desktop/src/renderer/src/features/composer/ComposerDropdown.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerDropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 /**
@@ -58,6 +58,7 @@ export function ComposerDropdown(props: {
   kind?: "branch";
   tone?: "danger";
   onChange: (value: string) => void;
+  onOpenChange?: (open: boolean) => void;
   onPointerEnter?: () => void;
   options: ComposerDropdownOption[];
   tooltip?: string;
@@ -65,9 +66,14 @@ export function ComposerDropdown(props: {
 }) {
   const [open, setOpen] = useState(false);
   const listboxId = useId();
+  const onOpenChange = props.onOpenChange;
   const selectedOption =
     props.options.find((option) => option.value === props.value) ?? props.options[0];
-  const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
+  const closeMenu = useCallback((): void => {
+    setOpen(false);
+    onOpenChange?.(false);
+  }, [onOpenChange]);
+  const ref = useDismissableMenu<HTMLDivElement>(open, closeMenu);
   const Icon = props.icon;
 
   return (
@@ -98,7 +104,11 @@ export function ComposerDropdown(props: {
         id={props.id}
         type="button"
         value={props.value}
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => {
+          const nextOpen = !open;
+          setOpen(nextOpen);
+          onOpenChange?.(nextOpen);
+        }}
       >
         {Icon ? (
           <span aria-hidden="true" className="composer-dropdown__icon">
@@ -120,7 +130,7 @@ export function ComposerDropdown(props: {
               role="option"
               type="button"
               onClick={() => {
-                setOpen(false);
+                closeMenu();
                 if (option.value !== props.value) {
                   props.onChange(option.value);
                 }

--- a/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
@@ -7,7 +7,7 @@ const REVIEW_LOCATION_OPTIONS: Array<{
   value: ReviewRunMode;
 }> = [
   { label: "This thread", value: "inline" },
-  { label: "Separate thread", value: "managed-child" },
+  { label: "Subagent", value: "managed-child" },
 ];
 
 export function ReviewLocationDropdown(props: {
@@ -15,7 +15,7 @@ export function ReviewLocationDropdown(props: {
   onChange: (runMode: ReviewRunMode) => void;
 }) {
   const selectedLabel = props.decision.runMode === "managed-child"
-    ? "Separate thread"
+    ? "Subagent"
     : props.decision.explicitRunModeSupported
       ? "This thread"
       : "Owner default";
@@ -46,7 +46,7 @@ export function ReviewLocationDropdown(props: {
               : option.label,
           disabled:
             option.value === "managed-child"
-            && props.decision.separateThreadDisabled,
+            && props.decision.subagentDisabled,
         }))}
         value={props.decision.runMode}
       />

--- a/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
@@ -16,7 +16,9 @@ export function ReviewLocationDropdown(props: {
 }) {
   const selectedLabel = props.decision.runMode === "managed-child"
     ? "Separate thread"
-    : "This thread";
+    : props.decision.explicitRunModeSupported
+      ? "This thread"
+      : "Owner default";
   const accessibleLabel = props.decision.helpText
     ? `Review location: ${selectedLabel}. ${props.decision.helpText}`
     : `Review location: ${selectedLabel}`;
@@ -37,6 +39,11 @@ export function ReviewLocationDropdown(props: {
         onChange={(value) => props.onChange(value as ReviewRunMode)}
         options={REVIEW_LOCATION_OPTIONS.map((option) => ({
           ...option,
+          label:
+            option.value === "inline"
+            && !props.decision.explicitRunModeSupported
+              ? "Owner default"
+              : option.label,
           disabled:
             option.value === "managed-child"
             && props.decision.separateThreadDisabled,

--- a/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import type { ReviewRunMode } from "@pwragent/shared";
 import type { ReviewRunModeDecision } from "../../lib/review-run-mode";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { ComposerDropdown } from "./ComposerDropdown";
 
 const REVIEW_LOCATION_OPTIONS: Array<{
@@ -14,6 +16,14 @@ export function ReviewLocationDropdown(props: {
   decision: ReviewRunModeDecision;
   onChange: (runMode: ReviewRunMode) => void;
 }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const {
+    hide: hideTooltip,
+    show: showTooltip,
+    tooltipNode,
+    update: updateTooltip,
+    visible: tooltipVisible,
+  } = useViewportTooltip({ className: "viewport-tooltip" });
   const selectedLabel = props.decision.runMode === "managed-child"
     ? "Subagent"
     : props.decision.explicitRunModeSupported
@@ -23,20 +33,49 @@ export function ReviewLocationDropdown(props: {
     ? `Review location: ${selectedLabel}. ${props.decision.helpText}`
     : `Review location: ${selectedLabel}`;
 
+  useEffect(() => {
+    if (!props.decision.helpText || menuOpen) {
+      hideTooltip();
+    } else if (tooltipVisible) {
+      updateTooltip(props.decision.helpText);
+    }
+  }, [
+    hideTooltip,
+    menuOpen,
+    props.decision.helpText,
+    tooltipVisible,
+    updateTooltip,
+  ]);
+
+  const showHelp = (target: HTMLElement): void => {
+    if (props.decision.helpText && !menuOpen) {
+      showTooltip(target, props.decision.helpText);
+    }
+  };
+
   return (
     <div
       aria-label={accessibleLabel}
-      className={`composer__review-location-chip${
-        props.decision.helpText ? " tooltip-target" : ""
-      }`}
-      data-tooltip={props.decision.helpText}
+      className="composer__review-location-chip"
+      onBlur={hideTooltip}
+      onFocus={(event) => showHelp(event.currentTarget)}
+      onMouseEnter={(event) => showHelp(event.currentTarget)}
+      onMouseLeave={hideTooltip}
       role="group"
-      tabIndex={props.decision.helpText ? 0 : undefined}
+      tabIndex={
+        props.decision.helpText && props.decision.controlDisabled
+          ? 0
+          : undefined
+      }
     >
       <ComposerDropdown
         ariaLabel="Review location"
         disabled={props.decision.controlDisabled}
         onChange={(value) => props.onChange(value as ReviewRunMode)}
+        onOpenChange={(open) => {
+          setMenuOpen(open);
+          if (open) hideTooltip();
+        }}
         options={REVIEW_LOCATION_OPTIONS.map((option) => ({
           ...option,
           label:
@@ -50,6 +89,7 @@ export function ReviewLocationDropdown(props: {
         }))}
         value={props.decision.runMode}
       />
+      {tooltipNode}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ReviewLocationDropdown.tsx
@@ -1,0 +1,48 @@
+import type { ReviewRunMode } from "@pwragent/shared";
+import type { ReviewRunModeDecision } from "../../lib/review-run-mode";
+import { ComposerDropdown } from "./ComposerDropdown";
+
+const REVIEW_LOCATION_OPTIONS: Array<{
+  label: string;
+  value: ReviewRunMode;
+}> = [
+  { label: "This thread", value: "inline" },
+  { label: "Separate thread", value: "managed-child" },
+];
+
+export function ReviewLocationDropdown(props: {
+  decision: ReviewRunModeDecision;
+  onChange: (runMode: ReviewRunMode) => void;
+}) {
+  const selectedLabel = props.decision.runMode === "managed-child"
+    ? "Separate thread"
+    : "This thread";
+  const accessibleLabel = props.decision.helpText
+    ? `Review location: ${selectedLabel}. ${props.decision.helpText}`
+    : `Review location: ${selectedLabel}`;
+
+  return (
+    <div
+      aria-label={accessibleLabel}
+      className={`composer__review-location-chip${
+        props.decision.helpText ? " tooltip-target" : ""
+      }`}
+      data-tooltip={props.decision.helpText}
+      role="group"
+      tabIndex={props.decision.helpText ? 0 : undefined}
+    >
+      <ComposerDropdown
+        ariaLabel="Review location"
+        disabled={props.decision.controlDisabled}
+        onChange={(value) => props.onChange(value as ReviewRunMode)}
+        options={REVIEW_LOCATION_OPTIONS.map((option) => ({
+          ...option,
+          disabled:
+            option.value === "managed-child"
+            && props.decision.separateThreadDisabled,
+        }))}
+        value={props.decision.runMode}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5679,6 +5679,16 @@ describe("Composer", () => {
         name: "Reset reviewer to thread settings",
       })
     ).toBeInTheDocument();
+    const location = within(reviewTarget).getByRole("radiogroup", {
+      name: "Review location",
+    });
+    expect(location).toHaveAttribute("aria-disabled", "true");
+    expect(
+      within(location).getByRole("radio", { name: "Separate thread" }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(location.parentElement?.getAttribute("data-tooltip")).toMatch(
+      /Grok, a different provider/,
+    );
 
     await act(async () => {
       fireEvent.click(
@@ -5692,6 +5702,7 @@ describe("Composer", () => {
         reviewBackend: "acp:grok",
         model: "grok-4",
         reasoningEffort: "high",
+        runMode: "managed-child",
       })
     );
     // A reviewer override is for one review; it must not repoint the thread.
@@ -9877,10 +9888,122 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
     expect(addOptimisticReviewEntry).toHaveBeenCalledWith("Review changes against main");
     expect(startTurn).not.toHaveBeenCalled();
+  });
+
+  it("lets the review card choose a managed child for this review", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: "review-child",
+      turnId: "turn-review-1",
+    }));
+    const codexBackend = backendSummary("codex");
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = true;
+
+    render(
+      <Composer
+        backends={[codexBackend]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review location",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    const location = screen.getByRole("radiogroup", {
+      name: "Review location",
+    });
+    expect(
+      within(location).getByRole("radio", { name: "This thread" }),
+    ).toHaveAttribute("aria-checked", "true");
+    const separate = within(location).getByRole("radio", {
+      name: "Separate thread",
+    });
+    expect(separate).toBeEnabled();
+    fireEvent.click(separate);
+    expect(separate).toHaveAttribute("aria-checked", "true");
+
+    await clickButton("Start review");
+
+    expect(startReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        runMode: "managed-child",
+        threadId: "thread-1",
+      }),
+    );
+  });
+
+  it("disables Separate thread with accessible help when no review child can run", () => {
+    const codexBackend = backendSummary("codex");
+    codexBackend.label = "Codex";
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = false;
+
+    render(
+      <Composer
+        backends={[codexBackend]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review location",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    const location = screen.getByRole("radiogroup", {
+      name: "Review location",
+    });
+    const separate = within(location).getByRole("radio", {
+      name: "Separate thread",
+    });
+    expect(separate).toBeDisabled();
+    const helpId = location.getAttribute("aria-describedby");
+    expect(helpId).toBeTruthy();
+    expect(document.getElementById(helpId!)).toHaveTextContent(
+      "Codex cannot run a managed review in a separate thread.",
+    );
+    expect(location.parentElement).toHaveAttribute(
+      "data-tooltip",
+      "Codex cannot run a managed review in a separate thread.",
+    );
   });
 
   it("requires a project choice before reviewing a thread with multiple worktrees", async () => {
@@ -9891,8 +10014,13 @@ describe("Composer", () => {
       turnId: "turn-review-1",
     }));
 
+    const codexBackend = backendSummary("codex");
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = true;
+
     render(
       <Composer
+        backends={[codexBackend]}
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startReview,
@@ -9943,6 +10071,16 @@ describe("Composer", () => {
           "/Users/example/.codex/profiles/sample/worktrees/tree-gamma/tea-recommendations",
       },
     });
+    const location = screen.getByRole("radiogroup", {
+      name: "Review location",
+    });
+    expect(location).toHaveAttribute("aria-disabled", "true");
+    expect(
+      within(location).getByRole("radio", { name: "Separate thread" }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(location.parentElement?.getAttribute("data-tooltip")).toMatch(
+      /not this thread's primary workspace/,
+    );
     await clickButton("Start review");
 
     await waitFor(() => {
@@ -9951,6 +10089,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "managed-child",
         cwd: "/Users/example/.codex/profiles/sample/worktrees/tree-gamma/tea-recommendations",
       });
     });
@@ -10058,6 +10197,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "release" },
         delivery: "inline",
+        runMode: "inline",
         cwd: "/worktrees/app",
       });
     });
@@ -10183,6 +10323,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/develop" },
         delivery: "inline",
+        runMode: "managed-child",
         cwd:
           "/Users/fixture-user/.codex/profiles/work/worktrees/mrctwp7f/kube-manifests",
       });
@@ -10312,6 +10453,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "commit", sha: kubeCommit.sha, title: null },
         delivery: "inline",
+        runMode: "managed-child",
         cwd:
           "/Users/fixture-user/.codex/profiles/work/worktrees/mrctwp7f/kube-manifests",
       });
@@ -10381,6 +10523,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "inline",
         model: "gpt-5.5",
         reasoningEffort: "high",
         serviceTier: "priority",
@@ -11025,6 +11168,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -11095,6 +11239,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "uncommittedChanges" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -11149,6 +11294,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "uncommittedChanges" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -11294,6 +11440,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "release" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -11473,6 +11620,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/releases/2026.07" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -11700,6 +11848,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/develop" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -11778,6 +11927,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/develop" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -11936,6 +12086,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/develop" },
         delivery: "inline",
+        runMode: "inline",
         cwd:
           "/Users/example/.codex/profiles/sample/worktrees/tree-alpha/catalog-service",
       });
@@ -12099,6 +12250,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "commit", sha: recentCommits[3]!.sha, title: null },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -12214,6 +12366,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "commit", sha: "abc123def456", title: null },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -12288,6 +12441,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/main" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -12366,6 +12520,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });
@@ -12411,6 +12566,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "uncommittedChanges" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -283,6 +283,7 @@ function backendSummary(
       resumeThread: true,
       renameThread: false,
       readThread: true,
+      reviewRunMode: true,
       startTurn: true,
       interruptTurn: true,
       steerTurn: false,
@@ -9950,6 +9951,99 @@ describe("Composer", () => {
     );
   });
 
+  it("uses the owner default when a federated owner predates explicit run modes", () => {
+    const codexBackend = backendSummary("codex");
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = true;
+    delete codexBackend.capabilities.reviewRunMode;
+
+    render(
+      <Composer
+        backends={[codexBackend]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Older owner",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    const location = screen.getByRole("button", { name: "Review location" });
+    expect(location).toBeDisabled();
+    expect(location).toHaveAttribute("data-value", "inline");
+    expect(location).toHaveTextContent("Owner default");
+    expect(
+      location.closest(".composer__review-location-chip")
+        ?.getAttribute("data-tooltip"),
+    ).toMatch(
+      /owner's configured default/,
+    );
+  });
+
+  it("closes the review location menu before Escape cancels the review", async () => {
+    const codexBackend = backendSummary("codex");
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = true;
+
+    render(
+      <Composer
+        backends={[codexBackend]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review location",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    const location = screen.getByRole("button", { name: "Review location" });
+    fireEvent.click(location);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.keyDown(location, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+
+    fireEvent.keyDown(location, { key: "Escape" });
+
+    expect(
+      screen.queryByRole("group", { name: "Review target" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("disables Separate thread with accessible help when no review child can run", () => {
     const codexBackend = backendSummary("codex");
     codexBackend.label = "Codex";
@@ -10080,6 +10174,68 @@ describe("Composer", () => {
     });
   });
 
+  it("blocks keyboard submission when a forced review child is unavailable", async () => {
+    const startReview = vi.fn();
+    const codexBackend = backendSummary("codex");
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = false;
+
+    render(
+      <Composer
+        backends={[codexBackend]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [
+            {
+              id: "/repo/primary",
+              kind: "worktree",
+              label: "primary",
+              path: "/repo/primary",
+              worktreePath: "/worktrees/primary",
+            },
+            {
+              id: "/repo/secondary",
+              kind: "worktree",
+              label: "secondary",
+              path: "/repo/secondary",
+              worktreePath: "/worktrees/secondary",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review main" },
+    });
+    await clickButton("Send");
+    fireEvent.change(screen.getByLabelText("Review project"), {
+      target: { value: "/worktrees/secondary" },
+    });
+
+    expect(screen.getByRole("button", { name: "Start review" })).toBeDisabled();
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: /Compare this branch with a base branch/i,
+      }),
+      { key: "Enter" },
+    );
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+  });
+
   it("defaults a multi-project review to the changed primary workspace", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
@@ -10195,6 +10351,9 @@ describe("Composer", () => {
       reviewThreadId: request.threadId,
       turnId: "turn-review-1",
     }));
+    const codexBackend = backendSummary("codex");
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = true;
     const exampleDirectory: NavigationDirectorySummary = {
       key: "directory:/Users/example/Projects/catalog-service",
       kind: "directory",
@@ -10236,6 +10395,7 @@ describe("Composer", () => {
 
     render(
       <Composer
+        backends={[codexBackend]}
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startReview,
@@ -10322,6 +10482,9 @@ describe("Composer", () => {
       reviewThreadId: request.threadId,
       turnId: "turn-review-1",
     }));
+    const codexBackend = backendSummary("codex");
+    codexBackend.capabilities.startReview = true;
+    codexBackend.capabilities.reviewRunner = true;
     const exampleCommit = {
       sha: "1111111111111111111111111111111111111111",
       shortSha: "1111111",
@@ -10367,6 +10530,7 @@ describe("Composer", () => {
 
     render(
       <Composer
+        backends={[codexBackend]}
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startReview,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9897,7 +9897,7 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
-  it("lets the review card choose a managed child for this review", async () => {
+  it("lets the review card choose a subagent for this review", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -9937,7 +9937,7 @@ describe("Composer", () => {
     const location = screen.getByRole("button", { name: "Review location" });
     expect(location).toHaveAttribute("data-value", "inline");
     fireEvent.click(location);
-    fireEvent.click(screen.getByRole("option", { name: "Separate thread" }));
+    fireEvent.click(screen.getByRole("option", { name: "Subagent" }));
     expect(location).toHaveAttribute("data-value", "managed-child");
 
     await clickButton("Start review");
@@ -10044,7 +10044,7 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("disables Separate thread with accessible help when no review child can run", () => {
+  it("disables Subagent with accessible help when no review subagent can run", () => {
     const codexBackend = backendSummary("codex");
     codexBackend.label = "Codex";
     codexBackend.capabilities.startReview = true;
@@ -10078,11 +10078,11 @@ describe("Composer", () => {
 
     const location = screen.getByRole("button", { name: "Review location" });
     fireEvent.click(location);
-    const separate = screen.getByRole("option", { name: "Separate thread" });
-    expect(separate).toBeDisabled();
+    const subagent = screen.getByRole("option", { name: "Subagent" });
+    expect(subagent).toBeDisabled();
     expect(location.closest(".composer__review-location-chip")).toHaveAttribute(
       "data-tooltip",
-      "Codex cannot run a managed review in a separate thread.",
+      "Codex cannot run this review in a subagent.",
     );
   });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5679,14 +5679,15 @@ describe("Composer", () => {
         name: "Reset reviewer to thread settings",
       })
     ).toBeInTheDocument();
-    const location = within(reviewTarget).getByRole("radiogroup", {
+    const location = within(reviewTarget).getByRole("button", {
       name: "Review location",
     });
-    expect(location).toHaveAttribute("aria-disabled", "true");
+    expect(location).toBeDisabled();
+    expect(location).toHaveAttribute("data-value", "managed-child");
     expect(
-      within(location).getByRole("radio", { name: "Separate thread" }),
-    ).toHaveAttribute("aria-checked", "true");
-    expect(location.parentElement?.getAttribute("data-tooltip")).toMatch(
+      location.closest(".composer__review-location-chip")
+        ?.getAttribute("data-tooltip"),
+    ).toMatch(
       /Grok, a different provider/,
     );
 
@@ -9932,18 +9933,11 @@ describe("Composer", () => {
     });
     fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
 
-    const location = screen.getByRole("radiogroup", {
-      name: "Review location",
-    });
-    expect(
-      within(location).getByRole("radio", { name: "This thread" }),
-    ).toHaveAttribute("aria-checked", "true");
-    const separate = within(location).getByRole("radio", {
-      name: "Separate thread",
-    });
-    expect(separate).toBeEnabled();
-    fireEvent.click(separate);
-    expect(separate).toHaveAttribute("aria-checked", "true");
+    const location = screen.getByRole("button", { name: "Review location" });
+    expect(location).toHaveAttribute("data-value", "inline");
+    fireEvent.click(location);
+    fireEvent.click(screen.getByRole("option", { name: "Separate thread" }));
+    expect(location).toHaveAttribute("data-value", "managed-child");
 
     await clickButton("Start review");
 
@@ -9988,19 +9982,11 @@ describe("Composer", () => {
     });
     fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
 
-    const location = screen.getByRole("radiogroup", {
-      name: "Review location",
-    });
-    const separate = within(location).getByRole("radio", {
-      name: "Separate thread",
-    });
+    const location = screen.getByRole("button", { name: "Review location" });
+    fireEvent.click(location);
+    const separate = screen.getByRole("option", { name: "Separate thread" });
     expect(separate).toBeDisabled();
-    const helpId = location.getAttribute("aria-describedby");
-    expect(helpId).toBeTruthy();
-    expect(document.getElementById(helpId!)).toHaveTextContent(
-      "Codex cannot run a managed review in a separate thread.",
-    );
-    expect(location.parentElement).toHaveAttribute(
+    expect(location.closest(".composer__review-location-chip")).toHaveAttribute(
       "data-tooltip",
       "Codex cannot run a managed review in a separate thread.",
     );
@@ -10071,14 +10057,13 @@ describe("Composer", () => {
           "/Users/example/.codex/profiles/sample/worktrees/tree-gamma/tea-recommendations",
       },
     });
-    const location = screen.getByRole("radiogroup", {
-      name: "Review location",
-    });
-    expect(location).toHaveAttribute("aria-disabled", "true");
+    const location = screen.getByRole("button", { name: "Review location" });
+    expect(location).toBeDisabled();
+    expect(location).toHaveAttribute("data-value", "managed-child");
     expect(
-      within(location).getByRole("radio", { name: "Separate thread" }),
-    ).toHaveAttribute("aria-checked", "true");
-    expect(location.parentElement?.getAttribute("data-tooltip")).toMatch(
+      location.closest(".composer__review-location-chip")
+        ?.getAttribute("data-tooltip"),
+    ).toMatch(
       /not this thread's primary workspace/,
     );
     await clickButton("Start review");

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5686,9 +5686,8 @@ describe("Composer", () => {
     expect(location).toBeDisabled();
     expect(location).toHaveAttribute("data-value", "managed-child");
     expect(
-      location.closest(".composer__review-location-chip")
-        ?.getAttribute("data-tooltip"),
-    ).toMatch(
+      location.closest(".composer__review-location-chip"),
+    ).toHaveAccessibleName(
       /Grok, a different provider/,
     );
 
@@ -9987,10 +9986,12 @@ describe("Composer", () => {
     expect(location).toBeDisabled();
     expect(location).toHaveAttribute("data-value", "inline");
     expect(location).toHaveTextContent("Owner default");
-    expect(
-      location.closest(".composer__review-location-chip")
-        ?.getAttribute("data-tooltip"),
-    ).toMatch(
+    const locationChip = location.closest(".composer__review-location-chip");
+    expect(locationChip).toHaveAccessibleName(
+      /owner's configured default/,
+    );
+    fireEvent.focus(locationChip!);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
       /owner's configured default/,
     );
   });
@@ -10077,12 +10078,19 @@ describe("Composer", () => {
     fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
 
     const location = screen.getByRole("button", { name: "Review location" });
+    const locationChip = location.closest(".composer__review-location-chip");
+    fireEvent.focus(location);
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent(
+      "Codex cannot run this review in a subagent.",
+    );
+    expect(locationChip).not.toContainElement(tooltip);
     fireEvent.click(location);
     const subagent = screen.getByRole("option", { name: "Subagent" });
     expect(subagent).toBeDisabled();
-    expect(location.closest(".composer__review-location-chip")).toHaveAttribute(
-      "data-tooltip",
-      "Codex cannot run this review in a subagent.",
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(locationChip).toHaveAccessibleName(
+      /Codex cannot run this review in a subagent/,
     );
   });
 
@@ -10155,9 +10163,8 @@ describe("Composer", () => {
     expect(location).toBeDisabled();
     expect(location).toHaveAttribute("data-value", "managed-child");
     expect(
-      location.closest(".composer__review-location-chip")
-        ?.getAttribute("data-tooltip"),
-    ).toMatch(
+      location.closest(".composer__review-location-chip"),
+    ).toHaveAccessibleName(
       /not this thread's primary workspace/,
     );
     await clickButton("Start review");

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -10,6 +10,7 @@ import type {
   NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
   ModelSettingsRecent,
+  ReviewRunMode,
   ThreadIdentifier,
 } from "@pwragent/shared";
 import type { ComposerSkillToken } from "./ComposerInputTypes";
@@ -44,6 +45,7 @@ export type ComposerQueuedTurnSnapshot = {
   reviewCommand?: {
     cwd?: string;
     displayText: string;
+    runMode?: ReviewRunMode;
     target: AppServerReviewTarget;
     /**
      * Reviewer picked when the review was queued. Carried here because a

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -30,11 +30,6 @@ const DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT = {
   source: "default" as const,
 };
 
-const DEFAULT_MANAGED_REVIEW = {
-  value: false,
-  source: "default" as const,
-};
-
 const DEFAULT_THREAD_TOOL_ACCOUNTING = {
   value: false,
   source: "default" as const,
@@ -63,7 +58,6 @@ export function ExperimentalSettings(props: {
   onCodexDefaultModeRequestUserInputChange: (
     enabled: boolean,
   ) => Promise<void>;
-  onManagedReviewChange: (enabled: boolean) => Promise<void>;
 }) {
   const [tokenMiserWriteTarget, setTokenMiserWriteTarget] = useState<
     boolean | undefined
@@ -113,8 +107,6 @@ export function ExperimentalSettings(props: {
   const codexDefaultModeRequestUserInput =
     props.snapshot.experimental.codexDefaultModeRequestUserInput ??
     DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT;
-  const managedReview =
-    props.snapshot.experimental.managedReview ?? DEFAULT_MANAGED_REVIEW;
   const discontinuedEnabledCount =
     (condensation.enabled.value ? 1 : 0) +
     (liveTranscriptEventFiltering.value ? 1 : 0);
@@ -273,28 +265,6 @@ export function ExperimentalSettings(props: {
             source={sourceBadge(lightweightNavigationRefresh)}
             onChange={(enabled) => {
               return props.onLightweightNavigationRefreshChange(enabled);
-            }}
-          />
-        </div>
-      </SettingsSection>
-
-      <SettingsSection
-        eyebrow="Experimental"
-        title="PwrAgent-managed Code Review"
-        description="Run code reviews in a PwrAgent-managed child turn instead of Codex's native review lifecycle. Disabled by default while failure handling and usage attribution are validated."
-        chip={managedReview.value ? "On" : "Off"}
-        chipKind={managedReview.value ? "ok" : "default"}
-      >
-        <div className="settings-fields">
-          <ToggleField
-            checked={managedReview.value}
-            disabled={props.saving}
-            label="Enable managed code review"
-            sub="Route desktop and messaging /review requests through a managed child turn."
-            help="Existing threads are not migrated; turning this off restores native Codex review/start for the next review."
-            source={sourceBadge(managedReview)}
-            onChange={(enabled) => {
-              return props.onManagedReviewChange(enabled);
             }}
           />
         </div>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -815,11 +815,6 @@ function SettingsSectionBody(props: {
             experimental: { codexDefaultModeRequestUserInput: enabled },
           });
         }}
-        onManagedReviewChange={async (enabled: boolean) => {
-          await props.settings.writeConfig({
-            experimental: { managedReview: enabled },
-          });
-        }}
       />
     );
   }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1402,16 +1402,9 @@ describe("SettingsScreen", () => {
       });
     });
 
-    const managedReviewSwitch = screen.getByRole("switch", {
-      name: "Enable managed code review",
-    });
-    expect(managedReviewSwitch).toHaveAttribute("aria-checked", "false");
-    fireEvent.click(managedReviewSwitch);
-    await waitFor(() => {
-      expect(settings.writeConfig).toHaveBeenCalledWith({
-        experimental: { managedReview: true },
-      });
-    });
+    expect(
+      screen.queryByRole("switch", { name: "Enable managed code review" }),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(within(sections).getByRole("button", { name: "Messaging" }));
     expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -786,6 +786,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             threadId: thread.id,
             target: reviewCommand.target,
             delivery: "inline",
+            runMode: "inline",
           });
           return true;
         } catch (error) {
@@ -1572,6 +1573,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
 
         {reviewSetupOpen ? (
           <StarMapReviewSetup
+            backend={backendSummary}
             busy={session.threadBusy}
             directories={navigationSources.directories}
             error={reviewError}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
@@ -251,7 +251,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
     && !submitting
     && (
       reviewRunModeDecision.runMode === "inline"
-      || !reviewRunModeDecision.separateThreadDisabled
+      || !reviewRunModeDecision.subagentDisabled
     )
   );
 
@@ -322,7 +322,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
         || submitting
         || (
           reviewRunModeDecision.runMode === "managed-child"
-          && reviewRunModeDecision.separateThreadDisabled
+          && reviewRunModeDecision.subagentDisabled
         )
       ) {
         return;
@@ -345,7 +345,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
     onSubmit,
     request,
     reviewRunModeDecision.runMode,
-    reviewRunModeDecision.separateThreadDisabled,
+    reviewRunModeDecision.subagentDisabled,
     submitting,
     workspaceCwd,
     workspaceSelectionRequired,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
@@ -10,19 +10,24 @@ import {
   buildReviewBranchOptions,
   findPreferredReviewWorkspaceCwd,
   type AppServerReviewTarget,
+  type BackendSummary,
   type NavigationDirectorySummary,
   type NavigationThreadSummary,
+  type ReviewRunMode,
 } from "@pwragent/shared";
+import { resolveReviewRunMode } from "../../lib/review-run-mode";
 
 type ReviewTargetChoice = AppServerReviewTarget["type"];
 
 export type StarMapReviewRequest = {
   cwd?: string;
+  runMode: ReviewRunMode;
   target: AppServerReviewTarget;
 };
 
 type StarMapReviewSetupProps = {
   busy: boolean;
+  backend?: BackendSummary;
   directories: readonly NavigationDirectorySummary[];
   error?: string;
   onCancel: () => void;
@@ -123,6 +128,7 @@ function buildReviewRequest(params: {
   branch: string;
   commit: string;
   customInstructions: string;
+  runMode: ReviewRunMode;
   target: ReviewTargetChoice;
   workspaceCwd?: string;
 }): StarMapReviewRequest | undefined {
@@ -130,6 +136,7 @@ function buildReviewRequest(params: {
   if (params.target === "uncommittedChanges") {
     return {
       ...(cwd ? { cwd } : {}),
+      runMode: params.runMode,
       target: { type: "uncommittedChanges" },
     };
   }
@@ -138,6 +145,7 @@ function buildReviewRequest(params: {
     return branch
       ? {
           ...(cwd ? { cwd } : {}),
+          runMode: params.runMode,
           target: { type: "baseBranch", branch },
         }
       : undefined;
@@ -147,6 +155,7 @@ function buildReviewRequest(params: {
     return sha
       ? {
           ...(cwd ? { cwd } : {}),
+          runMode: params.runMode,
           target: { type: "commit", sha, title: null },
         }
       : undefined;
@@ -155,6 +164,7 @@ function buildReviewRequest(params: {
   return instructions
     ? {
         ...(cwd ? { cwd } : {}),
+        runMode: params.runMode,
         target: { type: "custom", instructions },
       }
     : undefined;
@@ -184,10 +194,12 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
   const [branchEdited, setBranchEdited] = useState(false);
   const [commit, setCommit] = useState("");
   const [customInstructions, setCustomInstructions] = useState("");
+  const [runMode, setRunMode] = useState<ReviewRunMode>("inline");
   const targetRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const dialogRef = useRef<HTMLElement | null>(null);
   const branchListId = useId();
   const commitListId = useId();
+  const reviewLocationHelpId = useId();
 
   useEffect(() => {
     // The compact editor also synchronizes editability when this mounts and
@@ -205,22 +217,41 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
     }
   }, [branchEdited, branchOptions]);
 
+  const reviewRunModeDecision = resolveReviewRunMode({
+    requestedRunMode: runMode,
+    reviewerBackend: props.thread.source,
+    reviewerSummary: props.backend,
+    thread: props.thread,
+    workspaceCwd,
+  });
   const request = useMemo(
     () => buildReviewRequest({
       branch,
       commit,
       customInstructions,
+      runMode: reviewRunModeDecision.runMode,
       target,
       workspaceCwd,
     }),
-    [branch, commit, customInstructions, target, workspaceCwd],
+    [
+      branch,
+      commit,
+      customInstructions,
+      reviewRunModeDecision.runMode,
+      target,
+      workspaceCwd,
+    ],
   );
   const workspaceSelectionRequired = workspaceOptions.length > 1;
   const canSubmit = Boolean(
     request
     && (!workspaceSelectionRequired || workspaceCwd)
     && !busy
-    && !submitting,
+    && !submitting
+    && (
+      reviewRunModeDecision.runMode === "inline"
+      || !reviewRunModeDecision.separateThreadDisabled
+    )
   );
 
   const submit = (event: FormEvent<HTMLFormElement>): void => {
@@ -274,6 +305,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
             branch,
             commit,
             customInstructions,
+            runMode: reviewRunModeDecision.runMode,
             target: requestedTarget,
             workspaceCwd,
           })
@@ -283,6 +315,10 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
         || (workspaceSelectionRequired && !workspaceCwd)
         || busy
         || submitting
+        || (
+          reviewRunModeDecision.runMode === "managed-child"
+          && reviewRunModeDecision.separateThreadDisabled
+        )
       ) {
         return;
       }
@@ -303,6 +339,8 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
     onCancel,
     onSubmit,
     request,
+    reviewRunModeDecision.runMode,
+    reviewRunModeDecision.separateThreadDisabled,
     submitting,
     workspaceCwd,
     workspaceSelectionRequired,
@@ -432,6 +470,71 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
               />
             </label>
           ) : null}
+
+          <div className="composer__review-field composer__review-location">
+            <span>Review location</span>
+            <div
+              className={`composer__review-location-control${
+                reviewRunModeDecision.helpText ? " tooltip-target" : ""
+              }`}
+              data-tooltip={reviewRunModeDecision.helpText}
+              tabIndex={reviewRunModeDecision.helpText ? 0 : undefined}
+            >
+              <div
+                aria-describedby={
+                  reviewRunModeDecision.helpText
+                    ? reviewLocationHelpId
+                    : undefined
+                }
+                aria-disabled={reviewRunModeDecision.controlDisabled}
+                aria-label="Review location"
+                className="settings-segmented"
+                role="radiogroup"
+              >
+                <button
+                  aria-checked={reviewRunModeDecision.runMode === "inline"}
+                  className={`settings-segmented__button${
+                    reviewRunModeDecision.runMode === "inline"
+                      ? " is-active"
+                      : ""
+                  }`}
+                  disabled={reviewRunModeDecision.controlDisabled}
+                  onClick={() => setRunMode("inline")}
+                  role="radio"
+                  type="button"
+                >
+                  This thread
+                </button>
+                <button
+                  aria-checked={
+                    reviewRunModeDecision.runMode === "managed-child"
+                  }
+                  className={`settings-segmented__button${
+                    reviewRunModeDecision.runMode === "managed-child"
+                      ? " is-active"
+                      : ""
+                  }`}
+                  disabled={
+                    reviewRunModeDecision.controlDisabled
+                    || reviewRunModeDecision.separateThreadDisabled
+                  }
+                  onClick={() => setRunMode("managed-child")}
+                  role="radio"
+                  type="button"
+                >
+                  Separate thread
+                </button>
+              </div>
+              {reviewRunModeDecision.helpText ? (
+                <small
+                  className="composer__review-location-help"
+                  id={reviewLocationHelpId}
+                >
+                  {reviewRunModeDecision.helpText}
+                </small>
+              ) : null}
+            </div>
+          </div>
 
           {props.busy ? (
             <p className="star-map-review-setup__message" role="status">

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
@@ -16,6 +16,7 @@ import {
   type ReviewRunMode,
 } from "@pwragent/shared";
 import { resolveReviewRunMode } from "../../lib/review-run-mode";
+import { ReviewLocationDropdown } from "../composer/ReviewLocationDropdown";
 
 type ReviewTargetChoice = AppServerReviewTarget["type"];
 
@@ -199,7 +200,6 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
   const dialogRef = useRef<HTMLElement | null>(null);
   const branchListId = useId();
   const commitListId = useId();
-  const reviewLocationHelpId = useId();
 
   useEffect(() => {
     // The compact editor also synchronizes editability when this mounts and
@@ -266,8 +266,13 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
       if (!dialog || !(targetNode instanceof Node)) return;
       const ownerCard = dialog.closest(".star-map-chat-card");
       if (!ownerCard?.contains(targetNode)) return;
+      const targetElement =
+        targetNode instanceof HTMLElement ? targetNode : undefined;
 
       if (event.key === "Escape" && !submitting) {
+        if (targetElement?.closest(".composer-dropdown")) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         onCancel();
@@ -283,8 +288,6 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
         return;
       }
 
-      const targetElement =
-        targetNode instanceof HTMLElement ? targetNode : undefined;
       const insideDialog = dialog.contains(targetNode);
       const insideDisabledComposer = Boolean(
         targetElement?.closest(".compact-composer"),
@@ -292,6 +295,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
       if (!insideDialog && !insideDisabledComposer) return;
       if (
         targetElement?.closest("textarea, select")
+        || targetElement?.closest(".composer-dropdown")
         || targetElement?.closest("[data-review-dismiss]")
       ) {
         return;
@@ -471,68 +475,13 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
             </label>
           ) : null}
 
-          <div className="composer__review-field composer__review-location">
-            <span>Review location</span>
-            <div
-              className={`composer__review-location-control${
-                reviewRunModeDecision.helpText ? " tooltip-target" : ""
-              }`}
-              data-tooltip={reviewRunModeDecision.helpText}
-              tabIndex={reviewRunModeDecision.helpText ? 0 : undefined}
-            >
-              <div
-                aria-describedby={
-                  reviewRunModeDecision.helpText
-                    ? reviewLocationHelpId
-                    : undefined
-                }
-                aria-disabled={reviewRunModeDecision.controlDisabled}
-                aria-label="Review location"
-                className="settings-segmented"
-                role="radiogroup"
-              >
-                <button
-                  aria-checked={reviewRunModeDecision.runMode === "inline"}
-                  className={`settings-segmented__button${
-                    reviewRunModeDecision.runMode === "inline"
-                      ? " is-active"
-                      : ""
-                  }`}
-                  disabled={reviewRunModeDecision.controlDisabled}
-                  onClick={() => setRunMode("inline")}
-                  role="radio"
-                  type="button"
-                >
-                  This thread
-                </button>
-                <button
-                  aria-checked={
-                    reviewRunModeDecision.runMode === "managed-child"
-                  }
-                  className={`settings-segmented__button${
-                    reviewRunModeDecision.runMode === "managed-child"
-                      ? " is-active"
-                      : ""
-                  }`}
-                  disabled={
-                    reviewRunModeDecision.controlDisabled
-                    || reviewRunModeDecision.separateThreadDisabled
-                  }
-                  onClick={() => setRunMode("managed-child")}
-                  role="radio"
-                  type="button"
-                >
-                  Separate thread
-                </button>
-              </div>
-              {reviewRunModeDecision.helpText ? (
-                <small
-                  className="composer__review-location-help"
-                  id={reviewLocationHelpId}
-                >
-                  {reviewRunModeDecision.helpText}
-                </small>
-              ) : null}
+          <div className="composer__review-field composer__review-reviewer">
+            <span>Reviewer</span>
+            <div className="composer__review-reviewer-chips">
+              <ReviewLocationDropdown
+                decision={reviewRunModeDecision}
+                onChange={setRunMode}
+              />
             </div>
           </div>
 

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapReviewSetup.tsx
@@ -218,6 +218,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
   }, [branchEdited, branchOptions]);
 
   const reviewRunModeDecision = resolveReviewRunMode({
+    ownerSummary: props.backend,
     requestedRunMode: runMode,
     reviewerBackend: props.thread.source,
     reviewerSummary: props.backend,
@@ -270,7 +271,7 @@ export function StarMapReviewSetup(props: StarMapReviewSetupProps) {
         targetNode instanceof HTMLElement ? targetNode : undefined;
 
       if (event.key === "Escape" && !submitting) {
-        if (targetElement?.closest(".composer-dropdown")) {
+        if (targetElement?.closest(".composer-dropdown--open")) {
           return;
         }
         event.preventDefault();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -136,6 +136,7 @@ function reviewCapabilities(startReview: boolean): BackendCapabilities {
     renameThread: true,
     resumeThread: true,
     startReview,
+    reviewRunner: startReview,
     startTurn: true,
     steerTurn: false,
     toolUse: true,
@@ -1032,6 +1033,7 @@ describe("StarMapChatCard slash commands", () => {
           threadId: "t-local",
           target: { type: "uncommittedChanges" },
           delivery: "inline",
+          runMode: backend === "codex" ? "inline" : "managed-child",
         });
       });
       await waitFor(() => {
@@ -1166,6 +1168,7 @@ describe("StarMapChatCard slash commands", () => {
         threadId: "t-local",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
     expect(
@@ -1200,6 +1203,7 @@ describe("StarMapChatCard slash commands", () => {
         threadId: "t-local",
         target: { type: "uncommittedChanges" },
         delivery: "inline",
+        runMode: "inline",
       });
     });
     expect(

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1146,6 +1146,32 @@ describe("StarMapChatCard slash commands", () => {
     expect(desktopApi.startReview).not.toHaveBeenCalled();
   });
 
+  it("lets Escape close the review location chip without cancelling setup", async () => {
+    const desktopApi = buildApi({ startReview: vi.fn() });
+    renderCard({ desktopApi, thread: localThread() });
+    const input = screen.getByRole("textbox", { name: "Message Local work" });
+    fireEvent.change(input, { target: { value: "/review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    const dialog = await screen.findByRole("dialog", {
+      name: "Start review for Local work",
+    });
+    const location = within(dialog).getByRole("button", {
+      name: "Review location",
+    });
+    fireEvent.click(location);
+    expect(within(dialog).getByRole("listbox")).toBeTruthy();
+
+    fireEvent.keyDown(location, { key: "Escape" });
+
+    expect(
+      screen.getByRole("dialog", { name: "Start review for Local work" }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(within(dialog).queryByRole("listbox")).toBeNull();
+    });
+    expect(desktopApi.startReview).not.toHaveBeenCalled();
+  });
+
   it("starts the selected review on Enter even if the disabled editor kept focus", async () => {
     const startReview = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -134,6 +134,7 @@ function reviewCapabilities(startReview: boolean): BackendCapabilities {
     multiDirectoryThreads: true,
     readThread: true,
     renameThread: true,
+    reviewRunMode: startReview,
     resumeThread: true,
     startReview,
     reviewRunner: startReview,
@@ -149,23 +150,19 @@ function reviewCapableApi(
   overrides: Partial<DesktopApi> = {},
 ): DesktopApi {
   return buildApi({
-    ...(backend.startsWith("acp:")
-      ? {
-          listBackends: vi.fn(async () => ({
-            fetchedAt: 1,
-            backends: [
-              {
-                available: true,
-                capabilities: reviewCapabilities(true),
-                executionModes: [],
-                kind: backend,
-                label: "Grok",
-                methods: [],
-              },
-            ],
-          })),
-        }
-      : {}),
+    listBackends: vi.fn(async () => ({
+      fetchedAt: 1,
+      backends: [
+        {
+          available: true,
+          capabilities: reviewCapabilities(true),
+          executionModes: [],
+          kind: backend,
+          label: backend === "codex" ? "OpenAI" : "Grok",
+          methods: [],
+        },
+      ],
+    })),
     ...overrides,
   });
 }
@@ -1147,7 +1144,7 @@ describe("StarMapChatCard slash commands", () => {
   });
 
   it("lets Escape close the review location chip without cancelling setup", async () => {
-    const desktopApi = buildApi({ startReview: vi.fn() });
+    const desktopApi = reviewCapableApi("codex", { startReview: vi.fn() });
     renderCard({ desktopApi, thread: localThread() });
     const input = screen.getByRole("textbox", { name: "Message Local work" });
     fireEvent.change(input, { target: { value: "/review" } });
@@ -1168,6 +1165,12 @@ describe("StarMapChatCard slash commands", () => {
     ).toBeTruthy();
     await waitFor(() => {
       expect(within(dialog).queryByRole("listbox")).toBeNull();
+    });
+    fireEvent.keyDown(location, { key: "Escape" });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Start review for Local work" }),
+      ).toBeNull();
     });
     expect(desktopApi.startReview).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -9,6 +9,7 @@ import type {
   AppServerThreadActivityEntry,
   AppServerThreadEntry,
   AppServerPendingRequestNotification,
+  BackendSummary,
   MessagingPlatformStatus,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
@@ -663,6 +664,30 @@ describe("ThreadView", () => {
       reviewThreadId: request.threadId,
       turnId: "turn-review-1",
     }));
+    const codexBackend: BackendSummary = {
+      available: true,
+      capabilities: {
+        approvalRequests: true,
+        createThread: true,
+        interruptTurn: true,
+        listThreads: true,
+        multiDirectoryThreads: true,
+        readThread: true,
+        renameThread: true,
+        resumeThread: true,
+        reviewRunner: true,
+        reviewRunMode: true,
+        startReview: true,
+        startTurn: true,
+        steerTurn: true,
+        toolUse: true,
+        transcriptPagination: true,
+      },
+      executionModes: [],
+      kind: "codex",
+      label: "OpenAI",
+      methods: ["thread/start", "turn/start"],
+    };
     const exampleDirectory: NavigationDirectorySummary = {
       key: "directory:/Users/example/Projects/catalog-service",
       kind: "directory",
@@ -706,7 +731,7 @@ describe("ThreadView", () => {
       <ThreadView
         addOptimisticReviewEntry={(_text) => "optimistic-review-1"}
         addOptimisticUserMessage={(_text) => "optimistic-1"}
-        backends={[]}
+        backends={[codexBackend]}
         clearPendingRequest={() => undefined}
         composerDisabled={false}
         desktopApi={{

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -782,9 +782,11 @@ describe("ThreadView", () => {
     await waitFor(() => {
       expect(startReview).toHaveBeenCalledWith({
         backend: "codex",
+        federationTarget: undefined,
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/develop" },
         delivery: "inline",
+        runMode: "managed-child",
         cwd:
           "/Users/fixture-user/.codex/profiles/work/worktrees/mrctwp7f/kube-manifests",
       });

--- a/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppServerBackendKind,
+  BackendSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { resolveReviewRunMode } from "../review-run-mode";
+
+function thread(
+  source: AppServerBackendKind = "codex",
+): NavigationThreadSummary {
+  return {
+    id: "thread-1",
+    title: "Review me",
+    titleSource: "explicit",
+    source,
+    executionMode: "default",
+    linkedDirectories: [{
+      id: "/repo/primary",
+      kind: "local",
+      label: "primary",
+      path: "/repo/primary",
+    }],
+    inbox: { inInbox: false },
+  };
+}
+
+function reviewer(
+  kind: AppServerBackendKind,
+  reviewRunner: boolean,
+): BackendSummary {
+  return {
+    kind,
+    label: kind === "codex" ? "Codex" : "Grok",
+    available: true,
+    methods: [],
+    capabilities: { reviewRunner } as BackendSummary["capabilities"],
+    executionModes: [],
+  };
+}
+
+describe("resolveReviewRunMode", () => {
+  it("defaults same-provider reviews to this thread", () => {
+    expect(resolveReviewRunMode({
+      reviewerBackend: "codex",
+      reviewerSummary: reviewer("codex", true),
+      thread: thread(),
+    })).toEqual({
+      controlDisabled: false,
+      runMode: "inline",
+      separateThreadDisabled: false,
+    });
+  });
+
+  it("honors an optional separate-thread choice", () => {
+    expect(resolveReviewRunMode({
+      requestedRunMode: "managed-child",
+      reviewerBackend: "codex",
+      reviewerSummary: reviewer("codex", true),
+      thread: thread(),
+    }).runMode).toBe("managed-child");
+  });
+
+  it("forces another provider into a managed child with a concrete reason", () => {
+    const decision = resolveReviewRunMode({
+      requestedRunMode: "inline",
+      reviewerBackend: "acp:grok",
+      reviewerSummary: reviewer("acp:grok", true),
+      thread: thread(),
+    });
+
+    expect(decision.runMode).toBe("managed-child");
+    expect(decision.controlDisabled).toBe(true);
+    expect(decision.helpText).toMatch(/Grok, a different provider/);
+  });
+
+  it("forces a selected secondary workspace into a managed child", () => {
+    const parent = thread();
+    parent.linkedDirectories.push({
+      id: "/repo/secondary",
+      kind: "local",
+      label: "secondary",
+      path: "/repo/secondary",
+    });
+    const decision = resolveReviewRunMode({
+      reviewerBackend: "codex",
+      reviewerSummary: reviewer("codex", true),
+      thread: parent,
+      workspaceCwd: "/repo/secondary",
+    });
+
+    expect(decision.runMode).toBe("managed-child");
+    expect(decision.helpText).toMatch(/not this thread's primary workspace/);
+  });
+
+  it("forces ACP review providers into managed children", () => {
+    const decision = resolveReviewRunMode({
+      reviewerBackend: "acp:grok",
+      reviewerSummary: reviewer("acp:grok", true),
+      thread: thread("acp:grok"),
+    });
+
+    expect(decision.runMode).toBe("managed-child");
+    expect(decision.helpText).toMatch(/Grok runs reviews as managed child threads/);
+  });
+
+  it("disables separate thread when the reviewer cannot run a managed child", () => {
+    const decision = resolveReviewRunMode({
+      reviewerBackend: "codex",
+      reviewerSummary: reviewer("codex", false),
+      thread: thread(),
+    });
+
+    expect(decision.runMode).toBe("inline");
+    expect(decision.separateThreadDisabled).toBe(true);
+    expect(decision.helpText).toBe(
+      "Codex cannot run a managed review in a separate thread.",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
@@ -28,13 +28,17 @@ function thread(
 function reviewer(
   kind: AppServerBackendKind,
   reviewRunner: boolean,
+  reviewRunMode = true,
 ): BackendSummary {
   return {
     kind,
     label: kind === "codex" ? "Codex" : "Grok",
     available: true,
     methods: [],
-    capabilities: { reviewRunner } as BackendSummary["capabilities"],
+    capabilities: {
+      reviewRunner,
+      reviewRunMode,
+    } as BackendSummary["capabilities"],
     executionModes: [],
   };
 }
@@ -42,11 +46,13 @@ function reviewer(
 describe("resolveReviewRunMode", () => {
   it("defaults same-provider reviews to this thread", () => {
     expect(resolveReviewRunMode({
+      ownerSummary: reviewer("codex", true),
       reviewerBackend: "codex",
       reviewerSummary: reviewer("codex", true),
       thread: thread(),
     })).toEqual({
       controlDisabled: false,
+      explicitRunModeSupported: true,
       runMode: "inline",
       separateThreadDisabled: false,
     });
@@ -54,6 +60,7 @@ describe("resolveReviewRunMode", () => {
 
   it("honors an optional separate-thread choice", () => {
     expect(resolveReviewRunMode({
+      ownerSummary: reviewer("codex", true),
       requestedRunMode: "managed-child",
       reviewerBackend: "codex",
       reviewerSummary: reviewer("codex", true),
@@ -63,6 +70,7 @@ describe("resolveReviewRunMode", () => {
 
   it("forces another provider into a managed child with a concrete reason", () => {
     const decision = resolveReviewRunMode({
+      ownerSummary: reviewer("codex", true),
       requestedRunMode: "inline",
       reviewerBackend: "acp:grok",
       reviewerSummary: reviewer("acp:grok", true),
@@ -83,6 +91,7 @@ describe("resolveReviewRunMode", () => {
       path: "/repo/secondary",
     });
     const decision = resolveReviewRunMode({
+      ownerSummary: reviewer("codex", true),
       reviewerBackend: "codex",
       reviewerSummary: reviewer("codex", true),
       thread: parent,
@@ -95,6 +104,7 @@ describe("resolveReviewRunMode", () => {
 
   it("forces ACP review providers into managed children", () => {
     const decision = resolveReviewRunMode({
+      ownerSummary: reviewer("acp:grok", true),
       reviewerBackend: "acp:grok",
       reviewerSummary: reviewer("acp:grok", true),
       thread: thread("acp:grok"),
@@ -106,6 +116,7 @@ describe("resolveReviewRunMode", () => {
 
   it("disables separate thread when the reviewer cannot run a managed child", () => {
     const decision = resolveReviewRunMode({
+      ownerSummary: reviewer("codex", false),
       reviewerBackend: "codex",
       reviewerSummary: reviewer("codex", false),
       thread: thread(),
@@ -116,5 +127,20 @@ describe("resolveReviewRunMode", () => {
     expect(decision.helpText).toBe(
       "Codex cannot run a managed review in a separate thread.",
     );
+  });
+
+  it("uses the owner default when a federated owner predates explicit run modes", () => {
+    const decision = resolveReviewRunMode({
+      ownerSummary: reviewer("codex", true, false),
+      requestedRunMode: "managed-child",
+      reviewerBackend: "codex",
+      reviewerSummary: reviewer("codex", true),
+      thread: thread(),
+    });
+
+    expect(decision.runMode).toBe("inline");
+    expect(decision.controlDisabled).toBe(true);
+    expect(decision.explicitRunModeSupported).toBe(false);
+    expect(decision.helpText).toMatch(/owner's configured default/);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
@@ -54,11 +54,11 @@ describe("resolveReviewRunMode", () => {
       controlDisabled: false,
       explicitRunModeSupported: true,
       runMode: "inline",
-      separateThreadDisabled: false,
+      subagentDisabled: false,
     });
   });
 
-  it("honors an optional separate-thread choice", () => {
+  it("honors an optional subagent choice", () => {
     expect(resolveReviewRunMode({
       ownerSummary: reviewer("codex", true),
       requestedRunMode: "managed-child",
@@ -111,10 +111,10 @@ describe("resolveReviewRunMode", () => {
     });
 
     expect(decision.runMode).toBe("managed-child");
-    expect(decision.helpText).toMatch(/Grok runs reviews as managed child threads/);
+    expect(decision.helpText).toMatch(/Grok runs reviews in a managed subagent/);
   });
 
-  it("disables separate thread when the reviewer cannot run a managed child", () => {
+  it("disables the subagent when the reviewer cannot run one", () => {
     const decision = resolveReviewRunMode({
       ownerSummary: reviewer("codex", false),
       reviewerBackend: "codex",
@@ -123,9 +123,9 @@ describe("resolveReviewRunMode", () => {
     });
 
     expect(decision.runMode).toBe("inline");
-    expect(decision.separateThreadDisabled).toBe(true);
+    expect(decision.subagentDisabled).toBe(true);
     expect(decision.helpText).toBe(
-      "Codex cannot run a managed review in a separate thread.",
+      "Codex cannot run this review in a subagent.",
     );
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/review-run-mode.test.ts
@@ -102,6 +102,30 @@ describe("resolveReviewRunMode", () => {
     expect(decision.helpText).toMatch(/not this thread's primary workspace/);
   });
 
+  it("keeps the project-linked local provider workspace primary", () => {
+    const parent = thread();
+    parent.projectKey = "/repo/primary";
+    parent.linkedDirectories.push({
+      id: "/repo/secondary",
+      kind: "worktree",
+      label: "secondary",
+      path: "/repo/secondary",
+      worktreePath: "/worktrees/secondary",
+    });
+    const decision = resolveReviewRunMode({
+      ownerSummary: reviewer("codex", true),
+      requestedRunMode: "inline",
+      reviewerBackend: "codex",
+      reviewerSummary: reviewer("codex", true),
+      thread: parent,
+      workspaceCwd: "/repo/primary",
+    });
+
+    expect(decision.runMode).toBe("inline");
+    expect(decision.controlDisabled).toBe(false);
+    expect(decision.helpText).toBeUndefined();
+  });
+
   it("forces ACP review providers into managed children", () => {
     const decision = resolveReviewRunMode({
       ownerSummary: reviewer("acp:grok", true),

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -724,6 +724,7 @@ describe("useQueuedTurnRelease", () => {
           branch: "main",
         },
         delivery: "inline",
+        runMode: "inline",
         cwd: "/repo/selected-worktree",
         model: "gpt-5.5",
         reasoningEffort: "high",
@@ -761,6 +762,7 @@ describe("useQueuedTurnRelease", () => {
       fileAttachments: [],
       reviewCommand: {
         displayText: "Review changes against main",
+        runMode: "managed-child",
         target: { type: "baseBranch", branch: "main" },
         reviewer: {
           backend: "acp:grok",
@@ -814,6 +816,7 @@ describe("useQueuedTurnRelease", () => {
           reviewBackend: "acp:grok",
           model: "grok-4",
           reasoningEffort: "high",
+          runMode: "managed-child",
         })
       );
     });
@@ -1134,6 +1137,7 @@ describe("useQueuedTurnRelease", () => {
         threadId: "thread-a",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "inline",
         cwd: "/repo/background-worktree",
       });
     });
@@ -1394,6 +1398,7 @@ describe("useQueuedTurnRelease", () => {
         threadId: "thread-a",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        runMode: "inline",
         cwd: "/repo/retained-worktree",
       });
     });
@@ -2018,6 +2023,7 @@ describe("useQueuedTurnRelease", () => {
       threadId: "thread-a",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      runMode: "inline",
       cwd: "/repo/polled-worktree",
     });
     expect(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useScheduledThreadActionProjection.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useScheduledThreadActionProjection.test.ts
@@ -351,6 +351,7 @@ describe("scheduled thread action projections", () => {
       review: {
         target: { type: "baseBranch", branch: "main" },
         draftText: "/review main",
+        runMode: "managed-child",
         reviewBackend: "acp:grok",
         model: "grok-4",
         reasoningEffort: "high",
@@ -362,6 +363,7 @@ describe("scheduled thread action projections", () => {
     expect(store.getQueuedTurns(scopeKey)).toEqual([
       expect.objectContaining({
         reviewCommand: expect.objectContaining({
+          runMode: "managed-child",
           reviewer: {
             backend: "acp:grok",
             model: "grok-4",

--- a/apps/desktop/src/renderer/src/lib/review-run-mode.ts
+++ b/apps/desktop/src/renderer/src/lib/review-run-mode.ts
@@ -1,0 +1,92 @@
+import {
+  findPreferredReviewWorkspaceCwd,
+  type AppServerBackendKind,
+  type BackendSummary,
+  type NavigationThreadSummary,
+  type ReviewRunMode,
+} from "@pwragent/shared";
+import { formatBackendLabel } from "./backend-label";
+
+export type ReviewRunModeDecision = {
+  controlDisabled: boolean;
+  helpText?: string;
+  runMode: ReviewRunMode;
+  separateThreadDisabled: boolean;
+};
+
+function normalizeWorkspacePath(value?: string): string | undefined {
+  const normalized = value?.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || undefined;
+}
+
+function usesSecondaryWorkspace(
+  thread: NavigationThreadSummary,
+  workspaceCwd?: string,
+): boolean {
+  if (thread.source !== "codex") return false;
+  const selected = normalizeWorkspacePath(workspaceCwd);
+  const fallbackPrimary =
+    thread.linkedDirectories.find((directory) => directory.kind === "worktree")
+    ?? thread.linkedDirectories.find((directory) => directory.kind === "local")
+    ?? thread.linkedDirectories[0];
+  const primary = normalizeWorkspacePath(
+    findPreferredReviewWorkspaceCwd(thread)
+    ?? fallbackPrimary?.worktreePath
+    ?? fallbackPrimary?.path
+    ?? thread.projectKey,
+  );
+  return Boolean(selected && primary && selected !== primary);
+}
+
+function backendLabel(
+  backend: AppServerBackendKind,
+  summary?: BackendSummary,
+): string {
+  return formatBackendLabel(backend, summary ? [summary] : undefined);
+}
+
+export function resolveReviewRunMode(params: {
+  requestedRunMode?: ReviewRunMode;
+  reviewerBackend?: AppServerBackendKind;
+  reviewerSummary?: BackendSummary;
+  thread: NavigationThreadSummary;
+  workspaceCwd?: string;
+}): ReviewRunModeDecision {
+  const reviewerBackend = params.reviewerBackend ?? params.thread.source;
+  const reviewerLabel = backendLabel(reviewerBackend, params.reviewerSummary);
+  // A missing summary is still loading, not proof that the owner cannot run a
+  // child. Once a summary is present, require the explicit capability probe so
+  // older federation owners and unsupported providers stay gated.
+  const managedChildSupported = params.reviewerSummary
+    ? params.reviewerSummary.capabilities.reviewRunner === true
+    : reviewerBackend === "codex";
+  const differentProvider = reviewerBackend !== params.thread.source;
+
+  let forcedReason: string | undefined;
+  if (differentProvider) {
+    forcedReason =
+      `Separate thread is required because the selected reviewer uses ${reviewerLabel}, a different provider from this thread.`;
+  } else if (usesSecondaryWorkspace(params.thread, params.workspaceCwd)) {
+    forcedReason =
+      "Separate thread is required because the selected project is not this thread's primary workspace.";
+  } else if (params.thread.source.startsWith("acp:")) {
+    forcedReason =
+      `Separate thread is required because ${reviewerLabel} runs reviews as managed child threads.`;
+  }
+
+  const unavailableReason = managedChildSupported
+    ? undefined
+    : `${reviewerLabel} cannot run a managed review in a separate thread.`;
+  const helpText = [forcedReason, unavailableReason].filter(Boolean).join(" ")
+    || undefined;
+  const runMode = forcedReason
+    ? "managed-child"
+    : params.requestedRunMode ?? "inline";
+
+  return {
+    controlDisabled: Boolean(forcedReason),
+    helpText,
+    runMode,
+    separateThreadDisabled: !managedChildSupported,
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/review-run-mode.ts
+++ b/apps/desktop/src/renderer/src/lib/review-run-mode.ts
@@ -20,18 +20,43 @@ function normalizeWorkspacePath(value?: string): string | undefined {
   return normalized || undefined;
 }
 
+function findProjectWorkspaceCwd(
+  thread: NavigationThreadSummary,
+): string | undefined {
+  const projectKey = normalizeWorkspacePath(thread.projectKey);
+  if (!projectKey) return undefined;
+
+  return thread.linkedDirectories
+    .flatMap((directory) => {
+      const workspaceCwd = normalizeWorkspacePath(
+        directory.worktreePath ?? directory.path,
+      );
+      const matchLength = [directory.worktreePath, directory.path]
+        .map(normalizeWorkspacePath)
+        .filter((candidate): candidate is string => Boolean(candidate))
+        .filter((candidate) => (
+          projectKey === candidate
+          || projectKey.startsWith(`${candidate}/`)
+        ))
+        .reduce((longest, candidate) => Math.max(longest, candidate.length), 0);
+      return workspaceCwd && matchLength > 0
+        ? [{ matchLength, workspaceCwd }]
+        : [];
+    })
+    .sort((left, right) => right.matchLength - left.matchLength)[0]
+    ?.workspaceCwd;
+}
+
 function usesSecondaryWorkspace(
   thread: NavigationThreadSummary,
   workspaceCwd?: string,
 ): boolean {
   if (thread.source !== "codex") return false;
   const selected = normalizeWorkspacePath(workspaceCwd);
-  const fallbackPrimary =
-    thread.linkedDirectories.find((directory) => directory.kind === "worktree")
-    ?? thread.linkedDirectories.find((directory) => directory.kind === "local")
-    ?? thread.linkedDirectories[0];
+  const fallbackPrimary = thread.linkedDirectories[0];
   const primary = normalizeWorkspacePath(
     findPreferredReviewWorkspaceCwd(thread)
+    ?? findProjectWorkspaceCwd(thread)
     ?? fallbackPrimary?.worktreePath
     ?? fallbackPrimary?.path
     ?? thread.projectKey,

--- a/apps/desktop/src/renderer/src/lib/review-run-mode.ts
+++ b/apps/desktop/src/renderer/src/lib/review-run-mode.ts
@@ -9,6 +9,7 @@ import { formatBackendLabel } from "./backend-label";
 
 export type ReviewRunModeDecision = {
   controlDisabled: boolean;
+  explicitRunModeSupported: boolean;
   helpText?: string;
   runMode: ReviewRunMode;
   separateThreadDisabled: boolean;
@@ -46,6 +47,7 @@ function backendLabel(
 }
 
 export function resolveReviewRunMode(params: {
+  ownerSummary?: BackendSummary;
   requestedRunMode?: ReviewRunMode;
   reviewerBackend?: AppServerBackendKind;
   reviewerSummary?: BackendSummary;
@@ -54,12 +56,10 @@ export function resolveReviewRunMode(params: {
 }): ReviewRunModeDecision {
   const reviewerBackend = params.reviewerBackend ?? params.thread.source;
   const reviewerLabel = backendLabel(reviewerBackend, params.reviewerSummary);
-  // A missing summary is still loading, not proof that the owner cannot run a
-  // child. Once a summary is present, require the explicit capability probe so
-  // older federation owners and unsupported providers stay gated.
-  const managedChildSupported = params.reviewerSummary
-    ? params.reviewerSummary.capabilities.reviewRunner === true
-    : reviewerBackend === "codex";
+  const explicitRunModeSupported =
+    params.ownerSummary?.capabilities.reviewRunMode === true;
+  const managedChildSupported =
+    params.reviewerSummary?.capabilities.reviewRunner === true;
   const differentProvider = reviewerBackend !== params.thread.source;
 
   let forcedReason: string | undefined;
@@ -74,17 +74,27 @@ export function resolveReviewRunMode(params: {
       `Separate thread is required because ${reviewerLabel} runs reviews as managed child threads.`;
   }
 
-  const unavailableReason = managedChildSupported
+  const unavailableReason = params.reviewerSummary && !managedChildSupported
+    ? `${reviewerLabel} cannot run a managed review in a separate thread.`
+    : undefined;
+  const unsupportedOwnerReason = explicitRunModeSupported || forcedReason
     ? undefined
-    : `${reviewerLabel} cannot run a managed review in a separate thread.`;
-  const helpText = [forcedReason, unavailableReason].filter(Boolean).join(" ")
+    : "This thread's owner does not support choosing a review location. Reviews use the owner's configured default.";
+  const helpText = [
+    forcedReason,
+    unavailableReason,
+    unsupportedOwnerReason,
+  ].filter(Boolean).join(" ")
     || undefined;
   const runMode = forcedReason
     ? "managed-child"
-    : params.requestedRunMode ?? "inline";
+    : explicitRunModeSupported
+      ? params.requestedRunMode ?? "inline"
+      : "inline";
 
   return {
-    controlDisabled: Boolean(forcedReason),
+    controlDisabled: Boolean(forcedReason) || !explicitRunModeSupported,
+    explicitRunModeSupported,
     helpText,
     runMode,
     separateThreadDisabled: !managedChildSupported,

--- a/apps/desktop/src/renderer/src/lib/review-run-mode.ts
+++ b/apps/desktop/src/renderer/src/lib/review-run-mode.ts
@@ -12,7 +12,7 @@ export type ReviewRunModeDecision = {
   explicitRunModeSupported: boolean;
   helpText?: string;
   runMode: ReviewRunMode;
-  separateThreadDisabled: boolean;
+  subagentDisabled: boolean;
 };
 
 function normalizeWorkspacePath(value?: string): string | undefined {
@@ -58,24 +58,24 @@ export function resolveReviewRunMode(params: {
   const reviewerLabel = backendLabel(reviewerBackend, params.reviewerSummary);
   const explicitRunModeSupported =
     params.ownerSummary?.capabilities.reviewRunMode === true;
-  const managedChildSupported =
+  const subagentSupported =
     params.reviewerSummary?.capabilities.reviewRunner === true;
   const differentProvider = reviewerBackend !== params.thread.source;
 
   let forcedReason: string | undefined;
   if (differentProvider) {
     forcedReason =
-      `Separate thread is required because the selected reviewer uses ${reviewerLabel}, a different provider from this thread.`;
+      `A review subagent is required because the selected reviewer uses ${reviewerLabel}, a different provider from this thread.`;
   } else if (usesSecondaryWorkspace(params.thread, params.workspaceCwd)) {
     forcedReason =
-      "Separate thread is required because the selected project is not this thread's primary workspace.";
+      "A review subagent is required because the selected project is not this thread's primary workspace.";
   } else if (params.thread.source.startsWith("acp:")) {
     forcedReason =
-      `Separate thread is required because ${reviewerLabel} runs reviews as managed child threads.`;
+      `A review subagent is required because ${reviewerLabel} runs reviews in a managed subagent.`;
   }
 
-  const unavailableReason = params.reviewerSummary && !managedChildSupported
-    ? `${reviewerLabel} cannot run a managed review in a separate thread.`
+  const unavailableReason = params.reviewerSummary && !subagentSupported
+    ? `${reviewerLabel} cannot run this review in a subagent.`
     : undefined;
   const unsupportedOwnerReason = explicitRunModeSupported || forcedReason
     ? undefined
@@ -97,6 +97,6 @@ export function resolveReviewRunMode(params: {
     explicitRunModeSupported,
     helpText,
     runMode,
-    separateThreadDisabled: !managedChildSupported,
+    subagentDisabled: !subagentSupported,
   };
 }

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -341,6 +341,7 @@ export function useQueuedTurnRelease(params: {
             threadId: releaseThread.id,
             target: reviewCommand.target,
             delivery: "inline",
+            runMode: reviewCommand.runMode ?? "inline",
             ...(reviewCommand.cwd ? { cwd: reviewCommand.cwd } : {}),
             // A reviewer picked when the review was queued replaces the
             // thread's settings wholesale — its model names an entry in

--- a/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
@@ -263,6 +263,7 @@ function projectionFromAction(action: ScheduledThreadAction) {
           reviewCommand: {
             cwd: action.review.cwd,
             displayText: action.displayText,
+            runMode: action.review.runMode,
             target: action.review.target,
             // A scheduled review can also be released client-side, so the
             // picked reviewer has to survive the round trip through this

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -29195,31 +29195,16 @@ button.pricing-token-miser__folded:focus-visible {
   resize: vertical;
 }
 
-.composer__review-location {
-  padding-top: 10px;
-  border-top: 1px solid var(--border-subtle);
-}
-
-.composer__review-location-control {
-  display: flex;
-  width: fit-content;
+.composer__review-location-chip {
   max-width: 100%;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 5px;
 }
 
-.composer__review-location-help {
-  max-width: 560px;
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.35;
+.composer__review-location-chip .composer-dropdown {
+  max-width: 100%;
 }
 
-/* Reviewer override row. Sits below the target detail, above the actions,
-   separated so it reads as "who runs this" rather than another facet of
-   "what to review". */
+/* Reviewer row. Sits below the target detail, above the actions, and carries
+   both who runs the review and the compact location choice. */
 .composer__review-reviewer {
   padding-top: 10px;
   border-top: 1px solid var(--border-subtle);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -29195,6 +29195,28 @@ button.pricing-token-miser__folded:focus-visible {
   resize: vertical;
 }
 
+.composer__review-location {
+  padding-top: 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.composer__review-location-control {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.composer__review-location-help {
+  max-width: 560px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
 /* Reviewer override row. Sits below the target detail, above the actions,
    separated so it reads as "who runs this" rather than another facet of
    "what to review". */

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -288,12 +288,22 @@ export type CancelQueuedTurnResponse = {
   turnId?: string;
 };
 
+export type ReviewRunMode = "inline" | "managed-child";
+
 export type StartReviewRequest = {
   backend: AppServerBackendKind;
   federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   target: AppServerReviewTarget;
   delivery?: AppServerReviewDelivery;
+  /**
+   * Where PwrAgent runs the review. `inline` uses a turn on the reviewed
+   * thread; `managed-child` creates a first-class PwrAgent review child.
+   * Optional for wire compatibility with clients that predate this choice;
+   * owners treat an omitted value as inline unless a provider or workspace
+   * constraint requires a managed child.
+   */
+  runMode?: ReviewRunMode;
   cwd?: string;
   /**
    * Backend that should actually run the review, when the operator overrode it

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -298,7 +298,7 @@ export type StartReviewRequest = {
   delivery?: AppServerReviewDelivery;
   /**
    * Where PwrAgent runs the review. `inline` uses a turn on the reviewed
-   * thread; `managed-child` creates a first-class PwrAgent review child.
+   * thread; `managed-child` uses a disposable PwrAgent review subagent.
    * Optional for wire compatibility with clients that predate this choice;
    * owners treat an omitted value as inline unless a provider or workspace
    * constraint requires a managed child.

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -162,6 +162,12 @@ export type BackendCapabilities = {
    * silently ignore.
    */
   reviewRunner?: boolean;
+  /**
+   * This thread owner understands and honors the explicit `runMode` on a
+   * review-start request. Older federation owners omit this capability and
+   * continue to use their configured review behavior.
+   */
+  reviewRunMode?: boolean;
   interruptTurn: boolean;
   steerTurn: boolean;
   transcriptPagination: boolean;

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -148,6 +148,11 @@ export type BackendCapabilities = {
   startTurn: boolean;
   startReview?: boolean;
   /**
+   * This backend can honor `delivery: "detached"` either through its native
+   * review method or through a managed review child.
+   */
+  startDetachedReview?: boolean;
+  /**
    * This backend can run a PwrAgent-managed review on behalf of a thread that
    * lives on a different provider, so it can be offered as a reviewer
    * override. Doubles as the feature probe for the override itself: an

--- a/packages/shared/src/contracts/scheduled-thread-actions.ts
+++ b/packages/shared/src/contracts/scheduled-thread-actions.ts
@@ -7,7 +7,10 @@ import type {
   ThreadExecutionMode,
   ThreadIdentifier,
 } from "./normalized-app-server";
-import type { AppServerCollaborationModeRequest } from "./agent";
+import type {
+  AppServerCollaborationModeRequest,
+  ReviewRunMode,
+} from "./agent";
 import type { FederationTarget } from "./federation";
 import type {
   NavigationLaunchpadFileAttachment,
@@ -43,6 +46,7 @@ export type ScheduledThreadReviewPayload = {
   target: AppServerReviewTarget;
   draftText?: string;
   delivery?: AppServerReviewDelivery;
+  runMode?: ReviewRunMode;
   cwd?: string;
   /**
    * Reviewer override captured when the review was queued, so releasing it

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -872,8 +872,9 @@ export type DesktopSettingsSnapshot = {
      */
     codexDefaultModeRequestUserInput: DesktopSettingsValue<boolean>;
     /**
-     * Runs reviews as PwrAgent-managed Codex child turns instead of calling
-     * Codex App Server review/start. Disabled by default.
+     * Retained so settings snapshots can round-trip configurations written by
+     * the former global managed-review experiment. Review requests now choose
+     * their run mode explicitly.
      */
     managedReview?: DesktopSettingsValue<boolean>;
     /**


### PR DESCRIPTION
## Summary

- add an explicit Review location choice for inline parent reviews or PwrAgent-managed child reviews
- force and explain managed-child routing for cross-provider, ACP, and secondary-workspace reviews while gating unsupported reviewers
- propagate the explicit run mode through IPC, queued, scheduled, messaging, and Star Map review starts
- retire the global experimental managed-review switch while preserving config round-trip compatibility

## Validation

- 1,650 affected tests passed across 12 complete test files
- pnpm typecheck
- pnpm lint:eslint (0 errors; existing warnings only)
- pnpm lint:boundaries
- pnpm lint:colors
- pnpm build

## Stack

Base: #1869 (fix/inline-review-parent-turn)