### PR TITLE
docs(workflow): remove obsolete Compound Engineering guidance

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -5,8 +5,8 @@
 #
 # Override per-search with: `rg --no-ignore <pattern>` or `rg -u`.
 
-# Decision-artifact directories. See `docs/plans/AGENTS.md` for the
-# don't-edit-historical-plans rule that motivates this exclusion.
+# Historical record directories. See the root `AGENTS.md` for the
+# preservation rule that motivates this exclusion.
 docs/plans/
 docs/brainstorms/
 docs/solutions/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,6 @@
 
 ## Source of Truth
 
-- Put new product requirements in `docs/brainstorms/`.
-- Put new implementation plans in `docs/plans/`.
 - UI theme tokens and visual rules are in [docs/UI-THEME.md](docs/UI-THEME.md).
 - Desktop UI direction is in [docs/design/desktop-style-guide.md](docs/design/desktop-style-guide.md).
 - PwrAgent v2 design references are in [docs/design/pwragent-v2/](docs/design/pwragent-v2/).
@@ -16,13 +14,9 @@
 
 ## Workflow
 
-- Treat plans as decision records. Do not use them as implementation scripts.
-- Follow the active plan unless the user changes the scope.
-- Treat brainstorms, plans, and solutions as historical records.
+- Treat existing brainstorms, plans, and solutions as historical records.
   - The record directories are `docs/brainstorms/`, `docs/plans/`, and `docs/solutions/`.
   - Do not delete or rewrite a record without explicit user authorization.
-  - You may update the plan that the current branch implements.
-  - Limit updates to progress, dependencies, and resolved implementation questions.
   - Read a record only for a specific provenance question or an explicit document reference.
   - Use current code, `ARCHITECTURE.md`, and package guidance for current behavior and API shape.
 - Default `rg` searches exclude brainstorms, plans, and solutions through [`.rgignore`](.rgignore).

--- a/docs/desktop-distribution-phase-2-runbook.md
+++ b/docs/desktop-distribution-phase-2-runbook.md
@@ -91,7 +91,7 @@ Required changes:
   ```
 - `release.mjs` upload step: replace `--publish always` with a manual rclone
   copy of `dist/*.dmg`, `dist/*.zip`, `dist/*.blockmap`, `dist/latest-mac.yml`
-  to the bucket. `compound-engineering:rclone` skill can do this.
+  to the bucket.
 - Cache headers: `latest-mac.yml` ≤ 60s; `.zip` and `.dmg` for a year, busted
   by version.
 


### PR DESCRIPTION
## Summary

- I removed the obsolete requirement to put new product requirements in `docs/brainstorms/` and new implementation plans in `docs/plans/`.
- I removed active-plan workflow conventions while preserving the rule that existing brainstorm, plan, and solution records are historical and must not be rewritten without authorization.
- I replaced the stale `.rgignore` provenance comment and removed the explicit `compound-engineering:rclone` skill reference from the desktop distribution runbook.

## Verification

- I ran `git diff --check origin/main...HEAD`.
- I searched live contributor and workflow guidance for remaining explicit Compound Engineering references.
- I verified the signed commit and confirmed this handoff workspace owns the pushed branch head.

## Notes

- I did not edit or delete any historical brainstorm, plan, solution, changelog, fixture, or todo record.
