### PR TITLE
feat(desktop): split Pricing spend by model, not by provider

### DIFF
--- a/apps/desktop/e2e/thread-pricing-panel.spec.ts
+++ b/apps/desktop/e2e/thread-pricing-panel.spec.ts
@@ -74,6 +74,14 @@ test("hydrates provider-scoped pricing totals in the context rail", async () => 
       "Unknown model",
       "grok-4.5",
     ]);
+    // A bucket nothing could price says so; "$0.000" is what a model that
+    // genuinely cost nothing would read as.
+    const unpricedSpendRow = contextRail.locator(".pricing-spend-row", {
+      hasText: "Unknown model",
+    });
+    await expect(
+      unpricedSpendRow.locator(".pricing-spend-row__cost"),
+    ).toHaveText("Unpriced");
 
     // Rows arrive collapsed whenever the thread spent on more than one model,
     // and expanding one shows that model's own token volume — the reviewer's

--- a/apps/desktop/e2e/thread-pricing-panel.spec.ts
+++ b/apps/desktop/e2e/thread-pricing-panel.spec.ts
@@ -54,18 +54,53 @@ test("hydrates provider-scoped pricing totals in the context rail", async () => 
     await expect(
       contextRail.getByText(/2 priced · 1 unpriced ·/),
     ).toBeVisible();
-    await expect(contextRail.getByText("Token volume")).toBeVisible();
     await expect(
       contextRail.getByText("1 usage row could not be priced."),
     ).toBeVisible();
-    await expect(contextRail.getByText("openai · USD")).toBeVisible();
-    await expect(contextRail.getByText("$0.017 list price · 2 rows")).toBeVisible();
-    await expect(contextRail.getByText("xai · USD")).toBeVisible();
-    await expect(contextRail.getByText("$0.002 list price · 1 row")).toBeVisible();
-    await expect(contextRail.getByText("gpt-5.5 · high")).toBeVisible();
-    await expect(contextRail.getByText("$0.017 list price this turn")).toBeVisible();
-    await expect(contextRail.getByText("Unknown model")).toBeVisible();
-    await expect(contextRail.getByText("grok-4.5")).toBeVisible();
+
+    // Spend by model replaced the per-provider cards that used to reprint the
+    // summary's own by-provider breakdown directly underneath it.
+    await expect(contextRail.getByText("Spend by model")).toBeVisible();
+    await expect(contextRail.getByText("openai · USD")).toHaveCount(0);
+
+    // Only OpenAI ran more than one model here, so it is the one provider
+    // whose subtotal is not already a row of its own.
+    const spendGroupHead = contextRail.locator(".pricing-spend-group__head");
+    await expect(spendGroupHead).toHaveCount(1);
+    await expect(spendGroupHead).toContainText("OpenAI");
+    await expect(spendGroupHead).toContainText("$0.017 · 2 rows");
+    await expect(contextRail.locator(".pricing-spend-row__label")).toHaveText([
+      "gpt-5.5",
+      "Unknown model",
+      "grok-4.5",
+    ]);
+
+    // Rows arrive collapsed whenever the thread spent on more than one model,
+    // and expanding one shows that model's own token volume — the reviewer's
+    // here, which the old parent-only fold never displayed at all.
+    const grokSpendRow = contextRail.locator(".pricing-spend-row", {
+      hasText: "grok-4.5",
+    });
+    await expect(grokSpendRow.locator(".pricing-spend-row__meta")).toHaveText(
+      "xAI · 1 row",
+    );
+    await expect(grokSpendRow.locator(".pricing-spend-row__cost")).toHaveText(
+      "$0.002",
+    );
+    await expect(grokSpendRow.getByText("Uncached input")).toHaveCount(0);
+    await grokSpendRow.getByRole("button").click();
+    await expect(grokSpendRow.getByText("Uncached input")).toBeVisible();
+    await expect(grokSpendRow.getByText("400", { exact: true })).toBeVisible();
+
+    // The usage cards still name every model, so each of these now resolves
+    // against a spend row too and has to be scoped to the card list.
+    const usageRows = contextRail.locator(".pricing-usage-row");
+    await expect(usageRows.getByText("gpt-5.5 · high")).toBeVisible();
+    await expect(
+      contextRail.getByText("$0.017 list price this turn"),
+    ).toBeVisible();
+    await expect(usageRows.getByText("Unknown model")).toBeVisible();
+    await expect(usageRows.getByText("grok-4.5")).toBeVisible();
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -93,6 +93,27 @@ function buildMonitorLine(
   };
 }
 
+/**
+ * One row of the Pricing rail's "Spend by model" section, found by the model
+ * it is keyed on. Scoped to the section because the same model name also
+ * appears on every usage card below it.
+ */
+function spendRow(model: string): HTMLElement {
+  const list = document.querySelector(".pricing-spend-list");
+  expect(list).not.toBeNull();
+  const row = within(list as HTMLElement)
+    .getByText(model)
+    .closest(".pricing-spend-row");
+  expect(row).not.toBeNull();
+  return row as HTMLElement;
+}
+
+function expandSpendRow(model: string): HTMLElement {
+  const row = spendRow(model);
+  fireEvent.click(within(row).getByRole("button"));
+  return row;
+}
+
 const baseBackend: BackendSummary = {
   kind: "codex",
   label: "OpenAI",
@@ -1072,9 +1093,26 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByRole("heading", { level: 3, name: "Pricing" })).toBeInTheDocument();
     expect(screen.getByText("Pricing summary")).toBeInTheDocument();
     expect(screen.getByText("1 row")).toBeInTheDocument();
-    expect(screen.getByText("Parent model token volume")).toBeInTheDocument();
-    expect(screen.getByText("$0.010")).toBeInTheDocument();
+    expect(screen.getByText("Spend by model")).toBeInTheDocument();
+    const summaryCard = screen.getByText("Pricing summary").closest(
+      ".pricing-summary-card",
+    ) as HTMLElement;
+    expect(
+      summaryCard.querySelector(".rail-summary-card__primary"),
+    ).toHaveTextContent("$0.010");
     expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    /* One model, so its row opens on the token volume the section replaced —
+       there is nothing for it to hide behind a click. */
+    const onlyModel = spendRow("gpt-5.5");
+    expect(within(onlyModel).getByText("OpenAI · 1 row")).toBeInTheDocument();
+    expect(onlyModel).toHaveTextContent("Uncached input1.5k");
+    expect(onlyModel).toHaveTextContent("Cached input500");
+    expect(onlyModel).toHaveTextContent("Output300");
+    expect(onlyModel).toHaveTextContent("Reasoning120");
+    /* Open by default is a default, not a fixture: an operator who does not
+       want the volume can still close it. */
+    fireEvent.click(within(onlyModel).getByRole("button"));
+    expect(spendRow("gpt-5.5")).not.toHaveTextContent("Uncached input");
     expect(screen.getByText("gpt-5.5 · high · Fast")).toBeInTheDocument();
     expect(screen.queryByText("Turn usage")).not.toBeInTheDocument();
     expect(
@@ -1087,7 +1125,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Running total: $0.010 list price")).toBeInTheDocument();
   });
 
