### PR TITLE
feat(desktop): transfer cross-thread attachments

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -15,7 +15,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, onTestFinished, vi } from "vitest";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
   buildFederatedThreadRef,
@@ -27102,6 +27102,18 @@ command = "pnpm dev"
 
   it("groups a Codex handoff under its Kimi parent", async () => {
     const acpBackendId = "acp:kimi" as AcpBackendId;
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-image-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    const previousProfile = process.env.PWRAGENT_PROFILE;
+    process.env.PWRAGENT_HOME = tempRoot;
+    process.env.PWRAGENT_PROFILE = "test";
+    onTestFinished(async () => {
+      if (previousHome === undefined) delete process.env.PWRAGENT_HOME;
+      else process.env.PWRAGENT_HOME = previousHome;
+      if (previousProfile === undefined) delete process.env.PWRAGENT_PROFILE;
+      else process.env.PWRAGENT_PROFILE = previousProfile;
+      await rm(tempRoot, { recursive: true, force: true });
+    });
     const parentDirectory = {
       id: expectedDir("/repo/app"),
       kind: "local" as const,
@@ -27135,13 +27147,32 @@ command = "pnpm dev"
       acpBackendId,
       codexClient,
       overlayStore,
+      sessionId: "kimi-parent",
       sessions: [parentSession],
     });
     const turn = await registry.startTurn({
       backend: acpBackendId,
       threadId: "kimi-parent",
-      input: [{ type: "text", text: "Delegate the migration lock fix." }],
+      input: [
+        { type: "text", text: "Delegate the migration lock fix." },
+        {
+          type: "image",
+          name: "migration.png",
+          url: "data:image/png;base64,AQID",
+        },
+      ],
     });
+    const remembered = registry.getTurnInputAttachments({
+      backend: acpBackendId,
+      threadId: "kimi-parent",
+      turnId: turn.turnId,
+    });
+    expect(remembered).toEqual([expect.objectContaining({
+      type: "localImage",
+      name: "migration.png",
+      path: expect.stringContaining("turn-input-attachments"),
+    })]);
+    expect(JSON.stringify(remembered)).not.toContain("base64");
     await registry.publishLocalEvent({
       backend: acpBackendId,
       notification: {
@@ -27177,6 +27208,27 @@ command = "pnpm dev"
         groupedUnderThreadId: "kimi-parent",
       },
     });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-1",
+      input: [
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Fix the migration lock race."),
+        }),
+        expect.objectContaining({
+          type: "localImage",
+          name: "migration.png",
+          path: expect.stringContaining("image-inputs"),
+        }),
+      ],
+    });
+    const childImage = codexClient.lastStartTurnParams?.input[1];
+    expect(childImage?.type).toBe("localImage");
+    if (childImage?.type === "localImage") {
+      await expect(readFile(childImage.path)).resolves.toEqual(
+        Buffer.from([1, 2, 3]),
+      );
+    }
     await expect(
       overlayStore.getThreadOverlayState({
         backend: "codex",
@@ -32004,6 +32056,103 @@ script = "printf setup"
     });
 
     await registry.close();
+  });
+
+  it("forwards remembered source images as staged paths to send_message_to_thread", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-source-image-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    const previousProfile = process.env.PWRAGENT_PROFILE;
+    process.env.PWRAGENT_HOME = tempRoot;
+    process.env.PWRAGENT_PROFILE = "test";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        id: "source-thread",
+        title: "Source",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      }, {
+        id: "target-thread",
+        title: "Target",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    try {
+      const source = await registry.startTurn({
+        backend: "codex",
+        threadId: "source-thread",
+        input: [
+          { type: "text", text: "Inspect this screenshot." },
+          {
+            type: "image",
+            name: "screen.png",
+            url: "data:image/png;base64,AQID",
+          },
+        ],
+      });
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "source-thread",
+            turnId: source.turnId,
+            turn: { id: source.turnId },
+          },
+        },
+      });
+      const remembered = registry.getTurnInputAttachments({
+        backend: "codex",
+        threadId: "source-thread",
+        turnId: source.turnId,
+      });
+      expect(remembered).toEqual([expect.objectContaining({
+        type: "localImage",
+        name: "screen.png",
+        path: expect.stringContaining("turn-input-attachments"),
+      })]);
+      expect(JSON.stringify(remembered)).not.toContain("base64");
+
+      await callRegistryMcpTool({
+        registry,
+        backend: "codex",
+        threadId: "source-thread",
+        turnId: source.turnId,
+        tool: "send_message_to_thread",
+        args: {
+          backend: "codex",
+          threadId: "target-thread",
+          prompt: "Use the source screenshot.",
+        },
+      });
+
+      expect(codexClient.lastStartTurnParams).toMatchObject({
+        threadId: "target-thread",
+        input: [
+          { type: "text", text: "Use the source screenshot." },
+          expect.objectContaining({
+            type: "localImage",
+            name: "screen.png",
+            path: expect.stringContaining("image-inputs"),
+          }),
+        ],
+      });
+    } finally {
+      await registry.close();
+      if (previousHome === undefined) delete process.env.PWRAGENT_HOME;
+      else process.env.PWRAGENT_HOME = previousHome;
+      if (previousProfile === undefined) delete process.env.PWRAGENT_PROFILE;
+      else process.env.PWRAGENT_PROFILE = previousProfile;
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("queues a follow-up prompt while the target thread has an active turn", async () => {

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -595,6 +595,11 @@ describe("federation agent tools service", () => {
     const handler = createFederationAgentToolsHandler({
       // Never let unit tests mint a machine-id in the real PwrAgent root.
       collectHostInfo: async () => localHostInfo,
+      resolveSourceTurnAttachments: async () => [{
+        type: "localImage",
+        name: "source.png",
+        path: "/pwragent/staged/source.png",
+      }],
       runtime: buildRuntime({
         health: async () => buildHealth(),
         localBackend: (() => ({
@@ -628,7 +633,14 @@ describe("federation agent tools service", () => {
           directoryLabel: "PwrAgent",
           prompt: "",
         }),
-        input: [{ type: "text", text: "Fix the recorder crash" }],
+        input: [
+          { type: "text", text: "Fix the recorder crash" },
+          {
+            type: "localImage",
+            name: "source.png",
+            path: "/pwragent/staged/source.png",
+          },
+        ],
       },
       {
         messageOrigin: {

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AppServerTurnInputItem,
   FederationProtocolEnvelope,
   NavigationSnapshotTransportResponse,
   NavigationThreadSummary,
@@ -21,6 +22,195 @@ import { FederationRpcEndpoint } from "../federation/federation-rpc";
 import { FEDERATION_MAX_FRAME_BYTES } from "../federation/federation-transport";
 
 describe("federation backend bridge", () => {
+  it("prepares start, steer, handoff, and Star Map attachments before remote RPC", async () => {
+    const request = vi.fn(async ({ method }: { method: string }) => {
+      if (method === FEDERATION_BACKEND_METHODS.startTurn) {
+        return { backend: "codex", threadId: "thread-1", turnId: "turn-1" };
+      }
+      if (method === FEDERATION_BACKEND_METHODS.controlActiveTurn) {
+        return {
+          ok: true,
+          backend: "codex",
+          threadId: "thread-1",
+          turnId: "turn-live",
+          requestId: "steer-1",
+          disposition: "steered",
+        };
+      }
+      return { accepted: true, threadId: "manager-1" };
+    });
+    const prepare = vi.fn(async (input: readonly AppServerTurnInputItem[]) =>
+      input.map((item, index) => item.type === "text"
+        ? item
+        : { type: "federationBlob" as const, transferId: `blob-${index}` }),
+    );
+    const client = new FederationRemoteBackendClient(
+      { request } as unknown as FederationRpcEndpoint,
+      (response) => response,
+      prepare,
+    );
+    const image = {
+      type: "localImage" as const,
+      name: "screen.png",
+      path: "/sender/staged/screen.png",
+    };
+
+    await client.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Inspect" }, image],
+    });
+    await client.controlActiveTurn({
+      operation: "steer",
+      backend: "codex",
+      threadId: "thread-1",
+      requestId: "steer-1",
+      input: [{ type: "text", text: "Also inspect" }, image],
+    });
+    await client.materializeDirectoryLaunchpad({
+      directoryKey: "dir:/repo",
+      input: [{ type: "text", text: "Delegate" }, image],
+    });
+    await client.starMapIntake({
+      requestId: "intake-1",
+      request: "Create a manager",
+      attachments: [image],
+    });
+
+    expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.startTurn,
+      params: expect.objectContaining({
+        input: [
+          { type: "text", text: "Inspect" },
+          { type: "federationBlob", transferId: "blob-1" },
+        ],
+      }),
+    }));
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
+      params: expect.objectContaining({
+        input: [
+          { type: "text", text: "Also inspect" },
+          { type: "federationBlob", transferId: "blob-1" },
+        ],
+      }),
+    }));
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
+      params: expect.objectContaining({
+        directoryKey: "dir:/repo",
+        input: [
+          { type: "text", text: "Delegate" },
+          { type: "federationBlob", transferId: "blob-1" },
+        ],
+      }),
+    }));
+    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.starMapIntake,
+      params: {
+        requestId: "intake-1",
+        request: "Create a manager",
+        attachments: [{ type: "federationBlob", transferId: "blob-0" }],
+      },
+    }));
+    expect(JSON.stringify(request.mock.calls)).not.toContain(image.path);
+  });
+
+  it("resolves verified steer refs and rejects raw peer Star Map paths", async () => {
+    const controlActiveTurn = vi.fn(async (request) => ({
+      ok: true as const,
+      backend: request.backend,
+      threadId: request.threadId,
+      requestId: request.requestId,
+      turnId: "turn-live",
+      disposition: "steered" as const,
+    }));
+    const starMapIntake = vi.fn(async () => ({
+      accepted: true,
+      threadId: "manager-1",
+    }));
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["turn_control", "environment_actions"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        controlActiveTurn,
+        starMapIntake,
+      } as unknown as FederationBackendOperations,
+      resolveTurnInput: async (input) => {
+        if (input.some((item) => item.type !== "federationBlob")) {
+          throw new Error("Peer paths are forbidden.");
+        }
+        return [{
+          type: "localImage",
+          name: "screen.png",
+          path: "/receiver/staged/screen.png",
+        }];
+      },
+    });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "steer-with-blob",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
+        params: {
+          operation: "steer",
+          backend: "codex",
+          threadId: "thread-1",
+          requestId: "steer-1",
+          input: [{ type: "federationBlob", transferId: "blob-1" }],
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "star-map-with-path",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.starMapIntake,
+        params: {
+          requestId: "intake-1",
+          request: "Create a manager",
+          attachments: [{
+            type: "localImage",
+            path: "/peer/controlled/screen.png",
+          }],
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_001,
+      },
+    });
+
+    expect(controlActiveTurn).toHaveBeenCalledWith(expect.objectContaining({
+      input: [{
+        type: "localImage",
+        name: "screen.png",
+        path: "/receiver/staged/screen.png",
+      }],
+    }));
+    expect(starMapIntake).not.toHaveBeenCalled();
+    expect(replies).toContainEqual(expect.objectContaining({
+      kind: "error",
+      requestId: "star-map-with-path",
+    }));
+  });
+
   it("negotiates launchpad metadata separately from environment actions", () => {
     expect(
       FEDERATION_BACKEND_METHOD_CAPABILITIES[

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -27,6 +27,7 @@ import { FederationSessionRegistry } from "../federation/federation-session-stat
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
+  federationTransportCodecForTest,
   FederationGatewayWebSocketServer,
   FederationSocketKeepalive,
   type FederationKeepaliveSocket,
@@ -60,6 +61,41 @@ afterEach(async () => {
 });
 
 describe("federation transport", () => {
+  it("encodes blob bytes as a binary tail and rejects blob JSON envelopes", () => {
+    const data = Buffer.from([0, 1, 2, 0xff]);
+    const envelope = {
+      id: "blob-codec",
+      kind: "blob_chunk" as const,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_000,
+      transferId: "transfer-1",
+      chunkIndex: 0,
+      chunkCount: 1,
+      totalSize: data.byteLength,
+      sha256: "0".repeat(64),
+      name: "screen.png",
+      inputType: "localImage" as const,
+      data,
+    };
+
+    const wire = federationTransportCodecForTest.encodeEnvelope(envelope);
+    expect(wire.subarray(0, 8).toString("ascii")).toBe("PWRBLOB1");
+    const headerLength = wire.readUInt32BE(8);
+    const header = JSON.parse(wire.subarray(12, 12 + headerLength).toString("utf8"));
+    expect(header.envelope).not.toHaveProperty("data");
+    expect(JSON.stringify(header)).not.toContain(data.toString("base64"));
+    expect(wire.subarray(12 + headerLength)).toEqual(data);
+    expect(federationTransportCodecForTest.decodeEnvelope(wire)).toEqual(envelope);
+
+    const jsonWire = Buffer.from(JSON.stringify({
+      kind: "envelope",
+      envelope,
+    }), "utf8");
+    expect(federationTransportCodecForTest.decodeEnvelope(jsonWire)).toBeUndefined();
+  });
+
   it("authenticates a client and carries protocol envelopes", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     let closeCount = 0;
@@ -164,6 +200,67 @@ describe("federation transport", () => {
     // report "re-pair needed" instead of a generic connection loss.
     expect(lastCloseInfo).toMatchObject({ code: 4002, reason: "revoked" });
     expect(server?.closePeer("client_one")).toBe(false);
+  });
+
+  it("carries attachment bytes in the binary blob frame instead of JSON", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-binary-blob",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received = new Promise<FederationProtocolEnvelope>((resolve) => {
+      server = new FederationGatewayWebSocketServer({
+        gatewayInstanceId: "gateway_one",
+        gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        host: "127.0.0.1",
+        port: 0,
+        store,
+        onEnvelope: resolve,
+      });
+    });
+    const { url } = await server!.start();
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["turn_input_blobs"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+    });
+    const bytes = Buffer.from([0, 1, 2, 0xff]);
+
+    client.sendEnvelope({
+      id: "blob-1",
+      kind: "blob_chunk",
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_000,
+      transferId: "transfer-1",
+      chunkIndex: 0,
+      chunkCount: 1,
+      totalSize: bytes.byteLength,
+      sha256: "0".repeat(64),
+      name: "screen.png",
+      inputType: "localImage",
+      data: bytes,
+    });
+
+    await expect(received).resolves.toMatchObject({
+      kind: "blob_chunk",
+      transferId: "transfer-1",
+      data: bytes,
+    });
+    client.close();
   });
 
   it("reports envelope wire bytes to both ends' transfer taps", async () => {

--- a/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
@@ -1,0 +1,294 @@
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  FederationBlobChunkEnvelope,
+  FederationProtocolEnvelope,
+} from "@pwragent/shared";
+import { imageInputFileRoot } from "../app-server/image-input-files";
+import {
+  stageTurnInputAttachment,
+  turnInputAttachmentRoot,
+} from "../app-server/turn-input-attachment-files";
+import {
+  FEDERATION_BLOB_CHUNK_BYTES,
+  FederationTurnInputAttachmentReceiver,
+  MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE,
+  prepareOutgoingFederationTurnInput,
+} from "../federation/federation-turn-input-attachments";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("federation turn input attachments", () => {
+  it("stages data URLs and existing PwrAgent image inputs before binary upload", async () => {
+    const root = await createTestRoot();
+    const existingBytes = Buffer.from([9, 8, 7, 6]);
+    const existingPath = path.join(imageInputFileRoot(), "existing.png");
+    await mkdir(path.dirname(existingPath), { recursive: true });
+    await writeFile(existingPath, existingBytes);
+    const envelopes: FederationBlobChunkEnvelope[] = [];
+
+    const prepared = await prepareOutgoingFederationTurnInput({
+      input: [
+        {
+          type: "image",
+          name: "pasted.png",
+          url: "data:image/png;base64,AQID",
+        },
+        { type: "localImage", name: "existing.png", path: existingPath },
+      ],
+      localInstanceId: "source_one",
+      targetInstanceId: "owner_one",
+      privateStorageRoots: [path.join(root, "profiles", "test")],
+      sendEnvelope: (envelope) => {
+        if (envelope.kind === "blob_chunk") {
+          envelopes.push(envelope);
+        }
+      },
+    });
+
+    expect(prepared).toEqual([
+      { type: "federationBlob", transferId: expect.any(String) },
+      { type: "federationBlob", transferId: expect.any(String) },
+    ]);
+    expect(JSON.stringify(prepared)).not.toContain("base64");
+    expect(JSON.stringify(prepared)).not.toContain(existingPath);
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[0]?.data).toEqual(Buffer.from([1, 2, 3]));
+    expect(envelopes[1]?.data).toEqual(existingBytes);
+  });
+
+  it("round-trips multi-chunk bytes into receiver-owned verified paths", async () => {
+    await createTestRoot();
+    const sourcePath = path.join(turnInputAttachmentRoot(), "source.bin");
+    const data = Buffer.alloc(FEDERATION_BLOB_CHUNK_BYTES + 3, 0x5a);
+    await mkdir(path.dirname(sourcePath), { recursive: true });
+    await writeFile(sourcePath, data);
+    const envelopes: FederationBlobChunkEnvelope[] = [];
+    const prepared = await prepareOutgoingFederationTurnInput({
+      input: [{ type: "localFile", name: "source.bin", path: sourcePath }],
+      localInstanceId: "source_one",
+      targetInstanceId: "owner_one",
+      sendEnvelope: collectBlobChunks(envelopes),
+    });
+    const receiverRoot = path.join(path.dirname(turnInputAttachmentRoot()), "received");
+    const receiver = new FederationTurnInputAttachmentReceiver({
+      resolveRoot: () => receiverRoot,
+    });
+    const resolved = receiver.resolveInput(prepared, "source_one");
+
+    for (const envelope of envelopes) {
+      await receiver.receive(envelope, "source_one");
+    }
+
+    const input = await resolved;
+    expect(input).toHaveLength(1);
+    expect(input[0]).toMatchObject({
+      type: "localFile",
+      name: "source.bin",
+      path: expect.stringMatching(/received/u),
+    });
+    const receivedPath = input[0]?.type === "localFile" ? input[0].path : "";
+    await expect(readFile(receivedPath)).resolves.toEqual(data);
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[0]?.data).toHaveLength(FEDERATION_BLOB_CHUNK_BYTES);
+    expect(envelopes[1]?.data).toHaveLength(3);
+  });
+
+  it("rejects peer paths and malformed chunk geometry", async () => {
+    const receiver = new FederationTurnInputAttachmentReceiver({
+      resolveRoot: () => path.join(os.tmpdir(), "unused-federation-inputs"),
+    });
+    await expect(receiver.resolveInput(
+      [{ type: "localImage", path: "/tmp/peer-controlled.png" }],
+      "source_one",
+    )).rejects.toThrow(/verified blob transfer reference/u);
+
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 1_000_000,
+      data: Uint8Array.from([1]),
+      totalSize: 1,
+    }), "source_one")).rejects.toThrow(/geometry/u);
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES - 1),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+    }), "source_one")).rejects.toThrow(/geometry/u);
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      chunkIndex: 1,
+      data: new Uint8Array(0),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+    }), "source_one")).rejects.toThrow(/geometry/u);
+  });
+
+  it("caps incomplete transfers per authenticated source", async () => {
+    const receiver = new FederationTurnInputAttachmentReceiver();
+    for (
+      let index = 0;
+      index < MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE;
+      index += 1
+    ) {
+      await receiver.receive(blobEnvelope({
+        chunkCount: 2,
+        data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES),
+        totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+        transferId: `transfer-${index}`,
+      }), "source_one");
+    }
+
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+      transferId: "transfer-over-limit",
+    }), "source_one")).rejects.toThrow(/Too many incomplete/u);
+
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+      transferId: "other-peer-transfer",
+    }), "source_two")).resolves.toBeUndefined();
+  });
+
+  it("replaces corrupt content-addressed receiver files and reuses verified files", async () => {
+    const root = await createTestRoot();
+    const receiverRoot = path.join(root, "receiver");
+    const data = Buffer.from([1, 3, 3, 7]);
+    const digest = sha256(data);
+    const destination = path.join(
+      receiverRoot,
+      "source_one",
+      digest,
+      "screen.png",
+    );
+    await mkdir(path.dirname(destination), { recursive: true });
+    await writeFile(destination, Buffer.from([9, 9, 9, 9]));
+    const corruptInode = (await stat(destination)).ino;
+    const envelope = blobEnvelope({
+      data,
+      name: "screen.png",
+      sha256: digest,
+      totalSize: data.byteLength,
+      transferId: "replace-corrupt",
+    });
+    const receiver = new FederationTurnInputAttachmentReceiver({
+      resolveRoot: () => receiverRoot,
+    });
+    const resolved = receiver.resolveInput(
+      [{ type: "federationBlob", transferId: envelope.transferId }],
+      "source_one",
+    );
+    await receiver.receive(envelope, "source_one");
+    await resolved;
+
+    await expect(readFile(destination)).resolves.toEqual(data);
+    expect((await stat(destination)).ino).not.toBe(corruptInode);
+
+    const verifiedInode = (await stat(destination)).ino;
+    const reuseEnvelope = {
+      ...envelope,
+      id: "blob-reuse",
+      transferId: "reuse-verified",
+    };
+    const reused = receiver.resolveInput(
+      [{ type: "federationBlob", transferId: reuseEnvelope.transferId }],
+      "source_one",
+    );
+    await receiver.receive(reuseEnvelope, "source_one");
+    await reused;
+    expect((await stat(destination)).ino).toBe(verifiedInode);
+  });
+
+  it("atomically replaces corrupt local staged content and reuses verified content", async () => {
+    await createTestRoot();
+    const data = Uint8Array.from([4, 5, 6]);
+    const first = await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "paste.png",
+    });
+    await writeFile(first.path, Buffer.from([0, 0, 0]));
+    const corruptInode = (await stat(first.path)).ino;
+
+    const replaced = await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "paste.png",
+    });
+    await expect(readFile(replaced.path)).resolves.toEqual(Buffer.from(data));
+    expect((await stat(replaced.path)).ino).not.toBe(corruptInode);
+
+    const verifiedInode = (await stat(replaced.path)).ino;
+    await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "paste.png",
+    });
+    expect((await stat(replaced.path)).ino).toBe(verifiedInode);
+  });
+});
+
+async function createTestRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-federation-input-"));
+  temporaryRoots.push(root);
+  vi.stubEnv("PWRAGENT_HOME", root);
+  vi.stubEnv("PWRAGENT_PROFILE", "test");
+  return root;
+}
+
+function collectBlobChunks(
+  chunks: FederationBlobChunkEnvelope[],
+): (envelope: FederationProtocolEnvelope) => void {
+  return (envelope) => {
+    if (envelope.kind === "blob_chunk") {
+      chunks.push(envelope);
+    }
+  };
+}
+
+function blobEnvelope(
+  overrides: Partial<FederationBlobChunkEnvelope> = {},
+): FederationBlobChunkEnvelope {
+  const data = overrides.data ?? Uint8Array.from([1]);
+  return {
+    id: "blob-1",
+    kind: "blob_chunk",
+    protocolVersion: 1,
+    sourceInstanceId: "source_one",
+    targetInstanceId: "owner_one",
+    createdAt: 1_000,
+    transferId: "transfer-1",
+    chunkIndex: 0,
+    chunkCount: 1,
+    totalSize: data.byteLength,
+    sha256: sha256(data),
+    name: "screen.png",
+    inputType: "localImage",
+    data,
+    ...overrides,
+  };
+}
+
+function sha256(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -553,6 +553,7 @@ import {
 } from "./thread-turn-queue";
 import { materializeLocalImageInputs } from "./image-input-files";
 import { enrichLocalFileInputs } from "./local-file-input";
+import { stageTurnInputAttachmentsForRetention } from "./turn-input-attachment-files";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 import {
   PdfAttachmentStore,
@@ -7320,6 +7321,10 @@ export class DesktopBackendRegistry {
     string,
     AppServerTurnInputItem[]
   >();
+  private readonly turnInputAttachments = new Map<
+    string,
+    { input: AppServerTurnInputItem[] }
+  >();
   private readonly pendingThreadMessageContexts = new Map<
     string,
     PendingThreadMessageContext
@@ -13908,6 +13913,12 @@ export class DesktopBackendRegistry {
           messageId: buildTurnUserMessageOriginId(result.turnId),
           origin: resolveThreadMessageOrigin(params),
         });
+        await this.rememberTurnInputAttachments({
+          backend: params.backend,
+          threadId: result.threadId,
+          turnId: result.turnId,
+          input: userInput,
+        });
         this.forgetPendingThreadMessageContext(pendingMessageContextId);
         return result;
       } catch (error) {
@@ -14274,6 +14285,12 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       turnId: result.turnId,
     };
+    await this.rememberTurnInputAttachments({
+      backend: params.backend,
+      threadId: result.threadId,
+      turnId: result.turnId,
+      input,
+    });
     this.scheduleCompletedTurnFromReplay({
       backend: params.backend,
       threadId: result.threadId,
@@ -28423,6 +28440,47 @@ export class DesktopBackendRegistry {
     return this.localFilePrivateStorageRoots;
   }
 
+  getTurnInputAttachments(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+  }): AppServerTurnInputItem[] {
+    return (
+      this.turnInputAttachments.get(
+        buildActiveTurnKey(params.backend, params.threadId, params.turnId),
+      )?.input ?? []
+    ).map((item) => ({ ...item }));
+  }
+
+  private async rememberTurnInputAttachments(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+    input: readonly AppServerTurnInputItem[];
+  }): Promise<void> {
+    const attachments = await stageTurnInputAttachmentsForRetention(
+      params.input,
+      { privateStorageRoots: this.localFilePrivateStorageRoots },
+    );
+    if (attachments.length === 0) {
+      return;
+    }
+    const key = buildActiveTurnKey(
+      params.backend,
+      params.threadId,
+      params.turnId,
+    );
+    this.turnInputAttachments.delete(key);
+    this.turnInputAttachments.set(key, {
+      input: attachments,
+    });
+    while (this.turnInputAttachments.size > 256) {
+      const oldestKey = this.turnInputAttachments.keys().next().value;
+      if (!oldestKey) break;
+      this.turnInputAttachments.delete(oldestKey);
+    }
+  }
+
   private async handleThreadOrchestrationRequest(
     request: PwrAgentThreadOrchestrationRequest,
   ): Promise<PwrAgentThreadOrchestrationResponse> {
@@ -29606,7 +29664,14 @@ export class DesktopBackendRegistry {
           : {}),
         ...(request.args.sandbox ? { sandbox: request.args.sandbox } : {}),
       };
-      const input = [{ type: "text" as const, text: prompt }];
+      const input = [
+        { type: "text" as const, text: prompt },
+        ...this.getTurnInputAttachments({
+          backend: request.context.backend,
+          threadId: request.context.threadId,
+          turnId: sourceTurnId,
+        }),
+      ];
       const messageOrigin = await this.buildAgentMessageOrigin({
         backend: request.context.backend,
         threadId: request.context.threadId,
@@ -29950,7 +30015,14 @@ export class DesktopBackendRegistry {
         : {}),
       ...(request.operation === "steer_thread"
         ? {
-            input: [{ type: "text" as const, text: request.args.prompt }],
+            input: [
+              { type: "text" as const, text: request.args.prompt },
+              ...this.getTurnInputAttachments({
+                backend: request.context.backend,
+                threadId: request.context.threadId,
+                turnId: sourceTurnId,
+              }),
+            ],
           }
         : {}),
       messageOrigin,
@@ -30632,7 +30704,14 @@ export class DesktopBackendRegistry {
       const turn = await this.startTurn({
         backend,
         threadId,
-        input: [{ type: "text", text: prompt }],
+        input: [
+          { type: "text", text: prompt },
+          ...this.getTurnInputAttachments({
+            backend: sourceBackend,
+            threadId: sourceThreadId,
+            turnId: sourceTurnId,
+          }),
+        ],
         messageOrigin: {
           kind: "agent",
           sourceThread: {

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -29,7 +29,7 @@ export type ImageInputFileDependencies = {
 const defaultDependencies: ImageInputFileDependencies = {
   now: () => Date.now(),
   readFile,
-  resolveRoot: () => resolveActiveProfilePath(path.join("state", "image-inputs")),
+  resolveRoot: imageInputFileRoot,
   writeFile,
   mkdir,
   readdir,
@@ -37,6 +37,10 @@ const defaultDependencies: ImageInputFileDependencies = {
   unlink,
   rm,
 };
+
+export function imageInputFileRoot(): string {
+  return resolveActiveProfilePath(path.join("state", "image-inputs"));
+}
 
 export async function materializeLocalImageInputs(
   input: AppServerTurnInputItem[],

--- a/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
+++ b/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
@@ -1,0 +1,332 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AppServerLocalFileInputItem,
+  AppServerLocalImageInputItem,
+  AppServerTurnInputItem,
+} from "@pwragent/shared";
+import { resolveActiveProfilePath } from "../profile";
+import { imageInputFileRoot } from "./image-input-files";
+import { resolveReadableLocalFilePath } from "./local-file-input";
+
+const TURN_INPUT_ATTACHMENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const MAX_TURN_INPUT_ATTACHMENT_BYTES = 128 * 1024 * 1024;
+
+export type TurnInputAttachmentUpload = {
+  type: "localImage" | "localFile";
+  data: Uint8Array;
+  name?: string;
+  mimeType?: string;
+};
+
+export type StagedTurnInputAttachment =
+  | AppServerLocalImageInputItem
+  | AppServerLocalFileInputItem;
+
+export function turnInputAttachmentRoot(): string {
+  return resolveActiveProfilePath(path.join("state", "turn-input-attachments"));
+}
+
+/**
+ * Persist cloneable renderer bytes in PwrAgent-owned storage and return the
+ * path-only input shape used by local backends and the federation uploader.
+ */
+export async function stageTurnInputAttachment(
+  upload: TurnInputAttachmentUpload,
+): Promise<StagedTurnInputAttachment> {
+  const data = Buffer.from(upload.data);
+  if (data.byteLength > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
+    throw new Error(
+      `Turn attachment exceeds the ${MAX_TURN_INPUT_ATTACHMENT_BYTES}-byte limit.`,
+    );
+  }
+  if (upload.type === "localImage" && data.byteLength === 0) {
+    throw new Error("Image attachments cannot be empty.");
+  }
+
+  const digest = createHash("sha256").update(data).digest("hex");
+  const root = turnInputAttachmentRoot();
+  const name = sanitizeTurnAttachmentName(
+    upload.name,
+    fallbackName(upload.type, upload.mimeType),
+  );
+  const filePath = path.join(root, digest, name);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const existing = await stat(filePath).catch(() => undefined);
+  let reusable = false;
+  if (existing?.isFile() && existing.size === data.byteLength) {
+    const existingData = await readFile(filePath).catch(() => undefined);
+    reusable = Boolean(
+      existingData
+      && createHash("sha256").update(existingData).digest("hex") === digest,
+    );
+  }
+  if (!reusable) {
+    const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporaryPath, data);
+      await rename(temporaryPath, filePath);
+    } finally {
+      await unlink(temporaryPath).catch(() => undefined);
+    }
+  }
+
+  void cleanupOldTurnInputAttachments(root, new Set([filePath])).catch(
+    () => undefined,
+  );
+
+  return upload.type === "localImage"
+    ? {
+        type: "localImage",
+        ...(upload.name?.trim() ? { name: upload.name.trim() } : {}),
+        path: filePath,
+      }
+    : {
+        type: "localFile",
+        ...(upload.name?.trim() ? { name: upload.name.trim() } : {}),
+        ...(upload.mimeType?.trim() ? { mimeType: upload.mimeType.trim() } : {}),
+        sizeBytes: data.byteLength,
+        path: filePath,
+      };
+}
+
+export async function stageTurnInputAttachments(
+  uploads: readonly TurnInputAttachmentUpload[],
+): Promise<StagedTurnInputAttachment[]> {
+  return await Promise.all(uploads.map(stageTurnInputAttachment));
+}
+
+export async function stageLocalTurnInputAttachment(
+  item: StagedTurnInputAttachment,
+  options?: { privateStorageRoots?: readonly string[] },
+): Promise<StagedTurnInputAttachment> {
+  const ownedStagingPath = await resolveOwnedStagingPath(item.path);
+  const readable = ownedStagingPath
+    ? { ok: true as const, path: ownedStagingPath }
+    : await resolveReadableLocalFilePath(item.path, {
+        privateStorageRoots: options?.privateStorageRoots,
+      });
+  if (!readable.ok) {
+    throw new Error(
+      readable.reason === "forbidden"
+        ? "The attachment path is inside private Codex storage and cannot be transferred."
+        : `The attachment file was not found: ${item.path}`,
+    );
+  }
+  const fileInfo = await stat(readable.path).catch(() => undefined);
+  if (!fileInfo?.isFile()) {
+    throw new Error(`The attachment path is not a regular file: ${item.path}`);
+  }
+  if (fileInfo.size > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
+    throw new Error(
+      `Turn attachment exceeds the ${MAX_TURN_INPUT_ATTACHMENT_BYTES}-byte limit.`,
+    );
+  }
+  const data = await readFile(readable.path);
+  return await stageTurnInputAttachment({
+    type: item.type,
+    data,
+    name: item.name ?? path.basename(item.path),
+    ...(item.type === "localFile" && item.mimeType
+      ? { mimeType: item.mimeType }
+      : {}),
+  });
+}
+
+/**
+ * Convert source-turn attachments to PwrAgent-owned path references before
+ * retaining them for cross-thread forwarding. Inline payloads never enter the
+ * registry cache.
+ */
+export async function stageTurnInputAttachmentsForRetention(
+  input: readonly AppServerTurnInputItem[],
+  options?: { privateStorageRoots?: readonly string[] },
+): Promise<AppServerTurnInputItem[]> {
+  const attachments: AppServerTurnInputItem[] = [];
+  for (const item of input) {
+    if (item.type === "text") {
+      continue;
+    }
+    try {
+      if (item.type === "localImage" || item.type === "localFile") {
+        attachments.push(await stageLocalTurnInputAttachment(item, options));
+        continue;
+      }
+      if (item.type === "file") {
+        const data = decodeBase64(item.data);
+        if (data) {
+          attachments.push(await stageTurnInputAttachment({
+            type: "localFile",
+            data,
+            name: item.name,
+            mimeType: item.mimeType,
+          }));
+        }
+        continue;
+      }
+      if (item.type === "image" && item.url.startsWith("data:")) {
+        const parsed = parseImageDataUrl(item.url);
+        if (parsed) {
+          attachments.push(await stageTurnInputAttachment({
+            type: "localImage",
+            data: parsed.data,
+            name: item.name,
+            mimeType: parsed.mimeType,
+          }));
+        }
+        continue;
+      }
+      if (item.type === "image" && item.url.startsWith("file:")) {
+        const filePath = filePathFromUrl(item.url);
+        if (filePath) {
+          attachments.push(await stageLocalTurnInputAttachment({
+            type: "localImage",
+            ...(item.name ? { name: item.name } : {}),
+            path: filePath,
+          }, options));
+        }
+        continue;
+      }
+      attachments.push(item);
+    } catch {
+      // Forwarding is secondary to the already-admitted source turn. Omit an
+      // unreadable attachment instead of retaining its inline payload or
+      // failing the source turn after the backend accepted it.
+    }
+  }
+  return attachments;
+}
+
+function filePathFromUrl(value: string): string | undefined {
+  try {
+    return fileURLToPath(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function isStagedTurnInputAttachmentPath(filePath: string): boolean {
+  const relative = path.relative(
+    path.resolve(turnInputAttachmentRoot()),
+    path.resolve(filePath),
+  );
+  return relative !== ""
+    && relative !== ".."
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
+async function resolveOwnedStagingPath(filePath: string): Promise<string | undefined> {
+  const roots = [turnInputAttachmentRoot(), imageInputFileRoot()];
+  if (!roots.some((root) => isPathWithinRoot(path.resolve(filePath), path.resolve(root)))) {
+    return undefined;
+  }
+  const [resolvedPath, ...canonicalRoots] = await Promise.all([
+    realpath(filePath).catch(() => undefined),
+    ...roots.map(canonicalRoot),
+  ]);
+  return resolvedPath
+    && canonicalRoots.some((root) => isPathWithinRoot(resolvedPath, root))
+    ? resolvedPath
+    : undefined;
+}
+
+async function canonicalRoot(root: string): Promise<string> {
+  return await realpath(root).catch(() => path.resolve(root));
+}
+
+function isPathWithinRoot(filePath: string, root: string): boolean {
+  const relative = path.relative(root, filePath);
+  return relative !== ""
+    && relative !== ".."
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
+function decodeBase64(value: string): Buffer | undefined {
+  if (!/^[a-z0-9+/]*={0,2}$/iu.test(value) || value.length % 4 !== 0) {
+    return undefined;
+  }
+  return Buffer.from(value, "base64");
+}
+
+function parseImageDataUrl(
+  value: string,
+): { data: Buffer; mimeType: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]*={0,2})$/iu.exec(value);
+  if (!match || (match[2]?.length ?? 0) % 4 !== 0) {
+    return undefined;
+  }
+  const data = Buffer.from(match[2] ?? "", "base64");
+  return data.byteLength > 0
+    ? { data, mimeType: match[1] ?? "application/octet-stream" }
+    : undefined;
+}
+
+function fallbackName(
+  inputType: TurnInputAttachmentUpload["type"],
+  mimeType: string | undefined,
+): string {
+  if (inputType === "localFile") {
+    return "attachment";
+  }
+  switch (mimeType?.trim().toLowerCase()) {
+    case "image/gif":
+      return "image.gif";
+    case "image/jpeg":
+    case "image/jpg":
+      return "image.jpg";
+    case "image/webp":
+      return "image.webp";
+    default:
+      return "image.png";
+  }
+}
+
+export function sanitizeTurnAttachmentName(
+  value: string | undefined,
+  fallback = "attachment",
+): string {
+  const baseName = path.basename(value?.trim() || fallback).replace(/[\0]/g, "");
+  const sanitized = baseName
+    .replace(/[^a-zA-Z0-9._@()+,= -]/g, "_")
+    .slice(0, 160);
+  return sanitized && sanitized !== "." && sanitized !== ".."
+    ? sanitized
+    : fallback;
+}
+
+async function cleanupOldTurnInputAttachments(
+  root: string,
+  excludedFiles: ReadonlySet<string>,
+): Promise<void> {
+  const cutoff = Date.now() - TURN_INPUT_ATTACHMENT_MAX_AGE_MS;
+  const entries = await readdir(root).catch(() => []);
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(root, entry);
+      const children = await readdir(entryPath).catch(() => []);
+      if (children.some((child) => excludedFiles.has(path.join(entryPath, child)))) {
+        return;
+      }
+      const info = await stat(entryPath).catch(() => undefined);
+      if (info?.isDirectory() && info.mtimeMs < cutoff) {
+        await rm(entryPath, { recursive: true, force: true }).catch(
+          () => undefined,
+        );
+      }
+    }),
+  );
+}

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type {
   AppServerThreadMessageOrigin,
+  AppServerTurnInputItem,
   CreateInstanceThreadResult,
   CreateInstanceThreadToolArgs,
   FederationHealthStatus,
@@ -111,6 +112,9 @@ export function createFederationAgentToolsHandler(
       backend: CreateInstanceThreadResult["backend"];
       threadId: string;
     }) => Promise<void> | void;
+    resolveSourceTurnAttachments?: (
+      context: PwrAgentFederationContext,
+    ) => AppServerTurnInputItem[] | Promise<AppServerTurnInputItem[]>;
   } = {},
 ): PwrAgentFederationHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
@@ -140,6 +144,7 @@ export function createFederationAgentToolsHandler(
           collectHostInfo,
           options.targetStore,
           options.onRemoteChildMounted,
+          options.resolveSourceTurnAttachments,
         );
       }
       return await searchFederationThreads(
@@ -379,6 +384,9 @@ async function createInstanceThread(
     backend: CreateInstanceThreadResult["backend"];
     threadId: string;
   }) => Promise<void> | void) | undefined,
+  resolveSourceTurnAttachments: ((
+    context: PwrAgentFederationContext,
+  ) => AppServerTurnInputItem[] | Promise<AppServerTurnInputItem[]>) | undefined,
 ): Promise<PwrAgentFederationResponse> {
   const resolved = await resolveInstance(runtime, args.instanceId, collectHostInfo);
   if (!resolved.ok) {
@@ -428,6 +436,13 @@ async function createInstanceThread(
       threadId: context.threadId,
     },
   };
+  const attachmentInput = resolveSourceTurnAttachments
+    ? await resolveSourceTurnAttachments(context)
+    : [];
+  const input = [
+    ...(args.input ? [{ type: "text" as const, text: args.input }] : []),
+    ...attachmentInput,
+  ];
   const response = await backend.materializeDirectoryLaunchpad(
     {
       directoryKey: args.projectKey,
@@ -441,7 +456,7 @@ async function createInstanceThread(
               : {}),
           }
         : {}),
-      ...(args.input ? { input: [{ type: "text", text: args.input }] } : {}),
+      ...(input.length > 0 ? { input } : {}),
     },
     { messageOrigin },
   );

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -7,7 +7,10 @@ import type {
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AppServerLocalFileInputItem,
+  AppServerLocalImageInputItem,
   AppServerThreadMessageOrigin,
+  AppServerTurnInputItem,
   AgentEvent,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
@@ -179,6 +182,70 @@ export type FederationStartTurnRequest = StartTurnRequest & {
   messageOrigin?: AppServerThreadMessageOrigin;
 };
 
+export type FederationTurnInputBlobReference = {
+  type: "federationBlob";
+  transferId: string;
+};
+
+export type FederationWireTurnInputItem =
+  | AppServerTurnInputItem
+  | FederationTurnInputBlobReference;
+
+export type FederationStarMapIntakeAttachment =
+  | Pick<AppServerLocalImageInputItem, "type" | "name" | "path">
+  | Pick<AppServerLocalFileInputItem, "type" | "name" | "path">;
+
+export type FederationStarMapIntakeRequest =
+  Omit<StarMapIntakeRequest, "attachments"> & {
+    attachments?: FederationStarMapIntakeAttachment[];
+  };
+
+type FederationWireStarMapIntakeRequest =
+  Omit<FederationStarMapIntakeRequest, "attachments"> & {
+    attachments?: FederationWireTurnInputItem[];
+  };
+
+type FederationWireControlActiveTurnRequest =
+  Omit<ControlActiveTurnRequest, "input"> & {
+    input?: FederationWireTurnInputItem[];
+  };
+
+export type PrepareOutgoingFederationTurnInput = (
+  input: readonly AppServerTurnInputItem[],
+) => Promise<FederationWireTurnInputItem[]>;
+
+export type ResolveIncomingFederationTurnInput = (
+  input: readonly FederationWireTurnInputItem[],
+  sourceInstanceId: FederationInstanceId,
+) => Promise<AppServerTurnInputItem[]>;
+
+async function resolveFederationTurnInput(
+  resolver: ResolveIncomingFederationTurnInput | undefined,
+  input: readonly FederationWireTurnInputItem[],
+  sourceInstanceId: FederationInstanceId,
+): Promise<AppServerTurnInputItem[]> {
+  if (resolver) {
+    return await resolver(input, sourceInstanceId);
+  }
+  for (const item of input) {
+    if (
+      item.type === "federationBlob"
+      || item.type === "localImage"
+      || item.type === "localFile"
+      || item.type === "file"
+      || (
+        item.type === "image"
+        && (item.url.startsWith("data:") || item.url.startsWith("file:"))
+      )
+    ) {
+      throw new Error(
+        "Federation attachment references require the staged-input resolver.",
+      );
+    }
+  }
+  return input as AppServerTurnInputItem[];
+}
+
 export type FederationRefreshThreadPullRequestsRequest =
   RefreshOwnedThreadPullRequestsRequest;
 
@@ -194,7 +261,8 @@ function localizeRefreshThreadPullRequestsRequest(
 }
 
 type FederationMaterializeDirectoryLaunchpadRequest =
-  MaterializeDirectoryLaunchpadRequest & {
+  Omit<MaterializeDirectoryLaunchpadRequest, "input"> & {
+    input?: FederationWireTurnInputItem[];
     messageOrigin?: AppServerThreadMessageOrigin;
   };
 
@@ -661,7 +729,9 @@ export type FederationBackendOperations = {
   setCelestialIcon(
     request: SetCelestialIconRequest,
   ): Promise<SetCelestialIconResponse>;
-  starMapIntake(request: StarMapIntakeRequest): Promise<StarMapIntakeResponse>;
+  starMapIntake(
+    request: FederationStarMapIntakeRequest,
+  ): Promise<StarMapIntakeResponse>;
 };
 
 export function registerFederationBackendHandlers(params: {
@@ -674,6 +744,7 @@ export function registerFederationBackendHandlers(params: {
     event: CodexEnvironmentSetupProgressEvent,
     targetInstanceId: string,
   ) => void;
+  resolveTurnInput?: ResolveIncomingFederationTurnInput;
 }): NavigationSnapshotTransport {
   const navigationSnapshotTransport = new NavigationSnapshotTransport({
     // Federation has one owner collection and one resource-version history.
@@ -934,14 +1005,23 @@ export function registerFederationBackendHandlers(params: {
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.startTurn,
     async (envelope) => {
-      const request = envelope.params as FederationStartTurnRequest;
+      const request = envelope.params as Omit<
+        FederationStartTurnRequest,
+        "input"
+      > & { input: FederationWireTurnInputItem[] };
       const messageOrigin = authenticateMessageOrigin({
         messageOrigin: request.messageOrigin,
         resolveSourceInstance: params.resolveSourceInstance,
         sourceInstanceId: envelope.sourceInstanceId,
       });
+      const input = await resolveFederationTurnInput(
+        params.resolveTurnInput,
+        request.input,
+        envelope.sourceInstanceId,
+      );
       return await params.backend.startTurn({
         ...request,
+        input,
         ...(messageOrigin ? { messageOrigin } : {}),
       });
     },
@@ -1032,14 +1112,25 @@ export function registerFederationBackendHandlers(params: {
     params.router.registerHandler(
       FEDERATION_BACKEND_METHODS.controlActiveTurn,
       async (envelope) => {
-        const request = envelope.params as ControlActiveTurnRequest;
+        const {
+          input: wireInput,
+          ...request
+        } = envelope.params as FederationWireControlActiveTurnRequest;
         const messageOrigin = authenticateMessageOrigin({
           messageOrigin: request.messageOrigin,
           resolveSourceInstance: params.resolveSourceInstance,
           sourceInstanceId: envelope.sourceInstanceId,
         });
+        const input = wireInput
+          ? await resolveFederationTurnInput(
+              params.resolveTurnInput,
+              wireInput,
+              envelope.sourceInstanceId,
+            )
+          : undefined;
         return await params.backend.controlActiveTurn!({
           ...request,
+          ...(input ? { input } : {}),
           ...(messageOrigin ? { messageOrigin } : {}),
         });
       },
@@ -1231,6 +1322,7 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) => {
       const {
         messageOrigin: claimedMessageOrigin,
+        input: wireInput,
         ...request
       } = envelope.params as FederationMaterializeDirectoryLaunchpadRequest;
       const messageOrigin = authenticateMessageOrigin({
@@ -1238,8 +1330,18 @@ export function registerFederationBackendHandlers(params: {
         resolveSourceInstance: params.resolveSourceInstance,
         sourceInstanceId: envelope.sourceInstanceId,
       });
+      const input = wireInput
+        ? await resolveFederationTurnInput(
+            params.resolveTurnInput,
+            wireInput,
+            envelope.sourceInstanceId,
+          )
+        : undefined;
       return await params.backend.materializeDirectoryLaunchpad(
-        request,
+        {
+          ...request,
+          ...(input ? { input } : {}),
+        },
         {
           ...(messageOrigin ? { messageOrigin } : {}),
           sourceInstanceId: envelope.sourceInstanceId,
@@ -1306,10 +1408,37 @@ export function registerFederationBackendHandlers(params: {
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.starMapIntake,
-    async (envelope) =>
-      await params.backend.starMapIntake(
-        envelope.params as StarMapIntakeRequest,
-      ),
+    async (envelope) => {
+      const {
+        attachments: wireAttachments,
+        ...request
+      } = envelope.params as FederationWireStarMapIntakeRequest;
+      const attachments = wireAttachments
+        ? await resolveFederationTurnInput(
+            params.resolveTurnInput,
+            wireAttachments,
+            envelope.sourceInstanceId,
+          )
+        : undefined;
+      if (
+        attachments?.some(
+          (item) => item.type !== "localImage" && item.type !== "localFile",
+        )
+      ) {
+        throw new Error(
+          "Star Map intake attachments must resolve to staged local inputs.",
+        );
+      }
+      return await params.backend.starMapIntake({
+        ...request,
+        ...(attachments
+          ? {
+              attachments:
+                attachments as FederationStarMapIntakeAttachment[],
+            }
+          : {}),
+      });
+    },
   );
   return navigationSnapshotTransport;
 }
@@ -1322,6 +1451,7 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     ) =>
       | AppServerReadThreadResponse
       | Promise<AppServerReadThreadResponse> = (response) => response,
+    private readonly prepareTurnInput?: PrepareOutgoingFederationTurnInput,
   ) {}
 
   async getNavigationSnapshot(
@@ -1544,9 +1674,12 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async startTurn(
     request: FederationStartTurnRequest,
   ): Promise<StartTurnResponse> {
+    const input = this.prepareTurnInput
+      ? await this.prepareTurnInput(request.input)
+      : request.input;
     return await this.rpc.request<StartTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.startTurn,
-      params: request,
+      params: { ...request, input },
     });
   }
 
@@ -1641,9 +1774,12 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async controlActiveTurn(
     request: ControlActiveTurnRequest,
   ): Promise<ControlActiveTurnResponse> {
+    const input = request.input && this.prepareTurnInput
+      ? await this.prepareTurnInput(request.input)
+      : request.input;
     return await this.rpc.request<ControlActiveTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
-      params: request,
+      params: { ...request, ...(input ? { input } : {}) },
     });
   }
 
@@ -1881,10 +2017,14 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     request: MaterializeDirectoryLaunchpadRequest,
     options?: MaterializeDirectoryLaunchpadOptions,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
+    const input = request.input && this.prepareTurnInput
+      ? await this.prepareTurnInput(request.input)
+      : request.input;
     return await this.rpc.request<MaterializeDirectoryLaunchpadResponse>({
       method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
       params: {
         ...request,
+        ...(input ? { input } : {}),
         ...(options?.messageOrigin
           ? { messageOrigin: options.messageOrigin }
           : {}),
@@ -1967,11 +2107,19 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   }
 
   async starMapIntake(
-    request: StarMapIntakeRequest,
+    request: FederationStarMapIntakeRequest,
   ): Promise<StarMapIntakeResponse> {
+    const attachments = request.attachments && this.prepareTurnInput
+      ? await this.prepareTurnInput(
+          request.attachments as AppServerTurnInputItem[],
+        )
+      : request.attachments;
     return await this.rpc.request<StarMapIntakeResponse>({
       method: FEDERATION_BACKEND_METHODS.starMapIntake,
-      params: request,
+      params: {
+        ...request,
+        ...(attachments ? { attachments } : {}),
+      } satisfies FederationWireStarMapIntakeRequest,
       // Resolution + thread materialization can outlive the default 30s
       // (Grok call + worktree preparation), so give intake a longer leash.
       timeoutMs: 120_000,

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -1,4 +1,5 @@
 import type {
+  FederationBlobChunkEnvelope,
   FederationCapability,
   FederationErrorEnvelope,
   FederationInstanceId,
@@ -26,6 +27,11 @@ export type FederationRequestHandler = (
   sourcePeerId?: FederationInstanceId,
 ) => Promise<unknown> | unknown;
 
+export type FederationBlobChunkHandler = (
+  envelope: FederationBlobChunkEnvelope,
+  sourcePeerId?: FederationInstanceId,
+) => Promise<void> | void;
+
 export type FederationRouteResult =
   | { status: "handled"; response?: FederationResponseEnvelope }
   | { status: "relayed"; targetInstanceId: FederationInstanceId }
@@ -34,6 +40,7 @@ export type FederationRouteResult =
 export class FederationRouter {
   private readonly connections = new Map<FederationInstanceId, FederationRouterConnection>();
   private readonly handlers = new Map<string, FederationRequestHandler>();
+  private blobChunkHandler?: FederationBlobChunkHandler;
 
   constructor(
     private readonly options: {
@@ -80,6 +87,10 @@ export class FederationRouter {
 
   registerHandler(method: string, handler: FederationRequestHandler): void {
     this.handlers.set(method, handler);
+  }
+
+  registerBlobChunkHandler(handler: FederationBlobChunkHandler): void {
+    this.blobChunkHandler = handler;
   }
 
   async routeEnvelope(params: {
@@ -134,12 +145,46 @@ export class FederationRouter {
         };
       }
     }
+    if (params.envelope.kind === "blob_chunk") {
+      const capabilityFailure = this.checkBlobChunkCapability(
+        params.envelope,
+        params.sourcePeerId,
+      );
+      if (capabilityFailure) {
+        this.replyToSource(params.sourcePeerId, capabilityFailure);
+        return {
+          status: "rejected",
+          code: capabilityFailure.error.code,
+          message: capabilityFailure.error.message,
+        };
+      }
+    }
 
     if (
       params.envelope.targetInstanceId &&
       params.envelope.targetInstanceId !== this.options.localInstanceId
     ) {
       return this.relayEnvelope(params);
+    }
+
+    if (params.envelope.kind === "blob_chunk") {
+      if (!this.blobChunkHandler) {
+        return {
+          status: "rejected",
+          code: "blob_handler_unavailable",
+          message: "Federation blob transfer is unavailable.",
+        };
+      }
+      try {
+        await this.blobChunkHandler(params.envelope, params.sourcePeerId);
+        return { status: "handled" };
+      } catch (error) {
+        return {
+          status: "rejected",
+          code: "blob_transfer_failed",
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
     }
 
     if (params.envelope.kind !== "request") {
@@ -281,6 +326,19 @@ export class FederationRouter {
     return this.errorEnvelope(envelope, {
       code: "capability_denied",
       message: `Method ${envelope.method} requires ${requiredCapability}.`,
+    });
+  }
+
+  private checkBlobChunkCapability(
+    envelope: FederationBlobChunkEnvelope,
+    sourcePeerId: FederationInstanceId | undefined,
+  ): FederationErrorEnvelope | undefined {
+    if (!sourcePeerId) return undefined;
+    const source = this.connections.get(sourcePeerId);
+    if (source?.capabilities.includes("turn_input_blobs")) return undefined;
+    return this.errorEnvelope(envelope, {
+      code: "capability_denied",
+      message: "Federation blob transfer requires turn_input_blobs.",
     });
   }
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -244,6 +244,11 @@ import {
   type FederationStartTurnRequest,
 } from "./federation-backend-bridge";
 import {
+  FederationTurnInputAttachmentReceiver,
+  hasFederationTurnInputAttachments,
+  prepareOutgoingFederationTurnInput,
+} from "./federation-turn-input-attachments";
+import {
   applyFederationLeaseSnapshot,
   buildFederationHealthStatus,
   publicPeerSummary,
@@ -397,6 +402,7 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   // granted — but stays a dedicated capability so it is revocable on its own.
   "remote_pty",
   "event_subscriptions",
+  "turn_input_blobs",
 ];
 
 const REMOTE_THREAD_SUMMARY_EVENT_CONSUMER_ID =
@@ -778,6 +784,8 @@ export class DesktopFederationRuntime {
     }
   >();
   private ownedNavigationSnapshotTransport?: NavigationSnapshotTransport;
+  private readonly turnInputAttachmentReceiver =
+    new FederationTurnInputAttachmentReceiver();
   private readonly remotePeerDirectory = new Map<
     FederationInstanceId,
     FederationPeerSummary
@@ -1619,6 +1627,30 @@ export class DesktopFederationRuntime {
           ),
           target.instanceId,
         ),
+      async (input) => {
+        if (!hasFederationTurnInputAttachments(input)) {
+          return [...input];
+        }
+        if (
+          !this.remotePeerAdvertisesCapability(
+            target.instanceId,
+            "turn_input_blobs",
+          )
+        ) {
+          throw new Error(
+            `Federation instance ${target.instanceId} does not support binary turn attachments.`,
+          );
+        }
+        return await prepareOutgoingFederationTurnInput({
+          input,
+          localInstanceId: this.ensureLocalInstanceId(),
+          targetInstanceId: target.instanceId,
+          privateStorageRoots:
+            getDesktopBackendRegistry().getLocalFilePrivateStorageRoots(),
+          sendEnvelope: (envelope) =>
+            this.sendEnvelopeToTarget(target.instanceId, envelope),
+        });
+      },
     );
   }
 
@@ -2320,9 +2352,20 @@ export class DesktopFederationRuntime {
       },
       additionalRequiredCapabilities: additionalFederationBackendCapabilities,
     });
+    router.registerBlobChunkHandler(async (envelope) => {
+      await this.turnInputAttachmentReceiver.receive(
+        envelope,
+        envelope.sourceInstanceId,
+      );
+    });
     this.ownedNavigationSnapshotTransport = registerFederationBackendHandlers({
       router,
       backend: localBackendOperations(),
+      resolveTurnInput: async (input, sourceInstanceId) =>
+        await this.turnInputAttachmentReceiver.resolveInput(
+          input,
+          sourceInstanceId,
+        ),
       resolveSourceInstance: (instanceId) =>
         this.resolveThreadMessageOriginInstance(instanceId),
       onEnvironmentSetupProgress: (event, targetInstanceId) => {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -74,6 +74,10 @@ export const FEDERATION_KEEPALIVE_INTERVAL_MS = 15_000;
  * peer can force that allocation per frame.
  */
 export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+const FEDERATION_BLOB_FRAME_MAGIC = Buffer.from("PWRBLOB1", "ascii");
+const FEDERATION_BLOB_FRAME_PREFIX_BYTES =
+  FEDERATION_BLOB_FRAME_MAGIC.byteLength + 4;
+const FEDERATION_BLOB_FRAME_MAX_HEADER_BYTES = 64 * 1024;
 
 /**
  * The socket surface the keepalive watchdog needs. Structural (rather than
@@ -1208,8 +1212,8 @@ function sendFrame(
   transport?: NoiseTransport,
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
-  const json = Buffer.from(JSON.stringify(message), "utf8");
-  const wire = transport ? transport.encrypt(json) : json;
+  const payload = encodeFederationSocketPayload(message);
+  const wire = transport ? transport.encrypt(payload) : payload;
   socket.send(wire);
   return wire.byteLength;
 }
@@ -1223,16 +1227,54 @@ function decodeFrame(
   frame: Buffer,
   transport?: NoiseTransport,
 ): FederationSocketMessage | undefined {
-  let json = frame;
+  let payload = frame;
   if (transport) {
     try {
-      json = transport.decrypt(frame);
+      payload = transport.decrypt(frame);
     } catch {
       throw new FederationFrameAuthenticationError();
     }
   }
+  return decodeFederationSocketPayload(payload);
+}
+
+function encodeFederationSocketPayload(
+  message: FederationSocketMessage,
+): Buffer {
+  if (
+    message.kind !== "envelope"
+    || message.envelope.kind !== "blob_chunk"
+  ) {
+    return Buffer.from(JSON.stringify(message), "utf8");
+  }
+  const { data, ...headerEnvelope } = message.envelope;
+  const header = Buffer.from(
+    JSON.stringify({ kind: "envelope", envelope: headerEnvelope }),
+    "utf8",
+  );
+  if (header.byteLength > FEDERATION_BLOB_FRAME_MAX_HEADER_BYTES) {
+    throw new Error("Federation blob frame header is too large.");
+  }
+  const prefix = Buffer.allocUnsafe(FEDERATION_BLOB_FRAME_PREFIX_BYTES);
+  FEDERATION_BLOB_FRAME_MAGIC.copy(prefix, 0);
+  prefix.writeUInt32BE(header.byteLength, FEDERATION_BLOB_FRAME_MAGIC.byteLength);
+  return Buffer.concat([prefix, header, Buffer.from(data)]);
+}
+
+function decodeFederationSocketPayload(
+  payload: Buffer,
+): FederationSocketMessage | undefined {
+  if (
+    payload.byteLength >= FEDERATION_BLOB_FRAME_PREFIX_BYTES
+    && payload.subarray(0, FEDERATION_BLOB_FRAME_MAGIC.byteLength)
+      .equals(FEDERATION_BLOB_FRAME_MAGIC)
+  ) {
+    return decodeFederationBlobSocketPayload(payload);
+  }
   try {
-    const parsed = JSON.parse(json.toString("utf8")) as Partial<FederationSocketMessage>;
+    const parsed = JSON.parse(
+      payload.toString("utf8"),
+    ) as Partial<FederationSocketMessage>;
     if (
       parsed.kind === "transport.hello"
       && isTransportHelloMessage(parsed)
@@ -1245,7 +1287,11 @@ function decodeFrame(
     if (parsed.kind === "auth.rejected" && parsed.failure) {
       return parsed as FederationSocketRejectedMessage;
     }
-    if (parsed.kind === "envelope" && parsed.envelope) {
+    if (
+      parsed.kind === "envelope"
+      && parsed.envelope
+      && parsed.envelope.kind !== "blob_chunk"
+    ) {
       return parsed as FederationSocketEnvelopeMessage;
     }
     return undefined;
@@ -1253,6 +1299,61 @@ function decodeFrame(
     return undefined;
   }
 }
+
+function decodeFederationBlobSocketPayload(
+  payload: Buffer,
+): FederationSocketMessage | undefined {
+  const headerLength = payload.readUInt32BE(
+    FEDERATION_BLOB_FRAME_MAGIC.byteLength,
+  );
+  if (
+    headerLength <= 0
+    || headerLength > FEDERATION_BLOB_FRAME_MAX_HEADER_BYTES
+    || FEDERATION_BLOB_FRAME_PREFIX_BYTES + headerLength > payload.byteLength
+  ) {
+    return undefined;
+  }
+  try {
+    const header = JSON.parse(
+      payload
+        .subarray(
+          FEDERATION_BLOB_FRAME_PREFIX_BYTES,
+          FEDERATION_BLOB_FRAME_PREFIX_BYTES + headerLength,
+        )
+        .toString("utf8"),
+    ) as Partial<FederationSocketEnvelopeMessage>;
+    if (
+      header.kind !== "envelope"
+      || !header.envelope
+      || header.envelope.kind !== "blob_chunk"
+      || Object.hasOwn(header.envelope, "data")
+    ) {
+      return undefined;
+    }
+    return {
+      kind: "envelope",
+      envelope: {
+        ...header.envelope,
+        data: payload.subarray(
+          FEDERATION_BLOB_FRAME_PREFIX_BYTES + headerLength,
+        ),
+      },
+    } as FederationSocketEnvelopeMessage;
+  } catch {
+    return undefined;
+  }
+}
+
+/** @internal Narrow wire-codec seam for protocol conformance tests. */
+export const federationTransportCodecForTest = {
+  encodeEnvelope(envelope: FederationProtocolEnvelope): Buffer {
+    return encodeFederationSocketPayload({ kind: "envelope", envelope });
+  },
+  decodeEnvelope(payload: Buffer): FederationProtocolEnvelope | undefined {
+    const decoded = decodeFederationSocketPayload(payload);
+    return decoded?.kind === "envelope" ? decoded.envelope : undefined;
+  },
+};
 
 class FederationFrameAuthenticationError extends Error {
   constructor() {

--- a/apps/desktop/src/main/federation/federation-turn-input-attachments.ts
+++ b/apps/desktop/src/main/federation/federation-turn-input-attachments.ts
@@ -1,0 +1,559 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AppServerFileInputItem,
+  AppServerTurnInputItem,
+  FederationBlobChunkEnvelope,
+  FederationInstanceId,
+  FederationProtocolEnvelope,
+} from "@pwragent/shared";
+import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+import {
+  MAX_TURN_INPUT_ATTACHMENT_BYTES,
+  sanitizeTurnAttachmentName,
+  stageLocalTurnInputAttachment,
+  stageTurnInputAttachment,
+  type StagedTurnInputAttachment,
+} from "../app-server/turn-input-attachment-files";
+import { resolveActiveProfilePath } from "../profile";
+
+export const FEDERATION_BLOB_CHUNK_BYTES = 512 * 1024;
+const FEDERATION_BLOB_WAIT_TIMEOUT_MS = 30_000;
+const FEDERATION_BLOB_COMPLETED_RETENTION_MS = 10 * 60_000;
+export const MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE = 8;
+export const MAX_BUFFERED_FEDERATION_BLOB_BYTES = 256 * 1024 * 1024;
+
+export type FederationTurnInputBlobReference = {
+  type: "federationBlob";
+  transferId: string;
+};
+
+export type FederationWireTurnInputItem =
+  | AppServerTurnInputItem
+  | FederationTurnInputBlobReference;
+
+type IncomingTransferMetadata = {
+  transferId: string;
+  chunkCount: number;
+  totalSize: number;
+  sha256: string;
+  name: string;
+  mimeType?: string;
+  inputType: "localFile" | "localImage";
+};
+
+type IncomingTransfer = {
+  chunks: Map<number, Buffer>;
+  completion: Promise<StagedTurnInputAttachment>;
+  metadata?: IncomingTransferMetadata;
+  receivedBytes: number;
+  reject: (error: Error) => void;
+  resolve: (attachment: StagedTurnInputAttachment) => void;
+  sourceInstanceId: FederationInstanceId;
+  settled: boolean;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+export async function prepareOutgoingFederationTurnInput(params: {
+  input: readonly AppServerTurnInputItem[];
+  localInstanceId: FederationInstanceId;
+  targetInstanceId: FederationInstanceId;
+  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  privateStorageRoots?: readonly string[];
+}): Promise<FederationWireTurnInputItem[]> {
+  const prepared: FederationWireTurnInputItem[] = [];
+
+  for (const item of params.input) {
+    const staged = await stageTransferableInput(item, {
+      privateStorageRoots: params.privateStorageRoots,
+    });
+    if (!staged) {
+      if (item.type === "image" && item.url.startsWith("data:")) {
+        throw new Error(
+          "Inline image data could not be staged for federation transfer.",
+        );
+      }
+      prepared.push(item);
+      continue;
+    }
+    prepared.push(
+      await sendStagedAttachment({
+        attachment: staged,
+        localInstanceId: params.localInstanceId,
+        targetInstanceId: params.targetInstanceId,
+        sendEnvelope: params.sendEnvelope,
+      }),
+    );
+  }
+
+  return prepared;
+}
+
+export function hasFederationTurnInputAttachments(
+  input: readonly AppServerTurnInputItem[],
+): boolean {
+  return input.some(
+    (item) =>
+      item.type === "file"
+      || item.type === "localFile"
+      || item.type === "localImage"
+      || (item.type === "image" && item.url.startsWith("data:"))
+      || (item.type === "image" && item.url.startsWith("file:")),
+  );
+}
+
+async function stageTransferableInput(
+  item: AppServerTurnInputItem,
+  options: { privateStorageRoots?: readonly string[] },
+): Promise<StagedTurnInputAttachment | undefined> {
+  if (item.type === "localImage" || item.type === "localFile") {
+    return await stageLocalTurnInputAttachment(item, options);
+  }
+  if (item.type === "file") {
+    return await stageTurnInputAttachment({
+      type: "localFile",
+      data: decodeBase64File(item),
+      name: item.name,
+      mimeType: item.mimeType,
+    });
+  }
+  if (item.type !== "image") {
+    return undefined;
+  }
+  if (item.url.startsWith("file:")) {
+    const filePath = filePathFromUrl(item.url);
+    if (!filePath) {
+      throw new Error("Invalid local image file URL.");
+    }
+    return await stageLocalTurnInputAttachment({
+      type: "localImage",
+      ...(item.name ? { name: item.name } : {}),
+      path: filePath,
+    }, options);
+  }
+  const parsed = parseImageDataUrl(item.url);
+  if (!parsed) {
+    return undefined;
+  }
+  return await stageTurnInputAttachment({
+    type: "localImage",
+    data: parsed.data,
+    name: item.name,
+    mimeType: parsed.mimeType,
+  });
+}
+
+function filePathFromUrl(value: string): string | undefined {
+  try {
+    return fileURLToPath(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeBase64File(item: AppServerFileInputItem): Buffer {
+  if (!/^[a-z0-9+/]*={0,2}$/iu.test(item.data) || item.data.length % 4 !== 0) {
+    throw new Error(`File attachment ${item.name} has invalid base64 data.`);
+  }
+  return Buffer.from(item.data, "base64");
+}
+
+function parseImageDataUrl(
+  url: string,
+): { data: Buffer; mimeType: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]*={0,2})$/iu.exec(url);
+  if (!match || (match[2]?.length ?? 0) % 4 !== 0) {
+    return undefined;
+  }
+  const data = Buffer.from(match[2] ?? "", "base64");
+  if (data.byteLength === 0) {
+    return undefined;
+  }
+  return { data, mimeType: match[1] ?? "application/octet-stream" };
+}
+
+async function sendStagedAttachment(params: {
+  attachment: StagedTurnInputAttachment;
+  localInstanceId: FederationInstanceId;
+  targetInstanceId: FederationInstanceId;
+  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+}): Promise<FederationTurnInputBlobReference> {
+  const data = await readFile(params.attachment.path);
+  if (data.byteLength > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
+    throw new Error(
+      `Turn attachment exceeds the ${MAX_TURN_INPUT_ATTACHMENT_BYTES}-byte limit.`,
+    );
+  }
+  const transferId = randomUUID();
+  const chunkCount = Math.max(1, Math.ceil(data.byteLength / FEDERATION_BLOB_CHUNK_BYTES));
+  const sha256 = createHash("sha256").update(data).digest("hex");
+  const name = sanitizeTurnAttachmentName(
+    params.attachment.name,
+    path.basename(params.attachment.path),
+  );
+  const mimeType = params.attachment.type === "localFile"
+    ? params.attachment.mimeType
+    : undefined;
+
+  for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+    const offset = chunkIndex * FEDERATION_BLOB_CHUNK_BYTES;
+    const chunk = data.subarray(
+      offset,
+      Math.min(data.byteLength, offset + FEDERATION_BLOB_CHUNK_BYTES),
+    );
+    params.sendEnvelope({
+      id: `federation-blob:${transferId}:${chunkIndex}`,
+      kind: "blob_chunk",
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: params.localInstanceId,
+      targetInstanceId: params.targetInstanceId,
+      createdAt: Date.now(),
+      transferId,
+      chunkIndex,
+      chunkCount,
+      totalSize: data.byteLength,
+      sha256,
+      name,
+      ...(mimeType ? { mimeType } : {}),
+      inputType: params.attachment.type,
+      data: chunk,
+    });
+  }
+
+  return { type: "federationBlob", transferId };
+}
+
+export class FederationTurnInputAttachmentReceiver {
+  private readonly transfers = new Map<string, IncomingTransfer>();
+  private bufferedBytes = 0;
+
+  constructor(
+    private readonly options: {
+      resolveRoot?: () => string;
+      now?: () => number;
+    } = {},
+  ) {}
+
+  async receive(
+    envelope: FederationBlobChunkEnvelope,
+    sourceInstanceId: FederationInstanceId,
+  ): Promise<void> {
+    validateBlobChunk(envelope);
+    const key = transferKey(sourceInstanceId, envelope.transferId);
+    const transfer = this.getOrCreateTransfer(key, sourceInstanceId);
+    const metadata = metadataFromEnvelope(envelope);
+    if (transfer.metadata && !sameMetadata(transfer.metadata, metadata)) {
+      this.failTransfer(key, transfer, new Error("Federation blob metadata changed between chunks."));
+      throw new Error("Federation blob metadata changed between chunks.");
+    }
+    transfer.metadata ??= metadata;
+
+    const previous = transfer.chunks.get(envelope.chunkIndex);
+    const chunk = Buffer.from(envelope.data);
+    if (previous) {
+      if (!previous.equals(chunk)) {
+        this.failTransfer(key, transfer, new Error("Federation blob chunk was replayed with different bytes."));
+        throw new Error("Federation blob chunk was replayed with different bytes.");
+      }
+      return;
+    }
+    if (
+      this.bufferedBytes + chunk.byteLength
+      > MAX_BUFFERED_FEDERATION_BLOB_BYTES
+    ) {
+      this.failTransfer(
+        key,
+        transfer,
+        new Error("Federation blob buffer limit exceeded."),
+      );
+      throw new Error("Federation blob buffer limit exceeded.");
+    }
+    transfer.chunks.set(envelope.chunkIndex, chunk);
+    transfer.receivedBytes += chunk.byteLength;
+    this.bufferedBytes += chunk.byteLength;
+    if (transfer.receivedBytes > metadata.totalSize) {
+      this.failTransfer(key, transfer, new Error("Federation blob exceeded its declared size."));
+      throw new Error("Federation blob exceeded its declared size.");
+    }
+    if (transfer.chunks.size !== metadata.chunkCount) {
+      return;
+    }
+
+    try {
+      const attachment = await this.persistCompletedTransfer(
+        sourceInstanceId,
+        metadata,
+        transfer.chunks,
+      );
+      transfer.settled = true;
+      this.releaseBufferedChunks(transfer);
+      clearTimeout(transfer.timeout);
+      transfer.resolve(attachment);
+      const cleanup = setTimeout(() => {
+        if (this.transfers.get(key) === transfer) {
+          this.transfers.delete(key);
+        }
+      }, FEDERATION_BLOB_COMPLETED_RETENTION_MS);
+      cleanup.unref?.();
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      this.failTransfer(key, transfer, failure);
+      throw failure;
+    }
+  }
+
+  async resolveInput(
+    input: readonly FederationWireTurnInputItem[],
+    sourceInstanceId: FederationInstanceId,
+  ): Promise<AppServerTurnInputItem[]> {
+    return await Promise.all(
+      input.map(async (item) => {
+        if (!isFederationTurnInputBlobReference(item)) {
+          assertSafeFederationInlineInput(item);
+          return item;
+        }
+        const transfer = this.getOrCreateTransfer(
+          transferKey(sourceInstanceId, item.transferId),
+          sourceInstanceId,
+        );
+        return await transfer.completion;
+      }),
+    );
+  }
+
+  private getOrCreateTransfer(
+    key: string,
+    sourceInstanceId: FederationInstanceId,
+  ): IncomingTransfer {
+    const existing = this.transfers.get(key);
+    if (existing) {
+      return existing;
+    }
+    const incompleteForSource = [...this.transfers.values()].filter(
+      (transfer) =>
+        !transfer.settled
+        && transfer.sourceInstanceId === sourceInstanceId,
+    ).length;
+    if (incompleteForSource >= MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE) {
+      throw new Error(
+        "Too many incomplete federation blob transfers from this peer.",
+      );
+    }
+    let resolve!: (attachment: StagedTurnInputAttachment) => void;
+    let reject!: (error: Error) => void;
+    const completion = new Promise<StagedTurnInputAttachment>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    // A malformed peer chunk can fail before the matching RPC reaches the
+    // resolver. Keep the original rejecting promise for callers while also
+    // marking it observed so an unaffiliated peer cannot cause an unhandled
+    // rejection in the main process.
+    void completion.catch(() => undefined);
+    const transfer = {
+      chunks: new Map<number, Buffer>(),
+      completion,
+      receivedBytes: 0,
+      reject,
+      resolve,
+      sourceInstanceId,
+      settled: false,
+      timeout: setTimeout(() => undefined, 0),
+    } satisfies IncomingTransfer;
+    clearTimeout(transfer.timeout);
+    transfer.timeout = setTimeout(() => {
+      this.failTransfer(
+        key,
+        transfer,
+        new Error("Timed out waiting for federation attachment bytes."),
+      );
+    }, FEDERATION_BLOB_WAIT_TIMEOUT_MS);
+    transfer.timeout.unref?.();
+    this.transfers.set(key, transfer);
+    return transfer;
+  }
+
+  private failTransfer(
+    key: string,
+    transfer: IncomingTransfer,
+    error: Error,
+  ): void {
+    if (transfer.settled) {
+      return;
+    }
+    transfer.settled = true;
+    clearTimeout(transfer.timeout);
+    this.releaseBufferedChunks(transfer);
+    transfer.reject(error);
+    if (this.transfers.get(key) === transfer) {
+      this.transfers.delete(key);
+    }
+  }
+
+  private releaseBufferedChunks(transfer: IncomingTransfer): void {
+    this.bufferedBytes = Math.max(
+      0,
+      this.bufferedBytes - transfer.receivedBytes,
+    );
+    transfer.receivedBytes = 0;
+    transfer.chunks.clear();
+  }
+
+  private async persistCompletedTransfer(
+    sourceInstanceId: FederationInstanceId,
+    metadata: IncomingTransferMetadata,
+    chunks: ReadonlyMap<number, Buffer>,
+  ): Promise<StagedTurnInputAttachment> {
+    const ordered = Array.from(
+      { length: metadata.chunkCount },
+      (_, index) => chunks.get(index),
+    );
+    if (ordered.some((chunk) => !chunk)) {
+      throw new Error("Federation blob is missing one or more chunks.");
+    }
+    const data = Buffer.concat(ordered as Buffer[]);
+    if (data.byteLength !== metadata.totalSize) {
+      throw new Error("Federation blob size does not match its metadata.");
+    }
+    const digest = createHash("sha256").update(data).digest("hex");
+    if (digest !== metadata.sha256) {
+      throw new Error("Federation blob failed its SHA-256 integrity check.");
+    }
+
+    const root = this.options.resolveRoot?.()
+      ?? resolveActiveProfilePath(path.join("state", "federation-turn-inputs"));
+    const filePath = path.join(
+      root,
+      sanitizeTurnAttachmentName(sourceInstanceId, "peer"),
+      digest,
+      sanitizeTurnAttachmentName(metadata.name),
+    );
+    await mkdir(path.dirname(filePath), { recursive: true });
+    const existing = await stat(filePath).catch(() => undefined);
+    let reusable = false;
+    if (existing?.isFile() && existing.size === metadata.totalSize) {
+      const existingData = await readFile(filePath).catch(() => undefined);
+      reusable = Boolean(
+        existingData
+        && createHash("sha256").update(existingData).digest("hex") === digest,
+      );
+    }
+    if (!reusable) {
+      const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+      try {
+        await writeFile(temporaryPath, data);
+        await rename(temporaryPath, filePath);
+      } finally {
+        await unlink(temporaryPath).catch(() => undefined);
+      }
+    }
+
+    return metadata.inputType === "localImage"
+      ? { type: "localImage", name: metadata.name, path: filePath }
+      : {
+          type: "localFile",
+          name: metadata.name,
+          path: filePath,
+          ...(metadata.mimeType ? { mimeType: metadata.mimeType } : {}),
+          sizeBytes: metadata.totalSize,
+        };
+  }
+}
+
+function assertSafeFederationInlineInput(item: AppServerTurnInputItem): void {
+  if (
+    item.type === "localImage"
+    || item.type === "localFile"
+    || item.type === "file"
+    || (
+      item.type === "image"
+      && (item.url.startsWith("data:") || item.url.startsWith("file:"))
+    )
+  ) {
+    throw new Error(
+      "Federation turn attachments must use a verified blob transfer reference.",
+    );
+  }
+}
+
+export function isFederationTurnInputBlobReference(
+  value: FederationWireTurnInputItem,
+): value is FederationTurnInputBlobReference {
+  return value.type === "federationBlob"
+    && typeof value.transferId === "string"
+    && value.transferId.length > 0
+    && value.transferId.length <= 120;
+}
+
+function validateBlobChunk(envelope: FederationBlobChunkEnvelope): void {
+  if (
+    !envelope.transferId
+    || envelope.transferId.length > 120
+    || !Number.isSafeInteger(envelope.chunkIndex)
+    || envelope.chunkIndex < 0
+    || !Number.isSafeInteger(envelope.chunkCount)
+    || envelope.chunkCount < 1
+    || envelope.chunkIndex >= envelope.chunkCount
+    || !Number.isSafeInteger(envelope.totalSize)
+    || envelope.totalSize < 0
+    || envelope.totalSize > MAX_TURN_INPUT_ATTACHMENT_BYTES
+    || !/^[a-f0-9]{64}$/u.test(envelope.sha256)
+    || !envelope.name
+    || envelope.name.length > 200
+    || !(envelope.data instanceof Uint8Array)
+    || envelope.data.byteLength > FEDERATION_BLOB_CHUNK_BYTES
+    || (envelope.inputType !== "localFile" && envelope.inputType !== "localImage")
+  ) {
+    throw new Error("Invalid federation blob chunk.");
+  }
+  const expectedChunkCount = Math.max(
+    1,
+    Math.ceil(envelope.totalSize / FEDERATION_BLOB_CHUNK_BYTES),
+  );
+  const expectedChunkSize = envelope.chunkIndex < expectedChunkCount - 1
+    ? FEDERATION_BLOB_CHUNK_BYTES
+    : envelope.totalSize
+      - (expectedChunkCount - 1) * FEDERATION_BLOB_CHUNK_BYTES;
+  if (
+    envelope.chunkCount !== expectedChunkCount
+    || envelope.data.byteLength !== expectedChunkSize
+  ) {
+    throw new Error("Invalid federation blob chunk geometry.");
+  }
+}
+
+function metadataFromEnvelope(
+  envelope: FederationBlobChunkEnvelope,
+): IncomingTransferMetadata {
+  return {
+    transferId: envelope.transferId,
+    chunkCount: envelope.chunkCount,
+    totalSize: envelope.totalSize,
+    sha256: envelope.sha256,
+    name: envelope.name,
+    ...(envelope.mimeType ? { mimeType: envelope.mimeType } : {}),
+    inputType: envelope.inputType,
+  };
+}
+
+function sameMetadata(
+  left: IncomingTransferMetadata,
+  right: IncomingTransferMetadata,
+): boolean {
+  return left.transferId === right.transferId
+    && left.chunkCount === right.chunkCount
+    && left.totalSize === right.totalSize
+    && left.sha256 === right.sha256
+    && left.name === right.name
+    && left.mimeType === right.mimeType
+    && left.inputType === right.inputType;
+}
+
+function transferKey(
+  sourceInstanceId: FederationInstanceId,
+  transferId: string,
+): string {
+  return `${sourceInstanceId}\u0000${transferId}`;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1237,6 +1237,16 @@ export function bootstrapApp(): void {
     getDesktopBackendRegistry().setPwrAgentFederationHandler(
       createFederationAgentToolsHandler({
         targetStore: getDesktopOverlayStore(),
+        resolveSourceTurnAttachments: (context) => {
+          const turnId = context.turnId?.trim();
+          return turnId
+            ? getDesktopBackendRegistry().getTurnInputAttachments({
+                backend: context.backend,
+                threadId: context.threadId,
+                turnId,
+              })
+            : [];
+        },
         onRemoteChildMounted: async ({ backend, instanceId, threadId }) => {
           await getDesktopBackendRegistry().publishLocalEvent({
             backend,

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1698,6 +1698,7 @@ const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
   gateway_relay: "reach sibling instances",
   remote_pty: "open a remote terminal",
   event_subscriptions: "stream explicitly subscribed events",
+  turn_input_blobs: "transfer turn attachments",
 };
 
 function formatFederationCapabilities(

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -27,6 +27,7 @@ export const FEDERATION_CAPABILITIES = [
   "gateway_relay",
   "remote_pty",
   "event_subscriptions",
+  "turn_input_blobs",
 ] as const;
 
 export type FederationCapability = (typeof FEDERATION_CAPABILITIES)[number];
@@ -678,11 +679,30 @@ export type FederationNotificationEnvelope<
   params: Params;
 };
 
+/**
+ * One binary chunk of a content-addressed turn attachment. The transport
+ * encodes `data` after a small JSON metadata header in a binary WebSocket
+ * frame; it must never pass this envelope through JSON.stringify directly.
+ */
+export type FederationBlobChunkEnvelope = FederationEnvelopeBase & {
+  kind: "blob_chunk";
+  transferId: string;
+  chunkIndex: number;
+  chunkCount: number;
+  totalSize: number;
+  sha256: string;
+  name: string;
+  mimeType?: string;
+  inputType: "localFile" | "localImage";
+  data: Uint8Array;
+};
+
 export type FederationProtocolEnvelope =
   | FederationRequestEnvelope
   | FederationResponseEnvelope
   | FederationErrorEnvelope
-  | FederationNotificationEnvelope;
+  | FederationNotificationEnvelope
+  | FederationBlobChunkEnvelope;
 
 export function isFederationCapability(
   value: unknown,


### PR DESCRIPTION
## Summary
- stage image and file inputs in PwrAgent-owned content-addressed storage
- transfer attachment bytes in authenticated binary federation frames without base64 JSON payloads
- propagate source-turn attachments through send, steer, handoff, create-instance, and Star Map intake paths
- reject peer-controlled paths and enforce chunk geometry, memory limits, size limits, and SHA-256 validation

## Validation
- desktop TypeScript typecheck
- focused staging, transport, bridge, agent-tool, send-message, and handoff tests
- federation router tests
- ESLint typed and untyped checks
- dependency-boundary lint
- Codex-storage boundary lint
- git diff check