### PR TITLE
feat(desktop): forward Star Map image attachments

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
@@ -11,6 +13,7 @@ import type {
 import {
   AcpBackendAdapter,
   describeInstalledAcpBackend,
+  inputToAcpPrompt,
   isAcpSessionMissingForProjectError,
   withAcpModelRuntimeSelection,
   type AcpBackendAdapterOptions,
@@ -23,6 +26,36 @@ const fixtureDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "fixtures/acp-transcripts",
 );
+
+describe("inputToAcpPrompt", () => {
+  it("embeds trusted local image bytes for ACP providers", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-image-"));
+    const imagePath = path.join(root, "normalized.heic");
+    const imageBytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3,
+    ]);
+    try {
+      await writeFile(imagePath, imageBytes);
+
+      await expect(inputToAcpPrompt([{
+        type: "localImage",
+        name: "original.heic",
+        path: imagePath,
+      }])).resolves.toMatchObject({
+        promptContent: [
+          { type: "text", text: "[Local image: original.heic]" },
+          {
+            type: "image",
+            mimeType: "image/png",
+            data: imageBytes.toString("base64"),
+          },
+        ],
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("describeInstalledAcpBackend", () => {
   it("does not advertise session/load when the agent reports it is unsupported", () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -15,7 +15,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, onTestFinished, vi } from "vitest";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
   buildFederatedThreadRef,
@@ -27283,6 +27283,18 @@ command = "pnpm dev"
 
   it("groups a Codex handoff under its Kimi parent", async () => {
     const acpBackendId = "acp:kimi" as AcpBackendId;
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-image-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    const previousProfile = process.env.PWRAGENT_PROFILE;
+    process.env.PWRAGENT_HOME = tempRoot;
+    process.env.PWRAGENT_PROFILE = "test";
+    onTestFinished(async () => {
+      if (previousHome === undefined) delete process.env.PWRAGENT_HOME;
+      else process.env.PWRAGENT_HOME = previousHome;
+      if (previousProfile === undefined) delete process.env.PWRAGENT_PROFILE;
+      else process.env.PWRAGENT_PROFILE = previousProfile;
+      await rm(tempRoot, { recursive: true, force: true });
+    });
     const parentDirectory = {
       id: expectedDir("/repo/app"),
       kind: "local" as const,
@@ -27316,13 +27328,32 @@ command = "pnpm dev"
       acpBackendId,
       codexClient,
       overlayStore,
+      sessionId: "kimi-parent",
       sessions: [parentSession],
     });
     const turn = await registry.startTurn({
       backend: acpBackendId,
       threadId: "kimi-parent",
-      input: [{ type: "text", text: "Delegate the migration lock fix." }],
+      input: [
+        { type: "text", text: "Delegate the migration lock fix." },
+        {
+          type: "image",
+          name: "migration.png",
+          url: "data:image/png;base64,AQID",
+        },
+      ],
     });
+    const remembered = registry.getTurnInputAttachments({
+      backend: acpBackendId,
+      threadId: "kimi-parent",
+      turnId: turn.turnId,
+    });
+    expect(remembered).toEqual([expect.objectContaining({
+      type: "localImage",
+      name: "migration.png",
+      path: expect.stringContaining("turn-input-attachments"),
+    })]);
+    expect(JSON.stringify(remembered)).not.toContain("base64");
     await registry.publishLocalEvent({
       backend: acpBackendId,
       notification: {
@@ -27358,6 +27389,27 @@ command = "pnpm dev"
         groupedUnderThreadId: "kimi-parent",
       },
     });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-1",
+      input: [
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Fix the migration lock race."),
+        }),
+        expect.objectContaining({
+          type: "localImage",
+          name: "migration.png",
+          path: expect.stringContaining("image-inputs"),
+        }),
+      ],
+    });
+    const childImage = codexClient.lastStartTurnParams?.input[1];
+    expect(childImage?.type).toBe("localImage");
+    if (childImage?.type === "localImage") {
+      await expect(readFile(childImage.path)).resolves.toEqual(
+        Buffer.from([1, 2, 3]),
+      );
+    }
     await expect(
       overlayStore.getThreadOverlayState({
         backend: "codex",
@@ -32185,6 +32237,103 @@ script = "printf setup"
     });
 
     await registry.close();
+  });
+
+  it("forwards remembered source images as staged paths to send_message_to_thread", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-source-image-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    const previousProfile = process.env.PWRAGENT_PROFILE;
+    process.env.PWRAGENT_HOME = tempRoot;
+    process.env.PWRAGENT_PROFILE = "test";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        id: "source-thread",
+        title: "Source",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      }, {
+        id: "target-thread",
+        title: "Target",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    try {
+      const source = await registry.startTurn({
+        backend: "codex",
+        threadId: "source-thread",
+        input: [
+          { type: "text", text: "Inspect this screenshot." },
+          {
+            type: "image",
+            name: "screen.png",
+            url: "data:image/png;base64,AQID",
+          },
+        ],
+      });
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "source-thread",
+            turnId: source.turnId,
+            turn: { id: source.turnId },
+          },
+        },
+      });
+      const remembered = registry.getTurnInputAttachments({
+        backend: "codex",
+        threadId: "source-thread",
+        turnId: source.turnId,
+      });
+      expect(remembered).toEqual([expect.objectContaining({
+        type: "localImage",
+        name: "screen.png",
+        path: expect.stringContaining("turn-input-attachments"),
+      })]);
+      expect(JSON.stringify(remembered)).not.toContain("base64");
+
+      await callRegistryMcpTool({
+        registry,
+        backend: "codex",
+        threadId: "source-thread",
+        turnId: source.turnId,
+        tool: "send_message_to_thread",
+        args: {
+          backend: "codex",
+          threadId: "target-thread",
+          prompt: "Use the source screenshot.",
+        },
+      });
+
+      expect(codexClient.lastStartTurnParams).toMatchObject({
+        threadId: "target-thread",
+        input: [
+          { type: "text", text: "Use the source screenshot." },
+          expect.objectContaining({
+            type: "localImage",
+            name: "screen.png",
+            path: expect.stringContaining("image-inputs"),
+          }),
+        ],
+      });
+    } finally {
+      await registry.close();
+      if (previousHome === undefined) delete process.env.PWRAGENT_HOME;
+      else process.env.PWRAGENT_HOME = previousHome;
+      if (previousProfile === undefined) delete process.env.PWRAGENT_PROFILE;
+      else process.env.PWRAGENT_PROFILE = previousProfile;
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("queues a follow-up prompt while the target thread has an active turn", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19526,6 +19526,59 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("merges accepted Codex steer attachments into the source turn cache", async () => {
+    const tempHome = await mkdtemp(path.join(os.tmpdir(), "pwragent-steer-images-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    process.env.PWRAGENT_HOME = tempHome;
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/steer"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({ executionMode: "full-access" }),
+    });
+
+    try {
+      const turn = await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-steer-images",
+        input: [{
+          type: "image",
+          name: "initial.png",
+          url: "data:image/png;base64,AQID",
+        }],
+      });
+      await registry.steerTurn({
+        backend: "codex",
+        threadId: turn.threadId,
+        expectedTurnId: turn.turnId,
+        input: [{
+          type: "image",
+          name: "steered.png",
+          url: "data:image/png;base64,BAUG",
+        }],
+        requestId: "steer-image-1",
+      });
+
+      const retained = registry.getTurnInputAttachments({
+        backend: "codex",
+        threadId: turn.threadId,
+        turnId: turn.turnId,
+      });
+      expect(retained).toHaveLength(2);
+      expect(retained.map((item) => item.type === "localImage" && item.name))
+        .toEqual(["initial.png", "steered.png"]);
+    } finally {
+      await registry.close();
+      await rm(tempHome, { recursive: true, force: true });
+      if (previousHome === undefined) {
+        delete process.env.PWRAGENT_HOME;
+      } else {
+        process.env.PWRAGENT_HOME = previousHome;
+      }
+    }
+  });
+
   it("steers an active Grok turn through its ACP extension", async () => {
     const backend = "acp:grok" as AcpBackendId;
     const sessions: AcpSessionMetadata[] = [
@@ -19616,6 +19669,17 @@ command = "pnpm dev"
   });
 
   it("projects Grok next-turn steering and leaves its message context unbound", async () => {
+    const tempHome = await mkdtemp(path.join(os.tmpdir(), "pwragent-grok-steer-image-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    process.env.PWRAGENT_HOME = tempHome;
+    onTestFinished(async () => {
+      if (previousHome === undefined) {
+        delete process.env.PWRAGENT_HOME;
+      } else {
+        process.env.PWRAGENT_HOME = previousHome;
+      }
+      await rm(tempHome, { recursive: true, force: true });
+    });
     const backend = "acp:grok" as AcpBackendId;
     const sessions: AcpSessionMetadata[] = [{
       backendId: backend,
@@ -19648,7 +19712,14 @@ command = "pnpm dev"
         backend,
         threadId: "grok-session-next",
         expectedTurnId: "turn-a",
-        input: [{ type: "text", text: "Add blueberries" }],
+        input: [
+          { type: "text", text: "Add blueberries" },
+          {
+            type: "image",
+            name: "blueberries.png",
+            url: "data:image/png;base64,iVBORw0KGgo=",
+          },
+        ],
         requestId: "grok-steer-next",
       },
       { kind: "pwragent" },
@@ -19659,6 +19730,16 @@ command = "pnpm dev"
 
     await emitCompletedTurn(registry, backend, "grok-session-next", "turn-a");
     await emitStartedTurn(registry, backend, "grok-session-next", "turn-b");
+    expect(registry.getTurnInputAttachments({
+      backend,
+      threadId: "grok-session-next",
+      turnId: "turn-b",
+    })).toEqual([
+      expect.objectContaining({
+        type: "localImage",
+        name: "blueberries.png",
+      }),
+    ]);
     await (
       registry as unknown as { emit(event: AgentEvent): Promise<void> }
     ).emit({

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -611,6 +611,11 @@ describe("federation agent tools service", () => {
     const handler = createFederationAgentToolsHandler({
       // Never let unit tests mint a machine-id in the real PwrAgent root.
       collectHostInfo: async () => localHostInfo,
+      resolveSourceTurnAttachments: async () => [{
+        type: "localImage",
+        name: "source.png",
+        path: "/pwragent/staged/source.png",
+      }],
       runtime: buildRuntime({
         health: async () => buildHealth(),
         localBackend: (() => ({
@@ -646,7 +651,14 @@ describe("federation agent tools service", () => {
           directoryLabel: "PwrAgent",
           prompt: "",
         }),
-        input: [{ type: "text", text: "Fix the recorder crash" }],
+        input: [
+          { type: "text", text: "Fix the recorder crash" },
+          {
+            type: "localImage",
+            name: "source.png",
+            path: "/pwragent/staged/source.png",
+          },
+        ],
       },
       {
         messageOrigin: {

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AppServerTurnInputItem,
   FederationProtocolEnvelope,
   NavigationSnapshotTransportResponse,
   NavigationThreadSummary,
@@ -21,6 +22,195 @@ import { FederationRpcEndpoint } from "../federation/federation-rpc";
 import { FEDERATION_MAX_FRAME_BYTES } from "../federation/federation-transport";
 
 describe("federation backend bridge", () => {
+  it("prepares start, steer, handoff, and Star Map attachments before remote RPC", async () => {
+    const request = vi.fn(async ({ method }: { method: string }) => {
+      if (method === FEDERATION_BACKEND_METHODS.startTurn) {
+        return { backend: "codex", threadId: "thread-1", turnId: "turn-1" };
+      }
+      if (method === FEDERATION_BACKEND_METHODS.controlActiveTurn) {
+        return {
+          ok: true,
+          backend: "codex",
+          threadId: "thread-1",
+          turnId: "turn-live",
+          requestId: "steer-1",
+          disposition: "steered",
+        };
+      }
+      return { accepted: true, threadId: "manager-1" };
+    });
+    const prepare = vi.fn(async (input: readonly AppServerTurnInputItem[]) =>
+      input.map((item, index) => item.type === "text"
+        ? item
+        : { type: "federationBlob" as const, transferId: `blob-${index}` }),
+    );
+    const client = new FederationRemoteBackendClient(
+      { request } as unknown as FederationRpcEndpoint,
+      (response) => response,
+      prepare,
+    );
+    const image = {
+      type: "localImage" as const,
+      name: "screen.png",
+      path: "/sender/staged/screen.png",
+    };
+
+    await client.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Inspect" }, image],
+    });
+    await client.controlActiveTurn({
+      operation: "steer",
+      backend: "codex",
+      threadId: "thread-1",
+      requestId: "steer-1",
+      input: [{ type: "text", text: "Also inspect" }, image],
+    });
+    await client.materializeDirectoryLaunchpad({
+      directoryKey: "dir:/repo",
+      input: [{ type: "text", text: "Delegate" }, image],
+    });
+    await client.starMapIntake({
+      requestId: "intake-1",
+      request: "Create a manager",
+      attachments: [image],
+    });
+
+    expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.startTurn,
+      params: expect.objectContaining({
+        input: [
+          { type: "text", text: "Inspect" },
+          { type: "federationBlob", transferId: "blob-1" },
+        ],
+      }),
+    }));
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
+      params: expect.objectContaining({
+        input: [
+          { type: "text", text: "Also inspect" },
+          { type: "federationBlob", transferId: "blob-1" },
+        ],
+      }),
+    }));
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
+      params: expect.objectContaining({
+        directoryKey: "dir:/repo",
+        input: [
+          { type: "text", text: "Delegate" },
+          { type: "federationBlob", transferId: "blob-1" },
+        ],
+      }),
+    }));
+    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({
+      method: FEDERATION_BACKEND_METHODS.starMapIntake,
+      params: {
+        requestId: "intake-1",
+        request: "Create a manager",
+        attachments: [{ type: "federationBlob", transferId: "blob-0" }],
+      },
+    }));
+    expect(JSON.stringify(request.mock.calls)).not.toContain(image.path);
+  });
+
+  it("resolves verified steer refs and rejects raw peer Star Map paths", async () => {
+    const controlActiveTurn = vi.fn(async (request) => ({
+      ok: true as const,
+      backend: request.backend,
+      threadId: request.threadId,
+      requestId: request.requestId,
+      turnId: "turn-live",
+      disposition: "steered" as const,
+    }));
+    const starMapIntake = vi.fn(async () => ({
+      accepted: true,
+      threadId: "manager-1",
+    }));
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["turn_control", "environment_actions"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        controlActiveTurn,
+        starMapIntake,
+      } as unknown as FederationBackendOperations,
+      resolveTurnInput: async (input) => {
+        if (input.some((item) => item.type !== "federationBlob")) {
+          throw new Error("Peer paths are forbidden.");
+        }
+        return [{
+          type: "localImage",
+          name: "screen.png",
+          path: "/receiver/staged/screen.png",
+        }];
+      },
+    });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "steer-with-blob",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
+        params: {
+          operation: "steer",
+          backend: "codex",
+          threadId: "thread-1",
+          requestId: "steer-1",
+          input: [{ type: "federationBlob", transferId: "blob-1" }],
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "star-map-with-path",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.starMapIntake,
+        params: {
+          requestId: "intake-1",
+          request: "Create a manager",
+          attachments: [{
+            type: "localImage",
+            path: "/peer/controlled/screen.png",
+          }],
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_001,
+      },
+    });
+
+    expect(controlActiveTurn).toHaveBeenCalledWith(expect.objectContaining({
+      input: [{
+        type: "localImage",
+        name: "screen.png",
+        path: "/receiver/staged/screen.png",
+      }],
+    }));
+    expect(starMapIntake).not.toHaveBeenCalled();
+    expect(replies).toContainEqual(expect.objectContaining({
+      kind: "error",
+      requestId: "star-map-with-path",
+    }));
+  });
+
   it("negotiates launchpad metadata separately from environment actions", () => {
     expect(
       FEDERATION_BACKEND_METHOD_CAPABILITIES[

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -27,9 +27,11 @@ import { FederationSessionRegistry } from "../federation/federation-session-stat
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
+  FEDERATION_SEND_BUFFER_HIGH_WATER_BYTES,
   federationTransportCodecForTest,
   FederationGatewayWebSocketServer,
   FederationSocketKeepalive,
+  waitForFederationSendCapacity,
   type FederationKeepaliveSocket,
 } from "../federation/federation-transport";
 import { StateDb } from "../state/state-db";
@@ -1404,6 +1406,34 @@ describe("federation transport liveness", () => {
       closeReason: "timeout",
     });
     expect(registry.getSession("session-live")?.status).toBe("active");
+  });
+});
+
+describe("federation send backpressure", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for the WebSocket buffer to drain below the high-water mark", async () => {
+    const socket = {
+      bufferedAmount: FEDERATION_SEND_BUFFER_HIGH_WATER_BYTES + 1,
+      readyState: WebSocket.OPEN,
+    };
+    let resolved = false;
+    const waiting = waitForFederationSendCapacity(socket).then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    socket.bufferedAmount = FEDERATION_SEND_BUFFER_HIGH_WATER_BYTES;
+    await vi.advanceTimersByTimeAsync(5);
+    await waiting;
+    expect(resolved).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -27,6 +27,7 @@ import { FederationSessionRegistry } from "../federation/federation-session-stat
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
+  federationTransportCodecForTest,
   FederationGatewayWebSocketServer,
   FederationSocketKeepalive,
   type FederationKeepaliveSocket,
@@ -60,6 +61,41 @@ afterEach(async () => {
 });
 
 describe("federation transport", () => {
+  it("encodes blob bytes as a binary tail and rejects blob JSON envelopes", () => {
+    const data = Buffer.from([0, 1, 2, 0xff]);
+    const envelope = {
+      id: "blob-codec",
+      kind: "blob_chunk" as const,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_000,
+      transferId: "transfer-1",
+      chunkIndex: 0,
+      chunkCount: 1,
+      totalSize: data.byteLength,
+      sha256: "0".repeat(64),
+      name: "screen.png",
+      inputType: "localImage" as const,
+      data,
+    };
+
+    const wire = federationTransportCodecForTest.encodeEnvelope(envelope);
+    expect(wire.subarray(0, 8).toString("ascii")).toBe("PWRBLOB1");
+    const headerLength = wire.readUInt32BE(8);
+    const header = JSON.parse(wire.subarray(12, 12 + headerLength).toString("utf8"));
+    expect(header.envelope).not.toHaveProperty("data");
+    expect(JSON.stringify(header)).not.toContain(data.toString("base64"));
+    expect(wire.subarray(12 + headerLength)).toEqual(data);
+    expect(federationTransportCodecForTest.decodeEnvelope(wire)).toEqual(envelope);
+
+    const jsonWire = Buffer.from(JSON.stringify({
+      kind: "envelope",
+      envelope,
+    }), "utf8");
+    expect(federationTransportCodecForTest.decodeEnvelope(jsonWire)).toBeUndefined();
+  });
+
   it("authenticates a client and carries protocol envelopes", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     let closeCount = 0;
@@ -164,6 +200,67 @@ describe("federation transport", () => {
     // report "re-pair needed" instead of a generic connection loss.
     expect(lastCloseInfo).toMatchObject({ code: 4002, reason: "revoked" });
     expect(server?.closePeer("client_one")).toBe(false);
+  });
+
+  it("carries attachment bytes in the binary blob frame instead of JSON", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-binary-blob",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received = new Promise<FederationProtocolEnvelope>((resolve) => {
+      server = new FederationGatewayWebSocketServer({
+        gatewayInstanceId: "gateway_one",
+        gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        host: "127.0.0.1",
+        port: 0,
+        store,
+        onEnvelope: resolve,
+      });
+    });
+    const { url } = await server!.start();
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["turn_input_blobs"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+    });
+    const bytes = Buffer.from([0, 1, 2, 0xff]);
+
+    client.sendEnvelope({
+      id: "blob-1",
+      kind: "blob_chunk",
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_000,
+      transferId: "transfer-1",
+      chunkIndex: 0,
+      chunkCount: 1,
+      totalSize: bytes.byteLength,
+      sha256: "0".repeat(64),
+      name: "screen.png",
+      inputType: "localImage",
+      data: bytes,
+    });
+
+    await expect(received).resolves.toMatchObject({
+      kind: "blob_chunk",
+      transferId: "transfer-1",
+      data: bytes,
+    });
+    client.close();
   });
 
   it("reports envelope wire bytes to both ends' transfer taps", async () => {

--- a/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
@@ -5,6 +5,7 @@ import {
   readFile,
   rm,
   stat,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
@@ -17,10 +18,13 @@ import type {
 import { imageInputFileRoot } from "../app-server/image-input-files";
 import {
   stageTurnInputAttachment,
+  TURN_INPUT_ATTACHMENT_MAX_AGE_MS,
   turnInputAttachmentRoot,
 } from "../app-server/turn-input-attachment-files";
 import {
   FEDERATION_BLOB_CHUNK_BYTES,
+  FEDERATION_BLOB_WAIT_TIMEOUT_MS,
+  FEDERATION_TURN_INPUT_MAX_AGE_MS,
   FederationTurnInputAttachmentReceiver,
   MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE,
   prepareOutgoingFederationTurnInput,
@@ -111,6 +115,86 @@ describe("federation turn input attachments", () => {
     expect(envelopes).toHaveLength(2);
     expect(envelopes[0]?.data).toHaveLength(FEDERATION_BLOB_CHUNK_BYTES);
     expect(envelopes[1]?.data).toHaveLength(3);
+  });
+
+  it("awaits each asynchronous chunk writer before reading the next chunk", async () => {
+    await createTestRoot();
+    const sourcePath = path.join(turnInputAttachmentRoot(), "slow-source.bin");
+    await mkdir(path.dirname(sourcePath), { recursive: true });
+    await writeFile(
+      sourcePath,
+      Buffer.alloc(FEDERATION_BLOB_CHUNK_BYTES + 1, 0x5a),
+    );
+    let releaseFirst!: () => void;
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let sendCount = 0;
+    const preparing = prepareOutgoingFederationTurnInput({
+      input: [{ type: "localFile", name: "slow-source.bin", path: sourcePath }],
+      localInstanceId: "source_one",
+      targetInstanceId: "owner_one",
+      sendEnvelope: async () => {
+        sendCount += 1;
+        if (sendCount === 1) {
+          await firstReleased;
+        }
+      },
+    });
+
+    await vi.waitFor(() => expect(sendCount).toBe(1));
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(sendCount).toBe(1);
+    releaseFirst();
+    await preparing;
+    expect(sendCount).toBe(2);
+  });
+
+  it("treats the receive deadline as an inactivity timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const root = await createTestRoot();
+      const data = Buffer.alloc(FEDERATION_BLOB_CHUNK_BYTES * 2 + 1, 0x2a);
+      const transferId = "progressing-transfer";
+      const receiver = new FederationTurnInputAttachmentReceiver({
+        resolveRoot: () => path.join(root, "receiver"),
+      });
+      const resolved = receiver.resolveInput(
+        [{ type: "federationBlob", transferId }],
+        "source_one",
+      );
+      const metadata = {
+        chunkCount: 3,
+        sha256: sha256(data),
+        totalSize: data.byteLength,
+        transferId,
+      };
+
+      await receiver.receive(blobEnvelope({
+        ...metadata,
+        chunkIndex: 0,
+        data: data.subarray(0, FEDERATION_BLOB_CHUNK_BYTES),
+      }), "source_one");
+      await vi.advanceTimersByTimeAsync(FEDERATION_BLOB_WAIT_TIMEOUT_MS - 1);
+      await receiver.receive(blobEnvelope({
+        ...metadata,
+        chunkIndex: 1,
+        data: data.subarray(
+          FEDERATION_BLOB_CHUNK_BYTES,
+          FEDERATION_BLOB_CHUNK_BYTES * 2,
+        ),
+      }), "source_one");
+      await vi.advanceTimersByTimeAsync(FEDERATION_BLOB_WAIT_TIMEOUT_MS - 1);
+      await receiver.receive(blobEnvelope({
+        ...metadata,
+        chunkIndex: 2,
+        data: data.subarray(FEDERATION_BLOB_CHUNK_BYTES * 2),
+      }), "source_one");
+
+      await expect(resolved).resolves.toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects peer paths and malformed chunk geometry", async () => {
@@ -219,6 +303,30 @@ describe("federation turn input attachments", () => {
     expect((await stat(destination)).ino).toBe(verifiedInode);
   });
 
+  it("expires old receiver-owned blob files after a later transfer", async () => {
+    const root = await createTestRoot();
+    const receiverRoot = path.join(root, "receiver");
+    const stalePath = path.join(
+      receiverRoot,
+      "source_one",
+      "a".repeat(64),
+      "stale.png",
+    );
+    await mkdir(path.dirname(stalePath), { recursive: true });
+    await writeFile(stalePath, Buffer.from([1]));
+    const staleDate = new Date(Date.now() - FEDERATION_TURN_INPUT_MAX_AGE_MS - 1);
+    await utimes(path.dirname(stalePath), staleDate, staleDate);
+
+    const receiver = new FederationTurnInputAttachmentReceiver({
+      resolveRoot: () => receiverRoot,
+    });
+    await receiver.receive(blobEnvelope({ transferId: "cleanup-trigger" }), "source_one");
+
+    await vi.waitFor(async () => {
+      expect(await stat(stalePath).catch(() => undefined)).toBeUndefined();
+    });
+  });
+
   it("atomically replaces corrupt local staged content and reuses verified content", async () => {
     await createTestRoot();
     const data = Uint8Array.from([4, 5, 6]);
@@ -245,6 +353,36 @@ describe("federation turn input attachments", () => {
       name: "paste.png",
     });
     expect((await stat(replaced.path)).ino).toBe(verifiedInode);
+  });
+
+  it("refreshes reused local staging directories before age cleanup", async () => {
+    await createTestRoot();
+    const data = Uint8Array.from([7, 8, 9]);
+    const staged = await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "reused.png",
+    });
+    const staleDate = new Date(Date.now() - TURN_INPUT_ATTACHMENT_MAX_AGE_MS - 1);
+    await utimes(staged.path, staleDate, staleDate);
+    await utimes(path.dirname(staged.path), staleDate, staleDate);
+
+    const reused = await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "reused.png",
+    });
+    expect((await stat(path.dirname(reused.path))).mtimeMs)
+      .toBeGreaterThan(staleDate.getTime());
+    await stageTurnInputAttachment({
+      type: "localImage",
+      data: Uint8Array.from([1, 2, 3]),
+      name: "cleanup-trigger.png",
+    });
+
+    await vi.waitFor(async () => {
+      await expect(readFile(reused.path)).resolves.toEqual(Buffer.from(data));
+    });
   });
 });
 

--- a/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
@@ -1,0 +1,294 @@
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  FederationBlobChunkEnvelope,
+  FederationProtocolEnvelope,
+} from "@pwragent/shared";
+import { imageInputFileRoot } from "../app-server/image-input-files";
+import {
+  stageTurnInputAttachment,
+  turnInputAttachmentRoot,
+} from "../app-server/turn-input-attachment-files";
+import {
+  FEDERATION_BLOB_CHUNK_BYTES,
+  FederationTurnInputAttachmentReceiver,
+  MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE,
+  prepareOutgoingFederationTurnInput,
+} from "../federation/federation-turn-input-attachments";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("federation turn input attachments", () => {
+  it("stages data URLs and existing PwrAgent image inputs before binary upload", async () => {
+    const root = await createTestRoot();
+    const existingBytes = Buffer.from([9, 8, 7, 6]);
+    const existingPath = path.join(imageInputFileRoot(), "existing.png");
+    await mkdir(path.dirname(existingPath), { recursive: true });
+    await writeFile(existingPath, existingBytes);
+    const envelopes: FederationBlobChunkEnvelope[] = [];
+
+    const prepared = await prepareOutgoingFederationTurnInput({
+      input: [
+        {
+          type: "image",
+          name: "pasted.png",
+          url: "data:image/png;base64,AQID",
+        },
+        { type: "localImage", name: "existing.png", path: existingPath },
+      ],
+      localInstanceId: "source_one",
+      targetInstanceId: "owner_one",
+      privateStorageRoots: [path.join(root, "profiles", "test")],
+      sendEnvelope: (envelope) => {
+        if (envelope.kind === "blob_chunk") {
+          envelopes.push(envelope);
+        }
+      },
+    });
+
+    expect(prepared).toEqual([
+      { type: "federationBlob", transferId: expect.any(String) },
+      { type: "federationBlob", transferId: expect.any(String) },
+    ]);
+    expect(JSON.stringify(prepared)).not.toContain("base64");
+    expect(JSON.stringify(prepared)).not.toContain(existingPath);
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[0]?.data).toEqual(Buffer.from([1, 2, 3]));
+    expect(envelopes[1]?.data).toEqual(existingBytes);
+  });
+
+  it("round-trips multi-chunk bytes into receiver-owned verified paths", async () => {
+    await createTestRoot();
+    const sourcePath = path.join(turnInputAttachmentRoot(), "source.bin");
+    const data = Buffer.alloc(FEDERATION_BLOB_CHUNK_BYTES + 3, 0x5a);
+    await mkdir(path.dirname(sourcePath), { recursive: true });
+    await writeFile(sourcePath, data);
+    const envelopes: FederationBlobChunkEnvelope[] = [];
+    const prepared = await prepareOutgoingFederationTurnInput({
+      input: [{ type: "localFile", name: "source.bin", path: sourcePath }],
+      localInstanceId: "source_one",
+      targetInstanceId: "owner_one",
+      sendEnvelope: collectBlobChunks(envelopes),
+    });
+    const receiverRoot = path.join(path.dirname(turnInputAttachmentRoot()), "received");
+    const receiver = new FederationTurnInputAttachmentReceiver({
+      resolveRoot: () => receiverRoot,
+    });
+    const resolved = receiver.resolveInput(prepared, "source_one");
+
+    for (const envelope of envelopes) {
+      await receiver.receive(envelope, "source_one");
+    }
+
+    const input = await resolved;
+    expect(input).toHaveLength(1);
+    expect(input[0]).toMatchObject({
+      type: "localFile",
+      name: "source.bin",
+      path: expect.stringMatching(/received/u),
+    });
+    const receivedPath = input[0]?.type === "localFile" ? input[0].path : "";
+    await expect(readFile(receivedPath)).resolves.toEqual(data);
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[0]?.data).toHaveLength(FEDERATION_BLOB_CHUNK_BYTES);
+    expect(envelopes[1]?.data).toHaveLength(3);
+  });
+
+  it("rejects peer paths and malformed chunk geometry", async () => {
+    const receiver = new FederationTurnInputAttachmentReceiver({
+      resolveRoot: () => path.join(os.tmpdir(), "unused-federation-inputs"),
+    });
+    await expect(receiver.resolveInput(
+      [{ type: "localImage", path: "/tmp/peer-controlled.png" }],
+      "source_one",
+    )).rejects.toThrow(/verified blob transfer reference/u);
+
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 1_000_000,
+      data: Uint8Array.from([1]),
+      totalSize: 1,
+    }), "source_one")).rejects.toThrow(/geometry/u);
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES - 1),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+    }), "source_one")).rejects.toThrow(/geometry/u);
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      chunkIndex: 1,
+      data: new Uint8Array(0),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+    }), "source_one")).rejects.toThrow(/geometry/u);
+  });
+
+  it("caps incomplete transfers per authenticated source", async () => {
+    const receiver = new FederationTurnInputAttachmentReceiver();
+    for (
+      let index = 0;
+      index < MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE;
+      index += 1
+    ) {
+      await receiver.receive(blobEnvelope({
+        chunkCount: 2,
+        data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES),
+        totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+        transferId: `transfer-${index}`,
+      }), "source_one");
+    }
+
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+      transferId: "transfer-over-limit",
+    }), "source_one")).rejects.toThrow(/Too many incomplete/u);
+
+    await expect(receiver.receive(blobEnvelope({
+      chunkCount: 2,
+      data: new Uint8Array(FEDERATION_BLOB_CHUNK_BYTES),
+      totalSize: FEDERATION_BLOB_CHUNK_BYTES + 1,
+      transferId: "other-peer-transfer",
+    }), "source_two")).resolves.toBeUndefined();
+  });
+
+  it("replaces corrupt content-addressed receiver files and reuses verified files", async () => {
+    const root = await createTestRoot();
+    const receiverRoot = path.join(root, "receiver");
+    const data = Buffer.from([1, 3, 3, 7]);
+    const digest = sha256(data);
+    const destination = path.join(
+      receiverRoot,
+      "source_one",
+      digest,
+      "screen.png",
+    );
+    await mkdir(path.dirname(destination), { recursive: true });
+    await writeFile(destination, Buffer.from([9, 9, 9, 9]));
+    const corruptInode = (await stat(destination)).ino;
+    const envelope = blobEnvelope({
+      data,
+      name: "screen.png",
+      sha256: digest,
+      totalSize: data.byteLength,
+      transferId: "replace-corrupt",
+    });
+    const receiver = new FederationTurnInputAttachmentReceiver({
+      resolveRoot: () => receiverRoot,
+    });
+    const resolved = receiver.resolveInput(
+      [{ type: "federationBlob", transferId: envelope.transferId }],
+      "source_one",
+    );
+    await receiver.receive(envelope, "source_one");
+    await resolved;
+
+    await expect(readFile(destination)).resolves.toEqual(data);
+    expect((await stat(destination)).ino).not.toBe(corruptInode);
+
+    const verifiedInode = (await stat(destination)).ino;
+    const reuseEnvelope = {
+      ...envelope,
+      id: "blob-reuse",
+      transferId: "reuse-verified",
+    };
+    const reused = receiver.resolveInput(
+      [{ type: "federationBlob", transferId: reuseEnvelope.transferId }],
+      "source_one",
+    );
+    await receiver.receive(reuseEnvelope, "source_one");
+    await reused;
+    expect((await stat(destination)).ino).toBe(verifiedInode);
+  });
+
+  it("atomically replaces corrupt local staged content and reuses verified content", async () => {
+    await createTestRoot();
+    const data = Uint8Array.from([4, 5, 6]);
+    const first = await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "paste.png",
+    });
+    await writeFile(first.path, Buffer.from([0, 0, 0]));
+    const corruptInode = (await stat(first.path)).ino;
+
+    const replaced = await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "paste.png",
+    });
+    await expect(readFile(replaced.path)).resolves.toEqual(Buffer.from(data));
+    expect((await stat(replaced.path)).ino).not.toBe(corruptInode);
+
+    const verifiedInode = (await stat(replaced.path)).ino;
+    await stageTurnInputAttachment({
+      type: "localImage",
+      data,
+      name: "paste.png",
+    });
+    expect((await stat(replaced.path)).ino).toBe(verifiedInode);
+  });
+});
+
+async function createTestRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-federation-input-"));
+  temporaryRoots.push(root);
+  vi.stubEnv("PWRAGENT_HOME", root);
+  vi.stubEnv("PWRAGENT_PROFILE", "test");
+  return root;
+}
+
+function collectBlobChunks(
+  chunks: FederationBlobChunkEnvelope[],
+): (envelope: FederationProtocolEnvelope) => void {
+  return (envelope) => {
+    if (envelope.kind === "blob_chunk") {
+      chunks.push(envelope);
+    }
+  };
+}
+
+function blobEnvelope(
+  overrides: Partial<FederationBlobChunkEnvelope> = {},
+): FederationBlobChunkEnvelope {
+  const data = overrides.data ?? Uint8Array.from([1]);
+  return {
+    id: "blob-1",
+    kind: "blob_chunk",
+    protocolVersion: 1,
+    sourceInstanceId: "source_one",
+    targetInstanceId: "owner_one",
+    createdAt: 1_000,
+    transferId: "transfer-1",
+    chunkIndex: 0,
+    chunkCount: 1,
+    totalSize: data.byteLength,
+    sha256: sha256(data),
+    name: "screen.png",
+    inputType: "localImage",
+    data,
+    ...overrides,
+  };
+}
+
+function sha256(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -141,6 +141,37 @@ describe("dispatchStarMapIntake", () => {
     );
   });
 
