### PR TITLE
fix(desktop): remove startup window timeout dialog

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -874,27 +874,13 @@ describe("bootstrapApp", () => {
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
   });
 
-  it("cancels the watchdog when the window shows before createMainWindow returns", async () => {
+  it("does not infer a boot failure when the main window is slow to show", async () => {
     vi.useFakeTimers();
     startupProfilerInstance.start.mockResolvedValue();
-    createMainWindowMock.mockImplementation(
-      (options?: { onShown?: () => void }) => {
-        options?.onShown?.();
-        return {
-          isVisible: () => false,
-          on: (event: string, handler: (...args: unknown[]) => void) => {
-            mainWindowHandlers.set(event, handler);
-          },
-          once: (event: string, handler: (...args: unknown[]) => void) => {
-            mainWindowHandlers.set(event, handler);
-          },
-        };
-      },
-    );
 
     await import("../index");
     await flushMicrotasks();
-    await vi.advanceTimersByTimeAsync(25_000);
+    await vi.advanceTimersByTimeAsync(60_000);
 
     expect(showMessageBoxSyncMock).not.toHaveBeenCalled();
     expect(mainLogErrorMock).not.toHaveBeenCalledWith(
@@ -903,22 +889,21 @@ describe("bootstrapApp", () => {
     );
   });
 
-  it("surfaces a boot failure when the main window never shows", async () => {
-    vi.useFakeTimers();
-    startupProfilerInstance.start.mockResolvedValue();
+  it("surfaces an actual startup rejection before the main window shows", async () => {
+    whenReadyMock.mockReturnValue(Promise.reject(new Error("startup exploded")));
 
     await import("../index");
     await flushMicrotasks();
-    await vi.advanceTimersByTimeAsync(25_000);
 
     expect(showMessageBoxSyncMock).toHaveBeenCalledWith(
       expect.objectContaining({
         title: "PwrAgent failed to start",
+        detail: expect.stringContaining("startup exploded"),
       }),
     );
     expect(mainLogErrorMock).toHaveBeenCalledWith(
       "startup failed before the main window appeared",
-      expect.objectContaining({ reason: "watchdog-timeout" }),
+      expect.objectContaining({ reason: "whenReady" }),
     );
   });
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -258,40 +258,17 @@ let startupCpuProfilerForNewWindows:
   | undefined;
 
 // --- Boot failure surfacing -------------------------------------------------
-// A failed startup must never leave the app "running but unusable" with no
-// explanation. We track whether the main window ever became visible; if boot
-// rejects (a throw anywhere in the whenReady chain) or simply never produces a
-// visible window within a grace period, we log it and put a native dialog in
-// front of the user with the actual error and a one-click path to the log
-// file. This is the backstop for the class of incident where an automation row
-// written by a newer build threw during startup reconciliation, rejected the
-// whenReady promise, and silently aborted the rest of boot — no window, no
-// dialog, not even a log line.
-const BOOT_WATCHDOG_MS = 25_000;
+// A rejected startup must never leave the app "running but unusable" with no
+// explanation. We track whether the main window ever became visible so an
+// actual startup error can be surfaced before first paint. Do not infer failure
+// from elapsed time: macOS can defer window visibility while the login session
+// is locked even though startup succeeded and the window will appear later.
 let mainWindowEverShown = false;
 let bootFailureSurfaced = false;
-let bootWatchdogTimer: NodeJS.Timeout | undefined;
 let lastBootError: unknown;
-
-function clearBootWatchdog(): void {
-  if (bootWatchdogTimer) {
-    clearTimeout(bootWatchdogTimer);
-    bootWatchdogTimer = undefined;
-  }
-}
-
-function startBootWatchdog(): void {
-  clearBootWatchdog();
-  bootWatchdogTimer = setTimeout(() => {
-    surfaceBootFailure("watchdog-timeout");
-  }, BOOT_WATCHDOG_MS);
-  // Never let the watchdog itself keep the process alive.
-  bootWatchdogTimer.unref?.();
-}
 
 function markMainWindowBooted(): void {
   mainWindowEverShown = true;
-  clearBootWatchdog();
 }
 
 function formatBootError(error: unknown): string {
@@ -309,7 +286,6 @@ function surfaceBootFailure(reason: string, error?: unknown): void {
     return;
   }
   bootFailureSurfaced = true;
-  clearBootWatchdog();
   const detail = error ?? lastBootError;
   const logFilePath = getMainLogFilePath();
   mainLog.error("startup failed before the main window appeared", {
@@ -367,10 +343,9 @@ function installBootErrorHandlers(): void {
   bootErrorHandlersInstalled = true;
   // We deliberately do NOT register an uncaughtException handler here: doing so
   // would change Node/Electron's crash semantics for *post*-boot exceptions.
-  // The watchdog above is the catch-all for "the window never appeared" no
-  // matter how boot failed; this handler just gives faster, more specific
-  // reporting for the common async-rejection case and ensures stray rejections
-  // are always logged (previously they produced no log line at all).
+  // This handler gives specific reporting for the common async-rejection case
+  // and ensures stray rejections are always logged (previously they produced no
+  // log line at all).
   process.on("unhandledRejection", (reason) => {
     mainLog.error("unhandled promise rejection", {
       bootCompleted: mainWindowEverShown,
@@ -1152,7 +1127,6 @@ export function bootstrapApp(): void {
   installBootErrorHandlers();
 
   app.whenReady().then(async () => {
-    startBootWatchdog();
     const startupCpuProfiler = new StartupCpuProfiler();
     startupCpuProfilerForNewWindows = startupCpuProfiler;
     await startupCpuProfiler.start();


### PR DESCRIPTION
## Summary

- I removed the 25-second startup-window watchdog that treated delayed Electron window visibility as a startup failure.
- I preserved the native failure dialog for actual startup promise rejections and early unhandled rejections.
- I added coverage proving that a slow-to-show window does not produce an error while a real startup rejection still does.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/index.test.ts` (47 tests passed).
- I ran `pnpm lint:eslint` (0 errors; existing warnings remain).
- I verified the commit has a valid SSH signature.

## Notes

- This addresses background launches while the macOS login session is locked. In that state, window visibility can be delayed beyond the watchdog timeout even though startup succeeds and the window appears after unlock.
