### PR TITLE
feat(desktop): expandable provider nav with hub screens in Settings

### DIFF
--- a/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
+++ b/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
@@ -213,6 +213,19 @@ test("settings-models — Settings → AI Providers panel", async () => {
       regionLabel: "Model settings",
     });
 
+    // The provider index populates asynchronously (cached catalog read,
+    // then the mount probe's re-read mutating status chips). Wait for
+    // the discovery placeholder to clear and give the probe the same
+    // settle window the messaging shots use, so regens don't capture a
+    // different intermediate frame each run.
+    await expect(
+      app.window.getByRole("button", { name: "Open Codex settings" }),
+    ).toBeVisible();
+    await expect(
+      app.window.getByText("Discovering AI providers…"),
+    ).toHaveCount(0);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
     await bringToFront(app.electronApp);
     captureNative("settings-models.png");
   } finally {

--- a/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
+++ b/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
@@ -116,9 +116,10 @@ async function openSettingsSection(
   await expect(page.getByRole("button", { name: "Open settings" })).toBeVisible();
   await page.getByRole("button", { name: "Open settings" }).click();
 
+  // Exact, so a group's "Expand <label>" caret toggle doesn't also match.
   const navButton = page
     .getByRole("navigation", { name: "Settings sections" })
-    .getByRole("button", { name: params.navLabel });
+    .getByRole("button", { name: params.navLabel, exact: true });
   await expect(navButton).toBeVisible();
   await navButton.click();
 
@@ -126,26 +127,28 @@ async function openSettingsSection(
 }
 
 /**
- * Scroll the named platform section within Settings → Messaging into
- * the center of the viewport, then capture. Each per-platform section
- * is rendered with a heading containing the platform name (Telegram,
- * Discord, Slack, Mattermost, Feishu / Lark, LINE).
+ * From the Settings → Messaging hub, open the named platform's focused
+ * screen via its index row (Telegram, Discord, Slack, Mattermost,
+ * Feishu / Lark, LINE), then wait for the platform's own pane region.
  */
-async function scrollMessagingPlatformIntoView(
+async function openMessagingPlatformScreen(
   page: Page,
   platformLabel: string,
 ): Promise<void> {
-  const region = page.getByRole("region", { name: "Messaging settings" });
-  await expect(region).toBeVisible();
+  const hub = page.getByRole("region", { name: "Messaging settings" });
+  await expect(hub).toBeVisible();
+  await hub
+    .getByRole("button", { name: `Open ${platformLabel} settings` })
+    .click();
 
-  // The platform header is rendered as a heading within the messaging
-  // section stack. Use a text locator scoped to the region so we
-  // don't catch matches elsewhere on the page.
-  const platformHeading = region.getByText(platformLabel, { exact: true }).first();
-  await platformHeading.waitFor({ state: "visible", timeout: 10_000 });
-  await platformHeading.evaluate((node) => {
-    node.scrollIntoView({ behavior: "instant", block: "center" });
+  const region = page.getByRole("region", {
+    name: `${platformLabel} messaging settings`,
   });
+  await expect(region).toBeVisible();
+  const platformHeading = region
+    .getByRole("heading", { name: platformLabel })
+    .first();
+  await platformHeading.waitFor({ state: "visible", timeout: 10_000 });
   await new Promise((resolve) => setTimeout(resolve, 250));
 }
 
@@ -195,7 +198,7 @@ test("settings-worktrees — Settings → Worktrees panel", async () => {
   }
 });
 
-test("settings-models — Settings → Models panel", async () => {
+test("settings-models — Settings → AI Providers panel", async () => {
   test.setTimeout(120_000);
 
   const app = await launchDocsSiteApp({
@@ -206,7 +209,7 @@ test("settings-models — Settings → Models panel", async () => {
 
   try {
     await openSettingsSection(app.window, {
-      navLabel: "Models",
+      navLabel: "AI Providers",
       regionLabel: "Model settings",
     });
 
@@ -311,17 +314,17 @@ for (const shot of MESSAGING_PLATFORM_SHOTS) {
         regionLabel: "Messaging settings",
       });
 
-      const messagingRegion = app.window.getByRole("region", {
-        name: "Messaging settings",
+      await openMessagingPlatformScreen(app.window, shot.label);
+
+      const platformRegion = app.window.getByRole("region", {
+        name: `${shot.label} messaging settings`,
       });
       await expect(
-        messagingRegion.locator('input[type="password"]:disabled'),
+        platformRegion.locator('input[type="password"]:disabled'),
       ).toHaveCount(0);
       await expect(
-        messagingRegion.getByText(/Secret storage disabled via/i),
+        platformRegion.getByText(/Secret storage disabled via/i),
       ).toHaveCount(0);
-
-      await scrollMessagingPlatformIntoView(app.window, shot.label);
 
       await bringToFront(app.electronApp);
       captureNative(shot.filename);
@@ -354,10 +357,16 @@ async function navigateToTelegramPairing(page: Page): Promise<void> {
 
   const messagingNav = page
     .getByRole("navigation", { name: "Settings sections" })
-    .getByRole("button", { name: "Messaging" });
+    .getByRole("button", { name: "Messaging", exact: true });
   await messagingNav.click();
   await expect(
     page.getByRole("region", { name: "Messaging settings" }),
+  ).toBeVisible();
+
+  // Pairing lives on Telegram's focused screen behind the hub index.
+  await page.getByRole("button", { name: "Open Telegram settings" }).click();
+  await expect(
+    page.getByRole("region", { name: "Telegram messaging settings" }),
   ).toBeVisible();
 
   const pairingTarget = page

--- a/apps/desktop/e2e/readme-screenshots.inspect.spec.ts
+++ b/apps/desktop/e2e/readme-screenshots.inspect.spec.ts
@@ -404,10 +404,11 @@ test("messenger-status — Settings → Messaging surface", async () => {
     ).toBeVisible();
     await app.window.getByRole("button", { name: "Open settings" }).click();
 
-    // Settings nav: click the Messaging row.
+    // Settings nav: click the Messaging row. Exact, so the group's
+    // "Expand Messaging" caret toggle doesn't also match.
     const messagingNav = app.window
       .getByRole("navigation", { name: "Settings sections" })
-      .getByRole("button", { name: "Messaging" });
+      .getByRole("button", { name: "Messaging", exact: true });
     await expect(messagingNav).toBeVisible();
     await messagingNav.click();
 
@@ -440,10 +441,18 @@ async function navigateToTelegramPairing(
 
   const messagingNav = app.window
     .getByRole("navigation", { name: "Settings sections" })
-    .getByRole("button", { name: "Messaging" });
+    .getByRole("button", { name: "Messaging", exact: true });
   await messagingNav.click();
   await expect(
     app.window.getByRole("region", { name: "Messaging settings" }),
+  ).toBeVisible();
+
+  // Pairing lives on Telegram's focused screen behind the hub index.
+  await app.window
+    .getByRole("button", { name: "Open Telegram settings" })
+    .click();
+  await expect(
+    app.window.getByRole("region", { name: "Telegram messaging settings" }),
   ).toBeVisible();
 
   const pairingTarget = app.window

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -55,6 +55,21 @@ function managedGrokBuildsSnapshot(
 }
 
 /**
+ * Settings-screen display order. Gemini CLI sorts last: Google withdrew CLI
+ * access for regular consumer accounts, so the section is unusable for most
+ * operators. Display-only — the IPC/catalog order from listAcpAgents is
+ * unchanged for other consumers.
+ */
+function displayOrderedEntries(
+  entries: AcpAgentSettingsEntry[],
+): AcpAgentSettingsEntry[] {
+  return [
+    ...entries.filter((entry) => entry.registryId !== "gemini"),
+    ...entries.filter((entry) => entry.registryId === "gemini"),
+  ];
+}
+
+/**
  * Renders each discovered ACP agent (Gemini / Grok / Kimi / Qwen) as its own
  * `SettingsSection`, styled identically to the Codex section (SettingsField
  * rows + the shared SettingsPathRow install list). Returns a FRAGMENT — no
@@ -133,7 +148,7 @@ export function AcpAgentsSettings(props: {
 
   return (
     <>
-      {entries.map((entry) => (
+      {displayOrderedEntries(entries).map((entry) => (
         <Fragment key={entry.backendId}>
           {entry.registryId === "kimi"
           && entry.incompatibleInstances?.length ? (

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -11,6 +11,10 @@ import { SettingsCopyValue } from "./SettingsCopyValue";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
 import { SettingsSwitch } from "./SettingsSwitch";
 import { acpStatusLabel } from "./acp-agent-copy";
+import {
+  acpAgentEnabledInSnapshot,
+  displayOrderedAcpEntries,
+} from "./useAcpAgentCatalog";
 
 const KIMI_CODE_INSTALL_GUIDE_URL =
   "https://www.kimi.com/help/kimi-code/cli-getting-started";
@@ -37,36 +41,10 @@ function cliPathSnapshotFor(
   return agents?.[registryId]?.cliPath;
 }
 
-/** Whether an agent is enabled per the snapshot (defaults to enabled). */
-function enabledSnapshotFor(
-  snapshot: DesktopSettingsSnapshot | undefined,
-  registryId: string,
-): boolean {
-  const agents = snapshot?.acpAgents as
-    | Record<string, { enabled?: boolean } | undefined>
-    | undefined;
-  return agents?.[registryId]?.enabled !== false;
-}
-
 function managedGrokBuildsSnapshot(
   snapshot: DesktopSettingsSnapshot | undefined,
 ): boolean {
   return snapshot?.acpAgents.grok?.managedBuilds !== false;
-}
-
-/**
- * Settings-screen display order. Gemini CLI sorts last: Google withdrew CLI
- * access for regular consumer accounts, so the section is unusable for most
- * operators. Display-only — the IPC/catalog order from listAcpAgents is
- * unchanged for other consumers.
- */
-function displayOrderedEntries(
-  entries: AcpAgentSettingsEntry[],
-): AcpAgentSettingsEntry[] {
-  return [
-    ...entries.filter((entry) => entry.registryId !== "gemini"),
-    ...entries.filter((entry) => entry.registryId === "gemini"),
-  ];
 }
 
 /**
@@ -79,6 +57,9 @@ function displayOrderedEntries(
 export function AcpAgentsSettings(props: {
   catalogRefreshing?: boolean;
   desktopApi?: DesktopApi;
+  /** Render only the agent with this registry id — the focused
+   *  per-provider screen. Omitted = every discovered agent. */
+  only?: string;
   saving?: boolean;
   snapshot?: DesktopSettingsSnapshot;
   /** Persist a per-agent CLI-path override (also used to "pin" a discovered
@@ -146,9 +127,13 @@ export function AcpAgentsSettings(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
 
+  const visibleEntries = props.only
+    ? entries.filter((entry) => entry.registryId === props.only)
+    : displayOrderedAcpEntries(entries);
+
   return (
     <>
-      {displayOrderedEntries(entries).map((entry) => (
+      {visibleEntries.map((entry) => (
         <Fragment key={entry.backendId}>
           {entry.registryId === "kimi"
           && entry.incompatibleInstances?.length ? (
@@ -160,7 +145,7 @@ export function AcpAgentsSettings(props: {
           <AcpAgentSection
             entry={entry}
             cliPathSnapshot={cliPathSnapshotFor(props.snapshot, entry.registryId)}
-            enabled={enabledSnapshotFor(props.snapshot, entry.registryId)}
+            enabled={acpAgentEnabledInSnapshot(props.snapshot, entry.registryId)}
             managedGrokBuilds={managedGrokBuildsSnapshot(props.snapshot)}
             saving={props.saving}
             refreshing={refreshing || loading || props.catalogRefreshing}
@@ -174,7 +159,7 @@ export function AcpAgentsSettings(props: {
                     if (!saved) {
                       return { saved: false };
                     }
-                    if (!enabledSnapshotFor(props.snapshot, registryId)) {
+                    if (!acpAgentEnabledInSnapshot(props.snapshot, registryId)) {
                       return { saved: true, verification: "deferred" };
                     }
                     return {
@@ -192,14 +177,17 @@ export function AcpAgentsSettings(props: {
           />
         </Fragment>
       ))}
-      {!loading && entries.length === 0 ? (
+      {!loading && visibleEntries.length === 0 ? (
         <SettingsSection
           eyebrow="Models"
           title="AI providers"
           sectionId="acp-unavailable"
         >
           <p className="settings-empty">
-            {error ?? "No AI providers are available right now."}
+            {error
+              ?? (props.only
+                ? "This provider is unavailable right now."
+                : "No AI providers are available right now.")}
           </p>
         </SettingsSection>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -55,7 +55,9 @@ import {
 } from "../../lib/slack-pairing-approval";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
+  SettingsContextStrip,
   SettingsField,
+  SettingsIndexRow,
   SettingsPanelHead,
   SettingsSection,
   SettingsSectionStack,
@@ -77,8 +79,33 @@ import {
   sourceBadge,
 } from "./settings-fields";
 
+/** The six platforms that have a focused Settings screen. */
+export type MessagingSettingsFocus =
+  | "telegram"
+  | "discord"
+  | "mattermost"
+  | "slack"
+  | "feishu"
+  | "line";
+
+const MESSAGING_PLATFORM_LABELS: Record<MessagingSettingsFocus, string> = {
+  telegram: "Telegram",
+  discord: "Discord",
+  mattermost: "Mattermost",
+  slack: "Slack",
+  feishu: "Feishu / Lark",
+  line: "LINE",
+};
+
 export function MessagingSettings(props: {
   desktopApi?: DesktopApi;
+  /**
+   * Focused platform screen. Undefined renders the messaging hub —
+   * general defaults, routes, and the platform index.
+   */
+  focus?: MessagingSettingsFocus;
+  /** Navigate between the hub (undefined) and a focused platform screen. */
+  onFocusChange?: (focus?: MessagingSettingsFocus) => void;
   onOpenThread?: (target: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -222,6 +249,9 @@ export function MessagingSettings(props: {
   const configuredRoutePlatforms = configuredMessagingRoutePlatforms(
     props.snapshot,
   );
+  const focusedPlatformLabel = props.focus
+    ? MESSAGING_PLATFORM_LABELS[props.focus]
+    : undefined;
 
   const previewToolUpdateBindingReset = async (
     targetKind: "thread" | "agent_thread",
@@ -287,12 +317,41 @@ export function MessagingSettings(props: {
 
   return (
     <MessagingRoutesProvider desktopApi={props.desktopApi}>
-      <SettingsSectionStack paneId="messaging" aria-label="Messaging settings">
-      <SettingsPanelHead
-        eyebrow="Messaging"
-        title="Connected chat platforms"
-        help="Bridge PwrAgent threads to messaging platforms so you can drive runs from your phone. Tokens are stored in the system keychain. Authorization defaults closed: if no allowed IDs are configured, inbound messages are discarded but logged in Messaging Activity so you can copy IDs into the allowlist."
-      />
+      <SettingsSectionStack
+        paneId={props.focus ? `messaging-${props.focus}` : "messaging"}
+        aria-label={
+          focusedPlatformLabel
+            ? `${focusedPlatformLabel} messaging settings`
+            : "Messaging settings"
+        }
+      >
+      {focusedPlatformLabel ? (
+        <SettingsPanelHead
+          eyebrow="Messaging"
+          title={focusedPlatformLabel}
+          help={`Adapter switch, tokens, pairing, and access controls for the ${focusedPlatformLabel} bridge.`}
+        />
+      ) : (
+        <SettingsPanelHead
+          eyebrow="Messaging"
+          title="Connected chat platforms"
+          help="Bridge PwrAgent threads to messaging platforms so you can drive runs from your phone. Tokens are stored in the system keychain. Authorization defaults closed: if no allowed IDs are configured, inbound messages are discarded but logged in Messaging Activity so you can copy IDs into the allowlist."
+        />
+      )}
+
+      {focusedPlatformLabel ? (
+        <SettingsContextStrip
+          actionLabel="Edit general"
+          eyebrow="Messaging"
+          items={[
+            masterEnabled ? "Messaging on" : "Messaging off",
+            `${toolUpdateModeLabel(toolUpdateMode.value)} thread updates`,
+            `${inputDebounceMs.value} ms debounce`,
+          ]}
+          label="General"
+          onAction={() => props.onFocusChange?.(undefined)}
+        />
+      ) : null}
 
       {runtimeMessaging.overrideActive && runtimeMessaging.disabled ? (
         <section className="settings-panel settings-panel--warning" role="status">
@@ -308,6 +367,7 @@ export function MessagingSettings(props: {
         </section>
       ) : null}
 
+      {!props.focus ? (
       <SettingsSection eyebrow="Messaging" title="General">
         <div className="settings-fields">
           <ToggleField
@@ -509,14 +569,86 @@ export function MessagingSettings(props: {
           ) : null}
         </div>
       </SettingsSection>
+      ) : null}
 
-      <MessagingRoutesSettings
-        agentRouteToolUpdateMode={managerToolUpdateMode.value}
-        configuredPlatforms={configuredRoutePlatforms}
-        desktopApi={props.desktopApi}
-        onOpenThread={props.onOpenThread}
-      />
+      {!props.focus ? (
+        <MessagingRoutesSettings
+          agentRouteToolUpdateMode={managerToolUpdateMode.value}
+          configuredPlatforms={configuredRoutePlatforms}
+          desktopApi={props.desktopApi}
+          onOpenThread={props.onOpenThread}
+        />
+      ) : null}
 
+      {!props.focus ? (
+        <SettingsSection
+          eyebrow="Messaging"
+          title="Platforms"
+          sectionId="platform-index"
+          description="Each platform has its own screen for tokens, pairing, and access controls."
+        >
+          <div className="settings-index" aria-label="Platform index">
+            <SettingsIndexRow
+              glyph={<TelegramIcon size={16} variant="color" />}
+              name="Telegram"
+              meta={telegram.enabled.value ? "Adapter enabled" : "Adapter off"}
+              chip={chipLabelForBotToken(telegram.botToken)}
+              chipKind={chipKindForBotToken(telegram.botToken)}
+              off={!telegram.enabled.value}
+              onOpen={() => props.onFocusChange?.("telegram")}
+            />
+            <SettingsIndexRow
+              glyph={<DiscordIcon size={16} variant="white" />}
+              name="Discord"
+              meta={discord.enabled.value ? "Adapter enabled" : "Adapter off"}
+              chip={chipLabelForBotToken(discord.botToken)}
+              chipKind={chipKindForBotToken(discord.botToken)}
+              off={!discord.enabled.value}
+              onOpen={() => props.onFocusChange?.("discord")}
+            />
+            <SettingsIndexRow
+              glyph={<MattermostIcon size={16} />}
+              name="Mattermost"
+              meta={
+                mattermost.enabled.value ? "Adapter enabled" : "Adapter off"
+              }
+              chip={chipLabelForBotToken(mattermost.botToken)}
+              chipKind={chipKindForBotToken(mattermost.botToken)}
+              off={!mattermost.enabled.value}
+              onOpen={() => props.onFocusChange?.("mattermost")}
+            />
+            <SettingsIndexRow
+              glyph={<SlackIcon size={16} />}
+              name="Slack"
+              meta={slack.enabled.value ? "Adapter enabled" : "Adapter off"}
+              chip={chipLabelForBotToken(slack.botToken)}
+              chipKind={chipKindForBotToken(slack.botToken)}
+              off={!slack.enabled.value}
+              onOpen={() => props.onFocusChange?.("slack")}
+            />
+            <SettingsIndexRow
+              glyph={<FeishuIcon size={16} />}
+              name="Feishu / Lark"
+              meta={feishu.enabled.value ? "Adapter enabled" : "Adapter off"}
+              chip={chipLabelForBotToken(feishu.appSecret)}
+              chipKind={chipKindForBotToken(feishu.appSecret)}
+              off={!feishu.enabled.value}
+              onOpen={() => props.onFocusChange?.("feishu")}
+            />
+            <SettingsIndexRow
+              glyph={<LineIcon size={16} />}
+              name="LINE"
+              meta={line.enabled.value ? "Adapter enabled" : "Adapter off"}
+              chip={chipLabelForBotToken(line.channelAccessToken)}
+              chipKind={chipKindForBotToken(line.channelAccessToken)}
+              off={!line.enabled.value}
+              onOpen={() => props.onFocusChange?.("line")}
+            />
+          </div>
+        </SettingsSection>
+      ) : null}
+
+      {props.focus === "telegram" ? (
       <SettingsSection
         eyebrow="Messaging"
         title="Telegram"
@@ -657,7 +789,9 @@ export function MessagingSettings(props: {
           />
         </div>
       </SettingsSection>
+      ) : null}
 
+      {props.focus === "discord" ? (
       <SettingsSection
         eyebrow="Messaging"
         title="Discord"
@@ -795,7 +929,9 @@ export function MessagingSettings(props: {
           />
         </div>
       </SettingsSection>
+      ) : null}
 
+      {props.focus === "mattermost" ? (
       <SettingsSection
         eyebrow="Messaging"
         title="Mattermost"
@@ -1034,7 +1170,9 @@ export function MessagingSettings(props: {
           />
         </div>
       </SettingsSection>
+      ) : null}
 
+      {props.focus === "slack" ? (
       <SettingsSection
         eyebrow="Messaging"
         title="Slack"
@@ -1419,7 +1557,9 @@ export function MessagingSettings(props: {
           />
         </div>
       </SettingsSection>
+      ) : null}
 
+      {props.focus === "feishu" ? (
       <SettingsSection
         eyebrow="Messaging"
         title="Feishu / Lark"
@@ -1682,7 +1822,9 @@ export function MessagingSettings(props: {
           />
         </div>
       </SettingsSection>
+      ) : null}
 
+      {props.focus === "line" ? (
       <SettingsSection
         eyebrow="Messaging"
         title="LINE"
@@ -1862,6 +2004,7 @@ export function MessagingSettings(props: {
           />
         </div>
       </SettingsSection>
+      ) : null}
       </SettingsSectionStack>
     </MessagingRoutesProvider>
   );

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -48,6 +48,7 @@ import {
 } from "@pwragent/shared";
 import { DiscordIcon, FeishuIcon, LineIcon, MattermostIcon, SlackIcon, TelegramIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
+import { formatMessagingPlatformName } from "../../lib/messaging-platform-branding";
 import {
   SLACK_APPROVAL_TARGET_LABELS,
   slackApplicableApprovalTargets,
@@ -88,14 +89,17 @@ export type MessagingSettingsFocus =
   | "feishu"
   | "line";
 
-const MESSAGING_PLATFORM_LABELS: Record<MessagingSettingsFocus, string> = {
-  telegram: "Telegram",
-  discord: "Discord",
-  mattermost: "Mattermost",
-  slack: "Slack",
-  feishu: "Feishu / Lark",
-  line: "LINE",
-};
+/** Settings-order list of the focused-screen platforms. The nav and
+ *  the hub index both derive from this, and labels come from
+ *  `formatMessagingPlatformName`, so the surfaces can never drift. */
+export const MESSAGING_SETTINGS_PLATFORMS: readonly MessagingSettingsFocus[] = [
+  "telegram",
+  "discord",
+  "mattermost",
+  "slack",
+  "feishu",
+  "line",
+];
 
 export function MessagingSettings(props: {
   desktopApi?: DesktopApi;
@@ -250,8 +254,55 @@ export function MessagingSettings(props: {
     props.snapshot,
   );
   const focusedPlatformLabel = props.focus
-    ? MESSAGING_PLATFORM_LABELS[props.focus]
+    ? formatMessagingPlatformName(props.focus)
     : undefined;
+  // Hub index descriptors — the one place a platform's glyph and
+  // credential secret are chosen. Discord uses the blurple mark: the
+  // brand-kit white variant disappears against the light theme's
+  // panel-elevated glyph backdrop.
+  const platformIndex: Array<{
+    kind: MessagingSettingsFocus;
+    glyph: ReactNode;
+    enabled: boolean;
+    secret: DesktopSettingsSnapshot["messaging"]["telegram"]["botToken"];
+  }> = [
+    {
+      kind: "telegram",
+      glyph: <TelegramIcon size={16} variant="color" />,
+      enabled: telegram.enabled.value,
+      secret: telegram.botToken,
+    },
+    {
+      kind: "discord",
+      glyph: <DiscordIcon size={16} variant="blurple" />,
+      enabled: discord.enabled.value,
+      secret: discord.botToken,
+    },
+    {
+      kind: "mattermost",
+      glyph: <MattermostIcon size={16} />,
+      enabled: mattermost.enabled.value,
+      secret: mattermost.botToken,
+    },
+    {
+      kind: "slack",
+      glyph: <SlackIcon size={16} />,
+      enabled: slack.enabled.value,
+      secret: slack.botToken,
+    },
+    {
+      kind: "feishu",
+      glyph: <FeishuIcon size={16} />,
+      enabled: feishu.enabled.value,
+      secret: feishu.appSecret,
+    },
+    {
+      kind: "line",
+      glyph: <LineIcon size={16} />,
+      enabled: line.enabled.value,
+      secret: line.channelAccessToken,
+    },
+  ];
 
   const previewToolUpdateBindingReset = async (
     targetKind: "thread" | "agent_thread",
@@ -364,6 +415,49 @@ export function MessagingSettings(props: {
           <p className="settings-row__description">
             {runtimeWarningBody}
           </p>
+        </section>
+      ) : null}
+
+      {/* Armed by the per-platform streaming toggles on the focused
+          screens, so it must render on every messaging pane — hub and
+          focused alike — or the offer is invisible where it was earned. */}
+      {streamingNudgeProvider ? (
+        <section
+          className="settings-panel settings-panel--warning"
+          role="status"
+        >
+          <div className="settings-panel__header">
+            <div>
+              <p className="eyebrow">Streaming enabled</p>
+              <h2>Show the streaming option on thread cards?</h2>
+            </div>
+          </div>
+          <p className="settings-row__description">
+            You turned on streaming for {streamingNudgeProvider}. Show the
+            per-thread streaming toggle in chat status cards and the New
+            Thread menu so you can pick it per thread? It stays an advanced
+            option — most people leave it off.
+          </p>
+          <div className="settings-inline-actions">
+            <button
+              className="button button--secondary"
+              disabled={props.saving}
+              onClick={() => {
+                setStreamingNudgeProvider(null);
+                void props.onShowStreamingOptionChange(true);
+              }}
+              type="button"
+            >
+              Show it on thread cards
+            </button>
+            <button
+              className="button button--ghost"
+              onClick={() => setStreamingNudgeProvider(null)}
+              type="button"
+            >
+              Not now
+            </button>
+          </div>
         </section>
       ) : null}
 
@@ -528,45 +622,6 @@ export function MessagingSettings(props: {
               void props.onShowStreamingOptionChange(enabled);
             }}
           />
-          {streamingNudgeProvider ? (
-            <section
-              className="settings-panel settings-panel--warning"
-              role="status"
-            >
-              <div className="settings-panel__header">
-                <div>
-                  <p className="eyebrow">Streaming enabled</p>
-                  <h2>Show the streaming option on thread cards?</h2>
-                </div>
-              </div>
-              <p className="settings-row__description">
-                You turned on streaming for {streamingNudgeProvider}. Show the
-                per-thread streaming toggle in chat status cards and the New
-                Thread menu so you can pick it per thread? It stays an advanced
-                option — most people leave it off.
-              </p>
-              <div className="settings-inline-actions">
-                <button
-                  className="button button--secondary"
-                  disabled={props.saving}
-                  onClick={() => {
-                    setStreamingNudgeProvider(null);
-                    void props.onShowStreamingOptionChange(true);
-                  }}
-                  type="button"
-                >
-                  Show it on thread cards
-                </button>
-                <button
-                  className="button button--ghost"
-                  onClick={() => setStreamingNudgeProvider(null)}
-                  type="button"
-                >
-                  Not now
-                </button>
-              </div>
-            </section>
-          ) : null}
         </div>
       </SettingsSection>
       ) : null}
@@ -588,62 +643,18 @@ export function MessagingSettings(props: {
           description="Each platform has its own screen for tokens, pairing, and access controls."
         >
           <div className="settings-index" aria-label="Platform index">
-            <SettingsIndexRow
-              glyph={<TelegramIcon size={16} variant="color" />}
-              name="Telegram"
-              meta={telegram.enabled.value ? "Adapter enabled" : "Adapter off"}
-              chip={chipLabelForBotToken(telegram.botToken)}
-              chipKind={chipKindForBotToken(telegram.botToken)}
-              off={!telegram.enabled.value}
-              onOpen={() => props.onFocusChange?.("telegram")}
-            />
-            <SettingsIndexRow
-              glyph={<DiscordIcon size={16} variant="white" />}
-              name="Discord"
-              meta={discord.enabled.value ? "Adapter enabled" : "Adapter off"}
-              chip={chipLabelForBotToken(discord.botToken)}
-              chipKind={chipKindForBotToken(discord.botToken)}
-              off={!discord.enabled.value}
-              onOpen={() => props.onFocusChange?.("discord")}
-            />
-            <SettingsIndexRow
-              glyph={<MattermostIcon size={16} />}
-              name="Mattermost"
-              meta={
-                mattermost.enabled.value ? "Adapter enabled" : "Adapter off"
-              }
-              chip={chipLabelForBotToken(mattermost.botToken)}
-              chipKind={chipKindForBotToken(mattermost.botToken)}
-              off={!mattermost.enabled.value}
-              onOpen={() => props.onFocusChange?.("mattermost")}
-            />
-            <SettingsIndexRow
-              glyph={<SlackIcon size={16} />}
-              name="Slack"
-              meta={slack.enabled.value ? "Adapter enabled" : "Adapter off"}
-              chip={chipLabelForBotToken(slack.botToken)}
-              chipKind={chipKindForBotToken(slack.botToken)}
-              off={!slack.enabled.value}
-              onOpen={() => props.onFocusChange?.("slack")}
-            />
-            <SettingsIndexRow
-              glyph={<FeishuIcon size={16} />}
-              name="Feishu / Lark"
-              meta={feishu.enabled.value ? "Adapter enabled" : "Adapter off"}
-              chip={chipLabelForBotToken(feishu.appSecret)}
-              chipKind={chipKindForBotToken(feishu.appSecret)}
-              off={!feishu.enabled.value}
-              onOpen={() => props.onFocusChange?.("feishu")}
-            />
-            <SettingsIndexRow
-              glyph={<LineIcon size={16} />}
-              name="LINE"
-              meta={line.enabled.value ? "Adapter enabled" : "Adapter off"}
-              chip={chipLabelForBotToken(line.channelAccessToken)}
-              chipKind={chipKindForBotToken(line.channelAccessToken)}
-              off={!line.enabled.value}
-              onOpen={() => props.onFocusChange?.("line")}
-            />
+            {platformIndex.map((platform) => (
+              <SettingsIndexRow
+                key={platform.kind}
+                glyph={platform.glyph}
+                name={formatMessagingPlatformName(platform.kind)}
+                meta={platform.enabled ? "Adapter enabled" : "Adapter off"}
+                chip={chipLabelForBotToken(platform.secret)}
+                chipKind={chipKindForBotToken(platform.secret)}
+                off={!platform.enabled}
+                onOpen={() => props.onFocusChange?.(platform.kind)}
+              />
+            ))}
           </div>
         </SettingsSection>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -177,11 +177,13 @@ export function ModelsSettings(props: {
     }
     setRefreshingCatalog(true);
     try {
+      let acpRegistryRefreshed = false;
       if (force && props.desktopApi.listAcpAgents) {
         await props.desktopApi.listAcpAgents({
           refresh: true,
           force: true,
         });
+        acpRegistryRefreshed = true;
       }
       const response = await props.desktopApi.listBackends({
         includeUnavailable: true,
@@ -189,6 +191,12 @@ export function ModelsSettings(props: {
       });
       setBackends(response.backends);
       setCatalogError(undefined);
+      if (acpRegistryRefreshed) {
+        // Announce the registry refresh so every catalog consumer (the
+        // hub index, the nav sub-items, other panes) re-reads — the
+        // catalog has no push channel of its own.
+        window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+      }
     } catch (error) {
       setCatalogError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -226,10 +234,11 @@ export function ModelsSettings(props: {
   };
 
   // Names and status for the hub index + focused-screen titles. The
-  // registry probe runs from the hub; focused ACP screens probe via
-  // their own AcpAgentsSettings mount.
+  // registry probe runs from the hub and the Codex screen (which mounts
+  // no AcpAgentsSettings); focused ACP screens probe via their own
+  // AcpAgentsSettings mount.
   const acpCatalog = useAcpAgentCatalog(props.desktopApi, {
-    probe: props.focus === undefined,
+    probe: props.focus === undefined || props.focus === "codex",
   });
   const orderedAcpEntries = displayOrderedAcpEntries(acpCatalog.entries);
   const focusedAcpEntry =
@@ -413,6 +422,7 @@ export function ModelsSettings(props: {
           backends={backends}
           codexFastAllowed={props.snapshot.models.codex.allowFast?.value ?? true}
           defaults={props.snapshot.models.providerDefaults ?? {}}
+          error={catalogError}
           onEditDefaults={editDefaults}
         />
         {codexSection}
@@ -435,6 +445,7 @@ export function ModelsSettings(props: {
           backendKind={focusedAcpEntry?.backendId}
           backends={backends}
           defaults={props.snapshot.models.providerDefaults ?? {}}
+          error={catalogError}
           onEditDefaults={editDefaults}
         />
         <AcpAgentsSettings
@@ -493,20 +504,40 @@ export function ModelsSettings(props: {
               props.snapshot,
               entry.registryId,
             );
+            // Only a legacy CLI on disk: the operator must act, and the
+            // remediation card lives on the focused screen — the hub
+            // chip is their only hint anything is wrong.
+            const legacyOnly =
+              !entry.installed && Boolean(entry.incompatibleInstances?.length);
             return (
               <SettingsIndexRow
                 key={entry.registryId}
                 name={entry.name}
                 meta={entry.version ? `v${entry.version}` : undefined}
                 chip={enabled ? acpStatusLabel(entry) : "Disabled"}
-                chipKind={enabled ? (entry.installed ? "ok" : "muted") : "muted"}
+                chipKind={
+                  enabled
+                    ? entry.installed
+                      ? "ok"
+                      : legacyOnly
+                        ? "warn"
+                        : "muted"
+                    : "muted"
+                }
                 off={!enabled}
                 onOpen={() => props.onFocusChange?.(entry.registryId)}
               />
             );
           })}
           {orderedAcpEntries.length === 0 ? (
-            <p className="settings-empty">Discovering AI providers…</p>
+            <p className="settings-empty">
+              {acpCatalog.unavailable
+                ? "ACP registry controls are unavailable in this build."
+                : acpCatalog.error
+                  ?? (acpCatalog.loaded
+                    ? "No AI providers are available right now."
+                    : "Discovering AI providers…")}
+            </p>
           ) : null}
         </div>
       </SettingsSection>
@@ -526,6 +557,9 @@ function ProviderDefaultsStrip(props: {
   /** Codex only: surface the Fast-mode master switch state. */
   codexFastAllowed?: boolean;
   defaults: Record<string, DesktopProviderModelDefaults>;
+  /** Model-catalog load failure — without it the strip silently falls
+   *  back to "Catalog default model" as if nothing went wrong. */
+  error?: string;
   onEditDefaults: () => void;
 }) {
   const backend = props.backends.find(
@@ -550,13 +584,20 @@ function ProviderDefaultsStrip(props: {
     items.push(props.codexFastAllowed ? "Fast mode allowed" : "Fast mode off");
   }
   return (
-    <SettingsContextStrip
-      actionLabel="Edit defaults"
-      eyebrow="Defaults"
-      items={items}
-      label="New thread defaults"
-      onAction={props.onEditDefaults}
-    />
+    <>
+      <SettingsContextStrip
+        actionLabel="Edit defaults"
+        eyebrow="Defaults"
+        items={items}
+        label="New thread defaults"
+        onAction={props.onEditDefaults}
+      />
+      {props.error ? (
+        <p className="settings-row__error" role="alert">
+          Last refresh failed: {props.error}
+        </p>
+      ) : null}
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { isValidatedDiscoveryCandidate } from "@pwragent/shared";
 import type {
   BackendModelOption,
@@ -13,7 +13,9 @@ import type {
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import {
+  SettingsContextStrip,
   SettingsField,
+  SettingsIndexRow,
   SettingsPanelHead,
   SettingsSection,
   SettingsSectionStack,
@@ -29,6 +31,12 @@ import {
   CodexAuthProfileLoginButton,
 } from "./CodexAuthProfileSelect";
 import { AcpAgentsSettings } from "./AcpAgentsSettings";
+import { acpStatusLabel } from "./acp-agent-copy";
+import {
+  acpAgentEnabledInSnapshot,
+  displayOrderedAcpEntries,
+  useAcpAgentCatalog,
+} from "./useAcpAgentCatalog";
 import { SettingsSwitch } from "./SettingsSwitch";
 import {
   commandDiscoveryFailureDetail,
@@ -83,6 +91,11 @@ function migrationMatchesSelection(
 export function ModelsSettings(props: {
   cachedBackends?: BackendSummary[];
   desktopApi?: DesktopApi;
+  /** Focused provider screen: "codex" or an ACP registry id. Omitted =
+   *  the AI Providers hub (new-thread defaults + provider index). */
+  focus?: string;
+  /** Route within AI Providers — undefined returns to the hub. */
+  onFocusChange?: (focus?: string) => void;
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
   onClearSecret: (secret: DesktopSettingsSecretName) => Promise<boolean>;
@@ -212,29 +225,20 @@ export function ModelsSettings(props: {
     void props.onSaveCodexPath(path.trim());
   };
 
-  return (
-    <SettingsSectionStack paneId="models" aria-label="Model settings">
-      <SettingsPanelHead
-        eyebrow="Models"
-        title="AI providers"
-        help="Choose profile-wide model baselines, inspect discovered models, and configure provider credentials."
-      />
+  // Names and status for the hub index + focused-screen titles. The
+  // registry probe runs from the hub; focused ACP screens probe via
+  // their own AcpAgentsSettings mount.
+  const acpCatalog = useAcpAgentCatalog(props.desktopApi, {
+    probe: props.focus === undefined,
+  });
+  const orderedAcpEntries = displayOrderedAcpEntries(acpCatalog.entries);
+  const focusedAcpEntry =
+    props.focus && props.focus !== "codex"
+      ? acpCatalog.entries.find((entry) => entry.registryId === props.focus)
+      : undefined;
+  const editDefaults = (): void => props.onFocusChange?.(undefined);
 
-      <ProviderModelDefaultsSettings
-        backends={backends}
-        desktopApi={props.desktopApi}
-        defaults={props.snapshot.models.providerDefaults ?? {}}
-        migrations={props.snapshot.models.providerThreadMigrations ?? {}}
-        codexFastAllowed={props.snapshot.models.codex.allowFast?.value ?? true}
-        error={catalogError}
-        refreshing={refreshingCatalog}
-        saving={props.saving}
-        onRefresh={() => refreshCatalog(true, true)}
-        onSave={props.onSaveProviderDefaults}
-        onSaveMigrations={props.onSaveProviderThreadMigrations}
-        onSaveCodexFastAllowed={props.onSaveCodexFastAllowed}
-      />
-
+  const codexSection = (
       <SettingsSection eyebrow="Models" title="Codex">
         <div className="settings-fields">
           <SettingsField
@@ -391,17 +395,168 @@ export function ModelsSettings(props: {
           />
         </div>
       </SettingsSection>
+  );
 
-      <AcpAgentsSettings
-        catalogRefreshing={refreshingCatalog}
-        desktopApi={props.desktopApi}
-        saving={props.saving}
-        snapshot={props.snapshot}
-        onCliPathChange={props.onAcpCliPathChange}
-        onEnabledChange={props.onAcpEnabledChange}
-        onManagedGrokBuildsChange={props.onManagedGrokBuildsChange}
+  if (props.focus === "codex") {
+    return (
+      <SettingsSectionStack
+        paneId="models-codex"
+        aria-label="Codex provider settings"
+      >
+        <SettingsPanelHead
+          eyebrow="AI Providers"
+          title="Codex"
+          help="Binary path, auth profile, and connection checks for the Codex CLI behind OpenAI threads."
+        />
+        <ProviderDefaultsStrip
+          backendKind="codex"
+          backends={backends}
+          codexFastAllowed={props.snapshot.models.codex.allowFast?.value ?? true}
+          defaults={props.snapshot.models.providerDefaults ?? {}}
+          onEditDefaults={editDefaults}
+        />
+        {codexSection}
+      </SettingsSectionStack>
+    );
+  }
+
+  if (props.focus) {
+    return (
+      <SettingsSectionStack
+        paneId={`models-${props.focus}`}
+        aria-label={`${focusedAcpEntry?.name ?? "Provider"} settings`}
+      >
+        <SettingsPanelHead
+          eyebrow="AI Providers"
+          title={focusedAcpEntry?.name ?? "Provider"}
+          help="Install status, detected binaries, and discovery for this agent."
+        />
+        <ProviderDefaultsStrip
+          backendKind={focusedAcpEntry?.backendId}
+          backends={backends}
+          defaults={props.snapshot.models.providerDefaults ?? {}}
+          onEditDefaults={editDefaults}
+        />
+        <AcpAgentsSettings
+          catalogRefreshing={refreshingCatalog}
+          desktopApi={props.desktopApi}
+          only={props.focus}
+          saving={props.saving}
+          snapshot={props.snapshot}
+          onCliPathChange={props.onAcpCliPathChange}
+          onEnabledChange={props.onAcpEnabledChange}
+          onManagedGrokBuildsChange={props.onManagedGrokBuildsChange}
+        />
+      </SettingsSectionStack>
+    );
+  }
+
+  return (
+    <SettingsSectionStack paneId="models" aria-label="Model settings">
+      <SettingsPanelHead
+        eyebrow="Models"
+        title="AI providers"
+        help="Choose profile-wide model baselines, inspect discovered models, and configure provider credentials."
       />
+
+      <ProviderModelDefaultsSettings
+        backends={backends}
+        desktopApi={props.desktopApi}
+        defaults={props.snapshot.models.providerDefaults ?? {}}
+        migrations={props.snapshot.models.providerThreadMigrations ?? {}}
+        codexFastAllowed={props.snapshot.models.codex.allowFast?.value ?? true}
+        error={catalogError}
+        refreshing={refreshingCatalog}
+        saving={props.saving}
+        onRefresh={() => refreshCatalog(true, true)}
+        onSave={props.onSaveProviderDefaults}
+        onSaveMigrations={props.onSaveProviderThreadMigrations}
+        onSaveCodexFastAllowed={props.onSaveCodexFastAllowed}
+      />
+
+      <SettingsSection
+        eyebrow="Models"
+        title="Providers"
+        sectionId="provider-index"
+        description="Each provider has its own screen for paths, auth, and connection checks."
+      >
+        <div className="settings-index" aria-label="Provider index">
+          <SettingsIndexRow
+            name="Codex"
+            meta={codex.discovery.selectedCommand ?? "No executable selected"}
+            chip={codex.discovery.selectedCommand ? "Discovered" : "Not found"}
+            chipKind={codex.discovery.selectedCommand ? "ok" : "muted"}
+            onOpen={() => props.onFocusChange?.("codex")}
+          />
+          {orderedAcpEntries.map((entry) => {
+            const enabled = acpAgentEnabledInSnapshot(
+              props.snapshot,
+              entry.registryId,
+            );
+            return (
+              <SettingsIndexRow
+                key={entry.registryId}
+                name={entry.name}
+                meta={entry.version ? `v${entry.version}` : undefined}
+                chip={enabled ? acpStatusLabel(entry) : "Disabled"}
+                chipKind={enabled ? (entry.installed ? "ok" : "muted") : "muted"}
+                off={!enabled}
+                onOpen={() => props.onFocusChange?.(entry.registryId)}
+              />
+            );
+          })}
+          {orderedAcpEntries.length === 0 ? (
+            <p className="settings-empty">Discovering AI providers…</p>
+          ) : null}
+        </div>
+      </SettingsSection>
     </SettingsSectionStack>
+  );
+}
+
+/**
+ * Defaults cross-link strip for focused provider screens. Editing a
+ * provider's paths must not strand the operator away from the model
+ * defaults, so each screen leads with the hub's current answer for
+ * this provider and one action back to the full editor.
+ */
+function ProviderDefaultsStrip(props: {
+  backendKind?: string;
+  backends: BackendSummary[];
+  /** Codex only: surface the Fast-mode master switch state. */
+  codexFastAllowed?: boolean;
+  defaults: Record<string, DesktopProviderModelDefaults>;
+  onEditDefaults: () => void;
+}) {
+  const backend = props.backends.find(
+    (candidate) => candidate.kind === props.backendKind,
+  );
+  const providerDefaults = props.backendKind
+    ? props.defaults[props.backendKind]
+    : undefined;
+  const model = providerDefaults?.model;
+  const modelLabel = model
+    ? backend?.launchpadOptions?.models?.find((option) => option.id === model)
+      ?.label ?? model
+    : "Catalog default model";
+  const effort = model
+    ? providerDefaults?.reasoningEffortsByModel?.[model]
+    : undefined;
+  const items: ReactNode[] = [modelLabel];
+  if (effort) {
+    items.push(`${effort} effort`);
+  }
+  if (props.codexFastAllowed !== undefined) {
+    items.push(props.codexFastAllowed ? "Fast mode allowed" : "Fast mode off");
+  }
+  return (
+    <SettingsContextStrip
+      actionLabel="Edit defaults"
+      eyebrow="Defaults"
+      items={items}
+      label="New thread defaults"
+      onAction={props.onEditDefaults}
+    />
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -92,6 +92,21 @@ export function SettingsSectionStack(props: {
     Record<string, boolean>
   >(() => savedCollapsedSectionsByPane.get(props.paneId) ?? {});
   const didRestoreFocusRef = useRef(false);
+  const stackRef = useRef<HTMLElement | null>(null);
+  const paneChangedRef = useRef(false);
+  const [seededPaneId, setSeededPaneId] = useState(props.paneId);
+  if (seededPaneId !== props.paneId) {
+    // The stack instance survives hub↔focused pane swaps (same component
+    // type at the same tree position), so per-pane state must be
+    // re-seeded by hand: the initializer read the saved map for the old
+    // pane, and carrying that state over would restore nothing for the
+    // new pane and save the old pane's map under the new id.
+    setSeededPaneId(props.paneId);
+    setCollapsedSections(savedCollapsedSectionsByPane.get(props.paneId) ?? {});
+    setRegisteredSections([]);
+    didRestoreFocusRef.current = false;
+    paneChangedRef.current = true;
+  }
 
   const updateCollapsedSections = useCallback(
     (
@@ -186,14 +201,23 @@ export function SettingsSectionStack(props: {
       return;
     }
     didRestoreFocusRef.current = true;
+    const paneChanged = paneChangedRef.current;
+    paneChangedRef.current = false;
     const visitedSectionId = savedVisitedSectionByPane.get(props.paneId);
-    if (!visitedSectionId) {
+    const visitedSection = visitedSectionId
+      ? registeredSections.find((section) => section.id === visitedSectionId)
+      : undefined;
+    if (visitedSection) {
+      visitedSection.element.focus();
       return;
     }
-    const visitedSection = registeredSections.find(
-      (section) => section.id === visitedSectionId,
-    );
-    visitedSection?.element.focus();
+    // A pane swap unmounts the control that had focus (an index row, a
+    // strip action, a breadcrumb crumb); without a programmatic target
+    // the browser drops focus to <body> and Tab restarts at the top of
+    // the overlay. Land on the pane itself instead.
+    if (paneChanged && document.activeElement === document.body) {
+      stackRef.current?.focus();
+    }
   }, [props.paneId, registeredSections]);
 
   const value = useMemo<SettingsSectionPaneContextValue>(
@@ -225,7 +249,12 @@ export function SettingsSectionStack(props: {
 
   return (
     <SettingsSectionPaneContext.Provider value={value}>
-      <section className="settings-stack" aria-label={props["aria-label"]}>
+      <section
+        ref={stackRef}
+        className="settings-stack"
+        aria-label={props["aria-label"]}
+        tabIndex={-1}
+      >
         {props.children}
       </section>
     </SettingsSectionPaneContext.Provider>
@@ -633,8 +662,17 @@ export function SettingsIndexRow(props: {
   off?: boolean;
   onOpen: () => void;
 }) {
+  // The aria-label wins the accname computation, which silences the
+  // meta and chip text inside the button — re-expose them as the
+  // button's description instead of stuffing them into the label.
+  const descriptionId = useId();
+  const metaId = props.meta ? `${descriptionId}-meta` : undefined;
+  const chipId = props.chip ? `${descriptionId}-chip` : undefined;
+  const describedBy =
+    [metaId, chipId].filter(Boolean).join(" ") || undefined;
   return (
     <button
+      aria-describedby={describedBy}
       aria-label={`Open ${props.name} settings`}
       className={`settings-index__row${props.off ? " is-off" : ""}`}
       type="button"
@@ -648,11 +686,13 @@ export function SettingsIndexRow(props: {
       <span className="settings-index__main">
         <span className="settings-index__name">{props.name}</span>
         {props.meta ? (
-          <span className="settings-index__meta">{props.meta}</span>
+          <span id={metaId} className="settings-index__meta">
+            {props.meta}
+          </span>
         ) : null}
       </span>
       {props.chip ? (
-        <span className={settingsChipClassName(props.chipKind)}>
+        <span id={chipId} className={settingsChipClassName(props.chipKind)}>
           {props.chip}
         </span>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -41,6 +41,12 @@ import {
  */
 export type SettingsChipTone = "default" | "muted" | "ok" | "err" | "warn";
 
+function settingsChipClassName(kind?: SettingsChipTone): string {
+  return kind && kind !== "default" && kind !== "muted"
+    ? `settings-card__chip settings-card__chip--${kind}`
+    : "settings-card__chip";
+}
+
 type SettingsSectionRegistration = {
   element: HTMLElement;
   id: string;
@@ -306,10 +312,7 @@ export function SettingsSection(props: {
   const bodyId = `settings-section-${sectionId}-body`;
   const collapsed = pane?.collapsedSections[sectionId] === true;
 
-  const chipClass =
-    props.chipKind && props.chipKind !== "default" && props.chipKind !== "muted"
-      ? `settings-card__chip settings-card__chip--${props.chipKind}`
-      : "settings-card__chip";
+  const chipClass = settingsChipClassName(props.chipKind);
 
   useLayoutEffect(() => {
     const element = headerRef.current;
@@ -456,10 +459,7 @@ export function SettingsSectionGroup(props: {
   const headingId = `settings-group-${props.groupId}-heading`;
   const bodyId = `settings-group-${props.groupId}-body`;
 
-  const chipClass =
-    props.chipKind && props.chipKind !== "default" && props.chipKind !== "muted"
-      ? `settings-card__chip settings-card__chip--${props.chipKind}`
-      : "settings-card__chip";
+  const chipClass = settingsChipClassName(props.chipKind);
 
   const toggle = () => {
     setCollapsed((current) => {
@@ -574,6 +574,92 @@ export function SettingsField(props: {
         ) : null}
       </div>
     </div>
+  );
+}
+
+/**
+ * Compact cross-link strip shown at the top of a focused sub-screen
+ * (per-provider, per-platform). Summarizes the parent hub's key state
+ * — "New thread defaults" on a provider screen, "Messaging general"
+ * on a platform screen — with one action back to the hub, so editing
+ * a provider never strands the operator away from the defaults.
+ */
+export function SettingsContextStrip(props: {
+  /** Tiny uppercase kicker, e.g. "Defaults" / "General". */
+  eyebrow: string;
+  /** Name of the summarized hub surface, e.g. "New thread defaults". */
+  label: string;
+  /** Summary chips (current model, effort, master switch state, …). */
+  items: ReactNode[];
+  actionLabel: string;
+  onAction: () => void;
+}) {
+  return (
+    <div aria-label={`${props.label} summary`} className="settings-strip" role="note">
+      <span className="settings-strip__eyebrow">{props.eyebrow}</span>
+      <span className="settings-strip__label">{props.label}</span>
+      <span className="settings-strip__meta">
+        {props.items.map((item, index) => (
+          <span key={index} className="settings-strip__chip">
+            {item}
+          </span>
+        ))}
+      </span>
+      <button
+        className="button button--ghost settings-strip__action"
+        type="button"
+        onClick={props.onAction}
+      >
+        {props.actionLabel}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * One row of a hub index (AI Providers → provider list, Messaging →
+ * platform list). The whole row is the button that opens the entry's
+ * focused screen.
+ */
+export function SettingsIndexRow(props: {
+  name: string;
+  /** Optional leading mark (platform icon). */
+  glyph?: ReactNode;
+  /** Mono detail under the name (active path, version, adapter state). */
+  meta?: ReactNode;
+  chip?: ReactNode;
+  chipKind?: SettingsChipTone;
+  /** Renders the name muted — the entry is switched off. */
+  off?: boolean;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      aria-label={`Open ${props.name} settings`}
+      className={`settings-index__row${props.off ? " is-off" : ""}`}
+      type="button"
+      onClick={props.onOpen}
+    >
+      {props.glyph ? (
+        <span aria-hidden="true" className="settings-index__glyph">
+          {props.glyph}
+        </span>
+      ) : null}
+      <span className="settings-index__main">
+        <span className="settings-index__name">{props.name}</span>
+        {props.meta ? (
+          <span className="settings-index__meta">{props.meta}</span>
+        ) : null}
+      </span>
+      {props.chip ? (
+        <span className={settingsChipClassName(props.chipKind)}>
+          {props.chip}
+        </span>
+      ) : null}
+      <span aria-hidden="true" className="settings-index__open">
+        Configure ›
+      </span>
+    </button>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -20,7 +20,12 @@ import { ExperimentalSettings } from "./ExperimentalSettings";
 import { FederationSettings } from "./FederationSettings";
 import { GeneralSettings } from "./GeneralSettings";
 import { GitSettings } from "./GitSettings";
-import { MessagingSettings } from "./MessagingSettings";
+import {
+  MESSAGING_SETTINGS_PLATFORMS,
+  MessagingSettings,
+  type MessagingSettingsFocus,
+} from "./MessagingSettings";
+import { formatMessagingPlatformName } from "../../lib/messaging-platform-branding";
 import { ModelsSettings } from "./ModelsSettings";
 import { ProfilesSettings } from "./ProfilesSettings";
 import { PricingSettings } from "./PricingSettings";
@@ -111,36 +116,10 @@ const SETTINGS_NAV_GROUPS = new Set<SettingsSection>([
   "messaging",
 ]);
 
-/** The platforms the desktop Settings screen configures — the keys of
- *  the messaging settings snapshot, a subset of MessagingChannelKind. */
-type MessagingNavPlatformKind =
-  | "telegram"
-  | "discord"
-  | "mattermost"
-  | "slack"
-  | "feishu"
-  | "line";
-
-/** Messaging platforms in Settings → Messaging section order. Labels
- *  mirror the platform SettingsSection titles so the nav, the hub
- *  index, and the focused screen all name a platform identically. */
-const MESSAGING_NAV_PLATFORMS: Array<{
-  kind: MessagingNavPlatformKind;
-  label: string;
-}> = [
-  { kind: "telegram", label: "Telegram" },
-  { kind: "discord", label: "Discord" },
-  { kind: "mattermost", label: "Mattermost" },
-  { kind: "slack", label: "Slack" },
-  { kind: "feishu", label: "Feishu / Lark" },
-  { kind: "line", label: "LINE" },
-];
-
 function messagingPlatformFromSub(
   sub: string | undefined,
-): MessagingNavPlatformKind | undefined {
-  return MESSAGING_NAV_PLATFORMS.find((platform) => platform.kind === sub)
-    ?.kind;
+): MessagingSettingsFocus | undefined {
+  return MESSAGING_SETTINGS_PLATFORMS.find((platform) => platform === sub);
 }
 
 type SettingsNavChild = {
@@ -338,12 +317,12 @@ export function SettingsScreen(props: {
       ];
     }
     if (target === "messaging") {
-      return MESSAGING_NAV_PLATFORMS.map((platform) => ({
-        key: platform.kind,
-        label: platform.label,
-        sub: platform.kind,
+      return MESSAGING_SETTINGS_PLATFORMS.map((platform) => ({
+        key: platform,
+        label: formatMessagingPlatformName(platform),
+        sub: platform,
         dot: snapshot
-          ? snapshot.messaging[platform.kind].enabled.value
+          ? snapshot.messaging[platform].enabled.value
             ? "ok"
             : "off"
           : undefined,
@@ -351,14 +330,11 @@ export function SettingsScreen(props: {
     }
     return [];
   };
+  // Crumb label from the same catalog the nav renders. An unknown sub
+  // gets no crumb rather than leaking the raw route id into the
+  // breadcrumb.
   const activeSubLabel = route.sub
-    ? section === "models"
-      ? route.sub === "codex"
-        ? "Codex"
-        : acpCatalog.entries.find((entry) => entry.registryId === route.sub)
-          ?.name ?? route.sub
-      : MESSAGING_NAV_PLATFORMS.find((platform) => platform.kind === route.sub)
-        ?.label ?? route.sub
+    ? navChildren(section).find((child) => child.sub === route.sub)?.label
     : undefined;
   // Platform-chip clicks in the title-bar strip route to the top-level
   // Messaging Activity overlay (NOT a settings section). The App-level
@@ -407,15 +383,22 @@ export function SettingsScreen(props: {
           // Plugins keeps its long-standing contract: the MCPs child —
           // the pane's whole content — carries the active state, not
           // the parent row.
+          const groupHoldsRoute = section === item.id;
           const parentActive =
-            section === item.id
+            groupHoldsRoute
             && route.sub === undefined
             && item.id !== "plugins";
+          // A collapsed group hides its aria-current child inside an
+          // aria-hidden, inert sublist, so the parent row takes over
+          // the marker — the nav must always show where the operator
+          // is (this also covers collapsed Plugins).
+          const parentMarksRoute =
+            parentActive || (isGroup && !open && groupHoldsRoute);
           const children = isGroup ? navChildren(item.id) : [];
           return (
             <Fragment key={item.id}>
               <div
-                className={`settings-nav__row${parentActive ? " is-active" : ""}`}
+                className={`settings-nav__row${parentMarksRoute ? " is-active" : ""}`}
               >
                 {isGroup ? (
                   <button
@@ -438,8 +421,8 @@ export function SettingsScreen(props: {
                   />
                 )}
                 <button
-                  aria-current={parentActive ? "page" : undefined}
-                  className={`settings-nav__button${parentActive ? " is-active" : ""}`}
+                  aria-current={parentMarksRoute ? "page" : undefined}
+                  className={`settings-nav__button${parentMarksRoute ? " is-active" : ""}`}
                   type="button"
                   onClick={() => openRoute(item.id)}
                 >

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -40,7 +40,19 @@ import {
   buildSlackPatchDelta,
   buildTelegramPatchDelta,
 } from "./settings-patch-delta";
-import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import {
+  acpAgentEnabledInSnapshot,
+  displayOrderedAcpEntries,
+  useAcpAgentCatalog,
+} from "./useAcpAgentCatalog";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 export type SettingsSection =
   | "general"
@@ -92,6 +104,57 @@ const PRIMARY_SECTIONS: SettingsSection[] = [
 
 const SETTINGS_NAV_DIVIDER_AFTER: SettingsSection = "federation";
 
+/** Sections whose nav row expands into a sub-list (thread-list caret). */
+const SETTINGS_NAV_GROUPS = new Set<SettingsSection>([
+  "plugins",
+  "models",
+  "messaging",
+]);
+
+/** The platforms the desktop Settings screen configures — the keys of
+ *  the messaging settings snapshot, a subset of MessagingChannelKind. */
+type MessagingNavPlatformKind =
+  | "telegram"
+  | "discord"
+  | "mattermost"
+  | "slack"
+  | "feishu"
+  | "line";
+
+/** Messaging platforms in Settings → Messaging section order. Labels
+ *  mirror the platform SettingsSection titles so the nav, the hub
+ *  index, and the focused screen all name a platform identically. */
+const MESSAGING_NAV_PLATFORMS: Array<{
+  kind: MessagingNavPlatformKind;
+  label: string;
+}> = [
+  { kind: "telegram", label: "Telegram" },
+  { kind: "discord", label: "Discord" },
+  { kind: "mattermost", label: "Mattermost" },
+  { kind: "slack", label: "Slack" },
+  { kind: "feishu", label: "Feishu / Lark" },
+  { kind: "line", label: "LINE" },
+];
+
+function messagingPlatformFromSub(
+  sub: string | undefined,
+): MessagingNavPlatformKind | undefined {
+  return MESSAGING_NAV_PLATFORMS.find((platform) => platform.kind === sub)
+    ?.kind;
+}
+
+type SettingsNavChild = {
+  key: string;
+  label: string;
+  /** Sub-route id; undefined = the child re-targets the parent section
+   *  (Plugins → MCPs, which IS the plugins pane). */
+  sub?: string;
+  /** Status dot tone; omitted when the snapshot can't say. */
+  dot?: "ok" | "off";
+  /** Tiny trailing chip, e.g. "off" on a disabled provider. */
+  chip?: string;
+};
+
 const SECTION_LABELS = new Map(
   SECTIONS.map((section) => [section.id, section.label] as const),
 );
@@ -126,6 +189,10 @@ export function SettingsScreen(props: {
   settings: DesktopSettingsState;
   /** Initial section to render. Defaults to Applications. */
   initialSection?: SettingsSection;
+  /** Optional sub-screen within the initial section (a provider's
+   *  registry id under "models", a platform kind under "messaging").
+   *  Ignored without `initialSection`. */
+  initialSubsection?: string;
   onClose?: () => void;
   onOpenThread?: (target: {
     backend: AppServerBackendKind;
@@ -137,14 +204,67 @@ export function SettingsScreen(props: {
    *  Messaging Activity overlay (its own top-level mainView). */
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
 }) {
-  const [section, setSection] = useState<SettingsSection>(
-    props.initialSection ?? "general",
+  const [route, setRoute] = useState<{
+    section: SettingsSection;
+    sub?: string;
+  }>(() => ({
+    section: props.initialSection ?? "general",
+    sub: props.initialSection ? props.initialSubsection : undefined,
+  }));
+  const section = route.section;
+  // Which nav groups are expanded. Groups open collapsed except the
+  // one holding the initial route — an active section hidden behind a
+  // closed caret would read as a dead nav.
+  const [openGroups, setOpenGroups] = useState<
+    Partial<Record<SettingsSection, boolean>>
+  >(() => {
+    const initial = props.initialSection ?? "general";
+    return SETTINGS_NAV_GROUPS.has(initial) ? { [initial]: true } : {};
+  });
+  const expandGroup = useCallback((target: SettingsSection) => {
+    if (!SETTINGS_NAV_GROUPS.has(target)) {
+      return;
+    }
+    setOpenGroups((current) =>
+      current[target] === true ? current : { ...current, [target]: true },
+    );
+  }, []);
+  const toggleGroup = useCallback((target: SettingsSection) => {
+    setOpenGroups((current) => ({
+      ...current,
+      [target]: current[target] !== true,
+    }));
+  }, []);
+  // Navigating always expands the destination group; only the caret
+  // collapses one. Clicking a parent label therefore both routes to
+  // the hub screen and reveals its children.
+  const openRoute = useCallback(
+    (target: SettingsSection, sub?: string) => {
+      setRoute((current) =>
+        current.section === target && current.sub === sub
+          ? current
+          : { section: target, sub },
+      );
+      expandGroup(target);
+    },
+    [expandGroup],
   );
   // When the parent re-mounts with a different initialSection (e.g.
   // a future deep-link), follow it.
   useEffect(() => {
-    if (props.initialSection) setSection(props.initialSection);
-  }, [props.initialSection]);
+    if (props.initialSection) {
+      openRoute(props.initialSection, props.initialSubsection);
+    }
+  }, [openRoute, props.initialSection, props.initialSubsection]);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // Reset the pane scroll on every route change. Runs in a layout
+  // effect so the stack's own visited-section focus restore (a plain
+  // effect) can still win afterwards by scrolling its header into view.
+  useLayoutEffect(() => {
+    if (contentRef.current) {
+      contentRef.current.scrollTop = 0;
+    }
+  }, [route.section, route.sub]);
   const scrollClampFrameRef = useRef<number | undefined>(undefined);
   useEffect(() => {
     const clampDocumentScroll = () => {
@@ -186,6 +306,60 @@ export function SettingsScreen(props: {
   const snapshot = props.settings.snapshot;
   const activeSectionLabel =
     SECTIONS.find((entry) => entry.id === section)?.label ?? "Settings";
+  // Cached catalog read only — the nav never triggers agent probes.
+  // The AI Providers screens own refreshing; this re-reads on their
+  // BACKEND_SUMMARIES_REFRESH_EVENT announcements.
+  const acpCatalog = useAcpAgentCatalog(props.desktopApi);
+  const navChildren = (target: SettingsSection): SettingsNavChild[] => {
+    if (target === "plugins") {
+      return [{ key: "mcps", label: "MCPs" }];
+    }
+    if (target === "models") {
+      const codexConfigured = Boolean(
+        snapshot?.models.codex.discovery.selectedCommand,
+      );
+      return [
+        {
+          key: "codex",
+          label: "Codex",
+          sub: "codex",
+          dot: snapshot ? (codexConfigured ? "ok" : "off") : undefined,
+        },
+        ...displayOrderedAcpEntries(acpCatalog.entries).map((entry) => {
+          const enabled = acpAgentEnabledInSnapshot(snapshot, entry.registryId);
+          return {
+            key: entry.registryId,
+            label: entry.name,
+            sub: entry.registryId,
+            dot: (enabled && entry.installed ? "ok" : "off") as "ok" | "off",
+            ...(enabled ? {} : { chip: "off" }),
+          };
+        }),
+      ];
+    }
+    if (target === "messaging") {
+      return MESSAGING_NAV_PLATFORMS.map((platform) => ({
+        key: platform.kind,
+        label: platform.label,
+        sub: platform.kind,
+        dot: snapshot
+          ? snapshot.messaging[platform.kind].enabled.value
+            ? "ok"
+            : "off"
+          : undefined,
+      }));
+    }
+    return [];
+  };
+  const activeSubLabel = route.sub
+    ? section === "models"
+      ? route.sub === "codex"
+        ? "Codex"
+        : acpCatalog.entries.find((entry) => entry.registryId === route.sub)
+          ?.name ?? route.sub
+      : MESSAGING_NAV_PLATFORMS.find((platform) => platform.kind === route.sub)
+        ?.label ?? route.sub
+    : undefined;
   // Platform-chip clicks in the title-bar strip route to the top-level
   // Messaging Activity overlay (NOT a settings section). The App-level
   // handler swaps mainView for us; no internal state change here.
@@ -226,37 +400,99 @@ export function SettingsScreen(props: {
         {/* Group label between Exit and the section list. */}
         <p className="settings-nav__group-label">General</p>
 
-        {ORDERED_SECTIONS.map((item) => (
-          <Fragment key={item.id}>
-            <button
-              aria-current={
-                section === item.id && item.id !== "plugins"
-                  ? "page"
-                  : undefined
-              }
-              className={`settings-nav__button${section === item.id ? " is-active" : ""}`}
-              type="button"
-              onClick={() => setSection(item.id)}
-            >
-              {item.label}
-            </button>
-            {item.id === "plugins" ? (
-              <button
-                aria-current={section === "plugins" ? "page" : undefined}
-                className={`settings-nav__subbutton${
-                  section === "plugins" ? " is-active" : ""
-                }`}
-                type="button"
-                onClick={() => setSection("plugins")}
+        {ORDERED_SECTIONS.map((item) => {
+          const isGroup = SETTINGS_NAV_GROUPS.has(item.id);
+          const open = openGroups[item.id] === true;
+          const sublistId = `settings-nav-sublist-${item.id}`;
+          // Plugins keeps its long-standing contract: the MCPs child —
+          // the pane's whole content — carries the active state, not
+          // the parent row.
+          const parentActive =
+            section === item.id
+            && route.sub === undefined
+            && item.id !== "plugins";
+          const children = isGroup ? navChildren(item.id) : [];
+          return (
+            <Fragment key={item.id}>
+              <div
+                className={`settings-nav__row${parentActive ? " is-active" : ""}`}
               >
-                MCPs
-              </button>
-            ) : null}
-            {item.id === SETTINGS_NAV_DIVIDER_AFTER ? (
-              <hr className="settings-nav__divider" />
-            ) : null}
-          </Fragment>
-        ))}
+                {isGroup ? (
+                  <button
+                    aria-controls={sublistId}
+                    aria-expanded={open}
+                    aria-label={`${open ? "Collapse" : "Expand"} ${item.label}`}
+                    className="settings-nav__caret"
+                    type="button"
+                    onClick={() => toggleGroup(item.id)}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`settings-nav__caret-mark${open ? " is-open" : ""}`}
+                    />
+                  </button>
+                ) : (
+                  <span
+                    aria-hidden="true"
+                    className="settings-nav__caret-spacer"
+                  />
+                )}
+                <button
+                  aria-current={parentActive ? "page" : undefined}
+                  className={`settings-nav__button${parentActive ? " is-active" : ""}`}
+                  type="button"
+                  onClick={() => openRoute(item.id)}
+                >
+                  {item.label}
+                </button>
+              </div>
+              {isGroup ? (
+                <div
+                  aria-hidden={!open}
+                  className={`settings-nav__sublist${open ? " is-open" : ""}`}
+                  id={sublistId}
+                  inert={open ? undefined : true}
+                >
+                  <div className="settings-nav__sublist-clip">
+                    {children.map((child) => {
+                      const childActive =
+                        section === item.id && route.sub === child.sub;
+                      return (
+                        <button
+                          key={child.key}
+                          aria-current={childActive ? "page" : undefined}
+                          className={`settings-nav__subbutton${
+                            childActive ? " is-active" : ""
+                          }`}
+                          type="button"
+                          onClick={() => openRoute(item.id, child.sub)}
+                        >
+                          {child.dot ? (
+                            <span
+                              aria-hidden="true"
+                              className={`settings-nav__subdot settings-nav__subdot--${child.dot}`}
+                            />
+                          ) : null}
+                          <span className="settings-nav__sublabel">
+                            {child.label}
+                          </span>
+                          {child.chip ? (
+                            <span className="settings-nav__subchip">
+                              {child.chip}
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              {item.id === SETTINGS_NAV_DIVIDER_AFTER ? (
+                <hr className="settings-nav__divider" />
+              ) : null}
+            </Fragment>
+          );
+        })}
       </nav>
 
       {/* Right pane — its own header (breadcrumb + MessagingStatusBar)
@@ -271,22 +507,46 @@ export function SettingsScreen(props: {
             <span aria-hidden="true" className="settings-titlebar__separator">
               ›
             </span>
-            <span
-              className="settings-titlebar__current"
-              title={activeSectionLabel}
-            >
-              {activeSectionLabel}
-            </span>
+            {route.sub && activeSubLabel ? (
+              <>
+                <button
+                  className="settings-titlebar__crumb"
+                  type="button"
+                  onClick={() => openRoute(section)}
+                >
+                  {activeSectionLabel}
+                </button>
+                <span
+                  aria-hidden="true"
+                  className="settings-titlebar__separator"
+                >
+                  ›
+                </span>
+                <span
+                  className="settings-titlebar__current"
+                  title={activeSubLabel}
+                >
+                  {activeSubLabel}
+                </span>
+              </>
+            ) : (
+              <span
+                className="settings-titlebar__current"
+                title={activeSectionLabel}
+              >
+                {activeSectionLabel}
+              </span>
+            )}
           </div>
           <div className="settings-titlebar__spacer" />
           <MessagingStatusBar
             desktopApi={props.desktopApi}
             onOpenActivity={onOpenActivity}
-            onOpenSettings={() => setSection("messaging")}
+            onOpenSettings={() => openRoute("messaging")}
           />
         </header>
 
-        <div className="settings-content">
+        <div className="settings-content" ref={contentRef}>
           {props.settings.loading && !snapshot ? (
             <p className="settings-empty">Loading settings...</p>
           ) : props.settings.error && !snapshot ? (
@@ -329,12 +589,14 @@ export function SettingsScreen(props: {
               appearanceController={props.appearanceController}
               cachedBackends={props.cachedBackends}
               desktopApi={props.desktopApi}
+              onOpenRoute={openRoute}
               onOpenThread={props.onOpenThread}
               onShowNotice={props.onShowNotice}
               profiles={props.profiles}
               section={section}
               settings={props.settings}
               snapshot={snapshot}
+              sub={route.sub}
             />
           ) : (
             <p className="settings-empty">Settings are unavailable.</p>
@@ -352,6 +614,7 @@ function SettingsSectionBody(props: {
   appearanceController?: AppearanceController;
   cachedBackends?: BackendSummary[];
   desktopApi?: DesktopApi;
+  onOpenRoute: (section: SettingsSection, sub?: string) => void;
   onOpenThread?: (target: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -361,6 +624,7 @@ function SettingsSectionBody(props: {
   section: SettingsSection;
   settings: DesktopSettingsState;
   snapshot: DesktopSettingsSnapshot;
+  sub?: string;
 }) {
   if (props.section === "about") {
     return <AboutSettings desktopApi={props.desktopApi} />;
@@ -574,6 +838,8 @@ function SettingsSectionBody(props: {
     return (
       <MessagingSettings
         desktopApi={props.desktopApi}
+        focus={messagingPlatformFromSub(props.sub)}
+        onFocusChange={(focus) => props.onOpenRoute("messaging", focus)}
         onOpenThread={props.onOpenThread}
         saving={props.settings.saving}
         snapshot={props.snapshot}
@@ -858,6 +1124,8 @@ function SettingsSectionBody(props: {
     <ModelsSettings
       cachedBackends={props.cachedBackends}
       desktopApi={props.desktopApi}
+      focus={props.sub}
+      onFocusChange={(focus) => props.onOpenRoute("models", focus)}
       saving={props.settings.saving}
       snapshot={props.snapshot}
       onClearSecret={props.settings.clearSecret}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -800,4 +800,19 @@ describe("AcpAgentsSettings", () => {
       ),
     ).not.toBeInTheDocument();
   });
+
+  it("renders Gemini CLI last even though the catalog lists it first", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [geminiEntry(), grokEntry()],
+    }));
+
+    render(<AcpAgentsSettings desktopApi={{ listAcpAgents } as DesktopApi} />);
+
+    await screen.findByText("Gemini CLI");
+    const headings = screen
+      .getAllByRole("heading", { level: 2 })
+      .map((heading) => heading.textContent);
+    expect(headings).toEqual(["Grok", "Gemini CLI"]);
+  });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -591,6 +591,42 @@ describe("AcpAgentsSettings", () => {
     expect(screen.getByText("Not installed.")).toBeInTheDocument();
   });
 
+  it("renders only the requested agent on a focused provider screen", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [grokEntry(), geminiEntry()],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        only="gemini"
+      />,
+    );
+
+    expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
+    expect(screen.queryByText("Grok")).not.toBeInTheDocument();
+  });
+
+  it("says the provider is unavailable when the focused agent is missing", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [grokEntry()],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        only="qwen"
+      />,
+    );
+
+    expect(
+      await screen.findByText("This provider is unavailable right now."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Grok")).not.toBeInTheDocument();
+  });
+
   it("surfaces a detected CLI that failed ACP verification", async () => {
     const rejectedPath = "/usr/local/bin/qwen";
     const desktopApi = {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1315,6 +1315,13 @@ describe("SettingsScreen", () => {
         },
       });
     });
+    // Turning on a provider's streaming arms the thread-card nudge, and
+    // the panel renders on the focused screen where it was earned — it
+    // used to render only inside the hub's General section, which the
+    // focused screens never show.
+    expect(
+      screen.getByRole("button", { name: "Show it on thread cards" }),
+    ).toBeInTheDocument();
     // The focused screen's General strip leads back to the hub.
     fireEvent.click(screen.getByRole("button", { name: "Edit general" }));
     fireEvent.click(screen.getByRole("button", { name: "Open Slack settings" }));
@@ -1335,6 +1342,44 @@ describe("SettingsScreen", () => {
         },
       });
     });
+    // Slack's streaming toggle carries its own label (no "(Advanced)"
+    // suffix) and writes a Slack-scoped delta.
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Streaming responses" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          slack: {
+            streamingResponses: true,
+          },
+        },
+      });
+    });
+    // Discord, Mattermost, and Feishu each carry the advanced streaming
+    // toggle on their focused screens and write per-platform deltas.
+    for (const [platform, label] of [
+      ["discord", "Discord"],
+      ["mattermost", "Mattermost"],
+      ["feishu", "Feishu / Lark"],
+    ] as const) {
+      fireEvent.click(screen.getByRole("button", { name: "Edit general" }));
+      fireEvent.click(
+        screen.getByRole("button", { name: `Open ${label} settings` }),
+      );
+      fireEvent.click(
+        screen.getByRole("switch", { name: "Streaming Responses (Advanced)" }),
+      );
+      await waitFor(() => {
+        expect(settings.writeConfig).toHaveBeenCalledWith({
+          messaging: {
+            [platform]: {
+              streamingResponses: true,
+            },
+          },
+        });
+      });
+    }
     // LINE has no message-edit API, so its screen deliberately has no
     // streaming toggle.
     fireEvent.click(screen.getByRole("button", { name: "Edit general" }));
@@ -2387,8 +2432,9 @@ describe("SettingsScreen", () => {
     );
 
     // Providers live under the "AI Providers" pane (no separate "ACP
-    // Agents" nav item). The hub's index always lists Codex, and holds
-    // the discovery empty state until ACP agents arrive.
+    // Agents" nav item). The hub's index always lists Codex, and once
+    // the catalog read settles with no agents it reports the settled
+    // empty state — not the transient "Discovering…" copy.
     expect(
       screen.getByRole("button", { name: "AI Providers" }),
     ).toHaveAttribute("aria-current", "page");
@@ -2399,8 +2445,11 @@ describe("SettingsScreen", () => {
       screen.getByRole("button", { name: "Open Codex settings" }),
     ).toBeInTheDocument();
     expect(
-      await screen.findByText("Discovering AI providers…"),
+      await screen.findByText("No AI providers are available right now."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Discovering AI providers…"),
+    ).not.toBeInTheDocument();
   });
 
   it("saves defaults and confirms launchpad, thread, and Fast bulk actions", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -626,8 +626,13 @@ describe("SettingsScreen", () => {
         refreshModels: true,
       });
     });
-    await waitFor(() => expect(listAcpAgents).toHaveBeenCalledTimes(2));
-    expect(screen.getByLabelText("Grok manual path")).toBeDisabled();
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true });
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Open Grok settings" }),
+    );
+    expect(await screen.findByLabelText("Grok manual path")).toBeDisabled();
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     expect(
       within(screen.getByLabelText("Grok installs")).getByRole("button", {
@@ -677,6 +682,7 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         initialSection="models"
+        initialSubsection="codex"
         settings={createSettingsState(snapshot)}
         onClose={() => undefined}
       />,
@@ -697,6 +703,7 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         initialSection="models"
+        initialSubsection="codex"
         settings={settings}
         onClose={() => undefined}
       />,
@@ -1283,11 +1290,34 @@ describe("SettingsScreen", () => {
         },
       });
     });
-    expect(screen.getByRole("heading", { name: "Telegram" })).toBeInTheDocument();
+    // Platforms live behind the hub's index now — each opens a focused
+    // screen with the platform's full section.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Telegram settings" }),
+    );
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Telegram" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Authorized Groups / Supergroups")).toBeInTheDocument();
     expect(
       screen.getByRole("radio", { name: "Group/supergroup chat" }),
     ).toBeInTheDocument();
+    expect(screen.getAllByText("unset").length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Streaming Responses (Advanced)" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          telegram: {
+            streamingResponses: true,
+          },
+        },
+      });
+    });
+    // The focused screen's General strip leads back to the hub.
+    fireEvent.click(screen.getByRole("button", { name: "Edit general" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Slack settings" }));
     expect(
       screen.getByText(
         "Shows Working Updates in one Slack task card per turn when Slack stream APIs are available; otherwise uses text updates.",
@@ -1305,27 +1335,19 @@ describe("SettingsScreen", () => {
         },
       });
     });
-    // Five providers expose a streaming toggle; LINE has no message-edit API so
-    // it deliberately has none.
-    expect(screen.getAllByText(/does not make turns finish sooner/)).toHaveLength(5);
-    expect(screen.getAllByText(/reach platform rate limits much sooner/)).toHaveLength(5);
-    fireEvent.click(
-      screen.getAllByRole("switch", { name: "Streaming Responses (Advanced)" })[0]!,
-    );
-    await waitFor(() => {
-      expect(settings.writeConfig).toHaveBeenCalledWith({
-        messaging: {
-          telegram: {
-            streamingResponses: true,
-          },
-        },
-      });
-    });
-    expect(screen.getAllByText("unset").length).toBeGreaterThanOrEqual(5);
-    expect(screen.getAllByText("default").length).toBeGreaterThanOrEqual(2);
+    // LINE has no message-edit API, so its screen deliberately has no
+    // streaming toggle.
+    fireEvent.click(screen.getByRole("button", { name: "Edit general" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open LINE settings" }));
+    expect(
+      screen.queryByRole("switch", { name: "Streaming Responses (Advanced)" }),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(within(sections).getByRole("button", { name: "AI Providers" }));
-    expect(screen.getByRole("heading", { name: "Codex" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open Codex settings" }));
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Codex" }),
+    ).toBeInTheDocument();
     // The selected command appears in two places now: the pathrow
     // list (Codex discovery candidates) AND the SettingsTestBlock's
     // default name (it shows the path the Test button would invoke).
@@ -2364,8 +2386,9 @@ describe("SettingsScreen", () => {
       />,
     );
 
-    // The ACP agents card now lives under the "AI Providers" pane (no separate
-    // "ACP Agents" nav item).
+    // Providers live under the "AI Providers" pane (no separate "ACP
+    // Agents" nav item). The hub's index always lists Codex, and holds
+    // the discovery empty state until ACP agents arrive.
     expect(
       screen.getByRole("button", { name: "AI Providers" }),
     ).toHaveAttribute("aria-current", "page");
@@ -2373,7 +2396,10 @@ describe("SettingsScreen", () => {
       screen.queryByRole("button", { name: "ACP Agents" }),
     ).not.toBeInTheDocument();
     expect(
-      await screen.findByText("No AI providers are available right now."),
+      screen.getByRole("button", { name: "Open Codex settings" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Discovering AI providers…"),
     ).toBeInTheDocument();
   });
 
@@ -2814,6 +2840,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         desktopApi={desktopApi}
         initialSection="models"
+        initialSubsection="codex"
         settings={settings}
         onClose={() => undefined}
       />,
@@ -2879,6 +2906,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         desktopApi={desktopApi}
         initialSection="models"
+        initialSubsection="codex"
         settings={settings}
         onClose={() => undefined}
       />,
@@ -3191,6 +3219,7 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         initialSection="models"
+        initialSubsection="codex"
         settings={createSettingsState(snapshot)}
         onClose={() => undefined}
       />,
@@ -3230,6 +3259,7 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         initialSection="models"
+        initialSubsection="codex"
         settings={createSettingsState(snapshot)}
         onClose={() => undefined}
       />,
@@ -3291,6 +3321,7 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         initialSection="models"
+        initialSubsection="codex"
         settings={createSettingsState(snapshot)}
         onClose={() => undefined}
       />,
@@ -3380,9 +3411,12 @@ describe("SettingsScreen", () => {
 
     const sections = screen.getByRole("navigation", { name: "Settings sections" });
     fireEvent.click(within(sections).getByRole("button", { name: "Messaging" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Mattermost settings" }),
+    );
 
     expect(
-      screen.getByRole("heading", { name: "Mattermost" }),
+      screen.getByRole("heading", { level: 2, name: "Mattermost" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Server URL")).toBeInTheDocument();
     expect(screen.getAllByText("Callback Base URL").length).toBeGreaterThan(0);
@@ -3480,13 +3514,17 @@ describe("SettingsScreen", () => {
           onMessagingBindingsChanged: () => () => undefined,
         }}
         initialSection="messaging"
+        initialSubsection="telegram"
         settings={createSettingsState(snapshot)}
         onClose={() => undefined}
       />,
     );
 
     expect(await screen.findByText("Topic default Agent")).toBeInTheDocument();
-    expect(screen.getAllByText("Jeeves")).toHaveLength(2);
+    // Routes (with their own default-agent list) live on the messaging
+    // hub now, so the focused Telegram screen shows one "Jeeves": the
+    // approved surface's picker.
+    expect(screen.getAllByText("Jeeves")).toHaveLength(1);
     expect(
       screen.getAllByText("OpenAI").every(
         (element) => element.classList.contains("chip--backend"),
@@ -3512,6 +3550,9 @@ describe("SettingsScreen", () => {
     );
 
     expect(screen.getByText(/Authorization defaults closed/)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Telegram settings" }),
+    );
     expect(screen.getByText(/Rejected Telegram DMs show the peer ID/)).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole("button", { name: "Add" })[0]!);
@@ -3556,6 +3597,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={createSettingsState()}
         initialSection="messaging"
+        initialSubsection="line"
         onClose={() => undefined}
       />,
     );
@@ -3580,6 +3622,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={createSettingsState()}
         initialSection="messaging"
+        initialSubsection="feishu"
         onClose={() => undefined}
       />,
     );
@@ -3589,11 +3632,11 @@ describe("SettingsScreen", () => {
     expect(screen.getByText(/Feishu is China only/)).toBeInTheDocument();
     expect(screen.getByLabelText("Tenant URL")).toHaveValue("");
     expect(screen.getByText(/Leave blank to use/)).toBeInTheDocument();
-    expect(screen.getAllByLabelText("Local Webhook Listener")).toHaveLength(1);
-    expect(screen.getByLabelText("Local Webhook Listener")).toHaveAttribute(
-      "placeholder",
-      "http://127.0.0.1:47822",
-    );
+    // Events mode hides the Feishu local webhook listener (LINE's
+    // listener now lives on LINE's own screen).
+    expect(
+      screen.queryByLabelText("Local Webhook Listener"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows the Feishu local webhook listener only for webhook mode", () => {
@@ -3604,13 +3647,12 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={createSettingsState(snapshot)}
         initialSection="messaging"
+        initialSubsection="feishu"
         onClose={() => undefined}
       />,
     );
 
-    const feishuLocalWebhook = screen
-      .getAllByLabelText("Local Webhook Listener")
-      .find((input) => !input.hasAttribute("placeholder"));
+    const feishuLocalWebhook = screen.getByLabelText("Local Webhook Listener");
     expect(feishuLocalWebhook).toHaveValue("");
     expect(screen.getByText(/Default:/)).toHaveTextContent("http://127.0.0.1:47823");
     expect(screen.getByText(/Only used when Webhook is selected/)).toBeInTheDocument();
@@ -3633,6 +3675,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="telegram"
         onClose={() => undefined}
       />,
     );
@@ -3713,6 +3756,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="telegram"
         onClose={() => undefined}
       />,
     );
@@ -3777,6 +3821,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="telegram"
         onClose={() => undefined}
       />,
     );
@@ -3898,6 +3943,7 @@ describe("SettingsScreen", () => {
           desktopApi={desktopApi}
           settings={settings}
           initialSection="messaging"
+          initialSubsection="telegram"
           onClose={() => undefined}
         />
       );
@@ -3981,6 +4027,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
@@ -4076,6 +4123,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="telegram"
         onClose={() => undefined}
       />,
     );
@@ -4119,6 +4167,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
@@ -4205,6 +4254,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
@@ -4257,11 +4307,16 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={settings}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
 
-    const slackHeader = screen.getByRole("button", { name: "Slack" });
+    // The nav's Slack sub-item shares the name, so scope to the pane.
+    const pane = screen.getByRole("region", {
+      name: "Slack messaging settings",
+    });
+    const slackHeader = within(pane).getByRole("button", { name: "Slack" });
     if (slackHeader.getAttribute("aria-expanded") !== "true") {
       fireEvent.click(slackHeader);
     }
@@ -4321,6 +4376,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={settings}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
@@ -4354,6 +4410,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={settings}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
@@ -4376,6 +4433,7 @@ describe("SettingsScreen", () => {
         settings={settings}
         desktopApi={{ openSlackCreateApp }}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
@@ -4397,6 +4455,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={settings}
         initialSection="messaging"
+        initialSubsection="slack"
         onClose={() => undefined}
       />,
     );
@@ -4427,6 +4486,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={settings}
         initialSection="messaging"
+        initialSubsection="telegram"
         onClose={() => undefined}
       />,
     );
@@ -4499,6 +4559,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         settings={settings}
         initialSection="messaging"
+        initialSubsection="telegram"
         onClose={() => undefined}
       />,
     );
@@ -4576,6 +4637,7 @@ describe("SettingsScreen", () => {
       <SettingsScreen
         settings={settings}
         initialSection="messaging"
+        initialSubsection="telegram"
         onClose={() => undefined}
       />,
     );
@@ -5045,15 +5107,16 @@ describe("SettingsScreen", () => {
     expect(label?.textContent?.toLowerCase()).toBe("general");
 
     const nav = screen.getByRole("navigation", { name: "Settings sections" });
-    const buttons = within(nav)
-      .getAllByRole("button")
-      .map((button) => button.textContent);
+    // Caret toggles sit beside the group labels and sub-items live in
+    // collapsed sublists; the order contract is about section labels.
+    const buttons = Array.from(
+      nav.querySelectorAll(".settings-nav__exit, .settings-nav__button"),
+    ).map((button) => button.textContent);
     expect(buttons).toEqual([
       "← Exit Settings",
       "General",
       "Applications",
       "Plugins",
-      "MCPs",
       "Profiles",
       "AI Providers",
       "Usage & Pricing",
@@ -5068,9 +5131,204 @@ describe("SettingsScreen", () => {
       "Troubleshooting",
       "About",
     ]);
+    // The three group sections expand; every other row keeps the caret
+    // gutter so labels stay aligned.
+    const caretLabels = Array.from(
+      nav.querySelectorAll(".settings-nav__caret"),
+    ).map((button) => button.getAttribute("aria-label"));
+    expect(caretLabels).toEqual([
+      "Expand Plugins",
+      "Expand AI Providers",
+      "Expand Messaging",
+    ]);
+    // Collapsed sublists keep their children out of the accessibility
+    // tree — MCPs only appears once Plugins expands.
+    expect(
+      within(nav).queryByRole("button", { name: "MCPs" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(
+      within(nav).getByRole("button", { name: "Expand Plugins" }),
+    );
+    expect(
+      within(nav).getByRole("button", { name: "MCPs" }),
+    ).toBeInTheDocument();
     expect(within(nav).getByRole("separator")).toHaveClass(
       "settings-nav__divider",
     );
+  });
+
+  it("expands a nav group from the caret without navigating", () => {
+    render(
+      <SettingsScreen
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Settings sections" });
+    const caret = within(nav).getByRole("button", {
+      name: "Expand AI Providers",
+    });
+    fireEvent.click(caret);
+
+    // Expanded, but still on General — the caret only discloses.
+    expect(within(nav).getByRole("button", { name: "Codex" }))
+      .toBeInTheDocument();
+    expect(
+      document.querySelector(".settings-titlebar__current")?.textContent,
+    ).toBe("General");
+    expect(within(nav).getByRole("button", { name: "General" }))
+      .toHaveAttribute("aria-current", "page");
+
+    fireEvent.click(
+      within(nav).getByRole("button", { name: "Collapse AI Providers" }),
+    );
+    expect(
+      within(nav).queryByRole("button", { name: "Codex" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("navigates and expands together when a group label is clicked", () => {
+    render(
+      <SettingsScreen
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Settings sections" });
+    fireEvent.click(within(nav).getByRole("button", { name: "Messaging" }));
+
+    expect(within(nav).getByRole("button", { name: "Messaging" }))
+      .toHaveAttribute("aria-current", "page");
+    expect(within(nav).getByRole("button", { name: "Telegram" }))
+      .toBeInTheDocument();
+    expect(
+      document.querySelector(".settings-titlebar__current")?.textContent,
+    ).toBe("Messaging");
+  });
+
+  it("opens a focused provider screen and returns through the breadcrumb", () => {
+    render(
+      <SettingsScreen
+        initialSection="models"
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Settings sections" });
+    fireEvent.click(within(nav).getByRole("button", { name: "Codex" }));
+
+    expect(within(nav).getByRole("button", { name: "Codex" }))
+      .toHaveAttribute("aria-current", "page");
+    expect(
+      screen.getByRole("region", { name: "Codex provider settings" }),
+    ).toBeInTheDocument();
+    // The defaults cross-link keeps the hub's answer one click away.
+    expect(
+      screen.getByRole("note", { name: "New thread defaults summary" }),
+    ).toBeInTheDocument();
+
+    // Breadcrumb: Settings › AI Providers › Codex, with a clickable
+    // parent crumb back to the hub.
+    expect(
+      document.querySelector(".settings-titlebar__current")?.textContent,
+    ).toBe("Codex");
+    const crumb = document.querySelector(".settings-titlebar__crumb");
+    expect(crumb).toHaveTextContent("AI Providers");
+    fireEvent.click(crumb as HTMLElement);
+    expect(
+      document.querySelector(".settings-titlebar__current")?.textContent,
+    ).toBe("AI Providers");
+    expect(
+      screen.getByRole("region", { name: "Model settings" }),
+    ).toBeInTheDocument();
+  });
+
+  it("returns to the models hub from a focused screen's Edit defaults action", () => {
+    render(
+      <SettingsScreen
+        initialSection="models"
+        initialSubsection="codex"
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit defaults" }));
+    expect(
+      screen.getByRole("region", { name: "Model settings" }),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector(".settings-titlebar__current")?.textContent,
+    ).toBe("AI Providers");
+  });
+
+  it("sorts Gemini CLI last and marks disabled providers off in the nav", async () => {
+    const baseSnapshot = createSnapshot();
+    const snapshot = createSnapshot({
+      acpAgents: {
+        ...baseSnapshot.acpAgents,
+        gemini: { cliPath: { value: "", source: "default" }, enabled: false },
+      },
+    } as Partial<DesktopSettingsSnapshot>);
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [
+        {
+          backendId: "acp:gemini",
+          registryId: "gemini",
+          name: "Gemini CLI",
+          authors: [],
+          distributionKind: "local",
+          distributionSource: "gemini --acp",
+          installable: false,
+          installed: true,
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+        } satisfies AcpAgentSettingsEntry,
+        {
+          backendId: "acp:grok",
+          registryId: "grok",
+          name: "Grok",
+          authors: [],
+          distributionKind: "local",
+          distributionSource: "/usr/bin/grok",
+          installable: false,
+          installed: true,
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+        } satisfies AcpAgentSettingsEntry,
+      ],
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listAcpAgents }}
+        initialSection="models"
+        settings={createSettingsState(snapshot)}
+        onClose={() => undefined}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Settings sections" });
+    await within(nav).findByRole("button", { name: /Gemini CLI/ });
+    const subLabels = Array.from(
+      nav.querySelectorAll("#settings-nav-sublist-models .settings-nav__sublabel"),
+    ).map((label) => label.textContent);
+    expect(subLabels).toEqual(["Codex", "Grok", "Gemini CLI"]);
+    const geminiButton = within(nav).getByRole("button", {
+      name: /Gemini CLI/,
+    });
+    expect(
+      geminiButton.querySelector(".settings-nav__subchip")?.textContent,
+    ).toBe("off");
+    expect(
+      geminiButton.querySelector(".settings-nav__subdot--off"),
+    ).not.toBeNull();
   });
 
   it("relogs and removes MCP servers from the Plugins settings pane", async () => {
@@ -5372,6 +5630,9 @@ describe("SettingsScreen", () => {
     render(<SettingsScreen settings={settings} onClose={() => undefined} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Messaging" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Telegram settings" }),
+    );
     const tokenInput = screen.getAllByLabelText("Bot Token")[0];
     fireEvent.change(tokenInput, {
       target: { value: "123456789:secret-token" },
@@ -5392,6 +5653,9 @@ describe("SettingsScreen", () => {
     render(<SettingsScreen settings={settings} onClose={() => undefined} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Messaging" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Telegram settings" }),
+    );
     const tokenInput = screen.getAllByLabelText("Bot Token")[0];
     fireEvent.change(tokenInput, {
       target: { value: "123456789:secret-token" },

--- a/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
+++ b/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
@@ -7,6 +7,12 @@ export function acpStatusLabel(entry: AcpAgentSettingsEntry): string {
   if (entry.installed) {
     return "Discovered";
   }
+  // Only an incompatible legacy CLI is on disk (e.g. the retired
+  // Python kimi-cli). Plain "Not installed" copy would hide that the
+  // operator has something to remediate.
+  if (entry.incompatibleInstances?.length) {
+    return "Legacy CLI - action required";
+  }
   if (entry.installStatus === "install-failed") {
     return "Discovery failed";
   }

--- a/apps/desktop/src/renderer/src/features/settings/useAcpAgentCatalog.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useAcpAgentCatalog.ts
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import type {
+  AcpAgentSettingsEntry,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
+
+/**
+ * Settings-screen display order. Gemini CLI sorts last: Google withdrew CLI
+ * access for regular consumer accounts, so the section is unusable for most
+ * operators. Display-only — the IPC/catalog order from listAcpAgents is
+ * unchanged for other consumers.
+ */
+export function displayOrderedAcpEntries(
+  entries: AcpAgentSettingsEntry[],
+): AcpAgentSettingsEntry[] {
+  return [
+    ...entries.filter((entry) => entry.registryId !== "gemini"),
+    ...entries.filter((entry) => entry.registryId === "gemini"),
+  ];
+}
+
+/** Whether an agent is enabled per the snapshot (defaults to enabled). */
+export function acpAgentEnabledInSnapshot(
+  snapshot: DesktopSettingsSnapshot | undefined,
+  registryId: string,
+): boolean {
+  const agents = snapshot?.acpAgents as
+    | Record<string, { enabled?: boolean } | undefined>
+    | undefined;
+  return agents?.[registryId]?.enabled !== false;
+}
+
+/**
+ * Light read of the ACP agent catalog for surfaces that need names and
+ * status but do not own the full per-agent editing flow: the settings
+ * nav sub-items and the AI Providers hub index. Reads the cached
+ * catalog immediately; with `probe` it then asks the registry to
+ * refresh stale agents (the main process coalesces concurrent
+ * refreshes) and re-reads when any surface announces new summaries.
+ */
+export function useAcpAgentCatalog(
+  desktopApi: DesktopApi | undefined,
+  options?: { probe?: boolean },
+): { entries: AcpAgentSettingsEntry[] } {
+  const [entries, setEntries] = useState<AcpAgentSettingsEntry[]>([]);
+  const probe = options?.probe === true;
+
+  useEffect(() => {
+    const listAcpAgents = desktopApi?.listAcpAgents;
+    if (!listAcpAgents) {
+      return;
+    }
+    let disposed = false;
+    const read = async (refresh: boolean): Promise<void> => {
+      try {
+        const response = await listAcpAgents({ refresh });
+        if (disposed) {
+          return;
+        }
+        setEntries(response.entries);
+        if (refresh) {
+          window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+        }
+      } catch {
+        // Status decoration only — keep whatever entries we last saw.
+      }
+    };
+    const onSummariesRefreshed = (): void => {
+      void read(false);
+    };
+    window.addEventListener(
+      BACKEND_SUMMARIES_REFRESH_EVENT,
+      onSummariesRefreshed,
+    );
+    if (probe) {
+      void read(false).then(() => read(true));
+    } else {
+      void read(false);
+    }
+    return () => {
+      disposed = true;
+      window.removeEventListener(
+        BACKEND_SUMMARIES_REFRESH_EVENT,
+        onSummariesRefreshed,
+      );
+    };
+  }, [desktopApi, probe]);
+
+  return { entries };
+}

--- a/apps/desktop/src/renderer/src/features/settings/useAcpAgentCatalog.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useAcpAgentCatalog.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   AcpAgentSettingsEntry,
   DesktopSettingsSnapshot,
@@ -32,23 +32,44 @@ export function acpAgentEnabledInSnapshot(
   return agents?.[registryId]?.enabled !== false;
 }
 
+export type AcpAgentCatalogState = {
+  entries: AcpAgentSettingsEntry[];
+  /** True once a read has settled, successfully or not. */
+  loaded: boolean;
+  /** Message from the most recent failed read, cleared on success. */
+  error?: string;
+  /** True when this build exposes no ACP registry IPC at all. */
+  unavailable: boolean;
+};
+
 /**
  * Light read of the ACP agent catalog for surfaces that need names and
  * status but do not own the full per-agent editing flow: the settings
  * nav sub-items and the AI Providers hub index. Reads the cached
  * catalog immediately; with `probe` it then asks the registry to
- * refresh stale agents (the main process coalesces concurrent
- * refreshes) and re-reads when any surface announces new summaries.
+ * refresh stale agents once per mount (the main process coalesces
+ * concurrent refreshes) and re-reads when any surface announces new
+ * summaries.
  */
 export function useAcpAgentCatalog(
   desktopApi: DesktopApi | undefined,
   options?: { probe?: boolean },
-): { entries: AcpAgentSettingsEntry[] } {
+): AcpAgentCatalogState {
   const [entries, setEntries] = useState<AcpAgentSettingsEntry[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | undefined>();
   const probe = options?.probe === true;
+  // The probe runs once per mounted consumer, not once per effect run —
+  // `probe` flips with hub↔focused navigation and re-probing (plus the
+  // event fan-out it triggers) on every hop is pure churn.
+  const probedRef = useRef(false);
+  // Set just before this instance dispatches the refresh event so its
+  // own listener can skip the echo — the dispatching read already holds
+  // the fresh response.
+  const selfAnnouncedRef = useRef(false);
+  const listAcpAgents = desktopApi?.listAcpAgents;
 
   useEffect(() => {
-    const listAcpAgents = desktopApi?.listAcpAgents;
     if (!listAcpAgents) {
       return;
     }
@@ -56,25 +77,45 @@ export function useAcpAgentCatalog(
     const read = async (refresh: boolean): Promise<void> => {
       try {
         const response = await listAcpAgents({ refresh });
+        if (refresh) {
+          // The main-process cache refreshed even if this consumer was
+          // cleaned up mid-flight (hub→focused navigation), so always
+          // announce — other catalog consumers have no push channel.
+          if (!disposed) {
+            selfAnnouncedRef.current = true;
+          }
+          window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+        }
         if (disposed) {
           return;
         }
         setEntries(response.entries);
-        if (refresh) {
-          window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+        setError(response.error);
+        setLoaded(true);
+      } catch (cause) {
+        if (disposed) {
+          return;
         }
-      } catch {
-        // Status decoration only — keep whatever entries we last saw.
+        // Keep whatever entries we last saw, but surface the failure —
+        // an empty catalog behind a swallowed error reads as "still
+        // discovering" forever.
+        setError(cause instanceof Error ? cause.message : String(cause));
+        setLoaded(true);
       }
     };
     const onSummariesRefreshed = (): void => {
+      if (selfAnnouncedRef.current) {
+        selfAnnouncedRef.current = false;
+        return;
+      }
       void read(false);
     };
     window.addEventListener(
       BACKEND_SUMMARIES_REFRESH_EVENT,
       onSummariesRefreshed,
     );
-    if (probe) {
+    if (probe && !probedRef.current) {
+      probedRef.current = true;
       void read(false).then(() => read(true));
     } else {
       void read(false);
@@ -86,7 +127,7 @@ export function useAcpAgentCatalog(
         onSummariesRefreshed,
       );
     };
-  }, [desktopApi, probe]);
+  }, [listAcpAgents, probe]);
 
-  return { entries };
+  return { entries, loaded, error, unavailable: listAcpAgents === undefined };
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8199,8 +8199,12 @@ textarea,
 }
 
 /* Section row: caret gutter + label button. Every row reserves the
-   22px gutter (caret button or spacer) so section labels align whether
-   or not the section expands into a sublist. */
+   24px gutter (caret button or spacer) so section labels align whether
+   or not the section expands into a sublist. The gutter is 24px rather
+   than the mark's visual width because the caret is a real click
+   target sitting flush against the label button: WCAG 2.2 target-size
+   (AA) wants 24x24, and adjacency rules out the spacing exception.
+   `a11y.spec.ts` gates this. */
 .settings-nav__row {
   display: flex;
   align-items: stretch;
@@ -8210,8 +8214,8 @@ textarea,
 .settings-nav__caret,
 .settings-nav__caret-spacer {
   display: inline-flex;
-  flex: 0 0 22px;
-  width: 22px;
+  flex: 0 0 24px;
+  width: 24px;
   align-items: center;
   justify-content: center;
 }
@@ -8307,14 +8311,17 @@ textarea,
   overflow: hidden;
 }
 
+/* Indent = the row's 24px caret gutter + the label button's 12px
+   padding, so the sublist's left rule lands under the section label's
+   first character. */
 .settings-nav__subbutton {
   display: flex;
   align-items: center;
   gap: 8px;
-  width: calc(100% - 34px);
+  width: calc(100% - 36px);
   appearance: none;
   cursor: pointer;
-  margin: 0 0 2px 34px;
+  margin: 0 0 2px 36px;
   padding: 6px 10px;
   border: 0;
   border-left: 1px solid var(--border-subtle);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8345,7 +8345,7 @@ textarea,
 }
 
 .settings-nav__subdot--ok {
-  background: var(--success-text);
+  background: var(--status-ok);
 }
 
 .settings-nav__subdot--off {
@@ -8402,6 +8402,12 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 14px;
+}
+
+/* Programmatic focus target for hub↔focused pane swaps (tabindex="-1").
+   The pane is a landing spot, not an interactive control — no ring. */
+.settings-stack:focus {
+  outline: none;
 }
 
 /* Per-pane head: editorial preamble at the top of every settings pane.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8002,6 +8002,28 @@ textarea,
   color: var(--text-muted);
 }
 
+/* Clickable parent crumb when a sub-screen is open
+   (Settings › AI Providers › Codex). The `.settings-titlebar button`
+   drag carve-out already keeps it clickable. */
+.settings-titlebar__crumb {
+  appearance: none;
+  cursor: pointer;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.settings-titlebar__crumb:hover,
+.settings-titlebar__crumb:focus-visible {
+  color: var(--text-primary);
+  outline: none;
+  text-decoration: underline;
+}
+
 .settings-titlebar__current {
   min-width: 0;
   max-width: 380px;
@@ -8176,6 +8198,61 @@ textarea,
   text-transform: uppercase;
 }
 
+/* Section row: caret gutter + label button. Every row reserves the
+   22px gutter (caret button or spacer) so section labels align whether
+   or not the section expands into a sublist. */
+.settings-nav__row {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.settings-nav__caret,
+.settings-nav__caret-spacer {
+  display: inline-flex;
+  flex: 0 0 22px;
+  width: 22px;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-nav__caret {
+  appearance: none;
+  cursor: pointer;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+}
+
+.settings-nav__caret:focus-visible {
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.settings-nav__caret:hover .settings-nav__caret-mark,
+.settings-nav__caret:focus-visible .settings-nav__caret-mark {
+  border-left-color: var(--text-primary);
+  opacity: 1;
+}
+
+/* Same filled disclosure triangle as `.directory-row__chevron` — the
+   app carries ONE disclosure vocabulary. Points right collapsed,
+   rotates to point down when the group is expanded. */
+.settings-nav__caret-mark {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid var(--text-muted);
+  opacity: 0.82;
+  transition: transform 120ms ease;
+}
+
+.settings-nav__caret-mark.is-open {
+  transform: rotate(90deg);
+}
+
 .settings-nav__button {
   display: flex;
   width: 100%;
@@ -8193,6 +8270,15 @@ textarea,
   text-align: left;
 }
 
+/* Inside a caret row the label shares the width with the 22px gutter.
+   (Automations reuses `.settings-nav__button` without rows, where the
+   bare `width: 100%` still applies.) */
+.settings-nav__row .settings-nav__button {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+}
+
 .settings-nav__button:hover,
 .settings-nav__button:focus-visible,
 .settings-nav__button.is-active {
@@ -8202,12 +8288,34 @@ textarea,
   outline: none;
 }
 
+/* Collapsible sublist under a group row — the same 120ms grid-rows
+   collapse the section bodies use (`.settings-section__body-clip`). */
+.settings-nav__sublist {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 120ms ease, opacity 120ms ease;
+}
+
+.settings-nav__sublist.is-open {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.settings-nav__sublist-clip {
+  min-height: 0;
+  overflow: hidden;
+}
+
 .settings-nav__subbutton {
-  width: calc(100% - 24px);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: calc(100% - 34px);
   appearance: none;
   cursor: pointer;
-  margin: -4px 0 4px 24px;
-  padding: 6px 12px;
+  margin: 0 0 2px 34px;
+  padding: 6px 10px;
   border: 0;
   border-left: 1px solid var(--border-subtle);
   background: transparent;
@@ -8217,12 +8325,51 @@ textarea,
   text-align: left;
 }
 
+.settings-nav__subbutton:last-child {
+  margin-bottom: 6px;
+}
+
 .settings-nav__subbutton:hover,
 .settings-nav__subbutton:focus-visible,
 .settings-nav__subbutton.is-active {
   border-left-color: var(--accent);
   color: var(--accent);
   outline: none;
+}
+
+.settings-nav__subdot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.settings-nav__subdot--ok {
+  background: var(--success-text);
+}
+
+.settings-nav__subdot--off {
+  background: color-mix(in srgb, var(--text-primary) 16%, transparent);
+}
+
+.settings-nav__sublabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-nav__subchip {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .settings-nav__divider {
@@ -8308,6 +8455,143 @@ textarea,
   justify-content: flex-end;
   gap: 8px;
   flex: 0 0 auto;
+}
+
+/* ----------------------------------------------------------------
+   SETTINGS CONTEXT STRIP — compact cross-link on focused sub-screens
+   (provider screens show the hub's "New thread defaults"; platform
+   screens show messaging "General"). One row: eyebrow + label,
+   summary chips, and a ghost action back to the hub editor.
+   ---------------------------------------------------------------- */
+
+.settings-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.settings-strip__eyebrow {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-strip__label {
+  flex: 0 0 auto;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.settings-strip__meta {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.settings-strip__chip {
+  padding: 2px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 550;
+  white-space: nowrap;
+}
+
+.settings-strip__action {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+/* ----------------------------------------------------------------
+   SETTINGS INDEX — hub list of per-provider / per-platform screens.
+   One bordered row per entry: optional glyph, name + mono meta,
+   status chip, and a "Configure ›" affordance on the right.
+   ---------------------------------------------------------------- */
+
+.settings-index {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-index__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  appearance: none;
+  cursor: pointer;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.settings-index__row:hover,
+.settings-index__row:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  outline: none;
+}
+
+.settings-index__row:hover .settings-index__open,
+.settings-index__row:focus-visible .settings-index__open {
+  color: var(--accent);
+}
+
+.settings-index__glyph {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-index__main {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.settings-index__name {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.settings-index__row.is-off .settings-index__name {
+  color: var(--text-muted);
+}
+
+.settings-index__meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.settings-index__open {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
 }
 
 /* Card panel — eyebrow + title + optional chip in head, body below. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8306,6 +8306,18 @@ textarea,
   opacity: 1;
 }
 
+/* Every animation on an audited surface is disabled under reduced motion
+   so `a11y.spec.ts` measures contrast at rest. Navigating to a group
+   expands its sublist immediately before the scan, and mid-fade axe
+   blends the sublabels toward the sidebar: `--text-muted` reads 4.55:1
+   at rest but 4.21:1 at ~94% opacity, which fails AA in light theme. */
+@media (prefers-reduced-motion: reduce) {
+  .settings-nav__sublist,
+  .settings-nav__caret-mark {
+    transition: none;
+  }
+}
+
 .settings-nav__sublist-clip {
   min-height: 0;
   overflow: hidden;


### PR DESCRIPTION
## Summary

Implements the approved "A · hub" Settings navigation design:

- **Expandable nav groups.** Plugins, AI Providers, and Messaging use the thread-list directory caret (filled triangle, 120ms rotate). Groups start collapsed. The caret toggles expansion only; clicking the parent label navigates *and* expands. Every nav row keeps a 22px caret gutter so labels stay aligned, and collapsed sublists are `aria-hidden` + `inert`.
- **Sub-item status.** Each provider/platform sub-item shows a status dot (ok/off); the disabled Gemini CLI additionally shows an "off" chip and sorts last.
- **AI Providers hub → focused screens.** The parent screen keeps New thread defaults and adds a provider index (Codex + Grok/Kimi/Qwen/Gemini). Each provider gets a focused screen with a "New thread defaults" cross-link strip whose **Edit defaults** action returns to the hub.
- **Messaging hub → focused screens.** The parent screen keeps General and Routes and adds a platform index with brand glyphs (Telegram, Discord, Mattermost, Slack, Feishu / Lark, LINE). Each platform gets a focused screen with a "General" strip whose **Edit general** action returns to the hub.
- **Breadcrumb.** Focused screens render `Settings › AI Providers › Codex` (etc.) with a clickable parent crumb.
- Rides on the already-pushed 6269e864e (`feat(desktop): sort Gemini CLI last in AI provider settings`).

## Implementation notes

- New `useAcpAgentCatalog` hook centralizes the ACP catalog read (cache-first, optional probe) and the `BACKEND_SUMMARIES_REFRESH_EVENT` subscription shared by the nav, hub index, and focused screens.
- `AcpAgentsSettings` gains an `only` filter so a focused screen renders a single agent, with an unavailable-state fallback.
- Hub pane `aria-label`s ("Model settings", "Messaging settings") are unchanged, preserving the a11y E2E contract; focused panes use `"<name> provider settings"` / `"<name> messaging settings"`.
- README and docs-site screenshot specs now navigate through the hub index rows to the focused platform screens, and nav-label locators use `exact: true` so the new "Expand Messaging" caret can't alias the section button (Playwright matches accessible names by substring).

## Testing

- `pnpm --filter @pwragent/desktop typecheck` — clean.
- ESLint over every changed file — clean (one pre-existing warning on an untouched line).
- `pnpm lint:colors` — passed.
- Full renderer vitest suite: 219 files / 3,485 tests passed; settings suites re-run after final edits (11 files / 181 tests).
- Desktop E2E specs (a11y, README + docs-site screenshots) were updated to the new navigation but are only runnable on the lab, not locally. The screenshot pipelines will need a re-capture pass after merge since both Settings surfaces changed visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)