### PR TITLE
fix(desktop): keep quit blocker titles stable

### DIFF
--- a/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
@@ -20,6 +20,27 @@ const GROUPS: ReadonlyArray<{
   { kind: "action", heading: "Environment actions" },
 ];
 
+function retainKnownTitles(
+  current: QuitBlockerQueueSnapshot | undefined,
+  next: QuitBlockerQueueSnapshot,
+): QuitBlockerQueueSnapshot {
+  if (!current) return next;
+  const titlesByItemKey = new Map(
+    current.items.flatMap((item) => {
+      const title = item.title?.trim();
+      return title ? [[quitBlockerItemKey(item), title] as const] : [];
+    }),
+  );
+  return {
+    ...next,
+    items: next.items.map((item) => {
+      if (item.title?.trim()) return item;
+      const title = titlesByItemKey.get(quitBlockerItemKey(item));
+      return title ? { ...item, title } : item;
+    }),
+  };
+}
+
 type QuitBlockerQueueApi = Pick<
   DesktopApi,
   | "copyText"
@@ -52,7 +73,10 @@ export function QuitBlockerQueueToast(props: {
       try {
         const nextSnapshot = await readQuitBlockerQueue();
         if (!disposed) {
-          setSnapshot(nextSnapshot);
+          // Blocker membership is authoritative, but title resolution is
+          // best-effort and bounded. Do not downgrade a known label when one
+          // refresh times out and omits only that optional presentation data.
+          setSnapshot((current) => retainKnownTitles(current, nextSnapshot));
         }
       } catch {
         // Keep the last authoritative snapshot visible. The next interval can

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
@@ -22,6 +22,55 @@ function snapshot(
 }
 
 describe("QuitBlockerQueueToast", () => {
+  it("keeps a known title when a refresh temporarily omits it", async () => {
+    vi.useFakeTimers();
+    let showQueue!: (snapshot: QuitBlockerQueueSnapshot) => void;
+    const titled = snapshot([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "01a05891-bfb8-7bc0-affd-97354d0080b1",
+        threadKey: "codex:01a05891-bfb8-7bc0-affd-97354d0080b1",
+        title: "Investigate compaction cost",
+      },
+    ]);
+    const unresolved = snapshot([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "01a05891-bfb8-7bc0-affd-97354d0080b1",
+        threadKey: "codex:01a05891-bfb8-7bc0-affd-97354d0080b1",
+      },
+    ]);
+    const readQuitBlockerQueue = vi.fn(async () => unresolved);
+
+    render(
+      <QuitBlockerQueueToast
+        desktopApi={{
+          onShowQuitBlockersRequested: (callback) => {
+            showQueue = callback;
+            return () => undefined;
+          },
+          readQuitBlockerQueue,
+          revealQuitBlocker: vi.fn(async () => ({ revealed: true })),
+        }}
+      />,
+    );
+
+    act(() => showQueue(titled));
+    expect(screen.getByText("Investigate compaction cost")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(readQuitBlockerQueue).toHaveBeenCalled();
+    expect(screen.getByText("Investigate compaction cost")).toBeInTheDocument();
+    expect(
+      screen.queryByText("01a05891-bfb8-7bc0-affd-97354d0080b1"),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the live queue reachable while authoritative refreshes remove resolved work", async () => {
     vi.useFakeTimers();
     let showQueue!: (snapshot: QuitBlockerQueueSnapshot) => void;


### PR DESCRIPTION
## Summary
- retain a known quit-blocker title when an authoritative refresh temporarily omits optional title data
- continue accepting blocker removals, count changes, and later non-empty title updates
- add a regression test reproducing the title-to-UUID downgrade caused by alternating title-resolution outcomes

## Root cause
The durable queue polls every 500 ms. Missing labels are resolved through a best-effort listThreads call bounded by a 1.5-second timeout, so cache hits can return titles while slower refreshes fall back to thread IDs. Replacing the whole renderer snapshot made the visible label oscillate. This fix keeps membership authoritative while preventing optional presentation data from degrading.

## Validation
- pnpm test apps/desktop/src/renderer/src/features/notifications
- pnpm --filter @pwragent/desktop typecheck
- targeted ESLint
- pnpm lint:boundaries