### PR TITLE
fix(desktop): paginate Codex thread hydration

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -89,6 +89,16 @@ class MockTransport implements JsonRpcTransport {
     Array<{ code: number; message: string }>
   >();
   static readThreadResultByThreadId = new Map<string, unknown>();
+  static threadTurnsListResultByRequest = new Map<string, unknown>();
+  static threadTurnsListTransientErrorsByRequest = new Map<
+    string,
+    Array<{ code: number; message: string }>
+  >();
+  static threadItemsListResultByRequest = new Map<string, unknown>();
+  static threadItemsListTransientErrorsByRequest = new Map<
+    string,
+    Array<{ code: number; message: string }>
+  >();
   static threadStartResult: unknown = {
     thread: {
       id: "thread-3",
@@ -795,6 +805,70 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "thread/turns/list") {
+      const threadId = String(payload.params?.threadId ?? "");
+      const cursor = String(payload.params?.cursor ?? "");
+      const transientError =
+        MockTransport.threadTurnsListTransientErrorsByRequest
+          .get(`${threadId}:${cursor}`)
+          ?.shift();
+      if (transientError) {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            error: transientError,
+          }),
+        );
+        return;
+      }
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result:
+            MockTransport.threadTurnsListResultByRequest.get(
+              `${threadId}:${cursor}`,
+            ) ?? { data: [], nextCursor: null, backwardsCursor: null },
+        }),
+      );
+      return;
+    }
+
+    if (
+      payload.method === "thread/items/list"
+      || payload.method === "thread/turns/items/list"
+    ) {
+      const threadId = String(payload.params?.threadId ?? "");
+      const turnId = String(payload.params?.turnId ?? "");
+      const cursor = String(payload.params?.cursor ?? "");
+      const transientError =
+        MockTransport.threadItemsListTransientErrorsByRequest
+          .get(`${threadId}:${turnId}:${cursor}`)
+          ?.shift();
+      if (transientError) {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            error: transientError,
+          }),
+        );
+        return;
+      }
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result:
+            MockTransport.threadItemsListResultByRequest.get(
+              `${threadId}:${turnId}:${cursor}`,
+            ) ?? { data: [], nextCursor: null, backwardsCursor: null },
+        }),
+      );
+      return;
+    }
+
     if (payload.method === "thread/read") {
       const threadId = (JSON.parse(message) as { params?: { threadId?: string } }).params?.threadId;
       const transientErrors = threadId
@@ -1214,6 +1288,10 @@ describe("CodexAppServerClient", () => {
     MockTransport.readThreadErrorByThreadId.clear();
     MockTransport.readThreadTransientErrorsByThreadId.clear();
     MockTransport.readThreadResultByThreadId.clear();
+    MockTransport.threadTurnsListResultByRequest.clear();
+    MockTransport.threadTurnsListTransientErrorsByRequest.clear();
+    MockTransport.threadItemsListResultByRequest.clear();
+    MockTransport.threadItemsListTransientErrorsByRequest.clear();
     MockTransport.threadStartResult = {
       thread: {
         id: "thread-3",
@@ -4123,33 +4201,373 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("forwards pagination params when reading older Codex transcript pages", async () => {
+  it("hydrates paginated Codex transcripts through turn and item list requests", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
+    MockTransport.readThreadResultByThreadId.set("thread-paginated", {
+      thread: {
+        id: "thread-paginated",
+        status: { type: "idle" },
+        turns: [],
+      },
+    });
+    MockTransport.threadTurnsListResultByRequest.set("thread-paginated:", {
+      data: [
+        {
+          id: "turn-2",
+          status: "completed",
+          items: [
+            {
+              type: "userMessage",
+              id: "user-2",
+              clientId: null,
+              content: [{ type: "text", text: "Second question" }],
+            },
+            {
+              type: "agentMessage",
+              id: "assistant-2",
+              text: "Second answer",
+              phase: "final",
+              memoryCitation: null,
+            },
+          ],
+          itemsView: "full",
+          startedAt: 200,
+          completedAt: 201,
+        },
+      ],
+      nextCursor: "older-turns",
+      backwardsCursor: null,
+    });
+    MockTransport.threadTurnsListResultByRequest.set(
+      "thread-paginated:older-turns",
+      {
+        data: [
+          {
+            id: "turn-1",
+            status: "completed",
+            items: [],
+            itemsView: "notLoaded",
+            startedAt: 100,
+            completedAt: 101,
+          },
+        ],
+        nextCursor: null,
+        backwardsCursor: null,
+      },
+    );
+    MockTransport.threadItemsListResultByRequest.set(
+      "thread-paginated:turn-1:",
+      {
+        data: [
+          {
+            type: "userMessage",
+            id: "user-1",
+            clientId: null,
+            content: [{ type: "text", text: "First question" }],
+          },
+        ],
+        nextCursor: "turn-1-more-items",
+        backwardsCursor: null,
+      },
+    );
+    MockTransport.threadItemsListResultByRequest.set(
+      "thread-paginated:turn-1:turn-1-more-items",
+      {
+        data: [
+          {
+            type: "agentMessage",
+            id: "assistant-1",
+            text: "First answer",
+            phase: "final",
+            memoryCitation: null,
+          },
+        ],
+        nextCursor: null,
+        backwardsCursor: null,
+      },
+    );
     const client = new CodexAppServerClient({
       command: "codex",
       directoryResolver: async () => []
     });
 
-    await client.readThread({
-      threadId: "thread-2",
-      before: "cursor-before-1",
-      limit: 25
+    const replay = await client.readThread({
+      threadId: "thread-paginated",
     });
 
     const transport = MockTransport.instances.at(-1);
     expect(transport).toBeDefined();
 
-    const readRequest = transport!.sentMessages
-      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
-      .find((message) => message.method === "thread/read");
+    const requests = transport!.sentMessages.map(
+      (message) => JSON.parse(message) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      },
+    );
+    const readRequest = requests.find((message) => message.method === "thread/read");
+    const turnRequests = requests.filter(
+      (message) => message.method === "thread/turns/list",
+    );
+    const itemRequests = requests.filter(
+      (message) => message.method === "thread/items/list",
+    );
 
-    expect(readRequest?.params).toMatchObject({
-      threadId: "thread-2",
-      includeTurns: true,
-      before: "cursor-before-1",
-      limit: 25
+    expect(readRequest?.params).toEqual({
+      threadId: "thread-paginated",
+      includeTurns: false,
     });
+    expect(turnRequests.map((request) => request.params)).toEqual([
+      {
+        threadId: "thread-paginated",
+        limit: 100,
+        sortDirection: "desc",
+        itemsView: "full",
+      },
+      {
+        threadId: "thread-paginated",
+        cursor: "older-turns",
+        limit: 100,
+        sortDirection: "desc",
+        itemsView: "full",
+      },
+    ]);
+    expect(itemRequests.map((request) => request.params)).toEqual([
+      {
+        threadId: "thread-paginated",
+        turnId: "turn-1",
+        limit: 100,
+        sortDirection: "asc",
+      },
+      {
+        threadId: "thread-paginated",
+        turnId: "turn-1",
+        cursor: "turn-1-more-items",
+        limit: 100,
+        sortDirection: "asc",
+      },
+    ]);
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "First question",
+      "First answer",
+      "Second question",
+      "Second answer",
+    ]);
+
+    await client.close();
+  });
+
+  it("falls back to the legacy Codex turn item list method", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadId = "thread-legacy-item-list";
+    const turnId = "turn-legacy-item-list";
+    MockTransport.readThreadResultByThreadId.set(threadId, {
+      thread: { id: threadId, turns: [] },
+    });
+    MockTransport.threadTurnsListResultByRequest.set(`${threadId}:`, {
+      data: [
+        {
+          id: turnId,
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+          startedAt: 100,
+          completedAt: 101,
+        },
+      ],
+      nextCursor: null,
+      backwardsCursor: null,
+    });
+    MockTransport.threadItemsListTransientErrorsByRequest.set(
+      `${threadId}:${turnId}:`,
+      [{ code: -32601, message: "thread/items/list is not supported yet" }],
+    );
+    MockTransport.threadItemsListResultByRequest.set(`${threadId}:${turnId}:`, {
+      data: [
+        {
+          type: "agentMessage",
+          id: "assistant-legacy-item-list",
+          text: "Hydrated through the legacy method",
+          phase: "final",
+          memoryCitation: null,
+        },
+      ],
+      nextCursor: null,
+      backwardsCursor: null,
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId });
+    const itemMethods = MockTransport.instances.at(-1)!.sentMessages
+      .map((message) => (JSON.parse(message) as { method?: string }).method)
+      .filter(
+        (method) =>
+          method === "thread/items/list"
+          || method === "thread/turns/items/list",
+      );
+
+    expect(itemMethods).toEqual([
+      "thread/items/list",
+      "thread/turns/items/list",
+    ]);
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "Hydrated through the legacy method",
+    ]);
+
+    await client.close();
+  });
+
+  it("uses Codex turn cursors for bounded older transcript pages", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    MockTransport.readThreadResultByThreadId.set("thread-older-page", {
+      thread: { id: "thread-older-page", turns: [] },
+    });
+    MockTransport.threadTurnsListResultByRequest.set(
+      "thread-older-page:cursor-before-1",
+      {
+        data: [
+          {
+            id: "turn-older",
+            status: "completed",
+            items: [],
+            itemsView: "notLoaded",
+            startedAt: 100,
+            completedAt: 101,
+          },
+        ],
+        nextCursor: "cursor-before-2",
+        backwardsCursor: null,
+      },
+    );
+    MockTransport.threadItemsListResultByRequest.set(
+      "thread-older-page:turn-older:",
+      {
+        data: [
+          {
+            type: "agentMessage",
+            id: "assistant-older",
+            text: "Older answer",
+            phase: "final",
+            memoryCitation: null,
+          },
+        ],
+        nextCursor: null,
+        backwardsCursor: null,
+      },
+    );
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-older-page",
+      before: "cursor-before-1",
+      limit: 1,
+    });
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      },
+    );
+    expect(
+      requests.find((request) => request.method === "thread/read")?.params,
+    ).toEqual({
+      threadId: "thread-older-page",
+      includeTurns: false,
+    });
+    expect(
+      requests.find((request) => request.method === "thread/turns/list")?.params,
+    ).toEqual({
+      threadId: "thread-older-page",
+      cursor: "cursor-before-1",
+      limit: 1,
+      sortDirection: "desc",
+      itemsView: "full",
+    });
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "Older answer",
+    ]);
+    expect(replay.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "cursor-before-2",
+    });
+
+    await client.close();
+  });
+
+  it("retries transient session metadata failures while paging Codex history", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadId = "thread-transient-paginated-history";
+    const turnId = "turn-transient-paginated-history";
+    const transientError = {
+      code: -32603,
+      message:
+        `thread-store internal error: failed to read session metadata /tmp/rollout-${threadId}.jsonl`,
+    };
+    MockTransport.readThreadResultByThreadId.set(threadId, {
+      thread: { id: threadId, turns: [] },
+    });
+    MockTransport.threadTurnsListTransientErrorsByRequest.set(`${threadId}:`, [
+      transientError,
+    ]);
+    MockTransport.threadTurnsListResultByRequest.set(`${threadId}:`, {
+      data: [
+        {
+          id: turnId,
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+          startedAt: 100,
+          completedAt: 101,
+        },
+      ],
+      nextCursor: null,
+      backwardsCursor: null,
+    });
+    MockTransport.threadItemsListTransientErrorsByRequest.set(
+      `${threadId}:${turnId}:`,
+      [transientError],
+    );
+    MockTransport.threadItemsListResultByRequest.set(`${threadId}:${turnId}:`, {
+      data: [
+        {
+          type: "agentMessage",
+          id: "assistant-transient-history",
+          text: "Hydrated after retry",
+          phase: "final",
+          memoryCitation: null,
+        },
+      ],
+      nextCursor: null,
+      backwardsCursor: null,
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId });
+    const methods = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => (JSON.parse(message) as { method?: string }).method,
+    );
+
+    expect(methods.filter((method) => method === "thread/read")).toHaveLength(1);
+    expect(methods.filter((method) => method === "thread/turns/list")).toHaveLength(2);
+    expect(methods.filter((method) => method === "thread/items/list")).toHaveLength(2);
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "Hydrated after retry",
+    ]);
 
     await client.close();
   });
