### PR TITLE
refactor(desktop): give thread information its own store

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -96,6 +96,7 @@ const federationMock = vi.hoisted(() => {
     })),
     getWorktreeUnpublishedCommitDiff: vi.fn(async () => ({})),
   };
+  let nextThreadNameObservation = 0;
   const remoteThreadSummaries = {
     resolvePinnedThreads: vi.fn(
       async (): Promise<{
@@ -111,6 +112,7 @@ const federationMock = vi.hoisted(() => {
     searchForJump: vi.fn(async () => ({ results: [] })),
     threadFromPeer: vi.fn(async (): Promise<unknown> => undefined),
     rememberThreadNames: vi.fn(),
+    reserveThreadNameObservation: vi.fn(() => (nextThreadNameObservation += 1)),
     invalidate: vi.fn(),
   };
   return {
@@ -1968,6 +1970,11 @@ describe("app server ipc", () => {
         executionMode: "default" as const,
       },
     };
+    // These three carry calls over from earlier cases, and the assertions below
+    // read call zero rather than any call.
+    federationMock.runtime.remoteNavigationSnapshot.mockClear();
+    federationMock.remoteThreadSummaries.rememberThreadNames.mockClear();
+    federationMock.remoteThreadSummaries.reserveThreadNameObservation.mockClear();
     federationMock.runtime.remoteNavigationSnapshot
       .mockResolvedValueOnce(snapshot)
       .mockResolvedValueOnce(snapshot);
@@ -1976,9 +1983,21 @@ describe("app server ipc", () => {
     const handler = handlers.get(NAVIGATION_SNAPSHOT_CHANNEL);
 
     await expect(handler?.({}, { federationTarget })).resolves.toBe(snapshot);
+    const reserve =
+      federationMock.remoteThreadSummaries.reserveThreadNameObservation;
     expect(
       federationMock.remoteThreadSummaries.rememberThreadNames,
-    ).toHaveBeenCalledWith("peer_remembers_names", snapshot.threads);
+    ).toHaveBeenCalledWith(
+      "peer_remembers_names",
+      snapshot.threads,
+      reserve.mock.results[0]?.value,
+    );
+    // The sequence is taken before the peer is asked, so a snapshot that
+    // starts first and finishes last cannot revert a newer refresh's names.
+    expect(reserve.mock.invocationCallOrder[0]).toBeLessThan(
+      federationMock.runtime.remoteNavigationSnapshot.mock
+        .invocationCallOrder[0],
+    );
 
     federationMock.remoteThreadSummaries.rememberThreadNames.mockImplementationOnce(
       () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18229,6 +18229,9 @@ command = "pnpm dev"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: ["codex:thread-reattached"],
+      threadTitles: {
+        "codex:thread-reattached": "Still working after HMR",
+      },
     });
     await expect(
       registry.startTurn({
@@ -18348,6 +18351,9 @@ command = "pnpm dev"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: ["codex:thread-stale-active"],
+      threadTitles: {
+        "codex:thread-stale-active": "Finished remotely",
+      },
     });
 
     await registry.close();
@@ -18631,6 +18637,334 @@ command = "pnpm dev"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 2,
       threadIds: ["acp:grok:acp-thread-1", "codex:thread-1"],
+    });
+
+    await registry.close();
+  });
+
+  it("names ordinary quit blockers from cached metadata without provider refreshes", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "thread-named-quit",
+          title: "Resolve quit titles from memory",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const enrichThreadDirectories = vi.fn(async (threads) => threads);
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+      enrichDirectories: false,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-named-quit",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    const providerReadsBeforeQuit = codexClient.listThreadsCallCount;
+
+    for (let poll = 0; poll < 4; poll += 1) {
+      expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+        count: 1,
+        threadIds: ["codex:thread-named-quit"],
+        threadTitles: {
+          "codex:thread-named-quit": "Resolve quit titles from memory",
+        },
+      });
+    }
+
+    expect(codexClient.listThreadsCallCount).toBe(providerReadsBeforeQuit);
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-named-quit",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
+
+    await registry.close();
+  });
+
+  it("keeps a newer quit title when an invalidated older list finishes late", async () => {
+    const listThreadsDelay = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      listThreadsDelay: listThreadsDelay.promise,
+      threads: [
+        {
+          id: "thread-late-quit-title",
+          title: "Old provider title",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    const staleList = registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    await waitForCondition(() => codexClient.listThreadsCallCount === 1);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-late-quit-title",
+          threadName: "New explicit rename",
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-late-quit-title",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-late-quit-title"],
+      threadTitles: {
+        "codex:thread-late-quit-title": "New explicit rename",
+      },
+    });
+
+    listThreadsDelay.resolve();
+    await staleList;
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-late-quit-title"],
+      threadTitles: {
+        "codex:thread-late-quit-title": "New explicit rename",
+      },
+    });
+    expect(codexClient.listThreadsCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("never downgrades a known quit title for fallback or missing list rows", async () => {
+    const threadId = "thread-monotonic-quit-title";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: threadId,
+          title: "Known display title",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    await registry.listThreads({ backend: "codex", enrichDirectories: false });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId,
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    codexClient.setThreads([
+      {
+        id: threadId,
+        title: threadId,
+        titleSource: "fallback",
+        linkedDirectories: [],
+        source: "codex",
+      },
+    ]);
+    await registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    codexClient.setThreads([]);
+    await registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [`codex:${threadId}`],
+      threadTitles: {
+        [`codex:${threadId}`]: "Known display title",
+      },
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId,
+          threadName: "Newer renamed title",
+        },
+      },
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [`codex:${threadId}`],
+      threadTitles: {
+        [`codex:${threadId}`]: "Newer renamed title",
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("keeps a known quit title when a background provider list fails", async () => {
+    const threadId = "thread-failed-list-quit-title";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      listThreadsError: new Error("provider list unavailable"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId,
+          threadName: "Known before provider failure",
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId,
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        enrichDirectories: false,
+        forceRefresh: true,
+      }),
+    ).resolves.toEqual([]);
+    expect(codexClient.listThreadsCallCount).toBe(1);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [`codex:${threadId}`],
+      threadTitles: {
+        [`codex:${threadId}`]: "Known before provider failure",
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("keeps cached quit titles qualified when backends reuse a thread id", async () => {
+    const threadId = "shared-thread-id";
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    for (const [backend, threadName] of [
+      ["codex", "Local Codex work"],
+      ["acp:grok", "Local Grok work"],
+    ] as const) {
+      const turnId = backend === "codex" ? "turn-codex" : "turn-grok";
+      await registry.publishLocalEvent({
+        backend,
+        notification: {
+          method: "thread/name/updated",
+          params: { threadId, threadName },
+        },
+      });
+      await registry.publishLocalEvent({
+        backend,
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId,
+            turnId,
+            turn: { id: turnId },
+          },
+        },
+      });
+    }
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 2,
+      threadIds: ["acp:grok:shared-thread-id", "codex:shared-thread-id"],
+      threadTitles: {
+        "acp:grok:shared-thread-id": "Local Grok work",
+        "codex:shared-thread-id": "Local Codex work",
+      },
     });
 
     await registry.close();
@@ -29015,6 +29349,9 @@ script = "printf setup"
       expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
         count: 1,
         threadIds: ["codex:ordinary-thread"],
+        threadTitles: {
+          "codex:ordinary-thread": "Parent Thread",
+        },
       });
     });
 
