### PR TITLE
fix(tests): open Discord settings in permission specs

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4556,6 +4556,7 @@ describe("SettingsScreen", () => {
           openDiscordThreadPermissionRequest,
         }}
         initialSection="messaging"
+        initialSubsection="discord"
         onClose={() => undefined}
       />,
     );
@@ -4644,6 +4645,7 @@ describe("SettingsScreen", () => {
         settings={createSettingsState(initialSnapshot)}
         desktopApi={{ openDiscordThreadPermissionRequest }}
         initialSection="messaging"
+        initialSubsection="discord"
         onClose={() => undefined}
       />,
     );
@@ -4664,6 +4666,7 @@ describe("SettingsScreen", () => {
         settings={createSettingsState(firstSnapshot)}
         desktopApi={{ openDiscordThreadPermissionRequest }}
         initialSection="messaging"
+        initialSubsection="discord"
         onClose={() => undefined}
       />,
     );
@@ -4683,6 +4686,7 @@ describe("SettingsScreen", () => {
         settings={createSettingsState(replacementSnapshot)}
         desktopApi={{ openDiscordThreadPermissionRequest }}
         initialSection="messaging"
+        initialSubsection="discord"
         onClose={() => undefined}
       />,
     );
@@ -4742,6 +4746,7 @@ describe("SettingsScreen", () => {
           listDiscordThreadPermissionChannels,
         }}
         initialSection="messaging"
+        initialSubsection="discord"
         onClose={() => undefined}
       />,
     );


### PR DESCRIPTION
## Summary

- I updated the three Discord permission Settings specs to open the Discord provider subsection introduced by the expandable provider navigation.
- I kept this test-only fix limited to the stale navigation setup that broke the post-merge `main` test suite.

## Verification

- I reproduced the failure on current `origin/main`: 3 failed and 88 passed in `settings-screen.test.tsx`.
- I reran the focused file after the fix: 91 passed.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:eslint` with zero errors (43 pre-existing warnings).
- I ran `pnpm lint:boundaries` with no dependency violations.

## Notes

- This repairs the integration gap between #1880's provider sub-navigation and the Discord permission tests merged through #1875; it does not change product behavior.
