### PR TITLE
ci: cancel superseded PR builds, keep every main build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,19 @@ on:
       - synchronize
       - reopened
 
+concurrency:
+  # PRs share one group per PR number, so a new push cancels the run it
+  # supersedes instead of leaving three obsolete builds holding runners.
+  #
+  # Pushes group on the commit SHA, so no two pushes ever share a group. That
+  # matters more than it looks: the default queue is `single`, which keeps at
+  # most one run pending per group and cancels the pending run a newer one
+  # replaces. A branch-name group with cancel-in-progress disabled would
+  # therefore drop the middle commit of any three merged in quick succession,
+  # which is exactly the history needed to tell which commit broke main.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: read
@@ -527,11 +540,18 @@ jobs:
       # Electron launches. The persistent 8 GB guest remains healthy under
       # measured memory pressure, but Virtualization.framework kernel clients
       # still accumulate across a long lane; the two-app federation lifecycle
-      # previously ran last after 105 launches. Keep only the two lab VMs busy
-      # concurrently, and do not cancel the other shards on failure: their
-      # artifacts distinguish a product failure from guest degradation.
+      # previously ran last after 105 launches.
+      #
+      # Lane concurrency is bounded by the number of runners in the
+      # pwrdrvr-macos group rather than by max-parallel: a lane with no free
+      # guest waits for one instead of oversubscribing a guest that is already
+      # running Electron. Raised from 2 while the lab returns to 3 builders.
+      # Lower it again only if a lane has to be pinned to a subset of guests.
+      #
+      # Do not cancel the other shards on failure: their artifacts distinguish
+      # a product failure from guest degradation.
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix:
         lane: [1, 2, 3, 4]
     timeout-minutes: 30


### PR DESCRIPTION
## Problem

A PR with three pushes in flight holds three full CI runs — including the self-hosted macOS lanes — for two commits nobody is waiting on.

## Change

Add a workflow-level `concurrency` block to `ci.yml`:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **PRs** share one group per PR number, so a new push cancels the run it supersedes.
- **Pushes** (`main`, `releases/**`) group on the commit SHA, so every commit still gets its own build.

### Why the SHA and not the branch

The naive `group: ${{ github.ref }}` + `cancel-in-progress: false` does the opposite of what it looks like. The default is `queue: single`, which keeps **at most one run pending per group and cancels the pending run a newer one replaces**. Merge A, B, C in quick succession and B is dropped while pending — losing exactly the per-commit history needed to tell which commit broke main. A SHA group never collides, so nothing is ever cancelled or dropped.

`queue: max` (real FIFO, up to 100 pending) would serialize main instead, but it cannot be combined with `cancel-in-progress: true` and is not documented as accepting an expression, so it would mean splitting CI into two workflows over a reusable one. Not worth it here — parallel per-commit runs give the same signal without queueing behind a 30-minute macOS lane.

## macOS lane cap

`max-parallel` on `desktop-e2e-macos` goes from 2 to 4, ahead of the lab returning to three builders. Runner-group size, not `max-parallel`, is what keeps a lane off a guest that is already running Electron — a lane with no free guest waits for one. `fail-fast: false` is unchanged.

## Verification

- `actionlint .github/workflows/ci.yml` reports only the two pre-existing `pwrdrvr-macos` unknown-runner-label warnings; no new findings, none on the concurrency block or its expressions.
- YAML parse confirms both expressions survive as plain scalars rather than being reinterpreted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)