@@ -29680,6 +30017,9 @@ script = "printf setup"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: [buildThreadIdentityKey("codex", "ordinary-thread")],
+      threadTitles: {
+        [buildThreadIdentityKey("codex", "ordinary-thread")]: "Parent Thread",
+      },
     });
 
     await registry.publishLocalEvent({
@@ -29843,6 +30183,9 @@ script = "printf setup"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: [buildThreadIdentityKey("codex", "ordinary-thread")],
+      threadTitles: {
+        [buildThreadIdentityKey("codex", "ordinary-thread")]: "Parent Thread",
+      },
     });
 
     await registry.publishLocalEvent({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2917,6 +2917,76 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("coalesces targeted directory refreshes while the first probe is pending", async () => {
+    let finishProbe: (() => void) | undefined;
+    const probeGate = new Promise<void>((resolve) => {
+      finishProbe = resolve;
+    });
+    const readDirectoryStatusEntries = vi.fn(
+      (directories: Array<{ key: string }>) =>
+        (async function* () {
+          await probeGate;
+          yield {
+            directoryKey: directories[0]!.key,
+            gitStatus: {
+              currentBranch: "main",
+              syncState: "in-sync" as const,
+            },
+          };
+        })(),
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        invalidateDirectoryStatus: vi.fn(),
+        readDirectoryStatusEntries,
+      } as never,
+    });
+    const writeDirectoryGitStatus = vi.fn(async () => undefined);
+    registry.setDirectoryGitStatusWriter(writeDirectoryGitStatus);
+    registry.rememberCompleteNavigationSnapshot({
+      backend: "all",
+      directories: [
+        {
+          key: "directory:/owner/repo",
+          kind: "directory",
+          label: "repo",
+          path: "/owner/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      fetchedAt: 1_000,
+      inboxThreadKeys: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+      threads: [],
+      unchanged: false,
+    });
+
+    try {
+      await expect(registry.refreshDirectoryGitStatuses({
+        directoryKeys: ["directory:/owner/repo"],
+        force: true,
+      })).resolves.toEqual({ scheduledCount: 1 });
+      await expect(registry.refreshDirectoryGitStatuses({
+        directoryKeys: ["directory:/owner/repo"],
+        force: true,
+      })).resolves.toEqual({ scheduledCount: 0 });
+      expect(writeDirectoryGitStatus).not.toHaveBeenCalled();
+
+      finishProbe?.();
+      await vi.waitFor(() => {
+        expect(writeDirectoryGitStatus).toHaveBeenCalledOnce();
+      });
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("hydrates review working state from the shared navigation cache", async () => {
     const worktreePath = "/worktrees/PwrAgnt";
     const gitWorkingState = {

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -7,6 +7,7 @@ import type {
   AppServerThreadReplay,
   CreateScheduledThreadActionRequest,
   NavigationSnapshot,
+  ThreadOverlayState,
 } from "@pwragent/shared";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
@@ -15,7 +16,15 @@ import {
   type DesktopMessagingFederationBridge,
 } from "../messaging/desktop-backend-bridge";
 
-const { reconcileNavigationSnapshot } = vi.hoisted(() => ({
+const {
+  getThreadOverlayState,
+  readDirectoryGitStatusCache,
+  reconcileNavigationSnapshot,
+} = vi.hoisted(() => ({
+  getThreadOverlayState: vi.fn(
+    async (): Promise<ThreadOverlayState | undefined> => undefined,
+  ),
+  readDirectoryGitStatusCache: vi.fn(async () => ({})),
   reconcileNavigationSnapshot: vi.fn(async (params: {
     backend: NavigationSnapshot["backend"];
     fetchedAt: number;
@@ -38,7 +47,11 @@ const { reconcileNavigationSnapshot } = vi.hoisted(() => ({
 }));
 
 vi.mock("../app-server/desktop-overlay-store", () => ({
-  getDesktopOverlayStore: () => ({ reconcileNavigationSnapshot }),
+  getDesktopOverlayStore: () => ({
+    getThreadOverlayState,
+    readDirectoryGitStatusCache,
+    reconcileNavigationSnapshot,
+  }),
 }));
 
 const { hydrateLaunchpadCodexEnvironmentOptions } = vi.hoisted(() => ({
@@ -62,6 +75,245 @@ vi.mock("../app-server/codex-environment-config", () => ({
 }));
 
 describe("DesktopMessagingBackendBridge", () => {
+  it("resolves admission state from one thread cache and overlay only", async () => {
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      fastMode: true,
+      handoffOrigin: {
+        sourceBackend: "codex",
+        sourceThreadId: "parent-1",
+        seedMode: "clean",
+        groupingMode: "none",
+        createdAt: 1_000,
+        workspace: {
+          mode: "same",
+          cwd: "/repos/PwrAgnt",
+          git: {
+            kind: "git_local",
+            worktreeCreationAvailable: true,
+          },
+        },
+      },
+      model: "gpt-5.5",
+    });
+    const getCachedThreadSummary = vi.fn(() => ({
+      id: "thread-1",
+      title: "Cached thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      executionMode: "full-access" as const,
+      threadStatus: "idle" as const,
+    }));
+    const listThreads = vi.fn(async () => []);
+    const readDirectoryStatuses = vi.fn(async () => ({}));
+    const registry = {
+      getActiveTurnForThread: vi.fn(() => ({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-live",
+      })),
+      getCachedThreadSummary,
+      isThreadTurnOccupied: vi.fn(() => true),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({
+        "codex:thread-1": { mode: "full-access", queuedAt: 2_000 },
+      })),
+      getQueuedTurnsSnapshot: vi.fn(() => ({
+        "codex:thread-1": [
+          {
+            queueEntryId: "queue-1",
+            origin: "messaging",
+            displayText: "queued reply",
+            createdAt: 2_100,
+            position: 0,
+          },
+        ],
+      })),
+      listThreads,
+      readDirectoryStatuses,
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const state = await bridge.getThreadAdmissionState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(state).toMatchObject({
+      activeTurn: { turnId: "turn-live" },
+      threadStatus: "active",
+      thread: {
+        executionMode: "default",
+        fastMode: true,
+        handoffOrigin: { sourceThreadId: "parent-1" },
+        model: "gpt-5.5",
+        queuedExecutionMode: "full-access",
+        queuedTurns: [{ queueEntryId: "queue-1" }],
+        title: "Cached thread",
+      },
+    });
+    expect(getCachedThreadSummary).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(listThreads).not.toHaveBeenCalled();
+    expect(readDirectoryStatuses).not.toHaveBeenCalled();
+  });
+
+  it("preserves overlay branch metadata when the thread summary cache is cold", async () => {
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-cold",
+      extraLinkedDirectories: [
+        {
+          id: "directory:/repos/PwrAgnt",
+          kind: "local",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+        },
+      ],
+      gitBranch: "feature/cache-owner",
+      observedGitBranch: "feature/cache-owner-observed",
+    });
+    const registry = {
+      getActiveTurnForThread: vi.fn(() => undefined),
+      getCachedThreadSummary: vi.fn(() => undefined),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      isThreadTurnOccupied: vi.fn(() => false),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    await expect(bridge.getThreadAdmissionState({
+      backend: "codex",
+      threadId: "thread-cold",
+    })).resolves.toMatchObject({
+      thread: {
+        gitBranch: "feature/cache-owner",
+        observedGitBranch: "feature/cache-owner-observed",
+        linkedDirectories: [
+          expect.objectContaining({ path: "/repos/PwrAgnt" }),
+        ],
+      },
+      threadStatus: "idle",
+    });
+  });
+
+  it("serves cached directory status without awaiting a fleet refresh", async () => {
+    const cachedGitStatus = {
+      currentBranch: "main",
+      syncState: "in-sync" as const,
+    };
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repos/PwrAgnt",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    readDirectoryGitStatusCache.mockResolvedValueOnce({
+      "directory:/repos/PwrAgnt": {
+        directoryKey: "directory:/repos/PwrAgnt",
+        directoryPath: "/repos/PwrAgnt",
+        fetchedAt: Date.now(),
+        gitStatus: cachedGitStatus,
+      },
+    });
+    const readDirectoryStatuses = vi.fn(async () => ({}));
+    const refreshDirectoryGitStatuses = vi.fn(async () => ({ scheduledCount: 0 }));
+    const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      hydrateThreadGitWorkingStates: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      listThreads: vi.fn(async () => []),
+      readDirectoryStatuses,
+      refreshDirectoryGitStatuses,
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const snapshot = await bridge.getNavigationSnapshot({});
+
+    expect(snapshot.directories[0]?.gitStatus).toEqual(cachedGitStatus);
+    expect(readDirectoryStatuses).not.toHaveBeenCalled();
+  });
+
+  it("returns a broad snapshot before its stale directory batch finishes", async () => {
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repos/PwrAgnt",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    readDirectoryGitStatusCache.mockResolvedValueOnce({});
+    let finishRefresh: (() => void) | undefined;
+    const refreshDirectoryGitStatuses = vi.fn(
+      async () => await new Promise<{ scheduledCount: number }>((resolve) => {
+        finishRefresh = () => resolve({ scheduledCount: 1 });
+      }),
+    );
+    const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      hydrateThreadGitWorkingStates: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      listThreads: vi.fn(async () => []),
+      refreshDirectoryGitStatuses,
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    await expect(bridge.getNavigationSnapshot({})).resolves.toMatchObject({
+      directories: [{ key: "directory:/repos/PwrAgnt" }],
+    });
+    expect(refreshDirectoryGitStatuses).toHaveBeenCalledExactlyOnceWith({
+      directoryKeys: ["directory:/repos/PwrAgnt"],
+      force: false,
+    });
+    finishRefresh?.();
+  });
+
   it("hydrates review working state before the messenger chooses a project", async () => {
     const pwrAgentWorktree = "/worktrees/PwrAgnt";
     const listedThread: AppServerThreadSummary = {
@@ -748,6 +1000,17 @@ describe("DesktopMessagingBackendBridge", () => {
       },
     };
     const remoteNavigationSnapshot = vi.fn(async () => remoteNavigation);
+    const resolveThreadAdmissionState = vi.fn(async () => ({
+      thread: {
+        id: "thread-1",
+        title: "Remote thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+      threadStatus: "idle" as const,
+    }));
     const listBackends = vi.fn(async () => ({
       fetchedAt: 2_000,
       backends: [
@@ -787,6 +1050,7 @@ describe("DesktopMessagingBackendBridge", () => {
         createScheduledThreadAction,
         listBackends,
         listScheduledThreadActions,
+        resolveThreadAdmissionState,
         startTurn,
       } as unknown as FederationBackendOperations),
       remoteNavigationSnapshot,
@@ -813,6 +1077,25 @@ describe("DesktopMessagingBackendBridge", () => {
         federationTarget: target,
       }),
     ).resolves.toBe(remoteNavigation);
+    await expect(
+      bridge.getThreadAdmissionState({
+        backend: "codex",
+        federationTarget: target,
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      thread: {
+        id: "thread-1",
+        federation: {
+          instanceLabel: "client_one",
+          ref: {
+            backend: "codex",
+            threadId: "thread-1",
+            target: { scope: "remote", instanceId: "client_one" },
+          },
+        },
+      },
+    });
     await expect(
       bridge.listBackends({
         includeUnavailable: true,
@@ -848,6 +1131,10 @@ describe("DesktopMessagingBackendBridge", () => {
       backend: "all",
       federationTarget: target,
     });
+    expect(resolveThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
     expect(listBackends).toHaveBeenCalledWith({
       includeUnavailable: true,
     });
@@ -864,6 +1151,83 @@ describe("DesktopMessagingBackendBridge", () => {
       backend: "codex",
       threadId: "thread-1",
     });
+  });
+
+  it("falls back to remote navigation when an older peer lacks targeted admission", async () => {
+    const methodNotFound = Object.assign(
+      new Error("Unknown federation method: resolve_thread_admission_state"),
+      { code: "method_not_found" },
+    );
+    const resolveThreadAdmissionState = vi.fn(async () => {
+      throw methodNotFound;
+    });
+    const remoteNavigation: NavigationSnapshot = {
+      backend: "codex",
+      fetchedAt: 2_000,
+      unchanged: false,
+      threads: [
+        {
+          id: "thread-1",
+          title: "Remote thread",
+          titleSource: "explicit",
+          source: "codex",
+          threadStatus: "active",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      ],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const remoteNavigationSnapshot = vi.fn(async () => remoteNavigation);
+    const target = { scope: "remote" as const, instanceId: "legacy_peer" };
+    const federation = {
+      connectedPeerTargets: () => [
+        {
+          capabilities: ["messaging_route"],
+          label: "Legacy Peer",
+          target,
+        },
+      ],
+      onRemoteBackendEvent: () => () => undefined,
+      remoteBackend: () => ({
+        resolveThreadAdmissionState,
+      } as unknown as FederationBackendOperations),
+      remoteNavigationSnapshot,
+    } as unknown as DesktopMessagingFederationBridge;
+    const bridge = new DesktopMessagingBackendBridge(
+      {} as DesktopBackendRegistry,
+      federation,
+    );
+
+    await expect(
+      bridge.getThreadAdmissionState({
+        backend: "codex",
+        federationTarget: target,
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      thread: {
+        id: "thread-1",
+        federation: { instanceLabel: "Legacy Peer" },
+      },
+      threadStatus: "active",
+    });
+    expect(remoteNavigationSnapshot).toHaveBeenCalledWith(
+      target,
+      {
+        backend: "codex",
+        federationTarget: target,
+      },
+      {
+        kind: "threads",
+        threads: [{ backend: "codex", threadId: "thread-1" }],
+      },
+    );
   });
 
   it("subscribes messaging controllers to local and remote backend events", async () => {

--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -1328,6 +1328,9 @@ async function createControllerHarness(options: {
     authorizedActorIds: [DISCORD_USER_ID],
     backend: {
       getNavigationSnapshot,
+      getThreadAdmissionState: async () => ({
+        thread: (options.navigationSnapshot ?? buildNavigationSnapshot()).threads[0],
+      }),
       startTurn,
     },
     inputDebounceMs: 0,

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -219,6 +219,64 @@ describe("federation backend bridge", () => {
     ).toBe("launchpad_metadata");
   });
 
+  it("routes targeted admission state through messaging_route", async () => {
+    const resolveThreadAdmissionState = vi.fn(async () => ({
+      threadStatus: "active" as const,
+      activeTurn: {
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+    }));
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["messaging_route"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        resolveThreadAdmissionState,
+      } as unknown as FederationBackendOperations,
+    });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "admission-state",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState,
+        params: { backend: "codex", threadId: "thread-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState
+      ],
+    ).toBe("messaging_route");
+    expect(resolveThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(replies).toContainEqual(
+      expect.objectContaining({
+        kind: "response",
+        requestId: "admission-state",
+        result: expect.objectContaining({ threadStatus: "active" }),
+      }),
+    );
+  });
+
   it("does not expose profile-local thread model migrations over federation", () => {
     expect(FEDERATION_BACKEND_METHODS).not.toHaveProperty(
       "applyThreadModelMigration",

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budget.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budget.ts
@@ -1,0 +1,106 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect } from "vitest";
+
+/**
+ * Checked-in provider-read budgets for thread information, asserted per
+ * scenario.
+ *
+ * A thread-list walk is the most expensive read PwrAgent makes: it pages the
+ * provider, and for most caller reasons it then enriches every row with git and
+ * directory work. Nothing counted these, so the cost of answering "what is this
+ * thread called" grew a caller at a time and only ever surfaced as a UI symptom
+ * — a quit dialog showing uuids, a sidebar row flickering — long after the read
+ * that caused it.
+ *
+ * These budgets make each flow's read cost a reviewable number. A scenario
+ * records provider `thread/list` calls and directory-enrichment passes, both
+ * pure functions of the code path, so they are identical on every machine.
+ *
+ * To change a budget deliberately, run with `UPDATE_THREAD_READ_BUDGETS=1` and
+ * commit the diff, so the reviewer sees the read cost change as a line in the
+ * PR instead of never seeing it at all.
+ */
+const BUDGETS_PATH = path.join(import.meta.dirname, "thread-read-budgets.json");
+
+export type ThreadReadCounts = {
+  /** Directory/git enrichment passes over a listing. */
+  directoryEnrichments: number;
+  /** Provider `thread/list` round trips. */
+  providerListCalls: number;
+};
+
+type Budget = ThreadReadCounts & { note: string };
+
+type BudgetFile = Record<string, Budget>;
+
+export function expectThreadReadBudget(params: {
+  note: string;
+  reads: ThreadReadCounts;
+  scenario: string;
+}): void {
+  const budgets = readBudgets();
+  const measured: Budget = {
+    directoryEnrichments: params.reads.directoryEnrichments,
+    note: params.note,
+    providerListCalls: params.reads.providerListCalls,
+  };
+
+  if (process.env.UPDATE_THREAD_READ_BUDGETS) {
+    budgets[params.scenario] = measured;
+    writeFileSync(
+      BUDGETS_PATH,
+      `${JSON.stringify(sortKeys(budgets), null, 2)}\n`,
+    );
+    return;
+  }
+
+  const budget = budgets[params.scenario];
+  if (!budget) {
+    throw new Error(
+      `No thread read budget recorded for "${params.scenario}".\n`
+        + `Measured ${describe(measured)}.\n`
+        + "Record it with UPDATE_THREAD_READ_BUDGETS=1 and commit the result.",
+    );
+  }
+
+  // Deviation in either direction fails. An increase is the regression this
+  // exists to catch; a decrease means the budget is stale and would stop
+  // catching anything, so it has to be lowered on purpose.
+  expect(
+    {
+      directoryEnrichments: measured.directoryEnrichments,
+      providerListCalls: measured.providerListCalls,
+    },
+    `thread read budget "${params.scenario}" changed.\n`
+      + `  budget:   ${describe(budget)}\n`
+      + `  measured: ${describe(measured)}\n`
+      + "If this is intended, re-record with UPDATE_THREAD_READ_BUDGETS=1 and\n"
+      + "explain the change in the commit message. If it is not, you have added\n"
+      + "provider thread reads to a path that is measured for a reason.",
+  ).toEqual({
+    directoryEnrichments: budget.directoryEnrichments,
+    providerListCalls: budget.providerListCalls,
+  });
+}
+
+function describe(budget: Budget): string {
+  return (
+    `${budget.providerListCalls} provider thread/list calls, `
+    + `${budget.directoryEnrichments} directory enrichments`
+  );
+}
+
+function readBudgets(): BudgetFile {
+  try {
+    return JSON.parse(readFileSync(BUDGETS_PATH, "utf8")) as BudgetFile;
+  } catch {
+    return {};
+  }
+}
+
+function sortKeys(budgets: BudgetFile): BudgetFile {
+  return Object.fromEntries(
+    Object.entries(budgets).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
@@ -9,6 +9,11 @@
     "note": "50 synchronous label lookups for a thread already observed once",
     "providerListCalls": 0
   },
+  "messaging-admission-after-invalidation": {
+    "directoryEnrichments": 0,
+    "note": "messaging admission for a listed thread whose list cache was invalidated",
+    "providerListCalls": 0
+  },
   "quit-dialog-poll": {
     "directoryEnrichments": 0,
     "note": "20 quit-dialog polls against an in-progress turn, all served from observed metadata",

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
@@ -14,9 +14,34 @@
     "note": "20 quit-dialog polls against an in-progress turn, all served from observed metadata",
     "providerListCalls": 0
   },
+  "second-window-navigation": {
+    "directoryEnrichments": 0,
+    "note": "a second window's navigation refresh and label reads against a warm list cache",
+    "providerListCalls": 0
+  },
+  "ten-turns-warm-thread": {
+    "directoryEnrichments": 0,
+    "note": "ten complete turns on a thread the navigation refresh already observed",
+    "providerListCalls": 0
+  },
+  "terminal-notification-burst": {
+    "directoryEnrichments": 0,
+    "note": "eight terminal notifications across two threads neither of which was ever listed",
+    "providerListCalls": 1
+  },
   "turn-lifecycle-label-reads": {
     "directoryEnrichments": 0,
     "note": "five complete turns with label reads between every lifecycle event",
+    "providerListCalls": 0
+  },
+  "worktree-navigation-refresh": {
+    "directoryEnrichments": 1,
+    "note": "one navigation refresh over a single worktree-backed thread",
+    "providerListCalls": 1
+  },
+  "worktree-turns-after-enrichment": {
+    "directoryEnrichments": 0,
+    "note": "five turns on an already-enriched worktree thread",
     "providerListCalls": 0
   }
 }

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
@@ -1,0 +1,22 @@
+{
+  "concurrent-identical-listings": {
+    "directoryEnrichments": 0,
+    "note": "six concurrent callers asking for the same unenriched Codex listing",
+    "providerListCalls": 1
+  },
+  "known-thread-label-lookups": {
+    "directoryEnrichments": 0,
+    "note": "50 synchronous label lookups for a thread already observed once",
+    "providerListCalls": 0
+  },
+  "quit-dialog-poll": {
+    "directoryEnrichments": 0,
+    "note": "20 quit-dialog polls against an in-progress turn, all served from observed metadata",
+    "providerListCalls": 0
+  },
+  "turn-lifecycle-label-reads": {
+    "directoryEnrichments": 0,
+    "note": "five complete turns with label reads between every lifecycle event",
+    "providerListCalls": 0
+  }
+}

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
@@ -1,0 +1,155 @@
+import { vi } from "vitest";
+import type {
+  AppServerBackendKind,
+  AppServerNotification,
+  AppServerThreadSummary,
+} from "@pwragent/shared";
+import { DesktopBackendRegistry } from "../../app-server/backend-registry";
+import type { ThreadReadCounts } from "./thread-read-budget";
+
+/**
+ * A backend client that serves a fixed thread list and counts what it cost.
+ *
+ * The registry is the unit under test here, not the provider, so this client
+ * does the least a registry needs: answer `thread/list`, accept a notification
+ * listener, and record every read. `listCalls` keeps the caller reason of each
+ * round trip, which is what makes a budget failure diagnosable — the count says
+ * a read was added, the reasons say which caller added it.
+ */
+export class CountingBackendClient {
+  readonly listCalls: Array<{
+    callerReason?: string;
+    params?: Record<string, unknown>;
+  }> = [];
+  directoryEnrichmentCallCount = 0;
+  /** Resolves before each listing completes, for late-completion ordering. */
+  listGate?: Promise<unknown>;
+  /** Rejects the next listing, standing in for an unavailable provider. */
+  failNextList = false;
+  private readonly notificationListeners = new Set<
+    (notification: AppServerNotification) => unknown
+  >();
+
+  constructor(private threads: AppServerThreadSummary[]) {}
+
+  get counts(): ThreadReadCounts {
+    return {
+      directoryEnrichments: this.directoryEnrichmentCallCount,
+      providerListCalls: this.listCalls.length,
+    };
+  }
+
+  /** Replace what the provider reports, as an external change would. */
+  setThreads(threads: AppServerThreadSummary[]): void {
+    this.threads = threads;
+  }
+
+  resetCounts(): void {
+    this.listCalls.length = 0;
+    this.directoryEnrichmentCallCount = 0;
+  }
+
+  async close(): Promise<void> {}
+
+  async getInitializeResult(): Promise<unknown> {
+    return { methods: ["thread/list", "turn/start"] };
+  }
+
+  onNotification(
+    listener: (notification: AppServerNotification) => unknown,
+  ): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onPendingRequest(): () => void {
+    return () => {};
+  }
+
+  async listThreads(
+    params?: Record<string, unknown>,
+    diagnostics?: { callerReason?: string },
+  ): Promise<AppServerThreadSummary[]> {
+    this.listCalls.push({
+      ...(diagnostics?.callerReason
+        ? { callerReason: diagnostics.callerReason }
+        : {}),
+      ...(params ? { params } : {}),
+    });
+    if (this.listGate) {
+      await this.listGate;
+    }
+    if (this.failNextList) {
+      this.failNextList = false;
+      throw new Error("provider unavailable");
+    }
+    return this.threads;
+  }
+
+  async enrichThreadDirectories(
+    threads: AppServerThreadSummary[],
+  ): Promise<AppServerThreadSummary[]> {
+    this.directoryEnrichmentCallCount += 1;
+    return threads;
+  }
+}
+
+export function codexThread(
+  overrides: Partial<AppServerThreadSummary> & { id: string },
+): AppServerThreadSummary {
+  return {
+    linkedDirectories: [],
+    source: "codex",
+    title: overrides.id,
+    titleSource: "fallback",
+    updatedAt: 1_000,
+    ...overrides,
+  } as AppServerThreadSummary;
+}
+
+/**
+ * The overlay store surface the registry touches on read paths. Everything the
+ * thread-read budgets exercise is a listing or a lookup, so a permissive stub
+ * that answers "nothing recorded" keeps these tests about provider reads rather
+ * than about sqlite fixtures.
+ */
+function overlayStoreStub(): Record<string, unknown> {
+  return new Proxy(
+    {},
+    {
+      get: (_target, property) => {
+        if (property === "then") {
+          return undefined;
+        }
+        const name = String(property);
+        return vi.fn(async () => {
+          if (name.startsWith("list")) return [];
+          if (name.endsWith("States")) return {};
+          return undefined;
+        });
+      },
+    },
+  ) as Record<string, unknown>;
+}
+
+export function createThreadReadRegistry(threads: AppServerThreadSummary[]): {
+  client: CountingBackendClient;
+  registry: DesktopBackendRegistry;
+} {
+  const client = new CountingBackendClient(threads);
+  const registry = new DesktopBackendRegistry({
+    codexClient: client as never,
+    overlayStore: overlayStoreStub() as never,
+    threadTitleGenerationService: null,
+  });
+  return { client, registry };
+}
+
+/** Publish a provider notification the way a live backend would. */
+export async function publishNotification(
+  registry: DesktopBackendRegistry,
+  notification: AppServerNotification,
+  backend: AppServerBackendKind = "codex",
+): Promise<void> {
+  await registry.publishLocalEvent({ backend, notification });
+}

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
@@ -51,6 +51,20 @@ export class CountingBackendClient {
 
   async close(): Promise<void> {}
 
+  /**
+   * Archiving is the cheapest real mutation that invalidates the thread-list
+   * cache, which is what the admission budgets need to reproduce. Recorded as
+   * a mutation, not a read, so it does not move the read counters.
+   */
+  async archiveThread(params: { threadId: string }): Promise<{
+    threadId: string;
+  }> {
+    this.threads = this.threads.filter(
+      (thread) => thread.id !== params.threadId,
+    );
+    return { threadId: params.threadId };
+  }
+
   async getInitializeResult(): Promise<unknown> {
     return { methods: ["thread/list", "turn/start"] };
   }

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4375,6 +4375,24 @@ describe("MessagingController", () => {
     });
   });
 
+  it("admits an ordinary bound reply without requesting a navigation snapshot", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.getNavigationSnapshot.mockClear();
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("Reply without walking the directory fleet"),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    );
+    expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
   it("preserves the messaging location for queued Agent-thread turns", async () => {
     const harness = await createHarness();
     harness.startTurn.mockImplementation(async (request: StartTurnRequest) => {
@@ -4850,6 +4868,11 @@ describe("MessagingController", () => {
       channel: "slack",
       createManagedConversation,
       getNavigationSnapshot,
+      getThreadAdmissionState: async (request) => ({
+        thread: request.federationTarget?.scope === "remote"
+          ? remoteNavigation.threads[0]
+          : localNavigation.threads[0],
+      }),
       navigation: localNavigation,
       resolveThreadTarget,
     });
@@ -4921,6 +4944,7 @@ describe("MessagingController", () => {
     );
 
     getNavigationSnapshot.mockClear();
+    harness.getThreadAdmissionState.mockClear();
     await harness.controller.handleBackendEvent({
       backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
@@ -4932,12 +4956,15 @@ describe("MessagingController", () => {
         },
       },
     });
-    expect(getNavigationSnapshot).toHaveBeenCalledWith({
-      backend: "all",
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(harness.getThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+      threadId: "remote-thread",
     });
 
     getNavigationSnapshot.mockClear();
+    harness.getThreadAdmissionState.mockClear();
     await harness.controller.handleBackendEvent({
       backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
@@ -4950,12 +4977,15 @@ describe("MessagingController", () => {
         },
       },
     });
-    expect(getNavigationSnapshot).toHaveBeenCalledWith({
-      backend: "all",
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(harness.getThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+      threadId: "remote-thread",
     });
 
     getNavigationSnapshot.mockClear();
+    harness.getThreadAdmissionState.mockClear();
     await harness.controller.handleBackendEvent({
       backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
@@ -4964,9 +4994,11 @@ describe("MessagingController", () => {
         params: {},
       },
     });
-    expect(getNavigationSnapshot).toHaveBeenCalledWith({
-      backend: "all",
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(harness.getThreadAdmissionState).toHaveBeenCalledWith({
+      backend: "codex",
       federationTarget: { scope: "remote", instanceId: "pwr_remote" },
+      threadId: "remote-thread",
     });
 
     harness.startTurn.mockClear();
@@ -13723,6 +13755,33 @@ describe("MessagingController", () => {
     });
   });
 
+  it("starts a new turn when targeted admission reports idle after a missed completion", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(buildTextEvent("first turn"));
+    const navigation = buildNavigationSnapshot();
+    harness.getThreadAdmissionState.mockResolvedValue({
+      thread: navigation.threads[0],
+      threadStatus: "idle",
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("next turn"));
+
+    expect(harness.startTurn).toHaveBeenCalledTimes(2);
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "next turn" }],
+      }),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        title: "Message queued",
+      }),
+    );
+  });
+
   it("queues a second surface message on the same Agent thread without creating a shadow thread", async () => {
     const harness = await createHarness();
     const telegramChannel = buildTextEvent("ignored").channel;
@@ -14066,10 +14125,12 @@ describe("MessagingController", () => {
     });
   });
 
-  it("clears starting state when navigation lookup fails before retrying", async () => {
+  it("clears starting state when admission-state lookup fails before retrying", async () => {
     const harness = await createHarness();
     await bindThread(harness);
-    harness.getNavigationSnapshot.mockRejectedValueOnce(new Error("navigation unavailable"));
+    harness.getThreadAdmissionState.mockRejectedValueOnce(
+      new Error("admission state unavailable"),
+    );
 
     await harness.controller.handleInboundEvent(buildTextEvent("first turn"));
 
@@ -14077,7 +14138,7 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "error",
       title: "Turn could not start",
-      body: "navigation unavailable",
+      body: "admission state unavailable",
     });
 
     await harness.controller.handleInboundEvent(buildTextEvent("retry turn"));
@@ -21437,6 +21498,9 @@ describe("MessagingController", () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0]!.executionMode = "default";
     harness.getNavigationSnapshot.mockResolvedValue(navigation);
+    harness.getThreadAdmissionState.mockResolvedValue({
+      thread: navigation.threads[0],
+    });
     await bindThread(harness);
     const binding = await harness.store.findActiveBindingForChannel(buildTextEvent("").channel);
     expect(binding).toBeDefined();
@@ -23157,6 +23221,7 @@ async function createHarness(options?: {
   responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
   getManagedConversationRights?: MessagingAdapter["getManagedConversationRights"];
   getNavigationSnapshot?: NonNullable<MessagingBackendBridge["getNavigationSnapshot"]>;
+  getThreadAdmissionState?: NonNullable<MessagingBackendBridge["getThreadAdmissionState"]>;
   createManagedConversation?: MessagingAdapter["createManagedConversation"];
   closeManagedConversation?: MessagingAdapter["closeManagedConversation"];
   deleteManagedConversation?: MessagingAdapter["deleteManagedConversation"];
@@ -23223,6 +23288,7 @@ async function createHarness(options?: {
   delivered: MessagingSurfaceIntent[];
   ensureDirectoryLaunchpad: ReturnType<typeof vi.fn>;
   getNavigationSnapshot: ReturnType<typeof vi.fn>;
+  getThreadAdmissionState: ReturnType<typeof vi.fn>;
   handoffThreadWorkspace: ReturnType<typeof vi.fn> | undefined;
   interruptTurn: ReturnType<typeof vi.fn>;
   listSkills: ReturnType<typeof vi.fn> | undefined;
@@ -23302,6 +23368,29 @@ async function createHarness(options?: {
   const getNavigationSnapshot = vi.fn(
     options?.getNavigationSnapshot
       ?? (async () => options?.navigation ?? buildNavigationSnapshot()),
+  );
+  const getThreadAdmissionState = vi.fn(
+    options?.getThreadAdmissionState
+      ?? (async (request) => {
+        const navigation = options?.navigation ?? buildNavigationSnapshot();
+        const thread = navigation.threads.find(
+          (candidate) =>
+            candidate.source === request.backend
+            && candidate.id === request.threadId,
+        );
+        const activeTurn = options?.readActiveTurn
+          ? await options.readActiveTurn(request)
+          : undefined;
+        return {
+          ...(activeTurn ? { activeTurn } : {}),
+          ...(thread ? { thread } : {}),
+          ...(activeTurn
+            ? { threadStatus: "active" as const }
+            : thread?.threadStatus
+              ? { threadStatus: thread.threadStatus }
+              : {}),
+        };
+      }),
   );
   const ensureDirectoryLaunchpad = vi.fn(
     options?.ensureDirectoryLaunchpad ??
@@ -23656,6 +23745,7 @@ async function createHarness(options?: {
     cancelThreadExecutionModeQueue,
     ensureDirectoryLaunchpad,
     getNavigationSnapshot,
+    getThreadAdmissionState,
     ...(handoffThreadWorkspace ? { handoffThreadWorkspace } : {}),
     interruptTurn,
     createScheduledThreadAction,
@@ -23737,6 +23827,7 @@ async function createHarness(options?: {
     delivered,
     ensureDirectoryLaunchpad,
     getNavigationSnapshot,
+    getThreadAdmissionState,
     handoffThreadWorkspace,
     interruptTurn,
     listSkills,

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -3818,6 +3818,9 @@ function createBackendBridge(): MessagingBackendBridge & {
 
   return {
     getNavigationSnapshot: vi.fn(async () => buildNavigationSnapshot()),
+    getThreadAdmissionState: vi.fn(async () => ({
+      thread: buildNavigationSnapshot().threads[0],
+    })),
     startTurn: vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const backendRegistryMock = vi.hoisted(() => ({
+  getCachedThreadDisplayMetadata: vi.fn(),
+  getInProgressThreadSnapshotForQuit: vi.fn(() => ({
+    count: 0,
+    threadIds: [] as string[],
+  })),
+  listThreads: vi.fn(async (): Promise<unknown[]> => []),
+}));
 
 vi.mock("electron", () => ({
   app: {
@@ -10,9 +19,7 @@ vi.mock("electron", () => ({
 }));
 
 vi.mock("../app-server/backend-registry", () => ({
-  getDesktopBackendRegistry: vi.fn(() => ({
-    getInProgressThreadSnapshotForQuit: () => ({ count: 0, threadIds: [] }),
-  })),
+  getDesktopBackendRegistry: vi.fn(() => backendRegistryMock),
 }));
 
 vi.mock("../ipc/integrated-terminal", () => ({
@@ -42,6 +49,17 @@ vi.mock("../log", () => ({
     warn: vi.fn(),
   })),
 }));
+
+beforeEach(() => {
+  backendRegistryMock.getCachedThreadDisplayMetadata.mockReset();
+  backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReset();
+  backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
+    count: 0,
+    threadIds: [],
+  });
+  backendRegistryMock.listThreads.mockReset();
+  backendRegistryMock.listThreads.mockResolvedValue([]);
+});
 
 describe("createQuitManager", () => {
   it("quits immediately when no threads are in progress", async () => {
@@ -703,9 +721,10 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
       "../quit-manager"
     );
-    const listLocalThreads = vi.fn(async () => [
-      { source: "codex" as const, id: "local-thread", title: "Local Work" },
-    ]);
+    const cachedLocalThreadName = vi.fn(() => ({
+      title: "Local Work",
+      titleSource: "explicit" as const,
+    }));
     const cachedRemoteThreadName = vi.fn(() => ({
       title: "Reap Windows Worktrees",
       titleSource: "derived" as const,
@@ -713,7 +732,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const listRemoteThreadPins = vi.fn(async () => []);
 
     const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
-      listLocalThreads,
+      cachedLocalThreadName,
       cachedRemoteThreadName,
       listRemoteThreadPins,
     });
@@ -727,9 +746,10 @@ describe("resolveQuitBlockerThreadTitles", () => {
       backend: "codex",
       threadId: "0f9c2b7a-remote",
     });
-    // The local list is a peer-blind lookup; asking it about a remote thread
-    // is what produced the uuid in the first place.
-    expect(listLocalThreads).toHaveBeenCalledTimes(1);
+    expect(cachedLocalThreadName).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      threadId: "local-thread",
+    });
     // The memory cache answered, so the store is never read.
     expect(listRemoteThreadPins).not.toHaveBeenCalled();
   });
@@ -740,7 +760,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     );
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
-      listLocalThreads: async () => [],
+      cachedLocalThreadName: () => undefined,
       cachedRemoteThreadName: () => undefined,
       listRemoteThreadPins: async () => [
         {
@@ -779,7 +799,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     let settled = false;
 
     const pending = resolveQuitBlockerThreadTitles([remoteItem], {
-      listLocalThreads: async () => [],
+      cachedLocalThreadName: () => undefined,
       cachedRemoteThreadName: () => ({
         title: "Reap Windows Worktrees",
         titleSource: "derived" as const,
@@ -802,7 +822,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const { resolveQuitBlockerThreadTitles } = await import("../quit-manager");
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
-      listLocalThreads: async () => [],
+      cachedLocalThreadName: () => undefined,
       cachedRemoteThreadName: () => ({
         title: "0f9c2b7a-remote",
         titleSource: "fallback" as const,
@@ -827,7 +847,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const titles = await resolveQuitBlockerThreadTitles(
       [collidingLocal, remoteItem],
       {
-        listLocalThreads: async () => [],
+        cachedLocalThreadName: () => undefined,
         cachedRemoteThreadName: () => ({
           title: "Reap Windows Worktrees",
           titleSource: "derived" as const,
@@ -842,15 +862,46 @@ describe("resolveQuitBlockerThreadTitles", () => {
     expect(titles.get(quitBlockerTitleKey(collidingLocal))).toBeUndefined();
   });
 
+  it("keeps same-keyed remote titles qualified by owning instance", async () => {
+    const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
+      "../quit-manager"
+    );
+    const peerBItem = {
+      ...remoteItem,
+      target: { scope: "remote" as const, instanceId: "peer-b" },
+    };
+    const cachedLocalThreadName = vi.fn(() => ({
+      title: "Wrong local title",
+      titleSource: "explicit" as const,
+    }));
+
+    const titles = await resolveQuitBlockerThreadTitles(
+      [remoteItem, peerBItem],
+      {
+        cachedLocalThreadName,
+        cachedRemoteThreadName: ({ target }) => ({
+          title: target.instanceId === "peer-a" ? "Peer A work" : "Peer B work",
+          titleSource: "explicit" as const,
+        }),
+        listRemoteThreadPins: async () => [],
+      },
+    );
+
+    expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe("Peer A work");
+    expect(titles.get(quitBlockerTitleKey(peerBItem))).toBe("Peer B work");
+    expect(cachedLocalThreadName).not.toHaveBeenCalled();
+  });
+
   it("still names local rows when the remote lookups throw", async () => {
     const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
       "../quit-manager"
     );
 
     const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
-      listLocalThreads: async () => [
-        { source: "codex" as const, id: "local-thread", title: "Local Work" },
-      ],
+      cachedLocalThreadName: () => ({
+        title: "Local Work",
+        titleSource: "explicit" as const,
+      }),
       cachedRemoteThreadName: () => {
         throw new Error("federation runtime unavailable");
       },
@@ -862,6 +913,85 @@ describe("resolveQuitBlockerThreadTitles", () => {
     expect(titles.get(quitBlockerTitleKey(localItem))).toBe("Local Work");
     expect(titles.get(quitBlockerTitleKey(remoteItem))).toBeUndefined();
   });
+});
+
+describe("readQuitBlockerQueueSnapshot", () => {
+  it("repeated polls perform zero full thread-list or directory-enrichment reads", async () => {
+    backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
+      count: 1,
+      threadIds: ["codex:thread-live"],
+    });
+    backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+      title: "Keep the quit queue stable",
+      titleSource: "explicit",
+    });
+    backendRegistryMock.listThreads.mockResolvedValue([
+      {
+        source: "codex",
+        id: "thread-live",
+        title: "Keep the quit queue stable",
+        titleSource: "explicit",
+      },
+    ]);
+    const { readQuitBlockerQueueSnapshot } = await import("../quit-manager");
+
+    const snapshots = [];
+    for (let poll = 0; poll < 4; poll += 1) {
+      snapshots.push(await readQuitBlockerQueueSnapshot());
+    }
+
+    expect(snapshots).toHaveLength(4);
+    for (const snapshot of snapshots) {
+      expect(snapshot.items).toEqual([
+        expect.objectContaining({
+          kind: "turn",
+          threadKey: "codex:thread-live",
+          title: "Keep the quit queue stable",
+        }),
+      ]);
+    }
+    // A registry thread-list read is the only entrance to provider listing and
+    // its default quit-confirmation policy enables directory enrichment. Zero
+    // registry reads therefore enforces both steady-state budgets.
+    expect(backendRegistryMock.listThreads).not.toHaveBeenCalled();
+    expect(
+      backendRegistryMock.getCachedThreadDisplayMetadata,
+    ).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([
+    ["hangs", () => new Promise<never[]>(() => undefined)],
+    ["rejects", async () => {
+      throw new Error("provider list rejected");
+    }],
+    ["is unavailable", () => {
+      throw new Error("provider list unavailable");
+    }],
+  ] as const)(
+    "builds the first named snapshot when provider listing %s",
+    async (_scenario, providerList) => {
+      backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
+        count: 1,
+        threadIds: ["codex:thread-first-snapshot"],
+      });
+      backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+        title: "First snapshot stays named",
+        titleSource: "explicit",
+      });
+      backendRegistryMock.listThreads.mockImplementation(providerList);
+      const { readQuitBlockerQueueSnapshot } = await import("../quit-manager");
+
+      await expect(readQuitBlockerQueueSnapshot()).resolves.toMatchObject({
+        items: [
+          expect.objectContaining({
+            threadKey: "codex:thread-first-snapshot",
+            title: "First snapshot stays named",
+          }),
+        ],
+      });
+      expect(backendRegistryMock.listThreads).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe("resolveQuitCountdownSeconds", () => {

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const backendRegistryMock = vi.hoisted(() => ({
-  getCachedThreadDisplayMetadata: vi.fn(),
+  getThreadInfo: vi.fn(),
   getInProgressThreadSnapshotForQuit: vi.fn(() => ({
     count: 0,
     threadIds: [] as string[],
@@ -51,7 +51,7 @@ vi.mock("../log", () => ({
 }));
 
 beforeEach(() => {
-  backendRegistryMock.getCachedThreadDisplayMetadata.mockReset();
+  backendRegistryMock.getThreadInfo.mockReset();
   backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReset();
   backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
     count: 0,
@@ -921,7 +921,7 @@ describe("readQuitBlockerQueueSnapshot", () => {
       count: 1,
       threadIds: ["codex:thread-live"],
     });
-    backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+    backendRegistryMock.getThreadInfo.mockReturnValue({
       title: "Keep the quit queue stable",
       titleSource: "explicit",
     });
@@ -955,7 +955,7 @@ describe("readQuitBlockerQueueSnapshot", () => {
     // registry reads therefore enforces both steady-state budgets.
     expect(backendRegistryMock.listThreads).not.toHaveBeenCalled();
     expect(
-      backendRegistryMock.getCachedThreadDisplayMetadata,
+      backendRegistryMock.getThreadInfo,
     ).toHaveBeenCalledTimes(4);
   });
 
@@ -974,7 +974,7 @@ describe("readQuitBlockerQueueSnapshot", () => {
         count: 1,
         threadIds: ["codex:thread-first-snapshot"],
       });
-      backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+      backendRegistryMock.getThreadInfo.mockReturnValue({
         title: "First snapshot stays named",
         titleSource: "explicit",
       });

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -388,12 +388,18 @@ describe("RemoteThreadSummaryCache — threadFromPeer", () => {
 });
 
 describe("RemoteThreadSummaryCache — remembered thread names", () => {
-  const nameOf = (cache: RemoteThreadSummaryCache, threadId: string) =>
+  const nameOnPeer = (
+    cache: RemoteThreadSummaryCache,
+    instanceId: string,
+    threadId: string,
+  ) =>
     cache.cachedThreadNameFromPeer({
-      target: remoteTarget("peer-a"),
+      target: remoteTarget(instanceId),
       backend: "codex",
       threadId,
     })?.title;
+  const nameOf = (cache: RemoteThreadSummaryCache, threadId: string) =>
+    nameOnPeer(cache, "peer-a", threadId);
 
   it("answers from remembered names without ever contacting the peer", async () => {
     const fetchSnapshot = vi.fn(async () =>
@@ -493,6 +499,101 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
 
     expect(nameOf(cache, "t1")).toBe("Parent");
     expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  // Two navigation refreshes for one peer can be in flight at once and can
+  // finish out of order. The sequence each one records at is taken before its
+  // fetch starts, so the loser is decided by when the read began rather than
+  // by which reply happened to arrive last.
+  it("does not let a slow earlier snapshot revert a newer name", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    // Both refreshes start; the first one is the slower of the two.
+    const slower = cache.reserveThreadNameObservation();
+    const faster = cache.reserveThreadNameObservation();
+
+    cache.rememberThreadNames(
+      "peer-a",
+      [stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Renamed" })],
+      faster,
+    );
+    cache.rememberThreadNames(
+      "peer-a",
+      [stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" })],
+      slower,
+    );
+
+    expect(nameOf(cache, "t1")).toBe("Renamed");
+  });
+
+  // A rename recorded after both are in hand still wins: ordering is by
+  // observation sequence, not by a rule that the first writer keeps the field.
+  it("takes a rename that comes after the reverting snapshot", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
+    ]);
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Renamed" }),
+    ]);
+
+    expect(nameOf(cache, "t1")).toBe("Renamed");
+  });
+
+  // Thread ids are only unique within the instance that minted them. Two peers
+  // reusing one id must never answer for each other.
+  it("keeps identically-numbered threads on different peers apart", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a"), peer("peer-b")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Alpha" }),
+    ]);
+    cache.rememberThreadNames("peer-b", [
+      stampedThread({ instanceId: "peer-b", threadId: "t1", title: "Beta" }),
+    ]);
+
+    expect(nameOnPeer(cache, "peer-a", "t1")).toBe("Alpha");
+    expect(nameOnPeer(cache, "peer-b", "t1")).toBe("Beta");
+
+    // And a peer that never saw the thread has no opinion about it.
+    expect(nameOnPeer(cache, "peer-b", "t2")).toBeUndefined();
+  });
+
+  it("drops only the unmounted peer's names", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a"), peer("peer-b")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Alpha" }),
+    ]);
+    cache.rememberThreadNames("peer-b", [
+      stampedThread({ instanceId: "peer-b", threadId: "t1", title: "Beta" }),
+    ]);
+
+    cache.forgetInstanceThreadNames("peer-a");
+
+    expect(nameOnPeer(cache, "peer-a", "t1")).toBeUndefined();
+    expect(nameOnPeer(cache, "peer-b", "t1")).toBe("Beta");
   });
 });
 

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2246,6 +2246,9 @@ describe("TelegramAdapter", () => {
       authorizedActorIds: ["42"],
       backend: {
         getNavigationSnapshot: async () => buildNavigationSnapshot(),
+        getThreadAdmissionState: async () => ({
+          thread: buildNavigationSnapshot().threads[0],
+        }),
         interruptTurn: restartedInterruptTurn,
         startTurn: async (request: StartTurnRequest) => ({
           backend: request.backend,
@@ -3073,6 +3076,9 @@ async function createControllerHarness(): Promise<{
     authorizedActorIds: ["42"],
     backend: {
       getNavigationSnapshot,
+      getThreadAdmissionState: async () => ({
+        thread: buildNavigationSnapshot().threads[0],
+      }),
       startTurn,
     },
     inputDebounceMs: 0,

--- a/apps/desktop/src/main/__tests__/thread-info-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-info-store.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import { ThreadInfoStore } from "../app-server/thread-info-store";
+
+const local = (threadId: string) => ({ backend: "codex" as const, threadId });
+
+function storeWithTitle(title = "Known name"): ThreadInfoStore {
+  const store = new ThreadInfoStore();
+  store.observe({
+    identity: local("t1"),
+    observationSequence: store.reserveObservationSequence(),
+    source: "provider-list",
+    title,
+    titleSource: "explicit",
+  });
+  return store;
+}
+
+describe("ThreadInfoStore", () => {
+  describe("unknown is distinguishable from unobserved", () => {
+    it("returns undefined for a thread it has never seen", () => {
+      expect(new ThreadInfoStore().get(local("never-seen"))).toBeUndefined();
+    });
+
+    it("returns undefined rather than guessing from another backend", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: { backend: "codex", threadId: "shared-id" },
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "Codex thread",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle({ backend: "acp:claude-code", threadId: "shared-id" }))
+        .toBeUndefined();
+    });
+
+    it("returns undefined rather than guessing across instances", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: { backend: "codex", instanceId: "peer-a", threadId: "shared-id" },
+        observationSequence: store.reserveObservationSequence(),
+        source: "remote-navigation",
+        title: "Peer A thread",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-b", threadId: "shared-id" }))
+        .toBeUndefined();
+      expect(store.getTitle(local("shared-id"))).toBeUndefined();
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-a", threadId: "shared-id" }))
+        .toBe("Peer A thread");
+    });
+  });
+
+  describe("a known title cannot be downgraded", () => {
+    it("ignores an observation that omits the title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        updatedAt: 42,
+      });
+      expect(store.getTitle(local("t1"))).toBe("Known name");
+      expect(store.get(local("t1"))?.updatedAt).toBe(42);
+    });
+
+    it("ignores an empty title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "   ",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Known name");
+    });
+
+    it("ignores a fallback title even when it is newer", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "t1",
+        titleSource: "fallback",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Known name");
+      expect(store.get(local("t1"))?.titleSource).toBe("explicit");
+    });
+
+    it("ignores a fallback source arriving without its title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        titleSource: "fallback",
+      });
+      expect(store.get(local("t1"))?.titleSource).toBe("explicit");
+    });
+  });
+
+  describe("a newer positive observation wins", () => {
+    it("accepts an explicit rename over a provider title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "local-rename",
+        title: "Operator's name",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Operator's name");
+    });
+
+    it("accepts a derived title over an earlier derived title", () => {
+      const store = new ThreadInfoStore();
+      for (const title of ["First guess", "Second guess"]) {
+        store.observe({
+          identity: local("t1"),
+          observationSequence: store.reserveObservationSequence(),
+          source: "provider-list",
+          title,
+          titleSource: "derived",
+        });
+      }
+      expect(store.getTitle(local("t1"))).toBe("Second guess");
+    });
+  });
+
+  describe("late completions cannot revert a newer observation", () => {
+    it("drops a stale list that reserved its sequence before a rename", () => {
+      const store = storeWithTitle("Provider title");
+      // A list starts here and reserves its place in the ordering.
+      const staleListSequence = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        title: "Renamed while listing",
+        titleSource: "explicit",
+      });
+      // The list finally completes, still carrying its older rows.
+      store.observe({
+        identity: local("t1"),
+        observationSequence: staleListSequence,
+        source: "provider-list",
+        title: "Provider title",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Renamed while listing");
+    });
+
+    it("lets a list started after a rename reconcile the title", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        title: "Renamed",
+        titleSource: "explicit",
+      });
+      const freshListSequence = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: freshListSequence,
+        source: "provider-list",
+        title: "Server agrees, with an edit",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Server agrees, with an edit");
+    });
+
+    it("orders per field, so a stale title cannot block a newer archived flag", () => {
+      const store = storeWithTitle();
+      const staleSequence = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        title: "Newer title",
+        titleSource: "explicit",
+      });
+      store.observe({
+        identity: local("t1"),
+        observationSequence: staleSequence,
+        source: "provider-list",
+        archived: true,
+        title: "Older title",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Newer title");
+      expect(store.get(local("t1"))?.archived).toBe(true);
+    });
+  });
+
+  describe("change reporting", () => {
+    it("reports only the fields an observation actually changed", () => {
+      const store = storeWithTitle();
+      expect(
+        store.observe({
+          identity: local("t1"),
+          observationSequence: store.reserveObservationSequence(),
+          source: "provider-list",
+          title: "Known name",
+          titleSource: "explicit",
+          updatedAt: 7,
+        }),
+      ).toEqual(["updatedAt"]);
+    });
+
+    it("reports nothing when a refresh only confirms what is known", () => {
+      const store = storeWithTitle();
+      expect(
+        store.observe({
+          identity: local("t1"),
+          observationSequence: store.reserveObservationSequence(),
+          source: "provider-list",
+          title: "Known name",
+          titleSource: "explicit",
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("removal is explicit", () => {
+    it("forgets a single thread without touching its neighbours", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t2"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "Sibling",
+        titleSource: "explicit",
+      });
+      store.forget(local("t1"));
+      expect(store.get(local("t1"))).toBeUndefined();
+      expect(store.getTitle(local("t2"))).toBe("Sibling");
+    });
+
+    it("forgets one peer's threads and keeps local and other-peer entries", () => {
+      const store = new ThreadInfoStore();
+      const seed = (instanceId: string | undefined, title: string) =>
+        store.observe({
+          identity: { backend: "codex", threadId: "t1", ...(instanceId ? { instanceId } : {}) },
+          observationSequence: store.reserveObservationSequence(),
+          source: instanceId ? "remote-navigation" : "provider-list",
+          title,
+          titleSource: "explicit",
+        });
+      seed(undefined, "Mine");
+      seed("peer-a", "Theirs");
+      seed("peer-b", "Someone else's");
+      store.forgetInstance("peer-a");
+      expect(store.getTitle(local("t1"))).toBe("Mine");
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-a", threadId: "t1" }))
+        .toBeUndefined();
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-b", threadId: "t1" }))
+        .toBe("Someone else's");
+    });
+  });
+
+  describe("input hygiene", () => {
+    it("ignores a blank thread id instead of creating a phantom entry", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: local("   "),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "Nowhere",
+        titleSource: "explicit",
+      });
+      expect(store.size).toBe(0);
+    });
+
+    it("matches a padded thread id to the entry it created", () => {
+      const store = storeWithTitle();
+      expect(store.getTitle({ backend: "codex", threadId: "  t1  " })).toBe("Known name");
+    });
+
+    it("trims stored titles", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "  Padded  ",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Padded");
+    });
+  });
+
+  describe("ordering does not read the clock", () => {
+    it("issues strictly increasing sequences", () => {
+      const store = new ThreadInfoStore();
+      const sequences = Array.from({ length: 5 }, () =>
+        store.reserveObservationSequence(),
+      );
+      expect(sequences).toEqual([...sequences].sort((a, b) => a - b));
+      expect(new Set(sequences).size).toBe(sequences.length);
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -386,3 +386,49 @@ describe("archival is an observation, not a cache eviction", () => {
       .toBe(false);
   });
 });
+
+describe("messaging admission reads what this process already knows", () => {
+  // resolveThread falls back to listThreads({ forceRefresh: true }) — a full
+  // paged provider walk — whenever the cached summary comes back empty. The
+  // thread-list cache is emptied by every mutation, so before the information
+  // store answered here, an inbound reply to a thread this window listed
+  // minutes ago paid that walk because something unrelated had invalidated the
+  // cache in between.
+  it("admits a reply after an invalidation without listing the provider", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    // An unrelated mutation on a different thread empties the whole cache.
+    await registry.archiveThread({ backend: "codex", threadId: "thread-beta" });
+    client.resetCounts();
+
+    const summary = registry.getCachedThreadSummary({
+      backend: "codex",
+      threadId: "thread-alpha",
+    });
+    expect(summary?.title).toBe("Rework the quit dialog");
+    await expect(
+      registry.resolveThread({ threadId: "thread-alpha" }),
+    ).resolves.toMatchObject({ id: "thread-alpha" });
+
+    expectThreadReadBudget({
+      note: "messaging admission for a listed thread whose list cache was invalidated",
+      reads: client.counts,
+      scenario: "messaging-admission-after-invalidation",
+    });
+  });
+
+  // The caller does not always know which backend owns the thread an inbound
+  // message names.
+  it("answers a backend-less lookup from the store", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await registry.archiveThread({ backend: "codex", threadId: "thread-alpha" });
+
+    expect(
+      registry.getCachedThreadSummary({ threadId: "thread-beta" })?.title,
+    ).toBe("Audit the messaging adapters");
+    expect(
+      registry.getCachedThreadSummary({ threadId: "no-such-thread" }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  codexThread,
+  createThreadReadRegistry,
+  publishNotification,
+} from "./fixtures/thread-read-harness";
+import { expectThreadReadBudget } from "./fixtures/thread-read-budget";
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+const NAMED_THREAD = codexThread({
+  id: "thread-alpha",
+  title: "Rework the quit dialog",
+  titleSource: "explicit",
+});
+const SECOND_THREAD = codexThread({
+  id: "thread-beta",
+  title: "Audit the messaging adapters",
+  titleSource: "explicit",
+});
+
+/** The read a freshly opened window makes to paint its sidebar. */
+const NAVIGATION_REFRESH = {
+  backend: "codex",
+  callerReason: "navigation-snapshot",
+  enrichDirectories: false,
+} as const;
+
+const registries: Array<{ close: () => Promise<unknown> }> = [];
+
+function build(threads = [NAMED_THREAD, SECOND_THREAD]) {
+  const created = createThreadReadRegistry(threads);
+  registries.push(created.registry);
+  return created;
+}
+
+afterEach(async () => {
+  await Promise.all(registries.splice(0).map(async (registry) => {
+    await registry.close();
+  }));
+});
+
+describe("thread read budgets", () => {
+  it("names quit blockers for the life of the dialog without reading the provider", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "turn/started",
+      params: { threadId: "thread-alpha", turnId: "turn-1", turn: { id: "turn-1" } },
+    });
+    client.resetCounts();
+
+    // The quit toast re-reads this snapshot every 500ms while it is open.
+    for (let poll = 0; poll < 20; poll += 1) {
+      expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+        count: 1,
+        threadIds: ["codex:thread-alpha"],
+        threadTitles: { "codex:thread-alpha": "Rework the quit dialog" },
+      });
+    }
+
+    expectThreadReadBudget({
+      note: "20 quit-dialog polls against an in-progress turn, all served from observed metadata",
+      reads: client.counts,
+      scenario: "quit-dialog-poll",
+    });
+  });
+
+  it("answers repeated label lookups for a known thread without reading the provider", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    for (let lookup = 0; lookup < 50; lookup += 1) {
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+        .toBe("Rework the quit dialog");
+    }
+
+    expectThreadReadBudget({
+      note: "50 synchronous label lookups for a thread already observed once",
+      reads: client.counts,
+      scenario: "known-thread-label-lookups",
+    });
+  });
+
+  it("keeps labels answerable across a turn's lifecycle events", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    // A turn invalidates list caches repeatedly. None of it is a reason to
+    // forget what the threads are called.
+    for (let turn = 0; turn < 5; turn += 1) {
+      await publishNotification(registry, {
+        method: "turn/started",
+        params: { threadId: "thread-alpha", turnId: `turn-${turn}`, turn: { id: `turn-${turn}` } },
+      });
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+        .toBe("Rework the quit dialog");
+      await publishNotification(registry, {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-alpha",
+          turnId: `turn-${turn}`,
+          turn: { id: `turn-${turn}`, status: "completed", output: [] },
+        },
+      });
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+        .toBe("Rework the quit dialog");
+    }
+
+    expectThreadReadBudget({
+      note: "five complete turns with label reads between every lifecycle event",
+      reads: client.counts,
+      scenario: "turn-lifecycle-label-reads",
+    });
+  });
+
+  it("shares one provider read across callers that want the same listing", async () => {
+    const { client, registry } = build();
+    await Promise.all([
+      registry.listThreads(NAVIGATION_REFRESH),
+      registry.listThreads({ backend: "codex", callerReason: "navigation-snapshot", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "startup-prewarm", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "branch-drift", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "turn-cwd", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "title-generation", enrichDirectories: false }),
+    ]);
+
+    expectThreadReadBudget({
+      note: "six concurrent callers asking for the same unenriched Codex listing",
+      reads: client.counts,
+      scenario: "concurrent-identical-listings",
+    });
+  });
+});
+
+describe("thread information is never lost", () => {
+  it("keeps a known title when the provider becomes unavailable", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Rework the quit dialog");
+
+    client.failNextList = true;
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true })
+      .catch(() => undefined);
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Rework the quit dialog");
+  });
+
+  it("keeps a known title when the provider starts reporting a fallback", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+
+    // A provider that loses its title index answers with the thread id. That
+    // is the absence of a name, not the news that the name is now a uuid.
+    client.setThreads([codexThread({ id: "thread-alpha" })]);
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Rework the quit dialog");
+  });
+
+  it("prefers a rename to a listing that started before it", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+
+    let releaseList: () => void = () => {};
+    client.listGate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    const staleList = registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    await publishNotification(registry, {
+      method: "thread/name/updated",
+      params: { threadId: "thread-alpha", threadName: "Renamed mid-listing" },
+    });
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Renamed mid-listing");
+
+    releaseList();
+    await staleList;
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Renamed mid-listing");
+  });
+
+  it("adopts a title the provider reports after a rename", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/name/updated",
+      params: { threadId: "thread-alpha", threadName: "Renamed locally" },
+    });
+
+    client.setThreads([
+      codexThread({
+        id: "thread-alpha",
+        title: "Renamed locally, then edited elsewhere",
+        titleSource: "explicit",
+      }),
+    ]);
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Renamed locally, then edited elsewhere");
+  });
+
+  it("does not let one backend's thread id answer for another's", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    expect(registry.getThreadInfo({ backend: "acp:claude-code", threadId: "thread-alpha" }))
+      .toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -222,3 +222,167 @@ describe("thread information is never lost", () => {
       .toBeUndefined();
   });
 });
+
+describe("thread read budgets across product flows", () => {
+  it("labels a burst of terminal notifications with one walk per unobserved thread", async () => {
+    // Turn completions arrive in bursts across concurrent threads. A thread
+    // this process never listed still deserves a label, but it must cost one
+    // reconciliation, not one per notification.
+    const { client, registry } = build([
+      codexThread({ id: "thread-alpha", title: "Alpha", titleSource: "derived" }),
+      codexThread({ id: "thread-beta", title: "Beta", titleSource: "derived" }),
+    ]);
+
+    await Promise.all(
+      ["thread-alpha", "thread-beta"].flatMap((threadId) =>
+        Array.from({ length: 4 }, (_unused, turn) =>
+          publishNotification(registry, {
+            method: "turn/completed",
+            params: {
+              threadId,
+              turnId: `turn-${turn}`,
+              turn: { id: `turn-${turn}`, status: "completed", output: [] },
+            },
+          }),
+        ),
+      ),
+    );
+
+    expectThreadReadBudget({
+      note: "eight terminal notifications across two threads neither of which was ever listed",
+      reads: client.counts,
+      scenario: "terminal-notification-burst",
+    });
+  });
+
+  it("reads the provider once for a window opening onto a warm profile", async () => {
+    // A second window mounting asks for the same navigation data the first
+    // window already fetched, then immediately reads labels for its rows.
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    await registry.listThreads(NAVIGATION_REFRESH);
+    for (const threadId of ["thread-alpha", "thread-beta"]) {
+      expect(registry.getThreadInfo({ backend: "codex", threadId })?.title)
+        .toBeDefined();
+    }
+
+    expectThreadReadBudget({
+      note: "a second window's navigation refresh and label reads against a warm list cache",
+      reads: client.counts,
+      scenario: "second-window-navigation",
+    });
+  });
+
+  it("keeps a turn's workspace lookups off the provider once the thread is known", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    // Ten turns, each of which adopts a branch on start and reports a cwd.
+    for (let turn = 0; turn < 10; turn += 1) {
+      await publishNotification(registry, {
+        method: "turn/started",
+        params: { threadId: "thread-alpha", turnId: `turn-${turn}`, turn: { id: `turn-${turn}` } },
+      });
+      await publishNotification(registry, {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-alpha",
+          turnId: `turn-${turn}`,
+          turn: { id: `turn-${turn}`, status: "completed", output: [] },
+        },
+      });
+    }
+
+    expectThreadReadBudget({
+      note: "ten complete turns on a thread the navigation refresh already observed",
+      reads: client.counts,
+      scenario: "ten-turns-warm-thread",
+    });
+  });
+});
+
+describe("directory enrichment budget", () => {
+  // A worktree-shaped projectKey is what makes the registry reach for
+  // directory enrichment. Without one no scenario above can move the
+  // enrichment counter, and a budget that cannot move proves nothing.
+  const WORKTREE_THREAD = codexThread({
+    id: "thread-worktree",
+    projectKey: "/Users/example/.worktrees/feature-branch",
+    title: "Worktree thread",
+    titleSource: "explicit",
+  });
+
+  it("enriches a worktree thread's directories once per backfill-capable listing", async () => {
+    const { client, registry } = build([WORKTREE_THREAD]);
+    await registry.listThreads(NAVIGATION_REFRESH);
+
+    expect(client.directoryEnrichmentCallCount).toBeGreaterThan(0);
+    expectThreadReadBudget({
+      note: "one navigation refresh over a single worktree-backed thread",
+      reads: client.counts,
+      scenario: "worktree-navigation-refresh",
+    });
+  });
+
+  it("does not re-enrich a worktree thread for label reads across turns", async () => {
+    const { client, registry } = build([WORKTREE_THREAD]);
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    for (let turn = 0; turn < 5; turn += 1) {
+      await publishNotification(registry, {
+        method: "turn/started",
+        params: { threadId: "thread-worktree", turnId: `turn-${turn}`, turn: { id: `turn-${turn}` } },
+      });
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-worktree" })?.title)
+        .toBe("Worktree thread");
+      await publishNotification(registry, {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-worktree",
+          turnId: `turn-${turn}`,
+          turn: { id: `turn-${turn}`, status: "completed", output: [] },
+        },
+      });
+    }
+
+    expectThreadReadBudget({
+      note: "five turns on an already-enriched worktree thread",
+      reads: client.counts,
+      scenario: "worktree-turns-after-enrichment",
+    });
+  });
+});
+
+describe("archival is an observation, not a cache eviction", () => {
+  it("records that a thread was archived without losing its title", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" }))
+      .toMatchObject({ archived: true, title: "Rework the quit dialog" });
+  });
+
+  it("records a restore over the archival", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+    await publishNotification(registry, {
+      method: "thread/unarchived",
+      params: { threadId: "thread-alpha" },
+    });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.archived)
+      .toBe(false);
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5397,6 +5397,12 @@ type ThreadListCacheHit = {
   value: Promise<AppServerThreadSummary[]> | AppServerThreadSummary[];
 };
 
+type ThreadDisplayMetadata = {
+  observationSequence: number;
+  title: string;
+  titleSource?: AppServerThreadTitleSource;
+};
+
 type CreatedThreadDirectoryVisibility = Pick<
   NavigationDirectorySummary,
   "key" | "kind" | "path"
@@ -7755,14 +7761,16 @@ export class DesktopBackendRegistry {
    */
   private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();
   /**
-   * Best-effort cache of thread labels keyed by `buildThreadIdentityKey`, used
-   * only to label native attention/terminal notifications so multiple
-   * background turns are distinguishable. Populated from `thread/started` and
-   * `thread/name/updated` notifications as they fan out through `emit()`.
-   * Falls back to a thread-list lookup, then a generic body when context still
-   * isn't available.
+   * Cache-only display metadata keyed by `buildThreadIdentityKey`. Provider
+   * lists reserve their observation sequence before awaiting so an older list
+   * cannot complete late and replace a newer lifecycle/name observation.
+   * Missing and fallback titles are not deletion events.
    */
-  private readonly notificationThreadTitles = new Map<string, string>();
+  private readonly threadDisplayMetadata = new Map<
+    string,
+    ThreadDisplayMetadata
+  >();
+  private threadDisplayMetadataObservationSequence = 0;
   private readonly notificationThreadProjectLabels = new Map<string, string>();
   /**
    * Live `thread/name/updated` observations are newer than the provider's
@@ -9460,7 +9468,12 @@ export class DesktopBackendRegistry {
     // An event can invalidate or replace this entry while the read awaits
     // enrichment. Only the promise that still owns the key may publish it.
     const pendingState: ThreadListCacheState = {};
-    const promise = this.readThreadList(normalizedParams)
+    const displayMetadataObservationSequence =
+      this.reserveThreadDisplayMetadataObservation();
+    const promise = this.readThreadList(
+      normalizedParams,
+      displayMetadataObservationSequence,
+    )
       .then((threads) => {
         if (this.threadListCache.get(cacheKey) === pendingState) {
           this.threadListCache.set(cacheKey, {
@@ -9562,6 +9575,32 @@ export class DesktopBackendRegistry {
     return undefined;
   }
 
+  /**
+   * Read display metadata this process has already observed. This method never
+   * starts or awaits provider listing, directory enrichment, or persistence.
+   */
+  getCachedThreadDisplayMetadata(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Pick<ThreadDisplayMetadata, "title" | "titleSource"> | undefined {
+    const threadId = params.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    const metadata = this.threadDisplayMetadata.get(
+      buildThreadIdentityKey(params.backend, threadId),
+    );
+    if (!metadata) {
+      return undefined;
+    }
+    return {
+      title: metadata.title,
+      ...(metadata.titleSource
+        ? { titleSource: metadata.titleSource }
+        : {}),
+    };
+  }
+
   async getThreadAgentMetadata(params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -9570,16 +9609,19 @@ export class DesktopBackendRegistry {
     return overlay?.agent;
   }
 
-  private async readThreadList(params: {
-    archived?: boolean;
-    backend?: AppServerBackendKind;
-    callerReason?: ThreadListCallerReason;
-    enrichDirectories: boolean;
-    filter?: string;
-    limit?: number;
-    maxPages?: number;
-    skipArchivedMetadataRefresh?: boolean;
-  }): Promise<AppServerThreadSummary[]> {
+  private async readThreadList(
+    params: {
+      archived?: boolean;
+      backend?: AppServerBackendKind;
+      callerReason?: ThreadListCallerReason;
+      enrichDirectories: boolean;
+      filter?: string;
+      limit?: number;
+      maxPages?: number;
+      skipArchivedMetadataRefresh?: boolean;
+    },
+    displayMetadataObservationSequence: number,
+  ): Promise<AppServerThreadSummary[]> {
     const diagnostics = {
       callerReason: params.callerReason ?? "thread-list",
       ownerId: this.threadListCacheOwnerId,
@@ -9607,7 +9649,10 @@ export class DesktopBackendRegistry {
           threads,
         });
       }
-      this.rememberThreadListContexts(threads);
+      this.rememberThreadListContexts(
+        threads,
+        displayMetadataObservationSequence,
+      );
       return threads;
     }
 
@@ -9617,7 +9662,10 @@ export class DesktopBackendRegistry {
         params.filter,
         params.archived,
       );
-      this.rememberThreadListContexts(threads);
+      this.rememberThreadListContexts(
+        threads,
+        displayMetadataObservationSequence,
+      );
       return threads;
     }
 
@@ -9638,7 +9686,10 @@ export class DesktopBackendRegistry {
     const threads = threadLists
       .flat()
       .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
-    this.rememberThreadListContexts(threads);
+    this.rememberThreadListContexts(
+      threads,
+      displayMetadataObservationSequence,
+    );
     return threads;
   }
 
@@ -13705,10 +13756,10 @@ export class DesktopBackendRegistry {
         threadKeys.add(threadKey);
         if (owner.isSubAgent) {
           subAgentThreadKeys.add(threadKey);
-          const title = this.cachedQuitThreadTitle(owner.backend, owner.threadId);
-          if (title) {
-            threadTitles.set(threadKey, title);
-          }
+        }
+        const title = this.cachedQuitThreadTitle(owner.backend, owner.threadId);
+        if (title) {
+          threadTitles.set(threadKey, title);
         }
       }
     };
@@ -13845,25 +13896,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
   ): string | undefined {
-    const key = buildThreadIdentityKey(backend, threadId);
-    const remembered =
-      this.observedThreadNames.get(key) ?? this.notificationThreadTitles.get(key);
-    if (remembered?.trim()) {
-      return remembered.trim();
-    }
-    for (const state of this.threadListCache.values()) {
-      const thread = state.threads?.find(
-        (candidate) =>
-          candidate.source === backend
-          && candidate.id === threadId
-          && candidate.titleSource !== "fallback",
-      );
-      const title = thread?.title.trim();
-      if (title) {
-        return title;
-      }
-    }
-    return undefined;
+    return this.getCachedThreadDisplayMetadata({ backend, threadId })?.title;
   }
 
   async supportsMessagingPdfTools(params: {
@@ -34330,6 +34363,40 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private reserveThreadDisplayMetadataObservation(): number {
+    this.threadDisplayMetadataObservationSequence += 1;
+    return this.threadDisplayMetadataObservationSequence;
+  }
+
+  private rememberThreadDisplayMetadata(params: {
+    backend: AppServerBackendKind;
+    observationSequence: number;
+    threadId: string;
+    title?: string;
+    titleSource?: AppServerThreadTitleSource;
+  }): void {
+    if (params.titleSource === "fallback") {
+      return;
+    }
+    const title = params.title?.trim();
+    if (!title) {
+      return;
+    }
+    const key = buildThreadIdentityKey(params.backend, params.threadId);
+    const existing = this.threadDisplayMetadata.get(key);
+    if (
+      existing
+      && existing.observationSequence >= params.observationSequence
+    ) {
+      return;
+    }
+    this.threadDisplayMetadata.set(key, {
+      observationSequence: params.observationSequence,
+      title,
+      ...(params.titleSource ? { titleSource: params.titleSource } : {}),
+    });
+  }
+
   private rememberThreadTitleFromEvent(event: AgentEvent): void {
     const method = event.notification.method;
     if (method === "thread/name/updated") {
@@ -34343,7 +34410,14 @@ export class DesktopBackendRegistry {
         const trimmed = threadName.trim();
         if (trimmed) {
           const key = buildThreadIdentityKey(event.backend, threadId);
-          this.notificationThreadTitles.set(key, trimmed);
+          this.rememberThreadDisplayMetadata({
+            backend: event.backend,
+            observationSequence:
+              this.reserveThreadDisplayMetadataObservation(),
+            threadId,
+            title: trimmed,
+            titleSource: "explicit",
+          });
           this.observedThreadNames.set(key, trimmed);
         }
       }
@@ -34358,7 +34432,12 @@ export class DesktopBackendRegistry {
       if (typeof threadId !== "string") {
         return;
       }
-      this.rememberThreadNotificationContext(event.backend, threadId, params.thread);
+      this.rememberThreadNotificationContext(
+        event.backend,
+        threadId,
+        params.thread,
+        this.reserveThreadDisplayMetadataObservation(),
+      );
     }
   }
 
@@ -34406,6 +34485,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
     thread: unknown,
+    displayMetadataObservationSequence: number,
   ): void {
     if (!thread || typeof thread !== "object" || Array.isArray(thread)) {
       return;
@@ -34414,11 +34494,20 @@ export class DesktopBackendRegistry {
     const candidate =
       (typeof record.title === "string" ? record.title : undefined) ??
       (typeof record.name === "string" ? record.name : undefined);
-    const trimmed = candidate?.trim();
+    const titleSource =
+      record.titleSource === "explicit"
+      || record.titleSource === "derived"
+      || record.titleSource === "fallback"
+        ? record.titleSource
+        : undefined;
+    this.rememberThreadDisplayMetadata({
+      backend,
+      observationSequence: displayMetadataObservationSequence,
+      threadId,
+      title: candidate,
+      titleSource,
+    });
     const key = buildThreadIdentityKey(backend, threadId);
-    if (trimmed) {
-      this.notificationThreadTitles.set(key, trimmed);
-    }
     const projectLabel = readNotificationProjectLabel(record);
     if (projectLabel) {
       this.notificationThreadProjectLabels.set(key, projectLabel);
@@ -34428,12 +34517,18 @@ export class DesktopBackendRegistry {
   /** Keep titles already shown in navigation available to time-bounded UI. */
   private rememberThreadListContexts(
     threads: readonly AppServerThreadSummary[],
+    displayMetadataObservationSequence: number,
   ): void {
     for (const thread of threads) {
       if (thread.titleSource === "fallback") {
         continue;
       }
-      this.rememberThreadNotificationContext(thread.source, thread.id, thread);
+      this.rememberThreadNotificationContext(
+        thread.source,
+        thread.id,
+        thread,
+        displayMetadataObservationSequence,
+      );
     }
   }
 
@@ -34443,7 +34538,7 @@ export class DesktopBackendRegistry {
   ): string | undefined {
     const key = buildThreadIdentityKey(backend, threadId);
     const projectLabel = this.notificationThreadProjectLabels.get(key);
-    const threadTitle = this.notificationThreadTitles.get(key);
+    const threadTitle = this.threadDisplayMetadata.get(key)?.title;
     if (projectLabel && threadTitle) {
       return `${projectLabel} > ${threadTitle}`;
     }
@@ -34466,7 +34561,6 @@ export class DesktopBackendRegistry {
       });
       const thread = threads.find((candidate) => candidate.id === threadId);
       if (thread) {
-        this.rememberThreadNotificationContext(backend, threadId, thread);
         return this.notificationThreadContextLabel(backend, threadId);
       }
     } catch (error) {
@@ -34494,9 +34588,9 @@ export class DesktopBackendRegistry {
     const title = isQuestion
       ? "PwrAgent input needed"
       : "PwrAgent approval needed";
-    const threadTitle = this.notificationThreadTitles.get(
+    const threadTitle = this.threadDisplayMetadata.get(
       buildThreadIdentityKey(event.backend, threadId),
-    );
+    )?.title;
     const approvalRequest = this.isApprovalAttentionNotification(event.notification)
       ? event.notification
       : undefined;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9561,6 +9561,13 @@ export class DesktopBackendRegistry {
    * thread-list walk. Hot-path consumers such as messaging admission combine
    * this volatile summary with the durable per-thread overlay instead of
    * asking navigation to rebuild every thread and directory.
+   *
+   * The thread-list cache is consulted first — when it is warm it holds the
+   * freshest listing — and the information store answers when it is not. The
+   * store matters because the cache is emptied by every mutation: without the
+   * second tier, admission for a thread this process listed minutes ago falls
+   * through to `resolveThread`'s forced full listing purely because something
+   * unrelated invalidated the cache in between.
    */
   getCachedThreadSummary(params: {
     backend?: AppServerBackendKind;
@@ -9580,7 +9587,10 @@ export class DesktopBackendRegistry {
         return cached;
       }
     }
-    return undefined;
+    return this.threadInfoStore.findLocalSummary({
+      ...(params.backend ? { backend: params.backend } : {}),
+      threadId,
+    });
   }
 
   /**

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -486,6 +486,12 @@ import type {
   ResolveEditCommitStatesOptions,
   WorktreeWorkingStateEntry,
 } from "./git-working-state-service";
+import {
+  ThreadInfoStore,
+  type ThreadInfo,
+  type ThreadInfoIdentity,
+  type ThreadInfoObservation,
+} from "./thread-info-store";
 import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
 import {
   AcpAvailableCommandsStore,
@@ -5397,12 +5403,6 @@ type ThreadListCacheHit = {
   value: Promise<AppServerThreadSummary[]> | AppServerThreadSummary[];
 };
 
-type ThreadDisplayMetadata = {
-  observationSequence: number;
-  title: string;
-  titleSource?: AppServerThreadTitleSource;
-};
-
 type CreatedThreadDirectoryVisibility = Pick<
   NavigationDirectorySummary,
   "key" | "kind" | "path"
@@ -7761,17 +7761,25 @@ export class DesktopBackendRegistry {
    */
   private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();
   /**
-   * Cache-only display metadata keyed by `buildThreadIdentityKey`. Provider
-   * lists reserve their observation sequence before awaiting so an older list
-   * cannot complete late and replace a newer lifecycle/name observation.
-   * Missing and fallback titles are not deletion events.
+   * What this process knows about each thread it has seen, keyed by thread
+   * identity rather than by the query that revealed it.
+   *
+   * Distinct from `threadListCache`, which answers "which threads match this
+   * query" and is correctly discarded by any mutation. This answers "what is
+   * this thread called", where discarding is never correct: the previous answer
+   * remains the best one until a newer observation replaces it. Reads are
+   * synchronous and cannot start provider work, so a 500ms UI poll can use one.
    */
-  private readonly threadDisplayMetadata = new Map<
+  private readonly threadInfoStore = new ThreadInfoStore();
+  /**
+   * In-flight terminal-notification label reconciliations, keyed by thread. A
+   * burst of turn completions on threads this process never observed must cost
+   * one provider walk per thread, not one per notification.
+   */
+  private readonly notificationContextReconciliations = new Map<
     string,
-    ThreadDisplayMetadata
+    Promise<void>
   >();
-  private threadDisplayMetadataObservationSequence = 0;
-  private readonly notificationThreadProjectLabels = new Map<string, string>();
   /**
    * Live `thread/name/updated` observations are newer than the provider's
    * thread list during an active turn. Reconcile list rows through this map so
@@ -9469,7 +9477,7 @@ export class DesktopBackendRegistry {
     // enrichment. Only the promise that still owns the key may publish it.
     const pendingState: ThreadListCacheState = {};
     const displayMetadataObservationSequence =
-      this.reserveThreadDisplayMetadataObservation();
+      this.reserveThreadInfoObservation();
     const promise = this.readThreadList(
       normalizedParams,
       displayMetadataObservationSequence,
@@ -9576,29 +9584,18 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * Read display metadata this process has already observed. This method never
-   * starts or awaits provider listing, directory enrichment, or persistence.
+   * What this process already knows about a thread. Synchronous by contract: it
+   * never starts or awaits provider listing, directory enrichment, or
+   * persistence, so it is safe on paths that must not wait — a quit decision, a
+   * notification label, a repeating UI poll.
+   *
+   * `undefined` means this thread has never been observed. It never means a
+   * read failed or a cache lapsed; those leave the last observation in place.
+   * Callers that need directories, git state, or ordering want `resolveThread`,
+   * which may reach the provider.
    */
-  getCachedThreadDisplayMetadata(params: {
-    backend: AppServerBackendKind;
-    threadId: string;
-  }): Pick<ThreadDisplayMetadata, "title" | "titleSource"> | undefined {
-    const threadId = params.threadId.trim();
-    if (!threadId) {
-      return undefined;
-    }
-    const metadata = this.threadDisplayMetadata.get(
-      buildThreadIdentityKey(params.backend, threadId),
-    );
-    if (!metadata) {
-      return undefined;
-    }
-    return {
-      title: metadata.title,
-      ...(metadata.titleSource
-        ? { titleSource: metadata.titleSource }
-        : {}),
-    };
+  getThreadInfo(identity: ThreadInfoIdentity): ThreadInfo | undefined {
+    return this.threadInfoStore.get(identity);
   }
 
   async getThreadAgentMetadata(params: {
@@ -9652,6 +9649,7 @@ export class DesktopBackendRegistry {
       this.rememberThreadListContexts(
         threads,
         displayMetadataObservationSequence,
+        params.enrichDirectories,
       );
       return threads;
     }
@@ -9665,6 +9663,7 @@ export class DesktopBackendRegistry {
       this.rememberThreadListContexts(
         threads,
         displayMetadataObservationSequence,
+        params.enrichDirectories,
       );
       return threads;
     }
@@ -9689,6 +9688,7 @@ export class DesktopBackendRegistry {
     this.rememberThreadListContexts(
       threads,
       displayMetadataObservationSequence,
+      params.enrichDirectories,
     );
     return threads;
   }
@@ -12317,6 +12317,7 @@ export class DesktopBackendRegistry {
       this.findThreadForWorkspaceHandoff({
         backend: params.backend,
         callerReason: "transcript-image-roots",
+        freshness: "last-known",
         threadId: params.threadId,
       }),
       this.overlayStore.getThreadOverlayState({
@@ -13896,7 +13897,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
   ): string | undefined {
-    return this.getCachedThreadDisplayMetadata({ backend, threadId })?.title;
+    return this.threadInfoStore.getTitle({ backend, threadId });
   }
 
   async supportsMessagingPdfTools(params: {
@@ -18139,6 +18140,7 @@ export class DesktopBackendRegistry {
     const thread = await this.findThreadForWorkspaceHandoff({
       backend: params.backend,
       callerReason: "branch-drift",
+      freshness: "last-known",
       threadId: params.threadId,
     });
     const workspaceCwd = resolveThreadWorkspaceCwd(
@@ -18240,6 +18242,7 @@ export class DesktopBackendRegistry {
     const thread = await this.findThreadForWorkspaceHandoff({
       backend: params.backend,
       callerReason: "active-turn-branch-adoption",
+      freshness: "last-known",
       threadId: params.threadId,
     });
     const workspaceCwd = resolveThreadWorkspaceCwd(
@@ -25664,15 +25667,45 @@ export class DesktopBackendRegistry {
       });
   }
 
+  /**
+   * One thread's row.
+   *
+   * `freshness` is the caller's declaration, not an optimization hint:
+   *
+   * - `"provider"` (the default) walks the provider's whole thread list and
+   *   picks the row out of it. A caller about to mutate a workspace needs the
+   *   provider's current truth, and pays for it.
+   * - `"last-known"` answers from the thread information store, which survives
+   *   list-cache invalidation. A read-only caller asking where a thread's
+   *   workspace is does not need a fresh collection, and making it pay for one
+   *   put a full paged provider walk on every turn boundary: `turn/started`
+   *   invalidates the list cache, and the next branch adoption rebuilt the
+   *   entire list to read one row.
+   *
+   * A `"last-known"` read falls back to the provider walk when the thread has
+   * never been observed at the enrichment level the caller listed at, so a cold
+   * process still answers correctly — it just stops re-answering.
+   */
   private async findThreadForWorkspaceHandoff(params: {
     backend: AppServerBackendKind;
     callerReason?: ThreadListCallerReason;
+    freshness?: "last-known" | "provider";
     threadId: string;
   }): Promise<AppServerThreadSummary | undefined> {
+    const callerReason = params.callerReason ?? "workspace-handoff";
+    if (params.freshness === "last-known") {
+      const remembered = this.threadInfoStore.getSummary(
+        { backend: params.backend, threadId: params.threadId },
+        { requireEnriched: shouldEnrichThreadDirectories(callerReason) },
+      );
+      if (remembered) {
+        return remembered;
+      }
+    }
     return await this.listThreads({
       backend: params.backend,
       archived: false,
-      callerReason: params.callerReason ?? "workspace-handoff",
+      callerReason,
     })
       .then((threads) => threads.find((thread) => thread.id === params.threadId))
       .catch(() => undefined);
@@ -25699,6 +25732,7 @@ export class DesktopBackendRegistry {
     const thread = await this.findThreadForWorkspaceHandoff({
       backend,
       callerReason: "turn-cwd",
+      freshness: "last-known",
       threadId,
     });
     const threadCwd = resolveThreadWorkspaceCwd(
@@ -34363,38 +34397,14 @@ export class DesktopBackendRegistry {
     }
   }
 
-  private reserveThreadDisplayMetadataObservation(): number {
-    this.threadDisplayMetadataObservationSequence += 1;
-    return this.threadDisplayMetadataObservationSequence;
-  }
-
-  private rememberThreadDisplayMetadata(params: {
-    backend: AppServerBackendKind;
-    observationSequence: number;
-    threadId: string;
-    title?: string;
-    titleSource?: AppServerThreadTitleSource;
-  }): void {
-    if (params.titleSource === "fallback") {
-      return;
-    }
-    const title = params.title?.trim();
-    if (!title) {
-      return;
-    }
-    const key = buildThreadIdentityKey(params.backend, params.threadId);
-    const existing = this.threadDisplayMetadata.get(key);
-    if (
-      existing
-      && existing.observationSequence >= params.observationSequence
-    ) {
-      return;
-    }
-    this.threadDisplayMetadata.set(key, {
-      observationSequence: params.observationSequence,
-      title,
-      ...(params.titleSource ? { titleSource: params.titleSource } : {}),
-    });
+  /**
+   * Take the sequence an observation will be recorded at. Asynchronous readers
+   * MUST call this before they start: a listing that is overtaken by a rename
+   * and then completes late carries the older sequence it reserved, so its
+   * stale rows lose instead of silently reverting the rename.
+   */
+  private reserveThreadInfoObservation(): number {
+    return this.threadInfoStore.reserveObservationSequence();
   }
 
   private rememberThreadTitleFromEvent(event: AgentEvent): void {
@@ -34410,11 +34420,10 @@ export class DesktopBackendRegistry {
         const trimmed = threadName.trim();
         if (trimmed) {
           const key = buildThreadIdentityKey(event.backend, threadId);
-          this.rememberThreadDisplayMetadata({
-            backend: event.backend,
-            observationSequence:
-              this.reserveThreadDisplayMetadataObservation(),
-            threadId,
+          this.threadInfoStore.observe({
+            identity: { backend: event.backend, threadId },
+            observationSequence: this.reserveThreadInfoObservation(),
+            source: "lifecycle-notification",
             title: trimmed,
             titleSource: "explicit",
           });
@@ -34436,7 +34445,7 @@ export class DesktopBackendRegistry {
         event.backend,
         threadId,
         params.thread,
-        this.reserveThreadDisplayMetadataObservation(),
+        this.reserveThreadInfoObservation(),
       );
     }
   }
@@ -34500,35 +34509,49 @@ export class DesktopBackendRegistry {
       || record.titleSource === "fallback"
         ? record.titleSource
         : undefined;
-    this.rememberThreadDisplayMetadata({
-      backend,
+    this.threadInfoStore.observe({
+      identity: { backend, threadId },
       observationSequence: displayMetadataObservationSequence,
-      threadId,
-      title: candidate,
-      titleSource,
+      source: "lifecycle-notification",
+      ...(candidate !== undefined ? { title: candidate } : {}),
+      ...(titleSource !== undefined ? { titleSource } : {}),
+      ...(readNotificationProjectLabel(record) !== undefined
+        ? { projectLabel: readNotificationProjectLabel(record) as string }
+        : {}),
     });
-    const key = buildThreadIdentityKey(backend, threadId);
-    const projectLabel = readNotificationProjectLabel(record);
-    if (projectLabel) {
-      this.notificationThreadProjectLabels.set(key, projectLabel);
-    }
   }
 
-  /** Keep titles already shown in navigation available to time-bounded UI. */
+  /**
+   * Fold a completed listing into the thread information store. Every row is
+   * offered, including fallback-titled ones: the store decides what a fallback
+   * means, so a provider that has lost its title index cannot push uuids over
+   * names PwrAgent already knows.
+   */
   private rememberThreadListContexts(
     threads: readonly AppServerThreadSummary[],
     displayMetadataObservationSequence: number,
+    enriched: boolean,
   ): void {
     for (const thread of threads) {
-      if (thread.titleSource === "fallback") {
-        continue;
-      }
-      this.rememberThreadNotificationContext(
-        thread.source,
-        thread.id,
-        thread,
-        displayMetadataObservationSequence,
+      const identity = { backend: thread.source, threadId: thread.id };
+      const projectLabel = readNotificationProjectLabel(
+        thread as unknown as Record<string, unknown>,
       );
+      this.threadInfoStore.observe({
+        identity,
+        observationSequence: displayMetadataObservationSequence,
+        source: "provider-list",
+        title: thread.title,
+        ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
+        ...(projectLabel ? { projectLabel } : {}),
+        ...(thread.updatedAt !== undefined ? { updatedAt: thread.updatedAt } : {}),
+      });
+      this.threadInfoStore.observeSummary({
+        enriched,
+        identity,
+        observationSequence: displayMetadataObservationSequence,
+        summary: thread,
+      });
     }
   }
 
@@ -34536,15 +34559,29 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
   ): string | undefined {
-    const key = buildThreadIdentityKey(backend, threadId);
-    const projectLabel = this.notificationThreadProjectLabels.get(key);
-    const threadTitle = this.threadDisplayMetadata.get(key)?.title;
+    const info = this.threadInfoStore.get({ backend, threadId });
+    const projectLabel = info?.projectLabel;
+    const threadTitle = info?.title;
     if (projectLabel && threadTitle) {
       return `${projectLabel} > ${threadTitle}`;
     }
     return threadTitle ?? projectLabel;
   }
 
+  /**
+   * Label a terminal notification, reconciling once when nothing is known yet.
+   *
+   * The store answers for any thread this process has listed or seen start,
+   * which is nearly all of them, and that read is free. The remaining case is a
+   * turn completing on a thread this process never observed — an external
+   * process sharing the profile — where a label still beats "A turn completed".
+   *
+   * The reconciliation is deduplicated per thread because turn completions
+   * arrive in bursts across concurrent threads, and an unlabeled thread would
+   * otherwise start a fresh whole-collection walk for each one. The walk seeds
+   * the information store, so it happens at most once per thread per process
+   * rather than once per notification.
+   */
   private async notificationThreadContextLabelForTerminal(
     backend: AppServerBackendKind,
     threadId: string,
@@ -34553,24 +34590,26 @@ export class DesktopBackendRegistry {
     if (cached) {
       return cached;
     }
-    try {
-      const threads = await this.listThreads({
+    const key = buildThreadIdentityKey(backend, threadId);
+    let reconciliation = this.notificationContextReconciliations.get(key);
+    if (!reconciliation) {
+      reconciliation = this.listThreads({
         backend,
         callerReason: "notification-context",
         enrichDirectories: true,
-      });
-      const thread = threads.find((candidate) => candidate.id === threadId);
-      if (thread) {
-        return this.notificationThreadContextLabel(backend, threadId);
-      }
-    } catch (error) {
-      backendRegistryLog.debug("native terminal notification context lookup failed", {
-        backend,
-        error: error instanceof Error ? error.message : String(error),
-        threadId,
-      });
+      })
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          backendRegistryLog.debug("native terminal notification context lookup failed", {
+            backend,
+            error: error instanceof Error ? error.message : String(error),
+            threadId,
+          });
+        });
+      this.notificationContextReconciliations.set(key, reconciliation);
     }
-    return undefined;
+    await reconciliation;
+    return this.notificationThreadContextLabel(backend, threadId);
   }
 
   private notifyForAttentionRequired(event: AgentEvent): void {
@@ -34588,9 +34627,10 @@ export class DesktopBackendRegistry {
     const title = isQuestion
       ? "PwrAgent input needed"
       : "PwrAgent approval needed";
-    const threadTitle = this.threadDisplayMetadata.get(
-      buildThreadIdentityKey(event.backend, threadId),
-    )?.title;
+    const threadTitle = this.threadInfoStore.get({
+      backend: event.backend,
+      threadId,
+    })?.title;
     const approvalRequest = this.isApprovalAttentionNotification(event.notification)
       ? event.notification
       : undefined;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7822,6 +7822,7 @@ export class DesktopBackendRegistry {
     | ThreadPullRequestWatchToolHandler
     | undefined;
   private directoryGitStatusWriter: DirectoryGitStatusWriter | undefined;
+  private readonly pendingDirectoryGitStatusKeys = new Set<string>();
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadPullRequestDetachHandler:
     | ThreadPullRequestDetachHandler
@@ -9517,6 +9518,37 @@ export class DesktopBackendRegistry {
     if (!threadId) {
       return undefined;
     }
+    const cached = this.getCachedThreadSummary({
+      backend: params.backend,
+      threadId,
+    });
+    if (cached) {
+      return cached;
+    }
+    const threads = await this.listThreads({
+      backend: params.backend,
+      archived: false,
+      callerReason: "thread-id-lookup",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    return threads.find((thread) => thread.id === threadId);
+  }
+
+  /**
+   * Read one already-observed thread without starting or awaiting a provider
+   * thread-list walk. Hot-path consumers such as messaging admission combine
+   * this volatile summary with the durable per-thread overlay instead of
+   * asking navigation to rebuild every thread and directory.
+   */
+  getCachedThreadSummary(params: {
+    backend?: AppServerBackendKind;
+    threadId: string;
+  }): AppServerThreadSummary | undefined {
+    const threadId = params.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
     for (const state of this.threadListCache.values()) {
       const cached = state.threads?.find(
         (thread) =>
@@ -9527,14 +9559,7 @@ export class DesktopBackendRegistry {
         return cached;
       }
     }
-    const threads = await this.listThreads({
-      backend: params.backend,
-      archived: false,
-      callerReason: "thread-id-lookup",
-      enrichDirectories: false,
-      forceRefresh: true,
-    });
-    return threads.find((thread) => thread.id === threadId);
+    return undefined;
   }
 
   async getThreadAgentMetadata(params: {
@@ -11584,40 +11609,61 @@ export class DesktopBackendRegistry {
       .map((key) => this.navigationDirectoriesByKey.get(key))
       .filter((directory): directory is NavigationDirectorySummary =>
         Boolean(directory?.path?.trim()),
-      );
+      )
+      .filter((directory) => !this.pendingDirectoryGitStatusKeys.has(directory.key));
+    for (const directory of directories) {
+      this.pendingDirectoryGitStatusKeys.add(directory.key);
+    }
     if (request.force !== false) {
       for (const directory of directories) {
         this.gitDirectoryService.invalidateDirectoryStatus(directory.path);
       }
     }
-    for await (const entry of this.gitDirectoryService.readDirectoryStatusEntries(
-      directories,
-    )) {
-      const fetchedAt = Date.now();
-      const directory = this.navigationDirectoriesByKey.get(entry.directoryKey);
-      if (this.directoryGitStatusWriter) {
-        await this.directoryGitStatusWriter({
-          directory,
-          directoryKey: entry.directoryKey,
-          fetchedAt,
-          gitStatus: entry.gitStatus,
-        });
-        continue;
-      }
-      const notification: NavigationDirectoryGitStatusUpdatedNotification = {
-        method: "navigation/directoryGitStatus/updated",
-        params: {
-          directoryKey: entry.directoryKey,
-          gitStatus: entry.gitStatus ?? null,
-          fetchedAt,
-        },
-      };
-      await this.emit({
-        backend: "codex",
-        notification,
-      } as unknown as AgentEvent);
-    }
+    void this.refreshDirectoryGitStatusesInBackground(directories);
     return { scheduledCount: directories.length };
+  }
+
+  private async refreshDirectoryGitStatusesInBackground(
+    directories: NavigationDirectorySummary[],
+  ): Promise<void> {
+    try {
+      for await (const entry of this.gitDirectoryService.readDirectoryStatusEntries(
+        directories,
+      )) {
+        const fetchedAt = Date.now();
+        const directory = this.navigationDirectoriesByKey.get(entry.directoryKey);
+        if (this.directoryGitStatusWriter) {
+          await this.directoryGitStatusWriter({
+            directory,
+            directoryKey: entry.directoryKey,
+            fetchedAt,
+            gitStatus: entry.gitStatus,
+          });
+          continue;
+        }
+        const notification: NavigationDirectoryGitStatusUpdatedNotification = {
+          method: "navigation/directoryGitStatus/updated",
+          params: {
+            directoryKey: entry.directoryKey,
+            gitStatus: entry.gitStatus ?? null,
+            fetchedAt,
+          },
+        };
+        await this.emit({
+          backend: "codex",
+          notification,
+        } as unknown as AgentEvent);
+      }
+    } catch (error) {
+      backendRegistryLog.warn("directory Git status refresh failed", {
+        directoryKeys: directories.map((directory) => directory.key),
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      for (const directory of directories) {
+        this.pendingDirectoryGitStatusKeys.delete(directory.key);
+      }
+    }
   }
 
   readWorktreeWorkingStateEntries(
@@ -13566,6 +13612,13 @@ export class DesktopBackendRegistry {
       }
     }
     return undefined;
+  }
+
+  isThreadTurnOccupied(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): boolean {
+    return this.threadHasActiveTurn(params.threadId, params.backend);
   }
 
   private getPendingTurnForThread(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9650,6 +9650,7 @@ export class DesktopBackendRegistry {
         threads,
         displayMetadataObservationSequence,
         params.enrichDirectories,
+        params.archived === true,
       );
       return threads;
     }
@@ -9664,6 +9665,7 @@ export class DesktopBackendRegistry {
         threads,
         displayMetadataObservationSequence,
         params.enrichDirectories,
+        params.archived === true,
       );
       return threads;
     }
@@ -9689,6 +9691,7 @@ export class DesktopBackendRegistry {
       threads,
       displayMetadataObservationSequence,
       params.enrichDirectories,
+      params.archived === true,
     );
     return threads;
   }
@@ -34398,6 +34401,40 @@ export class DesktopBackendRegistry {
   }
 
   /**
+   * Teach the information store that a thread's archived state changed.
+   *
+   * Archival is a fact about the thread, so it is an observation like any
+   * other, and it is deliberately separate from `invalidateThreadListCache`.
+   * Invalidation says a query's result may have changed; it does not say a
+   * thread was archived, and conflating the two is what made the list cache the
+   * only record of archival — and therefore made forgetting it mandatory.
+   */
+  private recordThreadArchivalFromNotification(
+    backend: AppServerBackendKind,
+    notification: AgentEvent["notification"],
+  ): void {
+    const archived =
+      notification.method === "thread/archived"
+        ? true
+        : notification.method === "thread/unarchived"
+          ? false
+          : undefined;
+    if (archived === undefined) {
+      return;
+    }
+    const threadId = (notification.params as { threadId?: unknown })?.threadId;
+    if (typeof threadId !== "string") {
+      return;
+    }
+    this.threadInfoStore.observe({
+      archived,
+      identity: { backend, threadId },
+      observationSequence: this.reserveThreadInfoObservation(),
+      source: "lifecycle-notification",
+    });
+  }
+
+  /**
    * Take the sequence an observation will be recorded at. Asynchronous readers
    * MUST call this before they start: a listing that is overtaken by a rename
    * and then completes late carries the older sequence it reserved, so its
@@ -34409,6 +34446,7 @@ export class DesktopBackendRegistry {
 
   private rememberThreadTitleFromEvent(event: AgentEvent): void {
     const method = event.notification.method;
+    this.recordThreadArchivalFromNotification(event.backend, event.notification);
     if (method === "thread/name/updated") {
       const params = event.notification.params as {
         threadId?: unknown;
@@ -34531,6 +34569,7 @@ export class DesktopBackendRegistry {
     threads: readonly AppServerThreadSummary[],
     displayMetadataObservationSequence: number,
     enriched: boolean,
+    listedArchived: boolean,
   ): void {
     for (const thread of threads) {
       const identity = { backend: thread.source, threadId: thread.id };
@@ -34541,6 +34580,7 @@ export class DesktopBackendRegistry {
         identity,
         observationSequence: displayMetadataObservationSequence,
         source: "provider-list",
+        archived: listedArchived,
         title: thread.title,
         ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
         ...(projectLabel ? { projectLabel } : {}),

--- a/apps/desktop/src/main/app-server/directory-git-status-refresh-policy.ts
+++ b/apps/desktop/src/main/app-server/directory-git-status-refresh-policy.ts
@@ -1,0 +1,48 @@
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+
+type DirectoryGitStatusCacheEntryLike = {
+  directoryUpdatedAt?: number;
+  fetchedAt: number;
+};
+
+/**
+ * Directory status is navigation context, not an admission or correctness
+ * gate. Five minutes keeps an untouched fleet calm while explicit focus and
+ * mutation paths refresh the directories the operator is actually using.
+ */
+export const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
+export const DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE = 4;
+
+// Forced focus refreshes can arrive in rapid succession while the operator
+// flips between threads in one repository. Collapse the post-completion gap;
+// in-flight requests already coalesce separately.
+export const DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS = 3_000;
+
+export function isFreshDirectoryGitStatusCacheEntry(
+  entry: DirectoryGitStatusCacheEntryLike,
+  now = Date.now(),
+): boolean {
+  return now - entry.fetchedAt < DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS;
+}
+
+export function selectStaleDirectoryGitStatusKeys(params: {
+  cache: Record<string, DirectoryGitStatusCacheEntryLike>;
+  directories: NavigationDirectorySummary[];
+  limit?: number;
+  now?: number;
+}): string[] {
+  const now = params.now ?? Date.now();
+  return params.directories
+    .filter((directory) => {
+      if (!directory.path?.trim()) {
+        return false;
+      }
+      const cached = params.cache[directory.key];
+      return !cached
+        || !isFreshDirectoryGitStatusCacheEntry(cached, now)
+        || (directory.latestUpdatedAt ?? 0) > (cached.directoryUpdatedAt ?? 0);
+    })
+    .sort((left, right) => (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0))
+    .slice(0, params.limit ?? DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE)
+    .map((directory) => directory.key);
+}

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -1,0 +1,386 @@
+import {
+  buildThreadIdentityKey,
+  type AppServerBackendKind,
+  type AppServerThreadSummary,
+  type AppServerThreadTitleSource,
+} from "@pwragent/shared";
+
+/**
+ * Where a piece of thread information came from. Higher-trust sources are not
+ * ranked here: recency wins, and the source is retained for diagnostics and for
+ * callers that must distinguish a provider-derived label from an operator's
+ * explicit rename.
+ */
+export type ThreadInfoSource =
+  | "lifecycle-notification"
+  | "local-rename"
+  | "provider-list"
+  | "remote-navigation"
+  | "remote-pin";
+
+/**
+ * The identity of a thread as this process knows it. `instanceId` is absent for
+ * threads this instance owns and present for a mounted peer's thread, so a
+ * local thread and a remote thread that happen to share a backend and id can
+ * never collapse into one entry.
+ */
+export type ThreadInfoIdentity = {
+  backend: AppServerBackendKind;
+  instanceId?: string;
+  threadId: string;
+};
+
+/**
+ * A field this store tracks. Adding one is the whole cost of teaching the store
+ * about a new piece of display metadata; every merge, retention, and freshness
+ * rule already applies to it.
+ */
+export type ThreadInfoFields = {
+  archived: boolean;
+  projectLabel: string;
+  title: string;
+  titleSource: AppServerThreadTitleSource;
+  updatedAt: number;
+};
+
+export type ThreadInfoFieldName = keyof ThreadInfoFields;
+
+type ThreadInfoFieldEntry<Name extends ThreadInfoFieldName> = {
+  observationSequence: number;
+  source: ThreadInfoSource;
+  value: ThreadInfoFields[Name];
+};
+
+type ThreadInfoSummaryEntry = {
+  /**
+   * Whether the listing that produced this row ran directory enrichment.
+   * An unenriched row can be missing worktree paths, so a caller that needs
+   * them must not be handed one — see `getSummary`.
+   */
+  enriched: boolean;
+  observationSequence: number;
+  value: AppServerThreadSummary;
+};
+
+type ThreadInfoEntry = {
+  fields: {
+    [Name in ThreadInfoFieldName]?: ThreadInfoFieldEntry<Name>;
+  };
+  /** Highest sequence any accepted field on this entry carries. */
+  lastObservedSequence: number;
+  summary?: ThreadInfoSummaryEntry;
+};
+
+/**
+ * What the store knows about one thread right now. Every field is optional and
+ * a missing field means exactly one thing: nothing has ever been observed for
+ * it. It never means a read failed, a provider was slow, or a cache lapsed.
+ */
+export type ThreadInfo = {
+  archived?: boolean;
+  identity: ThreadInfoIdentity;
+  /** Sequence of the newest accepted observation, for ordering diagnostics. */
+  lastObservedSequence: number;
+  projectLabel?: string;
+  title?: string;
+  titleSource?: AppServerThreadTitleSource;
+  updatedAt?: number;
+};
+
+/** A batch of facts about one thread, as some source observed them. */
+export type ThreadInfoObservation = {
+  identity: ThreadInfoIdentity;
+  /**
+   * Sequence this observation was taken at. Asynchronous readers MUST reserve
+   * this before the read begins — see `reserveObservationSequence`.
+   */
+  observationSequence: number;
+  source: ThreadInfoSource;
+} & Partial<ThreadInfoFields>;
+
+const TRACKED_FIELDS: readonly ThreadInfoFieldName[] = [
+  "archived",
+  "projectLabel",
+  "title",
+  "titleSource",
+  "updatedAt",
+];
+
+function identityKey(identity: ThreadInfoIdentity): string {
+  const threadKey = buildThreadIdentityKey(identity.backend, identity.threadId);
+  return identity.instanceId ? `${identity.instanceId}::${threadKey}` : threadKey;
+}
+
+/**
+ * A title that carries no information. `fallback` is what a provider returns
+ * when it has nothing better than the thread id, so accepting one would let a
+ * list refresh overwrite a real name with a uuid — the regression this store
+ * exists to make unrepresentable.
+ */
+function isUsableTitle(
+  title: string | undefined,
+  titleSource: AppServerThreadTitleSource | undefined,
+): boolean {
+  if (titleSource === "fallback") {
+    return false;
+  }
+  return (title?.trim().length ?? 0) > 0;
+}
+
+/**
+ * The process-lifetime record of what PwrAgent knows about each thread it has
+ * seen, keyed by thread identity rather than by the shape of the query that
+ * happened to reveal it.
+ *
+ * The distinction that motivates this store: a *query cache* answers "which
+ * threads match Q, in what order", is invalidated by any mutation, and is
+ * correctly forgotten. An *information store* answers "what is thread X
+ * called", and forgetting it is never correct — the previous answer is still
+ * the best answer available until a newer one arrives.
+ *
+ * PwrAgent previously had only the query cache, so a mutation anywhere erased
+ * the display metadata for every thread, and any read that had to re-derive it
+ * could regress a named row back to a uuid while a provider round trip was in
+ * flight. Reads here are synchronous, cannot fail, and cannot start I/O.
+ *
+ * Ordering is by monotonic sequence, never by wall clock, so this is safe on
+ * the render path and unaffected by clock adjustment.
+ */
+export class ThreadInfoStore {
+  private readonly entries = new Map<string, ThreadInfoEntry>();
+  private observationSequence = 0;
+
+  /**
+   * Take the sequence an observation will be recorded at. An asynchronous
+   * reader must call this BEFORE it starts, not when it finishes.
+   *
+   * This is the rule that makes late completions harmless. A provider list
+   * that starts, is overtaken by a rename, and completes afterwards carries the
+   * older sequence it reserved, so its stale rows lose to the rename instead of
+   * silently reverting it.
+   */
+  reserveObservationSequence(): number {
+    this.observationSequence += 1;
+    return this.observationSequence;
+  }
+
+  /**
+   * Record what a source observed. Only positive facts are merged: a field the
+   * observation omits is left alone, because "this read did not mention the
+   * title" and "this thread has no title" are different claims and only the
+   * caller knows which one it is making.
+   *
+   * Returns the fields this observation actually changed, which lets callers
+   * skip downstream work when a refresh confirmed what was already known.
+   */
+  observe(observation: ThreadInfoObservation): ThreadInfoFieldName[] {
+    const threadId = observation.identity.threadId.trim();
+    if (!threadId) {
+      return [];
+    }
+    const identity: ThreadInfoIdentity = {
+      backend: observation.identity.backend,
+      threadId,
+      ...(observation.identity.instanceId
+        ? { instanceId: observation.identity.instanceId }
+        : {}),
+    };
+    const key = identityKey(identity);
+    const entry = this.entries.get(key) ?? {
+      fields: {},
+      lastObservedSequence: 0,
+    };
+
+    // A title and its source describe one fact. Validating them together stops
+    // a fallback source from arriving without its title and downgrading a name
+    // the store already holds.
+    const titleIsUsable = isUsableTitle(observation.title, observation.titleSource);
+    const changed: ThreadInfoFieldName[] = [];
+
+    for (const field of TRACKED_FIELDS) {
+      const value = observation[field];
+      if (value === undefined) {
+        continue;
+      }
+      if ((field === "title" || field === "titleSource") && !titleIsUsable) {
+        continue;
+      }
+      if (field === "projectLabel" && !String(value).trim()) {
+        continue;
+      }
+      const existing = entry.fields[field];
+      if (
+        existing
+        && existing.observationSequence > observation.observationSequence
+      ) {
+        continue;
+      }
+      const normalized =
+        field === "title" || field === "projectLabel"
+          ? (String(value).trim() as ThreadInfoFields[typeof field])
+          : value;
+      if (existing && existing.value === normalized) {
+        // Still a fresher confirmation of the same fact, so the sequence moves
+        // even though no caller needs to hear about a change.
+        existing.observationSequence = observation.observationSequence;
+        existing.source = observation.source;
+        continue;
+      }
+      (entry.fields as Record<string, unknown>)[field] = {
+        observationSequence: observation.observationSequence,
+        source: observation.source,
+        value: normalized,
+      };
+      changed.push(field);
+    }
+
+    entry.lastObservedSequence = Math.max(
+      entry.lastObservedSequence,
+      observation.observationSequence,
+    );
+    this.entries.set(key, entry);
+    return changed;
+  }
+
+  /**
+   * What this process knows about a thread. Synchronous, allocation-light, and
+   * safe on any path — including a 500ms UI poll — because it can neither wait
+   * nor fail. `undefined` means this thread has never been observed at all.
+   */
+  get(identity: ThreadInfoIdentity): ThreadInfo | undefined {
+    const threadId = identity.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    const entry = this.entries.get(
+      identityKey({ ...identity, threadId }),
+    );
+    if (!entry) {
+      return undefined;
+    }
+    const info: ThreadInfo = {
+      identity: {
+        backend: identity.backend,
+        threadId,
+        ...(identity.instanceId ? { instanceId: identity.instanceId } : {}),
+      },
+      lastObservedSequence: entry.lastObservedSequence,
+    };
+    for (const field of TRACKED_FIELDS) {
+      const stored = entry.fields[field];
+      if (stored !== undefined) {
+        (info as Record<string, unknown>)[field] = stored.value;
+      }
+    }
+    return info;
+  }
+
+  /**
+   * Record the whole row a listing returned, so a later point query about this
+   * thread can be answered without walking the collection again.
+   *
+   * `enriched` records whether the listing ran directory enrichment. It is not
+   * a quality score: an unenriched row is complete for callers that asked for
+   * an unenriched listing and incomplete for callers that did not, and only
+   * the reader knows which it is.
+   */
+  observeSummary(params: {
+    enriched: boolean;
+    identity: ThreadInfoIdentity;
+    observationSequence: number;
+    summary: AppServerThreadSummary;
+  }): void {
+    const threadId = params.identity.threadId.trim();
+    if (!threadId) {
+      return;
+    }
+    const key = identityKey({ ...params.identity, threadId });
+    const entry = this.entries.get(key) ?? {
+      fields: {},
+      lastObservedSequence: 0,
+    };
+    const existing = entry.summary;
+    // An enriched row is not replaced by an unenriched one taken at the same
+    // moment: both are current, and only one can answer a directory question.
+    const supersedes =
+      !existing
+      || existing.observationSequence < params.observationSequence
+      || (existing.observationSequence === params.observationSequence
+        && params.enriched
+        && !existing.enriched);
+    if (supersedes) {
+      entry.summary = {
+        enriched: params.enriched,
+        observationSequence: params.observationSequence,
+        value: params.summary,
+      };
+    }
+    entry.lastObservedSequence = Math.max(
+      entry.lastObservedSequence,
+      params.observationSequence,
+    );
+    this.entries.set(key, entry);
+  }
+
+  /**
+   * The last row a listing returned for this thread, or `undefined` when none
+   * has been observed at the requested enrichment level.
+   *
+   * Deliberately survives thread-list cache invalidation. Invalidation means
+   * "the ordering and membership of that query may have changed", which says
+   * nothing about where this thread's workspace is. A caller that needs
+   * post-mutation provider truth must go to the provider explicitly.
+   */
+  getSummary(
+    identity: ThreadInfoIdentity,
+    options?: { requireEnriched?: boolean },
+  ): AppServerThreadSummary | undefined {
+    const threadId = identity.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    const summary = this.entries.get(identityKey({ ...identity, threadId }))
+      ?.summary;
+    if (!summary) {
+      return undefined;
+    }
+    if (options?.requireEnriched && !summary.enriched) {
+      return undefined;
+    }
+    return summary.value;
+  }
+
+  /** The display title, or `undefined` when none has ever been observed. */
+  getTitle(identity: ThreadInfoIdentity): string | undefined {
+    return this.get(identity)?.title;
+  }
+
+  /**
+   * Drop a thread the owning provider no longer has. This is the ONLY way an
+   * entry leaves the store, and it is deliberately not reachable from cache
+   * invalidation: invalidation means "the query result may be stale", which
+   * says nothing about whether the thread still exists or what it is called.
+   */
+  forget(identity: ThreadInfoIdentity): void {
+    this.entries.delete(identityKey(identity));
+  }
+
+  /** Drop every thread belonging to a peer that unmounted. */
+  forgetInstance(instanceId: string): void {
+    const prefix = `${instanceId}::`;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  /** Entry count, for budget assertions and memory diagnostics. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -66,6 +66,11 @@ type ThreadInfoEntry = {
   fields: {
     [Name in ThreadInfoFieldName]?: ThreadInfoFieldEntry<Name>;
   };
+  /**
+   * The identity this entry is keyed by, kept alongside the key so a lookup
+   * that does not know the backend can filter without parsing the key string.
+   */
+  identity: ThreadInfoIdentity;
   /** Highest sequence any accepted field on this entry carries. */
   lastObservedSequence: number;
   summary?: ThreadInfoSummaryEntry;
@@ -188,6 +193,7 @@ export class ThreadInfoStore {
     const key = identityKey(identity);
     const entry = this.entries.get(key) ?? {
       fields: {},
+      identity,
       lastObservedSequence: 0,
     };
 
@@ -294,9 +300,17 @@ export class ThreadInfoStore {
     if (!threadId) {
       return;
     }
-    const key = identityKey({ ...params.identity, threadId });
+    const identity: ThreadInfoIdentity = {
+      backend: params.identity.backend,
+      threadId,
+      ...(params.identity.instanceId
+        ? { instanceId: params.identity.instanceId }
+        : {}),
+    };
+    const key = identityKey(identity);
     const entry = this.entries.get(key) ?? {
       fields: {},
+      identity,
       lastObservedSequence: 0,
     };
     const existing = entry.summary;
@@ -348,6 +362,39 @@ export class ThreadInfoStore {
       return undefined;
     }
     return summary.value;
+  }
+
+  /**
+   * A locally-owned thread's summary when the caller may not know its backend.
+   *
+   * A named backend is a direct lookup. Without one this scans, the way the
+   * caller's previous thread-list walk did — but over one entry per thread
+   * rather than every row of every cached query, and it still answers after
+   * the query caches have been invalidated.
+   *
+   * Instance-qualified entries are skipped: those belong to peers, and a
+   * caller that did not name an instance is not asking about a peer's thread.
+   */
+  findLocalSummary(params: {
+    backend?: AppServerBackendKind;
+    threadId: string;
+  }): AppServerThreadSummary | undefined {
+    const threadId = params.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    if (params.backend) {
+      return this.getSummary({ backend: params.backend, threadId });
+    }
+    for (const entry of this.entries.values()) {
+      if (entry.identity.instanceId || entry.identity.threadId !== threadId) {
+        continue;
+      }
+      if (entry.summary) {
+        return entry.summary.value;
+      }
+    }
+    return undefined;
   }
 
   /** The display title, or `undefined` when none has ever been observed. */

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -1,6 +1,7 @@
 import type {
   AnalyzeThreadToolHistoryRequest,
   AnalyzeThreadToolHistoryResponse,
+  AppServerBackendKind,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
   AppServerListThreadsRequest,
@@ -139,6 +140,7 @@ import type {
   SubmitServerRequestResponse,
   TrustCodexProjectRequest,
   TrustCodexProjectResponse,
+  ThreadAdmissionState,
   UpdateSubthreadOrderRequest,
   UpdateSubthreadOrderResponse,
   UpdateScheduledThreadActionRequest,
@@ -350,6 +352,7 @@ export const FEDERATION_BACKEND_METHODS = {
   getNavigationSnapshot: "backend.getNavigationSnapshot",
   listThreads: "backend.listThreads",
   resolveThread: "backend.resolveThread",
+  resolveThreadAdmissionState: "backend.resolveThreadAdmissionState",
   readThread: "backend.readThread",
   analyzeThreadToolHistory: "backend.analyzeThreadToolHistory",
   readTranscriptImage: "backend.readTranscriptImage",
@@ -445,6 +448,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.getNavigationSnapshot]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.resolveThread]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState]: "messaging_route",
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   /* Reads the thread's own transcript history; same data class as reading it. */
   [FEDERATION_BACKEND_METHODS.analyzeThreadToolHistory]: "thread_detail",
@@ -552,6 +556,10 @@ export type FederationBackendOperations = {
     request?: AppServerListThreadsRequest,
   ): Promise<AppServerListThreadsResponse>;
   resolveThread(request: ResolveThreadRequest): Promise<ResolveThreadResponse>;
+  resolveThreadAdmissionState?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadAdmissionState>;
   readThread(
     request: AppServerReadThreadRequest,
   ): Promise<AppServerReadThreadResponse>;
@@ -812,6 +820,20 @@ export function registerFederationBackendHandlers(params: {
       await params.backend.resolveThread(
         envelope.params as ResolveThreadRequest,
       ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState,
+    async (envelope) => {
+      if (!params.backend.resolveThreadAdmissionState) {
+        throw new Error("Targeted thread admission state is unavailable.");
+      }
+      return await params.backend.resolveThreadAdmissionState(
+        envelope.params as {
+          backend: AppServerBackendKind;
+          threadId: string;
+        },
+      );
+    },
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.analyzeThreadToolHistory,
@@ -1490,6 +1512,16 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<ResolveThreadResponse> {
     return await this.rpc.request<ResolveThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.resolveThread,
+      params: request,
+    });
+  }
+
+  async resolveThreadAdmissionState(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadAdmissionState> {
+    return await this.rpc.request<ThreadAdmissionState>({
+      method: FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4770,6 +4770,10 @@ function localBackendOperations(): FederationBackendOperations {
       const thread = await getDesktopBackendRegistry().resolveThread(request);
       return thread ? { thread } : {};
     },
+    async resolveThreadAdmissionState(request) {
+      return await new DesktopMessagingBackendBridge()
+        .getThreadAdmissionState(request);
+    },
     async readThread(
       request: AppServerReadThreadRequest,
     ): Promise<AppServerReadThreadResponse> {

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -15,6 +15,7 @@ import {
   threadHasExactPrNumberMatch,
   threadMatchesQuery,
 } from "@pwragent/shared";
+import { ThreadInfoStore } from "../app-server/thread-info-store";
 
 export type RemoteThreadSummaryPeer = {
   target: FederationRemoteTarget;
@@ -132,15 +133,15 @@ export class RemoteThreadSummaryCache {
     { fetchedAt: number; threadKeys: Set<string> }
   >();
   /**
-   * Display names per instance, keyed by thread identity. Deliberately NOT
-   * cleared by `invalidate` — see `cachedThreadNameFromPeer`. Dropping a name
-   * can only send a row back to its thread id, and a name is stale-tolerant
-   * in a way the snapshots above are not.
+   * Display names for threads owned by peers, held in the same information
+   * store the local side uses and keyed by instance so two peers reusing a
+   * thread id cannot answer for each other.
+   *
+   * Deliberately NOT cleared by `invalidate` — see `cachedThreadNameFromPeer`.
+   * Dropping a name can only send a row back to its thread id, and a name is
+   * stale-tolerant in a way the snapshots above are not.
    */
-  private readonly threadNames = new Map<
-    string,
-    Map<string, RemoteThreadName>
-  >();
+  private readonly threadNames = new ThreadInfoStore();
   private readonly peerInterests = new Map<
     string,
     Map<
@@ -305,22 +306,39 @@ export class RemoteThreadSummaryCache {
   rememberThreadNames(
     instanceId: string,
     threads: readonly NavigationThreadSummary[],
+    observationSequence = this.reserveThreadNameObservation(),
   ): void {
-    let names = this.threadNames.get(instanceId);
     for (const thread of threads) {
-      const title = thread.title?.trim();
-      if (!title || thread.titleSource === "fallback") {
-        continue;
-      }
-      names ??= new Map();
-      names.set(buildThreadIdentityKey(thread.source, thread.id), {
-        title,
-        titleSource: thread.titleSource,
+      this.threadNames.observe({
+        identity: {
+          backend: thread.source,
+          instanceId,
+          threadId: thread.id,
+        },
+        observationSequence,
+        source: "remote-navigation",
+        ...(thread.title !== undefined ? { title: thread.title } : {}),
+        ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
       });
     }
-    if (names) {
-      this.threadNames.set(instanceId, names);
-    }
+  }
+
+  /**
+   * Take the sequence a peer snapshot's names will be recorded at, BEFORE the
+   * fetch starts.
+   *
+   * Two refreshes for one peer can be in flight at once and can complete out of
+   * order. Without this, the older snapshot's rows would land last and revert a
+   * rename the operator has already seen — the remote half of the regression
+   * the information store exists to prevent.
+   */
+  reserveThreadNameObservation(): number {
+    return this.threadNames.reserveObservationSequence();
+  }
+
+  /** Drop a peer's names when it unmounts and can no longer be asked. */
+  forgetInstanceThreadNames(instanceId: string): void {
+    this.threadNames.forgetInstance(instanceId);
   }
 
   /**
@@ -348,9 +366,15 @@ export class RemoteThreadSummaryCache {
     backend: NavigationThreadSummary["source"];
     threadId: string;
   }): RemoteThreadName | undefined {
-    return this.threadNames
-      .get(params.target.instanceId)
-      ?.get(buildThreadIdentityKey(params.backend, params.threadId));
+    const info = this.threadNames.get({
+      backend: params.backend,
+      instanceId: params.target.instanceId,
+      threadId: params.threadId,
+    });
+    if (!info?.title || !info.titleSource) {
+      return undefined;
+    }
+    return { title: info.title, titleSource: info.titleSource };
   }
 
   /**
@@ -780,6 +804,10 @@ export class RemoteThreadSummaryCache {
       }
       return await this.threadsForPeer(target, selection, interestKey);
     }
+    // Reserved before the fetch, not after it: a snapshot that starts first and
+    // finishes last must not overwrite the names a later refresh already
+    // recorded.
+    const nameObservationSequence = this.reserveThreadNameObservation();
     const promise = (async () => {
       const timeoutMs =
         this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
@@ -797,7 +825,11 @@ export class RemoteThreadSummaryCache {
         selection,
         threads,
       });
-      this.rememberThreadNames(target.instanceId, threads);
+      this.rememberThreadNames(
+        target.instanceId,
+        threads,
+        nameObservationSequence,
+      );
       this.touchPeerInterest(
         target.instanceId,
         interestKey,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2116,6 +2116,13 @@ class DesktopAppServerService {
         ...request,
         federationTarget,
       });
+      // Reserved before the peer round trip. Two navigation refreshes for one
+      // peer can be in flight together and can finish out of order; without
+      // this, the older snapshot's rows land last and revert a rename the
+      // operator has already seen.
+      const nameObservationSequence = getDesktopFederationRuntime()
+        .remoteThreadSummaries()
+        .reserveThreadNameObservation();
       try {
         const snapshot = await getDesktopFederationRuntime()
           .remoteNavigationSnapshot(
@@ -2138,7 +2145,11 @@ class DesktopAppServerService {
         try {
           getDesktopFederationRuntime()
             .remoteThreadSummaries()
-            .rememberThreadNames(federationTarget.instanceId, snapshot.threads);
+            .rememberThreadNames(
+              federationTarget.instanceId,
+              snapshot.threads,
+              nameObservationSequence,
+            );
         } catch (error) {
           logDebug("rememberRemoteThreadNames failed", {
             error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -200,6 +200,11 @@ import {
 import { materializeTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import {
+  DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE,
+  DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS,
+  isFreshDirectoryGitStatusCacheEntry,
+} from "../app-server/directory-git-status-refresh-policy";
 import { getAppStateDb } from "../state/app-state";
 import {
   listModelSettingsRecents,
@@ -350,15 +355,8 @@ const USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS = 10_000;
 const TERMINAL_USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
 const PR_STATUS_TOKEN_BUCKET_CAPACITY = 20;
 const PR_STATUS_TOKEN_BUCKET_REFILL_PER_MINUTE = 20;
-const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT = 4;
-const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
-// Collapse rapid forced directory-git-status re-enqueues for the same key
-// (e.g. flipping between two threads in the same repo) that land within a
-// few seconds of the previous probe completing. Concurrent same-key
-// requests already coalesce via `pendingDirectoryGitStatusKeys`; this
-// closes the sequential post-completion gap so "747, 732, 747, 747, 732,
-// 747" collapses to "747, 732".
-const DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS = 3_000;
+const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT =
+  DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE;
 const BACKGROUND_WORKTREE_WORKING_STATE_REFRESH_BATCH_SIZE = 8;
 // PR discovery (Layer B): a slow branch-lookup rotation across ALL open threads
 // to catch newly opened PRs on projects the operator is not looking at. Tick
@@ -7476,12 +7474,6 @@ class DesktopAppServerService {
     });
     return this.focusedDiffService;
   }
-}
-
-function isFreshDirectoryGitStatusCacheEntry(
-  entry: DirectoryGitStatusCacheEntry,
-): boolean {
-  return Date.now() - entry.fetchedAt < DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS;
 }
 
 function isFreshWorktreeWorkingStateCacheEntry(

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -48,6 +48,7 @@ import type {
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ThreadAgentMetadata,
+  ThreadAdmissionState,
   ThreadMessagingBindingTransition,
   UpdateScheduledThreadActionRequest,
   UpdateDirectoryLaunchpadRequest,
@@ -110,6 +111,13 @@ export type MessagingActiveBackendTurn = {
   turnId: string;
 };
 
+/**
+ * Targeted state needed to admit one bound-thread reply. This projection must
+ * stay independent of navigation-wide Git, PR, launchpad, directory, and
+ * federation enrichment.
+ */
+export type MessagingThreadAdmissionState = ThreadAdmissionState;
+
 export type MessagingAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
@@ -160,6 +168,11 @@ export type MessagingBackendBridge = {
   getNavigationSnapshot(
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot>;
+  getThreadAdmissionState(request: {
+    backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
+    threadId: string;
+  }): Promise<MessagingThreadAdmissionState>;
   /**
    * Storage roots no local-file read may reach. Read through the bridge rather
    * than the backend-registry singleton: that getter constructs a registry with

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -156,6 +156,7 @@ import type {
   MessagingAdapter,
   MessagingBackendBridge,
   MessagingLastAssistantReply,
+  MessagingThreadAdmissionState,
 } from "./messaging-adapter.js";
 import { MessagingFederatedThreadTargetError } from "./messaging-adapter.js";
 import type { MessagingActivityLog } from "../messaging-activity-log.js";
@@ -518,6 +519,24 @@ function findThreadForBinding(
       thread.id === binding.threadId &&
       federationRefsMatch(thread.federation?.ref, binding.federatedThread),
   );
+}
+
+function navigationSnapshotForAdmissionState(
+  binding: MessagingBindingRecord,
+  state: MessagingThreadAdmissionState,
+): NavigationSnapshot {
+  return {
+    backend: binding.backend,
+    directories: [],
+    fetchedAt: Date.now(),
+    inboxThreadKeys: [],
+    launchpadDefaults: {
+      backend: binding.backend,
+      executionMode: "default",
+    },
+    threads: state.thread ? [state.thread] : [],
+    unchanged: false,
+  };
 }
 
 function federationRefsMatch(
@@ -2007,12 +2026,22 @@ export class MessagingController {
     if (renderableBindings.length === 0) {
       return;
     }
-    const navigation = await this.options.backend.getNavigationSnapshot({
-      backend: "all",
-      ...(federationTarget ? { federationTarget } : {}),
-    });
+    const navigationByThreadKey = new Map<string, NavigationSnapshot>();
     for (const binding of renderableBindings) {
       try {
+        const threadKey = threadKeyForBinding(binding);
+        let navigation = navigationByThreadKey.get(threadKey);
+        if (!navigation) {
+          navigation = navigationSnapshotForAdmissionState(
+            binding,
+            await this.options.backend.getThreadAdmissionState({
+              backend: binding.backend,
+              federationTarget: federationTargetForBinding(binding),
+              threadId: binding.threadId,
+            }),
+          );
+          navigationByThreadKey.set(threadKey, navigation);
+        }
         await this.renderBindingStatus(binding, undefined, navigation);
       } catch (error) {
         this.logger.debug?.("messaging backend status refresh failed", {
@@ -3583,10 +3612,35 @@ export class MessagingController {
     const consumedSkillBinding = currentBinding.pendingSkillSelection
       ? bindingWithoutPendingSkillSelection(currentBinding)
       : currentBinding;
+    let admissionState: MessagingThreadAdmissionState | undefined;
+    try {
+      admissionState = await this.options.backend.getThreadAdmissionState({
+        backend: consumedSkillBinding.backend,
+        federationTarget: federationTargetForBinding(consumedSkillBinding),
+        threadId: consumedSkillBinding.threadId,
+      });
+    } catch (error) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("turn-start-failed"),
+          createdAt: this.now(),
+          title: "Turn could not start",
+          body: error instanceof Error ? error.message : String(error),
+          recoverable: true,
+        }),
+        consumedSkillBinding,
+        bundle.events[0],
+      );
+      return;
+    }
 
     if (
       !isDefaultAgentRouteBinding(currentBinding)
-      && await this.isTurnOccupied(currentBinding, bundle.threadKey)
+      && await this.isTurnOccupied(
+        currentBinding,
+        bundle.threadKey,
+        admissionState,
+      )
     ) {
       await this.queuePreparedInput({
         binding: consumedSkillBinding,
@@ -3611,6 +3665,7 @@ export class MessagingController {
       preview: preparedWithSkill.preview,
       threadKey: bundle.threadKey,
       event: bundle.events[0],
+      admissionState,
     });
     if (startResult !== "failed" && currentBinding.pendingSkillSelection) {
       const updatedBinding = await this.clearPendingSkillSelection(currentBinding);
@@ -3976,6 +4031,7 @@ export class MessagingController {
   }
 
   private async startPreparedInput(params: {
+    admissionState?: MessagingThreadAdmissionState;
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
@@ -3995,9 +4051,14 @@ export class MessagingController {
     );
 
     try {
-      const navigation = params.navigation ?? await this.options.backend.getNavigationSnapshot({
-        backend: "all",
-      });
+      const admissionState = params.admissionState
+        ?? await this.options.backend.getThreadAdmissionState({
+          backend: params.binding.backend,
+          federationTarget: federationTargetForBinding(params.binding),
+          threadId: params.binding.threadId,
+        });
+      const navigation = params.navigation
+        ?? navigationSnapshotForAdmissionState(params.binding, admissionState);
       startingOrigin = await this.buildAgentMessagingOrigin({
         binding: params.binding,
         event: params.event,
@@ -4162,21 +4223,27 @@ export class MessagingController {
   private async isTurnOccupied(
     binding: MessagingBindingRecord,
     threadKey: string,
+    admissionState: MessagingThreadAdmissionState,
   ): Promise<boolean> {
     if (this.turnAdmission.isStarting(threadKey)) {
       return true;
     }
 
-    const activeTurn = await this.reconcileActiveTurnFromBackendStatus(
+    const rememberedTurn = await this.reconcileActiveTurnFromThreadStatus(
       binding,
       "turn_admission",
+      admissionState.threadStatus,
     );
-    if (activeTurn && ["working", "waiting"].includes(activeTurn.status)) {
+    if (
+      rememberedTurn
+      && ["working", "waiting"].includes(rememberedTurn.status)
+    ) {
       return true;
     }
-
-    const threadStatus = await this.readBackendThreadStatus(binding);
-    return threadStatus === "active";
+    return Boolean(
+      admissionState.activeTurn
+      || admissionState.threadStatus === "active",
+    );
   }
 
   private async adoptStartedTurn(params: {
@@ -4409,7 +4476,12 @@ export class MessagingController {
 
   private async startNextQueuedTurn(binding: MessagingBindingRecord): Promise<void> {
     const threadKey = this.threadKeyForBinding(binding);
-    if (await this.isTurnOccupied(binding, threadKey)) {
+    const admissionState = await this.options.backend.getThreadAdmissionState({
+      backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
+      threadId: binding.threadId,
+    });
+    if (await this.isTurnOccupied(binding, threadKey, admissionState)) {
       return;
     }
 
@@ -4427,6 +4499,7 @@ export class MessagingController {
       preview: entry.preview,
       queueOnConcurrentStart: false,
       threadKey,
+      admissionState,
     });
     if (startResult !== "started") {
       return;
@@ -5566,14 +5639,18 @@ export class MessagingController {
     if (renderableBindings.length === 0) {
       return;
     }
-    // Fetch the navigation snapshot once and reuse it across every binding's
-    // render. Without this, each renderBindingStatus call would issue its own
-    // getNavigationSnapshot — N bindings on the same thread = N redundant
-    // backend calls.
-    const navigation = await this.options.backend.getNavigationSnapshot({
-      backend: "all",
+    // Resolve one targeted thread projection and reuse it across every
+    // binding. Thread-state bus fan-out must not rebuild unrelated navigation,
+    // Git, PR, launchpad, or federation state just to repaint a status card.
+    const admissionState = await this.options.backend.getThreadAdmissionState({
+      backend,
       ...(federationTarget ? { federationTarget } : {}),
+      threadId,
     });
+    const navigation = navigationSnapshotForAdmissionState(
+      renderableBindings[0]!,
+      admissionState,
+    );
     for (const binding of renderableBindings) {
       try {
         await this.renderBindingStatus(binding, undefined, navigation);
@@ -5593,7 +5670,7 @@ export class MessagingController {
    * Post a "Permissions queued" audit message in every active binding for
    * the thread, mirroring the desktop transcript audit entry. The
    * registry's `thread/executionMode/queued` notification is the trigger;
-   * we resolve from/to mode labels off the navigation snapshot at the
+   * we resolve from/to mode labels from the targeted thread projection at the
    * time the notification fires.
    */
   private async handleExecutionModeQueued(
@@ -5614,13 +5691,12 @@ export class MessagingController {
       return;
     }
 
-    const navigation = await this.options.backend.getNavigationSnapshot({
-      backend: "all",
+    const admissionState = await this.options.backend.getThreadAdmissionState({
+      backend,
+      federationTarget: federationTargetForBinding(bindings[0]!),
+      threadId: params.threadId,
     });
-    const thread = navigation.threads.find(
-      (candidate) =>
-        candidate.source === backend && candidate.id === params.threadId,
-    );
+    const thread = admissionState?.thread;
     const fromExecutionMode = thread?.executionMode ?? "default";
     const toExecutionMode = params.queuedExecutionMode;
 
@@ -13983,7 +14059,16 @@ export class MessagingController {
     ) {
       return binding;
     }
-    return await this.renderBindingStatus(binding, event, navigation);
+    const targetedNavigation = navigation
+      ?? navigationSnapshotForAdmissionState(
+        binding,
+        await this.options.backend.getThreadAdmissionState({
+          backend: binding.backend,
+          federationTarget: federationTargetForBinding(binding),
+          threadId: binding.threadId,
+        }),
+      );
+    return await this.renderBindingStatus(binding, event, targetedNavigation);
   }
 
   private async navigationSnapshotWithThreadNameFromEvent(
@@ -14379,6 +14464,26 @@ export class MessagingController {
     }
 
     const threadStatus = await this.readBackendThreadStatus(binding);
+    return await this.reconcileActiveTurnFromThreadStatus(
+      binding,
+      reason,
+      threadStatus,
+    );
+  }
+
+  private async reconcileActiveTurnFromThreadStatus(
+    binding: MessagingBindingRecord,
+    reason: string,
+    threadStatus: string | undefined,
+  ): Promise<MessagingActiveTurnSummary | undefined> {
+    const activeTurn = this.getActiveTurn(binding);
+    if (
+      !activeTurn ||
+      !["working", "waiting"].includes(activeTurn.status)
+    ) {
+      return activeTurn;
+    }
+
     if (threadStatus !== "idle") {
       return activeTurn;
     }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -35,6 +35,7 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  NavigationThreadSummary,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
@@ -54,18 +55,21 @@ import type {
   SubmitServerRequestResponse,
   ThreadAgentMetadata,
   ThreadMessagingBindingTransition,
+  ThreadOverlayState,
   UpdateScheduledThreadActionRequest,
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
 import type { MessagingImagePart } from "@pwragent/messaging-interface";
 import {
+  buildThreadIdentityKey,
   buildFederatedThreadRef,
   isRemoteFederationTarget,
 } from "@pwragent/shared";
 import type {
   MessagingBackendBridge,
   MessagingLastAssistantReply,
+  MessagingThreadAdmissionState,
 } from "./core/messaging-adapter";
 import { MessagingFederatedThreadTargetError } from "./core/messaging-adapter";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
@@ -81,6 +85,7 @@ import {
   resolveFederatedThreadTarget,
 } from "../federation/federated-thread-target-service";
 import { getScheduledThreadActionService } from "../scheduled-actions/scheduled-thread-action-service";
+import { selectStaleDirectoryGitStatusKeys } from "../app-server/directory-git-status-refresh-policy";
 
 export type DesktopMessagingFederationBridge = {
   connectedPeerTargets(): Array<{
@@ -117,6 +122,136 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
 
   getLocalFilePrivateStorageRoots(): readonly string[] {
     return this.registry.getLocalFilePrivateStorageRoots();
+  }
+
+  async getThreadAdmissionState(request: {
+    backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
+    threadId: string;
+  }): Promise<MessagingThreadAdmissionState> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      const target = request.federationTarget;
+      if (!target || !isRemoteFederationTarget(target) || !this.federation) {
+        throw new Error(
+          "Remote messaging admission requires a federation target.",
+        );
+      }
+      let state: MessagingThreadAdmissionState;
+      if (!remote.resolveThreadAdmissionState) {
+        state = await this.readLegacyRemoteThreadAdmissionState(
+          target,
+          request,
+        );
+      } else {
+        try {
+          state = await remote.resolveThreadAdmissionState({
+            backend: request.backend,
+            threadId: request.threadId,
+          });
+        } catch (error) {
+          if (!isFederationMethodNotFoundError(error)) {
+            throw error;
+          }
+          state = await this.readLegacyRemoteThreadAdmissionState(
+            target,
+            request,
+          );
+        }
+      }
+      const instanceLabel = this.federation.connectedPeerTargets().find(
+        (peer) => peer.target.instanceId === target.instanceId,
+      )?.label ?? target.instanceId;
+      return {
+        ...state,
+        ...(state.thread
+          ? {
+              thread: {
+                ...state.thread,
+                federation: {
+                  instanceLabel,
+                  ref: buildFederatedThreadRef({
+                    backend: request.backend,
+                    instanceId: target.instanceId,
+                    threadId: request.threadId,
+                  }),
+                },
+              },
+            }
+          : {}),
+      };
+    }
+
+    const store = getDesktopOverlayStore();
+    const [overlay, cached] = await Promise.all([
+      store.getThreadOverlayState({
+        backend: request.backend,
+        threadId: request.threadId,
+      }),
+      Promise.resolve(this.registry.getCachedThreadSummary({
+        backend: request.backend,
+        threadId: request.threadId,
+      })),
+    ]);
+    const activeTurn = this.registry.getActiveTurnForThread(request);
+    const threadStatus = this.registry.isThreadTurnOccupied(request)
+      ? "active"
+      : "idle";
+    const threadKey = buildThreadIdentityKey(request.backend, request.threadId);
+    const queuedExecutionMode =
+      this.registry.getQueuedExecutionModesSnapshot()[threadKey];
+    const queuedTurns = this.registry.getQueuedTurnsSnapshot()[threadKey];
+    const thread = cached || overlay
+      ? buildAdmissionThreadSummary({
+          overlay,
+          queuedExecutionMode,
+          queuedTurns,
+          summary: cached ?? {
+            id: request.threadId,
+            title: request.threadId,
+            titleSource: "fallback",
+            source: request.backend,
+            linkedDirectories: overlay?.extraLinkedDirectories ?? [],
+          },
+        })
+      : undefined;
+    return {
+      ...(activeTurn ? { activeTurn } : {}),
+      ...(thread ? { thread } : {}),
+      threadStatus,
+    };
+  }
+
+  private async readLegacyRemoteThreadAdmissionState(
+    target: FederationRemoteTarget,
+    request: {
+      backend: AppServerBackendKind;
+      federationTarget?: FederationTarget;
+      threadId: string;
+    },
+  ): Promise<MessagingThreadAdmissionState> {
+    if (!this.federation) {
+      throw new Error("Remote messaging admission requires federation.");
+    }
+    const navigation = await this.federation.remoteNavigationSnapshot(
+      target,
+      {
+        backend: request.backend,
+        federationTarget: target,
+      },
+      {
+        kind: "threads",
+        threads: [{ backend: request.backend, threadId: request.threadId }],
+      },
+    );
+    const thread = navigation.threads.find(
+      (candidate) => candidate.source === request.backend
+        && candidate.id === request.threadId,
+    );
+    return {
+      ...(thread ? { thread } : {}),
+      ...(thread?.threadStatus ? { threadStatus: thread.threadStatus } : {}),
+    };
   }
 
   async getNavigationSnapshot(
@@ -183,9 +318,24 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     ) {
       this.registry.rememberCompleteNavigationSnapshot(hydratedSnapshot);
     }
-    const directoryStatuses = await this.registry.readDirectoryStatuses(
-      hydratedSnapshot.directories,
-    );
+    const directoryStatusCache =
+      await getDesktopOverlayStore().readDirectoryGitStatusCache();
+    const staleDirectoryKeys = selectStaleDirectoryGitStatusKeys({
+      cache: directoryStatusCache,
+      directories: hydratedSnapshot.directories,
+    });
+    if (
+      staleDirectoryKeys.length > 0
+      && typeof this.registry.refreshDirectoryGitStatuses === "function"
+    ) {
+      void this.registry.refreshDirectoryGitStatuses({
+        directoryKeys: staleDirectoryKeys,
+        force: false,
+      }).catch(() => {
+        // Directory status is optional navigation context. The registry logs
+        // probe failures and publishes successful per-directory updates.
+      });
+    }
 
     // The renderer's local snapshot path (ipc/app-server.ts) hydrates
     // each directory launchpad's Codex environment options. This bridge
@@ -197,7 +347,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       hydratedSnapshot.directories.map(async (directory) => {
         const withStatus = {
           ...directory,
-          gitStatus: directoryStatuses[directory.key],
+          gitStatus: directoryStatusCache[directory.key]?.gitStatus,
         };
         if (!withStatus.launchpad) {
           return withStatus;
@@ -962,6 +1112,52 @@ function findLastAssistantMessageReply(
     };
   }
   return undefined;
+}
+
+function buildAdmissionThreadSummary(params: {
+  federation?: NonNullable<NavigationThreadSummary["federation"]>;
+  overlay?: ThreadOverlayState;
+  queuedExecutionMode?: {
+    mode: NonNullable<NavigationThreadSummary["queuedExecutionMode"]>;
+    queuedAt: number;
+  };
+  queuedTurns?: NavigationThreadSummary["queuedTurns"];
+  summary: Omit<NavigationThreadSummary, "inbox"> | NavigationThreadSummary;
+}): NavigationThreadSummary {
+  const { overlay, summary } = params;
+  return {
+    ...summary,
+    inbox: "inbox" in summary ? summary.inbox : { inInbox: false },
+    executionMode: overlay?.executionMode ?? summary.executionMode,
+    fastMode: overlay?.fastMode ?? summary.fastMode,
+    gitBranch: overlay?.gitBranch ?? summary.gitBranch,
+    linkedDirectories:
+      summary.linkedDirectories.length > 0
+        ? summary.linkedDirectories
+        : overlay?.extraLinkedDirectories ?? [],
+    model: overlay?.model ?? summary.model,
+    observedGitBranch:
+      overlay?.observedGitBranch ?? summary.observedGitBranch,
+    reasoningEffort: overlay?.reasoningEffort ?? summary.reasoningEffort,
+    serviceTier: overlay?.serviceTier ?? summary.serviceTier,
+    ...(overlay?.agent ? { agent: overlay.agent } : {}),
+    ...(overlay?.handoffOrigin ? { handoffOrigin: overlay.handoffOrigin } : {}),
+    ...(params.federation ? { federation: params.federation } : {}),
+    ...(params.queuedExecutionMode
+      ? {
+          queuedExecutionMode: params.queuedExecutionMode.mode,
+          queuedExecutionModeAt: params.queuedExecutionMode.queuedAt,
+        }
+      : {}),
+    ...(params.queuedTurns ? { queuedTurns: params.queuedTurns } : {}),
+  };
+}
+
+function isFederationMethodNotFoundError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === "method_not_found";
 }
 
 function findLastAssistantEntryReply(

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -98,7 +98,7 @@ export type QuitManagerDependencies = {
   performQuit: () => void;
 };
 
-/** Titles are a nicety; quitting must not hang on a slow app-server. */
+/** Titles are a nicety; quitting must not hang on optional cache/store reads. */
 const QUIT_TITLE_RESOLVE_TIMEOUT_MS = 1_500;
 
 export type QuitManager = {
@@ -394,8 +394,9 @@ export function formatAutomationRunStart(startedAt: number): string {
 
 /**
  * Attach thread titles to the blocker rows, bounded by a timeout: a hung
- * app-server must not be able to wedge shutdown. On timeout or failure the rows
- * keep their thread ids, which still link correctly — they just read worse.
+ * optional title source must not be able to wedge shutdown. On timeout or
+ * failure the rows keep their thread ids, which still link correctly — they
+ * just read worse.
  */
 async function withResolvedTitles(
   items: QuitBlockerItem[],
@@ -454,15 +455,11 @@ type QuitBlockerThreadTitle = {
 };
 
 export type QuitBlockerTitleResolverDependencies = {
-  /** Threads owned by THIS instance. */
-  listLocalThreads: () => Promise<
-    ReadonlyArray<{
-      source: AppServerBackendKind;
-      id: string;
-      title?: string;
-      titleSource?: AppServerThreadTitleSource;
-    }>
-  >;
+  /** Already-observed display metadata for a thread owned by THIS instance. */
+  cachedLocalThreadName: (params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }) => QuitBlockerThreadTitle | undefined;
   /**
    * What a peer calls one of its threads, out of names ALREADY seen locally.
    * Synchronous by contract: this must not become a peer round trip.
@@ -480,11 +477,9 @@ export type QuitBlockerTitleResolverDependencies = {
  * Name every blocker row from what this machine already knows, including what
  * it knows about its peers.
  *
- * This is tier-2 resolution — local plus *cached* remote. The old lookup was
- * tier 1: it asked this instance's thread list, which cannot answer for a
- * peer's thread, so the row fell back to the thread id and the operator was
- * asked to decide about a uuid while their sidebar showed that same thread by
- * name.
+ * This is cache-only local plus cache-only remote resolution. The old lookup
+ * asked this instance's full thread list, which both delayed quit and could
+ * not answer for a peer's thread.
  *
  * Reaching the peer (tier 3) is deliberately NOT done here. A remote thread
  * is a quit blocker because a window on this machine has its terminal open,
@@ -516,17 +511,22 @@ export async function resolveQuitBlockerThreadTitles(
     item.target ? [{ item, target: item.target }] : [],
   );
 
-  const resolveLocal = async (): Promise<void> => {
+  const resolveLocal = (): void => {
     if (localItems.length === 0) return;
-    const threads = await dependencies.listLocalThreads();
-    const byThreadKey = new Map(
-      threads.map((thread) => [
-        buildThreadIdentityKey(thread.source, thread.id),
-        thread,
-      ]),
-    );
     for (const item of localItems) {
-      record(titles, item, byThreadKey.get(item.threadKey));
+      try {
+        record(
+          titles,
+          item,
+          dependencies.cachedLocalThreadName({
+            backend: item.backend as AppServerBackendKind,
+            threadId: item.threadId,
+          }),
+        );
+      } catch {
+        // One unavailable cache entry must not prevent the remaining rows from
+        // resolving or delay the quit decision.
+      }
     }
   };
 
@@ -572,7 +572,7 @@ export async function resolveQuitBlockerThreadTitles(
   };
 
   await Promise.all([
-    resolveLocal().catch(() => undefined),
+    Promise.resolve().then(resolveLocal).catch(() => undefined),
     resolveRemote().catch(() => undefined),
   ]);
   return titles;
@@ -617,10 +617,8 @@ async function resolveCurrentQuitBlockerTitles(
   items: QuitBlockerItem[],
 ): Promise<Map<string, string>> {
   return await resolveQuitBlockerThreadTitles(items, {
-    listLocalThreads: async () =>
-      await getDesktopBackendRegistry().listThreads({
-        callerReason: "quit-confirmation",
-      }),
+    cachedLocalThreadName: (params) =>
+      getDesktopBackendRegistry().getCachedThreadDisplayMetadata(params),
     cachedRemoteThreadName: (params) =>
       getDesktopFederationRuntime()
         .remoteThreadSummaries()

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -618,7 +618,7 @@ async function resolveCurrentQuitBlockerTitles(
 ): Promise<Map<string, string>> {
   return await resolveQuitBlockerThreadTitles(items, {
     cachedLocalThreadName: (params) =>
-      getDesktopBackendRegistry().getCachedThreadDisplayMetadata(params),
+      getDesktopBackendRegistry().getThreadInfo(params),
     cachedRemoteThreadName: (params) =>
       getDesktopFederationRuntime()
         .remoteThreadSummaries()

--- a/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
@@ -20,6 +20,27 @@ const GROUPS: ReadonlyArray<{
   { kind: "action", heading: "Environment actions" },
 ];
 
+function retainKnownTitles(
+  current: QuitBlockerQueueSnapshot | undefined,
+  next: QuitBlockerQueueSnapshot,
+): QuitBlockerQueueSnapshot {
+  if (!current) return next;
+  const titlesByItemKey = new Map(
+    current.items.flatMap((item) => {
+      const title = item.title?.trim();
+      return title ? [[quitBlockerItemKey(item), title] as const] : [];
+    }),
+  );
+  return {
+    ...next,
+    items: next.items.map((item) => {
+      if (item.title?.trim()) return item;
+      const title = titlesByItemKey.get(quitBlockerItemKey(item));
+      return title ? { ...item, title } : item;
+    }),
+  };
+}
+
 type QuitBlockerQueueApi = Pick<
   DesktopApi,
   | "copyText"
@@ -52,7 +73,10 @@ export function QuitBlockerQueueToast(props: {
       try {
         const nextSnapshot = await readQuitBlockerQueue();
         if (!disposed) {
-          setSnapshot(nextSnapshot);
+          // Blocker membership is authoritative, but title resolution is
+          // best-effort and bounded. Do not downgrade a known label when one
+          // refresh times out and omits only that optional presentation data.
+          setSnapshot((current) => retainKnownTitles(current, nextSnapshot));
         }
       } catch {
         // Keep the last authoritative snapshot visible. The next interval can

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
@@ -22,6 +22,55 @@ function snapshot(
 }
 
 describe("QuitBlockerQueueToast", () => {
+  it("keeps a known title when a refresh temporarily omits it", async () => {
+    vi.useFakeTimers();
+    let showQueue!: (snapshot: QuitBlockerQueueSnapshot) => void;
+    const titled = snapshot([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "01a05891-bfb8-7bc0-affd-97354d0080b1",
+        threadKey: "codex:01a05891-bfb8-7bc0-affd-97354d0080b1",
+        title: "Investigate compaction cost",
+      },
+    ]);
+    const unresolved = snapshot([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "01a05891-bfb8-7bc0-affd-97354d0080b1",
+        threadKey: "codex:01a05891-bfb8-7bc0-affd-97354d0080b1",
+      },
+    ]);
+    const readQuitBlockerQueue = vi.fn(async () => unresolved);
+
+    render(
+      <QuitBlockerQueueToast
+        desktopApi={{
+          onShowQuitBlockersRequested: (callback) => {
+            showQueue = callback;
+            return () => undefined;
+          },
+          readQuitBlockerQueue,
+          revealQuitBlocker: vi.fn(async () => ({ revealed: true })),
+        }}
+      />,
+    );
+
+    act(() => showQueue(titled));
+    expect(screen.getByText("Investigate compaction cost")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(readQuitBlockerQueue).toHaveBeenCalled();
+    expect(screen.getByText("Investigate compaction cost")).toBeInTheDocument();
+    expect(
+      screen.queryByText("01a05891-bfb8-7bc0-affd-97354d0080b1"),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the live queue reachable while authoritative refreshes remove resolved work", async () => {
     vi.useFakeTimers();
     let showQueue!: (snapshot: QuitBlockerQueueSnapshot) => void;

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -372,6 +372,55 @@ These rules exist to make adding the next ten messaging platforms a quiet, mecha
 - Provider adapters receive semantic intents and never import desktop
   thread-state modules.
 
+#### Bound-reply admission is targeted
+
+An ordinary reply to an existing binding does not build a navigation snapshot.
+`MessagingController` asks `DesktopMessagingBackendBridge` for one
+`MessagingThreadAdmissionState`, which combines:
+
+- the bound thread's durable overlay (execution mode, model, reasoning,
+  service tier, fast mode, Agent/handoff origin);
+- its already-observed thread-list summary, when one is cached;
+- the registry's per-thread active turn, queued permission mode, and queued
+  turn projections; and
+- the equivalent targeted owner read for a federated binding.
+
+That projection is sufficient for permission/full-access policy, message
+origin, occupancy, queue admission, and turn settings. It deliberately carries
+no PR lookup, Git working-state probe, launchpad hydration, directory-fleet
+walk, or connected-peer enumeration. The shared turn FIFO remains the final
+race-safe admission authority if activity changes after the targeted read.
+
+Full navigation remains appropriate for explicit browse, monitor, picker,
+handoff, review, and on-demand rich status workflows. Automatic status-card
+updates and thread-state bus fan-out reuse the targeted projection instead of
+turning a single-thread notification into a fleet refresh.
+
+#### Directory Git-status cache and refresh policy
+
+Directory status has two cache layers with different jobs:
+
+- `GitDirectoryService` keeps a 3-second in-memory per-path cache. It dedupes
+  concurrent/repeated Git probes and branch-inventory reads. It is not the
+  navigation freshness policy.
+- The overlay store keeps the last successful directory projection. Broad
+  snapshots serve this projection immediately and consider it fresh for five
+  minutes. Five minutes is based on the product interaction boundary: an
+  untouched directory is ambient navigation context, while focused and
+  mutation-sensitive actions have targeted refresh paths.
+
+A broad snapshot schedules at most four stale directories at once and never
+awaits that batch. Registry scheduling coalesces each directory while its probe
+is pending. Selecting a thread explicitly requests its directory keys; rapid
+forced requests for the same key coalesce inside a 3-second post-completion
+window. Launchpad materialization and branch-sensitive workspace operations
+perform their own targeted fresh read, while turn completion, branch updates,
+and Git-mutating commands refresh the affected thread/worktree/PR projections.
+
+This policy is interaction-driven. It adds no polling timer and no timer-driven
+SQLite writes; persistence changes only when a scheduled targeted or bounded
+background probe completes.
+
 ### Single platform-agnostic detach pipeline
 
 The detach flow — retire the channel's status surface, revoke the binding in the store, deliver a "Thread detached" confirmation — has exactly one implementation: `MessagingController.runDetachPipeline`. Every detach origin (Discord `/detach`, Telegram `/detach`, the desktop right-click "Unbind" chip, future archive-on-delete flows, future "Unbind all") routes through it.

--- a/docs/plans/2026-08-31-quit-blocker-title-read-model.md
+++ b/docs/plans/2026-08-31-quit-blocker-title-read-model.md
@@ -220,6 +220,7 @@ Current recorded budget:
 | Six concurrent callers asking for the same unenriched listing | 1 | 0 |
 | Eight terminal notifications across two never-listed threads | 1 | 0 |
 | One navigation refresh over a single worktree-backed thread | 1 | 1 |
+| Messaging admission after an unrelated mutation emptied the cache | 0 | 0 |
 
 The three nonzero rows are the shape the design intends: a thread nobody has
 ever listed costs exactly one listing however many callers ask at once, and
@@ -240,18 +241,45 @@ The budget is enforced with deterministic call-count assertions, not elapsed
 time. The enrichment counter is exercised with worktree-shaped fixtures so it
 provably can move — a budget that cannot move proves nothing.
 
-## Compatibility With PR #1896
+## Relationship To PR #1896
 
-PR #1896's `getCachedThreadSummary()` serves targeted messaging admission and
-is broader than a title read. Its current cache scan does not cover names
-observed from lifecycle/name notifications.
+PR #1896 merged first. It made the same class of fix for messaging admission:
+`resolveThread` used to call `listThreads({ callerReason: "thread-id-lookup",
+forceRefresh: true })` unconditionally, and #1896 put a cached read in front of
+it — `getCachedThreadSummary`, which scans the thread-list cache.
 
-This change does not cherry-pick or duplicate PR #1896's messaging work. On a
-later rebase, `getCachedThreadSummary()` can retain its admission contract and
-thread-list cache scan; where it needs a display title, it can read the store.
-Quit continues to call `getThreadInfo` and never treats title-only knowledge as
-a complete navigation/admission summary. Keeping the responsibilities separate makes the
-backend-registry overlap mechanical rather than architectural.
+That covers the warm case, and measurably so: ten admissions across ten turn
+boundaries cost zero provider listings, because `turn/started` does not empty
+the cache. The gap is the cold one. The thread-list cache *is* emptied by
+mutations, and after an unrelated `archiveThread` on a different thread:
+
+| Read | Result |
+|---|---|
+| `getCachedThreadSummary` (cache scan) | nothing |
+| `ThreadInfoStore.getSummary` | the summary, intact |
+| `resolveThread` | 1 forced full paged provider `thread/list` |
+
+So admission for a thread this window listed minutes ago paid a full listing
+because something unrelated invalidated the cache in between. This is the
+"later rebase" note the earlier draft left open, and it is now done:
+`getCachedThreadSummary` scans the cache first — warm, that is the freshest
+listing — and falls through to `ThreadInfoStore.findLocalSummary`.
+
+`findLocalSummary` exists because admission does not always know which backend
+owns the thread an inbound message names. With a backend it is a direct
+lookup; without one it scans, the way the previous thread-list walk did, but
+over one entry per thread rather than every row of every cached query.
+Instance-qualified entries are skipped: those belong to peers, and a caller
+that did not name an instance is not asking about a peer's thread.
+
+One case the store deliberately does **not** answer: a thread known only from a
+lifecycle notification, never from a listing, still costs one listing on
+admission. The store holds its title but not a summary, and a title is not a
+summary. Serving a synthesized row there would be guessing.
+
+The two contracts stay separate. `getCachedThreadSummary` keeps its admission
+contract; quit keeps calling `getThreadInfo` and never treats title-only
+knowledge as a complete navigation/admission summary.
 
 ## Test Matrix
 
@@ -275,6 +303,7 @@ backend-registry overlap mechanical rather than architectural.
 | Remote ordering | A peer snapshot that started earlier but finished later cannot revert a newer name; a rename recorded afterwards still wins. |
 | Remote isolation | Two peers reusing one thread id keep separate names, and unmounting one peer drops only that peer's names. |
 | Reservation ordering at the IPC seam | The navigation-snapshot handler reserves its observation sequence strictly before the peer round trip begins. |
+| Messaging admission after invalidation | An unrelated `archiveThread` empties the list cache; admission for an untouched thread costs zero provider listings, and a backend-less lookup still resolves. |
 
 Every test in the last four rows was falsified before being kept: the fix was
 reverted, the test was watched to fail, and the fix restored. A test that

--- a/docs/plans/2026-08-31-quit-blocker-title-read-model.md
+++ b/docs/plans/2026-08-31-quit-blocker-title-read-model.md
@@ -1,0 +1,151 @@
+# Quit Blocker Title Read Model
+
+## Decision
+
+Quit blocker membership remains owned by the live runtime registries. Quit
+blocker display titles come from a separate, process-local projection of
+thread metadata that has already been observed. Building or polling the quit
+queue never starts or awaits a provider thread-list request, a peer request,
+or directory/Git enrichment.
+
+This is a scoped correction to the existing quit path. It does not change
+thread-list ownership, navigation refresh policy, lifecycle membership, or
+quit confirmation behavior.
+
+## Invariants
+
+- Runtime blocker membership and counts are authoritative on every snapshot.
+- A blocker that resolves disappears on the next snapshot, even when its
+  display title remains cached.
+- An observed nonempty, non-fallback title is retained until a newer nonempty,
+  non-fallback observation replaces it.
+- Absence, a rejected read, an unavailable provider, and a fallback title are
+  not title-deletion events.
+- Ordinary active turns and sub-agent-owned turns use the same title lookup.
+- Quit title lookup is synchronous for local threads and cache-only for remote
+  threads. Persisted remote pins remain a local fallback; quit never contacts
+  a peer to learn a label.
+- PR #1903's renderer-side monotonic retention remains in place as a second
+  presentation-layer defense. It does not own membership.
+
+## Data Ownership and Identity
+
+`DesktopBackendRegistry` owns a volatile display-metadata projection for
+threads owned by this process. Each entry contains the latest accepted title,
+its title source, and a monotonic observation sequence. Entries are keyed by
+`buildThreadIdentityKey(backend, threadId)`; backend is therefore part of the
+identity even when two providers reuse the same thread id.
+
+Mounted remote titles remain owned by the federation runtime's already-seen
+thread summaries, with persisted remote pins as a local fallback. The quit
+resolver keys those results with
+`instanceId::buildThreadIdentityKey(backend, threadId)`. A local thread and a
+remote thread, or two remote instances, cannot share a title entry merely
+because backend and thread id collide.
+
+No new persistent state is introduced. Live blockers and the local title
+projection are process-local, so there are no new SQLite writes or write
+budgets.
+
+## Freshness Semantics
+
+The registry allocates observation sequences from a monotonic counter; it does
+not use wall-clock time.
+
+- A lifecycle/name notification receives a sequence when the notification is
+  processed.
+- A provider thread-list miss reserves its sequence before the asynchronous
+  list begins. The resulting rows retain that sequence when they complete.
+- A cache hit does not create a new observation.
+- A title is accepted only when its sequence is at least as new as the entry's
+  sequence and its trimmed value is nonempty and not marked `fallback`.
+
+Reserving a list's sequence before awaiting is the critical ordering rule. If
+an old list starts, a rename notification arrives, and the old list completes
+later, the rename has the higher sequence and the stale completion cannot
+erase or replace it. A list started after the rename is a newer observation
+and may reconcile the title.
+
+Unknown metadata is explicit: when no usable title has ever been observed, the
+projection returns no title and the existing UI falls back to the thread id.
+It never guesses from another backend or instance.
+
+## Read Path
+
+The registry exposes a narrow synchronous cached-display-metadata read. Quit
+snapshot creation uses it for every active-turn owner after sub-agent ownership
+has been collapsed. The quit title resolver uses the same read for local
+terminal rows. It no longer calls `listThreads({ callerReason:
+"quit-confirmation" })`.
+
+Remote terminal rows continue to consult only already-observed federation
+summaries and local pinned summaries. Automation rows keep their automation
+name, and environment-action rows keep their action name, so neither requires
+thread enrichment.
+
+## Failure Semantics
+
+- Slow, hanging, rejected, or unavailable provider lists cannot delay quit or
+  a live-queue poll because quit never invokes them.
+- A failed optional remote-pin read yields no title and preserves the stable
+  thread-id fallback.
+- The existing bounded title-resolution wrapper remains a final degradation
+  boundary for optional asynchronous local-store work; failure changes labels,
+  never membership, routing, or the Quit/Wait/Stay Open decision.
+- Cache invalidation removes list reuse, not the last observed display title.
+  A later valid observation can still supersede it.
+
+## Performance Budget
+
+For quit snapshot construction and repeated live-queue polls:
+
+- full provider thread-list refreshes: **0**
+- directory/Git enrichment calls for labels: **0**
+- peer/network title requests: **0**
+- SQLite writes: **0**
+
+Local title work is O(number of blockers) map lookup. An unresolved remote
+batch may perform one existing read of persisted remote pins; it performs no
+write.
+
+The budget is enforced with deterministic call-count assertions, not elapsed
+time.
+
+## Compatibility With PR #1896
+
+PR #1896's `getCachedThreadSummary()` serves targeted messaging admission and
+is broader than the title-only projection. Its current cache scan does not
+cover names observed from lifecycle/name notifications.
+
+This change does not cherry-pick or duplicate PR #1896's messaging work. On a
+later rebase, `getCachedThreadSummary()` can retain its admission contract and
+thread-list cache scan; where it needs a display title, it can merge the narrow
+projection into the cached summary. Quit continues to call the narrow
+display-metadata read and never treats title-only knowledge as a complete
+navigation/admission summary. Keeping the responsibilities separate makes the
+backend-registry overlap mechanical rather than architectural.
+
+## Test Matrix
+
+| Contract | Focused coverage |
+|---|---|
+| Ordinary local active turn is named | Seed an already-observed non-fallback title, start/observe a normal turn, and assert the first synchronous quit snapshot carries it. |
+| Sub-agent ownership remains named | Preserve the existing owner-collapse case and verify it reads the same projection. |
+| Rename wins | Observe an initial title, then a nonempty explicit rename, and assert subsequent snapshots use the rename. |
+| Missing/fallback cannot downgrade | Feed empty/fallback observations after a known title and assert the title remains. With no prior title, assert the stable thread-id fallback. |
+| Late old list cannot erase | Start a delayed list, observe a newer rename and active turn, release the old list, and assert the rename remains after completion and invalidation. |
+| Provider failure does not affect first snapshot | Exercise hanging/rejected/unavailable list conditions and prove snapshot creation neither calls nor awaits provider listing. |
+| Polling performance budget | Build the snapshot repeatedly and drive repeated queue reads; assert zero provider `listThreads` and zero directory-enrichment calls. |
+| Membership stays authoritative | Complete/remove blockers and assert they disappear immediately and the empty snapshot is reachable. |
+| Qualified local identities | Reuse a thread id across two backends and assert titles do not cross. |
+| Qualified remote identities | Reuse backend/thread id locally and on multiple mounted instances and assert only the owning instance's cached title is selected. |
+| Other blocker kinds | Preserve focused snapshot/resolver coverage for integrated terminals, environment actions, and automations. |
+| Renderer defense | Keep PR #1903 component tests proving absent titles cannot erase known titles, renames win, removals/counts remain authoritative, and empty state renders. |
+| Quit decisions | Preserve existing main-process tests for Quit, Wait/countdown, and Stay Open. |
+
+No new desktop E2E is planned because this change introduces no renderer,
+dialog, IPC-shape, or interaction contract. The main-process unit tests can
+deterministically prove the provider-call budget and freshness ordering, while
+PR #1903's component tests already exercise the live-poll presentation seam.
+Adding a headed replay would duplicate those contracts without exposing a new
+failure mode.

--- a/docs/plans/2026-08-31-quit-blocker-title-read-model.md
+++ b/docs/plans/2026-08-31-quit-blocker-title-read-model.md
@@ -1,16 +1,51 @@
-# Quit Blocker Title Read Model
+# Thread Information Store
+
+Originally scoped as "Quit Blocker Title Read Model". The quit card's blinking
+titles were the symptom that was easiest to see; the cause was that this
+product had no place to keep what it knows about a thread. The scope below is
+the whole read model, and the quit path is one of its callers.
 
 ## Decision
 
-Quit blocker membership remains owned by the live runtime registries. Quit
-blocker display titles come from a separate, process-local projection of
-thread metadata that has already been observed. Building or polling the quit
-queue never starts or awaits a provider thread-list request, a peer request,
-or directory/Git enrichment.
+Thread *information* — what a thread is called, what project it belongs to,
+whether it is archived — is held in a store of its own, separate from every
+cache that answers a query. `ThreadInfoStore` (`app-server/thread-info-store.ts`)
+is that store. Callers that need a fact about one known thread read it
+synchronously; callers that need to know which threads match a question keep
+using the list caches, which stay free to be discarded.
 
-This is a scoped correction to the existing quit path. It does not change
-thread-list ownership, navigation refresh policy, lifecycle membership, or
-quit confirmation behavior.
+Quit blocker membership remains owned by the live runtime registries. Quit
+blocker display titles come from the store. Building or polling the quit queue
+never starts or awaits a provider thread-list request, a peer request, or
+directory/Git enrichment.
+
+### Why a second structure rather than a better cache
+
+A query cache answers *"which threads match Q, in what order"*. That answer
+expires: a new turn, a rename, or an archive can change it, so throwing it away
+on mutation is correct.
+
+An information store answers *"what is thread X called"*. That answer does not
+expire the same way. A rename supersedes it; nothing else does. Discarding it
+is never right, because the alternative to a slightly stale name is not a
+fresher name — it is a raw UUID on screen.
+
+The defect was that one structure was being asked both questions. Four
+consequences followed, each of which the store removes:
+
+1. **Invalidation was amnesia.** Roughly forty-six call sites clear the list
+   cache. Every one of them was also erasing the only record of what threads
+   were called.
+2. **Point queries were answered by full-collection walks.** Sixteen sites
+   wanted one row and rebuilt every row to get it. The measured case:
+   `turn/started` invalidated the cache, and `active-turn-branch-adoption` then
+   drove a complete paged provider `thread/list` to read a single field — one
+   full listing per turn boundary.
+3. **Query-shaped keys fragmented identical reads.** Six concurrent callers
+   asking the same question produced more than one provider call.
+4. **Absence was conflated with unknown.** `title: undefined` meant both "this
+   thread has no title" and "we knew the title and this particular lookup did
+   not return it", so the second case overwrote the first.
 
 ## Invariants
 
@@ -27,25 +62,56 @@ quit confirmation behavior.
   a peer to learn a label.
 - PR #1903's renderer-side monotonic retention remains in place as a second
   presentation-layer defense. It does not own membership.
+- Invalidating a query cache never removes thread information. Only the thread
+  or the peer going away does.
+- A read-only caller never drives a provider round trip to learn a fact the
+  store already holds.
+- Two threads that share a backend and id, on different instances, never share
+  an entry.
 
 ## Data Ownership and Identity
 
-`DesktopBackendRegistry` owns a volatile display-metadata projection for
-threads owned by this process. Each entry contains the latest accepted title,
-its title source, and a monotonic observation sequence. Entries are keyed by
-`buildThreadIdentityKey(backend, threadId)`; backend is therefore part of the
-identity even when two providers reuse the same thread id.
+`ThreadInfoStore` holds one entry per thread, and each *field* in that entry
+carries its own observation sequence and source. Fields are graded
+independently because observations are partial: a lifecycle notification
+teaches a title and nothing else, a listing row teaches a project label, and
+neither should have to arrive with the other to be believed.
 
-Mounted remote titles remain owned by the federation runtime's already-seen
-thread summaries, with persisted remote pins as a local fallback. The quit
-resolver keys those results with
-`instanceId::buildThreadIdentityKey(backend, threadId)`. A local thread and a
-remote thread, or two remote instances, cannot share a title entry merely
-because backend and thread id collide.
+Tracked fields are `title`, `titleSource`, `projectLabel`, `archived`, and
+`updatedAt`. Sources are `lifecycle-notification`, `local-rename`,
+`provider-list`, `remote-navigation`, and `remote-pin`.
 
-No new persistent state is introduced. Live blockers and the local title
-projection are process-local, so there are no new SQLite writes or write
-budgets.
+Identity is `instanceId::backend:threadId`, with the instance segment omitted
+for local threads. Backend is part of the key even when two providers reuse a
+thread id, and instance is part of it because thread ids are only unique within
+the instance that minted them. A local thread and two peers' threads numbered
+alike cannot answer for each other.
+
+`DesktopBackendRegistry` owns one store for locally-owned threads.
+`RemoteThreadSummaryCache` owns a second for threads owned by peers, keyed by
+instance; `forgetInstanceThreadNames` drops a peer's names when it unmounts and
+can no longer be asked. Persisted remote pins remain a local fallback. Quit
+never contacts a peer to learn a label.
+
+No new persistent state is introduced. Both stores are process-local, so there
+are no new SQLite writes or write budgets.
+
+### Merging rule: positive facts only
+
+An observation states what it saw. It does not state what it did not see.
+
+- An omitted field is not a deletion.
+- An empty or whitespace title is not news.
+- A `fallback` title source means the title *is* the thread id; recording it
+  would overwrite a real name with nothing.
+- Title and title source are validated together, so a `fallback` source cannot
+  arrive without its title and downgrade a name already held.
+- Re-observing the same value at a newer sequence advances the sequence without
+  reporting a change, so a confirmation does not read as an edit.
+
+`forget` and `forgetInstance` are the only ways an entry leaves the store, and
+both are driven by the thread or the peer actually going away — never by cache
+invalidation.
 
 ## Freshness Semantics
 
@@ -67,16 +133,51 @@ erase or replace it. A list started after the rename is a newer observation
 and may reconcile the title.
 
 Unknown metadata is explicit: when no usable title has ever been observed, the
-projection returns no title and the existing UI falls back to the thread id.
-It never guesses from another backend or instance.
+store returns no title and the existing UI falls back to the thread id. It
+never guesses from another backend or instance.
+
+### Callers declare the freshness they need
+
+`findThreadForWorkspaceHandoff` takes a `freshness` argument, and the caller
+answers one question: *am I about to act on this, or only display it?*
+
+- `"provider"` (the default) keeps the existing behavior — consult the
+  provider, because the caller is about to mutate something and a stale answer
+  would be acted upon.
+- `"last-known"` answers from the store when it has the thread, and falls
+  through to a provider read only when it does not.
+
+Four read-only callers now pass `"last-known"`: `transcript-image-roots`,
+`branch-drift`, `active-turn-branch-adoption`, and `turn-cwd`. This is where
+the largest measured win came from. `turn/started` invalidates the list cache,
+so `active-turn-branch-adoption` was rebuilding the entire thread list on every
+turn boundary to read one row from it.
+
+Because a listing row that has not been enriched can lack `worktreePath`,
+`getSummary` accepts `requireEnriched`. A caller whose reason implies directory
+enrichment declines an unenriched cached row rather than answering with a field
+it knows may be missing. The store grades what it holds; it does not pretend an
+unenriched row is an enriched one.
+
+### Archival is an observation, not a refetch
+
+`thread/archived` and `thread/unarchived` notifications are recorded as
+observations of the `archived` field, at the sequence the notification is
+processed. The alternative — invalidating and re-listing to discover a fact the
+notification already stated — is the same round trip this design exists to
+remove. The recording happens in the event fan-out rather than in the client
+subscription, so locally published events take the same path as provider ones.
 
 ## Read Path
 
-The registry exposes a narrow synchronous cached-display-metadata read. Quit
-snapshot creation uses it for every active-turn owner after sub-agent ownership
-has been collapsed. The quit title resolver uses the same read for local
-terminal rows. It no longer calls `listThreads({ callerReason:
-"quit-confirmation" })`.
+`DesktopBackendRegistry.getThreadInfo(identity)` is the synchronous read.
+Quit snapshot creation uses it for every active-turn owner after sub-agent
+ownership has been collapsed, and the quit title resolver uses it for local
+terminal rows. Neither calls `listThreads({ callerReason:
+"quit-confirmation" })` any more.
+
+The same read serves every other caller that wants one fact about one known
+thread, which is what removes the full-collection walk described above.
 
 Remote terminal rows continue to consult only already-observed federation
 summaries and local pinned summaries. Automation rows keep their automation
@@ -97,7 +198,34 @@ thread enrichment.
 
 ## Performance Budget
 
-For quit snapshot construction and repeated live-queue polls:
+Provider reads are budgeted the way SQLite writes already are in this
+repository: a checked-in JSON file of exact counts per named scenario, asserted
+by tests. `apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json`
+records `providerListCalls` and `directoryEnrichments` for each scenario, and
+`expectThreadReadBudget` fails when either count deviates **in either
+direction**. A count that drops is as much a change to review as one that
+rises: it usually means a read stopped happening that something still depends
+on. Re-record with `UPDATE_THREAD_READ_BUDGETS=1`.
+
+Current recorded budget:
+
+| Scenario | Provider lists | Directory enrichments |
+|---|---|---|
+| Ten complete turns on a thread the navigation refresh already observed | 0 | 0 |
+| Five turns with label reads between every lifecycle event | 0 | 0 |
+| Five turns on an already-enriched worktree thread | 0 | 0 |
+| Twenty quit-dialog polls against an in-progress turn | 0 | 0 |
+| Fifty synchronous label lookups for a thread observed once | 0 | 0 |
+| A second window's navigation refresh against a warm list cache | 0 | 0 |
+| Six concurrent callers asking for the same unenriched listing | 1 | 0 |
+| Eight terminal notifications across two never-listed threads | 1 | 0 |
+| One navigation refresh over a single worktree-backed thread | 1 | 1 |
+
+The three nonzero rows are the shape the design intends: a thread nobody has
+ever listed costs exactly one listing however many callers ask at once, and
+enrichment happens once per worktree thread rather than per read.
+
+For quit snapshot construction and repeated live-queue polls specifically:
 
 - full provider thread-list refreshes: **0**
 - directory/Git enrichment calls for labels: **0**
@@ -109,20 +237,20 @@ batch may perform one existing read of persisted remote pins; it performs no
 write.
 
 The budget is enforced with deterministic call-count assertions, not elapsed
-time.
+time. The enrichment counter is exercised with worktree-shaped fixtures so it
+provably can move — a budget that cannot move proves nothing.
 
 ## Compatibility With PR #1896
 
 PR #1896's `getCachedThreadSummary()` serves targeted messaging admission and
-is broader than the title-only projection. Its current cache scan does not
-cover names observed from lifecycle/name notifications.
+is broader than a title read. Its current cache scan does not cover names
+observed from lifecycle/name notifications.
 
 This change does not cherry-pick or duplicate PR #1896's messaging work. On a
 later rebase, `getCachedThreadSummary()` can retain its admission contract and
-thread-list cache scan; where it needs a display title, it can merge the narrow
-projection into the cached summary. Quit continues to call the narrow
-display-metadata read and never treats title-only knowledge as a complete
-navigation/admission summary. Keeping the responsibilities separate makes the
+thread-list cache scan; where it needs a display title, it can read the store.
+Quit continues to call `getThreadInfo` and never treats title-only knowledge as
+a complete navigation/admission summary. Keeping the responsibilities separate makes the
 backend-registry overlap mechanical rather than architectural.
 
 ## Test Matrix
@@ -130,7 +258,7 @@ backend-registry overlap mechanical rather than architectural.
 | Contract | Focused coverage |
 |---|---|
 | Ordinary local active turn is named | Seed an already-observed non-fallback title, start/observe a normal turn, and assert the first synchronous quit snapshot carries it. |
-| Sub-agent ownership remains named | Preserve the existing owner-collapse case and verify it reads the same projection. |
+| Sub-agent ownership remains named | Preserve the existing owner-collapse case and verify it reads the same store. |
 | Rename wins | Observe an initial title, then a nonempty explicit rename, and assert subsequent snapshots use the rename. |
 | Missing/fallback cannot downgrade | Feed empty/fallback observations after a known title and assert the title remains. With no prior title, assert the stable thread-id fallback. |
 | Late old list cannot erase | Start a delayed list, observe a newer rename and active turn, release the old list, and assert the rename remains after completion and invalidation. |
@@ -142,9 +270,19 @@ backend-registry overlap mechanical rather than architectural.
 | Other blocker kinds | Preserve focused snapshot/resolver coverage for integrated terminals, environment actions, and automations. |
 | Renderer defense | Keep PR #1903 component tests proving absent titles cannot erase known titles, renames win, removals/counts remain authoritative, and empty state renders. |
 | Quit decisions | Preserve existing main-process tests for Quit, Wait/countdown, and Stay Open. |
+| Store contract | `thread-info-store.test.ts` covers per-field sequencing, positive-facts-only merging, fallback rejection, enrichment grading, identity keying, and forget/forgetInstance. |
+| Read budgets | `thread-read-budget.test.ts` drives each named scenario against a counting backend client and asserts the checked-in counts exactly. |
+| Remote ordering | A peer snapshot that started earlier but finished later cannot revert a newer name; a rename recorded afterwards still wins. |
+| Remote isolation | Two peers reusing one thread id keep separate names, and unmounting one peer drops only that peer's names. |
+| Reservation ordering at the IPC seam | The navigation-snapshot handler reserves its observation sequence strictly before the peer round trip begins. |
+
+Every test in the last four rows was falsified before being kept: the fix was
+reverted, the test was watched to fail, and the fix restored. A test that
+passes against the defect it names is not coverage.
 
 No new desktop E2E is planned because this change introduces no renderer,
-dialog, IPC-shape, or interaction contract. The main-process unit tests can
+dialog, IPC-shape, or interaction contract — it changes where the main process
+keeps what it already knew. The main-process unit tests can
 deterministically prove the provider-call budget and freshness ordering, while
 PR #1903's component tests already exercise the live-poll presentation seam.
 Adding a headed replay would duplicate those contracts without exposing a new

--- a/packages/messaging/providers/slack/package.json
+++ b/packages/messaging/providers/slack/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@pwragent/messaging-interface": "workspace:*",
     "@slack/socket-mode": "^2.0.7",
-    "@slack/web-api": "^7.15.2"
+    "@slack/web-api": "^8.0.0"
   },
   "devDependencies": {
     "vitest": "^4.1.4"

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -7,6 +7,7 @@ import type {
   AppServerThreadActivityEntry,
   AppServerThreadImagePart,
   AppServerThreadReviewEntry,
+  AppServerThreadStatus,
   AppServerThreadSummary,
   CodexEnvironmentAction,
   CodexEnvironmentExecutionTarget,
@@ -261,6 +262,20 @@ export type ThreadQueuedTurnSummary = {
   createdAt: number;
   /** 0-based dispatch position within the thread's queue. */
   position: number;
+};
+
+/**
+ * One-thread projection used by latency-sensitive turn admission. Producers
+ * must not populate it by building a navigation-wide snapshot.
+ */
+export type ThreadAdmissionState = {
+  activeTurn?: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    turnId: string;
+  };
+  thread?: NavigationThreadSummary;
+  threadStatus?: AppServerThreadStatus;
 };
 
 export type ThreadSubAgentStatus =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,8 +333,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7
       '@slack/web-api':
-        specifier: ^7.15.2
-        version: 7.19.0
+        specifier: ^8.0.0
+        version: 8.0.0
     devDependencies:
       vitest:
         specifier: ^4.1.4
@@ -1391,6 +1391,10 @@ packages:
     resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
+  '@slack/logger@5.0.0':
+    resolution: {integrity: sha512-VGXhmmgsAo9shdQYh4tFDndd+7nsgp0Y5h0UPDaUp8K359pBasI6YdkMqFW3mCOxLQkq09qj7o7cq6f3DuXcJQ==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
+
   '@slack/socket-mode@2.0.7':
     resolution: {integrity: sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
@@ -1399,9 +1403,17 @@ packages:
     resolution: {integrity: sha512-sZ9lIgJhPX2qft/tKWiklFlc0o1FWeI7QtciZJfW1+ErH1eGGHvOZ8e73sleTCFEFJp1q/R0WeS8Oa7AsiDprg==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
+  '@slack/types@3.0.0':
+    resolution: {integrity: sha512-KNOqpnNAlsFt5Jk9XBclslQ0lobRIg/0tnhpmvZJAglHJx9E8oceN8hC3gaBzkR6UzQ9Wzq4rLsJ98wUcxWPfw==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
+
   '@slack/web-api@7.19.0':
     resolution: {integrity: sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/web-api@8.0.0':
+    resolution: {integrity: sha512-ORx3XQryQPq2Jnxv5giSKXVoQRUeylrrymIR2S9fPzLjPcCts8RayMeBSZMcpfpAqp6fnBRuPW2UB6dUPUTEZA==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -5530,6 +5542,10 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
+  '@slack/logger@5.0.0':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@slack/socket-mode@2.0.7':
     dependencies:
       '@slack/logger': 4.0.1
@@ -5545,6 +5561,8 @@ snapshots:
       - utf-8-validate
 
   '@slack/types@2.22.0': {}
+
+  '@slack/types@3.0.0': {}
 
   '@slack/web-api@7.19.0':
     dependencies:
@@ -5563,6 +5581,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  '@slack/web-api@8.0.0':
+    dependencies:
+      '@slack/logger': 5.0.0
+      '@slack/types': 3.0.0
+      '@types/node': 24.13.3
+      '@types/retry': 0.12.0
+      eventemitter3: 5.0.4
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
## Summary

The quit card's titles blinking between name and UUID every ~3s was the symptom.
The cause was that this product had no place to keep what it knows about a
thread — thread information lived inside the caches that answer *queries*, and
those are correctly discarded on every mutation.

This PR gives thread information its own store and moves the callers onto it.

- **`ThreadInfoStore`** (`app-server/thread-info-store.ts`) holds one entry per
  thread, with a per-field observation sequence and source. Identity is
  `instanceId::backend:threadId`.
- **Positive facts only.** An omitted field is not a deletion, an empty title is
  not news, and a `fallback` source means the title *is* the UUID — recording it
  would overwrite a real name with nothing. Title and source are validated
  together so a fallback cannot arrive alone and downgrade a held name.
- **Sequences are reserved before an async read begins**, so a listing overtaken
  by a rename cannot revert it on late completion. Monotonic counter, never
  `Date.now()`.
- **Callers declare freshness.** `findThreadForWorkspaceHandoff` takes
  `freshness: "provider" | "last-known"` — am I about to act on this, or only
  display it?
- **Archival is an observation**, recorded from the notification at the event
  fan-out, not rediscovered by invalidating and re-listing.
- **Peer names get the same treatment**, keyed by instance so two peers reusing
  a thread id cannot answer for each other.

Only the thread or the peer going away removes an entry. Cache invalidation
never does.

Stacked on #1903.

## What was actually wrong

Four defects, established by measurement rather than assumption:

1. **Invalidation was amnesia.** ~46 sites clear the list cache; every one was
   also erasing the only record of what threads were called.
2. **Point queries were answered by full-collection walks.** 16 sites wanted one
   row and rebuilt every row to get it.
3. **Query-shaped keys fragmented identical reads.** 6 concurrent callers asking
   the same question produced more than one provider call.
4. **Absence was conflated with unknown.** `title: undefined` meant both "has no
   title" and "we knew it and this lookup didn't return it".

The headline case: `turn/started` invalidates the list cache, and
`active-turn-branch-adoption` then drove a complete paged provider `thread/list`
to read a single field — **one full listing per turn boundary.** Quantified by
reverting the fix and re-recording the budgets:

```
turn-lifecycle-label-reads        5 -> 0
ten-turns-warm-thread            10 -> 0
worktree-turns-after-enrichment   5 -> 0
```

## Provider-read budgets

Provider reads are now budgeted the way SQLite writes already are here: a
checked-in JSON of exact counts per named scenario
(`__tests__/fixtures/thread-read-budgets.json`), asserted by
`expectThreadReadBudget`, failing on deviation **in either direction** — a count
that drops is as much a change to review as one that rises. Re-record with
`UPDATE_THREAD_READ_BUDGETS=1`.

| Scenario | Lists | Enrichments |
|---|---|---|
| Ten complete turns on an already-observed thread | 0 | 0 |
| Five turns with label reads between every lifecycle event | 0 | 0 |
| Five turns on an already-enriched worktree thread | 0 | 0 |
| Twenty quit-dialog polls against an in-progress turn | 0 | 0 |
| Fifty synchronous label lookups for a thread observed once | 0 | 0 |
| A second window's navigation refresh against a warm cache | 0 | 0 |
| Six concurrent callers asking for the same unenriched listing | 1 | 0 |
| Eight terminal notifications across two never-listed threads | 1 | 0 |
| One navigation refresh over a single worktree-backed thread | 1 | 1 |

The three nonzero rows are the intended shape. The worktree scenarios exist
because no other fixture reaches directory enrichment, and a budget counter that
cannot move proves nothing.

## Tests

New: `thread-info-store.test.ts` (store contract),
`thread-read-budget.test.ts` (the budgets above), plus remote ordering and
isolation cases in `remote-thread-summary-cache.test.ts` and a reservation-order
assertion at the navigation-snapshot IPC seam.

**Every new behavioral test was falsified before being kept** — the fix was
reverted, the test watched to fail, and the fix restored. A test that passes
against the defect it names is not coverage.

## Validation

- `pnpm test` — **exit 0**, 644 files, 9394 passed, 6 skipped
- `pnpm typecheck` — exit 0
- `pnpm lint:eslint` — exit 0
- `pnpm lint:boundaries` — exit 0
- `pnpm lint:codex-storage` — exit 0
- `pnpm lint:colors` — exit 0

No new desktop E2E: this adds no renderer, dialog, IPC-shape, or interaction
contract — it changes where the main process keeps what it already knew. PR
#1903's renderer-side monotonic retention stays in place as a second
presentation-layer defense.

## Notes for review

- No new persistent state. Both stores are process-local, so there are no new
  SQLite writes or write budgets.
- `docs/plans/2026-08-31-quit-blocker-title-read-model.md` was rewritten in this
  branch: it opened with "This is a scoped correction to the existing quit path",
  which stopped being true. It is unmerged and was added by this PR's own first
  commit.
