### PR TITLE
feat(desktop): say Server for Discord and separate response behavior from access

### DIFF
--- a/apps/desktop/e2e/fixtures/readme-state-seeding.ts
+++ b/apps/desktop/e2e/fixtures/readme-state-seeding.ts
@@ -139,7 +139,7 @@ export type SeedActivityEntry = {
   /**
    * Free-form payload bag. The renderer reads:
    *   - conversationKind
-   *   - conversationParentId (becomes "Supergroup ID" / "Guild ID" / etc.)
+   *   - conversationParentId (becomes "Supergroup ID" / "Server ID" / etc.)
    *   - conversationBucketId
    * Anything else is preserved but not rendered.
    */

--- a/apps/desktop/src/main/__tests__/messaging-response-mode.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-response-mode.test.ts
@@ -54,6 +54,36 @@ describe("resolveMessagingResponseModeForChannel", () => {
       responseModeOverrides: [],
     }), channelRef)).toBe("every_message");
   });
+
+  it("inherits past an override row that carries no response mode", () => {
+    // An override row with no `response_mode` is the "Default" state the
+    // Routes picker offers. It must fall through to the server row, and a
+    // server row with no mode of its own must fall through to the Discord-wide
+    // default — this is what the Routes empty state promises operators.
+    const withoutModes = discordConfig({
+      responseMode: "mention_only",
+      authorizedGuildIds: [{ id: GUILD_ID, displayName: "Test server" }],
+      responseModeOverrides: [
+        { id: THREAD_ID, displayName: "native-thread" },
+        { id: CHANNEL_ID, displayName: "parent-channel" },
+      ],
+    });
+
+    expect(resolve(withoutModes, discordThreadRef())).toBe("mention_only");
+
+    const serverOnly = discordConfig({
+      ...withoutModes.discord,
+      authorizedGuildIds: [
+        {
+          id: GUILD_ID,
+          displayName: "Test server",
+          responseMode: "every_message",
+        },
+      ],
+    });
+
+    expect(resolve(serverOnly, discordThreadRef())).toBe("every_message");
+  });
 });
 
 function discordConfig(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -3001,7 +3001,10 @@ function pairingScopeFailure(
     return "token was generated for a user-in-group flow but was pasted in a DM";
   }
   if (entry.scope === "bucket" && isDm) {
-    return "token was generated for a group/server bucket but was pasted in a DM";
+    // Platform-neutral on purpose: this reply reaches Telegram supergroups,
+    // Slack workspaces, Mattermost teams, Feishu tenants, and LINE groups as
+    // well as Discord servers, so it must not name any one platform's noun.
+    return "token was generated for a group/workspace bucket but was pasted in a DM";
   }
   return undefined;
 }

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -3001,7 +3001,7 @@ function pairingScopeFailure(
     return "token was generated for a user-in-group flow but was pasted in a DM";
   }
   if (entry.scope === "bucket" && isDm) {
-    return "token was generated for a group/guild bucket but was pasted in a DM";
+    return "token was generated for a group/server bucket but was pasted in a DM";
   }
   return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -439,7 +439,7 @@ function parentIdLabel(
   conversationKind?: string,
 ): string {
   if (platform === "telegram") return "Supergroup ID";
-  if (platform === "discord") return "Guild ID";
+  if (platform === "discord") return "Server ID";
   if (platform === "feishu") return "Tenant Key";
   if (platform === "mattermost" && conversationKind === "thread") return "Root ID";
   return "Parent ID";
@@ -447,7 +447,7 @@ function parentIdLabel(
 
 function bucketIdLabel(platform: MessagingActivityEntry["platform"]): string {
   if (platform === "telegram") return "Supergroup ID";
-  if (platform === "discord") return "Guild ID";
+  if (platform === "discord") return "Server ID";
   if (platform === "slack") return "Workspace ID";
   if (platform === "feishu") return "Tenant Key";
   if (platform === "mattermost") return "Team ID";

--- a/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
 });
 
 describe("MessagingActivityScreen", () => {
-  it("shows rejected actor and guild IDs as copyable controls", async () => {
+  it("shows rejected actor and server IDs as copyable controls", async () => {
     const desktopApi = {
       listMessagingActivity: vi.fn(async () => ({
         entries: [
@@ -39,8 +39,10 @@ describe("MessagingActivityScreen", () => {
     });
     expect((await screen.findByText("1177378744822943744")).closest("button"))
       .toHaveTextContent("User ID");
+    // Discord's API calls this a guild; every operator-facing surface says
+    // Server, so Messaging Activity has to match what Settings asks for.
     expect(screen.getByText("1480554271907905731").closest("button"))
-      .toHaveTextContent("Guild ID");
+      .toHaveTextContent("Server ID");
     expect(screen.getByText("1480554271907905000").closest("button"))
       .toHaveTextContent("Channel ID");
   });

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -3998,7 +3998,7 @@ const PROVIDER_SETUP_CONFIGS: Record<OnboardingProvider, ProviderSetupConfig> = 
         label: "Pair your DMs with the bot",
         help: (
           <>
-            Invite the bot to a guild (Developer Portal → OAuth2 URL
+            Invite the bot to a server (Developer Portal → OAuth2 URL
             Generator, scopes <code>bot</code> + <code>applications.commands</code>),
             then DM the bot the pairing message below from your Discord
             account.

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -2723,7 +2723,7 @@ const PROVIDER_ROWS: readonly ProviderRow[] = [
     name: "Discord",
     icon: <DiscordIcon size={20} aria-hidden />,
     notes:
-      "Developer Portal app · bot token · OAuth invite to a guild. No ports or tunnels needed.",
+      "Developer Portal app · bot token · OAuth invite to a server. No ports or tunnels needed.",
     setupTime: "~10 min",
     risk: "low",
     riskLabel: "Low",
@@ -5264,7 +5264,7 @@ function PairingBlock(props: {
 /**
  * Human label for a pairing scope, scoped by the onboarding-known
  * platforms so we say "DM" / "Supergroup" for Telegram, "DM" /
- * "Guild" for Discord, etc. Falls back to a generic "Group" /
+ * "Server" for Discord, etc. Falls back to a generic "Group" /
  * "Conversation" label for any platform the wizard doesn't render
  * a setup step for (currently none — the union is wider than the
  * wizard's surface area to leave room for future providers).
@@ -5281,7 +5281,7 @@ function labelForPairingScope(
     case "telegram":
       return "Supergroup";
     case "discord":
-      return "Guild";
+      return "Server";
     case "slack":
       return "Workspace";
     case "mattermost":

--- a/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../lib/messaging-platform-branding";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { SettingsSection } from "./SettingsLayout";
+import { RESPONSE_MODE_OPTIONS, responseModeTitle } from "./settings-fields";
 
 const EMPTY_ROUTES: ListMessagingRoutesResponse = {
   defaultAgents: [],
@@ -181,7 +182,7 @@ export function MessagingRoutesSettings(props: {
   desktopApi?: DesktopApi;
   discordResponseBehavior?: Omit<
     DiscordResponseBehaviorProps,
-    "observedSurfaces"
+    "loading" | "observedSurfaces"
   >;
   onOpenThread?: (target: {
     backend: AppServerBackendKind;
@@ -358,6 +359,7 @@ export function MessagingRoutesSettings(props: {
         {props.discordResponseBehavior ? (
           <DiscordResponseBehavior
             {...props.discordResponseBehavior}
+            loading={loading}
             observedSurfaces={routes.observedSurfaces ?? []}
           />
         ) : null}
@@ -1379,6 +1381,7 @@ function formatTimestamp(value: number): string {
  */
 export type DiscordResponseBehaviorProps = {
   disabled?: boolean;
+  loading?: boolean;
   observedSurfaces: DesktopMessagingObservedSurface[];
   source: string;
   value: DesktopAuthorizedContact[];
@@ -1388,13 +1391,22 @@ export type DiscordResponseBehaviorProps = {
 function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
   const selectId = useId();
   const configured = props.value;
-  const configuredIds = new Set(configured.map((entry) => entry.id));
-  const candidates = discordResponseSurfaceCandidates(props.observedSurfaces)
-    .filter((candidate) => !configuredIds.has(candidate.id));
+  // Built once and shared with every row. Recomputing per row made the section
+  // O(rows x surfaces log surfaces) on every render, and `observedSurfaces` is
+  // a fresh array each render so a row-level memo could never have helped.
+  const candidatesById = useMemo(
+    () => discordResponseSurfaceCandidates(props.observedSurfaces),
+    [props.observedSurfaces],
+  );
+  const unconfigured = useMemo(() => {
+    const configuredIds = new Set(configured.map((entry) => entry.id));
+    return [...candidatesById.values()]
+      .filter((candidate) => !configuredIds.has(candidate.id));
+  }, [candidatesById, configured]);
 
   const addSurface = (id: string) => {
-    const candidate = candidates.find((entry) => entry.id === id);
-    if (!candidate || configuredIds.has(id)) return;
+    const candidate = candidatesById.get(id);
+    if (!candidate || configured.some((entry) => entry.id === id)) return;
     props.onSave([
       ...configured,
       {
@@ -1405,13 +1417,22 @@ function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
     ]);
   };
 
-  const updateMode = (id: string, responseMode: DesktopMessagingResponseMode) => {
-    props.onSave(configured.map((entry) =>
-      entry.id === id ? { ...entry, responseMode } : entry));
+  // Indexed rather than keyed by id: `response_mode_overrides` is a plain array
+  // that nothing dedupes, and the raw-ID editor this replaced could persist two
+  // rows with the same snowflake. Matching by id would delete or rewrite both.
+  const updateMode = (
+    index: number,
+    responseMode: DesktopMessagingResponseMode | undefined,
+  ) => {
+    props.onSave(configured.map((entry, entryIndex) => {
+      if (entryIndex !== index) return entry;
+      const { responseMode: _drop, ...rest } = entry;
+      return responseMode ? { ...rest, responseMode } : rest;
+    }));
   };
 
-  const removeSurface = (id: string) => {
-    props.onSave(configured.filter((entry) => entry.id !== id));
+  const removeSurface = (index: number) => {
+    props.onSave(configured.filter((_entry, entryIndex) => entryIndex !== index));
   };
 
   return (
@@ -1420,8 +1441,9 @@ function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
         <strong>When PwrAgent responds</strong>
         <span>
           Pick a Discord channel or native thread PwrAgent has seen, then choose
-          whether it replies to every message there or only when @ mentioned.
-          This does not choose an Agent or authorize access.
+          whether it replies to every message there or only when @ mentioned. A
+          native thread's own setting beats its parent channel's. This does not
+          choose an Agent or authorize access.
         </span>
         <span className="settings-source">{props.source}</span>
       </div>
@@ -1431,7 +1453,7 @@ function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
         </label>
         <select
           className="settings-input"
-          disabled={props.disabled || candidates.length === 0}
+          disabled={props.disabled || props.loading || unconfigured.length === 0}
           id={selectId}
           value=""
           onChange={(event) => {
@@ -1440,11 +1462,13 @@ function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
           }}
         >
           <option value="">
-            {candidates.length === 0
-              ? "No unconfigured Discord channels seen yet"
-              : "Select a channel or thread..."}
+            {props.loading
+              ? "Loading channels..."
+              : unconfigured.length === 0
+                ? "No unconfigured Discord channels seen yet"
+                : "Select a channel or thread..."}
           </option>
-          {candidates.map((candidate) => (
+          {unconfigured.map((candidate) => (
             <option key={candidate.id} value={candidate.id}>
               {candidate.label}
             </option>
@@ -1455,19 +1479,22 @@ function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
         className="messaging-routes__list"
         aria-label="Discord channel and thread response behavior"
       >
-        {configured.length === 0 ? (
+        {props.loading ? (
+          <p className="messaging-routes__empty">Loading routes...</p>
+        ) : configured.length === 0 ? (
           <p className="messaging-routes__empty">
-            Every Discord channel and native thread follows its server setting.
+            Every Discord channel and native thread follows its server&apos;s
+            setting, or the Discord-wide default when that server has none.
           </p>
         ) : (
-          configured.map((entry) => (
+          configured.map((entry, index) => (
             <DiscordResponseRow
-              key={entry.id}
+              key={`${entry.id}-${index}`}
               disabled={props.disabled}
               entry={entry}
-              observedSurfaces={props.observedSurfaces}
-              onChangeMode={(responseMode) => updateMode(entry.id, responseMode)}
-              onRemove={() => removeSurface(entry.id)}
+              observed={candidatesById.get(entry.id)}
+              onChangeMode={(responseMode) => updateMode(index, responseMode)}
+              onRemove={() => removeSurface(index)}
             />
           ))
         )}
@@ -1479,18 +1506,17 @@ function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
 function DiscordResponseRow(props: {
   disabled?: boolean;
   entry: DesktopAuthorizedContact;
-  observedSurfaces: DesktopMessagingObservedSurface[];
-  onChangeMode: (responseMode: DesktopMessagingResponseMode) => void;
+  observed?: DiscordResponseSurfaceCandidate;
+  onChangeMode: (responseMode: DesktopMessagingResponseMode | undefined) => void;
   onRemove: () => void;
 }) {
   const selectId = useId();
-  const observed = discordResponseSurfaceCandidates(props.observedSurfaces)
-    .find((candidate) => candidate.id === props.entry.id);
   // A configured surface the adapter has not seen recently still has to render
-  // with whatever identity we stored, so removing it stays possible.
-  const label = observed?.label
-    ?? props.entry.displayName
-    ?? props.entry.id;
+  // with whatever identity we stored, so removing it stays possible. `||`, not
+  // `??`: `displayName` is a required string that is routinely "".
+  const label = props.observed?.label
+    || props.entry.displayName.trim()
+    || props.entry.id;
   const DiscordIcon = MESSAGING_PLATFORM_ICONS.discord;
   return (
     <div className="messaging-route-row">
@@ -1501,32 +1527,35 @@ function DiscordResponseRow(props: {
         <div className="messaging-route-row__main">
           <div className="messaging-route-row__title">{label}</div>
           <div className="messaging-route-row__meta">
-            {observed ? observed.kindLabel : "Not seen recently"}
+            {props.observed ? props.observed.kindLabel : "Not seen recently"}
             {" / ID "}
             {props.entry.id}
           </div>
         </div>
       </div>
-      <div className="messaging-routes__response-controls">
+      <div className="messaging-route-row__actions messaging-routes__response-controls">
         <label className="settings-authorized-list__policy-label" htmlFor={selectId}>
           Responds to
         </label>
         <select
+          aria-label={`Responds to for ${label}`}
           className="settings-input"
           disabled={props.disabled}
           id={selectId}
-          title={
-            "Sets whether PwrAgent replies to every message in this channel or "
-            + "thread or only when @ mentioned. This does not choose an Agent or "
-            + "authorize access."
-          }
-          value={props.entry.responseMode ?? "mention_only"}
+          title={responseModeTitle("channel or thread")}
+          value={props.entry.responseMode ?? ""}
           onChange={(event) => props.onChangeMode(
-            event.currentTarget.value as DesktopMessagingResponseMode,
+            event.currentTarget.value === ""
+              ? undefined
+              : event.currentTarget.value as DesktopMessagingResponseMode,
           )}
         >
-          <option value="mention_only">@ mention only</option>
-          <option value="every_message">Every message</option>
+          <option value="">Default (follow server)</option>
+          {RESPONSE_MODE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
         <button
           aria-label={`Remove response behavior for ${label}`}
@@ -1543,6 +1572,10 @@ function DiscordResponseRow(props: {
 }
 
 type DiscordResponseSurfaceCandidate = {
+  // True when this record was derived from a thread's parent pointer rather
+  // than observed directly. A derived record carries a weaker identity and
+  // must never displace a direct observation of the same channel.
+  derived: boolean;
   displayName: string;
   id: string;
   kindLabel: string;
@@ -1557,11 +1590,22 @@ type DiscordResponseSurfaceCandidate = {
  */
 function discordResponseSurfaceCandidates(
   surfaces: DesktopMessagingObservedSurface[],
-): DiscordResponseSurfaceCandidate[] {
+): Map<string, DiscordResponseSurfaceCandidate> {
   const candidates = new Map<string, DiscordResponseSurfaceCandidate>();
   const remember = (candidate: DiscordResponseSurfaceCandidate) => {
     const existing = candidates.get(candidate.id);
-    if (existing && existing.lastSeenAt >= candidate.lastSeenAt) return;
+    if (!existing) {
+      candidates.set(candidate.id, candidate);
+      return;
+    }
+    // A direct observation always wins over a derived one, however stale. The
+    // adapter names a thread's parent from a separate REST fetch that can fail,
+    // so a newer derived record is not a better record.
+    if (existing.derived !== candidate.derived) {
+      if (existing.derived) candidates.set(candidate.id, candidate);
+      return;
+    }
+    if (existing.lastSeenAt >= candidate.lastSeenAt) return;
     candidates.set(candidate.id, candidate);
   };
   for (const surface of surfaces) {
@@ -1569,6 +1613,7 @@ function discordResponseSurfaceCandidates(
     const conversation = surface.conversation;
     if (conversation.kind === "channel" || conversation.kind === "thread") {
       remember({
+        derived: false,
         displayName: conversation.title ?? "",
         id: conversation.id,
         kindLabel: conversation.kind === "thread" ? "Native thread" : "Channel",
@@ -1578,20 +1623,49 @@ function discordResponseSurfaceCandidates(
     }
     const parentConversationId = conversation.parentConversationId;
     if (conversation.kind === "thread" && parentConversationId) {
+      // The adapter sets `ancestorTitle` only when it actually resolved the
+      // parent channel's name; without it `parentTitle` holds the SERVER name
+      // (`parentChannelName ?? guildName`), which would offer a channel under
+      // its server's name. Fall back to the bare id instead of lying.
+      const parentResolved = Boolean(conversation.ancestorTitle?.trim());
+      const parentName = parentResolved ? conversation.parentTitle : undefined;
       remember({
-        displayName: conversation.parentTitle ?? "",
+        derived: true,
+        displayName: parentName ?? "",
         id: parentConversationId,
         kindLabel: "Channel",
         label: formatObservedContainerLabel({
           platform: "discord",
           id: parentConversationId,
-          names: [conversation.ancestorTitle, conversation.parentTitle],
+          names: parentResolved
+            ? [conversation.ancestorTitle, conversation.parentTitle]
+            : [],
         }),
         lastSeenAt: surface.lastSeenAt,
       });
     }
   }
-  return [...candidates.values()].sort((left, right) =>
-    right.lastSeenAt - left.lastSeenAt
-    || left.label.localeCompare(right.label));
+  return disambiguateCandidateLabels(candidates);
+}
+
+/**
+ * Discord does not enforce unique channel or thread names, so two surfaces can
+ * format to the same label. The picker shows label text only, so a collision
+ * would leave the operator unable to tell which snowflake they selected.
+ */
+function disambiguateCandidateLabels(
+  candidates: Map<string, DiscordResponseSurfaceCandidate>,
+): Map<string, DiscordResponseSurfaceCandidate> {
+  const counts = new Map<string, number>();
+  for (const candidate of candidates.values()) {
+    counts.set(candidate.label, (counts.get(candidate.label) ?? 0) + 1);
+  }
+  const sorted = [...candidates.values()]
+    .map((candidate) => (counts.get(candidate.label) ?? 0) > 1
+      ? { ...candidate, label: `${candidate.label} (ID ${candidate.id})` }
+      : candidate)
+    .sort((left, right) =>
+      right.lastSeenAt - left.lastSeenAt
+      || left.label.localeCompare(right.label));
+  return new Map(sorted.map((candidate) => [candidate.id, candidate]));
 }

--- a/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -10,10 +11,12 @@ import {
 } from "react";
 import type {
   AppServerBackendKind,
+  DesktopAuthorizedContact,
   DesktopMessagingAgentRouteTarget,
   DesktopMessagingDefaultAgentRoute,
   DesktopMessagingDefaultAgentScope,
   DesktopMessagingObservedSurface,
+  DesktopMessagingResponseMode,
   ListMessagingRoutesResponse,
   MessagingChannelKind,
   MessagingConversationKind,
@@ -176,6 +179,10 @@ export function MessagingRoutesSettings(props: {
   agentRouteToolUpdateMode?: MessagingToolUpdateMode;
   configuredPlatforms?: readonly MessagingChannelKind[];
   desktopApi?: DesktopApi;
+  discordResponseBehavior?: Omit<
+    DiscordResponseBehaviorProps,
+    "observedSurfaces"
+  >;
   onOpenThread?: (target: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -347,6 +354,13 @@ export function MessagingRoutesSettings(props: {
             ))
           )}
         </div>
+
+        {props.discordResponseBehavior ? (
+          <DiscordResponseBehavior
+            {...props.discordResponseBehavior}
+            observedSurfaces={routes.observedSurfaces ?? []}
+          />
+        ) : null}
 
         <div className="messaging-routes__subhead">
           <strong>Active bindings</strong>
@@ -1351,4 +1365,233 @@ function formatTimestamp(value: number): string {
     dateStyle: "medium",
     timeStyle: "short",
   });
+}
+
+/**
+ * Response behavior for one exact Discord channel or native thread.
+ *
+ * This sits beside Default Agents rather than inside it because the two
+ * decisions are independent: admission runs first and only decides whether an
+ * ambient message is accepted at all, and routing then picks the Agent for an
+ * accepted unbound message. Sharing the observed-surface picker keeps operators
+ * choosing a named channel instead of pasting a snowflake, but the two lists
+ * never share a value.
+ */
+export type DiscordResponseBehaviorProps = {
+  disabled?: boolean;
+  observedSurfaces: DesktopMessagingObservedSurface[];
+  source: string;
+  value: DesktopAuthorizedContact[];
+  onSave: (value: DesktopAuthorizedContact[]) => void;
+};
+
+function DiscordResponseBehavior(props: DiscordResponseBehaviorProps) {
+  const selectId = useId();
+  const configured = props.value;
+  const configuredIds = new Set(configured.map((entry) => entry.id));
+  const candidates = discordResponseSurfaceCandidates(props.observedSurfaces)
+    .filter((candidate) => !configuredIds.has(candidate.id));
+
+  const addSurface = (id: string) => {
+    const candidate = candidates.find((entry) => entry.id === id);
+    if (!candidate || configuredIds.has(id)) return;
+    props.onSave([
+      ...configured,
+      {
+        id: candidate.id,
+        displayName: candidate.displayName,
+        responseMode: "mention_only",
+      },
+    ]);
+  };
+
+  const updateMode = (id: string, responseMode: DesktopMessagingResponseMode) => {
+    props.onSave(configured.map((entry) =>
+      entry.id === id ? { ...entry, responseMode } : entry));
+  };
+
+  const removeSurface = (id: string) => {
+    props.onSave(configured.filter((entry) => entry.id !== id));
+  };
+
+  return (
+    <>
+      <div className="messaging-routes__subhead">
+        <strong>When PwrAgent responds</strong>
+        <span>
+          Pick a Discord channel or native thread PwrAgent has seen, then choose
+          whether it replies to every message there or only when @ mentioned.
+          This does not choose an Agent or authorize access.
+        </span>
+        <span className="settings-source">{props.source}</span>
+      </div>
+      <div className="messaging-routes__response-add">
+        <label className="settings-authorized-list__policy-label" htmlFor={selectId}>
+          Add a channel or thread
+        </label>
+        <select
+          className="settings-input"
+          disabled={props.disabled || candidates.length === 0}
+          id={selectId}
+          value=""
+          onChange={(event) => {
+            const id = event.currentTarget.value;
+            if (id) addSurface(id);
+          }}
+        >
+          <option value="">
+            {candidates.length === 0
+              ? "No unconfigured Discord channels seen yet"
+              : "Select a channel or thread..."}
+          </option>
+          {candidates.map((candidate) => (
+            <option key={candidate.id} value={candidate.id}>
+              {candidate.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div
+        className="messaging-routes__list"
+        aria-label="Discord channel and thread response behavior"
+      >
+        {configured.length === 0 ? (
+          <p className="messaging-routes__empty">
+            Every Discord channel and native thread follows its server setting.
+          </p>
+        ) : (
+          configured.map((entry) => (
+            <DiscordResponseRow
+              key={entry.id}
+              disabled={props.disabled}
+              entry={entry}
+              observedSurfaces={props.observedSurfaces}
+              onChangeMode={(responseMode) => updateMode(entry.id, responseMode)}
+              onRemove={() => removeSurface(entry.id)}
+            />
+          ))
+        )}
+      </div>
+    </>
+  );
+}
+
+function DiscordResponseRow(props: {
+  disabled?: boolean;
+  entry: DesktopAuthorizedContact;
+  observedSurfaces: DesktopMessagingObservedSurface[];
+  onChangeMode: (responseMode: DesktopMessagingResponseMode) => void;
+  onRemove: () => void;
+}) {
+  const selectId = useId();
+  const observed = discordResponseSurfaceCandidates(props.observedSurfaces)
+    .find((candidate) => candidate.id === props.entry.id);
+  // A configured surface the adapter has not seen recently still has to render
+  // with whatever identity we stored, so removing it stays possible.
+  const label = observed?.label
+    ?? props.entry.displayName
+    ?? props.entry.id;
+  const DiscordIcon = MESSAGING_PLATFORM_ICONS.discord;
+  return (
+    <div className="messaging-route-row">
+      <div className="messaging-routes__response-identity">
+        <div className="messaging-route-row__platform" aria-hidden="true">
+          {DiscordIcon ? <DiscordIcon size={16} /> : null}
+        </div>
+        <div className="messaging-route-row__main">
+          <div className="messaging-route-row__title">{label}</div>
+          <div className="messaging-route-row__meta">
+            {observed ? observed.kindLabel : "Not seen recently"}
+            {" / ID "}
+            {props.entry.id}
+          </div>
+        </div>
+      </div>
+      <div className="messaging-routes__response-controls">
+        <label className="settings-authorized-list__policy-label" htmlFor={selectId}>
+          Responds to
+        </label>
+        <select
+          className="settings-input"
+          disabled={props.disabled}
+          id={selectId}
+          title={
+            "Sets whether PwrAgent replies to every message in this channel or "
+            + "thread or only when @ mentioned. This does not choose an Agent or "
+            + "authorize access."
+          }
+          value={props.entry.responseMode ?? "mention_only"}
+          onChange={(event) => props.onChangeMode(
+            event.currentTarget.value as DesktopMessagingResponseMode,
+          )}
+        >
+          <option value="mention_only">@ mention only</option>
+          <option value="every_message">Every message</option>
+        </select>
+        <button
+          aria-label={`Remove response behavior for ${label}`}
+          className="button button--ghost"
+          disabled={props.disabled}
+          type="button"
+          onClick={props.onRemove}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type DiscordResponseSurfaceCandidate = {
+  displayName: string;
+  id: string;
+  kindLabel: string;
+  label: string;
+  lastSeenAt: number;
+};
+
+/**
+ * Observed Discord channels and native threads, plus the parent channel of any
+ * observed thread. The parent is offered because an operator who has only ever
+ * seen thread traffic may still want to set the containing channel's behavior.
+ */
+function discordResponseSurfaceCandidates(
+  surfaces: DesktopMessagingObservedSurface[],
+): DiscordResponseSurfaceCandidate[] {
+  const candidates = new Map<string, DiscordResponseSurfaceCandidate>();
+  const remember = (candidate: DiscordResponseSurfaceCandidate) => {
+    const existing = candidates.get(candidate.id);
+    if (existing && existing.lastSeenAt >= candidate.lastSeenAt) return;
+    candidates.set(candidate.id, candidate);
+  };
+  for (const surface of surfaces) {
+    if (surface.platform !== "discord") continue;
+    const conversation = surface.conversation;
+    if (conversation.kind === "channel" || conversation.kind === "thread") {
+      remember({
+        displayName: conversation.title ?? "",
+        id: conversation.id,
+        kindLabel: conversation.kind === "thread" ? "Native thread" : "Channel",
+        label: formatConversationLabel("discord", conversation),
+        lastSeenAt: surface.lastSeenAt,
+      });
+    }
+    const parentConversationId = conversation.parentConversationId;
+    if (conversation.kind === "thread" && parentConversationId) {
+      remember({
+        displayName: conversation.parentTitle ?? "",
+        id: parentConversationId,
+        kindLabel: "Channel",
+        label: formatObservedContainerLabel({
+          platform: "discord",
+          id: parentConversationId,
+          names: [conversation.ancestorTitle, conversation.parentTitle],
+        }),
+        lastSeenAt: surface.lastSeenAt,
+      });
+    }
+  }
+  return [...candidates.values()].sort((left, right) =>
+    right.lastSeenAt - left.lastSeenAt
+    || left.label.localeCompare(right.label));
 }

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -645,6 +645,22 @@ export function MessagingSettings(props: {
           agentRouteToolUpdateMode={managerToolUpdateMode.value}
           configuredPlatforms={configuredRoutePlatforms}
           desktopApi={props.desktopApi}
+          discordResponseBehavior={discordIdentityConfigured
+            ? {
+                disabled: props.saving,
+                source: optionalListSourceBadge(discord.responseModeOverrides),
+                value: discord.responseModeOverrides.value,
+                onSave: (responseModeOverrides) => {
+                  void props.onSaveDiscord({
+                    ...discord,
+                    responseModeOverrides: {
+                      ...discord.responseModeOverrides,
+                      value: responseModeOverrides,
+                    },
+                  });
+                },
+              }
+            : undefined}
           onOpenThread={props.onOpenThread}
         />
       ) : null}
@@ -802,6 +818,7 @@ export function MessagingSettings(props: {
             validateEntry={validateTelegramGroupChatEntry}
             value={telegram.authorizedSupergroups.value}
             responseModePolicy
+            responseModeScopeNoun="group"
             onSave={(authorizedSupergroups) => {
               void props.onSaveTelegram({
                 ...telegram,
@@ -914,10 +931,10 @@ export function MessagingSettings(props: {
           />
           <SegmentedField
             disabled={props.saving || !discordIdentityConfigured}
-            label="Discord response default"
+            label="When PwrAgent responds"
             sub={discordIdentityConfigured
-              ? "Global default for Discord servers, channels, and native threads unless a server, channel/thread, or bound PwrAgent thread override is more specific."
-              : "Configure a bot token before enabling leading @bot mention response modes."}
+              ? "Discord-wide default for servers, channels, and native threads. An authorized server row is more specific, an exact channel or native thread in Routes is more specific still, and a bound PwrAgent thread wins over all of them."
+              : "Configure a bot token before choosing to respond only to leading @bot mentions."}
             options={RESPONSE_MODE_OPTIONS}
             source={sourceBadge(discord.responseMode)}
             value={discord.responseMode.value}
@@ -967,13 +984,15 @@ export function MessagingSettings(props: {
               "discord",
               "guild",
             )}
-            label="Authorized Guilds"
-            sub="Discord guild (server) IDs that may host bound threads. A row response mode overrides the global Discord default for that server."
-            help="Snowflake (17-19 digit number), e.g. 1480554271907905731. Rejected server messages show the guild ID in Messaging Activity. Channel, native-thread, and bound-thread overrides remain more specific."
+            label="Authorized Servers"
+            sub="Discord servers PwrAgent accepts messages from. Authorizing a server covers every channel and native thread in it that the bot can see."
+            help="Discord's API calls a server a guild, so a server ID is the same value Discord documents as a guild ID: a snowflake (17-19 digit number), e.g. 1480554271907905731. Rejected server messages show the server ID in Messaging Activity."
             source={optionalListSourceBadge(discord.authorizedGuilds)}
             validateEntry={validateDiscordGuildIdEntry}
             value={discord.authorizedGuilds.value}
+            refreshNamesLabel="Refresh server names"
             responseModePolicy={discordIdentityConfigured}
+            responseModeScopeNoun="server"
             onSave={(authorizedGuilds) => {
               void props.onSaveDiscord({
                 ...discord,
@@ -984,27 +1003,6 @@ export function MessagingSettings(props: {
               });
             }}
           />
-          {discordIdentityConfigured ? (
-            <AuthorizedListField
-              disabled={props.saving}
-              label="Channel / Thread Response Overrides"
-              sub="Optional response behavior for one Discord channel or native thread. An exact native-thread override beats its parent channel; either beats the server and global defaults."
-              help="Use the Discord channel or native thread snowflake. Bound PwrAgent thread controls remain the most specific override."
-              source={optionalListSourceBadge(discord.responseModeOverrides)}
-              validateEntry={validateDiscordConversationIdEntry}
-              value={discord.responseModeOverrides.value}
-              responseModePolicy
-              onSave={(responseModeOverrides) => {
-                void props.onSaveDiscord({
-                  ...discord,
-                  responseModeOverrides: {
-                    ...discord.responseModeOverrides,
-                    value: responseModeOverrides,
-                  },
-                });
-              }}
-            />
-          ) : null}
         </div>
       </SettingsSection>
       ) : null}
@@ -1477,6 +1475,7 @@ export function MessagingSettings(props: {
               validateEntry={validateSlackChannelIdEntry}
               value={slack.authorizedChannels.value}
               responseModePolicy
+              responseModeScopeNoun="channel"
               onSave={(authorizedChannels) => {
                 void props.onSaveSlack({
                   ...slack,
@@ -3330,7 +3329,13 @@ function AuthorizedListField(props: {
   help?: ReactNode;
   label: string;
   lookup?: (id: string) => Promise<DesktopMessagingContactLookupResponse>;
+  // Label for an explicit bulk name repair. Omitted callers get no button:
+  // names are never rewritten in the background or by heuristic.
+  refreshNamesLabel?: string;
   responseModePolicy?: boolean;
+  // Names what a row stands for, so the response control never claims a server
+  // row is "this channel". Every caller that sets responseModePolicy sets this.
+  responseModeScopeNoun?: string;
   showUsername?: boolean;
   sub?: ReactNode;
   source: string;
@@ -3353,10 +3358,15 @@ function AuthorizedListField(props: {
   const [lookupState, setLookupState] = useState<
     Record<number, { loading?: boolean; message?: string }>
   >({});
+  const [refreshState, setRefreshState] = useState<{
+    message?: string;
+    running?: boolean;
+  }>({});
   useEffect(() => {
     rowsRef.current = props.value;
     setRowsState(props.value);
     setLookupState({});
+    setRefreshState({});
   }, [props.value]);
   const normalizedRows = rows.map(normalizeAuthorizedContactRow);
   const invalidEntries = props.validateEntry
@@ -3502,6 +3512,73 @@ function AuthorizedListField(props: {
         message: lookupFailureMessage(result),
       },
     }));
+  };
+
+  /**
+   * Re-resolve every configured ID and adopt only the names the provider
+   * actually returned. A failed or empty lookup leaves that row exactly as it
+   * was: this repairs a stale label, it never invents or clears one. Rows are
+   * matched by ID against the latest state, so ordering, response settings, and
+   * every other field survive untouched, and the whole pass saves once.
+   */
+  const refreshNames = async () => {
+    const lookup = props.lookup;
+    if (!lookup || refreshState.running) return;
+    const uniqueIds = [...new Set(
+      rowsRef.current
+        .map(normalizeAuthorizedContactRow)
+        .filter((row) => row.id.length > 0 && !props.validateEntry?.(row.id))
+        .map((row) => row.id),
+    )];
+    if (uniqueIds.length === 0) {
+      setRefreshState({ message: "No valid IDs to refresh." });
+      return;
+    }
+
+    setRefreshState({ running: true });
+    const resolvedNames = new Map<string, string>();
+    let failures = 0;
+    for (const id of uniqueIds) {
+      let result: DesktopMessagingContactLookupResponse;
+      try {
+        result = await lookup(id);
+      } catch (error) {
+        result = {
+          status: "failed",
+          id,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        };
+      }
+      const resolved = result.status === "ok"
+        ? sanitizeMessagingContactLabel(result.displayName)
+        : "";
+      if (resolved) {
+        resolvedNames.set(id, resolved);
+      } else {
+        failures += 1;
+      }
+    }
+
+    let renamed = 0;
+    const nextRows = rowsRef.current.map((row) => {
+      const resolved = resolvedNames.get(
+        normalizeAuthorizedContactRow(row).id,
+      );
+      if (!resolved || resolved === row.displayName) return row;
+      renamed += 1;
+      return { ...row, displayName: resolved };
+    });
+    if (renamed > 0) {
+      setRows(nextRows);
+      saveIfValid(nextRows);
+    }
+    setRefreshState({
+      message: refreshSummary({
+        checked: uniqueIds.length,
+        failures,
+        renamed,
+      }),
+    });
   };
 
   return (
@@ -3690,14 +3767,16 @@ function AuthorizedListField(props: {
                         className="settings-authorized-list__policy-label"
                         htmlFor={responseModeSelectId}
                       >
-                        Response mode
+                        Responds to
                       </label>
                       <select
-                        aria-label={`${props.label} response mode ${index + 1}`}
+                        aria-label={`${props.label} responds to ${index + 1}`}
                         className="settings-input settings-authorized-list__response-mode"
                         disabled={props.disabled}
                         id={responseModeSelectId}
-                        title="Overrides whether this channel responds to every message or only @ mentions."
+                        title={`Sets whether PwrAgent replies to every message in this ${
+                          props.responseModeScopeNoun ?? "conversation"
+                        } or only when @ mentioned. This does not choose an Agent or authorize access.`}
                         value={row.responseMode ?? ""}
                         onBlur={() => {
                           const nextRows = rows.map((current, rowIndex) =>
@@ -3761,26 +3840,51 @@ function AuthorizedListField(props: {
                 </div>
               );
             })}
-            <button
-              className="button button--secondary settings-authorized-list__add"
-              disabled={props.disabled}
-              type="button"
-              onClick={() =>
-                setRows((current) => [
-                  ...current,
-                  {
-                    id: "",
-                    displayName: "",
-                    ...(props.fullAccessWarningPolicy
-                      ? { fullAccessWarningOverride: "default" as const }
-                      : {}),
-                  },
-                ])
-              }
-            >
-              Add
-            </button>
+            <div className="settings-authorized-list__actions">
+              <button
+                className="button button--secondary settings-authorized-list__add"
+                disabled={props.disabled}
+                type="button"
+                onClick={() =>
+                  setRows((current) => [
+                    ...current,
+                    {
+                      id: "",
+                      displayName: "",
+                      ...(props.fullAccessWarningPolicy
+                        ? { fullAccessWarningOverride: "default" as const }
+                        : {}),
+                    },
+                  ])
+                }
+              >
+                Add
+              </button>
+              {props.refreshNamesLabel && props.lookup ? (
+                <button
+                  className="button button--secondary settings-authorized-list__refresh"
+                  disabled={props.disabled || refreshState.running}
+                  type="button"
+                  onClick={() => {
+                    void refreshNames();
+                  }}
+                >
+                  {refreshState.running
+                    ? "Refreshing..."
+                    : props.refreshNamesLabel}
+                </button>
+              ) : null}
+            </div>
           </div>
+          {refreshState.message ? (
+            <div className="settings-list-validation" role="status">
+              <div className="settings-list-validation__item">
+                <span className="settings-list-validation__message">
+                  {refreshState.message}
+                </span>
+              </div>
+            </div>
+          ) : null}
           {Object.entries(lookupState).some(([, state]) => state.message) ? (
             <div className="settings-list-validation" role="status">
               {Object.entries(lookupState)
@@ -3925,20 +4029,31 @@ function validateDiscordUserIdEntry(value: string): string | undefined {
   });
 }
 
-function validateDiscordGuildIdEntry(value: string): string | undefined {
-  return validationMessage(validateDiscordSnowflake(value), "Discord guild ID", {
-    format: "Use the numeric Discord guild snowflake, e.g. 1480554271907905731.",
-    future: "That snowflake timestamp is in the future. Copy the guild ID from Messaging Activity.",
-    length: "Discord guild IDs are snowflakes: 17-19 digits.",
-    range: "Use a positive Discord guild snowflake, e.g. 1480554271907905731.",
-  });
+function refreshSummary(counts: {
+  checked: number;
+  failures: number;
+  renamed: number;
+}): string {
+  const parts = [
+    `Checked ${counts.checked} ${counts.checked === 1 ? "ID" : "IDs"}.`,
+    counts.renamed > 0
+      ? `Updated ${counts.renamed} ${counts.renamed === 1 ? "name" : "names"}.`
+      : "No names changed.",
+  ];
+  if (counts.failures > 0) {
+    parts.push(counts.failures === 1
+      ? "1 lookup failed and was left unchanged."
+      : `${counts.failures} lookups failed and were left unchanged.`);
+  }
+  return parts.join(" ");
 }
 
-function validateDiscordConversationIdEntry(value: string): string | undefined {
-  return validationMessage(validateDiscordSnowflake(value), "Discord channel or thread ID", {
-    format: "Use the numeric Discord snowflake, e.g. 1480556454498009352.",
-    length: "Discord IDs are snowflakes: 17-19 digits.",
-    range: "Use a positive Discord snowflake, e.g. 1480556454498009352.",
+function validateDiscordGuildIdEntry(value: string): string | undefined {
+  return validationMessage(validateDiscordSnowflake(value), "Discord server ID", {
+    format: "Use the numeric Discord server snowflake, e.g. 1480554271907905731.",
+    future: "That snowflake timestamp is in the future. Copy the server ID from Messaging Activity.",
+    length: "Discord server IDs are snowflakes: 17-19 digits.",
+    range: "Use a positive Discord server snowflake, e.g. 1480554271907905731.",
   });
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -85,9 +85,11 @@ import {
   MessagingRoutesSettings,
 } from "./MessagingRoutesSettings";
 import {
+  RESPONSE_MODE_OPTIONS,
   formatSourceLabel,
   optionalListSourceBadge,
   optionalStringSourceBadge,
+  responseModeTitle,
   sourceBadge,
 } from "./settings-fields";
 
@@ -990,7 +992,9 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(discord.authorizedGuilds)}
             validateEntry={validateDiscordGuildIdEntry}
             value={discord.authorizedGuilds.value}
-            refreshNamesLabel="Refresh server names"
+            refreshNamesLabel={discordIdentityConfigured
+              ? "Refresh server names"
+              : undefined}
             responseModePolicy={discordIdentityConfigured}
             responseModeScopeNoun="server"
             onSave={(authorizedGuilds) => {
@@ -2475,14 +2479,6 @@ const PDF_PROFILE_OPTIONS: Array<{
   { label: "Maximum", value: "actual" },
 ];
 
-const RESPONSE_MODE_OPTIONS: Array<{
-  label: string;
-  value: DesktopMessagingResponseMode;
-}> = [
-  { label: "@ mention only", value: "mention_only" },
-  { label: "Every message", value: "every_message" },
-];
-
 const TEAM_AUTHORIZATION_MODE_OPTIONS: Array<{
   label: string;
   value: DesktopMessagingAuthorizationMode;
@@ -3329,8 +3325,10 @@ function AuthorizedListField(props: {
   help?: ReactNode;
   label: string;
   lookup?: (id: string) => Promise<DesktopMessagingContactLookupResponse>;
-  // Label for an explicit bulk name repair. Omitted callers get no button:
-  // names are never rewritten in the background or by heuristic.
+  // Label for an explicit bulk name repair, and the switch that renders the
+  // button: omit it — or pass undefined while the platform has no credential,
+  // since every lookup would then fail for one uninteresting reason — and
+  // there is none. Names are never rewritten in the background or by heuristic.
   refreshNamesLabel?: string;
   responseModePolicy?: boolean;
   // Names what a row stands for, so the response control never claims a server
@@ -3362,11 +3360,18 @@ function AuthorizedListField(props: {
     message?: string;
     running?: boolean;
   }>({});
+  // The pass owns this, not React state: a successful refresh saves, which
+  // hands back a new `props.value` identity and re-runs the effect below. A
+  // state-only guard was cleared there mid-pass, re-enabling the button and
+  // letting a second concurrent pass start.
+  const refreshRunningRef = useRef(false);
   useEffect(() => {
     rowsRef.current = props.value;
     setRowsState(props.value);
     setLookupState({});
-    setRefreshState({});
+    // `refreshState` is deliberately NOT reset here. A rename saves, and the
+    // save returns a fresh snapshot — resetting would erase the summary in
+    // exactly the case where it reports work that happened.
   }, [props.value]);
   const normalizedRows = rows.map(normalizeAuthorizedContactRow);
   const invalidEntries = props.validateEntry
@@ -3398,7 +3403,8 @@ function AuthorizedListField(props: {
     setRowsState(nextRows);
   };
 
-  const saveIfValid = (nextRows: DesktopAuthorizedContact[]) => {
+  /** Returns false when an invalid row blocked the save, so callers can say so. */
+  const saveIfValid = (nextRows: DesktopAuthorizedContact[]): boolean => {
     const normalized = nextRows.map(normalizeAuthorizedContactRow);
     if (
       props.validateEntry &&
@@ -3409,9 +3415,10 @@ function AuthorizedListField(props: {
             && (row.displayName.length > 0 || Boolean(row.username))),
       )
     ) {
-      return;
+      return false;
     }
     props.onSave(normalized.filter((row) => row.id.length > 0));
+    return true;
   };
 
   const updateRow = (
@@ -3451,16 +3458,7 @@ function AuthorizedListField(props: {
       ...current,
       [indexToLookup]: { loading: true },
     }));
-    let result: DesktopMessagingContactLookupResponse;
-    try {
-      result = await lookup(row.id);
-    } catch (error) {
-      result = {
-        status: "failed",
-        id: row.id,
-        errorMessage: error instanceof Error ? error.message : String(error),
-      };
-    }
+    const result = await resolveContact(lookup, row.id);
     const resolvedUsername = props.showUsername
       ? sanitizeMessagingContactHandle(result.handle)
       : "";
@@ -3523,7 +3521,7 @@ function AuthorizedListField(props: {
    */
   const refreshNames = async () => {
     const lookup = props.lookup;
-    if (!lookup || refreshState.running) return;
+    if (!lookup || refreshRunningRef.current) return;
     const uniqueIds = [...new Set(
       rowsRef.current
         .map(normalizeAuthorizedContactRow)
@@ -3535,50 +3533,53 @@ function AuthorizedListField(props: {
       return;
     }
 
+    refreshRunningRef.current = true;
     setRefreshState({ running: true });
-    const resolvedNames = new Map<string, string>();
-    let failures = 0;
-    for (const id of uniqueIds) {
-      let result: DesktopMessagingContactLookupResponse;
-      try {
-        result = await lookup(id);
-      } catch (error) {
-        result = {
-          status: "failed",
-          id,
-          errorMessage: error instanceof Error ? error.message : String(error),
-        };
+    try {
+      const resolvedNames = new Map<string, string>();
+      let failures = 0;
+      let failureReason: string | undefined;
+      for (const id of uniqueIds) {
+        const result = await resolveContact(lookup, id);
+        const resolved = result.status === "ok"
+          ? sanitizeMessagingContactLabel(result.displayName)
+          : "";
+        if (resolved) {
+          resolvedNames.set(id, resolved);
+        } else {
+          failures += 1;
+          // Keep the first cause. "2 lookups failed" alone hides the one thing
+          // the operator can act on, such as a token that is not configured.
+          failureReason ??= lookupFailureMessage(result);
+        }
       }
-      const resolved = result.status === "ok"
-        ? sanitizeMessagingContactLabel(result.displayName)
-        : "";
-      if (resolved) {
-        resolvedNames.set(id, resolved);
-      } else {
-        failures += 1;
-      }
-    }
 
-    let renamed = 0;
-    const nextRows = rowsRef.current.map((row) => {
-      const resolved = resolvedNames.get(
-        normalizeAuthorizedContactRow(row).id,
-      );
-      if (!resolved || resolved === row.displayName) return row;
-      renamed += 1;
-      return { ...row, displayName: resolved };
-    });
-    if (renamed > 0) {
-      setRows(nextRows);
-      saveIfValid(nextRows);
+      let renamed = 0;
+      const nextRows = rowsRef.current.map((row) => {
+        const resolved = resolvedNames.get(
+          normalizeAuthorizedContactRow(row).id,
+        );
+        if (!resolved || resolved === row.displayName) return row;
+        renamed += 1;
+        return { ...row, displayName: resolved };
+      });
+      let saved = true;
+      if (renamed > 0) {
+        setRows(nextRows);
+        saved = saveIfValid(nextRows);
+      }
+      setRefreshState({
+        message: refreshSummary({
+          checked: uniqueIds.length,
+          failureReason,
+          failures,
+          renamed,
+          saved,
+        }),
+      });
+    } finally {
+      refreshRunningRef.current = false;
     }
-    setRefreshState({
-      message: refreshSummary({
-        checked: uniqueIds.length,
-        failures,
-        renamed,
-      }),
-    });
   };
 
   return (
@@ -3680,7 +3681,7 @@ function AuthorizedListField(props: {
                     <input
                       aria-label={`${props.label} display name ${index + 1}`}
                       className="settings-input settings-authorized-list__name"
-                      disabled={props.disabled}
+                      disabled={props.disabled || refreshState.running}
                       maxLength={64}
                       placeholder="Display name"
                       value={row.displayName}
@@ -3774,9 +3775,9 @@ function AuthorizedListField(props: {
                         className="settings-input settings-authorized-list__response-mode"
                         disabled={props.disabled}
                         id={responseModeSelectId}
-                        title={`Sets whether PwrAgent replies to every message in this ${
-                          props.responseModeScopeNoun ?? "conversation"
-                        } or only when @ mentioned. This does not choose an Agent or authorize access.`}
+                        title={responseModeTitle(
+                          props.responseModeScopeNoun ?? "conversation",
+                        )}
                         value={row.responseMode ?? ""}
                         onBlur={() => {
                           const nextRows = rows.map((current, rowIndex) =>
@@ -4031,21 +4032,48 @@ function validateDiscordUserIdEntry(value: string): string | undefined {
 
 function refreshSummary(counts: {
   checked: number;
+  failureReason?: string;
   failures: number;
   renamed: number;
+  saved: boolean;
 }): string {
+  const names = counts.renamed === 1 ? "name" : "names";
   const parts = [
     `Checked ${counts.checked} ${counts.checked === 1 ? "ID" : "IDs"}.`,
-    counts.renamed > 0
-      ? `Updated ${counts.renamed} ${counts.renamed === 1 ? "name" : "names"}.`
-      : "No names changed.",
+    counts.renamed === 0
+      ? "No names changed."
+      : counts.saved
+        ? `Updated ${counts.renamed} ${names}.`
+        // Never claim a write that saveIfValid refused. The rename is only in
+        // this list until the invalid row is fixed, and would revert silently.
+        : `Resolved ${counts.renamed} ${names}, but nothing was saved: fix or`
+          + " remove the invalid IDs above, then refresh again.",
   ];
   if (counts.failures > 0) {
     parts.push(counts.failures === 1
       ? "1 lookup failed and was left unchanged."
       : `${counts.failures} lookups failed and were left unchanged.`);
+    if (counts.failureReason) {
+      parts.push(counts.failureReason);
+    }
   }
   return parts.join(" ");
+}
+
+/** One lookup, with the rejection normalized into a response the UI can read. */
+async function resolveContact(
+  lookup: (id: string) => Promise<DesktopMessagingContactLookupResponse>,
+  id: string,
+): Promise<DesktopMessagingContactLookupResponse> {
+  try {
+    return await lookup(id);
+  } catch (error) {
+    return {
+      status: "failed",
+      id,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 function validateDiscordGuildIdEntry(value: string): string | undefined {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
@@ -177,6 +177,93 @@ function renderRoutes(
 }
 
 describe("MessagingRoutesSettings", () => {
+  it("sets Discord response behavior from named surfaces without touching routes", async () => {
+    const routes = buildRoutes();
+    routes.observedSurfaces.push({
+      platform: "discord",
+      conversation: {
+        id: "1480556454498009352",
+        kind: "channel",
+        title: "general",
+        ancestorTitle: "Test server",
+        workspaceId: "1480556454498009353",
+      },
+      firstSeenAt: 1000,
+      lastSeenAt: 3000,
+    });
+    const api = buildDesktopApi(routes);
+    const onSave = vi.fn();
+
+    render(
+      <MessagingRoutesProvider desktopApi={api.desktopApi}>
+        <MessagingRoutesSettings
+          desktopApi={api.desktopApi}
+          discordResponseBehavior={{ source: "config", value: [], onSave }}
+        />
+      </MessagingRoutesProvider>,
+    );
+
+    // The picker offers the observed channel by name. An operator never types
+    // a snowflake to set response behavior.
+    const picker = await screen.findByRole("combobox", {
+      name: "Add a channel or thread",
+    });
+    const named = await screen.findByRole("option", {
+      name: "Discord / Test server / general",
+    });
+    fireEvent.change(picker, { target: { value: "1480556454498009352" } });
+
+    expect(named).toBeInTheDocument();
+    expect(onSave).toHaveBeenCalledWith([
+      {
+        id: "1480556454498009352",
+        displayName: "general",
+        responseMode: "mention_only",
+      },
+    ]);
+    // Admission and routing are independent: choosing when to respond must not
+    // assign, clear, or otherwise disturb a default Agent.
+    expect(api.setMessagingDefaultAgent).not.toHaveBeenCalled();
+    expect(api.clearMessagingDefaultAgent).not.toHaveBeenCalled();
+  });
+
+  it("assigns a default Agent without writing response behavior", async () => {
+    const api = buildDesktopApi();
+    const onSave = vi.fn();
+
+    render(
+      <MessagingRoutesProvider desktopApi={api.desktopApi}>
+        <MessagingRoutesSettings
+          desktopApi={api.desktopApi}
+          discordResponseBehavior={{
+            source: "config",
+            value: [
+              {
+                id: "1480556454498009352",
+                displayName: "general",
+                responseMode: "mention_only",
+              },
+            ],
+            onSave,
+          }}
+        />
+      </MessagingRoutesProvider>,
+    );
+
+    fireEvent.click((await screen.findAllByRole("button", { name: "Change" }))[0]!);
+    fireEvent.change(screen.getByLabelText("Route Working Updates"), {
+      target: { value: "show_all" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save default" }));
+
+    await waitFor(() => {
+      expect(api.setMessagingDefaultAgent).toHaveBeenCalled();
+    });
+    // The mirror of the test above: changing the route leaves the configured
+    // response behavior exactly as it was.
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
   it("shows an empty inventory when no messaging routes exist", async () => {
     const { desktopApi } = buildDesktopApi({
       eligibleAgents: [],

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
@@ -194,7 +194,7 @@ describe("MessagingRoutesSettings", () => {
     const api = buildDesktopApi(routes);
     const onSave = vi.fn();
 
-    render(
+    const { rerender } = render(
       <MessagingRoutesProvider desktopApi={api.desktopApi}>
         <MessagingRoutesSettings
           desktopApi={api.desktopApi}
@@ -208,23 +208,129 @@ describe("MessagingRoutesSettings", () => {
     const picker = await screen.findByRole("combobox", {
       name: "Add a channel or thread",
     });
-    const named = await screen.findByRole("option", {
+    await screen.findByRole("option", {
       name: "Discord / Test server / general",
     });
     fireEvent.change(picker, { target: { value: "1480556454498009352" } });
 
-    expect(named).toBeInTheDocument();
-    expect(onSave).toHaveBeenCalledWith([
+    const saved = [
       {
         id: "1480556454498009352",
         displayName: "general",
-        responseMode: "mention_only",
+        responseMode: "mention_only" as const,
       },
-    ]);
+    ];
+    expect(onSave).toHaveBeenCalledWith(saved);
     // Admission and routing are independent: choosing when to respond must not
     // assign, clear, or otherwise disturb a default Agent.
     expect(api.setMessagingDefaultAgent).not.toHaveBeenCalled();
     expect(api.clearMessagingDefaultAgent).not.toHaveBeenCalled();
+
+    // The component is controlled, so re-render with what the save produced:
+    // the surface becomes a row and leaves the "add" list.
+    rerender(
+      <MessagingRoutesProvider desktopApi={api.desktopApi}>
+        <MessagingRoutesSettings
+          desktopApi={api.desktopApi}
+          discordResponseBehavior={{ source: "config", value: saved, onSave }}
+        />
+      </MessagingRoutesProvider>,
+    );
+
+    expect(
+      screen.queryByRole("option", { name: "Discord / Test server / general" }),
+    ).toBeNull();
+    const rowMode = screen.getByRole("combobox", {
+      name: "Responds to for Discord / Test server / general",
+    });
+    expect(rowMode).toHaveValue("mention_only");
+
+    // "Default" has to be reachable, or a row can never be returned to
+    // inheriting its server's setting once it has been given one.
+    onSave.mockClear();
+    fireEvent.change(rowMode, { target: { value: "" } });
+    expect(onSave).toHaveBeenCalledWith([
+      { id: "1480556454498009352", displayName: "general" },
+    ]);
+  });
+
+  it("edits one of two rows that share an ID", async () => {
+    // `response_mode_overrides` is a plain array and nothing dedupes it; the
+    // raw-ID editor this replaced could persist the same snowflake twice.
+    // Matching by ID would delete or rewrite both rows.
+    const api = buildDesktopApi();
+    const onSave = vi.fn();
+    const duplicated = [
+      {
+        id: "1480556454498009352",
+        displayName: "first",
+        responseMode: "mention_only" as const,
+      },
+      {
+        id: "1480556454498009352",
+        displayName: "second",
+        responseMode: "every_message" as const,
+      },
+    ];
+
+    render(
+      <MessagingRoutesProvider desktopApi={api.desktopApi}>
+        <MessagingRoutesSettings
+          desktopApi={api.desktopApi}
+          discordResponseBehavior={{
+            source: "config",
+            value: duplicated,
+            onSave,
+          }}
+        />
+      </MessagingRoutesProvider>,
+    );
+
+    const removes = await screen.findAllByRole("button", {
+      name: "Remove response behavior for second",
+    });
+    fireEvent.click(removes[0]!);
+
+    expect(onSave).toHaveBeenCalledWith([duplicated[0]]);
+  });
+
+  it("does not label a channel with its server name when the parent lookup failed", async () => {
+    // The adapter sets `parentTitle` to `parentChannelName ?? guildName`, and
+    // marks a resolved parent by also setting `ancestorTitle`. Without that
+    // marker the name in hand is the server's, so the picker must fall back to
+    // the ID rather than offer a channel that reads as the whole server.
+    const routes = buildRoutes();
+    routes.observedSurfaces.push({
+      platform: "discord",
+      conversation: {
+        id: "1480556454498009400",
+        kind: "thread",
+        title: "bugfix",
+        parentConversationId: "1480556454498009352",
+        parentTitle: "Test server",
+        workspaceId: "1480556454498009353",
+      },
+      firstSeenAt: 1000,
+      lastSeenAt: 3000,
+    });
+    const api = buildDesktopApi(routes);
+
+    render(
+      <MessagingRoutesProvider desktopApi={api.desktopApi}>
+        <MessagingRoutesSettings
+          desktopApi={api.desktopApi}
+          discordResponseBehavior={{ source: "config", value: [], onSave: vi.fn() }}
+        />
+      </MessagingRoutesProvider>,
+    );
+
+    await screen.findByRole("combobox", { name: "Add a channel or thread" });
+    expect(
+      screen.queryByRole("option", { name: "Discord / Test server" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("option", { name: "Discord / 1480556454498009352" }),
+    ).toBeInTheDocument();
   });
 
   it("assigns a default Agent without writing response behavior", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4808,19 +4808,21 @@ describe("SettingsScreen", () => {
     expect(discordSection).not.toBeNull();
     const discordControls = within(discordSection as HTMLElement);
 
-    expect(discordControls.getByText("Discord response default")).toBeInTheDocument();
+    expect(discordControls.getByText("When PwrAgent responds")).toBeInTheDocument();
     expect(discordControls.getByText("automatic")).toBeInTheDocument();
     expect(
       discordControls.getByRole("textbox", {
         name: "Application ID Override (Advanced)",
       }),
     ).toHaveAttribute("placeholder", "Auto-discovered from bot token");
+    // Exact channel and native-thread behavior now lives beside Routes with a
+    // named surface picker, so the Discord screen offers no raw-ID editor.
     expect(
-      discordControls.getByText("Channel / Thread Response Overrides"),
-    ).toBeInTheDocument();
+      discordControls.queryByText("Channel / Thread Response Overrides"),
+    ).toBeNull();
     expect(
       discordControls.getByRole("combobox", {
-        name: "Authorized Guilds response mode 1",
+        name: "Authorized Servers responds to 1",
       }),
     ).toBeInTheDocument();
 
@@ -4836,6 +4838,130 @@ describe("SettingsScreen", () => {
         },
       });
     });
+  });
+
+  it("names Discord servers and scopes the response control to the server", async () => {
+    const snapshot = createSnapshot();
+    snapshot.messaging.discord.botToken = {
+      configured: true,
+      source: "keychain",
+      writable: true,
+    };
+    snapshot.messaging.discord.authorizedGuilds.value = [
+      { id: "1480556454498009353", displayName: "Test server" },
+    ];
+    const settings = createSettingsState(snapshot);
+
+    render(
+      <SettingsScreen
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    const discordHeader = screen.getByRole("button", { name: "Discord" });
+    if (discordHeader.getAttribute("aria-expanded") !== "true") {
+      fireEvent.click(discordHeader);
+    }
+    const discordControls = within(discordHeader.closest("section") as HTMLElement);
+
+    expect(discordControls.getByText("Authorized Servers")).toBeInTheDocument();
+    expect(discordControls.queryByText("Authorized Guilds")).toBeNull();
+    // Authorization is whole-server, and the copy has to say so rather than
+    // implying a row only covers the channel an operator happened to see.
+    expect(
+      discordControls.getByText(/covers every channel and native thread/i),
+    ).toBeInTheDocument();
+
+    // The tooltip is shared with Slack and Telegram rows, so it has to name
+    // the row's own scope instead of always claiming "this channel".
+    const responseControl = discordControls.getByRole("combobox", {
+      name: "Authorized Servers responds to 1",
+    });
+    expect(responseControl).toHaveAttribute(
+      "title",
+      expect.stringContaining("in this server"),
+    );
+    expect(responseControl.getAttribute("title")).not.toContain("this channel");
+    expect(responseControl).toHaveAttribute(
+      "title",
+      expect.stringContaining("does not choose an Agent or authorize access"),
+    );
+  });
+
+  it("refreshes server names without disturbing other row settings", async () => {
+    const snapshot = createSnapshot();
+    snapshot.messaging.discord.botToken = {
+      configured: true,
+      source: "keychain",
+      writable: true,
+    };
+    snapshot.messaging.discord.authorizedGuilds.value = [
+      {
+        id: "1480556454498009353",
+        displayName: "stale-name",
+        responseMode: "every_message",
+      },
+      { id: "1480556454498009354", displayName: "kept-name" },
+    ];
+    const settings = createSettingsState(snapshot);
+    const resolveMessagingContact = vi.fn(async (request: { id: string }) =>
+      request.id === "1480556454498009353"
+        ? {
+            status: "ok" as const,
+            id: request.id,
+            displayName: "resolved-name",
+          }
+        : { status: "not_found" as const, id: request.id });
+
+    render(
+      <SettingsScreen
+        desktopApi={{ resolveMessagingContact } as never}
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    const discordHeader = screen.getByRole("button", { name: "Discord" });
+    if (discordHeader.getAttribute("aria-expanded") !== "true") {
+      fireEvent.click(discordHeader);
+    }
+    const discordControls = within(discordHeader.closest("section") as HTMLElement);
+
+    fireEvent.click(
+      discordControls.getByRole("button", { name: "Refresh server names" }),
+    );
+
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalled();
+    });
+
+    // Only the resolved row is renamed. The failed lookup keeps its stored
+    // name, and every row keeps its ID, order, and response setting.
+    expect(settings.writeConfig).toHaveBeenCalledWith({
+      messaging: {
+        discord: {
+          authorizedGuilds: [
+            {
+              id: "1480556454498009353",
+              displayName: "resolved-name",
+              responseMode: "every_message",
+            },
+            { id: "1480556454498009354", displayName: "kept-name" },
+          ],
+        },
+      },
+    });
+    expect(resolveMessagingContact).toHaveBeenCalledTimes(2);
+    // One save for the whole pass, not one per resolved row.
+    expect(settings.writeConfig).toHaveBeenCalledTimes(1);
+    expect(
+      await discordControls.findByText(
+        "Checked 2 IDs. Updated 1 name. 1 lookup failed and was left unchanged.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("disables Discord mention modes until a bot identity can be resolved", () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4915,7 +4915,7 @@ describe("SettingsScreen", () => {
           }
         : { status: "not_found" as const, id: request.id });
 
-    render(
+    const { rerender } = render(
       <SettingsScreen
         desktopApi={{ resolveMessagingContact } as never}
         settings={settings}
@@ -4957,11 +4957,34 @@ describe("SettingsScreen", () => {
     expect(resolveMessagingContact).toHaveBeenCalledTimes(2);
     // One save for the whole pass, not one per resolved row.
     expect(settings.writeConfig).toHaveBeenCalledTimes(1);
-    expect(
-      await discordControls.findByText(
-        "Checked 2 IDs. Updated 1 name. 1 lookup failed and was left unchanged.",
-      ),
-    ).toBeInTheDocument();
+    const summary =
+      "Checked 2 IDs. Updated 1 name. 1 lookup failed and was left unchanged."
+      + " No matching platform identity was found.";
+    expect(await discordControls.findByText(summary)).toBeInTheDocument();
+
+    // The real writeConfig resolves by replacing the snapshot, which hands the
+    // list a brand-new `value` array. The summary has to survive that: it
+    // reports the save that caused it, and it names the row that failed.
+    const saved = createSnapshot();
+    saved.messaging.discord.botToken = snapshot.messaging.discord.botToken;
+    saved.messaging.discord.authorizedGuilds.value = [
+      {
+        id: "1480556454498009353",
+        displayName: "resolved-name",
+        responseMode: "every_message",
+      },
+      { id: "1480556454498009354", displayName: "kept-name" },
+    ];
+    rerender(
+      <SettingsScreen
+        desktopApi={{ resolveMessagingContact } as never}
+        settings={{ ...settings, snapshot: saved }}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(discordControls.getByText(summary)).toBeInTheDocument();
   });
 
   it("disables Discord mention modes until a bot identity can be resolved", () => {

--- a/apps/desktop/src/renderer/src/features/settings/settings-fields.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-fields.ts
@@ -1,8 +1,29 @@
 import type {
   DesktopAuthorizedContact,
+  DesktopMessagingResponseMode,
   DesktopSettingsValue,
 } from "@pwragent/shared";
 import type { AppMetadata } from "../../../../shared/app-metadata";
+
+/**
+ * The one wording for response modes. Lives here so the Messaging screen's
+ * segmented fields, its authorized-list rows, and the Routes per-surface rows
+ * cannot drift apart.
+ */
+export const RESPONSE_MODE_OPTIONS: Array<{
+  label: string;
+  value: DesktopMessagingResponseMode;
+}> = [
+  { label: "@ mention only", value: "mention_only" },
+  { label: "Every message", value: "every_message" },
+];
+
+/** Shared tooltip for every per-row response-mode control. */
+export function responseModeTitle(scopeNoun: string): string {
+  return `Sets whether PwrAgent replies to every message in this ${scopeNoun}`
+    + " or only when @ mentioned. This does not choose an Agent or authorize"
+    + " access.";
+}
 
 /** Renderer pid is absent when metadata was resolved outside a window. */
 export function formatProcessIds(metadata: AppMetadata): string {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9295,13 +9295,8 @@ textarea,
   gap: 12px;
 }
 
-.messaging-routes__response-controls {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 10px;
-}
-
+/* Composes .messaging-route-row__actions for layout and compact button
+   sizing; only the select needs a width of its own. */
 .messaging-routes__response-controls select {
   width: auto;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9278,6 +9278,11 @@ textarea,
   padding: 0 18px 14px;
 }
 
+.messaging-routes__response-add > label {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .messaging-routes__response-add select {
   min-width: 0;
   flex: 1 1 auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9262,6 +9262,45 @@ textarea,
   gap: 7px;
 }
 
+/* The subhead's generic span rule would flatten the source chip into body
+   copy, so the chip restates its own presentation at matching specificity. */
+.messaging-routes__subhead .settings-source {
+  display: inline-flex;
+  margin-top: 6px;
+  font-size: 10px;
+}
+
+.messaging-routes__response-add {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+  padding: 0 18px 14px;
+}
+
+.messaging-routes__response-add select {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.messaging-routes__response-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+}
+
+.messaging-routes__response-controls {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.messaging-routes__response-controls select {
+  width: auto;
+}
+
 .messaging-routes__error,
 .messaging-route-editor__error {
   margin: 0;
@@ -9508,6 +9547,12 @@ textarea,
 
 @media (max-width: 640px) {
   .messaging-routes__toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .messaging-routes__response-add,
+  .messaging-routes__response-controls {
     align-items: flex-start;
     flex-direction: column;
   }
@@ -9788,12 +9833,16 @@ textarea,
 
 .settings-authorized-list__remove,
 .settings-authorized-list__lookup,
-.settings-authorized-list__add {
+.settings-authorized-list__add,
+.settings-authorized-list__refresh {
   width: max-content;
 }
 
-.settings-authorized-list__add {
+.settings-authorized-list__actions {
+  display: flex;
   align-self: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .settings-authorized-list__default-agent {

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -5,6 +5,7 @@ import {
   type MessagingCallbackHandleStore,
   type MessagingInboundEvent,
   type MessagingRejectedInboundEvent,
+  type MessagingResponseMode,
   type MessagingStatusIntent,
 } from "@pwragent/messaging-interface";
 import { describe, expect, it, vi } from "vitest";
@@ -1676,6 +1677,116 @@ describe("discord adapter", () => {
         expect.anything(),
       );
       await adapter.stop();
+    });
+
+    it("admits every channel and native thread inside an authorized server", async () => {
+      // Authorization is server-wide: there is no channel allowlist, so one
+      // authorized server ID has to cover each of its channels and native
+      // threads, while a second server stays denied.
+      const otherGuildId = "1480556454498009888";
+      const secondChannelId = "1480556454498009777";
+      const nativeThreadId = "1480556454498009666";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: [{ id: TEST_GUILD_ID, displayName: "Test server" }],
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+
+      for (const dispatch of [
+        { channelId: TEST_CHANNEL_ID, id: "authorized-channel", isThread: false },
+        { channelId: secondChannelId, id: "authorized-second", isThread: false },
+        { channelId: nativeThreadId, id: "authorized-thread", isThread: true },
+      ]) {
+        await gateway.emit({
+          op: 0,
+          t: "MESSAGE_CREATE",
+          d: {
+            ...messageDispatch({
+              authorBot: false,
+              content: "/status",
+              id: dispatch.id,
+            }),
+            channel_id: dispatch.channelId,
+            channel_type: dispatch.isThread ? 11 : 0,
+            is_thread: dispatch.isThread,
+          },
+        });
+      }
+
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: {
+          ...messageDispatch({
+            authorBot: false,
+            content: "/status",
+            id: "other-server",
+          }),
+          guild_id: otherGuildId,
+        },
+      });
+
+      expect(events.map((event) => event.channel.conversation.id)).toEqual([
+        TEST_CHANNEL_ID,
+        secondChannelId,
+        nativeThreadId,
+      ]);
+      await adapter.stop();
+    });
+
+    it("ignores a server row's response setting when deciding authorization", async () => {
+      // Response behavior and access are separate decisions. Whatever a row
+      // says about when to reply, admission depends only on the ID matching.
+      const admitted: Array<MessagingResponseMode | undefined> = [];
+      for (const responseMode of [
+        undefined,
+        "mention_only" as const,
+        "every_message" as const,
+      ]) {
+        const events: MessagingInboundEvent[] = [];
+        const gateway = new TestDiscordGateway();
+        const adapter = new DiscordAdapter({
+          api: createApi(),
+          config: {
+            authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+            authorizedGuildIds: [
+              { id: TEST_GUILD_ID, displayName: "Test server", responseMode },
+            ],
+            botToken: "token",
+            channel: "discord",
+          },
+          gateway,
+          now: () => 1234,
+        });
+        await adapter.start(async (event) => {
+          events.push(event);
+        });
+        await gateway.emit({
+          op: 0,
+          t: "MESSAGE_CREATE",
+          d: messageDispatch({
+            authorBot: false,
+            content: "/status",
+            id: `response-mode-${responseMode ?? "default"}`,
+          }),
+        });
+        if (events.length === 1) admitted.push(responseMode);
+        await adapter.stop();
+      }
+
+      expect(admitted).toEqual([undefined, "mention_only", "every_message"]);
     });
 
     it("drops messages from unauthorized guilds before listener dispatch", async () => {

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -1614,7 +1614,7 @@ describe("discord adapter", () => {
       expect(events[0]?.routingState?.opaque).not.toHaveProperty("messageId");
       expect(rejectedEvents).toEqual([]);
       expect(logger.warn).not.toHaveBeenCalledWith(
-        "discord inbound ignored unauthorized guild",
+        "discord inbound ignored unauthorized server",
         expect.anything(),
       );
       await adapter.stop();
@@ -1672,7 +1672,7 @@ describe("discord adapter", () => {
       ]);
       expect(rejectedEvents).toEqual([]);
       expect(logger.warn).not.toHaveBeenCalledWith(
-        "discord inbound ignored unauthorized guild",
+        "discord inbound ignored unauthorized server",
         expect.anything(),
       );
       await adapter.stop();
@@ -1727,7 +1727,7 @@ describe("discord adapter", () => {
         }),
       ]);
       expect(logger.warn).toHaveBeenCalledWith(
-        "discord inbound ignored unauthorized guild",
+        "discord inbound ignored unauthorized server",
         expect.objectContaining({ guildId: TEST_GUILD_ID }),
       );
       await adapter.stop();
@@ -1774,7 +1774,7 @@ describe("discord adapter", () => {
         }),
       ]);
       expect(logger.warn).toHaveBeenCalledWith(
-        "discord inbound ignored unauthorized guild",
+        "discord inbound ignored unauthorized server",
         expect.objectContaining({ guildId: TEST_GUILD_ID }),
       );
       await adapter.stop();
@@ -1829,7 +1829,7 @@ describe("discord adapter", () => {
         }),
       ]);
       expect(logger.warn).toHaveBeenCalledWith(
-        "discord inbound ignored unauthorized non-guild conversation",
+        "discord inbound ignored unauthorized non-server conversation",
         expect.objectContaining({ channelType: 3 }),
       );
       await adapter.stop();
@@ -1950,7 +1950,7 @@ describe("discord adapter", () => {
         }),
       ]);
       expect(logger.warn).toHaveBeenCalledWith(
-        "discord inbound ignored unauthorized guild",
+        "discord inbound ignored unauthorized server",
         expect.objectContaining({ guildId: TEST_GUILD_ID, surface: "interaction" }),
       );
       await adapter.stop();

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -5,7 +5,6 @@ import {
   type MessagingCallbackHandleStore,
   type MessagingInboundEvent,
   type MessagingRejectedInboundEvent,
-  type MessagingResponseMode,
   type MessagingStatusIntent,
 } from "@pwragent/messaging-interface";
 import { describe, expect, it, vi } from "vitest";
@@ -1746,47 +1745,47 @@ describe("discord adapter", () => {
       await adapter.stop();
     });
 
-    it("ignores a server row's response setting when deciding authorization", async () => {
-      // Response behavior and access are separate decisions. Whatever a row
-      // says about when to reply, admission depends only on the ID matching.
-      const admitted: Array<MessagingResponseMode | undefined> = [];
-      for (const responseMode of [
-        undefined,
-        "mention_only" as const,
-        "every_message" as const,
-      ]) {
-        const events: MessagingInboundEvent[] = [];
-        const gateway = new TestDiscordGateway();
-        const adapter = new DiscordAdapter({
-          api: createApi(),
-          config: {
-            authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
-            authorizedGuildIds: [
-              { id: TEST_GUILD_ID, displayName: "Test server", responseMode },
-            ],
-            botToken: "token",
-            channel: "discord",
-          },
-          gateway,
-          now: () => 1234,
-        });
-        await adapter.start(async (event) => {
-          events.push(event);
-        });
-        await gateway.emit({
-          op: 0,
-          t: "MESSAGE_CREATE",
-          d: messageDispatch({
-            authorBot: false,
-            content: "/status",
-            id: `response-mode-${responseMode ?? "default"}`,
-          }),
-        });
-        if (events.length === 1) admitted.push(responseMode);
-        await adapter.stop();
-      }
+    it("admits an unmentioned message from a mention_only server row", async () => {
+      // Response behavior and access are separate decisions, and "mention_only"
+      // is the setting most likely to be mistaken for an admission gate. The
+      // adapter must still hand the message up; whether PwrAgent replies is
+      // decided later by resolveMessagingResponseModeForChannel. One adapter is
+      // enough — the adapter reads only `id`, so this guards a future change
+      // that starts reading `responseMode` here, not today's behavior.
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: [
+            {
+              id: TEST_GUILD_ID,
+              displayName: "Test server",
+              responseMode: "mention_only",
+            },
+          ],
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: messageDispatch({
+          authorBot: false,
+          content: "no mention here",
+          id: "mention-only-server-row",
+        }),
+      });
 
-      expect(admitted).toEqual([undefined, "mention_only", "every_message"]);
+      expect(events).toHaveLength(1);
+      await adapter.stop();
     });
 
     it("drops messages from unauthorized guilds before listener dispatch", async () => {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -1526,7 +1526,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       const logKey = `non-guild:${channelType ?? "unknown"}`;
       if (!this.unauthorizedGuildLogKeys.has(logKey)) {
         this.unauthorizedGuildLogKeys.add(logKey);
-        this.options.logger?.warn?.("discord inbound ignored unauthorized non-guild conversation", {
+        this.options.logger?.warn?.("discord inbound ignored unauthorized non-server conversation", {
           channelType: channelType ?? null,
           surface,
         });
@@ -1539,7 +1539,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     }
     if (!this.unauthorizedGuildLogKeys.has(guildId)) {
       this.unauthorizedGuildLogKeys.add(guildId);
-      this.options.logger?.warn?.("discord inbound ignored unauthorized guild", {
+      this.options.logger?.warn?.("discord inbound ignored unauthorized server", {
         guildId,
         surface,
       });
@@ -2825,7 +2825,7 @@ function discordManagedThreadTarget(
 function discordManagedThreadUnsupportedReason(channel: MessagingChannelRef): string {
   return channel.conversation.kind === "thread"
     ? "Discord does not support nested threads."
-    : "Discord thread creation needs the source message in a guild text channel.";
+    : "Discord thread creation needs the source message in a server text channel.";
 }
 
 function isDiscordThreadChannel(


### PR DESCRIPTION
Discord Settings used Discord's internal API word for a server, described the
wrong scope for what authorizing one grants, and mixed three independent
decisions into one screen. This resolves the recorded terminology audit.

## Terminology

User-facing surfaces now say **Server**. Discord's API is the only place that
calls the object a guild, and Settings carries one note saying so:

- **Settings** — "Authorized Guilds" → "Authorized Servers"; ID validation
  messages; the Discord-wide response default.
- **Messaging Activity** — the parent and bucket ID chips now read "Server ID".
- **Onboarding** — the Discord pairing-scope label and the provider note.
- **Log messages** — both unauthorized-inbound warnings.
- **Emitted to Discord** — the thread-creation error users actually read.
- **Pairing** — the bucket-scope mismatch reason.

Wire and stored identifiers are deliberately unchanged, because they are
Discord's names rather than ours: `guild_id`, `Routes.guild`, the `guild`
contact-lookup kind, the `authorized_guilds` TOML key, and
`PWRAGENT_MESSAGING_DISCORD_AUTHORIZED_GUILDS`. Renaming the last two would be
an incompatible config change for a copy fix.

## Three decisions, told apart

Authorization is server-level and has no channel allowlist, so the copy now
says authorizing a server covers every channel and native thread the bot can
see. The per-row response control is named for its own scope — it previously
said "this channel" while attached to a server row — and states outright that
it **does not choose an Agent or authorize access**.

Exact channel and native-thread response behavior moves out of the Discord
section, where a raw-snowflake list invited reading it as part of
authorization, and sits beside Routes as its own subsection. It reuses the
observed-surface picker, so an operator selects a named channel instead of
pasting a snowflake. It is deliberately **not** folded into Default Agents:
admission decides whether an ambient message is accepted, and routing then
picks the Agent for an accepted one.

"Response mode" jargon is gone; the concept is "When PwrAgent responds", with
compact rows labeled "Responds to" so no two controls in a section share a name.

## Refresh server names

Authorized Servers gains an explicit repair for labels that have gone stale. It
re-resolves each configured ID through Discord's guild lookup and adopts only
names the provider actually returned. Failed lookups are left exactly as they
were, IDs / ordering / response settings are preserved, the whole pass saves
once, and it reports a bounded summary. Nothing is rewritten in the background
or by heuristic.

## Tests

New regression coverage, matching the audit's list:

- An authorized server admits multiple channels **and** native threads, while a
  second server stays denied. Mutation-checked: denying native threads fails it.
- A row's response setting never changes admission.
- Refresh renames only the resolved row, preserves the other row's stored name
  and the first row's response setting, saves once, and reports the failure.
- Settings uses Server terminology, explains whole-server scope, has no
  "this channel" tooltip on a server row, and offers no raw-ID response editor.
- Response changes write only response configuration; route changes write only
  the default-Agent assignment.

The refresh test caught a real copy bug on the way in ("1 lookup failed and
*were* left unchanged").

## Verification

`pnpm test` 642 files / 9349 passed, plus `typecheck`, `lint:eslint` (0 errors),
`lint:colors`, and `lint:boundaries` all clean. The new subsection's layout was
checked in a standalone `app.css` harness in both themes and down to 520px —
long channel names truncate and nothing overflows.

## Notes

- Based on `main` including the squash-merged #1874 and #1875. #1895 and #1896
  are latency fixes that touch none of this.
- The shared row control is used by Telegram and Slack too, so their rows pick
  up the same "Responds to" label and a scope-accurate tooltip.
- Per-channel *authorization* remains out of scope and a separate decision.
- Operator docs live in `pwrdrvr/docs.pwragent.ai`; nothing in this repo's docs
  referenced the renamed labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)