### PR TITLE
fix(messaging): target bound reply admission

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2912,6 +2912,76 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("coalesces targeted directory refreshes while the first probe is pending", async () => {
+    let finishProbe: (() => void) | undefined;
+    const probeGate = new Promise<void>((resolve) => {
+      finishProbe = resolve;
+    });
+    const readDirectoryStatusEntries = vi.fn(
+      (directories: Array<{ key: string }>) =>
+        (async function* () {
+          await probeGate;
+          yield {
+            directoryKey: directories[0]!.key,
+            gitStatus: {
+              currentBranch: "main",
+              syncState: "in-sync" as const,
+            },
+          };
+        })(),
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        invalidateDirectoryStatus: vi.fn(),
+        readDirectoryStatusEntries,
+      } as never,
+    });
+    const writeDirectoryGitStatus = vi.fn(async () => undefined);
+    registry.setDirectoryGitStatusWriter(writeDirectoryGitStatus);
+    registry.rememberCompleteNavigationSnapshot({
+      backend: "all",
+      directories: [
+        {
+          key: "directory:/owner/repo",
+          kind: "directory",
+          label: "repo",
+          path: "/owner/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      fetchedAt: 1_000,
+      inboxThreadKeys: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+      threads: [],
+      unchanged: false,
+    });
+
+    try {
+      await expect(registry.refreshDirectoryGitStatuses({
+        directoryKeys: ["directory:/owner/repo"],
+        force: true,
+      })).resolves.toEqual({ scheduledCount: 1 });
+      await expect(registry.refreshDirectoryGitStatuses({
+        directoryKeys: ["directory:/owner/repo"],
+        force: true,
+      })).resolves.toEqual({ scheduledCount: 0 });
+      expect(writeDirectoryGitStatus).not.toHaveBeenCalled();
+
+      finishProbe?.();
+      await vi.waitFor(() => {
+        expect(writeDirectoryGitStatus).toHaveBeenCalledOnce();
+      });
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("hydrates review working state from the shared navigation cache", async () => {
     const worktreePath = "/worktrees/PwrAgnt";
     const gitWorkingState = {

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -7,6 +7,7 @@ import type {
   AppServerThreadReplay,
   CreateScheduledThreadActionRequest,
   NavigationSnapshot,
+  ThreadOverlayState,
 } from "@pwragent/shared";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
@@ -15,7 +16,14 @@ import {
   type DesktopMessagingFederationBridge,
 } from "../messaging/desktop-backend-bridge";
 
-const { readDirectoryGitStatusCache, reconcileNavigationSnapshot } = vi.hoisted(() => ({
+const {
+  getThreadOverlayState,
+  readDirectoryGitStatusCache,
+  reconcileNavigationSnapshot,
+} = vi.hoisted(() => ({
+  getThreadOverlayState: vi.fn(
+    async (): Promise<ThreadOverlayState | undefined> => undefined,
+  ),
   readDirectoryGitStatusCache: vi.fn(async () => ({})),
   reconcileNavigationSnapshot: vi.fn(async (params: {
     backend: NavigationSnapshot["backend"];
@@ -40,6 +48,7 @@ const { readDirectoryGitStatusCache, reconcileNavigationSnapshot } = vi.hoisted(
 
 vi.mock("../app-server/desktop-overlay-store", () => ({
   getDesktopOverlayStore: () => ({
+    getThreadOverlayState,
     readDirectoryGitStatusCache,
     reconcileNavigationSnapshot,
   }),
@@ -66,6 +75,94 @@ vi.mock("../app-server/codex-environment-config", () => ({
 }));
 
 describe("DesktopMessagingBackendBridge", () => {
+  it("resolves admission state from one thread cache and overlay only", async () => {
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      fastMode: true,
+      handoffOrigin: {
+        sourceBackend: "codex",
+        sourceThreadId: "parent-1",
+        seedMode: "clean",
+        groupingMode: "none",
+        createdAt: 1_000,
+        workspace: {
+          mode: "same",
+          cwd: "/repos/PwrAgnt",
+          git: {
+            kind: "git_local",
+            worktreeCreationAvailable: true,
+          },
+        },
+      },
+      model: "gpt-5.5",
+    });
+    const getCachedThreadSummary = vi.fn(() => ({
+      id: "thread-1",
+      title: "Cached thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      executionMode: "full-access" as const,
+      threadStatus: "idle" as const,
+    }));
+    const listThreads = vi.fn(async () => []);
+    const readDirectoryStatuses = vi.fn(async () => ({}));
+    const registry = {
+      getActiveTurnForThread: vi.fn(() => ({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-live",
+      })),
+      getCachedThreadSummary,
+      isThreadTurnOccupied: vi.fn(() => true),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({
+        "codex:thread-1": { mode: "full-access", queuedAt: 2_000 },
+      })),
+      getQueuedTurnsSnapshot: vi.fn(() => ({
+        "codex:thread-1": [
+          {
+            queueEntryId: "queue-1",
+            origin: "messaging",
+            displayText: "queued reply",
+            createdAt: 2_100,
+            position: 0,
+          },
+        ],
+      })),
+      listThreads,
+      readDirectoryStatuses,
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const state = await bridge.getThreadAdmissionState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(state).toMatchObject({
+      activeTurn: { turnId: "turn-live" },
+      threadStatus: "active",
+      thread: {
+        executionMode: "default",
+        fastMode: true,
+        handoffOrigin: { sourceThreadId: "parent-1" },
+        model: "gpt-5.5",
+        queuedExecutionMode: "full-access",
+        queuedTurns: [{ queueEntryId: "queue-1" }],
+        title: "Cached thread",
+      },
+    });
+    expect(getCachedThreadSummary).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(listThreads).not.toHaveBeenCalled();
+    expect(readDirectoryStatuses).not.toHaveBeenCalled();
+  });
+
   it("serves cached directory status without awaiting a fleet refresh", async () => {
     const cachedGitStatus = {
       currentBranch: "main",
@@ -122,6 +219,60 @@ describe("DesktopMessagingBackendBridge", () => {
 
     expect(snapshot.directories[0]?.gitStatus).toEqual(cachedGitStatus);
     expect(readDirectoryStatuses).not.toHaveBeenCalled();
+  });
+
+  it("returns a broad snapshot before its stale directory batch finishes", async () => {
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repos/PwrAgnt",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    readDirectoryGitStatusCache.mockResolvedValueOnce({});
+    let finishRefresh: (() => void) | undefined;
+    const refreshDirectoryGitStatuses = vi.fn(
+      async () => await new Promise<{ scheduledCount: number }>((resolve) => {
+        finishRefresh = () => resolve({ scheduledCount: 1 });
+      }),
+    );
+    const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      hydrateThreadGitWorkingStates: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      listThreads: vi.fn(async () => []),
+      refreshDirectoryGitStatuses,
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    await expect(bridge.getNavigationSnapshot({})).resolves.toMatchObject({
+      directories: [{ key: "directory:/repos/PwrAgnt" }],
+    });
+    expect(refreshDirectoryGitStatuses).toHaveBeenCalledExactlyOnceWith({
+      directoryKeys: ["directory:/repos/PwrAgnt"],
+      force: false,
+    });
+    finishRefresh?.();
   });
 
   it("hydrates review working state before the messenger chooses a project", async () => {
@@ -810,6 +961,17 @@ describe("DesktopMessagingBackendBridge", () => {
       },
     };
     const remoteNavigationSnapshot = vi.fn(async () => remoteNavigation);
+    const resolveThreadAdmissionState = vi.fn(async () => ({
+      thread: {
+        id: "thread-1",
+        title: "Remote thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+      threadStatus: "idle" as const,
+    }));
     const listBackends = vi.fn(async () => ({
       fetchedAt: 2_000,
       backends: [
@@ -849,6 +1011,7 @@ describe("DesktopMessagingBackendBridge", () => {
         createScheduledThreadAction,
         listBackends,
         listScheduledThreadActions,
+        resolveThreadAdmissionState,
         startTurn,
       } as unknown as FederationBackendOperations),
       remoteNavigationSnapshot,
@@ -875,6 +1038,25 @@ describe("DesktopMessagingBackendBridge", () => {
         federationTarget: target,
       }),
     ).resolves.toBe(remoteNavigation);
+    await expect(
+      bridge.getThreadAdmissionState({
+        backend: "codex",
+        federationTarget: target,
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      thread: {
+        id: "thread-1",
+        federation: {
+          instanceLabel: "client_one",
+          ref: {
+            backend: "codex",
+            threadId: "thread-1",
+            target: { scope: "remote", instanceId: "client_one" },
+          },
+        },
+      },
+    });
     await expect(
       bridge.listBackends({
         includeUnavailable: true,
@@ -909,6 +1091,10 @@ describe("DesktopMessagingBackendBridge", () => {
     expect(remoteNavigationSnapshot).toHaveBeenCalledWith(target, {
       backend: "all",
       federationTarget: target,
+    });
+    expect(resolveThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
     });
     expect(listBackends).toHaveBeenCalledWith({
       includeUnavailable: true,

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -163,6 +163,45 @@ describe("DesktopMessagingBackendBridge", () => {
     expect(readDirectoryStatuses).not.toHaveBeenCalled();
   });
 
+  it("preserves overlay branch metadata when the thread summary cache is cold", async () => {
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-cold",
+      extraLinkedDirectories: [
+        {
+          id: "directory:/repos/PwrAgnt",
+          kind: "local",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+        },
+      ],
+      gitBranch: "feature/cache-owner",
+      observedGitBranch: "feature/cache-owner-observed",
+    });
+    const registry = {
+      getActiveTurnForThread: vi.fn(() => undefined),
+      getCachedThreadSummary: vi.fn(() => undefined),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      isThreadTurnOccupied: vi.fn(() => false),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    await expect(bridge.getThreadAdmissionState({
+      backend: "codex",
+      threadId: "thread-cold",
+    })).resolves.toMatchObject({
+      thread: {
+        gitBranch: "feature/cache-owner",
+        observedGitBranch: "feature/cache-owner-observed",
+        linkedDirectories: [
+          expect.objectContaining({ path: "/repos/PwrAgnt" }),
+        ],
+      },
+      threadStatus: "idle",
+    });
+  });
+
   it("serves cached directory status without awaiting a fleet refresh", async () => {
     const cachedGitStatus = {
       currentBranch: "main",
@@ -1112,6 +1151,83 @@ describe("DesktopMessagingBackendBridge", () => {
       backend: "codex",
       threadId: "thread-1",
     });
+  });
+
+  it("falls back to remote navigation when an older peer lacks targeted admission", async () => {
+    const methodNotFound = Object.assign(
+      new Error("Unknown federation method: resolve_thread_admission_state"),
+      { code: "method_not_found" },
+    );
+    const resolveThreadAdmissionState = vi.fn(async () => {
+      throw methodNotFound;
+    });
+    const remoteNavigation: NavigationSnapshot = {
+      backend: "codex",
+      fetchedAt: 2_000,
+      unchanged: false,
+      threads: [
+        {
+          id: "thread-1",
+          title: "Remote thread",
+          titleSource: "explicit",
+          source: "codex",
+          threadStatus: "active",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      ],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const remoteNavigationSnapshot = vi.fn(async () => remoteNavigation);
+    const target = { scope: "remote" as const, instanceId: "legacy_peer" };
+    const federation = {
+      connectedPeerTargets: () => [
+        {
+          capabilities: ["messaging_route"],
+          label: "Legacy Peer",
+          target,
+        },
+      ],
+      onRemoteBackendEvent: () => () => undefined,
+      remoteBackend: () => ({
+        resolveThreadAdmissionState,
+      } as unknown as FederationBackendOperations),
+      remoteNavigationSnapshot,
+    } as unknown as DesktopMessagingFederationBridge;
+    const bridge = new DesktopMessagingBackendBridge(
+      {} as DesktopBackendRegistry,
+      federation,
+    );
+
+    await expect(
+      bridge.getThreadAdmissionState({
+        backend: "codex",
+        federationTarget: target,
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      thread: {
+        id: "thread-1",
+        federation: { instanceLabel: "Legacy Peer" },
+      },
+      threadStatus: "active",
+    });
+    expect(remoteNavigationSnapshot).toHaveBeenCalledWith(
+      target,
+      {
+        backend: "codex",
+        federationTarget: target,
+      },
+      {
+        kind: "threads",
+        threads: [{ backend: "codex", threadId: "thread-1" }],
+      },
+    );
   });
 
   it("subscribes messaging controllers to local and remote backend events", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -15,7 +15,8 @@ import {
   type DesktopMessagingFederationBridge,
 } from "../messaging/desktop-backend-bridge";
 
-const { reconcileNavigationSnapshot } = vi.hoisted(() => ({
+const { readDirectoryGitStatusCache, reconcileNavigationSnapshot } = vi.hoisted(() => ({
+  readDirectoryGitStatusCache: vi.fn(async () => ({})),
   reconcileNavigationSnapshot: vi.fn(async (params: {
     backend: NavigationSnapshot["backend"];
     fetchedAt: number;
@@ -38,7 +39,10 @@ const { reconcileNavigationSnapshot } = vi.hoisted(() => ({
 }));
 
 vi.mock("../app-server/desktop-overlay-store", () => ({
-  getDesktopOverlayStore: () => ({ reconcileNavigationSnapshot }),
+  getDesktopOverlayStore: () => ({
+    readDirectoryGitStatusCache,
+    reconcileNavigationSnapshot,
+  }),
 }));
 
 const { hydrateLaunchpadCodexEnvironmentOptions } = vi.hoisted(() => ({
@@ -62,6 +66,64 @@ vi.mock("../app-server/codex-environment-config", () => ({
 }));
 
 describe("DesktopMessagingBackendBridge", () => {
+  it("serves cached directory status without awaiting a fleet refresh", async () => {
+    const cachedGitStatus = {
+      currentBranch: "main",
+      syncState: "in-sync" as const,
+    };
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repos/PwrAgnt",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    readDirectoryGitStatusCache.mockResolvedValueOnce({
+      "directory:/repos/PwrAgnt": {
+        directoryKey: "directory:/repos/PwrAgnt",
+        directoryPath: "/repos/PwrAgnt",
+        fetchedAt: Date.now(),
+        gitStatus: cachedGitStatus,
+      },
+    });
+    const readDirectoryStatuses = vi.fn(async () => ({}));
+    const refreshDirectoryGitStatuses = vi.fn(async () => ({ scheduledCount: 0 }));
+    const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      hydrateThreadGitWorkingStates: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      listThreads: vi.fn(async () => []),
+      readDirectoryStatuses,
+      refreshDirectoryGitStatuses,
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const snapshot = await bridge.getNavigationSnapshot({});
+
+    expect(snapshot.directories[0]?.gitStatus).toEqual(cachedGitStatus);
+    expect(readDirectoryStatuses).not.toHaveBeenCalled();
+  });
+
   it("hydrates review working state before the messenger chooses a project", async () => {
     const pwrAgentWorktree = "/worktrees/PwrAgnt";
     const listedThread: AppServerThreadSummary = {

--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -1328,6 +1328,9 @@ async function createControllerHarness(options: {
     authorizedActorIds: [DISCORD_USER_ID],
     backend: {
       getNavigationSnapshot,
+      getThreadAdmissionState: async () => ({
+        thread: (options.navigationSnapshot ?? buildNavigationSnapshot()).threads[0],
+      }),
       startTurn,
     },
     inputDebounceMs: 0,

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -219,6 +219,64 @@ describe("federation backend bridge", () => {
     ).toBe("launchpad_metadata");
   });
 
+  it("routes targeted admission state through messaging_route", async () => {
+    const resolveThreadAdmissionState = vi.fn(async () => ({
+      threadStatus: "active" as const,
+      activeTurn: {
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+    }));
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["messaging_route"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        resolveThreadAdmissionState,
+      } as unknown as FederationBackendOperations,
+    });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "admission-state",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState,
+        params: { backend: "codex", threadId: "thread-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState
+      ],
+    ).toBe("messaging_route");
+    expect(resolveThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(replies).toContainEqual(
+      expect.objectContaining({
+        kind: "response",
+        requestId: "admission-state",
+        result: expect.objectContaining({ threadStatus: "active" }),
+      }),
+    );
+  });
+
   it("does not expose profile-local thread model migrations over federation", () => {
     expect(FEDERATION_BACKEND_METHODS).not.toHaveProperty(
       "applyThreadModelMigration",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4375,6 +4375,24 @@ describe("MessagingController", () => {
     });
   });
 
+  it("admits an ordinary bound reply without requesting a navigation snapshot", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.getNavigationSnapshot.mockClear();
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("Reply without walking the directory fleet"),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    );
+    expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
   it("preserves the messaging location for queued Agent-thread turns", async () => {
     const harness = await createHarness();
     harness.startTurn.mockImplementation(async (request: StartTurnRequest) => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4868,6 +4868,11 @@ describe("MessagingController", () => {
       channel: "slack",
       createManagedConversation,
       getNavigationSnapshot,
+      getThreadAdmissionState: async (request) => ({
+        thread: request.federationTarget?.scope === "remote"
+          ? remoteNavigation.threads[0]
+          : localNavigation.threads[0],
+      }),
       navigation: localNavigation,
       resolveThreadTarget,
     });
@@ -4939,6 +4944,7 @@ describe("MessagingController", () => {
     );
 
     getNavigationSnapshot.mockClear();
+    harness.getThreadAdmissionState.mockClear();
     await harness.controller.handleBackendEvent({
       backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
@@ -4950,12 +4956,15 @@ describe("MessagingController", () => {
         },
       },
     });
-    expect(getNavigationSnapshot).toHaveBeenCalledWith({
-      backend: "all",
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(harness.getThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+      threadId: "remote-thread",
     });
 
     getNavigationSnapshot.mockClear();
+    harness.getThreadAdmissionState.mockClear();
     await harness.controller.handleBackendEvent({
       backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
@@ -4968,12 +4977,15 @@ describe("MessagingController", () => {
         },
       },
     });
-    expect(getNavigationSnapshot).toHaveBeenCalledWith({
-      backend: "all",
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(harness.getThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+      threadId: "remote-thread",
     });
 
     getNavigationSnapshot.mockClear();
+    harness.getThreadAdmissionState.mockClear();
     await harness.controller.handleBackendEvent({
       backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
@@ -4982,9 +4994,11 @@ describe("MessagingController", () => {
         params: {},
       },
     });
-    expect(getNavigationSnapshot).toHaveBeenCalledWith({
-      backend: "all",
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(harness.getThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+      threadId: "remote-thread",
     });
 
     harness.startTurn.mockClear();
@@ -14084,10 +14098,12 @@ describe("MessagingController", () => {
     });
   });
 
-  it("clears starting state when navigation lookup fails before retrying", async () => {
+  it("clears starting state when admission-state lookup fails before retrying", async () => {
     const harness = await createHarness();
     await bindThread(harness);
-    harness.getNavigationSnapshot.mockRejectedValueOnce(new Error("navigation unavailable"));
+    harness.getThreadAdmissionState.mockRejectedValueOnce(
+      new Error("admission state unavailable"),
+    );
 
     await harness.controller.handleInboundEvent(buildTextEvent("first turn"));
 
@@ -14095,7 +14111,7 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "error",
       title: "Turn could not start",
-      body: "navigation unavailable",
+      body: "admission state unavailable",
     });
 
     await harness.controller.handleInboundEvent(buildTextEvent("retry turn"));
@@ -21392,6 +21408,9 @@ describe("MessagingController", () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0]!.executionMode = "default";
     harness.getNavigationSnapshot.mockResolvedValue(navigation);
+    harness.getThreadAdmissionState.mockResolvedValue({
+      thread: navigation.threads[0],
+    });
     await bindThread(harness);
     const binding = await harness.store.findActiveBindingForChannel(buildTextEvent("").channel);
     expect(binding).toBeDefined();
@@ -23112,6 +23131,7 @@ async function createHarness(options?: {
   responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
   getManagedConversationRights?: MessagingAdapter["getManagedConversationRights"];
   getNavigationSnapshot?: NonNullable<MessagingBackendBridge["getNavigationSnapshot"]>;
+  getThreadAdmissionState?: NonNullable<MessagingBackendBridge["getThreadAdmissionState"]>;
   createManagedConversation?: MessagingAdapter["createManagedConversation"];
   closeManagedConversation?: MessagingAdapter["closeManagedConversation"];
   deleteManagedConversation?: MessagingAdapter["deleteManagedConversation"];
@@ -23178,6 +23198,7 @@ async function createHarness(options?: {
   delivered: MessagingSurfaceIntent[];
   ensureDirectoryLaunchpad: ReturnType<typeof vi.fn>;
   getNavigationSnapshot: ReturnType<typeof vi.fn>;
+  getThreadAdmissionState: ReturnType<typeof vi.fn>;
   handoffThreadWorkspace: ReturnType<typeof vi.fn> | undefined;
   interruptTurn: ReturnType<typeof vi.fn>;
   listSkills: ReturnType<typeof vi.fn> | undefined;
@@ -23257,6 +23278,29 @@ async function createHarness(options?: {
   const getNavigationSnapshot = vi.fn(
     options?.getNavigationSnapshot
       ?? (async () => options?.navigation ?? buildNavigationSnapshot()),
+  );
+  const getThreadAdmissionState = vi.fn(
+    options?.getThreadAdmissionState
+      ?? (async (request) => {
+        const navigation = options?.navigation ?? buildNavigationSnapshot();
+        const thread = navigation.threads.find(
+          (candidate) =>
+            candidate.source === request.backend
+            && candidate.id === request.threadId,
+        );
+        const activeTurn = options?.readActiveTurn
+          ? await options.readActiveTurn(request)
+          : undefined;
+        return {
+          ...(activeTurn ? { activeTurn } : {}),
+          ...(thread ? { thread } : {}),
+          ...(activeTurn
+            ? { threadStatus: "active" as const }
+            : thread?.threadStatus
+              ? { threadStatus: thread.threadStatus }
+              : {}),
+        };
+      }),
   );
   const ensureDirectoryLaunchpad = vi.fn(
     options?.ensureDirectoryLaunchpad ??
@@ -23611,6 +23655,7 @@ async function createHarness(options?: {
     cancelThreadExecutionModeQueue,
     ensureDirectoryLaunchpad,
     getNavigationSnapshot,
+    getThreadAdmissionState,
     ...(handoffThreadWorkspace ? { handoffThreadWorkspace } : {}),
     interruptTurn,
     createScheduledThreadAction,
@@ -23692,6 +23737,7 @@ async function createHarness(options?: {
     delivered,
     ensureDirectoryLaunchpad,
     getNavigationSnapshot,
+    getThreadAdmissionState,
     handoffThreadWorkspace,
     interruptTurn,
     listSkills,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -13755,6 +13755,33 @@ describe("MessagingController", () => {
     });
   });
 
+  it("starts a new turn when targeted admission reports idle after a missed completion", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(buildTextEvent("first turn"));
+    const navigation = buildNavigationSnapshot();
+    harness.getThreadAdmissionState.mockResolvedValue({
+      thread: navigation.threads[0],
+      threadStatus: "idle",
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("next turn"));
+
+    expect(harness.startTurn).toHaveBeenCalledTimes(2);
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "next turn" }],
+      }),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        title: "Message queued",
+      }),
+    );
+  });
+
   it("queues a second surface message on the same Agent thread without creating a shadow thread", async () => {
     const harness = await createHarness();
     const telegramChannel = buildTextEvent("ignored").channel;

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -3818,6 +3818,9 @@ function createBackendBridge(): MessagingBackendBridge & {
 
   return {
     getNavigationSnapshot: vi.fn(async () => buildNavigationSnapshot()),
+    getThreadAdmissionState: vi.fn(async () => ({
+      thread: buildNavigationSnapshot().threads[0],
+    })),
     startTurn: vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2246,6 +2246,9 @@ describe("TelegramAdapter", () => {
       authorizedActorIds: ["42"],
       backend: {
         getNavigationSnapshot: async () => buildNavigationSnapshot(),
+        getThreadAdmissionState: async () => ({
+          thread: buildNavigationSnapshot().threads[0],
+        }),
         interruptTurn: restartedInterruptTurn,
         startTurn: async (request: StartTurnRequest) => ({
           backend: request.backend,
@@ -3073,6 +3076,9 @@ async function createControllerHarness(): Promise<{
     authorizedActorIds: ["42"],
     backend: {
       getNavigationSnapshot,
+      getThreadAdmissionState: async () => ({
+        thread: buildNavigationSnapshot().threads[0],
+      }),
       startTurn,
     },
     inputDebounceMs: 0,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7821,6 +7821,7 @@ export class DesktopBackendRegistry {
     | ThreadPullRequestWatchToolHandler
     | undefined;
   private directoryGitStatusWriter: DirectoryGitStatusWriter | undefined;
+  private readonly pendingDirectoryGitStatusKeys = new Set<string>();
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadPullRequestDetachHandler:
     | ThreadPullRequestDetachHandler
@@ -9512,6 +9513,37 @@ export class DesktopBackendRegistry {
     if (!threadId) {
       return undefined;
     }
+    const cached = this.getCachedThreadSummary({
+      backend: params.backend,
+      threadId,
+    });
+    if (cached) {
+      return cached;
+    }
+    const threads = await this.listThreads({
+      backend: params.backend,
+      archived: false,
+      callerReason: "thread-id-lookup",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    return threads.find((thread) => thread.id === threadId);
+  }
+
+  /**
+   * Read one already-observed thread without starting or awaiting a provider
+   * thread-list walk. Hot-path consumers such as messaging admission combine
+   * this volatile summary with the durable per-thread overlay instead of
+   * asking navigation to rebuild every thread and directory.
+   */
+  getCachedThreadSummary(params: {
+    backend?: AppServerBackendKind;
+    threadId: string;
+  }): AppServerThreadSummary | undefined {
+    const threadId = params.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
     for (const state of this.threadListCache.values()) {
       const cached = state.threads?.find(
         (thread) =>
@@ -9522,14 +9554,7 @@ export class DesktopBackendRegistry {
         return cached;
       }
     }
-    const threads = await this.listThreads({
-      backend: params.backend,
-      archived: false,
-      callerReason: "thread-id-lookup",
-      enrichDirectories: false,
-      forceRefresh: true,
-    });
-    return threads.find((thread) => thread.id === threadId);
+    return undefined;
   }
 
   async getThreadAgentMetadata(params: {
@@ -11579,40 +11604,61 @@ export class DesktopBackendRegistry {
       .map((key) => this.navigationDirectoriesByKey.get(key))
       .filter((directory): directory is NavigationDirectorySummary =>
         Boolean(directory?.path?.trim()),
-      );
+      )
+      .filter((directory) => !this.pendingDirectoryGitStatusKeys.has(directory.key));
+    for (const directory of directories) {
+      this.pendingDirectoryGitStatusKeys.add(directory.key);
+    }
     if (request.force !== false) {
       for (const directory of directories) {
         this.gitDirectoryService.invalidateDirectoryStatus(directory.path);
       }
     }
-    for await (const entry of this.gitDirectoryService.readDirectoryStatusEntries(
-      directories,
-    )) {
-      const fetchedAt = Date.now();
-      const directory = this.navigationDirectoriesByKey.get(entry.directoryKey);
-      if (this.directoryGitStatusWriter) {
-        await this.directoryGitStatusWriter({
-          directory,
-          directoryKey: entry.directoryKey,
-          fetchedAt,
-          gitStatus: entry.gitStatus,
-        });
-        continue;
-      }
-      const notification: NavigationDirectoryGitStatusUpdatedNotification = {
-        method: "navigation/directoryGitStatus/updated",
-        params: {
-          directoryKey: entry.directoryKey,
-          gitStatus: entry.gitStatus ?? null,
-          fetchedAt,
-        },
-      };
-      await this.emit({
-        backend: "codex",
-        notification,
-      } as unknown as AgentEvent);
-    }
+    void this.refreshDirectoryGitStatusesInBackground(directories);
     return { scheduledCount: directories.length };
+  }
+
+  private async refreshDirectoryGitStatusesInBackground(
+    directories: NavigationDirectorySummary[],
+  ): Promise<void> {
+    try {
+      for await (const entry of this.gitDirectoryService.readDirectoryStatusEntries(
+        directories,
+      )) {
+        const fetchedAt = Date.now();
+        const directory = this.navigationDirectoriesByKey.get(entry.directoryKey);
+        if (this.directoryGitStatusWriter) {
+          await this.directoryGitStatusWriter({
+            directory,
+            directoryKey: entry.directoryKey,
+            fetchedAt,
+            gitStatus: entry.gitStatus,
+          });
+          continue;
+        }
+        const notification: NavigationDirectoryGitStatusUpdatedNotification = {
+          method: "navigation/directoryGitStatus/updated",
+          params: {
+            directoryKey: entry.directoryKey,
+            gitStatus: entry.gitStatus ?? null,
+            fetchedAt,
+          },
+        };
+        await this.emit({
+          backend: "codex",
+          notification,
+        } as unknown as AgentEvent);
+      }
+    } catch (error) {
+      backendRegistryLog.warn("directory Git status refresh failed", {
+        directoryKeys: directories.map((directory) => directory.key),
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      for (const directory of directories) {
+        this.pendingDirectoryGitStatusKeys.delete(directory.key);
+      }
+    }
   }
 
   readWorktreeWorkingStateEntries(
@@ -13561,6 +13607,13 @@ export class DesktopBackendRegistry {
       }
     }
     return undefined;
+  }
+
+  isThreadTurnOccupied(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): boolean {
+    return this.threadHasActiveTurn(params.threadId, params.backend);
   }
 
   private getPendingTurnForThread(params: {

--- a/apps/desktop/src/main/app-server/directory-git-status-refresh-policy.ts
+++ b/apps/desktop/src/main/app-server/directory-git-status-refresh-policy.ts
@@ -1,0 +1,48 @@
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+
+type DirectoryGitStatusCacheEntryLike = {
+  directoryUpdatedAt?: number;
+  fetchedAt: number;
+};
+
+/**
+ * Directory status is navigation context, not an admission or correctness
+ * gate. Five minutes keeps an untouched fleet calm while explicit focus and
+ * mutation paths refresh the directories the operator is actually using.
+ */
+export const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
+export const DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE = 4;
+
+// Forced focus refreshes can arrive in rapid succession while the operator
+// flips between threads in one repository. Collapse the post-completion gap;
+// in-flight requests already coalesce separately.
+export const DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS = 3_000;
+
+export function isFreshDirectoryGitStatusCacheEntry(
+  entry: DirectoryGitStatusCacheEntryLike,
+  now = Date.now(),
+): boolean {
+  return now - entry.fetchedAt < DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS;
+}
+
+export function selectStaleDirectoryGitStatusKeys(params: {
+  cache: Record<string, DirectoryGitStatusCacheEntryLike>;
+  directories: NavigationDirectorySummary[];
+  limit?: number;
+  now?: number;
+}): string[] {
+  const now = params.now ?? Date.now();
+  return params.directories
+    .filter((directory) => {
+      if (!directory.path?.trim()) {
+        return false;
+      }
+      const cached = params.cache[directory.key];
+      return !cached
+        || !isFreshDirectoryGitStatusCacheEntry(cached, now)
+        || (directory.latestUpdatedAt ?? 0) > (cached.directoryUpdatedAt ?? 0);
+    })
+    .sort((left, right) => (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0))
+    .slice(0, params.limit ?? DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE)
+    .map((directory) => directory.key);
+}

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -1,6 +1,7 @@
 import type {
   AnalyzeThreadToolHistoryRequest,
   AnalyzeThreadToolHistoryResponse,
+  AppServerBackendKind,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
   AppServerListThreadsRequest,
@@ -139,6 +140,7 @@ import type {
   SubmitServerRequestResponse,
   TrustCodexProjectRequest,
   TrustCodexProjectResponse,
+  ThreadAdmissionState,
   UpdateSubthreadOrderRequest,
   UpdateSubthreadOrderResponse,
   UpdateScheduledThreadActionRequest,
@@ -350,6 +352,7 @@ export const FEDERATION_BACKEND_METHODS = {
   getNavigationSnapshot: "backend.getNavigationSnapshot",
   listThreads: "backend.listThreads",
   resolveThread: "backend.resolveThread",
+  resolveThreadAdmissionState: "backend.resolveThreadAdmissionState",
   readThread: "backend.readThread",
   analyzeThreadToolHistory: "backend.analyzeThreadToolHistory",
   readTranscriptImage: "backend.readTranscriptImage",
@@ -445,6 +448,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.getNavigationSnapshot]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.resolveThread]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState]: "messaging_route",
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   /* Reads the thread's own transcript history; same data class as reading it. */
   [FEDERATION_BACKEND_METHODS.analyzeThreadToolHistory]: "thread_detail",
@@ -552,6 +556,10 @@ export type FederationBackendOperations = {
     request?: AppServerListThreadsRequest,
   ): Promise<AppServerListThreadsResponse>;
   resolveThread(request: ResolveThreadRequest): Promise<ResolveThreadResponse>;
+  resolveThreadAdmissionState?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadAdmissionState>;
   readThread(
     request: AppServerReadThreadRequest,
   ): Promise<AppServerReadThreadResponse>;
@@ -812,6 +820,20 @@ export function registerFederationBackendHandlers(params: {
       await params.backend.resolveThread(
         envelope.params as ResolveThreadRequest,
       ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState,
+    async (envelope) => {
+      if (!params.backend.resolveThreadAdmissionState) {
+        throw new Error("Targeted thread admission state is unavailable.");
+      }
+      return await params.backend.resolveThreadAdmissionState(
+        envelope.params as {
+          backend: AppServerBackendKind;
+          threadId: string;
+        },
+      );
+    },
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.analyzeThreadToolHistory,
@@ -1490,6 +1512,16 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<ResolveThreadResponse> {
     return await this.rpc.request<ResolveThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.resolveThread,
+      params: request,
+    });
+  }
+
+  async resolveThreadAdmissionState(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadAdmissionState> {
+    return await this.rpc.request<ThreadAdmissionState>({
+      method: FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4770,6 +4770,10 @@ function localBackendOperations(): FederationBackendOperations {
       const thread = await getDesktopBackendRegistry().resolveThread(request);
       return thread ? { thread } : {};
     },
+    async resolveThreadAdmissionState(request) {
+      return await new DesktopMessagingBackendBridge()
+        .getThreadAdmissionState(request);
+    },
     async readThread(
       request: AppServerReadThreadRequest,
     ): Promise<AppServerReadThreadResponse> {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -200,6 +200,11 @@ import {
 import { materializeTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import {
+  DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE,
+  DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS,
+  isFreshDirectoryGitStatusCacheEntry,
+} from "../app-server/directory-git-status-refresh-policy";
 import { getAppStateDb } from "../state/app-state";
 import {
   listModelSettingsRecents,
@@ -350,15 +355,8 @@ const USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS = 10_000;
 const TERMINAL_USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
 const PR_STATUS_TOKEN_BUCKET_CAPACITY = 20;
 const PR_STATUS_TOKEN_BUCKET_REFILL_PER_MINUTE = 20;
-const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT = 4;
-const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
-// Collapse rapid forced directory-git-status re-enqueues for the same key
-// (e.g. flipping between two threads in the same repo) that land within a
-// few seconds of the previous probe completing. Concurrent same-key
-// requests already coalesce via `pendingDirectoryGitStatusKeys`; this
-// closes the sequential post-completion gap so "747, 732, 747, 747, 732,
-// 747" collapses to "747, 732".
-const DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS = 3_000;
+const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT =
+  DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE;
 const BACKGROUND_WORKTREE_WORKING_STATE_REFRESH_BATCH_SIZE = 8;
 // PR discovery (Layer B): a slow branch-lookup rotation across ALL open threads
 // to catch newly opened PRs on projects the operator is not looking at. Tick
@@ -7476,12 +7474,6 @@ class DesktopAppServerService {
     });
     return this.focusedDiffService;
   }
-}
-
-function isFreshDirectoryGitStatusCacheEntry(
-  entry: DirectoryGitStatusCacheEntry,
-): boolean {
-  return Date.now() - entry.fetchedAt < DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS;
 }
 
 function isFreshWorktreeWorkingStateCacheEntry(

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -48,6 +48,7 @@ import type {
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ThreadAgentMetadata,
+  ThreadAdmissionState,
   ThreadMessagingBindingTransition,
   UpdateScheduledThreadActionRequest,
   UpdateDirectoryLaunchpadRequest,
@@ -110,6 +111,13 @@ export type MessagingActiveBackendTurn = {
   turnId: string;
 };
 
+/**
+ * Targeted state needed to admit one bound-thread reply. This projection must
+ * stay independent of navigation-wide Git, PR, launchpad, directory, and
+ * federation enrichment.
+ */
+export type MessagingThreadAdmissionState = ThreadAdmissionState;
+
 export type MessagingAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
@@ -160,6 +168,11 @@ export type MessagingBackendBridge = {
   getNavigationSnapshot(
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot>;
+  getThreadAdmissionState(request: {
+    backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
+    threadId: string;
+  }): Promise<MessagingThreadAdmissionState>;
   /**
    * Storage roots no local-file read may reach. Read through the bridge rather
    * than the backend-registry singleton: that getter constructs a registry with

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -156,6 +156,7 @@ import type {
   MessagingAdapter,
   MessagingBackendBridge,
   MessagingLastAssistantReply,
+  MessagingThreadAdmissionState,
 } from "./messaging-adapter.js";
 import { MessagingFederatedThreadTargetError } from "./messaging-adapter.js";
 import type { MessagingActivityLog } from "../messaging-activity-log.js";
@@ -515,6 +516,24 @@ function findThreadForBinding(
       thread.id === binding.threadId &&
       federationRefsMatch(thread.federation?.ref, binding.federatedThread),
   );
+}
+
+function navigationSnapshotForAdmissionState(
+  binding: MessagingBindingRecord,
+  state: MessagingThreadAdmissionState,
+): NavigationSnapshot {
+  return {
+    backend: binding.backend,
+    directories: [],
+    fetchedAt: Date.now(),
+    inboxThreadKeys: [],
+    launchpadDefaults: {
+      backend: binding.backend,
+      executionMode: "default",
+    },
+    threads: state.thread ? [state.thread] : [],
+    unchanged: false,
+  };
 }
 
 function federationRefsMatch(
@@ -2004,12 +2023,22 @@ export class MessagingController {
     if (renderableBindings.length === 0) {
       return;
     }
-    const navigation = await this.options.backend.getNavigationSnapshot({
-      backend: "all",
-      ...(federationTarget ? { federationTarget } : {}),
-    });
+    const navigationByThreadKey = new Map<string, NavigationSnapshot>();
     for (const binding of renderableBindings) {
       try {
+        const threadKey = threadKeyForBinding(binding);
+        let navigation = navigationByThreadKey.get(threadKey);
+        if (!navigation) {
+          navigation = navigationSnapshotForAdmissionState(
+            binding,
+            await this.options.backend.getThreadAdmissionState({
+              backend: binding.backend,
+              federationTarget: federationTargetForBinding(binding),
+              threadId: binding.threadId,
+            }),
+          );
+          navigationByThreadKey.set(threadKey, navigation);
+        }
         await this.renderBindingStatus(binding, undefined, navigation);
       } catch (error) {
         this.logger.debug?.("messaging backend status refresh failed", {
@@ -3580,10 +3609,35 @@ export class MessagingController {
     const consumedSkillBinding = currentBinding.pendingSkillSelection
       ? bindingWithoutPendingSkillSelection(currentBinding)
       : currentBinding;
+    let admissionState: MessagingThreadAdmissionState | undefined;
+    try {
+      admissionState = await this.options.backend.getThreadAdmissionState({
+        backend: consumedSkillBinding.backend,
+        federationTarget: federationTargetForBinding(consumedSkillBinding),
+        threadId: consumedSkillBinding.threadId,
+      });
+    } catch (error) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("turn-start-failed"),
+          createdAt: this.now(),
+          title: "Turn could not start",
+          body: error instanceof Error ? error.message : String(error),
+          recoverable: true,
+        }),
+        consumedSkillBinding,
+        bundle.events[0],
+      );
+      return;
+    }
 
     if (
       !isDefaultAgentRouteBinding(currentBinding)
-      && await this.isTurnOccupied(currentBinding, bundle.threadKey)
+      && await this.isTurnOccupied(
+        currentBinding,
+        bundle.threadKey,
+        admissionState,
+      )
     ) {
       await this.queuePreparedInput({
         binding: consumedSkillBinding,
@@ -3608,6 +3662,7 @@ export class MessagingController {
       preview: preparedWithSkill.preview,
       threadKey: bundle.threadKey,
       event: bundle.events[0],
+      admissionState,
     });
     if (startResult !== "failed" && currentBinding.pendingSkillSelection) {
       const updatedBinding = await this.clearPendingSkillSelection(currentBinding);
@@ -3973,6 +4028,7 @@ export class MessagingController {
   }
 
   private async startPreparedInput(params: {
+    admissionState?: MessagingThreadAdmissionState;
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
@@ -3992,9 +4048,14 @@ export class MessagingController {
     );
 
     try {
-      const navigation = params.navigation ?? await this.options.backend.getNavigationSnapshot({
-        backend: "all",
-      });
+      const admissionState = params.admissionState
+        ?? await this.options.backend.getThreadAdmissionState({
+          backend: params.binding.backend,
+          federationTarget: federationTargetForBinding(params.binding),
+          threadId: params.binding.threadId,
+        });
+      const navigation = params.navigation
+        ?? navigationSnapshotForAdmissionState(params.binding, admissionState);
       startingOrigin = await this.buildAgentMessagingOrigin({
         binding: params.binding,
         event: params.event,
@@ -4159,21 +4220,23 @@ export class MessagingController {
   private async isTurnOccupied(
     binding: MessagingBindingRecord,
     threadKey: string,
+    admissionState: MessagingThreadAdmissionState,
   ): Promise<boolean> {
     if (this.turnAdmission.isStarting(threadKey)) {
       return true;
     }
 
-    const activeTurn = await this.reconcileActiveTurnFromBackendStatus(
-      binding,
-      "turn_admission",
-    );
-    if (activeTurn && ["working", "waiting"].includes(activeTurn.status)) {
+    const rememberedTurn = this.getActiveTurn(binding);
+    if (
+      rememberedTurn
+      && ["working", "waiting"].includes(rememberedTurn.status)
+    ) {
       return true;
     }
-
-    const threadStatus = await this.readBackendThreadStatus(binding);
-    return threadStatus === "active";
+    return Boolean(
+      admissionState.activeTurn
+      || admissionState.threadStatus === "active",
+    );
   }
 
   private async adoptStartedTurn(params: {
@@ -4406,7 +4469,12 @@ export class MessagingController {
 
   private async startNextQueuedTurn(binding: MessagingBindingRecord): Promise<void> {
     const threadKey = this.threadKeyForBinding(binding);
-    if (await this.isTurnOccupied(binding, threadKey)) {
+    const admissionState = await this.options.backend.getThreadAdmissionState({
+      backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
+      threadId: binding.threadId,
+    });
+    if (await this.isTurnOccupied(binding, threadKey, admissionState)) {
       return;
     }
 
@@ -4424,6 +4492,7 @@ export class MessagingController {
       preview: entry.preview,
       queueOnConcurrentStart: false,
       threadKey,
+      admissionState,
     });
     if (startResult !== "started") {
       return;
@@ -5563,14 +5632,18 @@ export class MessagingController {
     if (renderableBindings.length === 0) {
       return;
     }
-    // Fetch the navigation snapshot once and reuse it across every binding's
-    // render. Without this, each renderBindingStatus call would issue its own
-    // getNavigationSnapshot — N bindings on the same thread = N redundant
-    // backend calls.
-    const navigation = await this.options.backend.getNavigationSnapshot({
-      backend: "all",
+    // Resolve one targeted thread projection and reuse it across every
+    // binding. Thread-state bus fan-out must not rebuild unrelated navigation,
+    // Git, PR, launchpad, or federation state just to repaint a status card.
+    const admissionState = await this.options.backend.getThreadAdmissionState({
+      backend,
       ...(federationTarget ? { federationTarget } : {}),
+      threadId,
     });
+    const navigation = navigationSnapshotForAdmissionState(
+      renderableBindings[0]!,
+      admissionState,
+    );
     for (const binding of renderableBindings) {
       try {
         await this.renderBindingStatus(binding, undefined, navigation);
@@ -5590,7 +5663,7 @@ export class MessagingController {
    * Post a "Permissions queued" audit message in every active binding for
    * the thread, mirroring the desktop transcript audit entry. The
    * registry's `thread/executionMode/queued` notification is the trigger;
-   * we resolve from/to mode labels off the navigation snapshot at the
+   * we resolve from/to mode labels from the targeted thread projection at the
    * time the notification fires.
    */
   private async handleExecutionModeQueued(
@@ -5611,13 +5684,12 @@ export class MessagingController {
       return;
     }
 
-    const navigation = await this.options.backend.getNavigationSnapshot({
-      backend: "all",
+    const admissionState = await this.options.backend.getThreadAdmissionState({
+      backend,
+      federationTarget: federationTargetForBinding(bindings[0]!),
+      threadId: params.threadId,
     });
-    const thread = navigation.threads.find(
-      (candidate) =>
-        candidate.source === backend && candidate.id === params.threadId,
-    );
+    const thread = admissionState?.thread;
     const fromExecutionMode = thread?.executionMode ?? "default";
     const toExecutionMode = params.queuedExecutionMode;
 
@@ -13980,7 +14052,16 @@ export class MessagingController {
     ) {
       return binding;
     }
-    return await this.renderBindingStatus(binding, event, navigation);
+    const targetedNavigation = navigation
+      ?? navigationSnapshotForAdmissionState(
+        binding,
+        await this.options.backend.getThreadAdmissionState({
+          backend: binding.backend,
+          federationTarget: federationTargetForBinding(binding),
+          threadId: binding.threadId,
+        }),
+      );
+    return await this.renderBindingStatus(binding, event, targetedNavigation);
   }
 
   private async navigationSnapshotWithThreadNameFromEvent(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4226,7 +4226,11 @@ export class MessagingController {
       return true;
     }
 
-    const rememberedTurn = this.getActiveTurn(binding);
+    const rememberedTurn = await this.reconcileActiveTurnFromThreadStatus(
+      binding,
+      "turn_admission",
+      admissionState.threadStatus,
+    );
     if (
       rememberedTurn
       && ["working", "waiting"].includes(rememberedTurn.status)
@@ -14457,6 +14461,26 @@ export class MessagingController {
     }
 
     const threadStatus = await this.readBackendThreadStatus(binding);
+    return await this.reconcileActiveTurnFromThreadStatus(
+      binding,
+      reason,
+      threadStatus,
+    );
+  }
+
+  private async reconcileActiveTurnFromThreadStatus(
+    binding: MessagingBindingRecord,
+    reason: string,
+    threadStatus: string | undefined,
+  ): Promise<MessagingActiveTurnSummary | undefined> {
+    const activeTurn = this.getActiveTurn(binding);
+    if (
+      !activeTurn ||
+      !["working", "waiting"].includes(activeTurn.status)
+    ) {
+      return activeTurn;
+    }
+
     if (threadStatus !== "idle") {
       return activeTurn;
     }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -131,39 +131,51 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   }): Promise<MessagingThreadAdmissionState> {
     const remote = this.remoteBackend(request.federationTarget);
     if (remote) {
-      if (!remote.resolveThreadAdmissionState) {
+      const target = request.federationTarget;
+      if (!target || !isRemoteFederationTarget(target) || !this.federation) {
         throw new Error(
-          "The remote instance does not support targeted messaging admission.",
+          "Remote messaging admission requires a federation target.",
         );
       }
-      const state = await remote.resolveThreadAdmissionState({
-        backend: request.backend,
-        threadId: request.threadId,
-      });
-      const target = request.federationTarget;
-      const instanceLabel = target?.scope === "remote"
-        ? this.federation?.connectedPeerTargets().find(
-            (peer) => peer.target.instanceId === target.instanceId,
-          )?.label ?? target.instanceId
-        : undefined;
+      let state: MessagingThreadAdmissionState;
+      if (!remote.resolveThreadAdmissionState) {
+        state = await this.readLegacyRemoteThreadAdmissionState(
+          target,
+          request,
+        );
+      } else {
+        try {
+          state = await remote.resolveThreadAdmissionState({
+            backend: request.backend,
+            threadId: request.threadId,
+          });
+        } catch (error) {
+          if (!isFederationMethodNotFoundError(error)) {
+            throw error;
+          }
+          state = await this.readLegacyRemoteThreadAdmissionState(
+            target,
+            request,
+          );
+        }
+      }
+      const instanceLabel = this.federation.connectedPeerTargets().find(
+        (peer) => peer.target.instanceId === target.instanceId,
+      )?.label ?? target.instanceId;
       return {
         ...state,
         ...(state.thread
           ? {
               thread: {
                 ...state.thread,
-                ...(target?.scope === "remote" && instanceLabel
-                  ? {
-                      federation: {
-                        instanceLabel,
-                        ref: buildFederatedThreadRef({
-                          backend: request.backend,
-                          instanceId: target.instanceId,
-                          threadId: request.threadId,
-                        }),
-                      },
-                    }
-                  : {}),
+                federation: {
+                  instanceLabel,
+                  ref: buildFederatedThreadRef({
+                    backend: request.backend,
+                    instanceId: target.instanceId,
+                    threadId: request.threadId,
+                  }),
+                },
               },
             }
           : {}),
@@ -207,6 +219,38 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       ...(activeTurn ? { activeTurn } : {}),
       ...(thread ? { thread } : {}),
       threadStatus,
+    };
+  }
+
+  private async readLegacyRemoteThreadAdmissionState(
+    target: FederationRemoteTarget,
+    request: {
+      backend: AppServerBackendKind;
+      federationTarget?: FederationTarget;
+      threadId: string;
+    },
+  ): Promise<MessagingThreadAdmissionState> {
+    if (!this.federation) {
+      throw new Error("Remote messaging admission requires federation.");
+    }
+    const navigation = await this.federation.remoteNavigationSnapshot(
+      target,
+      {
+        backend: request.backend,
+        federationTarget: target,
+      },
+      {
+        kind: "threads",
+        threads: [{ backend: request.backend, threadId: request.threadId }],
+      },
+    );
+    const thread = navigation.threads.find(
+      (candidate) => candidate.source === request.backend
+        && candidate.id === request.threadId,
+    );
+    return {
+      ...(thread ? { thread } : {}),
+      ...(thread?.threadStatus ? { threadStatus: thread.threadStatus } : {}),
     };
   }
 
@@ -1086,11 +1130,14 @@ function buildAdmissionThreadSummary(params: {
     inbox: "inbox" in summary ? summary.inbox : { inInbox: false },
     executionMode: overlay?.executionMode ?? summary.executionMode,
     fastMode: overlay?.fastMode ?? summary.fastMode,
+    gitBranch: overlay?.gitBranch ?? summary.gitBranch,
     linkedDirectories:
       summary.linkedDirectories.length > 0
         ? summary.linkedDirectories
         : overlay?.extraLinkedDirectories ?? [],
     model: overlay?.model ?? summary.model,
+    observedGitBranch:
+      overlay?.observedGitBranch ?? summary.observedGitBranch,
     reasoningEffort: overlay?.reasoningEffort ?? summary.reasoningEffort,
     serviceTier: overlay?.serviceTier ?? summary.serviceTier,
     ...(overlay?.agent ? { agent: overlay.agent } : {}),
@@ -1104,6 +1151,13 @@ function buildAdmissionThreadSummary(params: {
       : {}),
     ...(params.queuedTurns ? { queuedTurns: params.queuedTurns } : {}),
   };
+}
+
+function isFederationMethodNotFoundError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === "method_not_found";
 }
 
 function findLastAssistantEntryReply(

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -35,6 +35,7 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  NavigationThreadSummary,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
@@ -54,18 +55,21 @@ import type {
   SubmitServerRequestResponse,
   ThreadAgentMetadata,
   ThreadMessagingBindingTransition,
+  ThreadOverlayState,
   UpdateScheduledThreadActionRequest,
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
 import type { MessagingImagePart } from "@pwragent/messaging-interface";
 import {
+  buildThreadIdentityKey,
   buildFederatedThreadRef,
   isRemoteFederationTarget,
 } from "@pwragent/shared";
 import type {
   MessagingBackendBridge,
   MessagingLastAssistantReply,
+  MessagingThreadAdmissionState,
 } from "./core/messaging-adapter";
 import { MessagingFederatedThreadTargetError } from "./core/messaging-adapter";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
@@ -81,6 +85,7 @@ import {
   resolveFederatedThreadTarget,
 } from "../federation/federated-thread-target-service";
 import { getScheduledThreadActionService } from "../scheduled-actions/scheduled-thread-action-service";
+import { selectStaleDirectoryGitStatusKeys } from "../app-server/directory-git-status-refresh-policy";
 
 export type DesktopMessagingFederationBridge = {
   connectedPeerTargets(): Array<{
@@ -117,6 +122,92 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
 
   getLocalFilePrivateStorageRoots(): readonly string[] {
     return this.registry.getLocalFilePrivateStorageRoots();
+  }
+
+  async getThreadAdmissionState(request: {
+    backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
+    threadId: string;
+  }): Promise<MessagingThreadAdmissionState> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      if (!remote.resolveThreadAdmissionState) {
+        throw new Error(
+          "The remote instance does not support targeted messaging admission.",
+        );
+      }
+      const state = await remote.resolveThreadAdmissionState({
+        backend: request.backend,
+        threadId: request.threadId,
+      });
+      const target = request.federationTarget;
+      const instanceLabel = target?.scope === "remote"
+        ? this.federation?.connectedPeerTargets().find(
+            (peer) => peer.target.instanceId === target.instanceId,
+          )?.label ?? target.instanceId
+        : undefined;
+      return {
+        ...state,
+        ...(state.thread
+          ? {
+              thread: {
+                ...state.thread,
+                ...(target?.scope === "remote" && instanceLabel
+                  ? {
+                      federation: {
+                        instanceLabel,
+                        ref: buildFederatedThreadRef({
+                          backend: request.backend,
+                          instanceId: target.instanceId,
+                          threadId: request.threadId,
+                        }),
+                      },
+                    }
+                  : {}),
+              },
+            }
+          : {}),
+      };
+    }
+
+    const store = getDesktopOverlayStore();
+    const [overlay, cached] = await Promise.all([
+      store.getThreadOverlayState({
+        backend: request.backend,
+        threadId: request.threadId,
+      }),
+      Promise.resolve(this.registry.getCachedThreadSummary({
+        backend: request.backend,
+        threadId: request.threadId,
+      })),
+    ]);
+    const activeTurn = this.registry.getActiveTurnForThread(request);
+    const threadStatus = this.registry.isThreadTurnOccupied(request)
+      ? "active"
+      : "idle";
+    const threadKey = buildThreadIdentityKey(request.backend, request.threadId);
+    const queuedExecutionMode =
+      this.registry.getQueuedExecutionModesSnapshot()[threadKey];
+    const queuedTurns = this.registry.getQueuedTurnsSnapshot()[threadKey];
+    const thread = cached || overlay
+      ? buildAdmissionThreadSummary({
+          overlay,
+          queuedExecutionMode,
+          queuedTurns,
+          summary: cached ?? {
+            id: request.threadId,
+            title: request.threadId,
+            titleSource: "fallback",
+            source: request.backend,
+            linkedDirectories: overlay?.extraLinkedDirectories ?? [],
+          },
+        })
+      : undefined;
+    return {
+      ...(activeTurn ? { activeTurn } : {}),
+      ...(thread ? { thread } : {}),
+      threadStatus,
+    };
   }
 
   async getNavigationSnapshot(
@@ -183,9 +274,24 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     ) {
       this.registry.rememberCompleteNavigationSnapshot(hydratedSnapshot);
     }
-    const directoryStatuses = await this.registry.readDirectoryStatuses(
-      hydratedSnapshot.directories,
-    );
+    const directoryStatusCache =
+      await getDesktopOverlayStore().readDirectoryGitStatusCache();
+    const staleDirectoryKeys = selectStaleDirectoryGitStatusKeys({
+      cache: directoryStatusCache,
+      directories: hydratedSnapshot.directories,
+    });
+    if (
+      staleDirectoryKeys.length > 0
+      && typeof this.registry.refreshDirectoryGitStatuses === "function"
+    ) {
+      void this.registry.refreshDirectoryGitStatuses({
+        directoryKeys: staleDirectoryKeys,
+        force: false,
+      }).catch(() => {
+        // Directory status is optional navigation context. The registry logs
+        // probe failures and publishes successful per-directory updates.
+      });
+    }
 
     // The renderer's local snapshot path (ipc/app-server.ts) hydrates
     // each directory launchpad's Codex environment options. This bridge
@@ -197,7 +303,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       hydratedSnapshot.directories.map(async (directory) => {
         const withStatus = {
           ...directory,
-          gitStatus: directoryStatuses[directory.key],
+          gitStatus: directoryStatusCache[directory.key]?.gitStatus,
         };
         if (!withStatus.launchpad) {
           return withStatus;
@@ -962,6 +1068,42 @@ function findLastAssistantMessageReply(
     };
   }
   return undefined;
+}
+
+function buildAdmissionThreadSummary(params: {
+  federation?: NonNullable<NavigationThreadSummary["federation"]>;
+  overlay?: ThreadOverlayState;
+  queuedExecutionMode?: {
+    mode: NonNullable<NavigationThreadSummary["queuedExecutionMode"]>;
+    queuedAt: number;
+  };
+  queuedTurns?: NavigationThreadSummary["queuedTurns"];
+  summary: Omit<NavigationThreadSummary, "inbox"> | NavigationThreadSummary;
+}): NavigationThreadSummary {
+  const { overlay, summary } = params;
+  return {
+    ...summary,
+    inbox: "inbox" in summary ? summary.inbox : { inInbox: false },
+    executionMode: overlay?.executionMode ?? summary.executionMode,
+    fastMode: overlay?.fastMode ?? summary.fastMode,
+    linkedDirectories:
+      summary.linkedDirectories.length > 0
+        ? summary.linkedDirectories
+        : overlay?.extraLinkedDirectories ?? [],
+    model: overlay?.model ?? summary.model,
+    reasoningEffort: overlay?.reasoningEffort ?? summary.reasoningEffort,
+    serviceTier: overlay?.serviceTier ?? summary.serviceTier,
+    ...(overlay?.agent ? { agent: overlay.agent } : {}),
+    ...(overlay?.handoffOrigin ? { handoffOrigin: overlay.handoffOrigin } : {}),
+    ...(params.federation ? { federation: params.federation } : {}),
+    ...(params.queuedExecutionMode
+      ? {
+          queuedExecutionMode: params.queuedExecutionMode.mode,
+          queuedExecutionModeAt: params.queuedExecutionMode.queuedAt,
+        }
+      : {}),
+    ...(params.queuedTurns ? { queuedTurns: params.queuedTurns } : {}),
+  };
 }
 
 function findLastAssistantEntryReply(

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -372,6 +372,55 @@ These rules exist to make adding the next ten messaging platforms a quiet, mecha
 - Provider adapters receive semantic intents and never import desktop
   thread-state modules.
 
+#### Bound-reply admission is targeted
+
+An ordinary reply to an existing binding does not build a navigation snapshot.
+`MessagingController` asks `DesktopMessagingBackendBridge` for one
+`MessagingThreadAdmissionState`, which combines:
+
+- the bound thread's durable overlay (execution mode, model, reasoning,
+  service tier, fast mode, Agent/handoff origin);
+- its already-observed thread-list summary, when one is cached;
+- the registry's per-thread active turn, queued permission mode, and queued
+  turn projections; and
+- the equivalent targeted owner read for a federated binding.
+
+That projection is sufficient for permission/full-access policy, message
+origin, occupancy, queue admission, and turn settings. It deliberately carries
+no PR lookup, Git working-state probe, launchpad hydration, directory-fleet
+walk, or connected-peer enumeration. The shared turn FIFO remains the final
+race-safe admission authority if activity changes after the targeted read.
+
+Full navigation remains appropriate for explicit browse, monitor, picker,
+handoff, review, and on-demand rich status workflows. Automatic status-card
+updates and thread-state bus fan-out reuse the targeted projection instead of
+turning a single-thread notification into a fleet refresh.
+
+#### Directory Git-status cache and refresh policy
+
+Directory status has two cache layers with different jobs:
+
+- `GitDirectoryService` keeps a 3-second in-memory per-path cache. It dedupes
+  concurrent/repeated Git probes and branch-inventory reads. It is not the
+  navigation freshness policy.
+- The overlay store keeps the last successful directory projection. Broad
+  snapshots serve this projection immediately and consider it fresh for five
+  minutes. Five minutes is based on the product interaction boundary: an
+  untouched directory is ambient navigation context, while focused and
+  mutation-sensitive actions have targeted refresh paths.
+
+A broad snapshot schedules at most four stale directories at once and never
+awaits that batch. Registry scheduling coalesces each directory while its probe
+is pending. Selecting a thread explicitly requests its directory keys; rapid
+forced requests for the same key coalesce inside a 3-second post-completion
+window. Launchpad materialization and branch-sensitive workspace operations
+perform their own targeted fresh read, while turn completion, branch updates,
+and Git-mutating commands refresh the affected thread/worktree/PR projections.
+
+This policy is interaction-driven. It adds no polling timer and no timer-driven
+SQLite writes; persistence changes only when a scheduled targeted or bounded
+background probe completes.
+
 ### Single platform-agnostic detach pipeline
 
 The detach flow — retire the channel's status surface, revoke the binding in the store, deliver a "Thread detached" confirmation — has exactly one implementation: `MessagingController.runDetachPipeline`. Every detach origin (Discord `/detach`, Telegram `/detach`, the desktop right-click "Unbind" chip, future archive-on-delete flows, future "Unbind all") routes through it.

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -7,6 +7,7 @@ import type {
   AppServerThreadActivityEntry,
   AppServerThreadImagePart,
   AppServerThreadReviewEntry,
+  AppServerThreadStatus,
   AppServerThreadSummary,
   CodexEnvironmentAction,
   CodexEnvironmentExecutionTarget,
@@ -261,6 +262,20 @@ export type ThreadQueuedTurnSummary = {
   createdAt: number;
   /** 0-based dispatch position within the thread's queue. */
   position: number;
+};
+
+/**
+ * One-thread projection used by latency-sensitive turn admission. Producers
+ * must not populate it by building a navigation-wide snapshot.
+ */
+export type ThreadAdmissionState = {
+  activeTurn?: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    turnId: string;
+  };
+  thread?: NavigationThreadSummary;
+  threadStatus?: AppServerThreadStatus;
 };
 
 export type ThreadSubAgentStatus =


### PR DESCRIPTION
## Summary

- I replaced ordinary bound-reply admission with a mandatory one-thread projection that resolves settings, policy inputs, origin, authoritative occupancy, and queued state without building navigation.
- I added the same targeted admission RPC for federated owners, preserving the `messaging_route` capability boundary without reading a remote thread list or transcript.
- I changed messaging navigation to serve persisted directory Git status immediately and schedule at most four stale entries in the background, with per-key in-flight coalescing and existing focus/mutation refresh paths left targeted.
- I documented the two cache layers and their ownership: the 3-second `GitDirectoryService` cache only deduplicates per-path probes, while the persisted aggregate cache uses a five-minute ambient-navigation policy backed by incremental refreshes.

## Verification

- I ran `pnpm test`: 637 files passed; 9,263 tests passed and 6 skipped.
- I ran `pnpm lint`: SQL, Codex-storage, renderer-color, Electron-version, package/third-party license, ESLint, typecheck, and dependency-boundary checks passed. ESLint retained the repository's existing warning set and reported no errors.
- I ran focused messaging, bridge, registry, federation, and adapter tests: 8 files and 1,250 tests passed before the final full run; the added federation admission RPC test also passed in its focused suite.
- The admission regression records one full-navigation call before this change and zero after it. The supplied cold profile measured about 3.47 seconds for 72 unique directory statuses; the new admission path performs zero directory-fleet, Git, PR, launchpad, or peer-enrichment calls.
- The stale-cache regression holds a directory refresh unresolved and verifies that the broad snapshot still returns from cached state.

## Notes

- The 3-second value was not a durable aggregate cache TTL. It was the effective lifetime of `GitDirectoryService`'s in-memory per-path Git probe and branch-inventory entries, with concurrency four.
- The longer-lived aggregate cache already existed in the overlay store. This change makes the messaging bridge consume it and centralizes the five-minute freshness, four-entry batch, and three-second forced-focus coalescing constants in one policy module.
- Explicit branch drift, review/workspace operations, launchpad materialization, selected-thread focus, turn completion, and Git mutations retain targeted fresh-state paths.
- I added no polling timer and no timer-driven SQLite persistence, so no new SQLite write budget is required.
