### PR TITLE
fix(desktop): accept unknown MCP auth status

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -7231,7 +7231,7 @@ describe("CodexAppServerClient", () => {
     MockTransport.threadMcpServerStatusResult = {
       data: [
         {
-          name: "search-compare-local",
+          name: "offline-local-server",
           serverInfo: null,
           authStatus: "unknown",
           tools: {},
@@ -7251,7 +7251,7 @@ describe("CodexAppServerClient", () => {
       detail: "toolsAndAuthOnly",
     })).resolves.toEqual([
       {
-        name: "search-compare-local",
+        name: "offline-local-server",
         authStatus: "unknown",
         tools: [],
       },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -7226,6 +7226,40 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("preserves an unknown MCP authentication status", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadMcpServerStatusResult = {
+      data: [
+        {
+          name: "search-compare-local",
+          serverInfo: null,
+          authStatus: "unknown",
+          tools: {},
+          resources: [],
+          resourceTemplates: [],
+        },
+      ],
+      nextCursor: null,
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(client.listMcpServers({
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly",
+    })).resolves.toEqual([
+      {
+        name: "search-compare-local",
+        authStatus: "unknown",
+        tools: [],
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("falls back to global MCP inventory when the thread is not loaded", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.mcpServerStatusThreadError = {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -793,7 +793,8 @@ function readMcpServerInventoryPage(value: unknown): {
 
 function readMcpAuthStatus(value: unknown): CodexMcpServerSummary["authStatus"] {
   if (
-    value === "unsupported"
+    value === "unknown"
+    || value === "unsupported"
     || value === "notLoggedIn"
     || value === "bearerToken"
     || value === "oAuth"

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -571,5 +571,6 @@ function formatAuthStatus(status: CodexMcpAuthStatus): string {
   if (status === "oAuth") return "OAuth";
   if (status === "bearerToken") return "Bearer token";
   if (status === "notLoggedIn") return "Login required";
+  if (status === "unknown") return "Authentication unknown";
   return "No login";
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
@@ -318,6 +318,8 @@ function InventoryLine(props: {
 
 function formatAuthStatus(status: CodexMcpAuthStatus): string {
   switch (status) {
+    case "unknown":
+      return "Authentication unknown";
     case "notLoggedIn":
       return "Sign-in required";
     case "bearerToken":

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
@@ -73,7 +73,7 @@ describe("McpInventoryPanel", () => {
             detail: "toolsAndAuthOnly",
             servers: [
               {
-                name: "search-compare-local",
+                name: "offline-local-server",
                 authStatus: "unknown",
                 tools: [],
               },
@@ -86,7 +86,7 @@ describe("McpInventoryPanel", () => {
       />,
     );
 
-    expect(await screen.findByText("search-compare-local")).toBeInTheDocument();
+    expect(await screen.findByText("offline-local-server")).toBeInTheDocument();
     expect(screen.getByText("Authentication unknown")).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
@@ -63,6 +63,33 @@ describe("McpInventoryPanel", () => {
     });
   });
 
+  it("shows an unknown authentication status without hiding the inventory", async () => {
+    render(
+      <McpInventoryPanel
+        desktopApi={{
+          listThreadMcpServers: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            detail: "toolsAndAuthOnly",
+            servers: [
+              {
+                name: "search-compare-local",
+                authStatus: "unknown",
+                tools: [],
+              },
+            ],
+          }),
+        }}
+        onDismiss={vi.fn()}
+        request={{ detail: "toolsAndAuthOnly", requestId: 1 }}
+        thread={thread}
+      />,
+    );
+
+    expect(await screen.findByText("search-compare-local")).toBeInTheDocument();
+    expect(screen.getByText("Authentication unknown")).toBeInTheDocument();
+  });
+
   it("holds confirmed reload feedback and explains the next-turn boundary", async () => {
     const reloadCodexMcpConfig = vi.fn(async () => ({
       backend: "codex" as const,

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -412,6 +412,7 @@ export type CompactThreadResponse = {
 export type CodexMcpInventoryDetail = "toolsAndAuthOnly" | "full";
 
 export type CodexMcpAuthStatus =
+  | "unknown"
   | "unsupported"
   | "notLoggedIn"
   | "bearerToken"


### PR DESCRIPTION
## Summary

- accept the Codex App Server MCP auth status "unknown" in the shared contract and response parser
- render a neutral "Authentication unknown" label in thread inventory and Settings
- add client and renderer regression coverage

## Problem

Codex 0.149 can return authStatus "unknown" for an MCP server whose authentication state cannot be determined. PwrAgent treated that valid protocol value as malformed and rejected the entire mcpServerStatus/list response with codex_mcp_inventory_invalid_auth_status.

## Verification

The new client regression test failed before the fix with codex_mcp_inventory_invalid_auth_status.

- pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
- pnpm lint:eslint
- pnpm typecheck
- pnpm lint:boundaries
- pnpm lint:sql
- pnpm lint:codex-storage
- pnpm lint:colors
- pnpm licenses:check