### PR TITLE
refactor(desktop): give thread information its own store

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -96,6 +96,7 @@ const federationMock = vi.hoisted(() => {
     })),
     getWorktreeUnpublishedCommitDiff: vi.fn(async () => ({})),
   };
+  let nextThreadNameObservation = 0;
   const remoteThreadSummaries = {
     resolvePinnedThreads: vi.fn(
       async (): Promise<{
@@ -111,6 +112,7 @@ const federationMock = vi.hoisted(() => {
     searchForJump: vi.fn(async () => ({ results: [] })),
     threadFromPeer: vi.fn(async (): Promise<unknown> => undefined),
     rememberThreadNames: vi.fn(),
+    reserveThreadNameObservation: vi.fn(() => (nextThreadNameObservation += 1)),
     invalidate: vi.fn(),
   };
   return {
@@ -1975,6 +1977,11 @@ describe("app server ipc", () => {
         executionMode: "default" as const,
       },
     };
+    // These three carry calls over from earlier cases, and the assertions below
+    // read call zero rather than any call.
+    federationMock.runtime.remoteNavigationSnapshot.mockClear();
+    federationMock.remoteThreadSummaries.rememberThreadNames.mockClear();
+    federationMock.remoteThreadSummaries.reserveThreadNameObservation.mockClear();
     federationMock.runtime.remoteNavigationSnapshot
       .mockResolvedValueOnce(snapshot)
       .mockResolvedValueOnce(snapshot);
@@ -1983,9 +1990,21 @@ describe("app server ipc", () => {
     const handler = handlers.get(NAVIGATION_SNAPSHOT_CHANNEL);
 
     await expect(handler?.({}, { federationTarget })).resolves.toBe(snapshot);
+    const reserve =
+      federationMock.remoteThreadSummaries.reserveThreadNameObservation;
     expect(
       federationMock.remoteThreadSummaries.rememberThreadNames,
-    ).toHaveBeenCalledWith("peer_remembers_names", snapshot.threads);
+    ).toHaveBeenCalledWith(
+      "peer_remembers_names",
+      snapshot.threads,
+      reserve.mock.results[0]?.value,
+    );
+    // The sequence is taken before the peer is asked, so a snapshot that
+    // starts first and finishes last cannot revert a newer refresh's names.
+    expect(reserve.mock.invocationCallOrder[0]).toBeLessThan(
+      federationMock.runtime.remoteNavigationSnapshot.mock
+        .invocationCallOrder[0],
+    );
 
     federationMock.remoteThreadSummaries.rememberThreadNames.mockImplementationOnce(
       () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18229,6 +18229,9 @@ command = "pnpm dev"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: ["codex:thread-reattached"],
+      threadTitles: {
+        "codex:thread-reattached": "Still working after HMR",
+      },
     });
     await expect(
       registry.startTurn({
@@ -18348,6 +18351,9 @@ command = "pnpm dev"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: ["codex:thread-stale-active"],
+      threadTitles: {
+        "codex:thread-stale-active": "Finished remotely",
+      },
     });
 
     await registry.close();
@@ -18631,6 +18637,334 @@ command = "pnpm dev"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 2,
       threadIds: ["acp:grok:acp-thread-1", "codex:thread-1"],
+    });
+
+    await registry.close();
+  });
+
+  it("names ordinary quit blockers from cached metadata without provider refreshes", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "thread-named-quit",
+          title: "Resolve quit titles from memory",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const enrichThreadDirectories = vi.fn(async (threads) => threads);
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+      enrichDirectories: false,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-named-quit",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    const providerReadsBeforeQuit = codexClient.listThreadsCallCount;
+
+    for (let poll = 0; poll < 4; poll += 1) {
+      expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+        count: 1,
+        threadIds: ["codex:thread-named-quit"],
+        threadTitles: {
+          "codex:thread-named-quit": "Resolve quit titles from memory",
+        },
+      });
+    }
+
+    expect(codexClient.listThreadsCallCount).toBe(providerReadsBeforeQuit);
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-named-quit",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
+
+    await registry.close();
+  });
+
+  it("keeps a newer quit title when an invalidated older list finishes late", async () => {
+    const listThreadsDelay = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      listThreadsDelay: listThreadsDelay.promise,
+      threads: [
+        {
+          id: "thread-late-quit-title",
+          title: "Old provider title",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    const staleList = registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    await waitForCondition(() => codexClient.listThreadsCallCount === 1);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-late-quit-title",
+          threadName: "New explicit rename",
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-late-quit-title",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-late-quit-title"],
+      threadTitles: {
+        "codex:thread-late-quit-title": "New explicit rename",
+      },
+    });
+
+    listThreadsDelay.resolve();
+    await staleList;
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-late-quit-title"],
+      threadTitles: {
+        "codex:thread-late-quit-title": "New explicit rename",
+      },
+    });
+    expect(codexClient.listThreadsCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("never downgrades a known quit title for fallback or missing list rows", async () => {
+    const threadId = "thread-monotonic-quit-title";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: threadId,
+          title: "Known display title",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    await registry.listThreads({ backend: "codex", enrichDirectories: false });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId,
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    codexClient.setThreads([
+      {
+        id: threadId,
+        title: threadId,
+        titleSource: "fallback",
+        linkedDirectories: [],
+        source: "codex",
+      },
+    ]);
+    await registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    codexClient.setThreads([]);
+    await registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [`codex:${threadId}`],
+      threadTitles: {
+        [`codex:${threadId}`]: "Known display title",
+      },
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId,
+          threadName: "Newer renamed title",
+        },
+      },
+    });
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [`codex:${threadId}`],
+      threadTitles: {
+        [`codex:${threadId}`]: "Newer renamed title",
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("keeps a known quit title when a background provider list fails", async () => {
+    const threadId = "thread-failed-list-quit-title";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      listThreadsError: new Error("provider list unavailable"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId,
+          threadName: "Known before provider failure",
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId,
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        enrichDirectories: false,
+        forceRefresh: true,
+      }),
+    ).resolves.toEqual([]);
+    expect(codexClient.listThreadsCallCount).toBe(1);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [`codex:${threadId}`],
+      threadTitles: {
+        [`codex:${threadId}`]: "Known before provider failure",
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("keeps cached quit titles qualified when backends reuse a thread id", async () => {
+    const threadId = "shared-thread-id";
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    for (const [backend, threadName] of [
+      ["codex", "Local Codex work"],
+      ["acp:grok", "Local Grok work"],
+    ] as const) {
+      const turnId = backend === "codex" ? "turn-codex" : "turn-grok";
+      await registry.publishLocalEvent({
+        backend,
+        notification: {
+          method: "thread/name/updated",
+          params: { threadId, threadName },
+        },
+      });
+      await registry.publishLocalEvent({
+        backend,
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId,
+            turnId,
+            turn: { id: turnId },
+          },
+        },
+      });
+    }
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 2,
+      threadIds: ["acp:grok:shared-thread-id", "codex:shared-thread-id"],
+      threadTitles: {
+        "acp:grok:shared-thread-id": "Local Grok work",
+        "codex:shared-thread-id": "Local Codex work",
+      },
     });
 
     await registry.close();
@@ -29015,6 +29349,9 @@ script = "printf setup"
       expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
         count: 1,
         threadIds: ["codex:ordinary-thread"],
+        threadTitles: {
+          "codex:ordinary-thread": "Parent Thread",
+        },
       });
     });
 
@@ -29680,6 +30017,9 @@ script = "printf setup"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: [buildThreadIdentityKey("codex", "ordinary-thread")],
+      threadTitles: {
+        [buildThreadIdentityKey("codex", "ordinary-thread")]: "Parent Thread",
+      },
     });
 
     await registry.publishLocalEvent({
@@ -29843,6 +30183,9 @@ script = "printf setup"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: [buildThreadIdentityKey("codex", "ordinary-thread")],
+      threadTitles: {
+        [buildThreadIdentityKey("codex", "ordinary-thread")]: "Parent Thread",
+      },
     });
 
     await registry.publishLocalEvent({

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budget.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budget.ts
@@ -1,0 +1,106 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect } from "vitest";
+
+/**
+ * Checked-in provider-read budgets for thread information, asserted per
+ * scenario.
+ *
+ * A thread-list walk is the most expensive read PwrAgent makes: it pages the
+ * provider, and for most caller reasons it then enriches every row with git and
+ * directory work. Nothing counted these, so the cost of answering "what is this
+ * thread called" grew a caller at a time and only ever surfaced as a UI symptom
+ * — a quit dialog showing uuids, a sidebar row flickering — long after the read
+ * that caused it.
+ *
+ * These budgets make each flow's read cost a reviewable number. A scenario
+ * records provider `thread/list` calls and directory-enrichment passes, both
+ * pure functions of the code path, so they are identical on every machine.
+ *
+ * To change a budget deliberately, run with `UPDATE_THREAD_READ_BUDGETS=1` and
+ * commit the diff, so the reviewer sees the read cost change as a line in the
+ * PR instead of never seeing it at all.
+ */
+const BUDGETS_PATH = path.join(import.meta.dirname, "thread-read-budgets.json");
+
+export type ThreadReadCounts = {
+  /** Directory/git enrichment passes over a listing. */
+  directoryEnrichments: number;
+  /** Provider `thread/list` round trips. */
+  providerListCalls: number;
+};
+
+type Budget = ThreadReadCounts & { note: string };
+
+type BudgetFile = Record<string, Budget>;
+
+export function expectThreadReadBudget(params: {
+  note: string;
+  reads: ThreadReadCounts;
+  scenario: string;
+}): void {
+  const budgets = readBudgets();
+  const measured: Budget = {
+    directoryEnrichments: params.reads.directoryEnrichments,
+    note: params.note,
+    providerListCalls: params.reads.providerListCalls,
+  };
+
+  if (process.env.UPDATE_THREAD_READ_BUDGETS) {
+    budgets[params.scenario] = measured;
+    writeFileSync(
+      BUDGETS_PATH,
+      `${JSON.stringify(sortKeys(budgets), null, 2)}\n`,
+    );
+    return;
+  }
+
+  const budget = budgets[params.scenario];
+  if (!budget) {
+    throw new Error(
+      `No thread read budget recorded for "${params.scenario}".\n`
+        + `Measured ${describe(measured)}.\n`
+        + "Record it with UPDATE_THREAD_READ_BUDGETS=1 and commit the result.",
+    );
+  }
+
+  // Deviation in either direction fails. An increase is the regression this
+  // exists to catch; a decrease means the budget is stale and would stop
+  // catching anything, so it has to be lowered on purpose.
+  expect(
+    {
+      directoryEnrichments: measured.directoryEnrichments,
+      providerListCalls: measured.providerListCalls,
+    },
+    `thread read budget "${params.scenario}" changed.\n`
+      + `  budget:   ${describe(budget)}\n`
+      + `  measured: ${describe(measured)}\n`
+      + "If this is intended, re-record with UPDATE_THREAD_READ_BUDGETS=1 and\n"
+      + "explain the change in the commit message. If it is not, you have added\n"
+      + "provider thread reads to a path that is measured for a reason.",
+  ).toEqual({
+    directoryEnrichments: budget.directoryEnrichments,
+    providerListCalls: budget.providerListCalls,
+  });
+}
+
+function describe(budget: Budget): string {
+  return (
+    `${budget.providerListCalls} provider thread/list calls, `
+    + `${budget.directoryEnrichments} directory enrichments`
+  );
+}
+
+function readBudgets(): BudgetFile {
+  try {
+    return JSON.parse(readFileSync(BUDGETS_PATH, "utf8")) as BudgetFile;
+  } catch {
+    return {};
+  }
+}
+
+function sortKeys(budgets: BudgetFile): BudgetFile {
+  return Object.fromEntries(
+    Object.entries(budgets).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
@@ -9,6 +9,11 @@
     "note": "50 synchronous label lookups for a thread already observed once",
     "providerListCalls": 0
   },
+  "messaging-admission-after-invalidation": {
+    "directoryEnrichments": 0,
+    "note": "messaging admission for a listed thread whose list cache was invalidated",
+    "providerListCalls": 0
+  },
   "quit-dialog-poll": {
     "directoryEnrichments": 0,
     "note": "20 quit-dialog polls against an in-progress turn, all served from observed metadata",

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
@@ -14,9 +14,34 @@
     "note": "20 quit-dialog polls against an in-progress turn, all served from observed metadata",
     "providerListCalls": 0
   },
+  "second-window-navigation": {
+    "directoryEnrichments": 0,
+    "note": "a second window's navigation refresh and label reads against a warm list cache",
+    "providerListCalls": 0
+  },
+  "ten-turns-warm-thread": {
+    "directoryEnrichments": 0,
+    "note": "ten complete turns on a thread the navigation refresh already observed",
+    "providerListCalls": 0
+  },
+  "terminal-notification-burst": {
+    "directoryEnrichments": 0,
+    "note": "eight terminal notifications across two threads neither of which was ever listed",
+    "providerListCalls": 1
+  },
   "turn-lifecycle-label-reads": {
     "directoryEnrichments": 0,
     "note": "five complete turns with label reads between every lifecycle event",
+    "providerListCalls": 0
+  },
+  "worktree-navigation-refresh": {
+    "directoryEnrichments": 1,
+    "note": "one navigation refresh over a single worktree-backed thread",
+    "providerListCalls": 1
+  },
+  "worktree-turns-after-enrichment": {
+    "directoryEnrichments": 0,
+    "note": "five turns on an already-enriched worktree thread",
     "providerListCalls": 0
   }
 }

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
@@ -1,0 +1,22 @@
+{
+  "concurrent-identical-listings": {
+    "directoryEnrichments": 0,
+    "note": "six concurrent callers asking for the same unenriched Codex listing",
+    "providerListCalls": 1
+  },
+  "known-thread-label-lookups": {
+    "directoryEnrichments": 0,
+    "note": "50 synchronous label lookups for a thread already observed once",
+    "providerListCalls": 0
+  },
+  "quit-dialog-poll": {
+    "directoryEnrichments": 0,
+    "note": "20 quit-dialog polls against an in-progress turn, all served from observed metadata",
+    "providerListCalls": 0
+  },
+  "turn-lifecycle-label-reads": {
+    "directoryEnrichments": 0,
+    "note": "five complete turns with label reads between every lifecycle event",
+    "providerListCalls": 0
+  }
+}

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
@@ -1,0 +1,155 @@
+import { vi } from "vitest";
+import type {
+  AppServerBackendKind,
+  AppServerNotification,
+  AppServerThreadSummary,
+} from "@pwragent/shared";
+import { DesktopBackendRegistry } from "../../app-server/backend-registry";
+import type { ThreadReadCounts } from "./thread-read-budget";
+
+/**
+ * A backend client that serves a fixed thread list and counts what it cost.
+ *
+ * The registry is the unit under test here, not the provider, so this client
+ * does the least a registry needs: answer `thread/list`, accept a notification
+ * listener, and record every read. `listCalls` keeps the caller reason of each
+ * round trip, which is what makes a budget failure diagnosable — the count says
+ * a read was added, the reasons say which caller added it.
+ */
+export class CountingBackendClient {
+  readonly listCalls: Array<{
+    callerReason?: string;
+    params?: Record<string, unknown>;
+  }> = [];
+  directoryEnrichmentCallCount = 0;
+  /** Resolves before each listing completes, for late-completion ordering. */
+  listGate?: Promise<unknown>;
+  /** Rejects the next listing, standing in for an unavailable provider. */
+  failNextList = false;
+  private readonly notificationListeners = new Set<
+    (notification: AppServerNotification) => unknown
+  >();
+
+  constructor(private threads: AppServerThreadSummary[]) {}
+
+  get counts(): ThreadReadCounts {
+    return {
+      directoryEnrichments: this.directoryEnrichmentCallCount,
+      providerListCalls: this.listCalls.length,
+    };
+  }
+
+  /** Replace what the provider reports, as an external change would. */
+  setThreads(threads: AppServerThreadSummary[]): void {
+    this.threads = threads;
+  }
+
+  resetCounts(): void {
+    this.listCalls.length = 0;
+    this.directoryEnrichmentCallCount = 0;
+  }
+
+  async close(): Promise<void> {}
+
+  async getInitializeResult(): Promise<unknown> {
+    return { methods: ["thread/list", "turn/start"] };
+  }
+
+  onNotification(
+    listener: (notification: AppServerNotification) => unknown,
+  ): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onPendingRequest(): () => void {
+    return () => {};
+  }
+
+  async listThreads(
+    params?: Record<string, unknown>,
+    diagnostics?: { callerReason?: string },
+  ): Promise<AppServerThreadSummary[]> {
+    this.listCalls.push({
+      ...(diagnostics?.callerReason
+        ? { callerReason: diagnostics.callerReason }
+        : {}),
+      ...(params ? { params } : {}),
+    });
+    if (this.listGate) {
+      await this.listGate;
+    }
+    if (this.failNextList) {
+      this.failNextList = false;
+      throw new Error("provider unavailable");
+    }
+    return this.threads;
+  }
+
+  async enrichThreadDirectories(
+    threads: AppServerThreadSummary[],
+  ): Promise<AppServerThreadSummary[]> {
+    this.directoryEnrichmentCallCount += 1;
+    return threads;
+  }
+}
+
+export function codexThread(
+  overrides: Partial<AppServerThreadSummary> & { id: string },
+): AppServerThreadSummary {
+  return {
+    linkedDirectories: [],
+    source: "codex",
+    title: overrides.id,
+    titleSource: "fallback",
+    updatedAt: 1_000,
+    ...overrides,
+  } as AppServerThreadSummary;
+}
+
+/**
+ * The overlay store surface the registry touches on read paths. Everything the
+ * thread-read budgets exercise is a listing or a lookup, so a permissive stub
+ * that answers "nothing recorded" keeps these tests about provider reads rather
+ * than about sqlite fixtures.
+ */
+function overlayStoreStub(): Record<string, unknown> {
+  return new Proxy(
+    {},
+    {
+      get: (_target, property) => {
+        if (property === "then") {
+          return undefined;
+        }
+        const name = String(property);
+        return vi.fn(async () => {
+          if (name.startsWith("list")) return [];
+          if (name.endsWith("States")) return {};
+          return undefined;
+        });
+      },
+    },
+  ) as Record<string, unknown>;
+}
+
+export function createThreadReadRegistry(threads: AppServerThreadSummary[]): {
+  client: CountingBackendClient;
+  registry: DesktopBackendRegistry;
+} {
+  const client = new CountingBackendClient(threads);
+  const registry = new DesktopBackendRegistry({
+    codexClient: client as never,
+    overlayStore: overlayStoreStub() as never,
+    threadTitleGenerationService: null,
+  });
+  return { client, registry };
+}
+
+/** Publish a provider notification the way a live backend would. */
+export async function publishNotification(
+  registry: DesktopBackendRegistry,
+  notification: AppServerNotification,
+  backend: AppServerBackendKind = "codex",
+): Promise<void> {
+  await registry.publishLocalEvent({ backend, notification });
+}

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-harness.ts
@@ -51,6 +51,20 @@ export class CountingBackendClient {
 
   async close(): Promise<void> {}
 
+  /**
+   * Archiving is the cheapest real mutation that invalidates the thread-list
+   * cache, which is what the admission budgets need to reproduce. Recorded as
+   * a mutation, not a read, so it does not move the read counters.
+   */
+  async archiveThread(params: { threadId: string }): Promise<{
+    threadId: string;
+  }> {
+    this.threads = this.threads.filter(
+      (thread) => thread.id !== params.threadId,
+    );
+    return { threadId: params.threadId };
+  }
+
   async getInitializeResult(): Promise<unknown> {
     return { methods: ["thread/list", "turn/start"] };
   }

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4674,7 +4674,9 @@ describe("MessagingController", () => {
         },
       }),
     });
