### PR TITLE
fix(desktop): merge overlay turn usage into older transcript pages

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerReadThreadResponse,
+  AppServerThreadActivityEntry,
   AppServerThreadEntry,
   AppServerThreadMessageEntry,
 } from "@pwragent/shared";
@@ -13,12 +14,36 @@ import {
   type TranscriptHistoryPage,
 } from "../segmented-transcript";
 
-function message(id: string, text = id): AppServerThreadMessageEntry {
+function message(
+  id: string,
+  text = id,
+  extras: Partial<AppServerThreadMessageEntry> = {},
+): AppServerThreadMessageEntry {
   return {
     type: "message",
     id,
     role: "assistant",
     text,
+    ...extras,
+  };
+}
+
+function turnUsage(params: {
+  createdAt: number;
+  summary: string;
+  turnId: string;
+}): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: `live-turn-usage-${params.turnId}`,
+    summary: params.summary,
+    status: "completed",
+    createdAt: params.createdAt,
+    details: [],
+    turn: {
+      id: params.turnId,
+      status: "completed",
+    },
   };
 }
 
@@ -249,5 +274,268 @@ describe("segmented transcript history", () => {
 
     expect(found).toBe(false);
     expect(retainedHistoryIdReads).toBe(2_000);
+  });
+
+  it("merges overlay turn usage into an older history page once instead of leaving it in the tail", () => {
+    const olderTurn = {
+      id: "older-turn",
+      status: "completed" as const,
+    };
+    const laterOlderTurn = {
+      id: "later-older-turn",
+      status: "completed" as const,
+    };
+    const recentTurn = {
+      id: "recent-turn",
+      status: "completed" as const,
+    };
+    const environmentSetup: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "codex-environment-setup-pwragent",
+      summary: "Environment setup completed: PwrAgent",
+      status: "completed",
+      details: [],
+    };
+    const olderUsage = turnUsage({
+      createdAt: 181,
+      summary: "Turn usage: 170,652 uncached in · 2,342,912 cached · 12,266 out",
+      turnId: olderTurn.id,
+    });
+    const laterOlderUsage = turnUsage({
+      createdAt: 281,
+      summary: "Turn usage: 6,057 uncached in · 473,344 cached · 1,312 out",
+      turnId: laterOlderTurn.id,
+    });
+    const recentUsage = turnUsage({
+      createdAt: 481,
+      summary: "Turn usage: 3,034 uncached in · 160,512 cached · 1,367 out",
+      turnId: recentTurn.id,
+    });
+    const tail = [
+      environmentSetup,
+      olderUsage,
+      laterOlderUsage,
+      message("recent-user", "Recent prompt", {
+        role: "user",
+        createdAt: 400,
+        turn: recentTurn,
+      }),
+      message("recent-final", "Recent answer", {
+        createdAt: 480,
+        turn: recentTurn,
+      }),
+      recentUsage,
+    ];
+    const index = createTranscriptHistoryIndex();
+    const history = prependTranscriptHistoryPage({
+      history: undefined,
+      index,
+      page: response([
+        message("older-user", "Older prompt", {
+          role: "user",
+          createdAt: 100,
+          turn: olderTurn,
+        }),
+        message("older-final", "Older answer", {
+          createdAt: 180,
+          turn: olderTurn,
+        }),
+        message("later-older-user", "Later older prompt", {
+          role: "user",
+          createdAt: 200,
+          turn: laterOlderTurn,
+        }),
+        message("later-older-final", "Later older answer", {
+          createdAt: 280,
+          turn: laterOlderTurn,
+        }),
+      ]),
+      tailEntries: tail,
+    });
+    const entries = combineTranscriptEntries(history, index, tail);
+
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "older-user",
+      "older-final",
+      olderUsage.id,
+      "later-older-user",
+      "later-older-final",
+      laterOlderUsage.id,
+      environmentSetup.id,
+      "recent-user",
+      "recent-final",
+      recentUsage.id,
+    ]);
+  });
+
+  it("hides overlay usage for turns that are not in the loaded window yet", () => {
+    const olderTurn = {
+      id: "older-turn",
+      status: "completed" as const,
+    };
+    const laterOlderTurn = {
+      id: "later-older-turn",
+      status: "completed" as const,
+    };
+    const recentTurn = {
+      id: "recent-turn",
+      status: "completed" as const,
+    };
+    const olderUsage = turnUsage({
+      createdAt: 181,
+      summary: "Turn usage: older",
+      turnId: olderTurn.id,
+    });
+    const laterOlderUsage = turnUsage({
+      createdAt: 281,
+      summary: "Turn usage: later older",
+      turnId: laterOlderTurn.id,
+    });
+    const recentUsage = turnUsage({
+      createdAt: 481,
+      summary: "Turn usage: recent",
+      turnId: recentTurn.id,
+    });
+    const tail = [
+      olderUsage,
+      laterOlderUsage,
+      message("recent-final", "Recent answer", {
+        createdAt: 480,
+        turn: recentTurn,
+      }),
+      recentUsage,
+    ];
+
+    expect(
+      combineTranscriptEntries(undefined, undefined, tail).map((entry) => entry.id),
+    ).toEqual(["recent-final", recentUsage.id]);
+
+    const index = createTranscriptHistoryIndex();
+    const history = prependTranscriptHistoryPage({
+      history: undefined,
+      index,
+      page: response([
+        message("later-older-final", "Later older answer", {
+          createdAt: 280,
+          turn: laterOlderTurn,
+        }),
+      ]),
+      tailEntries: tail,
+    });
+
+    expect(
+      combineTranscriptEntries(history, index, tail).map((entry) => entry.id),
+    ).toEqual([
+      "later-older-final",
+      laterOlderUsage.id,
+      "recent-final",
+      recentUsage.id,
+    ]);
+  });
+
+  it("relocates overlay usage with one linear pass over the new page and tail", () => {
+    const priorPageCount = 20;
+    const entriesPerPage = 50;
+    const index = createTranscriptHistoryIndex();
+    let history: LoadedTranscriptHistory | undefined;
+    let retainedHistoryIdReads = 0;
+
+    for (let pageIndex = 0; pageIndex < priorPageCount; pageIndex += 1) {
+      const entries = Array.from(
+        { length: entriesPerPage },
+        (_value, entryIndex): AppServerThreadMessageEntry => {
+          const id = `history-${pageIndex}-${entryIndex}`;
+          return {
+            type: "message",
+            get id() {
+              retainedHistoryIdReads += 1;
+              return id;
+            },
+            role: "assistant",
+            text: id,
+            turn: {
+              id: `history-turn-${pageIndex}-${entryIndex}`,
+              status: "completed",
+            },
+          };
+        },
+      );
+      history = prependTranscriptHistoryPage({
+        history,
+        index,
+        page: response(entries, `cursor-${pageIndex}`),
+        tailEntries: [],
+      });
+    }
+
+    const retainedPages = historyPages(history);
+    const olderTurnIds = Array.from(
+      { length: 10 },
+      (_value, turnIndex) => `older-turn-${turnIndex}`,
+    );
+    const unmatchedTurnIds = Array.from(
+      { length: 90 },
+      (_value, turnIndex) => `unloaded-turn-${turnIndex}`,
+    );
+    const tail: AppServerThreadEntry[] = [
+      ...unmatchedTurnIds.map((turnId, turnIndex) =>
+        turnUsage({
+          createdAt: 100 + turnIndex,
+          summary: `Turn usage: ${turnId}`,
+          turnId,
+        }),
+      ),
+      ...olderTurnIds.map((turnId, turnIndex) =>
+        turnUsage({
+          createdAt: 1_100 + turnIndex,
+          summary: `Turn usage: ${turnId}`,
+          turnId,
+        }),
+      ),
+      message("recent-final", "Recent answer", {
+        createdAt: 2_000,
+        turn: { id: "recent-turn", status: "completed" },
+      }),
+    ];
+    const olderPageEntries = olderTurnIds.map((turnId, turnIndex) =>
+      message(`older-final-${turnIndex}`, `Older answer ${turnIndex}`, {
+        createdAt: 1_000 + turnIndex,
+        turn: { id: turnId, status: "completed" },
+      }),
+    );
+
+    retainedHistoryIdReads = 0;
+    history = prependTranscriptHistoryPage({
+      history,
+      index,
+      page: response(olderPageEntries, "older-cursor"),
+      tailEntries: tail,
+    });
+
+    const nextPages = historyPages(history);
+    const nextArrays = new Set(nextPages.map((page) => page.entries));
+    let copiedPriorEntrySlots = 0;
+    for (const retainedPage of retainedPages) {
+      if (!nextArrays.has(retainedPage.entries)) {
+        copiedPriorEntrySlots += retainedPage.entries.length;
+      }
+    }
+
+    expect(copiedPriorEntrySlots).toBe(0);
+    expect(retainedHistoryIdReads).toBe(0);
+
+    const entries = combineTranscriptEntries(history, index, tail);
+    expect(
+      entries.slice(0, olderTurnIds.length * 2).map((entry) => entry.id),
+    ).toEqual(
+      olderTurnIds.flatMap((turnId, turnIndex) => [
+        `older-final-${turnIndex}`,
+        `live-turn-usage-${turnId}`,
+      ]),
+    );
+    expect(entries.at(-1)?.id).toBe("recent-final");
+    expect(
+      entries.some((entry) => entry.id.startsWith("live-turn-usage-unloaded-")),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
@@ -433,6 +433,102 @@ describe("segmented transcript history", () => {
     ]);
   });
 
+  it("keeps overlay usage that arrives after its historical turn is already indexed", () => {
+    const olderTurn = {
+      id: "older-turn",
+      status: "completed" as const,
+    };
+    const recentTurn = {
+      id: "recent-turn",
+      status: "completed" as const,
+    };
+    const index = createTranscriptHistoryIndex();
+    const history = prependTranscriptHistoryPage({
+      history: undefined,
+      index,
+      page: response([
+        message("older-final", "Older answer", {
+          createdAt: 180,
+          turn: olderTurn,
+        }),
+      ]),
+      tailEntries: [
+        message("recent-final", "Recent answer", {
+          createdAt: 480,
+          turn: recentTurn,
+        }),
+      ],
+    });
+    const lateUsage = turnUsage({
+      createdAt: 181,
+      summary: "Turn usage: older",
+      turnId: olderTurn.id,
+    });
+    const tail = [
+      lateUsage,
+      message("recent-final", "Recent answer", {
+        createdAt: 480,
+        turn: recentTurn,
+      }),
+    ];
+
+    expect(
+      combineTranscriptEntries(history, index, tail).map((entry) => entry.id),
+    ).toEqual([
+      "older-final",
+      lateUsage.id,
+      "recent-final",
+    ]);
+  });
+
+  it("does not relocate overlay usage while the same turn still has tail entries", () => {
+    const splitTurn = {
+      id: "split-turn",
+      status: "completed" as const,
+    };
+    const recentTurn = {
+      id: "recent-turn",
+      status: "completed" as const,
+    };
+    const splitUsage = turnUsage({
+      createdAt: 160,
+      summary: "Turn usage: split",
+      turnId: splitTurn.id,
+    });
+    const tail = [
+      message("split-tail", "Later split-turn work", {
+        createdAt: 150,
+        turn: splitTurn,
+      }),
+      splitUsage,
+      message("recent-final", "Recent answer", {
+        createdAt: 480,
+        turn: recentTurn,
+      }),
+    ];
+    const index = createTranscriptHistoryIndex();
+    const history = prependTranscriptHistoryPage({
+      history: undefined,
+      index,
+      page: response([
+        message("split-older", "Earlier split-turn work", {
+          createdAt: 100,
+          turn: splitTurn,
+        }),
+      ]),
+      tailEntries: tail,
+    });
+
+    expect(
+      combineTranscriptEntries(history, index, tail).map((entry) => entry.id),
+    ).toEqual([
+      "split-older",
+      "split-tail",
+      splitUsage.id,
+      "recent-final",
+    ]);
+  });
+
   it("relocates overlay usage with one linear pass over the new page and tail", () => {
     const priorPageCount = 20;
     const entriesPerPage = 50;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -412,6 +412,182 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("merges overlay turn usage into older history instead of leaving it below newer messages", async () => {
+    const olderTurn = {
+      id: "older-turn",
+      status: "completed" as const,
+      startedAt: 100,
+      completedAt: 180,
+    };
+    const laterOlderTurn = {
+      id: "later-older-turn",
+      status: "completed" as const,
+      startedAt: 200,
+      completedAt: 280,
+    };
+    const recentTurn = {
+      id: "recent-turn",
+      status: "completed" as const,
+      startedAt: 400,
+      completedAt: 480,
+    };
+    const olderUsage: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-turn-usage-older-turn",
+      summary: "Turn usage: 170,652 uncached in · 2,342,912 cached · 12,266 out",
+      status: "completed",
+      createdAt: 181,
+      details: [],
+      turn: olderTurn,
+    };
+    const laterOlderUsage: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-turn-usage-later-older-turn",
+      summary: "Turn usage: 6,057 uncached in · 473,344 cached · 1,312 out",
+      status: "completed",
+      createdAt: 281,
+      details: [],
+      turn: laterOlderTurn,
+    };
+    const recentUsage: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-turn-usage-recent-turn",
+      summary: "Turn usage: 3,034 uncached in · 160,512 cached · 1,367 out",
+      status: "completed",
+      createdAt: 481,
+      details: [],
+      turn: recentTurn,
+    };
+    const environmentSetup: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "codex-environment-setup-pwragent",
+      summary: "Environment setup completed: PwrAgent",
+      status: "completed",
+      details: [],
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        environmentSetup,
+        olderUsage,
+        laterOlderUsage,
+        {
+          ...messageEntry({
+            id: "recent-user",
+            role: "user",
+            text: "Recent prompt",
+            createdAt: 400,
+          }),
+          turn: recentTurn,
+        },
+        {
+          ...messageEntry({
+            id: "recent-final",
+            text: "Recent answer",
+            createdAt: 480,
+          }),
+          phase: "final" as const,
+          turn: recentTurn,
+        },
+        recentUsage,
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older-page",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "older-user",
+            role: "user",
+            text: "Older prompt",
+            createdAt: 100,
+          }),
+          turn: olderTurn,
+        },
+        {
+          ...messageEntry({
+            id: "older-final",
+            text: "Older answer",
+            createdAt: 180,
+          }),
+          phase: "final" as const,
+          turn: olderTurn,
+        },
+        {
+          ...messageEntry({
+            id: "later-older-user",
+            role: "user",
+            text: "Later older prompt",
+            createdAt: 200,
+          }),
+          turn: laterOlderTurn,
+        },
+        {
+          ...messageEntry({
+            id: "later-older-final",
+            text: "Later older answer",
+            createdAt: 280,
+          }),
+          phase: "final" as const,
+          turn: laterOlderTurn,
+        },
+      ],
+      hasPreviousPage: false,
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      }),
+    );
+
+    await waitForThreadHydration(result);
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      environmentSetup.id,
+      "recent-user",
+      "recent-final",
+      recentUsage.id,
+    ]);
+
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "older-user",
+      "older-final",
+      olderUsage.id,
+      "later-older-user",
+      "later-older-final",
+      laterOlderUsage.id,
+      environmentSetup.id,
+      "recent-user",
+      "recent-final",
+      recentUsage.id,
+    ]);
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Older prompt",
+      "message:Older answer",
+      "activity:Turn usage: 170,652 uncached in · 2,342,912 cached · 12,266 out",
+      "message:Later older prompt",
+      "message:Later older answer",
+      "activity:Turn usage: 6,057 uncached in · 473,344 cached · 1,312 out",
+      "activity:Environment setup completed: PwrAgent",
+      "message:Recent prompt",
+      "message:Recent answer",
+      "activity:Turn usage: 3,034 uncached in · 160,512 cached · 1,367 out",
+    ]);
+  });
+
   it("keeps completed remote turns ordered when a bounded refresh advances past them", async () => {
     const publishedTurn = {
       id: "published-turn",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -588,6 +588,191 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("keeps overlay turn usage in the tail while that turn still straddles the page boundary", async () => {
+    const splitTurn = {
+      id: "split-turn",
+      status: "completed" as const,
+      startedAt: 100,
+      completedAt: 160,
+    };
+    const recentTurn = {
+      id: "recent-turn",
+      status: "completed" as const,
+      startedAt: 400,
+      completedAt: 480,
+    };
+    const splitUsage: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-turn-usage-split-turn",
+      summary: "Turn usage: split",
+      status: "completed",
+      createdAt: 160,
+      details: [],
+      turn: splitTurn,
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "split-tail",
+            text: "Later split-turn work",
+            createdAt: 150,
+          }),
+          turn: splitTurn,
+        },
+        splitUsage,
+        {
+          ...messageEntry({
+            id: "recent-final",
+            text: "Recent answer",
+            createdAt: 480,
+          }),
+          phase: "final" as const,
+          turn: recentTurn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older-page",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "split-older",
+            text: "Earlier split-turn work",
+            createdAt: 100,
+          }),
+          turn: splitTurn,
+        },
+      ],
+      hasPreviousPage: false,
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      }),
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "split-older",
+      "split-tail",
+      splitUsage.id,
+      "recent-final",
+    ]);
+  });
+
+  it("keeps overlay turn usage that arrives after its historical turn is already loaded", async () => {
+    const olderTurn = {
+      id: "older-turn",
+      status: "completed" as const,
+      startedAt: 100,
+      completedAt: 180,
+    };
+    const recentTurn = {
+      id: "recent-turn",
+      status: "completed" as const,
+      startedAt: 400,
+      completedAt: 480,
+    };
+    const lateUsage: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-turn-usage-older-turn",
+      summary: "Turn usage: older",
+      status: "completed",
+      createdAt: 181,
+      details: [],
+      turn: olderTurn,
+    };
+    const recentFinal = {
+      ...messageEntry({
+        id: "recent-final",
+        text: "Recent answer",
+        createdAt: 480,
+      }),
+      phase: "final" as const,
+      turn: recentTurn,
+    };
+    const initialTail = readThreadResponse({
+      entries: [recentFinal],
+      hasPreviousPage: true,
+      previousCursor: "older-page",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "older-final",
+            text: "Older answer",
+            createdAt: 180,
+          }),
+          phase: "final" as const,
+          turn: olderTurn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "oldest-page",
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [lateUsage, recentFinal],
+      hasPreviousPage: true,
+      previousCursor: "older-page-again",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    expect(result.current.entries.map((entry) => entry.id)).toEqual([
+      "older-final",
+      "recent-final",
+    ]);
+
+    rerender({ updatedAt: 2_000 });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "older-final",
+        lateUsage.id,
+        "recent-final",
+      ]);
+    });
+  });
+
   it("keeps completed remote turns ordered when a bounded refresh advances past them", async () => {
     const publishedTurn = {
       id: "published-turn",

--- a/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
+++ b/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
@@ -59,6 +59,18 @@ function isRelocatableOverlayUsage(
   );
 }
 
+function transcriptAnchorTurnIds(
+  entries: readonly AppServerThreadEntry[],
+): Set<string> {
+  const turnIds = new Set<string>();
+  for (const entry of entries) {
+    if (!isRelocatableOverlayUsage(entry) && entry.turn?.id) {
+      turnIds.add(entry.turn.id);
+    }
+  }
+  return turnIds;
+}
+
 /**
  * Weave overlay usage into one already-ordered page. Matching turns are
  * inserted after the last same-turn entry in a single forward pass so a
@@ -116,14 +128,11 @@ function visibleTranscriptTailEntries(
   tailEntries: AppServerThreadEntry[],
   index: TranscriptHistoryIndex | undefined,
 ): AppServerThreadEntry[] {
-  const tailTurnIds = new Set<string>();
+  const tailTurnIds = transcriptAnchorTurnIds(tailEntries);
   let oldestTailAnchorCreatedAt: number | undefined;
   for (const entry of tailEntries) {
     if (isRelocatableOverlayUsage(entry)) {
       continue;
-    }
-    if (entry.turn?.id) {
-      tailTurnIds.add(entry.turn.id);
     }
     if (typeof entry.createdAt === "number") {
       oldestTailAnchorCreatedAt = Math.min(
@@ -144,8 +153,10 @@ function visibleTranscriptTailEntries(
     if (turnId && tailTurnIds.has(turnId)) {
       return true;
     }
+    // A later refresh can introduce usage for a turn already in immutable
+    // history. Keep that tail copy; hiding by turn id would drop it.
     if (turnId && index?.turnIds.has(turnId)) {
-      return false;
+      return true;
     }
     if (
       typeof entry.createdAt === "number"
@@ -190,7 +201,8 @@ function messagesForEntries(
  * Adds one server page without traversing or copying previously loaded pages.
  *
  * Overlay turn usage is hydrated on the latest page, so a newly loaded older
- * page merges matching usage from the tail once. Prior pages stay immutable.
+ * page merges matching usage from the tail once, and only when that turn no
+ * longer has non-usage entries in the tail. Prior pages stay immutable.
  *
  * The index is an append-only, non-rendered companion owned by one thread
  * session. Keeping it outside React state is deliberate: cloning a growing
@@ -216,6 +228,7 @@ export function prependTranscriptHistoryPage(params: {
       pageTurnIds.add(entry.turn.id);
     }
   }
+  const tailTurnIds = transcriptAnchorTurnIds(params.tailEntries);
   const relocatedUsage: AppServerThreadActivityEntry[] = [];
   if (pageTurnIds.size > 0) {
     for (const entry of params.tailEntries) {
@@ -223,6 +236,7 @@ export function prependTranscriptHistoryPage(params: {
         !isRelocatableOverlayUsage(entry)
         || !entry.turn?.id
         || !pageTurnIds.has(entry.turn.id)
+        || tailTurnIds.has(entry.turn.id)
         || params.index.entryIds.has(entry.id)
         || pageEntryIds.has(entry.id)
       ) {

--- a/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
+++ b/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerReadThreadResponse,
+  AppServerThreadActivityEntry,
   AppServerThreadEntry,
   AppServerThreadMessage,
 } from "@pwragent/shared";
@@ -34,6 +35,7 @@ export type TranscriptHistoryIndex = {
   entryIds: Set<string>;
   messageIds: Set<string>;
   review: TranscriptReviewHistoryIndex;
+  turnIds: Set<string>;
 };
 
 export function createTranscriptHistoryIndex(): TranscriptHistoryIndex {
@@ -41,7 +43,120 @@ export function createTranscriptHistoryIndex(): TranscriptHistoryIndex {
     entryIds: new Set(),
     messageIds: new Set(),
     review: createTranscriptReviewHistoryIndex(),
+    turnIds: new Set(),
   };
+}
+
+function isRelocatableOverlayUsage(
+  entry: AppServerThreadEntry,
+): entry is AppServerThreadActivityEntry {
+  return (
+    entry.type === "activity"
+    && (
+      entry.id.startsWith("live-turn-usage-")
+      || entry.summary.startsWith("Turn usage:")
+    )
+  );
+}
+
+/**
+ * Weave overlay usage into one already-ordered page. Matching turns are
+ * inserted after the last same-turn entry in a single forward pass so a
+ * history prepend stays O(page + matching usage), not a rescan of the
+ * combined transcript.
+ */
+function mergeOverlayUsageIntoEntries(
+  entries: AppServerThreadEntry[],
+  usageEntries: readonly AppServerThreadActivityEntry[],
+): AppServerThreadEntry[] {
+  if (usageEntries.length === 0) {
+    return entries;
+  }
+
+  const lastIndexByTurn = new Map<string, number>();
+  for (let index = 0; index < entries.length; index += 1) {
+    const turnId = entries[index]?.turn?.id;
+    if (turnId) {
+      lastIndexByTurn.set(turnId, index);
+    }
+  }
+
+  const usageAfterIndex = new Map<number, AppServerThreadActivityEntry[]>();
+  for (const usage of usageEntries) {
+    const turnId = usage.turn?.id;
+    const turnIndex = turnId === undefined
+      ? undefined
+      : lastIndexByTurn.get(turnId);
+    if (turnIndex === undefined) {
+      continue;
+    }
+    const bucket = usageAfterIndex.get(turnIndex);
+    if (bucket) {
+      bucket.push(usage);
+    } else {
+      usageAfterIndex.set(turnIndex, [usage]);
+    }
+  }
+  if (usageAfterIndex.size === 0) {
+    return entries;
+  }
+
+  const merged: AppServerThreadEntry[] = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    merged.push(entries[index]!);
+    const bucket = usageAfterIndex.get(index);
+    if (bucket) {
+      merged.push(...bucket);
+    }
+  }
+  return merged;
+}
+
+function visibleTranscriptTailEntries(
+  tailEntries: AppServerThreadEntry[],
+  index: TranscriptHistoryIndex | undefined,
+): AppServerThreadEntry[] {
+  const tailTurnIds = new Set<string>();
+  let oldestTailAnchorCreatedAt: number | undefined;
+  for (const entry of tailEntries) {
+    if (isRelocatableOverlayUsage(entry)) {
+      continue;
+    }
+    if (entry.turn?.id) {
+      tailTurnIds.add(entry.turn.id);
+    }
+    if (typeof entry.createdAt === "number") {
+      oldestTailAnchorCreatedAt = Math.min(
+        oldestTailAnchorCreatedAt ?? entry.createdAt,
+        entry.createdAt,
+      );
+    }
+  }
+
+  const filtered = tailEntries.filter((entry) => {
+    if (!isRelocatableOverlayUsage(entry)) {
+      return true;
+    }
+    if (index?.entryIds.has(entry.id)) {
+      return false;
+    }
+    const turnId = entry.turn?.id;
+    if (turnId && tailTurnIds.has(turnId)) {
+      return true;
+    }
+    if (turnId && index?.turnIds.has(turnId)) {
+      return false;
+    }
+    if (
+      typeof entry.createdAt === "number"
+      && oldestTailAnchorCreatedAt !== undefined
+      && entry.createdAt < oldestTailAnchorCreatedAt
+    ) {
+      return false;
+    }
+    return true;
+  });
+  return filtered.length === tailEntries.length ? tailEntries : filtered;
 }
 
 function messagesForEntries(
@@ -74,6 +189,9 @@ function messagesForEntries(
 /**
  * Adds one server page without traversing or copying previously loaded pages.
  *
+ * Overlay turn usage is hydrated on the latest page, so a newly loaded older
+ * page merges matching usage from the tail once. Prior pages stay immutable.
+ *
  * The index is an append-only, non-rendered companion owned by one thread
  * session. Keeping it outside React state is deliberate: cloning a growing
  * Set here would merely move the cumulative history copy from the entry array
@@ -86,16 +204,46 @@ export function prependTranscriptHistoryPage(params: {
   tailEntries: AppServerThreadEntry[];
 }): LoadedTranscriptHistory {
   const tailEntryIds = new Set(params.tailEntries.map((entry) => entry.id));
-  const entries = params.page.replay.entries.filter(
+  const historicalEntries = params.page.replay.entries.filter(
     (entry) =>
       !tailEntryIds.has(entry.id)
       && !params.index.entryIds.has(entry.id),
+  );
+  const pageEntryIds = new Set(historicalEntries.map((entry) => entry.id));
+  const pageTurnIds = new Set<string>();
+  for (const entry of historicalEntries) {
+    if (entry.turn?.id) {
+      pageTurnIds.add(entry.turn.id);
+    }
+  }
+  const relocatedUsage: AppServerThreadActivityEntry[] = [];
+  if (pageTurnIds.size > 0) {
+    for (const entry of params.tailEntries) {
+      if (
+        !isRelocatableOverlayUsage(entry)
+        || !entry.turn?.id
+        || !pageTurnIds.has(entry.turn.id)
+        || params.index.entryIds.has(entry.id)
+        || pageEntryIds.has(entry.id)
+      ) {
+        continue;
+      }
+      relocatedUsage.push(entry);
+      pageEntryIds.add(entry.id);
+    }
+  }
+  const entries = mergeOverlayUsageIntoEntries(
+    historicalEntries,
+    relocatedUsage,
   );
   const messages = messagesForEntries(entries, params.page.replay.messages);
   const reviewSummary = summarizeTranscriptReviewSegment(entries, messages);
 
   for (const entry of entries) {
     params.index.entryIds.add(entry.id);
+    if (entry.turn?.id) {
+      params.index.turnIds.add(entry.turn.id);
+    }
   }
   for (const message of messages) {
     params.index.messageIds.add(message.id);
@@ -436,10 +584,11 @@ export function combineTranscriptEntries(
     "excludedHistoryEntryIds" | "historyEntryOverrides"
   >,
 ): AppServerThreadEntry[] {
+  const displayTail = visibleTranscriptTailEntries(tailEntries, index);
   if (!history?.oldestPage || !index) {
-    return tailEntries;
+    return displayTail;
   }
-  const excludedHistoryIds = historyOverlapIds(tailEntries, index.entryIds);
+  const excludedHistoryIds = historyOverlapIds(displayTail, index.entryIds);
   for (const id of presentation?.excludedHistoryEntryIds ?? []) {
     excludedHistoryIds.add(id);
   }
@@ -450,7 +599,7 @@ export function combineTranscriptEntries(
     historyPage: history.oldestPage,
     itemOverrides: presentation?.historyEntryOverrides,
     pageItems: (page) => page.entries,
-    tail: tailEntries,
+    tail: displayTail,
   });
 }
 


### PR DESCRIPTION
## Summary

Opening a long thread hydrates only the latest Codex page, then dumps **every** persisted Turn Usage overlay into that tail. Scrolling back prepended older provider messages above that clump without merging the two sources, so Aug 3 usage sat under an Aug 5 review (reproduced on `135 MB Test - MCP registration for Codex and ACP`).

- Hide overlay turn usage whose turns are not in the loaded window yet, so the latest page no longer shows every historical usage card.
- When an older history page is prepended, merge matching overlay usage into that page once (`O(page + matching usage)`), after the last same-turn entry.
- Keep prior history pages immutable. The live tail stays the latest window; relocated usage is excluded from it so the history copy wins.

## Test plan

- [x] `pnpm test apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- [ ] Open a long thread with many Turn Usage cards, scroll back, and confirm usage sits with its turn instead of in a clump under later messages / environment setup.
- [ ] Confirm live/recent turn usage in the latest window is unchanged.