### PR TITLE
fix(desktop): scope overlay turn usage to the page that carries its turn

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -408,15 +408,18 @@ async function expectEventually<T>(
  */
 function usageActivity(params: {
   createdAt: number;
-  turnId: string;
+  turnId?: string;
+  id?: string;
 }): AppServerThreadActivityEntry {
   return {
     type: "activity",
-    id: `live-turn-usage-${params.turnId}`,
+    id: params.id ?? `live-turn-usage-${params.turnId}`,
     summary: "Turn usage: 1,000 uncached in · 2,000 cached · 300 out",
     status: "completed",
     createdAt: params.createdAt,
-    turn: { id: params.turnId, status: "completed" },
+    ...(params.turnId
+      ? { turn: { id: params.turnId, status: "completed" as const } }
+      : {}),
     details: [],
   };
 }
@@ -13332,6 +13335,77 @@ script = "echo setup"
 
     expect(response.replay.entries.map((entry) => entry.id)).toEqual([
       "assistant-turn-9",
+      "live-turn-usage-turn-9",
+    ]);
+
+    await registry.close();
+  });
+
+  it("places overlay turn usage the page's turn ids cannot account for", async () => {
+    // Omitting a row is sound only where the page's own turn ids prove the row
+    // belongs to another page. A row with no turn id has no page that will
+    // ever claim it, and a page with no turn metadata — the shape
+    // findTurnPageStartIndex documents as still live — cannot claim anything.
+    // Dropping either hides the row on every page: the operator watches usage
+    // lines arrive during the turn and finds an empty transcript on restart.
+    const codexClient = new MockBackendClient({
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "assistant-early",
+            role: "assistant",
+            phase: "final",
+            text: "Earlier answer.",
+            createdAt: 10_000,
+          },
+          {
+            type: "message",
+            id: "assistant-late",
+            role: "assistant",
+            phase: "final",
+            text: "Later answer.",
+            createdAt: 90_000,
+          },
+        ],
+        messages: [],
+        pagination: { supportsPagination: true, hasPreviousPage: false },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            immutableUsageActivities: [
+              usageActivity({ createdAt: 90_001, turnId: "turn-9" }),
+              usageActivity({ createdAt: 50_000, turnId: "turn-5" }),
+              usageActivity({
+                createdAt: 20_000,
+                id: "live-turn-usage-thread-1",
+              }),
+            ],
+          },
+        },
+      }),
+    });
+
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    // createdAt order, exactly where insertTranscriptEntry put them: the
+    // 20_000 and 50_000 rows before the 90_000 message, the 90_001 row after.
+    expect(response.replay.entries.map((entry) => entry.id)).toEqual([
+      "assistant-early",
+      "live-turn-usage-thread-1",
+      "live-turn-usage-turn-5",
+      "assistant-late",
       "live-turn-usage-turn-9",
     ]);
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -34,6 +34,8 @@ import type {
   AppServerPendingRequestNotification,
   AppServerSkillSummary,
   AppServerThreadReplay,
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
   AppServerThreadMessageOrigin,
   AppServerThreadSummary,
   AppServerReviewTarget,
@@ -398,6 +400,25 @@ async function expectEventually<T>(
     throw lastError;
   }
   expect(lastValue).toBe(expected);
+}
+
+/**
+ * One finalized overlay turn-usage row. The overlay keeps these outside the
+ * provider rollout, so a read has to place them against the page it returns.
+ */
+function usageActivity(params: {
+  createdAt: number;
+  turnId: string;
+}): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: `live-turn-usage-${params.turnId}`,
+    summary: "Turn usage: 1,000 uncached in · 2,000 cached · 300 out",
+    status: "completed",
+    createdAt: params.createdAt,
+    turn: { id: params.turnId, status: "completed" },
+    details: [],
+  };
 }
 
 function createOverlayStoreMock(params?: {
@@ -13258,6 +13279,213 @@ script = "echo setup"
       summary:
         "Turn usage: 23,000 uncached in · 20,000 cached · 900 out (450 reasoning) · $0.12 list price",
     });