@@ -4162,7 +4580,7 @@ describe("CodexAppServerClient", () => {
       directoryResolver: async () => []
     });
 
-    await client.readThread({
+    const replay = await client.readThread({
       threadId: "thread-2",
       includeTurns: false
     });
@@ -4178,6 +4596,13 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       includeTurns: false
     });
+    expect(replay.entries).toEqual([]);
+    expect(
+      transport!.sentMessages.some((message) => {
+        const method = (JSON.parse(message) as { method?: string }).method;
+        return method === "thread/turns/list" || method === "thread/items/list";
+      }),
+    ).toBe(false);
 
     await client.close();
   });
@@ -9975,6 +10400,38 @@ describe("CodexAppServerClient", () => {
         supportsPagination: false,
         hasPreviousPage: false
       }
+    });
+
+    await client.close();
+  });
+
+  it("treats unmaterialized turns-list reads as empty transcripts", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadId = "thread-empty-turns-list";
+    MockTransport.readThreadResultByThreadId.set(threadId, {
+      thread: { id: threadId, turns: [] },
+    });
+    MockTransport.threadTurnsListTransientErrorsByRequest.set(`${threadId}:`, [
+      {
+        code: -32600,
+        message: "thread/turns/list is unavailable before first user message",
+      },
+    ]);
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId });
+
+    expect(replay).toEqual({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
     });
 
     await client.close();

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -78,11 +78,17 @@ import type {
   SkillsListParams as CodexSkillsListParams,
   ThreadForkParams as CodexThreadForkParams,
   ThreadInjectItemsParams as CodexThreadInjectItemsParams,
+  ThreadItem as CodexThreadItem,
+  ThreadItemsListParams as CodexThreadItemsListParams,
+  ThreadItemsListResponse as CodexThreadItemsListResponse,
   ThreadListParams as CodexThreadListParams,
   ThreadReadParams as CodexThreadReadParams,
   ThreadResumeParams as CodexThreadResumeParams,
   ThreadSettingsUpdateParams as CodexThreadSettingsUpdateParams,
   ThreadStartParams as CodexThreadStartParams,
+  ThreadTurnsListParams as CodexThreadTurnsListParams,
+  ThreadTurnsListResponse as CodexThreadTurnsListResponse,
+  Turn as CodexTurn,
   TurnInterruptParams as CodexTurnInterruptParams,
   TurnStartParams as CodexTurnStartParams,
   TurnSteerParams as CodexTurnSteerParams,
@@ -5770,8 +5776,15 @@ function isMethodUnavailableError(error: unknown, method?: string): boolean {
   const text = error instanceof Error ? error.message : String(error);
   const normalized = text.toLowerCase();
 
-  if (normalized.includes("method not found") || normalized.includes("unknown method")) {
+  if (
+    normalized.includes("method not found")
+    || normalized.includes("unknown method")
+  ) {
     return true;
+  }
+
+  if (normalized.includes("is not supported yet")) {
+    return !method || normalized.includes(method.toLowerCase());
   }
 
   if (!normalized.includes("unknown variant")) {
@@ -5794,8 +5807,11 @@ function isUnmaterializedThreadError(error: unknown): boolean {
   const text = error instanceof Error ? error.message : String(error);
   const normalized = text.toLowerCase();
   return (
-    normalized.includes("not materialized yet") &&
-    normalized.includes("includeturns is unavailable before first user message")
+    normalized.includes("unavailable before first user message")
+    && (
+      normalized.includes("includeturns")
+      || normalized.includes("thread/turns/list")
+    )
   );
 }
 
@@ -6911,31 +6927,178 @@ function buildThreadSettingsUpdatePayload(params: {
     : undefined;
 }
 
-type CodexThreadReadPayload = CodexThreadReadParams & {
-  before?: string;
-  limit?: number;
-};
+const CODEX_THREAD_HISTORY_PAGE_SIZE = 100;
+const CODEX_THREAD_ITEM_HYDRATION_CONCURRENCY = 8;
 
 function buildThreadReadPayload(params: {
   threadId: string;
-  includeTurns?: boolean;
-  before?: string;
-  limit?: number;
-}): CodexThreadReadPayload {
-  const payload: CodexThreadReadPayload = {
+}): CodexThreadReadParams {
+  return {
     threadId: params.threadId,
-    includeTurns: params.includeTurns ?? true,
+    includeTurns: false,
   };
+}
 
-  if (params.before) {
-    payload.before = params.before;
+function threadReadResultIncludesTurns(value: unknown): boolean {
+  const record = asRecord(value);
+  const thread = asRecord(record?.thread);
+  return Array.isArray(thread?.turns) && thread.turns.length > 0;
+}
+
+async function requestCodexThreadItemsPage(params: {
+  client: JsonRpcConnection;
+  payload: CodexThreadItemsListParams;
+  timeoutMs: number;
+}): Promise<CodexThreadItemsListResponse> {
+  try {
+    return await requestWithThreadMetadataReadRetry(async () => {
+      return await requestWithFallbacks({
+        client: params.client,
+        methods: ["thread/items/list"],
+        payloads: [params.payload],
+        timeoutMs: params.timeoutMs,
+      }) as CodexThreadItemsListResponse;
+    });
+  } catch (error) {
+    if (!isMethodUnavailableError(error, "thread/items/list")) {
+      throw error;
+    }
   }
 
-  if (params.limit !== undefined) {
-    payload.limit = params.limit;
+  return await requestWithThreadMetadataReadRetry(async () => {
+    return await requestWithFallbacks({
+      client: params.client,
+      methods: ["thread/turns/items/list"],
+      payloads: [params.payload],
+      timeoutMs: params.timeoutMs,
+    }) as CodexThreadItemsListResponse;
+  });
+}
+
+async function listCodexThreadItems(params: {
+  client: JsonRpcConnection;
+  threadId: string;
+  timeoutMs: number;
+  turnId: string;
+}): Promise<CodexThreadItem[]> {
+  const items: CodexThreadItem[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  while (true) {
+    const payload = {
+      threadId: params.threadId,
+      turnId: params.turnId,
+      ...(cursor ? { cursor } : {}),
+      limit: CODEX_THREAD_HISTORY_PAGE_SIZE,
+      sortDirection: "asc",
+    } satisfies CodexThreadItemsListParams;
+    const page = await requestCodexThreadItemsPage({
+      client: params.client,
+      payload,
+      timeoutMs: params.timeoutMs,
+    });
+    items.push(...page.data);
+    const nextCursor = page.nextCursor ?? undefined;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      break;
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
   }
 
-  return payload;
+  return items;
+}
+
+async function hydrateCodexThreadHistory(params: {
+  before?: string;
+  client: JsonRpcConnection;
+  limit?: number;
+  readResult: unknown;
+  threadId: string;
+  timeoutMs: number;
+}): Promise<unknown> {
+  const turns: CodexTurn[] = [];
+  const seenCursors = new Set<string>();
+  const requestedLimit = params.limit === undefined
+    ? undefined
+    : Math.max(0, Math.floor(params.limit));
+  let cursor = params.before;
+  let nextCursor: string | undefined;
+
+  while (requestedLimit === undefined || turns.length < requestedLimit) {
+    const remaining = requestedLimit === undefined
+      ? CODEX_THREAD_HISTORY_PAGE_SIZE
+      : requestedLimit - turns.length;
+    if (remaining <= 0) {
+      break;
+    }
+    const payload = {
+      threadId: params.threadId,
+      ...(cursor ? { cursor } : {}),
+      limit: Math.min(CODEX_THREAD_HISTORY_PAGE_SIZE, remaining),
+      sortDirection: "desc",
+      itemsView: "full",
+    } satisfies CodexThreadTurnsListParams;
+    const page = await requestWithThreadMetadataReadRetry(async () => {
+      return await requestWithFallbacks({
+        client: params.client,
+        methods: ["thread/turns/list"],
+        payloads: [payload],
+        timeoutMs: params.timeoutMs,
+      });
+    }) as CodexThreadTurnsListResponse;
+    turns.push(...page.data);
+    nextCursor = page.nextCursor ?? undefined;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      break;
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+
+  const hydratedTurns: Array<CodexTurn | undefined> = [];
+  for await (const hydrated of new IterableMapper(
+    turns.map((turn, index) => ({ index, turn })),
+    async ({ index, turn }) => {
+      if (turn.itemsView === "full") {
+        return { index, turn };
+      }
+      return {
+        index,
+        turn: {
+          ...turn,
+          items: await listCodexThreadItems({
+            client: params.client,
+            threadId: params.threadId,
+            timeoutMs: params.timeoutMs,
+            turnId: turn.id,
+          }),
+          itemsView: "full" as const,
+        },
+      };
+    },
+    {
+      concurrency: CODEX_THREAD_ITEM_HYDRATION_CONCURRENCY,
+      maxUnread: CODEX_THREAD_ITEM_HYDRATION_CONCURRENCY,
+    },
+  )) {
+    hydratedTurns[hydrated.index] = hydrated.turn;
+  }
+  const record = asRecord(params.readResult) ?? {};
+  const thread = asRecord(record.thread) ?? {};
+  return {
+    ...record,
+    thread: {
+      ...thread,
+      turns: hydratedTurns
+        .filter((turn): turn is CodexTurn => Boolean(turn))
+        .reverse(),
+    },
+    supportsPagination: true,
+    hasPreviousPage: Boolean(nextCursor),
+    ...(nextCursor ? { previousCursor: nextCursor } : {}),
+  };
 }
 
 async function requestWithFallbacks(params: {
@@ -8293,6 +8456,9 @@ export class CodexAppServerClient {
 
     let result: unknown;
     try {
+      // Full-history hydration on thread/read is deprecated for paginated
+      // threads. Read metadata first, then hydrate turns and items through
+      // their cursor-based list methods.
       const payload = buildThreadReadPayload(params);
       result = await requestWithThreadMetadataReadRetry(async () => {
         return await requestWithFallbacks({
@@ -8302,6 +8468,26 @@ export class CodexAppServerClient {
           timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
         });
       });
+      if (params.includeTurns === false) {
+        const record = asRecord(result) ?? {};
+        const thread = asRecord(record.thread) ?? {};
+        result = {
+          ...record,
+          thread: {
+            ...thread,
+            turns: [],
+          },
+        };
+      } else if (!threadReadResultIncludesTurns(result)) {
+        result = await hydrateCodexThreadHistory({
+          before: params.before,
+          client: this.connection,
+          limit: params.limit,
+          readResult: result,
+          threadId: params.threadId,
+          timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+        });
+      }
     } catch (error) {
       if (!isUnmaterializedThreadError(error)) {
         throw error;


### PR DESCRIPTION
## Stack

Depends on #1884. Merge #1884 first; this PR is based on `fix/codex-thread-metadata-race` and contains only the pagination follow-up.

## Summary

- stop requesting deprecated full-history hydration from `thread/read`
- hydrate Codex transcripts through paginated `thread/turns/list` requests with full turn items
- fall back from `thread/items/list` to legacy `thread/turns/items/list` when separate item paging is required
- preserve #1884's transient session-metadata retry for the metadata read and pagination RPCs
- preserve bounded older-page cursors, chronological replay order, metadata-only reads, and empty unmaterialized threads
- add regression coverage for turn pagination, item pagination compatibility, metadata-only reads, and transient pagination failures

## Tests

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `git diff --check`