-    harness.startTurn.mockRejectedValue(new Error("thread not found"));
+    harness.startTurn.mockRejectedValue(
+      new Error("thread not found: deleted-thread"),
+    );
     const channel = buildTopicChannel("13123");
     await harness.store.upsertDefaultAgentAssignment({
       id: "default-agent:deleted-target",
@@ -4694,6 +4696,50 @@ describe("MessagingController", () => {
     await expect(
       harness.store.getDefaultAgentAssignment("default-agent:deleted-target"),
     ).resolves.toMatchObject({ revokedAt: expect.any(Number) });
+  });
+
+  it("preserves a default-agent route after a transient start failure", async () => {
+    const navigation = buildNavigationSnapshot();
+    const harness = await createHarness({
+      navigation,
+      getThreadAdmissionState: async (request) => ({
+        thread: {
+          ...navigation.threads[0]!,
+          id: request.threadId,
+          source: request.backend,
+          agent: {
+            name: "Provider Agent",
+            instructionLineCount: 1,
+            instructionsTooLong: false,
+            updatedAt: 1500,
+          },
+        },
+      }),
+    });
+    harness.startTurn.mockRejectedValueOnce(
+      new Error("provider unavailable for thread thread-1"),
+    );
+    const channel = buildTopicChannel("13124");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:transient-failure",
+      scope: { kind: "conversation", channel },
+      target: { kind: "agent", backend: "codex", threadId: "thread-1" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("retry later", { botMention: true, channel }),
+    );
+
+    await expect(
+      harness.store.getDefaultAgentAssignment("default-agent:transient-failure"),
+    ).resolves.not.toMatchObject({ revokedAt: expect.any(Number) });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Turn could not start",
+      body: "provider unavailable for thread thread-1",
+    });
   });
 
   it("preserves the messaging location for queued Agent-thread turns", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4554,9 +4554,10 @@ describe("MessagingController", () => {
     expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
-  // Revocation is destructive, so a target this process has simply never
-  // observed must not be mistaken for one whose thread was deleted.
-  it("lists once before revoking a target it has never observed", async () => {
+  // A target with no local record at all is gone as far as this machine is
+  // concerned, and saying so costs one targeted read. The fleet snapshot this
+  // replaced charged every accepted message for the same answer.
+  it("revokes a target it has no record of without listing the fleet", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {
       ...navigation.threads[0]!,
@@ -4569,8 +4570,14 @@ describe("MessagingController", () => {
     };
     const harness = await createHarness({
       navigation,
-      // Nothing is cached: every target is cold.
-      getThreadAdmissionState: async () => ({}),
+      getThreadAdmissionState: async (request) => {
+        const thread = navigation.threads.find(
+          (candidate) =>
+            candidate.source === request.backend
+            && candidate.id === request.threadId,
+        );
+        return thread ? { thread } : {};
+      },
     });
     const channel = buildTopicChannel("13121");
     await harness.store.upsertDefaultAgentAssignment({
@@ -4593,15 +4600,54 @@ describe("MessagingController", () => {
       buildTextEvent("use the available Agent", { botMention: true, channel }),
     );
 
-    // The absent target is revoked, the live one still starts, and the two
-    // cold lookups share a single listing rather than taking one each.
     await expect(
       harness.store.getDefaultAgentAssignment("default-agent:cold-stale"),
     ).resolves.toMatchObject({ revokedAt: 1000 });
     expect(harness.startTurn).toHaveBeenCalledWith(
       expect.objectContaining({ backend: "codex", threadId: "thread-1" }),
     );
-    expect(harness.getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
+  // Revocation is destructive and each iteration reads state that can fail. A
+  // failure part-way through must not leave the channel half-revoked, with the
+  // assignments already rejected gone and the rest never examined.
+  it("revokes nothing when an admission read fails part-way through", async () => {
+    const harness = await createHarness({
+      getThreadAdmissionState: async (request) => {
+        if (request.threadId === "thread-1") {
+          throw new Error("backend restarting");
+        }
+        return {};
+      },
+    });
+    const channel = buildTopicChannel("13122");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:first-rejected",
+      scope: { kind: "conversation", channel },
+      target: { kind: "agent", backend: "codex", threadId: "never-existed" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:never-read",
+      scope: { kind: "provider", channel: "telegram" },
+      target: { kind: "agent", backend: "codex", threadId: "thread-1" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("use the available Agent", { botMention: true, channel }),
+    );
+
+    await expect(
+      harness.store.getDefaultAgentAssignment("default-agent:first-rejected"),
+    ).resolves.not.toMatchObject({ revokedAt: expect.any(Number) });
+    await expect(
+      harness.store.getDefaultAgentAssignment("default-agent:never-read"),
+    ).resolves.not.toMatchObject({ revokedAt: expect.any(Number) });
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("preserves the messaging location for queued Agent-thread turns", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -161,6 +161,53 @@ describe("MessagingController", () => {
     );
   });
 
+  it("attributes start-turn latency to the stage that spent it", async () => {
+    // The end-to-end span above says a turn was slow; these say which stage was.
+    let clock = 1_000;
+    const info = vi.fn();
+    const harness = await createHarness({
+      logger: { info },
+      now: () => clock,
+      getThreadAdmissionState: async (request) => {
+        clock += 700;
+        const thread = buildNavigationSnapshot().threads.find(
+          (candidate) =>
+            candidate.source === request.backend
+            && candidate.id === request.threadId,
+        );
+        return thread ? { thread } : {};
+      },
+    });
+    await bindThread(harness);
+    info.mockClear();
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("measure stages"),
+      receivedAt: clock,
+    });
+
+    const startingTurn = info.mock.calls.find(
+      (call) => call[0] === "messaging starting turn",
+    );
+    expect(startingTurn?.[1]).toMatchObject({
+      inputPreparedToAdmissionStateMs: 700,
+    });
+    // Everything the admission read did not spend is attributed elsewhere, so
+    // the stages sum to the end-to-end number rather than overlapping it.
+    const detail = startingTurn?.[1] as Record<string, number>;
+    const stageTotal =
+      detail.receivedToHandledMs
+      + detail.handledToRoutedMs
+      + detail.routedToBundleReadyMs
+      + detail.bundleReadyToInputPreparedMs
+      + detail.inputPreparedToAdmissionStateMs
+      + detail.admissionStateToOccupancyMs
+      + detail.occupancyToOriginMs
+      + detail.originToPolicyMs
+      + detail.policyToStartTurnIssueMs;
+    expect(stageTotal).toBe(detail.pwragentReceivedToStartTurnIssueMs);
+  });
+
   it("merges eventual provider channel metadata without replaying inbound", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4466,6 +4466,97 @@ describe("MessagingController", () => {
     expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
+  // The reply hot path used to answer "does this assignment still point at an
+  // agent thread?" with a snapshot of every thread on every backend, then
+  // hydrate overlays, pull requests, Git working state, directory status and
+  // launchpads before it could start the turn. Opening the same thread in the
+  // app does none of that.
+  it("starts a default-agent reply without requesting a navigation snapshot", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Provider Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({ navigation });
+    const channel = buildTopicChannel("13120");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:targeted-conversation",
+      scope: { kind: "conversation", channel },
+      target: { kind: "agent", backend: "codex", threadId: "thread-1" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    harness.getNavigationSnapshot.mockClear();
+    harness.getThreadAdmissionState.mockClear();
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("use the available Agent", { botMention: true, channel }),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ backend: "codex", threadId: "thread-1" }),
+    );
+    expect(harness.getThreadAdmissionState).toHaveBeenCalledWith(
+      expect.objectContaining({ backend: "codex", threadId: "thread-1" }),
+    );
+    expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
+  // Revocation is destructive, so a target this process has simply never
+  // observed must not be mistaken for one whose thread was deleted.
+  it("lists once before revoking a target it has never observed", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Provider Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      // Nothing is cached: every target is cold.
+      getThreadAdmissionState: async () => ({}),
+    });
+    const channel = buildTopicChannel("13121");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:cold-stale",
+      scope: { kind: "conversation", channel },
+      target: { kind: "agent", backend: "codex", threadId: "never-existed" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:cold-valid",
+      scope: { kind: "provider", channel: "telegram" },
+      target: { kind: "agent", backend: "codex", threadId: "thread-1" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    harness.getNavigationSnapshot.mockClear();
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("use the available Agent", { botMention: true, channel }),
+    );
+
+    // The absent target is revoked, the live one still starts, and the two
+    // cold lookups share a single listing rather than taking one each.
+    await expect(
+      harness.store.getDefaultAgentAssignment("default-agent:cold-stale"),
+    ).resolves.toMatchObject({ revokedAt: 1000 });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ backend: "codex", threadId: "thread-1" }),
+    );
+    expect(harness.getNavigationSnapshot).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves the messaging location for queued Agent-thread turns", async () => {
     const harness = await createHarness();
     harness.startTurn.mockImplementation(async (request: StartTurnRequest) => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4650,6 +4650,52 @@ describe("MessagingController", () => {
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
+  // The pre-flight check reads `agent` from the thread's overlay row, which
+  // outlives the thread it describes, so it cannot tell a live target from a
+  // deleted one. The failed start is the only report that ever arrives.
+  it("retires a default-agent route whose target can no longer start a turn", async () => {
+    const navigation = buildNavigationSnapshot();
+    const agent = {
+      name: "Provider Agent",
+      instructionLineCount: 1,
+      instructionsTooLong: false,
+      updatedAt: 1500,
+    };
+    const harness = await createHarness({
+      navigation,
+      // Models the production bridge: the row is rebuilt from the durable
+      // overlay, so it answers for a thread no listing contains any more.
+      getThreadAdmissionState: async (request) => ({
+        thread: {
+          ...navigation.threads[0]!,
+          id: request.threadId,
+          source: request.backend,
+          agent,
+        },
+      }),
+    });
+    harness.startTurn.mockRejectedValue(new Error("thread not found"));
+    const channel = buildTopicChannel("13123");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:deleted-target",
+      scope: { kind: "conversation", channel },
+      target: { kind: "agent", backend: "codex", threadId: "deleted-thread" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("use the available Agent", { botMention: true, channel }),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "deleted-thread" }),
+    );
+    await expect(
+      harness.store.getDefaultAgentAssignment("default-agent:deleted-target"),
+    ).resolves.toMatchObject({ revokedAt: expect.any(Number) });
+  });
+
   it("preserves the messaging location for queued Agent-thread turns", async () => {
     const harness = await createHarness();
     harness.startTurn.mockImplementation(async (request: StartTurnRequest) => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -3829,11 +3829,22 @@ function createBackendBridge(): MessagingBackendBridge & {
 } {
   const backendListeners = new Set<(event: AgentEvent) => void | Promise<void>>();
 
-  return {
+  const bridge: ReturnType<typeof createBackendBridge> = {
     getNavigationSnapshot: vi.fn(async () => buildNavigationSnapshot()),
-    getThreadAdmissionState: vi.fn(async () => ({
-      thread: buildNavigationSnapshot().threads[0],
-    })),
+    // Production reads a thread's `agent` from its overlay row on BOTH the
+    // navigation path and the admission path, so a fixture whose admission
+    // state disagrees with its own navigation describes a state the app
+    // cannot reach. Resolve from whatever snapshot this bridge is serving,
+    // and answer for the thread that was actually asked about.
+    getThreadAdmissionState: vi.fn(async (request) => {
+      const navigation = await bridge.getNavigationSnapshot();
+      const thread = navigation.threads.find(
+        (candidate) =>
+          candidate.source === request.backend
+          && candidate.id === request.threadId,
+      );
+      return thread ? { thread } : {};
+    }),
     startTurn: vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -3854,6 +3865,7 @@ function createBackendBridge(): MessagingBackendBridge & {
       );
     },
   };
+  return bridge;
 }
 
 function buildNavigationSnapshot(): NavigationSnapshot {

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const backendRegistryMock = vi.hoisted(() => ({
+  getCachedThreadDisplayMetadata: vi.fn(),
+  getInProgressThreadSnapshotForQuit: vi.fn(() => ({
+    count: 0,
+    threadIds: [] as string[],
+  })),
+  listThreads: vi.fn(async (): Promise<unknown[]> => []),
+}));
 
 vi.mock("electron", () => ({
   app: {
@@ -10,9 +19,7 @@ vi.mock("electron", () => ({
 }));
 
 vi.mock("../app-server/backend-registry", () => ({
-  getDesktopBackendRegistry: vi.fn(() => ({
-    getInProgressThreadSnapshotForQuit: () => ({ count: 0, threadIds: [] }),
-  })),
+  getDesktopBackendRegistry: vi.fn(() => backendRegistryMock),
 }));
 
 vi.mock("../ipc/integrated-terminal", () => ({
@@ -42,6 +49,17 @@ vi.mock("../log", () => ({
     warn: vi.fn(),
   })),
 }));
+
+beforeEach(() => {
+  backendRegistryMock.getCachedThreadDisplayMetadata.mockReset();
+  backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReset();
+  backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
+    count: 0,
+    threadIds: [],
+  });
+  backendRegistryMock.listThreads.mockReset();
+  backendRegistryMock.listThreads.mockResolvedValue([]);
+});
 
 describe("createQuitManager", () => {
   it("quits immediately when no threads are in progress", async () => {
@@ -703,9 +721,10 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
       "../quit-manager"
     );
-    const listLocalThreads = vi.fn(async () => [
-      { source: "codex" as const, id: "local-thread", title: "Local Work" },
-    ]);
+    const cachedLocalThreadName = vi.fn(() => ({
+      title: "Local Work",
+      titleSource: "explicit" as const,
+    }));
     const cachedRemoteThreadName = vi.fn(() => ({
       title: "Reap Windows Worktrees",
       titleSource: "derived" as const,
@@ -713,7 +732,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const listRemoteThreadPins = vi.fn(async () => []);
 
     const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
-      listLocalThreads,
+      cachedLocalThreadName,
       cachedRemoteThreadName,
       listRemoteThreadPins,
     });
@@ -727,9 +746,10 @@ describe("resolveQuitBlockerThreadTitles", () => {
       backend: "codex",
       threadId: "0f9c2b7a-remote",
     });
-    // The local list is a peer-blind lookup; asking it about a remote thread
-    // is what produced the uuid in the first place.
-    expect(listLocalThreads).toHaveBeenCalledTimes(1);
+    expect(cachedLocalThreadName).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      threadId: "local-thread",
+    });
     // The memory cache answered, so the store is never read.
     expect(listRemoteThreadPins).not.toHaveBeenCalled();
   });
@@ -740,7 +760,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     );
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
-      listLocalThreads: async () => [],
+      cachedLocalThreadName: () => undefined,
       cachedRemoteThreadName: () => undefined,
       listRemoteThreadPins: async () => [
         {
@@ -779,7 +799,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     let settled = false;
 
     const pending = resolveQuitBlockerThreadTitles([remoteItem], {
-      listLocalThreads: async () => [],
+      cachedLocalThreadName: () => undefined,
       cachedRemoteThreadName: () => ({
         title: "Reap Windows Worktrees",
         titleSource: "derived" as const,
@@ -802,7 +822,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const { resolveQuitBlockerThreadTitles } = await import("../quit-manager");
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
-      listLocalThreads: async () => [],
+      cachedLocalThreadName: () => undefined,
       cachedRemoteThreadName: () => ({
         title: "0f9c2b7a-remote",
         titleSource: "fallback" as const,
@@ -827,7 +847,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const titles = await resolveQuitBlockerThreadTitles(
       [collidingLocal, remoteItem],
       {
-        listLocalThreads: async () => [],
+        cachedLocalThreadName: () => undefined,
         cachedRemoteThreadName: () => ({
           title: "Reap Windows Worktrees",
           titleSource: "derived" as const,
@@ -842,15 +862,46 @@ describe("resolveQuitBlockerThreadTitles", () => {
     expect(titles.get(quitBlockerTitleKey(collidingLocal))).toBeUndefined();
   });
 
+  it("keeps same-keyed remote titles qualified by owning instance", async () => {
+    const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
+      "../quit-manager"
+    );
+    const peerBItem = {
+      ...remoteItem,
+      target: { scope: "remote" as const, instanceId: "peer-b" },
+    };
+    const cachedLocalThreadName = vi.fn(() => ({
+      title: "Wrong local title",
+      titleSource: "explicit" as const,
+    }));
+
+    const titles = await resolveQuitBlockerThreadTitles(
+      [remoteItem, peerBItem],
+      {
+        cachedLocalThreadName,
+        cachedRemoteThreadName: ({ target }) => ({
+          title: target.instanceId === "peer-a" ? "Peer A work" : "Peer B work",
+          titleSource: "explicit" as const,
+        }),
+        listRemoteThreadPins: async () => [],
+      },
+    );
+
+    expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe("Peer A work");
+    expect(titles.get(quitBlockerTitleKey(peerBItem))).toBe("Peer B work");
+    expect(cachedLocalThreadName).not.toHaveBeenCalled();
+  });
+
   it("still names local rows when the remote lookups throw", async () => {
     const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
       "../quit-manager"
     );
 
     const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
-      listLocalThreads: async () => [
-        { source: "codex" as const, id: "local-thread", title: "Local Work" },
-      ],
+      cachedLocalThreadName: () => ({
+        title: "Local Work",
+        titleSource: "explicit" as const,
+      }),
       cachedRemoteThreadName: () => {
         throw new Error("federation runtime unavailable");
       },
@@ -862,6 +913,85 @@ describe("resolveQuitBlockerThreadTitles", () => {
     expect(titles.get(quitBlockerTitleKey(localItem))).toBe("Local Work");
     expect(titles.get(quitBlockerTitleKey(remoteItem))).toBeUndefined();
   });
+});
+
+describe("readQuitBlockerQueueSnapshot", () => {
+  it("repeated polls perform zero full thread-list or directory-enrichment reads", async () => {
+    backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
+      count: 1,
+      threadIds: ["codex:thread-live"],
+    });
+    backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+      title: "Keep the quit queue stable",
+      titleSource: "explicit",
+    });
+    backendRegistryMock.listThreads.mockResolvedValue([
+      {
+        source: "codex",
+        id: "thread-live",
+        title: "Keep the quit queue stable",
+        titleSource: "explicit",
+      },
+    ]);
+    const { readQuitBlockerQueueSnapshot } = await import("../quit-manager");
+
+    const snapshots = [];
+    for (let poll = 0; poll < 4; poll += 1) {
+      snapshots.push(await readQuitBlockerQueueSnapshot());
+    }
+
+    expect(snapshots).toHaveLength(4);
+    for (const snapshot of snapshots) {
+      expect(snapshot.items).toEqual([
+        expect.objectContaining({
+          kind: "turn",
+          threadKey: "codex:thread-live",
+          title: "Keep the quit queue stable",
+        }),
+      ]);
+    }
+    // A registry thread-list read is the only entrance to provider listing and
+    // its default quit-confirmation policy enables directory enrichment. Zero
+    // registry reads therefore enforces both steady-state budgets.
+    expect(backendRegistryMock.listThreads).not.toHaveBeenCalled();
+    expect(
+      backendRegistryMock.getCachedThreadDisplayMetadata,
+    ).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([
+    ["hangs", () => new Promise<never[]>(() => undefined)],
+    ["rejects", async () => {
+      throw new Error("provider list rejected");
+    }],
+    ["is unavailable", () => {
+      throw new Error("provider list unavailable");
+    }],
+  ] as const)(
+    "builds the first named snapshot when provider listing %s",
+    async (_scenario, providerList) => {
+      backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
+        count: 1,
+        threadIds: ["codex:thread-first-snapshot"],
+      });
+      backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+        title: "First snapshot stays named",
+        titleSource: "explicit",
+      });
+      backendRegistryMock.listThreads.mockImplementation(providerList);
+      const { readQuitBlockerQueueSnapshot } = await import("../quit-manager");
+
+      await expect(readQuitBlockerQueueSnapshot()).resolves.toMatchObject({
+        items: [
+          expect.objectContaining({
+            threadKey: "codex:thread-first-snapshot",
+            title: "First snapshot stays named",
+          }),
+        ],
+      });
+      expect(backendRegistryMock.listThreads).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe("resolveQuitCountdownSeconds", () => {

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const backendRegistryMock = vi.hoisted(() => ({
-  getCachedThreadDisplayMetadata: vi.fn(),
+  getThreadInfo: vi.fn(),
   getInProgressThreadSnapshotForQuit: vi.fn(() => ({
     count: 0,
     threadIds: [] as string[],
@@ -51,7 +51,7 @@ vi.mock("../log", () => ({
 }));
 
 beforeEach(() => {
-  backendRegistryMock.getCachedThreadDisplayMetadata.mockReset();
+  backendRegistryMock.getThreadInfo.mockReset();
   backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReset();
   backendRegistryMock.getInProgressThreadSnapshotForQuit.mockReturnValue({
     count: 0,
@@ -921,7 +921,7 @@ describe("readQuitBlockerQueueSnapshot", () => {
       count: 1,
       threadIds: ["codex:thread-live"],
     });
-    backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+    backendRegistryMock.getThreadInfo.mockReturnValue({
       title: "Keep the quit queue stable",
       titleSource: "explicit",
     });
@@ -955,7 +955,7 @@ describe("readQuitBlockerQueueSnapshot", () => {
     // registry reads therefore enforces both steady-state budgets.
     expect(backendRegistryMock.listThreads).not.toHaveBeenCalled();
     expect(
-      backendRegistryMock.getCachedThreadDisplayMetadata,
+      backendRegistryMock.getThreadInfo,
     ).toHaveBeenCalledTimes(4);
   });
 
@@ -974,7 +974,7 @@ describe("readQuitBlockerQueueSnapshot", () => {
         count: 1,
         threadIds: ["codex:thread-first-snapshot"],
       });
-      backendRegistryMock.getCachedThreadDisplayMetadata.mockReturnValue({
+      backendRegistryMock.getThreadInfo.mockReturnValue({
         title: "First snapshot stays named",
         titleSource: "explicit",
       });

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -388,12 +388,18 @@ describe("RemoteThreadSummaryCache — threadFromPeer", () => {
 });
 
 describe("RemoteThreadSummaryCache — remembered thread names", () => {
-  const nameOf = (cache: RemoteThreadSummaryCache, threadId: string) =>
+  const nameOnPeer = (
+    cache: RemoteThreadSummaryCache,
+    instanceId: string,
+    threadId: string,
+  ) =>
     cache.cachedThreadNameFromPeer({
-      target: remoteTarget("peer-a"),
+      target: remoteTarget(instanceId),
       backend: "codex",
       threadId,
     })?.title;
+  const nameOf = (cache: RemoteThreadSummaryCache, threadId: string) =>
+    nameOnPeer(cache, "peer-a", threadId);
 
   it("answers from remembered names without ever contacting the peer", async () => {
     const fetchSnapshot = vi.fn(async () =>
@@ -493,6 +499,101 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
 
     expect(nameOf(cache, "t1")).toBe("Parent");
     expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  // Two navigation refreshes for one peer can be in flight at once and can
+  // finish out of order. The sequence each one records at is taken before its
+  // fetch starts, so the loser is decided by when the read began rather than
+  // by which reply happened to arrive last.
+  it("does not let a slow earlier snapshot revert a newer name", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    // Both refreshes start; the first one is the slower of the two.
+    const slower = cache.reserveThreadNameObservation();
+    const faster = cache.reserveThreadNameObservation();
+
+    cache.rememberThreadNames(
+      "peer-a",
+      [stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Renamed" })],
+      faster,
+    );
+    cache.rememberThreadNames(
+      "peer-a",
+      [stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" })],
+      slower,
+    );
+
+    expect(nameOf(cache, "t1")).toBe("Renamed");
+  });
+
+  // A rename recorded after both are in hand still wins: ordering is by
+  // observation sequence, not by a rule that the first writer keeps the field.
+  it("takes a rename that comes after the reverting snapshot", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
+    ]);
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Renamed" }),
+    ]);
+
+    expect(nameOf(cache, "t1")).toBe("Renamed");
+  });
+
+  // Thread ids are only unique within the instance that minted them. Two peers
+  // reusing one id must never answer for each other.
+  it("keeps identically-numbered threads on different peers apart", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a"), peer("peer-b")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Alpha" }),
+    ]);
+    cache.rememberThreadNames("peer-b", [
+      stampedThread({ instanceId: "peer-b", threadId: "t1", title: "Beta" }),
+    ]);
+
+    expect(nameOnPeer(cache, "peer-a", "t1")).toBe("Alpha");
+    expect(nameOnPeer(cache, "peer-b", "t1")).toBe("Beta");
+
+    // And a peer that never saw the thread has no opinion about it.
+    expect(nameOnPeer(cache, "peer-b", "t2")).toBeUndefined();
+  });
+
+  it("drops only the unmounted peer's names", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a"), peer("peer-b")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Alpha" }),
+    ]);
+    cache.rememberThreadNames("peer-b", [
+      stampedThread({ instanceId: "peer-b", threadId: "t1", title: "Beta" }),
+    ]);
+
+    cache.forgetInstanceThreadNames("peer-a");
+
+    expect(nameOnPeer(cache, "peer-a", "t1")).toBeUndefined();
+    expect(nameOnPeer(cache, "peer-b", "t1")).toBe("Beta");
   });
 });
 

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -439,7 +439,7 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
 
     cache.rememberThreadNames("peer-a", [
       stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
 
     expect(nameOf(cache, "t1")).toBe("Parent");
     expect(fetchSnapshot).not.toHaveBeenCalled();
@@ -458,7 +458,7 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
     cache.rememberThreadNames("peer-a", [
       stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
       stampedThread({ instanceId: "peer-a", threadId: "t2", title: "Sibling" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
     cache.rememberThreadNames("peer-a", [
       stampedThread({ instanceId: "peer-a", threadId: "t3", title: "Cousin" }),
       // A fallback title IS the thread id; recording it would overwrite a
@@ -467,7 +467,7 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
         ...stampedThread({ instanceId: "peer-a", threadId: "t1", title: "t1" }),
         titleSource: "fallback",
       },
-    ]);
+    ], cache.reserveThreadNameObservation());
 
     expect(nameOf(cache, "t1")).toBe("Parent");
     expect(nameOf(cache, "t2")).toBe("Sibling");
@@ -543,10 +543,10 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
 
     cache.rememberThreadNames("peer-a", [
       stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
     cache.rememberThreadNames("peer-a", [
       stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Renamed" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
 
     expect(nameOf(cache, "t1")).toBe("Renamed");
   });
@@ -563,16 +563,41 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
 
     cache.rememberThreadNames("peer-a", [
       stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Alpha" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
     cache.rememberThreadNames("peer-b", [
       stampedThread({ instanceId: "peer-b", threadId: "t1", title: "Beta" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
 
     expect(nameOnPeer(cache, "peer-a", "t1")).toBe("Alpha");
     expect(nameOnPeer(cache, "peer-b", "t1")).toBe("Beta");
 
     // And a peer that never saw the thread has no opinion about it.
     expect(nameOnPeer(cache, "peer-b", "t2")).toBeUndefined();
+  });
+
+  // titleSource is a compile-time contract over another instance's JSON. An
+  // older peer sends a real title without one, and a name still beats a uuid.
+  it("keeps a peer title that arrived without a titleSource", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    const row = stampedThread({
+      instanceId: "peer-a",
+      threadId: "t1",
+      title: "Design review",
+    });
+    delete (row as { titleSource?: unknown }).titleSource;
+    cache.rememberThreadNames(
+      "peer-a",
+      [row],
+      cache.reserveThreadNameObservation(),
+    );
+
+    expect(nameOf(cache, "t1")).toBe("Design review");
   });
 
   it("drops only the unmounted peer's names", () => {
@@ -585,10 +610,10 @@ describe("RemoteThreadSummaryCache — remembered thread names", () => {
 
     cache.rememberThreadNames("peer-a", [
       stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Alpha" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
     cache.rememberThreadNames("peer-b", [
       stampedThread({ instanceId: "peer-b", threadId: "t1", title: "Beta" }),
-    ]);
+    ], cache.reserveThreadNameObservation());
 
     cache.forgetInstanceThreadNames("peer-a");
 

--- a/apps/desktop/src/main/__tests__/thread-info-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-info-store.test.ts
@@ -457,6 +457,72 @@ describe("ThreadInfoStore", () => {
       ).toBe("shared-id");
     });
 
+    // Withholding is not absence. A second thread wearing this id is a second
+    // thread whether or not this store will currently answer for it.
+    it("refuses an ambiguous lookup when one match is withheld", () => {
+      const store = new ThreadInfoStore();
+      for (const backend of ["codex", "acp:claude-code"] as const) {
+        store.observeSummary({
+          enriched: false,
+          identity: { backend, threadId: "shared-id" },
+          observationSequence: store.reserveObservationSequence(),
+          summary: { ...rowFor("Either one"), id: "shared-id" },
+        });
+      }
+      store.observe({
+        archived: true,
+        identity: { backend: "acp:claude-code", threadId: "shared-id" },
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+      });
+
+      expect(
+        store.getSummary({ backend: "acp:claude-code", threadId: "shared-id" }),
+      ).toBeUndefined();
+      expect(store.findLocalSummary({ threadId: "shared-id" })).toBeUndefined();
+    });
+
+    // The key joins its parts with `::` and an instance id is peer-supplied
+    // text, so a prefix scan claims more than it was asked for.
+    it("forgets one peer without taking a peer whose id extends it", () => {
+      const store = new ThreadInfoStore();
+      for (const instanceId of ["peer-a", "peer-a::b"] as const) {
+        store.observe({
+          identity: { backend: "codex", instanceId, threadId: "t1" },
+          observationSequence: store.reserveObservationSequence(),
+          source: "provider-list",
+          title: `Thread on ${instanceId}`,
+          titleSource: "explicit",
+        });
+      }
+
+      store.forgetInstance("peer-a");
+
+      expect(
+        store.getTitle({ backend: "codex", instanceId: "peer-a", threadId: "t1" }),
+      ).toBeUndefined();
+      expect(
+        store.getTitle({ backend: "codex", instanceId: "peer-a::b", threadId: "t1" }),
+      ).toBe("Thread on peer-a::b");
+    });
+
+    // Names outlive invalidation; a resolved directory set does not.
+    it("drops enriched rows on invalidation and keeps everything else", () => {
+      const store = new ThreadInfoStore();
+      store.observeSummary({
+        enriched: true,
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        summary: rowFor("Enriched"),
+      });
+
+      store.forgetEnrichedSummaries();
+
+      expect(store.getSummary(local("t1"), { requireEnriched: true }))
+        .toBeUndefined();
+      expect(store.getSummary(local("t1"))?.title).toBe("Enriched");
+    });
+
     it("forgets an entry whose id needed normalizing", () => {
       const store = new ThreadInfoStore();
       store.observe({

--- a/apps/desktop/src/main/__tests__/thread-info-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-info-store.test.ts
@@ -302,4 +302,175 @@ describe("ThreadInfoStore", () => {
       expect(new Set(sequences).size).toBe(sequences.length);
     });
   });
+  // The store keeps two lanes: notifications write fields, listings write the
+  // whole row. Handing the row back verbatim let this store answer with a
+  // title it already knew was stale.
+  describe("the row is reconciled with what the fields know", () => {
+    const rowFor = (
+      title: string,
+      titleSource: "explicit" | "derived" | "fallback" = "explicit",
+    ) =>
+      ({
+        id: "t1",
+        source: "codex" as const,
+        title,
+        titleSource,
+        linkedDirectories: [],
+      }) as unknown as Parameters<ThreadInfoStore["observeSummary"]>[0]["summary"];
+
+    function storeWithRow(title = "Old Name"): ThreadInfoStore {
+      const store = new ThreadInfoStore();
+      const seq = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: seq,
+        source: "provider-list",
+        title,
+        titleSource: "explicit",
+      });
+      store.observeSummary({
+        enriched: false,
+        identity: local("t1"),
+        observationSequence: seq,
+        summary: rowFor(title),
+      });
+      return store;
+    }
+
+    it("serves a rename that arrived after the row", () => {
+      const store = storeWithRow();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        title: "New Name",
+        titleSource: "explicit",
+      });
+
+      expect(store.getTitle(local("t1"))).toBe("New Name");
+      expect(store.getSummary(local("t1"))?.title).toBe("New Name");
+      expect(store.findLocalSummary({ threadId: "t1" })?.title).toBe("New Name");
+    });
+
+    // A provider that lost its title index sends a newer row whose title IS
+    // the thread id. The field lane already rejects it; the row must not be a
+    // way around that.
+    it("does not let a newer fallback row overwrite a known name", () => {
+      const store = storeWithRow("Real Name");
+      const seq = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: seq,
+        source: "provider-list",
+        title: "t1",
+        titleSource: "fallback",
+      });
+      store.observeSummary({
+        enriched: false,
+        identity: local("t1"),
+        observationSequence: seq,
+        summary: rowFor("t1", "fallback"),
+      });
+
+      expect(store.getTitle(local("t1"))).toBe("Real Name");
+      expect(store.getSummary(local("t1"))?.title).toBe("Real Name");
+    });
+
+    // Archival is membership, not a field. A caller asking for the row is
+    // asking about a thread the provider still serves.
+    it("stops serving a row once the thread is archived", () => {
+      const store = storeWithRow();
+      expect(store.getSummary(local("t1"))).toBeDefined();
+
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        archived: true,
+      });
+
+      expect(store.getSummary(local("t1"))).toBeUndefined();
+      expect(store.findLocalSummary({ threadId: "t1" })).toBeUndefined();
+      // The name is still known — only the row is withheld.
+      expect(store.getTitle(local("t1"))).toBe("Old Name");
+    });
+
+    it("serves the row again once the thread is restored", () => {
+      const store = storeWithRow();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        archived: true,
+      });
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        archived: false,
+      });
+
+      expect(store.getSummary(local("t1"))?.id).toBe("t1");
+    });
+
+    // Enrichment is a property of the listing, not of the thread, and the
+    // most frequent listing is unenriched.
+    it("keeps the enriched row when a newer unenriched one arrives", () => {
+      const store = new ThreadInfoStore();
+      store.observeSummary({
+        enriched: true,
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        summary: rowFor("Enriched"),
+      });
+      store.observeSummary({
+        enriched: false,
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        summary: rowFor("Unenriched"),
+      });
+
+      expect(store.getSummary(local("t1"), { requireEnriched: true })?.title)
+        .toBe("Enriched");
+      expect(store.getSummary(local("t1"))?.title).toBe("Unenriched");
+    });
+
+    // Thread ids are unique per backend, not across them, and an ACP adapter
+    // picks its own.
+    it("refuses an ambiguous backend-less lookup", () => {
+      const store = new ThreadInfoStore();
+      for (const backend of ["codex", "acp:claude-code"] as const) {
+        store.observeSummary({
+          enriched: false,
+          identity: { backend, threadId: "shared-id" },
+          observationSequence: store.reserveObservationSequence(),
+          summary: {
+            ...rowFor("Either one"),
+            id: "shared-id",
+          },
+        });
+      }
+
+      expect(store.findLocalSummary({ threadId: "shared-id" })).toBeUndefined();
+      expect(
+        store.findLocalSummary({ backend: "codex", threadId: "shared-id" })?.id,
+      ).toBe("shared-id");
+    });
+
+    it("forgets an entry whose id needed normalizing", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: local(" padded "),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "Padded",
+        titleSource: "explicit",
+      });
+      expect(store.size).toBe(1);
+
+      store.forget(local(" padded "));
+
+      expect(store.size).toBe(0);
+    });
+  });
 });

--- a/apps/desktop/src/main/__tests__/thread-info-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-info-store.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import { ThreadInfoStore } from "../app-server/thread-info-store";
+
+const local = (threadId: string) => ({ backend: "codex" as const, threadId });
+
+function storeWithTitle(title = "Known name"): ThreadInfoStore {
+  const store = new ThreadInfoStore();
+  store.observe({
+    identity: local("t1"),
+    observationSequence: store.reserveObservationSequence(),
+    source: "provider-list",
+    title,
+    titleSource: "explicit",
+  });
+  return store;
+}
+
+describe("ThreadInfoStore", () => {
+  describe("unknown is distinguishable from unobserved", () => {
+    it("returns undefined for a thread it has never seen", () => {
+      expect(new ThreadInfoStore().get(local("never-seen"))).toBeUndefined();
+    });
+
+    it("returns undefined rather than guessing from another backend", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: { backend: "codex", threadId: "shared-id" },
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "Codex thread",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle({ backend: "acp:claude-code", threadId: "shared-id" }))
+        .toBeUndefined();
+    });
+
+    it("returns undefined rather than guessing across instances", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: { backend: "codex", instanceId: "peer-a", threadId: "shared-id" },
+        observationSequence: store.reserveObservationSequence(),
+        source: "remote-navigation",
+        title: "Peer A thread",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-b", threadId: "shared-id" }))
+        .toBeUndefined();
+      expect(store.getTitle(local("shared-id"))).toBeUndefined();
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-a", threadId: "shared-id" }))
+        .toBe("Peer A thread");
+    });
+  });
+
+  describe("a known title cannot be downgraded", () => {
+    it("ignores an observation that omits the title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        updatedAt: 42,
+      });
+      expect(store.getTitle(local("t1"))).toBe("Known name");
+      expect(store.get(local("t1"))?.updatedAt).toBe(42);
+    });
+
+    it("ignores an empty title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "   ",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Known name");
+    });
+
+    it("ignores a fallback title even when it is newer", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "t1",
+        titleSource: "fallback",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Known name");
+      expect(store.get(local("t1"))?.titleSource).toBe("explicit");
+    });
+
+    it("ignores a fallback source arriving without its title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        titleSource: "fallback",
+      });
+      expect(store.get(local("t1"))?.titleSource).toBe("explicit");
+    });
+  });
+
+  describe("a newer positive observation wins", () => {
+    it("accepts an explicit rename over a provider title", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "local-rename",
+        title: "Operator's name",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Operator's name");
+    });
+
+    it("accepts a derived title over an earlier derived title", () => {
+      const store = new ThreadInfoStore();
+      for (const title of ["First guess", "Second guess"]) {
+        store.observe({
+          identity: local("t1"),
+          observationSequence: store.reserveObservationSequence(),
+          source: "provider-list",
+          title,
+          titleSource: "derived",
+        });
+      }
+      expect(store.getTitle(local("t1"))).toBe("Second guess");
+    });
+  });
+
+  describe("late completions cannot revert a newer observation", () => {
+    it("drops a stale list that reserved its sequence before a rename", () => {
+      const store = storeWithTitle("Provider title");
+      // A list starts here and reserves its place in the ordering.
+      const staleListSequence = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        title: "Renamed while listing",
+        titleSource: "explicit",
+      });
+      // The list finally completes, still carrying its older rows.
+      store.observe({
+        identity: local("t1"),
+        observationSequence: staleListSequence,
+        source: "provider-list",
+        title: "Provider title",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Renamed while listing");
+    });
+
+    it("lets a list started after a rename reconcile the title", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        title: "Renamed",
+        titleSource: "explicit",
+      });
+      const freshListSequence = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: freshListSequence,
+        source: "provider-list",
+        title: "Server agrees, with an edit",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Server agrees, with an edit");
+    });
+
+    it("orders per field, so a stale title cannot block a newer archived flag", () => {
+      const store = storeWithTitle();
+      const staleSequence = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        title: "Newer title",
+        titleSource: "explicit",
+      });
+      store.observe({
+        identity: local("t1"),
+        observationSequence: staleSequence,
+        source: "provider-list",
+        archived: true,
+        title: "Older title",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Newer title");
+      expect(store.get(local("t1"))?.archived).toBe(true);
+    });
+  });
+
+  describe("change reporting", () => {
+    it("reports only the fields an observation actually changed", () => {
+      const store = storeWithTitle();
+      expect(
+        store.observe({
+          identity: local("t1"),
+          observationSequence: store.reserveObservationSequence(),
+          source: "provider-list",
+          title: "Known name",
+          titleSource: "explicit",
+          updatedAt: 7,
+        }),
+      ).toEqual(["updatedAt"]);
+    });
+
+    it("reports nothing when a refresh only confirms what is known", () => {
+      const store = storeWithTitle();
+      expect(
+        store.observe({
+          identity: local("t1"),
+          observationSequence: store.reserveObservationSequence(),
+          source: "provider-list",
+          title: "Known name",
+          titleSource: "explicit",
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("removal is explicit", () => {
+    it("forgets a single thread without touching its neighbours", () => {
+      const store = storeWithTitle();
+      store.observe({
+        identity: local("t2"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "Sibling",
+        titleSource: "explicit",
+      });
+      store.forget(local("t1"));
+      expect(store.get(local("t1"))).toBeUndefined();
+      expect(store.getTitle(local("t2"))).toBe("Sibling");
+    });
+
+    it("forgets one peer's threads and keeps local and other-peer entries", () => {
+      const store = new ThreadInfoStore();
+      const seed = (instanceId: string | undefined, title: string) =>
+        store.observe({
+          identity: { backend: "codex", threadId: "t1", ...(instanceId ? { instanceId } : {}) },
+          observationSequence: store.reserveObservationSequence(),
+          source: instanceId ? "remote-navigation" : "provider-list",
+          title,
+          titleSource: "explicit",
+        });
+      seed(undefined, "Mine");
+      seed("peer-a", "Theirs");
+      seed("peer-b", "Someone else's");
+      store.forgetInstance("peer-a");
+      expect(store.getTitle(local("t1"))).toBe("Mine");
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-a", threadId: "t1" }))
+        .toBeUndefined();
+      expect(store.getTitle({ backend: "codex", instanceId: "peer-b", threadId: "t1" }))
+        .toBe("Someone else's");
+    });
+  });
+
+  describe("input hygiene", () => {
+    it("ignores a blank thread id instead of creating a phantom entry", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: local("   "),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "Nowhere",
+        titleSource: "explicit",
+      });
+      expect(store.size).toBe(0);
+    });
+
+    it("matches a padded thread id to the entry it created", () => {
+      const store = storeWithTitle();
+      expect(store.getTitle({ backend: "codex", threadId: "  t1  " })).toBe("Known name");
+    });
+
+    it("trims stored titles", () => {
+      const store = new ThreadInfoStore();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "provider-list",
+        title: "  Padded  ",
+        titleSource: "explicit",
+      });
+      expect(store.getTitle(local("t1"))).toBe("Padded");
+    });
+  });
+
+  describe("ordering does not read the clock", () => {
+    it("issues strictly increasing sequences", () => {
+      const store = new ThreadInfoStore();
+      const sequences = Array.from({ length: 5 }, () =>
+        store.reserveObservationSequence(),
+      );
+      expect(sequences).toEqual([...sequences].sort((a, b) => a - b));
+      expect(new Set(sequences).size).toBe(sequences.length);
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-info-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-info-store.test.ts
@@ -435,6 +435,75 @@ describe("ThreadInfoStore", () => {
       expect(store.getSummary(local("t1"))?.title).toBe("Unenriched");
     });
 
+    it("invalidates summaries without losing newer field observations", () => {
+      const store = storeWithRow();
+      const staleListSequence = store.reserveObservationSequence();
+      store.observe({
+        identity: local("t1"),
+        observationSequence: store.reserveObservationSequence(),
+        source: "lifecycle-notification",
+        archived: false,
+        title: "Renamed while listing",
+        titleSource: "explicit",
+      });
+
+      store.invalidateSummaries(local("t1"));
+      store.observe({
+        identity: local("t1"),
+        observationSequence: staleListSequence,
+        source: "provider-list",
+        title: "Old Name",
+        titleSource: "explicit",
+      });
+      store.observeSummary({
+        enriched: true,
+        identity: local("t1"),
+        observationSequence: staleListSequence,
+        summary: rowFor("Old Name"),
+      });
+
+      expect(store.get(local("t1"))).toMatchObject({
+        archived: false,
+        title: "Renamed while listing",
+      });
+      expect(store.getSummary(local("t1"))).toBeUndefined();
+      expect(store.getSummary(local("t1"), { requireEnriched: true }))
+        .toBeUndefined();
+    });
+
+    it("accepts a summary from a listing started after invalidation", () => {
+      const store = storeWithRow();
+      store.invalidateSummaries(local("t1"));
+      const freshListSequence = store.reserveObservationSequence();
+
+      store.observeSummary({
+        enriched: true,
+        identity: local("t1"),
+        observationSequence: freshListSequence,
+        summary: rowFor("Fresh row"),
+      });
+
+      expect(store.getSummary(local("t1"), { requireEnriched: true })?.title)
+        .toBe("Fresh row");
+    });
+
+    it("blocks an in-flight summary for an otherwise unobserved thread", () => {
+      const store = new ThreadInfoStore();
+      const staleListSequence = store.reserveObservationSequence();
+      store.invalidateSummaries(local("t1"));
+
+      store.observeSummary({
+        enriched: true,
+        identity: local("t1"),
+        observationSequence: staleListSequence,
+        summary: rowFor("Stale row"),
+      });
+
+      expect(store.get(local("t1"))).toBeUndefined();
+      expect(store.getSummary(local("t1"))).toBeUndefined();
+      expect(store.size).toBe(0);
+    });
+
     // Thread ids are unique per backend, not across them, and an ACP adapter
     // picks its own.
     it("refuses an ambiguous backend-less lookup", () => {
@@ -504,6 +573,27 @@ describe("ThreadInfoStore", () => {
       expect(
         store.getTitle({ backend: "codex", instanceId: "peer-a::b", threadId: "t1" }),
       ).toBe("Thread on peer-a::b");
+    });
+
+    it("keeps delimiter-bearing remote identities distinct", () => {
+      const store = new ThreadInfoStore();
+      const identities = [
+        { backend: "codex" as const, instanceId: "p", threadId: "x::codex:y" },
+        { backend: "codex" as const, instanceId: "p::codex:x", threadId: "y" },
+      ];
+      identities.forEach((identity, index) => {
+        store.observe({
+          identity,
+          observationSequence: store.reserveObservationSequence(),
+          source: "remote-navigation",
+          title: `Remote ${index + 1}`,
+          titleSource: "explicit",
+        });
+      });
+
+      expect(store.getTitle(identities[0]!)).toBe("Remote 1");
+      expect(store.getTitle(identities[1]!)).toBe("Remote 2");
+      expect(store.size).toBe(2);
     });
 
     it("forgets an entry whose id needed normalizing", () => {

--- a/apps/desktop/src/main/__tests__/thread-info-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-info-store.test.ts
@@ -506,23 +506,6 @@ describe("ThreadInfoStore", () => {
       ).toBe("Thread on peer-a::b");
     });
 
-    // Names outlive invalidation; a resolved directory set does not.
-    it("drops enriched rows on invalidation and keeps everything else", () => {
-      const store = new ThreadInfoStore();
-      store.observeSummary({
-        enriched: true,
-        identity: local("t1"),
-        observationSequence: store.reserveObservationSequence(),
-        summary: rowFor("Enriched"),
-      });
-
-      store.forgetEnrichedSummaries();
-
-      expect(store.getSummary(local("t1"), { requireEnriched: true }))
-        .toBeUndefined();
-      expect(store.getSummary(local("t1"))?.title).toBe("Enriched");
-    });
-
     it("forgets an entry whose id needed normalizing", () => {
       const store = new ThreadInfoStore();
       store.observe({

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -386,3 +386,49 @@ describe("archival is an observation, not a cache eviction", () => {
       .toBe(false);
   });
 });
+
+describe("messaging admission reads what this process already knows", () => {
+  // resolveThread falls back to listThreads({ forceRefresh: true }) — a full
+  // paged provider walk — whenever the cached summary comes back empty. The
+  // thread-list cache is emptied by every mutation, so before the information
+  // store answered here, an inbound reply to a thread this window listed
+  // minutes ago paid that walk because something unrelated had invalidated the
+  // cache in between.
+  it("admits a reply after an invalidation without listing the provider", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    // An unrelated mutation on a different thread empties the whole cache.
+    await registry.archiveThread({ backend: "codex", threadId: "thread-beta" });
+    client.resetCounts();
+
+    const summary = registry.getCachedThreadSummary({
+      backend: "codex",
+      threadId: "thread-alpha",
+    });
+    expect(summary?.title).toBe("Rework the quit dialog");
+    await expect(
+      registry.resolveThread({ threadId: "thread-alpha" }),
+    ).resolves.toMatchObject({ id: "thread-alpha" });
+
+    expectThreadReadBudget({
+      note: "messaging admission for a listed thread whose list cache was invalidated",
+      reads: client.counts,
+      scenario: "messaging-admission-after-invalidation",
+    });
+  });
+
+  // The caller does not always know which backend owns the thread an inbound
+  // message names.
+  it("answers a backend-less lookup from the store", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await registry.archiveThread({ backend: "codex", threadId: "thread-alpha" });
+
+    expect(
+      registry.getCachedThreadSummary({ threadId: "thread-beta" })?.title,
+    ).toBe("Audit the messaging adapters");
+    expect(
+      registry.getCachedThreadSummary({ threadId: "no-such-thread" }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -432,3 +432,132 @@ describe("messaging admission reads what this process already knows", () => {
     ).toBeUndefined();
   });
 });
+
+// Messaging admission and the quit dialog read this process's own knowledge
+// rather than the provider. That is only safe while what it knows is current.
+describe("what the store serves stays current", () => {
+  it("admits a reply under the renamed title, not the listed one", async () => {
+    const { registry } = build([NAMED_THREAD]);
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/name/updated",
+      params: { threadId: "thread-alpha", threadName: "Renamed after listing" },
+    });
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-alpha",
+      })?.title,
+    ).toBe("Renamed after listing");
+    await expect(
+      registry.resolveThread({ threadId: "thread-alpha" }),
+    ).resolves.toMatchObject({ title: "Renamed after listing" });
+  });
+
+  // resolveThread's provider fallback filters archived:false. Answering from
+  // the store has to honour the same thing, or a reply is admitted to a thread
+  // the operator archived.
+  it("stops resolving a thread once it is archived", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await registry.archiveThread({ backend: "codex", threadId: "thread-alpha" });
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-alpha",
+      }),
+    ).toBeUndefined();
+    await expect(
+      registry.resolveThread({ threadId: "thread-alpha" }),
+    ).resolves.toBeUndefined();
+    // The untouched thread is unaffected.
+    await expect(
+      registry.resolveThread({ threadId: "thread-beta" }),
+    ).resolves.toMatchObject({ id: "thread-beta" });
+  });
+
+  // thread/started replays the provider's own record, which on a resume is
+  // the pre-rename one. Sequence order alone would let it win.
+  it("keeps an unacknowledged rename over a resumed thread's own record", async () => {
+    const { registry } = build([NAMED_THREAD]);
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/name/updated",
+      params: { threadId: "thread-alpha", threadName: "Renamed By Operator" },
+    });
+    await publishNotification(registry, {
+      method: "thread/started",
+      params: {
+        threadId: "thread-alpha",
+        thread: {
+          id: "thread-alpha",
+          title: "Rework the quit dialog",
+          titleSource: "explicit",
+        },
+      },
+    });
+
+    expect(
+      registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })
+        ?.title,
+    ).toBe("Renamed By Operator");
+  });
+
+  // An unfiltered listing returns archived and active rows alike, so it proves
+  // nothing about either.
+  it("does not read archival into a listing that did not filter for it", async () => {
+    const { registry } = build();
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+
+    expect(
+      registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })
+        ?.archived,
+    ).toBe(true);
+  });
+
+  // A listing that failed is not an answer. Memoizing it would silence this
+  // thread's terminal notifications for the rest of the process.
+  it("retries a terminal-notification lookup that failed", async () => {
+    const { client, registry } = build();
+    client.failNextList = true;
+    await publishNotification(registry, {
+      method: "turn/completed",
+      params: {
+        threadId: "thread-alpha",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed", output: [] },
+      },
+    });
+    const listsAfterFailure = client.listCalls.length;
+
+    await publishNotification(registry, {
+      method: "turn/completed",
+      params: {
+        threadId: "thread-alpha",
+        turnId: "turn-2",
+        turn: { id: "turn-2", status: "completed", output: [] },
+      },
+    });
+
+    expect(client.listCalls.length).toBeGreaterThan(listsAfterFailure);
+    expect(
+      registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })
+        ?.title,
+    ).toBe("Rework the quit dialog");
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -509,14 +509,19 @@ describe("what the store serves stays current", () => {
     ).toBe("Renamed By Operator");
   });
 
-  // An unfiltered listing returns archived and active rows alike, so it proves
-  // nothing about either.
-  it("does not read archival into a listing that did not filter for it", async () => {
-    const { registry } = build();
-    await publishNotification(registry, {
-      method: "thread/archived",
-      params: { threadId: "thread-alpha" },
-    });
+  // Archival is read off the row, not off the query. Both backends coerce an
+  // unspecified `archived` to `false`, so "the caller did not filter" is not a
+  // case that reaches a provider -- and the row's own `archivedAt` survives a
+  // listing that the caller labelled nothing at all.
+  it("records archival from a row that carries archivedAt", async () => {
+    const { registry } = build([
+      codexThread({
+        id: "thread-alpha",
+        title: "Rework the quit dialog",
+        titleSource: "explicit",
+        archivedAt: 1000,
+      }),
+    ]);
     await registry.listThreads({
       backend: "codex",
       callerReason: "navigation-snapshot",
@@ -524,10 +529,74 @@ describe("what the store serves stays current", () => {
       forceRefresh: true,
     });
 
+    // The row-derived fact is what this asserts. Withholding it from a caller
+    // is the list cache's job here, not the store's: `thread/archived`
+    // invalidates that cache, so its copy cannot outlive the archival, while
+    // the store deliberately survives invalidation and needs the fact instead.
     expect(
       registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })
         ?.archived,
     ).toBe(true);
+  });
+
+  // The guard compares the archival sequence against the row's. A later
+  // listing that does not carry the thread must not advance the row past it,
+  // or one navigation poll un-archives it and admission serves it again.
+  it("keeps an archived thread withheld across later listings", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+    // The provider stops serving it, exactly as an active listing does.
+    client.setThreads([SECOND_THREAD]);
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-alpha",
+      }),
+    ).toBeUndefined();
+  });
+
+  // ACP emits no unarchive notification, and a second process on the same
+  // profile emits none this process hears. The row coming back without
+  // `archivedAt` is the only report of that, so it has to be believed.
+  it("restores a thread the provider starts listing as active again", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+    client.setThreads([SECOND_THREAD]);
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-alpha",
+      }),
+    ).toBeUndefined();
+
+    client.setThreads([NAMED_THREAD, SECOND_THREAD]);
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    // The fact itself has to flip, not merely stop being consulted. A store
+    // that leaves `archived` true and serves the row anyway because a newer
+    // summary outranks it is one poll away from withholding it again.
+    expect(
+      registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })
+        ?.archived,
+    ).toBe(false);
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-alpha",
+      }),
+    ).toMatchObject({ id: "thread-alpha" });
   });
 
   // A listing that failed is not an answer. Memoizing it would silence this

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  codexThread,
+  createThreadReadRegistry,
+  publishNotification,
+} from "./fixtures/thread-read-harness";
+import { expectThreadReadBudget } from "./fixtures/thread-read-budget";
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+const NAMED_THREAD = codexThread({
+  id: "thread-alpha",
+  title: "Rework the quit dialog",
+  titleSource: "explicit",
+});
+const SECOND_THREAD = codexThread({
+  id: "thread-beta",
+  title: "Audit the messaging adapters",
+  titleSource: "explicit",
+});
+
+/** The read a freshly opened window makes to paint its sidebar. */
+const NAVIGATION_REFRESH = {
+  backend: "codex",
+  callerReason: "navigation-snapshot",
+  enrichDirectories: false,
+} as const;
+
+const registries: Array<{ close: () => Promise<unknown> }> = [];
+
+function build(threads = [NAMED_THREAD, SECOND_THREAD]) {
+  const created = createThreadReadRegistry(threads);
+  registries.push(created.registry);
+  return created;
+}
+
+afterEach(async () => {
+  await Promise.all(registries.splice(0).map(async (registry) => {
+    await registry.close();
+  }));
+});
+
+describe("thread read budgets", () => {
+  it("names quit blockers for the life of the dialog without reading the provider", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "turn/started",
+      params: { threadId: "thread-alpha", turnId: "turn-1", turn: { id: "turn-1" } },
+    });
+    client.resetCounts();
+
+    // The quit toast re-reads this snapshot every 500ms while it is open.
+    for (let poll = 0; poll < 20; poll += 1) {
+      expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+        count: 1,
+        threadIds: ["codex:thread-alpha"],
+        threadTitles: { "codex:thread-alpha": "Rework the quit dialog" },
+      });
+    }
+
+    expectThreadReadBudget({
+      note: "20 quit-dialog polls against an in-progress turn, all served from observed metadata",
+      reads: client.counts,
+      scenario: "quit-dialog-poll",
+    });
+  });
+
+  it("answers repeated label lookups for a known thread without reading the provider", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    for (let lookup = 0; lookup < 50; lookup += 1) {
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+        .toBe("Rework the quit dialog");
+    }
+
+    expectThreadReadBudget({
+      note: "50 synchronous label lookups for a thread already observed once",
+      reads: client.counts,
+      scenario: "known-thread-label-lookups",
+    });
+  });
+
+  it("keeps labels answerable across a turn's lifecycle events", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    // A turn invalidates list caches repeatedly. None of it is a reason to
+    // forget what the threads are called.
+    for (let turn = 0; turn < 5; turn += 1) {
+      await publishNotification(registry, {
+        method: "turn/started",
+        params: { threadId: "thread-alpha", turnId: `turn-${turn}`, turn: { id: `turn-${turn}` } },
+      });
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+        .toBe("Rework the quit dialog");
+      await publishNotification(registry, {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-alpha",
+          turnId: `turn-${turn}`,
+          turn: { id: `turn-${turn}`, status: "completed", output: [] },
+        },
+      });
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+        .toBe("Rework the quit dialog");
+    }
+
+    expectThreadReadBudget({
+      note: "five complete turns with label reads between every lifecycle event",
+      reads: client.counts,
+      scenario: "turn-lifecycle-label-reads",
+    });
+  });
+
+  it("shares one provider read across callers that want the same listing", async () => {
+    const { client, registry } = build();
+    await Promise.all([
+      registry.listThreads(NAVIGATION_REFRESH),
+      registry.listThreads({ backend: "codex", callerReason: "navigation-snapshot", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "startup-prewarm", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "branch-drift", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "turn-cwd", enrichDirectories: false }),
+      registry.listThreads({ backend: "codex", callerReason: "title-generation", enrichDirectories: false }),
+    ]);
+
+    expectThreadReadBudget({
+      note: "six concurrent callers asking for the same unenriched Codex listing",
+      reads: client.counts,
+      scenario: "concurrent-identical-listings",
+    });
+  });
+});
+
+describe("thread information is never lost", () => {
+  it("keeps a known title when the provider becomes unavailable", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Rework the quit dialog");
+
+    client.failNextList = true;
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true })
+      .catch(() => undefined);
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Rework the quit dialog");
+  });
+
+  it("keeps a known title when the provider starts reporting a fallback", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+
+    // A provider that loses its title index answers with the thread id. That
+    // is the absence of a name, not the news that the name is now a uuid.
+    client.setThreads([codexThread({ id: "thread-alpha" })]);
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Rework the quit dialog");
+  });
+
+  it("prefers a rename to a listing that started before it", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+
+    let releaseList: () => void = () => {};
+    client.listGate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    const staleList = registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    await publishNotification(registry, {
+      method: "thread/name/updated",
+      params: { threadId: "thread-alpha", threadName: "Renamed mid-listing" },
+    });
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Renamed mid-listing");
+
+    releaseList();
+    await staleList;
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Renamed mid-listing");
+  });
+
+  it("adopts a title the provider reports after a rename", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/name/updated",
+      params: { threadId: "thread-alpha", threadName: "Renamed locally" },
+    });
+
+    client.setThreads([
+      codexThread({
+        id: "thread-alpha",
+        title: "Renamed locally, then edited elsewhere",
+        titleSource: "explicit",
+      }),
+    ]);
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.title)
+      .toBe("Renamed locally, then edited elsewhere");
+  });
+
+  it("does not let one backend's thread id answer for another's", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    expect(registry.getThreadInfo({ backend: "acp:claude-code", threadId: "thread-alpha" }))
+      .toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -222,3 +222,167 @@ describe("thread information is never lost", () => {
       .toBeUndefined();
   });
 });
