### PR TITLE
feat(desktop): summarize Token Miser on the Pricing rail

### DIFF
--- a/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-output-incident-explorer-window.test.ts
@@ -116,7 +116,7 @@ describe("tool-output incident explorer window", () => {
     expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
       "/renderer.html",
       {
-        hash: "tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent",
+        hash: "tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent/",
       },
     );
     expect(mocks.showAndFocusAuxiliaryWindow).toHaveBeenCalledOnce();
@@ -127,8 +127,8 @@ describe("tool-output incident explorer window", () => {
   });
 
   it("names the owning instance in the route only for a peer's thread", async () => {
-    /* A local thread's route must stay exactly as it was — an always-emitted
-       segment appended a trailing slash to every ordinary route. */
+    /* The lens segment sits between them and is always emitted, so the owner
+       keeps a fixed position whether or not a lens was asked for. */
     const { showToolOutputIncidentExplorerWindow } = await import(
       "../tool-output-incident-explorer-window"
     );
@@ -144,7 +144,32 @@ describe("tool-output incident explorer window", () => {
       "/renderer.html",
       {
         hash:
-          "tool-output-incidents/codex/thread-2/Peer%20work/PwrAgent/peer-instance",
+          "tool-output-incidents/codex/thread-2/Peer%20work/PwrAgent//peer-instance",
+      },
+    );
+  });
+
+  it("carries the requested lens into a window it has to create", async () => {
+    /* The refresh event only reaches a window that already exists. A first
+       click on "Token Miser Savings" creates the window, and the renderer's
+       own opening choice reads accounting that has a lookback the durable
+       gate records outlive. */
+    const { showToolOutputIncidentExplorerWindow } = await import(
+      "../tool-output-incident-explorer-window"
+    );
+    showToolOutputIncidentExplorerWindow({
+      backend: "codex" as const,
+      lens: "savings",
+      projectLabel: "PwrAgent",
+      threadId: "thread-3",
+      title: "Gated work",
+    });
+
+    expect(mocks.windows[0]?.loadFile).toHaveBeenCalledWith(
+      "/renderer.html",
+      {
+        hash:
+          "tool-output-incidents/codex/thread-3/Gated%20work/PwrAgent/savings",
       },
     );
   });

--- a/apps/desktop/src/main/tool-output-incident-explorer-window.ts
+++ b/apps/desktop/src/main/tool-output-incident-explorer-window.ts
@@ -109,10 +109,17 @@ export function showToolOutputIncidentExplorerWindow(
     encodeURIComponent(threadId),
     encodeURIComponent(title.slice(0, TITLE_MAX_LENGTH)),
     encodeURIComponent(request.projectLabel?.trim() ?? ""),
+    /* The lens the operator asked for, so a window created by this click opens
+       on it. The renderer otherwise picks the lens from the thread's own
+       accounting, and that accounting has a lookback window the durable gate
+       records outlive — an older gated thread would open on incidents with the
+       Savings tab sitting right there unselected. Always emitted, empty when
+       the request expresses no preference, so the segment below keeps a fixed
+       position. */
+    encodeURIComponent(request.lens ?? ""),
     /* The owning instance, appended only for a peer's thread: a viewer's
        explorer must read the peer's thread, not a local thread that happens
-       to share the id. Emitting an empty segment for local threads would add
-       a trailing slash to every ordinary route for nothing. */
+       to share the id. */
     ...(request.federationTarget?.scope === "remote"
       ? [encodeURIComponent(request.federationTarget.instanceId)]
       : []),

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -21,6 +21,7 @@ import type {
   ThreadToolAccounting,
   ThreadToolInvocationRecord,
   ThreadUsageLineRecord,
+  ToolOutputIncidentExplorerLens,
 } from "@pwragent/shared";
 import type { WindowPointerSnapshot } from "../../../../shared/window-pointer";
 import {
@@ -119,7 +120,9 @@ type ThreadContextPanelProps = {
   loadingToolCallDetailItemId?: string;
   onRequestToolCallDetails?: (invocation: ThreadToolInvocationRecord) => void;
   onAnalyzeToolHistory?: () => void;
-  onOpenToolOutputIncidentExplorer?: () => void;
+  onOpenToolOutputIncidentExplorer?: (
+    lens?: ToolOutputIncidentExplorerLens,
+  ) => void;
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
@@ -696,6 +699,11 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             activeTurnId={props.activeTurnId}
             pricing={props.pricing}
             displayOptions={props.pricingDisplayOptions}
+            onOpenTokenMiserSavings={
+              props.onOpenToolOutputIncidentExplorer
+                ? () => props.onOpenToolOutputIncidentExplorer?.("savings")
+                : undefined
+            }
             onScrollToTurn={props.onScrollToTurn}
             subAgents={props.thread.subAgents}
             tokenMiserAccounting={props.toolAccounting?.tokenMiser}
@@ -712,7 +720,11 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             entries={props.toolCallEntries}
             loadingDetailItemId={props.loadingToolCallDetailItemId}
             onAnalyzeHistory={props.onAnalyzeToolHistory}
-            onOpenIncidentExplorer={props.onOpenToolOutputIncidentExplorer}
+            onOpenIncidentExplorer={
+              props.onOpenToolOutputIncidentExplorer
+                ? () => props.onOpenToolOutputIncidentExplorer?.("incidents")
+                : undefined
+            }
             onRequestInvocationDetails={props.onRequestToolCallDetails}
             onScrollToTurn={props.onScrollToTurn}
             threadLinkSource={

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -720,9 +720,13 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             entries={props.toolCallEntries}
             loadingDetailItemId={props.loadingToolCallDetailItemId}
             onAnalyzeHistory={props.onAnalyzeToolHistory}
+            /* No lens: this button opens the window by the window's own name,
+               so a thread that gated still gets the opening lens its
+               accounting chooses. Only the Pricing rail's button, which names
+               a lens inside the window, asks for one. */
             onOpenIncidentExplorer={
               props.onOpenToolOutputIncidentExplorer
-                ? () => props.onOpenToolOutputIncidentExplorer?.("incidents")
+                ? () => props.onOpenToolOutputIncidentExplorer?.()
                 : undefined
             }
             onRequestInvocationDetails={props.onRequestToolCallDetails}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -47,6 +47,7 @@ import type {
   ThreadToolAccounting,
   ThreadToolInvocationRecord,
   ThreadUsageLineRecord,
+  ToolOutputIncidentExplorerLens,
 } from "@pwragent/shared";
 import {
   buildPendingRequestResponse,
@@ -2541,22 +2542,26 @@ export function ThreadView(props: ThreadViewProps) {
       selectedThreadKey,
     ],
   );
-  const handleOpenToolOutputIncidentExplorer = useCallback(() => {
-    if (!selectedThread) return;
-    const projectLabel =
-      props.selectedDirectory?.label
-      ?? selectedThread.linkedDirectories[0]?.label;
-    void desktopApi?.openToolOutputIncidentExplorerWindow?.({
-      backend: selectedThread.source,
-      /* A peer's thread is analyzed and read on the instance that owns it. */
-      ...(selectedThread.federation?.ref.target
-        ? { federationTarget: selectedThread.federation.ref.target }
-        : {}),
-      ...(projectLabel ? { projectLabel } : {}),
-      threadId: selectedThread.id,
-      title: selectedThread.title,
-    });
-  }, [desktopApi, props.selectedDirectory?.label, selectedThread]);
+  const handleOpenToolOutputIncidentExplorer = useCallback(
+    (lens?: ToolOutputIncidentExplorerLens) => {
+      if (!selectedThread) return;
+      const projectLabel =
+        props.selectedDirectory?.label
+        ?? selectedThread.linkedDirectories[0]?.label;
+      void desktopApi?.openToolOutputIncidentExplorerWindow?.({
+        backend: selectedThread.source,
+        /* A peer's thread is analyzed and read on the instance that owns it. */
+        ...(selectedThread.federation?.ref.target
+          ? { federationTarget: selectedThread.federation.ref.target }
+          : {}),
+        ...(lens ? { lens } : {}),
+        ...(projectLabel ? { projectLabel } : {}),
+        threadId: selectedThread.id,
+        title: selectedThread.title,
+      });
+    },
+    [desktopApi, props.selectedDirectory?.label, selectedThread],
+  );
   const handleAnalyzeToolHistory = useCallback(() => {
     if (!selectedThread) return;
     void desktopApi?.analyzeThreadToolHistory?.({

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -10,6 +10,7 @@ import type {
   ThreadCompactionRecord,
   ThreadTokenMiserSavings,
   ThreadToolInvocationRecord,
+  ToolOutputIncidentExplorerLens,
 } from "@pwragent/shared";
 import {
   buildThreadToolIncidentPrompt,
@@ -22,6 +23,7 @@ import { useDesktopApi } from "../../lib/desktop-api";
 import { useDesktopSettings } from "../settings/useDesktopSettings";
 import { ThreadChip } from "./ThreadChip";
 import { detailMatchesInvocationItem } from "./tool-call-details";
+import { describeSameTrajectoryCostChange } from "./token-miser-savings-summary";
 import type {
   CategoryShare,
   IncidentSortMode,
@@ -78,6 +80,12 @@ export function ToolOutputIncidentExplorerWindow() {
   const [statusTone, setStatusTone] = useState<"error" | "info">("info");
   const [loading, setLoading] = useState(true);
   const [analyzing, setAnalyzing] = useState(false);
+  const [lensChoice, setLens] =
+    useState<ToolOutputIncidentExplorerLens>("incidents");
+  /* Whether the opening lens has been chosen. Declared with the state it
+     guards rather than beside the latch below, because the refresh effect
+     sets it too. */
+  const lensLatched = useRef(false);
 
   /* Stable identity: `refresh` depends on it, and a refresh that changed every
      render would re-run the effect that calls it on every render. */
@@ -125,6 +133,14 @@ export function ToolOutputIncidentExplorerWindow() {
           threadId: request.threadId,
           title: request.title,
         });
+        /* A window already open keeps the lens it is on, so an operator who
+           clicks "Token Miser Savings" on the Pricing rail and gets a focused
+           window still sitting on incidents got the wrong screen. Honor the
+           request, and stop the opening latch from overruling it. */
+        if (request.lens) {
+          lensLatched.current = true;
+          setLens(request.lens);
+        }
       }
       void refresh();
     });
@@ -225,7 +241,6 @@ export function ToolOutputIncidentExplorerWindow() {
   // feature off and nothing ever gated, this stays the single-lens screen it
   // was rather than growing a tab that can only say "nothing happened".
   const showSavingsLens = tokenMiserEnabled || Boolean(activeTokenMiser);
-  const [lensChoice, setLens] = useState<ExplorerLens>("incidents");
   // Latch the opening lens the first time accounting arrives, then leave it
   // alone. Re-deriving it from `activeTokenMiser` would yank the operator out
   // of the case they are reading the moment a gate lands mid-turn.
@@ -234,7 +249,6 @@ export function ToolOutputIncidentExplorerWindow() {
   // painted frame on the incidents lens before switching, so a thread that
   // gated would open on the wrong lens and visibly flip. React discards this
   // render and re-runs before painting.
-  const lensLatched = useRef(false);
   if (!lensLatched.current && accounting) {
     lensLatched.current = true;
     if (
@@ -244,7 +258,8 @@ export function ToolOutputIncidentExplorerWindow() {
       setLens("savings");
     }
   }
-  const lens: ExplorerLens = showSavingsLens ? lensChoice : "incidents";
+  const lens: ToolOutputIncidentExplorerLens =
+    showSavingsLens ? lensChoice : "incidents";
   const tokenMiserUsageLines = useMemo(
     () => (usageLines ?? []).filter((line) =>
       line.scope === "monitor"
@@ -1015,27 +1030,10 @@ function describeTokenMiserReach(params: {
     + `${params.toolCallCount === 1 ? "call" : "calls"} and ${kept}`;
 }
 
-type ExplorerLens = "incidents" | "savings";
-
 function describeTokenMiserOutcome(estimatedTokensSaved: number): string {
   return estimatedTokensSaved >= 0
     ? `${formatCompactTokens(estimatedTokensSaved)} estimated parent-context footprint avoided`
     : `${formatCompactTokens(Math.abs(estimatedTokensSaved))} estimated net parent-context token overhead`;
-}
-
-function describeSameTrajectoryCostChange(
-  observedCostMicros: number,
-  savingsMicros: number,
-): string | undefined {
-  if (observedCostMicros <= 0) return undefined;
-  const unfilteredCostMicros = observedCostMicros + savingsMicros;
-  if (unfilteredCostMicros <= 0) return undefined;
-  const percent = Math.abs(savingsMicros) / unfilteredCostMicros * 100;
-  if (savingsMicros === 0) {
-    return `${percent.toFixed(1)}% change from estimated unfiltered cost`;
-  }
-  return `${percent.toFixed(1)}% ${savingsMicros > 0 ? "less" : "more"} `
-    + "than estimated unfiltered cost";
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -23,7 +23,10 @@ import { useDesktopApi } from "../../lib/desktop-api";
 import { useDesktopSettings } from "../settings/useDesktopSettings";
 import { ThreadChip } from "./ThreadChip";
 import { detailMatchesInvocationItem } from "./tool-call-details";
-import { describeSameTrajectoryCostChange } from "./token-miser-savings-summary";
+import {
+  describeSameTrajectoryCostChange,
+  TOKEN_MISER_PENDING_PRICING_CAPTION,
+} from "./token-miser-savings-summary";
 import type {
   CategoryShare,
   IncidentSortMode,
@@ -81,11 +84,11 @@ export function ToolOutputIncidentExplorerWindow() {
   const [loading, setLoading] = useState(true);
   const [analyzing, setAnalyzing] = useState(false);
   const [lensChoice, setLens] =
-    useState<ToolOutputIncidentExplorerLens>("incidents");
+    useState<ToolOutputIncidentExplorerLens>(route?.lens ?? "incidents");
   /* Whether the opening lens has been chosen. Declared with the state it
      guards rather than beside the latch below, because the refresh effect
-     sets it too. */
-  const lensLatched = useRef(false);
+     sets it too. A route that named a lens has already chosen. */
+  const lensLatched = useRef(route?.lens !== undefined);
 
   /* Stable identity: `refresh` depends on it, and a refresh that changed every
      render would re-run the effect that calls it on every render. */
@@ -129,6 +132,12 @@ export function ToolOutputIncidentExplorerWindow() {
       if (request) {
         setRoute({
           backend: request.backend,
+          /* A viewer's explorer reads the peer's thread. Dropping the target
+             here would send the next refresh at the local registry, which
+             does not have this thread. */
+          ...(request.federationTarget
+            ? { federationTarget: request.federationTarget }
+            : {}),
           projectLabel: request.projectLabel,
           threadId: request.threadId,
           title: request.title,
@@ -1179,7 +1188,7 @@ function TokenMiserSavingsLens(props: {
                   )}
                 </strong>
                 {sameTrajectoryCostChange ? (
-                  <span>{sameTrajectoryCostChange}</span>
+                  <span>{sameTrajectoryCostChange.sentence}</span>
                 ) : null}
               </p>
               {props.threadCostMicros > 0 ? (
@@ -1213,7 +1222,7 @@ function TokenMiserSavingsLens(props: {
                 </span>
               </p>
               <p className="incident-explorer__savings-compare">
-                Dollar terms appear once the gate's usage line is priced.
+                {TOKEN_MISER_PENDING_PRICING_CAPTION}
               </p>
             </>
           )}
@@ -1982,14 +1991,16 @@ function countLaterTripsInTurn(
 function readIncidentRoute(): {
   backend: AppServerBackendKind;
   federationTarget?: FederationTarget;
+  lens?: ToolOutputIncidentExplorerLens;
   projectLabel?: string;
   threadId: string;
   title: string;
 } | undefined {
-  const [kind, backend, threadId, title, projectLabel, instanceId] =
+  const [kind, backend, threadId, title, projectLabel, lens, instanceId] =
     window.location.hash.replace(/^#/, "").split("/");
   if (kind !== "tool-output-incidents" || !backend || !threadId) return undefined;
   const owner = instanceId ? decodeURIComponent(instanceId) : "";
+  const requestedLens = lens ? decodeURIComponent(lens) : "";
   return {
     backend: decodeURIComponent(backend) as AppServerBackendKind,
     /* Present only for a peer's thread; a local thread carries no target and
@@ -2001,6 +2012,12 @@ function readIncidentRoute(): {
             instanceId: owner as FederationInstanceId,
           },
         }
+      : {}),
+    /* Present only when the click that opened this window named a lens. An
+       unrecognized value is treated as no preference rather than as a lens
+       nothing renders. */
+    ...(requestedLens === "incidents" || requestedLens === "savings"
+      ? { lens: requestedLens }
       : {}),
     ...(projectLabel
       ? { projectLabel: decodeURIComponent(projectLabel) }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -15,6 +15,7 @@ import type {
   AppServerThreadEntry,
   NavigationThreadSummary,
   ThreadPricingSummary,
+  ThreadSubAgentSummary,
   ThreadToolAccounting,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
@@ -54,6 +55,14 @@ const baseThread: NavigationThreadSummary = {
 
 // A monitor-scope pricing row for a sub-agent. `sourceItemId` is the join key
 // to a `ThreadSubAgentSummary.monitorId`.
+function cardRowValue(
+  scope: ReturnType<typeof within>,
+  label: string,
+): string {
+  const row = scope.getByText(label).closest(".rail-summary-card__row");
+  return row?.querySelector(".rail-summary-card__row-value")?.textContent ?? "";
+}
+
 function buildMonitorLine(
   overrides: Partial<ThreadUsageLineRecord> = {},
 ): ThreadUsageLineRecord {
@@ -973,9 +982,11 @@ describe("ThreadContextPanel", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Analyze history" }));
-    fireEvent.click(screen.getByRole("button", { name: "Explore" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Tool Output Incidents" }),
+    );
     expect(onAnalyzeToolHistory).toHaveBeenCalledOnce();
-    expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledOnce();
+    expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledWith("incidents");
   });
 
   it("hides the Tool calls tab while its experimental flag is off", () => {
@@ -1144,6 +1155,134 @@ describe("ThreadContextPanel", () => {
     expect(summary.getByText("1k")).toBeInTheDocument();
     expect(summary.getByText("250")).toBeInTheDocument();
     expect(summary.queryByText("17k")).not.toBeInTheDocument();
+  });
+
+  it("summarizes Token Miser above the turn rows on the Pricing tab", () => {
+    /* The savings window used to be reachable only from Tool calls, a tab the
+       tool-accounting experiment hides by default — so this card is built from
+       the per-gate records the Pricing rail always has, and is asserted here
+       with that experiment off. */
+    const onOpenToolOutputIncidentExplorer = vi.fn();
+    const gateSubAgents: ThreadSubAgentSummary[] = [
+      {
+        monitorId: "system:token-miser:gate-1",
+        task: "Gate Bash output",
+        status: "success",
+        createdAt: 1_800_000_000_000,
+        updatedAt: 1_800_000_000_500,
+        tokenMiserAccounting: {
+          currency: "USD",
+          disposition: "summarized",
+          decisionSource: "helper",
+          originalModel: "gpt-5.6-sol",
+          baselineParentTokens: 60_000,
+          baselineParentCostMicros: 900_000,
+          gateModel: "gpt-5.6-luna",
+          gateTotalTokens: 12_000,
+          gateCostMicros: 60_000,
+          revealedParentTokens: 6_000,
+          revealedParentCostMicros: 90_000,
+          savingsMicros: 750_000,
+        },
+      },
+      {
+        monitorId: "system:token-miser:gate-2",
+        task: "Gate search output",
+        status: "success",
+        createdAt: 1_800_000_000_000,
+        updatedAt: 1_800_000_000_600,
+        tokenMiserAccounting: {
+          currency: "USD",
+          disposition: "passed_through",
+          decisionSource: "policy",
+          originalModel: "gpt-5.6-sol",
+          baselineParentTokens: 20_000,
+          baselineParentCostMicros: 300_000,
+          gateModel: "gpt-5.6-luna",
+          gateTotalTokens: 8_000,
+          gateCostMicros: 40_000,
+          revealedParentTokens: 20_000,
+          revealedParentCostMicros: 300_000,
+          savingsMicros: -40_000,
+        },
+      },
+    ];
+    const parentLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      cachedInputCostMicros: 0,
+      cachedInputTokens: 0,
+      createdAt: 1_800_000_000_000,
+      currency: "USD",
+      inputTokens: 100_000,
+      model: "gpt-5.6-sol",
+      outputCostMicros: 30_000,
+      outputTokens: 1_000,
+      priceStatus: "priced",
+      provider: "openai",
+      reasoningOutputTokens: 250,
+      scope: "turn",
+      source: "live",
+      status: "finalized",
+      threadId: "thread-1",
+      totalCostMicros: 1_290_000,
+      totalTokens: 101_000,
+      turnId: "turn-1",
+      uncachedInputCostMicros: 1_260_000,
+      uncachedInputTokens: 100_000,
+      usageLineId: "turn-line-1",
+    };
+
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      onOpenToolOutputIncidentExplorer,
+      pinned: true,
+      pricing: {
+        lines: [
+          buildMonitorLine({
+            model: "gpt-5.6-luna",
+            sourceItemId: "system:token-miser:gate-1",
+            totalCostMicros: 60_000,
+            usageLineId: "gate-line-1",
+          }),
+          buildMonitorLine({
+            model: "gpt-5.6-luna",
+            sourceItemId: "system:token-miser:gate-2",
+            totalCostMicros: 40_000,
+            usageLineId: "gate-line-2",
+          }),
+          parentLine,
+        ],
+        summaries: [],
+      },
+      thread: { ...baseThread, subAgents: gateSubAgents },
+      threadPricingSummaryEnabled: true,
+      threadToolAccountingEnabled: false,
+    });
+
+    expect(
+      screen.queryByRole("tab", { name: "Tool calls" }),
+    ).not.toBeInTheDocument();
+    const card = container.querySelector(".token-miser-summary-card");
+    expect(card).not.toBeNull();
+    const miser = within(card as HTMLElement);
+    expect(miser.getByText("$0.71 saved")).toBeInTheDocument();
+    expect(miser.getByText("33.8% less")).toBeInTheDocument();
+    expect(
+      miser.getByText("Estimated same-trajectory savings · $2.10 unfiltered"),
+    ).toBeInTheDocument();
+    expect(miser.getByText("2 decisions")).toBeInTheDocument();
+    expect(cardRowValue(miser, "1 · Without the gate")).toBe("$1.20");
+    expect(cardRowValue(miser, "2 · Gate compute")).toBe("$0.10");
+    expect(cardRowValue(miser, "3 · Revealed to parent")).toBe("$0.39");
+    expect(cardRowValue(miser, "Summarized")).toBe("1");
+    expect(cardRowValue(miser, "Passed through")).toBe("1");
+    expect(cardRowValue(miser, "Luna evaluations")).toBe("1");
+    expect(cardRowValue(miser, "Parent context avoided")).toBe("54k");
+
+    fireEvent.click(
+      miser.getByRole("button", { name: "Token Miser Savings" }),
+    );
+    expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledWith("savings");
   });
 
   it("pages enormous pricing histories instead of rendering every row at once", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -53,8 +53,6 @@ const baseThread: NavigationThreadSummary = {
   },
 };
 
-// A monitor-scope pricing row for a sub-agent. `sourceItemId` is the join key
-// to a `ThreadSubAgentSummary.monitorId`.
 function cardRowValue(
   scope: ReturnType<typeof within>,
   label: string,
@@ -63,6 +61,8 @@ function cardRowValue(
   return row?.querySelector(".rail-summary-card__row-value")?.textContent ?? "";
 }
 
+// A monitor-scope pricing row for a sub-agent. `sourceItemId` is the join key
+// to a `ThreadSubAgentSummary.monitorId`.
 function buildMonitorLine(
   overrides: Partial<ThreadUsageLineRecord> = {},
 ): ThreadUsageLineRecord {
@@ -986,7 +986,9 @@ describe("ThreadContextPanel", () => {
       screen.getByRole("button", { name: "Tool Output Incidents" }),
     );
     expect(onAnalyzeToolHistory).toHaveBeenCalledOnce();
-    expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledWith("incidents");
+    /* No lens: the button opens the window by the window's own name and
+       leaves the opening lens to the thread's accounting. */
+    expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledWith();
   });
 
   it("hides the Tool calls tab while its experimental flag is off", () => {
@@ -1252,7 +1254,29 @@ describe("ThreadContextPanel", () => {
           }),
           parentLine,
         ],
-        summaries: [],
+        /* The provider summary is the comparison's denominator, the same rows
+           the savings window divides by — a rail that used its own headline
+           total instead would quote a different percentage than the window it
+           links to. */
+        summaries: [
+          {
+            backend: "codex",
+            cachedInputTokens: 0,
+            currency: "USD",
+            inputTokens: 100_000,
+            outputTokens: 1_000,
+            pricedUsageLineCount: 3,
+            provider: "openai",
+            reasoningOutputTokens: 250,
+            threadId: "thread-1",
+            totalCostMicros: 1_390_000,
+            totalTokens: 101_000,
+            uncachedInputTokens: 100_000,
+            unpricedUsageLineCount: 0,
+            updatedAt: 1_800_000_000_600,
+            usageLineCount: 3,
+          },
+        ],
       },
       thread: { ...baseThread, subAgents: gateSubAgents },
       threadPricingSummaryEnabled: true,
@@ -1283,6 +1307,51 @@ describe("ThreadContextPanel", () => {
       miser.getByRole("button", { name: "Token Miser Savings" }),
     );
     expect(onOpenToolOutputIncidentExplorer).toHaveBeenCalledWith("savings");
+  });
+
+  it("counts a policy pass-through that never billed a helper turn", () => {
+    /* A decision deterministic policy passed through records accounting and a
+       sub-agent and no usage line at all. Enumerated from the gate rows, an
+       all-policy thread looked like a thread with no gate. */
+    const gateSubAgents: ThreadSubAgentSummary[] = [
+      {
+        monitorId: "system:token-miser:gate-1",
+        task: "Gate Bash output",
+        status: "success",
+        createdAt: 1_800_000_000_000,
+        updatedAt: 1_800_000_000_500,
+        tokenMiserAccounting: {
+          currency: "USD",
+          disposition: "passed_through",
+          decisionSource: "policy",
+          originalModel: "gpt-5.6-sol",
+          baselineParentTokens: 20_000,
+          baselineParentCostMicros: 300_000,
+          gateModel: "gpt-5.6-luna",
+          gateTotalTokens: 0,
+          gateCostMicros: 0,
+          revealedParentTokens: 20_000,
+          revealedParentCostMicros: 300_000,
+          savingsMicros: 0,
+        },
+      },
+    ];
+
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: { lines: [], summaries: [] },
+      thread: { ...baseThread, subAgents: gateSubAgents },
+      threadPricingSummaryEnabled: true,
+      threadToolAccountingEnabled: false,
+    });
+
+    const card = container.querySelector(".token-miser-summary-card");
+    expect(card).not.toBeNull();
+    const miser = within(card as HTMLElement);
+    expect(miser.getByText("1 decision")).toBeInTheDocument();
+    expect(cardRowValue(miser, "Passed through")).toBe("1");
+    expect(cardRowValue(miser, "Luna evaluations")).toBe("0");
   });
 
   it("pages enormous pricing histories instead of rendering every row at once", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -842,6 +842,61 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(readCount).toBe(2);
   });
 
+  it("moves an open window to the lens the request asks for", async () => {
+    /* The Pricing rail's "Token Miser Savings" action focuses whatever window
+       is already open. Without the lens in the request it stays on whichever
+       tab the operator left it on, which for this thread is Incidents. */
+    let refreshListener:
+      | ((request?: { backend: string; lens?: string; threadId: string; title: string }) => void)
+      | undefined;
+    const response = buildResponse();
+    response.toolAccounting!.tokenMiser = {
+      interceptionCount: 1,
+      originalCharacters: 40_000,
+      baselineParentTokens: 10_000,
+      replacementTokens: 300,
+      retrievedTokens: 0,
+      estimatedParentTokensSaved: 9_700,
+      interceptions: [],
+    };
+    installApi({
+      onToolOutputIncidentExplorerRefresh: (
+        callback: (request?: unknown) => void,
+      ) => {
+        refreshListener = callback as typeof refreshListener;
+        return () => {
+          refreshListener = undefined;
+        };
+      },
+      readThread: async () => response,
+    });
+    window.location.hash =
+      "#tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    await screen.findByRole("tab", { name: /Savings/, selected: true });
+    fireEvent.click(screen.getByRole("tab", { name: /Incidents/ }));
+    expect(
+      screen.getByRole("tab", { name: /Incidents/, selected: true }),
+    ).toBeInTheDocument();
+
+    const request = {
+      backend: "codex",
+      projectLabel: "PwrAgent",
+      threadId: "thread-1",
+      title: "Noisy work",
+    };
+    await act(async () => refreshListener?.(request));
+    expect(
+      screen.getByRole("tab", { name: /Incidents/, selected: true }),
+    ).toBeInTheDocument();
+
+    await act(async () => refreshListener?.({ ...request, lens: "savings" }));
+    expect(
+      screen.getByRole("tab", { name: /Savings/, selected: true }),
+    ).toBeInTheDocument();
+  });
+
   it("updates Token Miser accounting from live tool-accounting events", async () => {
     let agentEventListener: ((event: never) => void) | undefined;
     const initial = buildResponse();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -897,6 +897,35 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens on the lens its route names, not on the one accounting suggests", async () => {
+    /* The refresh event only reaches a window that already exists, so a
+       window this click creates has to read the lens off its own route. The
+       thread below gates, which is exactly the case the opening latch sends
+       to Savings — the route has to win, or a request naming a lens means
+       nothing until the second click. */
+    const response = buildResponse();
+    response.toolAccounting!.tokenMiser = {
+      interceptionCount: 1,
+      originalCharacters: 40_000,
+      baselineParentTokens: 10_000,
+      replacementTokens: 300,
+      retrievedTokens: 0,
+      estimatedParentTokensSaved: 9_700,
+      interceptions: [],
+    };
+    installApi({ readThread: async () => response });
+    window.location.hash =
+      "#tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent/incidents";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    expect(
+      await screen.findByRole("tab", { name: /Incidents/, selected: true }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /Savings/, selected: false }),
+    ).toBeInTheDocument();
+  });
+
   it("updates Token Miser accounting from live tool-accounting events", async () => {
     let agentEventListener: ((event: never) => void) | undefined;
     const initial = buildResponse();
@@ -1346,7 +1375,7 @@ describe("ToolOutputIncidentExplorerWindow federation", () => {
     }));
     installApi({ analyzeThreadToolHistory, readThread });
     window.location.hash =
-      "#tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent/peer-instance";
+      "#tool-output-incidents/codex/thread-1/Noisy%20work/PwrAgent//peer-instance";
     render(<ToolOutputIncidentExplorerWindow />);
 
     await waitFor(() => expect(readThread).toHaveBeenCalledWith(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/token-miser-savings-summary.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/token-miser-savings-summary.test.ts
@@ -86,7 +86,9 @@ describe("buildTokenMiserSavingsSummary", () => {
     expect(summary?.passThroughCount).toBe(2);
     expect(summary?.summarizedCount).toBe(3);
     expect(summary?.helperDecisionCount).toBe(4);
-    expect(summary?.avoidedParentTokens).toBe(100_000);
+    /* Replays are the window's second figure, not part of this one. Adding
+       them here would print a bigger number under the same words. */
+    expect(summary?.avoidedParentTokens).toBe(93_000);
   });
 
   it("sums the gate rows when the thread accounting is not available", () => {
@@ -107,7 +109,7 @@ describe("buildTokenMiserSavingsSummary", () => {
     expect(summary?.passThroughCount).toBe(1);
     expect(summary?.summarizedCount).toBe(1);
     expect(summary?.helperDecisionCount).toBe(1);
-    expect(summary?.avoidedParentTokens).toBe(9_250);
+    expect(summary?.avoidedParentTokens).toBe(9_200);
   });
 
   it("returns nothing when the thread made no gate decisions", () => {
@@ -128,7 +130,7 @@ describe("buildTokenMiserSavingsSummary", () => {
     expect(summary?.decisionCount).toBe(5);
     expect(summary?.pricedDecisionCount).toBe(0);
     expect(summary?.terms).toBeUndefined();
-    expect(summary?.avoidedParentTokens).toBe(100_000);
+    expect(summary?.avoidedParentTokens).toBe(93_000);
   });
 
   it("omits the decision mix rather than reporting zero of everything", () => {
@@ -155,26 +157,94 @@ describe("buildTokenMiserSavingsSummary", () => {
     expect(summary?.decisionCount).toBe(3);
     expect(summary?.pricedDecisionCount).toBe(1);
     expect(summary?.terms?.savingsMicros).toBe(16_200);
+    /* One gate priced, and it summarized. The two that have not priced yet
+       are not summarized decisions — subtracting the pass-through count from
+       every decision would have claimed all three were. */
+    expect(summary?.summarizedCount).toBe(1);
+    expect(summary?.passThroughCount).toBe(0);
+  });
+
+  it("omits the mix when the gates predate the disposition fields", () => {
+    const summary = buildTokenMiserSavingsSummary({
+      gateAccountings: [
+        gate({ disposition: undefined, decisionSource: undefined }),
+      ],
+    });
+
+    expect(summary?.decisionCount).toBe(1);
+    expect(summary?.pricedDecisionCount).toBe(1);
+    expect(summary?.passThroughCount).toBeUndefined();
+    expect(summary?.summarizedCount).toBeUndefined();
+    expect(summary?.helperDecisionCount).toBeUndefined();
+  });
+
+  it("counts only Luna's decisions as Luna evaluations", () => {
+    /* Every gate here records who decided, and only one of the two was Luna.
+       Counting "not policy" made a gate that recorded nothing look evaluated. */
+    const summary = buildTokenMiserSavingsSummary({
+      gateAccountings: [gate(), passedThroughGate],
+    });
+
+    expect(summary?.helperDecisionCount).toBe(1);
+  });
+
+  it("summarizes a thread that ran Code Mode and gated nothing", () => {
+    /* Code Mode is Token Miser too. Keyed on reducer decisions alone, this
+       thread got no card at all and no way to reach the savings window. */
+    const summary = buildTokenMiserSavingsSummary({
+      accounting: {
+        ...threadAccounting,
+        interceptionCount: 0,
+        savings: undefined,
+        codeMode: {
+          callCount: 12,
+          commandCellCount: 9,
+          directCommandCellCount: 9,
+          dispatchClusterCount: 3,
+          multiInvocationClusterCount: 1,
+          largestDispatchCluster: 4,
+          nestedCommandInvocationCount: 14,
+          patchCellCount: 1,
+          otherCellCount: 2,
+          pollingCellCount: 0,
+          directCount: 9,
+          summarizedCount: 0,
+          passThroughCount: 0,
+          retrievalCount: 0,
+          capturedNestedInvocationCount: 14,
+          observations: [],
+        },
+      },
+      gateAccountings: [],
+    });
+
+    expect(summary?.decisionCount).toBe(0);
+    expect(summary?.codeModeCallCount).toBe(12);
   });
 });
 
 describe("describeSameTrajectoryCostChange", () => {
   it("compares the observed bill to the unfiltered one", () => {
-    expect(describeSameTrajectoryCostChange(512_000, 500_000)).toBe(
-      "49.4% less than estimated unfiltered cost",
-    );
+    /* Both widths come from here. The rail used to cut the short one out of
+       the sentence, which found nothing to cut in the wording below. */
+    expect(describeSameTrajectoryCostChange(512_000, 500_000)).toEqual({
+      short: "49.4% less",
+      sentence: "49.4% less than estimated unfiltered cost",
+    });
   });
 
   it("says so when the gate cost more than it saved", () => {
-    expect(describeSameTrajectoryCostChange(120_000, -20_000)).toBe(
-      "20.0% more than estimated unfiltered cost",
-    );
+    expect(describeSameTrajectoryCostChange(120_000, -20_000)).toEqual({
+      short: "20.0% more",
+      sentence: "20.0% more than estimated unfiltered cost",
+    });
   });
 
   it("avoids a direction word when nothing changed", () => {
-    expect(describeSameTrajectoryCostChange(100_000, 0)).toBe(
-      "0.0% change from estimated unfiltered cost",
-    );
+    expect(describeSameTrajectoryCostChange(100_000, 0)).toEqual({
+      short: "0.0% change",
+      sentence: "0.0% change from estimated unfiltered cost",
+    });
   });
 
   it("says nothing without a priced thread to compare against", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/token-miser-savings-summary.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/token-miser-savings-summary.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ThreadTokenMiserAccounting,
+  TokenMiserSubAgentAccounting,
+} from "@pwragent/shared";
+import {
+  buildTokenMiserSavingsSummary,
+  describeSameTrajectoryCostChange,
+} from "../token-miser-savings-summary";
+
+function gate(
+  overrides: Partial<TokenMiserSubAgentAccounting> = {},
+): TokenMiserSubAgentAccounting {
+  return {
+    currency: "USD",
+    disposition: "summarized",
+    decisionSource: "helper",
+    originalModel: "gpt-5",
+    baselineParentTokens: 10_000,
+    baselineParentCostMicros: 20_000,
+    gateModel: "gpt-5-mini",
+    gateTotalTokens: 4_000,
+    gateCostMicros: 2_000,
+    revealedParentTokens: 900,
+    revealedParentCostMicros: 1_800,
+    savingsMicros: 16_200,
+    ...overrides,
+  };
+}
+
+const passedThroughGate = gate({
+  disposition: "passed_through",
+  decisionSource: "policy",
+  baselineParentTokens: 2_500,
+  baselineParentCostMicros: 5_000,
+  cachedBaselineTokens: 500,
+  cachedBaselineCostMicros: 1_000,
+  gateCostMicros: 500,
+  revealedParentTokens: 2_400,
+  revealedParentCostMicros: 4_800,
+  cachedRevealedTokens: 450,
+  cachedRevealedCostMicros: 900,
+  savingsMicros: -200,
+});
+
+const threadAccounting: ThreadTokenMiserAccounting = {
+  interceptionCount: 5,
+  passThroughCount: 2,
+  helperDecisionCount: 4,
+  originalCharacters: 400_000,
+  baselineParentTokens: 100_000,
+  replacementTokens: 6_000,
+  retrievedTokens: 1_000,
+  estimatedParentTokensSaved: 93_000,
+  estimatedCachedReplayTokensSaved: 7_000,
+  savings: {
+    currency: "USD",
+    pricedGateCount: 4,
+    gateCount: 5,
+    withoutGateCostMicros: 900_000,
+    gateCostMicros: 40_000,
+    revealedCostMicros: 60_000,
+    savingsMicros: 800_000,
+    directlyObservedReplayCount: 12,
+    reconstructedReplayCount: 3,
+  },
+};
+
+describe("buildTokenMiserSavingsSummary", () => {
+  it("quotes the thread-level terms the savings window shows", () => {
+    /* The rail links to the window. Summing the two gate rows this view
+       happens to hold would print a different total beside that link. */
+    const summary = buildTokenMiserSavingsSummary({
+      accounting: threadAccounting,
+      gateAccountings: [gate(), passedThroughGate],
+    });
+
+    expect(summary?.terms).toEqual({
+      withoutGateCostMicros: 900_000,
+      gateCostMicros: 40_000,
+      revealedCostMicros: 60_000,
+      savingsMicros: 800_000,
+    });
+    expect(summary?.decisionCount).toBe(5);
+    expect(summary?.pricedDecisionCount).toBe(4);
+    expect(summary?.passThroughCount).toBe(2);
+    expect(summary?.summarizedCount).toBe(3);
+    expect(summary?.helperDecisionCount).toBe(4);
+    expect(summary?.avoidedParentTokens).toBe(100_000);
+  });
+
+  it("sums the gate rows when the thread accounting is not available", () => {
+    /* The Pricing rail only receives thread-level accounting while the
+       tool-accounting experiment is on, and this card ships to everyone. */
+    const summary = buildTokenMiserSavingsSummary({
+      gateAccountings: [gate(), passedThroughGate],
+    });
+
+    expect(summary?.terms).toEqual({
+      withoutGateCostMicros: 26_000,
+      gateCostMicros: 2_500,
+      revealedCostMicros: 7_500,
+      savingsMicros: 16_000,
+    });
+    expect(summary?.decisionCount).toBe(2);
+    expect(summary?.pricedDecisionCount).toBe(2);
+    expect(summary?.passThroughCount).toBe(1);
+    expect(summary?.summarizedCount).toBe(1);
+    expect(summary?.helperDecisionCount).toBe(1);
+    expect(summary?.avoidedParentTokens).toBe(9_250);
+  });
+
+  it("returns nothing when the thread made no gate decisions", () => {
+    expect(
+      buildTokenMiserSavingsSummary({ gateAccountings: [] }),
+    ).toBeUndefined();
+  });
+
+  it("reports decisions before any gate has priced", () => {
+    const summary = buildTokenMiserSavingsSummary({
+      accounting: {
+        ...threadAccounting,
+        savings: undefined,
+      },
+      gateAccountings: [undefined, undefined],
+    });
+
+    expect(summary?.decisionCount).toBe(5);
+    expect(summary?.pricedDecisionCount).toBe(0);
+    expect(summary?.terms).toBeUndefined();
+    expect(summary?.avoidedParentTokens).toBe(100_000);
+  });
+
+  it("omits the decision mix rather than reporting zero of everything", () => {
+    /* Nothing priced and no thread accounting: "0 passed through" would read
+       as a fact about the thread instead of as data that has not arrived. */
+    const summary = buildTokenMiserSavingsSummary({
+      gateAccountings: [undefined, undefined],
+    });
+
+    expect(summary?.decisionCount).toBe(2);
+    expect(summary?.pricedDecisionCount).toBe(0);
+    expect(summary?.passThroughCount).toBeUndefined();
+    expect(summary?.summarizedCount).toBeUndefined();
+    expect(summary?.helperDecisionCount).toBeUndefined();
+    expect(summary?.avoidedParentTokens).toBeUndefined();
+    expect(summary?.terms).toBeUndefined();
+  });
+
+  it("counts an unpriced gate as a decision the terms do not cover", () => {
+    const summary = buildTokenMiserSavingsSummary({
+      gateAccountings: [gate(), undefined, undefined],
+    });
+
+    expect(summary?.decisionCount).toBe(3);
+    expect(summary?.pricedDecisionCount).toBe(1);
+    expect(summary?.terms?.savingsMicros).toBe(16_200);
+  });
+});
+
+describe("describeSameTrajectoryCostChange", () => {
+  it("compares the observed bill to the unfiltered one", () => {
+    expect(describeSameTrajectoryCostChange(512_000, 500_000)).toBe(
+      "49.4% less than estimated unfiltered cost",
+    );
+  });
+
+  it("says so when the gate cost more than it saved", () => {
+    expect(describeSameTrajectoryCostChange(120_000, -20_000)).toBe(
+      "20.0% more than estimated unfiltered cost",
+    );
+  });
+
+  it("avoids a direction word when nothing changed", () => {
+    expect(describeSameTrajectoryCostChange(100_000, 0)).toBe(
+      "0.0% change from estimated unfiltered cost",
+    );
+  });
+
+  it("says nothing without a priced thread to compare against", () => {
+    expect(describeSameTrajectoryCostChange(0, 500_000)).toBeUndefined();
+  });
+
+  it("says nothing when the unfiltered cost is not positive", () => {
+    expect(describeSameTrajectoryCostChange(10_000, -10_000)).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -32,7 +32,10 @@ import {
   RailSummaryRow,
 } from "./context-rail-shared";
 import { RailStatusChip } from "./RailStatusChip";
-import { subAgentPricingUsageTitle } from "./subagent-kind";
+import {
+  isTokenMiserSubAgent,
+  subAgentPricingUsageTitle,
+} from "./subagent-kind";
 import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
 import { TokenMiserSavingsBreakdown } from "./TokenMiserSavingsBreakdown";
 import { TokenMiserSummaryCard } from "./TokenMiserSummaryCard";
@@ -119,22 +122,33 @@ export function PricingPanel(props: PricingPanelProps) {
   const parentModelSummary = aggregateUsageLines(
     allDisplayLines.filter(isMainThreadUsageLine),
   );
-  // Thread-level gate result, from every gate row on this tab. The per-turn
-  // folds below price one turn each; this is the same arithmetic run once
-  // across all of them, so the rail can answer "did the gate pay for itself"
-  // without expanding ninety folds.
-  const tokenMiserSummary = buildTokenMiserSavingsSummary({
-    ...(props.tokenMiserAccounting
-      ? { accounting: props.tokenMiserAccounting }
-      : {}),
-    gateAccountings: allDisplayLines
-      .filter(isTokenMiserGateLine)
-      .map((line) =>
-        line.sourceItemId
-          ? subAgentsById.get(line.sourceItemId)?.tokenMiserAccounting
-          : undefined,
-      ),
-  });
+  // Thread-level gate result, from every gate this thread spawned. The
+  // per-turn folds below price one turn each; this is the same arithmetic run
+  // once across all of them, so the rail can answer "did the gate pay for
+  // itself" without expanding ninety folds.
+  //
+  // Enumerated from the sub-agents rather than from the gate usage rows: a
+  // decision that deterministic policy passed through never bills a helper
+  // turn, so it has accounting and a sub-agent and no usage line at all. Read
+  // from the rows, an all-policy thread looked like a thread with no gate.
+  const tokenMiserSummary = useMemo(
+    () => buildTokenMiserSavingsSummary({
+      ...(props.tokenMiserAccounting
+        ? { accounting: props.tokenMiserAccounting }
+        : {}),
+      gateAccountings: (props.subAgents ?? [])
+        .filter(isTokenMiserSubAgent)
+        .map((subAgent) => subAgent.tokenMiserAccounting),
+    }),
+    [props.subAgents, props.tokenMiserAccounting],
+  );
+  // The Explorer's own basis for "would have cost", so the two surfaces divide
+  // by the same denominator: the provider summaries as recorded, without the
+  // estimated-gap lines the rail folds into its headline total.
+  const observedCostMicros = summaries.reduce(
+    (total, provider) => total + provider.totalCostMicros,
+    0,
+  );
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   // Totals run over every line, nested gates included: a gate's helper cost is
   // still part of the running total of every turn after it.
@@ -455,7 +469,7 @@ export function PricingPanel(props: PricingPanelProps) {
           {...(props.onOpenTokenMiserSavings
             ? { onOpenSavings: props.onOpenTokenMiserSavings }
             : {})}
-          {...(summary ? { observedCostMicros: summary.totalCostMicros } : {})}
+          {...(observedCostMicros > 0 ? { observedCostMicros } : {})}
           summary={tokenMiserSummary}
         />
       ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -35,10 +35,19 @@ import { RailStatusChip } from "./RailStatusChip";
 import { subAgentPricingUsageTitle } from "./subagent-kind";
 import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
 import { TokenMiserSavingsBreakdown } from "./TokenMiserSavingsBreakdown";
+import { TokenMiserSummaryCard } from "./TokenMiserSummaryCard";
+import { buildTokenMiserSavingsSummary } from "../token-miser-savings-summary";
 
 type PricingPanelProps = {
   activeTurnId?: string;
   displayOptions?: PricingDisplayOptions;
+  /**
+   * Opens the Explorer on its savings lens. The Pricing rail is where an
+   * operator asks what a thread cost, so it is where the full savings
+   * breakdown has to be reachable — until now that window could only be
+   * opened from Tool calls, a tab the tool-accounting experiment gates off.
+   */
+  onOpenTokenMiserSavings?: () => void;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   pricing?: {
     compactions?: ThreadCompactionRecord[];
@@ -110,6 +119,22 @@ export function PricingPanel(props: PricingPanelProps) {
   const parentModelSummary = aggregateUsageLines(
     allDisplayLines.filter(isMainThreadUsageLine),
   );
+  // Thread-level gate result, from every gate row on this tab. The per-turn
+  // folds below price one turn each; this is the same arithmetic run once
+  // across all of them, so the rail can answer "did the gate pay for itself"
+  // without expanding ninety folds.
+  const tokenMiserSummary = buildTokenMiserSavingsSummary({
+    ...(props.tokenMiserAccounting
+      ? { accounting: props.tokenMiserAccounting }
+      : {}),
+    gateAccountings: allDisplayLines
+      .filter(isTokenMiserGateLine)
+      .map((line) =>
+        line.sourceItemId
+          ? subAgentsById.get(line.sourceItemId)?.tokenMiserAccounting
+          : undefined,
+      ),
+  });
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   // Totals run over every line, nested gates included: a gate's helper cost is
   // still part of the running total of every turn after it.
@@ -421,6 +446,18 @@ export function PricingPanel(props: PricingPanelProps) {
         </>
       ) : displayLines.length === 0 ? (
         <p className="context-empty">No usage pricing recorded yet.</p>
+      ) : null}
+
+      {/* Under the provider summary, above the turn rows: the gate's result is
+          part of reading the bill, not a footnote to one turn of it. */}
+      {tokenMiserSummary ? (
+        <TokenMiserSummaryCard
+          {...(props.onOpenTokenMiserSavings
+            ? { onOpenSavings: props.onOpenTokenMiserSavings }
+            : {})}
+          {...(summary ? { observedCostMicros: summary.totalCostMicros } : {})}
+          summary={tokenMiserSummary}
+        />
       ) : null}
 
       {displayLines.length > 0 ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/TokenMiserSummaryCard.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/TokenMiserSummaryCard.tsx
@@ -2,6 +2,7 @@ import { formatTokenUsageMicrosAsUsd } from "@pwragent/shared";
 import { PopoutIcon } from "../../../icons";
 import {
   describeSameTrajectoryCostChange,
+  TOKEN_MISER_PENDING_PRICING_CAPTION,
   type TokenMiserSavingsSummary,
 } from "../token-miser-savings-summary";
 import { formatCompactCount, RailSummaryRow } from "./context-rail-shared";
@@ -25,8 +26,11 @@ export function TokenMiserSummaryCard(props: {
 }) {
   const summary = props.summary;
   const terms = summary.terms;
-  const savingsMicros = terms?.savingsMicros;
-  const negative = savingsMicros !== undefined && savingsMicros < 0;
+  const headline = describeHeadline(summary);
+  // Only the dollar headline has a percentage to compare against; a thread
+  // showing tokens or a bare decision count has no observed bill to divide by.
+  const savingsMicros =
+    summary.decisionCount > 0 ? terms?.savingsMicros : undefined;
   const costChange =
     savingsMicros !== undefined && props.observedCostMicros
       ? describeSameTrajectoryCostChange(props.observedCostMicros, savingsMicros)
@@ -45,20 +49,21 @@ export function TokenMiserSummaryCard(props: {
       <div className="rail-summary-card__headline">
         <span
           className="rail-summary-card__primary token-miser-summary-card__figure"
-          data-negative={negative}
+          data-negative={headline.negative}
         >
-          {formatHeadline(summary)}
+          {headline.text}
         </span>
-        {/* The percentage is the popup's, trimmed to the two words the rail has
-            room for. Its long form stays under the headline as the caption. */}
+        {/* The percentage is the popup's, in the shorter of the two widths the
+            comparison publishes. Its sentence stays under the headline. */}
         {costChange ? (
           <span className="rail-summary-card__secondary">
-            {costChange.split(" than ")[0]}
+            {costChange.short}
           </span>
         ) : null}
       </div>
       <div className="rail-summary-card__caption">
         {describeCaption({
+          decisionCount: summary.decisionCount,
           observedCostMicros: props.observedCostMicros,
           savingsMicros,
         })}
@@ -85,6 +90,7 @@ export function TokenMiserSummaryCard(props: {
         </div>
       ) : null}
       {summary.summarizedCount !== undefined
+      || summary.codeModeCallCount !== undefined
       || summary.avoidedParentTokens !== undefined ? (
         <div className="rail-summary-card__section">
           <span className="rail-summary-card__section-title">Decisions</span>
@@ -106,6 +112,12 @@ export function TokenMiserSummaryCard(props: {
               value={summary.helperDecisionCount.toLocaleString()}
             />
           ) : null}
+          {summary.codeModeCallCount !== undefined ? (
+            <RailSummaryRow
+              label="Code Mode calls"
+              value={summary.codeModeCallCount.toLocaleString()}
+            />
+          ) : null}
           {summary.avoidedParentTokens !== undefined ? (
             <RailSummaryRow
               label="Parent context avoided"
@@ -116,7 +128,7 @@ export function TokenMiserSummaryCard(props: {
       ) : null}
       {props.onOpenSavings ? (
         <button
-          className="token-miser-summary-card__action"
+          className="context-panel__section-action"
           onClick={props.onOpenSavings}
           type="button"
         >
@@ -128,35 +140,85 @@ export function TokenMiserSummaryCard(props: {
   );
 }
 
+type TokenMiserHeadline = {
+  /** True when the figure is a cost the gate added rather than one it removed. */
+  negative: boolean;
+  text: string;
+};
+
 /**
  * Dollars when the gate has priced, tokens when it has not. A thread mid-turn
  * has real decisions and no rates yet, and "$0.00 saved" would be a lie about
  * a number that simply has not arrived.
+ *
+ * Whichever figure lands here is also the one `negative` describes — a card
+ * that colored the dollars and not the tokens would render an overhead as a
+ * win the moment pricing was still pending.
  */
-function formatHeadline(summary: TokenMiserSavingsSummary): string {
-  const savingsMicros = summary.terms?.savingsMicros;
-  if (savingsMicros === undefined) {
-    return summary.avoidedParentTokens === undefined
-      ? `${summary.decisionCount.toLocaleString()} gated`
-      : `${formatCompactCount(summary.avoidedParentTokens)} kept out`;
+function describeHeadline(
+  summary: TokenMiserSavingsSummary,
+): TokenMiserHeadline {
+  const savingsMicros =
+    summary.decisionCount > 0 ? summary.terms?.savingsMicros : undefined;
+  if (savingsMicros !== undefined) {
+    return savingsMicros >= 0
+      ? {
+          negative: false,
+          text: `${formatTokenUsageMicrosAsUsd(savingsMicros)} saved`,
+        }
+      : {
+          negative: true,
+          text: `${formatTokenUsageMicrosAsUsd(
+            Math.abs(savingsMicros),
+          )} net overhead`,
+        };
   }
-  return savingsMicros >= 0
-    ? `${formatTokenUsageMicrosAsUsd(savingsMicros)} saved`
-    : `${formatTokenUsageMicrosAsUsd(Math.abs(savingsMicros))} net overhead`;
+  const avoided =
+    summary.decisionCount > 0 ? summary.avoidedParentTokens : undefined;
+  if (avoided !== undefined) {
+    // Summaries that ran longer than the payloads they replaced put more in
+    // the parent's context than passing the output through would have.
+    return avoided >= 0
+      ? { negative: false, text: `${formatCompactCount(avoided)} kept out` }
+      : {
+          negative: true,
+          text: `${formatCompactCount(Math.abs(avoided))} added to context`,
+        };
+  }
+  if (summary.decisionCount > 0) {
+    return {
+      negative: false,
+      text: `${summary.decisionCount.toLocaleString()} gated`,
+    };
+  }
+  const callCount = summary.codeModeCallCount ?? 0;
+  return {
+    negative: false,
+    text: `${callCount.toLocaleString()} Code Mode call${
+      callCount === 1 ? "" : "s"
+    }`,
+  };
 }
 
 function describeCaption(params: {
+  decisionCount: number;
   observedCostMicros?: number;
   savingsMicros?: number;
 }): string {
+  if (params.decisionCount === 0) return "No reducer decision was recorded.";
   if (params.savingsMicros === undefined) {
-    return "Dollar terms appear once each gate's usage line is priced";
+    return TOKEN_MISER_PENDING_PRICING_CAPTION;
   }
   const framing = params.savingsMicros >= 0
     ? "Estimated same-trajectory savings"
     : "Estimated same-trajectory overhead";
   if (!params.observedCostMicros) return framing;
+  // The comparison only exists while the unfiltered trajectory costs
+  // something. An overhead larger than the bill drives it to zero or below,
+  // where "$0.00 unfiltered" would read as a measurement rather than as one.
+  const unfilteredCostMicros = params.observedCostMicros + params.savingsMicros;
+  if (unfilteredCostMicros <= 0) return framing;
   return `${framing} · ${formatTokenUsageMicrosAsUsd(
-    params.observedCostMicros + params.savingsMicros,
+    unfilteredCostMicros,
   )} unfiltered`;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/TokenMiserSummaryCard.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/TokenMiserSummaryCard.tsx
@@ -1,0 +1,162 @@
+import { formatTokenUsageMicrosAsUsd } from "@pwragent/shared";
+import { PopoutIcon } from "../../../icons";
+import {
+  describeSameTrajectoryCostChange,
+  type TokenMiserSavingsSummary,
+} from "../token-miser-savings-summary";
+import { formatCompactCount, RailSummaryRow } from "./context-rail-shared";
+
+/**
+ * What the gate did for this thread's bill, once, at the top of the Pricing
+ * rail.
+ *
+ * The per-turn folds below already price each turn's decisions, but a thread
+ * with ninety of them answers "did Token Miser pay for itself" only by
+ * expanding ninety folds and adding up. This card is that addition, in the
+ * savings lens's own vocabulary — same three terms, same "estimated
+ * same-trajectory" framing — so an operator reading the rail and an operator
+ * reading the window are reading one story.
+ */
+export function TokenMiserSummaryCard(props: {
+  /** The thread's own billed total, for the "would have cost" comparison. */
+  observedCostMicros?: number;
+  onOpenSavings?: () => void;
+  summary: TokenMiserSavingsSummary;
+}) {
+  const summary = props.summary;
+  const terms = summary.terms;
+  const savingsMicros = terms?.savingsMicros;
+  const negative = savingsMicros !== undefined && savingsMicros < 0;
+  const costChange =
+    savingsMicros !== undefined && props.observedCostMicros
+      ? describeSameTrajectoryCostChange(props.observedCostMicros, savingsMicros)
+      : undefined;
+  const unpricedCount = summary.decisionCount - summary.pricedDecisionCount;
+
+  return (
+    <div className="rail-summary-card token-miser-summary-card">
+      <div className="rail-summary-card__header">
+        <span className="rail-summary-card__eyebrow">Token Miser</span>
+        <span className="rail-summary-card__meta">
+          {summary.decisionCount.toLocaleString()} decision
+          {summary.decisionCount === 1 ? "" : "s"}
+        </span>
+      </div>
+      <div className="rail-summary-card__headline">
+        <span
+          className="rail-summary-card__primary token-miser-summary-card__figure"
+          data-negative={negative}
+        >
+          {formatHeadline(summary)}
+        </span>
+        {/* The percentage is the popup's, trimmed to the two words the rail has
+            room for. Its long form stays under the headline as the caption. */}
+        {costChange ? (
+          <span className="rail-summary-card__secondary">
+            {costChange.split(" than ")[0]}
+          </span>
+        ) : null}
+      </div>
+      <div className="rail-summary-card__caption">
+        {describeCaption({
+          observedCostMicros: props.observedCostMicros,
+          savingsMicros,
+        })}
+      </div>
+      {terms ? (
+        <div className="rail-summary-card__section">
+          <span className="rail-summary-card__section-title">
+            {unpricedCount > 0
+              ? `Savings terms · ${summary.pricedDecisionCount.toLocaleString()} of ${summary.decisionCount.toLocaleString()} priced`
+              : "Savings terms"}
+          </span>
+          <RailSummaryRow
+            label="1 · Without the gate"
+            value={formatTokenUsageMicrosAsUsd(terms.withoutGateCostMicros)}
+          />
+          <RailSummaryRow
+            label="2 · Gate compute"
+            value={formatTokenUsageMicrosAsUsd(terms.gateCostMicros)}
+          />
+          <RailSummaryRow
+            label="3 · Revealed to parent"
+            value={formatTokenUsageMicrosAsUsd(terms.revealedCostMicros)}
+          />
+        </div>
+      ) : null}
+      {summary.summarizedCount !== undefined
+      || summary.avoidedParentTokens !== undefined ? (
+        <div className="rail-summary-card__section">
+          <span className="rail-summary-card__section-title">Decisions</span>
+          {summary.summarizedCount !== undefined ? (
+            <RailSummaryRow
+              label="Summarized"
+              value={summary.summarizedCount.toLocaleString()}
+            />
+          ) : null}
+          {summary.passThroughCount !== undefined ? (
+            <RailSummaryRow
+              label="Passed through"
+              value={summary.passThroughCount.toLocaleString()}
+            />
+          ) : null}
+          {summary.helperDecisionCount !== undefined ? (
+            <RailSummaryRow
+              label="Luna evaluations"
+              value={summary.helperDecisionCount.toLocaleString()}
+            />
+          ) : null}
+          {summary.avoidedParentTokens !== undefined ? (
+            <RailSummaryRow
+              label="Parent context avoided"
+              value={formatCompactCount(summary.avoidedParentTokens)}
+            />
+          ) : null}
+        </div>
+      ) : null}
+      {props.onOpenSavings ? (
+        <button
+          className="token-miser-summary-card__action"
+          onClick={props.onOpenSavings}
+          type="button"
+        >
+          <PopoutIcon size={11} aria-hidden="true" />
+          Token Miser Savings
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Dollars when the gate has priced, tokens when it has not. A thread mid-turn
+ * has real decisions and no rates yet, and "$0.00 saved" would be a lie about
+ * a number that simply has not arrived.
+ */
+function formatHeadline(summary: TokenMiserSavingsSummary): string {
+  const savingsMicros = summary.terms?.savingsMicros;
+  if (savingsMicros === undefined) {
+    return summary.avoidedParentTokens === undefined
+      ? `${summary.decisionCount.toLocaleString()} gated`
+      : `${formatCompactCount(summary.avoidedParentTokens)} kept out`;
+  }
+  return savingsMicros >= 0
+    ? `${formatTokenUsageMicrosAsUsd(savingsMicros)} saved`
+    : `${formatTokenUsageMicrosAsUsd(Math.abs(savingsMicros))} net overhead`;
+}
+
+function describeCaption(params: {
+  observedCostMicros?: number;
+  savingsMicros?: number;
+}): string {
+  if (params.savingsMicros === undefined) {
+    return "Dollar terms appear once each gate's usage line is priced";
+  }
+  const framing = params.savingsMicros >= 0
+    ? "Estimated same-trajectory savings"
+    : "Estimated same-trajectory overhead";
+  if (!params.observedCostMicros) return framing;
+  return `${framing} · ${formatTokenUsageMicrosAsUsd(
+    params.observedCostMicros + params.savingsMicros,
+  )} unfiltered`;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -6,6 +6,7 @@ import type {
   ThreadToolInvocationRecord,
   ThreadToolInvocationSummary,
 } from "@pwragent/shared";
+import { PopoutIcon } from "../../../icons";
 import type { ThreadLinkSource } from "../../../lib/thread-links";
 import { TranscriptCommandOutput } from "../TranscriptCommandOutput";
 import { detailMatchesInvocationItem } from "../tool-call-details";
@@ -54,12 +55,16 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
     <section className="context-panel__section tool-calls-panel">
       <div className="tool-calls-panel__heading">
         <h3>Tool calls</h3>
+        {/* Named for the window it opens rather than "Explore", and built at
+            rail scale: a 34px `.button` beside a 14px heading outweighed the
+            heading it sat next to. */}
         <button
-          className="button button--ghost"
+          className="context-panel__section-action"
           onClick={props.onOpenIncidentExplorer}
           type="button"
         >
-          Explore
+          <PopoutIcon size={11} aria-hidden="true" />
+          Tool Output Incidents
         </button>
       </div>
       {totals ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/TokenMiserSummaryCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/TokenMiserSummaryCard.test.tsx
@@ -1,0 +1,136 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  TokenMiserSavingsSummary,
+  TokenMiserSavingsTerms,
+} from "../../token-miser-savings-summary";
+import { TokenMiserSummaryCard } from "../TokenMiserSummaryCard";
+
+afterEach(() => {
+  cleanup();
+});
+
+const terms: TokenMiserSavingsTerms = {
+  withoutGateCostMicros: 1_200_000,
+  gateCostMicros: 150_000,
+  revealedCostMicros: 250_000,
+  savingsMicros: 800_000,
+};
+
+const summary: TokenMiserSavingsSummary = {
+  decisionCount: 9,
+  pricedDecisionCount: 9,
+  helperDecisionCount: 6,
+  passThroughCount: 2,
+  summarizedCount: 7,
+  avoidedParentTokens: 93_000,
+  terms,
+};
+
+function rowValue(label: string): string {
+  const row = screen.getByText(label).closest(".rail-summary-card__row");
+  return row?.querySelector(".rail-summary-card__row-value")?.textContent ?? "";
+}
+
+describe("TokenMiserSummaryCard", () => {
+  it("states the savings window's three terms and its headline", () => {
+    render(
+      <TokenMiserSummaryCard
+        observedCostMicros={1_200_000}
+        summary={summary}
+      />,
+    );
+
+    expect(screen.getByText("$0.80 saved")).toBeInTheDocument();
+    expect(screen.getByText("40.0% less")).toBeInTheDocument();
+    expect(
+      screen.getByText("Estimated same-trajectory savings · $2.00 unfiltered"),
+    ).toBeInTheDocument();
+    expect(rowValue("1 · Without the gate")).toBe("$1.20");
+    expect(rowValue("2 · Gate compute")).toBe("$0.15");
+    expect(rowValue("3 · Revealed to parent")).toBe("$0.25");
+  });
+
+  it("breaks the decisions down in the window's vocabulary", () => {
+    render(<TokenMiserSummaryCard summary={summary} />);
+
+    expect(screen.getByText("9 decisions")).toBeInTheDocument();
+    expect(rowValue("Summarized")).toBe("7");
+    expect(rowValue("Passed through")).toBe("2");
+    expect(rowValue("Luna evaluations")).toBe("6");
+    expect(rowValue("Parent context avoided")).toBe("93k");
+  });
+
+  it("opens the savings window from the card", () => {
+    const onOpenSavings = vi.fn();
+    render(
+      <TokenMiserSummaryCard onOpenSavings={onOpenSavings} summary={summary} />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Token Miser Savings" }),
+    );
+    expect(onOpenSavings).toHaveBeenCalledOnce();
+  });
+
+  it("omits the action when no window can be opened", () => {
+    render(<TokenMiserSummaryCard summary={summary} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Token Miser Savings" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("names an overhead instead of printing a negative saving", () => {
+    render(
+      <TokenMiserSummaryCard
+        observedCostMicros={1_000_000}
+        summary={{
+          ...summary,
+          terms: { ...terms, savingsMicros: -50_000 },
+        }}
+      />,
+    );
+
+    const headline = screen.getByText("$0.050 net overhead");
+    expect(headline).toHaveAttribute("data-negative", "true");
+    expect(screen.getByText("5.3% more")).toBeInTheDocument();
+    expect(
+      screen.getByText("Estimated same-trajectory overhead · $0.95 unfiltered"),
+    ).toBeInTheDocument();
+  });
+
+  it("waits for prices rather than reporting a $0.00 saving", () => {
+    /* A live turn has real decisions and no rates yet. Dollars that have not
+       arrived must not read as dollars that came to nothing. */
+    render(
+      <TokenMiserSummaryCard
+        observedCostMicros={1_200_000}
+        summary={{
+          decisionCount: 4,
+          pricedDecisionCount: 0,
+          avoidedParentTokens: 93_000,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("93k kept out")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Dollar terms appear once each gate's usage line is priced",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Savings terms")).not.toBeInTheDocument();
+  });
+
+  it("says how much of the thread a partial total covers", () => {
+    render(
+      <TokenMiserSummaryCard
+        summary={{ ...summary, pricedDecisionCount: 4 }}
+      />,
+    );
+
+    expect(screen.getByText("Savings terms · 4 of 9 priced")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/TokenMiserSummaryCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/TokenMiserSummaryCard.test.tsx
@@ -118,10 +118,71 @@ describe("TokenMiserSummaryCard", () => {
     expect(screen.getByText("93k kept out")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Dollar terms appear once each gate's usage line is priced",
+        "Dollar terms appear once the gate's usage line is priced.",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Savings terms")).not.toBeInTheDocument();
+  });
+
+  it("names an overhead the tokens show as clearly as the dollars would", () => {
+    /* A gate whose summaries ran longer than the payloads they replaced put
+       more in the parent's context, not less. Before pricing lands the token
+       figure is the only figure, and it read as a win. */
+    render(
+      <TokenMiserSummaryCard
+        summary={{
+          decisionCount: 4,
+          pricedDecisionCount: 0,
+          avoidedParentTokens: -12_000,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("12k added to context")).toHaveAttribute(
+      "data-negative",
+      "true",
+    );
+  });
+
+  it("drops the unfiltered comparison when the overhead swallows the bill", () => {
+    /* An overhead larger than the thread's own bill leaves nothing to compare
+       against; "$0.00 unfiltered" would read as a measurement. */
+    render(
+      <TokenMiserSummaryCard
+        observedCostMicros={40_000}
+        summary={{
+          ...summary,
+          terms: { ...terms, savingsMicros: -40_000 },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("Estimated same-trajectory overhead"),
+    ).toBeInTheDocument();
+  });
+
+  it("summarizes a Code Mode thread that reached no reducer decision", () => {
+    const onOpenSavings = vi.fn();
+    render(
+      <TokenMiserSummaryCard
+        onOpenSavings={onOpenSavings}
+        summary={{
+          decisionCount: 0,
+          pricedDecisionCount: 0,
+          codeModeCallCount: 12,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("12 Code Mode calls")).toBeInTheDocument();
+    expect(rowValue("Code Mode calls")).toBe("12");
+    expect(
+      screen.getByText("No reducer decision was recorded."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Token Miser Savings" }),
+    ).toBeInTheDocument();
   });
 
   it("says how much of the thread a partial total covers", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/token-miser-savings-summary.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/token-miser-savings-summary.ts
@@ -18,6 +18,11 @@ export type TokenMiserSavingsSummary = {
   decisionCount: number;
   /** Decisions whose dollar terms are complete. */
   pricedDecisionCount: number;
+  /**
+   * Code Mode calls the gate observed. A thread can run Code Mode and reach no
+   * reducer decision at all, which is still a Token Miser story worth telling.
+   */
+  codeModeCallCount?: number;
   /** Decisions Luna evaluated, as opposed to deterministic policy. */
   helperDecisionCount?: number;
   /** Decisions that deliberately returned the ordinary original result. */
@@ -25,8 +30,9 @@ export type TokenMiserSavingsSummary = {
   /** Decisions that replaced the payload with a summary. */
   summarizedCount?: number;
   /**
-   * Parent-context tokens the gate kept out, counted once plus every replay.
-   * The same figure the Explorer's lens tab reports as "avoided".
+   * Parent-context tokens the gate kept out of the first pass. The same figure
+   * the Explorer's lens tab reports as kept out "once" — replays are a second
+   * figure there and are deliberately not folded in here.
    */
   avoidedParentTokens?: number;
   /**
@@ -49,6 +55,24 @@ export type TokenMiserSavingsTerms = {
 };
 
 /**
+ * The same comparison in two widths: `short` for a rail headline, `sentence`
+ * for the popup's figure line. Both views need the same percentage, and a rail
+ * that re-cut the sentence with string surgery would silently print the whole
+ * sentence the moment the wording changed.
+ */
+export type TokenMiserSameTrajectoryChange = {
+  short: string;
+  sentence: string;
+};
+
+/**
+ * Shown wherever a thread has gate decisions and no rates yet. One string so
+ * the rail and the window make the same promise about when dollars arrive.
+ */
+export const TOKEN_MISER_PENDING_PRICING_CAPTION =
+  "Dollar terms appear once the gate's usage line is priced.";
+
+/**
  * Build the thread-level summary from whichever source this view has.
  *
  * `accounting` is thread-level and authoritative: the Explorer reads it
@@ -67,14 +91,23 @@ export function buildTokenMiserSavingsSummary(params: {
   );
   const decisionCount =
     params.accounting?.interceptionCount ?? params.gateAccountings.length;
-  if (decisionCount === 0) return undefined;
+  const codeModeCallCount = params.accounting?.codeMode?.callCount;
+  if (decisionCount === 0 && !codeModeCallCount) return undefined;
 
   const passThroughCount =
     params.accounting?.passThroughCount
-    ?? countGates(priced, (gate) => gate.disposition === "passed_through");
+    ?? countGates(priced, "disposition", "passed_through");
+  // On the thread-accounting path every decision is one or the other, so the
+  // complement is exact. Off it, only the gates that actually recorded a
+  // disposition can be counted — subtracting a priced-only count from a count
+  // of every decision would report unpriced gates as summarized.
+  const summarizedCount =
+    params.accounting?.passThroughCount === undefined
+      ? countGates(priced, "disposition", "summarized")
+      : Math.max(0, decisionCount - params.accounting.passThroughCount);
   const helperDecisionCount =
     params.accounting?.helperDecisionCount
-    ?? countGates(priced, (gate) => gate.decisionSource !== "policy");
+    ?? countGates(priced, "decisionSource", "helper");
   const avoidedParentTokens = readAvoidedParentTokens(params.accounting, priced);
   const terms = savings
     ? {
@@ -90,13 +123,10 @@ export function buildTokenMiserSavingsSummary(params: {
   return {
     decisionCount,
     pricedDecisionCount: savings?.pricedGateCount ?? priced.length,
+    ...(codeModeCallCount ? { codeModeCallCount } : {}),
     ...(helperDecisionCount === undefined ? {} : { helperDecisionCount }),
-    ...(passThroughCount === undefined
-      ? {}
-      : {
-          passThroughCount,
-          summarizedCount: Math.max(0, decisionCount - passThroughCount),
-        }),
+    ...(passThroughCount === undefined ? {} : { passThroughCount }),
+    ...(summarizedCount === undefined ? {} : { summarizedCount }),
     ...(avoidedParentTokens === undefined ? {} : { avoidedParentTokens }),
     ...(terms === undefined ? {} : { terms }),
   };
@@ -110,16 +140,19 @@ export function buildTokenMiserSavingsSummary(params: {
 export function describeSameTrajectoryCostChange(
   observedCostMicros: number,
   savingsMicros: number,
-): string | undefined {
+): TokenMiserSameTrajectoryChange | undefined {
   if (observedCostMicros <= 0) return undefined;
   const unfilteredCostMicros = observedCostMicros + savingsMicros;
   if (unfilteredCostMicros <= 0) return undefined;
   const percent = Math.abs(savingsMicros) / unfilteredCostMicros * 100;
   if (savingsMicros === 0) {
-    return `${percent.toFixed(1)}% change from estimated unfiltered cost`;
+    return {
+      short: `${percent.toFixed(1)}% change`,
+      sentence: `${percent.toFixed(1)}% change from estimated unfiltered cost`,
+    };
   }
-  return `${percent.toFixed(1)}% ${savingsMicros > 0 ? "less" : "more"} `
-    + "than estimated unfiltered cost";
+  const short = `${percent.toFixed(1)}% ${savingsMicros > 0 ? "less" : "more"}`;
+  return { short, sentence: `${short} than estimated unfiltered cost` };
 }
 
 /**
@@ -152,37 +185,40 @@ function sumGateTerms(
   );
 }
 
+/**
+ * Tokens the gate kept out of the parent's first pass, replays excluded.
+ *
+ * The Explorer reports the replay total as its own figure beside this one, so
+ * folding them together here would make the rail's number look like the
+ * window's while quoting a different quantity.
+ */
 function readAvoidedParentTokens(
   accounting: ThreadTokenMiserAccounting | undefined,
   priced: readonly TokenMiserSubAgentAccounting[],
 ): number | undefined {
-  if (accounting) {
-    return (
-      accounting.estimatedParentTokensSaved
-      + (accounting.estimatedCachedReplayTokensSaved ?? 0)
-    );
-  }
+  if (accounting) return accounting.estimatedParentTokensSaved;
   if (priced.length === 0) return undefined;
   return priced.reduce(
     (total, gate) =>
-      total
-      + gate.baselineParentTokens
-      + (gate.cachedBaselineTokens ?? 0)
-      - gate.revealedParentTokens
-      - (gate.cachedRevealedTokens ?? 0),
+      total + gate.baselineParentTokens - gate.revealedParentTokens,
     0,
   );
 }
 
 /**
- * Counting a disposition across only the priced gates would report "0 passed
- * through" on a thread whose gates have not priced yet, which reads as a fact
- * rather than as missing data. Absent beats wrong here.
+ * Count one value of an optional per-gate field across the priced gates.
+ *
+ * Two ways to report a fact nobody recorded, both avoided here: a thread whose
+ * gates have not priced yet has no gates to count, and older gates carry no
+ * `disposition` or `decisionSource` at all. Either way the honest answer is
+ * that the mix is unknown — "0 passed through" reads as a fact. Absent beats
+ * wrong here.
  */
-function countGates(
+function countGates<K extends "decisionSource" | "disposition">(
   priced: readonly TokenMiserSubAgentAccounting[],
-  predicate: (gate: TokenMiserSubAgentAccounting) => boolean,
+  field: K,
+  value: NonNullable<TokenMiserSubAgentAccounting[K]>,
 ): number | undefined {
-  if (priced.length === 0) return undefined;
-  return priced.filter(predicate).length;
+  if (!priced.some((gate) => gate[field] !== undefined)) return undefined;
+  return priced.filter((gate) => gate[field] === value).length;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/token-miser-savings-summary.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/token-miser-savings-summary.ts
@@ -1,0 +1,188 @@
+import type {
+  ThreadTokenMiserAccounting,
+  TokenMiserSubAgentAccounting,
+} from "@pwragent/shared";
+
+/**
+ * One thread's Token Miser result, in the same three terms the Explorer's
+ * savings lens and the per-gate breakdown already use.
+ *
+ * The Pricing rail and the Explorer window answer the same question from two
+ * different reads of the same thread, so the arithmetic lives here rather than
+ * in either view. Two copies of "1 − 2 − 3" is two chances to disagree, and a
+ * rail that quotes a different number than the window it links to is worse
+ * than a rail that says nothing.
+ */
+export type TokenMiserSavingsSummary = {
+  /** Reducer decisions, priced or not. */
+  decisionCount: number;
+  /** Decisions whose dollar terms are complete. */
+  pricedDecisionCount: number;
+  /** Decisions Luna evaluated, as opposed to deterministic policy. */
+  helperDecisionCount?: number;
+  /** Decisions that deliberately returned the ordinary original result. */
+  passThroughCount?: number;
+  /** Decisions that replaced the payload with a summary. */
+  summarizedCount?: number;
+  /**
+   * Parent-context tokens the gate kept out, counted once plus every replay.
+   * The same figure the Explorer's lens tab reports as "avoided".
+   */
+  avoidedParentTokens?: number;
+  /**
+   * The dollar terms, absent until at least one gate is priced. A gate is
+   * priced only once its own usage line lands and the parent turn has a known
+   * model and rate, so a live turn can have decisions and no terms yet.
+   */
+  terms?: TokenMiserSavingsTerms;
+};
+
+export type TokenMiserSavingsTerms = {
+  /** 1 — the gated payloads at parent rates, uncached once plus replays. */
+  withoutGateCostMicros: number;
+  /** 2 — what the helper actually charged. */
+  gateCostMicros: number;
+  /** 3 — summaries and retrievals the parent did receive, and their replays. */
+  revealedCostMicros: number;
+  /** 1 − 2 − 3. Negative when the gate cost more than it saved. */
+  savingsMicros: number;
+};
+
+/**
+ * Build the thread-level summary from whichever source this view has.
+ *
+ * `accounting` is thread-level and authoritative: the Explorer reads it
+ * straight from the main process and the numbers below are the ones that
+ * window shows. The Pricing rail only receives it when the thread
+ * tool-accounting experiment is on, so the per-gate records it always has are
+ * the fallback — the same records the per-turn folds already sum.
+ */
+export function buildTokenMiserSavingsSummary(params: {
+  accounting?: ThreadTokenMiserAccounting;
+  gateAccountings: readonly (TokenMiserSubAgentAccounting | undefined)[];
+}): TokenMiserSavingsSummary | undefined {
+  const savings = params.accounting?.savings;
+  const priced = params.gateAccountings.filter(
+    (gate): gate is TokenMiserSubAgentAccounting => gate !== undefined,
+  );
+  const decisionCount =
+    params.accounting?.interceptionCount ?? params.gateAccountings.length;
+  if (decisionCount === 0) return undefined;
+
+  const passThroughCount =
+    params.accounting?.passThroughCount
+    ?? countGates(priced, (gate) => gate.disposition === "passed_through");
+  const helperDecisionCount =
+    params.accounting?.helperDecisionCount
+    ?? countGates(priced, (gate) => gate.decisionSource !== "policy");
+  const avoidedParentTokens = readAvoidedParentTokens(params.accounting, priced);
+  const terms = savings
+    ? {
+        withoutGateCostMicros: savings.withoutGateCostMicros,
+        gateCostMicros: savings.gateCostMicros,
+        revealedCostMicros: savings.revealedCostMicros,
+        savingsMicros: savings.savingsMicros,
+      }
+    : priced.length > 0
+      ? sumGateTerms(priced)
+      : undefined;
+
+  return {
+    decisionCount,
+    pricedDecisionCount: savings?.pricedGateCount ?? priced.length,
+    ...(helperDecisionCount === undefined ? {} : { helperDecisionCount }),
+    ...(passThroughCount === undefined
+      ? {}
+      : {
+          passThroughCount,
+          summarizedCount: Math.max(0, decisionCount - passThroughCount),
+        }),
+    ...(avoidedParentTokens === undefined ? {} : { avoidedParentTokens }),
+    ...(terms === undefined ? {} : { terms }),
+  };
+}
+
+/**
+ * The popup's headline comparison, shared so the rail cannot round it
+ * differently: what the same trajectory would have cost with nothing filtered,
+ * and how far the observed bill came in under it.
+ */
+export function describeSameTrajectoryCostChange(
+  observedCostMicros: number,
+  savingsMicros: number,
+): string | undefined {
+  if (observedCostMicros <= 0) return undefined;
+  const unfilteredCostMicros = observedCostMicros + savingsMicros;
+  if (unfilteredCostMicros <= 0) return undefined;
+  const percent = Math.abs(savingsMicros) / unfilteredCostMicros * 100;
+  if (savingsMicros === 0) {
+    return `${percent.toFixed(1)}% change from estimated unfiltered cost`;
+  }
+  return `${percent.toFixed(1)}% ${savingsMicros > 0 ? "less" : "more"} `
+    + "than estimated unfiltered cost";
+}
+
+/**
+ * Sum only the gates that priced. An unpriced gate contributes tokens to the
+ * counts above and nothing here, which is why `pricedDecisionCount` is
+ * reported separately — a partial total must not read as a complete one.
+ */
+function sumGateTerms(
+  gates: readonly TokenMiserSubAgentAccounting[],
+): TokenMiserSavingsTerms {
+  return gates.reduce<TokenMiserSavingsTerms>(
+    (terms, gate) => ({
+      withoutGateCostMicros:
+        terms.withoutGateCostMicros
+        + gate.baselineParentCostMicros
+        + (gate.cachedBaselineCostMicros ?? 0),
+      gateCostMicros: terms.gateCostMicros + gate.gateCostMicros,
+      revealedCostMicros:
+        terms.revealedCostMicros
+        + gate.revealedParentCostMicros
+        + (gate.cachedRevealedCostMicros ?? 0),
+      savingsMicros: terms.savingsMicros + gate.savingsMicros,
+    }),
+    {
+      withoutGateCostMicros: 0,
+      gateCostMicros: 0,
+      revealedCostMicros: 0,
+      savingsMicros: 0,
+    },
+  );
+}
+
+function readAvoidedParentTokens(
+  accounting: ThreadTokenMiserAccounting | undefined,
+  priced: readonly TokenMiserSubAgentAccounting[],
+): number | undefined {
+  if (accounting) {
+    return (
+      accounting.estimatedParentTokensSaved
+      + (accounting.estimatedCachedReplayTokensSaved ?? 0)
+    );
+  }
+  if (priced.length === 0) return undefined;
+  return priced.reduce(
+    (total, gate) =>
+      total
+      + gate.baselineParentTokens
+      + (gate.cachedBaselineTokens ?? 0)
+      - gate.revealedParentTokens
+      - (gate.cachedRevealedTokens ?? 0),
+    0,
+  );
+}
+
+/**
+ * Counting a disposition across only the priced gates would report "0 passed
+ * through" on a thread whose gates have not priced yet, which reads as a fact
+ * rather than as missing data. Absent beats wrong here.
+ */
+function countGates(
+  priced: readonly TokenMiserSubAgentAccounting[],
+  predicate: (gate: TokenMiserSubAgentAccounting) => boolean,
+): number | undefined {
+  if (priced.length === 0) return undefined;
+  return priced.filter(predicate).length;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24147,48 +24147,25 @@ button.pricing-token-miser__folded:focus-visible {
 }
 
 /* Thread-level gate result, above the turn rows. It borrows the pricing
-   summary card wholesale — same shell, same eyebrow, same key/value rows — so
-   the two read as one stack rather than as a summary and a widget. Only the
-   figure and the action are its own. */
-.token-miser-summary-card__figure {
-  color: var(--accent);
-}
-
+   summary card wholesale — same shell, same eyebrow, same key/value rows, and
+   the section action the Tool calls tab already uses — so the two read as one
+   stack rather than as a summary and a widget. The figure keeps the card's own
+   text color; only an overhead is colored, and the accent stays a surface and
+   border signal. */
 .token-miser-summary-card__figure[data-negative="true"] {
-  color: var(--status-warning);
+  color: var(--danger-text);
 }
 
-.token-miser-summary-card__action {
+/* The rail's action is the section action, stretched: the card has a full
+   width to fill and a row of its own to sit in. Scoped to the card rather than
+   given its own class so it outranks the shared rule, which is defined further
+   down this file and would otherwise win on equal specificity. */
+.token-miser-summary-card .context-panel__section-action {
   display: flex;
-  align-items: center;
   justify-content: center;
-  gap: 6px;
   width: 100%;
   min-height: 26px;
   margin-top: 10px;
-  padding: 0 10px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--accent-bright);
-  font: inherit;
-  font-size: 11.5px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.token-miser-summary-card__action:hover {
-  border-color: var(--accent-border);
-  background: var(--bg-row-active);
-}
-
-.token-miser-summary-card__action:focus-visible {
-  outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
-}
-
-.token-miser-summary-card__action svg {
-  flex: 0 0 auto;
 }
 
 .rail-card__actions {
@@ -24293,6 +24270,10 @@ button.pricing-token-miser__folded:focus-visible {
 .context-panel__section-action:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+.context-panel__section-action svg {
+  flex: 0 0 auto;
 }
 
 .tool-call-alert .rail-card__title {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24146,6 +24146,51 @@ button.pricing-token-miser__folded:focus-visible {
   outline-offset: 2px;
 }
 
+/* Thread-level gate result, above the turn rows. It borrows the pricing
+   summary card wholesale — same shell, same eyebrow, same key/value rows — so
+   the two read as one stack rather than as a summary and a widget. Only the
+   figure and the action are its own. */
+.token-miser-summary-card__figure {
+  color: var(--accent);
+}
+
+.token-miser-summary-card__figure[data-negative="true"] {
+  color: var(--status-warning);
+}
+
+.token-miser-summary-card__action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 26px;
+  margin-top: 10px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent-bright);
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.token-miser-summary-card__action:hover {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+}
+
+.token-miser-summary-card__action:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.token-miser-summary-card__action svg {
+  flex: 0 0 auto;
+}
+
 .rail-card__actions {
   width: 100%;
   margin-top: 2px;
@@ -24214,6 +24259,40 @@ button.pricing-token-miser__folded:focus-visible {
 
 .tool-calls-panel__heading h3 {
   margin: 0;
+}
+
+/* A rail heading's action, at rail scale. The shared `.button` is 34px at
+   13px, which outweighed the 14px heading it sat beside; these are the same
+   measurements as `.tool-call-row__details`, the other in-rail control. Both
+   entry points to the tool-output explorer wear this class, so the Pricing
+   card's action and the Tool calls heading's action are one control with two
+   destinations. */
+.context-panel__section-action {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent-bright);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.context-panel__section-action:hover {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+}
+
+.context-panel__section-action:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .tool-call-alert .rail-card__title {

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -170,10 +170,22 @@ export type OpenToolOutputIncidentExplorerWindowRequest = {
    * against the local registry, which does not have it.
    */
   federationTarget?: FederationTarget;
+  /**
+   * Which lens the operator asked for.
+   *
+   * A window opening for the first time picks its own lens from the thread's
+   * accounting, so this only matters when the window is already open: the
+   * refresh event carries the request, and an explorer sitting on incidents
+   * has to move when the operator clicks "Token Miser Savings" on the Pricing
+   * rail. Omitted means "leave the lens alone".
+   */
+  lens?: ToolOutputIncidentExplorerLens;
   projectLabel?: string;
   threadId: string;
   title: string;
 };
+
+export type ToolOutputIncidentExplorerLens = "incidents" | "savings";
 
 export type OpenToolOutputIncidentExplorerWindowResponse = {
   opened: true;

--- a/packages/shared/src/contracts/tool-output-incidents.ts
+++ b/packages/shared/src/contracts/tool-output-incidents.ts
@@ -173,11 +173,11 @@ export type OpenToolOutputIncidentExplorerWindowRequest = {
   /**
    * Which lens the operator asked for.
    *
-   * A window opening for the first time picks its own lens from the thread's
-   * accounting, so this only matters when the window is already open: the
-   * refresh event carries the request, and an explorer sitting on incidents
-   * has to move when the operator clicks "Token Miser Savings" on the Pricing
-   * rail. Omitted means "leave the lens alone".
+   * A request that names one takes the window there either way: a new window
+   * opens on it, and an explorer already sitting on the other lens moves when
+   * the operator clicks "Token Miser Savings" on the Pricing rail. Omitted
+   * means "leave the lens alone" — a new window then picks its own from the
+   * thread's accounting, and an open one stays where the operator left it.
    */
   lens?: ToolOutputIncidentExplorerLens;
   projectLabel?: string;


### PR DESCRIPTION
## Why

The Pricing tab prices every turn and every gate, but never says what the gate did for the thread as a whole. A thread with ninety decisions answered *"did Token Miser pay for itself"* only by expanding ninety per-turn folds and adding up.

And the window that already answers it — **Token Miser Savings** — could only be opened from the **Tool calls** panel, a tab the `threadToolAccounting` experiment hides by default. In a default install it was unreachable.

## What

**A Token Miser card on the Pricing tab**, directly under the provider summary and above the turn rows, because the gate's result is part of reading the bill rather than a footnote to one turn of it.

It speaks the savings window's vocabulary so the rail and the window read as one story:

- headline `$X saved` / `$X net overhead`, with the window's own `N% less than estimated unfiltered cost` comparison
- the same three terms — `1 · Without the gate`, `2 · Gate compute`, `3 · Revealed to parent`
- the same decision mix — Summarized, Passed through, Luna evaluations, Parent context avoided
- a footer action, **Token Miser Savings**, that opens the window on its savings lens

**One module owns the arithmetic** ([token-miser-savings-summary.ts](apps/desktop/src/renderer/src/features/thread-detail/token-miser-savings-summary.ts)), read by both the rail and the Explorer. It prefers the thread-level accounting the window shows and falls back to summing the per-gate records the Pricing rail always has — so the card works with the experiment off, and a rail that links to a window can't quote a different total than the window it links to. `describeSameTrajectoryCostChange` moved here from the Explorer rather than being copied.

**Dollars stay absent until a gate prices.** A live turn has real decisions and no rates yet; the headline falls back to `Nk kept out` and the card says dollar terms are still coming. `$0.00 saved` would be a claim about a number that hasn't arrived. Same reasoning for the decision mix: with nothing priced it is omitted rather than reported as `0 passed through`.

**The open request carries a lens.** A window opening fresh still picks its own lens from the thread's accounting; the new field only matters when one is already open on Incidents and the operator clicks *Token Miser Savings* — the refresh event now moves it. Omitted means "leave the lens alone".

**The Tool calls heading action, rebuilt at rail scale.** A 34px ghost `.button` outweighed the 14px heading beside it, and "Explore" named no destination. It is now a 24px `.context-panel__section-action` with a popout icon, named for the window it opens: **Tool Output Incidents**.

## Design

Mockups are in the **PwrAgent** Claude Design project — [Pricing Token Miser Summary](https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Pricing+Token+Miser+Summary.html). Shipped: option **1b** (full card) and option **2b** (rail-scale section action). Both are built from the real `app.css` tokens; the card reuses `.rail-summary-card` and its rows verbatim.

## Tests

- `token-miser-savings-summary.test.ts` — thread accounting wins over gate sums; the per-gate fallback (experiment-off path); no decisions → no card; unpriced gates report counts without terms and omit the mix rather than reporting zeros; the three `describeSameTrajectoryCostChange` wordings and both guards.
- `TokenMiserSummaryCard.test.tsx` — terms, headline, decision mix, the overhead and not-yet-priced states, the partial-total title, and the action's presence/absence.
- `ThreadContextPanel.test.tsx` — the card renders on the Pricing tab **with the tool-accounting experiment off** (Tool calls tab absent), from gate usage lines joined to `subAgents[].tokenMiserAccounting`, and its action requests lens `savings`; the Tool calls action requests `incidents`.
- `ToolOutputIncidentExplorerWindow.test.tsx` — an open window on Incidents moves to Savings when the request names the lens, and stays put when it doesn't.

`pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries`, and the full renderer suite (3521 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)