+
+    await registry.close();
+  });
+
+  it("omits overlay turn usage whose turn is not on the page being read", async () => {
+    // The overlay retains up to MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES finalized
+    // rows spanning the whole thread. Merging all of them into the newest page
+    // stacked weeks-old usage under recent messages, and shipped rows the
+    // reader had no turn for. Placement is turn-anchored, so a page carries
+    // usage only for the turns it actually holds.
+    const codexClient = new MockBackendClient({
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "assistant-turn-9",
+            role: "assistant",
+            phase: "final",
+            text: "Recent answer.",
+            createdAt: 90_000,
+            turn: { id: "turn-9", status: "completed" },
+          },
+        ],
+        messages: [],
+        pagination: { supportsPagination: true, hasPreviousPage: true },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            immutableUsageActivities: [
+              usageActivity({ createdAt: 10_000, turnId: "turn-1" }),
+              usageActivity({ createdAt: 20_000, turnId: "turn-2" }),
+              usageActivity({ createdAt: 90_001, turnId: "turn-9" }),
+            ],
+          },
+        },
+      }),
+    });
+
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(response.replay.entries.map((entry) => entry.id)).toEqual([
+      "assistant-turn-9",
+      "live-turn-usage-turn-9",
+    ]);
+
+    await registry.close();
+  });
+
+  it("anchors overlay turn usage inside an older pagination page", async () => {
+    // History pages used to receive no usage at all, which is why every row
+    // had to be merged into the newest page. A `before` read now carries the
+    // usage for its own turns, so scrolling back shows each row beside the
+    // turn it belongs to.
+    const codexClient = new MockBackendClient({
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "assistant-turn-1",
+            role: "assistant",
+            phase: "final",
+            text: "Older answer.",
+            createdAt: 10_000,
+            turn: { id: "turn-1", status: "completed" },
+          },
+          {
+            type: "activity",
+            id: "command-turn-1",
+            summary: "Ran shell command",
+            status: "completed",
+            createdAt: 10_001,
+            turn: { id: "turn-1", status: "completed" },
+            details: [],
+          },
+          {
+            type: "message",
+            id: "assistant-turn-2",
+            role: "assistant",
+            phase: "final",
+            text: "Next older answer.",
+            createdAt: 20_000,
+            turn: { id: "turn-2", status: "completed" },
+          },
+        ],
+        messages: [],
+        pagination: { supportsPagination: true, hasPreviousPage: true },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            immutableUsageActivities: [
+              usageActivity({ createdAt: 10_002, turnId: "turn-1" }),
+              usageActivity({ createdAt: 20_001, turnId: "turn-2" }),
+              usageActivity({ createdAt: 90_001, turnId: "turn-9" }),
+            ],
+          },
+        },
+      }),
+    });
+
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+      before: "assistant-turn-9",
+    });
+
+    // Each row sits after the last entry of its own turn, and turn-9 usage
+    // stays off a page that does not carry turn-9.
+    expect(response.replay.entries.map((entry) => entry.id)).toEqual([
+      "assistant-turn-1",
+      "command-turn-1",
+      "live-turn-usage-turn-1",
+      "assistant-turn-2",
+      "live-turn-usage-turn-2",
+    ]);
+
+    await registry.close();
+  });
+
+  it("weaves overlay turn usage in one pass over the page", async () => {
+    // The previous merge filtered and re-inserted the whole entry array once
+    // per overlay row: 100 rows against a 500-entry page cost ~217,000 element
+    // visits where ~1,000 suffice. Instrumented ids count how many times the
+    // page is traversed, so a regression to per-row rebuilding fails here
+    // rather than showing up as a slow thread months later.
+    const pageEntryCount = 200;
+    const overlayUsageCount = 100;
+    let entryIdReads = 0;
+    const entries = Array.from(
+      { length: pageEntryCount },
+      (_value, index): AppServerThreadEntry => {
+        const id = `assistant-${index}`;
+        return {
+          type: "message",
+          get id() {
+            entryIdReads += 1;
+            return id;
+          },
+          role: "assistant",
+          phase: "final",
+          text: `Answer ${index}`,
+          createdAt: 10_000 + index,
+          turn: { id: `turn-${index}`, status: "completed" },
+        } as AppServerThreadEntry;
+      },
+    );
+    const codexClient = new MockBackendClient({
+      replay: {
+        entries,
+        messages: [],
+        pagination: { supportsPagination: true, hasPreviousPage: true },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            // Half anchor to this page, half belong to turns it does not hold.
+            immutableUsageActivities: Array.from(
+              { length: overlayUsageCount },
+              (_value, index) =>
+                usageActivity({
+                  createdAt: 10_000 + index,
+                  turnId: index % 2 === 0 ? `turn-${index}` : `absent-${index}`,
+                }),
+            ),
+          },
+        },
+      }),
+    });
+
+    entryIdReads = 0;
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    // A per-row rebuild reads every id once per overlay row. Allow generous
+    // headroom for unrelated id reads elsewhere in readThread while still
+    // failing an O(page x usage) regression by two orders of magnitude.
+    expect(entryIdReads).toBeLessThan(pageEntryCount * 10);
+    expect(response.replay.entries).toHaveLength(
+      pageEntryCount + overlayUsageCount / 2,
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5928,11 +5928,17 @@ function attachReviewEntryReviewers(params: {
  * Scoping is what makes this correct, not just cheap. The overlay retains up
  * to MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES finalized rows spanning the whole
  * thread, so merging all of them into the newest page put weeks-old usage
- * under recent messages. Pages are cut on turn boundaries
- * (findTurnPageStartIndex, and each page's cursor is its own first entry), so
- * exactly one page owns any given turn. Where an older replay format forces
- * entry-count paging and splits a turn, prependTranscriptHistoryPage already
- * drops entry ids it has seen, so a row cannot render twice.
+ * under recent messages. Both backends page on turn boundaries — Codex asks
+ * the app server for whole turns (thread/turns/list cursors), ACP cuts on
+ * findTurnPageStartIndex whenever the page has turn ids — so exactly one page
+ * owns any given turn. Where an older replay format forces entry-count paging
+ * and splits a turn, prependTranscriptHistoryPage already drops entry ids it
+ * has seen, so a row cannot render twice.
+ *
+ * Omission is sound only where the page's turn ids can prove the row belongs
+ * elsewhere. A row with no turn id, and any row on a page that carries no turn
+ * metadata at all, keeps the createdAt-then-append placement this merge
+ * replaced: dropping those would hide them on every page rather than on one.
  *
  * One forward pass, O(page + usage). The previous per-activity filter and
  * insert rebuilt the whole page array for each of up to 100 rows: 217,000
@@ -5961,12 +5967,23 @@ function mergeTurnAnchoredUsageActivities(params: {
   const anchoredUsageByIndex = new Map<number, AppServerThreadActivityEntry[]>();
   const anchoredUsageIds = new Set<string>();
   const supersededTurnIds = new Set<string>();
+  const unanchoredUsage: AppServerThreadActivityEntry[] = [];
   for (const activity of usageActivities) {
     const turnId = activity.turn?.id;
     const anchorIndex = turnId === undefined
       ? undefined
       : lastEntryIndexByTurnId.get(turnId);
     if (anchorIndex === undefined) {
+      if (turnId !== undefined && lastEntryIndexByTurnId.size > 0) {
+        // The page names its turns and does not name this one, so another
+        // page owns the row.
+        continue;
+      }
+      // Nothing here can place the row by turn: it carries no turn id, or the
+      // page carries none. Absence proves nothing, and omitting it would hide
+      // the row on every page.
+      unanchoredUsage.push(activity);
+      anchoredUsageIds.add(activity.id);
       continue;
     }
     const anchored = anchoredUsageByIndex.get(anchorIndex);
@@ -5983,13 +6000,36 @@ function mergeTurnAnchoredUsageActivities(params: {
       supersededTurnIds.add(turnId);
     }
   }
-  if (anchoredUsageByIndex.size === 0) {
+  if (anchoredUsageByIndex.size === 0 && unanchoredUsage.length === 0) {
     return params.replay;
   }
+
+  // The unanchored rows keep insertTranscriptEntry's remaining tiers, resolved
+  // in this same forward pass: a row lands before the first entry newer than
+  // it, and a row with no createdAt has nothing to compare against and goes
+  // last. Sorting by createdAt preserves the sequential-insert order, since
+  // ties resolve after the row already placed.
+  const timedUnanchoredUsage = unanchoredUsage
+    .filter((activity) => typeof activity.createdAt === "number")
+    .sort((left, right) => (left.createdAt ?? 0) - (right.createdAt ?? 0));
+  const untimedUnanchoredUsage = unanchoredUsage.filter(
+    (activity) => typeof activity.createdAt !== "number",
+  );
+  let unanchoredIndex = 0;
 
   const entries: AppServerThreadEntry[] = [];
   for (let index = 0; index < params.replay.entries.length; index += 1) {
     const entry = params.replay.entries[index]!;
+    const entryCreatedAt = entry.createdAt;
+    if (typeof entryCreatedAt === "number") {
+      while (
+        unanchoredIndex < timedUnanchoredUsage.length
+        && entryCreatedAt > (timedUnanchoredUsage[unanchoredIndex]!.createdAt ?? 0)
+      ) {
+        entries.push(timedUnanchoredUsage[unanchoredIndex]!);
+        unanchoredIndex += 1;
+      }
+    }
     const entryTurnId = entry.turn?.id;
     const supersededByTurnTotal =
       entryTurnId !== undefined
@@ -6007,6 +6047,10 @@ function mergeTurnAnchoredUsageActivities(params: {
       entries.push(...anchored);
     }
   }
+  for (; unanchoredIndex < timedUnanchoredUsage.length; unanchoredIndex += 1) {
+    entries.push(timedUnanchoredUsage[unanchoredIndex]!);
+  }
+  entries.push(...untimedUnanchoredUsage);
 
   return {
     ...params.replay,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5917,40 +5917,95 @@ function attachReviewEntryReviewers(params: {
   return changed ? { ...params.replay, entries } : params.replay;
 }
 
-function mergeImmutableUsageActivities(params: {
+/**
+ * Weaves overlay-owned usage rows into one already-ordered transcript page.
+ *
+ * Placement is turn-anchored: a usage row is inserted after the last entry of
+ * its own turn *within this page*, and is omitted when that turn is not on
+ * this page at all. The transcript therefore drives which usage is sent, and
+ * a page never carries usage for turns the reader has not loaded.
+ *
+ * Scoping is what makes this correct, not just cheap. The overlay retains up
+ * to MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES finalized rows spanning the whole
+ * thread, so merging all of them into the newest page put weeks-old usage
+ * under recent messages. Pages are cut on turn boundaries
+ * (findTurnPageStartIndex, and each page's cursor is its own first entry), so
+ * exactly one page owns any given turn. Where an older replay format forces
+ * entry-count paging and splits a turn, prependTranscriptHistoryPage already
+ * drops entry ids it has seen, so a row cannot render twice.
+ *
+ * One forward pass, O(page + usage). The previous per-activity filter and
+ * insert rebuilt the whole page array for each of up to 100 rows: 217,000
+ * element visits for a 500-entry page where 1,000 suffice.
+ */
+function mergeTurnAnchoredUsageActivities(params: {
   replay: AppServerThreadReplay;
   activities?: AppServerThreadActivityEntry[];
 }): AppServerThreadReplay {
-  const immutableUsageActivities = params.activities?.filter(
-    (activity) => {
-      const scope = usageActivityScope(activity);
-      return scope === "turn" || scope === "monitor";
-    },
-  );
-  if (!immutableUsageActivities?.length) {
+  const usageActivities = params.activities?.filter((activity) => {
+    const scope = usageActivityScope(activity);
+    return scope === "turn" || scope === "monitor";
+  });
+  if (!usageActivities?.length) {
     return params.replay;
   }
 
-  let entries = params.replay.entries;
-  for (const activity of immutableUsageActivities) {
-    const activityScope = usageActivityScope(activity);
-    const activityTurnId = activity.turn?.id;
-    entries = entries.filter((entry) => {
-      if (entry.id === activity.id) {
-        return false;
-      }
-      if (
-        activityScope === "turn" &&
-        activityTurnId &&
-        isUsageActivityEntry(entry) &&
-        entry.turn?.id === activityTurnId
-      ) {
-        const entryScope = usageActivityScope(entry);
-        return entryScope !== "latest-request" && entryScope !== "total";
-      }
-      return true;
-    });
-    entries = insertTranscriptEntry(entries, activity);
+  const lastEntryIndexByTurnId = new Map<string, number>();
+  for (let index = 0; index < params.replay.entries.length; index += 1) {
+    const turnId = params.replay.entries[index]?.turn?.id;
+    if (turnId) {
+      lastEntryIndexByTurnId.set(turnId, index);
+    }
+  }
+
+  const anchoredUsageByIndex = new Map<number, AppServerThreadActivityEntry[]>();
+  const anchoredUsageIds = new Set<string>();
+  const supersededTurnIds = new Set<string>();
+  for (const activity of usageActivities) {
+    const turnId = activity.turn?.id;
+    const anchorIndex = turnId === undefined
+      ? undefined
+      : lastEntryIndexByTurnId.get(turnId);
+    if (anchorIndex === undefined) {
+      continue;
+    }
+    const anchored = anchoredUsageByIndex.get(anchorIndex);
+    if (anchored) {
+      anchored.push(activity);
+    } else {
+      anchoredUsageByIndex.set(anchorIndex, [activity]);
+    }
+    anchoredUsageIds.add(activity.id);
+    // A finalized turn total supersedes the provider's narrower per-request
+    // rows for the same turn. Monitor usage annotates a delegated child and
+    // supersedes nothing.
+    if (turnId && usageActivityScope(activity) === "turn") {
+      supersededTurnIds.add(turnId);
+    }
+  }
+  if (anchoredUsageByIndex.size === 0) {
+    return params.replay;
+  }
+
+  const entries: AppServerThreadEntry[] = [];
+  for (let index = 0; index < params.replay.entries.length; index += 1) {
+    const entry = params.replay.entries[index]!;
+    const entryTurnId = entry.turn?.id;
+    const supersededByTurnTotal =
+      entryTurnId !== undefined
+      && supersededTurnIds.has(entryTurnId)
+      && isUsageActivityEntry(entry)
+      && (
+        usageActivityScope(entry) === "latest-request"
+        || usageActivityScope(entry) === "total"
+      );
+    if (!anchoredUsageIds.has(entry.id) && !supersededByTurnTotal) {
+      entries.push(entry);
+    }
+    const anchored = anchoredUsageByIndex.get(index);
+    if (anchored) {
+      entries.push(...anchored);
+    }
   }
 
   return {
@@ -10235,8 +10290,7 @@ export class DesktopBackendRegistry {
     // A managed review runs in a hidden child session, so its transcript
     // entries and its usage line live in this thread's overlay rather than in
     // the provider's rollout. Splice them back in on the same terms as the
-    // Codex path: only for a live, turn-bearing read, never into an older
-    // pagination page.
+    // Codex path.
     //
     // Only monitor-scope usage is merged here. Turn-scope usage is persisted
     // for ACP threads too, but merging it would also apply the Codex
@@ -10244,14 +10298,23 @@ export class DesktopBackendRegistry {
     // transcript change for every ACP thread, well beyond managed review.
     // Replaying turn-scope usage for ACP is worth doing deliberately, with
     // its own tests; it is not this change.
-    const appendTranscriptOverlays =
-      !request.before && request.includeTurns !== false;
+    //
+    // Usage merges into an older pagination page too. It is turn-anchored, so
+    // a page only ever receives usage for turns it actually carries, and the
+    // reader sees each row beside its own turn as history loads.
+    //
+    // Managed review entries stay on the live page only. They originate a
+    // turn rather than annotate one, so their turn id need not appear in the
+    // provider rollout at all and they have no anchor to page against.
+    const appendTranscriptOverlays = request.includeTurns !== false;
     const replayWithTranscriptOverlays = appendTranscriptOverlays
-      ? mergeImmutableUsageActivities({
-          replay: mergeManagedReviewEntries({
-            replay,
-            entries: overlay?.managedReviewEntries,
-          }),
+      ? mergeTurnAnchoredUsageActivities({
+          replay: request.before
+            ? replay
+            : mergeManagedReviewEntries({
+                replay,
+                entries: overlay?.managedReviewEntries,
+              }),
           activities: overlay?.immutableUsageActivities?.filter(
             (activity) => usageActivityScope(activity) === "monitor",
           ),
@@ -12025,13 +12088,17 @@ export class DesktopBackendRegistry {
             replay: replayWithEnvironment,
             entries: overlay?.managedReviewEntries,
           });
-    const replayWithImmutableUsage =
-      request.before || !shouldAppendTranscriptOverlays
-        ? replayWithManagedReviews
-        : mergeImmutableUsageActivities({
-            replay: replayWithManagedReviews,
-            activities: overlay?.immutableUsageActivities,
-          });
+    // Usage merges into an older pagination page too. It is turn-anchored, so
+    // a page only ever receives usage for turns it actually carries, and the
+    // reader sees each row beside its own turn as history loads. Managed
+    // reviews above stay on the live page: they originate a turn rather than
+    // annotate one, so they have no anchor to page against.
+    const replayWithImmutableUsage = shouldAppendTranscriptOverlays
+      ? mergeTurnAnchoredUsageActivities({
+          replay: replayWithManagedReviews,
+          activities: overlay?.immutableUsageActivities,
+        })
+      : replayWithManagedReviews;
     const messageIds = [
       ...replayWithImmutableUsage.entries.flatMap((entry) =>
         entry.type === "message" && entry.role === "user"


### PR DESCRIPTION
## Summary

Supersedes #1904, which fixed the same symptom in the renderer. This fixes it at the source and needs **no renderer changes at all**.

Opening a long thread merged every persisted Turn Usage row into the newest page, so weeks-old usage stacked under recent messages for turns the reader had never loaded. History pages received *no* usage, which is why every row had to go into the newest page in the first place.

That same loop in `mergeImmutableUsageActivities` was also the performance problem — it filtered and re-inserted the whole entry array once per row:

| page entries | usage rows | element visits, before | after | ratio |
|---|---|---|---|---|
| 50 | 100 | 38,735 | 100 | 387x |
| 200 | 100 | 97,020 | 400 | 243x |
| 500 | 100 | 217,020 | 1,000 | 217x |
| 1000 | 100 | 417,020 | 2,000 | 209x |

The bug and the O(page x usage) were the same defect.

## Approach

Placement is now **turn-anchored** and runs in one forward pass, `O(page + usage)`. A usage row is inserted after the last entry of its own turn *within the page being read*, and is omitted when that turn is not on the page. Older pagination pages now receive their own usage — so the transcript drives the progressive window, and augmentation only lands on what was actually loaded.

No row can render twice: pages are cut on turn boundaries (`findTurnPageStartIndex`, and each page's cursor is its own first entry), so exactly one page owns any given turn. Where an older replay format forces entry-count paging and splits a turn, `prependTranscriptHistoryPage` already drops entry ids it has seen.

Managed review entries keep their live-page-only treatment. They originate a turn rather than annotate one, so their turn id need not appear in the provider rollout and they have no anchor to page against.

## Federation

`readThread` is a bridged federation method, so a federated thread stops shipping ~100 KiB of usage rows (1,023 bytes x 100) per read for turns the viewer cannot see. Those bytes also count against the per-frame budget that `fitNormalizedReplayWithinByteBudget` trims pages to, so on a page near that ceiling they were displacing real transcript entries.

## Test plan

Three new cases in `backend-registry.test.ts`, each verified to **fail on `main`**:

- `omits overlay turn usage whose turn is not on the page being read` — on `main`, turn-1 and turn-2 usage land above the recent message (the reported bug).
- `anchors overlay turn usage inside an older pagination page` — on `main`, a `before` read receives no usage at all.
- `weaves overlay turn usage in one pass over the page` — instrumented entry ids; on `main` this reads **20,000** ids for a 200-entry page with 100 rows against a 2,000 budget, exactly the O(page x usage) signature.

Green locally:

- [x] `pnpm test apps/desktop/src/main/` — 326 files, 4854 passed, 0 failures
- [x] `pnpm typecheck`
- [x] `pnpm lint:eslint` — 0 errors
- [x] `pnpm lint:boundaries`, `pnpm lint:codex-storage`
- [x] `pnpm test apps/desktop/src/renderer/` — 3511 passed; one unrelated `app-shell.test.tsx` load flake that passes in isolation (42/42)
- [ ] Open a long thread, scroll back, confirm each Turn Usage card sits with its own turn and none appear for unloaded turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)