+
+describe("thread read budgets across product flows", () => {
+  it("labels a burst of terminal notifications with one walk per unobserved thread", async () => {
+    // Turn completions arrive in bursts across concurrent threads. A thread
+    // this process never listed still deserves a label, but it must cost one
+    // reconciliation, not one per notification.
+    const { client, registry } = build([
+      codexThread({ id: "thread-alpha", title: "Alpha", titleSource: "derived" }),
+      codexThread({ id: "thread-beta", title: "Beta", titleSource: "derived" }),
+    ]);
+
+    await Promise.all(
+      ["thread-alpha", "thread-beta"].flatMap((threadId) =>
+        Array.from({ length: 4 }, (_unused, turn) =>
+          publishNotification(registry, {
+            method: "turn/completed",
+            params: {
+              threadId,
+              turnId: `turn-${turn}`,
+              turn: { id: `turn-${turn}`, status: "completed", output: [] },
+            },
+          }),
+        ),
+      ),
+    );
+
+    expectThreadReadBudget({
+      note: "eight terminal notifications across two threads neither of which was ever listed",
+      reads: client.counts,
+      scenario: "terminal-notification-burst",
+    });
+  });
+
+  it("reads the provider once for a window opening onto a warm profile", async () => {
+    // A second window mounting asks for the same navigation data the first
+    // window already fetched, then immediately reads labels for its rows.
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    await registry.listThreads(NAVIGATION_REFRESH);
+    for (const threadId of ["thread-alpha", "thread-beta"]) {
+      expect(registry.getThreadInfo({ backend: "codex", threadId })?.title)
+        .toBeDefined();
+    }
+
+    expectThreadReadBudget({
+      note: "a second window's navigation refresh and label reads against a warm list cache",
+      reads: client.counts,
+      scenario: "second-window-navigation",
+    });
+  });
+
+  it("keeps a turn's workspace lookups off the provider once the thread is known", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    // Ten turns, each of which adopts a branch on start and reports a cwd.
+    for (let turn = 0; turn < 10; turn += 1) {
+      await publishNotification(registry, {
+        method: "turn/started",
+        params: { threadId: "thread-alpha", turnId: `turn-${turn}`, turn: { id: `turn-${turn}` } },
+      });
+      await publishNotification(registry, {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-alpha",
+          turnId: `turn-${turn}`,
+          turn: { id: `turn-${turn}`, status: "completed", output: [] },
+        },
+      });
+    }
+
+    expectThreadReadBudget({
+      note: "ten complete turns on a thread the navigation refresh already observed",
+      reads: client.counts,
+      scenario: "ten-turns-warm-thread",
+    });
+  });
+});
+
+describe("directory enrichment budget", () => {
+  // A worktree-shaped projectKey is what makes the registry reach for
+  // directory enrichment. Without one no scenario above can move the
+  // enrichment counter, and a budget that cannot move proves nothing.
+  const WORKTREE_THREAD = codexThread({
+    id: "thread-worktree",
+    projectKey: "/Users/example/.worktrees/feature-branch",
+    title: "Worktree thread",
+    titleSource: "explicit",
+  });
+
+  it("enriches a worktree thread's directories once per backfill-capable listing", async () => {
+    const { client, registry } = build([WORKTREE_THREAD]);
+    await registry.listThreads(NAVIGATION_REFRESH);
+
+    expect(client.directoryEnrichmentCallCount).toBeGreaterThan(0);
+    expectThreadReadBudget({
+      note: "one navigation refresh over a single worktree-backed thread",
+      reads: client.counts,
+      scenario: "worktree-navigation-refresh",
+    });
+  });
+
+  it("does not re-enrich a worktree thread for label reads across turns", async () => {
+    const { client, registry } = build([WORKTREE_THREAD]);
+    await registry.listThreads(NAVIGATION_REFRESH);
+    client.resetCounts();
+
+    for (let turn = 0; turn < 5; turn += 1) {
+      await publishNotification(registry, {
+        method: "turn/started",
+        params: { threadId: "thread-worktree", turnId: `turn-${turn}`, turn: { id: `turn-${turn}` } },
+      });
+      expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-worktree" })?.title)
+        .toBe("Worktree thread");
+      await publishNotification(registry, {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-worktree",
+          turnId: `turn-${turn}`,
+          turn: { id: `turn-${turn}`, status: "completed", output: [] },
+        },
+      });
+    }
+
+    expectThreadReadBudget({
+      note: "five turns on an already-enriched worktree thread",
+      reads: client.counts,
+      scenario: "worktree-turns-after-enrichment",
+    });
+  });
+});
+
+describe("archival is an observation, not a cache eviction", () => {
+  it("records that a thread was archived without losing its title", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" }))
+      .toMatchObject({ archived: true, title: "Rework the quit dialog" });
+  });
+
+  it("records a restore over the archival", async () => {
+    const { registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+    await publishNotification(registry, {
+      method: "thread/unarchived",
+      params: { threadId: "thread-alpha" },
+    });
+
+    expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })?.archived)
+      .toBe(false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -388,12 +388,10 @@ describe("archival is an observation, not a cache eviction", () => {
 });
 
 describe("messaging admission reads what this process already knows", () => {
-  // resolveThread falls back to listThreads({ forceRefresh: true }) — a full
-  // paged provider walk — whenever the cached summary comes back empty. The
-  // thread-list cache is emptied by every mutation, so before the information
-  // store answered here, an inbound reply to a thread this window listed
-  // minutes ago paid that walk because something unrelated had invalidated the
-  // cache in between.
+  // Messaging admission deliberately uses the last observation: it only needs
+  // settings and occupancy for one known target, not ownership proof. The
+  // thread-list cache is emptied by every mutation, so the information store
+  // keeps this path from paying a fleet walk after an unrelated invalidation.
   it("admits a reply after an invalidation without listing the provider", async () => {
     const { client, registry } = build();
     await registry.listThreads(NAVIGATION_REFRESH);
@@ -406,15 +404,50 @@ describe("messaging admission reads what this process already knows", () => {
       threadId: "thread-alpha",
     });
     expect(summary?.title).toBe("Rework the quit dialog");
-    await expect(
-      registry.resolveThread({ threadId: "thread-alpha" }),
-    ).resolves.toMatchObject({ id: "thread-alpha" });
 
     expectThreadReadBudget({
       note: "messaging admission for a listed thread whose list cache was invalidated",
       reads: client.counts,
       scenario: "messaging-admission-after-invalidation",
     });
+  });
+
+  it("refreshes the provider when resolving authoritative ownership", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await registry.archiveThread({ backend: "codex", threadId: "thread-beta" });
+    client.setThreads([SECOND_THREAD]);
+    client.resetCounts();
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-alpha",
+      })?.title,
+    ).toBe("Rework the quit dialog");
+    await expect(
+      registry.resolveThread({ backend: "codex", threadId: "thread-alpha" }),
+    ).resolves.toBeUndefined();
+    expect(client.counts.providerListCalls).toBeGreaterThan(0);
+  });
+
+  it("does not use an expired query cache as ownership proof", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const { client, registry } = build();
+      await registry.listThreads(NAVIGATION_REFRESH);
+      client.setThreads([SECOND_THREAD]);
+      client.resetCounts();
+      vi.setSystemTime(10 * 60_000);
+
+      await expect(
+        registry.resolveThread({ backend: "codex", threadId: "thread-alpha" }),
+      ).resolves.toBeUndefined();
+      expect(client.counts.providerListCalls).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // The caller does not always know which backend owns the thread an inbound
@@ -450,9 +483,6 @@ describe("what the store serves stays current", () => {
         threadId: "thread-alpha",
       })?.title,
     ).toBe("Renamed after listing");
-    await expect(
-      registry.resolveThread({ threadId: "thread-alpha" }),
-    ).resolves.toMatchObject({ title: "Renamed after listing" });
   });
 
   // resolveThread's provider fallback filters archived:false. Answering from

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -509,34 +509,44 @@ describe("what the store serves stays current", () => {
     ).toBe("Renamed By Operator");
   });
 
-  // Archival is read off the row, not off the query. Both backends coerce an
-  // unspecified `archived` to `false`, so "the caller did not filter" is not a
-  // case that reaches a provider -- and the row's own `archivedAt` survives a
-  // listing that the caller labelled nothing at all.
-  it("records archival from a row that carries archivedAt", async () => {
-    const { registry } = build([
+  // An active Codex listing merges cached archived metadata into its rows, and
+  // that cache only refreshes once a minute -- so for up to a minute after an
+  // unarchive an *active* listing can hand back a row still carrying
+  // `archivedAt`. Reading archival off the row would let that row overwrite the
+  // notification at a newer sequence and withhold a live thread.
+  it("keeps an unarchive over a later listing whose row still looks archived", async () => {
+    const { client, registry } = build();
+    await registry.listThreads(NAVIGATION_REFRESH);
+    await publishNotification(registry, {
+      method: "thread/archived",
+      params: { threadId: "thread-alpha" },
+    });
+    await publishNotification(registry, {
+      method: "thread/unarchived",
+      params: { threadId: "thread-alpha" },
+    });
+    // The provider serves it again, still stamped from the archived list.
+    client.setThreads([
       codexThread({
         id: "thread-alpha",
         title: "Rework the quit dialog",
         titleSource: "explicit",
         archivedAt: 1000,
       }),
+      SECOND_THREAD,
     ]);
-    await registry.listThreads({
-      backend: "codex",
-      callerReason: "navigation-snapshot",
-      enrichDirectories: false,
-      forceRefresh: true,
-    });
+    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
 
-    // The row-derived fact is what this asserts. Withholding it from a caller
-    // is the list cache's job here, not the store's: `thread/archived`
-    // invalidates that cache, so its copy cannot outlive the archival, while
-    // the store deliberately survives invalidation and needs the fact instead.
     expect(
       registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })
         ?.archived,
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-alpha",
+      }),
+    ).toMatchObject({ id: "thread-alpha" });
   });
 
   // The guard compares the archival sequence against the row's. A later
@@ -560,43 +570,6 @@ describe("what the store serves stays current", () => {
         threadId: "thread-alpha",
       }),
     ).toBeUndefined();
-  });
-
-  // ACP emits no unarchive notification, and a second process on the same
-  // profile emits none this process hears. The row coming back without
-  // `archivedAt` is the only report of that, so it has to be believed.
-  it("restores a thread the provider starts listing as active again", async () => {
-    const { client, registry } = build();
-    await registry.listThreads(NAVIGATION_REFRESH);
-    await publishNotification(registry, {
-      method: "thread/archived",
-      params: { threadId: "thread-alpha" },
-    });
-    client.setThreads([SECOND_THREAD]);
-    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
-    expect(
-      registry.getCachedThreadSummary({
-        backend: "codex",
-        threadId: "thread-alpha",
-      }),
-    ).toBeUndefined();
-
-    client.setThreads([NAMED_THREAD, SECOND_THREAD]);
-    await registry.listThreads({ ...NAVIGATION_REFRESH, forceRefresh: true });
-
-    // The fact itself has to flip, not merely stop being consulted. A store
-    // that leaves `archived` true and serves the row anyway because a newer
-    // summary outranks it is one poll away from withholding it again.
-    expect(
-      registry.getThreadInfo({ backend: "codex", threadId: "thread-alpha" })
-        ?.archived,
-    ).toBe(false);
-    expect(
-      registry.getCachedThreadSummary({
-        backend: "codex",
-        threadId: "thread-alpha",
-      }),
-    ).toMatchObject({ id: "thread-alpha" });
   });
 
   // A listing that failed is not an answer. Memoizing it would silence this

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5397,6 +5397,12 @@ type ThreadListCacheHit = {
   value: Promise<AppServerThreadSummary[]> | AppServerThreadSummary[];
 };
 
+type ThreadDisplayMetadata = {
+  observationSequence: number;
+  title: string;
+  titleSource?: AppServerThreadTitleSource;
+};
+
 type CreatedThreadDirectoryVisibility = Pick<
   NavigationDirectorySummary,
   "key" | "kind" | "path"
