### PR TITLE
fix(desktop): align spend alerts with pricing estimates

### DIFF
--- a/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
+++ b/apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts
@@ -53,6 +53,84 @@ describe("usage spend alerts", () => {
     ]);
   });
 
+  it("includes estimated historical usage gaps in total-thread spend", () => {
+    const alerts = detectUsageSpendAlerts({
+      backend: "codex",
+      policy: {
+        ...POLICY,
+        activeTurnSpendEnabled: false,
+        threadSpendThresholdUsd: 23,
+      },
+      pricing: {
+        lines: [
+          usageLine({
+            createdAt: Date.UTC(2026, 7, 31),
+            cumulativeCachedInputTokens: 0,
+            cumulativeInputTokens: 2_000_000,
+            cumulativeOutputTokens: 0,
+            cumulativeTotalTokens: 2_000_000,
+            cumulativeUncachedInputTokens: 2_000_000,
+            inputTokens: 1_000_000,
+            model: "gpt-5.6-sol",
+            totalCostMicros: 20_000_000,
+            totalTokens: 1_000_000,
+            uncachedInputTokens: 1_000_000,
+          }),
+        ],
+        summaries: [pricingSummary(20_000_000)],
+      },
+      threadId: "thread-1",
+      triggeredAlertIds: new Set(),
+    });
+
+    expect(alerts).toMatchObject([
+      {
+        kind: "thread-spend",
+        spendMicros: 24_000_000,
+        thresholdMicros: 23_000_000,
+      },
+    ]);
+  });
+
+  it("prices historical usage gaps at the rate in effect when usage occurred", () => {
+    const alerts = detectUsageSpendAlerts({
+      backend: "codex",
+      policy: {
+        ...POLICY,
+        activeTurnSpendEnabled: false,
+        threadSpendThresholdUsd: 24.5,
+      },
+      pricing: {
+        lines: [
+          usageLine({
+            createdAt: Date.UTC(2026, 7, 20, 23, 59, 59),
+            cumulativeCachedInputTokens: 0,
+            cumulativeInputTokens: 2_000_000,
+            cumulativeOutputTokens: 0,
+            cumulativeTotalTokens: 2_000_000,
+            cumulativeUncachedInputTokens: 2_000_000,
+            inputTokens: 1_000_000,
+            model: "gpt-5.6-sol",
+            totalCostMicros: 20_000_000,
+            totalTokens: 1_000_000,
+            uncachedInputTokens: 1_000_000,
+          }),
+        ],
+        summaries: [pricingSummary(20_000_000)],
+      },
+      threadId: "thread-1",
+      triggeredAlertIds: new Set(),
+    });
+
+    expect(alerts).toMatchObject([
+      {
+        kind: "thread-spend",
+        spendMicros: 25_000_000,
+        thresholdMicros: 24_500_000,
+      },
+    ]);
+  });
+
   it("evaluates every active turn represented in one usage batch", () => {
     const alerts = detectUsageSpendAlerts({
       activeTurnIds: ["turn-1", "turn-2", "turn-1"],

--- a/apps/desktop/src/main/app-server/usage-spend-alerts.ts
+++ b/apps/desktop/src/main/app-server/usage-spend-alerts.ts
@@ -4,6 +4,7 @@ import type {
   ThreadSpendAlert,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
+import { estimateHistoricalThreadUsageGapLines } from "@pwragent/shared";
 
 const USD_MICROS = 1_000_000;
 
@@ -84,6 +85,13 @@ export function detectUsageSpendAlerts(params: {
       (total, summary) =>
         summary.currency.toUpperCase() === "USD"
           ? total + summary.totalCostMicros
+          : total,
+      0,
+    ) + estimateHistoricalThreadUsageGapLines(params.pricing.lines).reduce(
+      (total, line) =>
+        line.priceStatus === "priced"
+        && line.currency.toUpperCase() === "USD"
+          ? total + line.totalCostMicros
           : total,
       0,
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -9,7 +9,7 @@ import type {
 } from "@pwragent/shared";
 import {
   estimateOpenAiCodexCreditUsage,
-  estimateTokenUsageCost,
+  estimateHistoricalThreadUsageGapLines,
   formatTokenUsageMicrosAsUsd,
 } from "@pwragent/shared";
 import { useMemo, useRef, useState, type ReactNode } from "react";
@@ -838,45 +838,10 @@ function CompactionBreakdown(props: {
 }
 
 function buildPricingDisplayLines(lines: ThreadUsageLineRecord[]): PricingUsageLine[] {
-  const chronologicalLines = [...lines].sort(compareUsageLinesAscending);
-  const displayLines: PricingUsageLine[] = [];
-  let accountedMainTokens = emptyPricingTokenBreakdown();
-
-  for (const line of chronologicalLines) {
-    if (!isMainThreadUsageLine(line)) {
-      displayLines.push(line);
-      continue;
-    }
-
-    const cumulativeTokens = readCumulativeTokenBreakdown(line);
-    const lineTokens = tokenBreakdownFromUsageLine(line);
-    const gapTokens = cumulativeTokens
-      ? subtractPricingTokenBreakdowns(
-          cumulativeTokens,
-          addPricingTokenBreakdowns(accountedMainTokens, lineTokens),
-        )
-      : emptyPricingTokenBreakdown();
-    const gapLine = hasPricingTokenBreakdownValue(gapTokens)
-      ? buildEstimatedHistoricalGapLine({
-          anchorLine: line,
-          gapTokens,
-        })
-      : undefined;
-    if (gapLine) {
-      displayLines.push(gapLine);
-      accountedMainTokens = addPricingTokenBreakdowns(accountedMainTokens, gapTokens);
-    }
-
-    displayLines.push(line);
-    accountedMainTokens = cumulativeTokens
-      ? maxPricingTokenBreakdowns(
-          addPricingTokenBreakdowns(accountedMainTokens, lineTokens),
-          cumulativeTokens,
-        )
-      : addPricingTokenBreakdowns(accountedMainTokens, lineTokens);
-  }
-
-  return displayLines.sort(compareUsageLinesDescending);
+  return [
+    ...lines,
+    ...estimateHistoricalThreadUsageGapLines(lines),
+  ].sort(compareUsageLinesDescending);
 }
 
 function addEstimatedLinesToSummaries(
@@ -948,13 +913,6 @@ function aggregateUsageLines(lines: PricingUsageLine[]): ThreadPricingSummary | 
     },
   );
 }
-
-type PricingTokenBreakdown = {
-  cachedInputTokens: number;
-  outputTokens: number;
-  reasoningOutputTokens: number;
-  uncachedInputTokens: number;
-};
 
 function addUsageLineToSummary(
   summary: ThreadPricingSummary,
@@ -1028,168 +986,8 @@ function lineSortTimestamp(line: ThreadUsageLineRecord): number {
   return line.startedAt ?? line.createdAt;
 }
 
-function emptyPricingTokenBreakdown(): PricingTokenBreakdown {
-  return {
-    cachedInputTokens: 0,
-    outputTokens: 0,
-    reasoningOutputTokens: 0,
-    uncachedInputTokens: 0,
-  };
-}
-
-function tokenBreakdownFromUsageLine(
-  line: ThreadUsageLineRecord,
-): PricingTokenBreakdown {
-  return {
-    cachedInputTokens: Math.max(0, line.cachedInputTokens),
-    outputTokens: Math.max(0, line.outputTokens),
-    reasoningOutputTokens: Math.max(0, line.reasoningOutputTokens),
-    uncachedInputTokens: Math.max(0, line.uncachedInputTokens),
-  };
-}
-
-function readCumulativeTokenBreakdown(
-  line: ThreadUsageLineRecord,
-): PricingTokenBreakdown | undefined {
-  if (!hasCumulativeTokenBreakdown(line)) {
-    return undefined;
-  }
-  const uncachedInputTokens = readCumulativeUncachedInputTokens(line);
-  if (
-    uncachedInputTokens === undefined ||
-    line.cumulativeCachedInputTokens === undefined ||
-    line.cumulativeOutputTokens === undefined
-  ) {
-    return undefined;
-  }
-  return {
-    cachedInputTokens: Math.max(0, line.cumulativeCachedInputTokens),
-    outputTokens: Math.max(0, line.cumulativeOutputTokens),
-    reasoningOutputTokens: Math.max(0, line.cumulativeReasoningOutputTokens ?? 0),
-    uncachedInputTokens: Math.max(0, uncachedInputTokens),
-  };
-}
-
-function addPricingTokenBreakdowns(
-  left: PricingTokenBreakdown,
-  right: PricingTokenBreakdown,
-): PricingTokenBreakdown {
-  return {
-    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
-    outputTokens: left.outputTokens + right.outputTokens,
-    reasoningOutputTokens:
-      left.reasoningOutputTokens + right.reasoningOutputTokens,
-    uncachedInputTokens: left.uncachedInputTokens + right.uncachedInputTokens,
-  };
-}
-
-function subtractPricingTokenBreakdowns(
-  left: PricingTokenBreakdown,
-  right: PricingTokenBreakdown,
-): PricingTokenBreakdown {
-  return {
-    cachedInputTokens: Math.max(0, left.cachedInputTokens - right.cachedInputTokens),
-    outputTokens: Math.max(0, left.outputTokens - right.outputTokens),
-    reasoningOutputTokens: Math.max(
-      0,
-      left.reasoningOutputTokens - right.reasoningOutputTokens,
-    ),
-    uncachedInputTokens: Math.max(
-      0,
-      left.uncachedInputTokens - right.uncachedInputTokens,
-    ),
-  };
-}
-
-function maxPricingTokenBreakdowns(
-  left: PricingTokenBreakdown,
-  right: PricingTokenBreakdown,
-): PricingTokenBreakdown {
-  return {
-    cachedInputTokens: Math.max(left.cachedInputTokens, right.cachedInputTokens),
-    outputTokens: Math.max(left.outputTokens, right.outputTokens),
-    reasoningOutputTokens: Math.max(
-      left.reasoningOutputTokens,
-      right.reasoningOutputTokens,
-    ),
-    uncachedInputTokens: Math.max(
-      left.uncachedInputTokens,
-      right.uncachedInputTokens,
-    ),
-  };
-}
-
-function hasPricingTokenBreakdownValue(tokens: PricingTokenBreakdown): boolean {
-  return (
-    tokens.cachedInputTokens > 0 ||
-    tokens.outputTokens > 0 ||
-    tokens.reasoningOutputTokens > 0 ||
-    tokens.uncachedInputTokens > 0
-  );
-}
-
 function isMainThreadUsageLine(line: ThreadUsageLineRecord): boolean {
   return line.scope !== "monitor";
-}
-
-function buildEstimatedHistoricalGapLine(params: {
-  anchorLine: ThreadUsageLineRecord;
-  gapTokens: PricingTokenBreakdown;
-}): PricingUsageLine | undefined {
-  const cost = estimateTokenUsageCost({
-    at: params.anchorLine.createdAt,
-    cachedInputTokens: params.gapTokens.cachedInputTokens,
-    fastMode: false,
-    model: params.anchorLine.model,
-    outputTokens: params.gapTokens.outputTokens,
-    reasoningOutputTokens: params.gapTokens.reasoningOutputTokens,
-    serviceTier: "standard",
-    uncachedInputTokens: params.gapTokens.uncachedInputTokens,
-  });
-  const inputTokens =
-    params.gapTokens.cachedInputTokens + params.gapTokens.uncachedInputTokens;
-  const totalTokens =
-    inputTokens +
-    params.gapTokens.outputTokens +
-    params.gapTokens.reasoningOutputTokens;
-  const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
-    cost ? undefined : params.anchorLine.model ? "missing-rate" : "missing-model";
-
-  return {
-    backend: params.anchorLine.backend,
-    cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
-    cachedInputTokens: params.gapTokens.cachedInputTokens,
-    createdAt: Math.max(0, lineSortTimestamp(params.anchorLine) - 1),
-    currency: cost?.currency ?? params.anchorLine.currency,
-    estimatedUsageGap: true,
-    inputTokens,
-    model: params.anchorLine.model,
-    outputCostMicros: cost?.outputCostMicros ?? 0,
-    outputTokens: params.gapTokens.outputTokens,
-    parentThreadId: params.anchorLine.parentThreadId,
-    priceStatus: cost ? "priced" : "unpriced",
-    ...(priceUnavailableReason ? { priceUnavailableReason } : {}),
-    provider: cost?.provider ?? params.anchorLine.provider,
-    ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
-    ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
-    ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
-    reasoningEffort: params.anchorLine.reasoningEffort,
-    reasoningOutputTokens: params.gapTokens.reasoningOutputTokens,
-    scope: "backfill",
-    serviceTier: "standard",
-    settingsConfidence: "fallback",
-    settingsSource: "observed-settings",
-    source: "backfill",
-    sourceItemId: `estimated-gap:${params.anchorLine.usageLineId}`,
-    status: "finalized",
-    threadId: params.anchorLine.threadId,
-    totalCostMicros: cost?.totalCostMicros ?? 0,
-    totalTokens,
-    uncachedInputCostMicros: cost?.uncachedInputCostMicros ?? 0,
-    uncachedInputTokens: params.gapTokens.uncachedInputTokens,
-    usageLineId: `estimated-gap:${params.anchorLine.usageLineId}`,
-    usageTurnId: `estimated-gap:${params.anchorLine.usageTurnId ?? params.anchorLine.usageLineId}`,
-  };
 }
 
 function formatSummaryEstimates(params: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -50,4 +50,5 @@ export * from "./thread-terminal";
 export * from "./thread-titles";
 export * from "./tool-activity-burst";
 export * from "./token-usage-pricing";
+export * from "./thread-pricing-projection";
 export * from "./worktree-paths";

--- a/packages/shared/src/thread-pricing-projection.ts
+++ b/packages/shared/src/thread-pricing-projection.ts
@@ -1,0 +1,270 @@
+import {
+  estimateTokenUsageCost,
+  type ThreadUsageLineRecord,
+} from "./token-usage-pricing";
+
+type PricingTokenBreakdown = {
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+  uncachedInputTokens: number;
+};
+
+export type EstimatedThreadUsageGapLine = ThreadUsageLineRecord & {
+  estimatedUsageGap: true;
+};
+
+/**
+ * Reconstructs main-thread usage that appears in cumulative protocol counters
+ * but has no durable pricing row. Consumers must share this projection so
+ * operator-facing totals and spend alerts account for the same estimates.
+ */
+export function estimateHistoricalThreadUsageGapLines(
+  lines: readonly ThreadUsageLineRecord[],
+): EstimatedThreadUsageGapLine[] {
+  const chronologicalLines = [...lines].sort(compareUsageLinesAscending);
+  const estimatedLines: EstimatedThreadUsageGapLine[] = [];
+  let accountedMainTokens = emptyPricingTokenBreakdown();
+
+  for (const line of chronologicalLines) {
+    if (line.scope === "monitor") {
+      continue;
+    }
+
+    const cumulativeTokens = readCumulativeTokenBreakdown(line);
+    const lineTokens = tokenBreakdownFromUsageLine(line);
+    const gapTokens = cumulativeTokens
+      ? subtractPricingTokenBreakdowns(
+          cumulativeTokens,
+          addPricingTokenBreakdowns(accountedMainTokens, lineTokens),
+        )
+      : emptyPricingTokenBreakdown();
+    const gapLine = hasPricingTokenBreakdownValue(gapTokens)
+      ? buildEstimatedHistoricalGapLine({
+          anchorLine: line,
+          gapTokens,
+        })
+      : undefined;
+    if (gapLine) {
+      estimatedLines.push(gapLine);
+      accountedMainTokens = addPricingTokenBreakdowns(
+        accountedMainTokens,
+        gapTokens,
+      );
+    }
+
+    accountedMainTokens = cumulativeTokens
+      ? maxPricingTokenBreakdowns(
+          addPricingTokenBreakdowns(accountedMainTokens, lineTokens),
+          cumulativeTokens,
+        )
+      : addPricingTokenBreakdowns(accountedMainTokens, lineTokens);
+  }
+
+  return estimatedLines;
+}
+
+function compareUsageLinesAscending(
+  left: ThreadUsageLineRecord,
+  right: ThreadUsageLineRecord,
+): number {
+  const leftTimestamp = lineSortTimestamp(left);
+  const rightTimestamp = lineSortTimestamp(right);
+  if (leftTimestamp !== rightTimestamp) {
+    return leftTimestamp - rightTimestamp;
+  }
+  return left.usageLineId.localeCompare(right.usageLineId);
+}
+
+function lineSortTimestamp(line: ThreadUsageLineRecord): number {
+  return line.startedAt ?? line.createdAt;
+}
+
+function emptyPricingTokenBreakdown(): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+    uncachedInputTokens: 0,
+  };
+}
+
+function tokenBreakdownFromUsageLine(
+  line: ThreadUsageLineRecord,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: Math.max(0, line.cachedInputTokens),
+    outputTokens: Math.max(0, line.outputTokens),
+    reasoningOutputTokens: Math.max(0, line.reasoningOutputTokens),
+    uncachedInputTokens: Math.max(0, line.uncachedInputTokens),
+  };
+}
+
+function readCumulativeTokenBreakdown(
+  line: ThreadUsageLineRecord,
+): PricingTokenBreakdown | undefined {
+  if (!hasCumulativeTokenBreakdown(line)) {
+    return undefined;
+  }
+  const uncachedInputTokens = readCumulativeUncachedInputTokens(line);
+  if (
+    uncachedInputTokens === undefined
+    || line.cumulativeCachedInputTokens === undefined
+    || line.cumulativeOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    cachedInputTokens: Math.max(0, line.cumulativeCachedInputTokens),
+    outputTokens: Math.max(0, line.cumulativeOutputTokens),
+    reasoningOutputTokens: Math.max(0, line.cumulativeReasoningOutputTokens ?? 0),
+    uncachedInputTokens: Math.max(0, uncachedInputTokens),
+  };
+}
+
+function hasCumulativeTokenBreakdown(line: ThreadUsageLineRecord): boolean {
+  return (
+    line.cumulativeUncachedInputTokens !== undefined
+    || line.cumulativeInputTokens !== undefined
+    || line.cumulativeCachedInputTokens !== undefined
+    || line.cumulativeOutputTokens !== undefined
+    || line.cumulativeReasoningOutputTokens !== undefined
+    || line.cumulativeTotalTokens !== undefined
+  );
+}
+
+function readCumulativeUncachedInputTokens(
+  line: ThreadUsageLineRecord,
+): number | undefined {
+  if (line.cumulativeUncachedInputTokens !== undefined) {
+    return line.cumulativeUncachedInputTokens;
+  }
+  if (
+    line.cumulativeInputTokens === undefined
+    || line.cumulativeCachedInputTokens === undefined
+  ) {
+    return undefined;
+  }
+  return Math.max(
+    0,
+    line.cumulativeInputTokens - line.cumulativeCachedInputTokens,
+  );
+}
+
+function addPricingTokenBreakdowns(
+  left: PricingTokenBreakdown,
+  right: PricingTokenBreakdown,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningOutputTokens:
+      left.reasoningOutputTokens + right.reasoningOutputTokens,
+    uncachedInputTokens: left.uncachedInputTokens + right.uncachedInputTokens,
+  };
+}
+
+function subtractPricingTokenBreakdowns(
+  left: PricingTokenBreakdown,
+  right: PricingTokenBreakdown,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: Math.max(0, left.cachedInputTokens - right.cachedInputTokens),
+    outputTokens: Math.max(0, left.outputTokens - right.outputTokens),
+    reasoningOutputTokens: Math.max(
+      0,
+      left.reasoningOutputTokens - right.reasoningOutputTokens,
+    ),
+    uncachedInputTokens: Math.max(
+      0,
+      left.uncachedInputTokens - right.uncachedInputTokens,
+    ),
+  };
+}
+
+function maxPricingTokenBreakdowns(
+  left: PricingTokenBreakdown,
+  right: PricingTokenBreakdown,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: Math.max(left.cachedInputTokens, right.cachedInputTokens),
+    outputTokens: Math.max(left.outputTokens, right.outputTokens),
+    reasoningOutputTokens: Math.max(
+      left.reasoningOutputTokens,
+      right.reasoningOutputTokens,
+    ),
+    uncachedInputTokens: Math.max(
+      left.uncachedInputTokens,
+      right.uncachedInputTokens,
+    ),
+  };
+}
+
+function hasPricingTokenBreakdownValue(tokens: PricingTokenBreakdown): boolean {
+  return (
+    tokens.cachedInputTokens > 0
+    || tokens.outputTokens > 0
+    || tokens.reasoningOutputTokens > 0
+    || tokens.uncachedInputTokens > 0
+  );
+}
+
+function buildEstimatedHistoricalGapLine(params: {
+  anchorLine: ThreadUsageLineRecord;
+  gapTokens: PricingTokenBreakdown;
+}): EstimatedThreadUsageGapLine | undefined {
+  const cost = estimateTokenUsageCost({
+    at: params.anchorLine.createdAt,
+    cachedInputTokens: params.gapTokens.cachedInputTokens,
+    fastMode: false,
+    model: params.anchorLine.model,
+    outputTokens: params.gapTokens.outputTokens,
+    reasoningOutputTokens: params.gapTokens.reasoningOutputTokens,
+    serviceTier: "standard",
+    uncachedInputTokens: params.gapTokens.uncachedInputTokens,
+  });
+  const inputTokens =
+    params.gapTokens.cachedInputTokens + params.gapTokens.uncachedInputTokens;
+  const totalTokens =
+    inputTokens
+    + params.gapTokens.outputTokens
+    + params.gapTokens.reasoningOutputTokens;
+  const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
+    cost ? undefined : params.anchorLine.model ? "missing-rate" : "missing-model";
+
+  return {
+    backend: params.anchorLine.backend,
+    cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
+    cachedInputTokens: params.gapTokens.cachedInputTokens,
+    createdAt: Math.max(0, lineSortTimestamp(params.anchorLine) - 1),
+    currency: cost?.currency ?? params.anchorLine.currency,
+    estimatedUsageGap: true,
+    inputTokens,
+    model: params.anchorLine.model,
+    outputCostMicros: cost?.outputCostMicros ?? 0,
+    outputTokens: params.gapTokens.outputTokens,
+    parentThreadId: params.anchorLine.parentThreadId,
+    priceStatus: cost ? "priced" : "unpriced",
+    ...(priceUnavailableReason ? { priceUnavailableReason } : {}),
+    provider: cost?.provider ?? params.anchorLine.provider,
+    ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
+    ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
+    ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
+    reasoningEffort: params.anchorLine.reasoningEffort,
+    reasoningOutputTokens: params.gapTokens.reasoningOutputTokens,
+    scope: "backfill",
+    serviceTier: "standard",
+    settingsConfidence: "fallback",
+    settingsSource: "observed-settings",
+    source: "backfill",
+    sourceItemId: `estimated-gap:${params.anchorLine.usageLineId}`,
+    status: "finalized",
+    threadId: params.anchorLine.threadId,
+    totalCostMicros: cost?.totalCostMicros ?? 0,
+    totalTokens,
+    uncachedInputCostMicros: cost?.uncachedInputCostMicros ?? 0,
+    uncachedInputTokens: params.gapTokens.uncachedInputTokens,
+    usageLineId: `estimated-gap:${params.anchorLine.usageLineId}`,
+    usageTurnId: `estimated-gap:${params.anchorLine.usageTurnId ?? params.anchorLine.usageLineId}`,
+  };
+}


### PR DESCRIPTION
## Summary

- centralize historical pricing-gap projection in the shared pricing layer
- include the same estimated gap rows in thread spend alerts that the Pricing panel already displays
- preserve timestamp-based catalog selection so pre-August 21 Sol usage keeps the July rate
- add regressions for threshold crossing with estimated gaps and historical rate selection

## Root cause

The thread toast summed only durable pricing summaries. The Pricing panel added synthetic historical-gap rows derived from cumulative token counters. For thread `019ff404-ea6e-79f3-bf83-3cb4219a780e`, the toast snapshot contained $32.242221 of durable rows while the panel added $5.904862 of Aug 12/16/18 historical estimates, producing $38.147083 and displaying $38.15. The August 21 Sol discount was not applied to those earlier estimates.

## Validation

- `pnpm test packages/shared/src/__tests__/token-usage-pricing.test.ts apps/desktop/src/main/__tests__/usage-spend-alerts.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx` (124 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`