### PR TITLE
fix(desktop): keep Mattermost icon visible across themes

### DIFF
--- a/apps/desktop/src/renderer/src/icons/MattermostIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/MattermostIcon.tsx
@@ -1,4 +1,4 @@
-import type { ImgHTMLAttributes } from "react";
+import { useSyncExternalStore, type ImgHTMLAttributes } from "react";
 import { DEFAULT_ICON_SIZE } from "./icon-types";
 import iconBlackUrl from "../assets/mattermost/icon-black.svg";
 import iconDenimUrl from "../assets/mattermost/icon-denim.svg";
@@ -16,6 +16,11 @@ import iconWhiteUrl from "../assets/mattermost/icon-white.svg";
  * - `black`  — pure black (#1b1d22). Best on light surfaces when denim
  *              would clash with the surrounding accent.
  * - `white`  — pure white. Required on dark surfaces; denim disappears.
+ *
+ * With no explicit variant, the icon follows PwrAgent's resolved theme:
+ * denim on light surfaces and white on dark surfaces. Explicit variants
+ * remain available for surfaces whose background is independent of the app
+ * theme.
  *
  * Renders as an `<img>` element rather than inline `<svg>` so the asset
  * stays a verbatim, unaltered file — Vite emits each URL as a static
@@ -40,18 +45,14 @@ export type MattermostIconProps = Omit<
 
 export function MattermostIcon({
   size = DEFAULT_ICON_SIZE,
-  // The PwrAgent desktop UI is dark-themed throughout, so white is the
-  // right default — denim (#1e325c) and black both disappear against
-  // near-black surfaces. Light-surface callers (any future light theme,
-  // exported reports, brand pages) override with `variant="denim"` or
-  // `variant="black"`.
-  variant = "white",
+  variant,
   alt = "",
   ...rest
 }: MattermostIconProps) {
+  const resolvedVariant = useMattermostVariant(variant);
   return (
     <img
-      src={VARIANT_URL[variant]}
+      src={VARIANT_URL[resolvedVariant]}
       width={size}
       height={size}
       alt={alt}
@@ -63,4 +64,62 @@ export function MattermostIcon({
       {...rest}
     />
   );
+}
+
+function useMattermostVariant(
+  variant: MattermostIconVariant | undefined,
+): MattermostIconVariant {
+  const themeVariant = useSyncExternalStore(
+    variant ? subscribeToNothing : subscribeToTheme,
+    resolveThemeVariant,
+    resolveDarkThemeVariant,
+  );
+
+  return variant ?? themeVariant;
+}
+
+const themeListeners = new Set<() => void>();
+let themeObserver: MutationObserver | undefined;
+
+function subscribeToTheme(listener: () => void): () => void {
+  if (
+    typeof document === "undefined"
+    || typeof MutationObserver === "undefined"
+  ) {
+    return subscribeToNothing(listener);
+  }
+
+  themeListeners.add(listener);
+  if (!themeObserver) {
+    themeObserver = new MutationObserver(() => {
+      for (const notify of themeListeners) notify();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributeFilter: ["data-theme"],
+      attributes: true,
+    });
+  }
+
+  return () => {
+    themeListeners.delete(listener);
+    if (themeListeners.size === 0) {
+      themeObserver?.disconnect();
+      themeObserver = undefined;
+    }
+  };
+}
+
+function subscribeToNothing(_listener: () => void): () => void {
+  return () => undefined;
+}
+
+function resolveThemeVariant(): MattermostIconVariant {
+  return typeof document !== "undefined"
+    && document.documentElement.dataset.theme === "light"
+    ? "denim"
+    : "white";
+}
+
+function resolveDarkThemeVariant(): MattermostIconVariant {
+  return "white";
 }

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BranchIcon,
@@ -28,6 +28,7 @@ import {
 
 afterEach(() => {
   cleanup();
+  document.documentElement.removeAttribute("data-theme");
 });
 
 const ALL_ICONS = [
@@ -164,6 +165,55 @@ describe("icon library", () => {
       }
       // Three variants → three distinct asset URLs.
       expect(sources.size).toBe(3);
+    });
+
+    it("uses the official denim asset on light-theme surfaces", () => {
+      const { container: denimContainer } = render(
+        <MattermostIcon variant="denim" />,
+      );
+      const denimSrc = denimContainer.querySelector("img")?.getAttribute("src");
+      cleanup();
+
+      document.documentElement.setAttribute("data-theme", "light");
+      const { container } = render(<MattermostIcon />);
+
+      expect(container.querySelector("img")).toHaveAttribute("src", denimSrc);
+    });
+
+    it("uses the official white asset on dark-theme surfaces", () => {
+      const { container: whiteContainer } = render(
+        <MattermostIcon variant="white" />,
+      );
+      const whiteSrc = whiteContainer.querySelector("img")?.getAttribute("src");
+      cleanup();
+
+      const { container } = render(<MattermostIcon />);
+
+      expect(container.querySelector("img")).toHaveAttribute("src", whiteSrc);
+    });
+
+    it("follows live theme changes", async () => {
+      const { container: denimContainer } = render(
+        <MattermostIcon variant="denim" />,
+      );
+      const denimSrc = denimContainer.querySelector("img")?.getAttribute("src");
+      cleanup();
+      const { container: whiteContainer } = render(
+        <MattermostIcon variant="white" />,
+      );
+      const whiteSrc = whiteContainer.querySelector("img")?.getAttribute("src");
+      cleanup();
+
+      const { container } = render(<MattermostIcon />);
+      expect(container.querySelector("img")).toHaveAttribute("src", whiteSrc);
+
+      act(() => {
+        document.documentElement.setAttribute("data-theme", "light");
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector("img")).toHaveAttribute("src", denimSrc);
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/messaging-platform-branding.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/messaging-platform-branding.test.tsx
@@ -1,0 +1,26 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MattermostIcon } from "../../icons";
+import { MESSAGING_PLATFORM_ICONS } from "../messaging-platform-branding";
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("MESSAGING_PLATFORM_ICONS", () => {
+  it("uses the light-safe Mattermost mark across shared messaging surfaces", () => {
+    const { container: denimContainer } = render(
+      <MattermostIcon variant="denim" />,
+    );
+    const denimSrc = denimContainer.querySelector("img")?.getAttribute("src");
+    cleanup();
+
+    document.documentElement.setAttribute("data-theme", "light");
+    const Mattermost = MESSAGING_PLATFORM_ICONS.mattermost;
+    const { container } = render(Mattermost ? <Mattermost size={14} /> : null);
+
+    expect(container.querySelector("img")).toHaveAttribute("src", denimSrc);
+  });
+});


### PR DESCRIPTION
## Summary

- I made `MattermostIcon` select Mattermost's official denim asset on resolved light-theme surfaces and the official white asset on dark-theme surfaces.
- I kept explicit official black, denim, and white variants intact and used one shared theme observer so every audited renderer consumer updates live without per-row observers.
- I added regression coverage for the icon contract and the shared messaging-platform map used by thread rows, transcript origins, messaging routes, status surfaces, and messaging activity.

## Verification

- I first ran the two focused test files against the pre-fix implementation and confirmed 3 expected failures with 28 passing tests: the light default stayed white, a live theme flip stayed white, and the shared messaging map stayed white.
- I reran the focused tests after the fix: 31/31 passed across 2 files.
- I ran the broader audited consumer set covering icons, shared branding, messaging status, Access Control Settings, the Settings screen, and onboarding provider setup: 148/148 passed across 6 files.
- I ran `pnpm --filter @pwragent/desktop typecheck` successfully.
- I ran `pnpm lint:eslint` successfully with 0 errors. It reported 43 pre-existing warnings in unrelated files; none are in this PR's changed files.
- I ran `pnpm lint:boundaries` successfully: no violations across 1,608 modules and 5,460 dependencies.
- I visually verified Settings → Messaging in this checkout's managed dev-profile app. Mattermost used denim in light theme and white in dark theme with no layout shift. I restored the original light preference and closed the temporary dev instance.

## Notes

- The audit covered direct Mattermost icon consumers in Messaging Settings, Access Control Settings, onboarding provider cards, onboarding provider setup, and the shared messaging platform map.
- The shared map also covers thread rows, transcript origins, Messaging Routes Settings, the messaging status bar/popover, and Messaging Activity.
- I did not modify or depend on PR #1875 or its branch; this branch was created from the fetched `origin/main` at `ea5dae376`.