+  it("includes staged image attachments in the created thread's first turn", async () => {
+    const response = await dispatchStarMapIntake({
+      requestId: "req-image",
+      request: "Fix the screenshot issue in PwrAgent",
+      directoryKey: "dir-agent",
+      attachments: [
+        {
+          type: "localImage",
+          name: "screenshot.png",
+          path: "/pwragent/image-inputs/screenshot.png",
+        },
+      ],
+    });
+
+    expect(response.status).toBe("created");
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: "dir-agent",
+        input: [
+          { type: "text", text: "Fix the screenshot issue in PwrAgent" },
+          {
+            type: "localImage",
+            name: "screenshot.png",
+            path: "/pwragent/image-inputs/screenshot.png",
+          },
+        ],
+      }),
+      { messageOrigin: { kind: "pwragent" } },
+    );
+  });
+
   it("asks for disambiguation when no directory clearly matches", async () => {
     generateStructuredObject.mockResolvedValue({
       status: "ok",

--- a/apps/desktop/src/main/__tests__/star-map-window-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-window-ipc.test.ts
@@ -8,10 +8,14 @@ import type { WebContents } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL,
+  STAR_MAP_INTAKE_CHANNEL,
   STAR_MAP_OPEN_THREAD_IN_MAIN_CHANNEL,
   STAR_MAP_OPEN_WINDOW_CHANNEL,
   WINDOW_SHOW_THREAD_CHANNEL,
 } from "../../shared/ipc";
+import { dispatchStarMapIntake } from "../app-server/star-map-intake";
+import { stageTurnInputAttachments } from "../app-server/turn-input-attachment-files";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { registerStarMapIpcHandlers } from "../ipc/star-map";
 import { isFederationWindowWebContents } from "../window";
 import { subscribersForChannel } from "../window-channels";
@@ -49,6 +53,10 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
 vi.mock("../app-server/star-map-intake", () => ({
   dispatchStarMapIntake: vi.fn(),
 }));
+vi.mock("../app-server/turn-input-attachment-files", () => ({
+  MAX_TURN_INPUT_ATTACHMENT_BYTES: 128 * 1024 * 1024,
+  stageTurnInputAttachments: vi.fn(),
+}));
 vi.mock("../federation/federation-runtime", () => ({
   getDesktopFederationRuntime: vi.fn(),
 }));
@@ -78,6 +86,10 @@ describe("star map window IPC", () => {
     handlers.clear();
     fromWebContentsMock.mockReset();
     vi.mocked(isFederationWindowWebContents).mockReset();
+    vi.mocked(dispatchStarMapIntake).mockReset();
+    vi.mocked(stageTurnInputAttachments).mockReset();
+    vi.mocked(stageTurnInputAttachments).mockResolvedValue([]);
+    vi.mocked(getDesktopFederationRuntime).mockReset();
     vi.mocked(subscribersForChannel).mockReset();
     vi.mocked(requestShowThread).mockReset();
     vi.mocked(showStarMapWindow).mockReset();
@@ -170,5 +182,117 @@ describe("star map window IPC", () => {
       handlerFor(STAR_MAP_FOCUS_MAIN_WINDOW_CHANNEL)({}),
     ).resolves.toBeUndefined();
     expect(fromWebContentsMock).not.toHaveBeenCalled();
+  });
+
+  it("stages renderer image bytes before local Star Map intake", async () => {
+    const bytes = Uint8Array.from([1, 2, 3]);
+    const attachment = {
+      type: "localImage" as const,
+      name: "screen.png",
+      path: "/pwragent/turn-input-attachments/screen.png",
+    };
+    vi.mocked(stageTurnInputAttachments).mockResolvedValue([attachment]);
+    vi.mocked(dispatchStarMapIntake).mockResolvedValue({
+      status: "created",
+      requestId: "request-1",
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    await handlerFor(STAR_MAP_INTAKE_CHANNEL)({}, {
+      requestId: "request-1",
+      request: "Fix the screenshot issue",
+      imageUploads: [{ bytes, mimeType: "image/png", name: "screen.png" }],
+    });
+
+    expect(stageTurnInputAttachments).toHaveBeenCalledWith([{
+      type: "localImage",
+      data: bytes,
+      mimeType: "image/png",
+      name: "screen.png",
+    }]);
+    expect(dispatchStarMapIntake).toHaveBeenCalledWith({
+      requestId: "request-1",
+      request: "Fix the screenshot issue",
+      attachments: [attachment],
+    });
+  });
+
+  it("sends only staged attachment inputs to remote Star Map intake", async () => {
+    const bytes = Uint8Array.from([4, 5, 6]);
+    const attachment = {
+      type: "localImage" as const,
+      name: "remote.png",
+      path: "/pwragent/turn-input-attachments/remote.png",
+    };
+    const starMapIntake = vi.fn().mockResolvedValue({
+      status: "created",
+      requestId: "request-remote",
+      backend: "codex",
+      threadId: "remote-thread",
+    });
+    const remoteBackend = vi.fn().mockReturnValue({ starMapIntake });
+    vi.mocked(stageTurnInputAttachments).mockResolvedValue([attachment]);
+    vi.mocked(getDesktopFederationRuntime).mockReturnValue({
+      remoteBackend,
+    } as never);
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "peer-one",
+    };
+
+    await handlerFor(STAR_MAP_INTAKE_CHANNEL)({}, {
+      requestId: "request-remote",
+      request: "Investigate this image",
+      federationTarget,
+      imageUploads: [{ bytes, mimeType: "image/png", name: "remote.png" }],
+    });
+
+    expect(remoteBackend).toHaveBeenCalledWith(federationTarget);
+    expect(starMapIntake).toHaveBeenCalledWith({
+      requestId: "request-remote",
+      request: "Investigate this image",
+      attachments: [attachment],
+    });
+    expect(starMapIntake.mock.calls[0]?.[0]).not.toHaveProperty("imageUploads");
+  });
+
+  it("ignores renderer-nominated attachment paths", async () => {
+    vi.mocked(dispatchStarMapIntake).mockResolvedValue({
+      status: "needs_disambiguation",
+      requestId: "request-forged",
+      candidates: [],
+    });
+
+    await handlerFor(STAR_MAP_INTAKE_CHANNEL)({}, {
+      requestId: "request-forged",
+      request: "Use this path",
+      attachments: [{
+        type: "localImage",
+        path: "/private/peer-controlled.png",
+      }],
+    });
+
+    expect(stageTurnInputAttachments).not.toHaveBeenCalled();
+    expect(dispatchStarMapIntake).toHaveBeenCalledWith({
+      requestId: "request-forged",
+      request: "Use this path",
+    });
+  });
+
+  it("rejects image batches that bypass the renderer cap", async () => {
+    const imageUploads = Array.from({ length: 6 }, (_, index) => ({
+      bytes: Uint8Array.from([index + 1]),
+      mimeType: "image/png",
+      name: `screen-${index}.png`,
+    }));
+
+    await expect(handlerFor(STAR_MAP_INTAKE_CHANNEL)({}, {
+      requestId: "request-too-many",
+      request: "Too many images",
+      imageUploads,
+    })).rejects.toThrow(/at most 5 images/u);
+    expect(stageTurnInputAttachments).not.toHaveBeenCalled();
+    expect(dispatchStarMapIntake).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1,3 +1,4 @@
+import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { app } from "electron";
 import {
@@ -40,6 +41,7 @@ import {
   type AcpPromptContentBlock,
 } from "../acp/acp-client";
 import type { AcpProviderStatus } from "../acp/acp-provider-status";
+import { MAX_TURN_INPUT_ATTACHMENT_BYTES } from "./turn-input-attachment-files";
 import {
   acpRuntimeSupportsHttpMcp,
   buildAutomationInspectionAcpMcpServers,
@@ -867,9 +869,9 @@ export function acpSessionHasConversationHistory(
   return session.hasConversationHistory === true;
 }
 
-export function inputToAcpPrompt(
+export async function inputToAcpPrompt(
   input: AppServerTurnInputItem[],
-): AcpPromptPayload | undefined {
+): Promise<AcpPromptPayload | undefined> {
   const promptContent: AcpPromptContentBlock[] = [];
   const parts: AppServerThreadMessagePart[] = [];
 
@@ -925,6 +927,23 @@ export function inputToAcpPrompt(
     const text = `[Local image: ${fileName}]`;
     promptContent.push({ type: "text", text });
     parts.push({ type: "text", text });
+    const fileInfo = await stat(item.path);
+    if (
+      !fileInfo.isFile()
+      || fileInfo.size > MAX_TURN_INPUT_ATTACHMENT_BYTES
+    ) {
+      throw new Error(`Invalid local image attachment: ${fileName}`);
+    }
+    const data = await readFile(item.path);
+    const mimeType = detectLocalImageMimeType(data);
+    if (!mimeType) {
+      throw new Error(`Unsupported local image attachment: ${fileName}`);
+    }
+    promptContent.push({
+      type: "image",
+      mimeType,
+      data: data.toString("base64"),
+    });
   }
 
   if (promptContent.length === 0 && parts.length === 0) {
@@ -941,6 +960,40 @@ export function inputToAcpPrompt(
     promptContent,
     parts,
   };
+}
+
+function detectLocalImageMimeType(data: Buffer): string | undefined {
+  if (
+    data.byteLength >= 8
+    && data.subarray(0, 8).equals(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    )
+  ) {
+    return "image/png";
+  }
+  if (
+    data.byteLength >= 3
+    && data[0] === 0xff
+    && data[1] === 0xd8
+    && data[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    data.byteLength >= 6
+    && (data.subarray(0, 6).toString("ascii") === "GIF87a"
+      || data.subarray(0, 6).toString("ascii") === "GIF89a")
+  ) {
+    return "image/gif";
+  }
+  if (
+    data.byteLength >= 12
+    && data.subarray(0, 4).toString("ascii") === "RIFF"
+    && data.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return undefined;
 }
 
 function formatAcpLocalFileReference(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -556,6 +556,7 @@ import {
 } from "./thread-turn-queue";
 import { materializeLocalImageInputs } from "./image-input-files";
 import { enrichLocalFileInputs } from "./local-file-input";
+import { stageTurnInputAttachmentsForRetention } from "./turn-input-attachment-files";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 import {
   PdfAttachmentStore,
@@ -7478,6 +7479,10 @@ export class DesktopBackendRegistry {
     string,
     AppServerTurnInputItem[]
   >();
+  private readonly turnInputAttachments = new Map<
+    string,
+    { input: AppServerTurnInputItem[] }
+  >();
   private readonly pendingThreadMessageContexts = new Map<
     string,
     PendingThreadMessageContext
@@ -14074,6 +14079,12 @@ export class DesktopBackendRegistry {
           messageId: buildTurnUserMessageOriginId(result.turnId),
           origin: resolveThreadMessageOrigin(params),
         });
+        await this.rememberTurnInputAttachments({
+          backend: params.backend,
+          threadId: result.threadId,
+          turnId: result.turnId,
+          input: userInput,
+        });
         this.forgetPendingThreadMessageContext(pendingMessageContextId);
         return result;
       } catch (error) {
@@ -14440,6 +14451,12 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       turnId: result.turnId,
     };
+    await this.rememberTurnInputAttachments({
+      backend: params.backend,
+      threadId: result.threadId,
+      turnId: result.turnId,
+      input,
+    });
     this.scheduleCompletedTurnFromReplay({
       backend: params.backend,
       threadId: result.threadId,
@@ -28608,6 +28625,47 @@ export class DesktopBackendRegistry {
     return this.localFilePrivateStorageRoots;
   }
 
+  getTurnInputAttachments(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+  }): AppServerTurnInputItem[] {
+    return (
+      this.turnInputAttachments.get(
+        buildActiveTurnKey(params.backend, params.threadId, params.turnId),
+      )?.input ?? []
+    ).map((item) => ({ ...item }));
+  }
+
+  private async rememberTurnInputAttachments(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+    input: readonly AppServerTurnInputItem[];
+  }): Promise<void> {
+    const attachments = await stageTurnInputAttachmentsForRetention(
+      params.input,
+      { privateStorageRoots: this.localFilePrivateStorageRoots },
+    );
+    if (attachments.length === 0) {
+      return;
+    }
+    const key = buildActiveTurnKey(
+      params.backend,
+      params.threadId,
+      params.turnId,
+    );
+    this.turnInputAttachments.delete(key);
+    this.turnInputAttachments.set(key, {
+      input: attachments,
+    });
+    while (this.turnInputAttachments.size > 256) {
+      const oldestKey = this.turnInputAttachments.keys().next().value;
+      if (!oldestKey) break;
+      this.turnInputAttachments.delete(oldestKey);
+    }
+  }
+
   private async handleThreadOrchestrationRequest(
     request: PwrAgentThreadOrchestrationRequest,
   ): Promise<PwrAgentThreadOrchestrationResponse> {
@@ -29791,7 +29849,14 @@ export class DesktopBackendRegistry {
           : {}),
         ...(request.args.sandbox ? { sandbox: request.args.sandbox } : {}),
       };
-      const input = [{ type: "text" as const, text: prompt }];
+      const input = [
+        { type: "text" as const, text: prompt },
+        ...this.getTurnInputAttachments({
+          backend: request.context.backend,
+          threadId: request.context.threadId,
+          turnId: sourceTurnId,
+        }),
+      ];
       const messageOrigin = await this.buildAgentMessageOrigin({
         backend: request.context.backend,
         threadId: request.context.threadId,
@@ -30135,7 +30200,14 @@ export class DesktopBackendRegistry {
         : {}),
       ...(request.operation === "steer_thread"
         ? {
-            input: [{ type: "text" as const, text: request.args.prompt }],
+            input: [
+              { type: "text" as const, text: request.args.prompt },
+              ...this.getTurnInputAttachments({
+                backend: request.context.backend,
+                threadId: request.context.threadId,
+                turnId: sourceTurnId,
+              }),
+            ],
           }
         : {}),
       messageOrigin,
@@ -30817,7 +30889,14 @@ export class DesktopBackendRegistry {
       const turn = await this.startTurn({
         backend,
         threadId,
-        input: [{ type: "text", text: prompt }],
+        input: [
+          { type: "text", text: prompt },
+          ...this.getTurnInputAttachments({
+            backend: sourceBackend,
+            threadId: sourceThreadId,
+            turnId: sourceTurnId,
+          }),
+        ],
         messageOrigin: {
           kind: "agent",
           sourceThread: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2418,6 +2418,19 @@ function buildActiveTurnKey(
   return `${backend}:${threadId}:${turnId}`;
 }
 
+function turnInputAttachmentCacheKey(item: AppServerTurnInputItem): string {
+  if (item.type === "localImage" || item.type === "localFile") {
+    return `${item.type}:${item.path}`;
+  }
+  if (item.type === "image") {
+    return `${item.type}:${item.url}`;
+  }
+  if (item.type === "file") {
+    return `${item.type}:${item.name}:${item.data}`;
+  }
+  return `${item.type}:${item.text}`;
+}
+
 function buildReviewSubAgentKey(
   backend: AppServerBackendKind,
   threadId: string,
@@ -7103,6 +7116,7 @@ type PendingThreadMessageContext = {
   createdAt: number;
   id: string;
   imageParts?: AppServerThreadImagePart[];
+  retainedInput?: AppServerTurnInputItem[];
   origin?: AppServerThreadMessageOrigin;
   text?: string;
   threadId: string;
@@ -10352,7 +10366,7 @@ export class DesktopBackendRegistry {
     model?: string;
     reasoningEffort?: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
-    const promptPayload = inputToAcpPrompt(params.input);
+    const promptPayload = await inputToAcpPrompt(params.input);
     if (!promptPayload) {
       throw new Error("ACP turns require text or image input");
     }
@@ -14481,9 +14495,20 @@ export class DesktopBackendRegistry {
     origin?: AppServerThreadMessageOrigin;
     text?: string;
     turnId?: string;
+    retainAttachments?: boolean;
   }): Promise<string | undefined> {
     const imageParts = await pendingThreadMessageImageParts(params.input);
-    if (!params.origin && imageParts.length === 0) {
+    const retainedInput = params.retainAttachments
+      ? await stageTurnInputAttachmentsForRetention(
+          params.input ?? [],
+          { privateStorageRoots: this.localFilePrivateStorageRoots },
+        )
+      : [];
+    if (
+      !params.origin
+      && imageParts.length === 0
+      && retainedInput.length === 0
+    ) {
       return undefined;
     }
     const oldestAllowed = Date.now() - 10 * 60 * 1000;
@@ -14498,6 +14523,7 @@ export class DesktopBackendRegistry {
       createdAt: Date.now(),
       id,
       ...(imageParts.length > 0 ? { imageParts } : {}),
+      ...(retainedInput.length > 0 ? { retainedInput } : {}),
       ...(params.origin ? { origin: params.origin } : {}),
       ...(params.text ? { text: params.text } : {}),
       threadId: params.threadId,
@@ -14516,6 +14542,12 @@ export class DesktopBackendRegistry {
     const pending = this.pendingThreadMessageContexts.get(id);
     if (pending) {
       pending.turnId = turnId;
+      this.mergeTurnInputAttachments({
+        backend: pending.backend,
+        threadId: pending.threadId,
+        turnId,
+        input: pending.retainedInput ?? [],
+      });
     }
   }
 
@@ -14575,9 +14607,16 @@ export class DesktopBackendRegistry {
           ?? notification.params.turn.id,
       });
       if (pending && !pending.turnId) {
-        pending.turnId =
+        const turnId =
           notification.params.turnId
           ?? notification.params.turn.id;
+        pending.turnId = turnId;
+        this.mergeTurnInputAttachments({
+          backend: pending.backend,
+          threadId: pending.threadId,
+          turnId,
+          input: pending.retainedInput ?? [],
+        });
       }
       return event;
     }
@@ -16378,7 +16417,7 @@ export class DesktopBackendRegistry {
     });
     if (isAcpBackendId(params.backend)) {
       const acpBackend = params.backend;
-      const promptPayload = inputToAcpPrompt(input);
+      const promptPayload = await inputToAcpPrompt(input);
       if (!promptPayload) {
         throw new Error("ACP steering requires text or image input");
       }
@@ -16388,6 +16427,7 @@ export class DesktopBackendRegistry {
         threadId: params.threadId,
         origin: messageOrigin,
         text: extractFirstMeaningfulTextInput(params.input),
+        retainAttachments: true,
       });
       const text = promptPayload.prompt
         || promptPayload.promptContent.flatMap((block) =>
@@ -16465,6 +16505,13 @@ export class DesktopBackendRegistry {
       this.forgetPendingThreadMessageContext(pendingMessageContextId);
       throw error;
     }
+
+    await this.rememberTurnInputAttachments({
+      backend: params.backend,
+      threadId: result.threadId,
+      turnId: result.turnId,
+      input,
+    });
 
     return {
       backend: params.backend,
@@ -28650,14 +28697,40 @@ export class DesktopBackendRegistry {
     if (attachments.length === 0) {
       return;
     }
+    this.mergeTurnInputAttachments({
+      ...params,
+      input: attachments,
+    });
+  }
+
+  private mergeTurnInputAttachments(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+    input: readonly AppServerTurnInputItem[];
+  }): void {
+    if (params.input.length === 0) {
+      return;
+    }
     const key = buildActiveTurnKey(
       params.backend,
       params.threadId,
       params.turnId,
     );
+    const existing = this.turnInputAttachments.get(key)?.input ?? [];
+    const attachmentKeys = new Set(existing.map(turnInputAttachmentCacheKey));
+    const merged = [...existing];
+    for (const item of params.input) {
+      const attachmentKey = turnInputAttachmentCacheKey(item);
+      if (attachmentKeys.has(attachmentKey)) {
+        continue;
+      }
+      attachmentKeys.add(attachmentKey);
+      merged.push(item);
+    }
     this.turnInputAttachments.delete(key);
     this.turnInputAttachments.set(key, {
-      input: attachments,
+      input: merged,
     });
     while (this.turnInputAttachments.size > 256) {
       const oldestKey = this.turnInputAttachments.keys().next().value;

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -29,7 +29,7 @@ export type ImageInputFileDependencies = {
 const defaultDependencies: ImageInputFileDependencies = {
   now: () => Date.now(),
   readFile,
-  resolveRoot: () => resolveActiveProfilePath(path.join("state", "image-inputs")),
+  resolveRoot: imageInputFileRoot,
   writeFile,
   mkdir,
   readdir,
@@ -37,6 +37,10 @@ const defaultDependencies: ImageInputFileDependencies = {
   unlink,
   rm,
 };
+
+export function imageInputFileRoot(): string {
+  return resolveActiveProfilePath(path.join("state", "image-inputs"));
+}
 
 export async function materializeLocalImageInputs(
   input: AppServerTurnInputItem[],

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -270,7 +270,10 @@ export async function dispatchStarMapIntake(
       {
         directoryKey,
         launchpad,
-        input: [{ type: "text", text }],
+        input: [
+          { type: "text", text },
+          ...(request.attachments ?? []),
+        ],
       },
       { messageOrigin: { kind: "pwragent" } },
     );

--- a/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
+++ b/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
@@ -1,0 +1,332 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AppServerLocalFileInputItem,
+  AppServerLocalImageInputItem,
+  AppServerTurnInputItem,
+} from "@pwragent/shared";
+import { resolveActiveProfilePath } from "../profile";
+import { imageInputFileRoot } from "./image-input-files";
+import { resolveReadableLocalFilePath } from "./local-file-input";
+
+const TURN_INPUT_ATTACHMENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const MAX_TURN_INPUT_ATTACHMENT_BYTES = 128 * 1024 * 1024;
+
+export type TurnInputAttachmentUpload = {
+  type: "localImage" | "localFile";
+  data: Uint8Array;
+  name?: string;
+  mimeType?: string;
+};
+
+export type StagedTurnInputAttachment =
+  | AppServerLocalImageInputItem
+  | AppServerLocalFileInputItem;
+
+export function turnInputAttachmentRoot(): string {
+  return resolveActiveProfilePath(path.join("state", "turn-input-attachments"));
+}
+
+/**
+ * Persist cloneable renderer bytes in PwrAgent-owned storage and return the
+ * path-only input shape used by local backends and the federation uploader.
+ */
+export async function stageTurnInputAttachment(
+  upload: TurnInputAttachmentUpload,
+): Promise<StagedTurnInputAttachment> {
+  const data = Buffer.from(upload.data);
+  if (data.byteLength > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
+    throw new Error(
+      `Turn attachment exceeds the ${MAX_TURN_INPUT_ATTACHMENT_BYTES}-byte limit.`,
+    );
+  }
+  if (upload.type === "localImage" && data.byteLength === 0) {
+    throw new Error("Image attachments cannot be empty.");
+  }
+
+  const digest = createHash("sha256").update(data).digest("hex");
+  const root = turnInputAttachmentRoot();
+  const name = sanitizeTurnAttachmentName(
+    upload.name,
+    fallbackName(upload.type, upload.mimeType),
+  );
+  const filePath = path.join(root, digest, name);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const existing = await stat(filePath).catch(() => undefined);
+  let reusable = false;
+  if (existing?.isFile() && existing.size === data.byteLength) {
+    const existingData = await readFile(filePath).catch(() => undefined);
+    reusable = Boolean(
+      existingData
+      && createHash("sha256").update(existingData).digest("hex") === digest,
+    );
+  }
+  if (!reusable) {
+    const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporaryPath, data);
+      await rename(temporaryPath, filePath);
+    } finally {
+      await unlink(temporaryPath).catch(() => undefined);
+    }
+  }
+
+  void cleanupOldTurnInputAttachments(root, new Set([filePath])).catch(
+    () => undefined,
+  );
+
+  return upload.type === "localImage"
+    ? {
+        type: "localImage",
+        ...(upload.name?.trim() ? { name: upload.name.trim() } : {}),
+        path: filePath,
+      }
+    : {
+        type: "localFile",
+        ...(upload.name?.trim() ? { name: upload.name.trim() } : {}),
+        ...(upload.mimeType?.trim() ? { mimeType: upload.mimeType.trim() } : {}),
+        sizeBytes: data.byteLength,
+        path: filePath,
+      };
+}
+
+export async function stageTurnInputAttachments(
+  uploads: readonly TurnInputAttachmentUpload[],
+): Promise<StagedTurnInputAttachment[]> {
+  return await Promise.all(uploads.map(stageTurnInputAttachment));
+}
+
+export async function stageLocalTurnInputAttachment(
+  item: StagedTurnInputAttachment,
+  options?: { privateStorageRoots?: readonly string[] },
+): Promise<StagedTurnInputAttachment> {
+  const ownedStagingPath = await resolveOwnedStagingPath(item.path);
+  const readable = ownedStagingPath
+    ? { ok: true as const, path: ownedStagingPath }
+    : await resolveReadableLocalFilePath(item.path, {
+        privateStorageRoots: options?.privateStorageRoots,
+      });
+  if (!readable.ok) {
+    throw new Error(
+      readable.reason === "forbidden"
+        ? "The attachment path is inside private Codex storage and cannot be transferred."
+        : `The attachment file was not found: ${item.path}`,
+    );
+  }
+  const fileInfo = await stat(readable.path).catch(() => undefined);
+  if (!fileInfo?.isFile()) {
+    throw new Error(`The attachment path is not a regular file: ${item.path}`);
+  }
+  if (fileInfo.size > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
+    throw new Error(
+      `Turn attachment exceeds the ${MAX_TURN_INPUT_ATTACHMENT_BYTES}-byte limit.`,
+    );
+  }
+  const data = await readFile(readable.path);
+  return await stageTurnInputAttachment({
+    type: item.type,
+    data,
+    name: item.name ?? path.basename(item.path),
+    ...(item.type === "localFile" && item.mimeType
+      ? { mimeType: item.mimeType }
+      : {}),
+  });
+}
+
+/**
+ * Convert source-turn attachments to PwrAgent-owned path references before
+ * retaining them for cross-thread forwarding. Inline payloads never enter the
+ * registry cache.
+ */
+export async function stageTurnInputAttachmentsForRetention(
+  input: readonly AppServerTurnInputItem[],
+  options?: { privateStorageRoots?: readonly string[] },
+): Promise<AppServerTurnInputItem[]> {
+  const attachments: AppServerTurnInputItem[] = [];
+  for (const item of input) {
+    if (item.type === "text") {
+      continue;
+    }
+    try {
+      if (item.type === "localImage" || item.type === "localFile") {
+        attachments.push(await stageLocalTurnInputAttachment(item, options));
+        continue;
+      }
+      if (item.type === "file") {
+        const data = decodeBase64(item.data);
+        if (data) {
+          attachments.push(await stageTurnInputAttachment({
+            type: "localFile",
+            data,
+            name: item.name,
+            mimeType: item.mimeType,
+          }));
+        }
+        continue;
+      }
+      if (item.type === "image" && item.url.startsWith("data:")) {
+        const parsed = parseImageDataUrl(item.url);
+        if (parsed) {
+          attachments.push(await stageTurnInputAttachment({
+            type: "localImage",
+            data: parsed.data,
+            name: item.name,
+            mimeType: parsed.mimeType,
+          }));
+        }
+        continue;
+      }
+      if (item.type === "image" && item.url.startsWith("file:")) {
+        const filePath = filePathFromUrl(item.url);
+        if (filePath) {
+          attachments.push(await stageLocalTurnInputAttachment({
+            type: "localImage",
+            ...(item.name ? { name: item.name } : {}),
+            path: filePath,
+          }, options));
+        }
+        continue;
+      }
+      attachments.push(item);
+    } catch {
+      // Forwarding is secondary to the already-admitted source turn. Omit an
+      // unreadable attachment instead of retaining its inline payload or
+      // failing the source turn after the backend accepted it.
+    }
+  }
+  return attachments;
+}
+
+function filePathFromUrl(value: string): string | undefined {
+  try {
+    return fileURLToPath(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function isStagedTurnInputAttachmentPath(filePath: string): boolean {
+  const relative = path.relative(
+    path.resolve(turnInputAttachmentRoot()),
+    path.resolve(filePath),
+  );
+  return relative !== ""
+    && relative !== ".."
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
+async function resolveOwnedStagingPath(filePath: string): Promise<string | undefined> {
+  const roots = [turnInputAttachmentRoot(), imageInputFileRoot()];
+  if (!roots.some((root) => isPathWithinRoot(path.resolve(filePath), path.resolve(root)))) {
+    return undefined;
+  }
+  const [resolvedPath, ...canonicalRoots] = await Promise.all([
+    realpath(filePath).catch(() => undefined),
+    ...roots.map(canonicalRoot),
+  ]);
+  return resolvedPath
+    && canonicalRoots.some((root) => isPathWithinRoot(resolvedPath, root))
+    ? resolvedPath
+    : undefined;
+}
+
+async function canonicalRoot(root: string): Promise<string> {
+  return await realpath(root).catch(() => path.resolve(root));
+}
+
+function isPathWithinRoot(filePath: string, root: string): boolean {
+  const relative = path.relative(root, filePath);
+  return relative !== ""
+    && relative !== ".."
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
+function decodeBase64(value: string): Buffer | undefined {
+  if (!/^[a-z0-9+/]*={0,2}$/iu.test(value) || value.length % 4 !== 0) {
+    return undefined;
+  }
+  return Buffer.from(value, "base64");
+}
+
+function parseImageDataUrl(
+  value: string,
+): { data: Buffer; mimeType: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]*={0,2})$/iu.exec(value);
+  if (!match || (match[2]?.length ?? 0) % 4 !== 0) {
+    return undefined;
+  }
+  const data = Buffer.from(match[2] ?? "", "base64");
+  return data.byteLength > 0
+    ? { data, mimeType: match[1] ?? "application/octet-stream" }
+    : undefined;
+}
+
+function fallbackName(
+  inputType: TurnInputAttachmentUpload["type"],
+  mimeType: string | undefined,
+): string {
+  if (inputType === "localFile") {
+    return "attachment";
+  }
+  switch (mimeType?.trim().toLowerCase()) {
+    case "image/gif":
+      return "image.gif";
+    case "image/jpeg":
+    case "image/jpg":
+      return "image.jpg";
+    case "image/webp":
+      return "image.webp";
+    default:
+      return "image.png";
+  }
+}
+
+export function sanitizeTurnAttachmentName(
+  value: string | undefined,
+  fallback = "attachment",
+): string {
+  const baseName = path.basename(value?.trim() || fallback).replace(/[\0]/g, "");
+  const sanitized = baseName
+    .replace(/[^a-zA-Z0-9._@()+,= -]/g, "_")
+    .slice(0, 160);
+  return sanitized && sanitized !== "." && sanitized !== ".."
+    ? sanitized
+    : fallback;
+}
+
+async function cleanupOldTurnInputAttachments(
+  root: string,
+  excludedFiles: ReadonlySet<string>,
+): Promise<void> {
+  const cutoff = Date.now() - TURN_INPUT_ATTACHMENT_MAX_AGE_MS;
+  const entries = await readdir(root).catch(() => []);
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(root, entry);
+      const children = await readdir(entryPath).catch(() => []);
+      if (children.some((child) => excludedFiles.has(path.join(entryPath, child)))) {
+        return;
+      }
+      const info = await stat(entryPath).catch(() => undefined);
+      if (info?.isDirectory() && info.mtimeMs < cutoff) {
+        await rm(entryPath, { recursive: true, force: true }).catch(
+          () => undefined,
+        );
+      }
+    }),
+  );
+}

--- a/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
+++ b/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
@@ -8,6 +8,7 @@ import {
   rm,
   stat,
   unlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import path from "node:path";
@@ -21,7 +22,7 @@ import { resolveActiveProfilePath } from "../profile";
 import { imageInputFileRoot } from "./image-input-files";
 import { resolveReadableLocalFilePath } from "./local-file-input";
 
-const TURN_INPUT_ATTACHMENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const TURN_INPUT_ATTACHMENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export const MAX_TURN_INPUT_ATTACHMENT_BYTES = 128 * 1024 * 1024;
 
 export type TurnInputAttachmentUpload = {
@@ -64,6 +65,8 @@ export async function stageTurnInputAttachment(
   );
   const filePath = path.join(root, digest, name);
   await mkdir(path.dirname(filePath), { recursive: true });
+  const stagedAt = new Date();
+  await utimes(path.dirname(filePath), stagedAt, stagedAt);
   const existing = await stat(filePath).catch(() => undefined);
   let reusable = false;
   if (existing?.isFile() && existing.size === data.byteLength) {
@@ -81,6 +84,11 @@ export async function stageTurnInputAttachment(
     } finally {
       await unlink(temporaryPath).catch(() => undefined);
     }
+  } else {
+    await Promise.all([
+      utimes(filePath, stagedAt, stagedAt),
+      utimes(path.dirname(filePath), stagedAt, stagedAt),
+    ]);
   }
 
   void cleanupOldTurnInputAttachments(root, new Set([filePath])).catch(

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type {
   AppServerThreadMessageOrigin,
+  AppServerTurnInputItem,
   CreateInstanceThreadResult,
   CreateInstanceThreadToolArgs,
   FederationHealthStatus,
@@ -111,6 +112,9 @@ export function createFederationAgentToolsHandler(
       backend: CreateInstanceThreadResult["backend"];
       threadId: string;
     }) => Promise<void> | void;
+    resolveSourceTurnAttachments?: (
+      context: PwrAgentFederationContext,
+    ) => AppServerTurnInputItem[] | Promise<AppServerTurnInputItem[]>;
   } = {},
 ): PwrAgentFederationHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
@@ -140,6 +144,7 @@ export function createFederationAgentToolsHandler(
           collectHostInfo,
           options.targetStore,
           options.onRemoteChildMounted,
+          options.resolveSourceTurnAttachments,
         );
       }
       return await searchFederationThreads(
@@ -380,6 +385,9 @@ async function createInstanceThread(
     backend: CreateInstanceThreadResult["backend"];
     threadId: string;
   }) => Promise<void> | void) | undefined,
+  resolveSourceTurnAttachments: ((
+    context: PwrAgentFederationContext,
+  ) => AppServerTurnInputItem[] | Promise<AppServerTurnInputItem[]>) | undefined,
 ): Promise<PwrAgentFederationResponse> {
   const resolved = await resolveInstance(runtime, args.instanceId, collectHostInfo);
   if (!resolved.ok) {
@@ -437,6 +445,13 @@ async function createInstanceThread(
       threadId: context.threadId,
     },
   };
+  const attachmentInput = resolveSourceTurnAttachments
+    ? await resolveSourceTurnAttachments(context)
+    : [];
+  const input = [
+    ...(args.input ? [{ type: "text" as const, text: args.input }] : []),
+    ...attachmentInput,
+  ];
   const response = await backend.materializeDirectoryLaunchpad(
     {
       directoryKey: args.projectKey,
@@ -450,7 +465,7 @@ async function createInstanceThread(
               : {}),
           }
         : {}),
-      ...(args.input ? { input: [{ type: "text", text: args.input }] } : {}),
+      ...(input.length > 0 ? { input } : {}),
     },
     { messageOrigin },
   );

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -7,7 +7,10 @@ import type {
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AppServerLocalFileInputItem,
+  AppServerLocalImageInputItem,
   AppServerThreadMessageOrigin,
+  AppServerTurnInputItem,
   AgentEvent,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
@@ -179,6 +182,70 @@ export type FederationStartTurnRequest = StartTurnRequest & {
   messageOrigin?: AppServerThreadMessageOrigin;
 };
 
+export type FederationTurnInputBlobReference = {
+  type: "federationBlob";
+  transferId: string;
+};
+
+export type FederationWireTurnInputItem =
+  | AppServerTurnInputItem
+  | FederationTurnInputBlobReference;
+
+export type FederationStarMapIntakeAttachment =
+  | Pick<AppServerLocalImageInputItem, "type" | "name" | "path">
+  | Pick<AppServerLocalFileInputItem, "type" | "name" | "path">;
+
+export type FederationStarMapIntakeRequest =
+  Omit<StarMapIntakeRequest, "attachments"> & {
+    attachments?: FederationStarMapIntakeAttachment[];
+  };
+
+type FederationWireStarMapIntakeRequest =
+  Omit<FederationStarMapIntakeRequest, "attachments"> & {
+    attachments?: FederationWireTurnInputItem[];
+  };
+
+type FederationWireControlActiveTurnRequest =
+  Omit<ControlActiveTurnRequest, "input"> & {
+    input?: FederationWireTurnInputItem[];
+  };
+
+export type PrepareOutgoingFederationTurnInput = (
+  input: readonly AppServerTurnInputItem[],
+) => Promise<FederationWireTurnInputItem[]>;
+
+export type ResolveIncomingFederationTurnInput = (
+  input: readonly FederationWireTurnInputItem[],
+  sourceInstanceId: FederationInstanceId,
+) => Promise<AppServerTurnInputItem[]>;
+
+async function resolveFederationTurnInput(
+  resolver: ResolveIncomingFederationTurnInput | undefined,
+  input: readonly FederationWireTurnInputItem[],
+  sourceInstanceId: FederationInstanceId,
+): Promise<AppServerTurnInputItem[]> {
+  if (resolver) {
+    return await resolver(input, sourceInstanceId);
+  }
+  for (const item of input) {
+    if (
+      item.type === "federationBlob"
+      || item.type === "localImage"
+      || item.type === "localFile"
+      || item.type === "file"
+      || (
+        item.type === "image"
+        && (item.url.startsWith("data:") || item.url.startsWith("file:"))
+      )
+    ) {
+      throw new Error(
+        "Federation attachment references require the staged-input resolver.",
+      );
+    }
+  }
+  return input as AppServerTurnInputItem[];
+}
+
 export type FederationRefreshThreadPullRequestsRequest =
   RefreshOwnedThreadPullRequestsRequest;
 
@@ -194,7 +261,8 @@ function localizeRefreshThreadPullRequestsRequest(
 }
 
 type FederationMaterializeDirectoryLaunchpadRequest =
-  MaterializeDirectoryLaunchpadRequest & {
+  Omit<MaterializeDirectoryLaunchpadRequest, "input"> & {
+    input?: FederationWireTurnInputItem[];
     messageOrigin?: AppServerThreadMessageOrigin;
   };
 
@@ -661,7 +729,9 @@ export type FederationBackendOperations = {
   setCelestialIcon(
     request: SetCelestialIconRequest,
   ): Promise<SetCelestialIconResponse>;
-  starMapIntake(request: StarMapIntakeRequest): Promise<StarMapIntakeResponse>;
+  starMapIntake(
+    request: FederationStarMapIntakeRequest,
+  ): Promise<StarMapIntakeResponse>;
 };
 
 export function registerFederationBackendHandlers(params: {
@@ -674,6 +744,7 @@ export function registerFederationBackendHandlers(params: {
     event: CodexEnvironmentSetupProgressEvent,
     targetInstanceId: string,
   ) => void;
+  resolveTurnInput?: ResolveIncomingFederationTurnInput;
 }): NavigationSnapshotTransport {
   const navigationSnapshotTransport = new NavigationSnapshotTransport({
     // Federation has one owner collection and one resource-version history.
@@ -934,14 +1005,23 @@ export function registerFederationBackendHandlers(params: {
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.startTurn,
     async (envelope) => {
-      const request = envelope.params as FederationStartTurnRequest;
+      const request = envelope.params as Omit<
+        FederationStartTurnRequest,
+        "input"
+      > & { input: FederationWireTurnInputItem[] };
       const messageOrigin = authenticateMessageOrigin({
         messageOrigin: request.messageOrigin,
         resolveSourceInstance: params.resolveSourceInstance,
         sourceInstanceId: envelope.sourceInstanceId,
       });
+      const input = await resolveFederationTurnInput(
+        params.resolveTurnInput,
+        request.input,
+        envelope.sourceInstanceId,
+      );
       return await params.backend.startTurn({
         ...request,
+        input,
         ...(messageOrigin ? { messageOrigin } : {}),
       });
     },
@@ -1032,14 +1112,25 @@ export function registerFederationBackendHandlers(params: {
     params.router.registerHandler(
       FEDERATION_BACKEND_METHODS.controlActiveTurn,
       async (envelope) => {
-        const request = envelope.params as ControlActiveTurnRequest;
+        const {
+          input: wireInput,
+          ...request
+        } = envelope.params as FederationWireControlActiveTurnRequest;
         const messageOrigin = authenticateMessageOrigin({
           messageOrigin: request.messageOrigin,
           resolveSourceInstance: params.resolveSourceInstance,
           sourceInstanceId: envelope.sourceInstanceId,
         });
+        const input = wireInput
+          ? await resolveFederationTurnInput(
+              params.resolveTurnInput,
+              wireInput,
+              envelope.sourceInstanceId,
+            )
+          : undefined;
         return await params.backend.controlActiveTurn!({
           ...request,
+          ...(input ? { input } : {}),
           ...(messageOrigin ? { messageOrigin } : {}),
         });
       },
@@ -1231,6 +1322,7 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) => {
       const {
         messageOrigin: claimedMessageOrigin,
+        input: wireInput,
         ...request
       } = envelope.params as FederationMaterializeDirectoryLaunchpadRequest;
       const messageOrigin = authenticateMessageOrigin({
@@ -1238,8 +1330,18 @@ export function registerFederationBackendHandlers(params: {
         resolveSourceInstance: params.resolveSourceInstance,
         sourceInstanceId: envelope.sourceInstanceId,
       });
+      const input = wireInput
+        ? await resolveFederationTurnInput(
+            params.resolveTurnInput,
+            wireInput,
+            envelope.sourceInstanceId,
+          )
+        : undefined;
       return await params.backend.materializeDirectoryLaunchpad(
-        request,
+        {
+          ...request,
+          ...(input ? { input } : {}),
+        },
         {
           ...(messageOrigin ? { messageOrigin } : {}),
           sourceInstanceId: envelope.sourceInstanceId,
@@ -1306,10 +1408,37 @@ export function registerFederationBackendHandlers(params: {
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.starMapIntake,
-    async (envelope) =>
-      await params.backend.starMapIntake(
-        envelope.params as StarMapIntakeRequest,
-      ),
+    async (envelope) => {
+      const {
+        attachments: wireAttachments,
+        ...request
+      } = envelope.params as FederationWireStarMapIntakeRequest;
+      const attachments = wireAttachments
+        ? await resolveFederationTurnInput(
+            params.resolveTurnInput,
+            wireAttachments,
+            envelope.sourceInstanceId,
+          )
+        : undefined;
+      if (
+        attachments?.some(
+          (item) => item.type !== "localImage" && item.type !== "localFile",
+        )
+      ) {
+        throw new Error(
+          "Star Map intake attachments must resolve to staged local inputs.",
+        );
+      }
+      return await params.backend.starMapIntake({
+        ...request,
+        ...(attachments
+          ? {
+              attachments:
+                attachments as FederationStarMapIntakeAttachment[],
+            }
+          : {}),
+      });
+    },
   );
   return navigationSnapshotTransport;
 }
@@ -1322,6 +1451,7 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     ) =>
       | AppServerReadThreadResponse
       | Promise<AppServerReadThreadResponse> = (response) => response,
+    private readonly prepareTurnInput?: PrepareOutgoingFederationTurnInput,
   ) {}
 
   async getNavigationSnapshot(
@@ -1544,9 +1674,12 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async startTurn(
     request: FederationStartTurnRequest,
   ): Promise<StartTurnResponse> {
+    const input = this.prepareTurnInput
+      ? await this.prepareTurnInput(request.input)
+      : request.input;
     return await this.rpc.request<StartTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.startTurn,
-      params: request,
+      params: { ...request, input },
     });
   }
 
@@ -1641,9 +1774,12 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async controlActiveTurn(
     request: ControlActiveTurnRequest,
   ): Promise<ControlActiveTurnResponse> {
+    const input = request.input && this.prepareTurnInput
+      ? await this.prepareTurnInput(request.input)
+      : request.input;
     return await this.rpc.request<ControlActiveTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
-      params: request,
+      params: { ...request, ...(input ? { input } : {}) },
     });
   }
 
@@ -1881,10 +2017,14 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     request: MaterializeDirectoryLaunchpadRequest,
     options?: MaterializeDirectoryLaunchpadOptions,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
+    const input = request.input && this.prepareTurnInput
+      ? await this.prepareTurnInput(request.input)
+      : request.input;
     return await this.rpc.request<MaterializeDirectoryLaunchpadResponse>({
       method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
       params: {
         ...request,
+        ...(input ? { input } : {}),
         ...(options?.messageOrigin
           ? { messageOrigin: options.messageOrigin }
           : {}),
@@ -1967,11 +2107,19 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   }
 
   async starMapIntake(
-    request: StarMapIntakeRequest,
+    request: FederationStarMapIntakeRequest,
   ): Promise<StarMapIntakeResponse> {
+    const attachments = request.attachments && this.prepareTurnInput
+      ? await this.prepareTurnInput(
+          request.attachments as AppServerTurnInputItem[],
+        )
+      : request.attachments;
     return await this.rpc.request<StarMapIntakeResponse>({
       method: FEDERATION_BACKEND_METHODS.starMapIntake,
-      params: request,
+      params: {
+        ...request,
+        ...(attachments ? { attachments } : {}),
+      } satisfies FederationWireStarMapIntakeRequest,
       // Resolution + thread materialization can outlive the default 30s
       // (Grok call + worktree preparation), so give intake a longer leash.
       timeoutMs: 120_000,

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -13,6 +13,9 @@ export type FederationRouterConnection = {
   peerId: FederationInstanceId;
   capabilities: readonly FederationCapability[];
   sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  sendEnvelopeWithBackpressure?: (
+    envelope: FederationProtocolEnvelope,
+  ) => Promise<void>;
 };
 
 export type FederationRequestHandler = (
@@ -78,6 +81,20 @@ export class FederationRouter {
     const connection = this.connections.get(peerId);
     if (!connection) return false;
     connection.sendEnvelope(envelope);
+    return true;
+  }
+
+  async sendToPeerWithBackpressure(
+    peerId: FederationInstanceId,
+    envelope: FederationProtocolEnvelope,
+  ): Promise<boolean> {
+    const connection = this.connections.get(peerId);
+    if (!connection) return false;
+    if (connection.sendEnvelopeWithBackpressure) {
+      await connection.sendEnvelopeWithBackpressure(envelope);
+    } else {
+      connection.sendEnvelope(envelope);
+    }
     return true;
   }
 

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -1,4 +1,5 @@
 import type {
+  FederationBlobChunkEnvelope,
   FederationCapability,
   FederationErrorEnvelope,
   FederationInstanceId,
@@ -26,6 +27,11 @@ export type FederationRequestHandler = (
   sourcePeerId?: FederationInstanceId,
 ) => Promise<unknown> | unknown;
 
+export type FederationBlobChunkHandler = (
+  envelope: FederationBlobChunkEnvelope,
+  sourcePeerId?: FederationInstanceId,
+) => Promise<void> | void;
+
 export type FederationRouteResult =
   | { status: "handled"; response?: FederationResponseEnvelope }
   | { status: "relayed"; targetInstanceId: FederationInstanceId }
@@ -34,6 +40,7 @@ export type FederationRouteResult =
 export class FederationRouter {
   private readonly connections = new Map<FederationInstanceId, FederationRouterConnection>();
   private readonly handlers = new Map<string, FederationRequestHandler>();
+  private blobChunkHandler?: FederationBlobChunkHandler;
 
   constructor(
     private readonly options: {
@@ -80,6 +87,10 @@ export class FederationRouter {
 
   registerHandler(method: string, handler: FederationRequestHandler): void {
     this.handlers.set(method, handler);
+  }
+
+  registerBlobChunkHandler(handler: FederationBlobChunkHandler): void {
+    this.blobChunkHandler = handler;
   }
 
   async routeEnvelope(params: {
@@ -134,12 +145,46 @@ export class FederationRouter {
         };
       }
     }
+    if (params.envelope.kind === "blob_chunk") {
+      const capabilityFailure = this.checkBlobChunkCapability(
+        params.envelope,
+        params.sourcePeerId,
+      );
+      if (capabilityFailure) {
+        this.replyToSource(params.sourcePeerId, capabilityFailure);
+        return {
+          status: "rejected",
+          code: capabilityFailure.error.code,
+          message: capabilityFailure.error.message,
+        };
+      }
+    }
 
     if (
       params.envelope.targetInstanceId &&
       params.envelope.targetInstanceId !== this.options.localInstanceId
     ) {
       return this.relayEnvelope(params);
+    }
+
+    if (params.envelope.kind === "blob_chunk") {
+      if (!this.blobChunkHandler) {
+        return {
+          status: "rejected",
+          code: "blob_handler_unavailable",
+          message: "Federation blob transfer is unavailable.",
+        };
+      }
+      try {
+        await this.blobChunkHandler(params.envelope, params.sourcePeerId);
+        return { status: "handled" };
+      } catch (error) {
+        return {
+          status: "rejected",
+          code: "blob_transfer_failed",
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
     }
 
     if (params.envelope.kind !== "request") {
@@ -281,6 +326,19 @@ export class FederationRouter {
     return this.errorEnvelope(envelope, {
       code: "capability_denied",
       message: `Method ${envelope.method} requires ${requiredCapability}.`,
+    });
+  }
+
+  private checkBlobChunkCapability(
+    envelope: FederationBlobChunkEnvelope,
+    sourcePeerId: FederationInstanceId | undefined,
+  ): FederationErrorEnvelope | undefined {
+    if (!sourcePeerId) return undefined;
+    const source = this.connections.get(sourcePeerId);
+    if (source?.capabilities.includes("turn_input_blobs")) return undefined;
+    return this.errorEnvelope(envelope, {
+      code: "capability_denied",
+      message: "Federation blob transfer requires turn_input_blobs.",
     });
   }
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -244,6 +244,11 @@ import {
   type FederationStartTurnRequest,
 } from "./federation-backend-bridge";
 import {
+  FederationTurnInputAttachmentReceiver,
+  hasFederationTurnInputAttachments,
+  prepareOutgoingFederationTurnInput,
+} from "./federation-turn-input-attachments";
+import {
   applyFederationLeaseSnapshot,
   buildFederationHealthStatus,
   publicPeerSummary,
@@ -397,6 +402,7 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   // granted — but stays a dedicated capability so it is revocable on its own.
   "remote_pty",
   "event_subscriptions",
+  "turn_input_blobs",
 ];
 
 const REMOTE_THREAD_SUMMARY_EVENT_CONSUMER_ID =
@@ -778,6 +784,8 @@ export class DesktopFederationRuntime {
     }
   >();
   private ownedNavigationSnapshotTransport?: NavigationSnapshotTransport;
+  private readonly turnInputAttachmentReceiver =
+    new FederationTurnInputAttachmentReceiver();
   private readonly remotePeerDirectory = new Map<
     FederationInstanceId,
     FederationPeerSummary
@@ -1619,6 +1627,30 @@ export class DesktopFederationRuntime {
           ),
           target.instanceId,
         ),
+      async (input) => {
+        if (!hasFederationTurnInputAttachments(input)) {
+          return [...input];
+        }
+        if (
+          !this.remotePeerAdvertisesCapability(
+            target.instanceId,
+            "turn_input_blobs",
+          )
+        ) {
+          throw new Error(
+            `Federation instance ${target.instanceId} does not support binary turn attachments.`,
+          );
+        }
+        return await prepareOutgoingFederationTurnInput({
+          input,
+          localInstanceId: this.ensureLocalInstanceId(),
+          targetInstanceId: target.instanceId,
+          privateStorageRoots:
+            getDesktopBackendRegistry().getLocalFilePrivateStorageRoots(),
+          sendEnvelope: (envelope) =>
+            this.sendEnvelopeToTarget(target.instanceId, envelope),
+        });
+      },
     );
   }
 
@@ -2320,9 +2352,20 @@ export class DesktopFederationRuntime {
       },
       additionalRequiredCapabilities: additionalFederationBackendCapabilities,
     });
+    router.registerBlobChunkHandler(async (envelope) => {
+      await this.turnInputAttachmentReceiver.receive(
+        envelope,
+        envelope.sourceInstanceId,
+      );
+    });
     this.ownedNavigationSnapshotTransport = registerFederationBackendHandlers({
       router,
       backend: localBackendOperations(),
+      resolveTurnInput: async (input, sourceInstanceId) =>
+        await this.turnInputAttachmentReceiver.resolveInput(
+          input,
+          sourceInstanceId,
+        ),
       resolveSourceInstance: (instanceId) =>
         this.resolveThreadMessageOriginInstance(instanceId),
       onEnvironmentSetupProgress: (event, targetInstanceId) => {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1647,8 +1647,11 @@ export class DesktopFederationRuntime {
           targetInstanceId: target.instanceId,
           privateStorageRoots:
             getDesktopBackendRegistry().getLocalFilePrivateStorageRoots(),
-          sendEnvelope: (envelope) =>
-            this.sendEnvelopeToTarget(target.instanceId, envelope),
+          sendEnvelope: async (envelope) =>
+            await this.sendEnvelopeToTargetWithBackpressure(
+              target.instanceId,
+              envelope,
+            ),
         });
       },
     );
@@ -2791,7 +2794,14 @@ export class DesktopFederationRuntime {
     this.router?.registerConnection({
       peerId: gatewayInstanceId,
       capabilities: client.capabilities,
-      sendEnvelope: (envelope) => this.client?.sendEnvelope(envelope),
+      sendEnvelope: (envelope) => client.sendEnvelope(envelope),
+      sendEnvelopeWithBackpressure: async (envelope) => {
+        if (client.sendEnvelopeWithBackpressure) {
+          await client.sendEnvelopeWithBackpressure(envelope);
+          return;
+        }
+        client.sendEnvelope(envelope);
+      },
     });
     // This instance can also be the OWNER of remote PTY sessions the gateway
     // is viewing; a reconnect inside the grace keeps those alive.
@@ -2922,6 +2932,7 @@ export class DesktopFederationRuntime {
       peerId: connection.peerId,
       capabilities: connection.capabilities,
       sendEnvelope: connection.sendEnvelope,
+      sendEnvelopeWithBackpressure: connection.sendEnvelopeWithBackpressure,
     });
     // A transport blip that healed inside the reap grace keeps the peer's
     // remote PTY sessions alive.
@@ -3210,6 +3221,32 @@ export class DesktopFederationRuntime {
       gatewayInstanceId &&
       gatewayInstanceId !== targetInstanceId &&
       this.router?.sendToPeer(gatewayInstanceId, envelope)
+    ) {
+      return;
+    }
+
+    throw new FederationPeerUnavailableError(targetInstanceId);
+  }
+
+  private async sendEnvelopeToTargetWithBackpressure(
+    targetInstanceId: FederationInstanceId,
+    envelope: FederationProtocolEnvelope,
+  ): Promise<void> {
+    if (
+      await this.router?.sendToPeerWithBackpressure(
+        targetInstanceId,
+        envelope,
+      )
+    ) {
+      return;
+    }
+
+    const gatewayInstanceId = this.gatewayInstanceId
+      ?? getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY);
+    if (
+      gatewayInstanceId
+      && gatewayInstanceId !== targetInstanceId
+      && await this.router?.sendToPeerWithBackpressure(gatewayInstanceId, envelope)
     ) {
       return;
     }

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -74,6 +74,10 @@ export const FEDERATION_KEEPALIVE_INTERVAL_MS = 15_000;
  * peer can force that allocation per frame.
  */
 export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+const FEDERATION_BLOB_FRAME_MAGIC = Buffer.from("PWRBLOB1", "ascii");
+const FEDERATION_BLOB_FRAME_PREFIX_BYTES =
+  FEDERATION_BLOB_FRAME_MAGIC.byteLength + 4;
+const FEDERATION_BLOB_FRAME_MAX_HEADER_BYTES = 64 * 1024;
 
 /**
  * The socket surface the keepalive watchdog needs. Structural (rather than
@@ -1208,8 +1212,8 @@ function sendFrame(
   transport?: NoiseTransport,
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
-  const json = Buffer.from(JSON.stringify(message), "utf8");
-  const wire = transport ? transport.encrypt(json) : json;
+  const payload = encodeFederationSocketPayload(message);
+  const wire = transport ? transport.encrypt(payload) : payload;
   socket.send(wire);
   return wire.byteLength;
 }
@@ -1223,16 +1227,54 @@ function decodeFrame(
   frame: Buffer,
   transport?: NoiseTransport,
 ): FederationSocketMessage | undefined {
-  let json = frame;
+  let payload = frame;
   if (transport) {
     try {
-      json = transport.decrypt(frame);
+      payload = transport.decrypt(frame);
     } catch {
       throw new FederationFrameAuthenticationError();
     }
   }
+  return decodeFederationSocketPayload(payload);
+}
+
+function encodeFederationSocketPayload(
+  message: FederationSocketMessage,
+): Buffer {
+  if (
+    message.kind !== "envelope"
+    || message.envelope.kind !== "blob_chunk"
+  ) {
+    return Buffer.from(JSON.stringify(message), "utf8");
+  }
+  const { data, ...headerEnvelope } = message.envelope;
+  const header = Buffer.from(
+    JSON.stringify({ kind: "envelope", envelope: headerEnvelope }),
+    "utf8",
+  );
+  if (header.byteLength > FEDERATION_BLOB_FRAME_MAX_HEADER_BYTES) {
+    throw new Error("Federation blob frame header is too large.");
+  }
+  const prefix = Buffer.allocUnsafe(FEDERATION_BLOB_FRAME_PREFIX_BYTES);
+  FEDERATION_BLOB_FRAME_MAGIC.copy(prefix, 0);
+  prefix.writeUInt32BE(header.byteLength, FEDERATION_BLOB_FRAME_MAGIC.byteLength);
+  return Buffer.concat([prefix, header, Buffer.from(data)]);
+}
+
+function decodeFederationSocketPayload(
+  payload: Buffer,
+): FederationSocketMessage | undefined {
+  if (
+    payload.byteLength >= FEDERATION_BLOB_FRAME_PREFIX_BYTES
+    && payload.subarray(0, FEDERATION_BLOB_FRAME_MAGIC.byteLength)
+      .equals(FEDERATION_BLOB_FRAME_MAGIC)
+  ) {
+    return decodeFederationBlobSocketPayload(payload);
+  }
   try {
-    const parsed = JSON.parse(json.toString("utf8")) as Partial<FederationSocketMessage>;
+    const parsed = JSON.parse(
+      payload.toString("utf8"),
+    ) as Partial<FederationSocketMessage>;
     if (
       parsed.kind === "transport.hello"
       && isTransportHelloMessage(parsed)
@@ -1245,7 +1287,11 @@ function decodeFrame(
     if (parsed.kind === "auth.rejected" && parsed.failure) {
       return parsed as FederationSocketRejectedMessage;
     }
-    if (parsed.kind === "envelope" && parsed.envelope) {
+    if (
+      parsed.kind === "envelope"
+      && parsed.envelope
+      && parsed.envelope.kind !== "blob_chunk"
+    ) {
       return parsed as FederationSocketEnvelopeMessage;
     }
     return undefined;
@@ -1253,6 +1299,61 @@ function decodeFrame(
     return undefined;
   }
 }
+
+function decodeFederationBlobSocketPayload(
+  payload: Buffer,
+): FederationSocketMessage | undefined {
+  const headerLength = payload.readUInt32BE(
+    FEDERATION_BLOB_FRAME_MAGIC.byteLength,
+  );
+  if (
+    headerLength <= 0
+    || headerLength > FEDERATION_BLOB_FRAME_MAX_HEADER_BYTES
+    || FEDERATION_BLOB_FRAME_PREFIX_BYTES + headerLength > payload.byteLength
+  ) {
+    return undefined;
+  }
+  try {
+    const header = JSON.parse(
+      payload
+        .subarray(
+          FEDERATION_BLOB_FRAME_PREFIX_BYTES,
+          FEDERATION_BLOB_FRAME_PREFIX_BYTES + headerLength,
+        )
+        .toString("utf8"),
+    ) as Partial<FederationSocketEnvelopeMessage>;
+    if (
+      header.kind !== "envelope"
+      || !header.envelope
+      || header.envelope.kind !== "blob_chunk"
+      || Object.hasOwn(header.envelope, "data")
+    ) {
+      return undefined;
+    }
+    return {
+      kind: "envelope",
+      envelope: {
+        ...header.envelope,
+        data: payload.subarray(
+          FEDERATION_BLOB_FRAME_PREFIX_BYTES + headerLength,
+        ),
+      },
+    } as FederationSocketEnvelopeMessage;
+  } catch {
+    return undefined;
+  }
+}
+
+/** @internal Narrow wire-codec seam for protocol conformance tests. */
+export const federationTransportCodecForTest = {
+  encodeEnvelope(envelope: FederationProtocolEnvelope): Buffer {
+    return encodeFederationSocketPayload({ kind: "envelope", envelope });
+  },
+  decodeEnvelope(payload: Buffer): FederationProtocolEnvelope | undefined {
+    const decoded = decodeFederationSocketPayload(payload);
+    return decoded?.kind === "envelope" ? decoded.envelope : undefined;
+  },
+};
 
 class FederationFrameAuthenticationError extends Error {
   constructor() {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -78,6 +78,8 @@ const FEDERATION_BLOB_FRAME_MAGIC = Buffer.from("PWRBLOB1", "ascii");
 const FEDERATION_BLOB_FRAME_PREFIX_BYTES =
   FEDERATION_BLOB_FRAME_MAGIC.byteLength + 4;
 const FEDERATION_BLOB_FRAME_MAX_HEADER_BYTES = 64 * 1024;
+export const FEDERATION_SEND_BUFFER_HIGH_WATER_BYTES = 2 * 1024 * 1024;
+const FEDERATION_SEND_BUFFER_POLL_MS = 5;
 
 /**
  * The socket surface the keepalive watchdog needs. Structural (rather than
@@ -237,6 +239,9 @@ export type FederationGatewayConnection = {
   sessionId: FederationSessionId;
   capabilities: FederationCapability[];
   sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  sendEnvelopeWithBackpressure?: (
+    envelope: FederationProtocolEnvelope,
+  ) => Promise<void>;
   close: (code?: number, reason?: string) => void;
   /** Hard socket teardown for peers already presumed dead (stale sweep):
    *  a graceful close queues a frame a wedged socket may never deliver. */
@@ -578,6 +583,20 @@ export class FederationGatewayWebSocketServer {
           });
         }
       },
+      sendEnvelopeWithBackpressure: async (envelope) => {
+        const byteCount = await sendFrameWithBackpressure(
+          socket,
+          { kind: "envelope", envelope },
+          transport,
+        );
+        if (byteCount > 0) {
+          this.options.onEnvelopeTransfer?.({
+            peerId: decision.peer.id,
+            direction: "sent",
+            byteCount,
+          });
+        }
+      },
       close: (code?: number, reason?: string) => socket.close(code, reason),
       terminate: () => socket.terminate(),
     };
@@ -774,6 +793,9 @@ export type FederationClientWebSocketClient = {
   sessionId: FederationSessionId;
   capabilities: FederationCapability[];
   sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  sendEnvelopeWithBackpressure?: (
+    envelope: FederationProtocolEnvelope,
+  ) => Promise<void>;
   close: () => void;
 };
 
@@ -1111,6 +1133,16 @@ async function establishFederationClient(
         params.onEnvelopeTransfer?.({ direction: "sent", byteCount });
       }
     },
+    sendEnvelopeWithBackpressure: async (envelope) => {
+      const byteCount = await sendFrameWithBackpressure(
+        socket,
+        { kind: "envelope", envelope },
+        transport,
+      );
+      if (byteCount > 0) {
+        params.onEnvelopeTransfer?.({ direction: "sent", byteCount });
+      }
+    },
     close: () => socket.close(),
   };
 }
@@ -1216,6 +1248,32 @@ function sendFrame(
   const wire = transport ? transport.encrypt(payload) : payload;
   socket.send(wire);
   return wire.byteLength;
+}
+
+async function sendFrameWithBackpressure(
+  socket: WebSocket,
+  message: FederationSocketMessage,
+  transport?: NoiseTransport,
+): Promise<number> {
+  await waitForFederationSendCapacity(socket);
+  if (socket.readyState !== WebSocket.OPEN) {
+    throw new Error("Federation connection closed while sending an attachment.");
+  }
+  return sendFrame(socket, message, transport);
+}
+
+export async function waitForFederationSendCapacity(
+  socket: Pick<WebSocket, "bufferedAmount" | "readyState">,
+): Promise<void> {
+  while (
+    socket.readyState === WebSocket.OPEN
+    && socket.bufferedAmount > FEDERATION_SEND_BUFFER_HIGH_WATER_BYTES
+  ) {
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, FEDERATION_SEND_BUFFER_POLL_MS);
+      timer.unref?.();
+    });
+  }
 }
 
 function closeAfterFrameAuthenticationFailure(socket: WebSocket): void {

--- a/apps/desktop/src/main/federation/federation-turn-input-attachments.ts
+++ b/apps/desktop/src/main/federation/federation-turn-input-attachments.ts
@@ -1,5 +1,17 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import {
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  unlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
@@ -20,8 +32,9 @@ import {
 import { resolveActiveProfilePath } from "../profile";
 
 export const FEDERATION_BLOB_CHUNK_BYTES = 512 * 1024;
-const FEDERATION_BLOB_WAIT_TIMEOUT_MS = 30_000;
+export const FEDERATION_BLOB_WAIT_TIMEOUT_MS = 30_000;
 const FEDERATION_BLOB_COMPLETED_RETENTION_MS = 10 * 60_000;
+export const FEDERATION_TURN_INPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export const MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE = 8;
 export const MAX_BUFFERED_FEDERATION_BLOB_BYTES = 256 * 1024 * 1024;
 
@@ -60,7 +73,9 @@ export async function prepareOutgoingFederationTurnInput(params: {
   input: readonly AppServerTurnInputItem[];
   localInstanceId: FederationInstanceId;
   targetInstanceId: FederationInstanceId;
-  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  sendEnvelope: (
+    envelope: FederationProtocolEnvelope,
+  ) => Promise<void> | void;
   privateStorageRoots?: readonly string[];
 }): Promise<FederationWireTurnInputItem[]> {
   const prepared: FederationWireTurnInputItem[] = [];
@@ -178,17 +193,25 @@ async function sendStagedAttachment(params: {
   attachment: StagedTurnInputAttachment;
   localInstanceId: FederationInstanceId;
   targetInstanceId: FederationInstanceId;
-  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  sendEnvelope: (
+    envelope: FederationProtocolEnvelope,
+  ) => Promise<void> | void;
 }): Promise<FederationTurnInputBlobReference> {
-  const data = await readFile(params.attachment.path);
-  if (data.byteLength > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
+  const fileInfo = await stat(params.attachment.path);
+  if (!fileInfo.isFile()) {
+    throw new Error("Turn attachment path is not a regular file.");
+  }
+  if (fileInfo.size > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
     throw new Error(
       `Turn attachment exceeds the ${MAX_TURN_INPUT_ATTACHMENT_BYTES}-byte limit.`,
     );
   }
   const transferId = randomUUID();
-  const chunkCount = Math.max(1, Math.ceil(data.byteLength / FEDERATION_BLOB_CHUNK_BYTES));
-  const sha256 = createHash("sha256").update(data).digest("hex");
+  const chunkCount = Math.max(
+    1,
+    Math.ceil(fileInfo.size / FEDERATION_BLOB_CHUNK_BYTES),
+  );
+  const sha256 = await hashFile(params.attachment.path);
   const name = sanitizeTurnAttachmentName(
     params.attachment.name,
     path.basename(params.attachment.path),
@@ -197,32 +220,52 @@ async function sendStagedAttachment(params: {
     ? params.attachment.mimeType
     : undefined;
 
-  for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
-    const offset = chunkIndex * FEDERATION_BLOB_CHUNK_BYTES;
-    const chunk = data.subarray(
-      offset,
-      Math.min(data.byteLength, offset + FEDERATION_BLOB_CHUNK_BYTES),
-    );
-    params.sendEnvelope({
-      id: `federation-blob:${transferId}:${chunkIndex}`,
-      kind: "blob_chunk",
-      protocolVersion: FEDERATION_PROTOCOL_VERSION,
-      sourceInstanceId: params.localInstanceId,
-      targetInstanceId: params.targetInstanceId,
-      createdAt: Date.now(),
-      transferId,
-      chunkIndex,
-      chunkCount,
-      totalSize: data.byteLength,
-      sha256,
-      name,
-      ...(mimeType ? { mimeType } : {}),
-      inputType: params.attachment.type,
-      data: chunk,
-    });
+  const file = await open(params.attachment.path, "r");
+  try {
+    for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+      const remaining = fileInfo.size - chunkIndex * FEDERATION_BLOB_CHUNK_BYTES;
+      const chunk = Buffer.allocUnsafe(
+        Math.max(0, Math.min(FEDERATION_BLOB_CHUNK_BYTES, remaining)),
+      );
+      if (chunk.byteLength > 0) {
+        const result = await file.read(chunk, 0, chunk.byteLength, null);
+        if (result.bytesRead !== chunk.byteLength) {
+          throw new Error(
+            "Turn attachment changed while it was being transferred.",
+          );
+        }
+      }
+      await params.sendEnvelope({
+        id: `federation-blob:${transferId}:${chunkIndex}`,
+        kind: "blob_chunk",
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: params.localInstanceId,
+        targetInstanceId: params.targetInstanceId,
+        createdAt: Date.now(),
+        transferId,
+        chunkIndex,
+        chunkCount,
+        totalSize: fileInfo.size,
+        sha256,
+        name,
+        ...(mimeType ? { mimeType } : {}),
+        inputType: params.attachment.type,
+        data: chunk,
+      });
+    }
+  } finally {
+    await file.close();
   }
 
   return { type: "federationBlob", transferId };
+}
+
+async function hashFile(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk as Buffer);
+  }
+  return hash.digest("hex");
 }
 
 export class FederationTurnInputAttachmentReceiver {
@@ -278,8 +321,10 @@ export class FederationTurnInputAttachmentReceiver {
       throw new Error("Federation blob exceeded its declared size.");
     }
     if (transfer.chunks.size !== metadata.chunkCount) {
+      this.armTransferTimeout(key, transfer);
       return;
     }
+    clearTimeout(transfer.timeout);
 
     try {
       const attachment = await this.persistCompletedTransfer(
@@ -363,6 +408,16 @@ export class FederationTurnInputAttachmentReceiver {
       timeout: setTimeout(() => undefined, 0),
     } satisfies IncomingTransfer;
     clearTimeout(transfer.timeout);
+    this.armTransferTimeout(key, transfer);
+    this.transfers.set(key, transfer);
+    return transfer;
+  }
+
+  private armTransferTimeout(
+    key: string,
+    transfer: IncomingTransfer,
+  ): void {
+    clearTimeout(transfer.timeout);
     transfer.timeout = setTimeout(() => {
       this.failTransfer(
         key,
@@ -371,8 +426,6 @@ export class FederationTurnInputAttachmentReceiver {
       );
     }, FEDERATION_BLOB_WAIT_TIMEOUT_MS);
     transfer.timeout.unref?.();
-    this.transfers.set(key, transfer);
-    return transfer;
   }
 
   private failTransfer(
@@ -431,6 +484,8 @@ export class FederationTurnInputAttachmentReceiver {
       sanitizeTurnAttachmentName(metadata.name),
     );
     await mkdir(path.dirname(filePath), { recursive: true });
+    const persistedAt = new Date();
+    await utimes(path.dirname(filePath), persistedAt, persistedAt);
     const existing = await stat(filePath).catch(() => undefined);
     let reusable = false;
     if (existing?.isFile() && existing.size === metadata.totalSize) {
@@ -448,7 +503,16 @@ export class FederationTurnInputAttachmentReceiver {
       } finally {
         await unlink(temporaryPath).catch(() => undefined);
       }
+    } else {
+      await Promise.all([
+        utimes(filePath, persistedAt, persistedAt),
+        utimes(path.dirname(filePath), persistedAt, persistedAt),
+      ]);
     }
+
+    void cleanupOldFederationTurnInputs(root, new Set([filePath])).catch(
+      () => undefined,
+    );
 
     return metadata.inputType === "localImage"
       ? { type: "localImage", name: metadata.name, path: filePath }
@@ -460,6 +524,39 @@ export class FederationTurnInputAttachmentReceiver {
           sizeBytes: metadata.totalSize,
         };
   }
+}
+
+async function cleanupOldFederationTurnInputs(
+  root: string,
+  excludedFiles: ReadonlySet<string>,
+): Promise<void> {
+  const cutoff = Date.now() - FEDERATION_TURN_INPUT_MAX_AGE_MS;
+  const peerEntries = await readdir(root).catch(() => []);
+  await Promise.all(
+    peerEntries.map(async (peerEntry) => {
+      const peerPath = path.join(root, peerEntry);
+      const digestEntries = await readdir(peerPath).catch(() => []);
+      await Promise.all(
+        digestEntries.map(async (digestEntry) => {
+          const digestPath = path.join(peerPath, digestEntry);
+          const children = await readdir(digestPath).catch(() => []);
+          if (
+            children.some((child) =>
+              excludedFiles.has(path.join(digestPath, child))
+            )
+          ) {
+            return;
+          }
+          const info = await stat(digestPath).catch(() => undefined);
+          if (info?.isDirectory() && info.mtimeMs < cutoff) {
+            await rm(digestPath, { recursive: true, force: true }).catch(
+              () => undefined,
+            );
+          }
+        }),
+      );
+    }),
+  );
 }
 
 function assertSafeFederationInlineInput(item: AppServerTurnInputItem): void {

--- a/apps/desktop/src/main/federation/federation-turn-input-attachments.ts
+++ b/apps/desktop/src/main/federation/federation-turn-input-attachments.ts
@@ -1,0 +1,559 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AppServerFileInputItem,
+  AppServerTurnInputItem,
+  FederationBlobChunkEnvelope,
+  FederationInstanceId,
+  FederationProtocolEnvelope,
+} from "@pwragent/shared";
+import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+import {
+  MAX_TURN_INPUT_ATTACHMENT_BYTES,
+  sanitizeTurnAttachmentName,
+  stageLocalTurnInputAttachment,
+  stageTurnInputAttachment,
+  type StagedTurnInputAttachment,
+} from "../app-server/turn-input-attachment-files";
+import { resolveActiveProfilePath } from "../profile";
+
+export const FEDERATION_BLOB_CHUNK_BYTES = 512 * 1024;
+const FEDERATION_BLOB_WAIT_TIMEOUT_MS = 30_000;
+const FEDERATION_BLOB_COMPLETED_RETENTION_MS = 10 * 60_000;
+export const MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE = 8;
+export const MAX_BUFFERED_FEDERATION_BLOB_BYTES = 256 * 1024 * 1024;
+
+export type FederationTurnInputBlobReference = {
+  type: "federationBlob";
+  transferId: string;
+};
+
+export type FederationWireTurnInputItem =
+  | AppServerTurnInputItem
+  | FederationTurnInputBlobReference;
+
+type IncomingTransferMetadata = {
+  transferId: string;
+  chunkCount: number;
+  totalSize: number;
+  sha256: string;
+  name: string;
+  mimeType?: string;
+  inputType: "localFile" | "localImage";
+};
+
+type IncomingTransfer = {
+  chunks: Map<number, Buffer>;
+  completion: Promise<StagedTurnInputAttachment>;
+  metadata?: IncomingTransferMetadata;
+  receivedBytes: number;
+  reject: (error: Error) => void;
+  resolve: (attachment: StagedTurnInputAttachment) => void;
+  sourceInstanceId: FederationInstanceId;
+  settled: boolean;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+export async function prepareOutgoingFederationTurnInput(params: {
+  input: readonly AppServerTurnInputItem[];
+  localInstanceId: FederationInstanceId;
+  targetInstanceId: FederationInstanceId;
+  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  privateStorageRoots?: readonly string[];
+}): Promise<FederationWireTurnInputItem[]> {
+  const prepared: FederationWireTurnInputItem[] = [];
+
+  for (const item of params.input) {
+    const staged = await stageTransferableInput(item, {
+      privateStorageRoots: params.privateStorageRoots,
+    });
+    if (!staged) {
+      if (item.type === "image" && item.url.startsWith("data:")) {
+        throw new Error(
+          "Inline image data could not be staged for federation transfer.",
+        );
+      }
+      prepared.push(item);
+      continue;
+    }
+    prepared.push(
+      await sendStagedAttachment({
+        attachment: staged,
+        localInstanceId: params.localInstanceId,
+        targetInstanceId: params.targetInstanceId,
+        sendEnvelope: params.sendEnvelope,
+      }),
+    );
+  }
+
+  return prepared;
+}
+
+export function hasFederationTurnInputAttachments(
+  input: readonly AppServerTurnInputItem[],
+): boolean {
+  return input.some(
+    (item) =>
+      item.type === "file"
+      || item.type === "localFile"
+      || item.type === "localImage"
+      || (item.type === "image" && item.url.startsWith("data:"))
+      || (item.type === "image" && item.url.startsWith("file:")),
+  );
+}
+
+async function stageTransferableInput(
+  item: AppServerTurnInputItem,
+  options: { privateStorageRoots?: readonly string[] },
+): Promise<StagedTurnInputAttachment | undefined> {
+  if (item.type === "localImage" || item.type === "localFile") {
+    return await stageLocalTurnInputAttachment(item, options);
+  }
+  if (item.type === "file") {
+    return await stageTurnInputAttachment({
+      type: "localFile",
+      data: decodeBase64File(item),
+      name: item.name,
+      mimeType: item.mimeType,
+    });
+  }
+  if (item.type !== "image") {
+    return undefined;
+  }
+  if (item.url.startsWith("file:")) {
+    const filePath = filePathFromUrl(item.url);
+    if (!filePath) {
+      throw new Error("Invalid local image file URL.");
+    }
+    return await stageLocalTurnInputAttachment({
+      type: "localImage",
+      ...(item.name ? { name: item.name } : {}),
+      path: filePath,
+    }, options);
+  }
+  const parsed = parseImageDataUrl(item.url);
+  if (!parsed) {
+    return undefined;
+  }
+  return await stageTurnInputAttachment({
+    type: "localImage",
+    data: parsed.data,
+    name: item.name,
+    mimeType: parsed.mimeType,
+  });
+}
+
+function filePathFromUrl(value: string): string | undefined {
+  try {
+    return fileURLToPath(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeBase64File(item: AppServerFileInputItem): Buffer {
+  if (!/^[a-z0-9+/]*={0,2}$/iu.test(item.data) || item.data.length % 4 !== 0) {
+    throw new Error(`File attachment ${item.name} has invalid base64 data.`);
+  }
+  return Buffer.from(item.data, "base64");
+}
+
+function parseImageDataUrl(
+  url: string,
+): { data: Buffer; mimeType: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]*={0,2})$/iu.exec(url);
+  if (!match || (match[2]?.length ?? 0) % 4 !== 0) {
+    return undefined;
+  }
+  const data = Buffer.from(match[2] ?? "", "base64");
+  if (data.byteLength === 0) {
+    return undefined;
+  }
+  return { data, mimeType: match[1] ?? "application/octet-stream" };
+}
+
+async function sendStagedAttachment(params: {
+  attachment: StagedTurnInputAttachment;
+  localInstanceId: FederationInstanceId;
+  targetInstanceId: FederationInstanceId;
+  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+}): Promise<FederationTurnInputBlobReference> {
+  const data = await readFile(params.attachment.path);
+  if (data.byteLength > MAX_TURN_INPUT_ATTACHMENT_BYTES) {
+    throw new Error(
+      `Turn attachment exceeds the ${MAX_TURN_INPUT_ATTACHMENT_BYTES}-byte limit.`,
+    );
+  }
+  const transferId = randomUUID();
+  const chunkCount = Math.max(1, Math.ceil(data.byteLength / FEDERATION_BLOB_CHUNK_BYTES));
+  const sha256 = createHash("sha256").update(data).digest("hex");
+  const name = sanitizeTurnAttachmentName(
+    params.attachment.name,
+    path.basename(params.attachment.path),
+  );
+  const mimeType = params.attachment.type === "localFile"
+    ? params.attachment.mimeType
+    : undefined;
+
+  for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+    const offset = chunkIndex * FEDERATION_BLOB_CHUNK_BYTES;
+    const chunk = data.subarray(
+      offset,
+      Math.min(data.byteLength, offset + FEDERATION_BLOB_CHUNK_BYTES),
+    );
+    params.sendEnvelope({
+      id: `federation-blob:${transferId}:${chunkIndex}`,
+      kind: "blob_chunk",
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: params.localInstanceId,
+      targetInstanceId: params.targetInstanceId,
+      createdAt: Date.now(),
+      transferId,
+      chunkIndex,
+      chunkCount,
+      totalSize: data.byteLength,
+      sha256,
+      name,
+      ...(mimeType ? { mimeType } : {}),
+      inputType: params.attachment.type,
+      data: chunk,
+    });
+  }
+
+  return { type: "federationBlob", transferId };
+}
+
+export class FederationTurnInputAttachmentReceiver {
+  private readonly transfers = new Map<string, IncomingTransfer>();
+  private bufferedBytes = 0;
+
+  constructor(
+    private readonly options: {
+      resolveRoot?: () => string;
+      now?: () => number;
+    } = {},
+  ) {}
+
+  async receive(
+    envelope: FederationBlobChunkEnvelope,
+    sourceInstanceId: FederationInstanceId,
+  ): Promise<void> {
+    validateBlobChunk(envelope);
+    const key = transferKey(sourceInstanceId, envelope.transferId);
+    const transfer = this.getOrCreateTransfer(key, sourceInstanceId);
+    const metadata = metadataFromEnvelope(envelope);
+    if (transfer.metadata && !sameMetadata(transfer.metadata, metadata)) {
+      this.failTransfer(key, transfer, new Error("Federation blob metadata changed between chunks."));
+      throw new Error("Federation blob metadata changed between chunks.");
+    }
+    transfer.metadata ??= metadata;
+
+    const previous = transfer.chunks.get(envelope.chunkIndex);
+    const chunk = Buffer.from(envelope.data);
+    if (previous) {
+      if (!previous.equals(chunk)) {
+        this.failTransfer(key, transfer, new Error("Federation blob chunk was replayed with different bytes."));
+        throw new Error("Federation blob chunk was replayed with different bytes.");
+      }
+      return;
+    }
+    if (
+      this.bufferedBytes + chunk.byteLength
+      > MAX_BUFFERED_FEDERATION_BLOB_BYTES
+    ) {
+      this.failTransfer(
+        key,
+        transfer,
+        new Error("Federation blob buffer limit exceeded."),
+      );
+      throw new Error("Federation blob buffer limit exceeded.");
+    }
+    transfer.chunks.set(envelope.chunkIndex, chunk);
+    transfer.receivedBytes += chunk.byteLength;
+    this.bufferedBytes += chunk.byteLength;
+    if (transfer.receivedBytes > metadata.totalSize) {
+      this.failTransfer(key, transfer, new Error("Federation blob exceeded its declared size."));
+      throw new Error("Federation blob exceeded its declared size.");
+    }
+    if (transfer.chunks.size !== metadata.chunkCount) {
+      return;
+    }
+
+    try {
+      const attachment = await this.persistCompletedTransfer(
+        sourceInstanceId,
+        metadata,
+        transfer.chunks,
+      );
+      transfer.settled = true;
+      this.releaseBufferedChunks(transfer);
+      clearTimeout(transfer.timeout);
+      transfer.resolve(attachment);
+      const cleanup = setTimeout(() => {
+        if (this.transfers.get(key) === transfer) {
+          this.transfers.delete(key);
+        }
+      }, FEDERATION_BLOB_COMPLETED_RETENTION_MS);
+      cleanup.unref?.();
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      this.failTransfer(key, transfer, failure);
+      throw failure;
+    }
+  }
+
+  async resolveInput(
+    input: readonly FederationWireTurnInputItem[],
+    sourceInstanceId: FederationInstanceId,
+  ): Promise<AppServerTurnInputItem[]> {
+    return await Promise.all(
+      input.map(async (item) => {
+        if (!isFederationTurnInputBlobReference(item)) {
+          assertSafeFederationInlineInput(item);
+          return item;
+        }
+        const transfer = this.getOrCreateTransfer(
+          transferKey(sourceInstanceId, item.transferId),
+          sourceInstanceId,
+        );
+        return await transfer.completion;
+      }),
+    );
+  }
+
+  private getOrCreateTransfer(
+    key: string,
+    sourceInstanceId: FederationInstanceId,
+  ): IncomingTransfer {
+    const existing = this.transfers.get(key);
+    if (existing) {
+      return existing;
+    }
+    const incompleteForSource = [...this.transfers.values()].filter(
+      (transfer) =>
+        !transfer.settled
+        && transfer.sourceInstanceId === sourceInstanceId,
+    ).length;
+    if (incompleteForSource >= MAX_INCOMPLETE_FEDERATION_BLOBS_PER_SOURCE) {
+      throw new Error(
+        "Too many incomplete federation blob transfers from this peer.",
+      );
+    }
+    let resolve!: (attachment: StagedTurnInputAttachment) => void;
+    let reject!: (error: Error) => void;
+    const completion = new Promise<StagedTurnInputAttachment>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    // A malformed peer chunk can fail before the matching RPC reaches the
+    // resolver. Keep the original rejecting promise for callers while also
+    // marking it observed so an unaffiliated peer cannot cause an unhandled
+    // rejection in the main process.
+    void completion.catch(() => undefined);
+    const transfer = {
+      chunks: new Map<number, Buffer>(),
+      completion,
+      receivedBytes: 0,
+      reject,
+      resolve,
+      sourceInstanceId,
+      settled: false,
+      timeout: setTimeout(() => undefined, 0),
+    } satisfies IncomingTransfer;
+    clearTimeout(transfer.timeout);
+    transfer.timeout = setTimeout(() => {
+      this.failTransfer(
+        key,
+        transfer,
+        new Error("Timed out waiting for federation attachment bytes."),
+      );
+    }, FEDERATION_BLOB_WAIT_TIMEOUT_MS);
+    transfer.timeout.unref?.();
+    this.transfers.set(key, transfer);
+    return transfer;
+  }
+
+  private failTransfer(
+    key: string,
+    transfer: IncomingTransfer,
+    error: Error,
+  ): void {
+    if (transfer.settled) {
+      return;
+    }
+    transfer.settled = true;
+    clearTimeout(transfer.timeout);
+    this.releaseBufferedChunks(transfer);
+    transfer.reject(error);
+    if (this.transfers.get(key) === transfer) {
+      this.transfers.delete(key);
+    }
+  }
+
+  private releaseBufferedChunks(transfer: IncomingTransfer): void {
+    this.bufferedBytes = Math.max(
+      0,
+      this.bufferedBytes - transfer.receivedBytes,
+    );
+    transfer.receivedBytes = 0;
+    transfer.chunks.clear();
+  }
+
+  private async persistCompletedTransfer(
+    sourceInstanceId: FederationInstanceId,
+    metadata: IncomingTransferMetadata,
+    chunks: ReadonlyMap<number, Buffer>,
+  ): Promise<StagedTurnInputAttachment> {
+    const ordered = Array.from(
+      { length: metadata.chunkCount },
+      (_, index) => chunks.get(index),
+    );
+    if (ordered.some((chunk) => !chunk)) {
+      throw new Error("Federation blob is missing one or more chunks.");
+    }
+    const data = Buffer.concat(ordered as Buffer[]);
+    if (data.byteLength !== metadata.totalSize) {
+      throw new Error("Federation blob size does not match its metadata.");
+    }
+    const digest = createHash("sha256").update(data).digest("hex");
+    if (digest !== metadata.sha256) {
+      throw new Error("Federation blob failed its SHA-256 integrity check.");
+    }
+
+    const root = this.options.resolveRoot?.()
+      ?? resolveActiveProfilePath(path.join("state", "federation-turn-inputs"));
+    const filePath = path.join(
+      root,
+      sanitizeTurnAttachmentName(sourceInstanceId, "peer"),
+      digest,
+      sanitizeTurnAttachmentName(metadata.name),
+    );
+    await mkdir(path.dirname(filePath), { recursive: true });
+    const existing = await stat(filePath).catch(() => undefined);
+    let reusable = false;
+    if (existing?.isFile() && existing.size === metadata.totalSize) {
+      const existingData = await readFile(filePath).catch(() => undefined);
+      reusable = Boolean(
+        existingData
+        && createHash("sha256").update(existingData).digest("hex") === digest,
+      );
+    }
+    if (!reusable) {
+      const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+      try {
+        await writeFile(temporaryPath, data);
+        await rename(temporaryPath, filePath);
+      } finally {
+        await unlink(temporaryPath).catch(() => undefined);
+      }
+    }
+
+    return metadata.inputType === "localImage"
+      ? { type: "localImage", name: metadata.name, path: filePath }
+      : {
+          type: "localFile",
+          name: metadata.name,
+          path: filePath,
+          ...(metadata.mimeType ? { mimeType: metadata.mimeType } : {}),
+          sizeBytes: metadata.totalSize,
+        };
+  }
+}
+
+function assertSafeFederationInlineInput(item: AppServerTurnInputItem): void {
+  if (
+    item.type === "localImage"
+    || item.type === "localFile"
+    || item.type === "file"
+    || (
+      item.type === "image"
+      && (item.url.startsWith("data:") || item.url.startsWith("file:"))
+    )
+  ) {
+    throw new Error(
+      "Federation turn attachments must use a verified blob transfer reference.",
+    );
+  }
+}
+
+export function isFederationTurnInputBlobReference(
+  value: FederationWireTurnInputItem,
+): value is FederationTurnInputBlobReference {
+  return value.type === "federationBlob"
+    && typeof value.transferId === "string"
+    && value.transferId.length > 0
+    && value.transferId.length <= 120;
+}
+
+function validateBlobChunk(envelope: FederationBlobChunkEnvelope): void {
+  if (
+    !envelope.transferId
+    || envelope.transferId.length > 120
+    || !Number.isSafeInteger(envelope.chunkIndex)
+    || envelope.chunkIndex < 0
+    || !Number.isSafeInteger(envelope.chunkCount)
+    || envelope.chunkCount < 1
+    || envelope.chunkIndex >= envelope.chunkCount
+    || !Number.isSafeInteger(envelope.totalSize)
+    || envelope.totalSize < 0
+    || envelope.totalSize > MAX_TURN_INPUT_ATTACHMENT_BYTES
+    || !/^[a-f0-9]{64}$/u.test(envelope.sha256)
+    || !envelope.name
+    || envelope.name.length > 200
+    || !(envelope.data instanceof Uint8Array)
+    || envelope.data.byteLength > FEDERATION_BLOB_CHUNK_BYTES
+    || (envelope.inputType !== "localFile" && envelope.inputType !== "localImage")
+  ) {
+    throw new Error("Invalid federation blob chunk.");
+  }
+  const expectedChunkCount = Math.max(
+    1,
+    Math.ceil(envelope.totalSize / FEDERATION_BLOB_CHUNK_BYTES),
+  );
+  const expectedChunkSize = envelope.chunkIndex < expectedChunkCount - 1
+    ? FEDERATION_BLOB_CHUNK_BYTES
+    : envelope.totalSize
+      - (expectedChunkCount - 1) * FEDERATION_BLOB_CHUNK_BYTES;
+  if (
+    envelope.chunkCount !== expectedChunkCount
+    || envelope.data.byteLength !== expectedChunkSize
+  ) {
+    throw new Error("Invalid federation blob chunk geometry.");
+  }
+}
+
+function metadataFromEnvelope(
+  envelope: FederationBlobChunkEnvelope,
+): IncomingTransferMetadata {
+  return {
+    transferId: envelope.transferId,
+    chunkCount: envelope.chunkCount,
+    totalSize: envelope.totalSize,
+    sha256: envelope.sha256,
+    name: envelope.name,
+    ...(envelope.mimeType ? { mimeType: envelope.mimeType } : {}),
+    inputType: envelope.inputType,
+  };
+}
+
+function sameMetadata(
+  left: IncomingTransferMetadata,
+  right: IncomingTransferMetadata,
+): boolean {
+  return left.transferId === right.transferId
+    && left.chunkCount === right.chunkCount
+    && left.totalSize === right.totalSize
+    && left.sha256 === right.sha256
+    && left.name === right.name
+    && left.mimeType === right.mimeType
+    && left.inputType === right.inputType;
+}
+
+function transferKey(
+  sourceInstanceId: FederationInstanceId,
+  transferId: string,
+): string {
+  return `${sourceInstanceId}\u0000${transferId}`;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1237,6 +1237,16 @@ export function bootstrapApp(): void {
     getDesktopBackendRegistry().setPwrAgentFederationHandler(
       createFederationAgentToolsHandler({
         targetStore: getDesktopOverlayStore(),
+        resolveSourceTurnAttachments: (context) => {
+          const turnId = context.turnId?.trim();
+          return turnId
+            ? getDesktopBackendRegistry().getTurnInputAttachments({
+                backend: context.backend,
+                threadId: context.threadId,
+                turnId,
+              })
+            : [];
+        },
         onRemoteChildMounted: async ({ backend, instanceId, threadId }) => {
           await getDesktopBackendRegistry().publishLocalEvent({
             backend,

--- a/apps/desktop/src/main/ipc/star-map.ts
+++ b/apps/desktop/src/main/ipc/star-map.ts
@@ -1,14 +1,13 @@
 import { BrowserWindow, ipcMain, type WebContents } from "electron";
 import type {
-  FederationTarget,
   ReadStarMapArrangementResponse,
   ReadStarMapWorkspaceResponse,
   SetStarMapCardPositionRequest,
   StarMapArrangementEntry,
-  StarMapIntakeRequest,
   StarMapIntakeResponse,
   WriteStarMapWorkspaceRequest,
 } from "@pwragent/shared";
+import type { StarMapIntakeDispatchRequest } from "../../shared/star-map-intake";
 import {
   isRemoteFederationTarget,
   isStarMapArrangementEntry,
@@ -92,7 +91,7 @@ export function registerStarMapIpcHandlers(): void {
     STAR_MAP_INTAKE_CHANNEL,
     async (
       _event,
-      request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
+      request: StarMapIntakeDispatchRequest,
     ): Promise<StarMapIntakeResponse> => {
       const { federationTarget, ...intake } = request;
       if (federationTarget && isRemoteFederationTarget(federationTarget)) {

--- a/apps/desktop/src/main/ipc/star-map.ts
+++ b/apps/desktop/src/main/ipc/star-map.ts
@@ -4,10 +4,14 @@ import type {
   ReadStarMapWorkspaceResponse,
   SetStarMapCardPositionRequest,
   StarMapArrangementEntry,
+  StarMapIntakeRequest,
   StarMapIntakeResponse,
   WriteStarMapWorkspaceRequest,
 } from "@pwragent/shared";
-import type { StarMapIntakeDispatchRequest } from "../../shared/star-map-intake";
+import {
+  MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS,
+  type StarMapIntakeDispatchRequest,
+} from "../../shared/star-map-intake";
 import {
   isRemoteFederationTarget,
   isStarMapArrangementEntry,
@@ -27,6 +31,11 @@ import {
 import type { WindowShowThreadRequest } from "../../shared/window-show-thread";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { dispatchStarMapIntake } from "../app-server/star-map-intake";
+import {
+  MAX_TURN_INPUT_ATTACHMENT_BYTES,
+  stageTurnInputAttachments,
+  type TurnInputAttachmentUpload,
+} from "../app-server/turn-input-attachment-files";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { isFederationWindowWebContents } from "../window";
 import { subscribersForChannel } from "../window-channels";
@@ -43,6 +52,66 @@ function primaryMainWindowWebContents(): WebContents | undefined {
   return subscribersForChannel(WINDOW_SHOW_THREAD_CHANNEL).find(
     (subscriber) => !isFederationWindowWebContents(subscriber),
   );
+}
+
+function normalizeStarMapIntakeImageUploads(
+  value: unknown,
+): TurnInputAttachmentUpload[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid Star Map image uploads");
+  }
+  if (value.length > MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS) {
+    throw new Error(
+      `Star Map intake accepts at most ${MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS} images.`,
+    );
+  }
+  return value.map((candidate) => {
+    if (!candidate || typeof candidate !== "object") {
+      throw new Error("Invalid Star Map image upload");
+    }
+    const upload = candidate as {
+      bytes?: unknown;
+      mimeType?: unknown;
+      name?: unknown;
+    };
+    if (
+      !(upload.bytes instanceof Uint8Array)
+      || upload.bytes.byteLength === 0
+      || upload.bytes.byteLength > MAX_TURN_INPUT_ATTACHMENT_BYTES
+      || typeof upload.mimeType !== "string"
+      || !/^image\/[a-z0-9.+-]+$/iu.test(upload.mimeType)
+      || upload.mimeType.length > 100
+      || typeof upload.name !== "string"
+      || upload.name.trim().length === 0
+      || upload.name.length > 200
+    ) {
+      throw new Error("Invalid Star Map image upload");
+    }
+    return {
+      type: "localImage" as const,
+      data: upload.bytes,
+      mimeType: upload.mimeType,
+      name: upload.name.trim(),
+    };
+  });
+}
+
+async function stageStarMapIntakeRequest(
+  request: StarMapIntakeDispatchRequest,
+): Promise<StarMapIntakeRequest> {
+  const uploads = normalizeStarMapIntakeImageUploads(request.imageUploads);
+  const attachments = uploads.length > 0
+    ? await stageTurnInputAttachments(uploads)
+    : [];
+  return {
+    requestId: request.requestId,
+    request: request.request,
+    ...(request.directoryKey !== undefined
+      ? { directoryKey: request.directoryKey }
+      : {}),
+    ...(attachments.length > 0 ? { attachments } : {}),
+  };
 }
 
 export function registerStarMapIpcHandlers(): void {
@@ -93,7 +162,8 @@ export function registerStarMapIpcHandlers(): void {
       _event,
       request: StarMapIntakeDispatchRequest,
     ): Promise<StarMapIntakeResponse> => {
-      const { federationTarget, ...intake } = request;
+      const intake = await stageStarMapIntakeRequest(request);
+      const { federationTarget } = request;
       if (federationTarget && isRemoteFederationTarget(federationTarget)) {
         // Execute on the owning instance: its directory registry, defaults,
         // and AGENTS.md preferences are the ones the intake must consult.

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -356,10 +356,8 @@ import type {
   ReadStarMapArrangementResponse,
   ReadStarMapWorkspaceResponse,
   SetStarMapCardPositionRequest,
-  StarMapIntakeRequest,
   StarMapIntakeResponse,
   WriteStarMapWorkspaceRequest,
-  FederationTarget,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
   RefreshDesktopCodexDiscoveryRequest,
@@ -396,6 +394,7 @@ import type {
   UpdateThreadExpectedBranchResponse,
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
+import type { StarMapIntakeDispatchRequest } from "../shared/star-map-intake";
 import type { RendererErrorReport } from "../shared/renderer-error";
 import type { RendererDiagnosticLogRequest } from "../shared/renderer-diagnostic";
 import {
@@ -1099,7 +1098,7 @@ const desktopApi = Object.freeze({
   ): Promise<ReadStarMapWorkspaceResponse> =>
     await ipcRenderer.invoke(STAR_MAP_WRITE_WORKSPACE_CHANNEL, request),
   dispatchStarMapIntake: async (
-    request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
+    request: StarMapIntakeDispatchRequest,
   ): Promise<StarMapIntakeResponse> =>
     await ipcRenderer.invoke(STAR_MAP_INTAKE_CHANNEL, request),
   openStarMapWindow: async (): Promise<void> => {

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1698,6 +1698,7 @@ const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
   gateway_relay: "reach sibling instances",
   remote_pty: "open a remote terminal",
   event_subscriptions: "stream explicitly subscribed events",
+  turn_input_blobs: "transfer turn attachments",
 };
 
 function formatFederationCapabilities(

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  type ClipboardEvent,
+  type DragEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import type {
   CelestialIconId,
@@ -6,8 +13,15 @@ import type {
   StarMapIntakeCandidate,
   StarMapIntakePhase,
 } from "@pwragent/shared";
+import { MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS } from "../../../../shared/star-map-intake";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { CelestialIcon } from "../../icons";
+import { CelestialIcon, CloseIcon } from "../../icons";
+import {
+  formatPastedImageAlt,
+  formatPastedImageName,
+  getImageFilesFromDataTransfer,
+  hasAnyFiles,
+} from "../composer/composer-image-files";
 
 export type IntakeDialogTarget = {
   instanceId: string;
@@ -21,6 +35,19 @@ const PHASE_COPY: Partial<Record<StarMapIntakePhase, string>> = {
   resolving: "Finding the right project…",
   creating: "Creating the thread…",
 };
+
+type IntakeImageAttachment = {
+  bytes: Uint8Array;
+  id: string;
+  key: string;
+  mimeType: string;
+  name: string;
+  previewUrl: string;
+};
+
+function imageFileKey(file: File, mimeType: string): string {
+  return [file.name, mimeType, file.size, file.lastModified].join(":");
+}
 
 /**
  * The Star Map [+] intake chat: describe a task in natural language and the
@@ -40,13 +67,30 @@ export function IntakeDialog(props: {
   const [text, setText] = useState("");
   const [phase, setPhase] = useState<StarMapIntakePhase | "idle">("idle");
   const [error, setError] = useState<string>();
+  const [attachmentError, setAttachmentError] = useState<string>();
+  const [imageAttachments, setImageAttachments] = useState<
+    IntakeImageAttachment[]
+  >([]);
+  const [preparingImageCount, setPreparingImageCount] = useState(0);
   const [candidates, setCandidates] = useState<StarMapIntakeCandidate[]>();
   const requestIdRef = useRef<string | undefined>(undefined);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const previewUrlsRef = useRef(new Set<string>());
   const busy = phase === "resolving" || phase === "creating";
+  const preparingImages = preparingImageCount > 0;
 
   useEffect(() => {
     textareaRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const previewUrls = previewUrlsRef.current;
+    return () => {
+      for (const previewUrl of previewUrls) {
+        URL.revokeObjectURL(previewUrl);
+      }
+      previewUrls.clear();
+    };
   }, []);
 
   // Stream progress: the owning instance publishes starMap/intake/status
@@ -68,13 +112,129 @@ export function IntakeDialog(props: {
     return () => unsubscribe?.();
   }, [props.desktopApi]);
 
+  const attachTransferredImages = useCallback((dataTransfer: DataTransfer) => {
+    const images = getImageFilesFromDataTransfer(dataTransfer);
+    if (images.length === 0) return false;
+
+    setAttachmentError(undefined);
+    const knownKeys = new Set(
+      imageAttachments.map((attachment) => attachment.key),
+    );
+    const uniqueImages = images.filter(({ file, type }) => {
+      const key = imageFileKey(file, type);
+      if (knownKeys.has(key)) return false;
+      knownKeys.add(key);
+      return true;
+    });
+    const remaining = Math.max(
+      0,
+      MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS
+        - imageAttachments.length
+        - preparingImageCount,
+    );
+    const accepted = uniqueImages.slice(0, remaining);
+    if (accepted.length < uniqueImages.length) {
+      setAttachmentError(
+        `You can attach up to ${MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS} images per task.`,
+      );
+    }
+    if (accepted.length === 0) return true;
+
+    setPreparingImageCount((current) => current + accepted.length);
+    void Promise.all(
+      accepted.map(async ({ file, type }, index) => {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        if (bytes.byteLength === 0) {
+          throw new Error("The pasted image was empty.");
+        }
+        return {
+          bytes,
+          file,
+          key: imageFileKey(file, type),
+          mimeType: type,
+          name:
+            file.name
+            || formatPastedImageName(type, imageAttachments.length + index),
+        };
+      }),
+    )
+      .then((loaded) => {
+        const attachments = loaded.map((image) => {
+          const previewUrl = URL.createObjectURL(image.file);
+          previewUrlsRef.current.add(previewUrl);
+          return {
+            bytes: image.bytes,
+            id: `intake-image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            key: image.key,
+            mimeType: image.mimeType,
+            name: image.name,
+            previewUrl,
+          };
+        });
+        setImageAttachments((current) => {
+          const acceptedAttachments = attachments.filter(
+            (attachment) =>
+              !current.some((candidate) => candidate.key === attachment.key),
+          );
+          const next = [
+            ...current,
+            ...acceptedAttachments,
+          ].slice(0, MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS);
+          const retainedIds = new Set(next.map((attachment) => attachment.id));
+          for (const attachment of attachments) {
+            if (retainedIds.has(attachment.id)) continue;
+            URL.revokeObjectURL(attachment.previewUrl);
+            previewUrlsRef.current.delete(attachment.previewUrl);
+          }
+          return next;
+        });
+      })
+      .catch((readError: unknown) => {
+        setAttachmentError(
+          readError instanceof Error
+            ? readError.message
+            : "The pasted image could not be read.",
+        );
+      })
+      .finally(() => {
+        setPreparingImageCount((current) =>
+          Math.max(0, current - accepted.length),
+        );
+      });
+    return true;
+  }, [imageAttachments, preparingImageCount]);
+
+  const onPaste = useCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (attachTransferredImages(event.clipboardData)) {
+      event.preventDefault();
+    }
+  }, [attachTransferredImages]);
+
+  const onDragOver = useCallback((event: DragEvent<HTMLTextAreaElement>) => {
+    if (!hasAnyFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const onDrop = useCallback((event: DragEvent<HTMLTextAreaElement>) => {
+    if (attachTransferredImages(event.dataTransfer)) {
+      event.preventDefault();
+    }
+  }, [attachTransferredImages]);
+
   const submit = (directoryKey?: string) => {
     const request = text.trim();
-    if (!request || busy || !props.desktopApi?.dispatchStarMapIntake) return;
+    if (
+      !request
+      || busy
+      || preparingImages
+      || !props.desktopApi?.dispatchStarMapIntake
+    ) return;
     const requestId =
       requestIdRef.current ?? `intake-${Math.random().toString(36).slice(2)}`;
     requestIdRef.current = requestId;
     setError(undefined);
+    setAttachmentError(undefined);
     setCandidates(undefined);
     setPhase("resolving");
     void props.desktopApi
@@ -83,6 +243,15 @@ export function IntakeDialog(props: {
         request,
         directoryKey,
         federationTarget: props.target.federationTarget,
+        ...(imageAttachments.length > 0
+          ? {
+              imageUploads: imageAttachments.map((attachment) => ({
+                bytes: attachment.bytes,
+                mimeType: attachment.mimeType,
+                name: attachment.name,
+              })),
+            }
+          : {}),
       })
       .then((response) => {
         if (response.requestId !== requestIdRef.current) return;
@@ -117,7 +286,7 @@ export function IntakeDialog(props: {
       aria-modal="true"
       aria-label={`New thread on ${props.target.label}`}
       onKeyDown={(event) => {
-        if (event.key === "Escape" && !busy) {
+        if (event.key === "Escape" && !busy && !preparingImages) {
           event.stopPropagation();
           props.onClose();
         }
@@ -129,7 +298,7 @@ export function IntakeDialog(props: {
         aria-label="Close intake"
         tabIndex={-1}
         onClick={() => {
-          if (!busy) props.onClose();
+          if (!busy && !preparingImages) props.onClose();
         }}
       />
       <div className="star-map-intake__panel">
@@ -142,7 +311,7 @@ export function IntakeDialog(props: {
             type="button"
             className="star-map-intake__close"
             aria-label="Close"
-            disabled={busy}
+            disabled={busy || preparingImages}
             onClick={props.onClose}
           >
             ✕
@@ -153,9 +322,12 @@ export function IntakeDialog(props: {
           className="star-map-intake__input"
           placeholder="Give me a task, tell me the project, and any specifics that don't match your defaults."
           value={text}
-          disabled={busy}
+          disabled={busy || preparingImages}
           rows={4}
           onChange={(event) => setText(event.target.value)}
+          onDragOver={onDragOver}
+          onDrop={onDrop}
+          onPaste={onPaste}
           onKeyDown={(event) => {
             if (
               event.key === "Enter"
@@ -166,6 +338,42 @@ export function IntakeDialog(props: {
             }
           }}
         />
+        {imageAttachments.length > 0 ? (
+          <div
+            aria-label="Task images"
+            className="star-map-intake__attachments"
+          >
+            {imageAttachments.map((attachment, index) => (
+              <div
+                className="star-map-intake__attachment"
+                key={attachment.id}
+              >
+                <img
+                  alt={formatPastedImageAlt(attachment, index)}
+                  className="star-map-intake__attachment-preview"
+                  src={attachment.previewUrl}
+                />
+                <button
+                  aria-label={`Remove ${attachment.name}`}
+                  className="star-map-intake__attachment-remove"
+                  disabled={busy}
+                  onClick={() => {
+                    URL.revokeObjectURL(attachment.previewUrl);
+                    previewUrlsRef.current.delete(attachment.previewUrl);
+                    setImageAttachments((current) =>
+                      current.filter(
+                        (candidate) => candidate.id !== attachment.id,
+                      ),
+                    );
+                  }}
+                  type="button"
+                >
+                  <CloseIcon aria-hidden="true" size={10} />
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : null}
         {candidates ? (
           <div className="star-map-intake__candidates">
             <p className="star-map-intake__hint">Which project?</p>
@@ -191,19 +399,24 @@ export function IntakeDialog(props: {
         <div className="star-map-intake__footer">
           <span
             className={`star-map-intake__status${
-              busy ? " is-busy" : ""
-            }${phase === "failed" ? " is-failed" : ""}`}
+              busy || preparingImages ? " is-busy" : ""
+            }${phase === "failed" || attachmentError ? " is-failed" : ""}`}
             role="status"
           >
-            {phase === "failed" ? error : PHASE_COPY[phase as StarMapIntakePhase] ?? ""}
+            {attachmentError
+              ?? (phase === "failed"
+                ? error
+                : preparingImages
+                  ? "Preparing image…"
+                  : PHASE_COPY[phase as StarMapIntakePhase] ?? "")}
           </span>
           <button
             type="button"
             className="button button--secondary"
-            disabled={busy || text.trim().length === 0}
+            disabled={busy || preparingImages || text.trim().length === 0}
             onClick={() => submit()}
           >
-            {busy ? "Working…" : "Start thread"}
+            {busy ? "Working…" : preparingImages ? "Preparing…" : "Start thread"}
           </button>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -15,12 +15,17 @@ import type {
 } from "@pwragent/shared";
 import { MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS } from "../../../../shared/star-map-intake";
 import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  imageDataUrlToBytes,
+  normalizeImageFile,
+} from "../../lib/image-normalization";
 import { CelestialIcon, CloseIcon } from "../../icons";
 import {
   formatPastedImageAlt,
   formatPastedImageName,
   getImageFilesFromDataTransfer,
   hasAnyFiles,
+  isGifFile,
 } from "../composer/composer-image-files";
 
 export type IntakeDialogTarget = {
@@ -49,6 +54,16 @@ function imageFileKey(file: File, mimeType: string): string {
   return [file.name, mimeType, file.size, file.lastModified].join(":");
 }
 
+function normalizedImageName(
+  originalName: string,
+  fallbackName: string,
+  mimeType: "image/jpeg" | "image/png",
+): string {
+  const source = originalName || fallbackName;
+  const baseName = source.replace(/\.[^.]*$/u, "") || "pasted-image";
+  return `${baseName}.${mimeType === "image/jpeg" ? "jpg" : "png"}`;
+}
+
 /**
  * The Star Map [+] intake chat: describe a task in natural language and the
  * owning instance resolves the project (its registry + AGENTS.md
@@ -63,6 +78,7 @@ export function IntakeDialog(props: {
     backend: string;
     threadId: string;
   }) => void;
+  pastedImageMaxPatches?: number;
 }) {
   const [text, setText] = useState("");
   const [phase, setPhase] = useState<StarMapIntakePhase | "idle">("idle");
@@ -143,24 +159,73 @@ export function IntakeDialog(props: {
     setPreparingImageCount((current) => current + accepted.length);
     void Promise.all(
       accepted.map(async ({ file, type }, index) => {
-        const bytes = new Uint8Array(await file.arrayBuffer());
+        const fallbackName = formatPastedImageName(
+          type,
+          imageAttachments.length + index,
+        );
+        if (isGifFile(file, type)) {
+          const bytes = new Uint8Array(await file.arrayBuffer());
+          if (bytes.byteLength === 0) {
+            throw new Error("The pasted image was empty.");
+          }
+          return {
+            bytes,
+            key: imageFileKey(file, type),
+            mimeType: "image/gif",
+            name: file.name || fallbackName,
+          };
+        }
+
+        const normalized = await normalizeImageFile(file, {
+          fallback: props.desktopApi?.normalizeImageForUpload,
+          maxPatchCount: props.pastedImageMaxPatches,
+          sourceMimeType: type,
+        });
+        const bytes = await imageDataUrlToBytes(
+          normalized.dataUrl,
+          normalized.mimeType,
+        );
         if (bytes.byteLength === 0) {
           throw new Error("The pasted image was empty.");
         }
+        void props.desktopApi?.recordImageUploadNormalization?.({
+          fileName: file.name || fallbackName,
+          original: {
+            height: normalized.original.height,
+            mimeType: normalized.original.mimeType,
+            size: normalized.original.size,
+            width: normalized.original.width,
+          },
+          normalized: {
+            height: normalized.height,
+            mimeType: normalized.mimeType,
+            size: normalized.size,
+            width: normalized.width,
+          },
+          path: normalized.conversionPath,
+          resized:
+            normalized.original.width !== normalized.width
+            || normalized.original.height !== normalized.height,
+        });
         return {
           bytes,
-          file,
           key: imageFileKey(file, type),
-          mimeType: type,
-          name:
-            file.name
-            || formatPastedImageName(type, imageAttachments.length + index),
+          mimeType: normalized.mimeType,
+          name: normalizedImageName(
+            file.name,
+            fallbackName,
+            normalized.mimeType,
+          ),
         };
       }),
     )
       .then((loaded) => {
         const attachments = loaded.map((image) => {
-          const previewUrl = URL.createObjectURL(image.file);
+          const previewBytes = new Uint8Array(image.bytes.byteLength);
+          previewBytes.set(image.bytes);
+          const previewUrl = URL.createObjectURL(
+            new Blob([previewBytes.buffer], { type: image.mimeType }),
+          );
           previewUrlsRef.current.add(previewUrl);
           return {
             bytes: image.bytes,
@@ -202,7 +267,12 @@ export function IntakeDialog(props: {
         );
       });
     return true;
-  }, [imageAttachments, preparingImageCount]);
+  }, [
+    imageAttachments,
+    preparingImageCount,
+    props.desktopApi,
+    props.pastedImageMaxPatches,
+  ]);
 
   const onPaste = useCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
     if (attachTransferredImages(event.clipboardData)) {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -5189,6 +5189,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       {intakeTarget ? (
         <IntakeDialog
           desktopApi={props.desktopApi}
+          pastedImageMaxPatches={props.pastedImageMaxPatches}
           target={intakeTarget}
           onClose={() => setIntakeTarget(undefined)}
           onCreated={(created) => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -3,6 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { IntakeDialog } from "../IntakeDialog";
 
+const normalizeImageFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../lib/image-normalization", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../../lib/image-normalization")>(),
+  normalizeImageFile: normalizeImageFileMock,
+}));
+
 const target = {
   instanceId: "pwr_local",
   label: "Mac-Mini-M4",
@@ -12,6 +19,7 @@ const target = {
 function setup(
   dispatchResult: unknown,
   intakeTarget: Parameters<typeof IntakeDialog>[0]["target"] = target,
+  pastedImageMaxPatches?: number,
 ) {
   const dispatchStarMapIntake = vi.fn(
     async (_request: { requestId: string; directoryKey?: string }) =>
@@ -26,6 +34,7 @@ function setup(
   render(
     <IntakeDialog
       desktopApi={desktopApi}
+      pastedImageMaxPatches={pastedImageMaxPatches}
       target={intakeTarget}
       onClose={onClose}
       onCreated={onCreated}
@@ -55,6 +64,21 @@ function pastePng(bytes = new Uint8Array([137, 80, 78, 71])) {
   return { bytes, file };
 }
 
+function pasteImage(file: File, type: string): void {
+  fireEvent.paste(screen.getByPlaceholderText(/Give me a task/), {
+    clipboardData: {
+      files: [file],
+      items: [
+        {
+          getAsFile: () => file,
+          kind: "file",
+          type,
+        },
+      ],
+    },
+  });
+}
+
 function submitText(text: string) {
   fireEvent.change(screen.getByPlaceholderText(/Give me a task/), {
     target: { value: text },
@@ -64,6 +88,22 @@ function submitText(text: string) {
 
 describe("IntakeDialog", () => {
   beforeEach(() => {
+    normalizeImageFileMock.mockReset();
+    normalizeImageFileMock.mockImplementation(async (file: File) => ({
+      conversionPath: "renderer",
+      dataUrl: "data:image/png;base64,iVBORw==",
+      height: 1,
+      mimeType: "image/png",
+      original: {
+        height: 1,
+        mimeType: file.type || "image/png",
+        name: file.name,
+        size: file.size,
+        width: 1,
+      },
+      size: 4,
+      width: 1,
+    }));
     Object.defineProperty(URL, "createObjectURL", {
       configurable: true,
       value: vi.fn(() => "blob:intake-image"),
@@ -247,6 +287,61 @@ describe("IntakeDialog", () => {
         }),
       );
     });
+  });
+
+  it("normalizes non-GIF images before dispatching renderer bytes", async () => {
+    const { dispatchStarMapIntake } = setup(undefined, target, 321);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) => ({
+        status: "created",
+        requestId: request.requestId,
+        backend: "codex",
+        threadId: "thread-normalized-image",
+      }) as never,
+    );
+    normalizeImageFileMock.mockResolvedValueOnce({
+      conversionPath: "heic-fallback",
+      dataUrl: "data:image/jpeg;base64,/9j/",
+      height: 480,
+      mimeType: "image/jpeg",
+      original: {
+        height: 3_000,
+        mimeType: "image/heic",
+        name: "camera.heic",
+        size: 12,
+        width: 4_000,
+      },
+      size: 3,
+      width: 640,
+    });
+    const file = new File([Uint8Array.from([1, 2, 3])], "camera.heic", {
+      type: "image/heic",
+    });
+    pasteImage(file, "image/heic");
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove camera.jpg" }))
+        .toBeTruthy();
+    });
+    submitText("Inspect this camera image");
+
+    await waitFor(() => expect(dispatchStarMapIntake).toHaveBeenCalled());
+    expect(normalizeImageFileMock).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining({
+        maxPatchCount: 321,
+        sourceMimeType: "image/heic",
+      }),
+    );
+    expect(dispatchStarMapIntake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageUploads: [{
+          bytes: expect.any(Uint8Array),
+          mimeType: "image/jpeg",
+          name: "camera.jpg",
+        }],
+      }),
+    );
   });
 
   it("removes a pasted image before dispatch", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { IntakeDialog } from "../IntakeDialog";
 
@@ -9,7 +9,10 @@ const target = {
   icon: "sun" as const,
 };
 
-function setup(dispatchResult: unknown) {
+function setup(
+  dispatchResult: unknown,
+  intakeTarget: Parameters<typeof IntakeDialog>[0]["target"] = target,
+) {
   const dispatchStarMapIntake = vi.fn(
     async (_request: { requestId: string; directoryKey?: string }) =>
       dispatchResult as never,
@@ -23,12 +26,33 @@ function setup(dispatchResult: unknown) {
   render(
     <IntakeDialog
       desktopApi={desktopApi}
-      target={target}
+      target={intakeTarget}
       onClose={onClose}
       onCreated={onCreated}
     />,
   );
   return { dispatchStarMapIntake, onClose, onCreated };
+}
+
+function pastePng(bytes = new Uint8Array([137, 80, 78, 71])) {
+  const file = new File([bytes], "screenshot.png", { type: "image/png" });
+  Object.defineProperty(file, "arrayBuffer", {
+    configurable: true,
+    value: vi.fn(async () => bytes.buffer.slice(0)),
+  });
+  fireEvent.paste(screen.getByPlaceholderText(/Give me a task/), {
+    clipboardData: {
+      files: [file],
+      items: [
+        {
+          getAsFile: () => file,
+          kind: "file",
+          type: "image/png",
+        },
+      ],
+    },
+  });
+  return { bytes, file };
 }
 
 function submitText(text: string) {
@@ -39,6 +63,17 @@ function submitText(text: string) {
 }
 
 describe("IntakeDialog", () => {
+  beforeEach(() => {
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:intake-image"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
   it("dispatches the request and reports the created thread", async () => {
     const { dispatchStarMapIntake, onClose, onCreated } = setup({
       status: "created",
@@ -130,5 +165,117 @@ describe("IntakeDialog", () => {
     setup(undefined);
     const submit = screen.getByRole("button", { name: "Start thread" });
     expect((submit as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("pastes an image and dispatches typed bytes instead of a data URL", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "created",
+          requestId: request.requestId,
+          backend: "codex",
+          threadId: "thread-image",
+        }) as never,
+    );
+    const { bytes } = pastePng();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Task images")).toBeTruthy();
+    });
+    submitText("Fix the screenshot issue in PwrAgent");
+
+    await waitFor(() => {
+      expect(dispatchStarMapIntake).toHaveBeenCalled();
+    });
+    const request = dispatchStarMapIntake.mock.calls[0]?.[0] as {
+      imageUploads?: Array<{
+        bytes: Uint8Array;
+        mimeType: string;
+        name: string;
+      }>;
+    };
+    expect(request.imageUploads).toHaveLength(1);
+    expect(request.imageUploads?.[0]).toMatchObject({
+      mimeType: "image/png",
+      name: "screenshot.png",
+    });
+    expect(request.imageUploads?.[0]?.bytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(request.imageUploads?.[0]?.bytes ?? [])).toEqual(
+      Array.from(bytes),
+    );
+    expect(request.imageUploads?.[0]?.bytes).not.toEqual(
+      expect.any(String),
+    );
+  });
+
+  it("keeps the federation target beside binary image uploads", async () => {
+    const federationTarget = {
+      instanceId: "peer-1",
+      scope: "remote" as const,
+    };
+    const { dispatchStarMapIntake } = setup(undefined, {
+      federationTarget,
+      instanceId: "peer-1",
+      label: "Studio Mac",
+    });
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "created",
+          requestId: request.requestId,
+          backend: "codex",
+          threadId: "remote-thread-image",
+        }) as never,
+    );
+    pastePng(new Uint8Array([1, 2, 3]));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Task images")).toBeTruthy();
+    });
+    submitText("Fix this in PwrAgent");
+
+    await waitFor(() => {
+      expect(dispatchStarMapIntake).toHaveBeenCalledWith(
+        expect.objectContaining({
+          federationTarget,
+          imageUploads: [
+            expect.objectContaining({
+              bytes: expect.any(Uint8Array),
+              mimeType: "image/png",
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it("removes a pasted image before dispatch", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "created",
+          requestId: request.requestId,
+          backend: "codex",
+          threadId: "thread-without-image",
+        }) as never,
+    );
+    pastePng();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove screenshot.png" }))
+        .toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove screenshot.png" }),
+    );
+    submitText("Fix this in PwrAgent");
+
+    await waitFor(() => {
+      expect(dispatchStarMapIntake).toHaveBeenCalled();
+    });
+    expect(dispatchStarMapIntake.mock.calls[0]?.[0]).not.toHaveProperty(
+      "imageUploads",
+    );
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:intake-image");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -162,10 +162,8 @@ import type {
   ReadStarMapArrangementResponse,
   ReadStarMapWorkspaceResponse,
   SetStarMapCardPositionRequest,
-  StarMapIntakeRequest,
   StarMapIntakeResponse,
   WriteStarMapWorkspaceRequest,
-  FederationTarget,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
@@ -425,6 +423,7 @@ import type {
   UpdateThreadExpectedBranchResponse,
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
+import type { StarMapIntakeDispatchRequest } from "../../../shared/star-map-intake";
 import type { RuntimeIdentity } from "../../../shared/runtime-identity";
 import type { WindowPointerSnapshot } from "../../../shared/window-pointer";
 import type { WindowShowThreadRequest } from "../../../shared/window-show-thread";
@@ -625,7 +624,7 @@ export type DesktopApi = {
     request: WriteStarMapWorkspaceRequest,
   ) => Promise<ReadStarMapWorkspaceResponse>;
   dispatchStarMapIntake?: (
-    request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
+    request: StarMapIntakeDispatchRequest,
   ) => Promise<StarMapIntakeResponse>;
   /** Spawns or focuses the dedicated Federation Star Map window. */
   openStarMapWindow?: () => Promise<void>;

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -495,6 +495,14 @@ function dataUrlToBlob(dataUrl: string, fallbackMimeType: string): Blob {
   return new Blob([bytes], { type: mimeType });
 }
 
+export async function imageDataUrlToBytes(
+  dataUrl: string,
+  fallbackMimeType: string,
+): Promise<Uint8Array> {
+  const blob = dataUrlToBlob(dataUrl, fallbackMimeType);
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
 const defaultImageNormalizationDependencies: ImageNormalizationDependencies = {
   createCanvas: (width, height) => {
     const canvas = document.createElement("canvas");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11814,6 +11814,55 @@ textarea,
   outline-offset: 1px;
 }
 
+.star-map-intake__attachments {
+  display: flex;
+  gap: 6px;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.star-map-intake__attachment {
+  position: relative;
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+}
+
+.star-map-intake__attachment-preview {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.star-map-intake__attachment-remove {
+  display: inline-flex;
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.star-map-intake__attachment-remove:hover,
+.star-map-intake__attachment-remove:focus-visible {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+  outline: none;
+}
+
 .star-map-intake__hint {
   margin: 0;
   color: var(--text-muted);

--- a/apps/desktop/src/shared/star-map-intake.ts
+++ b/apps/desktop/src/shared/star-map-intake.ts
@@ -1,0 +1,28 @@
+import type {
+  FederationTarget,
+  StarMapIntakeRequest,
+} from "@pwragent/shared";
+
+export const MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS = 5;
+
+/**
+ * Renderer-to-main image upload for Star Map intake. Electron transports the
+ * typed array with structured clone; this shape must never be forwarded in a
+ * federation JSON-RPC envelope. The main process stages the bytes first and
+ * sends only attachment references into backend and federation contracts.
+ */
+export type StarMapIntakeImageUpload = {
+  bytes: Uint8Array;
+  mimeType: string;
+  name: string;
+};
+
+// Deliberately omit backend attachment paths: only the main process may mint
+// those after staging renderer bytes under the active PwrAgent profile.
+export type StarMapIntakeDispatchRequest = Omit<
+  StarMapIntakeRequest,
+  "attachments"
+> & {
+  federationTarget?: FederationTarget;
+  imageUploads?: StarMapIntakeImageUpload[];
+};

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -27,6 +27,7 @@ export const FEDERATION_CAPABILITIES = [
   "gateway_relay",
   "remote_pty",
   "event_subscriptions",
+  "turn_input_blobs",
 ] as const;
 
 export type FederationCapability = (typeof FEDERATION_CAPABILITIES)[number];
@@ -678,11 +679,30 @@ export type FederationNotificationEnvelope<
   params: Params;
 };
 
+/**
+ * One binary chunk of a content-addressed turn attachment. The transport
+ * encodes `data` after a small JSON metadata header in a binary WebSocket
+ * frame; it must never pass this envelope through JSON.stringify directly.
+ */
+export type FederationBlobChunkEnvelope = FederationEnvelopeBase & {
+  kind: "blob_chunk";
+  transferId: string;
+  chunkIndex: number;
+  chunkCount: number;
+  totalSize: number;
+  sha256: string;
+  name: string;
+  mimeType?: string;
+  inputType: "localFile" | "localImage";
+  data: Uint8Array;
+};
+
 export type FederationProtocolEnvelope =
   | FederationRequestEnvelope
   | FederationResponseEnvelope
   | FederationErrorEnvelope
-  | FederationNotificationEnvelope;
+  | FederationNotificationEnvelope
+  | FederationBlobChunkEnvelope;
 
 export function isFederationCapability(
   value: unknown,

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -471,6 +471,17 @@ export type StarMapIntakeCandidate = {
 };
 
 /**
+ * A PwrAgent-owned staged attachment supplied with a Star Map intake task.
+ * Federation replaces the sender-local path with a receiver-local path after
+ * transferring the binary payload outside the JSON-RPC envelope.
+ */
+export type StarMapIntakeAttachment = {
+  type: "localImage" | "localFile";
+  name?: string;
+  path: string;
+};
+
+/**
  * Intake dispatch, executed ON the owning instance so its directory
  * registry, launchpad defaults, and ~/.pwragent/AGENTS.md preferences are
  * the ones consulted. `directoryKey` is set on a disambiguation resubmit.
@@ -482,6 +493,7 @@ export type StarMapIntakeRequest = {
   requestId: string;
   request: string;
   directoryKey?: string;
+  attachments?: StarMapIntakeAttachment[];
 };
 
 export type StarMapIntakeResponse =


### PR DESCRIPTION
## Summary

- add paste and drop image previews with removal to the Star Map new-thread intake dialog
- keep raw Uint8Array data on renderer-to-main IPC only, then stage content-addressed files under the active PwrAgent profile
- transfer remote turn attachments as hash-verified, chunked binary WebSocket frames; federation JSON carries refs and metadata, never payload/base64
- forward current-turn attachments through handoff_task, send_message_to_thread, steer, and create_instance_thread
- reject renderer/peer path injection, malformed chunk geometry, oversized batches, corrupt cache hits, and unbounded incomplete transfers

## Tests

- Star Map intake UI, local/remote IPC, and intake dispatch: 24 tests
- federation transport, bridge, router, registry, handoff, and attachment staging: 677 tests
- pnpm typecheck
- pnpm lint:eslint
- pnpm lint:codex-storage
- pnpm lint:colors
- pnpm lint:boundaries
- pnpm lint:sql
- pnpm licenses:check

## Context

This closes the new-thread intake gap left by #1815 and #1823, which covered attachments in existing Star Map thread composers. It supersedes the transport-only #1881 by including the complete intake UI and renderer-to-main staging boundary.