### PR TITLE
fix(desktop): tighten the Settings nav to the thread list's density

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/automations-chrome-parity.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/automations-chrome-parity.test.ts
@@ -55,14 +55,15 @@ describe("Automations chrome matches Settings", () => {
   });
 
   it("gives the nav's create row the same rhythm Exit has in Settings", () => {
-    // `.settings-nav` is a flex column with `gap: 4px`, and `.settings-nav__exit`
-    // carries `margin: 8px 0 4px`. In Settings that yields exit → group label
-    // = 4 + 4 + 4 = 12px. Automations inserts this row into that gap, so it
-    // needs 4px on both sides to keep both halves at 12px; `0 0 8px` left 8px
-    // above and 16px below, clumping Exit and New together.
-    expect(ruleBody(".settings-nav")).toMatch(/gap:\s*4px;/);
-    expect(ruleBody(".settings-nav__exit")).toMatch(/margin:\s*8px 0 4px;/);
-    expect(ruleBody(".settings-nav__group-label")).toMatch(/margin:\s*4px 12px 6px;/);
-    expect(ruleBody(".settings-nav__new")).toMatch(/margin:\s*4px 0;/);
+    // `.settings-nav` is a flex column with `gap: 2px`, `.settings-nav__exit`
+    // carries `margin: 6px 0 2px`, and the group label leads with `8px`. In
+    // Settings that yields exit → group label = 2 + 2 + 8 = 12px. Automations
+    // inserts this row into that gap, so `8px 0 2px` keeps both halves at
+    // 12px; `0 0 8px` left 8px above and 16px below, clumping Exit and New
+    // together.
+    expect(ruleBody(".settings-nav")).toMatch(/gap:\s*2px;/);
+    expect(ruleBody(".settings-nav__exit")).toMatch(/margin:\s*6px 0 2px;/);
+    expect(ruleBody(".settings-nav__group-label")).toMatch(/margin:\s*8px 8px 2px;/);
+    expect(ruleBody(".settings-nav__new")).toMatch(/margin:\s*8px 0 2px;/);
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1753,6 +1753,53 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps the Settings nav on the sidebar's lane and brand alignment", () => {
+    // The Settings nav is the inset system's second consumer, and neither
+    // half of its participation can be read off a single declaration.
+    // Its rows run in the lane as a LITERAL — `--sidebar-lane-inset` is
+    // scoped to `.sidebar` and does not inherit into this subtree — and its
+    // brand x is a SUM, because the masthead adds back the rail difference
+    // the narrower lane gave up. Assert both, or a later edit to either
+    // number alone drifts the Settings list off the thread list's density
+    // (the bug this nav was retuned to fix) or its wordmark off the main
+    // one, with every existing literal assertion still green.
+    const sidebar = extractRuleBody(css, ".sidebar");
+    const lane = Number(sidebar.match(/--sidebar-lane-inset:\s*(\d+)px;/)?.[1]);
+    const rail = Number(sidebar.match(/--sidebar-rail-inset:\s*(\d+)px;/)?.[1]);
+    const navLane = Number(
+      extractRuleBody(css, ".settings-nav").match(
+        /\n\s*padding:\s*0\s+(\d+)px\s+\d+px;/,
+      )?.[1],
+    );
+    expect(navLane).toBe(lane);
+
+    // Brand x, macOS: both mastheads reserve the stoplight gutter from
+    // inside their own inset, and the two totals must be the same number.
+    const brandX = (inset: number, masthead: string, pattern: RegExp) =>
+      inset + Number(masthead.match(pattern)?.[1]);
+    const sidebarBrandX = brandX(
+      rail,
+      extractRuleBody(css, ".sidebar__masthead"),
+      /padding:\s*10px 0 0 (\d+)px;/,
+    );
+    expect(
+      brandX(
+        navLane,
+        extractRuleBody(css, ".settings-nav__masthead"),
+        /padding:\s*10px 0 0 (\d+)px;/,
+      ),
+    ).toBe(sidebarBrandX);
+
+    // …and on the two branches that release that reservation, where the
+    // main sidebar's masthead drops to 0 and lands the brand on the rail.
+    for (const override of [
+      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[^}]*?padding-left:\s*(\d+)px;/,
+      /:root\[data-platform="darwin"\]\[data-fullscreen="true"\]\s*\.settings-nav__masthead\s*\{[^}]*?padding-left:\s*(\d+)px;/,
+    ]) {
+      expect(navLane + Number(css.match(override)?.[1])).toBe(rail);
+    }
+  });
+
   it("applies a thin, themed scrollbar to every scroller via the universal selector (scrollbar-width does not inherit)", () => {
     // `scrollbar-color` inherits but `scrollbar-width` does NOT, so a
     // `:root` rule alone leaves scrollers at the chunky default width in

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1416,7 +1416,10 @@ describe("Tangerine Terminal theme contract", () => {
 
     expect(activityTitlebar).toContain("padding: 10px 14px 0 96px;");
     expect(sidebarMasthead).toContain("padding: 10px 0 0 80px;");
-    expect(settingsMasthead).toContain("padding: 10px 0 0 80px;");
+    // The Settings nav runs its rows in the narrower 8px lane rather than the
+    // sidebar's 16px rail, so its masthead pads 88px to put the brand at the
+    // same x≈96. Both numbers must move together or the two brands drift.
+    expect(settingsMasthead).toContain("padding: 10px 0 0 88px;");
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.activity-titlebar\s*\{[\s\S]*?padding-left:\s*14px;[\s\S]*?\}/,
     );
@@ -1436,8 +1439,11 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-platform="win32"\]\s*\.sidebar__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
     );
+    // Same drop, except the Settings nav keeps its 8px lane inset — that
+    // 8px is the row lane, not a stoplight reservation, and it puts the
+    // brand at x=16 exactly where the main sidebar's lands off macOS.
     expect(css).toMatch(
-      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
+      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*8px;[\s\S]*?\}/,
     );
     // Settings and Automations use the same Windows title strip as the main
     // shell, so their in-nav wordmarks would duplicate the one visible there.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2189,9 +2189,10 @@ textarea,
 }
 
 /* Title-bar strip — single-row chrome. Base padding keeps macOS
-   stoplight clearance on the left: `.settings-nav__masthead`
-   (10/0/0/96) alignment, stoplights end at ~x=72, brand lands at
-   x=96. Platforms without macOS/Windows chrome conventions override
+   stoplight clearance on the left: the same x=96 the two nav mastheads
+   reach (`.sidebar__masthead` pads 80px inside a 16px rail,
+   `.settings-nav__masthead` 88px inside an 8px lane); stoplights end at
+   ~x=72, brand lands at x=96. Platforms without macOS/Windows chrome conventions override
    the left padding below so auxiliary-window titles don't float
    awkwardly away from the window edge. */
 .activity-titlebar {
@@ -8336,7 +8337,11 @@ textarea,
 
 /* Indent = the row's 24px caret gutter + the label button's 4px left
    padding, so the sublist's left rule lands under the section label's
-   first character. */
+   first character. The explicit width is load-bearing and must track the
+   margin: a form control shrink-to-fits even as a block-level flex box,
+   so `width: auto` collapses this row to its label instead of filling
+   the clip. (`.settings-nav__divider` needs no such width — an `<hr>` is
+   a plain flex item and stretches.) */
 .settings-nav__subbutton {
   display: flex;
   align-items: center;
@@ -8402,8 +8407,9 @@ textarea,
   text-transform: uppercase;
 }
 
+/* Margins alone set the width — a flex item stretches across the
+   column, so the inset is stated once. */
 .settings-nav__divider {
-  width: calc(100% - 16px);
   height: 1px;
   margin: 6px 8px;
   border: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8049,23 +8049,28 @@ textarea,
 .settings-nav {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   /* No top padding — the masthead handles its own top spacing.
-     16px horizontal mirrors the main `.sidebar`'s padding so the
-     section rows align with where main-screen tabs sit. */
-  padding: 0 16px 12px;
+     8px horizontal is `--sidebar-lane-inset`, the same lane the main
+     screen's thread list runs in, so the two lists read at one
+     density. The masthead adds the missing 8px back below to keep the
+     brand on the main sidebar's rail. */
+  padding: 0 8px 10px;
   border-right: 1px solid var(--border-subtle);
   background: var(--bg-sidebar);
   overflow: hidden;
 }
 
-/* Masthead — brand + 80px stoplight gutter. Borrows the
-   `.sidebar__masthead` pattern verbatim:
-   - Lives inside the nav's own 16px horizontal padding, so
-     `padding-left: 80px` puts the brand at x≈96 from the window
+/* Masthead — brand + stoplight gutter. Borrows the
+   `.sidebar__masthead` pattern:
+   - Lives inside the nav's own 8px horizontal padding, so
+     `padding-left: 88px` puts the brand at x≈96 from the window
      edge (stoplights end at ~x=72 with
      `trafficLightPosition: { x: 20, y: 18 }` from window.ts).
-   - `padding: 10px 0 0 80px` mirrors main exactly.
+   - Main's rail is 16px and its masthead pads 80px to the same x=96.
+     The nav runs its rows in a tighter lane, so the masthead carries
+     the difference: every platform branch below re-inserts 8px too,
+     which is why the brand lands identically on both screens.
    - `min-height: 44px` gives the masthead the same effective
      height that `.sidebar__masthead` has on the main screen
      (10px top padding + 34px from the icon buttons it contains).
@@ -8078,13 +8083,13 @@ textarea,
   align-items: center;
   gap: 16px;
   min-height: 44px;
-  padding: 10px 0 0 80px;
+  padding: 10px 0 0 88px;
   -webkit-app-region: drag;
 }
 
 :root[data-platform]:not([data-platform="darwin"]):not([data-platform="win32"])
   .settings-nav__masthead {
-  padding-left: 0;
+  padding-left: 8px;
 }
 
 /* Windows already carries the PwrAgent wordmark in its custom title strip.
@@ -8097,10 +8102,11 @@ textarea,
 }
 
 /* macOS fullscreen drops the stoplights, so the Settings nav masthead
-   collapses its 80px reservation to the left edge too — mirrors the main
-   `.sidebar__masthead` fullscreen behavior so the two screens stay aligned. */
+   releases its stoplight reservation back to the nav's own lane — mirrors the
+   main `.sidebar__masthead` fullscreen behavior so the two screens stay
+   aligned (main falls to its 16px rail, this to the 8px lane + 8px here). */
 :root[data-platform="darwin"][data-fullscreen="true"] .settings-nav__masthead {
-  padding-left: 0;
+  padding-left: 8px;
 }
 
 .settings-nav__masthead * {
@@ -8132,8 +8138,8 @@ textarea,
   appearance: none;
   cursor: pointer;
   gap: 6px;
-  margin: 8px 0 4px;
-  padding: 6px 12px;
+  margin: 6px 0 2px;
+  padding: 6px 8px;
   border: none;
   background: transparent;
   color: var(--text-secondary);
@@ -8154,11 +8160,12 @@ textarea,
    rail) — a full-accent button across the empty canvas made the create action
    the farthest thing from the pointer. Only the plus carries accent.
 
-   The nav is a flex column with a 4px gap and Exit carries a 4px bottom
-   margin, so `margin: 4px 0` here puts both the Exit→New and New→group-label
-   gaps at 12px — the same Exit-to-next-thing rhythm Settings has. It was
-   `0 0 8px`, which left 8px above and 16px below: two rows of identical size,
-   weight, and color clumped together with a hole beneath them. */
+   The nav is a flex column with a 2px gap; Exit carries a 2px bottom margin
+   and the group label an 8px top margin, so `margin: 8px 0 2px` here puts
+   both the Exit→New and New→group-label gaps at 12px — the same
+   Exit-to-next-thing rhythm Settings has. It was `0 0 8px`, which left 8px
+   above and 16px below: two rows of identical size, weight, and color
+   clumped together with a hole beneath them. */
 .settings-nav__new {
   display: inline-flex;
   width: 100%;
@@ -8166,8 +8173,8 @@ textarea,
   appearance: none;
   cursor: pointer;
   gap: 6px;
-  margin: 4px 0;
-  padding: 6px 12px;
+  margin: 8px 0 2px;
+  padding: 6px 8px;
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -8190,7 +8197,7 @@ textarea,
 }
 
 .settings-nav__group-label {
-  margin: 4px 12px 6px;
+  margin: 8px 8px 2px;
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 700;
@@ -8264,7 +8271,7 @@ textarea,
   justify-content: flex-start;
   appearance: none;
   cursor: pointer;
-  padding: 10px 12px;
+  padding: 5px 8px;
   border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
@@ -8274,13 +8281,17 @@ textarea,
   text-align: left;
 }
 
-/* Inside a caret row the label shares the width with the 22px gutter.
-   (Automations reuses `.settings-nav__button` without rows, where the
-   bare `width: 100%` still applies.) */
+/* Inside a caret row the label shares the width with the 24px gutter, and
+   that gutter already supplies the row's left inset — so the label drops
+   most of its own left padding and sits close to the caret instead of
+   floating a second inset away from it. (Automations reuses
+   `.settings-nav__button` without rows, where the bare `width: 100%` and
+   the symmetric padding above still apply.) */
 .settings-nav__row .settings-nav__button {
   flex: 1 1 auto;
   width: auto;
   min-width: 0;
+  padding-left: 4px;
 }
 
 .settings-nav__button:hover,
@@ -8323,18 +8334,18 @@ textarea,
   overflow: hidden;
 }
 
-/* Indent = the row's 24px caret gutter + the label button's 12px
+/* Indent = the row's 24px caret gutter + the label button's 4px left
    padding, so the sublist's left rule lands under the section label's
    first character. */
 .settings-nav__subbutton {
   display: flex;
   align-items: center;
   gap: 8px;
-  width: calc(100% - 36px);
+  width: calc(100% - 28px);
   appearance: none;
   cursor: pointer;
-  margin: 0 0 2px 36px;
-  padding: 6px 10px;
+  margin: 0 0 2px 28px;
+  padding: 6px 8px;
   border: 0;
   border-left: 1px solid var(--border-subtle);
   background: transparent;
@@ -8345,7 +8356,7 @@ textarea,
 }
 
 .settings-nav__subbutton:last-child {
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .settings-nav__subbutton:hover,
@@ -8392,9 +8403,9 @@ textarea,
 }
 
 .settings-nav__divider {
-  width: calc(100% - 24px);
+  width: calc(100% - 16px);
   height: 1px;
-  margin: 8px 12px;
+  margin: 6px 8px;
   border: 0;
   background: var(--border-subtle);
 }


### PR DESCRIPTION
## What

The Settings section list was insetting its rows twice — the nav's 16px rail plus the label button's own 12px padding on the far side of a 24px caret gutter — so a section label started **52px** from the window edge on a **42px** row pitch. The main screen's thread list, three pixels away in the same window, starts its titles at 23px on a 28px pitch. Side by side the Settings list read as a different, much airier product surface.

Rows now run in the sidebar's own 8px lane (`--sidebar-lane-inset`), the label button drops to `5px 8px` with only 4px of left padding inside a caret row, and the vertical rhythm (nav gap, group label, divider, sublist tail) tightens to match. The 188px column width is unchanged.

Measured against the directory list in a headless harness:

| | before | after | thread list |
|---|---|---|---|
| caret triangle | 25.5px | **16px** | 13px |
| section label | 52px | **37px** | 23px |
| row height | 38px | **28px** | 24px |
| row pitch | 42px | **30px** | 28px |

## The one number left alone

The label cannot come closer than 33px. The caret is a real click target sitting flush against the label button, so WCAG 2.2 target-size (AA) holds the gutter at 24px and `a11y.spec.ts` gates it — that is the CI failure #1880 landed a fix for, and this pass does not undo it. The remaining triangle-to-text gap is that gutter, not a chosen inset.

## Brand alignment

The masthead absorbs the lane change (80px → 88px, and 0 → 8px on the platform branches that drop the stoplight reservation) so the brand stays at x≈96 on macOS and x=16 elsewhere, pixel-identical to `.sidebar__brand`.

## Tests

- `theme-contract.test.tsx` pins both halves of the brand alignment so the two wordmarks cannot drift apart.
- `automations-chrome-parity.test.ts` keeps the shared nav's 12px Exit-to-next-thing rhythm at its new numbers (`.settings-nav__new` moves to `8px 0 2px`).
- Headless Chromium harness against the real `app.css`: geometry above, plus axe (`wcag2a`/`2aa`/`21a`/`21aa`/`22aa`) clean in both themes with the caret measuring 24x28.
- `pnpm lint:colors` passes; renderer style + settings + automations suites pass (182 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)