### PR TITLE
fix(desktop): recover Token Miser runtime state

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1702,6 +1702,7 @@ class MockBackendClient {
       initializeError?: Error;
       serverCapabilities?: CodexServerCapabilities;
       serverCapabilitiesError?: Error;
+      serverCapabilitiesErrors?: Array<Error | undefined>;
       threads?: AppServerThreadSummary[];
       nativeSubAgentThreads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
@@ -1765,6 +1766,10 @@ class MockBackendClient {
 
   async readServerCapabilities() {
     this.readServerCapabilitiesCallCount += 1;
+    const sequencedError = this.options.serverCapabilitiesErrors?.shift();
+    if (sequencedError) {
+      throw sequencedError;
+    }
     if (this.options.serverCapabilitiesError) {
       throw this.options.serverCapabilitiesError;
     }
@@ -4218,6 +4223,56 @@ describe("DesktopBackendRegistry", () => {
       expect(codexClient.startTurnCalls[0]?.config).toBeUndefined();
       expect(codexClient.startTurnCalls[1]?.config).toBeUndefined();
       expect(codexClient.readServerCapabilitiesCallCount).toBe(1);
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("retries a transient reducer capability failure on the next turn", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [],
+      serverCapabilitiesErrors: [
+        new Error("codex app server connection cancelled"),
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    const internals = registry as unknown as {
+      resolveTokenMiserEnabledFn: () => boolean;
+      tokenMiserCodeModeReducerDescriptorPath?: string;
+    };
+    internals.tokenMiserCodeModeReducerDescriptorPath = path.join(
+      "/tmp",
+      "token-miser-transient-capability",
+      "code-mode-reducer.test.json",
+    );
+    internals.resolveTokenMiserEnabledFn = () => true;
+
+    try {
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-transient-1",
+        input: [{ type: "text", text: "first attempt" }],
+      });
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-transient-2",
+        input: [{ type: "text", text: "retry after reconnect" }],
+      });
+
+      expect(codexClient.startTurnCalls[0]?.config).toBeUndefined();
+      expect(codexClient.startTurnCalls[1]?.config).toMatchObject({
+        features: {
+          code_mode: {
+            output_reducer: {
+              descriptor_path: internals.tokenMiserCodeModeReducerDescriptorPath,
+            },
+          },
+        },
+      });
+      expect(codexClient.readServerCapabilitiesCallCount).toBe(2);
     } finally {
       await registry.close();
     }

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4256,6 +4256,7 @@ describe("DesktopBackendRegistry", () => {
         threadId: "thread-transient-1",
         input: [{ type: "text", text: "first attempt" }],
       });
+      expect(codexClient.readServerCapabilitiesCallCount).toBe(1);
       await registry.startTurn({
         backend: "codex",
         threadId: "thread-transient-2",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -19988,6 +19988,7 @@ export class DesktopBackendRegistry {
       return await cached;
     }
 
+    let cacheResult = true;
     const probe = (async () => {
       if (!client.readServerCapabilities) {
         this.tokenMiserReducerCapabilityState = "unsupported";
@@ -20052,13 +20053,14 @@ export class DesktopBackendRegistry {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const normalized = message.toLowerCase();
-        if (
+        const permanentlyUnsupported =
           normalized.includes("method not found")
           || normalized.includes("unknown method")
           || normalized.includes(
             "unknown variant `server/capabilities/read`",
-          )
-        ) {
+          );
+        cacheResult = permanentlyUnsupported;
+        if (permanentlyUnsupported) {
           backendRegistryLog.debug(
             "Codex code-mode output reducer capability is unavailable",
             { reason: message },
@@ -20069,7 +20071,9 @@ export class DesktopBackendRegistry {
             { error: message },
           );
         }
-        this.tokenMiserReducerCapabilityState = "unsupported";
+        this.tokenMiserReducerCapabilityState = permanentlyUnsupported
+          ? "unsupported"
+          : undefined;
         this.tokenMiserCodeModeGroupingVersion = undefined;
         this.tokenMiserPostToolUseExactOutputVersion = undefined;
         await this.recordTokenMiserActivation({
@@ -20082,7 +20086,20 @@ export class DesktopBackendRegistry {
       }
     })();
     this.tokenMiserServerCapabilities.set(client, probe);
-    return await probe;
+    try {
+      return await probe;
+    } finally {
+      // Capability support is immutable for one live app-server, but a
+      // reconnect cancellation says nothing about the replacement process.
+      // Keeping that transient result poisoned every later turn until the
+      // whole desktop app restarted.
+      if (
+        !cacheResult
+        && this.tokenMiserServerCapabilities.get(client) === probe
+      ) {
+        this.tokenMiserServerCapabilities.delete(client);
+      }
+    }
   }
 
   private async supportsTokenMiserCodeModeReducer(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,4 +1,5 @@
 import { app } from "electron";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
@@ -7949,6 +7950,10 @@ export class DesktopBackendRegistry {
     BackendClient,
     Promise<CodexServerCapabilities | undefined>
   >();
+  private readonly tokenMiserServerCapabilitiesForTurn =
+    new AsyncLocalStorage<
+      WeakMap<BackendClient, Promise<CodexServerCapabilities | undefined>>
+    >();
   private tokenMiserReducerCapabilityState?: "supported" | "unsupported";
   private tokenMiserCodeModeGroupingVersion?: number;
   private tokenMiserPostToolUseExactOutputVersion?: number;
@@ -13966,6 +13971,12 @@ export class DesktopBackendRegistry {
     messageOrigin?: AppServerThreadMessageOrigin;
     invalidIdRecoveryAttempted?: boolean;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
+    if (!this.tokenMiserServerCapabilitiesForTurn.getStore()) {
+      return await this.tokenMiserServerCapabilitiesForTurn.run(
+        new WeakMap(),
+        async () => await this.startTurnNow(params),
+      );
+    }
     this.assertNotBootstrap("startTurn");
     if (this.closed) {
       throw new Error("Desktop backend registry is closed");
@@ -19983,8 +19994,14 @@ export class DesktopBackendRegistry {
   private async readTokenMiserServerCapabilities(
     client: BackendClient,
   ): Promise<CodexServerCapabilities | undefined> {
+    const turnCache = this.tokenMiserServerCapabilitiesForTurn.getStore();
+    const turnCached = turnCache?.get(client);
+    if (turnCached) {
+      return await turnCached;
+    }
     const cached = this.tokenMiserServerCapabilities.get(client);
     if (cached) {
+      turnCache?.set(client, cached);
       return await cached;
     }
 
@@ -20086,13 +20103,16 @@ export class DesktopBackendRegistry {
       }
     })();
     this.tokenMiserServerCapabilities.set(client, probe);
+    turnCache?.set(client, probe);
     try {
       return await probe;
     } finally {
       // Capability support is immutable for one live app-server, but a
       // reconnect cancellation says nothing about the replacement process.
-      // Keeping that transient result poisoned every later turn until the
-      // whole desktop app restarted.
+      // Remove transient failures from the client-wide cache so the next
+      // turn retries. The turn-local cache retains this promise until the
+      // current start finishes, keeping its capability-dependent fields
+      // consistent and preventing repeated timeout-length probes.
       if (
         !cacheResult
         && this.tokenMiserServerCapabilities.get(client) === probe

--- a/packages/shared/src/__tests__/navigation-state.test.ts
+++ b/packages/shared/src/__tests__/navigation-state.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
-import type { NavigationThreadSummary, PrSummary } from "../contracts/navigation";
-import { buildNavigationSnapshotHash } from "../navigation-state";
+import type {
+  NavigationThreadSummary,
+  PrSummary,
+  ThreadOverlayState,
+} from "../contracts/navigation";
+import type { AppServerThreadSummary } from "../contracts/normalized-app-server";
+import {
+  buildNavigationSnapshotHash,
+  materializeNavigationThreads,
+} from "../navigation-state";
 
 type HoverCardField = keyof Pick<
   PrSummary,
@@ -33,6 +41,42 @@ describe("buildNavigationSnapshotHash", () => {
       expect(changed).not.toBe(baseline);
     },
   );
+
+  it("changes when the Token Miser override changes", () => {
+    const thread = navigationThread({ tokenMiserEnabled: false });
+    const baseline = buildNavigationSnapshotHash({
+      backend: "codex",
+      threads: [thread],
+    });
+    const changed = buildNavigationSnapshotHash({
+      backend: "codex",
+      threads: [{ ...thread, tokenMiserEnabled: true }],
+    });
+
+    expect(changed).not.toBe(baseline);
+  });
+});
+
+describe("materializeNavigationThreads", () => {
+  it("projects the persisted Token Miser override onto navigation", () => {
+    const thread = appServerThread();
+    const overlay: ThreadOverlayState = {
+      backend: "codex",
+      threadId: thread.id,
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      tokenMiserEnabled: true,
+    };
+
+    const [materialized] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: { [`codex:${thread.id}`]: overlay },
+      previousKnownThreadKeys: [],
+      threads: [thread],
+    });
+
+    expect(materialized?.tokenMiserEnabled).toBe(true);
+  });
 });
 
 function buildHash(pr: PrSummary): string {
@@ -61,6 +105,26 @@ function pullRequest(overrides: Partial<PrSummary> = {}): PrSummary {
     title: "Show structured PR hover metadata",
     state: "pending",
     url: "https://github.com/pwrdrvr/PwrAgent/pull/1381",
+    ...overrides,
+  };
+}
+
+function appServerThread(): AppServerThreadSummary {
+  return {
+    source: "codex",
+    id: "thread-token-miser-navigation",
+    title: "Keep Token Miser state live",
+    titleSource: "derived",
+    linkedDirectories: [],
+  };
+}
+
+function navigationThread(
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    ...appServerThread(),
+    inbox: { inInbox: true },
     ...overrides,
   };
 }

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -271,6 +271,7 @@ export function materializeNavigationThreads(params: {
         : {}),
       serviceTier: overlay?.serviceTier ?? thread.serviceTier,
       fastMode: overlay?.fastMode ?? thread.fastMode,
+      tokenMiserEnabled: overlay?.tokenMiserEnabled,
       prAutoDispatchEnabled: overlay?.prAutoDispatchEnabled ?? false,
       prAutoDispatchPending: overlay?.prAutoDispatchPending,
       codexEnvironmentRuntime:
@@ -506,6 +507,7 @@ export function buildNavigationSnapshotHash(params: {
       reasoningEffort: thread.reasoningEffort ?? null,
       serviceTier: thread.serviceTier ?? null,
       fastMode: thread.fastMode ?? null,
+      tokenMiserEnabled: thread.tokenMiserEnabled ?? null,
       scheduledStart: thread.scheduledStart
         ? {
             actionId: thread.scheduledStart.actionId,


### PR DESCRIPTION
## Summary

- I retry transient connection-cancelled Token Miser capability probes instead
  of caching a false unsupported result for the life of the runtime.
- I propagate the effective per-thread Token Miser state through navigation
  materialization and its change hash so the composer reflects persisted state.
- I added regressions for transient probe recovery and navigation-state updates.

## Verification

- I ran the focused backend-registry and navigation-state tests: 585 passed.
- I ran the shared and desktop typechecks.
- I rebuilt the desktop application successfully.

## Notes

- This restores reliable per-thread Token Miser activation/readback for the
  Electron evaluation harness.
- The change uses Codex App Server protocol state and adds no Codex-owned
  storage access.
