### PR TITLE
fix(messaging): remove Discord ingress enrichment latency

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -116,6 +116,79 @@ afterEach(async () => {
 });
 
 describe("MessagingController", () => {
+  it("logs provider-neutral ingress stages through startTurn acceptance", async () => {
+    let clock = 2_000;
+    const info = vi.fn();
+    const harness = await createHarness({
+      logger: { info },
+      now: () => clock,
+      startTurn: async (request) => {
+        clock = 2_213;
+        return {
+          backend: request.backend,
+          threadId: request.threadId,
+          turnId: "turn-latency",
+        };
+      },
+    });
+    await bindThread(harness);
+    info.mockClear();
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("measure ingress"),
+      providerSentAt: 900,
+      receivedAt: 1_000,
+    });
+
+    expect(info).toHaveBeenCalledWith(
+      "messaging starting turn",
+      expect.objectContaining({
+        inboundEventId: "event-text",
+        providerSentAt: 900,
+        providerSentToPwragentReceivedMs: 100,
+        pwragentReceivedAt: 1_000,
+        pwragentReceivedToStartTurnIssueMs: 1_000,
+        startTurnIssuedAt: 2_000,
+      }),
+    );
+    expect(info).toHaveBeenCalledWith(
+      "messaging turn started",
+      expect.objectContaining({
+        pwragentReceivedToStartTurnAcceptedMs: 1_213,
+        startTurnAcceptedAt: 2_213,
+        startTurnIssueToAcceptedMs: 213,
+      }),
+    );
+  });
+
+  it("merges eventual provider channel metadata without replaying inbound", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundChannelMetadata({
+      eventId: "event-text",
+      observedAt: 1_500,
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+          title: "Harold",
+        },
+      },
+    });
+
+    await expect(
+      harness.store.findActiveBindingForChannel(buildTextEvent("").channel),
+    ).resolves.toMatchObject({
+      channel: {
+        conversation: { title: "Harold" },
+      },
+    });
+    expect(harness.onBindingChanged).toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+  });
+
   it("creates, edits, sends, and cancels scheduled messages through the backend", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -112,6 +112,19 @@ describe("DesktopMessagingRuntime", () => {
     // regression there still fails fast instead of idling for the full 30s.
   }, process.platform === "win32" ? 30_000 : 15_000);
 
+  it("rejects provider events without a first-boundary receipt timestamp", async () => {
+    const { runtime, adapter } = await createRuntimeHarness();
+    await runtime.start();
+    const invalidEvent = {
+      ...buildCommandEvent("/resume"),
+      receivedAt: undefined,
+    } as unknown as MessagingInboundEvent;
+
+    await expect(adapter.listener?.(invalidEvent)).rejects.toThrow(
+      "omitted a finite first-boundary receivedAt",
+    );
+  });
+
   it("subscribes only to federated bindings on running adapters", async () => {
     const { runtime, bridge } = await createRuntimeHarness();
     const { getDesktopMessagingStore } = await import(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -87,6 +87,7 @@ import type {
   MessagingDefaultAgentScope,
   MessagingInboundCallbackEvent,
   MessagingInboundCommandEvent,
+  MessagingInboundChannelMetadataUpdate,
   MessagingInboundEvent,
   MessagingInboundMediaEvent,
   MessagingInboundTextEvent,
@@ -1151,6 +1152,20 @@ export class MessagingController {
     }
   }
 
+  async handleInboundChannelMetadata(
+    update: MessagingInboundChannelMetadataUpdate,
+  ): Promise<void> {
+    try {
+      await this.refreshBindingChannelMetadata(update.channel, update.routingState);
+    } catch (error) {
+      this.logger.debug?.("messaging inbound metadata enrichment failed", {
+        eventId: update.eventId,
+        platform: update.channel.channel,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async deliverAutomationSourceMessage(params: {
     broadcast?: boolean;
     destination: "source_thread" | "source_channel";
@@ -2130,17 +2145,24 @@ export class MessagingController {
   private async refreshBindingFromInbound(
     event: MessagingInboundEvent,
   ): Promise<void> {
+    await this.refreshBindingChannelMetadata(event.channel, event.routingState);
+  }
+
+  private async refreshBindingChannelMetadata(
+    channel: MessagingChannelRef,
+    routingStateUpdate?: MessagingAdapterState,
+  ): Promise<void> {
     const binding = await this.options.store.findActiveBindingForChannel(
-      event.channel,
+      channel,
     );
     if (!binding) return;
     const stored = binding.channel.conversation;
-    const incoming = event.channel.conversation;
+    const incoming = channel.conversation;
     // Incoming wins when present. Adapters fetch fresher metadata
     // than we stored at bind time:
-    //   - Discord resolves channel/parent/guild names via REST every
-    //     inbound (bounded LRU cache), so a server or channel rename
-    //     reaches us on the next message.
+    //   - Discord publishes channel/parent/guild names through the
+    //     post-dispatch metadata hook after bounded-LRU REST enrichment,
+    //     so a server or channel rename reaches us without delaying admission.
     //   - Telegram caches forum-topic names from `forum_topic_created`
     //     and `forum_topic_edited` service messages, so renames done
     //     in the Telegram client propagate to subsequent inbound
@@ -2158,7 +2180,7 @@ export class MessagingController {
     const managedTopic =
       incoming.kind === "topic" && incoming.parentId
         ? await this.options.store.findManagedTopicByConversation({
-            channel: event.channel.channel,
+            channel: channel.channel,
             supergroupId: incoming.parentId,
             topicId: incoming.id,
           })
@@ -2172,7 +2194,7 @@ export class MessagingController {
       ancestorTitle:
         incoming.ancestorTitle ?? stored.ancestorTitle ?? managedConversation?.ancestorTitle,
     };
-    const routingState = event.routingState ?? binding.routingState;
+    const routingState = routingStateUpdate ?? binding.routingState;
     const changed =
       merged.title !== stored.title
       || merged.parentTitle !== stored.parentTitle
@@ -4034,6 +4056,20 @@ export class MessagingController {
       // threadId to verify the routing matched intent. `executionModeSource` of
       // anything other than `thread` is suspicious for a thread the UI
       // claims has been explicitly toggled.
+      const startTurnIssuedAt = this.now();
+      const inboundTiming = params.event
+        ? {
+            inboundEventId: params.event.id,
+            providerSentAt: params.event.providerSentAt,
+            pwragentReceivedAt: params.event.receivedAt,
+            providerSentToPwragentReceivedMs:
+              params.event.providerSentAt === undefined
+                ? undefined
+                : params.event.receivedAt - params.event.providerSentAt,
+            pwragentReceivedToStartTurnIssueMs:
+              startTurnIssuedAt - params.event.receivedAt,
+          }
+        : {};
       this.logger.info?.("messaging starting turn", {
         backend: params.binding.backend,
         bindingId: params.binding.id,
@@ -4043,6 +4079,8 @@ export class MessagingController {
         executionModeSource: executionResolution.source,
         model: turnSettings.model,
         fastMode: turnSettings.fastMode,
+        startTurnIssuedAt,
+        ...inboundTiming,
       });
       const started = await this.options.backend.startTurn({
         backend: params.binding.backend,
@@ -4052,6 +4090,18 @@ export class MessagingController {
         messageOrigin: messageOriginForInboundEvent(params.event),
         ...turnSettings,
       });
+      const startTurnAcceptedAt = this.now();
+      const acceptanceTiming = params.event
+        ? {
+            pwragentReceivedToStartTurnAcceptedMs:
+              startTurnAcceptedAt - params.event.receivedAt,
+            startTurnIssueToAcceptedMs: startTurnAcceptedAt - startTurnIssuedAt,
+            startTurnAcceptedAt,
+          }
+        : {
+            startTurnIssueToAcceptedMs: startTurnAcceptedAt - startTurnIssuedAt,
+            startTurnAcceptedAt,
+          };
       if (started.queueStatus === "queued") {
         this.rememberQueuedAgentMessagingOrigin({
           binding: params.binding,
@@ -4065,6 +4115,7 @@ export class MessagingController {
           threadId: params.binding.threadId,
           queueEntryId: started.queueEntryId ?? started.turnId,
           requestedExecutionMode: turnSettings.executionMode ?? "unset",
+          ...acceptanceTiming,
         });
         return "queued";
       }
@@ -4074,6 +4125,7 @@ export class MessagingController {
         threadId: params.binding.threadId,
         turnId: started.turnId,
         requestedExecutionMode: turnSettings.executionMode ?? "unset",
+        ...acceptanceTiming,
       });
       const activeTurn: MessagingActiveTurnSummary = {
         turnId: started.turnId,

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -47,6 +47,7 @@ import type {
   MessagingDeliveryResult,
   MessagingDeliveryScope,
   MessagingInboundEvent,
+  MessagingInboundChannelMetadataListener,
   MessagingInboundRejectedListener,
   MessagingManagedConversationActionRequest,
   MessagingManagedConversationActionResult,
@@ -62,6 +63,7 @@ import type {
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import {
+  assertMessagingInboundReceipt,
   extractMessagingPairingToken,
   isMessagingPairingCommand,
   MESSAGING_PAIRING_COMMAND,
@@ -143,6 +145,7 @@ export type DesktopMessagingAdapter = {
   onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
   onReconnect?(listener: (info: MessagingReconnectInfo) => void): () => void;
   onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
+  onInboundChannelMetadata?(listener: MessagingInboundChannelMetadataListener): () => void;
   onDiagnostic?(listener: (event: MessagingAdapterDiagnosticEvent) => void): () => void;
   updateAuthorization?(update: MessagingAdapterAuthorizationUpdate): Promise<void>;
   updateRenderingPreferences?(
@@ -210,6 +213,7 @@ type RunningMessagingAdapter = {
   fingerprint: string;
   unsubscribeDiagnostic?: () => void;
   unsubscribeInboundRejected?: () => void;
+  unsubscribeInboundChannelMetadata?: () => void;
   unsubscribeRateLimit?: () => void;
   unsubscribeReconnect?: () => void;
   unsubscribeRuntimeError?: () => void;
@@ -1401,6 +1405,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
 
     let unsubscribeDiagnostic: (() => void) | undefined;
     let unsubscribeInboundRejected: (() => void) | undefined;
+    let unsubscribeInboundChannelMetadata: (() => void) | undefined;
     try {
       unsubscribeDiagnostic = adapter.onDiagnostic?.((event) => {
         this.emitPlatformActivity(adapter.channel);
@@ -1428,8 +1433,12 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       unsubscribeInboundRejected = adapter.onInboundRejected?.(async (event) => {
         await this.handleRejectedInbound(adapter.channel, event, store);
       });
+      unsubscribeInboundChannelMetadata = adapter.onInboundChannelMetadata?.(async (update) => {
+        await controller.handleInboundChannelMetadata(update);
+      });
       this.setPlatformHealth(adapter.channel, "unknown");
       await this.startAdapterWithDeadline(adapter, async (event) => {
+        assertMessagingInboundReceipt(event);
         // Activity ping fires on every inbound, before authorization checks.
         this.emitPlatformActivity(adapter.channel);
         if (await this.handlePairingInbound(adapter, event, store)) {
@@ -1527,6 +1536,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       } catch {
         // Best effort cleanup after startup failure.
       }
+      try {
+        unsubscribeInboundChannelMetadata?.();
+      } catch {
+        // Best effort cleanup after startup failure.
+      }
       controller.dispose();
       const cancelled = error instanceof AdapterStartCancelledError;
       if (cancelled) {
@@ -1584,6 +1598,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       fingerprint: messagingAdapterConfigFingerprint(config, adapter.channel),
       unsubscribeDiagnostic,
       unsubscribeInboundRejected,
+      unsubscribeInboundChannelMetadata,
       unsubscribeRateLimit,
       unsubscribeReconnect,
       unsubscribeRuntimeError,
@@ -1784,6 +1799,13 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       running.unsubscribeRuntimeError?.();
     } catch (error) {
       messagingLog.warn("messaging adapter runtime-error unsubscribe threw", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    try {
+      running.unsubscribeInboundChannelMetadata?.();
+    } catch (error) {
+      messagingLog.warn("messaging adapter inbound-metadata unsubscribe threw", {
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -49,6 +49,29 @@ turn admission policy that coalesces split input, prevents overlapping
 `turn/start` calls, queues follow-ups during active turns, and maps queued
 input to `turn/steer` or a later `turn/start`.
 
+Every inbound event carries two deliberately distinct time concepts:
+
+- `receivedAt` is required and means the PwrAgent wall-clock time captured at
+  the provider adapter's first handler boundary. Capture it before validation,
+  authorization, parsing that can throw, network enrichment, or any `await`.
+- `providerSentAt` is optional and preserves the original message time only
+  when the provider supplies one. Do not copy the provider time into
+  `receivedAt`, and do not invent `providerSentAt` for callbacks or transports
+  that omit it.
+
+Use `captureMessagingInboundReceipt(receivedAt, providerSentAt?)` from the
+interface package and spread the returned receipt into normalized events. The
+desktop runtime calls `assertMessagingInboundReceipt` before admission, so an
+adapter that omits or corrupts the first-boundary timestamp fails the contract
+at dispatch instead of producing misleading latency data.
+
+Inbound publication must precede optional network enrichment. If channel,
+workspace, guild, or parent-thread breadcrumbs require REST, dispatch the
+minimal authorized channel reference first. Providers may publish the eventual
+result through `onInboundChannelMetadata`; desktop orchestration merges it into
+an existing binding without replaying the inbound message or delaying turn
+admission.
+
 The `actor.platformUserId` must be the stable platform ID used for
 authorization. Mutable usernames and display names may be included for audit or
 operator visibility only.

--- a/docs/messaging-adding-a-provider.md
+++ b/docs/messaging-adding-a-provider.md
@@ -279,7 +279,15 @@ Whenever the platform reports something the user did, normalize it to a `Messagi
 | `media` | User uploaded a file. | Attachment descriptors (each with `id`, `kind`, `name`, `disposition: "available"` if it's downloadable, optional MIME/size/dimensions, and `state.opaque` for download metadata) + a top-level `disposition` on the event itself. |
 | `lifecycle` | Bot was added/removed from a channel; rare. | The fixed `lifecycle` enum: `"bound" \| "detached" \| "revoked" \| "adapter_started" \| "adapter_stopped"` — **not** a free-form reason. |
 
-**Required fields you'll forget:** every inbound event needs `receivedAt: this.now()` (not `occurredAt`). Every `media` event needs **both** a per-attachment `disposition` *and* a top-level `disposition` on the event. Every attachment descriptor needs `id` (the platform's stable file id, used by `downloadAttachment` to look up bytes).
+**Required fields you'll forget:** capture
+`captureMessagingInboundReceipt(this.now(), providerSentAt?)` as the first line
+of the provider handler, before validation or any `await`, and spread it into
+every dispatched event. `receivedAt` is PwrAgent receipt time, not the
+provider's original message time. Preserve the latter separately as
+`providerSentAt` only when the payload supplies it; never invent one. Every
+`media` event also needs **both** a per-attachment `disposition` and a top-level
+`disposition` on the event. Every attachment descriptor needs `id` (the
+platform's stable file id, used by `downloadAttachment` to look up bytes).
 
 For each event, **always**:
 
@@ -288,6 +296,11 @@ For each event, **always**:
 - In group/server surfaces, enforce the platform's configured conversation allowlist too (Telegram supergroups, Discord guilds, etc.) before dispatch. Unauthorized general chatter should drop silently; log only actionable attempts such as DMs, slash commands, button clicks, or bot mentions, and rate-limit repeated unauthorized conversation logs.
 - Mutable usernames / display names belong in `actor.displayName` / `actor.username` for audit, never as the authorization key.
 - Provider-specific routing (channel id, supergroup id, post id) goes inside `MessagingAdapterState.opaque`. The controller may persist and echo this state but **must not parse it** — only your adapter knows the schema.
+- Dispatch the normalized event before optional REST breadcrumb/permalink
+  enrichment. If the first event cannot carry full channel ancestry without a
+  lookup, emit the eventual channel metadata through
+  `onInboundChannelMetadata`; never make visibility or turn admission wait for
+  cosmetic enrichment.
 
 If your platform supports threads (Discord, Mattermost, Slack), set `conversation.kind: "thread"` and put the parent post / message id in `parentId`. See `MessagingConversationRef` in the interface.
 
@@ -641,7 +654,13 @@ Telegram's 4096 limit is bytes, not characters — a 2000-char Cyrillic message 
 If your platform uses out-of-band HTTP callbacks, you cannot rely on users' devices being publicly reachable. Document Cloudflare Tunnel / Tailscale Funnel / ngrok in the operator guide. Don't ship without that.
 
 ### `MessagingInboundEvent` field names
-The base event timestamp is `receivedAt`, not `occurredAt`. The lifecycle event uses a fixed `lifecycle` enum, not a free-form `reason`. The callback event echoes `actionId` (string) and `value` (separately) — there is no `action` field carrying the full `MessagingSurfaceAction` you persisted. Look up the resolved handle's `actionId` and `value` and pass those.
+The required local timestamp is `receivedAt`, not `occurredAt`, and it is not
+the provider's sent time. Capture it at the first handler boundary; preserve a
+provider timestamp separately as optional `providerSentAt`. The lifecycle
+event uses a fixed `lifecycle` enum, not a free-form `reason`. The callback
+event echoes `actionId` (string) and `value` (separately) — there is no `action`
+field carrying the full `MessagingSurfaceAction` you persisted. Look up the
+resolved handle's `actionId` and `value` and pass those.
 
 ### `MessagingAdapterState.opaque` is `MessagingJsonValue`
 Not `Record<string, unknown>`. Plain `Record<string, string>` works because every leaf is JSON-serializable; `Record<string, unknown>` does not satisfy the type. Same for any nested object you stuff into adapter state.

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -90,8 +90,9 @@ sequenceDiagram
 
     User->>Platform: types message / taps button
     Platform->>Adapter: webhook / gateway event
-    Note over Adapter: normalize to<br/>MessagingInboundEvent<br/>(text/command/callback/media/lifecycle)
+    Note over Adapter: capture PwrAgent receipt time,<br/>normalize and dispatch immediately<br/>(text/command/callback/media/lifecycle)
     Adapter->>Controller: handleInboundEvent(event)
+    Note over Adapter: optional REST breadcrumb<br/>enrichment runs off admission path
     Controller->>Automation: match inbound automation triggers
     Automation-->>Controller: matched or not matched
     Note over Controller: authorize actor,<br/>resolve binding,<br/>turn admission

--- a/packages/messaging/AGENTS.md
+++ b/packages/messaging/AGENTS.md
@@ -23,6 +23,10 @@ older clients can keep reading existing configs.
 
 - Keep workflow semantics channel-neutral. Resume navigation, status cards, approvals, questionnaires, markdown/content composition, attachments, and message routing should be expressed as generic intents and actions.
 - Provider adapters must validate every inbound platform identifier at the boundary before authorization, persistence, logging, store lookup, or listener dispatch. Use ReDoS-safe validators: hard length cap first, simple character loops or anchored single-class bounded regex only, and reject-and-log with `platform`, `identifier_field`, `length`, `first8_hash`, and `reason` without echoing raw attacker input.
+- Provider adapters must capture PwrAgent `receivedAt` at the first inbound
+  handler boundary, before validation or any `await`. Preserve an original
+  provider message time separately as optional `providerSentAt`; never use it
+  as `receivedAt` and never invent it. Dispatch before optional REST enrichment.
 - Provider adapters must enforce configured actor and conversation allowlists before dispatching to the desktop controller. Unauthorized general group/guild chatter should drop silently; log only DMs or actionable attempts such as slash commands, button clicks, or bot mentions, with rate-limiting for repeated unauthorized conversations.
 - Shared conversation authorization is fail-closed: empty or removed group/workspace/guild/team/supergroup allowlists deny access, even for an authorized actor. Treat 1:1 DMs separately from group DMs, and document/test new-provider behavior against [`docs/messaging-adding-a-provider.md` § Inbound authorization is fail-closed](../../docs/messaging-adding-a-provider.md#inbound-authorization-is-fail-closed).
 - Store provider-specific routing data only as opaque adapter state. Core workflow code may persist and echo this state, but must not parse Telegram chat IDs, Discord message IDs, callback payloads, or provider SDK types.

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertMessagingInboundReceipt,
+  captureMessagingInboundReceipt,
   MESSAGING_DELIVERY_OUTCOMES,
   MESSAGING_INBOUND_EVENT_KINDS,
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
@@ -22,6 +24,23 @@ import {
 } from "../index";
 
 describe("messaging surface contract", () => {
+  it("distinguishes local receipt time from optional provider sent time", () => {
+    expect(captureMessagingInboundReceipt(2_000, 1_000)).toEqual({
+      providerSentAt: 1_000,
+      receivedAt: 2_000,
+    });
+    expect(captureMessagingInboundReceipt(2_000)).toEqual({
+      receivedAt: 2_000,
+    });
+    expect(() => captureMessagingInboundReceipt(Number.NaN)).toThrow(
+      "receivedAt must be a finite timestamp",
+    );
+    expect(() => assertMessagingInboundReceipt({})).toThrow(
+      "omitted a finite first-boundary receivedAt",
+    );
+    expect(() => assertMessagingInboundReceipt({ receivedAt: 2_000 })).not.toThrow();
+  });
+
   it("enumerates the first-release semantic intent and inbound event kinds", () => {
     expect(MESSAGING_SURFACE_INTENT_KINDS).toEqual([
       "activity",

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1352,12 +1352,51 @@ export type MessagingConversationTitleUpdateResult = {
   updatedAt: number;
 };
 
-export type MessagingInboundBaseEvent = {
+export type MessagingInboundReceipt = {
+  /**
+   * Wall-clock time at the provider adapter's first inbound handler boundary.
+   * Capture this before validation, authorization, enrichment, or any await.
+   */
+  receivedAt: number;
+  /** Original sent time supplied by the provider, when available. */
+  providerSentAt?: number;
+};
+
+export function captureMessagingInboundReceipt(
+  receivedAt: number,
+  providerSentAt?: number,
+): MessagingInboundReceipt {
+  if (!Number.isFinite(receivedAt)) {
+    throw new Error("receivedAt must be a finite timestamp");
+  }
+  if (providerSentAt !== undefined && !Number.isFinite(providerSentAt)) {
+    throw new Error("providerSentAt must be a finite timestamp when supplied");
+  }
+  return {
+    receivedAt,
+    ...(providerSentAt !== undefined ? { providerSentAt } : {}),
+  };
+}
+
+export function assertMessagingInboundReceipt(
+  event: { providerSentAt?: unknown; receivedAt?: unknown },
+): asserts event is MessagingInboundReceipt {
+  if (typeof event.receivedAt !== "number" || !Number.isFinite(event.receivedAt)) {
+    throw new Error("Messaging provider omitted a finite first-boundary receivedAt timestamp.");
+  }
+  if (
+    event.providerSentAt !== undefined
+    && (typeof event.providerSentAt !== "number" || !Number.isFinite(event.providerSentAt))
+  ) {
+    throw new Error("Messaging provider supplied an invalid providerSentAt timestamp.");
+  }
+}
+
+export type MessagingInboundBaseEvent = MessagingInboundReceipt & {
   id: string;
   kind: MessagingInboundEventKind;
   actor: MessagingActorIdentity;
   channel: MessagingChannelRef;
-  receivedAt: number;
   /**
    * True when the adapter forwarded this event ONLY because its conversation
    * is being observed (an enabled inbound automation watches it), while the
@@ -1387,11 +1426,22 @@ export type MessagingInboundBaseEvent = {
   sourceSurface?: MessagingSurfaceRef;
 };
 
+export type MessagingInboundChannelMetadataUpdate = {
+  channel: MessagingChannelRef;
+  eventId: string;
+  observedAt: number;
+  routingState?: MessagingAdapterState;
+};
+
+export type MessagingInboundChannelMetadataListener = (
+  update: MessagingInboundChannelMetadataUpdate,
+) => Promise<void> | void;
+
 export type MessagingInboundRejectionReason =
   | "unauthorized-actor"
   | "unauthorized-conversation";
 
-export type MessagingRejectedInboundEvent = {
+export type MessagingRejectedInboundEvent = MessagingInboundReceipt & {
   id: string;
   kind: MessagingInboundEventKind;
   actor: MessagingActorIdentity;
@@ -1402,7 +1452,6 @@ export type MessagingRejectedInboundEvent = {
    */
   botMention?: boolean;
   channel: MessagingChannelRef;
-  receivedAt: number;
   reason: MessagingInboundRejectionReason;
   routingState?: MessagingAdapterState;
 };

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   type MessagingCallbackHandleRecord,
   type MessagingCallbackHandleStore,
   type MessagingInboundEvent,
+  type MessagingInboundChannelMetadataUpdate,
   type MessagingRejectedInboundEvent,
   type MessagingStatusIntent,
 } from "@pwragent/messaging-interface";
@@ -13,6 +14,7 @@ import {
   DiscordJsGatewayConnection,
   stripDiscordBotMention,
   type DiscordApi,
+  type DiscordChannelInfo,
   type DiscordGatewayConnection,
   type DiscordGatewayEvent,
   type DiscordGatewayListener,
@@ -1546,6 +1548,63 @@ describe("discord adapter", () => {
   });
 
   describe("text mention dispatch", () => {
+    it("dispatches before breadcrumb REST enrichment and preserves receipt provenance", async () => {
+      const providerSentAt = Date.parse("2026-08-31T17:13:26.477Z");
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      let clock = providerSentAt + 25;
+      let resolveChannel!: (value: DiscordChannelInfo) => void;
+      const pendingChannel = new Promise<DiscordChannelInfo>((resolve) => {
+        resolveChannel = resolve;
+      });
+      const getChannel = vi.fn(async () => {
+        clock = providerSentAt + 14_600;
+        return await pendingChannel;
+      });
+      const adapter = new DiscordAdapter({
+        api: createApi({ getChannel }),
+        config: {
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: TEST_AUTHORIZED_GUILD_IDS,
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => clock,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+      const dispatch = {
+        ...messageDispatch({
+          authorBot: false,
+          content: "investigate ingress latency",
+          id: "latency-regression",
+        }),
+        timestamp: "2026-08-31T17:13:26.477Z",
+      } as DiscordMessageCreateDispatch;
+      const emitted = gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: dispatch,
+      });
+
+      await vi.waitFor(() => {
+        expect(getChannel).toHaveBeenCalledTimes(1);
+      });
+      const visibleBeforeEnrichment = events.length;
+      resolveChannel({ id: TEST_CHANNEL_ID, name: "latency-lab" });
+      await emitted;
+
+      expect(visibleBeforeEnrichment).toBe(1);
+      expect(events[0]).toMatchObject({
+        providerSentAt,
+        receivedAt: providerSentAt + 25,
+      });
+      await adapter.stop();
+    });
+
     it("dispatches pairing tokens from unauthorized actors before allowlist checks", async () => {
       const events: MessagingInboundEvent[] = [];
       const rejectedEvents: MessagingRejectedInboundEvent[] = [];
@@ -2122,6 +2181,7 @@ describe("discord adapter", () => {
       const BOT_ID = "1480556454498009352";
       const parentChannelId = "1480556454498009357";
       const events: MessagingInboundEvent[] = [];
+      const metadataUpdates: MessagingInboundChannelMetadataUpdate[] = [];
       const gateway = new TestDiscordGateway();
       const adapter = new DiscordAdapter({
         api: createApi({
@@ -2153,6 +2213,9 @@ describe("discord adapter", () => {
       await adapter.start(async (event) => {
         events.push(event);
       });
+      adapter.onInboundChannelMetadata((update) => {
+        metadataUpdates.push(update);
+      });
 
       await gateway.emit({
         op: 0,
@@ -2173,6 +2236,21 @@ describe("discord adapter", () => {
         channel: {
           channel: "discord",
           conversation: {
+            id: TEST_CHANNEL_ID,
+            kind: "thread",
+            workspaceId: TEST_GUILD_ID,
+          },
+        },
+        kind: "text",
+        text: "investigate this",
+      });
+      await vi.waitFor(() => {
+        expect(metadataUpdates).toHaveLength(1);
+      });
+      expect(metadataUpdates[0]).toMatchObject({
+        channel: {
+          channel: "discord",
+          conversation: {
             ancestorTitle: "PwrDrvr",
             id: TEST_CHANNEL_ID,
             kind: "thread",
@@ -2182,8 +2260,6 @@ describe("discord adapter", () => {
             workspaceId: TEST_GUILD_ID,
           },
         },
-        kind: "text",
-        text: "investigate this",
       });
       await adapter.stop();
     });

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -18,6 +18,7 @@ import {
   type DiscordGatewayConnection,
   type DiscordGatewayEvent,
   type DiscordGatewayListener,
+  type DiscordInteractionCreateDispatch,
   type DiscordMessageCreateDispatch,
 } from "../discord-adapter.ts";
 import {
@@ -1507,6 +1508,112 @@ describe("discord adapter", () => {
     await restartedAdapter.stop();
   });
 
+  it.each([
+    {
+      data: { name: "resume" },
+      expectedKind: "command",
+      label: "slash commands",
+      responseType: 5,
+      type: 2,
+    },
+    {
+      data: { custom_id: "dc:abcdefghijklmnopqrstuvwx" },
+      expectedKind: "callback",
+      label: "component interactions",
+      responseType: 6,
+      type: 3,
+    },
+  ])("dispatches $label before breadcrumb REST enrichment", async ({
+    data,
+    expectedKind,
+    responseType,
+    type,
+  }) => {
+    const parentChannelId = "1480556454498009357";
+    const events: MessagingInboundEvent[] = [];
+    const metadataUpdates: MessagingInboundChannelMetadataUpdate[] = [];
+    const gateway = new TestDiscordGateway();
+    const createInteractionResponse = vi.fn(async () => {});
+    let resolveThreadChannel!: (value: DiscordChannelInfo) => void;
+    const pendingThreadChannel = new Promise<DiscordChannelInfo>((resolve) => {
+      resolveThreadChannel = resolve;
+    });
+    const getChannel = vi.fn(async (id: string) => id === TEST_CHANNEL_ID
+      ? await pendingThreadChannel
+      : { id, name: "project-parent" });
+    const adapter = new DiscordAdapter({
+      api: createApi({ createInteractionResponse, getChannel }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        authorizedGuildIds: TEST_AUTHORIZED_GUILD_IDS,
+        botToken: "token",
+        channel: "discord",
+      },
+      gateway,
+      now: () => 1234,
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    adapter.onInboundChannelMetadata((update) => {
+      metadataUpdates.push(update);
+    });
+
+    const emitted = gateway.emit({
+      op: 0,
+      t: "INTERACTION_CREATE",
+      d: {
+        channel_id: TEST_CHANNEL_ID,
+        channel_type: 11,
+        data,
+        guild_id: TEST_GUILD_ID,
+        id: TEST_MESSAGE_ID,
+        is_thread: true,
+        parent_id: parentChannelId,
+        token: "token_ABC.123",
+        type,
+        user: {
+          id: TEST_USER_ID,
+          username: "fixtureuser",
+        },
+      } as DiscordInteractionCreateDispatch & { parent_id: string },
+    });
+
+    await vi.waitFor(() => {
+      expect(getChannel).toHaveBeenCalledWith(TEST_CHANNEL_ID);
+    });
+    const visibleBeforeEnrichment = events.length;
+    resolveThreadChannel({
+      id: TEST_CHANNEL_ID,
+      name: "project-thread",
+      parentId: parentChannelId,
+    });
+    await emitted;
+
+    expect(createInteractionResponse).toHaveBeenCalledWith(
+      TEST_MESSAGE_ID,
+      "token_ABC.123",
+      { type: responseType },
+    );
+    expect(visibleBeforeEnrichment).toBe(1);
+    expect(events[0]).toMatchObject({
+      channel: {
+        conversation: {
+          id: TEST_CHANNEL_ID,
+          kind: "thread",
+          parentConversationId: parentChannelId,
+          parentConversationParentId: TEST_GUILD_ID,
+        },
+      },
+      kind: expectedKind,
+      receivedAt: 1234,
+    });
+    await vi.waitFor(() => {
+      expect(metadataUpdates).toHaveLength(1);
+    });
+    await adapter.stop();
+  });
+
   describe("stripDiscordBotMention", () => {
     const BOT_ID = "1480556454498009352";
 
@@ -2245,7 +2352,8 @@ describe("discord adapter", () => {
           }),
           channel_type: 11,
           is_thread: true,
-        },
+          parent_id: parentChannelId,
+        } as DiscordMessageCreateDispatch & { parent_id: string },
       });
 
       expect(events[0]).toMatchObject({
@@ -2255,6 +2363,8 @@ describe("discord adapter", () => {
           conversation: {
             id: TEST_CHANNEL_ID,
             kind: "thread",
+            parentConversationId: parentChannelId,
+            parentConversationParentId: TEST_GUILD_ID,
             workspaceId: TEST_GUILD_ID,
           },
         },

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -2115,6 +2115,7 @@ describe("discord adapter", () => {
       const BOT_ID = "1480556454498009352";
       const categoryId = "1480556454498009357";
       const events: MessagingInboundEvent[] = [];
+      const metadataUpdates: MessagingInboundChannelMetadataUpdate[] = [];
       const gateway = new TestDiscordGateway();
       const adapter = new DiscordAdapter({
         api: createApi({
@@ -2146,6 +2147,9 @@ describe("discord adapter", () => {
       await adapter.start(async (event) => {
         events.push(event);
       });
+      adapter.onInboundChannelMetadata((update) => {
+        metadataUpdates.push(update);
+      });
 
       await gateway.emit({
         op: 0,
@@ -2162,6 +2166,19 @@ describe("discord adapter", () => {
       });
 
       expect(events[0]).toMatchObject({
+        channel: {
+          channel: "discord",
+          conversation: {
+            id: TEST_CHANNEL_ID,
+            kind: "channel",
+            workspaceId: TEST_GUILD_ID,
+          },
+        },
+      });
+      await vi.waitFor(() => {
+        expect(metadataUpdates).toHaveLength(1);
+      });
+      expect(metadataUpdates[0]).toMatchObject({
         channel: {
           channel: "discord",
           conversation: {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -168,6 +168,7 @@ export type DiscordMessageCreateDispatch = {
   guild_id?: string;
   id: string;
   is_thread?: boolean;
+  parent_id?: string;
   timestamp?: string;
 };
 
@@ -189,6 +190,7 @@ export type DiscordInteractionCreateDispatch = {
   message?: {
     id: string;
   };
+  parent_id?: string;
   token: string;
   type: number;
   user?: DiscordUser;
@@ -1134,6 +1136,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         ? undefined
         : (message.author.global_name ?? message.author.username),
       isThread: message.is_thread,
+      parentChannelId: message.parent_id,
     });
     const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id, {
       channelType: message.channel_type,
@@ -1186,7 +1189,13 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         text: normalizedContent,
         ...(mentionRemainder !== undefined ? { botMention: true } : {}),
       };
-      await this.dispatchMessageWithBackgroundEnrichment(message, event, listener);
+      await this.dispatchWithBackgroundChannelEnrichment({
+        channelId: message.channel_id,
+        event,
+        guildId: message.guild_id,
+        isThread: message.is_thread,
+        listener,
+      });
       return;
     }
 
@@ -1219,36 +1228,44 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       sourceSurface,
       sourceUrl,
     } as MessagingInboundEvent;
-    await this.dispatchMessageWithBackgroundEnrichment(message, event, listener);
+    await this.dispatchWithBackgroundChannelEnrichment({
+      channelId: message.channel_id,
+      event,
+      guildId: message.guild_id,
+      isThread: message.is_thread,
+      listener,
+    });
   }
 
-  private async dispatchMessageWithBackgroundEnrichment(
-    message: DiscordMessageCreateDispatch,
-    event: MessagingInboundEvent,
-    listener: (event: MessagingInboundEvent) => Promise<void>,
-  ): Promise<void> {
-    const dispatched = Promise.resolve(listener(event));
-    if (message.guild_id) {
+  private async dispatchWithBackgroundChannelEnrichment(params: {
+    channelId: string;
+    event: MessagingInboundEvent;
+    guildId?: string;
+    isThread?: boolean;
+    listener: (event: MessagingInboundEvent) => Promise<void>;
+  }): Promise<void> {
+    const dispatched = Promise.resolve(params.listener(params.event));
+    if (params.guildId) {
       const enrichment = Promise.resolve().then(async () =>
-        await this.channelFromDiscord(message.channel_id, message.guild_id, {
-          isThread: message.is_thread,
+        await this.channelFromDiscord(params.channelId, params.guildId, {
+          isThread: params.isThread,
         })
       );
       void dispatched.then(async () => {
         const channel = await enrichment;
         const update = {
           channel,
-          eventId: event.id,
+          eventId: params.event.id,
           observedAt: this.now(),
-          routingState: event.routingState,
+          routingState: params.event.routingState,
         };
         for (const metadataListener of this.inboundChannelMetadataListeners) {
           await metadataListener(update);
         }
       }).catch((error) => {
         this.options.logger?.debug("discord inbound breadcrumb enrichment failed", {
-          channelId: message.channel_id,
-          eventId: event.id,
+          channelId: params.channelId,
+          eventId: params.event.id,
           error: errorMessage(error),
         });
       });
@@ -1316,10 +1333,14 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       return;
     }
 
-    const channel = await this.channelFromDiscord(
+    const channel = this.immediateChannelFromDiscord(
       interaction.channel_id,
       interaction.guild_id,
-      { isThread: interaction.is_thread },
+      {
+        channelType: interaction.channel_type,
+        isThread: interaction.is_thread,
+        parentChannelId: interaction.parent_id,
+      },
     );
     const persistedBinding = this.options.store
       ? await this.options.store.resolveCallbackHandle({
@@ -1337,7 +1358,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         isThread: interaction.is_thread,
       },
     );
-    await listener({
+    const event: MessagingInboundEvent = {
       id: `discord:interaction:${interaction.id}`,
       kind: "callback",
       actor: this.actorFromUser(actor, interaction.member?.nick ?? undefined),
@@ -1376,6 +1397,13 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         guildId: interaction.guild_id,
         messageId: interaction.message?.id,
       }),
+    };
+    await this.dispatchWithBackgroundChannelEnrichment({
+      channelId: interaction.channel_id,
+      event,
+      guildId: interaction.guild_id,
+      isThread: interaction.is_thread,
+      listener,
     });
   }
 
@@ -1391,12 +1419,16 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     }
 
     const args = commandArgsFromOptions(interaction.data?.options);
-    const channel = await this.channelFromDiscord(
+    const channel = this.immediateChannelFromDiscord(
       interaction.channel_id,
       interaction.guild_id,
-      { isThread: interaction.is_thread },
+      {
+        channelType: interaction.channel_type,
+        isThread: interaction.is_thread,
+        parentChannelId: interaction.parent_id,
+      },
     );
-    await listener({
+    const event: MessagingInboundEvent = {
       id: `discord:command:${interaction.id}`,
       kind: "command",
       actor: this.actorFromUser(actor, interaction.member?.nick ?? undefined),
@@ -1418,6 +1450,13 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           isThread: interaction.is_thread,
         },
       ),
+    };
+    await this.dispatchWithBackgroundChannelEnrichment({
+      channelId: interaction.channel_id,
+      event,
+      guildId: interaction.guild_id,
+      isThread: interaction.is_thread,
+      listener,
     });
   }
 
@@ -1428,6 +1467,8 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       && this.validateIdentifier("user.id", message.author.id, validateDiscordSnowflake)
       && (message.guild_id === undefined
         || this.validateIdentifier("guild_id", message.guild_id, validateDiscordSnowflake))
+      && (message.parent_id === undefined
+        || this.validateIdentifier("parent_id", message.parent_id, validateDiscordSnowflake))
       && this.validateAttachments(message.attachments ?? [])
     );
   }
@@ -1453,6 +1494,8 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         ))
       && (interaction.guild_id === undefined
         || this.validateIdentifier("guild_id", interaction.guild_id, validateDiscordSnowflake))
+      && (interaction.parent_id === undefined
+        || this.validateIdentifier("parent_id", interaction.parent_id, validateDiscordSnowflake))
       && (interaction.message?.id === undefined
         || this.validateIdentifier(
           "message.id",
@@ -2020,13 +2063,28 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private immediateChannelFromDiscord(
     channelId: string,
     guildId: string | undefined,
-    options?: { channelType?: number; dmPeerName?: string; isThread?: boolean },
+    options?: {
+      channelType?: number;
+      dmPeerName?: string;
+      isThread?: boolean;
+      parentChannelId?: string;
+    },
   ): MessagingInboundEvent["channel"] {
-    const channel = this.basicChannelRef(
+    const basicChannel = this.basicChannelRef(
       channelId,
       guildId,
       this.discordConversationKind(guildId, options?.channelType, options?.isThread),
     );
+    const channel = options?.isThread && options.parentChannelId
+      ? {
+          ...basicChannel,
+          conversation: {
+            ...basicChannel.conversation,
+            parentConversationId: options.parentChannelId,
+            ...(guildId ? { parentConversationParentId: guildId } : {}),
+          },
+        }
+      : basicChannel;
     return !guildId && options?.dmPeerName
       ? {
           ...channel,
@@ -2789,6 +2847,7 @@ function messageToDispatch(message: Message): DiscordMessageCreateDispatch {
     guild_id: message.guildId ?? undefined,
     id: message.id,
     is_thread: discordChannelIsThread(message.channel),
+    parent_id: discordChannelParentId(message.channel),
     timestamp: message.createdAt.toISOString(),
   };
 }
@@ -2809,6 +2868,7 @@ function interactionToDispatch(
       is_thread: buttonInteraction.channel
         ? discordChannelIsThread(buttonInteraction.channel)
         : undefined,
+      parent_id: discordChannelParentId(buttonInteraction.channel),
       member: buttonInteraction.inGuild()
         ? {
             nick:
@@ -2849,6 +2909,7 @@ function interactionToDispatch(
       is_thread: commandInteraction.channel
         ? discordChannelIsThread(commandInteraction.channel)
         : undefined,
+      parent_id: discordChannelParentId(commandInteraction.channel),
       member: commandInteraction.inGuild()
         ? {
             nick:
@@ -3015,6 +3076,14 @@ function discordChannelIsThread(channel: unknown): boolean {
   }
   const isThread = (channel as { isThread?: unknown }).isThread;
   return typeof isThread === "function" && Boolean(isThread.call(channel));
+}
+
+function discordChannelParentId(channel: unknown): string | undefined {
+  if (!channel || typeof channel !== "object" || !("parentId" in channel)) {
+    return undefined;
+  }
+  const parentId = (channel as { parentId?: unknown }).parentId;
+  return typeof parentId === "string" ? parentId : undefined;
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -27,6 +27,8 @@ import type {
   MessagingFilePart,
   MessagingImagePart,
   MessagingInboundEvent,
+  MessagingInboundChannelMetadataListener,
+  MessagingInboundReceipt,
   MessagingInboundRejectedListener,
   MessagingManagedConversationCreateRequest,
   MessagingManagedConversationCreateResult,
@@ -42,6 +44,7 @@ import type {
   MessagingSurfaceRef,
 } from "@pwragent/messaging-interface";
 import {
+  captureMessagingInboundReceipt,
   evictStaleStreamAnchors,
   extractMessagingPairingToken,
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
@@ -165,6 +168,7 @@ export type DiscordMessageCreateDispatch = {
   guild_id?: string;
   id: string;
   is_thread?: boolean;
+  timestamp?: string;
 };
 
 export type DiscordInteractionCreateDispatch = {
@@ -297,6 +301,7 @@ export type DiscordProviderAdapter = {
     request: MessagingManagedConversationCreateRequest,
   ): Promise<MessagingManagedConversationCreateResult>;
   onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
+  onInboundChannelMetadata?(listener: MessagingInboundChannelMetadataListener): () => void;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
 };
@@ -360,6 +365,8 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private applicationId?: string;
   private readonly unauthorizedGuildLogKeys = new Set<string>();
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
+  private readonly inboundChannelMetadataListeners =
+    new Set<MessagingInboundChannelMetadataListener>();
   private readonly rateLimitListeners = new Set<(info: MessagingRateLimitInfo) => void>();
   private listener?: (event: MessagingInboundEvent) => Promise<void>;
   private readonly options: DiscordAdapterOptions;
@@ -412,6 +419,13 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     this.inboundRejectedListeners.add(listener);
     return () => {
       this.inboundRejectedListeners.delete(listener);
+    };
+  }
+
+  onInboundChannelMetadata(listener: MessagingInboundChannelMetadataListener): () => void {
+    this.inboundChannelMetadataListeners.add(listener);
+    return () => {
+      this.inboundChannelMetadataListeners.delete(listener);
     };
   }
 
@@ -1061,16 +1075,26 @@ export class DiscordAdapter implements DiscordProviderAdapter {
 
   async handleGatewayEvent(event: DiscordGatewayEvent): Promise<void> {
     if (event.t === "MESSAGE_CREATE") {
-      await this.handleMessageCreate(event.d);
+      const receipt = captureMessagingInboundReceipt(
+        this.now(),
+        discordTimestampToMs(event.d.timestamp),
+      );
+      await this.handleMessageCreate(event.d, receipt);
       return;
     }
 
     if (event.t === "INTERACTION_CREATE") {
-      await this.handleInteractionCreate(event.d);
+      await this.handleInteractionCreate(
+        event.d,
+        captureMessagingInboundReceipt(this.now()),
+      );
     }
   }
 
-  private async handleMessageCreate(message: DiscordMessageCreateDispatch): Promise<void> {
+  private async handleMessageCreate(
+    message: DiscordMessageCreateDispatch,
+    receipt: MessagingInboundReceipt,
+  ): Promise<void> {
     const listener = this.listener;
     if (!listener) {
       return;
@@ -1098,21 +1122,19 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           isPairingMessage
           || mentionRemainder !== undefined
           || Boolean(message.content?.startsWith("/")),
+        receipt,
       })
     ) {
       return;
     }
 
-    const channel = await this.channelFromDiscord(message.channel_id, message.guild_id, {
-      // Best-effort DM peer name from the message author when the
-      // conversation is a DM (no guild). Channel + thread breadcrumbs
-      // are resolved via REST inside channelFromDiscord (cached).
+    const channel = this.immediateChannelFromDiscord(message.channel_id, message.guild_id, {
+      channelType: message.channel_type,
       dmPeerName: message.guild_id
         ? undefined
         : (message.author.global_name ?? message.author.username),
       isThread: message.is_thread,
     });
-    const receivedAt = this.now();
     const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id, {
       channelType: message.channel_type,
       isThread: message.is_thread,
@@ -1142,7 +1164,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       const attachments = message.attachments.map((attachment) =>
         this.attachmentFromDiscord(attachment),
       );
-      await listener({
+      const event: MessagingInboundEvent = {
         id: `discord:message:${message.id}`,
         kind: "media",
         attachments,
@@ -1157,13 +1179,14 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           mimeType: attachments[0]?.mimeType,
           sizeBytes: attachments[0]?.sizeBytes,
         },
-        receivedAt,
+        ...receipt,
         routingState,
         sourceSurface,
         sourceUrl,
         text: normalizedContent,
         ...(mentionRemainder !== undefined ? { botMention: true } : {}),
-      });
+      };
+      await this.dispatchMessageWithBackgroundEnrichment(message, event, listener);
       return;
     }
 
@@ -1176,7 +1199,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     const commandMatch = mentionRemainder === undefined
       ? /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(message.content)
       : undefined;
-    await listener({
+    const event = {
       id: `discord:message:${message.id}`,
       kind: commandMatch ? "command" : "text",
       actor: this.actorFromUser(message.author),
@@ -1191,15 +1214,51 @@ export class DiscordAdapter implements DiscordProviderAdapter {
             text: normalizedContent ?? "",
             ...(mentionRemainder !== undefined ? { botMention: true } : {}),
           }),
-      receivedAt,
+      ...receipt,
       routingState,
       sourceSurface,
       sourceUrl,
-    } as MessagingInboundEvent);
+    } as MessagingInboundEvent;
+    await this.dispatchMessageWithBackgroundEnrichment(message, event, listener);
+  }
+
+  private async dispatchMessageWithBackgroundEnrichment(
+    message: DiscordMessageCreateDispatch,
+    event: MessagingInboundEvent,
+    listener: (event: MessagingInboundEvent) => Promise<void>,
+  ): Promise<void> {
+    const dispatched = Promise.resolve(listener(event));
+    if (message.guild_id) {
+      const enrichment = Promise.resolve().then(async () =>
+        await this.channelFromDiscord(message.channel_id, message.guild_id, {
+          isThread: message.is_thread,
+        })
+      );
+      void dispatched.then(async () => {
+        const channel = await enrichment;
+        const update = {
+          channel,
+          eventId: event.id,
+          observedAt: this.now(),
+          routingState: event.routingState,
+        };
+        for (const metadataListener of this.inboundChannelMetadataListeners) {
+          await metadataListener(update);
+        }
+      }).catch((error) => {
+        this.options.logger?.debug("discord inbound breadcrumb enrichment failed", {
+          channelId: message.channel_id,
+          eventId: event.id,
+          error: errorMessage(error),
+        });
+      });
+    }
+    await dispatched;
   }
 
   private async handleInteractionCreate(
     interaction: DiscordInteractionCreateDispatch,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     const listener = this.listener;
     const actor = interaction.member?.user ?? interaction.user;
@@ -1212,7 +1271,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
 
     const customId = interaction.data?.custom_id ?? "";
     const commandName = interaction.data?.name?.toLowerCase();
-    if (!this.isAuthorizedInteractionSource(interaction, actor)) {
+    if (!this.isAuthorizedInteractionSource(interaction, actor, receipt)) {
       if (customId) {
         await this.api.createInteractionResponse(interaction.id, interaction.token, {
           type: 6,
@@ -1229,7 +1288,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       await this.api.createInteractionResponse(interaction.id, interaction.token, {
         type: 6,
       });
-      await this.handleComponentInteraction(interaction, actor, customId);
+      await this.handleComponentInteraction(interaction, actor, customId, receipt);
       return;
     }
 
@@ -1237,7 +1296,12 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       await this.api.createInteractionResponse(interaction.id, interaction.token, {
         type: 5,
       });
-      await this.handleApplicationCommandInteraction(interaction, actor, commandName);
+      await this.handleApplicationCommandInteraction(
+        interaction,
+        actor,
+        commandName,
+        receipt,
+      );
     }
   }
 
@@ -1245,6 +1309,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     interaction: DiscordInteractionCreateDispatch,
     actor: DiscordUser,
     customId: string,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     const listener = this.listener;
     if (!listener) {
@@ -1304,7 +1369,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         : {}),
       actionId: persistedBinding?.actionId,
       value: persistedBinding?.value,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
       sourceUrl: discordConversationUrl({
         channelId: interaction.channel_id,
@@ -1318,6 +1383,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     interaction: DiscordInteractionCreateDispatch,
     actor: DiscordUser,
     commandName: string,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     const listener = this.listener;
     if (!listener) {
@@ -1338,7 +1404,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       channel,
       command: commandName,
       rawText: [`/${commandName}`, ...args].join(" ").trim(),
-      receivedAt: this.now(),
+      ...receipt,
       sourceUrl: discordConversationUrl({
         channelId: interaction.channel_id,
         guildId: interaction.guild_id,
@@ -1440,7 +1506,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
 
   private isAuthorizedMessageSource(
     message: DiscordMessageCreateDispatch,
-    options: { actionable: boolean },
+    options: { actionable: boolean; receipt: MessagingInboundReceipt },
   ): boolean {
     if (
       !this.isAuthorizedDiscordConversation({
@@ -1453,6 +1519,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         this.emitInboundRejected(this.rejectedEventFromMessage(message, {
           kind: "command",
           reason: "unauthorized-conversation",
+          receipt: options.receipt,
         }));
       }
       return false;
@@ -1468,6 +1535,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         this.emitInboundRejected(this.rejectedEventFromMessage(message, {
           kind: options.actionable ? "command" : "text",
           reason: "unauthorized-actor",
+          receipt: options.receipt,
         }));
       }
       return false;
@@ -1478,6 +1546,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private isAuthorizedInteractionSource(
     interaction: DiscordInteractionCreateDispatch,
     actor: DiscordUser,
+    receipt: MessagingInboundReceipt,
   ): boolean {
     if (
       !this.isAuthorizedDiscordConversation({
@@ -1488,6 +1557,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     ) {
       this.emitInboundRejected(this.rejectedEventFromInteraction(interaction, actor, {
         reason: "unauthorized-conversation",
+        receipt,
       }));
       return false;
     }
@@ -1500,6 +1570,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       });
       this.emitInboundRejected(this.rejectedEventFromInteraction(interaction, actor, {
         reason: "unauthorized-actor",
+        receipt,
       }));
       return false;
     }
@@ -1946,6 +2017,27 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     };
   }
 
+  private immediateChannelFromDiscord(
+    channelId: string,
+    guildId: string | undefined,
+    options?: { channelType?: number; dmPeerName?: string; isThread?: boolean },
+  ): MessagingInboundEvent["channel"] {
+    const channel = this.basicChannelRef(
+      channelId,
+      guildId,
+      this.discordConversationKind(guildId, options?.channelType, options?.isThread),
+    );
+    return !guildId && options?.dmPeerName
+      ? {
+          ...channel,
+          conversation: {
+            ...channel.conversation,
+            title: options.dmPeerName,
+          },
+        }
+      : channel;
+  }
+
   /**
    * Resolve channel + guild + (for threads) parent-channel names via
    * the Discord REST API, with an unbounded in-memory cache keyed by
@@ -2040,7 +2132,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
 
   private rejectedEventFromMessage(
     message: DiscordMessageCreateDispatch,
-    options: Pick<MessagingRejectedInboundEvent, "kind" | "reason">,
+    options: Pick<MessagingRejectedInboundEvent, "kind" | "reason"> & {
+      receipt: MessagingInboundReceipt;
+    },
   ): MessagingRejectedInboundEvent {
     return {
       id: `discord:message:${message.id}:rejected`,
@@ -2051,7 +2145,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         message.guild_id,
         this.discordConversationKind(message.guild_id, message.channel_type),
       ),
-      receivedAt: this.now(),
+      ...options.receipt,
       reason: options.reason,
       routingState: this.routingStateFromDiscord(message.channel_id, message.guild_id, {
         channelType: message.channel_type,
@@ -2063,7 +2157,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private rejectedEventFromInteraction(
     interaction: DiscordInteractionCreateDispatch,
     actor: DiscordUser,
-    options: Pick<MessagingRejectedInboundEvent, "reason">,
+    options: Pick<MessagingRejectedInboundEvent, "reason"> & {
+      receipt: MessagingInboundReceipt;
+    },
   ): MessagingRejectedInboundEvent {
     const kind = interaction.data?.custom_id ? "callback" : "command";
     return {
@@ -2075,7 +2171,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         interaction.guild_id,
         this.discordConversationKind(interaction.guild_id, interaction.channel_type),
       ),
-      receivedAt: this.now(),
+      ...options.receipt,
       reason: options.reason,
       routingState: this.routingStateFromDiscord(
         interaction.channel_id,
@@ -2107,7 +2203,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private discordConversationKind(
     guildId: string | undefined,
     channelType?: number,
-  ): "dm" | "channel" {
+    isThread?: boolean,
+  ): "dm" | "channel" | "thread" {
+    if (isThread) return "thread";
     return !guildId && channelType === DISCORD_CHANNEL_TYPE_DM
       ? "dm"
       : "channel";
@@ -2188,6 +2286,12 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private get fetch(): FetchLike {
     return this.options.fetch ?? fetch;
   }
+}
+
+function discordTimestampToMs(timestamp: string | undefined): number | undefined {
+  if (!timestamp) return undefined;
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function uploadableFileParts(intent: MessagingSurfaceIntent): MessagingFilePart[] {
@@ -2685,6 +2789,7 @@ function messageToDispatch(message: Message): DiscordMessageCreateDispatch {
     guild_id: message.guildId ?? undefined,
     id: message.id,
     is_thread: discordChannelIsThread(message.channel),
+    timestamp: message.createdAt.toISOString(),
   };
 }
 

--- a/packages/messaging/providers/discord/src/validate-ids.ts
+++ b/packages/messaging/providers/discord/src/validate-ids.ts
@@ -15,6 +15,7 @@ export type DiscordIdentifierField =
   | "interaction.id"
   | "interaction.token"
   | "message.id"
+  | "parent_id"
   | "user.id";
 
 export type IdentifierRejectionLogger = {

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -1283,6 +1283,7 @@ describe("FeishuAdapter", () => {
           chat_id: "oc_chat",
           chat_type: "p2p",
           content: JSON.stringify({ text: "pair 11111111111111111111111111111111" }),
+          create_time: "1699999999500",
           message_id: "om_message",
           message_type: "text",
         },
@@ -1296,6 +1297,8 @@ describe("FeishuAdapter", () => {
         kind: "command",
         command: "pair",
         args: ["11111111111111111111111111111111"],
+        providerSentAt: 1_699_999_999_500,
+        receivedAt: 1_700_000_000_000,
       }),
     ]);
   });

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -26,6 +26,7 @@ import type {
   MessagingDeliveryScope,
   MessagingInboundCallbackEvent,
   MessagingInboundEvent,
+  MessagingInboundReceipt,
   MessagingInboundRejectedListener,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
@@ -33,6 +34,7 @@ import type {
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import {
+  captureMessagingInboundReceipt,
   evictStaleStreamAnchors,
   extractMessagingPairingToken,
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
@@ -914,6 +916,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   }
 
   private async handleMessageEvent(payload: FeishuEventEnvelope): Promise<void> {
+    const receivedAt = this.now();
     const event = payload.event as FeishuReceiveMessageEvent | undefined;
     const message = event?.message;
     const senderId = event?.sender?.sender_id?.open_id;
@@ -922,6 +925,10 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     const tenantKey = payload.header?.tenant_key ?? event?.sender?.tenant_key;
     const ids = this.validateInboundIds({ chatId, messageId, openId: senderId, tenantKey });
     if (!ids || !message) return;
+    const receipt = captureMessagingInboundReceipt(
+      receivedAt,
+      feishuTimestampToMs(message.create_time),
+    );
     const dedupKey = buildFeishuInboundDedupKey(payload, ids.messageId);
     // Feishu/Lark retries webhook deliveries after slow or failed ACKs. Once
     // the adapter has received a well-formed message, transport retries must
@@ -976,7 +983,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
       id: payload.header?.event_id ?? ids.messageId,
       actor,
       channel: channelRef,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
     };
     const command = parseFeishuCommandText(messageText);
@@ -1118,6 +1125,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   private async handleCardActionEvent(
     payload: FeishuEventEnvelope,
   ): Promise<FeishuCardActionResponse> {
+    const receipt: MessagingInboundReceipt = captureMessagingInboundReceipt(this.now());
     const event = payload.event as FeishuCardActionEvent | undefined;
     const openId = event?.operator?.open_id;
     const tenantKey = payload.header?.tenant_key ?? event?.tenant_key;
@@ -1240,7 +1248,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
         : {}),
       actionId: record.actionId,
       ...(record.value !== undefined ? { value: record.value } : {}),
-      receivedAt: this.now(),
+      ...receipt,
       ...(record.surface?.state ? { routingState: record.surface.state } : {}),
     });
     return FEISHU_CARD_ACTION_ACK;
@@ -1814,6 +1822,12 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     if (!this.config.verificationToken) return true;
     return typeof token === "string" && safeEqual(token, this.config.verificationToken);
   }
+}
+
+function feishuTimestampToMs(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 export function createFeishuAdapter(

--- a/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
+++ b/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
@@ -648,6 +648,7 @@ describe("LineAdapter", () => {
     await postLineWebhook(port, config.channelSecret, {
       events: [{
         type: "postback",
+        timestamp: 2_000,
         webhookEventId: "event-1",
         source: {
           type: "user",
@@ -662,6 +663,8 @@ describe("LineAdapter", () => {
     expect(events[0]).toMatchObject({
       kind: "callback",
       actionId: "confirm:yes",
+      providerSentAt: 2_000,
+      receivedAt: 2_234,
       value: "yes",
     });
   });

--- a/packages/messaging/providers/line/src/line-adapter.ts
+++ b/packages/messaging/providers/line/src/line-adapter.ts
@@ -18,12 +18,14 @@ import type {
   MessagingDeliveryResult,
   MessagingDeliveryScope,
   MessagingInboundEvent,
+  MessagingInboundReceipt,
   MessagingInboundRejectedListener,
   MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import {
+  captureMessagingInboundReceipt,
   extractMessagingPairingToken,
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
   splitTextForDelivery,
@@ -521,6 +523,7 @@ export class LineAdapter implements LineProviderAdapter {
     request: IncomingMessage,
     response: ServerResponse,
   ): Promise<void> {
+    const receivedAt = this.now();
     if (request.method !== "POST") {
       response.statusCode = 405;
       response.end();
@@ -568,11 +571,15 @@ export class LineAdapter implements LineProviderAdapter {
 
     if (!Array.isArray(parsed.events)) return;
     for (const event of parsed.events) {
-      await this.handleWebhookEvent(event);
+      await this.handleWebhookEvent(event, receivedAt);
     }
   }
 
-  private async handleWebhookEvent(event: LineWebhookEvent): Promise<void> {
+  private async handleWebhookEvent(
+    event: LineWebhookEvent,
+    receivedAt: number,
+  ): Promise<void> {
+    const receipt = captureMessagingInboundReceipt(receivedAt, event.timestamp);
     if (!this.listener) return;
     const ids = this.validateInboundIds(event);
     if (!ids) return;
@@ -587,10 +594,10 @@ export class LineAdapter implements LineProviderAdapter {
 
     switch (event.type) {
       case "message":
-        await this.handleMessageEvent(event, actor, channel, routingState);
+        await this.handleMessageEvent(event, actor, channel, routingState, receipt);
         return;
       case "postback":
-        await this.handlePostbackEvent(event, actor, channel, routingState);
+        await this.handlePostbackEvent(event, actor, channel, routingState, receipt);
         return;
       case "follow":
       case "unfollow":
@@ -603,7 +610,7 @@ export class LineAdapter implements LineProviderAdapter {
           kind: "lifecycle",
           actor,
           channel,
-          receivedAt: this.now(),
+          ...receipt,
           routingState,
           lifecycle: event.type === "follow" ? "bound" : "detached",
         });
@@ -628,7 +635,7 @@ export class LineAdapter implements LineProviderAdapter {
           kind: "lifecycle",
           actor,
           channel,
-          receivedAt: this.now(),
+          ...receipt,
           routingState,
           lifecycle:
             event.type === "join"
@@ -646,6 +653,7 @@ export class LineAdapter implements LineProviderAdapter {
     actor: MessagingActorIdentity,
     channel: MessagingChannelRef,
     routingState: MessagingAdapterState,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     if (!this.listener || !event.message) return;
     const text = event.message.type === "text" ? event.message.text ?? "" : "";
@@ -678,7 +686,7 @@ export class LineAdapter implements LineProviderAdapter {
           kind: "command",
           actor,
           channel,
-          receivedAt: this.now(),
+          ...receipt,
           routingState,
           rawText: text,
           command: text.slice(1).split(/\s+/)[0] ?? "",
@@ -691,7 +699,7 @@ export class LineAdapter implements LineProviderAdapter {
         kind: "text",
         actor,
         channel,
-        receivedAt: this.now(),
+        ...receipt,
         routingState,
         text: stripSelfMention(text, event.message.mention),
       });
@@ -705,7 +713,7 @@ export class LineAdapter implements LineProviderAdapter {
       kind: "media",
       actor,
       channel,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
       attachments: [attachment],
       disposition: attachment.disposition,
@@ -718,6 +726,7 @@ export class LineAdapter implements LineProviderAdapter {
     actor: MessagingActorIdentity,
     channel: MessagingChannelRef,
     routingState: MessagingAdapterState,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     if (!this.listener) return;
     const signed = this.parseSignedPostbackData(event.postback?.data);
@@ -754,7 +763,7 @@ export class LineAdapter implements LineProviderAdapter {
       kind: "callback",
       actor,
       channel,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
       interaction: {
         channel: "line",

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -482,6 +482,7 @@ describe("MattermostAdapter — capability profile", () => {
           channel_id: "channelabcdefghijklmn12345",
           user_id: "haroldabcdefghijklmnopqr12",
           message: "@pwragent new phone who dis?",
+          create_at: 1_699_999_999_500,
         }),
       },
     });
@@ -491,6 +492,8 @@ describe("MattermostAdapter — capability profile", () => {
       expect.objectContaining({
         botMention: true,
         kind: "text",
+        providerSentAt: 1_699_999_999_500,
+        receivedAt: 1_700_000_000_000,
         text: "new phone who dis?",
       }),
     ]);

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -28,6 +28,7 @@ import type {
   MessagingDeliveryScope,
   MessagingDeliveryResult,
   MessagingInboundEvent,
+  MessagingInboundReceipt,
   MessagingInboundRejectedListener,
   MessagingJsonValue,
   MessagingFilePart,
@@ -39,6 +40,7 @@ import type {
   MessagingSurfaceRef,
 } from "@pwragent/messaging-interface";
 import {
+  captureMessagingInboundReceipt,
   evictStaleStreamAnchors,
   extractMessagingPairingToken,
   messagingInlineImageBytes,
@@ -812,15 +814,19 @@ export class MattermostAdapter implements MattermostProviderAdapter {
   private async handleWebsocketMessage(
     message: WebSocketMessage,
   ): Promise<void> {
+    const receivedAt = this.now();
     if (!this.listener) {
       return;
     }
     switch (message.event) {
       case "posted":
-        await this.handlePostedEvent(message);
+        await this.handlePostedEvent(message, receivedAt);
         return;
       case "direct_added":
-        await this.handleDirectAddedEvent(message);
+        await this.handleDirectAddedEvent(
+          message,
+          captureMessagingInboundReceipt(receivedAt),
+        );
         return;
       // post_edited, post_deleted, channel_updated, typing — not surfaced
       // to the controller today; reactions to them belong in follow-up
@@ -830,7 +836,10 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     }
   }
 
-  private async handlePostedEvent(message: WebSocketMessage): Promise<void> {
+  private async handlePostedEvent(
+    message: WebSocketMessage,
+    receivedAt: number,
+  ): Promise<void> {
     const data = (message.data ?? {}) as {
       post?: string;
       sender_name?: string;
@@ -843,6 +852,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     if (!post) {
       return;
     }
+    const receipt = captureMessagingInboundReceipt(receivedAt, post.create_at);
     if (!this.validatePostIdentifiers(post)) {
       return;
     }
@@ -919,6 +929,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         eventId: post.id,
         fileIds,
         messageText,
+        receipt,
       });
       return;
     }
@@ -929,6 +940,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         channel: channelRef,
         eventId: post.id,
         rawText: messageText,
+        receipt,
       });
       return;
     }
@@ -948,6 +960,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
           channel: channelRef,
           eventId: post.id,
           rawText: "/help",
+          receipt,
         });
       } else {
         await this.dispatchTextEvent({
@@ -956,6 +969,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
           channel: channelRef,
           eventId: post.id,
           text: stripped,
+          receipt,
         });
       }
       return;
@@ -966,11 +980,13 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       channel: channelRef,
       eventId: post.id,
       text: messageText,
+      receipt,
     });
   }
 
   private async handleDirectAddedEvent(
     message: WebSocketMessage,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     if (!this.listener) {
       return;
@@ -986,7 +1002,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     await this.listener({
       kind: "lifecycle",
       id: this.newEventId("lifecycle"),
-      receivedAt: this.now(),
+      ...receipt,
       actor: {
         platformUserId: this.botUserId ?? "bot",
         isBot: true,
@@ -1093,6 +1109,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     body: MattermostInteractiveCallbackBody,
     rawBody: string,
   ): Promise<MattermostCallbackHandlerResult | void> {
+    const receipt = captureMessagingInboundReceipt(this.now());
     if (!this.listener) {
       return;
     }
@@ -1131,7 +1148,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
             ...(body.channel_name ? { title: body.channel_name } : {}),
           },
         },
-        receivedAt: this.now(),
+        ...receipt,
         reason: "unauthorized-actor",
       });
       return;
@@ -1246,7 +1263,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     await this.listener({
       kind: "callback",
       id: this.newEventId("callback"),
-      receivedAt: this.now(),
+      ...receipt,
       actor,
       channel: channelRef,
       actionId: resolvedHandle.actionId,
@@ -1289,6 +1306,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     botMention?: boolean;
     channel: MessagingChannelRef;
     eventId: string;
+    receipt: MessagingInboundReceipt;
     text: string;
   }): Promise<void> {
     if (!this.listener) {
@@ -1297,7 +1315,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     await this.listener({
       kind: "text",
       id: params.eventId,
-      receivedAt: this.now(),
+      ...params.receipt,
       actor: params.actor,
       channel: params.channel,
       ...(params.botMention ? { botMention: true } : {}),
@@ -1399,6 +1417,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     body: MattermostSlashCommandBody,
     rawBody: string,
   ): Promise<MattermostSlashCommandResult | void> {
+    const receipt = captureMessagingInboundReceipt(this.now());
     void rawBody;
     if (!this.listener) {
       return;
@@ -1459,7 +1478,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
             ...(body.channel_name ? { title: body.channel_name } : {}),
           },
         },
-        receivedAt: this.now(),
+        ...receipt,
         reason: "unauthorized-actor",
       });
       return undefined;
@@ -1556,6 +1575,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       channel: channelRef,
       eventId: this.newEventId("slashcmd"),
       rawText,
+      receipt,
       ...(routingState ? { routingState } : {}),
     });
     return undefined;
@@ -1605,6 +1625,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     channel: MessagingChannelRef;
     eventId: string;
     rawText: string;
+    receipt: MessagingInboundReceipt;
     routingState?: MessagingAdapterState;
   }): Promise<void> {
     if (!this.listener) {
@@ -1616,7 +1637,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     await this.listener({
       kind: "command",
       id: params.eventId,
-      receivedAt: this.now(),
+      ...params.receipt,
       actor: params.actor,
       channel: params.channel,
       command,
@@ -1632,6 +1653,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     eventId: string;
     fileIds: string[];
     messageText: string;
+    receipt: MessagingInboundReceipt;
   }): Promise<void> {
     if (!this.listener) {
       return;
@@ -1645,7 +1667,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     await this.listener({
       kind: "media",
       id: params.eventId,
-      receivedAt: this.now(),
+      ...params.receipt,
       actor: params.actor,
       channel: params.channel,
       text: params.messageText || undefined,
@@ -2772,7 +2794,7 @@ function requiresOutboundAttachments(intent: MessagingSurfaceIntent): boolean {
 
 function parseEmbeddedPost(
   raw: string | undefined,
-): { id: string; channel_id: string; user_id: string; message: string; root_id?: string; file_ids?: string[]; props?: Record<string, unknown> } | undefined {
+): { id: string; channel_id: string; user_id: string; message: string; create_at?: number; root_id?: string; file_ids?: string[]; props?: Record<string, unknown> } | undefined {
   if (!raw) {
     return undefined;
   }
@@ -2782,6 +2804,7 @@ function parseEmbeddedPost(
       channel_id?: string;
       user_id?: string;
       message?: string;
+      create_at?: number;
       root_id?: string;
       file_ids?: string[];
       props?: Record<string, unknown>;
@@ -2794,6 +2817,7 @@ function parseEmbeddedPost(
       channel_id: parsed.channel_id,
       user_id: parsed.user_id,
       message: parsed.message ?? "",
+      ...(typeof parsed.create_at === "number" ? { create_at: parsed.create_at } : {}),
       ...(parsed.root_id ? { root_id: parsed.root_id } : {}),
       ...(parsed.file_ids ? { file_ids: parsed.file_ids } : {}),
       ...(parsed.props ? { props: parsed.props } : {}),

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1513,7 +1513,7 @@ describe("SlackAdapter", () => {
         channel_type: "channel",
         team: "T012ABCDEF0",
         bot_id: "B012SPINNKR",
-        ts: "1712023032.000600",
+        ts: "1699999999.500000",
         text: "",
         attachments: [
           {
@@ -1530,6 +1530,10 @@ describe("SlackAdapter", () => {
     expect(event?.actor.platformUserId).toBe("B012SPINNKR");
     expect(event?.actor.isBot).toBe(true);
     expect(event?.observedOnly).toBe(true);
+    expect(event).toMatchObject({
+      providerSentAt: 1_699_999_999_500,
+      receivedAt: 1_700_000_000_000,
+    });
     if (event?.kind === "text") {
       expect(event.text).toContain("Pipeline failed for CATALOGAPI");
       expect(event.text).toContain("catalog-api-prod pipeline has failed");

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -26,6 +26,7 @@ import type {
   MessagingDeliveryResult,
   MessagingDeliveryScope,
   MessagingInboundEvent,
+  MessagingInboundReceipt,
   MessagingInboundRejectedListener,
   MessagingJsonValue,
   MessagingManagedConversationCreateRequest,
@@ -42,6 +43,7 @@ import type {
   MessagingSurfaceRef,
 } from "@pwragent/messaging-interface";
 import {
+  captureMessagingInboundReceipt,
   evictStaleStreamAnchors,
   extractMessagingPairingToken,
   MessagingRateLimitGate,
@@ -1134,12 +1136,18 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   private readonly handleSlackEvent = async (payload: unknown): Promise<void> => {
     const envelope = payload as SlackSocketEnvelope;
-    await envelope.ack?.();
     const body = envelope.body as SlackEventsApiBody | undefined;
     const event = (envelope.event ?? body?.event) as
       | SlackMessageEvent
       | SlackAppHomeOpenedEvent
       | undefined;
+    const receipt = captureMessagingInboundReceipt(
+      this.now(),
+      event && (event.type === "message" || event.type === "app_mention")
+        ? slackTimestampToMs(event.ts ?? event.event_ts)
+        : undefined,
+    );
+    await envelope.ack?.();
     if (event?.type === "app_home_opened") {
       if (!event.tab || event.tab === "home") {
         await this.publishAppHome(event.user);
@@ -1149,7 +1157,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     if (!event || (event.type !== "message" && event.type !== "app_mention")) {
       return;
     }
-    await this.handleMessageEvent(event, body?.team_id ?? event.team);
+    await this.handleMessageEvent(event, body?.team_id ?? event.team, receipt);
   };
 
   private async publishAppHomes(userIds: readonly string[]): Promise<void> {
@@ -1191,20 +1199,23 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   private readonly handleInteractive = async (payload: unknown): Promise<void> => {
+    const receipt = captureMessagingInboundReceipt(this.now());
     const envelope = payload as SlackSocketEnvelope;
     await envelope.ack?.();
-    await this.handleBlockAction(envelope.body as SlackBlockActionPayload);
+    await this.handleBlockAction(envelope.body as SlackBlockActionPayload, receipt);
   };
 
   private readonly handleSlashCommand = async (payload: unknown): Promise<void> => {
+    const receipt = captureMessagingInboundReceipt(this.now());
     const envelope = payload as SlackSocketEnvelope;
     await envelope.ack?.();
-    await this.handleSlashPayload(envelope.body as SlackSlashCommandPayload);
+    await this.handleSlashPayload(envelope.body as SlackSlashCommandPayload, receipt);
   };
 
   private async handleMessageEvent(
     event: SlackMessageEvent,
     teamId?: unknown,
+    receipt: MessagingInboundReceipt = captureMessagingInboundReceipt(this.now()),
   ): Promise<void> {
     if (!this.listener) return;
     if (
@@ -1313,7 +1324,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         kind: "media",
         actor,
         channel,
-        receivedAt: this.now(),
+        ...receipt,
         routingState,
         sourceUrl,
         ...(isMention ? { botMention: true } : {}),
@@ -1331,7 +1342,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         kind: "command",
         actor,
         channel,
-        receivedAt: this.now(),
+        ...receipt,
         routingState,
         sourceUrl,
         ...(isMention ? { botMention: true } : {}),
@@ -1348,7 +1359,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       kind: "text",
       actor,
       channel,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
       sourceUrl,
       ...(isMention ? { botMention: true } : {}),
@@ -1379,7 +1390,10 @@ export class SlackAdapter implements SlackProviderAdapter {
     }
   }
 
-  private async handleBlockAction(body: SlackBlockActionPayload): Promise<void> {
+  private async handleBlockAction(
+    body: SlackBlockActionPayload,
+    receipt: MessagingInboundReceipt,
+  ): Promise<void> {
     if (!this.listener) return;
     const action = body.actions?.[0];
     const ids = this.validateInboundIds({
@@ -1453,7 +1467,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       kind: "callback",
       actor,
       channel,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
       interaction: {
         channel: this.channel,
@@ -1471,7 +1485,10 @@ export class SlackAdapter implements SlackProviderAdapter {
     });
   }
 
-  private async handleSlashPayload(body: SlackSlashCommandPayload): Promise<void> {
+  private async handleSlashPayload(
+    body: SlackSlashCommandPayload,
+    receipt: MessagingInboundReceipt,
+  ): Promise<void> {
     if (!this.listener) return;
     const ids = this.validateInboundIds({
       channelId: body.channel_id,
@@ -1516,7 +1533,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       kind: "command",
       actor,
       channel,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
       sourceUrl: slackConversationUrl(ids.channelId, ids.teamId),
       command,

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -654,6 +654,8 @@ describe("TelegramAdapter callback persistence", () => {
     expect(events[0]).toMatchObject({
       kind: "text",
       text: "before",
+      providerSentAt: 1_700_000_000_000,
+      receivedAt: 1_700_000_000_000,
     });
     expect(rejected).toEqual(["unauthorized-conversation"]);
   });

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -16,6 +16,7 @@ import type {
   MessagingFilePart,
   MessagingClientRateLimitStrategy,
   MessagingInboundEvent,
+  MessagingInboundReceipt,
   MessagingInboundRejectedListener,
   MessagingManagedConversationActionRequest,
   MessagingManagedConversationActionResult,
@@ -31,6 +32,7 @@ import type {
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import {
+  captureMessagingInboundReceipt,
   evictStaleStreamAnchors,
   looksLikePairingAttempt,
   layoutMessagingActionRows,
@@ -1459,19 +1461,24 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   async handleUpdate(update: TelegramUpdate): Promise<void> {
+    const receipt = captureMessagingInboundReceipt(
+      this.now(),
+      update.message ? telegramMessageSentAt(update.message) : undefined,
+    );
     if (update.message) {
-      await this.handleMessage(update.update_id, update.message);
+      await this.handleMessage(update.update_id, update.message, receipt);
       return;
     }
 
     if (update.callback_query) {
-      await this.handleCallbackQuery(update.update_id, update.callback_query);
+      await this.handleCallbackQuery(update.update_id, update.callback_query, receipt);
     }
   }
 
   private async handleMessage(
     updateId: number,
     message: TelegramMessage,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     const listener = this.listener;
     if (!listener || !message.from) {
@@ -1545,6 +1552,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           isPairingMessage
           || mentionRemainder !== undefined
           || Boolean(message.text?.startsWith("/")),
+        receipt,
       })
     ) {
       return;
@@ -1571,7 +1579,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           channel: this.channelFromMessage(message),
           command: "help",
           rawText: "/help",
-          receivedAt: this.messageReceivedAt(message),
+          ...receipt,
           routingState: this.routingStateFromMessage(message),
           ...(sourceUrl ? { sourceUrl } : {}),
         });
@@ -1599,7 +1607,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
             message.video?.mime_type,
           sizeBytes: attachments[0]?.sizeBytes,
         },
-        receivedAt: this.messageReceivedAt(message),
+        ...receipt,
         routingState: this.routingStateFromMessage(message),
         ...(sourceUrl ? { sourceUrl } : {}),
         ...(mentionRemainder !== undefined ? { botMention: true } : {}),
@@ -1632,7 +1640,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         : {
             text: inboundText,
           }),
-      receivedAt: this.messageReceivedAt(message),
+      ...receipt,
       routingState: this.routingStateFromMessage(message),
       ...(sourceUrl ? { sourceUrl } : {}),
     } as MessagingInboundEvent);
@@ -1641,6 +1649,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   private async handleCallbackQuery(
     updateId: number,
     callbackQuery: TelegramCallbackQuery,
+    receipt: MessagingInboundReceipt,
   ): Promise<void> {
     const listener = this.listener;
     const message = callbackQuery.message;
@@ -1650,7 +1659,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     if (!this.validateCallbackIdentifiers(updateId, callbackQuery)) {
       return;
     }
-    if (!this.isAuthorizedCallbackSource(callbackQuery)) {
+    if (!this.isAuthorizedCallbackSource(callbackQuery, receipt)) {
       await this.bot.api.answerCallbackQuery({
         callback_query_id: callbackQuery.id,
       });
@@ -1704,7 +1713,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       },
       actionId: persistedBinding?.actionId,
       value: persistedBinding?.value,
-      receivedAt: this.now(),
+      ...receipt,
       routingState,
       ...(sourceUrl ? { sourceUrl } : {}),
     });
@@ -1794,7 +1803,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
   private isAuthorizedMessageSource(
     message: TelegramMessage,
-    options: { actionable: boolean },
+    options: { actionable: boolean; receipt: MessagingInboundReceipt },
   ): boolean {
     const actorId = String(message.from?.id ?? "");
     if (!this.isAuthorizedActor(actorId)) {
@@ -1808,6 +1817,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         this.emitInboundRejected(this.rejectedEventFromMessage(message, {
           kind: options.actionable ? "command" : "text",
           reason: "unauthorized-actor",
+          receipt: options.receipt,
         }));
       }
       return false;
@@ -1818,13 +1828,17 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       this.emitInboundRejected(this.rejectedEventFromMessage(message, {
         kind: options.actionable ? "command" : "text",
         reason: "unauthorized-conversation",
+        receipt: options.receipt,
       }));
       return false;
     }
     return true;
   }
 
-  private isAuthorizedCallbackSource(callbackQuery: TelegramCallbackQuery): boolean {
+  private isAuthorizedCallbackSource(
+    callbackQuery: TelegramCallbackQuery,
+    receipt: MessagingInboundReceipt,
+  ): boolean {
     const actorId = String(callbackQuery.from.id);
     const chat = callbackQuery.message?.chat;
     if (!this.isAuthorizedActor(actorId)) {
@@ -1835,6 +1849,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       if (chat) {
         this.emitInboundRejected(this.rejectedEventFromCallback(callbackQuery, {
           reason: "unauthorized-actor",
+          receipt,
         }));
       }
       return false;
@@ -1843,6 +1858,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       this.logUnauthorizedConversationOnce("callback", chat);
       this.emitInboundRejected(this.rejectedEventFromCallback(callbackQuery, {
         reason: "unauthorized-conversation",
+        receipt,
       }));
       return false;
     }
@@ -2574,14 +2590,16 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
   private rejectedEventFromMessage(
     message: TelegramMessage,
-    options: Pick<MessagingRejectedInboundEvent, "kind" | "reason">,
+    options: Pick<MessagingRejectedInboundEvent, "kind" | "reason"> & {
+      receipt: MessagingInboundReceipt;
+    },
   ): MessagingRejectedInboundEvent {
     return {
       id: `telegram:message:${message.message_id}:rejected`,
       kind: options.kind,
       actor: this.actorFromUser(message.from),
       channel: this.channelFromMessage(message),
-      receivedAt: this.messageReceivedAt(message),
+      ...options.receipt,
       reason: options.reason,
       routingState: this.routingStateFromMessage(message),
     };
@@ -2589,7 +2607,9 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
   private rejectedEventFromCallback(
     callbackQuery: TelegramCallbackQuery,
-    options: Pick<MessagingRejectedInboundEvent, "reason">,
+    options: Pick<MessagingRejectedInboundEvent, "reason"> & {
+      receipt: MessagingInboundReceipt;
+    },
   ): MessagingRejectedInboundEvent {
     const message = callbackQuery.message;
     return {
@@ -2605,7 +2625,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
               kind: "dm",
             },
           },
-      receivedAt: this.now(),
+      ...options.receipt,
       reason: options.reason,
       ...(message ? { routingState: this.routingStateFromMessage(message) } : {}),
     };
@@ -2699,10 +2719,6 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     return `${chatId}:${messageThreadId}`;
   }
 
-  private messageReceivedAt(message: TelegramMessage): number {
-    return message.date ? message.date * 1000 : this.now();
-  }
-
   private registerBotHandlers(): void {
     if (!this.bot.on) {
       return;
@@ -2713,7 +2729,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         update?: { update_id?: number };
       };
       if (update.message) {
-        await this.handleMessage(update.update?.update_id ?? this.now(), update.message);
+        await this.handleUpdate({
+          update_id: update.update?.update_id ?? this.now(),
+          message: update.message,
+        });
       }
     });
     this.bot.on("callback_query:data", async (context) => {
@@ -2722,10 +2741,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         update?: { update_id?: number };
       };
       if (update.callbackQuery) {
-        await this.handleCallbackQuery(
-          update.update?.update_id ?? this.now(),
-          update.callbackQuery,
-        );
+        await this.handleUpdate({
+          update_id: update.update?.update_id ?? this.now(),
+          callback_query: update.callbackQuery,
+        });
       }
     });
   }
@@ -2761,6 +2780,12 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     return this.options.fetch ?? fetch;
   }
 
+}
+
+function telegramMessageSentAt(message: TelegramMessage): number | undefined {
+  return typeof message.date === "number" && Number.isFinite(message.date)
+    ? message.date * 1000
+    : undefined;
 }
 
 export function createTelegramAdapter(


### PR DESCRIPTION
## Summary

- I capture a distinct PwrAgent receipt timestamp at each provider's first inbound handler boundary and preserve provider-supplied sent timestamps without inventing them.
- I admit authorized Discord messages before channel and breadcrumb REST enrichment, then publish eventual provider-neutral channel metadata updates without replaying the message.
- I add structured receipt-to-startTurn stage timings, runtime contract validation, provider coverage, and formal adapter guidance without logging message bodies or secrets.

## Verification

- I verified the focused Discord adapter suite passes (55 tests).
- I verified the pre-rebase full workspace suite passes (637 files, 9,262 tests, 6 skipped), and I verified all focused provider, runtime, controller, and contract suites pass.
- I verified `pnpm lint` passes with 43 existing warnings and no errors, including typecheck, license, Codex-storage, color, SQL, Electron-version, and dependency-boundary checks.
- After rebasing onto current `main`, I verified the focused Discord suite and aggregate lint gate again. The current full suite has three Settings failures introduced on `main` by the new Discord permission-check UI tests; this branch does not change the Settings renderer or those tests.

## Notes

- Initial Discord admission intentionally carries stable IDs and available gateway metadata. REST-derived titles and breadcrumb hierarchy arrive through the metadata-update hook after admission.
- Provider-to-receipt duration uses separate clocks and can expose clock skew; receipt-to-startTurn and issue-to-acceptance durations use the PwrAgent clock.
