### PR TITLE
perf(messaging): stop awaiting the Git working-state fleet in navigation

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -443,13 +443,58 @@ const writeThreadGitWorkingStateCacheEntry = vi.fn(async (_entry?: {
 const hydrateThreadGitWorkingStates = vi.fn(
   async (threads: AppServerThreadSummary[]) => threads,
 );
-const rememberThreadGitWorkingStateCacheEntry = vi.fn(async (entry: {
+// The registry owns the one working-state cache both refresh lanes read, so
+// this mock has to behave like it: keep a real map, stamp monotonically, and
+// publish. The IPC lane's freshness and rotation tests below select against
+// this map for real.
+type WorktreeWorkingStateCacheEntry = {
   worktreePath: string;
   fetchedAt: number;
   gitWorkingState?: ThreadGitWorkingState;
-}) => {
-  await writeThreadGitWorkingStateCacheEntry(entry);
+};
+const threadGitWorkingStateCache = new Map<
+  string,
+  WorktreeWorkingStateCacheEntry
+>();
+let threadGitWorkingStateCacheLoaded = false;
+const loadThreadGitWorkingStateCache = vi.fn(async () => {
+  if (threadGitWorkingStateCacheLoaded) {
+    return;
+  }
+  threadGitWorkingStateCacheLoaded = true;
+  for (const entry of Object.values(await readThreadGitWorkingStateCache())) {
+    const cached = entry as WorktreeWorkingStateCacheEntry;
+    threadGitWorkingStateCache.set(cached.worktreePath, cached);
+  }
 });
+const getThreadGitWorkingStateCache = vi.fn(
+  (): ReadonlyMap<string, WorktreeWorkingStateCacheEntry> =>
+    threadGitWorkingStateCache,
+);
+const rememberThreadGitWorkingStateCacheEntry = vi.fn(
+  async (entry: WorktreeWorkingStateCacheEntry) => {
+    await loadThreadGitWorkingStateCache();
+    const previous = threadGitWorkingStateCache.get(entry.worktreePath);
+    const fetchedAt = Math.max(
+      entry.fetchedAt,
+      (previous?.fetchedAt ?? entry.fetchedAt - 1) + 1,
+    );
+    const stored = { ...entry, fetchedAt };
+    threadGitWorkingStateCache.set(stored.worktreePath, stored);
+    await writeThreadGitWorkingStateCacheEntry(stored);
+    await publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "navigation/threadGitWorkingState/updated",
+        params: {
+          worktreePath: stored.worktreePath,
+          gitWorkingState: stored.gitWorkingState ?? null,
+          fetchedAt,
+        },
+      },
+    } as never);
+  },
+);
 type WorkingStateEntry = {
   worktreePath: string;
   gitWorkingState?: {
@@ -501,7 +546,7 @@ function emitRegistryEvent(event: unknown): void {
     listener(event);
   }
 }
-const publishLocalEvent = vi.fn(async () => undefined);
+const publishLocalEvent = vi.fn(async (_event?: unknown) => undefined);
 const setThreadPullRequestStatusToolHandler = vi.fn();
 const setThreadPullRequestCanonicalizer = vi.fn();
 const setLocalPullRequestAuthorityResolver = vi.fn();
@@ -915,6 +960,8 @@ vi.mock("../app-server/backend-registry", () => {
     invalidateDirectoryStatus,
     readWorktreeWorkingStateEntries,
     hydrateThreadGitWorkingStates,
+    getThreadGitWorkingStateCache,
+    loadThreadGitWorkingStateCache,
     rememberThreadGitWorkingStateCacheEntry,
     invalidateWorktreeWorkingState,
     resolveEditCommitStates,
@@ -937,7 +984,6 @@ vi.mock("../app-server/backend-registry", () => {
   };
   backendRegistryLifecycle.get.mockImplementation(() => registry);
   return {
-    WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS: 30_000,
     disposeDesktopBackendRegistry: vi.fn(async () => undefined),
     getDesktopBackendRegistry: backendRegistryLifecycle.get,
     getExistingDesktopBackendRegistry: () =>
@@ -1051,6 +1097,10 @@ describe("app server ipc", () => {
     hydrateThreadGitWorkingStates.mockImplementation(
       async (threads: AppServerThreadSummary[]) => threads,
     );
+    threadGitWorkingStateCache.clear();
+    threadGitWorkingStateCacheLoaded = false;
+    getThreadGitWorkingStateCache.mockClear();
+    loadThreadGitWorkingStateCache.mockClear();
     rememberThreadGitWorkingStateCacheEntry.mockClear();
     readWorktreeWorkingStateEntries.mockClear();
     resolveEditCommitStates.mockClear();
@@ -7216,6 +7266,63 @@ describe("app server ipc", () => {
     }
   });
 
+  it("reaches past a batch that is still in flight", async () => {
+    // In-flight worktrees are excluded before the cap, not after. Dropping
+    // them afterwards let a full batch of already-probing paths consume the
+    // cap and schedule nothing, so the stale one behind them waited for a
+    // round that had no reason to come.
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const threads = Array.from({ length: 9 }, (_unused, index) => ({
+      id: `thread-${index}`,
+      title: `Thread ${index}`,
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      projectKey: `/repo/wt-${index}`,
+      linkedDirectories: [],
+      updatedAt: 2_000 - index,
+    }));
+    listThreads.mockResolvedValue(threads as never);
+    let releaseFirstProbe: (() => void) | undefined;
+    const firstProbeGate = new Promise<void>((resolve) => {
+      releaseFirstProbe = resolve;
+    });
+    readWorktreeWorkingStateEntries.mockImplementationOnce(
+      (worktreePaths: string[]) =>
+        (async function* () {
+          await firstProbeGate;
+          for (const worktreePath of worktreePaths) {
+            yield { worktreePath } satisfies WorkingStateEntry;
+          }
+        })(),
+    );
+
+    try {
+      registerAppServerIpcHandlers();
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+      await vi.waitFor(() => {
+        expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(1);
+      });
+      expect(readWorktreeWorkingStateEntries.mock.calls[0]?.[0]).toEqual(
+        threads.slice(0, 8).map((thread) => thread.projectKey),
+      );
+
+      // Nothing has been written yet, so every worktree is still stale and a
+      // naive selection would pick the same first eight again.
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+      await vi.waitFor(() => {
+        expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(2);
+      });
+      expect(readWorktreeWorkingStateEntries.mock.calls[1]?.[0]).toEqual([
+        threads[8]!.projectKey,
+      ]);
+    } finally {
+      releaseFirstProbe?.();
+      await vi.waitFor(() => {
+        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(9);
+      });
+    }
+  });
+
   it("lets a user-triggered working-state refresh bypass fresh cache", async () => {
     const {
       NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL,
@@ -7360,6 +7467,53 @@ describe("app server ipc", () => {
         [worktreePath],
         expect.any(Object),
       );
+    });
+  });
+
+  it("serves a working-state value the registry lane wrote after startup", async () => {
+    // Both lanes read one cache. This window used to keep a second copy,
+    // loaded once at startup and never re-read, and its stale pre-stamp then
+    // satisfied the registry's own `if (thread.gitWorkingState)` short-circuit
+    // — so a registry-lane probe's result was discarded here until the next
+    // cold start.
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const worktreePath = "/repo/wt";
+    const gitWorkingState = {
+      dirtyFiles: 2,
+      dirtyAdditions: 7,
+      dirtyDeletions: 1,
+      untrackedFiles: 0,
+      unpushedCommits: 3,
+      baseBranch: "main",
+    };
+    listThreads.mockResolvedValue([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: worktreePath,
+        linkedDirectories: [],
+        updatedAt: 2_000,
+      },
+    ] as never);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(1);
+    });
+
+    // The registry's background convergence lane lands its own probe.
+    await rememberThreadGitWorkingStateCacheEntry({
+      fetchedAt: Date.now(),
+      gitWorkingState,
+      worktreePath,
+    });
+
+    const snapshot = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    expect(snapshot).toMatchObject({
+      threads: [expect.objectContaining({ gitWorkingState, id: "thread-1" })],
     });
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -424,6 +424,45 @@ function usageActivity(params: {
   };
 }
 
+const sampleGitWorkingState = {
+  dirtyFiles: 0,
+  dirtyAdditions: 0,
+  dirtyDeletions: 0,
+  untrackedFiles: 0,
+  unpushedCommits: 0,
+  baseBranch: "main",
+  baseAheadCommitCount: 16,
+};
+
+// Only a multi-project thread is probe-eligible: a single-directory thread's
+// review target needs no working state to disambiguate it.
+function multiProjectThread(params: {
+  worktreePath: string;
+}): AppServerThreadSummary {
+  return {
+    id: `thread-${params.worktreePath}`,
+    title: "PwrAgent federation dogfood",
+    titleSource: "explicit",
+    source: "codex",
+    projectKey: params.worktreePath,
+    linkedDirectories: [
+      {
+        id: "pwragent",
+        kind: "worktree",
+        label: "PwrAgnt",
+        path: "/repos/PwrAgnt",
+        worktreePath: params.worktreePath,
+      },
+      {
+        id: "pwrsnap",
+        kind: "local",
+        label: "PwrSnap",
+        path: "/repos/PwrSnap",
+      },
+    ],
+  };
+}
+
 function createOverlayStoreMock(params?: {
   executionMode?: "default" | "full-access";
   launchpadDefaults?: NavigationLaunchpadDefaults;
@@ -3330,6 +3369,162 @@ describe("DesktopBackendRegistry", () => {
         },
       );
     } finally {
+      await registry.close();
+    }
+  });
+
+  it("schedules a stale working-state probe without awaiting the Git fleet", async () => {
+    // A navigation serving path must answer from cache. Holding the snapshot
+    // until the fleet returns is what put a Git probe on every messaging
+    // command and on every remote viewer's snapshot.
+    const worktreePath = "/worktrees/PwrAgnt";
+    let releaseProbe: (() => void) | undefined;
+    const probeReleased = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+    const readWorkingStateEntries = vi.fn(() =>
+      (async function* () {
+        await probeReleased;
+        yield { worktreePath, gitWorkingState: sampleGitWorkingState };
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+
+    try {
+      await expect(
+        registry.refreshThreadGitWorkingStates([
+          multiProjectThread({ worktreePath }),
+        ]),
+      ).resolves.toEqual({ scheduledCount: 1 });
+      expect(overlayStore.writeThreadGitWorkingStateCacheEntry)
+        .not.toHaveBeenCalled();
+
+      releaseProbe?.();
+      await expectEventually(
+        async () =>
+          overlayStore.writeThreadGitWorkingStateCacheEntry.mock.calls.length,
+        1,
+      );
+    } finally {
+      releaseProbe?.();
+      await registry.close();
+    }
+  });
+
+  it("caps a background working-state round and rotates the oldest probe forward", async () => {
+    // Navigation hands over a stable thread order. Without rotation the same
+    // prefix would win every round and the tail would never converge.
+    const readWorkingStateEntries = vi.fn((paths: string[]) =>
+      (async function* () {
+        for (const path of paths) {
+          yield { worktreePath: path, gitWorkingState: sampleGitWorkingState };
+        }
+      })(),
+    );
+    const worktreePaths = Array.from(
+      { length: 9 },
+      (_unused, index) => `/worktrees/repo-${index}`,
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () =>
+        Object.fromEntries(worktreePaths.map((worktreePath, index) => [
+          worktreePath,
+          {
+            worktreePath,
+            gitWorkingState: sampleGitWorkingState,
+            // All stale; the highest index was probed most recently.
+            fetchedAt: 1_000 + index,
+          },
+        ])),
+      ),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+
+    try {
+      await expect(
+        registry.refreshThreadGitWorkingStates(
+          // Reversed, so a naive prefix would take the freshest eight and
+          // only rotation can produce the ascending expectation below.
+          worktreePaths
+            .map((worktreePath) => multiProjectThread({ worktreePath }))
+            .reverse(),
+        ),
+      ).resolves.toEqual({ scheduledCount: 8 });
+      expect(readWorkingStateEntries).toHaveBeenCalledWith(
+        worktreePaths.slice(0, 8),
+        expect.anything(),
+      );
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("coalesces a background working-state probe already in flight", async () => {
+    const worktreePath = "/worktrees/PwrAgnt";
+    let releaseProbe: (() => void) | undefined;
+    const probeReleased = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+    const readWorkingStateEntries = vi.fn((paths: string[]) =>
+      (async function* () {
+        await probeReleased;
+        for (const path of paths) {
+          yield { worktreePath: path, gitWorkingState: sampleGitWorkingState };
+        }
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+    const threads = [
+      multiProjectThread({ worktreePath }),
+      multiProjectThread({ worktreePath: `${worktreePath}-2` }),
+    ];
+
+    try {
+      await expect(
+        registry.refreshThreadGitWorkingStates(threads, { limit: 1 }),
+      ).resolves.toEqual({ scheduledCount: 1 });
+      // The first worktree is in flight, so a capped round has to reach past
+      // it rather than re-selecting it and scheduling nothing.
+      await expect(
+        registry.refreshThreadGitWorkingStates(threads, { limit: 1 }),
+      ).resolves.toEqual({ scheduledCount: 1 });
+      await expect(
+        registry.refreshThreadGitWorkingStates(threads, { limit: 1 }),
+      ).resolves.toEqual({ scheduledCount: 0 });
+      expect(readWorkingStateEntries.mock.calls.map(([paths]) => paths))
+        .toEqual([[worktreePath], [`${worktreePath}-2`]]);
+    } finally {
+      releaseProbe?.();
       await registry.close();
     }
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -79,6 +79,7 @@ import {
   DesktopBackendRegistry,
   getCodexFastModeMismatchWarning,
   withTokenMiserBridgeDescriptorEnv,
+  WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS,
 } from "../app-server/backend-registry";
 import type {
   CodexPwrdrvrTokenMiserActivation,
@@ -434,8 +435,6 @@ const sampleGitWorkingState = {
   baseAheadCommitCount: 16,
 };
 
-// Only a multi-project thread is probe-eligible: a single-directory thread's
-// review target needs no working state to disambiguate it.
 function multiProjectThread(params: {
   worktreePath: string;
 }): AppServerThreadSummary {
@@ -3525,6 +3524,106 @@ describe("DesktopBackendRegistry", () => {
         .toEqual([[worktreePath], [`${worktreePath}-2`]]);
     } finally {
       releaseProbe?.();
+      await registry.close();
+    }
+  });
+
+  it("re-probes a stale worktree that hydration already stamped", async () => {
+    // The serving path hydrates from the cache and then schedules, so every
+    // thread reaching the scheduler carries a `gitWorkingState`. Deciding
+    // staleness from that field instead of from the cache entry's age makes
+    // the probe inert the moment a worktree has any row: the operator commits
+    // from a terminal and the chips never move again.
+    const worktreePath = "/worktrees/PwrAgnt";
+    const readWorkingStateEntries = vi.fn((paths: string[]) =>
+      (async function* () {
+        for (const path of paths) {
+          yield { worktreePath: path, gitWorkingState: sampleGitWorkingState };
+        }
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({
+        [worktreePath]: {
+          worktreePath,
+          gitWorkingState: sampleGitWorkingState,
+          fetchedAt: Date.now() - WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS - 1,
+        },
+      })),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+    const hydrated = await registry.hydrateThreadGitWorkingStates([
+      multiProjectThread({ worktreePath }),
+    ]);
+
+    try {
+      expect(hydrated[0]?.gitWorkingState).toEqual(sampleGitWorkingState);
+      await expect(
+        registry.refreshThreadGitWorkingStates(hydrated),
+      ).resolves.toEqual({ scheduledCount: 1 });
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("schedules a single-directory thread the chips also need", async () => {
+    // The multi-project narrowing belongs to the awaited review probe, which
+    // uses working state to disambiguate a review target. The background lane
+    // feeds the dirty/unpushed chips every thread shows, so inheriting that
+    // filter would leave a federated viewer's ordinary threads frozen.
+    const worktreePath = "/worktrees/PwrAgnt";
+    const readWorkingStateEntries = vi.fn((paths: string[]) =>
+      (async function* () {
+        for (const path of paths) {
+          yield { worktreePath: path, gitWorkingState: sampleGitWorkingState };
+        }
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+    const singleDirectoryThread = (path: string): AppServerThreadSummary => {
+      const thread = multiProjectThread({ worktreePath: path });
+      return {
+        ...thread,
+        linkedDirectories: thread.linkedDirectories.slice(0, 1),
+      };
+    };
+    const reviewWorktreePath = "/worktrees/PwrSnap";
+
+    try {
+      await expect(
+        registry.refreshThreadGitWorkingStates([
+          singleDirectoryThread(worktreePath),
+        ]),
+      ).resolves.toEqual({ scheduledCount: 1 });
+
+      // The awaited review probe keeps the narrowing: one workspace needs no
+      // working state to disambiguate it.
+      await registry.hydrateThreadGitWorkingStates(
+        [singleDirectoryThread(reviewWorktreePath)],
+        { probeMissing: true },
+      );
+      expect(readWorkingStateEntries.mock.calls.flatMap(([paths]) => paths))
+        .not.toContain(reviewWorktreePath);
+    } finally {
       await registry.close();
     }
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -74,6 +74,7 @@ import type {
   ThreadStartParams as CodexThreadStartParams,
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 import {
+  BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE,
   buildCodexFastModeMismatchNotificationParams,
   CODEX_MISSING_THREAD_EVALUATION_DELAY_MS,
   DesktopBackendRegistry,
@@ -3432,7 +3433,7 @@ describe("DesktopBackendRegistry", () => {
       })(),
     );
     const worktreePaths = Array.from(
-      { length: 9 },
+      { length: BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE + 1 },
       (_unused, index) => `/worktrees/repo-${index}`,
     );
     const overlayStore = {
@@ -3467,11 +3468,62 @@ describe("DesktopBackendRegistry", () => {
             .map((worktreePath) => multiProjectThread({ worktreePath }))
             .reverse(),
         ),
-      ).resolves.toEqual({ scheduledCount: 8 });
+      ).resolves.toEqual({
+        scheduledCount: BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE,
+      });
+      // The round is scheduled, not awaited, so the fleet call lands some
+      // microtasks after the promise above settles.
+      await expectEventually(
+        async () => readWorkingStateEntries.mock.calls.length,
+        1,
+      );
       expect(readWorkingStateEntries).toHaveBeenCalledWith(
-        worktreePaths.slice(0, 8),
+        worktreePaths.slice(0, BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE),
         expect.anything(),
       );
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("leaves a fresh worktree alone for the rest of its window", async () => {
+    // Freshness is the only gate on this lane. Without it every messaging
+    // command and every federated viewer's poll runs a Git fleet again —
+    // the exact cost the lane exists to remove.
+    const worktreePath = "/worktrees/PwrAgnt";
+    const readWorkingStateEntries = vi.fn((paths: string[]) =>
+      (async function* () {
+        for (const path of paths) {
+          yield { worktreePath: path, gitWorkingState: sampleGitWorkingState };
+        }
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({
+        [worktreePath]: {
+          worktreePath,
+          gitWorkingState: sampleGitWorkingState,
+          fetchedAt: Date.now(),
+        },
+      })),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+
+    try {
+      await expect(
+        registry.refreshThreadGitWorkingStates([
+          multiProjectThread({ worktreePath }),
+        ]),
+      ).resolves.toEqual({ scheduledCount: 0 });
+      expect(readWorkingStateEntries).not.toHaveBeenCalled();
     } finally {
       await registry.close();
     }
@@ -3520,6 +3572,10 @@ describe("DesktopBackendRegistry", () => {
       await expect(
         registry.refreshThreadGitWorkingStates(threads, { limit: 1 }),
       ).resolves.toEqual({ scheduledCount: 0 });
+      await expectEventually(
+        async () => readWorkingStateEntries.mock.calls.length,
+        2,
+      );
       expect(readWorkingStateEntries.mock.calls.map(([paths]) => paths))
         .toEqual([[worktreePath], [`${worktreePath}-2`]]);
     } finally {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -74,14 +74,16 @@ import type {
   ThreadStartParams as CodexThreadStartParams,
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 import {
-  BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE,
   buildCodexFastModeMismatchNotificationParams,
   CODEX_MISSING_THREAD_EVALUATION_DELAY_MS,
   DesktopBackendRegistry,
   getCodexFastModeMismatchWarning,
   withTokenMiserBridgeDescriptorEnv,
-  WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS,
 } from "../app-server/backend-registry";
+import {
+  BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+  WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS,
+} from "../app-server/thread-working-state-refresh-policy";
 import type {
   CodexPwrdrvrTokenMiserActivation,
   CodexServerCapabilities,
@@ -3433,7 +3435,7 @@ describe("DesktopBackendRegistry", () => {
       })(),
     );
     const worktreePaths = Array.from(
-      { length: BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE + 1 },
+      { length: BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE + 1 },
       (_unused, index) => `/worktrees/repo-${index}`,
     );
     const overlayStore = {
@@ -3469,7 +3471,7 @@ describe("DesktopBackendRegistry", () => {
             .reverse(),
         ),
       ).resolves.toEqual({
-        scheduledCount: BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE,
+        scheduledCount: BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
       });
       // The round is scheduled, not awaited, so the fleet call lands some
       // microtasks after the promise above settles.
@@ -3478,7 +3480,7 @@ describe("DesktopBackendRegistry", () => {
         1,
       );
       expect(readWorkingStateEntries).toHaveBeenCalledWith(
-        worktreePaths.slice(0, BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE),
+        worktreePaths.slice(0, BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE),
         expect.anything(),
       );
     } finally {
@@ -3679,6 +3681,97 @@ describe("DesktopBackendRegistry", () => {
       );
       expect(readWorkingStateEntries.mock.calls.flatMap(([paths]) => paths))
         .not.toContain(reviewWorktreePath);
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("publishes a background probe so already-open surfaces see it", async () => {
+    // The durable cache alone only reaches the next full navigation snapshot.
+    // Without this the lane's whole point — a federated viewer and a local
+    // window converging at the same rate — held only for the viewer.
+    const worktreePath = "/worktrees/PwrAgnt";
+    const readWorkingStateEntries = vi.fn((paths: string[]) =>
+      (async function* () {
+        for (const path of paths) {
+          yield { worktreePath: path, gitWorkingState: sampleGitWorkingState };
+        }
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+    const workingStateEvents: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      if (
+        event.notification.method === "navigation/threadGitWorkingState/updated"
+      ) {
+        workingStateEvents.push(event);
+      }
+    });
+
+    try {
+      await registry.refreshThreadGitWorkingStates([
+        multiProjectThread({ worktreePath }),
+      ]);
+      await expectEventually(async () => workingStateEvents.length, 1);
+      expect(workingStateEvents[0]?.notification.params).toEqual(
+        expect.objectContaining({
+          gitWorkingState: sampleGitWorkingState,
+          worktreePath,
+        }),
+      );
+    } finally {
+      unsubscribe();
+      await registry.close();
+    }
+  });
+
+  it("advances fetchedAt past the entry a probe replaces", async () => {
+    // Both lanes write through this seam, so two probes of one worktree can
+    // land in the same millisecond. The renderer ignores an update whose
+    // fetchedAt does not advance, which would drop the later result.
+    const worktreePath = "/worktrees/PwrAgnt";
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(
+        async (_entry: { fetchedAt: number }) => undefined,
+      ),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+    });
+
+    try {
+      await registry.rememberThreadGitWorkingStateCacheEntry({
+        fetchedAt: 5_000,
+        gitWorkingState: sampleGitWorkingState,
+        worktreePath,
+      });
+      await registry.rememberThreadGitWorkingStateCacheEntry({
+        fetchedAt: 5_000,
+        gitWorkingState: sampleGitWorkingState,
+        worktreePath,
+      });
+      expect(
+        overlayStore.writeThreadGitWorkingStateCacheEntry.mock.calls.map(
+          ([entry]) => entry.fetchedAt,
+        ),
+      ).toEqual([5_000, 5_001]);
+      expect(
+        registry.getThreadGitWorkingStateCache().get(worktreePath)?.fetchedAt,
+      ).toBe(5_001);
     } finally {
       await registry.close();
     }

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -314,7 +314,7 @@ describe("DesktopMessagingBackendBridge", () => {
     finishRefresh?.();
   });
 
-  it("hydrates review working state before the messenger chooses a project", async () => {
+  it("serves cached review working state and probes in the background", async () => {
     const pwrAgentWorktree = "/worktrees/PwrAgnt";
     const listedThread: AppServerThreadSummary = {
       id: "thread-1",
@@ -379,6 +379,8 @@ describe("DesktopMessagingBackendBridge", () => {
       ),
       listThreads: vi.fn(async () => [listedThread]),
       readDirectoryStatuses: vi.fn(async () => ({})),
+      // A Git fleet that never settles: the snapshot must not wait on it.
+      refreshThreadGitWorkingStates: vi.fn(() => new Promise(() => {})),
       rememberCompleteNavigationSnapshot: vi.fn(),
     } as unknown as DesktopBackendRegistry;
     const bridge = new DesktopMessagingBackendBridge(registry);
@@ -387,7 +389,9 @@ describe("DesktopMessagingBackendBridge", () => {
 
     expect(registry.hydrateThreadGitWorkingStates).toHaveBeenCalledWith(
       [reconciledThread],
-      { probeMissing: true },
+    );
+    expect(registry.refreshThreadGitWorkingStates).toHaveBeenCalledExactlyOnceWith(
+      [{ ...reconciledThread, gitWorkingState }],
     );
     expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
       pwrAgentWorktree,

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -248,6 +248,7 @@ describe("DesktopMessagingBackendBridge", () => {
         async (threads: NavigationSnapshot["threads"]) => threads,
       ),
       listThreads: vi.fn(async () => []),
+      refreshThreadGitWorkingStates: vi.fn(async () => ({ scheduledCount: 0 })),
       readDirectoryStatuses,
       refreshDirectoryGitStatuses,
       rememberCompleteNavigationSnapshot: vi.fn(),
@@ -299,6 +300,7 @@ describe("DesktopMessagingBackendBridge", () => {
         async (threads: NavigationSnapshot["threads"]) => threads,
       ),
       listThreads: vi.fn(async () => []),
+      refreshThreadGitWorkingStates: vi.fn(async () => ({ scheduledCount: 0 })),
       refreshDirectoryGitStatuses,
       rememberCompleteNavigationSnapshot: vi.fn(),
     } as unknown as DesktopBackendRegistry;
@@ -389,10 +391,109 @@ describe("DesktopMessagingBackendBridge", () => {
 
     expect(registry.hydrateThreadGitWorkingStates).toHaveBeenCalledWith(
       [reconciledThread],
+      { probeMissing: false },
     );
+    // The canonical threads, not the hydrated ones: scheduling reads the
+    // cache to decide staleness, and passing threads that hydration just
+    // stamped from that same cache is how a probe stops converging.
     expect(registry.refreshThreadGitWorkingStates).toHaveBeenCalledExactlyOnceWith(
-      [{ ...reconciledThread, gitWorkingState }],
+      [reconciledThread],
     );
+    expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
+      pwrAgentWorktree,
+    );
+  });
+
+  it("awaits the working-state fleet when the caller opts in", async () => {
+    // The messenger's review picker resolves a multi-project thread's
+    // workspace from working state (findPreferredReviewWorkspaceCwd) and
+    // infers its base branch from it (buildReviewBranchOptions), so it cannot
+    // race a background probe: on a cold cache it would pick linkedDirectories[0].
+    const pwrAgentWorktree = "/worktrees/PwrAgnt";
+    const listedThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "PwrAgent federation dogfood PR #735",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: pwrAgentWorktree,
+      linkedDirectories: [
+        {
+          id: "pwrsnap",
+          kind: "local",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+        },
+        {
+          id: "pwragent",
+          kind: "worktree",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          worktreePath: pwrAgentWorktree,
+        },
+      ],
+    };
+    const reconciledThread: NavigationSnapshot["threads"][number] = {
+      ...listedThread,
+      inbox: { inInbox: false },
+    };
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "codex",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [reconciledThread],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      // Only the awaited probe answers here; a cached read returns the
+      // threads untouched, which is what a cold cache looks like.
+      hydrateThreadGitWorkingStates: vi.fn(async (
+        threads: NavigationSnapshot["threads"],
+        options?: { probeMissing?: boolean },
+      ) =>
+        options?.probeMissing
+          ? threads.map((thread) => ({
+            ...thread,
+            gitWorkingState: {
+              dirtyFiles: 2,
+              dirtyAdditions: 9,
+              dirtyDeletions: 1,
+              untrackedFiles: 0,
+              unpushedCommits: 0,
+              baseBranch: "main",
+              baseAheadCommitCount: 16,
+            },
+          }))
+          : threads
+      ),
+      listThreads: vi.fn(async () => [listedThread]),
+      readDirectoryStatuses: vi.fn(async () => ({})),
+      refreshThreadGitWorkingStates: vi.fn(async () => ({ scheduledCount: 0 })),
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const snapshot = await bridge.getNavigationSnapshot({
+      backend: "codex",
+      probeWorkingStates: true,
+    });
+
+    expect(registry.hydrateThreadGitWorkingStates).toHaveBeenCalledWith(
+      [reconciledThread],
+      { probeMissing: true },
+    );
+    // An opted-in caller already awaited the fleet; scheduling a second
+    // round behind it would re-probe the paths it just read.
+    expect(registry.refreshThreadGitWorkingStates).not.toHaveBeenCalled();
     expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
       pwrAgentWorktree,
     );
@@ -445,6 +546,7 @@ describe("DesktopMessagingBackendBridge", () => {
         async (threads: NavigationSnapshot["threads"]) => threads,
       ),
       listThreads: vi.fn(async () => []),
+      refreshThreadGitWorkingStates: vi.fn(async () => ({ scheduledCount: 0 })),
       readDirectoryStatuses: vi.fn(async () => ({})),
       rememberCompleteNavigationSnapshot: vi.fn(),
     } as unknown as DesktopBackendRegistry;
@@ -533,6 +635,7 @@ describe("DesktopMessagingBackendBridge", () => {
       hydrateThreadGitWorkingStates,
       listThreads: vi.fn(async () => []),
       readDirectoryStatuses: vi.fn(async () => ({})),
+      refreshThreadGitWorkingStates: vi.fn(async () => ({ scheduledCount: 0 })),
       rememberCompleteNavigationSnapshot: vi.fn(),
     } as unknown as DesktopBackendRegistry;
     const bridge = new DesktopMessagingBackendBridge(registry);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7928,6 +7928,7 @@ export class DesktopBackendRegistry {
   private directoryGitStatusWriter: DirectoryGitStatusWriter | undefined;
   private readonly pendingDirectoryGitStatusKeys = new Set<string>();
   private readonly pendingThreadGitWorkingStateKeys = new Set<string>();
+  private readonly threadGitWorkingStateRefreshRounds = new Set<Promise<void>>();
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadPullRequestDetachHandler:
     | ThreadPullRequestDetachHandler
@@ -11810,7 +11811,9 @@ export class DesktopBackendRegistry {
       return hydrated;
     }
 
-    const probePaths = this.selectStaleThreadWorkingStatePaths(candidates);
+    const probePaths = this.selectStaleThreadWorkingStatePaths(candidates, {
+      multiProjectOnly: true,
+    });
     if (probePaths.length === 0) {
       return hydrated;
     }
@@ -11839,17 +11842,19 @@ export class DesktopBackendRegistry {
     threads: Thread[],
     options: { limit?: number } = {},
   ): Promise<{ scheduledCount: number }> {
-    const candidates = threads.filter(
-      (thread) => !thread.gitWorkingState && resolveThreadWorkingStatePath(thread),
-    );
-    if (candidates.length === 0) {
+    if (this.closed) {
       return { scheduledCount: 0 };
     }
 
     await this.loadThreadGitWorkingStateCache();
+    // Staleness is decided in exactly one place: the cache. Filtering threads
+    // on `gitWorkingState` here would read the field a serving path has just
+    // hydrated from that same cache, so a worktree with any row — however old
+    // — would never be probed again and nothing would ever converge.
+    //
     // Exclude in-flight worktrees before the cap, not after: a round whose
     // whole batch is already in flight must still reach the paths behind it.
-    const worktreePaths = this.selectStaleThreadWorkingStatePaths(candidates, {
+    const worktreePaths = this.selectStaleThreadWorkingStatePaths(threads, {
       exclude: this.pendingThreadGitWorkingStateKeys,
       limit: options.limit ?? BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE,
     });
@@ -11860,7 +11865,22 @@ export class DesktopBackendRegistry {
     for (const worktreePath of worktreePaths) {
       this.pendingThreadGitWorkingStateKeys.add(worktreePath);
     }
-    void this.refreshThreadGitWorkingStatesInBackground(threads, worktreePaths);
+    // Carry only the threads behind this batch. The round outlives the
+    // snapshot that scheduled it, and retaining every thread would hold a full
+    // navigation snapshot for as long as the Git fleet runs.
+    const batched = new Set(worktreePaths);
+    const probedThreads = threads.filter((thread) => {
+      const worktreePath = resolveThreadWorkingStatePath(thread);
+      return worktreePath !== undefined && batched.has(worktreePath);
+    });
+    const round = this.refreshThreadGitWorkingStatesInBackground(
+      probedThreads,
+      worktreePaths,
+    );
+    this.threadGitWorkingStateRefreshRounds.add(round);
+    void round.finally(() => {
+      this.threadGitWorkingStateRefreshRounds.delete(round);
+    });
     return { scheduledCount: worktreePaths.length };
   }
 
@@ -11882,20 +11902,29 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * Only a multi-project thread needs a probe: a single-directory thread's
-   * review target is unambiguous without one.
+   * `multiProjectOnly` belongs to the awaited review probe, whose whole job is
+   * disambiguating a review target: a single-directory thread's target is
+   * unambiguous without working state. The background convergence lane must
+   * not inherit it — it feeds the dirty/unpushed/base-drift chips every thread
+   * shows, and the renderer lane it mirrors
+   * (ipc/app-server.ts:selectWorktreeWorkingStateRefreshCandidates) filters on
+   * cache freshness alone.
    */
   private selectStaleThreadWorkingStatePaths<
     Thread extends AppServerThreadSummary,
   >(
     candidates: Thread[],
-    options: { exclude?: ReadonlySet<string>; limit?: number } = {},
+    options: {
+      exclude?: ReadonlySet<string>;
+      limit?: number;
+      multiProjectOnly?: boolean;
+    } = {},
   ): string[] {
     const now = Date.now();
     const stale = [
       ...new Set(
         candidates.flatMap((thread) => {
-          if (thread.linkedDirectories.length <= 1) {
+          if (options.multiProjectOnly && thread.linkedDirectories.length <= 1) {
             return [];
           }
           const worktreePath = resolveThreadWorkingStatePath(thread);
@@ -20059,6 +20088,12 @@ export class DesktopBackendRegistry {
     this.acceptedSteerRequests.clear();
     this.acceptedThreadControlRequests.clear();
     this.acceptedActiveTurnControlRequests.clear();
+    // A background working-state round outlives the snapshot that scheduled
+    // it. `closed` stops a new one, and draining the live ones here keeps the
+    // clears below final: `rememberThreadGitWorkingStateCacheEntry` reloads
+    // the durable cache, so a late round would refill the map and write to a
+    // store that is on its way out.
+    await Promise.all([...this.threadGitWorkingStateRefreshRounds]);
     this.workingStateByWorktree.clear();
     this.workingStateCacheLoad = undefined;
     if (this.taskMonitorWatchdogTimer) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -919,6 +919,11 @@ function resolveThreadWorkingStatePath(
 // snapshot. Shorter than the per-repo directory status TTL.
 export const WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS = 30_000;
 
+// Navigation serving paths schedule this fleet in the background rather than
+// awaiting it. Mirrors the renderer's automatic navigation lane so a federated
+// viewer converges at the same rate a local window does.
+export const BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE = 8;
+
 function isFreshThreadGitWorkingStateCacheEntry(
   entry: WorktreeGitWorkingStateCacheEntry,
   now: number,
@@ -7922,6 +7927,7 @@ export class DesktopBackendRegistry {
     | undefined;
   private directoryGitStatusWriter: DirectoryGitStatusWriter | undefined;
   private readonly pendingDirectoryGitStatusKeys = new Set<string>();
+  private readonly pendingThreadGitWorkingStateKeys = new Set<string>();
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadPullRequestDetachHandler:
     | ThreadPullRequestDetachHandler
@@ -11784,8 +11790,8 @@ export class DesktopBackendRegistry {
    * Hydrate the durable working-state view at the backend boundary so every
    * navigation consumer (renderer IPC, messaging, and future transports) sees
    * the same review-selection evidence. Normal navigation only reads the
-   * durable cache. An explicit messenger review may opt into probing unresolved
-   * multi-project threads so its picker cannot race the background refresh.
+   * durable cache and lets `refreshThreadGitWorkingStates` converge the rest.
+   * A caller that cannot tolerate a stale answer awaits the probe instead.
    */
   async hydrateThreadGitWorkingStates<Thread extends AppServerThreadSummary>(
     threads: Thread[],
@@ -11804,43 +11810,13 @@ export class DesktopBackendRegistry {
       return hydrated;
     }
 
-    const now = Date.now();
-    const probePaths = [
-      ...new Set(
-        candidates.flatMap((thread) => {
-          if (thread.linkedDirectories.length <= 1) {
-            return [];
-          }
-          const worktreePath = resolveThreadWorkingStatePath(thread);
-          if (!worktreePath) {
-            return [];
-          }
-          const cached = this.workingStateByWorktree.get(worktreePath);
-          return !cached || !isFreshThreadGitWorkingStateCacheEntry(cached, now)
-            ? [worktreePath]
-            : [];
-        }),
-      ),
-    ];
+    const probePaths = this.selectStaleThreadWorkingStatePaths(candidates);
     if (probePaths.length === 0) {
       return hydrated;
     }
 
     try {
-      const acceptedPushedCommitShasByWorktreePath =
-        await this.readAcceptedMergedPrCommitShasByWorktreePath(
-          threads,
-          probePaths,
-        );
-      for await (const entry of this.gitWorkingStateService.readWorkingStateEntries(
-        probePaths,
-        { acceptedPushedCommitShasByWorktreePath },
-      )) {
-        await this.rememberThreadGitWorkingStateCacheEntry({
-          ...entry,
-          fetchedAt: Date.now(),
-        });
-      }
+      await this.probeThreadGitWorkingStates(threads, probePaths);
     } catch (error) {
       backendRegistryLog.warn("review working-state probe failed", {
         error: error instanceof Error ? error.message : String(error),
@@ -11850,6 +11826,127 @@ export class DesktopBackendRegistry {
     }
 
     return this.applyCachedThreadGitWorkingStates(threads);
+  }
+
+  /**
+   * Schedule the fleet that `hydrateThreadGitWorkingStates` would otherwise
+   * await. A navigation serving path calls this so its snapshot answers from
+   * the durable cache and converges on a later read, which is what the
+   * renderer's local navigation path already does. Requests for the same
+   * worktree coalesce, and each round probes a bounded batch.
+   */
+  async refreshThreadGitWorkingStates<Thread extends AppServerThreadSummary>(
+    threads: Thread[],
+    options: { limit?: number } = {},
+  ): Promise<{ scheduledCount: number }> {
+    const candidates = threads.filter(
+      (thread) => !thread.gitWorkingState && resolveThreadWorkingStatePath(thread),
+    );
+    if (candidates.length === 0) {
+      return { scheduledCount: 0 };
+    }
+
+    await this.loadThreadGitWorkingStateCache();
+    // Exclude in-flight worktrees before the cap, not after: a round whose
+    // whole batch is already in flight must still reach the paths behind it.
+    const worktreePaths = this.selectStaleThreadWorkingStatePaths(candidates, {
+      exclude: this.pendingThreadGitWorkingStateKeys,
+      limit: options.limit ?? BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE,
+    });
+    if (worktreePaths.length === 0) {
+      return { scheduledCount: 0 };
+    }
+
+    for (const worktreePath of worktreePaths) {
+      this.pendingThreadGitWorkingStateKeys.add(worktreePath);
+    }
+    void this.refreshThreadGitWorkingStatesInBackground(threads, worktreePaths);
+    return { scheduledCount: worktreePaths.length };
+  }
+
+  private async refreshThreadGitWorkingStatesInBackground<
+    Thread extends AppServerThreadSummary,
+  >(threads: Thread[], worktreePaths: string[]): Promise<void> {
+    try {
+      await this.probeThreadGitWorkingStates(threads, worktreePaths);
+    } catch (error) {
+      backendRegistryLog.warn("thread working-state refresh failed", {
+        error: error instanceof Error ? error.message : String(error),
+        worktreePaths,
+      });
+    } finally {
+      for (const worktreePath of worktreePaths) {
+        this.pendingThreadGitWorkingStateKeys.delete(worktreePath);
+      }
+    }
+  }
+
+  /**
+   * Only a multi-project thread needs a probe: a single-directory thread's
+   * review target is unambiguous without one.
+   */
+  private selectStaleThreadWorkingStatePaths<
+    Thread extends AppServerThreadSummary,
+  >(
+    candidates: Thread[],
+    options: { exclude?: ReadonlySet<string>; limit?: number } = {},
+  ): string[] {
+    const now = Date.now();
+    const stale = [
+      ...new Set(
+        candidates.flatMap((thread) => {
+          if (thread.linkedDirectories.length <= 1) {
+            return [];
+          }
+          const worktreePath = resolveThreadWorkingStatePath(thread);
+          if (!worktreePath || options.exclude?.has(worktreePath)) {
+            return [];
+          }
+          const cached = this.workingStateByWorktree.get(worktreePath);
+          return !cached || !isFreshThreadGitWorkingStateCacheEntry(cached, now)
+            ? [worktreePath]
+            : [];
+        }),
+      ),
+    ];
+    if (options.limit === undefined || stale.length <= options.limit) {
+      return stale;
+    }
+
+    // Stable thread ordering must not let the same prefix win every round.
+    // Never-probed worktrees go first; after that the oldest probe rotates
+    // forward, so a fleet larger than one batch still converges.
+    stale.sort((left, right) => {
+      const leftFetchedAt = this.workingStateByWorktree.get(left)?.fetchedAt;
+      const rightFetchedAt = this.workingStateByWorktree.get(right)?.fetchedAt;
+      if (leftFetchedAt === undefined) {
+        return rightFetchedAt === undefined ? 0 : -1;
+      }
+      if (rightFetchedAt === undefined) {
+        return 1;
+      }
+      return leftFetchedAt - rightFetchedAt;
+    });
+    return stale.slice(0, options.limit);
+  }
+
+  private async probeThreadGitWorkingStates<
+    Thread extends AppServerThreadSummary,
+  >(threads: Thread[], worktreePaths: string[]): Promise<void> {
+    const acceptedPushedCommitShasByWorktreePath =
+      await this.readAcceptedMergedPrCommitShasByWorktreePath(
+        threads,
+        worktreePaths,
+      );
+    for await (const entry of this.gitWorkingStateService.readWorkingStateEntries(
+      worktreePaths,
+      { acceptedPushedCommitShasByWorktreePath },
+    )) {
+      await this.rememberThreadGitWorkingStateCacheEntry({
+        ...entry,
+        fetchedAt: Date.now(),
+      });
+    }
   }
 
   private async readAcceptedMergedPrCommitShasByWorktreePath<

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -157,6 +157,7 @@ import {
   type NavigationLaunchpadDraft,
   type NavigationLaunchpadDefaults,
   type NavigationSnapshot,
+  type NavigationThreadGitWorkingStateUpdatedNotification,
   type NavigationThreadSummary,
   type ResetDirectoryLaunchpadRequest,
   type ResetDirectoryLaunchpadResponse,
@@ -487,6 +488,10 @@ import type {
   WorktreeWorkingStateEntry,
 } from "./git-working-state-service";
 import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
+import {
+  BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+  selectStaleWorktreeWorkingStatePaths,
+} from "./thread-working-state-refresh-policy";
 import {
   AcpAvailableCommandsStore,
   type AcpAvailableCommandsStoreLike,
@@ -911,24 +916,6 @@ function resolveThreadWorkingStatePath(
   }
 
   return undefined;
-}
-
-// Per-worktree working state changes as the agent edits/commits, but each
-// such turn pushes a fresh probe, so the background freshness window only
-// needs to catch out-of-band changes (terminal/IDE edits) on the next
-// snapshot. Shorter than the per-repo directory status TTL.
-export const WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS = 30_000;
-
-// Navigation serving paths schedule this fleet in the background rather than
-// awaiting it. Mirrors the renderer's automatic navigation lane so a federated
-// viewer converges at the same rate a local window does.
-export const BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE = 8;
-
-function isFreshThreadGitWorkingStateCacheEntry(
-  entry: WorktreeGitWorkingStateCacheEntry,
-  now: number,
-): boolean {
-  return now - entry.fetchedAt < WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS;
 }
 
 function mergedPrCommitShas(prs: PrSummary[]): string[] {
@@ -11856,7 +11843,7 @@ export class DesktopBackendRegistry {
     // whole batch is already in flight must still reach the paths behind it.
     const worktreePaths = this.selectStaleThreadWorkingStatePaths(threads, {
       exclude: this.pendingThreadGitWorkingStateKeys,
-      limit: options.limit ?? BACKGROUND_THREAD_WORKING_STATE_BATCH_SIZE,
+      limit: options.limit ?? BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
     });
     if (worktreePaths.length === 0) {
       return { scheduledCount: 0 };
@@ -11902,13 +11889,16 @@ export class DesktopBackendRegistry {
   }
 
   /**
+   * Everything registry-specific about picking a batch, and nothing else:
+   * resolving threads to worktree paths, and the `multiProjectOnly` narrowing.
+   * Freshness, the cap, and the rotation order are shared policy — see
+   * `thread-working-state-refresh-policy.ts`.
+   *
    * `multiProjectOnly` belongs to the awaited review probe, whose whole job is
    * disambiguating a review target: a single-directory thread's target is
    * unambiguous without working state. The background convergence lane must
    * not inherit it — it feeds the dirty/unpushed/base-drift chips every thread
-   * shows, and the renderer lane it mirrors
-   * (ipc/app-server.ts:selectWorktreeWorkingStateRefreshCandidates) filters on
-   * cache freshness alone.
+   * shows.
    */
   private selectStaleThreadWorkingStatePaths<
     Thread extends AppServerThreadSummary,
@@ -11920,43 +11910,18 @@ export class DesktopBackendRegistry {
       multiProjectOnly?: boolean;
     } = {},
   ): string[] {
-    const now = Date.now();
-    const stale = [
-      ...new Set(
-        candidates.flatMap((thread) => {
-          if (options.multiProjectOnly && thread.linkedDirectories.length <= 1) {
-            return [];
-          }
-          const worktreePath = resolveThreadWorkingStatePath(thread);
-          if (!worktreePath || options.exclude?.has(worktreePath)) {
-            return [];
-          }
-          const cached = this.workingStateByWorktree.get(worktreePath);
-          return !cached || !isFreshThreadGitWorkingStateCacheEntry(cached, now)
-            ? [worktreePath]
-            : [];
-        }),
-      ),
-    ];
-    if (options.limit === undefined || stale.length <= options.limit) {
-      return stale;
-    }
-
-    // Stable thread ordering must not let the same prefix win every round.
-    // Never-probed worktrees go first; after that the oldest probe rotates
-    // forward, so a fleet larger than one batch still converges.
-    stale.sort((left, right) => {
-      const leftFetchedAt = this.workingStateByWorktree.get(left)?.fetchedAt;
-      const rightFetchedAt = this.workingStateByWorktree.get(right)?.fetchedAt;
-      if (leftFetchedAt === undefined) {
-        return rightFetchedAt === undefined ? 0 : -1;
-      }
-      if (rightFetchedAt === undefined) {
-        return 1;
-      }
-      return leftFetchedAt - rightFetchedAt;
+    return selectStaleWorktreeWorkingStatePaths({
+      cache: this.workingStateByWorktree,
+      ...(options.exclude ? { exclude: options.exclude } : {}),
+      ...(options.limit === undefined ? {} : { limit: options.limit }),
+      worktreePaths: candidates.flatMap((thread) => {
+        if (options.multiProjectOnly && thread.linkedDirectories.length <= 1) {
+          return [];
+        }
+        const worktreePath = resolveThreadWorkingStatePath(thread);
+        return worktreePath ? [worktreePath] : [];
+      }),
     });
-    return stale.slice(0, options.limit);
   }
 
   private async probeThreadGitWorkingStates<
@@ -12032,15 +11997,61 @@ export class DesktopBackendRegistry {
     });
   }
 
+  /**
+   * The one write seam for the working-state cache, for both lanes. Keeping it
+   * single is what makes the shared cache safe: the monotonic stamp and the
+   * notification below have to happen on every write, and a lane that set the
+   * map itself would skip them.
+   */
   async rememberThreadGitWorkingStateCacheEntry(
     entry: WorktreeGitWorkingStateCacheEntry,
   ): Promise<void> {
     await this.loadThreadGitWorkingStateCache();
-    this.workingStateByWorktree.set(entry.worktreePath, entry);
-    await this.overlayStore.writeThreadGitWorkingStateCacheEntry?.(entry);
+    // Two lanes probing one worktree can land in the same millisecond, and the
+    // renderer drops an update whose `fetchedAt` does not advance. Derive the
+    // stamp from the entry it replaces rather than trusting the clock.
+    const previous = this.workingStateByWorktree.get(entry.worktreePath);
+    const fetchedAt = Math.max(
+      entry.fetchedAt,
+      (previous?.fetchedAt ?? entry.fetchedAt - 1) + 1,
+    );
+    const stored: WorktreeGitWorkingStateCacheEntry = { ...entry, fetchedAt };
+    this.workingStateByWorktree.set(stored.worktreePath, stored);
+    await this.overlayStore.writeThreadGitWorkingStateCacheEntry?.(stored);
+
+    // Reaches already-open surfaces. Without it a background round only landed
+    // in the durable cache, so the window that scheduled it kept showing the
+    // previous chips until its next full navigation snapshot.
+    const notification: NavigationThreadGitWorkingStateUpdatedNotification = {
+      method: "navigation/threadGitWorkingState/updated",
+      params: {
+        worktreePath: stored.worktreePath,
+        gitWorkingState: stored.gitWorkingState ?? null,
+        fetchedAt,
+      },
+    };
+    await this.publishLocalEvent({
+      // Working state belongs to a worktree, not a backend, but every event on
+      // this bus carries one. Matches the renderer lane's own publish.
+      backend: "codex",
+      notification,
+    } as unknown as AgentEvent);
   }
 
-  private async loadThreadGitWorkingStateCache(): Promise<void> {
+  /**
+   * Live view of the cache both refresh lanes decide staleness against.
+   * Read-only by type: `rememberThreadGitWorkingStateCacheEntry` is the only
+   * writer, and the lanes must not each keep their own copy — a second map
+   * disagrees about what is fresh and re-probes what the other just read.
+   */
+  getThreadGitWorkingStateCache(): ReadonlyMap<
+    string,
+    WorktreeGitWorkingStateCacheEntry
+  > {
+    return this.workingStateByWorktree;
+  }
+
+  async loadThreadGitWorkingStateCache(): Promise<void> {
     if (!this.workingStateCacheLoad) {
       this.workingStateCacheLoad = (async () => {
         const entries =

--- a/apps/desktop/src/main/app-server/thread-working-state-refresh-policy.ts
+++ b/apps/desktop/src/main/app-server/thread-working-state-refresh-policy.ts
@@ -1,0 +1,98 @@
+/**
+ * One home for the per-worktree Git working-state refresh policy.
+ *
+ * Two lanes probe the same worktrees over the same durable cache: the
+ * renderer's navigation path (`ipc/app-server.ts`) and the registry's
+ * background convergence lane (`backend-registry.ts`), which serves messaging
+ * commands and federated viewers. They are separate because they are driven by
+ * different clocks, not because they should disagree about what is stale — so
+ * the TTL, the batch size, the freshness predicate, and the selection order
+ * live here rather than in either lane.
+ *
+ * Sibling of `directory-git-status-refresh-policy.ts`, which does the same job
+ * for the directory lane.
+ */
+
+type WorktreeWorkingStateCacheEntryLike = {
+  fetchedAt: number;
+};
+
+/**
+ * Far shorter than the directory lane's five minutes. Directory status is
+ * navigation context; working state feeds the dirty / unpushed / base-drift
+ * chips an operator reads while a turn is running, so it has to converge
+ * inside one.
+ */
+export const WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS = 30_000;
+
+/**
+ * Bounds one round, not the process. A fleet larger than this converges over
+ * successive rounds because the selection below rotates; the cap only keeps a
+ * single navigation snapshot from spawning an unbounded Git fleet.
+ */
+export const BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE = 8;
+
+export function isFreshWorktreeWorkingStateCacheEntry(
+  entry: WorktreeWorkingStateCacheEntryLike,
+  now = Date.now(),
+): boolean {
+  return now - entry.fetchedAt < WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS;
+}
+
+/**
+ * Picks the worktrees a round should probe.
+ *
+ * `exclude` is applied before the cap, not after: a lane that drops its
+ * in-flight paths afterwards can select a full batch of paths it is already
+ * probing and schedule nothing, while a stale worktree behind them waits for
+ * a later round.
+ *
+ * `force` skips the freshness test but not `exclude` — a forced refresh still
+ * has nothing to add to a probe already running against that worktree.
+ *
+ * Omitting `limit` returns every stale path unsorted. Focus and user-triggered
+ * lanes ask about one worktree and want it now; the cap and the rotation below
+ * exist for the automatic lanes that see the whole fleet.
+ */
+export function selectStaleWorktreeWorkingStatePaths(params: {
+  cache: ReadonlyMap<string, WorktreeWorkingStateCacheEntryLike>;
+  exclude?: ReadonlySet<string>;
+  force?: boolean;
+  limit?: number;
+  now?: number;
+  worktreePaths: readonly string[];
+}): string[] {
+  const now = params.now ?? Date.now();
+  const stale = [
+    ...new Set(params.worktreePaths.map((worktreePath) => worktreePath.trim())),
+  ].filter((worktreePath) => {
+    if (!worktreePath || params.exclude?.has(worktreePath)) {
+      return false;
+    }
+    if (params.force) {
+      return true;
+    }
+    const cached = params.cache.get(worktreePath);
+    return !cached || !isFreshWorktreeWorkingStateCacheEntry(cached, now);
+  });
+
+  if (params.limit === undefined || stale.length <= params.limit) {
+    return stale;
+  }
+
+  // Stable thread ordering must not let the same prefix win every round.
+  // Never-probed worktrees go first; after that the oldest probe rotates
+  // forward, so a fleet larger than one batch still converges.
+  stale.sort((left, right) => {
+    const leftFetchedAt = params.cache.get(left)?.fetchedAt;
+    const rightFetchedAt = params.cache.get(right)?.fetchedAt;
+    if (leftFetchedAt === undefined) {
+      return rightFetchedAt === undefined ? 0 : -1;
+    }
+    if (rightFetchedAt === undefined) {
+      return 1;
+    }
+    return leftFetchedAt - rightFetchedAt;
+  });
+  return stale.slice(0, params.limit);
+}

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -9,7 +9,6 @@ import type {
   PrLookupCacheEntry,
   PrStatusCacheEntry,
   SqliteOverlayStore,
-  WorktreeGitWorkingStateCacheEntry,
 } from "../state/overlay-store-sqlite";
 import {
   sanitizeRendererPayload,
@@ -91,7 +90,6 @@ import {
   type NavigationDirectorySummary,
   type NavigationDirectoryGitStatus,
   type NavigationDirectoryGitStatusUpdatedNotification,
-  type NavigationThreadGitWorkingStateUpdatedNotification,
   type NavigationSnapshot,
   type NavigationSnapshotTransportResponse,
   type NavigationThreadSummary,
@@ -160,7 +158,6 @@ import {
   type ResolveMissingCodexThreadsResponse,
   type RestoreThreadRequest,
   type RestoreThreadResponse,
-  type ThreadGitWorkingState,
   type ThreadOverlayState,
   type ThreadPrAutoDispatchPending,
   type UpdateDirectoryLaunchpadRequest,
@@ -195,8 +192,11 @@ import {
   disposeDesktopBackendRegistry,
   getExistingDesktopBackendRegistry,
   getDesktopBackendRegistry,
-  WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS,
 } from "../app-server/backend-registry";
+import {
+  BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+  selectStaleWorktreeWorkingStatePaths,
+} from "../app-server/thread-working-state-refresh-policy";
 import { materializeTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
@@ -357,7 +357,6 @@ const PR_STATUS_TOKEN_BUCKET_CAPACITY = 20;
 const PR_STATUS_TOKEN_BUCKET_REFILL_PER_MINUTE = 20;
 const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT =
   DIRECTORY_GIT_STATUS_BACKGROUND_BATCH_SIZE;
-const BACKGROUND_WORKTREE_WORKING_STATE_REFRESH_BATCH_SIZE = 8;
 // PR discovery (Layer B): a slow branch-lookup rotation across ALL open threads
 // to catch newly opened PRs on projects the operator is not looking at. Tick
 // often, but sweep each thread rarely and only a few per tick, so discovery
@@ -1553,11 +1552,6 @@ class DesktopAppServerService {
   >();
   private readonly pendingDirectoryGitStatusRefreshes = new Map<string, Promise<void>>();
   private readonly pendingDirectoryGitStatusKeys = new Set<string>();
-  private readonly workingStateByWorktree = new Map<
-    string,
-    WorktreeGitWorkingStateCacheEntry
-  >();
-  private workingStateCacheLoaded = false;
   private readonly pendingWorktreeWorkingStateRefreshes = new Map<
     string,
     Promise<void>
@@ -2917,7 +2911,9 @@ class DesktopAppServerService {
   ): NavigationSnapshot["threads"][number] {
     const worktreePath = this.resolveThreadWorkingStatePath(thread);
     const cached = worktreePath
-      ? this.workingStateByWorktree.get(worktreePath)
+      ? getDesktopBackendRegistry()
+          .getThreadGitWorkingStateCache()
+          .get(worktreePath)
       : undefined;
     // Threads arrive without working state (the enricher no longer computes
     // it), so hydration only ever adds the cached value. A worktree the cache
@@ -3285,16 +3281,16 @@ class DesktopAppServerService {
     } as unknown as AgentEvent);
   }
 
+  /**
+   * The registry owns the cache both refresh lanes read. This window's lane
+   * used to keep a second copy, loaded exactly once and never re-read, so a
+   * registry-lane probe landing after startup was invisible here: the stale
+   * pre-stamp from `applyCachedWorktreeWorkingState` satisfied the registry's
+   * own `if (thread.gitWorkingState)` short-circuit and the newer value was
+   * dropped.
+   */
   private async loadThreadGitWorkingStateCache(): Promise<void> {
-    if (this.workingStateCacheLoaded) {
-      return;
-    }
-    this.workingStateCacheLoaded = true;
-
-    const entries = await this.getOverlayStore().readThreadGitWorkingStateCache();
-    for (const entry of Object.values(entries)) {
-      this.workingStateByWorktree.set(entry.worktreePath, entry);
-    }
+    await getDesktopBackendRegistry().loadThreadGitWorkingStateCache();
   }
 
   /**
@@ -3309,9 +3305,12 @@ class DesktopAppServerService {
     worktreePaths: string[];
     force?: boolean;
   }): number {
-    const worktreePaths = this.selectWorktreeWorkingStateRefreshCandidates(
-      params,
-    ).filter((worktreePath) => !this.pendingWorktreeWorkingStateKeys.has(worktreePath));
+    // In-flight paths are excluded during selection, not after it: dropping
+    // them afterwards let a full batch of already-probing worktrees consume
+    // the cap and schedule nothing, leaving the stale ones behind them for a
+    // later round.
+    const worktreePaths =
+      this.selectWorktreeWorkingStateRefreshCandidates(params);
     if (worktreePaths.length === 0) {
       return 0;
     }
@@ -3369,46 +3368,27 @@ class DesktopAppServerService {
     };
   }
 
+  /**
+   * Everything lane-specific about picking a batch: the automatic navigation
+   * lane sees the whole fleet and takes a capped, rotating slice, while the
+   * focused and user-triggered lanes name one worktree and want it now.
+   * Freshness and the rotation order are shared policy — see
+   * `app-server/thread-working-state-refresh-policy.ts`.
+   */
   private selectWorktreeWorkingStateRefreshCandidates(params: {
     automatic: boolean;
     worktreePaths: string[];
     force?: boolean;
   }): string[] {
-    const candidates = [
-      ...new Set(params.worktreePaths.map((p) => p.trim()).filter(Boolean)),
-    ].filter((worktreePath) => {
-      if (params.force) {
-        return true;
-      }
-      const cached = this.workingStateByWorktree.get(worktreePath);
-      if (!cached) {
-        return true;
-      }
-      return !isFreshWorktreeWorkingStateCacheEntry(cached);
+    return selectStaleWorktreeWorkingStatePaths({
+      cache: getDesktopBackendRegistry().getThreadGitWorkingStateCache(),
+      exclude: this.pendingWorktreeWorkingStateKeys,
+      ...(params.force ? { force: true } : {}),
+      ...(params.automatic
+        ? { limit: BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE }
+        : {}),
+      worktreePaths: params.worktreePaths,
     });
-
-    if (!params.automatic) {
-      return candidates;
-    }
-
-    // Stable thread ordering must not make the same prefix win forever.
-    // Unseen worktrees sort first; after that, rotate the oldest probes
-    // forward. Selected and hover-inspected threads use the focused/user lane.
-    candidates.sort((left, right) => {
-      const leftFetchedAt = this.workingStateByWorktree.get(left)?.fetchedAt;
-      const rightFetchedAt = this.workingStateByWorktree.get(right)?.fetchedAt;
-      if (leftFetchedAt === undefined) {
-        return rightFetchedAt === undefined ? 0 : -1;
-      }
-      if (rightFetchedAt === undefined) {
-        return 1;
-      }
-      return leftFetchedAt - rightFetchedAt;
-    });
-    return candidates.slice(
-      0,
-      BACKGROUND_WORKTREE_WORKING_STATE_REFRESH_BATCH_SIZE,
-    );
   }
 
   private async refreshWorktreeWorkingStates(
@@ -3430,45 +3410,17 @@ class DesktopAppServerService {
         ),
       },
     )) {
-      await this.writeWorktreeWorkingStateEntry({
+      // The registry owns the monotonic stamp, the durable write, and the
+      // `navigation/threadGitWorkingState/updated` publish, so a probe from
+      // either lane reaches open surfaces the same way.
+      await getDesktopBackendRegistry().rememberThreadGitWorkingStateCacheEntry({
         worktreePath: entry.worktreePath,
         fetchedAt: Date.now(),
-        gitWorkingState: entry.gitWorkingState,
+        ...(entry.gitWorkingState
+          ? { gitWorkingState: entry.gitWorkingState }
+          : {}),
       });
     }
-  }
-
-  private async writeWorktreeWorkingStateEntry(params: {
-    worktreePath: string;
-    fetchedAt: number;
-    gitWorkingState?: ThreadGitWorkingState;
-  }): Promise<void> {
-    const previous = this.workingStateByWorktree.get(params.worktreePath);
-    const fetchedAt = Math.max(
-      params.fetchedAt,
-      (previous?.fetchedAt ?? params.fetchedAt - 1) + 1,
-    );
-    const cacheEntry: WorktreeGitWorkingStateCacheEntry = {
-      worktreePath: params.worktreePath,
-      fetchedAt,
-      ...(params.gitWorkingState ? { gitWorkingState: params.gitWorkingState } : {}),
-    };
-    this.workingStateByWorktree.set(params.worktreePath, cacheEntry);
-    await getDesktopBackendRegistry()
-      .rememberThreadGitWorkingStateCacheEntry(cacheEntry);
-
-    const notification: NavigationThreadGitWorkingStateUpdatedNotification = {
-      method: "navigation/threadGitWorkingState/updated",
-      params: {
-        worktreePath: params.worktreePath,
-        gitWorkingState: params.gitWorkingState ?? null,
-        fetchedAt,
-      },
-    };
-    await getDesktopBackendRegistry().publishLocalEvent({
-      backend: "codex",
-      notification,
-    } as unknown as AgentEvent);
   }
 
   /**
@@ -7446,8 +7398,6 @@ class DesktopAppServerService {
     this.lastDirectoriesByKey.clear();
     this.pendingWorktreeWorkingStateRefreshes.clear();
     this.pendingWorktreeWorkingStateKeys.clear();
-    this.workingStateByWorktree.clear();
-    this.workingStateCacheLoaded = false;
     this.worktreePathByThreadKey.clear();
     this.prRefreshContextByThreadKey.clear();
     await disposeDesktopBackendRegistry();
@@ -7526,12 +7476,6 @@ class DesktopAppServerService {
     });
     return this.focusedDiffService;
   }
-}
-
-function isFreshWorktreeWorkingStateCacheEntry(
-  entry: WorktreeGitWorkingStateCacheEntry,
-): boolean {
-  return Date.now() - entry.fetchedAt < WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS;
 }
 
 async function resolvePrimaryThreadRepoKey(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2660,8 +2660,12 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
+    // findPreferredReviewWorkspaceCwd and buildReviewBranchOptions below read
+    // thread.gitWorkingState to choose a workspace and infer a base branch, so
+    // this picker cannot race the background refresh.
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: binding.backend,
+      probeWorkingStates: true,
     });
     const thread = findThreadForBinding(navigation, binding);
     const workspaces = (thread?.linkedDirectories ?? [])
@@ -5150,8 +5154,12 @@ export class MessagingController {
       return;
     }
 
+    // buildReviewBranchOptions below infers the base branch from
+    // thread.gitWorkingState, so this callback awaits working state for the
+    // same reason presentReviewPicker does.
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: binding.backend,
+      probeWorkingStates: true,
     });
     const targetSurface = pendingIntent.surface ?? (
       event.kind === "callback" ? event.interaction : undefined

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -303,10 +303,19 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       await this.registry.canonicalizeNavigationThreadPullRequests(
         snapshot.threads,
       );
+    // Working state is renderer-facing chip data — no main-process messaging
+    // or federation code reads it. Serve the durable cache the way the
+    // renderer's own navigation path does (ipc/app-server.ts) and let a
+    // bounded background probe converge the rest, instead of holding every
+    // messaging command and every remote viewer's snapshot behind a Git fleet.
     const threads = await this.registry.hydrateThreadGitWorkingStates(
       canonicalThreads,
-      { probeMissing: true },
     );
+    if (typeof this.registry.refreshThreadGitWorkingStates === "function") {
+      void this.registry.refreshThreadGitWorkingStates(threads).catch(() => {
+        // Background convergence: the next snapshot reads whatever landed.
+      });
+    }
     const hydratedSnapshot = {
       ...snapshot,
       threads,

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -303,18 +303,25 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       await this.registry.canonicalizeNavigationThreadPullRequests(
         snapshot.threads,
       );
-    // Working state is renderer-facing chip data — no main-process messaging
-    // or federation code reads it. Serve the durable cache the way the
-    // renderer's own navigation path does (ipc/app-server.ts) and let a
-    // bounded background probe converge the rest, instead of holding every
-    // messaging command and every remote viewer's snapshot behind a Git fleet.
+    // Working state is chip data for almost every caller, and the review
+    // picker is the exception that has to await it: it compares dirt and
+    // base-branch drift across a thread's workspaces to pick one
+    // (findPreferredReviewWorkspaceCwd, buildReviewBranchOptions). Everything
+    // else serves the durable cache the way the renderer's own navigation path
+    // does (ipc/app-server.ts) and lets a bounded background probe converge
+    // the rest, instead of holding every messaging command and every remote
+    // viewer's snapshot behind a Git fleet.
+    const probeWorkingStates = request.probeWorkingStates === true;
     const threads = await this.registry.hydrateThreadGitWorkingStates(
       canonicalThreads,
+      { probeMissing: probeWorkingStates },
     );
-    if (typeof this.registry.refreshThreadGitWorkingStates === "function") {
-      void this.registry.refreshThreadGitWorkingStates(threads).catch(() => {
-        // Background convergence: the next snapshot reads whatever landed.
-      });
+    if (!probeWorkingStates) {
+      void this.registry
+        .refreshThreadGitWorkingStates(canonicalThreads)
+        .catch(() => {
+          // Background convergence: the next snapshot reads whatever landed.
+        });
     }
     const hydratedSnapshot = {
       ...snapshot,

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -422,6 +422,26 @@ This policy is interaction-driven. It adds no polling timer and no timer-driven
 SQLite writes; persistence changes only when a scheduled targeted or bounded
 background probe completes.
 
+#### Thread working-state refresh policy
+
+Per-worktree working state (dirty files, unpushed commits, base-branch drift)
+follows the same shape. It is renderer-facing chip data: no main-process
+messaging or federation code reads it. A broad snapshot serves the durable
+per-worktree cache and treats an entry as fresh for 30 seconds — shorter than
+the directory TTL, because working state has to catch out-of-band terminal and
+IDE edits.
+
+Only a multi-project thread is probe-eligible; a single-directory thread's
+review target needs no working state to disambiguate it. A snapshot schedules
+at most eight stale worktrees at once and never awaits that batch. Never-probed
+worktrees are selected first, then the oldest probe rotates forward, so a fleet
+larger than one round still converges. Registry scheduling coalesces each
+worktree while its probe is pending, and in-flight worktrees are excluded
+before the batch cap so a saturated round still reaches the paths behind it.
+
+A caller that cannot tolerate a stale answer awaits the fleet through
+`hydrateThreadGitWorkingStates(..., { probeMissing: true })` instead.
+
 ### Single platform-agnostic detach pipeline
 
 The detach flow — retire the channel's status surface, revoke the binding in the store, deliver a "Thread detached" confirmation — has exactly one implementation: `MessagingController.runDetachPipeline`. Every detach origin (Discord `/detach`, Telegram `/detach`, the desktop right-click "Unbind" chip, future archive-on-delete flows, future "Unbind all") routes through it.

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -425,22 +425,28 @@ background probe completes.
 #### Thread working-state refresh policy
 
 Per-worktree working state (dirty files, unpushed commits, base-branch drift)
-follows the same shape. It is renderer-facing chip data: no main-process
-messaging or federation code reads it. A broad snapshot serves the durable
-per-worktree cache and treats an entry as fresh for 30 seconds — shorter than
-the directory TTL, because working state has to catch out-of-band terminal and
-IDE edits.
+follows the same shape. A broad snapshot serves the durable per-worktree cache
+and treats an entry as fresh for 30 seconds — shorter than the directory TTL,
+because working state has to catch out-of-band terminal and IDE edits.
 
-Only a multi-project thread is probe-eligible; a single-directory thread's
-review target needs no working state to disambiguate it. A snapshot schedules
-at most eight stale worktrees at once and never awaits that batch. Never-probed
-worktrees are selected first, then the oldest probe rotates forward, so a fleet
-larger than one round still converges. Registry scheduling coalesces each
-worktree while its probe is pending, and in-flight worktrees are excluded
-before the batch cap so a saturated round still reaches the paths behind it.
+Each such snapshot schedules at most eight stale worktrees per round and never
+awaits them. Never-probed worktrees are selected first, then the oldest probe
+rotates forward, so a fleet larger than one round still converges. Registry
+scheduling coalesces each worktree while its probe is pending, and in-flight
+worktrees are excluded before the batch cap so a saturated round still reaches
+the paths behind it. The cap bounds one round, not the process: concurrent
+snapshots can each hold a round, and per-worktree coalescing is what keeps them
+from probing the same path twice. `close()` drains the live rounds.
 
-A caller that cannot tolerate a stale answer awaits the fleet through
-`hydrateThreadGitWorkingStates(..., { probeMissing: true })` instead.
+One caller does await the fleet, through
+`hydrateThreadGitWorkingStates(..., { probeMissing: true })`: the messenger's
+review picker. `findPreferredReviewWorkspaceCwd` and `buildReviewBranchOptions`
+read `thread.gitWorkingState` to choose a workspace and infer a base branch, so
+the picker cannot race the background refresh. Requests opt in with
+`GetNavigationSnapshotRequest.probeWorkingStates`, and only that path narrows to
+multi-project threads — a single-directory thread's review target needs no
+working state to disambiguate it. The background lane covers every thread,
+because it feeds the chips every thread shows.
 
 ### Single platform-agnostic detach pipeline
 

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -438,6 +438,33 @@ the paths behind it. The cap bounds one round, not the process: concurrent
 snapshots can each hold a round, and per-worktree coalescing is what keeps them
 from probing the same path twice. `close()` drains the live rounds.
 
+Two lanes drive this: the registry's background lane above, which serves
+messaging commands and federated viewers, and the renderer's navigation lane in
+`ipc/app-server.ts`, driven by the local window's snapshot polling and by
+turn/commit events. They are separate schedulers on purpose — different clocks,
+different triggers — but they are not allowed to disagree about what is stale,
+so they share two things:
+
+- **One policy.** `app-server/thread-working-state-refresh-policy.ts` owns the
+  TTL, the batch size, the freshness predicate, and the selection order. Each
+  lane keeps only what is genuinely its own: the registry resolves threads to
+  worktree paths and applies the review picker's multi-project narrowing; the
+  renderer decides whether a round is the capped automatic one or a focused
+  single-worktree one.
+- **One cache.** The registry owns the in-memory map, exposed read-only through
+  `getThreadGitWorkingStateCache()`, and
+  `rememberThreadGitWorkingStateCacheEntry` is the only writer. It stamps
+  `fetchedAt` strictly above the entry it replaces — two lanes can land in the
+  same millisecond, and the renderer ignores an update whose stamp does not
+  advance — writes the durable row, and publishes
+  `navigation/threadGitWorkingState/updated` so a probe from either lane
+  reaches already-open surfaces instead of waiting for the next full snapshot.
+
+The one seam left unshared is the in-flight set: each lane tracks its own
+pending worktrees, so the two can briefly probe the same path at once. Whichever
+lands first makes it fresh for the shared window, so the other lane's next round
+skips it.
+
 One caller does await the fleet, through
 `hydrateThreadGitWorkingStates(..., { probeMissing: true })`: the messenger's
 review picker. `findPreferredReviewWorkspaceCwd` and `buildReviewBranchOptions`

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1340,6 +1340,14 @@ export type GetNavigationSnapshotRequest = {
   filter?: string;
   forceRefresh?: boolean;
   refreshMode?: "active-recent" | "full";
+  /**
+   * Await per-thread Git working state instead of serving the cache. Only a
+   * caller that reads `thread.gitWorkingState` to make a decision — the
+   * messenger's review picker, which compares dirt and base-branch drift
+   * across a multi-project thread's workspaces — should set this. Every other
+   * snapshot serves the durable cache and converges in the background.
+   */
+  probeWorkingStates?: boolean;
 };
 
 /**


### PR DESCRIPTION
Follow-up to #1896, which fixed one of two awaited Git fleets on the messaging navigation path and left the other.

## The asymmetry

`DesktopMessagingBackendBridge.getNavigationSnapshot` had two live Git fleets on adjacent lines. #1896 fixed the second one:

| Fleet | Before #1896 | After #1896 | After this PR |
|---|---|---|---|
| `readDirectoryStatuses` | awaited | cached + ≤4 background | unchanged |
| `hydrateThreadGitWorkingStates({ probeMissing: true })` | awaited | **awaited** | cached + ≤8 background |

The renderer's own navigation path has always been cached-first plus a background refresh:

```
ipc/app-server.ts:2289          hydrateThreadGitWorkingStates(threads)                    ← cached-only
                                + startWorktreeWorkingStateRefresh({ automatic: true })   ← background
desktop-backend-bridge.ts:171   hydrateThreadGitWorkingStates(threads, {probeMissing:true}) ← awaited fleet
```

So this removes an asymmetry rather than inventing a policy.

## Why it is safe to stop awaiting

> **Correction.** The first revision of this PR claimed the messenger's review picker "never reads working state" and dropped the awaited probe outright. That was wrong, and the claim came from a `rg` scoped to `src/main/messaging/` that missed the indirection through `packages/shared`. `MessagingController.presentReviewPicker` calls `findPreferredReviewWorkspaceCwd` (`packages/shared/src/review-branches.ts:174`) to choose a workspace, and both it and the review callback infer a base branch through `buildReviewBranchOptions` (`:142`). On a cold cache that picks `linkedDirectories[0]` for a multi-project thread instead of the workspace with the changes. Fixed in the second commit.

Working state is chip data for every caller **except** the review picker, which compares dirt and base-branch drift across a thread's workspaces to pick one. That caller opts in with `GetNavigationSnapshotRequest.probeWorkingStates` and still awaits the fleet; the two call sites are `messaging-controller.ts:2641` and `:5101`. Every other snapshot — 42 remaining `getNavigationSnapshot` call sites plus every federated remote viewer — serves the cache and converges in the background.

A federation remote viewer converges on its next navigation poll (`ipc/app-server.ts:2121` refetches the remote snapshot as part of the viewer's own navigation build), exactly as a local window does.

## Blast radius

The bridge serves 44 `getNavigationSnapshot` call sites in `MessagingController` plus every federated remote viewer's snapshot. #1896's targeted admission removed the fleet from the reply-routing hot path; this covers the browse and command surfaces that still build a full snapshot.

## What was added

`DesktopBackendRegistry.refreshThreadGitWorkingStates`, mirroring `refreshDirectoryGitStatuses`:

- bounded batch of 8, matching the renderer's automatic lane;
- per-worktree coalescing through `pendingThreadGitWorkingStateKeys`;
- oldest-first rotation, so a fleet larger than one round still converges instead of the same prefix winning forever;
- in-flight exclusion applied **before** the cap, so a round whose whole batch is already running still reaches the paths behind it.

The awaited form stays in production use via `hydrateThreadGitWorkingStates(..., { probeMissing: true })`, reached through `probeWorkingStates`, and keeps its three existing tests. Its `multiProjectOnly` narrowing — a single-directory thread's review target needs no working state to disambiguate it — belongs to that path only; the background lane covers every thread, because it feeds the chips every thread shows.

Staleness is decided in exactly one place, the cache entry's age. The first revision also prefiltered on `!thread.gitWorkingState`, which the bridge had already stamped from that same cache, so one row per worktree made the lane return `scheduledCount: 0` forever and the TTL, rotation, and cap were unreachable from production.

`close()` drains live rounds before clearing the working-state caches, since `rememberThreadGitWorkingStateCacheEntry` reloads them.

## SQLite

No new writes. The same `writeThreadGitWorkingStateCacheEntry` call moves off the critical path, and the batch cap bounds a per-snapshot write count that previously was not bounded at all — strictly fewer probes per snapshot than before.

## Verification

Each new test was checked against a deliberately broken implementation, not just against the fix:

| Guard | Broken by | Result |
|---|---|---|
| snapshot does not block on the fleet | `void` → `await` in the bridge | `Test timed out in 5000ms` |
| oldest-first rotation | removing the sort | `expected "vi.fn()" to be called with [ '/worktrees/repo-0', …(7) ]` |
| in-flight exclusion before the cap | filtering after the cap | `expected { scheduledCount: 0 } to deeply equal { scheduledCount: 1 }` |
| a stale worktree is re-probed | restoring the `!thread.gitWorkingState` prefilter | `re-probes a stale worktree that hydration already stamped` fails |
| the lane covers single-directory threads | making `multiProjectOnly` unconditional | `schedules a single-directory thread the chips also need` fails |
| the review picker still awaits the fleet | dropping `probeMissing: probeWorkingStates` | `awaits the working-state fleet when the caller opts in` fails |

Gates: `typecheck` ✓ · `lint:eslint` 0 errors (43 pre-existing warnings) ✓ · `lint:boundaries` ✓ · `lint:codex-storage` ✓ · `pnpm test` 642 files, 9358 passed, 0 failures ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

