### PR TITLE
fix(desktop): scroll the Settings nav section list

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -376,106 +376,113 @@ export function SettingsScreen(props: {
         {/* Group label between Exit and the section list. */}
         <p className="settings-nav__group-label">General</p>
 
-        {ORDERED_SECTIONS.map((item) => {
-          const isGroup = SETTINGS_NAV_GROUPS.has(item.id);
-          const open = openGroups[item.id] === true;
-          const sublistId = `settings-nav-sublist-${item.id}`;
-          // Plugins keeps its long-standing contract: the MCPs child —
-          // the pane's whole content — carries the active state, not
-          // the parent row.
-          const groupHoldsRoute = section === item.id;
-          const parentActive =
-            groupHoldsRoute
-            && route.sub === undefined
-            && item.id !== "plugins";
-          // A collapsed group hides its aria-current child inside an
-          // aria-hidden, inert sublist, so the parent row takes over
-          // the marker — the nav must always show where the operator
-          // is (this also covers collapsed Plugins).
-          const parentMarksRoute =
-            parentActive || (isGroup && !open && groupHoldsRoute);
-          const children = isGroup ? navChildren(item.id) : [];
-          return (
-            <Fragment key={item.id}>
-              <div
-                className={`settings-nav__row${parentMarksRoute ? " is-active" : ""}`}
-              >
-                {isGroup ? (
-                  <button
-                    aria-controls={sublistId}
-                    aria-expanded={open}
-                    aria-label={`${open ? "Collapse" : "Expand"} ${item.label}`}
-                    className="settings-nav__caret"
-                    type="button"
-                    onClick={() => toggleGroup(item.id)}
-                  >
+        {/* Section list is its own scroll container so the masthead and
+            Exit stay pinned. The nav itself is `overflow: hidden`; with
+            the rows as direct children the list clipped instead of
+            scrolling, and at the 640px minimum window height its tail
+            was unreachable by pointer. See `.settings-nav__sections`. */}
+        <div className="settings-nav__sections">
+          {ORDERED_SECTIONS.map((item) => {
+            const isGroup = SETTINGS_NAV_GROUPS.has(item.id);
+            const open = openGroups[item.id] === true;
+            const sublistId = `settings-nav-sublist-${item.id}`;
+            // Plugins keeps its long-standing contract: the MCPs child —
+            // the pane's whole content — carries the active state, not
+            // the parent row.
+            const groupHoldsRoute = section === item.id;
+            const parentActive =
+              groupHoldsRoute
+              && route.sub === undefined
+              && item.id !== "plugins";
+            // A collapsed group hides its aria-current child inside an
+            // aria-hidden, inert sublist, so the parent row takes over
+            // the marker — the nav must always show where the operator
+            // is (this also covers collapsed Plugins).
+            const parentMarksRoute =
+              parentActive || (isGroup && !open && groupHoldsRoute);
+            const children = isGroup ? navChildren(item.id) : [];
+            return (
+              <Fragment key={item.id}>
+                <div
+                  className={`settings-nav__row${parentMarksRoute ? " is-active" : ""}`}
+                >
+                  {isGroup ? (
+                    <button
+                      aria-controls={sublistId}
+                      aria-expanded={open}
+                      aria-label={`${open ? "Collapse" : "Expand"} ${item.label}`}
+                      className="settings-nav__caret"
+                      type="button"
+                      onClick={() => toggleGroup(item.id)}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className={`settings-nav__caret-mark${open ? " is-open" : ""}`}
+                      />
+                    </button>
+                  ) : (
                     <span
                       aria-hidden="true"
-                      className={`settings-nav__caret-mark${open ? " is-open" : ""}`}
+                      className="settings-nav__caret-spacer"
                     />
+                  )}
+                  <button
+                    aria-current={parentMarksRoute ? "page" : undefined}
+                    className={`settings-nav__button${parentMarksRoute ? " is-active" : ""}`}
+                    type="button"
+                    onClick={() => openRoute(item.id)}
+                  >
+                    {item.label}
                   </button>
-                ) : (
-                  <span
-                    aria-hidden="true"
-                    className="settings-nav__caret-spacer"
-                  />
-                )}
-                <button
-                  aria-current={parentMarksRoute ? "page" : undefined}
-                  className={`settings-nav__button${parentMarksRoute ? " is-active" : ""}`}
-                  type="button"
-                  onClick={() => openRoute(item.id)}
-                >
-                  {item.label}
-                </button>
-              </div>
-              {isGroup ? (
-                <div
-                  aria-hidden={!open}
-                  className={`settings-nav__sublist${open ? " is-open" : ""}`}
-                  id={sublistId}
-                  inert={open ? undefined : true}
-                >
-                  <div className="settings-nav__sublist-clip">
-                    {children.map((child) => {
-                      const childActive =
-                        section === item.id && route.sub === child.sub;
-                      return (
-                        <button
-                          key={child.key}
-                          aria-current={childActive ? "page" : undefined}
-                          className={`settings-nav__subbutton${
-                            childActive ? " is-active" : ""
-                          }`}
-                          type="button"
-                          onClick={() => openRoute(item.id, child.sub)}
-                        >
-                          {child.dot ? (
-                            <span
-                              aria-hidden="true"
-                              className={`settings-nav__subdot settings-nav__subdot--${child.dot}`}
-                            />
-                          ) : null}
-                          <span className="settings-nav__sublabel">
-                            {child.label}
-                          </span>
-                          {child.chip ? (
-                            <span className="settings-nav__subchip">
-                              {child.chip}
-                            </span>
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                  </div>
                 </div>
-              ) : null}
-              {item.id === SETTINGS_NAV_DIVIDER_AFTER ? (
-                <hr className="settings-nav__divider" />
-              ) : null}
-            </Fragment>
-          );
-        })}
+                {isGroup ? (
+                  <div
+                    aria-hidden={!open}
+                    className={`settings-nav__sublist${open ? " is-open" : ""}`}
+                    id={sublistId}
+                    inert={open ? undefined : true}
+                  >
+                    <div className="settings-nav__sublist-clip">
+                      {children.map((child) => {
+                        const childActive =
+                          section === item.id && route.sub === child.sub;
+                        return (
+                          <button
+                            key={child.key}
+                            aria-current={childActive ? "page" : undefined}
+                            className={`settings-nav__subbutton${
+                              childActive ? " is-active" : ""
+                            }`}
+                            type="button"
+                            onClick={() => openRoute(item.id, child.sub)}
+                          >
+                            {child.dot ? (
+                              <span
+                                aria-hidden="true"
+                                className={`settings-nav__subdot settings-nav__subdot--${child.dot}`}
+                              />
+                            ) : null}
+                            <span className="settings-nav__sublabel">
+                              {child.label}
+                            </span>
+                            {child.chip ? (
+                              <span className="settings-nav__subchip">
+                                {child.chip}
+                              </span>
+                            ) : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+                {item.id === SETTINGS_NAV_DIVIDER_AFTER ? (
+                  <hr className="settings-nav__divider" />
+                ) : null}
+              </Fragment>
+            );
+          })}
+        </div>
       </nav>
 
       {/* Right pane — its own header (breadcrumb + MessagingStatusBar)

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -770,6 +770,40 @@ describe("SettingsScreen", () => {
     );
   });
 
+  it("keeps every section row inside the scrolling lane and the chrome outside it", () => {
+    // Regression guard for the clipped nav. `.settings-nav` is
+    // `overflow: hidden`, so a section row rendered as a direct child of
+    // the nav does not scroll — it is painted below the clip and no
+    // pointer can reach it. At the 640px MAIN_WINDOW_MIN_HEIGHT that was
+    // the whole tail of the list (Experimental, Troubleshooting, About).
+    //
+    // jsdom has no layout, so this cannot assert the geometry; what it
+    // can pin is the structural invariant the geometry rests on — every
+    // row inside the lane, and the masthead + Exit deliberately outside
+    // it so they stay put while the list scrolls under them.
+    const { container } = render(
+      <SettingsScreen settings={createSettingsState()} onClose={() => undefined} />,
+    );
+
+    const nav = container.querySelector(".settings-nav");
+    const lane = container.querySelector(".settings-nav__sections");
+    expect(nav).not.toBeNull();
+    expect(lane).not.toBeNull();
+
+    const rows = [...container.querySelectorAll(".settings-nav__row")];
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(lane?.contains(row)).toBe(true);
+    }
+
+    // The pinned chrome is a sibling of the lane, not a passenger in it.
+    for (const selector of [".settings-nav__masthead", ".settings-nav__exit"]) {
+      const chrome = container.querySelector(selector);
+      expect(chrome).not.toBeNull();
+      expect(chrome?.parentElement).toBe(nav);
+    }
+  });
+
   it("switches sections and saves settings", async () => {
     const settings = createSettingsState();
     const desktopApi = {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -782,7 +782,10 @@ describe("SettingsScreen", () => {
     // row inside the lane, and the masthead + Exit deliberately outside
     // it so they stay put while the list scrolls under them.
     const { container } = render(
-      <SettingsScreen settings={createSettingsState()} onClose={() => undefined} />,
+      <SettingsScreen
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
     );
 
     const nav = container.querySelector(".settings-nav");
@@ -790,10 +793,21 @@ describe("SettingsScreen", () => {
     expect(nav).not.toBeNull();
     expect(lane).not.toBeNull();
 
-    const rows = [...container.querySelectorAll(".settings-nav__row")];
-    expect(rows.length).toBeGreaterThan(0);
-    for (const row of rows) {
-      expect(lane?.contains(row)).toBe(true);
+    // Every scrolling part, not just the rows: the collapsible sublists and
+    // the divider come out of the same map, and a refactor that hoisted the
+    // sublists out — to stop the scroller clipping them, say — would leave a
+    // rows-only assertion green while group children stopped scrolling with
+    // their parent row.
+    for (const selector of [
+      ".settings-nav__row",
+      ".settings-nav__sublist",
+      ".settings-nav__divider",
+    ]) {
+      const members = [...container.querySelectorAll(selector)];
+      expect(members.length).toBeGreaterThan(0);
+      for (const member of members) {
+        expect(lane?.contains(member)).toBe(true);
+      }
     }
 
     // The pinned chrome is a sibling of the lane, not a passenger in it.

--- a/apps/desktop/src/renderer/src/styles/__tests__/automations-chrome-parity.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/automations-chrome-parity.test.ts
@@ -31,6 +31,14 @@ function padding(selector: string): string[] {
  * two are one chrome wearing two labels. Everywhere they diverge is an
  * accident — and one already shipped: the content inset drifted to 20px
  * against Settings' 24px and nothing failed, which is what these lock.
+ *
+ * One divergence is deliberate and NOT locked here: Settings wraps its
+ * section list in `.settings-nav__sections`, a scroll lane, because 16 rows
+ * plus expanded groups overflow the nav at the minimum window height.
+ * Automations renders one static row ("All Automations"), so it cannot
+ * overflow and a lane around a single button would be scaffolding. If that
+ * nav ever grows a real list — a row per schedule — it needs the same lane,
+ * or it clips the way Settings did.
  */
 describe("Automations chrome matches Settings", () => {
   it("insets content from the window edge identically", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1747,6 +1747,38 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("scrolls the Settings nav's section list without letting the reserved gutter move the rows", () => {
+    // Regression guard. `.settings-nav` clips (that is what keeps the
+    // bleed below from escaping the column), so the section list needs a
+    // scroll container of its own or its tail is simply unreachable at
+    // the 640px minimum window height. The nav must KEEP clipping — the
+    // fix is the inner lane, not `overflow: auto` on the nav, which would
+    // scroll the brand out from under the stoplights.
+    expect(extractRuleBody(css, ".settings-nav")).toContain("overflow: hidden;");
+
+    const lane = extractRuleBody(css, ".settings-nav__sections");
+    expect(lane).toContain("overflow-y: auto;");
+    expect(lane).toContain("min-height: 0;");
+
+    // Same bleed-then-re-inset move as `.sidebar-list--dense`, but back to
+    // the nav's OWN 16px rail inset rather than the narrower lane inset:
+    // Exit and the GENERAL label sit outside the scroller, and the row
+    // pills have to stay lined up with them. The bleed is purely so the
+    // reserved gutter lands against the nav wall.
+    expect(lane).toMatch(/margin-inline:\s*-16px;/);
+    expect(lane).toMatch(/padding-inline:\s*16px;/);
+
+    // Without a reserved gutter every row would jump sideways the moment a
+    // classic scrollbar appeared (Windows and Linux always; macOS under
+    // "Show scroll bars: Always"), because the bar takes layout width.
+    expect(lane).toContain("scrollbar-gutter: stable;");
+
+    // Defining a `::-webkit-scrollbar` block here would override the
+    // universal `scrollbar-width: thin` and reintroduce the classic-mode
+    // fat-bar flicker — the same trap the sidebar lanes are guarded from.
+    expect(css).not.toMatch(/\.settings-nav__sections::-webkit-scrollbar/);
+  });
+
   it("applies a thin, themed scrollbar to every scroller via the universal selector (scrollbar-width does not inherit)", () => {
     // `scrollbar-color` inherits but `scrollbar-width` does NOT, so a
     // `:root` rule alone leaves scrollers at the chunky default width in

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -57,6 +57,21 @@ function extractRuleBody(source: string, selector: string): string {
   return ruleMatch.groups.body;
 }
 
+/**
+ * The Settings nav's horizontal inset, read off its `padding` shorthand.
+ * Two tests need it — one checks it equals the sidebar's lane inset, the
+ * other that `.settings-nav__sections` bleeds and re-insets by exactly it —
+ * and a copy of the shorthand regex in each is one edit away from drifting.
+ * NaN when the shorthand stops matching, so callers can guard once.
+ */
+function settingsNavInset(source: string): number {
+  return Number(
+    extractRuleBody(source, ".settings-nav").match(
+      /\n\s*padding:\s*0\s+(\d+)px\s+\d+px;/,
+    )?.[1],
+  );
+}
+
 /** First `z-index` in a rule body, NaN when the rule declares none. */
 function readZIndex(rule: string): number {
   return Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
@@ -1766,11 +1781,7 @@ describe("Tangerine Terminal theme contract", () => {
     const sidebar = extractRuleBody(css, ".sidebar");
     const lane = Number(sidebar.match(/--sidebar-lane-inset:\s*(\d+)px;/)?.[1]);
     const rail = Number(sidebar.match(/--sidebar-rail-inset:\s*(\d+)px;/)?.[1]);
-    const navLane = Number(
-      extractRuleBody(css, ".settings-nav").match(
-        /\n\s*padding:\s*0\s+(\d+)px\s+\d+px;/,
-      )?.[1],
-    );
+    const navLane = settingsNavInset(css);
     expect(navLane).toBe(lane);
 
     // Brand x, macOS: both mastheads reserve the stoplight gutter from
@@ -1807,10 +1818,17 @@ describe("Tangerine Terminal theme contract", () => {
     // the 640px minimum window height. The nav must KEEP clipping — the
     // fix is the inner lane, not `overflow: auto` on the nav, which would
     // scroll the brand out from under the stoplights.
-    expect(extractRuleBody(css, ".settings-nav")).toContain("overflow: hidden;");
+    const nav = extractRuleBody(css, ".settings-nav");
+    expect(nav).toContain("overflow: hidden;");
 
     const lane = extractRuleBody(css, ".settings-nav__sections");
     expect(lane).toContain("overflow-y: auto;");
+    // `flex: 1` + `min-height: 0` is what lets the lane fill the nav column
+    // and then shrink below its content. Drop the `flex` and the lane sizes
+    // to its content instead: it still scrolls (flex-shrink covers that), but
+    // it stops spanning the column, so the scrollbar track no longer reaches
+    // the nav's full height. Measured: 523px tall becomes 499px.
+    expect(lane).toContain("flex: 1;");
     expect(lane).toContain("min-height: 0;");
 
     // Same bleed-then-re-inset move as `.sidebar-list--dense`, and it must
@@ -1820,20 +1838,17 @@ describe("Tangerine Terminal theme contract", () => {
     // the nav's padding rather than repeating the number: this rule was
     // written against the pre-#1901 16px nav and went stale the same week
     // that padding moved to the 8px lane.
-    const navInset = Number(
-      extractRuleBody(css, ".settings-nav").match(
-        /\n\s*padding:\s*0\s+(\d+)px\s+\d+px;/,
-      )?.[1],
-    );
+    const navInset = settingsNavInset(css);
     expect(navInset).toBeGreaterThan(0);
     expect(lane).toMatch(new RegExp(`margin-inline:\\s*-${navInset}px;`));
     expect(lane).toMatch(new RegExp(`padding-inline:\\s*${navInset}px;`));
 
     // The rows lost the nav's own `gap` when they moved into the lane, so
-    // the lane has to restate it or the list re-spaces itself.
-    const navGap = extractRuleBody(css, ".settings-nav").match(
-      /\n\s*gap:\s*(\d+px);/,
-    )?.[1];
+    // the lane has to restate it or the list re-spaces itself. Guarded like
+    // `navInset` above, so a nav gap this regex stops matching reports the
+    // nav rather than blaming the lane for not containing "gap: undefined;".
+    const navGap = nav.match(/\n\s*gap:\s*(\d+px);/)?.[1];
+    expect(navGap).toBeDefined();
     expect(lane).toContain(`gap: ${navGap};`);
 
     // Without a reserved gutter every row would jump sideways the moment a

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8215,40 +8215,28 @@ textarea,
    lane (`.sidebar__scroll-region` + `.sidebar-list--dense`).
 
    Before this wrapper the rows were direct nav children, so the nav's
-   own `overflow: hidden` CLIPPED them: at the 640px
-   `MAIN_WINDOW_MIN_HEIGHT` (window.ts) the list is 868px against a
-   523px lane with the Plugins / AI Providers / Messaging groups
-   expanded, and its tail — Experimental, Troubleshooting, About —
-   painted below the clip with no scrollbar and no wheel scrolling,
-   out of a pointer's reach. (A clipped box still scrolls
-   programmatically, so tabbing into one of those rows dragged the
-   whole nav up behind the stoplights with no way to put it back.
-   That was the only thing that moved the list.) Collapsing every
-   group fits, at exactly 523px — which is the margin this is one
-   added section away from losing again.
-
-   `flex: 1` + `min-height: 0` lets the lane shrink below its content
-   inside the nav's flex column; the `gap` re-establishes the 2px row
-   rhythm the rows used to inherit from the nav.
+   own `overflow: hidden` CLIPPED them instead of scrolling: at the
+   640px `MAIN_WINDOW_MIN_HEIGHT` (window.ts) the tail of an expanded
+   list — Experimental, Troubleshooting, About — painted below the clip
+   with no scrollbar and no wheel scrolling, out of a pointer's reach.
+   Collapsing every group fits, but with no margin to spare.
 
    The bleed-then-re-inset is `.sidebar-list--dense`'s move, at the
-   same 8px the nav already runs in — the whole point of that inset is
-   that this list reads at the thread list's density, so the lane
-   holds it rather than picking its own. The bleed buys exactly one
-   thing: the reserved gutter lands between the padding edge and the
-   nav wall, parking the thumb AT the wall instead of 8px inside it.
-   Keep the two in lockstep — a bleed that stops matching the nav's
-   padding moves every row sideways.
+   same inset the nav already runs in (that inset is the point — it is
+   what makes this list read at the thread list's density). The bleed
+   buys exactly one thing: the reserved gutter lands between the
+   padding edge and the nav wall, so the thumb parks AT the wall
+   instead of inside it. Keep the two in lockstep — a bleed that stops
+   matching the nav's padding moves every row sideways.
+   `theme-contract.test.tsx` derives both from `.settings-nav` and
+   pins them, along with `flex`, `min-height` and `gap`.
 
    `scrollbar-gutter: stable` reserves the space permanently so no row
-   jumps sideways the moment the bar appears — which it does on
-   Windows and Linux, where classic scrollbars take layout width (and
-   on macOS under "Show scroll bars: Always"). Under an overlay
-   scrollbar the gutter is zero and every row's box is unchanged from
-   before this rule existed; where the bar does take width, a ~11px
-   thin classic one leaves the row box 128px instead of 139px, which
-   at this density costs no new wrapping and no new truncation —
-   "Thread Management" wraps either way.
+   jumps sideways the moment the bar appears — which it does on Windows
+   and Linux, where classic scrollbars take layout width (and on macOS
+   under "Show scroll bars: Always"). Under an overlay scrollbar the
+   gutter is zero and every row's box is unchanged from before this
+   rule existed.
 
    Do NOT add a `::-webkit-scrollbar` block here — see
    `.sidebar-list--dense` for why the universal `scrollbar-width: thin`

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8198,6 +8198,63 @@ textarea,
   text-transform: uppercase;
 }
 
+/* Section list — the ONLY part of the nav that scrolls. The masthead
+   owns the 80px stoplight gutter and the window drag region, and Exit
+   Settings is the escape hatch, so both stay pinned: scrolling them
+   away would slide the brand out from under the traffic lights and
+   put Exit out of reach on exactly the short windows that need it.
+   This is the main sidebar's split — fixed masthead above a scrolling
+   lane (`.sidebar__scroll-region` + `.sidebar-list--dense`).
+
+   Before this wrapper the rows were direct nav children, so the nav's
+   own `overflow: hidden` CLIPPED them: at the 640px
+   `MAIN_WINDOW_MIN_HEIGHT` (window.ts) the tail of the list —
+   Experimental, Troubleshooting, About — painted below the clip with
+   no scrollbar and no wheel scrolling, out of a pointer's reach. (A
+   clipped box still scrolls programmatically, so tabbing into one of
+   those rows dragged the whole nav up behind the stoplights with no
+   way to put it back. That was the only thing that moved the list.)
+
+   `flex: 1` + `min-height: 0` lets the lane shrink below its content
+   inside the nav's flex column; the `gap` re-establishes the 4px row
+   rhythm the rows used to inherit from the nav.
+
+   The bleed-then-re-inset is `.sidebar-list--dense`'s move, but it
+   re-insets to the nav's OWN 16px rail inset, not to the narrower
+   `--sidebar-lane-inset`: the sidebar's thread lanes may sit wider
+   than the chrome above them, these rows may not, because Exit and
+   the GENERAL label stay outside the scroller and the row pills have
+   to keep lining up with them. So the bleed buys exactly one thing —
+   the reserved gutter lands between the padding edge and the nav
+   wall, parking the thumb AT the wall instead of 16px inside it.
+   Under an overlay scrollbar (macOS default) that gutter is zero and
+   every row's box is unchanged from before this rule existed.
+
+   `scrollbar-gutter: stable` reserves the space permanently so no row
+   jumps sideways the moment the bar appears — which it does on
+   Windows and Linux, where classic scrollbars take layout width (and
+   on macOS under "Show scroll bars: Always"). The cost lands only
+   there, and lands as wrapping, not clipping: a ~11px thin classic
+   bar leaves the row box 120px instead of 131px, putting "Usage &
+   Pricing" and "Access Control" onto two lines next to "Thread
+   Management" and "Archived Threads", which already wrap here. Rows
+   that grow are fine now that the list scrolls.
+
+   Do NOT add a `::-webkit-scrollbar` block here — see
+   `.sidebar-list--dense` for why the universal `scrollbar-width: thin`
+   rule has to stay in charge. */
+.settings-nav__sections {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 0;
+  margin-inline: -16px;
+  padding-inline: 16px;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
 /* Section row: caret gutter + label button. Every row reserves the
    24px gutter (caret button or spacer) so section labels align whether
    or not the section expands into a sublist. The gutter is 24px rather


### PR DESCRIPTION
> **Updated after merging `main`.** [#1901](https://github.com/pwrdrvr/PwrAgent/pull/1901) retuned this same nav to the thread list's density while this branch was open, so every measurement below was re-taken against the merged CSS. The conflict was semantic, not textual — see the last Note.

## Summary

- `.settings-nav` is `overflow: hidden` and the section rows were direct children of it, so the list **clipped instead of scrolling**. Measured in a headless render of the real nav markup against the merged `app.css` at the 640px `MAIN_WINDOW_MIN_HEIGHT`: with the Plugins / AI Providers / Messaging groups expanded the list is **868px against a 523px lane**. "About" sat at y=931 in a 640px window; twenty wheel events over the column moved it **0px** and no click could land on it. Experimental, Troubleshooting and About were out of a pointer's reach.
- Put the rows in their own scroll container (`.settings-nav__sections`) rather than scrolling the nav. The masthead owns the stoplight gutter and the window drag region, and Exit Settings is the escape hatch, so both stay pinned — the same split the main sidebar already makes between `.sidebar__scroll-region` and its lanes.
- `overflow-y: auto` alone was not the fix: classic scrollbars take layout width, so every row would jump sideways the moment the bar appeared. The lane bleeds to the nav walls and re-insets — `.sidebar-list--dense`'s move, at the same 8px the nav itself now runs in. The bleed buys exactly one thing: the reserved gutter lands between the padding edge and the wall, parking the thumb there instead of 8px inside it. `scrollbar-gutter: stable` holds the width steady.

```css
.settings-nav__sections {
  display: flex; flex: 1; flex-direction: column; gap: 2px; min-height: 0;
  margin-inline: -8px; padding-inline: 8px;
  overflow-y: auto; scrollbar-gutter: stable;
}
```

## Verification

- **It scrolls, and the chrome stays put.** Same wheel probe after the change: "About" moves to y=602, on screen and clickable, with the brand pinned at y=19 and Exit / GENERAL above it.
- **Nothing moves that shouldn't.** Under an overlay scrollbar (macOS default) the reserved gutter is zero and the row box is unchanged. Where a classic bar does take width, the row box goes 139px → 128px — at this density that costs **no new wrapping and no new truncation** ("Thread Management" wraps either way).
- **axe clean** on the new scroll container in **both themes**, for the exact tag set `a11y.spec.ts` gates on (`wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa`) — `scrollable-region-focusable` included, since the lane is full of focusable rows.
- **Two new gates, negative-controlled four ways** — each fails against the pre-fix files, and the CSS one also fails against a stale `-16px` bleed and a stale `4px` gap (the two values the merge would have silently kept):
  - `theme-contract.test.tsx` — the nav still clips, the lane scrolls, and its bleed / re-inset / gap are **derived from `.settings-nav`'s own padding and gap** rather than repeated as literals. It also refuses a `::-webkit-scrollbar` block on the lane.
  - `settings-screen.test.tsx` — every section row inside the lane, masthead and Exit outside it. jsdom has no layout, so this pins the structural invariant the geometry rests on.
- `pnpm typecheck`, `lint:eslint` (0 errors), `lint:colors`, `lint:boundaries` all pass. 363 tests across `styles/`, `features/settings/` and `features/automations/` pass.

## Notes

- **Collapsing every group now fits at exactly 523px.** That is the whole margin — the list is one added section away from clipping again with nothing expanded, which is a decent argument for this landing regardless of density tuning.
- **One correction to how the bug was described to me.** Those panes were not unreachable *at all*. A clipped box still scrolls programmatically, so tabbing into a clipped row dragged the whole nav — masthead included — up behind the stoplights, with no way to put it back. That was the only thing that moved the list. The bug is pointer-unreachable, plus a keyboard path that broke the chrome.
- **Automations is left alone.** It reuses `.settings-nav` but renders one static row, so it cannot overflow; wrapping a single button would be speculative.
- **The `main` merge was a semantic conflict.** #1901 moved the nav from `padding: 0 16px 12px` / `gap: 4px` to `0 8px 10px` / `gap: 2px`. Textually only the test file conflicted — `app.css` auto-merged clean while leaving this branch's `-16px` bleed and `4px` gap in place, which would have pushed every row 8px past the nav's wall and re-spaced the list against the chrome above it. Resolved by re-deriving the lane from the nav, and the test now asserts that relationship instead of the numbers, so the next density change cannot repeat it. Both conflicting tests are kept: main's pins the nav's lane and brand alignment, this one pins the scroll lane.
- **Not run:** the Electron `a11y.spec.ts` on the macOS lab guest. The headless harness reproduces axe's size/role/name and (at rest) contrast findings faithfully, but a lab run is the CI-equivalent check if you want it before merge.
- The `SettingsScreen.tsx` diff looks large because the mapped block moved a level deeper; `git diff -w` shows it is the wrapper `<div>` and its comment, nothing else.
