### PR TITLE
fix(messaging): collapse near-duplicate terminal fragments

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -16237,11 +16237,11 @@ describe("MessagingController", () => {
             output: [
               {
                 type: "text",
-                text: "First final fragment.",
+                text: "The build completed successfully and every signed release artifact is ready for publication.",
               },
               {
                 type: "text",
-                text: "Second final fragment.",
+                text: "The operator documentation was updated and the acceptance smoke passed from end to end.",
               },
             ],
           },
@@ -16257,7 +16257,70 @@ describe("MessagingController", () => {
       expect.objectContaining({
         parts: [
           expect.objectContaining({
-            text: "First final fragment.\n\nSecond final fragment.",
+            text: [
+              "The build completed successfully and every signed release artifact is ready for publication.",
+              "The operator documentation was updated and the acceptance smoke passed from end to end.",
+            ].join("\n\n"),
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("keeps only the final completion fragment when terminal output nearly repeats itself", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: [
+                  "I’ll check the current messaging/thread binding. This Discord thread is bound to a PwrAgent thread.",
+                  "",
+                  "- PwrAgent title: Token Miser release. acceptance smoke. Do not edit files...",
+                  "- Discord thread title: Token Miser release — acceptance smoke",
+                ].join("\n"),
+              },
+              {
+                type: "text",
+                text: [
+                  "Yes. This Discord thread is bound to a PwrAgent thread.",
+                  "",
+                  "- PwrAgent title: Token Miser release. acceptance smoke. Do not edit files...",
+                  "- Discord thread title: Token Miser release — acceptance smoke",
+                ].join("\n"),
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "message" && intent.role === "assistant",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        parts: [
+          expect.objectContaining({
+            text: [
+              "Yes. This Discord thread is bound to a PwrAgent thread.",
+              "",
+              "- PwrAgent title: Token Miser release. acceptance smoke. Do not edit files...",
+              "- Discord thread title: Token Miser release — acceptance smoke",
+            ].join("\n"),
           }),
         ],
       }),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -307,6 +307,9 @@ const DEFAULT_INPUT_DEBOUNCE_MS = 500;
 const MAX_DELIVERED_AUTOMATION_KEYS = 1_000;
 const MAX_TRACKED_REVIEW_TURNS = 1_000;
 const MAX_TRACKED_TURN_PROSE = 256;
+const MIN_NEAR_DUPLICATE_ASSISTANT_WORDS = 12;
+const MIN_NEAR_DUPLICATE_ASSISTANT_LENGTH_RATIO = 0.7;
+const MIN_NEAR_DUPLICATE_ASSISTANT_BIGRAM_OVERLAP = 0.8;
 const MESSAGING_ENVIRONMENT_SETUP_PROGRESS_INTERVAL_MS = 15_000;
 
 type MessagingTurnProseState = {
@@ -20710,6 +20713,14 @@ function assistantTextForBackendEvent(event: AgentEvent): string | undefined {
 function assistantOutputTextFragmentsForBackendEvent(
   event: AgentEvent,
 ): string[] {
+  return deduplicateAssistantOutputTextFragments(
+    rawAssistantOutputTextFragmentsForBackendEvent(event),
+  );
+}
+
+function rawAssistantOutputTextFragmentsForBackendEvent(
+  event: AgentEvent,
+): string[] {
   if (event.notification.method !== "turn/completed") {
     return [];
   }
@@ -20730,6 +20741,75 @@ function assistantOutputTextFragmentsForBackendEvent(
     .filter((value): value is string => typeof value === "string")
     .map((value) => value.trim())
     .filter(Boolean);
+}
+
+function deduplicateAssistantOutputTextFragments(fragments: string[]): string[] {
+  // Some backends expose commentary and a rewritten final answer only through
+  // turn/completed. Keep the later fragment when the two are substantially the
+  // same response, but require enough ordered overlap that short acknowledgments
+  // and related multi-part answers remain separate.
+  const preserved: string[] = [];
+  for (let index = fragments.length - 1; index >= 0; index -= 1) {
+    const fragment = fragments[index]!;
+    if (
+      preserved.some((laterFragment) =>
+        areNearDuplicateAssistantTextFragments(fragment, laterFragment)
+      )
+    ) {
+      continue;
+    }
+    preserved.unshift(fragment);
+  }
+  return preserved;
+}
+
+function areNearDuplicateAssistantTextFragments(
+  left: string,
+  right: string,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  const leftWords = normalizedAssistantTextWords(left);
+  const rightWords = normalizedAssistantTextWords(right);
+  const shorterWords = leftWords.length <= rightWords.length
+    ? leftWords
+    : rightWords;
+  const longerWords = leftWords.length <= rightWords.length
+    ? rightWords
+    : leftWords;
+  if (
+    shorterWords.length < MIN_NEAR_DUPLICATE_ASSISTANT_WORDS
+    || shorterWords.length / longerWords.length
+      < MIN_NEAR_DUPLICATE_ASSISTANT_LENGTH_RATIO
+  ) {
+    return false;
+  }
+
+  const shorterBigrams = assistantTextBigrams(shorterWords);
+  const longerBigramCounts = new Map<string, number>();
+  for (const bigram of assistantTextBigrams(longerWords)) {
+    longerBigramCounts.set(bigram, (longerBigramCounts.get(bigram) ?? 0) + 1);
+  }
+  let overlap = 0;
+  for (const bigram of shorterBigrams) {
+    const remaining = longerBigramCounts.get(bigram) ?? 0;
+    if (remaining === 0) {
+      continue;
+    }
+    overlap += 1;
+    longerBigramCounts.set(bigram, remaining - 1);
+  }
+  return overlap / shorterBigrams.length
+    >= MIN_NEAR_DUPLICATE_ASSISTANT_BIGRAM_OVERLAP;
+}
+
+function normalizedAssistantTextWords(text: string): string[] {
+  return text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
+function assistantTextBigrams(words: string[]): string[] {
+  return words.slice(1).map((word, index) => `${words[index]}\0${word}`);
 }
 
 /**
@@ -20969,7 +21049,7 @@ function assistantMessageDeliveryKeys(
   // the repeated aggregate without changing completion-only aggregation.
   const contentKeys = [
     contentKey,
-    ...assistantOutputTextFragmentsForBackendEvent(event).map((fragment) =>
+    ...rawAssistantOutputTextFragmentsForBackendEvent(event).map((fragment) =>
       assistantMessageContentDeliveryKey(event, binding, fragment, identity)
     ),
   ];


### PR DESCRIPTION
## Summary

- I collapse substantial near-duplicate text fragments in completion-only terminal responses while keeping the later, final wording.
- I preserve raw fragment delivery keys so the exact terminal deduplication from #1852 continues to suppress aggregates already delivered through `item/completed`.
- I added a regression using the reported Discord response and strengthened the distinct-fragment coverage to guard legitimate multi-part terminal output.

## Verification

- I verified the new regression failed before the fix and passed afterward.
- I ran `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` (412 passed).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` (0 errors; 43 existing warnings).
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- The fix is in the channel-neutral messaging controller, so it applies consistently to Discord, Telegram, Slack, and the other providers.
- The dev log recorded one Discord provider delivery for the reported turn; the repetition came from two near-identical `turn/completed` output fragments joined into that one delivered message.