-  it("keeps helper tokens out of the parent model summary", () => {
+  it("gives each model its own token volume instead of only the parent's", () => {
     const parentLine: ThreadUsageLineRecord = {
       backend: "codex",
       cachedInputCostMicros: 45_000,
@@ -1144,19 +1182,33 @@ describe("ThreadContextPanel", () => {
       threadPricingSummaryEnabled: true,
     });
 
+    /* The rail used to show one token volume, filtered to the parent's own
+       turns, so a helper that spent 7k tokens appeared here as dollars and
+       nothing else. Each model now answers for its own rows — and still only
+       its own: a single merged figure was the bug, not the fix. */
     const summaryCard = screen.getByText("Pricing summary").closest(
       ".pricing-summary-card",
     );
     expect(summaryCard).not.toBeNull();
     const summary = within(summaryCard as HTMLElement);
-    expect(summary.getByText("$0.13")).toBeInTheDocument();
     expect(summary.getByText("3 rows")).toBeInTheDocument();
-    expect(summary.getByText("Parent model token volume")).toBeInTheDocument();
-    expect(summary.getByText("10k")).toBeInTheDocument();
-    expect(summary.getByText("90k")).toBeInTheDocument();
-    expect(summary.getByText("1k")).toBeInTheDocument();
-    expect(summary.getByText("250")).toBeInTheDocument();
-    expect(summary.queryByText("17k")).not.toBeInTheDocument();
+    expect(
+      summaryCard?.querySelector(".rail-summary-card__primary"),
+    ).toHaveTextContent("$0.13");
+
+    const parent = expandSpendRow("gpt-5.6-sol");
+    expect(parent).toHaveTextContent("This thread's model");
+    expect(parent).toHaveTextContent("Uncached input10k");
+    expect(parent).toHaveTextContent("Cached input90k");
+    expect(parent).toHaveTextContent("Output1k");
+    expect(parent).toHaveTextContent("Reasoning250");
+
+    const helper = expandSpendRow("gpt-5.6-luna");
+    expect(within(helper).getByText("2 rows")).toBeInTheDocument();
+    expect(helper).toHaveTextContent("2 sub-agents");
+    expect(helper).toHaveTextContent("Uncached input7k");
+    expect(helper).toHaveTextContent("Output420");
+    expect(helper).not.toHaveTextContent("90k");
   });
 
   it("summarizes Token Miser above the turn rows on the Pricing tab", () => {
@@ -1580,10 +1632,13 @@ describe("ThreadContextPanel", () => {
 
     expect(screen.getByText("$56.98 · 1,424 Codex Credits estimated")).toBeInTheDocument();
     expect(screen.queryByText("$21.44 · 1,423 Codex Credits")).not.toBeInTheDocument();
-    expect(document.body).toHaveTextContent("Uncached input2.8M");
-    expect(document.body).toHaveTextContent("Cached input70.5M");
-    expect(document.body).toHaveTextContent("Output221.7k");
-    expect(document.body).toHaveTextContent("Reasoning37k");
+    /* The estimated gap line is the thread model's, so the cumulative tokens
+       land in its spend row rather than in the monitor's. */
+    const parent = expandSpendRow("gpt-5.5");
+    expect(parent).toHaveTextContent("Uncached input2.8M");
+    expect(parent).toHaveTextContent("Cached input70.5M");
+    expect(parent).toHaveTextContent("Output221.7k");
+    expect(parent).toHaveTextContent("Reasoning37k");
     expect(screen.getByText("Historical usage estimate")).toBeInTheDocument();
     expect(
       screen.getByText("$56.23 estimated list price · 1,406 Codex Credits estimated"),
@@ -4584,22 +4639,22 @@ describe("ThreadContextPanel", () => {
       ".pricing-summary-card",
     );
     expect(summaryCard).not.toBeNull();
-    expect(within(summaryCard as HTMLElement).getByText("By provider")).toBeInTheDocument();
-    expect(within(summaryCard as HTMLElement).getByText("OpenAI")).toBeInTheDocument();
-    expect(within(summaryCard as HTMLElement).getByText("xAI")).toBeInTheDocument();
+    const summary = within(summaryCard as HTMLElement);
+    expect(summary.getByText("Spend by model")).toBeInTheDocument();
+    /* Costliest first, so the row that explains the bill is the one at the
+       top. The reviewer's own row carries no model of its own — its name comes
+       from the sub-agent, the same chain the usage card below walks. */
+    const rows = summaryCard?.querySelectorAll(".pricing-spend-row") ?? [];
+    expect(rows).toHaveLength(2);
+    expect(within(spendRow("gpt-5.5")).getByText("xAI · 1 row")).toBeInTheDocument();
+    expect(within(spendRow("gpt-5.5")).getByText("$2.00")).toBeInTheDocument();
     expect(
-      within(summaryCard as HTMLElement).getByText("$1.00 · 1 row"),
+      within(spendRow("gpt-5.6-sol")).getByText("OpenAI · 1 row"),
     ).toBeInTheDocument();
-    expect(
-      within(summaryCard as HTMLElement).getByText("$2.00 · 1 row"),
-    ).toBeInTheDocument();
-    const providerDetail = screen.getByText("openai · USD").closest(
-      ".pricing-provider-row",
-    );
-    expect(providerDetail).not.toBeNull();
-    expect(
-      within(providerDetail as HTMLElement).getByText("$1.00 list price · 1 row"),
-    ).toBeInTheDocument();
+    expect(within(spendRow("gpt-5.6-sol")).getByText("$1.00")).toBeInTheDocument();
+    /* The provider ids used to be printed raw, in a second list of cards that
+       repeated these same three facts underneath the card. */
+    expect(screen.queryByText("openai · USD")).not.toBeInTheDocument();
 
     const reviewUsage = screen.getByText("Review usage").closest(
       ".pricing-usage-row",
@@ -4610,6 +4665,80 @@ describe("ThreadContextPanel", () => {
       within(reviewUsage as HTMLElement).getByText("gpt-5.6-sol · high"),
     ).toBeInTheDocument();
     expect(within(reviewUsage as HTMLElement).queryByText("Grok")).not.toBeInTheDocument();
+  });
+
+  it("ranks a four-provider turn by spend and subtotals only the shared provider", () => {
+    /* The case the section exists for: one thread model and four reviewers on
+       three other providers. The old split printed four provider lines and
+       four cards repeating them, and melted the two OpenAI reviews into one
+       row that could not be taken apart. */
+    const createdAt = 1_800_000_000_000;
+    const turnLines = [0, 1, 2, 3].map((index) =>
+      buildMonitorLine({
+        backend: "acp:grok",
+        createdAt: createdAt - index,
+        model: "grok-4.1-fast",
+        provider: "xai",
+        scope: "turn",
+        source: "live",
+        totalCostMicros: 647_500,
+        usageLineId: `grok-turn-${index}`,
+      }),
+    );
+    const reviews = [
+      { cost: 1_070_000, id: "sol", model: "gpt-5.6-sol", provider: "openai" },
+      { cost: 840_000, id: "terra", model: "gpt-5.6-terra", provider: "openai" },
+      { cost: 210_000, id: "kimi", model: "kimi-k2.5", provider: "moonshot" },
+      { cost: 140_000, id: "qwen", model: "qwen3-max", provider: "qwen" },
+    ].map((review) =>
+      buildMonitorLine({
+        backend: "acp:grok",
+        createdAt,
+        model: review.model,
+        parentThreadId: "thread-1",
+        provider: review.provider,
+        sourceItemId: `review:${review.id}`,
+        totalCostMicros: review.cost,
+        usageLineId: `review-${review.id}`,
+      }),
+    );
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: { ...baseThread, source: "acp:grok" },
+      pricing: { lines: [...turnLines, ...reviews], summaries: [] },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const summaryCard = screen.getByText("Pricing summary").closest(
+      ".pricing-summary-card",
+    ) as HTMLElement;
+    expect(
+      summaryCard.querySelector(".rail-summary-card__primary"),
+    ).toHaveTextContent("$4.85");
+    expect(
+      [...summaryCard.querySelectorAll(".pricing-spend-row__label")].map(
+        (label) => label.textContent,
+      ),
+    ).toEqual([
+      "grok-4.1-fast",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "kimi-k2.5",
+      "qwen3-max",
+    ]);
+    /* Only OpenAI ran two models, so it is the only provider whose subtotal is
+       not already a row of its own. */
+    const heads = [...summaryCard.querySelectorAll(".pricing-spend-group__head")];
+    expect(heads).toHaveLength(1);
+    expect(heads[0]).toHaveTextContent("OpenAI$1.91 · 2 rows");
+    expect(
+      within(spendRow("grok-4.1-fast")).getByText("xAI · 4 rows"),
+    ).toBeInTheDocument();
+    expect(
+      within(spendRow("qwen3-max")).getByText("Qwen · 1 row"),
+    ).toBeInTheDocument();
   });
 
   it("renders accumulated edit groups on the Edits tab and toggles the dock", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -110,7 +110,13 @@ function spendRow(model: string): HTMLElement {
 
 function expandSpendRow(model: string): HTMLElement {
   const row = spendRow(model);
-  fireEvent.click(within(row).getByRole("button"));
+  const toggle = within(row).getByRole("button");
+  // A lone-model thread renders its row open, so clicking unconditionally
+  // would close the body these callers are about to read — and a negative
+  // assertion against a closed body passes for the wrong reason.
+  if (toggle.getAttribute("aria-expanded") !== "true") {
+    fireEvent.click(toggle);
+  }
   return row;
 }
 
@@ -1165,7 +1171,7 @@ describe("ThreadContextPanel", () => {
       inputTokens: 2_000,
       model: "gpt-5.6-luna",
       outputTokens: 20,
-      sourceItemId: "thread-naming-1",
+      sourceItemId: "system:title-helper:codex:thread-1",
       totalCostMicros: 1_000,
       totalTokens: 2_020,
       uncachedInputTokens: 2_000,
@@ -1204,11 +1210,113 @@ describe("ThreadContextPanel", () => {
     expect(parent).toHaveTextContent("Reasoning250");
 
     const helper = expandSpendRow("gpt-5.6-luna");
-    expect(within(helper).getByText("2 rows")).toBeInTheDocument();
-    expect(helper).toHaveTextContent("2 sub-agents");
+    // One provider, so no group heading restates the headline and the rows
+    // name the provider themselves.
+    expect(within(helper).getByText("OpenAI · 2 rows")).toBeInTheDocument();
+    // A Token Miser gate and the thread namer are PwrAgent's own helpers, not
+    // reviewers the operator dispatched, so they are counted apart.
+    expect(helper).toHaveTextContent("2 system helpers");
     expect(helper).toHaveTextContent("Uncached input7k");
     expect(helper).toHaveTextContent("Output420");
     expect(helper).not.toHaveTextContent("90k");
+  });
+
+  it("holds the lone row open when a second model starts billing", () => {
+    /* The default was derived from the live bucket count, so the row an
+       operator was reading closed itself the moment a reviewer — or the thread
+       namer — billed a second model. It is decided once and then held. */
+    const turnLine = buildMonitorLine({
+      model: "gpt-5.6-sol",
+      scope: "turn",
+      source: "live",
+      sourceItemId: "item-1",
+      uncachedInputTokens: 10_000,
+      usageLineId: "turn-line-1",
+    });
+    const reviewerLine = buildMonitorLine({
+      model: "gpt-5.6-luna",
+      parentThreadId: "thread-1",
+      sourceItemId: "review:luna",
+      uncachedInputTokens: 7_000,
+      usageLineId: "review-line-1",
+    });
+    const panelProps = (lines: ThreadUsageLineRecord[]) => (
+      <ThreadContextPanel
+        activeTab="pricing"
+        backends={[baseBackend]}
+        pinned
+        thread={baseThread}
+        onActiveTabChange={vi.fn()}
+        pricing={{ lines, summaries: [] }}
+        threadPricingSummaryEnabled
+      />
+    );
+    const { rerender } = render(panelProps([turnLine]));
+    expect(spendRow("gpt-5.6-sol")).toHaveTextContent("Uncached input10k");
+
+    rerender(panelProps([turnLine, reviewerLine]));
+
+    expect(spendRow("gpt-5.6-sol")).toHaveTextContent("Uncached input10k");
+    expect(spendRow("gpt-5.6-luna")).not.toHaveTextContent("Uncached input");
+  });
+
+  it("says a model is unpriced instead of pricing it at zero", () => {
+    /* An all-unpriced bucket rendered "$0.000", which is what a model that
+       genuinely cost nothing renders. The turn cards below already make the
+       distinction. */
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [
+          buildMonitorLine({
+            model: "gpt-6-preview",
+            priceStatus: "unpriced",
+            priceUnavailableReason: "missing-rate",
+            scope: "turn",
+            source: "live",
+            totalCostMicros: 0,
+            uncachedInputTokens: 4_000_000,
+            usageLineId: "unpriced-line",
+          }),
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const row = spendRow("gpt-6-preview");
+    expect(within(row).getByText("Unpriced")).toBeInTheDocument();
+    expect(row).not.toHaveTextContent("$0.000");
+  });
+
+  it("prints no dollars in the spend split when USD is turned off", () => {
+    /* The headline honors the display options; the rows used to print dollars
+       through them, so one card said "No estimate units selected" and
+       contradicted itself two lines below. */
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [
+          buildMonitorLine({
+            model: "gpt-5.6-sol",
+            scope: "turn",
+            source: "live",
+            totalCostMicros: 800_000,
+            usageLineId: "turn-line-1",
+          }),
+        ],
+        summaries: [],
+      },
+      pricingDisplayOptions: { codexCredits: false, usd: false },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("No estimate units selected")).toBeInTheDocument();
+    expect(document.querySelector(".pricing-spend-list")).not.toHaveTextContent(
+      "$0.80",
+    );
   });
 
   it("summarizes Token Miser above the turn rows on the Pricing tab", () => {
@@ -4623,6 +4731,7 @@ describe("ThreadContextPanel", () => {
           buildMonitorLine({
             backend: "acp:grok",
             createdAt: createdAt - 1,
+            model: "grok-4.5",
             parentThreadId: "thread-1",
             provider: "xai",
             sourceItemId: "turn-grok-1",
@@ -4646,8 +4755,8 @@ describe("ThreadContextPanel", () => {
        from the sub-agent, the same chain the usage card below walks. */
     const rows = summaryCard?.querySelectorAll(".pricing-spend-row") ?? [];
     expect(rows).toHaveLength(2);
-    expect(within(spendRow("gpt-5.5")).getByText("xAI · 1 row")).toBeInTheDocument();
-    expect(within(spendRow("gpt-5.5")).getByText("$2.00")).toBeInTheDocument();
+    expect(within(spendRow("grok-4.5")).getByText("xAI · 1 row")).toBeInTheDocument();
+    expect(within(spendRow("grok-4.5")).getByText("$2.00")).toBeInTheDocument();
     expect(
       within(spendRow("gpt-5.6-sol")).getByText("OpenAI · 1 row"),
     ).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pricing-spend-by-model.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pricing-spend-by-model.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadUsageLineRecord } from "@pwragent/shared";
+import { buildPricingSpendByModel } from "../pricing-spend-by-model";
+
+function line(
+  overrides: Partial<ThreadUsageLineRecord> = {},
+): ThreadUsageLineRecord {
+  return {
+    backend: "acp:grok",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 0,
+    createdAt: 1_800_000_000_000,
+    currency: "USD",
+    inputTokens: 100,
+    model: "grok-4.1-fast",
+    outputCostMicros: 0,
+    outputTokens: 10,
+    priceStatus: "priced",
+    provider: "xai",
+    reasoningOutputTokens: 0,
+    scope: "turn",
+    source: "live",
+    status: "finalized",
+    threadId: "thread-1",
+    totalCostMicros: 1_000,
+    totalTokens: 110,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 100,
+    usageLineId: "line-1",
+    ...overrides,
+  };
+}
+
+describe("buildPricingSpendByModel", () => {
+  it("splits a turn's reviewers out of the provider they share", () => {
+    /* Two OpenAI reviews used to collapse into one "OpenAI" row, which is the
+       one number an operator comparing reviewers cannot use. */
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({ totalCostMicros: 2_590_000, usageLineId: "parent" }),
+        line({
+          model: "gpt-5.6-sol",
+          provider: "openai",
+          scope: "monitor",
+          sourceItemId: "review:sol",
+          totalCostMicros: 1_070_000,
+          usageLineId: "sol",
+        }),
+        line({
+          model: "gpt-5.6-terra",
+          provider: "openai",
+          scope: "monitor",
+          sourceItemId: "review:terra",
+          totalCostMicros: 840_000,
+          usageLineId: "terra",
+        }),
+      ],
+    });
+
+    expect(groups.map((group) => group.provider)).toEqual(["xai", "openai"]);
+    expect(groups[1]?.totalCostMicros).toBe(1_910_000);
+    expect(groups[1]?.usageLineCount).toBe(2);
+    expect(groups[1]?.models.map((spend) => spend.model)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+    ]);
+  });
+
+  it("names the model from the sub-agent when the row carries none", () => {
+    /* A helper's usage row often records no model of its own. Bucketed on the
+       row alone, every review in a thread lands in one "Unknown model" pile. */
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({
+          model: undefined,
+          provider: "openai",
+          scope: "monitor",
+          sourceItemId: "review:sol",
+          usageLineId: "sol",
+        }),
+      ],
+      resolveModel: (record) => record.model ?? "gpt-5.6-sol",
+    });
+
+    expect(groups[0]?.models[0]?.model).toBe("gpt-5.6-sol");
+  });
+
+  it("counts sub-agents rather than the rows they billed", () => {
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({ usageLineId: "turn-1" }),
+        line({ usageLineId: "turn-2" }),
+        line({
+          scope: "monitor",
+          sourceItemId: "review:one",
+          usageLineId: "review-a",
+        }),
+        line({
+          scope: "monitor",
+          sourceItemId: "review:one",
+          usageLineId: "review-b",
+        }),
+        line({
+          scope: "monitor",
+          sourceItemId: "review:two",
+          usageLineId: "review-c",
+        }),
+      ],
+    });
+
+    const spend = groups[0]?.models[0];
+    expect(spend?.threadUsageLineCount).toBe(2);
+    expect(spend?.subAgentCount).toBe(2);
+    expect(spend?.summary.usageLineCount).toBe(5);
+  });
+
+  it("keeps unnamed rows in a bucket of their own rather than dropping them", () => {
+    /* The buckets have to add up to the headline above them, so a row nothing
+       named still has to land somewhere. */
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({ totalCostMicros: 500_000, usageLineId: "named" }),
+        line({
+          model: undefined,
+          totalCostMicros: 500_000,
+          usageLineId: "unnamed",
+        }),
+      ],
+    });
+
+    expect(groups[0]?.models.map((spend) => spend.model)).toEqual([
+      "grok-4.1-fast",
+      undefined,
+    ]);
+    expect(groups[0]?.totalCostMicros).toBe(1_000_000);
+  });
+
+  it("splits one provider's currencies instead of adding them together", () => {
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({ totalCostMicros: 1_000_000, usageLineId: "usd" }),
+        line({
+          currency: "EUR",
+          totalCostMicros: 2_000_000,
+          usageLineId: "eur",
+        }),
+      ],
+    });
+
+    expect(groups.map((group) => group.currency)).toEqual(["EUR", "USD"]);
+  });
+
+  it("counts an unpriced row as a decision the dollars do not cover", () => {
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({ usageLineId: "priced" }),
+        line({
+          priceStatus: "unpriced",
+          priceUnavailableReason: "missing-rate",
+          totalCostMicros: 0,
+          usageLineId: "unpriced",
+        }),
+      ],
+    });
+
+    expect(groups[0]?.models[0]?.summary.pricedUsageLineCount).toBe(1);
+    expect(groups[0]?.models[0]?.summary.unpricedUsageLineCount).toBe(1);
+  });
+
+  it("returns nothing for a thread with no usage rows", () => {
+    expect(buildPricingSpendByModel({ lines: [] })).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pricing-spend-by-model.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pricing-spend-by-model.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { ThreadUsageLineRecord } from "@pwragent/shared";
-import { buildPricingSpendByModel } from "../pricing-spend-by-model";
+import {
+  buildPricingSpendByModel,
+  type PricingSpendUsageLine,
+  prunePricingSpendOverrides,
+} from "../pricing-spend-by-model";
 
 function line(
-  overrides: Partial<ThreadUsageLineRecord> = {},
-): ThreadUsageLineRecord {
+  overrides: Partial<PricingSpendUsageLine> = {},
+): PricingSpendUsageLine {
   return {
     backend: "acp:grok",
     cachedInputCostMicros: 0,
@@ -169,5 +172,133 @@ describe("buildPricingSpendByModel", () => {
 
   it("returns nothing for a thread with no usage rows", () => {
     expect(buildPricingSpendByModel({ lines: [] })).toEqual([]);
+  });
+  it("keeps the thread's own token volume out of a helper's share", () => {
+    /* Sub-agents inherit the parent's model by default, so the common case is
+       one bucket holding both. Summing them is right for the bill and wrong
+       for the context question — a merged figure is what used to disagree
+       with the turn card and with Codex's context-window meter. */
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({
+          cachedInputTokens: 90_000,
+          outputTokens: 1_000,
+          totalTokens: 101_000,
+          uncachedInputTokens: 10_000,
+          usageLineId: "parent",
+        }),
+        line({
+          outputTokens: 35_000,
+          scope: "monitor",
+          sourceItemId: "review:sol",
+          totalTokens: 735_000,
+          uncachedInputTokens: 700_000,
+          usageLineId: "reviewer",
+        }),
+      ],
+    });
+
+    const bucket = groups[0]?.models[0];
+    expect(bucket?.summary.uncachedInputTokens).toBe(710_000);
+    expect(bucket?.threadSummary?.uncachedInputTokens).toBe(10_000);
+    expect(bucket?.threadSummary?.cachedInputTokens).toBe(90_000);
+    expect(bucket?.threadSummary?.outputTokens).toBe(1_000);
+  });
+
+  it("leaves threadSummary off a bucket nothing else shares", () => {
+    /* A second identical figure on the row would read as a second
+       measurement, so the split is carried only where there is one. */
+    const groups = buildPricingSpendByModel({
+      lines: [line({ usageLineId: "parent" })],
+    });
+
+    expect(groups[0]?.models[0]?.threadSummary).toBeUndefined();
+  });
+
+  it("counts PwrAgent's own helpers apart from dispatched sub-agents", () => {
+    /* Token Miser gates and the thread namer bill real money, but the
+       operator dispatched none of them; counting them as sub-agents reported
+       reviewers that never ran. */
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({ usageLineId: "parent" }),
+        line({
+          scope: "monitor",
+          sourceItemId: "system:token-miser:gate-1",
+          usageLineId: "gate-1",
+        }),
+        line({
+          scope: "monitor",
+          sourceItemId: "system:token-miser:gate-2",
+          usageLineId: "gate-2",
+        }),
+        line({
+          scope: "monitor",
+          sourceItemId: "system:title-helper:codex:thread-1",
+          usageLineId: "naming",
+        }),
+        line({
+          scope: "monitor",
+          sourceItemId: "review:sol",
+          usageLineId: "reviewer",
+        }),
+      ],
+    });
+
+    const bucket = groups[0]?.models[0];
+    expect(bucket?.subAgentCount).toBe(1);
+    expect(bucket?.systemHelperCount).toBe(3);
+    expect(bucket?.threadUsageLineCount).toBe(1);
+  });
+
+  it("marks a bucket that a history-gap estimate contributed to", () => {
+    const groups = buildPricingSpendByModel({
+      lines: [
+        line({ usageLineId: "observed" }),
+        line({
+          estimatedUsageGap: true,
+          model: "gpt-5.6-sol",
+          provider: "openai",
+          scope: "backfill",
+          totalCostMicros: 56_230_000,
+          usageLineId: "gap",
+        }),
+      ],
+    });
+
+    const byModel = new Map(
+      groups.flatMap((group) =>
+        group.models.map((model) => [model.model, model.hasEstimatedRows]),
+      ),
+    );
+    expect(byModel.get("gpt-5.6-sol")).toBe(true);
+    expect(byModel.get("grok-4.1-fast")).toBe(false);
+  });
+});
+
+describe("prunePricingSpendOverrides", () => {
+  it("drops an override whose bucket was re-keyed by a late model", () => {
+    /* A helper's row arrives before its sub-agent summary, so the bucket the
+       operator expanded as "Unknown model" is re-keyed once the model lands.
+       Left in place, its override would open the next unrelated row. */
+    const groups = buildPricingSpendByModel({
+      lines: [line({ usageLineId: "parent" })],
+    });
+
+    expect(
+      prunePricingSpendOverrides(
+        { "xai:USD:": true, "xai:USD:grok-4.1-fast": false },
+        groups,
+      ),
+    ).toEqual({ "xai:USD:grok-4.1-fast": false });
+  });
+
+  it("keeps every override while its bucket is still rendered", () => {
+    const groups = buildPricingSpendByModel({
+      lines: [line({ usageLineId: "parent" })],
+    });
+    const overrides = { "xai:USD:grok-4.1-fast": true };
+
+    expect(prunePricingSpendOverrides(overrides, groups)).toEqual(overrides);
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -39,6 +39,12 @@ import {
 import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
 import { TokenMiserSavingsBreakdown } from "./TokenMiserSavingsBreakdown";
 import { TokenMiserSummaryCard } from "./TokenMiserSummaryCard";
+import {
+  addUsageLineToSummary,
+  buildPricingSpendByModel,
+  emptyPricingSummary,
+  type PricingModelSpend,
+} from "../pricing-spend-by-model";
 import { buildTokenMiserSavingsSummary } from "../token-miser-savings-summary";
 
 type PricingPanelProps = {
@@ -108,6 +114,15 @@ export function PricingPanel(props: PricingPanelProps) {
     usagePage.key === pricingHistoryKey
       ? usagePage.count
       : PRICING_USAGE_PAGE_SIZE;
+  // Which spend rows the operator has opened, and which they have closed. A
+  // lone row starts open — there is nothing for it to hide, and closing it
+  // would take away the token volume this section replaced.
+  const [spendExpansion, setSpendExpansion] = useState<{
+    key: string;
+    overrides: Readonly<Record<string, boolean>>;
+  }>({ key: pricingHistoryKey, overrides: {} });
+  const spendOverrides =
+    spendExpansion.key === pricingHistoryKey ? spendExpansion.overrides : {};
   const visibleDisplayLines = displayLines.slice(0, visibleUsageRowCount);
   const hiddenUsageRowCount = displayLines.length - visibleDisplayLines.length;
   const estimatedLines = allDisplayLines.filter(isEstimatedUsageGap);
@@ -115,13 +130,41 @@ export function PricingPanel(props: PricingPanelProps) {
   const summary =
     aggregateSummaries(displaySummaries) ?? aggregateUsageLines(allDisplayLines);
   // The headline is the all-in bill, including naming, reviews, monitors and
-  // Token Miser. Token volume is a context question, though: only the parent
-  // thread's turn rows enter its model context. Helper usage already has its
-  // own cards below, and mixing it here made the summary disagree with both
-  // the turn card and Codex's context-window meter.
-  const parentModelSummary = aggregateUsageLines(
-    allDisplayLines.filter(isMainThreadUsageLine),
+  // Token Miser. Underneath it, the same bill split by the model that spent
+  // it: a turn that sends four reviewers to four models bills three providers,
+  // and a per-provider split answers none of the questions that raises.
+  const spendByModel = buildPricingSpendByModel({
+    lines: allDisplayLines,
+    resolveModel: (line) =>
+      resolveUsageLineModel(
+        line,
+        line.scope === "monitor" && line.sourceItemId
+          ? subAgentsById.get(line.sourceItemId)
+          : undefined,
+      ),
+  });
+  const spendModelCount = spendByModel.reduce(
+    (total, group) => total + group.models.length,
+    0,
   );
+  // A thread with one model has nothing to hide behind a click, and hiding it
+  // would take away the token volume this section replaced.
+  const spendRowStartsExpanded = spendModelCount === 1;
+  const isSpendRowExpanded = (key: string): boolean =>
+    spendOverrides[key] ?? spendRowStartsExpanded;
+  const toggleSpendRow = (key: string): void => {
+    setSpendExpansion((current) => {
+      const overrides =
+        current.key === pricingHistoryKey ? current.overrides : {};
+      return {
+        key: pricingHistoryKey,
+        overrides: {
+          ...overrides,
+          [key]: !(overrides[key] ?? spendRowStartsExpanded),
+        },
+      };
+    });
+  };
   // Thread-level gate result, from every gate this thread spawned. The
   // per-turn folds below price one turn each; this is the same arithmetic run
   // once across all of them, so the rail can answer "did the gate pay for
@@ -244,11 +287,7 @@ export function PricingPanel(props: PricingPanelProps) {
         ? props.threadReasoningEffort
         : undefined);
     const runtimeLabel = formatUsageLineRuntimeLabel(line, subAgent);
-    const runtimeModel =
-      line.model
-      ?? subAgent?.preferredModel
-      ?? subAgent?.monitorUsage?.model
-      ?? subAgent?.monitorUsage?.cost?.model;
+    const runtimeModel = resolveUsageLineModel(line, subAgent);
 
     return (
       <li
@@ -384,48 +423,41 @@ export function PricingPanel(props: PricingPanelProps) {
               {summary.unpricedUsageLineCount.toLocaleString()} unpriced ·{" "}
               {formatTimestamp(summary.updatedAt)}
             </div>
-            {parentModelSummary ? (
+            {spendByModel.length > 0 ? (
               <div className="rail-summary-card__section">
                 <span className="rail-summary-card__section-title">
-                  Parent model token volume
+                  Spend by model
                 </span>
-                <RailSummaryRow
-                  label="Uncached input"
-                  value={formatCompactCount(parentModelSummary.uncachedInputTokens)}
-                />
-                <RailSummaryRow
-                  label="Cached input"
-                  value={formatCompactCount(parentModelSummary.cachedInputTokens)}
-                />
-                <RailSummaryRow
-                  label="Output"
-                  value={formatCompactCount(parentModelSummary.outputTokens)}
-                />
-                {parentModelSummary.reasoningOutputTokens > 0 ? (
-                  <RailSummaryRow
-                    label="Reasoning"
-                    value={formatCompactCount(
-                      parentModelSummary.reasoningOutputTokens,
-                    )}
-                  />
-                ) : null}
-              </div>
-            ) : null}
-            {displaySummaries.length > 1 ? (
-              <div className="rail-summary-card__section">
-                <span className="rail-summary-card__section-title">By provider</span>
-                {displaySummaries.map((providerSummary) => (
-                  <RailSummaryRow
-                    key={`${providerSummary.provider}:${providerSummary.currency}`}
-                    label={formatPricingProviderLabel(providerSummary.provider)}
-                    value={`${formatMoney(
-                      providerSummary.totalCostMicros,
-                      providerSummary.currency,
-                    )} · ${providerSummary.usageLineCount.toLocaleString()} row${
-                      providerSummary.usageLineCount === 1 ? "" : "s"
-                    }`}
-                  />
-                ))}
+                <div className="pricing-spend-list">
+                  {spendByModel.map((group) => (
+                    <div className="pricing-spend-group" key={group.key}>
+                      {/* A provider gets a heading only where it contributed
+                          more than one model, because that is the one case
+                          where its subtotal is not already a row. */}
+                      {group.models.length > 1 ? (
+                        <div className="pricing-spend-group__head">
+                          <span>
+                            {formatPricingProviderLabel(group.provider)}
+                          </span>
+                          <span className="pricing-spend-group__total">
+                            {formatMoney(group.totalCostMicros, group.currency)}
+                            {" · "}
+                            {formatUsageRowCount(group.usageLineCount)}
+                          </span>
+                        </div>
+                      ) : null}
+                      {group.models.map((modelSpend) => (
+                        <PricingModelSpendRow
+                          expanded={isSpendRowExpanded(modelSpend.key)}
+                          key={modelSpend.key}
+                          onToggle={() => toggleSpendRow(modelSpend.key)}
+                          showProvider={group.models.length === 1}
+                          spend={modelSpend}
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
               </div>
             ) : null}
           </div>
@@ -434,28 +466,6 @@ export function PricingPanel(props: PricingPanelProps) {
               {summary.unpricedUsageLineCount.toLocaleString()} usage row
               {summary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
             </p>
-          ) : null}
-          {displaySummaries.length > 1 ? (
-            <ul className="context-list context-list--cards pricing-provider-list">
-              {displaySummaries.map((providerSummary) => (
-                <li
-                  key={`${providerSummary.provider}:${providerSummary.currency}`}
-                  className="rail-card pricing-provider-row"
-                >
-                  <p className="rail-card__title">
-                    {providerSummary.provider} · {providerSummary.currency}
-                  </p>
-                  <p className="rail-card__usage">
-                    {formatMoney(
-                      providerSummary.totalCostMicros,
-                      providerSummary.currency,
-                    )}{" "}
-                    list price · {providerSummary.usageLineCount.toLocaleString()} row
-                    {providerSummary.usageLineCount === 1 ? "" : "s"}
-                  </p>
-                </li>
-              ))}
-            </ul>
           ) : null}
         </>
       ) : displayLines.length === 0 ? (
@@ -508,6 +518,120 @@ export function PricingPanel(props: PricingPanelProps) {
         </div>
       ) : null}
     </section>
+  );
+}
+
+/**
+ * One model's share of the bill, closed by default, opening onto the token
+ * volume behind it.
+ *
+ * Only the parent thread's volume was ever shown here, so a review that spent
+ * a dollar and 1.3M tokens appeared in the rail as a dollar. The row that
+ * replaced the provider split carries both.
+ */
+function PricingModelSpendRow(props: {
+  expanded: boolean;
+  onToggle: () => void;
+  /** True when no provider heading sits above this row to name it. */
+  showProvider: boolean;
+  spend: PricingModelSpend;
+}) {
+  const summary = props.spend.summary;
+  const meta = [
+    props.showProvider
+      ? formatPricingProviderLabel(props.spend.provider)
+      : undefined,
+    formatUsageRowCount(summary.usageLineCount),
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(" · ");
+  const origin = formatModelSpendOrigin(props.spend);
+
+  return (
+    <div
+      className="pricing-spend-row"
+      data-expanded={props.expanded ? "true" : "false"}
+    >
+      <button
+        aria-expanded={props.expanded}
+        className="pricing-spend-row__summary"
+        onClick={props.onToggle}
+        type="button"
+      >
+        <span aria-hidden="true" className="pricing-spend-row__chevron">›</span>
+        <span className="pricing-spend-row__label">
+          {props.spend.model ?? "Unknown model"}
+        </span>
+        <span className="pricing-spend-row__meta">{meta}</span>
+        <span className="pricing-spend-row__cost">
+          {formatMoney(summary.totalCostMicros, summary.currency)}
+        </span>
+      </button>
+      {props.expanded ? (
+        <div className="pricing-spend-row__body">
+          {origin ? <p className="pricing-spend-row__origin">{origin}</p> : null}
+          <RailSummaryRow
+            label="Uncached input"
+            value={formatCompactCount(summary.uncachedInputTokens)}
+          />
+          <RailSummaryRow
+            label="Cached input"
+            value={formatCompactCount(summary.cachedInputTokens)}
+          />
+          <RailSummaryRow
+            label="Output"
+            value={formatCompactCount(summary.outputTokens)}
+          />
+          {summary.reasoningOutputTokens > 0 ? (
+            <RailSummaryRow
+              label="Reasoning"
+              value={formatCompactCount(summary.reasoningOutputTokens)}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Says where a model's rows came from, when saying it adds something. A thread
+ * whose own model is also a reviewer's reads "This thread's model · 2
+ * sub-agents"; a bucket that is only turn rows says so once and stops.
+ */
+function formatModelSpendOrigin(spend: PricingModelSpend): string | undefined {
+  const subAgents =
+    spend.subAgentCount > 0
+      ? `${spend.subAgentCount.toLocaleString()} sub-agent${
+          spend.subAgentCount === 1 ? "" : "s"
+        }`
+      : undefined;
+  if (spend.threadUsageLineCount > 0) {
+    return subAgents
+      ? `This thread's model · ${subAgents}`
+      : "This thread's model";
+  }
+  return subAgents;
+}
+
+function formatUsageRowCount(count: number): string {
+  return `${count.toLocaleString()} row${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * The model a usage row belongs to. A helper's row often carries none of its
+ * own and the sub-agent summary holds it, so the row card and the spend bucket
+ * walk the same chain rather than disagreeing about who spent the money.
+ */
+function resolveUsageLineModel(
+  line: ThreadUsageLineRecord,
+  subAgent?: ThreadSubAgentSummary,
+): string | undefined {
+  return (
+    line.model
+    ?? subAgent?.preferredModel
+    ?? subAgent?.monitorUsage?.model
+    ?? subAgent?.monitorUsage?.cost?.model
   );
 }
 
@@ -925,25 +1049,7 @@ function addEstimatedLinesToSummaries(
   }
   for (const line of estimatedLines) {
     const key = usageLineSummaryKey(line);
-    const existing =
-      byKey.get(key) ??
-      ({
-        backend: line.backend,
-        cachedInputTokens: 0,
-        currency: line.currency,
-        inputTokens: 0,
-        outputTokens: 0,
-        pricedUsageLineCount: 0,
-        provider: line.provider,
-        reasoningOutputTokens: 0,
-        threadId: line.parentThreadId ?? line.threadId,
-        totalCostMicros: 0,
-        totalTokens: 0,
-        uncachedInputTokens: 0,
-        unpricedUsageLineCount: 0,
-        updatedAt: 0,
-        usageLineCount: 0,
-      } satisfies ThreadPricingSummary);
+    const existing = byKey.get(key) ?? emptyPricingSummary(line);
     byKey.set(key, addUsageLineToSummary(existing, line));
   }
   return [...byKey.values()].sort((left, right) => {
@@ -958,53 +1064,10 @@ function aggregateUsageLines(lines: PricingUsageLine[]): ThreadPricingSummary | 
   if (lines.length === 0) {
     return undefined;
   }
-  const firstLine = lines[0];
   return lines.reduce<ThreadPricingSummary>(
     (summary, line) => addUsageLineToSummary(summary, line),
-    {
-      backend: firstLine.backend,
-      cachedInputTokens: 0,
-      currency: firstLine.currency,
-      inputTokens: 0,
-      outputTokens: 0,
-      pricedUsageLineCount: 0,
-      provider: firstLine.provider,
-      reasoningOutputTokens: 0,
-      threadId: firstLine.threadId,
-      totalCostMicros: 0,
-      totalTokens: 0,
-      uncachedInputTokens: 0,
-      unpricedUsageLineCount: 0,
-      updatedAt: 0,
-      usageLineCount: 0,
-    },
+    emptyPricingSummary(lines[0]),
   );
-}
-
-function addUsageLineToSummary(
-  summary: ThreadPricingSummary,
-  line: PricingUsageLine,
-): ThreadPricingSummary {
-  return {
-    backend: summary.backend,
-    cachedInputTokens: summary.cachedInputTokens + line.cachedInputTokens,
-    currency: summary.currency,
-    inputTokens: summary.inputTokens + line.inputTokens,
-    outputTokens: summary.outputTokens + line.outputTokens,
-    pricedUsageLineCount:
-      summary.pricedUsageLineCount + (line.priceStatus === "priced" ? 1 : 0),
-    provider: summary.provider,
-    reasoningOutputTokens:
-      summary.reasoningOutputTokens + line.reasoningOutputTokens,
-    threadId: summary.threadId,
-    totalCostMicros: summary.totalCostMicros + line.totalCostMicros,
-    totalTokens: summary.totalTokens + line.totalTokens,
-    uncachedInputTokens: summary.uncachedInputTokens + line.uncachedInputTokens,
-    unpricedUsageLineCount:
-      summary.unpricedUsageLineCount + (line.priceStatus === "priced" ? 0 : 1),
-    updatedAt: Math.max(summary.updatedAt, line.completedAt ?? line.createdAt),
-    usageLineCount: summary.usageLineCount + 1,
-  };
 }
 
 function summaryKey(summary: ThreadPricingSummary): string {
@@ -1051,10 +1114,6 @@ function compareUsageLinesDescending(
 
 function lineSortTimestamp(line: ThreadUsageLineRecord): number {
   return line.startedAt ?? line.createdAt;
-}
-
-function isMainThreadUsageLine(line: ThreadUsageLineRecord): boolean {
-  return line.scope !== "monitor";
 }
 
 function formatSummaryEstimates(params: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -44,6 +44,7 @@ import {
   buildPricingSpendByModel,
   emptyPricingSummary,
   type PricingModelSpend,
+  prunePricingSpendOverrides,
 } from "../pricing-spend-by-model";
 import { buildTokenMiserSavingsSummary } from "../token-miser-savings-summary";
 
@@ -114,15 +115,6 @@ export function PricingPanel(props: PricingPanelProps) {
     usagePage.key === pricingHistoryKey
       ? usagePage.count
       : PRICING_USAGE_PAGE_SIZE;
-  // Which spend rows the operator has opened, and which they have closed. A
-  // lone row starts open — there is nothing for it to hide, and closing it
-  // would take away the token volume this section replaced.
-  const [spendExpansion, setSpendExpansion] = useState<{
-    key: string;
-    overrides: Readonly<Record<string, boolean>>;
-  }>({ key: pricingHistoryKey, overrides: {} });
-  const spendOverrides =
-    spendExpansion.key === pricingHistoryKey ? spendExpansion.overrides : {};
   const visibleDisplayLines = displayLines.slice(0, visibleUsageRowCount);
   const hiddenUsageRowCount = displayLines.length - visibleDisplayLines.length;
   const estimatedLines = allDisplayLines.filter(isEstimatedUsageGap);
@@ -147,23 +139,49 @@ export function PricingPanel(props: PricingPanelProps) {
     (total, group) => total + group.models.length,
     0,
   );
-  // A thread with one model has nothing to hide behind a click, and hiding it
-  // would take away the token volume this section replaced.
-  const spendRowStartsExpanded = spendModelCount === 1;
-  const isSpendRowExpanded = (key: string): boolean =>
-    spendOverrides[key] ?? spendRowStartsExpanded;
-  const toggleSpendRow = (key: string): void => {
-    setSpendExpansion((current) => {
-      const overrides =
-        current.key === pricingHistoryKey ? current.overrides : {};
-      return {
-        key: pricingHistoryKey,
-        overrides: {
-          ...overrides,
-          [key]: !(overrides[key] ?? spendRowStartsExpanded),
-        },
-      };
+  // Which spend rows the operator has opened, and which they have closed.
+  //
+  // A thread whose spend is one model has nothing to hide behind a click, so
+  // that row starts open on the token volume this section replaced. `openKey`
+  // names it, and is settled once — on the first render with any spend — then
+  // held. Re-deriving the default from the live bucket count closed the row an
+  // operator was reading the moment a reviewer, or even the thread namer,
+  // billed a second model; latching a bare flag instead would have opened
+  // every later row too.
+  const soleSpendKey =
+    spendModelCount === 1 ? spendByModel[0]?.models[0]?.key : undefined;
+  const [spendExpansion, setSpendExpansion] = useState<{
+    key: string;
+    openKey?: string;
+    overrides: Readonly<Record<string, boolean>>;
+    settled: boolean;
+  }>({ key: pricingHistoryKey, overrides: {}, settled: false });
+  const spendKeyMatches = spendExpansion.key === pricingHistoryKey;
+  // A bucket's key carries its model, so a helper whose model arrives late is
+  // re-keyed and leaves its override behind. Reading through the live buckets
+  // keeps a dead override from opening some later unrelated row.
+  const spendOverrides = spendKeyMatches
+    ? prunePricingSpendOverrides(spendExpansion.overrides, spendByModel)
+    : {};
+  if (!spendKeyMatches || (!spendExpansion.settled && spendModelCount > 0)) {
+    setSpendExpansion({
+      key: pricingHistoryKey,
+      ...(soleSpendKey === undefined ? {} : { openKey: soleSpendKey }),
+      overrides: spendKeyMatches ? spendOverrides : {},
+      settled: spendModelCount > 0,
     });
+  }
+  const isSpendRowExpanded = (key: string): boolean =>
+    spendOverrides[key] ?? key === spendExpansion.openKey;
+  const toggleSpendRow = (key: string): void => {
+    setSpendExpansion((current) => ({
+      ...current,
+      key: pricingHistoryKey,
+      overrides: {
+        ...spendOverrides,
+        [key]: !isSpendRowExpanded(key),
+      },
+    }));
   };
   // Thread-level gate result, from every gate this thread spawned. The
   // per-turn folds below price one turn each; this is the same arithmetic run
@@ -429,18 +447,28 @@ export function PricingPanel(props: PricingPanelProps) {
                   Spend by model
                 </span>
                 <div className="pricing-spend-list">
-                  {spendByModel.map((group) => (
+                  {spendByModel.map((group) => {
+                    // A provider earns a subtotal only when it holds more than
+                    // one model AND it is not the whole bill — a lone provider's
+                    // subtotal is the headline three lines above, which is the
+                    // duplication this section was built to remove. Wherever no
+                    // heading names the provider, the rows carry it instead, so
+                    // it is never dropped entirely.
+                    const showGroupHead =
+                      group.models.length > 1 && spendByModel.length > 1;
+                    return (
                     <div className="pricing-spend-group" key={group.key}>
-                      {/* A provider gets a heading only where it contributed
-                          more than one model, because that is the one case
-                          where its subtotal is not already a row. */}
-                      {group.models.length > 1 ? (
+                      {showGroupHead ? (
                         <div className="pricing-spend-group__head">
                           <span>
                             {formatPricingProviderLabel(group.provider)}
                           </span>
                           <span className="pricing-spend-group__total">
-                            {formatMoney(group.totalCostMicros, group.currency)}
+                            {formatSpendMoney({
+                              currency: group.currency,
+                              displayOptions,
+                              totalCostMicros: group.totalCostMicros,
+                            })}
                             {" · "}
                             {formatUsageRowCount(group.usageLineCount)}
                           </span>
@@ -448,15 +476,17 @@ export function PricingPanel(props: PricingPanelProps) {
                       ) : null}
                       {group.models.map((modelSpend) => (
                         <PricingModelSpendRow
+                          displayOptions={displayOptions}
                           expanded={isSpendRowExpanded(modelSpend.key)}
                           key={modelSpend.key}
                           onToggle={() => toggleSpendRow(modelSpend.key)}
-                          showProvider={group.models.length === 1}
+                          showProvider={!showGroupHead}
                           spend={modelSpend}
                         />
                       ))}
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             ) : null}
@@ -472,7 +502,7 @@ export function PricingPanel(props: PricingPanelProps) {
         <p className="context-empty">No usage pricing recorded yet.</p>
       ) : null}
 
-      {/* Under the provider summary, above the turn rows: the gate's result is
+      {/* Under the spend breakdown, above the turn rows: the gate's result is
           part of reading the bill, not a footnote to one turn of it. */}
       {tokenMiserSummary ? (
         <TokenMiserSummaryCard
@@ -530,6 +560,7 @@ export function PricingPanel(props: PricingPanelProps) {
  * replaced the provider split carries both.
  */
 function PricingModelSpendRow(props: {
+  displayOptions: PricingDisplayOptions;
   expanded: boolean;
   onToggle: () => void;
   /** True when no provider heading sits above this row to name it. */
@@ -537,15 +568,39 @@ function PricingModelSpendRow(props: {
   spend: PricingModelSpend;
 }) {
   const summary = props.spend.summary;
+  // A bucket that is entirely unpriced is not a bucket that cost nothing, and
+  // "$0.000" is what it would otherwise read as. The per-turn cards below make
+  // the same distinction; this row was the one place that dropped it.
+  const whollyUnpriced =
+    summary.pricedUsageLineCount === 0 && summary.unpricedUsageLineCount > 0;
   const meta = [
     props.showProvider
       ? formatPricingProviderLabel(props.spend.provider)
       : undefined,
     formatUsageRowCount(summary.usageLineCount),
+    !whollyUnpriced && summary.unpricedUsageLineCount > 0
+      ? `${summary.unpricedUsageLineCount.toLocaleString()} unpriced`
+      : undefined,
   ]
     .filter((part): part is string => part !== undefined)
     .join(" · ");
+  const cost = whollyUnpriced
+    ? "Unpriced"
+    : formatSpendMoney({
+        currency: summary.currency,
+        displayOptions: props.displayOptions,
+        hasEstimates: props.spend.hasEstimatedRows,
+        totalCostMicros: summary.totalCostMicros,
+      });
   const origin = formatModelSpendOrigin(props.spend);
+  // When helpers share this model, the token volume the operator wants is the
+  // thread's own — that is the figure the turn card and Codex's context meter
+  // agree with. The helpers' share is accounted for on its own line rather
+  // than folded in silently.
+  const volume = props.spend.threadSummary ?? summary;
+  const helperTokens = props.spend.threadSummary
+    ? summary.totalTokens - props.spend.threadSummary.totalTokens
+    : 0;
 
   return (
     <div
@@ -563,29 +618,35 @@ function PricingModelSpendRow(props: {
           {props.spend.model ?? "Unknown model"}
         </span>
         <span className="pricing-spend-row__meta">{meta}</span>
-        <span className="pricing-spend-row__cost">
-          {formatMoney(summary.totalCostMicros, summary.currency)}
-        </span>
+        {cost ? (
+          <span className="pricing-spend-row__cost">{cost}</span>
+        ) : null}
       </button>
       {props.expanded ? (
         <div className="pricing-spend-row__body">
           {origin ? <p className="pricing-spend-row__origin">{origin}</p> : null}
           <RailSummaryRow
             label="Uncached input"
-            value={formatCompactCount(summary.uncachedInputTokens)}
+            value={formatCompactCount(volume.uncachedInputTokens)}
           />
           <RailSummaryRow
             label="Cached input"
-            value={formatCompactCount(summary.cachedInputTokens)}
+            value={formatCompactCount(volume.cachedInputTokens)}
           />
           <RailSummaryRow
             label="Output"
-            value={formatCompactCount(summary.outputTokens)}
+            value={formatCompactCount(volume.outputTokens)}
           />
-          {summary.reasoningOutputTokens > 0 ? (
+          {volume.reasoningOutputTokens > 0 ? (
             <RailSummaryRow
               label="Reasoning"
-              value={formatCompactCount(summary.reasoningOutputTokens)}
+              value={formatCompactCount(volume.reasoningOutputTokens)}
+            />
+          ) : null}
+          {props.spend.threadSummary ? (
+            <RailSummaryRow
+              label="Helper tokens"
+              value={formatCompactCount(helperTokens)}
             />
           ) : null}
         </div>
@@ -595,23 +656,47 @@ function PricingModelSpendRow(props: {
 }
 
 /**
+ * A spend figure in the units the operator asked for. Nothing at all when they
+ * turned dollars off — the headline already says why, and a row that kept
+ * printing them would contradict it inside one card.
+ */
+function formatSpendMoney(params: {
+  currency: string;
+  displayOptions: PricingDisplayOptions;
+  hasEstimates?: boolean;
+  totalCostMicros: number;
+}): string | undefined {
+  if (!params.displayOptions.usd) {
+    return undefined;
+  }
+  const money = formatMoney(params.totalCostMicros, params.currency);
+  return params.hasEstimates ? `${money} estimated` : money;
+}
+
+/**
  * Says where a model's rows came from, when saying it adds something. A thread
  * whose own model is also a reviewer's reads "This thread's model · 2
  * sub-agents"; a bucket that is only turn rows says so once and stops.
+ *
+ * Token Miser gates and the thread namer are counted apart from sub-agents.
+ * They bill real money, but the operator dispatched none of them, and folding
+ * them into the sub-agent count reported reviewers that never ran.
  */
 function formatModelSpendOrigin(spend: PricingModelSpend): string | undefined {
-  const subAgents =
+  const parts = [
+    spend.threadUsageLineCount > 0 ? "This thread's model" : undefined,
     spend.subAgentCount > 0
       ? `${spend.subAgentCount.toLocaleString()} sub-agent${
           spend.subAgentCount === 1 ? "" : "s"
         }`
-      : undefined;
-  if (spend.threadUsageLineCount > 0) {
-    return subAgents
-      ? `This thread's model · ${subAgents}`
-      : "This thread's model";
-  }
-  return subAgents;
+      : undefined,
+    spend.systemHelperCount > 0
+      ? `${spend.systemHelperCount.toLocaleString()} system helper${
+          spend.systemHelperCount === 1 ? "" : "s"
+        }`
+      : undefined,
+  ].filter((part): part is string => part !== undefined);
+  return parts.length > 0 ? parts.join(" · ") : undefined;
 }
 
 function formatUsageRowCount(count: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/pricing-spend-by-model.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/pricing-spend-by-model.ts
@@ -4,6 +4,14 @@ import type {
 } from "@pwragent/shared";
 
 /**
+ * A usage row as the Pricing rail sees it: the stored record, plus the flag the
+ * shared projection stamps on the rows it invents to cover a history gap.
+ */
+export type PricingSpendUsageLine = ThreadUsageLineRecord & {
+  estimatedUsageGap?: true;
+};
+
+/**
  * A thread's bill, split by the model that produced it.
  *
  * The Pricing rail's stored summaries carry a provider and no model, which was
@@ -14,7 +22,16 @@ import type {
  * recorded, and they sum to the same figures the per-turn cards below do.
  */
 export type PricingModelSpend = {
-  /** Stable across renders: React key, and the key expansion state is held under. */
+  /**
+   * True when any row here was invented by the history-gap projection rather
+   * than observed, so the row can mark its dollars the way the headline does.
+   */
+  hasEstimatedRows: boolean;
+  /**
+   * The React key, and the key expansion state is held under. It carries the
+   * resolved model, so a bucket whose model arrives late is a different bucket
+   * — see `prunePricingSpendOverrides` for what that costs and who pays it.
+   */
   key: string;
   /**
    * Undefined when nothing named the model — a row written before models were
@@ -22,10 +39,24 @@ export type PricingModelSpend = {
    */
   model?: string;
   provider: string;
-  /** Distinct sub-agents that billed to this model. */
+  /** Distinct sub-agents the operator dispatched that billed to this model. */
   subAgentCount: number;
   summary: ThreadPricingSummary;
-  /** Rows from the thread's own turns rather than from a sub-agent. */
+  /**
+   * Distinct PwrAgent-internal helpers — Token Miser gates and the thread
+   * namer — that billed to this model. They spend real money, so they are in
+   * `summary`, but the operator dispatched none of them and counting them as
+   * sub-agents reported reviewers that were never run.
+   */
+  systemHelperCount: number;
+  /**
+   * The thread's own turn rows alone, present only when helper rows share this
+   * bucket. A sub-agent inheriting the parent's model is the common case, and
+   * a merged token volume is the figure that disagrees with the turn card and
+   * with Codex's context-window meter.
+   */
+  threadSummary?: ThreadPricingSummary;
+  /** Rows from the thread's own turns rather than from a helper. */
   threadUsageLineCount: number;
 };
 
@@ -50,8 +81,17 @@ export type PricingSpendModelResolver = (
   line: ThreadUsageLineRecord,
 ) => string | undefined;
 
+/**
+ * Monitor ids in this namespace belong to helpers PwrAgent runs for itself —
+ * `system:token-miser:` gates and `system:title-helper:` — never to something
+ * the operator asked for. `subagent-kind.ts` makes the same split on the
+ * sub-agent summaries; this is the same rule applied to the usage rows, which
+ * arrive before their summaries do.
+ */
+const SYSTEM_HELPER_SOURCE_PREFIX = "system:";
+
 export function buildPricingSpendByModel(params: {
-  lines: readonly ThreadUsageLineRecord[];
+  lines: readonly PricingSpendUsageLine[];
   resolveModel?: PricingSpendModelResolver;
 }): PricingProviderSpend[] {
   const groups = new Map<string, MutableProviderSpend>();
@@ -72,23 +112,33 @@ export function buildPricingSpendByModel(params: {
     let bucket = group.models.get(modelKey);
     if (!bucket) {
       bucket = {
+        hasEstimatedRows: false,
         key: modelKey,
         ...(model === undefined ? {} : { model }),
         provider: line.provider,
         subAgentIds: new Set<string>(),
         summary: emptyPricingSummary(line),
+        systemHelperIds: new Set<string>(),
+        threadSummary: emptyPricingSummary(line),
         threadUsageLineCount: 0,
       };
       group.models.set(modelKey, bucket);
     }
     bucket.summary = addUsageLineToSummary(bucket.summary, line);
+    if (line.estimatedUsageGap) {
+      bucket.hasEstimatedRows = true;
+    }
     if (line.scope === "monitor") {
-      // Several rows can belong to one sub-agent; the count is of agents, not
-      // of rows, because that is the number the operator dispatched.
+      // Several rows can belong to one helper; the count is of helpers, not of
+      // rows, because that is the number the operator dispatched.
       if (line.sourceItemId) {
-        bucket.subAgentIds.add(line.sourceItemId);
+        const ids = line.sourceItemId.startsWith(SYSTEM_HELPER_SOURCE_PREFIX)
+          ? bucket.systemHelperIds
+          : bucket.subAgentIds;
+        ids.add(line.sourceItemId);
       }
     } else {
+      bucket.threadSummary = addUsageLineToSummary(bucket.threadSummary, line);
       bucket.threadUsageLineCount += 1;
     }
   }
@@ -96,14 +146,25 @@ export function buildPricingSpendByModel(params: {
   return [...groups.values()]
     .map((group) => {
       const models = [...group.models.values()]
-        .map((bucket) => ({
-          key: bucket.key,
-          ...(bucket.model === undefined ? {} : { model: bucket.model }),
-          provider: bucket.provider,
-          subAgentCount: bucket.subAgentIds.size,
-          summary: bucket.summary,
-          threadUsageLineCount: bucket.threadUsageLineCount,
-        } satisfies PricingModelSpend))
+        .map((bucket) => {
+          const helperCount = bucket.subAgentIds.size + bucket.systemHelperIds.size;
+          return {
+            hasEstimatedRows: bucket.hasEstimatedRows,
+            key: bucket.key,
+            ...(bucket.model === undefined ? {} : { model: bucket.model }),
+            provider: bucket.provider,
+            subAgentCount: bucket.subAgentIds.size,
+            summary: bucket.summary,
+            systemHelperCount: bucket.systemHelperIds.size,
+            // Only worth carrying when something else shares the bucket;
+            // otherwise it is the bucket, and a second identical figure on the
+            // row would read as a second measurement.
+            ...(helperCount > 0 && bucket.threadUsageLineCount > 0
+              ? { threadSummary: bucket.threadSummary }
+              : {}),
+            threadUsageLineCount: bucket.threadUsageLineCount,
+          } satisfies PricingModelSpend;
+        })
         .sort(compareModelSpend);
       return {
         currency: group.currency,
@@ -121,6 +182,35 @@ export function buildPricingSpendByModel(params: {
       } satisfies PricingProviderSpend;
     })
     .sort(compareProviderSpend);
+}
+
+/**
+ * Drops expansion overrides whose bucket no longer exists.
+ *
+ * A bucket's key carries its model, and a helper's model can arrive after its
+ * usage row does — the row lands synchronously with pricing while the
+ * sub-agent summary arrives on a scheduled refresh. The bucket the operator
+ * expanded as "Unknown model" is then re-keyed, and without this its override
+ * would sit in the map forever and open the next genuinely unknown bucket that
+ * the operator never touched.
+ */
+export function prunePricingSpendOverrides(
+  overrides: Readonly<Record<string, boolean>>,
+  groups: readonly PricingProviderSpend[],
+): Readonly<Record<string, boolean>> {
+  const live = new Set<string>();
+  for (const group of groups) {
+    for (const model of group.models) {
+      live.add(model.key);
+    }
+  }
+  const pruned: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    if (live.has(key)) {
+      pruned[key] = value;
+    }
+  }
+  return pruned;
 }
 
 /**
@@ -177,11 +267,14 @@ export function emptyPricingSummary(
 }
 
 type MutableModelSpend = {
+  hasEstimatedRows: boolean;
   key: string;
   model?: string;
   provider: string;
   subAgentIds: Set<string>;
   summary: ThreadPricingSummary;
+  systemHelperIds: Set<string>;
+  threadSummary: ThreadPricingSummary;
   threadUsageLineCount: number;
 };
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/pricing-spend-by-model.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/pricing-spend-by-model.ts
@@ -1,0 +1,223 @@
+import type {
+  ThreadPricingSummary,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+
+/**
+ * A thread's bill, split by the model that produced it.
+ *
+ * The Pricing rail's stored summaries carry a provider and no model, which was
+ * enough while a thread meant one model. A turn that dispatches four reviewers
+ * to four different models bills them all to two or three providers, and a
+ * per-provider split answers none of the questions an operator has about it.
+ * These buckets are folded out of the usage lines instead, where the model is
+ * recorded, and they sum to the same figures the per-turn cards below do.
+ */
+export type PricingModelSpend = {
+  /** Stable across renders: React key, and the key expansion state is held under. */
+  key: string;
+  /**
+   * Undefined when nothing named the model — a row written before models were
+   * recorded, or a helper whose sub-agent summary never carried one.
+   */
+  model?: string;
+  provider: string;
+  /** Distinct sub-agents that billed to this model. */
+  subAgentCount: number;
+  summary: ThreadPricingSummary;
+  /** Rows from the thread's own turns rather than from a sub-agent. */
+  threadUsageLineCount: number;
+};
+
+export type PricingProviderSpend = {
+  currency: string;
+  key: string;
+  models: PricingModelSpend[];
+  provider: string;
+  totalCostMicros: number;
+  usageLineCount: number;
+};
+
+/**
+ * Names the model a usage line should be bucketed under.
+ *
+ * A helper's usage row often carries no model of its own — the sub-agent
+ * summary holds it. The rail's row cards already walk that fallback chain, and
+ * passing the same resolver here keeps a row and its bucket agreeing on which
+ * model spent the money.
+ */
+export type PricingSpendModelResolver = (
+  line: ThreadUsageLineRecord,
+) => string | undefined;
+
+export function buildPricingSpendByModel(params: {
+  lines: readonly ThreadUsageLineRecord[];
+  resolveModel?: PricingSpendModelResolver;
+}): PricingProviderSpend[] {
+  const groups = new Map<string, MutableProviderSpend>();
+  for (const line of params.lines) {
+    const model = params.resolveModel?.(line) ?? line.model;
+    const groupKey = `${line.provider}:${line.currency}`;
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = {
+        currency: line.currency,
+        key: groupKey,
+        models: new Map(),
+        provider: line.provider,
+      };
+      groups.set(groupKey, group);
+    }
+    const modelKey = `${groupKey}:${model ?? ""}`;
+    let bucket = group.models.get(modelKey);
+    if (!bucket) {
+      bucket = {
+        key: modelKey,
+        ...(model === undefined ? {} : { model }),
+        provider: line.provider,
+        subAgentIds: new Set<string>(),
+        summary: emptyPricingSummary(line),
+        threadUsageLineCount: 0,
+      };
+      group.models.set(modelKey, bucket);
+    }
+    bucket.summary = addUsageLineToSummary(bucket.summary, line);
+    if (line.scope === "monitor") {
+      // Several rows can belong to one sub-agent; the count is of agents, not
+      // of rows, because that is the number the operator dispatched.
+      if (line.sourceItemId) {
+        bucket.subAgentIds.add(line.sourceItemId);
+      }
+    } else {
+      bucket.threadUsageLineCount += 1;
+    }
+  }
+
+  return [...groups.values()]
+    .map((group) => {
+      const models = [...group.models.values()]
+        .map((bucket) => ({
+          key: bucket.key,
+          ...(bucket.model === undefined ? {} : { model: bucket.model }),
+          provider: bucket.provider,
+          subAgentCount: bucket.subAgentIds.size,
+          summary: bucket.summary,
+          threadUsageLineCount: bucket.threadUsageLineCount,
+        } satisfies PricingModelSpend))
+        .sort(compareModelSpend);
+      return {
+        currency: group.currency,
+        key: group.key,
+        models,
+        provider: group.provider,
+        totalCostMicros: models.reduce(
+          (total, bucket) => total + bucket.summary.totalCostMicros,
+          0,
+        ),
+        usageLineCount: models.reduce(
+          (total, bucket) => total + bucket.summary.usageLineCount,
+          0,
+        ),
+      } satisfies PricingProviderSpend;
+    })
+    .sort(compareProviderSpend);
+}
+
+/**
+ * Folds one usage line into a running summary. Shared with the rail's own
+ * totals so a bucket and the headline above it are built by the same
+ * arithmetic.
+ */
+export function addUsageLineToSummary(
+  summary: ThreadPricingSummary,
+  line: ThreadUsageLineRecord,
+): ThreadPricingSummary {
+  return {
+    backend: summary.backend,
+    cachedInputTokens: summary.cachedInputTokens + line.cachedInputTokens,
+    currency: summary.currency,
+    inputTokens: summary.inputTokens + line.inputTokens,
+    outputTokens: summary.outputTokens + line.outputTokens,
+    pricedUsageLineCount:
+      summary.pricedUsageLineCount + (line.priceStatus === "priced" ? 1 : 0),
+    provider: summary.provider,
+    reasoningOutputTokens:
+      summary.reasoningOutputTokens + line.reasoningOutputTokens,
+    threadId: summary.threadId,
+    totalCostMicros: summary.totalCostMicros + line.totalCostMicros,
+    totalTokens: summary.totalTokens + line.totalTokens,
+    uncachedInputTokens: summary.uncachedInputTokens + line.uncachedInputTokens,
+    unpricedUsageLineCount:
+      summary.unpricedUsageLineCount + (line.priceStatus === "priced" ? 0 : 1),
+    updatedAt: Math.max(summary.updatedAt, line.completedAt ?? line.createdAt),
+    usageLineCount: summary.usageLineCount + 1,
+  };
+}
+
+export function emptyPricingSummary(
+  line: ThreadUsageLineRecord,
+): ThreadPricingSummary {
+  return {
+    backend: line.backend,
+    cachedInputTokens: 0,
+    currency: line.currency,
+    inputTokens: 0,
+    outputTokens: 0,
+    pricedUsageLineCount: 0,
+    provider: line.provider,
+    reasoningOutputTokens: 0,
+    threadId: line.parentThreadId ?? line.threadId,
+    totalCostMicros: 0,
+    totalTokens: 0,
+    uncachedInputTokens: 0,
+    unpricedUsageLineCount: 0,
+    updatedAt: 0,
+    usageLineCount: 0,
+  };
+}
+
+type MutableModelSpend = {
+  key: string;
+  model?: string;
+  provider: string;
+  subAgentIds: Set<string>;
+  summary: ThreadPricingSummary;
+  threadUsageLineCount: number;
+};
+
+type MutableProviderSpend = {
+  currency: string;
+  key: string;
+  models: Map<string, MutableModelSpend>;
+  provider: string;
+};
+
+function compareProviderSpend(
+  left: PricingProviderSpend,
+  right: PricingProviderSpend,
+): number {
+  if (left.totalCostMicros !== right.totalCostMicros) {
+    return right.totalCostMicros - left.totalCostMicros;
+  }
+  const providerCompare = left.provider.localeCompare(right.provider);
+  return providerCompare !== 0
+    ? providerCompare
+    : left.currency.localeCompare(right.currency);
+}
+
+function compareModelSpend(
+  left: PricingModelSpend,
+  right: PricingModelSpend,
+): number {
+  const leftCost = left.summary.totalCostMicros;
+  const rightCost = right.summary.totalCostMicros;
+  if (leftCost !== rightCost) {
+    return rightCost - leftCost;
+  }
+  // A bucket nothing named is leftovers, so it settles after every model that
+  // has a name rather than sorting into the middle of them on a tied cost.
+  if ((left.model === undefined) !== (right.model === undefined)) {
+    return left.model === undefined ? 1 : -1;
+  }
+  return (left.model ?? "").localeCompare(right.model ?? "");
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24038,6 +24038,129 @@ a.transcript-message__messaging-origin:focus-visible {
 
 /* Token Miser folded under its turn: one summary line that keeps moving as
    replays are counted, a chevron, and cards only for gates worth a card. */
+/* The bill split by the model that spent it. These rows live inside the
+   pricing summary card, so they carry no border box of their own — the
+   hairline between them is the whole frame, and the card supplies the rest. */
+.pricing-spend-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.pricing-spend-group + .pricing-spend-group {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.pricing-spend-group__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0 2px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pricing-spend-group:first-child .pricing-spend-group__head {
+  padding-top: 2px;
+}
+
+.pricing-spend-group__total {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.pricing-spend-row + .pricing-spend-row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.pricing-spend-row__summary {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  width: 100%;
+  padding: 5px 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+/* The row runs edge to edge inside the card's padding, so a hovered
+   background would bleed into it. The label carries the hover instead. */
+.pricing-spend-row__summary:hover .pricing-spend-row__label {
+  color: var(--accent-bright);
+}
+
+.pricing-spend-row__summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.pricing-spend-row__chevron {
+  display: inline-block;
+  width: 8px;
+  color: var(--text-muted);
+  transition: transform 120ms ease;
+}
+
+.pricing-spend-row[data-expanded="true"] .pricing-spend-row__chevron {
+  transform: rotate(90deg);
+}
+
+.pricing-spend-row__label {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.pricing-spend-row__meta {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.pricing-spend-row__cost {
+  margin-left: auto;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.pricing-spend-row__body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 0 8px 15px;
+  padding-left: 9px;
+  border-left: 1px solid var(--border-subtle);
+}
+
+.pricing-spend-row__body .rail-summary-card__row-label,
+.pricing-spend-row__body .rail-summary-card__row-value {
+  font-size: 11.5px;
+}
+
+.pricing-spend-row__origin {
+  margin: 0 0 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 .pricing-token-miser {
   margin: 6px 0 0;
   border: 1px solid var(--border-subtle);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24036,8 +24036,6 @@ a.transcript-message__messaging-origin:focus-visible {
   line-height: 1.35;
 }
 
-/* Token Miser folded under its turn: one summary line that keeps moving as
-   replays are counted, a chevron, and cards only for gates worth a card. */
 /* The bill split by the model that spent it. These rows live inside the
    pricing summary card, so they carry no border box of their own — the
    hairline between them is the whole frame, and the card supplies the rest. */
@@ -24117,9 +24115,13 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 .pricing-spend-row__label {
+  min-width: 0;
+  overflow: hidden;
   color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .pricing-spend-row__meta {
@@ -24161,6 +24163,8 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 11px;
 }
 
+/* Token Miser folded under its turn: one summary line that keeps moving as
+   replays are counted, a chevron, and cards only for gates worth a card. */
 .pricing-token-miser {
   margin: 6px 0 0;
   border: 1px solid var(--border-subtle);


### PR DESCRIPTION
Stacked on #1899 (base is `claude/pricing-token-miser-summary`, not `main`).

## The bug

The Pricing rail printed the same three facts twice. `displaySummaries.length > 1` gated a **By provider** section inside the summary card *and* a list of `.rail-card` rows immediately under it — both saying provider, cost, row count and nothing else. The lower list was strictly worse at it: it printed the raw provider id (`xai`) where the section above formatted it (`xAI`), and padded the same number with the words "list price".

Provider was also the wrong axis. A turn that dispatches reviews to Sol, Terra, Kimi and Qwen while Grok drives the thread bills three providers, and the two OpenAI reviews melt into one row that cannot be taken apart — which is the one row an operator comparing reviewers actually wants.

The card was quietly incomplete too: **Parent model token volume** was filtered to `isMainThreadUsageLine`, so a review that spent a dollar and 1.3M tokens appeared in the rail as a dollar and nothing else.

## The change

Both blocks are replaced by one **Spend by model** section:

- one row per `(provider, model, currency)`, ranked by cost, **collapsed by default**;
- opening a row shows that model's token volume — uncached input, cached input, output, reasoning;
- a provider gets a heading only where it contributed **more than one model**, because that is the one case where its subtotal is not already a row of its own;
- a thread with one model loses nothing: its lone row **starts open** on exactly what "Parent model token volume" used to show, plus the model and provider that section never named out loud. It stays collapsible.

## Implementation

`ThreadPricingSummary` carries a provider and no model, so the buckets are folded out of the usage lines in a new `pricing-spend-by-model` module, reusing `addUsageLineToSummary` — the reducer the rail's own totals already run through — which moved there alongside it.

A helper's usage row often records no model of its own; the sub-agent summary holds it. The fold takes a `resolveModel` callback so it walks the same fallback chain the usage cards do (`line.model` → `preferredModel` → `monitorUsage.model` → `monitorUsage.cost.model`), which is what keeps a row and its bucket from disagreeing about who spent the money. That chain was inlined in the row renderer and is now `resolveUsageLineModel`, used by both. Whatever is still unnamed collects into one row rather than vanishing from a total that has to add up.

## Design

UX review and mockups: [Pricing — spend by provider and model](https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Pricing+Provider+Spend.html) — today's duplication annotated, the two options considered, the five-model turn (grouped vs flat), and the single-model regression case.

## Verification

- `pnpm typecheck`, `lint:eslint` (0 errors), `lint:colors`, `lint:boundaries` — all clean.
- `pnpm test --project desktop-renderer` — 223 files / 3537 tests pass.
- New `pricing-spend-by-model.test.ts` (7 cases): the reviewer split, the sub-agent model fallback, sub-agents counted rather than their rows, unnamed rows kept in a bucket of their own, currencies split rather than added, unpriced rows counted.
- `ThreadContextPanel.test.tsx`: the four tests that asserted the old shape now assert the new one, plus a regression test for the four-provider / five-model turn — row order, the single OpenAI subtotal, and that the raw `openai · USD` card is gone.
- Contrast and geometry measured against the real `app.css` in headless Chromium, both themes: lowest ratio 4.82:1 (`--text-muted`), no overflow at 380px with a long model name, costs flush to the card's inner edge.

## Not changed

`formatPricingProviderLabel` still maps only `openai`, `qwen`, and `xai`; anything else falls through unformatted. No other provider id exists in the pricing catalogs today, so adding labels would be guessing at ids that do not ship — flagged in the mockups rather than fixed blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)