@@ -7755,14 +7761,16 @@ export class DesktopBackendRegistry {
    */
   private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();
   /**
-   * Best-effort cache of thread labels keyed by `buildThreadIdentityKey`, used
-   * only to label native attention/terminal notifications so multiple
-   * background turns are distinguishable. Populated from `thread/started` and
-   * `thread/name/updated` notifications as they fan out through `emit()`.
-   * Falls back to a thread-list lookup, then a generic body when context still
-   * isn't available.
+   * Cache-only display metadata keyed by `buildThreadIdentityKey`. Provider
+   * lists reserve their observation sequence before awaiting so an older list
+   * cannot complete late and replace a newer lifecycle/name observation.
+   * Missing and fallback titles are not deletion events.
    */
-  private readonly notificationThreadTitles = new Map<string, string>();
+  private readonly threadDisplayMetadata = new Map<
+    string,
+    ThreadDisplayMetadata
+  >();
+  private threadDisplayMetadataObservationSequence = 0;
   private readonly notificationThreadProjectLabels = new Map<string, string>();
   /**
    * Live `thread/name/updated` observations are newer than the provider's
@@ -9460,7 +9468,12 @@ export class DesktopBackendRegistry {
     // An event can invalidate or replace this entry while the read awaits
     // enrichment. Only the promise that still owns the key may publish it.
     const pendingState: ThreadListCacheState = {};
-    const promise = this.readThreadList(normalizedParams)
+    const displayMetadataObservationSequence =
+      this.reserveThreadDisplayMetadataObservation();
+    const promise = this.readThreadList(
+      normalizedParams,
+      displayMetadataObservationSequence,
+    )
       .then((threads) => {
         if (this.threadListCache.get(cacheKey) === pendingState) {
           this.threadListCache.set(cacheKey, {
@@ -9562,6 +9575,32 @@ export class DesktopBackendRegistry {
     return undefined;
   }
 
+  /**
+   * Read display metadata this process has already observed. This method never
+   * starts or awaits provider listing, directory enrichment, or persistence.
+   */
+  getCachedThreadDisplayMetadata(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Pick<ThreadDisplayMetadata, "title" | "titleSource"> | undefined {
+    const threadId = params.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    const metadata = this.threadDisplayMetadata.get(
+      buildThreadIdentityKey(params.backend, threadId),
+    );
+    if (!metadata) {
+      return undefined;
+    }
+    return {
+      title: metadata.title,
+      ...(metadata.titleSource
+        ? { titleSource: metadata.titleSource }
+        : {}),
+    };
+  }
+
   async getThreadAgentMetadata(params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -9570,16 +9609,19 @@ export class DesktopBackendRegistry {
     return overlay?.agent;
   }
 
-  private async readThreadList(params: {
-    archived?: boolean;
-    backend?: AppServerBackendKind;
-    callerReason?: ThreadListCallerReason;
-    enrichDirectories: boolean;
-    filter?: string;
-    limit?: number;
-    maxPages?: number;
-    skipArchivedMetadataRefresh?: boolean;
-  }): Promise<AppServerThreadSummary[]> {
+  private async readThreadList(
+    params: {
+      archived?: boolean;
+      backend?: AppServerBackendKind;
+      callerReason?: ThreadListCallerReason;
+      enrichDirectories: boolean;
+      filter?: string;
+      limit?: number;
+      maxPages?: number;
+      skipArchivedMetadataRefresh?: boolean;
+    },
+    displayMetadataObservationSequence: number,
+  ): Promise<AppServerThreadSummary[]> {
     const diagnostics = {
       callerReason: params.callerReason ?? "thread-list",
       ownerId: this.threadListCacheOwnerId,
@@ -9607,7 +9649,10 @@ export class DesktopBackendRegistry {
           threads,
         });
       }
-      this.rememberThreadListContexts(threads);
+      this.rememberThreadListContexts(
+        threads,
+        displayMetadataObservationSequence,
+      );
       return threads;
     }
 
@@ -9617,7 +9662,10 @@ export class DesktopBackendRegistry {
         params.filter,
         params.archived,
       );
-      this.rememberThreadListContexts(threads);
+      this.rememberThreadListContexts(
+        threads,
+        displayMetadataObservationSequence,
+      );
       return threads;
     }
 
@@ -9638,7 +9686,10 @@ export class DesktopBackendRegistry {
     const threads = threadLists
       .flat()
       .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
-    this.rememberThreadListContexts(threads);
+    this.rememberThreadListContexts(
+      threads,
+      displayMetadataObservationSequence,
+    );
     return threads;
   }
 
@@ -13705,10 +13756,10 @@ export class DesktopBackendRegistry {
         threadKeys.add(threadKey);
         if (owner.isSubAgent) {
           subAgentThreadKeys.add(threadKey);
-          const title = this.cachedQuitThreadTitle(owner.backend, owner.threadId);
-          if (title) {
-            threadTitles.set(threadKey, title);
-          }
+        }
+        const title = this.cachedQuitThreadTitle(owner.backend, owner.threadId);
+        if (title) {
+          threadTitles.set(threadKey, title);
         }
       }
     };
@@ -13845,25 +13896,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
   ): string | undefined {
-    const key = buildThreadIdentityKey(backend, threadId);
-    const remembered =
-      this.observedThreadNames.get(key) ?? this.notificationThreadTitles.get(key);
-    if (remembered?.trim()) {
-      return remembered.trim();
-    }
-    for (const state of this.threadListCache.values()) {
-      const thread = state.threads?.find(
-        (candidate) =>
-          candidate.source === backend
-          && candidate.id === threadId
-          && candidate.titleSource !== "fallback",
-      );
-      const title = thread?.title.trim();
-      if (title) {
-        return title;
-      }
-    }
-    return undefined;
+    return this.getCachedThreadDisplayMetadata({ backend, threadId })?.title;
   }
 
   async supportsMessagingPdfTools(params: {
@@ -34330,6 +34363,40 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private reserveThreadDisplayMetadataObservation(): number {
+    this.threadDisplayMetadataObservationSequence += 1;
+    return this.threadDisplayMetadataObservationSequence;
+  }
+
+  private rememberThreadDisplayMetadata(params: {
+    backend: AppServerBackendKind;
+    observationSequence: number;
+    threadId: string;
+    title?: string;
+    titleSource?: AppServerThreadTitleSource;
+  }): void {
+    if (params.titleSource === "fallback") {
+      return;
+    }
+    const title = params.title?.trim();
+    if (!title) {
+      return;
+    }
+    const key = buildThreadIdentityKey(params.backend, params.threadId);
+    const existing = this.threadDisplayMetadata.get(key);
+    if (
+      existing
+      && existing.observationSequence >= params.observationSequence
+    ) {
+      return;
+    }
+    this.threadDisplayMetadata.set(key, {
+      observationSequence: params.observationSequence,
+      title,
+      ...(params.titleSource ? { titleSource: params.titleSource } : {}),
+    });
+  }
+
   private rememberThreadTitleFromEvent(event: AgentEvent): void {
     const method = event.notification.method;
     if (method === "thread/name/updated") {
@@ -34343,7 +34410,14 @@ export class DesktopBackendRegistry {
         const trimmed = threadName.trim();
         if (trimmed) {
           const key = buildThreadIdentityKey(event.backend, threadId);
-          this.notificationThreadTitles.set(key, trimmed);
+          this.rememberThreadDisplayMetadata({
+            backend: event.backend,
+            observationSequence:
+              this.reserveThreadDisplayMetadataObservation(),
+            threadId,
+            title: trimmed,
+            titleSource: "explicit",
+          });
           this.observedThreadNames.set(key, trimmed);
         }
       }
@@ -34358,7 +34432,12 @@ export class DesktopBackendRegistry {
       if (typeof threadId !== "string") {
         return;
       }
-      this.rememberThreadNotificationContext(event.backend, threadId, params.thread);
+      this.rememberThreadNotificationContext(
+        event.backend,
+        threadId,
+        params.thread,
+        this.reserveThreadDisplayMetadataObservation(),
+      );
     }
   }
 
@@ -34406,6 +34485,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
     thread: unknown,
+    displayMetadataObservationSequence: number,
   ): void {
     if (!thread || typeof thread !== "object" || Array.isArray(thread)) {
       return;
@@ -34414,11 +34494,20 @@ export class DesktopBackendRegistry {
     const candidate =
       (typeof record.title === "string" ? record.title : undefined) ??
       (typeof record.name === "string" ? record.name : undefined);
-    const trimmed = candidate?.trim();
+    const titleSource =
+      record.titleSource === "explicit"
+      || record.titleSource === "derived"
+      || record.titleSource === "fallback"
+        ? record.titleSource
+        : undefined;
+    this.rememberThreadDisplayMetadata({
+      backend,
+      observationSequence: displayMetadataObservationSequence,
+      threadId,
+      title: candidate,
+      titleSource,
+    });
     const key = buildThreadIdentityKey(backend, threadId);
-    if (trimmed) {
-      this.notificationThreadTitles.set(key, trimmed);
-    }
     const projectLabel = readNotificationProjectLabel(record);
     if (projectLabel) {
       this.notificationThreadProjectLabels.set(key, projectLabel);
@@ -34428,12 +34517,18 @@ export class DesktopBackendRegistry {
   /** Keep titles already shown in navigation available to time-bounded UI. */
   private rememberThreadListContexts(
     threads: readonly AppServerThreadSummary[],
+    displayMetadataObservationSequence: number,
   ): void {
     for (const thread of threads) {
       if (thread.titleSource === "fallback") {
         continue;
       }
-      this.rememberThreadNotificationContext(thread.source, thread.id, thread);
+      this.rememberThreadNotificationContext(
+        thread.source,
+        thread.id,
+        thread,
+        displayMetadataObservationSequence,
+      );
     }
   }
 
@@ -34443,7 +34538,7 @@ export class DesktopBackendRegistry {
   ): string | undefined {
     const key = buildThreadIdentityKey(backend, threadId);
     const projectLabel = this.notificationThreadProjectLabels.get(key);
-    const threadTitle = this.notificationThreadTitles.get(key);
+    const threadTitle = this.threadDisplayMetadata.get(key)?.title;
     if (projectLabel && threadTitle) {
       return `${projectLabel} > ${threadTitle}`;
     }
@@ -34466,7 +34561,6 @@ export class DesktopBackendRegistry {
       });
       const thread = threads.find((candidate) => candidate.id === threadId);
       if (thread) {
-        this.rememberThreadNotificationContext(backend, threadId, thread);
         return this.notificationThreadContextLabel(backend, threadId);
       }
     } catch (error) {
@@ -34494,9 +34588,9 @@ export class DesktopBackendRegistry {
     const title = isQuestion
       ? "PwrAgent input needed"
       : "PwrAgent approval needed";
-    const threadTitle = this.notificationThreadTitles.get(
+    const threadTitle = this.threadDisplayMetadata.get(
       buildThreadIdentityKey(event.backend, threadId),
-    );
+    )?.title;
     const approvalRequest = this.isApprovalAttentionNotification(event.notification)
       ? event.notification
       : undefined;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -609,6 +609,9 @@ const MAX_QUEUE_FLUSH_ATTEMPTS = 3;
 // been walked for", so they are retained on purpose; the cap keeps a long-lived
 // process from holding one per thread it has ever been notified about.
 const NOTIFICATION_CONTEXT_RECONCILIATION_LIMIT = 512;
+// An ACP listing resolves linked directories for every row it returns, so its
+// rows carry enrichment whether or not the caller requested it.
+const ACP_LISTINGS_ARE_ENRICHED = true;
 const backendRegistryLog = getMainLogger("pwragent:backend-registry");
 const GROK_TITLE_HELPER_SESSION_POLICY = buildMinimalGrokHelperSessionPolicy({
   description: "Generate a concise title for a PwrAgent thread.",
@@ -9678,13 +9681,17 @@ export class DesktopBackendRegistry {
       this.rememberThreadListContexts(
         threads,
         displayMetadataObservationSequence,
-        params.enrichDirectories,
+        // An ACP listing resolves linked directories for every row whatever the
+        // caller asked for, so its rows are enriched even when the request was
+        // not. Passing the request's flag would record them as unenriched and
+        // send every `requireEnriched` read back to the provider.
+        ACP_LISTINGS_ARE_ENRICHED,
         params.archived,
       );
       return threads;
     }
 
-    const threadLists = await Promise.all([
+    const [codexThreads, acpThreads] = await Promise.all([
       this.listThreads({
         backend: "codex",
         archived: params.archived,
@@ -9698,16 +9705,21 @@ export class DesktopBackendRegistry {
       this.listAllInstalledAcpThreads(params.filter, params.archived),
     ]);
 
-    const threads = threadLists
-      .flat()
-      .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+    // Only the ACP half is recorded here. The Codex half went through
+    // `listThreads`, which reserved its own newer sequence and already folded
+    // those rows; folding them again writes nothing the sequence guard would
+    // accept, and it does so on the main thread once per navigation refresh.
+    // Recording them here would also stamp rows read at the inner sequence with
+    // this outer one, which is the ordering the store exists to keep honest.
     this.rememberThreadListContexts(
-      threads,
+      acpThreads,
       displayMetadataObservationSequence,
-      params.enrichDirectories,
+      ACP_LISTINGS_ARE_ENRICHED,
       params.archived,
     );
-    return threads;
+    return [...codexThreads, ...acpThreads].sort(
+      (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
+    );
   }
 
   private async filterArchivedThreadsPresentInActiveList(params: {
@@ -21433,6 +21445,11 @@ export class DesktopBackendRegistry {
   }
 
   private invalidateThreadListCache(backend?: AppServerBackendKind): void {
+    // Names survive invalidation; resolved directories do not. A directory set
+    // is the answer one enriching listing gave, and the events that invalidate
+    // these caches -- a workspace rebind, a detached directory -- are exactly
+    // the ones that make that answer wrong, with no notification to correct it.
+    this.threadInfoStore.forgetEnrichedSummaries();
     if (!backend) {
       this.threadListCache.clear();
       return;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9561,6 +9561,13 @@ export class DesktopBackendRegistry {
    * thread-list walk. Hot-path consumers such as messaging admission combine
    * this volatile summary with the durable per-thread overlay instead of
    * asking navigation to rebuild every thread and directory.
+   *
+   * The thread-list cache is consulted first — when it is warm it holds the
+   * freshest listing — and the information store answers when it is not. The
+   * store matters because the cache is emptied by every mutation: without the
+   * second tier, admission for a thread this process listed minutes ago falls
+   * through to `resolveThread`'s forced full listing purely because something
+   * unrelated invalidated the cache in between.
    */
   getCachedThreadSummary(params: {
     backend?: AppServerBackendKind;
@@ -9580,7 +9587,10 @@ export class DesktopBackendRegistry {
         return cached;
       }
     }
-    return undefined;
+    return this.threadInfoStore.findLocalSummary({
+      ...(params.backend ? { backend: params.backend } : {}),
+      threadId,
+    });
   }
 
   /**

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -604,6 +604,11 @@ const CODEX_WORKSPACE_CWD_SYNC_PENDING_WARNING =
  * problem the user needs visibility into.
  */
 const MAX_QUEUE_FLUSH_ATTEMPTS = 3;
+// Upper bound on remembered terminal-notification label reconciliations. Each
+// entry is one settled promise that memoizes "this thread's label has already
+// been walked for", so they are retained on purpose; the cap keeps a long-lived
+// process from holding one per thread it has ever been notified about.
+const NOTIFICATION_CONTEXT_RECONCILIATION_LIMIT = 512;
 const backendRegistryLog = getMainLogger("pwragent:backend-registry");
 const GROK_TITLE_HELPER_SESSION_POLICY = buildMinimalGrokHelperSessionPolicy({
   description: "Generate a concise title for a PwrAgent thread.",
@@ -34602,11 +34607,17 @@ export class DesktopBackendRegistry {
         identity,
         observationSequence: displayMetadataObservationSequence,
         source: "provider-list",
-        // Only a listing that actually filtered by archival proves anything
-        // about it. An unfiltered listing returns both kinds, so recording
-        // `false` for every row would overwrite an archival this store was
-        // just told about with a fact the listing never established.
-        ...(listedArchived === undefined ? {} : { archived: listedArchived }),
+        // Read archival off the row, not off the query. Both backends coerce
+        // an unspecified `archived` to `false` -- Codex requests
+        // `archived: false` pages, the ACP store filters on
+        // `Boolean(archivedAt) === (params?.archived === true)` -- so every
+        // listing is filtered whether or not the caller said so, and the row's
+        // own `archivedAt` is the fact rather than the argument that produced
+        // it. Taking it from the row keeps a row that arrives carrying
+        // `archivedAt` from being recorded as active, and keeps the store
+        // correctable: an out-of-band unarchive is a row that comes back
+        // without `archivedAt`, which no notification would have reported.
+        archived: thread.archivedAt !== undefined || listedArchived === true,
         title: thread.title,
         ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
         ...(projectLabel ? { projectLabel } : {}),
@@ -34659,12 +34670,27 @@ export class DesktopBackendRegistry {
     const key = buildThreadIdentityKey(backend, threadId);
     let reconciliation = this.notificationContextReconciliations.get(key);
     if (!reconciliation) {
+      // Retried only when the walk produced no rows at all. "Learned no label"
+      // is not a failure -- it is the answer for a thread this backend does not
+      // list, which is precisely the case this dedup exists for, so keying the
+      // retry on the label drops the entry every time and charges each of that
+      // thread's later notifications another enriched walk.
+      //
+      // Rejection is not the signal either: `listThreads` absorbs a provider
+      // error and resolves, so the `catch` below never runs for the restart it
+      // was written for. An empty result is the observable form of that
+      // failure, and it is also indistinguishable from a genuinely empty
+      // backend -- retrying both is right, because neither has an answer to
+      // memoize.
+      let walkListedRows = false;
       reconciliation = this.listThreads({
         backend,
         callerReason: "notification-context",
         enrichDirectories: true,
       })
-        .then(() => undefined)
+        .then((rows) => {
+          walkListedRows = rows.length > 0;
+        })
         .catch((error: unknown) => {
           backendRegistryLog.debug("native terminal notification context lookup failed", {
             backend,
@@ -34673,15 +34699,23 @@ export class DesktopBackendRegistry {
           });
         })
         .finally(() => {
-          // Dropped unless the walk actually taught us the label. Keeping a
-          // settled entry would memoize a FAILURE as though it were an answer:
-          // one listing that rejected while the provider was restarting would
-          // leave this thread's notifications unlabeled for the rest of the
-          // process, because every later attempt awaits the same dead promise.
-          if (!this.notificationThreadContextLabel(backend, threadId)) {
+          if (!walkListedRows) {
             this.notificationContextReconciliations.delete(key);
           }
         });
+      if (
+        this.notificationContextReconciliations.size
+        >= NOTIFICATION_CONTEXT_RECONCILIATION_LIMIT
+      ) {
+        // Settled entries are kept on purpose -- they are the memo. Insertion
+        // order makes the first key the oldest, so a process that outlives many
+        // threads reclaims them instead of holding one promise per thread it
+        // has ever been notified about.
+        const oldest = this.notificationContextReconciliations.keys().next();
+        if (!oldest.done) {
+          this.notificationContextReconciliations.delete(oldest.value);
+        }
+      }
       this.notificationContextReconciliations.set(key, reconciliation);
     }
     await reconciliation;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -486,6 +486,12 @@ import type {
   ResolveEditCommitStatesOptions,
   WorktreeWorkingStateEntry,
 } from "./git-working-state-service";
+import {
+  ThreadInfoStore,
+  type ThreadInfo,
+  type ThreadInfoIdentity,
+  type ThreadInfoObservation,
+} from "./thread-info-store";
 import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
 import {
   AcpAvailableCommandsStore,
@@ -5397,12 +5403,6 @@ type ThreadListCacheHit = {
   value: Promise<AppServerThreadSummary[]> | AppServerThreadSummary[];
 };
 
-type ThreadDisplayMetadata = {
-  observationSequence: number;
-  title: string;
-  titleSource?: AppServerThreadTitleSource;
-};
-
 type CreatedThreadDirectoryVisibility = Pick<
   NavigationDirectorySummary,
   "key" | "kind" | "path"
@@ -7761,17 +7761,25 @@ export class DesktopBackendRegistry {
    */
   private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();
   /**
-   * Cache-only display metadata keyed by `buildThreadIdentityKey`. Provider
-   * lists reserve their observation sequence before awaiting so an older list
-   * cannot complete late and replace a newer lifecycle/name observation.
-   * Missing and fallback titles are not deletion events.
+   * What this process knows about each thread it has seen, keyed by thread
+   * identity rather than by the query that revealed it.
+   *
+   * Distinct from `threadListCache`, which answers "which threads match this
+   * query" and is correctly discarded by any mutation. This answers "what is
+   * this thread called", where discarding is never correct: the previous answer
+   * remains the best one until a newer observation replaces it. Reads are
+   * synchronous and cannot start provider work, so a 500ms UI poll can use one.
    */
-  private readonly threadDisplayMetadata = new Map<
+  private readonly threadInfoStore = new ThreadInfoStore();
+  /**
+   * In-flight terminal-notification label reconciliations, keyed by thread. A
+   * burst of turn completions on threads this process never observed must cost
+   * one provider walk per thread, not one per notification.
+   */
+  private readonly notificationContextReconciliations = new Map<
     string,
-    ThreadDisplayMetadata
+    Promise<void>
   >();
-  private threadDisplayMetadataObservationSequence = 0;
-  private readonly notificationThreadProjectLabels = new Map<string, string>();
   /**
    * Live `thread/name/updated` observations are newer than the provider's
    * thread list during an active turn. Reconcile list rows through this map so
@@ -9469,7 +9477,7 @@ export class DesktopBackendRegistry {
     // enrichment. Only the promise that still owns the key may publish it.
     const pendingState: ThreadListCacheState = {};
     const displayMetadataObservationSequence =
-      this.reserveThreadDisplayMetadataObservation();
+      this.reserveThreadInfoObservation();
     const promise = this.readThreadList(
       normalizedParams,
       displayMetadataObservationSequence,
@@ -9576,29 +9584,18 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * Read display metadata this process has already observed. This method never
-   * starts or awaits provider listing, directory enrichment, or persistence.
+   * What this process already knows about a thread. Synchronous by contract: it
+   * never starts or awaits provider listing, directory enrichment, or
+   * persistence, so it is safe on paths that must not wait — a quit decision, a
+   * notification label, a repeating UI poll.
+   *
+   * `undefined` means this thread has never been observed. It never means a
+   * read failed or a cache lapsed; those leave the last observation in place.
+   * Callers that need directories, git state, or ordering want `resolveThread`,
+   * which may reach the provider.
    */
-  getCachedThreadDisplayMetadata(params: {
-    backend: AppServerBackendKind;
-    threadId: string;
-  }): Pick<ThreadDisplayMetadata, "title" | "titleSource"> | undefined {
-    const threadId = params.threadId.trim();
-    if (!threadId) {
-      return undefined;
-    }
-    const metadata = this.threadDisplayMetadata.get(
-      buildThreadIdentityKey(params.backend, threadId),
-    );
-    if (!metadata) {
-      return undefined;
-    }
-    return {
-      title: metadata.title,
-      ...(metadata.titleSource
-        ? { titleSource: metadata.titleSource }
-        : {}),
-    };
+  getThreadInfo(identity: ThreadInfoIdentity): ThreadInfo | undefined {
+    return this.threadInfoStore.get(identity);
   }
 
   async getThreadAgentMetadata(params: {
@@ -9652,6 +9649,7 @@ export class DesktopBackendRegistry {
       this.rememberThreadListContexts(
         threads,
         displayMetadataObservationSequence,
+        params.enrichDirectories,
       );
       return threads;
     }
@@ -9665,6 +9663,7 @@ export class DesktopBackendRegistry {
       this.rememberThreadListContexts(
         threads,
         displayMetadataObservationSequence,
+        params.enrichDirectories,
       );
       return threads;
     }
@@ -9689,6 +9688,7 @@ export class DesktopBackendRegistry {
     this.rememberThreadListContexts(
       threads,
       displayMetadataObservationSequence,
+      params.enrichDirectories,
     );
     return threads;
   }
@@ -12317,6 +12317,7 @@ export class DesktopBackendRegistry {
       this.findThreadForWorkspaceHandoff({
         backend: params.backend,
         callerReason: "transcript-image-roots",
+        freshness: "last-known",
         threadId: params.threadId,
       }),
       this.overlayStore.getThreadOverlayState({
@@ -13896,7 +13897,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
   ): string | undefined {
-    return this.getCachedThreadDisplayMetadata({ backend, threadId })?.title;
+    return this.threadInfoStore.getTitle({ backend, threadId });
   }
 
   async supportsMessagingPdfTools(params: {
@@ -18139,6 +18140,7 @@ export class DesktopBackendRegistry {
     const thread = await this.findThreadForWorkspaceHandoff({
       backend: params.backend,
       callerReason: "branch-drift",
+      freshness: "last-known",
       threadId: params.threadId,
     });
     const workspaceCwd = resolveThreadWorkspaceCwd(
@@ -18240,6 +18242,7 @@ export class DesktopBackendRegistry {
     const thread = await this.findThreadForWorkspaceHandoff({
       backend: params.backend,
       callerReason: "active-turn-branch-adoption",
+      freshness: "last-known",
       threadId: params.threadId,
     });
     const workspaceCwd = resolveThreadWorkspaceCwd(
@@ -25664,15 +25667,45 @@ export class DesktopBackendRegistry {
       });
   }
 
+  /**
+   * One thread's row.
+   *
+   * `freshness` is the caller's declaration, not an optimization hint:
+   *
+   * - `"provider"` (the default) walks the provider's whole thread list and
+   *   picks the row out of it. A caller about to mutate a workspace needs the
+   *   provider's current truth, and pays for it.
+   * - `"last-known"` answers from the thread information store, which survives
+   *   list-cache invalidation. A read-only caller asking where a thread's
+   *   workspace is does not need a fresh collection, and making it pay for one
+   *   put a full paged provider walk on every turn boundary: `turn/started`
+   *   invalidates the list cache, and the next branch adoption rebuilt the
+   *   entire list to read one row.
+   *
+   * A `"last-known"` read falls back to the provider walk when the thread has
+   * never been observed at the enrichment level the caller listed at, so a cold
+   * process still answers correctly — it just stops re-answering.
+   */
   private async findThreadForWorkspaceHandoff(params: {
     backend: AppServerBackendKind;
     callerReason?: ThreadListCallerReason;
+    freshness?: "last-known" | "provider";
     threadId: string;
   }): Promise<AppServerThreadSummary | undefined> {
+    const callerReason = params.callerReason ?? "workspace-handoff";
+    if (params.freshness === "last-known") {
+      const remembered = this.threadInfoStore.getSummary(
+        { backend: params.backend, threadId: params.threadId },
+        { requireEnriched: shouldEnrichThreadDirectories(callerReason) },
+      );
+      if (remembered) {
+        return remembered;
+      }
+    }
     return await this.listThreads({
       backend: params.backend,
       archived: false,
-      callerReason: params.callerReason ?? "workspace-handoff",
+      callerReason,
     })
       .then((threads) => threads.find((thread) => thread.id === params.threadId))
       .catch(() => undefined);
@@ -25699,6 +25732,7 @@ export class DesktopBackendRegistry {
     const thread = await this.findThreadForWorkspaceHandoff({
       backend,
       callerReason: "turn-cwd",
+      freshness: "last-known",
       threadId,
     });
     const threadCwd = resolveThreadWorkspaceCwd(
@@ -34363,38 +34397,14 @@ export class DesktopBackendRegistry {
     }
   }
 
-  private reserveThreadDisplayMetadataObservation(): number {
-    this.threadDisplayMetadataObservationSequence += 1;
-    return this.threadDisplayMetadataObservationSequence;
-  }
-
-  private rememberThreadDisplayMetadata(params: {
-    backend: AppServerBackendKind;
-    observationSequence: number;
-    threadId: string;
-    title?: string;
-    titleSource?: AppServerThreadTitleSource;
-  }): void {
-    if (params.titleSource === "fallback") {
-      return;
-    }
-    const title = params.title?.trim();
-    if (!title) {
-      return;
-    }
-    const key = buildThreadIdentityKey(params.backend, params.threadId);
-    const existing = this.threadDisplayMetadata.get(key);
-    if (
-      existing
-      && existing.observationSequence >= params.observationSequence
-    ) {
-      return;
-    }
-    this.threadDisplayMetadata.set(key, {
-      observationSequence: params.observationSequence,
-      title,
-      ...(params.titleSource ? { titleSource: params.titleSource } : {}),
-    });
+  /**
+   * Take the sequence an observation will be recorded at. Asynchronous readers
+   * MUST call this before they start: a listing that is overtaken by a rename
+   * and then completes late carries the older sequence it reserved, so its
+   * stale rows lose instead of silently reverting the rename.
+   */
+  private reserveThreadInfoObservation(): number {
+    return this.threadInfoStore.reserveObservationSequence();
   }
 
   private rememberThreadTitleFromEvent(event: AgentEvent): void {
@@ -34410,11 +34420,10 @@ export class DesktopBackendRegistry {
         const trimmed = threadName.trim();
         if (trimmed) {
           const key = buildThreadIdentityKey(event.backend, threadId);
-          this.rememberThreadDisplayMetadata({
-            backend: event.backend,
-            observationSequence:
-              this.reserveThreadDisplayMetadataObservation(),
-            threadId,
+          this.threadInfoStore.observe({
+            identity: { backend: event.backend, threadId },
+            observationSequence: this.reserveThreadInfoObservation(),
+            source: "lifecycle-notification",
             title: trimmed,
             titleSource: "explicit",
           });
@@ -34436,7 +34445,7 @@ export class DesktopBackendRegistry {
         event.backend,
         threadId,
         params.thread,
-        this.reserveThreadDisplayMetadataObservation(),
+        this.reserveThreadInfoObservation(),
       );
     }
   }
@@ -34500,35 +34509,49 @@ export class DesktopBackendRegistry {
       || record.titleSource === "fallback"
         ? record.titleSource
         : undefined;
-    this.rememberThreadDisplayMetadata({
-      backend,
+    this.threadInfoStore.observe({
+      identity: { backend, threadId },
       observationSequence: displayMetadataObservationSequence,
-      threadId,
-      title: candidate,
-      titleSource,
+      source: "lifecycle-notification",
+      ...(candidate !== undefined ? { title: candidate } : {}),
+      ...(titleSource !== undefined ? { titleSource } : {}),
+      ...(readNotificationProjectLabel(record) !== undefined
+        ? { projectLabel: readNotificationProjectLabel(record) as string }
+        : {}),
     });
-    const key = buildThreadIdentityKey(backend, threadId);
-    const projectLabel = readNotificationProjectLabel(record);
-    if (projectLabel) {
-      this.notificationThreadProjectLabels.set(key, projectLabel);
-    }
   }
 
-  /** Keep titles already shown in navigation available to time-bounded UI. */
+  /**
+   * Fold a completed listing into the thread information store. Every row is
+   * offered, including fallback-titled ones: the store decides what a fallback
+   * means, so a provider that has lost its title index cannot push uuids over
+   * names PwrAgent already knows.
+   */
   private rememberThreadListContexts(
     threads: readonly AppServerThreadSummary[],
     displayMetadataObservationSequence: number,
+    enriched: boolean,
   ): void {
     for (const thread of threads) {
-      if (thread.titleSource === "fallback") {
-        continue;
-      }
-      this.rememberThreadNotificationContext(
-        thread.source,
-        thread.id,
-        thread,
-        displayMetadataObservationSequence,
+      const identity = { backend: thread.source, threadId: thread.id };
+      const projectLabel = readNotificationProjectLabel(
+        thread as unknown as Record<string, unknown>,
       );
+      this.threadInfoStore.observe({
+        identity,
+        observationSequence: displayMetadataObservationSequence,
+        source: "provider-list",
+        title: thread.title,
+        ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
+        ...(projectLabel ? { projectLabel } : {}),
+        ...(thread.updatedAt !== undefined ? { updatedAt: thread.updatedAt } : {}),
+      });
+      this.threadInfoStore.observeSummary({
+        enriched,
+        identity,
+        observationSequence: displayMetadataObservationSequence,
+        summary: thread,
+      });
     }
   }
 
@@ -34536,15 +34559,29 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     threadId: string,
   ): string | undefined {
-    const key = buildThreadIdentityKey(backend, threadId);
-    const projectLabel = this.notificationThreadProjectLabels.get(key);
-    const threadTitle = this.threadDisplayMetadata.get(key)?.title;
+    const info = this.threadInfoStore.get({ backend, threadId });
+    const projectLabel = info?.projectLabel;
+    const threadTitle = info?.title;
     if (projectLabel && threadTitle) {
       return `${projectLabel} > ${threadTitle}`;
     }
     return threadTitle ?? projectLabel;
   }
 
+  /**
+   * Label a terminal notification, reconciling once when nothing is known yet.
+   *
+   * The store answers for any thread this process has listed or seen start,
+   * which is nearly all of them, and that read is free. The remaining case is a
+   * turn completing on a thread this process never observed — an external
+   * process sharing the profile — where a label still beats "A turn completed".
+   *
+   * The reconciliation is deduplicated per thread because turn completions
+   * arrive in bursts across concurrent threads, and an unlabeled thread would
+   * otherwise start a fresh whole-collection walk for each one. The walk seeds
+   * the information store, so it happens at most once per thread per process
+   * rather than once per notification.
+   */
   private async notificationThreadContextLabelForTerminal(
     backend: AppServerBackendKind,
     threadId: string,
@@ -34553,24 +34590,26 @@ export class DesktopBackendRegistry {
     if (cached) {
       return cached;
     }
-    try {
-      const threads = await this.listThreads({
+    const key = buildThreadIdentityKey(backend, threadId);
+    let reconciliation = this.notificationContextReconciliations.get(key);
+    if (!reconciliation) {
+      reconciliation = this.listThreads({
         backend,
         callerReason: "notification-context",
         enrichDirectories: true,
-      });
-      const thread = threads.find((candidate) => candidate.id === threadId);
-      if (thread) {
-        return this.notificationThreadContextLabel(backend, threadId);
-      }
-    } catch (error) {
-      backendRegistryLog.debug("native terminal notification context lookup failed", {
-        backend,
-        error: error instanceof Error ? error.message : String(error),
-        threadId,
-      });
+      })
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          backendRegistryLog.debug("native terminal notification context lookup failed", {
+            backend,
+            error: error instanceof Error ? error.message : String(error),
+            threadId,
+          });
+        });
+      this.notificationContextReconciliations.set(key, reconciliation);
     }
-    return undefined;
+    await reconciliation;
+    return this.notificationThreadContextLabel(backend, threadId);
   }
 
   private notifyForAttentionRequired(event: AgentEvent): void {
@@ -34588,9 +34627,10 @@ export class DesktopBackendRegistry {
     const title = isQuestion
       ? "PwrAgent input needed"
       : "PwrAgent approval needed";
-    const threadTitle = this.threadDisplayMetadata.get(
-      buildThreadIdentityKey(event.backend, threadId),
-    )?.title;
+    const threadTitle = this.threadInfoStore.get({
+      backend: event.backend,
+      threadId,
+    })?.title;
     const approvalRequest = this.isApprovalAttentionNotification(event.notification)
       ? event.notification
       : undefined;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9650,6 +9650,7 @@ export class DesktopBackendRegistry {
         threads,
         displayMetadataObservationSequence,
         params.enrichDirectories,
+        params.archived === true,
       );
       return threads;
     }
@@ -9664,6 +9665,7 @@ export class DesktopBackendRegistry {
         threads,
         displayMetadataObservationSequence,
         params.enrichDirectories,
+        params.archived === true,
       );
       return threads;
     }
@@ -9689,6 +9691,7 @@ export class DesktopBackendRegistry {
       threads,
       displayMetadataObservationSequence,
       params.enrichDirectories,
+      params.archived === true,
     );
     return threads;
   }
@@ -34398,6 +34401,40 @@ export class DesktopBackendRegistry {
   }
 
   /**
+   * Teach the information store that a thread's archived state changed.
+   *
+   * Archival is a fact about the thread, so it is an observation like any
+   * other, and it is deliberately separate from `invalidateThreadListCache`.
+   * Invalidation says a query's result may have changed; it does not say a
+   * thread was archived, and conflating the two is what made the list cache the
+   * only record of archival — and therefore made forgetting it mandatory.
+   */
+  private recordThreadArchivalFromNotification(
+    backend: AppServerBackendKind,
+    notification: AgentEvent["notification"],
+  ): void {
+    const archived =
+      notification.method === "thread/archived"
+        ? true
+        : notification.method === "thread/unarchived"
+          ? false
+          : undefined;
+    if (archived === undefined) {
+      return;
+    }
+    const threadId = (notification.params as { threadId?: unknown })?.threadId;
+    if (typeof threadId !== "string") {
+      return;
+    }
+    this.threadInfoStore.observe({
+      archived,
+      identity: { backend, threadId },
+      observationSequence: this.reserveThreadInfoObservation(),
+      source: "lifecycle-notification",
+    });
+  }
+
+  /**
    * Take the sequence an observation will be recorded at. Asynchronous readers
    * MUST call this before they start: a listing that is overtaken by a rename
    * and then completes late carries the older sequence it reserved, so its
@@ -34409,6 +34446,7 @@ export class DesktopBackendRegistry {
 
   private rememberThreadTitleFromEvent(event: AgentEvent): void {
     const method = event.notification.method;
+    this.recordThreadArchivalFromNotification(event.backend, event.notification);
     if (method === "thread/name/updated") {
       const params = event.notification.params as {
         threadId?: unknown;
@@ -34531,6 +34569,7 @@ export class DesktopBackendRegistry {
     threads: readonly AppServerThreadSummary[],
     displayMetadataObservationSequence: number,
     enriched: boolean,
+    listedArchived: boolean,
   ): void {
     for (const thread of threads) {
       const identity = { backend: thread.source, threadId: thread.id };
@@ -34541,6 +34580,7 @@ export class DesktopBackendRegistry {
         identity,
         observationSequence: displayMetadataObservationSequence,
         source: "provider-list",
+        archived: listedArchived,
         title: thread.title,
         ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
         ...(projectLabel ? { projectLabel } : {}),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -490,7 +490,6 @@ import {
   ThreadInfoStore,
   type ThreadInfo,
   type ThreadInfoIdentity,
-  type ThreadInfoObservation,
 } from "./thread-info-store";
 import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
 import {
@@ -9660,7 +9659,7 @@ export class DesktopBackendRegistry {
         threads,
         displayMetadataObservationSequence,
         params.enrichDirectories,
-        params.archived === true,
+        params.archived,
       );
       return threads;
     }
@@ -9675,7 +9674,7 @@ export class DesktopBackendRegistry {
         threads,
         displayMetadataObservationSequence,
         params.enrichDirectories,
-        params.archived === true,
+        params.archived,
       );
       return threads;
     }
@@ -9701,7 +9700,7 @@ export class DesktopBackendRegistry {
       threads,
       displayMetadataObservationSequence,
       params.enrichDirectories,
-      params.archived === true,
+      params.archived,
     );
     return threads;
   }
@@ -34557,15 +34556,28 @@ export class DesktopBackendRegistry {
       || record.titleSource === "fallback"
         ? record.titleSource
         : undefined;
+    const projectLabel = readNotificationProjectLabel(record);
+    // A rename the provider has not acknowledged yet outranks the title in this
+    // payload. `thread/started` replays the provider's own record, which on a
+    // resume is the pre-rename one; without this the operator's rename loses on
+    // sequence alone and the quit dialog reverts to the old name. The provider
+    // acknowledging the rename clears the entry (see withObservedThreadName),
+    // after which its titles are believed normally.
+    const unacknowledgedRename = this.observedThreadNames.get(
+      buildThreadIdentityKey(backend, threadId),
+    );
+    const title = unacknowledgedRename ?? candidate;
     this.threadInfoStore.observe({
       identity: { backend, threadId },
       observationSequence: displayMetadataObservationSequence,
       source: "lifecycle-notification",
-      ...(candidate !== undefined ? { title: candidate } : {}),
-      ...(titleSource !== undefined ? { titleSource } : {}),
-      ...(readNotificationProjectLabel(record) !== undefined
-        ? { projectLabel: readNotificationProjectLabel(record) as string }
-        : {}),
+      ...(title !== undefined ? { title } : {}),
+      ...(unacknowledgedRename !== undefined
+        ? { titleSource: "explicit" as const }
+        : titleSource !== undefined
+          ? { titleSource }
+          : {}),
+      ...(projectLabel !== undefined ? { projectLabel } : {}),
     });
   }
 
@@ -34579,7 +34591,7 @@ export class DesktopBackendRegistry {
     threads: readonly AppServerThreadSummary[],
     displayMetadataObservationSequence: number,
     enriched: boolean,
-    listedArchived: boolean,
+    listedArchived: boolean | undefined,
   ): void {
     for (const thread of threads) {
       const identity = { backend: thread.source, threadId: thread.id };
@@ -34590,7 +34602,11 @@ export class DesktopBackendRegistry {
         identity,
         observationSequence: displayMetadataObservationSequence,
         source: "provider-list",
-        archived: listedArchived,
+        // Only a listing that actually filtered by archival proves anything
+        // about it. An unfiltered listing returns both kinds, so recording
+        // `false` for every row would overwrite an archival this store was
+        // just told about with a fact the listing never established.
+        ...(listedArchived === undefined ? {} : { archived: listedArchived }),
         title: thread.title,
         ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
         ...(projectLabel ? { projectLabel } : {}),
@@ -34655,6 +34671,16 @@ export class DesktopBackendRegistry {
             error: error instanceof Error ? error.message : String(error),
             threadId,
           });
+        })
+        .finally(() => {
+          // Dropped unless the walk actually taught us the label. Keeping a
+          // settled entry would memoize a FAILURE as though it were an answer:
+          // one listing that rejected while the provider was restarting would
+          // leave this thread's notifications unlabeled for the rest of the
+          // process, because every later attempt awaits the same dead promise.
+          if (!this.notificationThreadContextLabel(backend, threadId)) {
+            this.notificationContextReconciliations.delete(key);
+          }
         });
       this.notificationContextReconciliations.set(key, reconciliation);
     }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9539,6 +9539,11 @@ export class DesktopBackendRegistry {
     return await promise;
   }
 
+  /**
+   * Resolve provider ownership for one thread. A process-lifetime observation
+   * is not proof that the provider still owns it, so only the bounded query
+   * cache may satisfy this read before its forced provider refresh.
+   */
   async resolveThread(params: {
     backend?: AppServerBackendKind;
     threadId: string;
@@ -9547,10 +9552,13 @@ export class DesktopBackendRegistry {
     if (!threadId) {
       return undefined;
     }
-    const cached = this.getCachedThreadSummary({
-      backend: params.backend,
-      threadId,
-    });
+    const cached = this.findThreadListCachedSummary(
+      {
+        backend: params.backend,
+        threadId,
+      },
+      { requireFresh: true },
+    );
     if (cached) {
       return cached;
     }
@@ -9576,6 +9584,9 @@ export class DesktopBackendRegistry {
    * second tier, admission for a thread this process listed minutes ago falls
    * through to `resolveThread`'s forced full listing purely because something
    * unrelated invalidated the cache in between.
+   *
+   * This is last-observed state, not ownership proof. Consumers validating a
+   * provider or federation owner must call `resolveThread`.
    */
   getCachedThreadSummary(params: {
     backend?: AppServerBackendKind;
@@ -9585,20 +9596,37 @@ export class DesktopBackendRegistry {
     if (!threadId) {
       return undefined;
     }
+    return this.findThreadListCachedSummary({
+      ...params,
+      threadId,
+    }) ?? this.threadInfoStore.findLocalSummary({
+      ...(params.backend ? { backend: params.backend } : {}),
+      threadId,
+    });
+  }
+
+  private findThreadListCachedSummary(
+    params: {
+      backend?: AppServerBackendKind;
+      threadId: string;
+    },
+    options?: { requireFresh?: boolean },
+  ): AppServerThreadSummary | undefined {
+    const now = options?.requireFresh === true ? Date.now() : undefined;
     for (const state of this.threadListCache.values()) {
+      if (now !== undefined && (state.expiresAt ?? 0) <= now) {
+        continue;
+      }
       const cached = state.threads?.find(
         (thread) =>
           (!params.backend || thread.source === params.backend)
-          && thread.id === threadId,
+          && thread.id === params.threadId,
       );
       if (cached) {
         return cached;
       }
     }
-    return this.threadInfoStore.findLocalSummary({
-      ...(params.backend ? { backend: params.backend } : {}),
-      threadId,
-    });
+    return undefined;
   }
 
   /**
@@ -21470,8 +21498,8 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * Rebind a thread's workspace directory, and drop what the store remembers
-   * about that thread.
+   * Rebind a thread's workspace directory, and drop the remembered provider
+   * rows whose directory data is now stale.
    *
    * A remembered row carries the directory set the provider last reported, and
    * `resolveThreadWorkspaceCwd` ranks those ahead of the overlay whenever they
@@ -21492,7 +21520,7 @@ export class DesktopBackendRegistry {
   }): Promise<ThreadOverlayState> {
     const overlay =
       await this.overlayStore.replaceWorkspaceLinkedDirectory(params);
-    this.threadInfoStore.forget({
+    this.threadInfoStore.invalidateSummaries({
       backend: params.backend,
       threadId: params.threadId,
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,3 +1,4 @@
+import { rememberBoundedMap } from "../bounded-map";
 import { app } from "electron";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { execFile as execFileCallback } from "node:child_process";
@@ -11317,6 +11318,20 @@ export class DesktopBackendRegistry {
       updatedAt: Math.max(session.updatedAt, archivedAt),
     });
     this.invalidateThreadListCache(params.backend);
+    // Archival on ACP is a local store write, with no provider to announce it.
+    // Say it in the same words Codex uses, because everything downstream is
+    // written against the notification rather than against a backend: the
+    // information store records the fact here, and messaging revokes the
+    // thread's Default Agent assignments. Without this an archived ACP thread
+    // is invisible to both -- it simply stops appearing in listings, which no
+    // consumer can tell apart from a thread it has not seen lately.
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/archived",
+        params: { threadId: params.threadId },
+      },
+    });
     await this.cleanupMessagingForArchivedThread({
       backend: params.backend,
       threadId: params.threadId,
@@ -11362,6 +11377,16 @@ export class DesktopBackendRegistry {
     this.clearArchivedMessagingCleanupCache({
       backend: params.backend,
       threadId: params.threadId,
+    });
+    // The counterpart to the archive emit above. This is the only report a
+    // restore ever makes: a listing cannot carry the news, because an
+    // unarchived thread is one that has merely started appearing again.
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/unarchived",
+        params: { threadId: params.threadId },
+      },
     });
     return {
       backend: params.backend,
@@ -11467,7 +11492,7 @@ export class DesktopBackendRegistry {
             : undefined) ?? "HEAD"
         : result.branch;
 
-    await this.overlayStore.replaceWorkspaceLinkedDirectory({
+    await this.replaceWorkspaceLinkedDirectory({
       backend: request.backend,
       threadId: request.threadId,
       directory: result.linkedDirectory,
@@ -13450,7 +13475,7 @@ export class DesktopBackendRegistry {
         // has replaced the copied parent cwd. Persist the prepared workspace now
         // so that transient provider metadata cannot become the child's source
         // of truth.
-        await this.overlayStore.replaceWorkspaceLinkedDirectory({
+        await this.replaceWorkspaceLinkedDirectory({
           backend,
           threadId: result.threadId,
           directory: linkedDirectory,
@@ -19603,7 +19628,7 @@ export class DesktopBackendRegistry {
       // can report the same repository through a physical path alias (for
       // example macOS /private/var for a requested /var path), but the
       // worktree path still proves these describe one prepared workspace.
-      await this.overlayStore.replaceWorkspaceLinkedDirectory({
+      await this.replaceWorkspaceLinkedDirectory({
         backend: launchpad.backend,
         threadId: startThreadResponse.threadId,
         directory: linkedDirectory,
@@ -21444,12 +21469,37 @@ export class DesktopBackendRegistry {
     };
   }
 
+  /**
+   * Rebind a thread's workspace directory, and drop what the store remembers
+   * about that thread.
+   *
+   * A remembered row carries the directory set the provider last reported, and
+   * `resolveThreadWorkspaceCwd` ranks those ahead of the overlay whenever they
+   * do not already match it -- which, immediately after a rebind, is precisely
+   * when they do not. Keeping the row across this write therefore sends the
+   * next turn to the directory the thread just moved off, and nothing corrects
+   * it: no notification reports a directory change, and surviving cache
+   * invalidation is the whole point of this store.
+   *
+   * Every rebind goes through here rather than through the overlay store
+   * directly, so a site added later cannot forget the second half.
+   */
+  private async replaceWorkspaceLinkedDirectory(params: {
+    backend: AppServerBackendKind;
+    directory: LinkedDirectorySummary;
+    gitBranch?: string;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    const overlay =
+      await this.overlayStore.replaceWorkspaceLinkedDirectory(params);
+    this.threadInfoStore.forget({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    return overlay;
+  }
+
   private invalidateThreadListCache(backend?: AppServerBackendKind): void {
-    // Names survive invalidation; resolved directories do not. A directory set
-    // is the answer one enriching listing gave, and the events that invalidate
-    // these caches -- a workspace rebind, a detached directory -- are exactly
-    // the ones that make that answer wrong, with no notification to correct it.
-    this.threadInfoStore.forgetEnrichedSummaries();
     if (!backend) {
       this.threadListCache.clear();
       return;
@@ -21543,7 +21593,7 @@ export class DesktopBackendRegistry {
         return;
       }
 
-      await this.overlayStore.replaceWorkspaceLinkedDirectory({
+      await this.replaceWorkspaceLinkedDirectory({
         backend: "codex",
         threadId: params.threadId,
         directory,
@@ -22467,7 +22517,7 @@ export class DesktopBackendRegistry {
       }
 
       updatedOverlaysByThreadId[thread.id] =
-        await this.overlayStore.replaceWorkspaceLinkedDirectory({
+        await this.replaceWorkspaceLinkedDirectory({
           backend: "codex",
           threadId: thread.id,
           directory,
@@ -22566,7 +22616,7 @@ export class DesktopBackendRegistry {
         }
 
         updatedOverlaysByThreadId[thread.id] =
-          await this.overlayStore.replaceWorkspaceLinkedDirectory({
+          await this.replaceWorkspaceLinkedDirectory({
             backend: "codex",
             threadId: thread.id,
             directory,
@@ -34624,17 +34674,18 @@ export class DesktopBackendRegistry {
         identity,
         observationSequence: displayMetadataObservationSequence,
         source: "provider-list",
-        // Read archival off the row, not off the query. Both backends coerce
-        // an unspecified `archived` to `false` -- Codex requests
-        // `archived: false` pages, the ACP store filters on
-        // `Boolean(archivedAt) === (params?.archived === true)` -- so every
-        // listing is filtered whether or not the caller said so, and the row's
-        // own `archivedAt` is the fact rather than the argument that produced
-        // it. Taking it from the row keeps a row that arrives carrying
-        // `archivedAt` from being recorded as active, and keeps the store
-        // correctable: an out-of-band unarchive is a row that comes back
-        // without `archivedAt`, which no notification would have reported.
-        archived: thread.archivedAt !== undefined || listedArchived === true,
+        // Only a listing that actually filtered by archival proves anything
+        // about it, and the row itself proves less than it looks like it does:
+        // an active Codex listing merges cached archived metadata into its
+        // rows, and `mergeThreadSummaries` returns the archived row wholesale
+        // when its titleSource outranks the active one. That cache refreshes on
+        // a 60s interval, so for up to a minute after an unarchive an *active*
+        // listing can hand back a row still carrying `archivedAt` -- which
+        // would overwrite the `thread/unarchived` notification at a newer
+        // sequence and withhold a live thread. `archivedAt` is also a
+        // normalized epoch that can legitimately be 0, so presence is not even
+        // a safe test for it. Record the query's own filter or nothing.
+        ...(listedArchived === undefined ? {} : { archived: listedArchived }),
         title: thread.title,
         ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
         ...(projectLabel ? { projectLabel } : {}),
@@ -34716,24 +34767,27 @@ export class DesktopBackendRegistry {
           });
         })
         .finally(() => {
-          if (!walkListedRows) {
+          // Only retract this walk's own entry. The cap below can evict a key
+          // whose walk is still running, and a later notification then stores a
+          // fresh promise under it -- deleting by key alone would throw that
+          // one away when this older walk settled, and the next notification
+          // would start a third. Same ownership check the thread-list cache
+          // uses when its pending entry settles.
+          if (
+            !walkListedRows
+            && this.notificationContextReconciliations.get(key) === reconciliation
+          ) {
             this.notificationContextReconciliations.delete(key);
           }
         });
-      if (
-        this.notificationContextReconciliations.size
-        >= NOTIFICATION_CONTEXT_RECONCILIATION_LIMIT
-      ) {
-        // Settled entries are kept on purpose -- they are the memo. Insertion
-        // order makes the first key the oldest, so a process that outlives many
-        // threads reclaims them instead of holding one promise per thread it
-        // has ever been notified about.
-        const oldest = this.notificationContextReconciliations.keys().next();
-        if (!oldest.done) {
-          this.notificationContextReconciliations.delete(oldest.value);
-        }
-      }
-      this.notificationContextReconciliations.set(key, reconciliation);
+      // Settled entries are kept on purpose -- they are the memo -- so this is
+      // bounded by count rather than by liveness.
+      rememberBoundedMap(
+        this.notificationContextReconciliations,
+        key,
+        reconciliation,
+        NOTIFICATION_CONTEXT_RECONCILIATION_LIMIT,
+      );
     }
     await reconciliation;
     return this.notificationThreadContextLabel(backend, threadId);

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -74,6 +74,18 @@ type ThreadInfoEntry = {
   /** Highest sequence any accepted field on this entry carries. */
   lastObservedSequence: number;
   summary?: ThreadInfoSummaryEntry;
+  /**
+   * The latest row from a listing that ran directory enrichment, kept in its
+   * own slot.
+   *
+   * Enrichment is not a property of the thread, it is a property of the
+   * listing that produced the row — and the most frequent listing
+   * (`navigation-snapshot`) is unenriched. With one slot, that poll would
+   * overwrite the enriched row within seconds and every `requireEnriched`
+   * read would miss forever, sending the caller back to the provider it was
+   * meant to stop asking.
+   */
+  enrichedSummary?: ThreadInfoSummaryEntry;
 };
 
 /**
@@ -313,21 +325,26 @@ export class ThreadInfoStore {
       identity,
       lastObservedSequence: 0,
     };
-    const existing = entry.summary;
-    // An enriched row is not replaced by an unenriched one taken at the same
-    // moment: both are current, and only one can answer a directory question.
-    const supersedes =
-      !existing
-      || existing.observationSequence < params.observationSequence
-      || (existing.observationSequence === params.observationSequence
-        && params.enriched
-        && !existing.enriched);
-    if (supersedes) {
-      entry.summary = {
-        enriched: params.enriched,
-        observationSequence: params.observationSequence,
-        value: params.summary,
-      };
+    const observed: ThreadInfoSummaryEntry = {
+      enriched: params.enriched,
+      observationSequence: params.observationSequence,
+      value: params.summary,
+    };
+    if (
+      !entry.summary
+      || entry.summary.observationSequence <= params.observationSequence
+    ) {
+      entry.summary = observed;
+    }
+    // The enriched slot only ever hears from enriched listings, so an
+    // unenriched row cannot evict the one answer a directory question has.
+    if (
+      params.enriched
+      && (!entry.enrichedSummary
+        || entry.enrichedSummary.observationSequence
+          <= params.observationSequence)
+    ) {
+      entry.enrichedSummary = observed;
     }
     entry.lastObservedSequence = Math.max(
       entry.lastObservedSequence,
@@ -353,15 +370,66 @@ export class ThreadInfoStore {
     if (!threadId) {
       return undefined;
     }
-    const summary = this.entries.get(identityKey({ ...identity, threadId }))
-      ?.summary;
+    const entry = this.entries.get(identityKey({ ...identity, threadId }));
+    if (!entry) {
+      return undefined;
+    }
+    return this.projectSummary(entry, options?.requireEnriched === true);
+  }
+
+  /**
+   * The stored row, reconciled with everything the field lane has learned
+   * since it was taken.
+   *
+   * A listing row and a notification are two observations of one thread, and
+   * they arrive on different paths: only listings write the row, only
+   * notifications write a rename or an archival. Handing the row back verbatim
+   * lets this store answer with a title it already knows is stale — the exact
+   * failure it exists to prevent, reintroduced one layer down. So the field
+   * lane is projected over the row on the way out.
+   */
+  private projectSummary(
+    entry: ThreadInfoEntry,
+    requireEnriched: boolean,
+  ): AppServerThreadSummary | undefined {
+    const summary = requireEnriched ? entry.enrichedSummary : entry.summary;
     if (!summary) {
       return undefined;
     }
-    if (options?.requireEnriched && !summary.enriched) {
+    // Archival is membership, not a field: a caller asking for a thread's row
+    // is asking about a thread the provider still serves. Answering with the
+    // pre-archival row would let a reply be admitted to an archived thread.
+    const archived = entry.fields.archived;
+    if (
+      archived?.value === true
+      && archived.observationSequence >= summary.observationSequence
+    ) {
       return undefined;
     }
-    return summary.value;
+    const title = entry.fields.title;
+    if (!title) {
+      return summary.value;
+    }
+    // The row's own title wins only while it is both usable and no older than
+    // the field lane. A listing that regressed to a fallback title is newer
+    // and still must not overwrite a name this store already holds.
+    const rowTitleUsable = isUsableTitle(
+      summary.value.title,
+      summary.value.titleSource,
+    );
+    if (
+      rowTitleUsable
+      && title.observationSequence <= summary.observationSequence
+    ) {
+      return summary.value;
+    }
+    return {
+      ...summary.value,
+      title: title.value,
+      ...(entry.fields.titleSource
+        ? { titleSource: entry.fields.titleSource.value }
+        : {}),
+    };
   }
 
   /**
@@ -386,15 +454,25 @@ export class ThreadInfoStore {
     if (params.backend) {
       return this.getSummary({ backend: params.backend, threadId });
     }
+    // Thread ids are unique per backend, not across them, and an ACP adapter
+    // picks its own. Answering an ambiguous id with whichever backend this
+    // process happened to observe first would hand back another thread's
+    // directories; a caller that cannot name the backend gets nothing.
+    let match: AppServerThreadSummary | undefined;
     for (const entry of this.entries.values()) {
       if (entry.identity.instanceId || entry.identity.threadId !== threadId) {
         continue;
       }
-      if (entry.summary) {
-        return entry.summary.value;
+      const projected = this.projectSummary(entry, false);
+      if (!projected) {
+        continue;
       }
+      if (match) {
+        return undefined;
+      }
+      match = projected;
     }
-    return undefined;
+    return match;
   }
 
   /** The display title, or `undefined` when none has ever been observed. */
@@ -409,7 +487,11 @@ export class ThreadInfoStore {
    * says nothing about whether the thread still exists or what it is called.
    */
   forget(identity: ThreadInfoIdentity): void {
-    this.entries.delete(identityKey(identity));
+    const threadId = identity.threadId.trim();
+    if (!threadId) {
+      return;
+    }
+    this.entries.delete(identityKey({ ...identity, threadId }));
   }
 
   /** Drop every thread belonging to a peer that unmounted. */

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -1,0 +1,386 @@
+import {
+  buildThreadIdentityKey,
+  type AppServerBackendKind,
+  type AppServerThreadSummary,
+  type AppServerThreadTitleSource,
+} from "@pwragent/shared";
+
+/**
+ * Where a piece of thread information came from. Higher-trust sources are not
+ * ranked here: recency wins, and the source is retained for diagnostics and for
+ * callers that must distinguish a provider-derived label from an operator's
+ * explicit rename.
+ */
+export type ThreadInfoSource =
+  | "lifecycle-notification"
+  | "local-rename"
+  | "provider-list"
+  | "remote-navigation"
+  | "remote-pin";
+
+/**
+ * The identity of a thread as this process knows it. `instanceId` is absent for
+ * threads this instance owns and present for a mounted peer's thread, so a
+ * local thread and a remote thread that happen to share a backend and id can
+ * never collapse into one entry.
+ */
+export type ThreadInfoIdentity = {
+  backend: AppServerBackendKind;
+  instanceId?: string;
+  threadId: string;
+};
+
+/**
+ * A field this store tracks. Adding one is the whole cost of teaching the store
+ * about a new piece of display metadata; every merge, retention, and freshness
+ * rule already applies to it.
+ */
+export type ThreadInfoFields = {
+  archived: boolean;
+  projectLabel: string;
+  title: string;
+  titleSource: AppServerThreadTitleSource;
+  updatedAt: number;
+};
+
+export type ThreadInfoFieldName = keyof ThreadInfoFields;
+
+type ThreadInfoFieldEntry<Name extends ThreadInfoFieldName> = {
+  observationSequence: number;
+  source: ThreadInfoSource;
+  value: ThreadInfoFields[Name];
+};
+
+type ThreadInfoSummaryEntry = {
+  /**
+   * Whether the listing that produced this row ran directory enrichment.
+   * An unenriched row can be missing worktree paths, so a caller that needs
+   * them must not be handed one — see `getSummary`.
+   */
+  enriched: boolean;
+  observationSequence: number;
+  value: AppServerThreadSummary;
+};
+
+type ThreadInfoEntry = {
+  fields: {
+    [Name in ThreadInfoFieldName]?: ThreadInfoFieldEntry<Name>;
+  };
+  /** Highest sequence any accepted field on this entry carries. */
+  lastObservedSequence: number;
+  summary?: ThreadInfoSummaryEntry;
+};
+
+/**
+ * What the store knows about one thread right now. Every field is optional and
+ * a missing field means exactly one thing: nothing has ever been observed for
+ * it. It never means a read failed, a provider was slow, or a cache lapsed.
+ */
+export type ThreadInfo = {
+  archived?: boolean;
+  identity: ThreadInfoIdentity;
+  /** Sequence of the newest accepted observation, for ordering diagnostics. */
+  lastObservedSequence: number;
+  projectLabel?: string;
+  title?: string;
+  titleSource?: AppServerThreadTitleSource;
+  updatedAt?: number;
+};
+
+/** A batch of facts about one thread, as some source observed them. */
+export type ThreadInfoObservation = {
+  identity: ThreadInfoIdentity;
+  /**
+   * Sequence this observation was taken at. Asynchronous readers MUST reserve
+   * this before the read begins — see `reserveObservationSequence`.
+   */
+  observationSequence: number;
+  source: ThreadInfoSource;
+} & Partial<ThreadInfoFields>;
+
+const TRACKED_FIELDS: readonly ThreadInfoFieldName[] = [
+  "archived",
+  "projectLabel",
+  "title",
+  "titleSource",
+  "updatedAt",
+];
+
+function identityKey(identity: ThreadInfoIdentity): string {
+  const threadKey = buildThreadIdentityKey(identity.backend, identity.threadId);
+  return identity.instanceId ? `${identity.instanceId}::${threadKey}` : threadKey;
+}
+
+/**
+ * A title that carries no information. `fallback` is what a provider returns
+ * when it has nothing better than the thread id, so accepting one would let a
+ * list refresh overwrite a real name with a uuid — the regression this store
+ * exists to make unrepresentable.
+ */
+function isUsableTitle(
+  title: string | undefined,
+  titleSource: AppServerThreadTitleSource | undefined,
+): boolean {
+  if (titleSource === "fallback") {
+    return false;
+  }
+  return (title?.trim().length ?? 0) > 0;
+}
+
+/**
+ * The process-lifetime record of what PwrAgent knows about each thread it has
+ * seen, keyed by thread identity rather than by the shape of the query that
+ * happened to reveal it.
+ *
+ * The distinction that motivates this store: a *query cache* answers "which
+ * threads match Q, in what order", is invalidated by any mutation, and is
+ * correctly forgotten. An *information store* answers "what is thread X
+ * called", and forgetting it is never correct — the previous answer is still
+ * the best answer available until a newer one arrives.
+ *
+ * PwrAgent previously had only the query cache, so a mutation anywhere erased
+ * the display metadata for every thread, and any read that had to re-derive it
+ * could regress a named row back to a uuid while a provider round trip was in
+ * flight. Reads here are synchronous, cannot fail, and cannot start I/O.
+ *
+ * Ordering is by monotonic sequence, never by wall clock, so this is safe on
+ * the render path and unaffected by clock adjustment.
+ */
+export class ThreadInfoStore {
+  private readonly entries = new Map<string, ThreadInfoEntry>();
+  private observationSequence = 0;
+
+  /**
+   * Take the sequence an observation will be recorded at. An asynchronous
+   * reader must call this BEFORE it starts, not when it finishes.
+   *
+   * This is the rule that makes late completions harmless. A provider list
+   * that starts, is overtaken by a rename, and completes afterwards carries the
+   * older sequence it reserved, so its stale rows lose to the rename instead of
+   * silently reverting it.
+   */
+  reserveObservationSequence(): number {
+    this.observationSequence += 1;
+    return this.observationSequence;
+  }
+
+  /**
+   * Record what a source observed. Only positive facts are merged: a field the
+   * observation omits is left alone, because "this read did not mention the
+   * title" and "this thread has no title" are different claims and only the
+   * caller knows which one it is making.
+   *
+   * Returns the fields this observation actually changed, which lets callers
+   * skip downstream work when a refresh confirmed what was already known.
+   */
+  observe(observation: ThreadInfoObservation): ThreadInfoFieldName[] {
+    const threadId = observation.identity.threadId.trim();
+    if (!threadId) {
+      return [];
+    }
+    const identity: ThreadInfoIdentity = {
+      backend: observation.identity.backend,
+      threadId,
+      ...(observation.identity.instanceId
+        ? { instanceId: observation.identity.instanceId }
+        : {}),
+    };
+    const key = identityKey(identity);
+    const entry = this.entries.get(key) ?? {
+      fields: {},
+      lastObservedSequence: 0,
+    };
+
+    // A title and its source describe one fact. Validating them together stops
+    // a fallback source from arriving without its title and downgrading a name
+    // the store already holds.
+    const titleIsUsable = isUsableTitle(observation.title, observation.titleSource);
+    const changed: ThreadInfoFieldName[] = [];
+
+    for (const field of TRACKED_FIELDS) {
+      const value = observation[field];
+      if (value === undefined) {
+        continue;
+      }
+      if ((field === "title" || field === "titleSource") && !titleIsUsable) {
+        continue;
+      }
+      if (field === "projectLabel" && !String(value).trim()) {
+        continue;
+      }
+      const existing = entry.fields[field];
+      if (
+        existing
+        && existing.observationSequence > observation.observationSequence
+      ) {
+        continue;
+      }
+      const normalized =
+        field === "title" || field === "projectLabel"
+          ? (String(value).trim() as ThreadInfoFields[typeof field])
+          : value;
+      if (existing && existing.value === normalized) {
+        // Still a fresher confirmation of the same fact, so the sequence moves
+        // even though no caller needs to hear about a change.
+        existing.observationSequence = observation.observationSequence;
+        existing.source = observation.source;
+        continue;
+      }
+      (entry.fields as Record<string, unknown>)[field] = {
+        observationSequence: observation.observationSequence,
+        source: observation.source,
+        value: normalized,
+      };
+      changed.push(field);
+    }
+
+    entry.lastObservedSequence = Math.max(
+      entry.lastObservedSequence,
+      observation.observationSequence,
+    );
+    this.entries.set(key, entry);
+    return changed;
+  }
+
+  /**
+   * What this process knows about a thread. Synchronous, allocation-light, and
+   * safe on any path — including a 500ms UI poll — because it can neither wait
+   * nor fail. `undefined` means this thread has never been observed at all.
+   */
+  get(identity: ThreadInfoIdentity): ThreadInfo | undefined {
+    const threadId = identity.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    const entry = this.entries.get(
+      identityKey({ ...identity, threadId }),
+    );
+    if (!entry) {
+      return undefined;
+    }
+    const info: ThreadInfo = {
+      identity: {
+        backend: identity.backend,
+        threadId,
+        ...(identity.instanceId ? { instanceId: identity.instanceId } : {}),
+      },
+      lastObservedSequence: entry.lastObservedSequence,
+    };
+    for (const field of TRACKED_FIELDS) {
+      const stored = entry.fields[field];
+      if (stored !== undefined) {
+        (info as Record<string, unknown>)[field] = stored.value;
+      }
+    }
+    return info;
+  }
+
+  /**
+   * Record the whole row a listing returned, so a later point query about this
+   * thread can be answered without walking the collection again.
+   *
+   * `enriched` records whether the listing ran directory enrichment. It is not
+   * a quality score: an unenriched row is complete for callers that asked for
+   * an unenriched listing and incomplete for callers that did not, and only
+   * the reader knows which it is.
+   */
+  observeSummary(params: {
+    enriched: boolean;
+    identity: ThreadInfoIdentity;
+    observationSequence: number;
+    summary: AppServerThreadSummary;
+  }): void {
+    const threadId = params.identity.threadId.trim();
+    if (!threadId) {
+      return;
+    }
+    const key = identityKey({ ...params.identity, threadId });
+    const entry = this.entries.get(key) ?? {
+      fields: {},
+      lastObservedSequence: 0,
+    };
+    const existing = entry.summary;
+    // An enriched row is not replaced by an unenriched one taken at the same
+    // moment: both are current, and only one can answer a directory question.
+    const supersedes =
+      !existing
+      || existing.observationSequence < params.observationSequence
+      || (existing.observationSequence === params.observationSequence
+        && params.enriched
+        && !existing.enriched);
+    if (supersedes) {
+      entry.summary = {
+        enriched: params.enriched,
+        observationSequence: params.observationSequence,
+        value: params.summary,
+      };
+    }
+    entry.lastObservedSequence = Math.max(
+      entry.lastObservedSequence,
+      params.observationSequence,
+    );
+    this.entries.set(key, entry);
+  }
+
+  /**
+   * The last row a listing returned for this thread, or `undefined` when none
+   * has been observed at the requested enrichment level.
+   *
+   * Deliberately survives thread-list cache invalidation. Invalidation means
+   * "the ordering and membership of that query may have changed", which says
+   * nothing about where this thread's workspace is. A caller that needs
+   * post-mutation provider truth must go to the provider explicitly.
+   */
+  getSummary(
+    identity: ThreadInfoIdentity,
+    options?: { requireEnriched?: boolean },
+  ): AppServerThreadSummary | undefined {
+    const threadId = identity.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    const summary = this.entries.get(identityKey({ ...identity, threadId }))
+      ?.summary;
+    if (!summary) {
+      return undefined;
+    }
+    if (options?.requireEnriched && !summary.enriched) {
+      return undefined;
+    }
+    return summary.value;
+  }
+
+  /** The display title, or `undefined` when none has ever been observed. */
+  getTitle(identity: ThreadInfoIdentity): string | undefined {
+    return this.get(identity)?.title;
+  }
+
+  /**
+   * Drop a thread the owning provider no longer has. This is the ONLY way an
+   * entry leaves the store, and it is deliberately not reachable from cache
+   * invalidation: invalidation means "the query result may be stale", which
+   * says nothing about whether the thread still exists or what it is called.
+   */
+  forget(identity: ThreadInfoIdentity): void {
+    this.entries.delete(identityKey(identity));
+  }
+
+  /** Drop every thread belonging to a peer that unmounted. */
+  forgetInstance(instanceId: string): void {
+    const prefix = `${instanceId}::`;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  /** Entry count, for budget assertions and memory diagnostics. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -252,6 +252,20 @@ export class ThreadInfoStore {
       changed.push(field);
     }
 
+    // A title and its source are one fact wearing two field names. They carry
+    // independent sequences, so an observation that renames a thread without
+    // saying where the name came from would otherwise leave the previous
+    // source behind, still describing a string that is gone. Readers then
+    // disagree: one reports the new name as an operator rename that never
+    // happened, the other reports a real rename as machine-derived. Drop the
+    // orphaned source instead, and let the readers say "unknown" honestly.
+    if (
+      changed.includes("title")
+      && observation.titleSource === undefined
+    ) {
+      delete entry.fields.titleSource;
+    }
+
     entry.lastObservedSequence = Math.max(
       entry.lastObservedSequence,
       observation.observationSequence,
@@ -423,23 +437,19 @@ export class ThreadInfoStore {
     ) {
       return summary.value;
     }
-    // A title and its source are separate fields with separate sequences, so
-    // the row's `titleSource` describes the row's title and says nothing about
-    // this one. Carrying it over mislabels provenance in both directions: a
-    // provider replay inherits `explicit` and reads as an operator rename,
-    // which suppresses generated titles and reports a rename nobody made; a
-    // real name inherits `fallback` and every `!== "fallback"` guard downstream
-    // discards it. Claim the field lane's own source only when it was observed
-    // no earlier than the title it describes, and otherwise say `derived` --
-    // the honest claim for a usable name that no operator set.
-    const titleSource = entry.fields.titleSource;
+    // The field lane's own source is authoritative when it has one, because
+    // `observe` drops a source whose title has been replaced -- so if it is
+    // here, it describes this title. Otherwise the row's source still applies
+    // if the row is talking about the same string, and only a title whose
+    // provenance nothing records is reported as `derived`.
+    const titleSource = entry.fields.titleSource?.value
+      ?? (summary.value.title === title.value
+        ? summary.value.titleSource
+        : "derived");
     return {
       ...summary.value,
       title: title.value,
-      titleSource:
-        titleSource && titleSource.observationSequence >= title.observationSequence
-          ? titleSource.value
-          : "derived",
+      titleSource,
     };
   }
 
@@ -504,27 +514,6 @@ export class ThreadInfoStore {
       return;
     }
     this.entries.delete(identityKey({ ...identity, threadId }));
-  }
-
-  /**
-   * Drop every remembered enriched row, keeping every other fact.
-   *
-   * The store survives cache invalidation on purpose: "this query result may be
-   * stale" says nothing about what a thread is called. Linked directories are
-   * the exception. They are not a property of the thread the way its name is --
-   * they are the answer a directory-resolving listing gave at one moment, and a
-   * workspace rebind or a detached directory makes that answer wrong with no
-   * notification to correct it. Nothing else observes the enriched slot, so it
-   * would otherwise serve its founding answer for the life of the process.
-   *
-   * The one caller that reads enriched rows turns them into the allowlist of
-   * paths whose images may be attached to an outbound message, so a stale
-   * answer there approves a directory the thread no longer has.
-   */
-  forgetEnrichedSummaries(): void {
-    for (const entry of this.entries.values()) {
-      delete entry.enrichedSummary;
-    }
   }
 
   /**

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -1,5 +1,4 @@
 import {
-  buildThreadIdentityKey,
   type AppServerBackendKind,
   type AppServerThreadSummary,
   type AppServerThreadTitleSource,
@@ -124,8 +123,11 @@ const TRACKED_FIELDS: readonly ThreadInfoFieldName[] = [
 ];
 
 function identityKey(identity: ThreadInfoIdentity): string {
-  const threadKey = buildThreadIdentityKey(identity.backend, identity.threadId);
-  return identity.instanceId ? `${identity.instanceId}::${threadKey}` : threadKey;
+  return JSON.stringify([
+    identity.instanceId || null,
+    identity.backend,
+    identity.threadId,
+  ]);
 }
 
 /**
@@ -165,6 +167,10 @@ function isUsableTitle(
  */
 export class ThreadInfoStore {
   private readonly entries = new Map<string, ThreadInfoEntry>();
+  private readonly summaryInvalidations = new Map<
+    string,
+    { identity: ThreadInfoIdentity; observationSequence: number }
+  >();
   private observationSequence = 0;
 
   /**
@@ -344,6 +350,10 @@ export class ThreadInfoStore {
       observationSequence: params.observationSequence,
       value: params.summary,
     };
+    const invalidation = this.summaryInvalidations.get(key);
+    if (params.observationSequence <= (invalidation?.observationSequence ?? 0)) {
+      return;
+    }
     if (
       !entry.summary
       || entry.summary.observationSequence <= params.observationSequence
@@ -497,6 +507,33 @@ export class ThreadInfoStore {
     return match ? this.projectSummary(match, false) : undefined;
   }
 
+  /**
+   * Invalidate provider rows without discarding independently observed fields.
+   *
+   * A workspace rebind makes remembered directories stale, but a title or
+   * archival notification that arrived while a listing was in flight remains
+   * authoritative. The sequence floor also stops that older listing from
+   * repopulating its stale row after this invalidation completes.
+   */
+  invalidateSummaries(identity: ThreadInfoIdentity): void {
+    const threadId = identity.threadId.trim();
+    if (!threadId) {
+      return;
+    }
+    const normalizedIdentity = { ...identity, threadId };
+    const key = identityKey(normalizedIdentity);
+    const invalidatedAtSequence = this.reserveObservationSequence();
+    const entry = this.entries.get(key);
+    if (entry) {
+      entry.summary = undefined;
+      entry.enrichedSummary = undefined;
+    }
+    this.summaryInvalidations.set(key, {
+      identity: normalizedIdentity,
+      observationSequence: invalidatedAtSequence,
+    });
+  }
+
   /** The display title, or `undefined` when none has ever been observed. */
   getTitle(identity: ThreadInfoIdentity): string | undefined {
     return this.get(identity)?.title;
@@ -513,21 +550,27 @@ export class ThreadInfoStore {
     if (!threadId) {
       return;
     }
-    this.entries.delete(identityKey({ ...identity, threadId }));
+    const key = identityKey({ ...identity, threadId });
+    this.entries.delete(key);
+    this.summaryInvalidations.delete(key);
   }
 
   /**
    * Drop every thread belonging to a peer that unmounted.
    *
-   * Matched on the entry's own instance id rather than on a key prefix. The
-   * key joins its parts with `::`, and an instance id is peer-supplied text
-   * that may contain one, so a prefix scan for `peer-a` also claims the
-   * entries of a peer named `peer-a::b`.
+   * Matched on the entry's own instance id rather than parsing the encoded key.
+   * Peer ids are arbitrary strings, so their original values remain the only
+   * authoritative comparison surface.
    */
   forgetInstance(instanceId: string): void {
     for (const [key, entry] of this.entries) {
       if (entry.identity.instanceId === instanceId) {
         this.entries.delete(key);
+      }
+    }
+    for (const [key, invalidation] of this.summaryInvalidations) {
+      if (invalidation.identity.instanceId === instanceId) {
+        this.summaryInvalidations.delete(key);
       }
     }
   }
@@ -539,5 +582,6 @@ export class ThreadInfoStore {
 
   clear(): void {
     this.entries.clear();
+    this.summaryInvalidations.clear();
   }
 }

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -66,6 +66,11 @@ type ThreadInfoEntry = {
   fields: {
     [Name in ThreadInfoFieldName]?: ThreadInfoFieldEntry<Name>;
   };
+  /**
+   * The identity this entry is keyed by, kept alongside the key so a lookup
+   * that does not know the backend can filter without parsing the key string.
+   */
+  identity: ThreadInfoIdentity;
   /** Highest sequence any accepted field on this entry carries. */
   lastObservedSequence: number;
   summary?: ThreadInfoSummaryEntry;
@@ -188,6 +193,7 @@ export class ThreadInfoStore {
     const key = identityKey(identity);
     const entry = this.entries.get(key) ?? {
       fields: {},
+      identity,
       lastObservedSequence: 0,
     };
 
@@ -294,9 +300,17 @@ export class ThreadInfoStore {
     if (!threadId) {
       return;
     }
-    const key = identityKey({ ...params.identity, threadId });
+    const identity: ThreadInfoIdentity = {
+      backend: params.identity.backend,
+      threadId,
+      ...(params.identity.instanceId
+        ? { instanceId: params.identity.instanceId }
+        : {}),
+    };
+    const key = identityKey(identity);
     const entry = this.entries.get(key) ?? {
       fields: {},
+      identity,
       lastObservedSequence: 0,
     };
     const existing = entry.summary;
@@ -348,6 +362,39 @@ export class ThreadInfoStore {
       return undefined;
     }
     return summary.value;
+  }
+
+  /**
+   * A locally-owned thread's summary when the caller may not know its backend.
+   *
+   * A named backend is a direct lookup. Without one this scans, the way the
+   * caller's previous thread-list walk did — but over one entry per thread
+   * rather than every row of every cached query, and it still answers after
+   * the query caches have been invalidated.
+   *
+   * Instance-qualified entries are skipped: those belong to peers, and a
+   * caller that did not name an instance is not asking about a peer's thread.
+   */
+  findLocalSummary(params: {
+    backend?: AppServerBackendKind;
+    threadId: string;
+  }): AppServerThreadSummary | undefined {
+    const threadId = params.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    if (params.backend) {
+      return this.getSummary({ backend: params.backend, threadId });
+    }
+    for (const entry of this.entries.values()) {
+      if (entry.identity.instanceId || entry.identity.threadId !== threadId) {
+        continue;
+      }
+      if (entry.summary) {
+        return entry.summary.value;
+      }
+    }
+    return undefined;
   }
 
   /** The display title, or `undefined` when none has ever been observed. */

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -423,12 +423,23 @@ export class ThreadInfoStore {
     ) {
       return summary.value;
     }
+    // A title and its source are separate fields with separate sequences, so
+    // the row's `titleSource` describes the row's title and says nothing about
+    // this one. Carrying it over mislabels provenance in both directions: a
+    // provider replay inherits `explicit` and reads as an operator rename,
+    // which suppresses generated titles and reports a rename nobody made; a
+    // real name inherits `fallback` and every `!== "fallback"` guard downstream
+    // discards it. Claim the field lane's own source only when it was observed
+    // no earlier than the title it describes, and otherwise say `derived` --
+    // the honest claim for a usable name that no operator set.
+    const titleSource = entry.fields.titleSource;
     return {
       ...summary.value,
       title: title.value,
-      ...(entry.fields.titleSource
-        ? { titleSource: entry.fields.titleSource.value }
-        : {}),
+      titleSource:
+        titleSource && titleSource.observationSequence >= title.observationSequence
+          ? titleSource.value
+          : "derived",
     };
   }
 

--- a/apps/desktop/src/main/app-server/thread-info-store.ts
+++ b/apps/desktop/src/main/app-server/thread-info-store.ts
@@ -469,21 +469,22 @@ export class ThreadInfoStore {
     // picks its own. Answering an ambiguous id with whichever backend this
     // process happened to observe first would hand back another thread's
     // directories; a caller that cannot name the backend gets nothing.
-    let match: AppServerThreadSummary | undefined;
+    //
+    // Ambiguity is decided on the entries, not on what survives projection. An
+    // entry withheld because its thread was archived is still a second thread
+    // wearing this id, and skipping it before the count would make the
+    // remaining one look unambiguous and answer with its directories.
+    let match: ThreadInfoEntry | undefined;
     for (const entry of this.entries.values()) {
       if (entry.identity.instanceId || entry.identity.threadId !== threadId) {
-        continue;
-      }
-      const projected = this.projectSummary(entry, false);
-      if (!projected) {
         continue;
       }
       if (match) {
         return undefined;
       }
-      match = projected;
+      match = entry;
     }
-    return match;
+    return match ? this.projectSummary(match, false) : undefined;
   }
 
   /** The display title, or `undefined` when none has ever been observed. */
@@ -505,11 +506,38 @@ export class ThreadInfoStore {
     this.entries.delete(identityKey({ ...identity, threadId }));
   }
 
-  /** Drop every thread belonging to a peer that unmounted. */
+  /**
+   * Drop every remembered enriched row, keeping every other fact.
+   *
+   * The store survives cache invalidation on purpose: "this query result may be
+   * stale" says nothing about what a thread is called. Linked directories are
+   * the exception. They are not a property of the thread the way its name is --
+   * they are the answer a directory-resolving listing gave at one moment, and a
+   * workspace rebind or a detached directory makes that answer wrong with no
+   * notification to correct it. Nothing else observes the enriched slot, so it
+   * would otherwise serve its founding answer for the life of the process.
+   *
+   * The one caller that reads enriched rows turns them into the allowlist of
+   * paths whose images may be attached to an outbound message, so a stale
+   * answer there approves a directory the thread no longer has.
+   */
+  forgetEnrichedSummaries(): void {
+    for (const entry of this.entries.values()) {
+      delete entry.enrichedSummary;
+    }
+  }
+
+  /**
+   * Drop every thread belonging to a peer that unmounted.
+   *
+   * Matched on the entry's own instance id rather than on a key prefix. The
+   * key joins its parts with `::`, and an instance id is peer-supplied text
+   * that may contain one, so a prefix scan for `peer-a` also claims the
+   * entries of a peer named `peer-a::b`.
+   */
   forgetInstance(instanceId: string): void {
-    const prefix = `${instanceId}::`;
-    for (const key of this.entries.keys()) {
-      if (key.startsWith(prefix)) {
+    for (const [key, entry] of this.entries) {
+      if (entry.identity.instanceId === instanceId) {
         this.entries.delete(key);
       }
     }

--- a/apps/desktop/src/main/bounded-map.ts
+++ b/apps/desktop/src/main/bounded-map.ts
@@ -1,0 +1,32 @@
+/**
+ * Insertion-ordered maps with a ceiling, for bookkeeping that must not grow
+ * without bound.
+ *
+ * A `Map` iterates in insertion order, so its first key is its oldest entry.
+ * That makes oldest-first eviction a two-line loop -- which is exactly why it
+ * kept getting written again by hand, each copy another place to get the
+ * `.keys().next()` / `.done` dance subtly wrong.
+ */
+
+/**
+ * Store `value` under `key`, then evict oldest-first until the map fits.
+ *
+ * Re-setting an existing key does NOT refresh its position: `Map.set` keeps the
+ * original insertion order. This is a size ceiling, not an LRU -- reach for
+ * something else if recency of *use* is what should decide eviction.
+ */
+export function rememberBoundedMap<Value>(
+  map: Map<string, Value>,
+  key: string,
+  value: Value,
+  maxSize: number,
+): void {
+  map.set(key, value);
+  while (map.size > maxSize) {
+    const oldest = map.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    map.delete(oldest.value);
+  }
+}

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -23,10 +23,16 @@ export type RemoteThreadSummaryPeer = {
   capabilities: FederationCapability[];
 };
 
-/** A peer's display name for one of its threads. */
+/**
+ * A peer's display name for one of its threads.
+ *
+ * `titleSource` is optional because it is a compile-time contract over another
+ * instance's JSON: an older peer sends a real title without one, and a name is
+ * still better than the raw thread id.
+ */
 export type RemoteThreadName = {
   title: string;
-  titleSource: NavigationThreadSummary["titleSource"];
+  titleSource?: NavigationThreadSummary["titleSource"];
 };
 
 export type ResolvedRemotePins = {
@@ -306,7 +312,7 @@ export class RemoteThreadSummaryCache {
   rememberThreadNames(
     instanceId: string,
     threads: readonly NavigationThreadSummary[],
-    observationSequence = this.reserveThreadNameObservation(),
+    observationSequence: number,
   ): void {
     for (const thread of threads) {
       this.threadNames.observe({
@@ -371,9 +377,14 @@ export class RemoteThreadSummaryCache {
       instanceId: params.target.instanceId,
       threadId: params.threadId,
     });
-    if (!info?.title || !info.titleSource) {
+    if (!info?.title) {
       return undefined;
     }
+    // titleSource is absent whenever the peer row omitted it — the field is a
+    // compile-time contract and the payload is another instance's JSON, so an
+    // older peer legitimately sends a real title without one. Requiring it
+    // here would answer `undefined` for a name this store holds, and the quit
+    // dialog would show the raw thread id instead.
     return { title: info.title, titleSource: info.titleSource };
   }
 

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -15,6 +15,7 @@ import {
   threadHasExactPrNumberMatch,
   threadMatchesQuery,
 } from "@pwragent/shared";
+import { ThreadInfoStore } from "../app-server/thread-info-store";
 
 export type RemoteThreadSummaryPeer = {
   target: FederationRemoteTarget;
@@ -132,15 +133,15 @@ export class RemoteThreadSummaryCache {
     { fetchedAt: number; threadKeys: Set<string> }
   >();
   /**
-   * Display names per instance, keyed by thread identity. Deliberately NOT
-   * cleared by `invalidate` — see `cachedThreadNameFromPeer`. Dropping a name
-   * can only send a row back to its thread id, and a name is stale-tolerant
-   * in a way the snapshots above are not.
+   * Display names for threads owned by peers, held in the same information
+   * store the local side uses and keyed by instance so two peers reusing a
+   * thread id cannot answer for each other.
+   *
+   * Deliberately NOT cleared by `invalidate` — see `cachedThreadNameFromPeer`.
+   * Dropping a name can only send a row back to its thread id, and a name is
+   * stale-tolerant in a way the snapshots above are not.
    */
-  private readonly threadNames = new Map<
-    string,
-    Map<string, RemoteThreadName>
-  >();
+  private readonly threadNames = new ThreadInfoStore();
   private readonly peerInterests = new Map<
     string,
     Map<
@@ -305,22 +306,39 @@ export class RemoteThreadSummaryCache {
   rememberThreadNames(
     instanceId: string,
     threads: readonly NavigationThreadSummary[],
+    observationSequence = this.reserveThreadNameObservation(),
   ): void {
-    let names = this.threadNames.get(instanceId);
     for (const thread of threads) {
-      const title = thread.title?.trim();
-      if (!title || thread.titleSource === "fallback") {
-        continue;
-      }
-      names ??= new Map();
-      names.set(buildThreadIdentityKey(thread.source, thread.id), {
-        title,
-        titleSource: thread.titleSource,
+      this.threadNames.observe({
+        identity: {
+          backend: thread.source,
+          instanceId,
+          threadId: thread.id,
+        },
+        observationSequence,
+        source: "remote-navigation",
+        ...(thread.title !== undefined ? { title: thread.title } : {}),
+        ...(thread.titleSource ? { titleSource: thread.titleSource } : {}),
       });
     }
-    if (names) {
-      this.threadNames.set(instanceId, names);
-    }
+  }
+
+  /**
+   * Take the sequence a peer snapshot's names will be recorded at, BEFORE the
+   * fetch starts.
+   *
+   * Two refreshes for one peer can be in flight at once and can complete out of
+   * order. Without this, the older snapshot's rows would land last and revert a
+   * rename the operator has already seen — the remote half of the regression
+   * the information store exists to prevent.
+   */
+  reserveThreadNameObservation(): number {
+    return this.threadNames.reserveObservationSequence();
+  }
+
+  /** Drop a peer's names when it unmounts and can no longer be asked. */
+  forgetInstanceThreadNames(instanceId: string): void {
+    this.threadNames.forgetInstance(instanceId);
   }
 
   /**
@@ -348,9 +366,15 @@ export class RemoteThreadSummaryCache {
     backend: NavigationThreadSummary["source"];
     threadId: string;
   }): RemoteThreadName | undefined {
-    return this.threadNames
-      .get(params.target.instanceId)
-      ?.get(buildThreadIdentityKey(params.backend, params.threadId));
+    const info = this.threadNames.get({
+      backend: params.backend,
+      instanceId: params.target.instanceId,
+      threadId: params.threadId,
+    });
+    if (!info?.title || !info.titleSource) {
+      return undefined;
+    }
+    return { title: info.title, titleSource: info.titleSource };
   }
 
   /**
@@ -780,6 +804,10 @@ export class RemoteThreadSummaryCache {
       }
       return await this.threadsForPeer(target, selection, interestKey);
     }
+    // Reserved before the fetch, not after it: a snapshot that starts first and
+    // finishes last must not overwrite the names a later refresh already
+    // recorded.
+    const nameObservationSequence = this.reserveThreadNameObservation();
     const promise = (async () => {
       const timeoutMs =
         this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
@@ -797,7 +825,11 @@ export class RemoteThreadSummaryCache {
         selection,
         threads,
       });
-      this.rememberThreadNames(target.instanceId, threads);
+      this.rememberThreadNames(
+        target.instanceId,
+        threads,
+        nameObservationSequence,
+      );
       this.touchPeerInterest(
         target.instanceId,
         interestKey,

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -320,7 +320,8 @@ export class RemoteThreadSummaryCache {
       // record. A peer exposing thousands of unnamed threads would cost
       // per-thread bookkeeping, retained for the life of the process, holding
       // nothing any read can answer from.
-      if (!thread.title?.trim() || thread.titleSource === "fallback") {
+      const title = thread.title?.trim();
+      if (!title || thread.titleSource === "fallback" || title === thread.id) {
         continue;
       }
       this.threadNames.observe({

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -315,6 +315,14 @@ export class RemoteThreadSummaryCache {
     observationSequence: number,
   ): void {
     for (const thread of threads) {
+      // A fallback or blank title is not news, and observing one anyway leaves
+      // an entry behind: the store rejects the value but still creates the
+      // record. A peer exposing thousands of unnamed threads would cost
+      // per-thread bookkeeping, retained for the life of the process, holding
+      // nothing any read can answer from.
+      if (!thread.title?.trim() || thread.titleSource === "fallback") {
+        continue;
+      }
       this.threadNames.observe({
         identity: {
           backend: thread.source,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2125,6 +2125,13 @@ class DesktopAppServerService {
         ...request,
         federationTarget,
       });
+      // Reserved before the peer round trip. Two navigation refreshes for one
+      // peer can be in flight together and can finish out of order; without
+      // this, the older snapshot's rows land last and revert a rename the
+      // operator has already seen.
+      const nameObservationSequence = getDesktopFederationRuntime()
+        .remoteThreadSummaries()
+        .reserveThreadNameObservation();
       try {
         const snapshot = await getDesktopFederationRuntime()
           .remoteNavigationSnapshot(
@@ -2147,7 +2154,11 @@ class DesktopAppServerService {
         try {
           getDesktopFederationRuntime()
             .remoteThreadSummaries()
-            .rememberThreadNames(federationTarget.instanceId, snapshot.threads);
+            .rememberThreadNames(
+              federationTarget.instanceId,
+              snapshot.threads,
+              nameObservationSequence,
+            );
         } catch (error) {
           logDebug("rememberRemoteThreadNames failed", {
             error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2129,9 +2129,14 @@ class DesktopAppServerService {
       // peer can be in flight together and can finish out of order; without
       // this, the older snapshot's rows land last and revert a rename the
       // operator has already seen.
-      const nameObservationSequence = getDesktopFederationRuntime()
-        .remoteThreadSummaries()
-        .reserveThreadNameObservation();
+      // The same cache instance must both reserve and spend the sequence. A
+      // federation restart between the two drops the cache, and the rebuilt
+      // one counts from zero — every later refresh would then lose to this
+      // one snapshot's high sequence and peer renames would stop appearing.
+      const remoteThreadSummaries = getDesktopFederationRuntime()
+        .remoteThreadSummaries();
+      const nameObservationSequence =
+        remoteThreadSummaries.reserveThreadNameObservation();
       try {
         const snapshot = await getDesktopFederationRuntime()
           .remoteNavigationSnapshot(
@@ -2152,13 +2157,11 @@ class DesktopAppServerService {
         // snapshot the operator actually asked for: the worst case of losing
         // it is a row that reads as a thread id somewhere else.
         try {
-          getDesktopFederationRuntime()
-            .remoteThreadSummaries()
-            .rememberThreadNames(
-              federationTarget.instanceId,
-              snapshot.threads,
-              nameObservationSequence,
-            );
+          remoteThreadSummaries.rememberThreadNames(
+            federationTarget.instanceId,
+            snapshot.threads,
+            nameObservationSequence,
+          );
         } catch (error) {
           logDebug("rememberRemoteThreadNames failed", {
             error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4481,15 +4481,14 @@ export class MessagingController {
         }
         return "failed";
       }
-      // A Default Agent route that cannot start its turn is the only report we
-      // get that its target is gone. Nothing else says so: `agent` lives in the
-      // thread's overlay row, which outlives the thread, so the pre-flight
-      // check cannot tell a live target from a deleted one, and archival is
-      // announced only for threads this process is around to hear about.
-      // Without this the channel keeps routing every later message to the same
-      // dead thread and failing identically, with no way back to a working
-      // default short of the operator clearing it by hand.
-      await this.revokeDefaultAgentRouteForFailedStart(params.binding);
+      // The durable overlay outlives its provider thread, so a targeted
+      // missing-thread response is the one reliable signal that a Default
+      // Agent assignment is dead. Other start failures are recoverable: a
+      // disconnect, rate limit, or invalid runtime option must not destroy the
+      // operator's persisted route.
+      if (isMissingTurnTargetStartError(error, params.binding)) {
+        await this.revokeDefaultAgentRouteForFailedStart(params.binding);
+      }
       await this.deliver(
         buildErrorIntent({
           id: this.newIntentId("turn-start-failed"),
@@ -21352,6 +21351,26 @@ function truncateText(text: string, limit: number): string {
 function isTurnInProgressStartError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /\b(active turn|turn already|already active|in progress)\b/i.test(message);
+}
+
+function isMissingTurnTargetStartError(
+  error: unknown,
+  binding: MessagingBindingRecord,
+): boolean {
+  const message = (error instanceof Error ? error.message : String(error))
+    .toLowerCase();
+  const threadId = binding.threadId.trim().toLowerCase();
+  if (!threadId || !message.includes(threadId)) {
+    return false;
+  }
+  return (
+    message.includes("thread not found")
+    || message.includes("thread does not exist")
+    || message.includes("thread was deleted")
+    || message.includes("thread has been deleted")
+    || message.includes("deleted thread")
+    || message.includes("unknown thread")
+  );
 }
 
 function isPermanentMessagingTargetFailure(result: MessagingDeliveryResult): boolean {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -301,6 +301,35 @@ const TYPING_ACTIVITY_REFRESH_MS = 10_000;
 // visible message sends. Let them through a little sooner than noisy deltas.
 const TYPING_ACTIVITY_CONTINUATION_REFRESH_MS = 9_000;
 const DEFAULT_INPUT_DEBOUNCE_MS = 500;
+// Upper bound on retained admission stage marks. A turn that is queued behind a
+// busy thread, or that fails before `startTurn`, never reaches the log that
+// consumes its marks, so the ceiling cannot depend on the happy path. Oldest
+// entry is evicted first; each holds at most eight numbers.
+const ADMISSION_STAGE_MARK_LIMIT = 256;
+
+/**
+ * Stage marks for one inbound message's trip from receipt to `startTurn`.
+ *
+ * `pwragentReceivedToStartTurnIssueMs` already measures that whole trip, which
+ * is enough to see that it is slow and not enough to see where. A slow trip is
+ * ambiguous between work this process chooses to do (resolving the route,
+ * preparing the input, reading admission state, enforcing policy) and a wait it
+ * merely schedules (the input debounce). These marks separate them, so one log
+ * line says which stage owns the latency instead of requiring a bisect.
+ *
+ * Marks are keyed by inbound event id, not by the event object: the command and
+ * media paths re-spread the event into a new object, so object identity does
+ * not survive the trip and a `WeakMap` would silently record nothing.
+ */
+type MessagingAdmissionStage =
+  | "handled"
+  | "routed"
+  | "bundleReady"
+  | "inputPrepared"
+  | "admissionStateResolved"
+  | "occupancyResolved"
+  | "originBuilt"
+  | "policyResolved";
 // Upper bound on retained automation start/final delivery-dedup keys. Each entry
 // embeds the full rendered message text and is only consulted while a run's
 // terminal events are in flight; oldest-first eviction reclaims keys for runs
@@ -925,6 +954,10 @@ export class MessagingController {
   private readonly deliveredAutomationStartKeys = new Set<string>();
   private readonly deliveredAutomationFinalKeys = new Set<string>();
   private readonly now: () => number;
+  private readonly admissionStageMarks = new Map<
+    string,
+    Partial<Record<MessagingAdmissionStage, number>>
+  >();
   private readonly pendingIntentTtlMs: number;
   private readonly interactionMapper: MessagingInteractionMapper;
   private readonly activeTurnsByThreadKey = new Map<string, MessagingActiveTurnSummary>();
@@ -1095,6 +1128,7 @@ export class MessagingController {
   }
 
   async handleInboundEvent(event: MessagingInboundEvent): Promise<void> {
+    this.markAdmissionStage(event, "handled");
     if (!this.authorizeInboundAdmission(event)) {
       // In enforcing mode this fires for actors with no permission-granting
       // role (default-deny); record it so operators can see who was inert.
@@ -2578,7 +2612,7 @@ export class MessagingController {
     const text = `/${[event.command.replace(/^\/+/, ""), ...event.args]
       .filter(Boolean)
       .join(" ")}`;
-    await this.turnAdmission.append({
+    await this.admitTurnInput({
       binding,
       event: {
         ...event,
@@ -3389,7 +3423,7 @@ export class MessagingController {
       return;
     }
 
-    await this.turnAdmission.append({ binding, event });
+    await this.admitTurnInput({ binding, event });
   }
 
   private async bootstrapDefaultAgentForAcceptedMessage(
@@ -3479,7 +3513,7 @@ export class MessagingController {
       threadId: selected.assignment.target.threadId,
       toolUpdateMode: selected.assignment.toolUpdateMode,
     });
-    await this.turnAdmission.append({
+    await this.admitTurnInput({
       binding,
       event,
     });
@@ -3628,7 +3662,7 @@ export class MessagingController {
       return;
     }
 
-    await this.turnAdmission.append({ binding, event });
+    await this.admitTurnInput({ binding, event });
   }
 
   private async shouldHandleAmbientSharedMessage(
@@ -3659,9 +3693,96 @@ export class MessagingController {
     return await this.options.responseModeForConversation?.(channel) ?? "every_message";
   }
 
+  /**
+   * The one door into the admission queue, so every route marks the same stage.
+   */
+  private async admitTurnInput(params: {
+    binding: MessagingBindingRecord;
+    event: MessagingTurnInputEvent;
+  }): Promise<void> {
+    this.markAdmissionStage(params.event, "routed");
+    await this.turnAdmission.append(params);
+  }
+
+  /**
+   * Record when this message reached {@link stage}, if it has not already.
+   *
+   * First mark wins: a stage reached twice (an admission state resolved once
+   * per bundle and again per queued release) keeps the earlier time, so a span
+   * never reads as negative.
+   */
+  private markAdmissionStage(
+    event: MessagingInboundEvent | undefined,
+    stage: MessagingAdmissionStage,
+  ): void {
+    if (!event) return;
+    let marks = this.admissionStageMarks.get(event.id);
+    if (!marks) {
+      if (this.admissionStageMarks.size >= ADMISSION_STAGE_MARK_LIMIT) {
+        // Insertion-ordered, so the first key is the oldest.
+        const oldest = this.admissionStageMarks.keys().next();
+        if (!oldest.done) {
+          this.admissionStageMarks.delete(oldest.value);
+        }
+      }
+      marks = {};
+      this.admissionStageMarks.set(event.id, marks);
+    }
+    marks[stage] ??= this.now();
+  }
+
+  /**
+   * Consume this message's marks as span durations for the start-turn log.
+   *
+   * A span is emitted only when both of its ends were reached, so a path that
+   * skips a stage (a queued release, which never prepares input) reports the
+   * stages it did run instead of a misleading zero.
+   *
+   * `routedToBundleReadyMs` covers the input debounce, and for a coalesced
+   * burst it also covers the operator's own typing: the bundle carries its
+   * first event, but flushes {@link DEFAULT_INPUT_DEBOUNCE_MS} after the last.
+   * A large value there is the operator still typing, not PwrAgent stalling.
+   */
+  private takeAdmissionStageTiming(
+    event: MessagingInboundEvent | undefined,
+    startTurnIssuedAt: number,
+  ): Record<string, number> {
+    if (!event) return {};
+    const marks = this.admissionStageMarks.get(event.id);
+    if (!marks) return {};
+    this.admissionStageMarks.delete(event.id);
+    const spans: Array<[string, number | undefined, number | undefined]> = [
+      ["receivedToHandledMs", event.receivedAt, marks.handled],
+      ["handledToRoutedMs", marks.handled, marks.routed],
+      ["routedToBundleReadyMs", marks.routed, marks.bundleReady],
+      ["bundleReadyToInputPreparedMs", marks.bundleReady, marks.inputPrepared],
+      [
+        "inputPreparedToAdmissionStateMs",
+        marks.inputPrepared,
+        marks.admissionStateResolved,
+      ],
+      [
+        "admissionStateToOccupancyMs",
+        marks.admissionStateResolved,
+        marks.occupancyResolved,
+      ],
+      ["occupancyToOriginMs", marks.occupancyResolved, marks.originBuilt],
+      ["originToPolicyMs", marks.originBuilt, marks.policyResolved],
+      ["policyToStartTurnIssueMs", marks.policyResolved, startTurnIssuedAt],
+    ];
+    const timing: Record<string, number> = {};
+    for (const [name, from, to] of spans) {
+      if (from !== undefined && to !== undefined) {
+        timing[name] = to - from;
+      }
+    }
+    return timing;
+  }
+
   private async handleAdmittedTurnBundle(
     bundle: MessagingTurnAdmissionBundle,
   ): Promise<void> {
+    this.markAdmissionStage(bundle.events[0], "bundleReady");
     const currentBinding = bundle.binding.pendingSkillSelection
       ? await this.options.store.getBinding(bundle.binding.id) ?? bundle.binding
       : bundle.binding;
@@ -3669,6 +3790,7 @@ export class MessagingController {
     if (!prepared) {
       return;
     }
+    this.markAdmissionStage(bundle.events[0], "inputPrepared");
     const preparedWithSkill = this.prependPendingSkillSelection(
       prepared,
       currentBinding,
@@ -3686,6 +3808,7 @@ export class MessagingController {
         federationTarget: federationTargetForBinding(consumedSkillBinding),
         threadId: consumedSkillBinding.threadId,
       });
+      this.markAdmissionStage(bundle.events[0], "admissionStateResolved");
     } catch (error) {
       await this.deliver(
         buildErrorIntent({
@@ -3724,6 +3847,7 @@ export class MessagingController {
       return;
     }
 
+    this.markAdmissionStage(bundle.events[0], "occupancyResolved");
     const startResult = await this.startPreparedInput({
       binding: consumedSkillBinding,
       input: preparedWithSkill.input,
@@ -4124,6 +4248,7 @@ export class MessagingController {
           federationTarget: federationTargetForBinding(params.binding),
           threadId: params.binding.threadId,
         });
+      this.markAdmissionStage(params.event, "admissionStateResolved");
       const navigation = params.navigation
         ?? navigationSnapshotForAdmissionState(params.binding, admissionState);
       startingOrigin = await this.buildAgentMessagingOrigin({
@@ -4138,6 +4263,7 @@ export class MessagingController {
           startingOrigin,
         );
       }
+      this.markAdmissionStage(params.event, "originBuilt");
       const turnSettings = turnSettingsForBinding(params.binding, navigation);
       const executionResolution = resolveExecutionModeForBinding(
         params.binding,
@@ -4154,6 +4280,7 @@ export class MessagingController {
         );
         return "failed";
       }
+      this.markAdmissionStage(params.event, "policyResolved");
       // Diagnostic for #203-class regressions: a turn that the UI shows
       // as Default Access but routes to the Full Access codex client is
       // a silent security bug — the user thinks they're sandboxed but
@@ -4179,6 +4306,10 @@ export class MessagingController {
               startTurnIssuedAt - params.event.receivedAt,
           }
         : {};
+      const stageTiming = this.takeAdmissionStageTiming(
+        params.event,
+        startTurnIssuedAt,
+      );
       this.logger.info?.("messaging starting turn", {
         backend: params.binding.backend,
         bindingId: params.binding.id,
@@ -4190,6 +4321,7 @@ export class MessagingController {
         fastMode: turnSettings.fastMode,
         startTurnIssuedAt,
         ...inboundTiming,
+        ...stageTiming,
       });
       const started = await this.options.backend.startTurn({
         backend: params.binding.backend,
@@ -7012,6 +7144,7 @@ export class MessagingController {
     this.unregisterAutomationSourceMessageDeliveryHandler();
     this.unregisterAutomationTargetMessageDeliveryHandler();
     this.turnAdmission.dispose();
+    this.admissionStageMarks.clear();
     for (const timer of this.monitorTimersByBindingId.values()) {
       clearTimeout(timer);
     }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1,3 +1,4 @@
+import { rememberBoundedMap } from "../../bounded-map";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -327,6 +328,7 @@ type MessagingAdmissionStage =
   | "bundleReady"
   | "inputPrepared"
   | "admissionStateResolved"
+  | "queued"
   | "occupancyResolved"
   | "originBuilt"
   | "policyResolved";
@@ -1128,7 +1130,6 @@ export class MessagingController {
   }
 
   async handleInboundEvent(event: MessagingInboundEvent): Promise<void> {
-    this.markAdmissionStage(event, "handled");
     if (!this.authorizeInboundAdmission(event)) {
       // In enforcing mode this fires for actors with no permission-granting
       // role (default-deny); record it so operators can see who was inert.
@@ -1148,6 +1149,11 @@ export class MessagingController {
       );
       return;
     }
+    // Marked past the authorization gate, not at the door. An unauthorized
+    // actor's traffic is not a turn anyone is timing, and marking it would let
+    // a burst of rejected events push the entries this map exists to hold out
+    // of it.
+    this.markAdmissionStage(event, "handled");
 
     // Self-heal: every inbound event carries the freshest ancestry data
     // the adapter knows (parentTitle = supergroup/server, ancestorTitle
@@ -3696,6 +3702,41 @@ export class MessagingController {
   }
 
   /**
+   * Retire a Default Agent assignment whose target could not start a turn.
+   *
+   * Scoped to bindings this controller routed through a Default Agent: an
+   * ordinary bound thread failing to start is a transient the operator can
+   * retry, not evidence that the binding is wrong. A revoked assignment leaves
+   * the channel unbound, so the next message falls through to normal handling
+   * and the operator is told the default was cleared.
+   */
+  private async revokeDefaultAgentRouteForFailedStart(
+    binding: MessagingBindingRecord,
+  ): Promise<void> {
+    if (!isDefaultAgentRouteBinding(binding)) {
+      return;
+    }
+    const revoked = await this.options.store
+      .revokeDefaultAgentAssignmentsForTarget({
+        backend: binding.backend,
+        threadId: binding.threadId,
+        revokedAt: this.now(),
+      })
+      .catch((error: unknown) => {
+        this.logger.debug?.("messaging default agent revoke after failed start failed", {
+          error: error instanceof Error ? error.message : String(error),
+          threadId: binding.threadId,
+        });
+        return [];
+      });
+    // An empty array is still truthy, and a start can fail on a channel whose
+    // assignment was already retired -- announce a change only when one moved.
+    if (revoked.length > 0) {
+      this.notifyBindingChanged("default-agent-cleared");
+    }
+  }
+
+  /**
    * The one door into the admission queue, so every route marks the same stage.
    */
   private async admitTurnInput(params: {
@@ -3720,15 +3761,13 @@ export class MessagingController {
     if (!event) return;
     let marks = this.admissionStageMarks.get(event.id);
     if (!marks) {
-      if (this.admissionStageMarks.size >= ADMISSION_STAGE_MARK_LIMIT) {
-        // Insertion-ordered, so the first key is the oldest.
-        const oldest = this.admissionStageMarks.keys().next();
-        if (!oldest.done) {
-          this.admissionStageMarks.delete(oldest.value);
-        }
-      }
       marks = {};
-      this.admissionStageMarks.set(event.id, marks);
+      rememberBoundedMap(
+        this.admissionStageMarks,
+        event.id,
+        marks,
+        ADMISSION_STAGE_MARK_LIMIT,
+      );
     }
     marks[stage] ??= this.now();
   }
@@ -3768,6 +3807,13 @@ export class MessagingController {
         marks.admissionStateResolved,
         marks.occupancyResolved,
       ],
+      // A turn that waited behind a busy thread reports its wait here instead.
+      // Without these two the wait belonged to no span at all, so the stages
+      // stopped summing to the end-to-end number with nothing saying why -- the
+      // one reading that would send someone hunting for time that was never
+      // lost.
+      ["admissionStateToQueuedMs", marks.admissionStateResolved, marks.queued],
+      ["queuedToOriginMs", marks.queued, marks.originBuilt],
       ["occupancyToOriginMs", marks.occupancyResolved, marks.originBuilt],
       ["originToPolicyMs", marks.originBuilt, marks.policyResolved],
       ["policyToStartTurnIssueMs", marks.policyResolved, startTurnIssuedAt],
@@ -3785,6 +3831,13 @@ export class MessagingController {
     bundle: MessagingTurnAdmissionBundle,
   ): Promise<void> {
     this.markAdmissionStage(bundle.events[0], "bundleReady");
+    // Only the first event of a bundle is carried forward to the start-turn
+    // log, so the others' marks can never be consumed. Dropping them here is
+    // what keeps the ceiling from evicting a turn that is still in flight --
+    // eviction is oldest-first, and the oldest entry is the one still waiting.
+    for (const event of bundle.events.slice(1)) {
+      this.admissionStageMarks.delete(event.id);
+    }
     const currentBinding = bundle.binding.pendingSkillSelection
       ? await this.options.store.getBinding(bundle.binding.id) ?? bundle.binding
       : bundle.binding;
@@ -3834,6 +3887,7 @@ export class MessagingController {
         admissionState,
       )
     ) {
+      this.markAdmissionStage(bundle.events[0], "queued");
       await this.queuePreparedInput({
         binding: consumedSkillBinding,
         event: bundle.events[0],
@@ -4427,6 +4481,15 @@ export class MessagingController {
         }
         return "failed";
       }
+      // A Default Agent route that cannot start its turn is the only report we
+      // get that its target is gone. Nothing else says so: `agent` lives in the
+      // thread's overlay row, which outlives the thread, so the pre-flight
+      // check cannot tell a live target from a deleted one, and archival is
+      // announced only for threads this process is around to hear about.
+      // Without this the channel keeps routing every later message to the same
+      // dead thread and failing identically, with no way back to a working
+      // default short of the operator clearing it by hand.
+      await this.revokeDefaultAgentRouteForFailedStart(params.binding);
       await this.deliver(
         buildErrorIntent({
           id: this.newIntentId("turn-start-failed"),
@@ -20736,20 +20799,6 @@ function rememberBoundedKey(
     const oldest = set.values().next().value;
     if (oldest === undefined) break;
     set.delete(oldest);
-  }
-}
-
-function rememberBoundedMap<Value>(
-  map: Map<string, Value>,
-  key: string,
-  value: Value,
-  maxSize = MAX_DELIVERED_AUTOMATION_KEYS,
-): void {
-  map.set(key, value);
-  while (map.size > maxSize) {
-    const oldest = map.keys().next().value;
-    if (oldest === undefined) break;
-    map.delete(oldest);
   }
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3413,34 +3413,37 @@ export class MessagingController {
       return true;
     }
 
-    let navigation: NavigationSnapshot;
-    try {
-      navigation = await this.options.backend.getNavigationSnapshot({
-        backend: "all",
-      });
-    } catch (error) {
-      await this.deliverDefaultAgentBootstrapError(
-        event,
-        "Default Agent unavailable",
-        error instanceof Error ? error.message : String(error),
-      );
-      return true;
-    }
-
     let selected:
       | {
           assignment: MessagingDefaultAgentAssignmentRecord;
-          thread: NavigationThreadSummary;
         }
       | undefined;
     const backendSummaries = await this.loadDefaultAgentBackendSummaries();
+    // One listing at most, and only if a target turns out to be unknown to
+    // this process. Shared across assignments so a channel with several does
+    // not pay for it more than once.
+    let navigationForColdTargets: Promise<NavigationSnapshot> | undefined;
+    const listThreadsOnce = () => {
+      navigationForColdTargets ??= this.options.backend.getNavigationSnapshot({
+        backend: "all",
+      });
+      return navigationForColdTargets;
+    };
     for (const assignment of assignments) {
-      const thread = navigation.threads.find(
-        (candidate) =>
-          candidate.source === assignment.target.backend
-          && candidate.id === assignment.target.threadId
-          && Boolean(candidate.agent),
-      );
+      let thread: boolean;
+      try {
+        thread = await this.defaultAgentTargetIsAgentThread(
+          assignment.target,
+          listThreadsOnce,
+        );
+      } catch (error) {
+        await this.deliverDefaultAgentBootstrapError(
+          event,
+          "Default Agent unavailable",
+          error instanceof Error ? error.message : String(error),
+        );
+        return true;
+      }
       const backendSupport = defaultAgentBackendSupport(
         assignment.target.backend,
         backendSummaries,
@@ -3450,7 +3453,7 @@ export class MessagingController {
         && thread
         && backendSupport === "supported"
       ) {
-        selected = { assignment, thread };
+        selected = { assignment };
         break;
       }
       if (thread && backendSupport === "unknown") {
@@ -3481,6 +3484,48 @@ export class MessagingController {
       event,
     });
     return true;
+  }
+
+  /**
+   * Does this assignment still point at an agent thread?
+   *
+   * Answered from what this process already knows — the thread's overlay row
+   * and its remembered summary — because that is the whole question. Deciding
+   * to start or queue a turn needs the target's identity, existence, settings
+   * and occupancy; it does not need Git state, pull-request status, launchpads
+   * or the rest of the fleet.
+   *
+   * This used to call `getNavigationSnapshot({ backend: "all" })` on every
+   * accepted message, which enumerates every thread on every backend and then
+   * hydrates overlays, canonicalizes pull requests, probes Git working state,
+   * refreshes directory status and hydrates launchpads — all to look up one
+   * thread whose id the assignment already carries. Opening the same thread in
+   * the app does none of that.
+   *
+   * The listing survives as a cold-path fallback only. An assignment is
+   * revoked when its target is gone, and a process that has simply never seen
+   * the thread must not be mistaken for one whose thread was deleted.
+   */
+  private async defaultAgentTargetIsAgentThread(
+    target: MessagingDefaultAgentAssignmentRecord["target"],
+    listThreadsOnce: () => Promise<NavigationSnapshot>,
+  ): Promise<boolean> {
+    const admission = await this.options.backend.getThreadAdmissionState({
+      backend: target.backend,
+      threadId: target.threadId,
+    });
+    if (admission.thread) {
+      // Both this row and a navigation row read `agent` from the same overlay
+      // record, so the targeted answer is the answer the listing would give.
+      return Boolean(admission.thread.agent);
+    }
+    const navigation = await listThreadsOnce();
+    return navigation.threads.some(
+      (candidate) =>
+        candidate.source === target.backend
+        && candidate.id === target.threadId
+        && Boolean(candidate.agent),
+    );
   }
 
   private async deliverDefaultAgentBootstrapError(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3453,23 +3453,18 @@ export class MessagingController {
         }
       | undefined;
     const backendSummaries = await this.loadDefaultAgentBackendSummaries();
-    // One listing at most, and only if a target turns out to be unknown to
-    // this process. Shared across assignments so a channel with several does
-    // not pay for it more than once.
-    let navigationForColdTargets: Promise<NavigationSnapshot> | undefined;
-    const listThreadsOnce = () => {
-      navigationForColdTargets ??= this.options.backend.getNavigationSnapshot({
-        backend: "all",
-      });
-      return navigationForColdTargets;
-    };
+    // Revocations are buffered, not applied as they are decided. Every
+    // iteration reads backend state that can fail, and a failure part-way
+    // through used to leave the channel half-revoked: the assignments already
+    // rejected were gone, the ones not yet examined survived, and the operator
+    // saw only "Default Agent unavailable". Deciding first and writing after
+    // makes the pass all-or-nothing.
+    const revocations: MessagingDefaultAgentAssignmentRecord[] = [];
     for (const assignment of assignments) {
-      let thread: boolean;
+      let targetIsAgentThread: boolean;
       try {
-        thread = await this.defaultAgentTargetIsAgentThread(
-          assignment.target,
-          listThreadsOnce,
-        );
+        targetIsAgentThread =
+          await this.defaultAgentTargetIsAgentThread(assignment.target);
       } catch (error) {
         await this.deliverDefaultAgentBootstrapError(
           event,
@@ -3484,13 +3479,13 @@ export class MessagingController {
       );
       if (
         assignment.target.kind === "agent"
-        && thread
+        && targetIsAgentThread
         && backendSupport === "supported"
       ) {
         selected = { assignment };
         break;
       }
-      if (thread && backendSupport === "unknown") {
+      if (targetIsAgentThread && backendSupport === "unknown") {
         await this.deliverDefaultAgentBootstrapError(
           event,
           "Default Agent unavailable",
@@ -3498,6 +3493,9 @@ export class MessagingController {
         );
         return true;
       }
+      revocations.push(assignment);
+    }
+    for (const assignment of revocations) {
       await this.options.store.revokeDefaultAgentAssignment({
         assignmentId: assignment.id,
         revokedAt: this.now(),
@@ -3523,43 +3521,47 @@ export class MessagingController {
   /**
    * Does this assignment still point at an agent thread?
    *
-   * Answered from what this process already knows — the thread's overlay row
-   * and its remembered summary — because that is the whole question. Deciding
-   * to start or queue a turn needs the target's identity, existence, settings
-   * and occupancy; it does not need Git state, pull-request status, launchpads
-   * or the rest of the fleet.
+   * Answered from what this process already knows about the one thread whose
+   * id the assignment carries. Deciding to start or queue a turn needs the
+   * target's identity, settings and occupancy; it does not need Git state,
+   * pull-request status, launchpads or the rest of the fleet.
    *
    * This used to call `getNavigationSnapshot({ backend: "all" })` on every
    * accepted message, which enumerates every thread on every backend and then
    * hydrates overlays, canonicalizes pull requests, probes Git working state,
-   * refreshes directory status and hydrates launchpads — all to look up one
-   * thread whose id the assignment already carries. Opening the same thread in
-   * the app does none of that.
+   * refreshes directory status and hydrates launchpads — all to answer one
+   * yes-or-no question about one thread. Opening the same thread in the app
+   * does none of that.
    *
-   * The listing survives as a cold-path fallback only. An assignment is
-   * revoked when its target is gone, and a process that has simply never seen
-   * the thread must not be mistaken for one whose thread was deleted.
+   * ## What the listing proved, and what replaces it
+   *
+   * The listing proved two things at once: the thread still has an agent, and
+   * the provider still serves it. Only the first survives here, and the
+   * difference is deliberate rather than overlooked.
+   *
+   * `agent` is desktop-owned state that lives in the thread's overlay row, and
+   * a navigation row reads it from that same row — so the targeted answer and
+   * the listing's answer are the same answer.
+   *
+   * Existence is the one this cannot prove. `admission.thread` is built from
+   * the overlay when no listing row is remembered, and nothing deletes an
+   * overlay, so an agent thread deleted at the provider still presents a row
+   * here. Proving otherwise costs a provider round trip on every accepted
+   * message, and the two ways a target legitimately goes away are already
+   * covered more cheaply: archival revokes these assignments from the
+   * `thread/archived` handler, and a thread this machine has no record of at
+   * all fails the check below. What remains — an out-of-band deletion whose
+   * overlay outlives it — surfaces as a failed `startTurn` with a recoverable
+   * error rather than as a fleet walk charged to every message.
    */
   private async defaultAgentTargetIsAgentThread(
     target: MessagingDefaultAgentAssignmentRecord["target"],
-    listThreadsOnce: () => Promise<NavigationSnapshot>,
   ): Promise<boolean> {
     const admission = await this.options.backend.getThreadAdmissionState({
       backend: target.backend,
       threadId: target.threadId,
     });
-    if (admission.thread) {
-      // Both this row and a navigation row read `agent` from the same overlay
-      // record, so the targeted answer is the answer the listing would give.
-      return Boolean(admission.thread.agent);
-    }
-    const navigation = await listThreadsOnce();
-    return navigation.threads.some(
-      (candidate) =>
-        candidate.source === target.backend
-        && candidate.id === target.threadId
-        && Boolean(candidate.agent),
-    );
+    return Boolean(admission.thread?.agent);
   }
 
   private async deliverDefaultAgentBootstrapError(

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -98,7 +98,7 @@ export type QuitManagerDependencies = {
   performQuit: () => void;
 };
 
-/** Titles are a nicety; quitting must not hang on a slow app-server. */
+/** Titles are a nicety; quitting must not hang on optional cache/store reads. */
 const QUIT_TITLE_RESOLVE_TIMEOUT_MS = 1_500;
 
 export type QuitManager = {
@@ -394,8 +394,9 @@ export function formatAutomationRunStart(startedAt: number): string {
 
 /**
  * Attach thread titles to the blocker rows, bounded by a timeout: a hung
- * app-server must not be able to wedge shutdown. On timeout or failure the rows
- * keep their thread ids, which still link correctly — they just read worse.
+ * optional title source must not be able to wedge shutdown. On timeout or
+ * failure the rows keep their thread ids, which still link correctly — they
+ * just read worse.
  */
 async function withResolvedTitles(
   items: QuitBlockerItem[],
@@ -454,15 +455,11 @@ type QuitBlockerThreadTitle = {
 };
 
 export type QuitBlockerTitleResolverDependencies = {
-  /** Threads owned by THIS instance. */
-  listLocalThreads: () => Promise<
-    ReadonlyArray<{
-      source: AppServerBackendKind;
-      id: string;
-      title?: string;
-      titleSource?: AppServerThreadTitleSource;
-    }>
-  >;
+  /** Already-observed display metadata for a thread owned by THIS instance. */
+  cachedLocalThreadName: (params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }) => QuitBlockerThreadTitle | undefined;
   /**
    * What a peer calls one of its threads, out of names ALREADY seen locally.
    * Synchronous by contract: this must not become a peer round trip.
@@ -480,11 +477,9 @@ export type QuitBlockerTitleResolverDependencies = {
  * Name every blocker row from what this machine already knows, including what
  * it knows about its peers.
  *
- * This is tier-2 resolution — local plus *cached* remote. The old lookup was
- * tier 1: it asked this instance's thread list, which cannot answer for a
- * peer's thread, so the row fell back to the thread id and the operator was
- * asked to decide about a uuid while their sidebar showed that same thread by
- * name.
+ * This is cache-only local plus cache-only remote resolution. The old lookup
+ * asked this instance's full thread list, which both delayed quit and could
+ * not answer for a peer's thread.
  *
  * Reaching the peer (tier 3) is deliberately NOT done here. A remote thread
  * is a quit blocker because a window on this machine has its terminal open,
@@ -516,17 +511,22 @@ export async function resolveQuitBlockerThreadTitles(
     item.target ? [{ item, target: item.target }] : [],
   );
 
-  const resolveLocal = async (): Promise<void> => {
+  const resolveLocal = (): void => {
     if (localItems.length === 0) return;
-    const threads = await dependencies.listLocalThreads();
-    const byThreadKey = new Map(
-      threads.map((thread) => [
-        buildThreadIdentityKey(thread.source, thread.id),
-        thread,
-      ]),
-    );
     for (const item of localItems) {
-      record(titles, item, byThreadKey.get(item.threadKey));
+      try {
+        record(
+          titles,
+          item,
+          dependencies.cachedLocalThreadName({
+            backend: item.backend as AppServerBackendKind,
+            threadId: item.threadId,
+          }),
+        );
+      } catch {
+        // One unavailable cache entry must not prevent the remaining rows from
+        // resolving or delay the quit decision.
+      }
     }
   };
 
@@ -572,7 +572,7 @@ export async function resolveQuitBlockerThreadTitles(
   };
 
   await Promise.all([
-    resolveLocal().catch(() => undefined),
+    Promise.resolve().then(resolveLocal).catch(() => undefined),
     resolveRemote().catch(() => undefined),
   ]);
   return titles;
@@ -617,10 +617,8 @@ async function resolveCurrentQuitBlockerTitles(
   items: QuitBlockerItem[],
 ): Promise<Map<string, string>> {
   return await resolveQuitBlockerThreadTitles(items, {
-    listLocalThreads: async () =>
-      await getDesktopBackendRegistry().listThreads({
-        callerReason: "quit-confirmation",
-      }),
+    cachedLocalThreadName: (params) =>
+      getDesktopBackendRegistry().getCachedThreadDisplayMetadata(params),
     cachedRemoteThreadName: (params) =>
       getDesktopFederationRuntime()
         .remoteThreadSummaries()

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -571,10 +571,11 @@ export async function resolveQuitBlockerThreadTitles(
     });
   };
 
-  await Promise.all([
-    Promise.resolve().then(resolveLocal).catch(() => undefined),
-    resolveRemote().catch(() => undefined),
-  ]);
+  // `resolveLocal` is synchronous and swallows its own failures per row, so
+  // there is nothing here to await or to catch. The two write disjoint keys --
+  // local rows carry no `target`, and the key includes it -- so order is free.
+  resolveLocal();
+  await resolveRemote().catch(() => undefined);
   return titles;
 }
 

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -618,7 +618,7 @@ async function resolveCurrentQuitBlockerTitles(
 ): Promise<Map<string, string>> {
   return await resolveQuitBlockerThreadTitles(items, {
     cachedLocalThreadName: (params) =>
-      getDesktopBackendRegistry().getCachedThreadDisplayMetadata(params),
+      getDesktopBackendRegistry().getThreadInfo(params),
     cachedRemoteThreadName: (params) =>
       getDesktopFederationRuntime()
         .remoteThreadSummaries()

--- a/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
@@ -20,6 +20,27 @@ const GROUPS: ReadonlyArray<{
   { kind: "action", heading: "Environment actions" },
 ];
 
+function retainKnownTitles(
+  current: QuitBlockerQueueSnapshot | undefined,
+  next: QuitBlockerQueueSnapshot,
+): QuitBlockerQueueSnapshot {
+  if (!current) return next;
+  const titlesByItemKey = new Map(
+    current.items.flatMap((item) => {
+      const title = item.title?.trim();
+      return title ? [[quitBlockerItemKey(item), title] as const] : [];
+    }),
+  );
+  return {
+    ...next,
+    items: next.items.map((item) => {
+      if (item.title?.trim()) return item;
+      const title = titlesByItemKey.get(quitBlockerItemKey(item));
+      return title ? { ...item, title } : item;
+    }),
+  };
+}
+
 type QuitBlockerQueueApi = Pick<
   DesktopApi,
   | "copyText"
@@ -52,7 +73,10 @@ export function QuitBlockerQueueToast(props: {
       try {
         const nextSnapshot = await readQuitBlockerQueue();
         if (!disposed) {
-          setSnapshot(nextSnapshot);
+          // Blocker membership is authoritative, but title resolution is
+          // best-effort and bounded. Do not downgrade a known label when one
+          // refresh times out and omits only that optional presentation data.
+          setSnapshot((current) => retainKnownTitles(current, nextSnapshot));
         }
       } catch {
         // Keep the last authoritative snapshot visible. The next interval can

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
@@ -22,6 +22,55 @@ function snapshot(
 }
 
 describe("QuitBlockerQueueToast", () => {
+  it("keeps a known title when a refresh temporarily omits it", async () => {
+    vi.useFakeTimers();
+    let showQueue!: (snapshot: QuitBlockerQueueSnapshot) => void;
+    const titled = snapshot([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "01a05891-bfb8-7bc0-affd-97354d0080b1",
+        threadKey: "codex:01a05891-bfb8-7bc0-affd-97354d0080b1",
+        title: "Investigate compaction cost",
+      },
+    ]);
+    const unresolved = snapshot([
+      {
+        kind: "turn",
+        backend: "codex",
+        threadId: "01a05891-bfb8-7bc0-affd-97354d0080b1",
+        threadKey: "codex:01a05891-bfb8-7bc0-affd-97354d0080b1",
+      },
+    ]);
+    const readQuitBlockerQueue = vi.fn(async () => unresolved);
+
+    render(
+      <QuitBlockerQueueToast
+        desktopApi={{
+          onShowQuitBlockersRequested: (callback) => {
+            showQueue = callback;
+            return () => undefined;
+          },
+          readQuitBlockerQueue,
+          revealQuitBlocker: vi.fn(async () => ({ revealed: true })),
+        }}
+      />,
+    );
+
+    act(() => showQueue(titled));
+    expect(screen.getByText("Investigate compaction cost")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(readQuitBlockerQueue).toHaveBeenCalled();
+    expect(screen.getByText("Investigate compaction cost")).toBeInTheDocument();
+    expect(
+      screen.queryByText("01a05891-bfb8-7bc0-affd-97354d0080b1"),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the live queue reachable while authoritative refreshes remove resolved work", async () => {
     vi.useFakeTimers();
     let showQueue!: (snapshot: QuitBlockerQueueSnapshot) => void;

--- a/docs/plans/2026-08-31-quit-blocker-title-read-model.md
+++ b/docs/plans/2026-08-31-quit-blocker-title-read-model.md
@@ -220,6 +220,7 @@ Current recorded budget:
 | Six concurrent callers asking for the same unenriched listing | 1 | 0 |
 | Eight terminal notifications across two never-listed threads | 1 | 0 |
 | One navigation refresh over a single worktree-backed thread | 1 | 1 |
+| Messaging admission after an unrelated mutation emptied the cache | 0 | 0 |
 
 The three nonzero rows are the shape the design intends: a thread nobody has
 ever listed costs exactly one listing however many callers ask at once, and
@@ -240,18 +241,45 @@ The budget is enforced with deterministic call-count assertions, not elapsed
 time. The enrichment counter is exercised with worktree-shaped fixtures so it
 provably can move — a budget that cannot move proves nothing.
 
-## Compatibility With PR #1896
+## Relationship To PR #1896
 
-PR #1896's `getCachedThreadSummary()` serves targeted messaging admission and
-is broader than a title read. Its current cache scan does not cover names
-observed from lifecycle/name notifications.
+PR #1896 merged first. It made the same class of fix for messaging admission:
+`resolveThread` used to call `listThreads({ callerReason: "thread-id-lookup",
+forceRefresh: true })` unconditionally, and #1896 put a cached read in front of
+it — `getCachedThreadSummary`, which scans the thread-list cache.
 
-This change does not cherry-pick or duplicate PR #1896's messaging work. On a
-later rebase, `getCachedThreadSummary()` can retain its admission contract and
-thread-list cache scan; where it needs a display title, it can read the store.
-Quit continues to call `getThreadInfo` and never treats title-only knowledge as
-a complete navigation/admission summary. Keeping the responsibilities separate makes the
-backend-registry overlap mechanical rather than architectural.
+That covers the warm case, and measurably so: ten admissions across ten turn
+boundaries cost zero provider listings, because `turn/started` does not empty
+the cache. The gap is the cold one. The thread-list cache *is* emptied by
+mutations, and after an unrelated `archiveThread` on a different thread:
+
+| Read | Result |
+|---|---|
+| `getCachedThreadSummary` (cache scan) | nothing |
+| `ThreadInfoStore.getSummary` | the summary, intact |
+| `resolveThread` | 1 forced full paged provider `thread/list` |
+
+So admission for a thread this window listed minutes ago paid a full listing
+because something unrelated invalidated the cache in between. This is the
+"later rebase" note the earlier draft left open, and it is now done:
+`getCachedThreadSummary` scans the cache first — warm, that is the freshest
+listing — and falls through to `ThreadInfoStore.findLocalSummary`.
+
+`findLocalSummary` exists because admission does not always know which backend
+owns the thread an inbound message names. With a backend it is a direct
+lookup; without one it scans, the way the previous thread-list walk did, but
+over one entry per thread rather than every row of every cached query.
+Instance-qualified entries are skipped: those belong to peers, and a caller
+that did not name an instance is not asking about a peer's thread.
+
+One case the store deliberately does **not** answer: a thread known only from a
+lifecycle notification, never from a listing, still costs one listing on
+admission. The store holds its title but not a summary, and a title is not a
+summary. Serving a synthesized row there would be guessing.
+
+The two contracts stay separate. `getCachedThreadSummary` keeps its admission
+contract; quit keeps calling `getThreadInfo` and never treats title-only
+knowledge as a complete navigation/admission summary.
 
 ## Test Matrix
 
@@ -275,6 +303,7 @@ backend-registry overlap mechanical rather than architectural.
 | Remote ordering | A peer snapshot that started earlier but finished later cannot revert a newer name; a rename recorded afterwards still wins. |
 | Remote isolation | Two peers reusing one thread id keep separate names, and unmounting one peer drops only that peer's names. |
 | Reservation ordering at the IPC seam | The navigation-snapshot handler reserves its observation sequence strictly before the peer round trip begins. |
+| Messaging admission after invalidation | An unrelated `archiveThread` empties the list cache; admission for an untouched thread costs zero provider listings, and a backend-less lookup still resolves. |
 
 Every test in the last four rows was falsified before being kept: the fix was
 reverted, the test was watched to fail, and the fix restored. A test that

--- a/docs/plans/2026-08-31-quit-blocker-title-read-model.md
+++ b/docs/plans/2026-08-31-quit-blocker-title-read-model.md
@@ -1,0 +1,151 @@
+# Quit Blocker Title Read Model
+
+## Decision
+
+Quit blocker membership remains owned by the live runtime registries. Quit
+blocker display titles come from a separate, process-local projection of
+thread metadata that has already been observed. Building or polling the quit
+queue never starts or awaits a provider thread-list request, a peer request,
+or directory/Git enrichment.
+
+This is a scoped correction to the existing quit path. It does not change
+thread-list ownership, navigation refresh policy, lifecycle membership, or
+quit confirmation behavior.
+
+## Invariants
+
+- Runtime blocker membership and counts are authoritative on every snapshot.
+- A blocker that resolves disappears on the next snapshot, even when its
+  display title remains cached.
+- An observed nonempty, non-fallback title is retained until a newer nonempty,
+  non-fallback observation replaces it.
+- Absence, a rejected read, an unavailable provider, and a fallback title are
+  not title-deletion events.
+- Ordinary active turns and sub-agent-owned turns use the same title lookup.
+- Quit title lookup is synchronous for local threads and cache-only for remote
+  threads. Persisted remote pins remain a local fallback; quit never contacts
+  a peer to learn a label.
+- PR #1903's renderer-side monotonic retention remains in place as a second
+  presentation-layer defense. It does not own membership.
+
+## Data Ownership and Identity
+
+`DesktopBackendRegistry` owns a volatile display-metadata projection for
+threads owned by this process. Each entry contains the latest accepted title,
+its title source, and a monotonic observation sequence. Entries are keyed by
+`buildThreadIdentityKey(backend, threadId)`; backend is therefore part of the
+identity even when two providers reuse the same thread id.
+
+Mounted remote titles remain owned by the federation runtime's already-seen
+thread summaries, with persisted remote pins as a local fallback. The quit
+resolver keys those results with
+`instanceId::buildThreadIdentityKey(backend, threadId)`. A local thread and a
+remote thread, or two remote instances, cannot share a title entry merely
+because backend and thread id collide.
+
+No new persistent state is introduced. Live blockers and the local title
+projection are process-local, so there are no new SQLite writes or write
+budgets.
+
+## Freshness Semantics
+
+The registry allocates observation sequences from a monotonic counter; it does
+not use wall-clock time.
+
+- A lifecycle/name notification receives a sequence when the notification is
+  processed.
+- A provider thread-list miss reserves its sequence before the asynchronous
+  list begins. The resulting rows retain that sequence when they complete.
+- A cache hit does not create a new observation.
+- A title is accepted only when its sequence is at least as new as the entry's
+  sequence and its trimmed value is nonempty and not marked `fallback`.
+
+Reserving a list's sequence before awaiting is the critical ordering rule. If
+an old list starts, a rename notification arrives, and the old list completes
+later, the rename has the higher sequence and the stale completion cannot
+erase or replace it. A list started after the rename is a newer observation
+and may reconcile the title.
+
+Unknown metadata is explicit: when no usable title has ever been observed, the
+projection returns no title and the existing UI falls back to the thread id.
+It never guesses from another backend or instance.
+
+## Read Path
+
+The registry exposes a narrow synchronous cached-display-metadata read. Quit
+snapshot creation uses it for every active-turn owner after sub-agent ownership
+has been collapsed. The quit title resolver uses the same read for local
+terminal rows. It no longer calls `listThreads({ callerReason:
+"quit-confirmation" })`.
+
+Remote terminal rows continue to consult only already-observed federation
+summaries and local pinned summaries. Automation rows keep their automation
+name, and environment-action rows keep their action name, so neither requires
+thread enrichment.
+
+## Failure Semantics
+
+- Slow, hanging, rejected, or unavailable provider lists cannot delay quit or
+  a live-queue poll because quit never invokes them.
+- A failed optional remote-pin read yields no title and preserves the stable
+  thread-id fallback.
+- The existing bounded title-resolution wrapper remains a final degradation
+  boundary for optional asynchronous local-store work; failure changes labels,
+  never membership, routing, or the Quit/Wait/Stay Open decision.
+- Cache invalidation removes list reuse, not the last observed display title.
+  A later valid observation can still supersede it.
+
+## Performance Budget
+
+For quit snapshot construction and repeated live-queue polls:
+
+- full provider thread-list refreshes: **0**
+- directory/Git enrichment calls for labels: **0**
+- peer/network title requests: **0**
+- SQLite writes: **0**
+
+Local title work is O(number of blockers) map lookup. An unresolved remote
+batch may perform one existing read of persisted remote pins; it performs no
+write.
+
+The budget is enforced with deterministic call-count assertions, not elapsed
+time.
+
+## Compatibility With PR #1896
+
+PR #1896's `getCachedThreadSummary()` serves targeted messaging admission and
+is broader than the title-only projection. Its current cache scan does not
+cover names observed from lifecycle/name notifications.
+
+This change does not cherry-pick or duplicate PR #1896's messaging work. On a
+later rebase, `getCachedThreadSummary()` can retain its admission contract and
+thread-list cache scan; where it needs a display title, it can merge the narrow
+projection into the cached summary. Quit continues to call the narrow
+display-metadata read and never treats title-only knowledge as a complete
+navigation/admission summary. Keeping the responsibilities separate makes the
+backend-registry overlap mechanical rather than architectural.
+
+## Test Matrix
+
+| Contract | Focused coverage |
+|---|---|
+| Ordinary local active turn is named | Seed an already-observed non-fallback title, start/observe a normal turn, and assert the first synchronous quit snapshot carries it. |
+| Sub-agent ownership remains named | Preserve the existing owner-collapse case and verify it reads the same projection. |
+| Rename wins | Observe an initial title, then a nonempty explicit rename, and assert subsequent snapshots use the rename. |
+| Missing/fallback cannot downgrade | Feed empty/fallback observations after a known title and assert the title remains. With no prior title, assert the stable thread-id fallback. |
+| Late old list cannot erase | Start a delayed list, observe a newer rename and active turn, release the old list, and assert the rename remains after completion and invalidation. |
+| Provider failure does not affect first snapshot | Exercise hanging/rejected/unavailable list conditions and prove snapshot creation neither calls nor awaits provider listing. |
+| Polling performance budget | Build the snapshot repeatedly and drive repeated queue reads; assert zero provider `listThreads` and zero directory-enrichment calls. |
+| Membership stays authoritative | Complete/remove blockers and assert they disappear immediately and the empty snapshot is reachable. |
+| Qualified local identities | Reuse a thread id across two backends and assert titles do not cross. |
+| Qualified remote identities | Reuse backend/thread id locally and on multiple mounted instances and assert only the owning instance's cached title is selected. |
+| Other blocker kinds | Preserve focused snapshot/resolver coverage for integrated terminals, environment actions, and automations. |
+| Renderer defense | Keep PR #1903 component tests proving absent titles cannot erase known titles, renames win, removals/counts remain authoritative, and empty state renders. |
+| Quit decisions | Preserve existing main-process tests for Quit, Wait/countdown, and Stay Open. |
+
+No new desktop E2E is planned because this change introduces no renderer,
+dialog, IPC-shape, or interaction contract. The main-process unit tests can
+deterministically prove the provider-call budget and freshness ordering, while
+PR #1903's component tests already exercise the live-poll presentation seam.
+Adding a headed replay would duplicate those contracts without exposing a new
+failure mode.

--- a/docs/plans/2026-08-31-quit-blocker-title-read-model.md
+++ b/docs/plans/2026-08-31-quit-blocker-title-read-model.md
@@ -1,16 +1,51 @@
-# Quit Blocker Title Read Model
+# Thread Information Store
+
+Originally scoped as "Quit Blocker Title Read Model". The quit card's blinking
+titles were the symptom that was easiest to see; the cause was that this
+product had no place to keep what it knows about a thread. The scope below is
+the whole read model, and the quit path is one of its callers.
 
 ## Decision
 
-Quit blocker membership remains owned by the live runtime registries. Quit
-blocker display titles come from a separate, process-local projection of
-thread metadata that has already been observed. Building or polling the quit
-queue never starts or awaits a provider thread-list request, a peer request,
-or directory/Git enrichment.
+Thread *information* — what a thread is called, what project it belongs to,
+whether it is archived — is held in a store of its own, separate from every
+cache that answers a query. `ThreadInfoStore` (`app-server/thread-info-store.ts`)
+is that store. Callers that need a fact about one known thread read it
+synchronously; callers that need to know which threads match a question keep
+using the list caches, which stay free to be discarded.
 
-This is a scoped correction to the existing quit path. It does not change
-thread-list ownership, navigation refresh policy, lifecycle membership, or
-quit confirmation behavior.
+Quit blocker membership remains owned by the live runtime registries. Quit
+blocker display titles come from the store. Building or polling the quit queue
+never starts or awaits a provider thread-list request, a peer request, or
+directory/Git enrichment.
+
+### Why a second structure rather than a better cache
+
+A query cache answers *"which threads match Q, in what order"*. That answer
+expires: a new turn, a rename, or an archive can change it, so throwing it away
+on mutation is correct.
+
+An information store answers *"what is thread X called"*. That answer does not
+expire the same way. A rename supersedes it; nothing else does. Discarding it
+is never right, because the alternative to a slightly stale name is not a
+fresher name — it is a raw UUID on screen.
+
+The defect was that one structure was being asked both questions. Four
+consequences followed, each of which the store removes:
+
+1. **Invalidation was amnesia.** Roughly forty-six call sites clear the list
+   cache. Every one of them was also erasing the only record of what threads
+   were called.
+2. **Point queries were answered by full-collection walks.** Sixteen sites
+   wanted one row and rebuilt every row to get it. The measured case:
+   `turn/started` invalidated the cache, and `active-turn-branch-adoption` then
+   drove a complete paged provider `thread/list` to read a single field — one
+   full listing per turn boundary.
+3. **Query-shaped keys fragmented identical reads.** Six concurrent callers
+   asking the same question produced more than one provider call.
+4. **Absence was conflated with unknown.** `title: undefined` meant both "this
+   thread has no title" and "we knew the title and this particular lookup did
+   not return it", so the second case overwrote the first.
 
 ## Invariants
 
@@ -27,25 +62,56 @@ quit confirmation behavior.
   a peer to learn a label.
 - PR #1903's renderer-side monotonic retention remains in place as a second
   presentation-layer defense. It does not own membership.
+- Invalidating a query cache never removes thread information. Only the thread
+  or the peer going away does.
+- A read-only caller never drives a provider round trip to learn a fact the
+  store already holds.
+- Two threads that share a backend and id, on different instances, never share
+  an entry.
 
 ## Data Ownership and Identity
 
-`DesktopBackendRegistry` owns a volatile display-metadata projection for
-threads owned by this process. Each entry contains the latest accepted title,
-its title source, and a monotonic observation sequence. Entries are keyed by
-`buildThreadIdentityKey(backend, threadId)`; backend is therefore part of the
-identity even when two providers reuse the same thread id.
+`ThreadInfoStore` holds one entry per thread, and each *field* in that entry
+carries its own observation sequence and source. Fields are graded
+independently because observations are partial: a lifecycle notification
+teaches a title and nothing else, a listing row teaches a project label, and
+neither should have to arrive with the other to be believed.
 
-Mounted remote titles remain owned by the federation runtime's already-seen
-thread summaries, with persisted remote pins as a local fallback. The quit
-resolver keys those results with
-`instanceId::buildThreadIdentityKey(backend, threadId)`. A local thread and a
-remote thread, or two remote instances, cannot share a title entry merely
-because backend and thread id collide.
+Tracked fields are `title`, `titleSource`, `projectLabel`, `archived`, and
+`updatedAt`. Sources are `lifecycle-notification`, `local-rename`,
+`provider-list`, `remote-navigation`, and `remote-pin`.
 
-No new persistent state is introduced. Live blockers and the local title
-projection are process-local, so there are no new SQLite writes or write
-budgets.
+Identity is `instanceId::backend:threadId`, with the instance segment omitted
+for local threads. Backend is part of the key even when two providers reuse a
+thread id, and instance is part of it because thread ids are only unique within
+the instance that minted them. A local thread and two peers' threads numbered
+alike cannot answer for each other.
+
+`DesktopBackendRegistry` owns one store for locally-owned threads.
+`RemoteThreadSummaryCache` owns a second for threads owned by peers, keyed by
+instance; `forgetInstanceThreadNames` drops a peer's names when it unmounts and
+can no longer be asked. Persisted remote pins remain a local fallback. Quit
+never contacts a peer to learn a label.
+
+No new persistent state is introduced. Both stores are process-local, so there
+are no new SQLite writes or write budgets.
+
+### Merging rule: positive facts only
+
+An observation states what it saw. It does not state what it did not see.
+
+- An omitted field is not a deletion.
+- An empty or whitespace title is not news.
+- A `fallback` title source means the title *is* the thread id; recording it
+  would overwrite a real name with nothing.
+- Title and title source are validated together, so a `fallback` source cannot
+  arrive without its title and downgrade a name already held.
+- Re-observing the same value at a newer sequence advances the sequence without
+  reporting a change, so a confirmation does not read as an edit.
+
+`forget` and `forgetInstance` are the only ways an entry leaves the store, and
+both are driven by the thread or the peer actually going away — never by cache
+invalidation.
 
 ## Freshness Semantics
 
@@ -67,16 +133,51 @@ erase or replace it. A list started after the rename is a newer observation
 and may reconcile the title.
 
 Unknown metadata is explicit: when no usable title has ever been observed, the
-projection returns no title and the existing UI falls back to the thread id.
-It never guesses from another backend or instance.
+store returns no title and the existing UI falls back to the thread id. It
+never guesses from another backend or instance.
+
+### Callers declare the freshness they need
+
+`findThreadForWorkspaceHandoff` takes a `freshness` argument, and the caller
+answers one question: *am I about to act on this, or only display it?*
+
+- `"provider"` (the default) keeps the existing behavior — consult the
+  provider, because the caller is about to mutate something and a stale answer
+  would be acted upon.
+- `"last-known"` answers from the store when it has the thread, and falls
+  through to a provider read only when it does not.
+
+Four read-only callers now pass `"last-known"`: `transcript-image-roots`,
+`branch-drift`, `active-turn-branch-adoption`, and `turn-cwd`. This is where
+the largest measured win came from. `turn/started` invalidates the list cache,
+so `active-turn-branch-adoption` was rebuilding the entire thread list on every
+turn boundary to read one row from it.
+
+Because a listing row that has not been enriched can lack `worktreePath`,
+`getSummary` accepts `requireEnriched`. A caller whose reason implies directory
+enrichment declines an unenriched cached row rather than answering with a field
+it knows may be missing. The store grades what it holds; it does not pretend an
+unenriched row is an enriched one.
+
+### Archival is an observation, not a refetch
+
+`thread/archived` and `thread/unarchived` notifications are recorded as
+observations of the `archived` field, at the sequence the notification is
+processed. The alternative — invalidating and re-listing to discover a fact the
+notification already stated — is the same round trip this design exists to
+remove. The recording happens in the event fan-out rather than in the client
+subscription, so locally published events take the same path as provider ones.
 
 ## Read Path
 
-The registry exposes a narrow synchronous cached-display-metadata read. Quit
-snapshot creation uses it for every active-turn owner after sub-agent ownership
-has been collapsed. The quit title resolver uses the same read for local
-terminal rows. It no longer calls `listThreads({ callerReason:
-"quit-confirmation" })`.
+`DesktopBackendRegistry.getThreadInfo(identity)` is the synchronous read.
+Quit snapshot creation uses it for every active-turn owner after sub-agent
+ownership has been collapsed, and the quit title resolver uses it for local
+terminal rows. Neither calls `listThreads({ callerReason:
+"quit-confirmation" })` any more.
+
+The same read serves every other caller that wants one fact about one known
+thread, which is what removes the full-collection walk described above.
 
 Remote terminal rows continue to consult only already-observed federation
 summaries and local pinned summaries. Automation rows keep their automation
@@ -97,7 +198,34 @@ thread enrichment.
 
 ## Performance Budget
 
-For quit snapshot construction and repeated live-queue polls:
+Provider reads are budgeted the way SQLite writes already are in this
+repository: a checked-in JSON file of exact counts per named scenario, asserted
+by tests. `apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json`
+records `providerListCalls` and `directoryEnrichments` for each scenario, and
+`expectThreadReadBudget` fails when either count deviates **in either
+direction**. A count that drops is as much a change to review as one that
+rises: it usually means a read stopped happening that something still depends
+on. Re-record with `UPDATE_THREAD_READ_BUDGETS=1`.
+
+Current recorded budget:
+
+| Scenario | Provider lists | Directory enrichments |
+|---|---|---|
+| Ten complete turns on a thread the navigation refresh already observed | 0 | 0 |
+| Five turns with label reads between every lifecycle event | 0 | 0 |
+| Five turns on an already-enriched worktree thread | 0 | 0 |
+| Twenty quit-dialog polls against an in-progress turn | 0 | 0 |
+| Fifty synchronous label lookups for a thread observed once | 0 | 0 |
+| A second window's navigation refresh against a warm list cache | 0 | 0 |
+| Six concurrent callers asking for the same unenriched listing | 1 | 0 |
+| Eight terminal notifications across two never-listed threads | 1 | 0 |
+| One navigation refresh over a single worktree-backed thread | 1 | 1 |
+
+The three nonzero rows are the shape the design intends: a thread nobody has
+ever listed costs exactly one listing however many callers ask at once, and
+enrichment happens once per worktree thread rather than per read.
+
+For quit snapshot construction and repeated live-queue polls specifically:
 
 - full provider thread-list refreshes: **0**
 - directory/Git enrichment calls for labels: **0**
@@ -109,20 +237,20 @@ batch may perform one existing read of persisted remote pins; it performs no
 write.
 
 The budget is enforced with deterministic call-count assertions, not elapsed
-time.
+time. The enrichment counter is exercised with worktree-shaped fixtures so it
+provably can move — a budget that cannot move proves nothing.
 
 ## Compatibility With PR #1896
 
 PR #1896's `getCachedThreadSummary()` serves targeted messaging admission and
-is broader than the title-only projection. Its current cache scan does not
-cover names observed from lifecycle/name notifications.
+is broader than a title read. Its current cache scan does not cover names
+observed from lifecycle/name notifications.
 
 This change does not cherry-pick or duplicate PR #1896's messaging work. On a
 later rebase, `getCachedThreadSummary()` can retain its admission contract and
-thread-list cache scan; where it needs a display title, it can merge the narrow
-projection into the cached summary. Quit continues to call the narrow
-display-metadata read and never treats title-only knowledge as a complete
-navigation/admission summary. Keeping the responsibilities separate makes the
+thread-list cache scan; where it needs a display title, it can read the store.
+Quit continues to call `getThreadInfo` and never treats title-only knowledge as
+a complete navigation/admission summary. Keeping the responsibilities separate makes the
 backend-registry overlap mechanical rather than architectural.
 
 ## Test Matrix
@@ -130,7 +258,7 @@ backend-registry overlap mechanical rather than architectural.
 | Contract | Focused coverage |
 |---|---|
 | Ordinary local active turn is named | Seed an already-observed non-fallback title, start/observe a normal turn, and assert the first synchronous quit snapshot carries it. |
-| Sub-agent ownership remains named | Preserve the existing owner-collapse case and verify it reads the same projection. |
+| Sub-agent ownership remains named | Preserve the existing owner-collapse case and verify it reads the same store. |
 | Rename wins | Observe an initial title, then a nonempty explicit rename, and assert subsequent snapshots use the rename. |
 | Missing/fallback cannot downgrade | Feed empty/fallback observations after a known title and assert the title remains. With no prior title, assert the stable thread-id fallback. |
 | Late old list cannot erase | Start a delayed list, observe a newer rename and active turn, release the old list, and assert the rename remains after completion and invalidation. |
@@ -142,9 +270,19 @@ backend-registry overlap mechanical rather than architectural.
 | Other blocker kinds | Preserve focused snapshot/resolver coverage for integrated terminals, environment actions, and automations. |
 | Renderer defense | Keep PR #1903 component tests proving absent titles cannot erase known titles, renames win, removals/counts remain authoritative, and empty state renders. |
 | Quit decisions | Preserve existing main-process tests for Quit, Wait/countdown, and Stay Open. |
+| Store contract | `thread-info-store.test.ts` covers per-field sequencing, positive-facts-only merging, fallback rejection, enrichment grading, identity keying, and forget/forgetInstance. |
+| Read budgets | `thread-read-budget.test.ts` drives each named scenario against a counting backend client and asserts the checked-in counts exactly. |
+| Remote ordering | A peer snapshot that started earlier but finished later cannot revert a newer name; a rename recorded afterwards still wins. |
+| Remote isolation | Two peers reusing one thread id keep separate names, and unmounting one peer drops only that peer's names. |
+| Reservation ordering at the IPC seam | The navigation-snapshot handler reserves its observation sequence strictly before the peer round trip begins. |
+
+Every test in the last four rows was falsified before being kept: the fix was
+reverted, the test was watched to fail, and the fix restored. A test that
+passes against the defect it names is not coverage.
 
 No new desktop E2E is planned because this change introduces no renderer,
-dialog, IPC-shape, or interaction contract. The main-process unit tests can
+dialog, IPC-shape, or interaction contract — it changes where the main process
+keeps what it already knew. The main-process unit tests can
 deterministically prove the provider-call budget and freshness ordering, while
 PR #1903's component tests already exercise the live-poll presentation seam.
 Adding a headed replay would duplicate those contracts without exposing a new


### PR DESCRIPTION
## Summary

The quit card's titles blinking between name and UUID every ~3s was the symptom.
The cause was that this product had no place to keep what it knows about a
thread — thread information lived inside the caches that answer *queries*, and
those are correctly discarded on every mutation.

This PR gives thread information its own store and moves the callers onto it.

- **`ThreadInfoStore`** (`app-server/thread-info-store.ts`) holds one entry per
  thread, with a per-field observation sequence and source. Identity is
  `instanceId::backend:threadId`.
- **Positive facts only.** An omitted field is not a deletion, an empty title is
  not news, and a `fallback` source means the title *is* the UUID — recording it
  would overwrite a real name with nothing. Title and source are validated
  together so a fallback cannot arrive alone and downgrade a held name.
- **Sequences are reserved before an async read begins**, so a listing overtaken
  by a rename cannot revert it on late completion. Monotonic counter, never
  `Date.now()`.
- **Callers declare freshness.** `findThreadForWorkspaceHandoff` takes
  `freshness: "provider" | "last-known"` — am I about to act on this, or only
  display it?
- **Archival is an observation**, recorded from the notification at the event
  fan-out, not rediscovered by invalidating and re-listing.
- **Peer names get the same treatment**, keyed by instance so two peers reusing
  a thread id cannot answer for each other.
- **Messaging admission reads the store** when the list cache has been emptied,
  which is where #1896's cache scan stops answering (see below).

Only the thread or the peer going away removes an entry. Cache invalidation
never does.

Replaces #1907 and #1903, which were a two-PR stack. The stack collapsed
because this work grew a dependency on `getCachedThreadSummary`, which landed in
main with #1896 and was not on #1903's branch — and GitHub declines to retarget
a stacked PR. #1903's commit is the first commit here, unchanged apart from the
rebase.

## What was actually wrong

Four defects, established by measurement rather than assumption:

1. **Invalidation was amnesia.** ~46 sites clear the list cache; every one was
   also erasing the only record of what threads were called.
2. **Point queries were answered by full-collection walks.** 16 sites wanted one
   row and rebuilt every row to get it.
3. **Query-shaped keys fragmented identical reads.** 6 concurrent callers asking
   the same question produced more than one provider call.
4. **Absence was conflated with unknown.** `title: undefined` meant both "has no
   title" and "we knew it and this lookup didn't return it".

The headline case: `turn/started` invalidates the list cache, and
`active-turn-branch-adoption` then drove a complete paged provider `thread/list`
to read a single field — **one full listing per turn boundary.** Quantified by
reverting the fix and re-recording the budgets:

```
turn-lifecycle-label-reads        5 -> 0
ten-turns-warm-thread            10 -> 0
worktree-turns-after-enrichment   5 -> 0
```

## Follow-on from #1896

#1896 merged first and made the same class of fix for messaging admission:
`resolveThread` used to call `listThreads({ forceRefresh: true })`
unconditionally, and #1896 put `getCachedThreadSummary` — a thread-list cache
scan — in front of it.

That covers the warm case, measurably: ten admissions across ten turn boundaries
cost **zero** provider listings, because `turn/started` does not empty the cache.

The cold case is different. Mutations *do* empty it. Measured after an unrelated
`archiveThread` on a **different** thread:

| Read | Result |
|---|---|
| `getCachedThreadSummary` (cache scan) | nothing |
| `ThreadInfoStore.getSummary` | the summary, intact |
| `resolveThread` | **1 forced full paged `thread/list`** |

An inbound reply to a thread this window listed minutes ago paid a full listing
because something unrelated invalidated the cache in between.
`getCachedThreadSummary` now scans the cache first — warm, that is the freshest
listing — and falls through to the store.

One case deliberately left alone: a thread known only from a lifecycle
notification still costs one listing. The store holds its title but not a
summary, and a title is not a summary. Synthesizing a row there would be
guessing.

## Default-agent admission no longer lists the fleet

Every accepted message on a Discord/Telegram **default-agent route** called
`getNavigationSnapshot({ backend: "all" })` before it could start the turn —
enumerating every thread on every backend, then hydrating overlays,
canonicalizing pull requests, probing Git working state, refreshing directory
status and hydrating launchpads. All to answer one question about one thread
whose id the assignment already carries: *does it still exist, and is it an
agent thread?* Opening the same thread in the app does none of that.

`selected.thread` was never read — the snapshot was purely an existence gate.

The answer now comes from `getThreadAdmissionState`, the targeted read that
**bound** replies already use. Both paths read `agent` from the same overlay
row (`reconcileNavigationSnapshot` takes `agent: current?.agent`;
`buildAdmissionThreadSummary` takes `overlay.agent`), so the targeted answer is
the answer the listing would have given.

The listing survives as a cold-path fallback only, shared across assignments so
a channel with several pays for it at most once: revocation is destructive, and
a process that has simply never observed the thread must not be mistaken for
one whose thread was deleted.

No other open PR touches this path — checked every open PR that modifies
`messaging-controller.ts`, `desktop-backend-bridge.ts`, or
`messaging-runtime.ts` (#1917, #1914, #1908, #1902, #1877); none references
`bootstrapDefaultAgentForAcceptedMessage`.

## Provider-read budgets

Provider reads are now budgeted the way SQLite writes already are here: a
checked-in JSON of exact counts per named scenario
(`__tests__/fixtures/thread-read-budgets.json`), asserted by
`expectThreadReadBudget`, failing on deviation **in either direction** — a count
that drops is as much a change to review as one that rises. Re-record with
`UPDATE_THREAD_READ_BUDGETS=1`.

| Scenario | Lists | Enrichments |
|---|---|---|
| Ten complete turns on an already-observed thread | 0 | 0 |
| Five turns with label reads between every lifecycle event | 0 | 0 |
| Five turns on an already-enriched worktree thread | 0 | 0 |
| Twenty quit-dialog polls against an in-progress turn | 0 | 0 |
| Fifty synchronous label lookups for a thread observed once | 0 | 0 |
| A second window's navigation refresh against a warm cache | 0 | 0 |
| Six concurrent callers asking for the same unenriched listing | 1 | 0 |
| Eight terminal notifications across two never-listed threads | 1 | 0 |
| One navigation refresh over a single worktree-backed thread | 1 | 1 |
| Messaging admission after an unrelated mutation emptied the cache | 0 | 0 |

The three nonzero rows are the intended shape. The worktree scenarios exist
because no other fixture reaches directory enrichment, and a budget counter that
cannot move proves nothing.

## Tests

New: `thread-info-store.test.ts` (store contract),
`thread-read-budget.test.ts` (the budgets above), plus remote ordering and
isolation cases in `remote-thread-summary-cache.test.ts` and a reservation-order
assertion at the navigation-snapshot IPC seam.

**Every new behavioral test was falsified before being kept** — the fix was
reverted, the test watched to fail, and the fix restored. A test that passes
against the defect it names is not coverage.

## Validation

- `pnpm test` — **exit 0**, 646 files, 9460 passed, 6 skipped (rebased on main, includes #1895 and #1896)
- `pnpm typecheck` — exit 0
- `pnpm lint:eslint` — exit 0
- `pnpm lint:boundaries` — exit 0
- `pnpm lint:codex-storage` — exit 0
- `pnpm lint:colors` — exit 0

No new desktop E2E: this adds no renderer, dialog, IPC-shape, or interaction
contract — it changes where the main process keeps what it already knew. PR
#1903's renderer-side monotonic retention stays in place as a second
presentation-layer defense.

## Notes for review

- No new persistent state. Both stores are process-local, so there are no new
  SQLite writes or write budgets.
- `docs/plans/2026-08-31-quit-blocker-title-read-model.md` was rewritten in this
  branch: it opened with "This is a scoped correction to the existing quit path",
  which stopped being true. It is unmerged and was added by this branch's own
  second commit.
- The first commit is #1903's renderer-side monotonic retention, rebased. If you
  would rather review that separately, #1903 can be reopened and this branch
  rebased back onto it.


