### PR TITLE
fix(desktop): preserve nested lists in composer markdown

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -454,12 +454,82 @@ function parseInlineMarkdownWithMarks(
   return nodes;
 }
 
+type MarkdownListKind = "bullet" | "ordered";
+
+type MarkdownListItemLine = {
+  indent: number;
+  kind: MarkdownListKind;
+  start?: number;
+  text: string;
+};
+
+function markdownLineIndent(line: string): { content: string; indent: number } {
+  let indent = 0;
+  let index = 0;
+  while (index < line.length) {
+    const character = line[index];
+    if (character === " ") {
+      indent += 1;
+      index += 1;
+      continue;
+    }
+    if (character === "\t") {
+      indent += 4 - (indent % 4);
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return {
+    content: line.slice(index),
+    indent,
+  };
+}
+
+function matchMarkdownListItemLine(line: string): MarkdownListItemLine | null {
+  const { content, indent } = markdownLineIndent(line);
+  const ordered = content.match(/^(\d+)\.\s+(.*)$/);
+  if (ordered) {
+    return {
+      indent,
+      kind: "ordered",
+      start: Number.parseInt(ordered[1] ?? "1", 10),
+      text: ordered[2] ?? "",
+    };
+  }
+  const bullet = content.match(/^[-*]\s+(.*)$/);
+  if (bullet) {
+    return {
+      indent,
+      kind: "bullet",
+      text: bullet[1] ?? "",
+    };
+  }
+  return null;
+}
+
 function matchMarkdownOrderedListItem(line: string): RegExpMatchArray | null {
+  const item = matchMarkdownListItemLine(line);
+  if (!item || item.kind !== "ordered" || item.indent > 3) {
+    return null;
+  }
   return line.match(/^\s{0,3}(\d+)\.\s+(.+)$/);
 }
 
 function matchMarkdownBulletListItem(line: string): RegExpMatchArray | null {
+  const item = matchMarkdownListItemLine(line);
+  if (!item || item.kind !== "bullet" || item.indent > 3) {
+    return null;
+  }
   return line.match(/^\s{0,3}[-*]\s+(.+)$/);
+}
+
+function markdownListMarker(
+  kind: MarkdownListKind,
+  index: number,
+  start = 1,
+): string {
+  return kind === "bullet" ? "- " : `${start + index}. `;
 }
 
 function isMarkdownThematicBreak(line: string): boolean {
@@ -557,15 +627,94 @@ function nextNonBlankLineIndex(lines: string[], index: number): number {
   return cursor;
 }
 
-function buildMarkdownListItem(text: string): JSONContent {
-  return {
-    type: "listItem",
-    content: [
+function tryParseMarkdownList(
+  lines: string[],
+  startIndex: number,
+  minIndent: number,
+): { nextIndex: number; node: JSONContent } | undefined {
+  const firstItem = matchMarkdownListItemLine(lines[startIndex] ?? "");
+  if (!firstItem || firstItem.indent < minIndent || firstItem.indent > minIndent + 3) {
+    return undefined;
+  }
+
+  const listIndent = firstItem.indent;
+  const kind = firstItem.kind;
+  const items: JSONContent[] = [];
+  let index = startIndex;
+
+  while (index < lines.length) {
+    const item = matchMarkdownListItemLine(lines[index] ?? "");
+    if (!item) {
+      const nextIndex = nextNonBlankLineIndex(lines, index);
+      if (nextIndex === index || nextIndex >= lines.length) {
+        break;
+      }
+      const peeked = matchMarkdownListItemLine(lines[nextIndex] ?? "");
+      if (peeked && peeked.kind === kind && peeked.indent === listIndent) {
+        index = nextIndex;
+        continue;
+      }
+      break;
+    }
+
+    if (item.indent !== listIndent || item.kind !== kind) {
+      break;
+    }
+
+    const itemContent: JSONContent[] = [
       {
         type: "paragraph",
-        content: parseInlineMarkdown(text),
+        content: parseInlineMarkdown(item.text),
       },
-    ],
+    ];
+    index += 1;
+
+    while (index < lines.length) {
+      let nested = tryParseMarkdownList(lines, index, listIndent + 1);
+      if (!nested) {
+        const nextIndex = nextNonBlankLineIndex(lines, index);
+        if (nextIndex === index || nextIndex >= lines.length) {
+          break;
+        }
+        nested = tryParseMarkdownList(lines, nextIndex, listIndent + 1);
+        if (!nested) {
+          break;
+        }
+      }
+      if (nested.nextIndex <= index) {
+        break;
+      }
+      itemContent.push(nested.node);
+      index = nested.nextIndex;
+    }
+
+    items.push({
+      type: "listItem",
+      content: itemContent,
+    });
+  }
+
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  if (kind === "ordered") {
+    return {
+      nextIndex: index,
+      node: {
+        type: "orderedList",
+        attrs: { start: firstItem.start ?? 1 },
+        content: items,
+      },
+    };
+  }
+
+  return {
+    nextIndex: index,
+    node: {
+      type: "bulletList",
+      content: items,
+    },
   };
 }
 
@@ -944,59 +1093,10 @@ function buildMarkdownTiptapContent(value: string): JSONContent {
       continue;
     }
 
-    const orderedListItem = matchMarkdownOrderedListItem(line);
-    if (orderedListItem) {
-      const start = Number.parseInt(orderedListItem[1] ?? "1", 10);
-      const items: JSONContent[] = [];
-      while (index < lines.length) {
-        const currentLine = lines[index] ?? "";
-        const currentItem = matchMarkdownOrderedListItem(currentLine);
-        if (!currentItem) {
-          const nextIndex = nextNonBlankLineIndex(lines, index);
-          if (
-            nextIndex !== index &&
-            matchMarkdownOrderedListItem(lines[nextIndex] ?? "") !== null
-          ) {
-            index = nextIndex;
-            continue;
-          }
-          break;
-        }
-        items.push(buildMarkdownListItem(currentItem[2] ?? ""));
-        index += 1;
-      }
-      content.push({
-        type: "orderedList",
-        attrs: { start },
-        content: items,
-      });
-      continue;
-    }
-
-    const bulletListItem = matchMarkdownBulletListItem(line);
-    if (bulletListItem) {
-      const items: JSONContent[] = [];
-      while (index < lines.length) {
-        const currentLine = lines[index] ?? "";
-        const currentItem = matchMarkdownBulletListItem(currentLine);
-        if (!currentItem) {
-          const nextIndex = nextNonBlankLineIndex(lines, index);
-          if (
-            nextIndex !== index &&
-            matchMarkdownBulletListItem(lines[nextIndex] ?? "") !== null
-          ) {
-            index = nextIndex;
-            continue;
-          }
-          break;
-        }
-        items.push(buildMarkdownListItem(currentItem[1] ?? ""));
-        index += 1;
-      }
-      content.push({
-        type: "bulletList",
-        content: items,
-      });
+    const parsedList = tryParseMarkdownList(lines, index, 0);
+    if (parsedList) {
+      content.push(parsedList.node);
+      index = parsedList.nextIndex;
       continue;
     }
 
@@ -1236,18 +1336,19 @@ function appendMarkdownInlineContent(
 function appendMarkdownListItem(
   node: ProseMirrorNode,
   state: TiptapReadState,
+  indent: string,
 ): void {
   let wroteFirstBlock = false;
   node.forEach((child) => {
     if (wroteFirstBlock) {
-      state.value += "\n  ";
+      state.value += `\n${indent}`;
     }
     wroteFirstBlock = true;
     if (child.type.name === "paragraph") {
       appendMarkdownInlineContent(child, state);
       return;
     }
-    appendMarkdownBlock(child, state, 0);
+    appendMarkdownBlock(child, state, 0, indent);
   });
 }
 
@@ -1255,9 +1356,10 @@ function appendMarkdownBlock(
   node: ProseMirrorNode,
   state: TiptapReadState,
   index: number,
+  indent = "",
 ): void {
   if (index > 0) {
-    state.value += "\n\n";
+    state.value += `\n\n${indent}`;
   }
 
   if (node.type.name === "paragraph") {
@@ -1286,10 +1388,11 @@ function appendMarkdownBlock(
   if (node.type.name === "bulletList") {
     node.forEach((child, _offset, listIndex) => {
       if (listIndex > 0) {
-        state.value += "\n";
+        state.value += `\n${indent}`;
       }
-      state.value += "- ";
-      appendMarkdownListItem(child, state);
+      const marker = markdownListMarker("bullet", listIndex);
+      state.value += marker;
+      appendMarkdownListItem(child, state, indent + " ".repeat(marker.length));
     });
     return;
   }
@@ -1298,10 +1401,11 @@ function appendMarkdownBlock(
     const start = typeof node.attrs.start === "number" ? node.attrs.start : 1;
     node.forEach((child, _offset, listIndex) => {
       if (listIndex > 0) {
-        state.value += "\n";
+        state.value += `\n${indent}`;
       }
-      state.value += `${start + listIndex}. `;
-      appendMarkdownListItem(child, state);
+      const marker = markdownListMarker("ordered", listIndex, start);
+      state.value += marker;
+      appendMarkdownListItem(child, state, indent + " ".repeat(marker.length));
     });
     return;
   }
@@ -1689,27 +1793,57 @@ function getCodeBlockMarkdownParts(node: ProseMirrorNode): {
   };
 }
 
+function getMarkdownListIndent(doc: ProseMirrorNode, pos: number): string {
+  const $pos = doc.resolve(pos);
+  let indent = "";
+  for (let depth = 1; depth <= $pos.depth; depth += 1) {
+    const ancestor = $pos.node(depth);
+    if (ancestor.type.name !== "listItem") {
+      continue;
+    }
+    const list = $pos.node(depth - 1);
+    if (list.type.name !== "bulletList" && list.type.name !== "orderedList") {
+      continue;
+    }
+    const start = typeof list.attrs.start === "number" ? list.attrs.start : 1;
+    indent += " ".repeat(
+      markdownListMarker(
+        list.type.name === "bulletList" ? "bullet" : "ordered",
+        $pos.index(depth - 1),
+        start,
+      ).length,
+    );
+  }
+  return indent;
+}
+
 function getMarkdownBlockPrefixLength(
   node: ProseMirrorNode,
   parent: ProseMirrorNode | null,
   childIndex: number,
+  doc: ProseMirrorNode,
+  pos: number,
 ): number {
   if (parent?.type.name === "doc" && node.type.name === "heading") {
     const level = typeof node.attrs.level === "number" ? node.attrs.level : 1;
     return `${"#".repeat(Math.min(Math.max(level, 1), 6))} `.length;
   }
 
+  const indent = getMarkdownListIndent(doc, pos);
+
   if (parent?.type.name === "bulletList" && node.type.name === "listItem") {
-    return `${childIndex > 0 ? "\n" : ""}- `.length;
+    const marker = markdownListMarker("bullet", childIndex);
+    return childIndex > 0 ? `\n${indent}${marker}`.length : marker.length;
   }
 
   if (parent?.type.name === "orderedList" && node.type.name === "listItem") {
     const start = typeof parent.attrs.start === "number" ? parent.attrs.start : 1;
-    return `${childIndex > 0 ? "\n" : ""}${start + childIndex}. `.length;
+    const marker = markdownListMarker("ordered", childIndex, start);
+    return childIndex > 0 ? `\n${indent}${marker}`.length : marker.length;
   }
 
   if (parent?.type.name === "listItem" && childIndex > 0) {
-    return "\n  ".length;
+    return `\n${indent}`.length;
   }
 
   return 0;
@@ -1763,7 +1897,13 @@ function getDraftIndexAtPosition(
     }
 
     if (mode === "markdown") {
-      const prefixLength = getMarkdownBlockPrefixLength(node, parent, childIndex);
+      const prefixLength = getMarkdownBlockPrefixLength(
+        node,
+        parent,
+        childIndex,
+        editor.state.doc,
+        pos,
+      );
       if (prefixLength > 0) {
         if (position <= pos + 1) {
           index += prefixLength;
@@ -1870,7 +2010,13 @@ function getPositionAtDraftIndex(
     }
 
     if (mode === "markdown") {
-      const prefixLength = getMarkdownBlockPrefixLength(node, parent, childIndex);
+      const prefixLength = getMarkdownBlockPrefixLength(
+        node,
+        parent,
+        childIndex,
+        editor.state.doc,
+        pos,
+      );
       if (prefixLength > 0) {
         if (draftIndex <= index + prefixLength) {
           position = pos + 1;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -138,6 +138,18 @@ const canonicalHandoffPrefixWithCodeBlock = [
   "```",
 ].join("\n");
 
+const nestedOrderedMarkdown = [
+  "1. Discord-specific fixes",
+  "   1. Timestamp inbound immediately",
+  "   2. Move breadcrumb lookups off the critical path",
+  "   3. Add stage timings through startTurn",
+  "2. Busted thread info cache",
+  "   1. Resolve occupancy from cached thread state",
+  "      1. Change the admission path as described",
+  "   2. Keep Git enrichment out of reply admission",
+  "      1. Do not wait on a 3 second full cache refresh",
+].join("\n");
+
 const pastedCatalogSql = [
   "SELECT s.item_code, m.category, aisle, SUM(units) AS _units",
   "",
@@ -1155,6 +1167,262 @@ describe("ComposerTiptapInput", () => {
     expect(container.querySelector("hr")).toBeNull();
     expect(container.querySelectorAll("li")).toHaveLength(4);
     expect(inputRef.current?.value).toBe(original);
+  });
+
+  it("serializes every nested ordered-list sibling with indent", async () => {
+    const inputRef = createRef<ComposerInputHandle>();
+
+    render(
+      <ComposerTiptapInput
+        ref={inputRef}
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "orderedList",
+              attrs: { start: 1 },
+              content: [
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Discord-specific fixes" }],
+                    },
+                    {
+                      type: "orderedList",
+                      attrs: { start: 1 },
+                      content: [
+                        {
+                          type: "listItem",
+                          content: [{
+                            type: "paragraph",
+                            content: [{ type: "text", text: "Timestamp inbound immediately" }],
+                          }],
+                        },
+                        {
+                          type: "listItem",
+                          content: [{
+                            type: "paragraph",
+                            content: [{
+                              type: "text",
+                              text: "Move breadcrumb lookups off the critical path",
+                            }],
+                          }],
+                        },
+                        {
+                          type: "listItem",
+                          content: [{
+                            type: "paragraph",
+                            content: [{
+                              type: "text",
+                              text: "Add stage timings through startTurn",
+                            }],
+                          }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Busted thread info cache" }],
+                    },
+                    {
+                      type: "orderedList",
+                      attrs: { start: 1 },
+                      content: [
+                        {
+                          type: "listItem",
+                          content: [
+                            {
+                              type: "paragraph",
+                              content: [{
+                                type: "text",
+                                text: "Resolve occupancy from cached thread state",
+                              }],
+                            },
+                            {
+                              type: "orderedList",
+                              attrs: { start: 1 },
+                              content: [{
+                                type: "listItem",
+                                content: [{
+                                  type: "paragraph",
+                                  content: [{
+                                    type: "text",
+                                    text: "Change the admission path as described",
+                                  }],
+                                }],
+                              }],
+                            },
+                          ],
+                        },
+                        {
+                          type: "listItem",
+                          content: [
+                            {
+                              type: "paragraph",
+                              content: [{
+                                type: "text",
+                                text: "Keep Git enrichment out of reply admission",
+                              }],
+                            },
+                            {
+                              type: "orderedList",
+                              attrs: { start: 1 },
+                              content: [{
+                                type: "listItem",
+                                content: [{
+                                  type: "paragraph",
+                                  content: [{
+                                    type: "text",
+                                    text: "Do not wait on a 3 second full cache refresh",
+                                  }],
+                                }],
+                              }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={() => undefined}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value={nestedOrderedMarkdown}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply" });
+
+    await waitFor(() => {
+      expect(inputRef.current?.value).toBe(nestedOrderedMarkdown);
+    });
+  });
+
+  it("parses an indented three-level numbered list instead of flattening it", async () => {
+    const inputRef = createRef<ComposerInputHandle>();
+    const { container } = render(
+      <ComposerTiptapInput
+        ref={inputRef}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={() => undefined}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value={nestedOrderedMarkdown}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply" });
+
+    const editor = container.querySelector(".composer-tiptap-input__editor");
+    expect(editor).not.toBeNull();
+    await waitFor(() => {
+      expect(editor?.querySelectorAll(":scope > ol")).toHaveLength(1);
+      expect(editor?.querySelectorAll(":scope > ol > li")).toHaveLength(2);
+      expect(editor?.querySelectorAll(":scope > ol > li:first-child > ol > li")).toHaveLength(3);
+      expect(editor?.querySelectorAll(":scope > ol > li:last-child > ol > li")).toHaveLength(2);
+      expect(
+        editor?.querySelectorAll(":scope > ol > li:last-child > ol > li:first-child > ol > li"),
+      ).toHaveLength(1);
+      expect(
+        editor?.querySelectorAll(":scope > ol > li:last-child > ol > li:last-child > ol > li"),
+      ).toHaveLength(1);
+      expect(inputRef.current?.value).toBe(nestedOrderedMarkdown);
+    });
+  });
+
+  it("serializes every nested bullet sibling with indent", async () => {
+    const inputRef = createRef<ComposerInputHandle>();
+    const nestedBulletMarkdown = [
+      "- Parent task",
+      "  - Nested one",
+      "  - Nested two",
+      "    - Grandchild",
+    ].join("\n");
+
+    render(
+      <ComposerTiptapInput
+        ref={inputRef}
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "bulletList",
+              content: [
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Parent task" }],
+                    },
+                    {
+                      type: "bulletList",
+                      content: [
+                        {
+                          type: "listItem",
+                          content: [{
+                            type: "paragraph",
+                            content: [{ type: "text", text: "Nested one" }],
+                          }],
+                        },
+                        {
+                          type: "listItem",
+                          content: [
+                            {
+                              type: "paragraph",
+                              content: [{ type: "text", text: "Nested two" }],
+                            },
+                            {
+                              type: "bulletList",
+                              content: [{
+                                type: "listItem",
+                                content: [{
+                                  type: "paragraph",
+                                  content: [{ type: "text", text: "Grandchild" }],
+                                }],
+                              }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={() => undefined}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value={nestedBulletMarkdown}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply" });
+
+    await waitFor(() => {
+      expect(inputRef.current?.value).toBe(nestedBulletMarkdown);
+    });
   });
 
   it("serializes marked trailing spaces outside delimiters before plain text", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -848,6 +848,36 @@ describe("ThreadMarkdown", () => {
     expect(screen.getByText("Second List - One")).toBeInTheDocument();
   });
 
+  it("renders nested numbered lists instead of flattening them", () => {
+    const { container } = render(
+      <ThreadMarkdown
+        text={[
+          "1. Discord-specific fixes",
+          "   1. Timestamp inbound immediately",
+          "   2. Move breadcrumb lookups off the critical path",
+          "   3. Add stage timings through startTurn",
+          "2. Busted thread info cache",
+          "   1. Resolve occupancy from cached thread state",
+          "      1. Change the admission path as described",
+          "   2. Keep Git enrichment out of reply admission",
+          "      1. Do not wait on a 3 second full cache refresh",
+        ].join("\n")}
+      />
+    );
+
+    const rootList = container.querySelector(".thread-markdown > ol.transcript-message__list");
+    expect(rootList).not.toBeNull();
+    expect(rootList?.querySelectorAll(":scope > li")).toHaveLength(2);
+    expect(rootList?.querySelectorAll(":scope > li:first-child > ol > li")).toHaveLength(3);
+    expect(rootList?.querySelectorAll(":scope > li:last-child > ol > li")).toHaveLength(2);
+    expect(
+      rootList?.querySelectorAll(":scope > li:last-child > ol > li:first-child > ol > li"),
+    ).toHaveLength(1);
+    expect(container.querySelectorAll(".thread-markdown > ol > li")).toHaveLength(2);
+    expect(screen.getByText("Discord-specific fixes")).toBeInTheDocument();
+    expect(screen.getByText("Change the admission path as described")).toBeInTheDocument();
+  });
+
   it("keeps composer-style hyphen-only bullet items visible", () => {
     const { container } = render(
       <ThreadMarkdown


### PR DESCRIPTION
## Summary

- Nested numbered lists in the composer were flattening to a single-level `1..N` list in the transcript and in the markdown sent to the model.
- The TipTap serializer only indented the first nested child (`\n  `). Later siblings and deeper items were written at column 0, so CommonMark treated them as one ordered list and auto-renumbered.
- The markdown parser had the same hole: it collected every `0–3` space `1. item` into one flat list and ignored deeper indent.
- This PR serializes every nested item with marker-width indent (`1. ` → 3 spaces, `- ` → 2 spaces) and reconstructs nested lists from indented markdown.

That is also the answer to “was it sent as a single- or triple-level list?”: **single-level**. The composer markdown is the user message. Codex stored and the transcript rendered the flattened form.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx` (82 passed)
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- Transcript rendering of *correctly indented* nested markdown already worked via `react-markdown` / `remark-gfm`. The new ThreadMarkdown test locks that so a future renderer change cannot flatten it again.
- Existing HTML-paste coverage for a single nested bullet inside a blockquote still passes. The new tests cover ordered 3-level lists with multiple siblings — the shape that actually hit this thread.