### PR TITLE
fix(desktop): prefer managed CLIs in integrated terminals

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -2711,6 +2711,38 @@ describe("DesktopSettingsService", () => {
     expect(resolveActiveManagedGrokCommand).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to the configured Codex path when Token Miser has no runtime yet", () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[experimental]",
+        "token_miser_enabled = true",
+        "",
+        "[acp_agents.grok]",
+        "enabled = false",
+        "",
+        "[models.codex]",
+        'path = "/custom/codex/bin/codex"',
+      ].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      defaultManagedGrokBuilds: true,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    // Token Miser is on but no managed runtime is active: still installing, or
+    // the download failed. Threads fall back to the configured command here,
+    // so a terminal that pinned nothing would send `codex` somewhere else.
+    expect(service.resolveIntegratedTerminalCommands()).toEqual([
+      "/custom/codex/bin/codex",
+    ]);
+  });
+
   it("uses configured Codex and Grok overrides without managed runtime work", () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -2698,7 +2698,9 @@ describe("DesktopSettingsService", () => {
       secretStore: new MemoryDesktopSecretStore(),
     });
 
-    await service.readSettings();
+    await service.refreshStartupDiscovery(
+      issueProviderDiscoveryPermit("startup"),
+    );
     ensureManagedCodexRuntime.mockClear();
 
     expect(service.resolveIntegratedTerminalCommands()).toEqual([

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -2642,38 +2642,74 @@ describe("DesktopSettingsService", () => {
     });
   });
 
-  it("resolves the selected Codex and managed Grok commands for integrated terminals", async () => {
+  it("uses only already-active managed runtimes for integrated terminals", async () => {
     const root = createTempRoot();
-    const resolveCodex = vi.fn(async () => ({
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(configPath, [
+      "[experimental]",
+      "token_miser_enabled = true",
+      "",
+      "[acp_agents.grok]",
+      "managed_builds = true",
+      "",
+    ].join("\n"));
+    const ensureManagedCodexRuntime = vi.fn(async () => ({
+      appServerCommand: "/pwragent/codex/codex-app-server",
+      codeModeHostCommand: "/pwragent/codex/codex-code-mode-host",
       command: "/pwragent/codex/versions/current/codex",
-      source: "config" as const,
-      version: "0.149.0-pwragent.2",
+      metadata: {
+        asset: "pwragent-codex-0.149.0-pwragent.2-darwin-arm64.tar.gz",
+        checkedAt: 1,
+        installedAt: 1,
+        repository: "pwrdrvr/codex",
+        schemaVersion: 1,
+        sha256: "a".repeat(64),
+        tag: "pwragent-v0.149.0-pwragent.2",
+        version: "0.149.0-pwragent.2",
+      },
     }));
-    const resolveManagedGrokCommand = vi.fn(
-      async () => "/pwragent/grok/versions/current/grok",
+    const resolveActiveManagedGrokCommand = vi.fn(
+      () => "/pwragent/grok/versions/current/grok",
     );
     const service = new DesktopSettingsService({
       codexDiscoveryCoordinator: {
-        discover: vi.fn(async () => ({ candidates: [] })),
+        discover: vi.fn(async (configuredCommand?: string) => ({
+          candidates: configuredCommand
+            ? [{
+                command: configuredCommand,
+                executable: true,
+                selected: true,
+                source: "config" as const,
+                version: "0.149.0-pwragent.2",
+              }]
+            : [],
+        })),
         invalidate: vi.fn(),
-        resolve: resolveCodex,
+        resolve: vi.fn(async () => ({
+          command: "/usr/local/bin/codex",
+          source: "path" as const,
+        })),
       },
-      configPath: path.join(root, "config.toml"),
+      configPath,
       defaultManagedGrokBuilds: true,
+      ensureManagedCodexRuntime,
       env: {},
-      resolveManagedGrokCommand,
+      resolveActiveManagedGrokCommand,
       secretStore: new MemoryDesktopSecretStore(),
     });
 
-    await expect(service.resolveIntegratedTerminalCommands()).resolves.toEqual([
+    await service.readSettings();
+    ensureManagedCodexRuntime.mockClear();
+
+    expect(service.resolveIntegratedTerminalCommands()).toEqual([
       "/pwragent/codex/versions/current/codex",
       "/pwragent/grok/versions/current/grok",
     ]);
-    expect(resolveCodex).toHaveBeenCalledTimes(1);
-    expect(resolveManagedGrokCommand).toHaveBeenCalledTimes(1);
+    expect(ensureManagedCodexRuntime).not.toHaveBeenCalled();
+    expect(resolveActiveManagedGrokCommand).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the configured Grok override instead of the managed runtime in terminals", async () => {
+  it("uses configured Codex and Grok overrides without managed runtime work", () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");
     fs.writeFileSync(
@@ -2682,33 +2718,61 @@ describe("DesktopSettingsService", () => {
         "[acp_agents.grok]",
         'cli_path = "/custom/grok/bin/grok"',
         "managed_builds = true",
+        "",
+        "[models.codex]",
+        'path = "/custom/codex/bin/codex"',
       ].join("\n"),
       "utf8",
     );
-    const resolveManagedGrokCommand = vi.fn(
-      async () => "/pwragent/grok/versions/current/grok",
+    const resolveActiveManagedGrokCommand = vi.fn(
+      () => "/pwragent/grok/versions/current/grok",
     );
     const service = new DesktopSettingsService({
-      codexDiscoveryCoordinator: {
-        discover: vi.fn(async () => ({ candidates: [] })),
-        invalidate: vi.fn(),
-        resolve: vi.fn(async () => ({
-          command: "/custom/codex/bin/codex",
-          source: "config" as const,
-        })),
-      },
       configPath,
       defaultManagedGrokBuilds: true,
       env: {},
-      resolveManagedGrokCommand,
+      resolveActiveManagedGrokCommand,
       secretStore: new MemoryDesktopSecretStore(),
     });
 
-    await expect(service.resolveIntegratedTerminalCommands()).resolves.toEqual([
+    expect(service.resolveIntegratedTerminalCommands()).toEqual([
       "/custom/codex/bin/codex",
       "/custom/grok/bin/grok",
     ]);
-    expect(resolveManagedGrokCommand).not.toHaveBeenCalled();
+    expect(resolveActiveManagedGrokCommand).not.toHaveBeenCalled();
+  });
+
+  it("does not prepend a configured Grok override when Grok is disabled", () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[acp_agents.grok]",
+        "enabled = false",
+        'cli_path = "/disabled/grok/bin/grok"',
+        "managed_builds = true",
+        "",
+        "[models.codex]",
+        'path = "/custom/codex/bin/codex"',
+      ].join("\n"),
+      "utf8",
+    );
+    const resolveActiveManagedGrokCommand = vi.fn(
+      () => "/pwragent/grok/versions/current/grok",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      defaultManagedGrokBuilds: true,
+      env: {},
+      resolveActiveManagedGrokCommand,
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect(service.resolveIntegratedTerminalCommands()).toEqual([
+      "/custom/codex/bin/codex",
+    ]);
+    expect(resolveActiveManagedGrokCommand).not.toHaveBeenCalled();
   });
 
   it("keeps CODEX_HOME fixed to the startup Codex auth profile", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -2642,6 +2642,75 @@ describe("DesktopSettingsService", () => {
     });
   });
 
+  it("resolves the selected Codex and managed Grok commands for integrated terminals", async () => {
+    const root = createTempRoot();
+    const resolveCodex = vi.fn(async () => ({
+      command: "/pwragent/codex/versions/current/codex",
+      source: "config" as const,
+      version: "0.149.0-pwragent.2",
+    }));
+    const resolveManagedGrokCommand = vi.fn(
+      async () => "/pwragent/grok/versions/current/grok",
+    );
+    const service = new DesktopSettingsService({
+      codexDiscoveryCoordinator: {
+        discover: vi.fn(async () => ({ candidates: [] })),
+        invalidate: vi.fn(),
+        resolve: resolveCodex,
+      },
+      configPath: path.join(root, "config.toml"),
+      defaultManagedGrokBuilds: true,
+      env: {},
+      resolveManagedGrokCommand,
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    await expect(service.resolveIntegratedTerminalCommands()).resolves.toEqual([
+      "/pwragent/codex/versions/current/codex",
+      "/pwragent/grok/versions/current/grok",
+    ]);
+    expect(resolveCodex).toHaveBeenCalledTimes(1);
+    expect(resolveManagedGrokCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the configured Grok override instead of the managed runtime in terminals", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[acp_agents.grok]",
+        'cli_path = "/custom/grok/bin/grok"',
+        "managed_builds = true",
+      ].join("\n"),
+      "utf8",
+    );
+    const resolveManagedGrokCommand = vi.fn(
+      async () => "/pwragent/grok/versions/current/grok",
+    );
+    const service = new DesktopSettingsService({
+      codexDiscoveryCoordinator: {
+        discover: vi.fn(async () => ({ candidates: [] })),
+        invalidate: vi.fn(),
+        resolve: vi.fn(async () => ({
+          command: "/custom/codex/bin/codex",
+          source: "config" as const,
+        })),
+      },
+      configPath,
+      defaultManagedGrokBuilds: true,
+      env: {},
+      resolveManagedGrokCommand,
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    await expect(service.resolveIntegratedTerminalCommands()).resolves.toEqual([
+      "/custom/codex/bin/codex",
+      "/custom/grok/bin/grok",
+    ]);
+    expect(resolveManagedGrokCommand).not.toHaveBeenCalled();
+  });
+
   it("keeps CODEX_HOME fixed to the startup Codex auth profile", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts
@@ -20,6 +20,7 @@ import {
   MANAGED_GROK_RELEASES_URL,
   selectManagedGrokRelease,
   selectManagedGrokReleaseFromFeed,
+  resolveActiveManagedGrokCommand,
   selectManagedGrokReleaseSlots,
   setManagedGrokSignatureRejectionReporter,
 } from "../acp/grok-managed-runtime";
@@ -260,6 +261,8 @@ describe("ensureManagedGrokRuntime", () => {
       })}\n`,
     );
 
+    expect(resolveActiveManagedGrokCommand(rootDir)).toBeUndefined();
+
     const runtime = await ensureManagedGrokRuntime({
       arch: "x64",
       checkMode: "force",
@@ -271,6 +274,9 @@ describe("ensureManagedGrokRuntime", () => {
 
     expect(runtime?.command).toBe(path.join(commandDir, "grok"));
     expect(runtime?.metadata.tag).toBe(tag);
+    expect(resolveActiveManagedGrokCommand(rootDir)).toBe(
+      path.join(commandDir, "grok"),
+    );
   });
 
   it("uses the public release feed on Prerelease when the API is limited", async () => {

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import type { WebContents } from "electron";
@@ -6,11 +13,15 @@ import type { IPty } from "node-pty";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   IntegratedTerminalService,
+  prependIntegratedTerminalRuntimePaths,
+  prepareIntegratedTerminalShellEnvironment,
   resolveTerminalShell,
+  writeZshIntegrationDirectory,
 } from "../terminal/integrated-terminal-service";
 
 const settingsServiceMock = vi.hoisted(() => ({
   resolveIntegratedTerminalWindowsShell: vi.fn(() => "auto"),
+  resolveIntegratedTerminalCommands: vi.fn(async () => [] as string[]),
   resolveTerminalSpawnEnvAsync: vi.fn(
     async (): Promise<NodeJS.ProcessEnv> => ({ SHELL: "/bin/sh" }),
   ),
@@ -22,12 +33,108 @@ vi.mock("../settings/desktop-settings-singleton", () => ({
 
 beforeEach(() => {
   settingsServiceMock.resolveIntegratedTerminalWindowsShell.mockReturnValue("auto");
+  settingsServiceMock.resolveIntegratedTerminalCommands.mockResolvedValue([]);
   settingsServiceMock.resolveTerminalSpawnEnvAsync.mockResolvedValue({
     SHELL: "/bin/sh",
   });
 });
 
 describe("resolveTerminalShell", () => {
+  it("puts selected Codex and Grok runtime directories first without duplicates", () => {
+    expect(
+      prependIntegratedTerminalRuntimePaths(
+        {
+          PATH: "/opt/homebrew/bin:/managed/codex/bin:/usr/bin",
+        },
+        [
+          "/managed/codex/bin/codex",
+          "/managed/grok/bin/grok",
+          "/managed/codex/bin/codex",
+          "codex",
+        ],
+        "darwin",
+      ),
+    ).toMatchObject({
+      PATH: "/managed/codex/bin:/managed/grok/bin:/opt/homebrew/bin:/usr/bin",
+      PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX:
+        "/managed/codex/bin:/managed/grok/bin",
+    });
+  });
+
+  it("wires the zsh startup integration without changing other shells", async () => {
+    const zshEnv = await prepareIntegratedTerminalShellEnvironment({
+      env: {
+        HOME: "/Users/alice",
+        PATH: "/managed/codex/bin:/usr/bin",
+        PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX:
+          "/managed/codex/bin",
+      },
+      platform: "darwin",
+      resolveZshIntegrationDirectory: async () => "/pwragent/zsh-integration",
+      shell: "/bin/zsh",
+    });
+    expect(zshEnv).toMatchObject({
+      ZDOTDIR: "/pwragent/zsh-integration",
+      PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: "/Users/alice",
+      PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET: "1",
+    });
+
+    const bashEnv = await prepareIntegratedTerminalShellEnvironment({
+      env: {
+        PATH: "/managed/codex/bin:/usr/bin",
+        PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX:
+          "/managed/codex/bin",
+      },
+      platform: "darwin",
+      resolveZshIntegrationDirectory: async () => "/unused",
+      shell: "/bin/bash",
+    });
+    expect(bashEnv).not.toHaveProperty("ZDOTDIR");
+  });
+
+  it.skipIf(process.platform !== "darwin")(
+    "reasserts the selected runtime after zsh login files rewrite PATH",
+    async () => {
+      const root = mkdtempSync(path.join(os.tmpdir(), "pwragent-zsh-path-"));
+      const integrationDir = path.join(root, "integration");
+      const originalZdotdir = path.join(root, "original");
+      const managedBin = path.join(root, "managed");
+      const otherBin = path.join(root, "other");
+      mkdirSync(originalZdotdir, { recursive: true });
+      mkdirSync(managedBin, { recursive: true });
+      mkdirSync(otherBin, { recursive: true });
+      const managedCodex = path.join(managedBin, "codex");
+      const otherCodex = path.join(otherBin, "codex");
+      writeFileSync(managedCodex, "#!/bin/sh\nexit 0\n");
+      writeFileSync(otherCodex, "#!/bin/sh\nexit 0\n");
+      chmodSync(managedCodex, 0o700);
+      chmodSync(otherCodex, 0o700);
+      writeFileSync(
+        path.join(originalZdotdir, ".zprofile"),
+        `export PATH="${otherBin}:$PATH"\n`,
+      );
+      await writeZshIntegrationDirectory(integrationDir);
+
+      expect(existsSync("/bin/zsh")).toBe(true);
+      const resolved = execFileSync(
+        "/bin/zsh",
+        ["-lic", "command -v codex"],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `/usr/bin:/bin`,
+            PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: originalZdotdir,
+            PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: managedBin,
+            ZDOTDIR: integrationDir,
+          },
+        },
+      ).trim();
+
+      expect(resolved).toBe(managedCodex);
+    },
+  );
+
   it("uses the login shell on POSIX", () => {
     expect(
       resolveTerminalShell({
@@ -211,8 +318,13 @@ describe("resolveTerminalShell", () => {
     settingsServiceMock.resolveTerminalSpawnEnvAsync.mockResolvedValue({
       ELECTRON_RENDERER_URL: "http://localhost:5175",
       KEEP_TERMINAL_ENV: "yes",
+      PATH: "/opt/homebrew/bin:/usr/bin",
       SHELL: "/bin/sh",
     });
+    settingsServiceMock.resolveIntegratedTerminalCommands.mockResolvedValue([
+      "/managed/codex/bin/codex",
+      "/managed/grok/bin/grok",
+    ]);
     const service = new IntegratedTerminalService({
       loadNodePty: async () => ({
         spawn: spawn as unknown as typeof import("node-pty").spawn,
@@ -233,6 +345,8 @@ describe("resolveTerminalShell", () => {
     expect(spawnOptions?.env).not.toHaveProperty("ELECTRON_RENDERER_URL");
     expect(spawnOptions?.env).toMatchObject({
       KEEP_TERMINAL_ENV: "yes",
+      PATH:
+        "/managed/codex/bin:/managed/grok/bin:/opt/homebrew/bin:/usr/bin",
       TERM: "xterm-256color",
       COLORTERM: "truecolor",
     });

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -146,8 +146,8 @@ describe("integrated terminal runtime PATH", () => {
         {
           encoding: "utf8",
           env: {
-            ...process.env,
-            PATH: `/usr/bin:/bin`,
+            HOME: root,
+            PATH: "/usr/bin:/bin",
             PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: originalZdotdir,
             PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: integrationDir,
             PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: managedBin,
@@ -188,7 +188,7 @@ describe("integrated terminal runtime PATH", () => {
         {
           encoding: "utf8",
           env: {
-            ...process.env,
+            HOME: root,
             PATH: "/usr/bin:/bin",
             PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: integrationDir,
             PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: originalZdotdir,
@@ -220,7 +220,7 @@ describe("integrated terminal runtime PATH", () => {
         {
           encoding: "utf8",
           env: {
-            ...process.env,
+            HOME: root,
             PATH: "/usr/bin:/bin",
             PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: integrationDir,
             PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: originalZdotdir,
@@ -241,6 +241,9 @@ describe("integrated terminal runtime PATH", () => {
     const env = prependIntegratedTerminalRuntimePaths(
       {
         PATH: "/usr/bin",
+        // Windows preserves the casing a variable was set with, and this is a
+        // plain object, so the delete has to be case-insensitive.
+        Pwragent_Integrated_Terminal_Runtime_Path_Prefix: "/stale/mixed",
         PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: "/stale/bin",
         PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: "/stale/integration",
         PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: "/stale/home",
@@ -252,6 +255,9 @@ describe("integrated terminal runtime PATH", () => {
 
     expect(env).not.toHaveProperty(
       "PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX",
+    );
+    expect(env).not.toHaveProperty(
+      "Pwragent_Integrated_Terminal_Runtime_Path_Prefix",
     );
     expect(env).not.toHaveProperty(
       "PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR",
@@ -518,6 +524,53 @@ describe("resolveTerminalShell", () => {
       TERM: "xterm-256color",
       COLORTERM: "truecolor",
     });
+  });
+
+  it("wires the zsh startup integration through the real spawn path", async () => {
+    const pty = fakePty();
+    let spawnOptions: { env?: NodeJS.ProcessEnv } | undefined;
+    const spawn = vi.fn((...args: unknown[]) => {
+      spawnOptions = args[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      return pty;
+    });
+    // Every other test of this feature calls the helpers directly, so the one
+    // function that actually spawns the PTY had no coverage of the ZDOTDIR
+    // half — a `/bin/sh` login shell leaves at the `basename !== "zsh"` guard.
+    settingsServiceMock.resolveTerminalSpawnEnvAsync.mockResolvedValue({
+      HOME: "/Users/alice",
+      PATH: "/usr/bin",
+      SHELL: "/bin/zsh",
+    });
+    settingsServiceMock.resolveIntegratedTerminalCommands.mockReturnValue([
+      "/managed/codex/bin/codex",
+    ]);
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: spawn as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "darwin",
+    });
+
+    await service.createOrAttach(
+      {
+        threadKey: "codex:thread-zsh-env",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(spawnOptions?.env).toMatchObject({
+      PATH: "/managed/codex/bin:/usr/bin",
+      PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: "/managed/codex/bin",
+      PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: "/Users/alice",
+      PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET: "1",
+    });
+    expect(spawnOptions?.env?.ZDOTDIR).toBe(
+      spawnOptions?.env?.PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR,
+    );
+    expect(spawnOptions?.env?.ZDOTDIR).toContain("shell-integration");
   });
 
   it("reports terminal sessions with a foreground command for quit confirmation", async () => {

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -1,8 +1,9 @@
 import {
   chmodSync,
   existsSync,
-  mkdtempSync,
   mkdirSync,
+  mkdtempSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -10,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import type { WebContents } from "electron";
 import type { IPty } from "node-pty";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   IntegratedTerminalService,
   prependIntegratedTerminalRuntimePaths,
@@ -39,7 +40,21 @@ beforeEach(() => {
   });
 });
 
-describe("resolveTerminalShell", () => {
+describe("integrated terminal runtime PATH", () => {
+  const temporaryRoots: string[] = [];
+  const createTemporaryRoot = (prefix: string): string => {
+    const root = mkdtempSync(path.join(os.tmpdir(), prefix));
+    temporaryRoots.push(root);
+    return root;
+  };
+
+  afterAll(() => {
+    for (const root of temporaryRoots) {
+      rmSync(root, { force: true, recursive: true });
+    }
+    temporaryRoots.length = 0;
+  });
+
   it("puts selected Codex and Grok runtime directories first without duplicates", () => {
     expect(
       prependIntegratedTerminalRuntimePaths(
@@ -97,7 +112,7 @@ describe("resolveTerminalShell", () => {
   it.skipIf(process.platform !== "darwin")(
     "reasserts the selected runtime after zsh login files rewrite PATH",
     async () => {
-      const root = mkdtempSync(path.join(os.tmpdir(), "pwragent-zsh-path-"));
+      const root = createTemporaryRoot("pwragent-zsh-path-");
       const integrationDir = path.join(root, "integration");
       const originalZdotdir = path.join(root, "original");
       const managedBin = path.join(root, "managed");
@@ -148,7 +163,7 @@ describe("resolveTerminalShell", () => {
   it.skipIf(process.platform !== "darwin")(
     "preserves a ZDOTDIR selected by the user zsh startup files",
     async () => {
-      const root = mkdtempSync(path.join(os.tmpdir(), "pwragent-zsh-zdotdir-"));
+      const root = createTemporaryRoot("pwragent-zsh-zdotdir-");
       const integrationDir = path.join(root, "integration");
       const originalZdotdir = path.join(root, "original");
       const selectedZdotdir = path.join(root, "selected");
@@ -188,6 +203,106 @@ describe("resolveTerminalShell", () => {
     },
   );
 
+  it.skipIf(process.platform !== "darwin")(
+    "restores ZDOTDIR for a zsh that reads only .zshenv",
+    async () => {
+      const root = createTemporaryRoot("pwragent-zsh-child-");
+      const integrationDir = path.join(root, "integration");
+      const originalZdotdir = path.join(root, "original");
+      mkdirSync(originalZdotdir, { recursive: true });
+      await writeZshIntegrationDirectory(integrationDir);
+
+      // A non-interactive, non-login zsh reads .zshenv and nothing else. Left
+      // unrestored it hands PwrAgent's ZDOTDIR to every one of its children.
+      const resolved = execFileSync(
+        "/bin/zsh",
+        ["-c", 'print -r -- "${ZDOTDIR-unset}|${PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX-unset}"'],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: "/usr/bin:/bin",
+            PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: integrationDir,
+            PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: originalZdotdir,
+            PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET: "1",
+            PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: "/managed/bin",
+            ZDOTDIR: integrationDir,
+          },
+        },
+      ).trim();
+
+      expect(resolved).toBe("unset|unset");
+    },
+  );
+
+  it("drops runtime path state inherited from a parent PwrAgent terminal", () => {
+    // PwrAgent launched from a PwrAgent terminal inherits these through
+    // process.env, and the wrapper reapplies whatever prefix it finds.
+    const env = prependIntegratedTerminalRuntimePaths(
+      {
+        PATH: "/usr/bin",
+        PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: "/stale/bin",
+        PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: "/stale/integration",
+        PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: "/stale/home",
+        PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET: "1",
+      },
+      [],
+      "darwin",
+    );
+
+    expect(env).not.toHaveProperty(
+      "PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX",
+    );
+    expect(env).not.toHaveProperty(
+      "PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR",
+    );
+    expect(env).not.toHaveProperty(
+      "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR",
+    );
+    expect(env).not.toHaveProperty(
+      "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET",
+    );
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("leaves the zsh-only prefix off a Windows terminal", () => {
+    const env = prependIntegratedTerminalRuntimePaths(
+      { Path: "C:\\Windows" },
+      ["C:\\managed\\codex\\codex.exe"],
+      "win32",
+    );
+
+    expect(env.Path).toBe("C:\\managed\\codex;C:\\Windows");
+    expect(env).not.toHaveProperty(
+      "PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX",
+    );
+  });
+
+  it("leaves no ZDOTDIR state behind when the integration directory fails", async () => {
+    const env = await prepareIntegratedTerminalShellEnvironment({
+      env: {
+        HOME: "/Users/alice",
+        PATH: "/managed/codex/bin:/usr/bin",
+        PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: "/managed/codex/bin",
+      },
+      platform: "darwin",
+      resolveZshIntegrationDirectory: async () => {
+        throw new Error("ENOSPC");
+      },
+      shell: "/bin/zsh",
+    });
+
+    expect(env).not.toHaveProperty("ZDOTDIR");
+    expect(env).not.toHaveProperty(
+      "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR",
+    );
+    expect(env).not.toHaveProperty(
+      "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET",
+    );
+  });
+});
+
+describe("resolveTerminalShell", () => {
   it("uses the login shell on POSIX", () => {
     expect(
       resolveTerminalShell({

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -32,6 +32,22 @@ vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: () => settingsServiceMock,
 }));
 
+const temporaryRoots: string[] = [];
+
+/** Fixture roots for the tests that need real files on disk. */
+function createTemporaryRoot(prefix: string): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterAll(() => {
+  for (const root of temporaryRoots) {
+    rmSync(root, { force: true, recursive: true });
+  }
+  temporaryRoots.length = 0;
+});
+
 beforeEach(() => {
   settingsServiceMock.resolveIntegratedTerminalWindowsShell.mockReturnValue("auto");
   settingsServiceMock.resolveIntegratedTerminalCommands.mockReturnValue([]);
@@ -41,20 +57,6 @@ beforeEach(() => {
 });
 
 describe("integrated terminal runtime PATH", () => {
-  const temporaryRoots: string[] = [];
-  const createTemporaryRoot = (prefix: string): string => {
-    const root = mkdtempSync(path.join(os.tmpdir(), prefix));
-    temporaryRoots.push(root);
-    return root;
-  };
-
-  afterAll(() => {
-    for (const root of temporaryRoots) {
-      rmSync(root, { force: true, recursive: true });
-    }
-    temporaryRoots.length = 0;
-  });
-
   it("puts selected Codex and Grok runtime directories first without duplicates", () => {
     expect(
       prependIntegratedTerminalRuntimePaths(
@@ -398,6 +400,28 @@ describe("resolveTerminalShell", () => {
     }
   });
 
+  it("does not let a pinned directory decide which PowerShell to launch", () => {
+    // `commandExistsOnPath` stats the filesystem, so the bundled pwsh has to
+    // really be there: a fixture path that does not exist would make this pass
+    // whether or not discovery skips the pinned directory.
+    const bundle = createTemporaryRoot("pwragent-pinned-shell-");
+    writeFileSync(path.join(bundle, "pwsh.exe"), "");
+
+    const shell = resolveTerminalShell({
+      env: {
+        ComSpec: "C:\\Windows\\System32\\cmd.exe",
+        Path: `${bundle};C:\\Windows\\System32`,
+        PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: bundle,
+      },
+      platform: "win32",
+      windowsShell: "auto",
+    });
+
+    // A `pwsh.exe` shipped inside a Codex or Grok release must not become the
+    // shell PwrAgent launches; discovery falls through to ComSpec instead.
+    expect(shell.file).toBe("C:\\Windows\\System32\\cmd.exe");
+  });
+
   it("leaves the PowerShell invocation alone when nothing is pinned", () => {
     expect(
       resolveTerminalShell({
@@ -624,6 +648,50 @@ describe("resolveTerminalShell", () => {
       spawnOptions?.env?.PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR,
     );
     expect(spawnOptions?.env?.ZDOTDIR).toContain("shell-integration");
+  });
+
+  it("carries the PowerShell reassertion through the real spawn path", async () => {
+    const pty = fakePty();
+    let spawnArgs: string[] | undefined;
+    const spawn = vi.fn((...args: unknown[]) => {
+      spawnArgs = args[1] as string[];
+      return pty;
+    });
+    // `resolveTerminalShell` only sees the prefix because the PATH prepend runs
+    // first in `spawnTerminalPty`. Nothing enforces that order, and every other
+    // test hands the resolver a hand-built env, so a swap of those two
+    // statements would drop the Windows reassertion with the suite still green.
+    settingsServiceMock.resolveIntegratedTerminalWindowsShell.mockReturnValue(
+      "pwsh",
+    );
+    settingsServiceMock.resolveTerminalSpawnEnvAsync.mockResolvedValue({
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+      Path: "C:\\Windows\\System32",
+    });
+    settingsServiceMock.resolveIntegratedTerminalCommands.mockReturnValue([
+      "C:\\managed\\codex\\codex.exe",
+    ]);
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: spawn as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "win32",
+    });
+
+    await service.createOrAttach(
+      {
+        threadKey: "codex:thread-windows-pin",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(spawnArgs?.slice(0, 3)).toEqual(["-NoLogo", "-NoExit", "-Command"]);
+    expect(spawnArgs?.[3]).toContain(
+      "PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX",
+    );
   });
 
   it("reports terminal sessions with a foreground command for quit confirmation", async () => {

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -271,7 +271,7 @@ describe("integrated terminal runtime PATH", () => {
     expect(env.PATH).toBe("/usr/bin");
   });
 
-  it("leaves the zsh-only prefix off a Windows terminal", () => {
+  it("pins the runtime directory on a Windows terminal", () => {
     const env = prependIntegratedTerminalRuntimePaths(
       { Path: "C:\\Windows" },
       ["C:\\managed\\codex\\codex.exe"],
@@ -279,8 +279,9 @@ describe("integrated terminal runtime PATH", () => {
     );
 
     expect(env.Path).toBe("C:\\managed\\codex;C:\\Windows");
-    expect(env).not.toHaveProperty(
-      "PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX",
+    // Read by the PowerShell command the Windows shell resolution appends.
+    expect(env.PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX).toBe(
+      "C:\\managed\\codex",
     );
   });
 
@@ -364,6 +365,58 @@ describe("resolveTerminalShell", () => {
         env: { PATH: "", ComSpec: "C:\\Windows\\System32\\cmd.exe" },
         platform: "win32",
         windowsShell: "auto",
+      }),
+    ).toEqual({ file: "C:\\Windows\\System32\\cmd.exe", args: [] });
+  });
+
+  it("reasserts the runtime path after the PowerShell profile", () => {
+    const env = {
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+      PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX:
+        "C:\\managed\\codex;C:\\managed\\grok",
+    };
+
+    for (const windowsShell of ["pwsh", "powershell"] as const) {
+      const shell = resolveTerminalShell({
+        env,
+        platform: "win32",
+        windowsShell,
+      });
+      // PwrAgent passes -NoLogo and never -NoProfile, so $PROFILE runs and can
+      // prepend to $env:Path the way .zprofile does. -Command runs after it.
+      expect(shell.args.slice(0, 3)).toEqual(["-NoLogo", "-NoExit", "-Command"]);
+      expect(shell.args).toHaveLength(4);
+      expect(shell.args[3]).toContain(
+        "PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX",
+      );
+      expect(shell.args[3]).toContain("$env:Path = $p + ';' + $c");
+      expect(shell.args[3]).toContain("Remove-Item Env:");
+      // node-pty wraps an argument containing spaces in double quotes and
+      // backslash-escapes any inside it. Carrying none keeps the command the
+      // shell receives byte-identical to the one generated here.
+      expect(shell.args[3]).not.toContain('"');
+    }
+  });
+
+  it("leaves the PowerShell invocation alone when nothing is pinned", () => {
+    expect(
+      resolveTerminalShell({
+        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+        platform: "win32",
+        windowsShell: "pwsh",
+      }),
+    ).toEqual({ file: "pwsh.exe", args: ["-NoLogo"] });
+  });
+
+  it("does not add a reassertion to cmd, which cannot cheaply test PATH", () => {
+    expect(
+      resolveTerminalShell({
+        env: {
+          ComSpec: "C:\\Windows\\System32\\cmd.exe",
+          PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: "C:\\managed\\codex",
+        },
+        platform: "win32",
+        windowsShell: "cmd",
       }),
     ).toEqual({ file: "C:\\Windows\\System32\\cmd.exe", args: [] });
   });

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -21,7 +21,7 @@ import {
 
 const settingsServiceMock = vi.hoisted(() => ({
   resolveIntegratedTerminalWindowsShell: vi.fn(() => "auto"),
-  resolveIntegratedTerminalCommands: vi.fn(async () => [] as string[]),
+  resolveIntegratedTerminalCommands: vi.fn(() => [] as string[]),
   resolveTerminalSpawnEnvAsync: vi.fn(
     async (): Promise<NodeJS.ProcessEnv> => ({ SHELL: "/bin/sh" }),
   ),
@@ -33,7 +33,7 @@ vi.mock("../settings/desktop-settings-singleton", () => ({
 
 beforeEach(() => {
   settingsServiceMock.resolveIntegratedTerminalWindowsShell.mockReturnValue("auto");
-  settingsServiceMock.resolveIntegratedTerminalCommands.mockResolvedValue([]);
+  settingsServiceMock.resolveIntegratedTerminalCommands.mockReturnValue([]);
   settingsServiceMock.resolveTerminalSpawnEnvAsync.mockResolvedValue({
     SHELL: "/bin/sh",
   });
@@ -77,6 +77,8 @@ describe("resolveTerminalShell", () => {
       ZDOTDIR: "/pwragent/zsh-integration",
       PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: "/Users/alice",
       PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET: "1",
+      PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR:
+        "/pwragent/zsh-integration",
     });
 
     const bashEnv = await prepareIntegratedTerminalShellEnvironment({
@@ -111,27 +113,78 @@ describe("resolveTerminalShell", () => {
       chmodSync(otherCodex, 0o700);
       writeFileSync(
         path.join(originalZdotdir, ".zprofile"),
-        `export PATH="${otherBin}:$PATH"\n`,
+        [
+          "typeset PWRAGENT_TEST_TOP_LEVEL=preserved",
+          `export PATH="${otherBin}:$PATH"`,
+          "",
+        ].join("\n"),
       );
       await writeZshIntegrationDirectory(integrationDir);
 
       expect(existsSync("/bin/zsh")).toBe(true);
       const resolved = execFileSync(
         "/bin/zsh",
-        ["-lic", "command -v codex"],
+        [
+          "-lic",
+          "print -r -- \"$(command -v codex)|${PWRAGENT_TEST_TOP_LEVEL:-missing}\"",
+        ],
         {
           encoding: "utf8",
           env: {
             ...process.env,
             PATH: `/usr/bin:/bin`,
             PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: originalZdotdir,
+            PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: integrationDir,
             PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: managedBin,
             ZDOTDIR: integrationDir,
           },
         },
       ).trim();
 
-      expect(resolved).toBe(managedCodex);
+      expect(resolved).toBe(`${managedCodex}|preserved`);
+    },
+  );
+
+  it.skipIf(process.platform !== "darwin")(
+    "preserves a ZDOTDIR selected by the user zsh startup files",
+    async () => {
+      const root = mkdtempSync(path.join(os.tmpdir(), "pwragent-zsh-zdotdir-"));
+      const integrationDir = path.join(root, "integration");
+      const originalZdotdir = path.join(root, "original");
+      const selectedZdotdir = path.join(root, "selected");
+      mkdirSync(originalZdotdir, { recursive: true });
+      mkdirSync(selectedZdotdir, { recursive: true });
+      writeFileSync(
+        path.join(originalZdotdir, ".zshenv"),
+        `ZDOTDIR="${selectedZdotdir}"\n`,
+      );
+      writeFileSync(
+        path.join(selectedZdotdir, ".zprofile"),
+        "typeset PWRAGENT_SELECTED_ZDOTDIR_PROFILE=loaded\n",
+      );
+      await writeZshIntegrationDirectory(integrationDir);
+
+      const resolved = execFileSync(
+        "/bin/zsh",
+        [
+          "-lic",
+          "print -r -- \"$ZDOTDIR|${PWRAGENT_SELECTED_ZDOTDIR_PROFILE:-missing}\"",
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: "/usr/bin:/bin",
+            PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR: integrationDir,
+            PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR: originalZdotdir,
+            PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET: "1",
+            PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX: "/managed/bin",
+            ZDOTDIR: integrationDir,
+          },
+        },
+      ).trim();
+
+      expect(resolved).toBe(`${selectedZdotdir}|loaded`);
     },
   );
 
@@ -321,7 +374,7 @@ describe("resolveTerminalShell", () => {
       PATH: "/opt/homebrew/bin:/usr/bin",
       SHELL: "/bin/sh",
     });
-    settingsServiceMock.resolveIntegratedTerminalCommands.mockResolvedValue([
+    settingsServiceMock.resolveIntegratedTerminalCommands.mockReturnValue([
       "/managed/codex/bin/codex",
       "/managed/grok/bin/grok",
     ]);

--- a/apps/desktop/src/main/acp/grok-managed-runtime.ts
+++ b/apps/desktop/src/main/acp/grok-managed-runtime.ts
@@ -210,6 +210,18 @@ const processChecks = new Set<string>();
 const activeChecks = new Map<string, Promise<ManagedGrokRuntime | undefined>>();
 const markedRuntimeCommands = new Map<string, string>();
 
+/**
+ * Return only the managed Grok command already activated by this process.
+ * This intentionally performs no filesystem validation, release lookup, or
+ * installation work so latency-sensitive callers such as terminal startup
+ * cannot trigger an update.
+ */
+export function resolveActiveManagedGrokCommand(
+  rootDir = managedGrokRoot(),
+): string | undefined {
+  return markedRuntimeCommands.get(rootDir);
+}
+
 /** What the last managed release check decided, as recorded on disk. */
 export type ManagedGrokInstallSummary = {
   tag: string;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -272,6 +272,7 @@ type DesktopSettingsServiceOptions = {
     signal?: AbortSignal;
     waitForUpdate?: boolean;
   }) => Promise<ManagedCodexRuntime>;
+  resolveManagedGrokCommand?: () => Promise<string | undefined>;
   env?: NodeJS.ProcessEnv;
   argv?: readonly string[];
   secretStore: DesktopSecretStore;
@@ -2280,6 +2281,59 @@ export class DesktopSettingsService {
       source: selected.source,
       ...(selected.version ? { version: selected.version } : {}),
     };
+  }
+
+  /**
+   * Commands whose containing directories must lead PATH in a newly opened
+   * human-facing integrated terminal. This is intentionally separate from the
+   * agent subprocess environments: an operator running `codex mcp login` or a
+   * Grok command in PwrAgent should reach the same selected runtime PwrAgent
+   * launches for threads.
+   */
+  async resolveIntegratedTerminalCommands(): Promise<string[]> {
+    const config = this.readConfig().config;
+    const grokOverride =
+      readEnvString(this.env, ACP_AGENTS_GROK_CLI_PATH_ENV)
+      || config.acpAgents?.grok?.cliPath?.trim()
+      || undefined;
+    const resolveManagedGrokCommand = this.options.resolveManagedGrokCommand;
+    const shouldResolveManagedGrok =
+      config.acpAgents?.grok?.enabled !== false
+      && !grokOverride
+      && (
+        config.acpAgents?.grok?.managedBuilds
+        ?? this.options.defaultManagedGrokBuilds
+        ?? true
+      );
+    const [codexResult, grokResult] = await Promise.allSettled([
+      this.resolveCodexCommand().then((candidate) => candidate.command),
+      grokOverride
+        ? Promise.resolve(grokOverride)
+        : shouldResolveManagedGrok && resolveManagedGrokCommand
+          ? resolveManagedGrokCommand()
+          : Promise.resolve(undefined),
+    ]);
+    const logger = getMainLogger("pwragent:integrated-terminal");
+    const commands: string[] = [];
+    if (codexResult.status === "fulfilled") {
+      commands.push(codexResult.value);
+    } else {
+      logger.warn("codex-command-resolution-failed", {
+        error: codexResult.reason instanceof Error
+          ? codexResult.reason.message
+          : String(codexResult.reason),
+      });
+    }
+    if (grokResult.status === "fulfilled") {
+      if (grokResult.value) commands.push(grokResult.value);
+    } else {
+      logger.warn("grok-command-resolution-failed", {
+        error: grokResult.reason instanceof Error
+          ? grokResult.reason.message
+          : String(grokResult.reason),
+      });
+    }
+    return commands;
   }
 
   /**

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -2290,8 +2290,12 @@ export class DesktopSettingsService {
    */
   resolveIntegratedTerminalCommands(): string[] {
     // Reads the two sections it needs rather than `readConfig()`, which
-    // `structuredClone`s every section — this runs on each terminal open.
-    const grok = providerConfigSection(this.configStore.read("providers").grok);
+    // `structuredClone`s every section — this runs on each terminal open. The
+    // store hands back its live objects, so clone the two that are read here:
+    // `readConfig` protects every other reader in the class the same way.
+    const grok = providerConfigSection(
+      structuredClone(this.configStore.read("providers").grok),
+    );
     const grokEnabled = grok.enabled !== false;
     const grokOverride = grokEnabled
       ? this.resolveString(grok.cliPath, ACP_AGENTS_GROK_CLI_PATH_ENV)
@@ -2307,7 +2311,7 @@ export class DesktopSettingsService {
         ?? true
       );
     const codexCommand = this.resolveActiveCodexCommand({
-      models: this.configStore.read("models"),
+      models: structuredClone(this.configStore.read("models")),
     });
     const grokCommand = grokOverride
       ?? (shouldResolveManagedGrok

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -272,7 +272,7 @@ type DesktopSettingsServiceOptions = {
     signal?: AbortSignal;
     waitForUpdate?: boolean;
   }) => Promise<ManagedCodexRuntime>;
-  resolveManagedGrokCommand?: () => Promise<string | undefined>;
+  resolveActiveManagedGrokCommand?: () => string | undefined;
   env?: NodeJS.ProcessEnv;
   argv?: readonly string[];
   secretStore: DesktopSecretStore;
@@ -2290,50 +2290,36 @@ export class DesktopSettingsService {
    * Grok command in PwrAgent should reach the same selected runtime PwrAgent
    * launches for threads.
    */
-  async resolveIntegratedTerminalCommands(): Promise<string[]> {
+  resolveIntegratedTerminalCommands(): string[] {
     const config = this.readConfig().config;
-    const grokOverride =
-      readEnvString(this.env, ACP_AGENTS_GROK_CLI_PATH_ENV)
-      || config.acpAgents?.grok?.cliPath?.trim()
-      || undefined;
-    const resolveManagedGrokCommand = this.options.resolveManagedGrokCommand;
+    const grokEnabled = config.acpAgents?.grok?.enabled !== false;
+    const grokOverride = grokEnabled
+      ? readEnvString(this.env, ACP_AGENTS_GROK_CLI_PATH_ENV)
+        || config.acpAgents?.grok?.cliPath?.trim()
+        || undefined
+      : undefined;
     const shouldResolveManagedGrok =
-      config.acpAgents?.grok?.enabled !== false
+      grokEnabled
       && !grokOverride
       && (
         config.acpAgents?.grok?.managedBuilds
         ?? this.options.defaultManagedGrokBuilds
         ?? true
       );
-    const [codexResult, grokResult] = await Promise.allSettled([
-      this.resolveCodexCommand().then((candidate) => candidate.command),
-      grokOverride
-        ? Promise.resolve(grokOverride)
-        : shouldResolveManagedGrok && resolveManagedGrokCommand
-          ? resolveManagedGrokCommand()
-          : Promise.resolve(undefined),
-    ]);
-    const logger = getMainLogger("pwragent:integrated-terminal");
-    const commands: string[] = [];
-    if (codexResult.status === "fulfilled") {
-      commands.push(codexResult.value);
-    } else {
-      logger.warn("codex-command-resolution-failed", {
-        error: codexResult.reason instanceof Error
-          ? codexResult.reason.message
-          : String(codexResult.reason),
-      });
-    }
-    if (grokResult.status === "fulfilled") {
-      if (grokResult.value) commands.push(grokResult.value);
-    } else {
-      logger.warn("grok-command-resolution-failed", {
-        error: grokResult.reason instanceof Error
-          ? grokResult.reason.message
-          : String(grokResult.reason),
-      });
-    }
-    return commands;
+    const managedCodexEnabled = this.resolveConfigBoolean(
+      config.experimental?.tokenMiserEnabled,
+      false,
+    ).value;
+    const codexCommand = managedCodexEnabled
+      ? this.managedCodexRuntime?.command
+      : this.resolveCodexCommandPreferenceFromConfig(config);
+    const grokCommand = grokOverride
+      ?? (shouldResolveManagedGrok
+        ? this.options.resolveActiveManagedGrokCommand?.()
+        : undefined);
+    return [codexCommand, grokCommand].filter(
+      (command): command is string => command !== undefined,
+    );
   }
 
   /**

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -686,8 +686,7 @@ export class DesktopSettingsService {
     );
     const managedCodexRuntime = this.managedCodexRuntime;
     const managedCodexError = this.managedCodexError;
-    const codexDiscoveryCommand = managedCodexRuntime?.command
-      ?? this.resolveCodexCommandPreferenceFromConfig(config);
+    const codexDiscoveryCommand = this.resolveActiveCodexCommand(config);
     const codexDiscovery = this.codexDiscoveryCoordinator.peek?.(
       codexDiscoveryCommand,
     ) ?? codexDiscoveryFromProvider(this.configStore.read("providers").codex);
@@ -2222,8 +2221,7 @@ export class DesktopSettingsService {
         runtime: this.managedCodexRuntime,
       });
     }
-    const configuredCommand = this.managedCodexRuntime?.command
-      ?? this.resolveCodexCommandPreferenceFromConfig(config);
+    const configuredCommand = this.resolveActiveCodexCommand(config);
     const discovery = await this.codexDiscoveryCoordinator.discover(
       configuredCommand,
       {
@@ -2291,28 +2289,26 @@ export class DesktopSettingsService {
    * launches for threads.
    */
   resolveIntegratedTerminalCommands(): string[] {
-    const config = this.readConfig().config;
-    const grokEnabled = config.acpAgents?.grok?.enabled !== false;
+    // Reads the two sections it needs rather than `readConfig()`, which
+    // `structuredClone`s every section — this runs on each terminal open.
+    const grok = providerConfigSection(this.configStore.read("providers").grok);
+    const grokEnabled = grok.enabled !== false;
     const grokOverride = grokEnabled
-      ? readEnvString(this.env, ACP_AGENTS_GROK_CLI_PATH_ENV)
-        || config.acpAgents?.grok?.cliPath?.trim()
-        || undefined
+      ? this.resolveString(grok.cliPath, ACP_AGENTS_GROK_CLI_PATH_ENV)
+        .value
+        .trim() || undefined
       : undefined;
     const shouldResolveManagedGrok =
       grokEnabled
       && !grokOverride
       && (
-        config.acpAgents?.grok?.managedBuilds
+        grok.managedBuilds
         ?? this.options.defaultManagedGrokBuilds
         ?? true
       );
-    const managedCodexEnabled = this.resolveConfigBoolean(
-      config.experimental?.tokenMiserEnabled,
-      false,
-    ).value;
-    const codexCommand = managedCodexEnabled
-      ? this.managedCodexRuntime?.command
-      : this.resolveCodexCommandPreferenceFromConfig(config);
+    const codexCommand = this.resolveActiveCodexCommand({
+      models: this.configStore.read("models"),
+    });
     const grokCommand = grokOverride
       ?? (shouldResolveManagedGrok
         ? this.options.resolveActiveManagedGrokCommand?.()
@@ -2545,8 +2541,21 @@ export class DesktopSettingsService {
     return this.codexSpawnEnv;
   }
 
+  /**
+   * The Codex command PwrAgent launches right now. Gating this on
+   * `experimental.tokenMiserEnabled` instead would answer `undefined` while
+   * the managed runtime is still installing or after it failed, even though a
+   * thread started at that moment falls back to the configured command.
+   */
+  private resolveActiveCodexCommand(
+    config: Pick<DesktopSettingsConfig, "models">,
+  ): string | undefined {
+    return this.managedCodexRuntime?.command
+      ?? this.resolveCodexCommandPreferenceFromConfig(config);
+  }
+
   private resolveCodexCommandPreferenceFromConfig(
-    config: DesktopSettingsConfig,
+    config: Pick<DesktopSettingsConfig, "models">,
   ): string | undefined {
     return (
       readEnvString(this.env, CODEX_COMMAND_ENV)

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -2291,11 +2291,11 @@ export class DesktopSettingsService {
   resolveIntegratedTerminalCommands(): string[] {
     // Reads the two sections it needs rather than `readConfig()`, which
     // `structuredClone`s every section — this runs on each terminal open. The
-    // store hands back its live objects, so clone the two that are read here:
-    // `readConfig` protects every other reader in the class the same way.
-    const grok = providerConfigSection(
-      structuredClone(this.configStore.read("providers").grok),
-    );
+    // store hands back its live objects, so `models` is cloned before it
+    // leaves; `providerConfigSection` already returns a fresh object built
+    // from three primitives, so cloning its input would guard nothing and
+    // would copy the projection's candidate and validation history.
+    const grok = providerConfigSection(this.configStore.read("providers").grok);
     const grokEnabled = grok.enabled !== false;
     const grokOverride = grokEnabled
       ? this.resolveString(grok.cliPath, ACP_AGENTS_GROK_CLI_PATH_ENV)

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -9,6 +9,7 @@ import {
   MemoryDesktopSecretStore,
 } from "./desktop-secret-store";
 import { ensureManagedCodexRuntime } from "../codex-managed-runtime";
+import { ensureManagedGrokRuntime } from "../acp/grok-managed-runtime";
 import { SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL } from "../../shared/ipc";
 import { subscribersForChannel } from "../window-channels";
 import {
@@ -62,6 +63,15 @@ export function getDesktopSettingsService(): DesktopSettingsService {
           signal,
           waitForUpdate,
         }),
+      resolveManagedGrokCommand: async () => {
+        if (!app.isPackaged && process.env.PWRAGENT_E2E === "1") {
+          return undefined;
+        }
+        return (await ensureManagedGrokRuntime({
+          checkMode: app.isPackaged ? "ttl" : "once-per-process",
+          requirePlatformSignature: app.isPackaged === true,
+        }))?.command;
+      },
       resolveAppVersion: () => app.getVersion(),
       secretStore,
       configPath,

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -9,7 +9,7 @@ import {
   MemoryDesktopSecretStore,
 } from "./desktop-secret-store";
 import { ensureManagedCodexRuntime } from "../codex-managed-runtime";
-import { ensureManagedGrokRuntime } from "../acp/grok-managed-runtime";
+import { resolveActiveManagedGrokCommand } from "../acp/grok-managed-runtime";
 import { SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL } from "../../shared/ipc";
 import { subscribersForChannel } from "../window-channels";
 import {
@@ -63,15 +63,7 @@ export function getDesktopSettingsService(): DesktopSettingsService {
           signal,
           waitForUpdate,
         }),
-      resolveManagedGrokCommand: async () => {
-        if (!app.isPackaged && process.env.PWRAGENT_E2E === "1") {
-          return undefined;
-        }
-        return (await ensureManagedGrokRuntime({
-          checkMode: app.isPackaged ? "ttl" : "once-per-process",
-          requirePlatformSignature: app.isPackaged === true,
-        }))?.command;
-      },
+      resolveActiveManagedGrokCommand,
       resolveAppVersion: () => app.getVersion(),
       secretStore,
       configPath,

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -42,17 +42,40 @@ const ORIGINAL_ZDOTDIR_UNSET_ENV =
 const INTEGRATION_ZDOTDIR_ENV =
   "PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR";
 
+// Every variable this module exports into a terminal. PwrAgent launched from
+// a PwrAgent terminal inherits them through `process.env`, so each spawn
+// clears them before deciding what this terminal needs. Without that, a stale
+// prefix from the previous instance is reapplied to PATH.
+const OWNED_TERMINAL_ENV = [
+  RUNTIME_PATH_PREFIX_ENV,
+  ORIGINAL_ZDOTDIR_ENV,
+  ORIGINAL_ZDOTDIR_UNSET_ENV,
+  INTEGRATION_ZDOTDIR_ENV,
+] as const;
+
 // Supplying PATH to `zsh -l` is insufficient: common `.zprofile` setup such
 // as `brew shellenv` prepends another bin directory during startup. ZDOTDIR is
 // zsh's supported user-startup-file root, so these wrappers source the user's
 // real files in order and reassert the selected runtime path afterward.
 const ZSH_INTEGRATION_FILES: Readonly<Record<string, string>> = {
-  ".zshenv": zshStartupFileWrapper(".zshenv"),
-  ".zprofile": zshStartupFileWrapper(".zprofile"),
-  ".zshrc": zshStartupFileWrapper(".zshrc", { prependRuntimePath: true }),
+  // Each wrapper hands off to the next startup file zsh will read, and the
+  // last one restores. `restoreWhen` names the case where there is no next
+  // file: without it a `zsh -c` spawned from a user startup file reads only
+  // `.zshenv`, never restores, and leaks ZDOTDIR to all of its descendants.
+  ".zshenv": zshStartupFileWrapper(".zshenv", {
+    restoreWhen: '[[ ! -o RCS ]] || [[ ! -o LOGIN && ! -o INTERACTIVE ]]',
+  }),
+  // `.zprofile` runs only for a login shell, which always reaches `.zlogin`.
+  ".zprofile": zshStartupFileWrapper(".zprofile", {
+    restoreWhen: "[[ ! -o RCS ]]",
+  }),
+  ".zshrc": zshStartupFileWrapper(".zshrc", {
+    prependRuntimePath: true,
+    restoreWhen: "[[ ! -o RCS ]] || [[ ! -o LOGIN ]]",
+  }),
   ".zlogin": zshStartupFileWrapper(".zlogin", {
     prependRuntimePath: true,
-    restoreZdotdir: true,
+    restoreWhen: "always",
   }),
 };
 
@@ -60,12 +83,15 @@ function zshStartupFileWrapper(
   fileName: string,
   options: {
     prependRuntimePath?: boolean;
-    restoreZdotdir?: boolean;
-  } = {},
+    restoreWhen: string | "always";
+  },
 ): string {
+  // Prepend only when the prefix is not already leading. `.zshrc` and
+  // `.zlogin` both run this on a PATH that already starts with the prefix
+  // Node put there, and an unconditional prepend duplicates it every time.
   const prependRuntimePath = options.prependRuntimePath
     ? `
-if [[ -n "$${RUNTIME_PATH_PREFIX_ENV}" ]]; then
+if [[ -n "$${RUNTIME_PATH_PREFIX_ENV}" && "$PATH" != "$${RUNTIME_PATH_PREFIX_ENV}" && "$PATH" != "$${RUNTIME_PATH_PREFIX_ENV}:"* ]]; then
   export PATH="$${RUNTIME_PATH_PREFIX_ENV}${"${PATH:+:$PATH}"}"
 fi
 `
@@ -88,10 +114,10 @@ else
   export ${ORIGINAL_ZDOTDIR_UNSET_ENV}="1"
 fi
 ZDOTDIR="$${INTEGRATION_ZDOTDIR_ENV}"
-${prependRuntimePath}${options.restoreZdotdir
+${prependRuntimePath}${options.restoreWhen === "always"
     ? restoreZdotdir
     : `
-if [[ ! -o RCS ]]; then
+if ${options.restoreWhen}; then
 ${restoreZdotdir}
 fi
 `}
@@ -104,7 +130,7 @@ function zshRestoreOriginalZdotdir(): string {
 else
   ZDOTDIR="$${ORIGINAL_ZDOTDIR_ENV}"
 fi
-unset ${ORIGINAL_ZDOTDIR_ENV} ${ORIGINAL_ZDOTDIR_UNSET_ENV} ${INTEGRATION_ZDOTDIR_ENV}`;
+unset ${OWNED_TERMINAL_ENV.join(" ")}`;
 }
 
 let zshIntegrationDirectoryPromise: Promise<string> | undefined;
@@ -693,6 +719,9 @@ export function prependIntegratedTerminalRuntimePaths(
   platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
   const env = buildPwrAgentChildProcessEnv(baseEnv);
+  for (const key of OWNED_TERMINAL_ENV) {
+    delete env[key];
+  }
   const pathApi = platform === "win32" ? path.win32 : path.posix;
   const runtimeDirectories = commands
     .map((command) => command.trim())
@@ -724,17 +753,27 @@ export function prependIntegratedTerminalRuntimePaths(
     return true;
   });
   env[pathKey] = entries.join(pathApi.delimiter);
-  env[RUNTIME_PATH_PREFIX_ENV] = runtimeEntries.join(pathApi.delimiter);
+  // The prefix exists for the zsh wrapper to reassert. Windows has no wrapper,
+  // so publishing it there would export an internal variable nothing reads.
+  if (platform !== "win32") {
+    env[RUNTIME_PATH_PREFIX_ENV] = runtimeEntries.join(pathApi.delimiter);
+  }
   return env;
 }
 
+/**
+ * Mutates and returns `options.env`. Pass the object
+ * `prependIntegratedTerminalRuntimePaths` returned, which is already a private
+ * copy — copying it a second time would rebuild the whole environment on a
+ * path that runs for every terminal.
+ */
 export async function prepareIntegratedTerminalShellEnvironment(options: {
   env: NodeJS.ProcessEnv;
   platform: NodeJS.Platform;
   shell: string;
   resolveZshIntegrationDirectory?: () => Promise<string>;
 }): Promise<NodeJS.ProcessEnv> {
-  const env = buildPwrAgentChildProcessEnv(options.env);
+  const env = options.env;
   if (
     options.platform === "win32"
     || path.basename(options.shell) !== "zsh"
@@ -742,16 +781,18 @@ export async function prepareIntegratedTerminalShellEnvironment(options: {
   ) {
     return env;
   }
-  const originalZdotdir = env.ZDOTDIR?.trim();
-  env[ORIGINAL_ZDOTDIR_ENV] = originalZdotdir || env.HOME || homedir();
-  if (!originalZdotdir) {
-    env[ORIGINAL_ZDOTDIR_UNSET_ENV] = "1";
-  }
   try {
     const integrationZdotdir = await (
       options.resolveZshIntegrationDirectory
       ?? ensureZshIntegrationDirectory
     )();
+    // Written only once the directory exists: a failure must not leave the
+    // shell describing an integration that was never wired.
+    const originalZdotdir = env.ZDOTDIR?.trim();
+    env[ORIGINAL_ZDOTDIR_ENV] = originalZdotdir || env.HOME || homedir();
+    if (!originalZdotdir) {
+      env[ORIGINAL_ZDOTDIR_UNSET_ENV] = "1";
+    }
     env[INTEGRATION_ZDOTDIR_ENV] = integrationZdotdir;
     env.ZDOTDIR = integrationZdotdir;
   } catch (error) {
@@ -764,7 +805,14 @@ export async function prepareIntegratedTerminalShellEnvironment(options: {
 }
 
 async function ensureZshIntegrationDirectory(): Promise<string> {
-  zshIntegrationDirectoryPromise ??= writeZshIntegrationDirectory();
+  // Caching a rejection would turn one transient write failure into a
+  // permanently disabled integration for the life of the process.
+  zshIntegrationDirectoryPromise ??= writeZshIntegrationDirectory().catch(
+    (error: unknown) => {
+      zshIntegrationDirectoryPromise = undefined;
+      throw error;
+    },
+  );
   return await zshIntegrationDirectoryPromise;
 }
 

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -135,6 +135,50 @@ unset ${OWNED_TERMINAL_ENV.join(" ")}`;
 
 let zshIntegrationDirectoryPromise: Promise<string> | undefined;
 
+/**
+ * The PowerShell counterpart to the zsh wrappers above. `$PROFILE` is the same
+ * hazard as `.zprofile` — conda, scoop and chocolatey initializers all prepend
+ * to `$env:Path` — and PwrAgent launches PowerShell with `-NoLogo` only, so
+ * profiles run. PowerShell has no ZDOTDIR, but it runs `-Command` *after* the
+ * profile, and `-NoExit` keeps the session interactive afterwards, so the
+ * reassertion rides on the invocation instead of on a startup file.
+ *
+ * Two deliberate constraints on the text:
+ *
+ * - Inline rather than a `.ps1`, because ExecutionPolicy gates script files
+ *   and not `-Command`. A `Restricted` machine would otherwise print a load
+ *   error into every terminal.
+ * - No `"` anywhere, so node-pty's `argsToCommandLine` quoting has nothing to
+ *   escape and PowerShell's own `-Command` requoting cannot alter it.
+ *
+ * The body runs inside `& { … }` so `$p` and `$c` do not leak into the
+ * operator's session; `$env:` assignments are process-wide regardless.
+ */
+const POWERSHELL_RUNTIME_PATH_COMMAND = [
+  "& {",
+  `$p = $env:${RUNTIME_PATH_PREFIX_ENV};`,
+  "if (-not $p) { return };",
+  "$c = $env:Path;",
+  "if (-not $c) { $env:Path = $p; return };",
+  "if ($c -eq $p -or $c.StartsWith($p + ';',"
+  + " [StringComparison]::OrdinalIgnoreCase)) { return };",
+  "$env:Path = $p + ';' + $c",
+  "};",
+  `Remove-Item Env:${RUNTIME_PATH_PREFIX_ENV} -ErrorAction SilentlyContinue`,
+].join(" ");
+
+/**
+ * `-NoExit -Command` is appended only when there is something to pin, so a
+ * terminal with no managed runtime keeps the plain invocation it always had.
+ * The exact-case lookup is safe because `prependIntegratedTerminalRuntimePaths`
+ * removes every other casing before writing this one.
+ */
+function windowsPowerShellArgs(env: NodeJS.ProcessEnv): string[] {
+  return env[RUNTIME_PATH_PREFIX_ENV]
+    ? ["-NoLogo", "-NoExit", "-Command", POWERSHELL_RUNTIME_PATH_COMMAND]
+    : ["-NoLogo"];
+}
+
 type TerminalSession = {
   sessionId: string;
   threadKey: string;
@@ -759,11 +803,10 @@ export function prependIntegratedTerminalRuntimePaths(
     return true;
   });
   env[pathKey] = entries.join(pathApi.delimiter);
-  // The prefix exists for the zsh wrapper to reassert. Windows has no wrapper,
-  // so publishing it there would export an internal variable nothing reads.
-  if (platform !== "win32") {
-    env[RUNTIME_PATH_PREFIX_ENV] = runtimeEntries.join(pathApi.delimiter);
-  }
+  // Read by the zsh startup wrappers on POSIX and by the PowerShell command
+  // `resolveWindowsTerminalShell` appends on Windows. Both consume it and
+  // remove it, so it does not survive into the operator's session.
+  env[RUNTIME_PATH_PREFIX_ENV] = runtimeEntries.join(pathApi.delimiter);
   return env;
 }
 
@@ -952,20 +995,23 @@ function resolveWindowsTerminalShell(
   args: string[];
 } {
   if (preference === "pwsh") {
-    return { file: "pwsh.exe", args: ["-NoLogo"] };
+    return { file: "pwsh.exe", args: windowsPowerShellArgs(env) };
   }
   if (preference === "powershell") {
-    return { file: "powershell.exe", args: ["-NoLogo"] };
+    return { file: "powershell.exe", args: windowsPowerShellArgs(env) };
   }
+  // cmd.exe reasserts nothing: its only startup hook is the AutoRun registry
+  // value, and batch has no cheap way to ask whether PATH already leads with
+  // the prefix. An AutoRun that rewrites PATH still wins here.
   if (preference === "cmd") {
     return { file: env.ComSpec || "cmd.exe", args: [] };
   }
 
   if (commandExistsOnPath("pwsh.exe", env, "win32")) {
-    return { file: "pwsh.exe", args: ["-NoLogo"] };
+    return { file: "pwsh.exe", args: windowsPowerShellArgs(env) };
   }
   if (commandExistsOnPath("powershell.exe", env, "win32")) {
-    return { file: "powershell.exe", args: ["-NoLogo"] };
+    return { file: "powershell.exe", args: windowsPowerShellArgs(env) };
   }
   return { file: env.ComSpec || "cmd.exe", args: [] };
 }

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -39,57 +39,73 @@ const RUNTIME_PATH_PREFIX_ENV =
 const ORIGINAL_ZDOTDIR_ENV = "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR";
 const ORIGINAL_ZDOTDIR_UNSET_ENV =
   "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET";
+const INTEGRATION_ZDOTDIR_ENV =
+  "PWRAGENT_INTEGRATED_TERMINAL_INTEGRATION_ZDOTDIR";
 
 // Supplying PATH to `zsh -l` is insufficient: common `.zprofile` setup such
 // as `brew shellenv` prepends another bin directory during startup. ZDOTDIR is
 // zsh's supported user-startup-file root, so these wrappers source the user's
 // real files in order and reassert the selected runtime path afterward.
 const ZSH_INTEGRATION_FILES: Readonly<Record<string, string>> = {
-  ".pwragent-runtime-path.zsh": `
-_pwragent_source_original_zdotfile() {
-  local _pwragent_integration_zdotdir="$ZDOTDIR"
-  local _pwragent_original_zdotdir="${"${"}${ORIGINAL_ZDOTDIR_ENV}:-$HOME}"
-  local _pwragent_zdotfile="$1"
-  if [[ "$_pwragent_original_zdotdir" != "$_pwragent_integration_zdotdir" && -r "$_pwragent_original_zdotdir/$_pwragent_zdotfile" ]]; then
-    ZDOTDIR="$_pwragent_original_zdotdir"
-    source "$_pwragent_original_zdotdir/$_pwragent_zdotfile"
-    export ${ORIGINAL_ZDOTDIR_ENV}="$ZDOTDIR"
-    ZDOTDIR="$_pwragent_integration_zdotdir"
-  fi
-}
+  ".zshenv": zshStartupFileWrapper(".zshenv"),
+  ".zprofile": zshStartupFileWrapper(".zprofile"),
+  ".zshrc": zshStartupFileWrapper(".zshrc", { prependRuntimePath: true }),
+  ".zlogin": zshStartupFileWrapper(".zlogin", {
+    prependRuntimePath: true,
+    restoreZdotdir: true,
+  }),
+};
 
-_pwragent_prepend_runtime_path() {
-  if [[ -n "$${RUNTIME_PATH_PREFIX_ENV}" ]]; then
-    export PATH="$${RUNTIME_PATH_PREFIX_ENV}${"${PATH:+:$PATH}"}"
-  fi
-}
-`.trimStart(),
-  ".zshenv": `
-source "$ZDOTDIR/.pwragent-runtime-path.zsh"
-_pwragent_source_original_zdotfile .zshenv
-`.trimStart(),
-  ".zprofile": `
-source "$ZDOTDIR/.pwragent-runtime-path.zsh"
-_pwragent_source_original_zdotfile .zprofile
-`.trimStart(),
-  ".zshrc": `
-source "$ZDOTDIR/.pwragent-runtime-path.zsh"
-_pwragent_source_original_zdotfile .zshrc
-_pwragent_prepend_runtime_path
-`.trimStart(),
-  ".zlogin": `
-source "$ZDOTDIR/.pwragent-runtime-path.zsh"
-_pwragent_source_original_zdotfile .zlogin
-_pwragent_prepend_runtime_path
+function zshStartupFileWrapper(
+  fileName: string,
+  options: {
+    prependRuntimePath?: boolean;
+    restoreZdotdir?: boolean;
+  } = {},
+): string {
+  const prependRuntimePath = options.prependRuntimePath
+    ? `
+if [[ -n "$${RUNTIME_PATH_PREFIX_ENV}" ]]; then
+  export PATH="$${RUNTIME_PATH_PREFIX_ENV}${"${PATH:+:$PATH}"}"
+fi
+`
+    : "";
+  const restoreZdotdir = zshRestoreOriginalZdotdir();
+  return `
 if [[ "$${ORIGINAL_ZDOTDIR_UNSET_ENV}" == "1" ]]; then
   unset ZDOTDIR
 else
   ZDOTDIR="$${ORIGINAL_ZDOTDIR_ENV}"
 fi
-unset ${ORIGINAL_ZDOTDIR_ENV} ${ORIGINAL_ZDOTDIR_UNSET_ENV}
-unset -f _pwragent_source_original_zdotfile _pwragent_prepend_runtime_path
-`.trimStart(),
-};
+if [[ "$${ORIGINAL_ZDOTDIR_ENV}" != "$${INTEGRATION_ZDOTDIR_ENV}" && -r "$${ORIGINAL_ZDOTDIR_ENV}/${fileName}" ]]; then
+  source "$${ORIGINAL_ZDOTDIR_ENV}/${fileName}"
+fi
+if (( ${"${+ZDOTDIR}"} )); then
+  export ${ORIGINAL_ZDOTDIR_ENV}="$ZDOTDIR"
+  unset ${ORIGINAL_ZDOTDIR_UNSET_ENV}
+else
+  export ${ORIGINAL_ZDOTDIR_ENV}="$HOME"
+  export ${ORIGINAL_ZDOTDIR_UNSET_ENV}="1"
+fi
+ZDOTDIR="$${INTEGRATION_ZDOTDIR_ENV}"
+${prependRuntimePath}${options.restoreZdotdir
+    ? restoreZdotdir
+    : `
+if [[ ! -o RCS ]]; then
+${restoreZdotdir}
+fi
+`}
+`.trimStart();
+}
+
+function zshRestoreOriginalZdotdir(): string {
+  return `if [[ "$${ORIGINAL_ZDOTDIR_UNSET_ENV}" == "1" ]]; then
+  unset ZDOTDIR
+else
+  ZDOTDIR="$${ORIGINAL_ZDOTDIR_ENV}"
+fi
+unset ${ORIGINAL_ZDOTDIR_ENV} ${ORIGINAL_ZDOTDIR_UNSET_ENV} ${INTEGRATION_ZDOTDIR_ENV}`;
+}
 
 let zshIntegrationDirectoryPromise: Promise<string> | undefined;
 
@@ -639,10 +655,8 @@ export async function spawnTerminalPty(params: {
 }): Promise<SpawnedTerminalPty> {
   const platform = params.platform ?? process.platform;
   const settings = getDesktopSettingsService();
-  const [baseEnv, runtimeCommands] = await Promise.all([
-    settings.resolveTerminalSpawnEnvAsync(),
-    settings.resolveIntegratedTerminalCommands(),
-  ]);
+  const runtimeCommands = settings.resolveIntegratedTerminalCommands();
+  const baseEnv = await settings.resolveTerminalSpawnEnvAsync();
   let env = prependIntegratedTerminalRuntimePaths(
     baseEnv,
     runtimeCommands,
@@ -734,10 +748,12 @@ export async function prepareIntegratedTerminalShellEnvironment(options: {
     env[ORIGINAL_ZDOTDIR_UNSET_ENV] = "1";
   }
   try {
-    env.ZDOTDIR = await (
+    const integrationZdotdir = await (
       options.resolveZshIntegrationDirectory
       ?? ensureZshIntegrationDirectory
     )();
+    env[INTEGRATION_ZDOTDIR_ENV] = integrationZdotdir;
+    env.ZDOTDIR = integrationZdotdir;
   } catch (error) {
     getMainLogger("pwragent:integrated-terminal").warn(
       "zsh-runtime-path-integration-failed",
@@ -756,7 +772,7 @@ export async function writeZshIntegrationDirectory(
   directory = path.join(
     resolvePwragentRoot(),
     "shell-integration",
-    "zsh-v1",
+    "zsh-v2",
   ),
 ): Promise<string> {
   await mkdir(directory, { recursive: true });

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -1007,13 +1007,45 @@ function resolveWindowsTerminalShell(
     return { file: env.ComSpec || "cmd.exe", args: [] };
   }
 
-  if (commandExistsOnPath("pwsh.exe", env, "win32")) {
+  // Discovery searches the operator's PATH, not the pinned one. The runtime
+  // directories lead PATH by the time this runs, so scanning them would let a
+  // `pwsh.exe` inside a Codex or Grok release bundle become the shell PwrAgent
+  // launches. The pin is for the operator's commands, not for choosing a shell.
+  const discoveryEnv = withoutRuntimePathPrefix(env);
+  if (commandExistsOnPath("pwsh.exe", discoveryEnv, "win32")) {
     return { file: "pwsh.exe", args: windowsPowerShellArgs(env) };
   }
-  if (commandExistsOnPath("powershell.exe", env, "win32")) {
+  if (commandExistsOnPath("powershell.exe", discoveryEnv, "win32")) {
     return { file: "powershell.exe", args: windowsPowerShellArgs(env) };
   }
   return { file: env.ComSpec || "cmd.exe", args: [] };
+}
+
+/**
+ * The environment with the pinned runtime directories removed from PATH, for
+ * decisions that must reflect what the operator had rather than what PwrAgent
+ * prepended.
+ */
+function withoutRuntimePathPrefix(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const prefix = env[RUNTIME_PATH_PREFIX_ENV];
+  if (!prefix) return env;
+  const pathKey = Object.keys(env).find((key) => key.toUpperCase() === "PATH");
+  if (!pathKey) return env;
+  const pinned = new Set(
+    prefix.split(";").map((entry) => path.win32.normalize(entry).toLowerCase()),
+  );
+  return {
+    ...env,
+    [pathKey]: (env[pathKey] ?? "")
+      .split(";")
+      .filter((entry) => {
+        if (entry.length === 0) return false;
+        return !pinned.has(path.win32.normalize(entry).toLowerCase());
+      })
+      .join(";"),
+  };
 }
 
 function commandExistsOnPath(

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -25,6 +26,7 @@ import type {
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { resolvePwragentRoot } from "../profile";
 
 const DEFAULT_COLUMNS = 80;
 const DEFAULT_ROWS = 18;
@@ -32,6 +34,64 @@ const MAX_COLUMNS = 500;
 const MAX_ROWS = 200;
 const OUTPUT_BUFFER_LIMIT = 128 * 1024;
 const PTY_SHUTDOWN_FORCE_KILL_MS = 500;
+const RUNTIME_PATH_PREFIX_ENV =
+  "PWRAGENT_INTEGRATED_TERMINAL_RUNTIME_PATH_PREFIX";
+const ORIGINAL_ZDOTDIR_ENV = "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR";
+const ORIGINAL_ZDOTDIR_UNSET_ENV =
+  "PWRAGENT_INTEGRATED_TERMINAL_ORIGINAL_ZDOTDIR_UNSET";
+
+// Supplying PATH to `zsh -l` is insufficient: common `.zprofile` setup such
+// as `brew shellenv` prepends another bin directory during startup. ZDOTDIR is
+// zsh's supported user-startup-file root, so these wrappers source the user's
+// real files in order and reassert the selected runtime path afterward.
+const ZSH_INTEGRATION_FILES: Readonly<Record<string, string>> = {
+  ".pwragent-runtime-path.zsh": `
+_pwragent_source_original_zdotfile() {
+  local _pwragent_integration_zdotdir="$ZDOTDIR"
+  local _pwragent_original_zdotdir="${"${"}${ORIGINAL_ZDOTDIR_ENV}:-$HOME}"
+  local _pwragent_zdotfile="$1"
+  if [[ "$_pwragent_original_zdotdir" != "$_pwragent_integration_zdotdir" && -r "$_pwragent_original_zdotdir/$_pwragent_zdotfile" ]]; then
+    ZDOTDIR="$_pwragent_original_zdotdir"
+    source "$_pwragent_original_zdotdir/$_pwragent_zdotfile"
+    export ${ORIGINAL_ZDOTDIR_ENV}="$ZDOTDIR"
+    ZDOTDIR="$_pwragent_integration_zdotdir"
+  fi
+}
+
+_pwragent_prepend_runtime_path() {
+  if [[ -n "$${RUNTIME_PATH_PREFIX_ENV}" ]]; then
+    export PATH="$${RUNTIME_PATH_PREFIX_ENV}${"${PATH:+:$PATH}"}"
+  fi
+}
+`.trimStart(),
+  ".zshenv": `
+source "$ZDOTDIR/.pwragent-runtime-path.zsh"
+_pwragent_source_original_zdotfile .zshenv
+`.trimStart(),
+  ".zprofile": `
+source "$ZDOTDIR/.pwragent-runtime-path.zsh"
+_pwragent_source_original_zdotfile .zprofile
+`.trimStart(),
+  ".zshrc": `
+source "$ZDOTDIR/.pwragent-runtime-path.zsh"
+_pwragent_source_original_zdotfile .zshrc
+_pwragent_prepend_runtime_path
+`.trimStart(),
+  ".zlogin": `
+source "$ZDOTDIR/.pwragent-runtime-path.zsh"
+_pwragent_source_original_zdotfile .zlogin
+_pwragent_prepend_runtime_path
+if [[ "$${ORIGINAL_ZDOTDIR_UNSET_ENV}" == "1" ]]; then
+  unset ZDOTDIR
+else
+  ZDOTDIR="$${ORIGINAL_ZDOTDIR_ENV}"
+fi
+unset ${ORIGINAL_ZDOTDIR_ENV} ${ORIGINAL_ZDOTDIR_UNSET_ENV}
+unset -f _pwragent_source_original_zdotfile _pwragent_prepend_runtime_path
+`.trimStart(),
+};
+
+let zshIntegrationDirectoryPromise: Promise<string> | undefined;
 
 type TerminalSession = {
   sessionId: string;
@@ -579,12 +639,25 @@ export async function spawnTerminalPty(params: {
 }): Promise<SpawnedTerminalPty> {
   const platform = params.platform ?? process.platform;
   const settings = getDesktopSettingsService();
-  const env = await settings.resolveTerminalSpawnEnvAsync();
+  const [baseEnv, runtimeCommands] = await Promise.all([
+    settings.resolveTerminalSpawnEnvAsync(),
+    settings.resolveIntegratedTerminalCommands(),
+  ]);
+  let env = prependIntegratedTerminalRuntimePaths(
+    baseEnv,
+    runtimeCommands,
+    platform,
+  );
   const cwd = resolveTerminalCwd(params.cwd);
   const shell = resolveTerminalShell({
     env,
     platform,
     windowsShell: settings.resolveIntegratedTerminalWindowsShell(),
+  });
+  env = await prepareIntegratedTerminalShellEnvironment({
+    env,
+    platform,
+    shell: shell.file,
   });
   const nodePty = await (params.loadNodePty ?? loadNodePty)();
   const pty = nodePty.spawn(shell.file, shell.args, {
@@ -598,6 +671,112 @@ export async function spawnTerminalPty(params: {
     }),
   });
   return { pty, cwd, shell };
+}
+
+export function prependIntegratedTerminalRuntimePaths(
+  baseEnv: NodeJS.ProcessEnv,
+  commands: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+  const env = buildPwrAgentChildProcessEnv(baseEnv);
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  const runtimeDirectories = commands
+    .map((command) => command.trim())
+    .filter((command) => pathApi.isAbsolute(command))
+    .map((command) => pathApi.dirname(command));
+  if (runtimeDirectories.length === 0) return env;
+
+  const pathKey = Object.keys(env).find((key) => key.toUpperCase() === "PATH")
+    ?? "PATH";
+  const existingEntries = (env[pathKey] ?? "")
+    .split(pathApi.delimiter)
+    .filter((entry) => entry.length > 0);
+  const seen = new Set<string>();
+  const normalizedKey = (entry: string): string => {
+    const normalized = pathApi.normalize(entry);
+    return platform === "win32" ? normalized.toLowerCase() : normalized;
+  };
+  const runtimeSeen = new Set<string>();
+  const runtimeEntries = runtimeDirectories.filter((entry) => {
+    const key = normalizedKey(entry);
+    if (runtimeSeen.has(key)) return false;
+    runtimeSeen.add(key);
+    return true;
+  });
+  const entries = [...runtimeEntries, ...existingEntries].filter((entry) => {
+    const key = normalizedKey(entry);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  env[pathKey] = entries.join(pathApi.delimiter);
+  env[RUNTIME_PATH_PREFIX_ENV] = runtimeEntries.join(pathApi.delimiter);
+  return env;
+}
+
+export async function prepareIntegratedTerminalShellEnvironment(options: {
+  env: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+  shell: string;
+  resolveZshIntegrationDirectory?: () => Promise<string>;
+}): Promise<NodeJS.ProcessEnv> {
+  const env = buildPwrAgentChildProcessEnv(options.env);
+  if (
+    options.platform === "win32"
+    || path.basename(options.shell) !== "zsh"
+    || !env[RUNTIME_PATH_PREFIX_ENV]
+  ) {
+    return env;
+  }
+  const originalZdotdir = env.ZDOTDIR?.trim();
+  env[ORIGINAL_ZDOTDIR_ENV] = originalZdotdir || env.HOME || homedir();
+  if (!originalZdotdir) {
+    env[ORIGINAL_ZDOTDIR_UNSET_ENV] = "1";
+  }
+  try {
+    env.ZDOTDIR = await (
+      options.resolveZshIntegrationDirectory
+      ?? ensureZshIntegrationDirectory
+    )();
+  } catch (error) {
+    getMainLogger("pwragent:integrated-terminal").warn(
+      "zsh-runtime-path-integration-failed",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+  }
+  return env;
+}
+
+async function ensureZshIntegrationDirectory(): Promise<string> {
+  zshIntegrationDirectoryPromise ??= writeZshIntegrationDirectory();
+  return await zshIntegrationDirectoryPromise;
+}
+
+export async function writeZshIntegrationDirectory(
+  directory = path.join(
+    resolvePwragentRoot(),
+    "shell-integration",
+    "zsh-v1",
+  ),
+): Promise<string> {
+  await mkdir(directory, { recursive: true });
+  await Promise.all(
+    Object.entries(ZSH_INTEGRATION_FILES).map(async ([name, contents]) => {
+      const destination = path.join(directory, name);
+      const temporary = path.join(
+        directory,
+        `.${name}.${process.pid}.${randomUUID()}.tmp`,
+      );
+      try {
+        await writeFile(temporary, contents, { encoding: "utf8", mode: 0o600 });
+        await rename(temporary, destination);
+      } catch (error) {
+        await unlink(temporary).catch(() => undefined);
+        throw error;
+      }
+    }),
+  );
+  return directory;
 }
 
 export function clampTerminalColumns(value: number): number {

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -719,8 +719,14 @@ export function prependIntegratedTerminalRuntimePaths(
   platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
   const env = buildPwrAgentChildProcessEnv(baseEnv);
-  for (const key of OWNED_TERMINAL_ENV) {
-    delete env[key];
+  // Same rule `mergePwrAgentChildProcessEnv` applies to ELECTRON_RENDERER_URL:
+  // Windows environment names are case-insensitive, and this is a plain object
+  // that is not, so every casing has to go.
+  const owned = new Set<string>(OWNED_TERMINAL_ENV);
+  for (const key of Object.keys(env)) {
+    if (owned.has(key.toUpperCase())) {
+      delete env[key];
+    }
   }
   const pathApi = platform === "win32" ? path.win32 : path.posix;
   const runtimeDirectories = commands
@@ -824,6 +830,10 @@ export async function writeZshIntegrationDirectory(
   ),
 ): Promise<string> {
   await mkdir(directory, { recursive: true });
+  // A crash between `writeFile` and `rename`, or a sibling write rejecting
+  // first and abandoning the others, leaves a staged file in the directory
+  // PwrAgent hands zsh as ZDOTDIR. Nothing else ever removes one.
+  await removeOrphanedIntegrationTempFiles(directory);
   await Promise.all(
     Object.entries(ZSH_INTEGRATION_FILES).map(async ([name, contents]) => {
       const destination = path.join(directory, name);
@@ -841,6 +851,23 @@ export async function writeZshIntegrationDirectory(
     }),
   );
   return directory;
+}
+
+async function removeOrphanedIntegrationTempFiles(
+  directory: string,
+): Promise<void> {
+  try {
+    const entries = await readdir(directory);
+    await Promise.all(
+      entries
+        .filter((entry) => entry.startsWith(".") && entry.endsWith(".tmp"))
+        .map(async (entry) => {
+          await unlink(path.join(directory, entry)).catch(() => undefined);
+        }),
+    );
+  } catch {
+    // A directory we cannot list is not a reason to skip writing the wrappers.
+  }
 }
 
 export function clampTerminalColumns(value: number): number {


### PR DESCRIPTION
## Summary

- make newly opened integrated terminals resolve the exact configured or already-active Codex and Grok runtimes selected by the active PwrAgent profile
- prepend and deduplicate those runtime directories without changing Codex/Grok agent subprocess environments or triggering runtime updates during terminal startup
- reassert the selected runtime path after zsh login startup files while preserving top-level startup semantics and the final user-selected `ZDOTDIR`
- exclude configured Grok paths when the Grok agent is disabled

## Verification

- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts` (133 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm --filter @pwragent/desktop build`

## Notes

- Existing terminal sessions keep their original environment; the selected runtime path applies to newly opened terminals.
- Managed runtime installation and update work stays on the existing background/settings paths; terminal creation reads only configured or already-active commands.
- The zsh integration specifically guards against login setup such as `brew shellenv` moving Homebrew ahead of the PwrAgent-selected runtime.