### PR TITLE
fix(desktop): skip unsupported remote PR refresh

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -117,6 +117,11 @@ const federationMock = vi.hoisted(() => {
     remoteBackend,
     remoteThreadSummaries,
     runtime: {
+      connectedPeerTargets: vi.fn((): Array<{
+        target: { scope: "remote"; instanceId: string };
+        label: string;
+        capabilities: string[];
+      }> => []),
       health: vi.fn(async () => ({ instanceId: "pwr_local" })),
       hydrateThreadMessageOrigins: vi.fn(async (response) => response),
       remoteBackend: vi.fn(() => remoteBackend),
@@ -1017,6 +1022,8 @@ describe("app server ipc", () => {
     federationMock.remoteBackend.listWorktreeUnpublishedCommits.mockClear();
     federationMock.remoteBackend.getWorktreeUnpublishedCommitDiff.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
+    federationMock.runtime.connectedPeerTargets.mockReset();
+    federationMock.runtime.connectedPeerTargets.mockReturnValue([]);
     federationMock.runtime.remoteTargetSupportsCapability.mockReset();
     federationMock.runtime.remoteTargetSupportsCapability.mockReturnValue(true);
     federationMock.runtime.hydrateThreadMessageOrigins.mockClear();
@@ -4222,6 +4229,111 @@ describe("app server ipc", () => {
       ghAvailable: true,
       prs: [],
     });
+  });
+
+  it("skips remote PR refresh when the attached profile lacks navigation support", async () => {
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "pwr_owner",
+    };
+    federationMock.runtime.remoteTargetSupportsCapability.mockReturnValueOnce(
+      false,
+    );
+    federationMock.runtime.connectedPeerTargets.mockReturnValueOnce([
+      {
+        target: federationTarget,
+        label: "Mac-Mini-M4 / dev",
+        capabilities: [],
+      },
+    ]);
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      { sender: { id: 999 } },
+      {
+        backend: "codex",
+        threadId: "thread-remote",
+        trigger: "scheduled",
+        branch: "fix/remote-pr-refresh",
+        directoryPaths: ["/remote/repo"],
+        federationTarget,
+      },
+    );
+
+    expect(
+      federationMock.remoteBackend.refreshThreadPullRequests,
+    ).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-remote",
+      provider: "github.com",
+      ghAvailable: false,
+      prs: [],
+      refreshStarted: false,
+      skippedReason: "remote_refresh_unsupported",
+    });
+    expect(mockAppServerLog.info).toHaveBeenCalledWith(
+      "thread PR refresh skipped: attached instance \"Mac-Mini-M4 / dev\" does not support remote PR refresh",
+      {
+        backend: "codex",
+        instanceId: "pwr_owner",
+        reason: "missing-thread-navigation-capability",
+        threadId: "thread-remote",
+      },
+    );
+  });
+
+  it("degrades missing remote PR refresh methods without surfacing an IPC error", async () => {
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "pwr_owner",
+    };
+    federationMock.runtime.connectedPeerTargets.mockReturnValueOnce([
+      {
+        target: federationTarget,
+        label: "Mac-Mini-M4 / default",
+        capabilities: ["thread_navigation"],
+      },
+    ]);
+    federationMock.remoteBackend.refreshThreadPullRequests.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "method_not_found: No federation handler registered for backend.refreshThreadPullRequests",
+        ),
+        { code: "method_not_found" },
+      ),
+    );
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      { sender: { id: 999 } },
+      {
+        backend: "codex",
+        threadId: "thread-remote",
+        trigger: "scheduled",
+        branch: "fix/remote-pr-refresh",
+        directoryPaths: ["/remote/repo"],
+        federationTarget,
+      },
+    );
+
+    expect(response).toMatchObject({
+      backend: "codex",
+      threadId: "thread-remote",
+      refreshStarted: false,
+      skippedReason: "remote_refresh_unsupported",
+    });
+    expect(mockAppServerLog.info).toHaveBeenCalledWith(
+      "thread PR refresh skipped: attached instance \"Mac-Mini-M4 / default\" does not support remote PR refresh",
+      {
+        backend: "codex",
+        instanceId: "pwr_owner",
+        reason: "remote-method-not-found",
+        threadId: "thread-remote",
+      },
+    );
   });
 
   it("resolves federated PR refresh inputs from the owner's thread state", async () => {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -767,6 +767,15 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
   appServerLog.debug(event, payload);
 }
 
+function isFederationMethodNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error
+    && typeof error === "object"
+    && "code" in error
+    && error.code === "method_not_found",
+  );
+}
+
 async function hydrateRetainedThreadOverlayData(
   overlayStore: OverlayStoreLike,
   threads: AppServerThreadSummary[],
@@ -3613,14 +3622,57 @@ class DesktopAppServerService {
       request.federationTarget
       && isRemoteFederationTarget(request.federationTarget)
     ) {
-      return await getDesktopFederationRuntime()
-        .remoteBackend(request.federationTarget)
-        .refreshThreadPullRequests({
-          backend: request.backend,
+      const federationTarget = request.federationTarget;
+      const federationRuntime = getDesktopFederationRuntime();
+      const instanceLabel = federationRuntime.connectedPeerTargets().find(
+        (peer) => peer.target.instanceId === federationTarget.instanceId,
+      )?.label ?? federationTarget.instanceId;
+      const skippedResponse = (
+        reason:
+          | "missing-thread-navigation-capability"
+          | "remote-method-not-found",
+      ): RefreshThreadPullRequestsResponse => {
+        const backend = request.backend ?? "codex";
+        appServerLog.info(
+          `thread PR refresh skipped: attached instance "${instanceLabel}" does not support remote PR refresh`,
+          {
+            backend,
+            instanceId: federationTarget.instanceId,
+            reason,
+            threadId: request.threadId,
+          },
+        );
+        return {
+          backend,
           threadId: request.threadId,
-          ...(request.provider ? { provider: request.provider } : {}),
-          ...(request.trigger ? { trigger: request.trigger } : {}),
-        });
+          provider: request.provider ?? DEFAULT_PULL_REQUEST_PROVIDER,
+          ghAvailable: false,
+          prs: [],
+          refreshStarted: false,
+          skippedReason: "remote_refresh_unsupported",
+        };
+      };
+      if (!federationRuntime.remoteTargetSupportsCapability(
+        federationTarget,
+        "thread_navigation",
+      )) {
+        return skippedResponse("missing-thread-navigation-capability");
+      }
+      try {
+        return await federationRuntime
+          .remoteBackend(federationTarget)
+          .refreshThreadPullRequests({
+            backend: request.backend,
+            threadId: request.threadId,
+            ...(request.provider ? { provider: request.provider } : {}),
+            ...(request.trigger ? { trigger: request.trigger } : {}),
+          });
+      } catch (error) {
+        if (isFederationMethodNotFoundError(error)) {
+          return skippedResponse("remote-method-not-found");
+        }
+        throw error;
+      }
     }
     const backend = request.backend ?? "codex";
     const requestKey = getThreadPullRequestsRequestKey(backend, request);

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -193,6 +193,32 @@ describe("usePullRequestRefresh", () => {
     expect(onRefreshNavigation).not.toHaveBeenCalled();
   });
 
+  it("does not refresh navigation when an attached instance skips the probe", async () => {
+    const onRefreshNavigation = vi.fn(async () => undefined);
+    const refreshThreadPullRequests = vi.fn(async () => buildResponse({
+      ghAvailable: false,
+      prs: [],
+      refreshStarted: false,
+      skippedReason: "remote_refresh_unsupported",
+    }));
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    renderHook(() =>
+      usePullRequestRefresh({
+        desktopApi,
+        onRefreshNavigation,
+        selectedThread: buildThread({ prs: buildResponse().prs }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledOnce();
+    });
+    expect(onRefreshNavigation).not.toHaveBeenCalled();
+  });
+
   it("refreshes navigation when a failing PR gains running-check metadata", async () => {
     const currentPr = {
       ...buildResponse().prs[0]!,

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -76,6 +76,9 @@ export function usePullRequestRefresh(params: {
           ...(federationTarget ? { federationTarget } : {}),
         })
         .then((response) => {
+          if (response.skippedReason) {
+            return;
+          }
           if (prSummariesEqual(thread.prs, response.prs)) {
             return;
           }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -4781,6 +4781,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 onOpen={() => openInstance(position.instanceId)}
                 onToggleLoad={
                   props.desktopApi?.readFederationInstanceLoad
+                  && health
                   && (position.instanceId === localInstanceId
                     || entry.peer?.status === "connected")
                     ? () => toggleLoadCard(position.instanceId)

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -147,9 +147,12 @@ describe("StarMapScreen", () => {
   });
 
   it("writes load-card membership into the synced arrangement", async () => {
+    const healthResponse = await buildDesktopApi().readFederationHealth!({});
+    const health = createDeferred<typeof healthResponse>();
     const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
     const desktopApi: DesktopApi = {
       ...buildDesktopApi(),
+      readFederationHealth: vi.fn(async () => await health.promise),
       readStarMapArrangement: vi.fn(async () => ({ entries: [] })),
       setStarMapCardPosition,
       readFederationInstanceLoad: vi.fn(async () => ({})),
@@ -165,6 +168,13 @@ describe("StarMapScreen", () => {
       />,
     );
 
+    expect(
+      screen.queryByRole("button", { name: /^Show load for/ }),
+    ).toBeNull();
+    await act(async () => {
+      health.resolve(healthResponse);
+      await health.promise;
+    });
     await waitFor(() => {
       expect(
         screen.queryByRole("button", { name: /^Show load for/ }),

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1815,6 +1815,11 @@ export type RefreshThreadPullRequestsResponse = {
   lastStatusCheckAgeMs?: number;
   /** True when main accepted this request and started a provider refresh. */
   refreshStarted?: boolean;
+  /**
+   * Present when main intentionally skipped the refresh because the attached
+   * remote instance does not support this federation operation.
+   */
+  skippedReason?: "remote_refresh_unsupported";
   /** True when the host doesn't have `gh` installed; degrade silently. */
   ghAvailable: boolean;
   /**


### PR DESCRIPTION
## Summary

- skip remote PR refresh RPCs when the attached instance does not advertise thread navigation support
- gracefully downgrade older-peer `method_not_found` responses to a structured skip with the disambiguated instance/profile label in the log
- prevent skipped responses from triggering a redundant renderer navigation refresh

## Regression coverage

- verifies unsupported peers never receive `backend.refreshThreadPullRequests`
- verifies older peers without the method do not surface an IPC error
- verifies skipped responses leave renderer navigation unchanged

## Verification

- `pnpm test` (637 files; 9,256 passed; 6 skipped)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`