### PR TITLE
fix(desktop): keep the Token Miser summary inside its card

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -2737,6 +2737,10 @@ describe("ThreadContextPanel", () => {
     const summary = screen.getByRole("button", { name: /Token Miser/ });
     expect(summary).toHaveTextContent("2 gates");
     expect(summary).toHaveTextContent("$0.26 saved");
+    // A settled verdict is not pending, and says nothing about pricing.
+    expect(summary.querySelector(".pricing-token-miser__verdict"))
+      .toHaveAttribute("data-pending", "false");
+    expect(summary).not.toHaveTextContent("not priced yet");
     expect(summary).toHaveAttribute("aria-expanded", "false");
 
     fireEvent.click(summary);
@@ -2897,6 +2901,139 @@ describe("ThreadContextPanel", () => {
     expect(summary).not.toHaveTextContent("2 decisions");
     fireEvent.click(summary);
     expect(screen.getAllByLabelText("Token Miser savings")).toHaveLength(2);
+  });
+
+  // Early in a turn the gates have usage rows but no accounting yet, so the
+  // group knows how many decisions were made and what the helper cost, and
+  // nothing about savings. That state used to put a 41-character sentence in
+  // the verdict slot — a `nowrap` cell that neither shrinks nor wraps — which
+  // overflowed the card and clipped against the rail until pricing landed and
+  // the string collapsed to "$0.021 saved".
+  it("keeps the unpriced verdict to the money and moves the reason to the counts", () => {
+    const interception = (objectId: string, decisionSource: "helper" | "policy") => ({
+      objectId,
+      turnId: "turn-1",
+      toolUseId: `tool-${objectId}`,
+      toolName: "Code Mode",
+      createdAt: 1_800_000_010_000,
+      originalCharacters: 40_000,
+      baselineParentTokens: 10_000,
+      replacementTokens: 300,
+      retrievedTokens: 0,
+      estimatedParentTokensSaved: 9_700,
+      disposition: "passed_through" as const,
+      decisionSource,
+    });
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        // No `tokenMiserAccounting` on either sub-agent: the gate ran and was
+        // billed, the savings equation has not been computed yet.
+        subAgents: [
+          {
+            agentName: "Token Miser",
+            createdAt: 1_800_000_010_000,
+            monitorId: "system:token-miser:pending-a",
+            parentTurnId: "turn-1",
+            status: "success",
+            task: "Gate Code Mode output",
+            updatedAt: 1_800_000_010_000,
+          },
+          {
+            agentName: "Token Miser",
+            createdAt: 1_800_000_020_000,
+            monitorId: "system:token-miser:pending-b",
+            parentTurnId: "turn-1",
+            status: "success",
+            task: "Gate Code Mode output",
+            updatedAt: 1_800_000_020_000,
+          },
+        ],
+      },
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            usageLineId: "turn-line-1",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            scope: "turn",
+            source: "live",
+            status: "finalized",
+            model: "gpt-5.6-sol",
+            inputTokens: 10_000,
+            uncachedInputTokens: 10_000,
+            cachedInputTokens: 0,
+            outputTokens: 100,
+            reasoningOutputTokens: 0,
+            totalTokens: 10_100,
+            priceStatus: "priced",
+            currency: "USD",
+            uncachedInputCostMicros: 50_000,
+            cachedInputCostMicros: 0,
+            outputCostMicros: 3_000,
+            totalCostMicros: 53_000,
+            provider: "openai",
+            createdAt: 1_800_000_000_000,
+          },
+          {
+            ...buildMonitorLine({
+              sourceItemId: "system:token-miser:pending-a",
+            }),
+            totalCostMicros: 1_000,
+            usageLineId: "gate-line-pending-a",
+          },
+          {
+            ...buildMonitorLine({
+              sourceItemId: "system:token-miser:pending-b",
+            }),
+            totalCostMicros: 1_000,
+            usageLineId: "gate-line-pending-b",
+          },
+        ],
+        summaries: [],
+      },
+      toolAccounting: {
+        alerts: [],
+        invocations: [],
+        summaries: [],
+        tokenMiser: {
+          interceptionCount: 3,
+          passThroughCount: 3,
+          policyPassThroughCount: 2,
+          helperPassThroughCount: 1,
+          helperDecisionCount: 1,
+          originalCharacters: 120_000,
+          baselineParentTokens: 30_000,
+          replacementTokens: 900,
+          retrievedTokens: 0,
+          estimatedParentTokensSaved: 0,
+          interceptions: [
+            interception("pending-a", "helper"),
+            interception("pending-b", "policy"),
+            interception("pending-c", "policy"),
+          ],
+        },
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const summary = screen.getByRole("button", { name: /Token Miser/ });
+    const verdict = summary.querySelector(".pricing-token-miser__verdict");
+    // The verdict slot is one money phrase, whatever the state: it sits on the
+    // header row beside "Token Miser", where only a short string fits.
+    expect(verdict).toHaveTextContent("$0.002 evaluating");
+    expect(verdict).not.toHaveTextContent("not priced yet");
+    // Cost-so-far is not a savings verdict, and must not wear its colors.
+    expect(verdict).toHaveAttribute("data-pending", "true");
+    // The reason there is no savings figure is detail, and detail lives on the
+    // counts row, which has a full line to wrap into.
+    expect(summary.querySelector(".pricing-token-miser__count")).toHaveTextContent(
+      "3 decisions · 1 Luna evaluation · 3 pass-throughs (1 helper · 2 policy)"
+        + " · savings not priced yet",
+    );
   });
 
   // A group with nothing past the threshold has nothing to hold back, so

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -3022,6 +3022,11 @@ describe("ThreadContextPanel", () => {
 
     const summary = screen.getByRole("button", { name: /Token Miser/ });
     const verdict = summary.querySelector(".pricing-token-miser__verdict");
+    // The grid puts the verdict on row 1 and the counts on row 2. DOM order
+    // has to agree, or the button's accessible name reads the money last.
+    const slots = [...summary.children].map((child) => child.className);
+    expect(slots.indexOf("pricing-token-miser__verdict"))
+      .toBeLessThan(slots.indexOf("pricing-token-miser__count"));
     // The verdict slot is one money phrase, whatever the state: it sits on the
     // header row beside "Token Miser", where only a short string fits.
     expect(verdict).toHaveTextContent("$0.002 evaluating");
@@ -3034,6 +3039,105 @@ describe("ThreadContextPanel", () => {
       "3 decisions · 1 Luna evaluation · 3 pass-throughs (1 helper · 2 policy)"
         + " · savings not priced yet",
     );
+  });
+
+
+  // Between those two states a group can be half priced. The sum is then a
+  // subtotal, not a verdict, and the collapsed row is the only thing most
+  // operators read — the expanded body's "not priced yet" note is not enough.
+  it("says how many gates are missing when a group is only partly priced", () => {
+    const gateLine = (id: string, createdAt: number) => ({
+      ...buildMonitorLine({
+        model: "gpt-5.6-luna",
+        sourceItemId: `system:token-miser:${id}`,
+      }),
+      createdAt,
+      usageLineId: `gate-line-${id}`,
+      totalCostMicros: 2_000,
+    });
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            agentName: "Token Miser",
+            createdAt: 1_800_000_010_000,
+            monitorId: "system:token-miser:priced",
+            parentTurnId: "turn-1",
+            status: "success",
+            task: "Gate Bash output",
+            tokenMiserAccounting: {
+              baselineParentCostMicros: 300_000,
+              baselineParentTokens: 60_000,
+              cachedReplayCount: 0,
+              cachedBaselineTokens: 0,
+              cachedBaselineCostMicros: 0,
+              currency: "USD" as const,
+              gateCostMicros: 2_000,
+              gateModel: "gpt-5.6-luna",
+              gateTotalTokens: 2_100,
+              originalModel: "gpt-5.6-sol",
+              revealedParentCostMicros: 1_500,
+              revealedParentTokens: 300,
+              savingsMicros: 250_000,
+            },
+            updatedAt: 1_800_000_010_000,
+          },
+          {
+            agentName: "Token Miser",
+            createdAt: 1_800_000_020_000,
+            monitorId: "system:token-miser:pending",
+            parentTurnId: "turn-1",
+            status: "success",
+            task: "Gate Bash output",
+            updatedAt: 1_800_000_020_000,
+          },
+        ],
+      },
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            usageLineId: "turn-line-1",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            scope: "turn",
+            source: "live",
+            status: "finalized",
+            model: "gpt-5.6-sol",
+            inputTokens: 100_000,
+            uncachedInputTokens: 100_000,
+            cachedInputTokens: 0,
+            outputTokens: 1_000,
+            reasoningOutputTokens: 0,
+            totalTokens: 101_000,
+            priceStatus: "priced",
+            currency: "USD",
+            uncachedInputCostMicros: 500_000,
+            cachedInputCostMicros: 0,
+            outputCostMicros: 30_000,
+            totalCostMicros: 530_000,
+            provider: "openai",
+            createdAt: 1_800_000_000_000,
+          },
+          gateLine("priced", 1_800_000_010_000),
+          gateLine("pending", 1_800_000_020_000),
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const summary = screen.getByRole("button", { name: /Token Miser/ });
+    const verdict = summary.querySelector(".pricing-token-miser__verdict");
+    // One gate priced, so the sum is real and settled in its own right.
+    expect(verdict).toHaveTextContent("$0.25 saved");
+    expect(verdict).toHaveAttribute("data-pending", "false");
+    // But it is a subtotal, and the row has to say so.
+    expect(summary.querySelector(".pricing-token-miser__count"))
+      .toHaveTextContent("2 gates · 1 not priced yet");
   });
 
   // A group with nothing past the threshold has nothing to hold back, so

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -665,8 +665,15 @@ function TokenMiserTurnGroup(props: {
   const countLabel = props.decisions || passThroughCount > 0
     ? count === 1 ? "decision" : "decisions"
     : count === 1 ? "gate" : "gates";
-  const verdict = priced.length === 0
-    ? `${formatTokenUsageMicrosAsUsd(gateCostMicros)} evaluating · savings not priced yet`
+  // The verdict slot is one money phrase and nothing else. It shares the
+  // header row with the label, so only a short string fits there — and early
+  // in a turn, when every gate has a usage row but no accounting yet, the
+  // reason there is no savings figure is what made it long. That reason is
+  // detail: it goes on the counts row below, which has a full line to wrap
+  // into.
+  const awaitingPricing = priced.length === 0;
+  const verdict = awaitingPricing
+    ? `${formatTokenUsageMicrosAsUsd(gateCostMicros)} evaluating`
     : savingsMicros >= 0
       ? `${formatTokenUsageMicrosAsUsd(savingsMicros)} saved`
       : `${formatTokenUsageMicrosAsUsd(Math.abs(savingsMicros))} net overhead`;
@@ -691,8 +698,13 @@ function TokenMiserTurnGroup(props: {
           {props.decisions && passThroughCount > 0
             ? ` · ${passThroughCount.toLocaleString()} ${passThroughCount === 1 ? "pass-through" : "pass-throughs"} (${helperPassThroughCount.toLocaleString()} helper · ${policyPassThroughCount.toLocaleString()} policy)`
             : ""}
+          {awaitingPricing ? " · savings not priced yet" : ""}
         </span>
-        <span className="pricing-token-miser__verdict" data-negative={savingsMicros < 0}>
+        <span
+          className="pricing-token-miser__verdict"
+          data-negative={savingsMicros < 0}
+          data-pending={awaitingPricing}
+        >
           {verdict}
         </span>
       </button>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -688,6 +688,13 @@ function TokenMiserTurnGroup(props: {
       >
         <span aria-hidden="true" className="pricing-token-miser__chevron">›</span>
         <span className="pricing-token-miser__label">Token Miser</span>
+        <span
+          className="pricing-token-miser__verdict"
+          data-negative={!awaitingPricing && savingsMicros < 0}
+          data-pending={awaitingPricing}
+        >
+          {verdict}
+        </span>
         <span className="pricing-token-miser__count">
           {count.toLocaleString()} {countLabel}
           {props.decisions
@@ -698,14 +705,11 @@ function TokenMiserTurnGroup(props: {
           {props.decisions && passThroughCount > 0
             ? ` · ${passThroughCount.toLocaleString()} ${passThroughCount === 1 ? "pass-through" : "pass-throughs"} (${helperPassThroughCount.toLocaleString()} helper · ${policyPassThroughCount.toLocaleString()} policy)`
             : ""}
-          {awaitingPricing ? " · savings not priced yet" : ""}
-        </span>
-        <span
-          className="pricing-token-miser__verdict"
-          data-negative={savingsMicros < 0}
-          data-pending={awaitingPricing}
-        >
-          {verdict}
+          {awaitingPricing
+            ? " · savings not priced yet"
+            : unpricedCount > 0
+              ? ` · ${unpricedCount.toLocaleString()} not priced yet`
+              : ""}
         </span>
       </button>
       {expanded ? (

--- a/apps/desktop/src/renderer/src/styles/__tests__/token-miser-summary-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/token-miser-summary-contract.test.ts
@@ -43,7 +43,13 @@ describe("Token Miser summary line", () => {
   it("lays the summary out as a grid so the counts get their own row", () => {
     const body = ruleBody(".pricing-token-miser__summary");
     expect(body).toMatch(/display:\s*grid;/);
-    expect(body).toMatch(/grid-template-columns:/);
+    // The verdict's track must stay flexible with a zero floor. `display:
+    // grid` alone does not fix anything: with a third track of `auto` the
+    // column sizes to the verdict's max-content and the overflow returns
+    // exactly as it was, while every other assertion here still passes.
+    expect(body).toMatch(
+      /grid-template-columns:[^;]*minmax\(\s*0\s*,\s*1fr\s*\);/,
+    );
   });
 
   it("gives the decision counts a full-width second row", () => {
@@ -62,6 +68,12 @@ describe("Token Miser summary line", () => {
     expect(body).not.toMatch(/white-space:\s*nowrap;/);
     expect(body).toMatch(/min-width:\s*0;/);
     expect(body).toMatch(/overflow-wrap:\s*anywhere;/);
+    // And it stays on the header row, right-aligned. Left unpinned, an edit
+    // could drop it onto row 2 with the counts — two items in one cell — and
+    // nothing here would notice.
+    expect(body).toMatch(/grid-row:\s*1;/);
+    expect(body).toMatch(/grid-column:\s*3;/);
+    expect(body).toMatch(/justify-self:\s*end;/);
   });
 
   it("ranks the awaiting-pricing figure as metadata, not as a verdict", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/token-miser-summary-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/token-miser-summary-contract.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const bodies = [
+    ...css.matchAll(
+      new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`, "g"),
+    ),
+  ].map((match) => match.groups?.body ?? "");
+  if (bodies.length === 0) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return bodies.join("\n");
+}
+
+/**
+ * The Token Miser summary line must fit inside its card at every string length
+ * the component can produce.
+ *
+ * It did not. As one flex row of four items, the verdict — `white-space:
+ * nowrap` plus `margin-left: auto`, so it can neither shrink nor wrap — took
+ * its full intrinsic width first and the rest of the row was squeezed to
+ * min-content behind it. Measured in headless Chromium against this
+ * stylesheet, at the default 380px rail: `$0.002 evaluating · savings not
+ * priced yet` (the verdict shown while a turn's gates are still unpriced)
+ * pushed the summary's scrollWidth to 407px inside a 331px box, hung 76px past
+ * the card's right border, and was clipped by the rail itself; "Token Miser"
+ * broke across two lines and the decision counts stacked into a 63px-wide
+ * ragged column eight lines tall.
+ *
+ * jsdom has no layout engine, so the invariant is pinned here in the
+ * stylesheet — the same way `automations-scroll-contract` pins its scroller.
+ * The shape that satisfies it: a two-row grid, so the counts get a full line of
+ * their own instead of competing with the verdict for one line's width.
+ */
+describe("Token Miser summary line", () => {
+  it("lays the summary out as a grid so the counts get their own row", () => {
+    const body = ruleBody(".pricing-token-miser__summary");
+    expect(body).toMatch(/display:\s*grid;/);
+    expect(body).toMatch(/grid-template-columns:/);
+  });
+
+  it("gives the decision counts a full-width second row", () => {
+    const body = ruleBody(".pricing-token-miser__count");
+    // Row 2, spanning from the label column to the end: the counts never
+    // share a line with the verdict, so neither one squeezes the other.
+    expect(body).toMatch(/grid-row:\s*2;/);
+    expect(body).toMatch(/grid-column:\s*2\s*\/\s*-1;/);
+    expect(body).toMatch(/min-width:\s*0;/);
+  });
+
+  it("lets a long verdict wrap inside the card instead of overflowing it", () => {
+    const body = ruleBody(".pricing-token-miser__verdict");
+    // `nowrap` is what made a 277px verdict overflow a 331px row rather than
+    // take a second line. It must not come back.
+    expect(body).not.toMatch(/white-space:\s*nowrap;/);
+    expect(body).toMatch(/min-width:\s*0;/);
+    expect(body).toMatch(/overflow-wrap:\s*anywhere;/);
+  });
+
+  it("ranks the awaiting-pricing figure as metadata, not as a verdict", () => {
+    // While the gates are unpriced the figure is what they have cost, not
+    // what they saved. In the settled accent it reads as good news that has
+    // not been measured yet.
+    const body = ruleBody('.pricing-token-miser__verdict[data-pending="true"]');
+    expect(body).toMatch(/color:\s*var\(--text-(secondary|muted)\);/);
+    expect(body).not.toMatch(/var\(--accent/);
+  });
+
+  it("keeps the product name on one line", () => {
+    // "Token Miser" wrapping to "Token / Miser" was the loudest symptom of
+    // the squeeze; the label is short and must never be the thing that gives.
+    expect(ruleBody(".pricing-token-miser__label")).toMatch(
+      /white-space:\s*nowrap;/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24028,10 +24028,26 @@ a.transcript-message__messaging-origin:focus-visible {
   background: var(--bg-panel);
 }
 
+/* Two rows, not one. As a single flex row the verdict — `nowrap`, pushed
+   right by `margin-left: auto` — could neither shrink nor wrap, so it took
+   its full intrinsic width first and squeezed the label and the counts to
+   min-content behind it: "Token Miser" broke into "Token / Miser", the counts
+   stacked into a 63px ragged column, and a long verdict still hung 76px past
+   the card and clipped against the rail. Measured at the default 380px rail;
+   the pathological string is the one shown while a turn's gates are billed
+   but not yet priced.
+
+   Row 1 is the header — chevron, label, verdict — and row 2 is the counts,
+   spanning to the end. Neither row competes with the other for width, so no
+   string in either can drive the other out of the card. Column 3 is
+   `minmax(0, 1fr)` so the verdict can shrink and take a second line rather
+   than overflow, and the counts (spanning a flexible track) never widen the
+   label column. */
 .pricing-token-miser__summary {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
   align-items: baseline;
-  gap: 7px;
+  gap: 2px 7px;
   width: 100%;
   padding: 5px 8px;
   border: 0;
@@ -24054,6 +24070,8 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .pricing-token-miser__chevron {
   display: inline-block;
+  grid-row: 1;
+  grid-column: 1;
   color: var(--text-muted);
   transition: transform 120ms ease;
 }
@@ -24063,29 +24081,53 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 .pricing-token-miser__label {
+  grid-row: 1;
+  grid-column: 2;
   color: var(--text-primary);
   font-weight: 600;
+  white-space: nowrap;
 }
 
+/* Row 2, indented under the label so the chevron column still reads as the
+   fold control. It is the only part of the summary allowed to run long. */
 .pricing-token-miser__count {
+  grid-row: 2;
+  grid-column: 2 / -1;
+  min-width: 0;
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 10.5px;
   font-variant-numeric: tabular-nums;
+  line-height: 1.4;
 }
 
 .pricing-token-miser__verdict {
-  margin-left: auto;
+  grid-row: 1;
+  grid-column: 3;
+  justify-self: end;
+  min-width: 0;
   color: var(--accent);
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  white-space: nowrap;
+  /* Right-aligned and wrappable: the money phrase is short, but a narrowed
+     rail must fold it onto a second line rather than push it out of the
+     card. */
+  overflow-wrap: anywhere;
+  text-align: right;
 }
 
 .pricing-token-miser__verdict[data-negative="true"] {
   color: var(--status-warning);
+}
+
+/* Awaiting pricing is not a verdict. The figure there is what the gates have
+   cost so far, not what they saved — in the settled colors it would read as
+   good news that has not been measured yet, so it ranks as metadata until a
+   savings number exists. */
+.pricing-token-miser__verdict[data-pending="true"] {
+  color: var(--text-secondary);
 }
 
 /* The body scrolls inside a bounded height so a long list of gates moves


### PR DESCRIPTION
## What happened

The Token Miser summary line in the Pricing rail overflowed its card early in a turn, then appeared to correct itself a couple of minutes later. Both halves of that are explained:

**The string changes length.** The verdict slot renders `$0.002 evaluating · savings not priced yet` whenever no gate in the group has accounting yet — the normal state between a gate's usage row landing and its savings equation being computed. Once pricing lands it collapses to `$0.021 saved`. 41 characters vs 12; that is why the row settled by itself.

**The row could not survive the long form.** As one flex row of four items, the verdict was `white-space: nowrap` with `margin-left: auto` — it could neither shrink nor wrap, so it claimed its full intrinsic width first and the label and counts were squeezed to min-content behind it.

Measured in headless Chromium against the real `app.css`, default 380px rail:

| | before | after |
|---|---|---|
| summary scrollWidth / clientWidth | 407px / 331px | 331px / 331px |
| verdict past the card's right border | **+76px** (clipped by the rail) | −8px (inside) |
| "Token Miser" label | 2 lines | 1 line |
| counts column | 63px wide, 8 lines | 303px wide, 3 lines |
| summary height | 128px | 70px |

It was not only the unpriced string. Across rail widths, pre-fix overflow ran from 16px at 440px to **216px** at the 240px minimum, and even the short `$0.021 saved` form overflowed below a 320px rail. Post-fix: **zero overflow at every width from 240px to 440px**, label never breaks, verdict folds to a second line only at the 240px minimum.

## The fix

- **Two-row grid instead of one flex line.** Header row is chevron + label + right-aligned verdict; the decision counts span a full-width second row. Neither row competes with the other for width, so no string in either can drive the other out of the card. Column 3 is `minmax(0, 1fr)` and the verdict is wrappable, so a narrowed rail folds it rather than pushing it out.
- **The verdict slot holds one money phrase.** `savings not priced yet` moves to the counts row, where the other detail lives and where there is a full line to wrap into.
- **Awaiting pricing ranks as metadata, not as a verdict.** That figure is what the gates have *cost* so far, not what they saved; in the settled accent orange it read as good news that had not been measured yet. It now uses `--text-secondary` until a savings number exists, alongside the existing accent (saved) / warning (net overhead) states.

## Tests

Both written failing first.

- `styles/__tests__/token-miser-summary-contract.test.ts` — jsdom has no layout engine, so the geometry invariant is pinned in the stylesheet, the same way `automations-scroll-contract` pins its scroller. The numbers above are recorded in the file's header comment as the provenance.
- `ThreadContextPanel.test.tsx` — a group whose gates are billed but not yet priced keeps the verdict to `$0.002 evaluating`, marks it pending, and puts the qualifier on the counts row; the settled case asserts the other side.

The geometry claims are mutation-tested rather than self-confirming: the pre-fix stylesheet reports the overflow at every rail width, the post-fix one reports none, measured through the same harness.

`pnpm test apps/desktop/src/renderer` (3483 tests), `lint:eslint`, `lint:colors`, `lint:boundaries`, `typecheck` all pass. Neither visual-regression snapshot covers the pricing rail, so no snapshot churn.

## Not done

No desktop E2E case — there is no Token Miser e2e fixture today, and seeding one (gate usage lines + sub-agent summaries + thread interception accounting) is a bigger lift than this fix. Say the word if you want that gate and I'll build the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)