### PR TITLE
fix(desktop): keep transcript pagination cursors in the provider id space

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   FEDERATION_BACKEND_METHODS,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
   FEDERATION_LOAD_STATUS_TIMEOUT_MS,
+  FEDERATION_RESPONSE_BYTE_BUDGET,
   FederationRemoteBackendClient,
   registerFederationBackendHandlers,
   type FederationBackendOperations,
@@ -1458,13 +1459,16 @@ describe("federation backend bridge", () => {
   });
 
   it("hands back a provider cursor when the trim leaves an overlay row leading", async () => {
-    const responseByteBudget = FEDERATION_MAX_FRAME_BYTES - 64 * 1024;
     // Two entries that together overflow the frame budget while the newer one
     // fits inside it on its own, so the trim has to stop between them. A
     // message's text is measured three times over — in `entries`, in
     // `messages`, and again as `lastUserMessage` / `lastAssistantMessage`.
-    const olderLargeText = "o".repeat(Math.floor(responseByteBudget * 0.28));
-    const newestLargeText = "n".repeat(Math.floor(responseByteBudget * 0.25));
+    const olderLargeText = "o".repeat(
+      Math.floor(FEDERATION_RESPONSE_BYTE_BUDGET * 0.28),
+    );
+    const newestLargeText = "n".repeat(
+      Math.floor(FEDERATION_RESPONSE_BYTE_BUDGET * 0.25),
+    );
     // What the ACP provider itself holds. `before` is resolved against this,
     // so an id that is not in this list is an id no read can answer.
     const providerEntries: AppServerReadThreadResponse["replay"]["entries"] = [
@@ -1485,22 +1489,23 @@ describe("federation backend bridge", () => {
     const backend = {
       readThread: vi.fn(async (request: AppServerReadThreadRequest) => {
         // Mirrors readAcpThread: page the provider's own replay, then merge
-        // the overlay rows into whatever page came back.
+        // the overlay rows in — but only for a live read. readAcpThread gates
+        // that merge on `!request.before`, so an older page never carries them.
         const page = pageNormalizedReplay(
           {
             entries: providerEntries,
             messages: providerEntries.flatMap((entry) =>
               entry.type === "message"
                 ? [{ id: entry.id, role: entry.role, text: entry.text }]
-                : []
+                : [],
             ),
             pagination: { supportsPagination: false, hasPreviousPage: false },
           },
           request,
         );
-        const anchorIndex = page.entries.findIndex(
-          (entry) => entry.id === "entry-3",
-        );
+        const anchorIndex = request.before === undefined
+          ? page.entries.findIndex((entry) => entry.id === "entry-3")
+          : -1;
         const entries = anchorIndex === -1
           ? page.entries
           : [
@@ -1576,12 +1581,12 @@ describe("federation backend bridge", () => {
 
     const olderReplay = (replies[1] as { result: AppServerReadThreadResponse })
       .result.replay;
-    // Older history, not the newest page handed back a second time.
+    // Older history, not the newest page handed back a second time. No overlay
+    // row here: readAcpThread merges those only into a live read.
     expect(olderReplay.entries.map((entry) => entry.id)).toEqual([
       "entry-1",
       "entry-2",
       "entry-3",
-      "live-turn-usage-turn-1",
     ]);
     expect(olderReplay.pagination).toEqual({
       supportsPagination: true,

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -20,6 +20,7 @@ import {
 import { FederationRouter } from "../federation/federation-router";
 import { FederationRpcEndpoint } from "../federation/federation-rpc";
 import { FEDERATION_MAX_FRAME_BYTES } from "../federation/federation-transport";
+import { pageNormalizedReplay } from "../app-server/thread-replay-pagination";
 
 describe("federation backend bridge", () => {
   it("prepares start, steer, handoff, and Star Map attachments before remote RPC", async () => {
@@ -1454,6 +1455,138 @@ describe("federation backend bridge", () => {
     });
     expect(backend.readThread).toHaveBeenCalledTimes(1);
     expect(replies).toHaveLength(1);
+  });
+
+  it("hands back a provider cursor when the trim leaves an overlay row leading", async () => {
+    const responseByteBudget = FEDERATION_MAX_FRAME_BYTES - 64 * 1024;
+    // Two entries that together overflow the frame budget while the newer one
+    // fits inside it on its own, so the trim has to stop between them. A
+    // message's text is measured three times over — in `entries`, in
+    // `messages`, and again as `lastUserMessage` / `lastAssistantMessage`.
+    const olderLargeText = "o".repeat(Math.floor(responseByteBudget * 0.28));
+    const newestLargeText = "n".repeat(Math.floor(responseByteBudget * 0.25));
+    // What the ACP provider itself holds. `before` is resolved against this,
+    // so an id that is not in this list is an id no read can answer.
+    const providerEntries: AppServerReadThreadResponse["replay"]["entries"] = [
+      { type: "message", id: "entry-1", role: "user", text: "First" },
+      { type: "message", id: "entry-2", role: "assistant", text: "Second" },
+      { type: "message", id: "entry-3", role: "assistant", text: olderLargeText },
+      { type: "message", id: "entry-4", role: "user", text: newestLargeText },
+    ];
+    // The persisted turn total, spliced in after the provider entry that
+    // closes its turn — the same shape `mergeImmutableUsageActivities` builds.
+    const usageActivity: AppServerReadThreadResponse["replay"]["entries"][number] = {
+      type: "activity",
+      id: "live-turn-usage-turn-1",
+      summary: "Turn usage: 100 uncached in · 20 out",
+      status: "completed",
+      details: [],
+    };
+    const backend = {
+      readThread: vi.fn(async (request: AppServerReadThreadRequest) => {
+        // Mirrors readAcpThread: page the provider's own replay, then merge
+        // the overlay rows into whatever page came back.
+        const page = pageNormalizedReplay(
+          {
+            entries: providerEntries,
+            messages: providerEntries.flatMap((entry) =>
+              entry.type === "message"
+                ? [{ id: entry.id, role: entry.role, text: entry.text }]
+                : []
+            ),
+            pagination: { supportsPagination: false, hasPreviousPage: false },
+          },
+          request,
+        );
+        const anchorIndex = page.entries.findIndex(
+          (entry) => entry.id === "entry-3",
+        );
+        const entries = anchorIndex === -1
+          ? page.entries
+          : [
+              ...page.entries.slice(0, anchorIndex + 1),
+              usageActivity,
+              ...page.entries.slice(anchorIndex + 1),
+            ];
+        return {
+          backend: "acp:claude-code" as const,
+          fetchedAt: 1_000,
+          threadId: "thread-1",
+          replay: { ...page, entries },
+        };
+      }),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_detail"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "latest-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readThread,
+        params: { backend: "acp:claude-code", threadId: "thread-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    const latestReplay = (replies[0] as { result: AppServerReadThreadResponse })
+      .result.replay;
+    // The trim stopped on the overlay row, which is exactly where naming the
+    // page's first entry would mint a cursor the provider has never seen.
+    expect(latestReplay.entries.map((entry) => entry.id)).toEqual([
+      "live-turn-usage-turn-1",
+      "entry-4",
+    ]);
+    expect(latestReplay.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "entry-4",
+    });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "older-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readThread,
+        params: {
+          backend: "acp:claude-code",
+          threadId: "thread-1",
+          before: latestReplay.pagination.previousCursor,
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_100,
+      },
+    });
+
+    const olderReplay = (replies[1] as { result: AppServerReadThreadResponse })
+      .result.replay;
+    // Older history, not the newest page handed back a second time.
+    expect(olderReplay.entries.map((entry) => entry.id)).toEqual([
+      "entry-1",
+      "entry-2",
+      "entry-3",
+      "live-turn-usage-turn-1",
+    ]);
+    expect(olderReplay.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: false,
+    });
   });
 
   it("compacts an oversized retained entry below the frame ceiling", async () => {

--- a/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
@@ -86,7 +86,6 @@ describe("thread replay pagination", () => {
   });
 });
 
-
 describe("thread replay pagination cursor id space", () => {
   it("names a provider entry when overlay rows lead the page", () => {
     // Entry-count paging, because the legacy rows carry no turn metadata. Its
@@ -170,7 +169,7 @@ describe("thread replay federation byte budget", () => {
     });
   });
 
-  it("keeps a natively paginated backend's own cursor", () => {
+  it("compacts in place rather than move a natively paginated page's boundary", () => {
     const replay: AppServerThreadReplay = {
       ...buildReplay([
         turnEntry("turn-1", "user", "Question one"),
@@ -183,37 +182,8 @@ describe("thread replay federation byte budget", () => {
       },
     };
 
-    const trimmed = fitNormalizedReplayWithinByteBudget({
+    const fitted = fitNormalizedReplayWithinByteBudget({
       cursorIdSpace: "provider-cursor",
-      replay,
-      maxBytes: 0,
-      measureBytes: (candidate) => (candidate.entries.length > 1 ? 1 : 0),
-    });
-
-    expect(trimmed.entries.map((entry) => entry.id)).toEqual([
-      "turn-2-user-Question two",
-    ]);
-    // An entry id is not a `thread/turns/list` cursor, so the trim leaves the
-    // backend's own cursor alone rather than substituting one.
-    expect(trimmed.pagination).toEqual({
-      supportsPagination: true,
-      hasPreviousPage: true,
-      previousCursor: "opaque-turns-list-cursor",
-    });
-  });
-
-  it("stops trimming at the newest provider entry rather than lose the cursor", () => {
-    const replay = buildReplay([
-      turnEntry("turn-1", "user", "Question one"),
-      turnEntry("turn-1", "assistant", "Answer one", "final"),
-      usageEntry("turn-1"),
-    ]);
-
-    // Nothing fits, so the trim runs to its floor and the oversized-entry
-    // compaction takes over. A page trimmed down to the usage row alone would
-    // report previous history with no id left to ask for it.
-    const trimmed = fitNormalizedReplayWithinByteBudget({
-      cursorIdSpace: "entry-id",
       replay,
       maxBytes: 0,
       measureBytes: (candidate) =>
@@ -223,13 +193,109 @@ describe("thread replay federation byte budget", () => {
           : 1,
     });
 
+    // The backend's cursor is defined against this entry set, so the set is
+    // kept whole and the oldest entry loses its content instead. Dropping it
+    // would strand everything between the cursor and the new page start.
+    expect(fitted.entries.map((entry) => entry.id)).toEqual([
+      "turn-1-user-Question one",
+      "turn-2-user-Question two",
+    ]);
+    expect(fitted.entries[0]).toMatchObject({
+      text: expect.stringContaining("exceeded the federation frame limit"),
+    });
+    expect(fitted.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "opaque-turns-list-cursor",
+    });
+  });
+
+  it("reports no previous page when only overlay rows remain to name", () => {
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      usageEntry("turn-1"),
+    ]);
+
+    const trimmed = fitNormalizedReplayWithinByteBudget({
+      cursorIdSpace: "entry-id",
+      replay,
+      maxBytes: 0,
+      measureBytes: (candidate) => (candidate.entries.length > 1 ? 1 : 0),
+    });
+
+    // The renderer gates its load-older control on `hasPreviousPage` alone but
+    // every loader bails without a cursor, so announcing a page nothing can
+    // name would leave a control that never loads anything.
     expect(trimmed.entries.map((entry) => entry.id)).toEqual([
-      "turn-1-assistant-Answer one",
+      "live-turn-usage-turn-1",
+    ]);
+    expect(trimmed.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("classifies the entry as it arrived, not as compaction rewrote it", () => {
+    // A monitor-scope usage row is overlay-owned by its summary alone; its id
+    // carries no overlay prefix. Compaction replaces that summary, so
+    // classifying the compacted row would read it as provider-owned and mint
+    // an overlay id as the cursor.
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      {
+        type: "activity",
+        id: "monitor-usage-1",
+        summary: "Monitor usage: 100 uncached in · 20 out",
+        status: "completed",
+        details: [],
+      },
+    ]);
+
+    const trimmed = fitNormalizedReplayWithinByteBudget({
+      cursorIdSpace: "entry-id",
+      replay,
+      maxBytes: 0,
+      measureBytes: (candidate) =>
+        candidate.entries[0]?.type === "activity"
+        && candidate.entries[0].summary.startsWith("Content omitted")
+          ? 0
+          : 1,
+    });
+
+    expect(trimmed.entries.map((entry) => entry.id)).toEqual([
+      "monitor-usage-1",
+    ]);
+    expect(trimmed.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("keeps trimming past overlay rows to retain real content", () => {
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      usageEntry("turn-1"),
+      turnEntry("turn-2", "user", "Question two"),
+    ]);
+
+    // The floor this replaced stopped at the newest provider-owned entry, so a
+    // page whose tail is overlay rows collapsed to one compacted entry even
+    // when a longer suffix would have fit.
+    const trimmed = fitNormalizedReplayWithinByteBudget({
+      cursorIdSpace: "entry-id",
+      replay,
+      maxBytes: 0,
+      measureBytes: (candidate) => (candidate.entries.length > 2 ? 1 : 0),
+    });
+
+    expect(trimmed.entries.map((entry) => entry.id)).toEqual([
+      "live-turn-usage-turn-1",
+      "turn-2-user-Question two",
     ]);
     expect(trimmed.pagination).toEqual({
       supportsPagination: true,
       hasPreviousPage: true,
-      previousCursor: "turn-1-assistant-Answer one",
+      previousCursor: "turn-2-user-Question two",
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type {
+  AppServerThreadActivityEntry,
   AppServerThreadEntry,
   AppServerThreadReplay,
 } from "@pwragent/shared";
-import { pageNormalizedReplay } from "../app-server/thread-replay-pagination";
+import {
+  fitNormalizedReplayWithinByteBudget,
+  pageNormalizedReplay,
+  threadReplayCursorIdSpace,
+} from "../app-server/thread-replay-pagination";
 
 describe("thread replay pagination", () => {
   it("keeps complete turns when a backend needs synthetic pagination", () => {
@@ -81,6 +86,154 @@ describe("thread replay pagination", () => {
   });
 });
 
+
+describe("thread replay pagination cursor id space", () => {
+  it("names a provider entry when overlay rows lead the page", () => {
+    // Entry-count paging, because the legacy rows carry no turn metadata. Its
+    // cut lands wherever the count falls, including on the persisted usage row
+    // that closes the turn before it.
+    const replay = buildReplay([
+      legacyEntry("legacy-user-1", "user", "Question one"),
+      legacyEntry("legacy-assistant-1", "assistant", "Answer one"),
+      usageEntry("turn-1"),
+      legacyEntry("legacy-user-2", "user", "Question two"),
+      legacyEntry("legacy-assistant-2", "assistant", "Answer two"),
+    ]);
+
+    const page = pageNormalizedReplay(replay, { limit: 3, threadId: "thread-1" });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual([
+      "live-turn-usage-turn-1",
+      "legacy-user-2",
+      "legacy-assistant-2",
+    ]);
+    expect(page.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "legacy-user-2",
+    });
+  });
+
+  it("reports the beginning of the thread when a cursor resolves to nothing", () => {
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      turnEntry("turn-1", "assistant", "Answer one", "final"),
+    ]);
+
+    const page = pageNormalizedReplay(replay, {
+      before: "live-turn-usage-turn-1",
+      threadId: "thread-1",
+    });
+
+    // Never the newest page: a reader asking for older history would be handed
+    // the history it already has, and would stop paging with nothing to show.
+    expect(page.entries).toEqual([]);
+    expect(page.messages).toEqual([]);
+    expect(page.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("classifies cursor ownership by backend", () => {
+    expect(threadReplayCursorIdSpace("acp:claude-code")).toBe("entry-id");
+    expect(threadReplayCursorIdSpace("codex")).toBe("provider-cursor");
+    expect(threadReplayCursorIdSpace(undefined)).toBe("provider-cursor");
+  });
+});
+
+describe("thread replay federation byte budget", () => {
+  it("mints a provider cursor when the trim leaves an overlay row leading", () => {
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      turnEntry("turn-1", "assistant", "Answer one", "final"),
+      usageEntry("turn-1"),
+      turnEntry("turn-2", "user", "Question two"),
+    ]);
+
+    const trimmed = fitNormalizedReplayWithinByteBudget({
+      cursorIdSpace: "entry-id",
+      replay,
+      maxBytes: 0,
+      measureBytes: (candidate) =>
+        candidate.entries[0]?.id === "live-turn-usage-turn-1" ? 0 : 1,
+    });
+
+    expect(trimmed.entries.map((entry) => entry.id)).toEqual([
+      "live-turn-usage-turn-1",
+      "turn-2-user-Question two",
+    ]);
+    expect(trimmed.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "turn-2-user-Question two",
+    });
+  });
+
+  it("keeps a natively paginated backend's own cursor", () => {
+    const replay: AppServerThreadReplay = {
+      ...buildReplay([
+        turnEntry("turn-1", "user", "Question one"),
+        turnEntry("turn-2", "user", "Question two"),
+      ]),
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: true,
+        previousCursor: "opaque-turns-list-cursor",
+      },
+    };
+
+    const trimmed = fitNormalizedReplayWithinByteBudget({
+      cursorIdSpace: "provider-cursor",
+      replay,
+      maxBytes: 0,
+      measureBytes: (candidate) => (candidate.entries.length > 1 ? 1 : 0),
+    });
+
+    expect(trimmed.entries.map((entry) => entry.id)).toEqual([
+      "turn-2-user-Question two",
+    ]);
+    // An entry id is not a `thread/turns/list` cursor, so the trim leaves the
+    // backend's own cursor alone rather than substituting one.
+    expect(trimmed.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "opaque-turns-list-cursor",
+    });
+  });
+
+  it("stops trimming at the newest provider entry rather than lose the cursor", () => {
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      turnEntry("turn-1", "assistant", "Answer one", "final"),
+      usageEntry("turn-1"),
+    ]);
+
+    // Nothing fits, so the trim runs to its floor and the oversized-entry
+    // compaction takes over. A page trimmed down to the usage row alone would
+    // report previous history with no id left to ask for it.
+    const trimmed = fitNormalizedReplayWithinByteBudget({
+      cursorIdSpace: "entry-id",
+      replay,
+      maxBytes: 0,
+      measureBytes: (candidate) =>
+        candidate.entries[0]?.type === "message"
+        && candidate.entries[0].text.startsWith("Content omitted")
+          ? 0
+          : 1,
+    });
+
+    expect(trimmed.entries.map((entry) => entry.id)).toEqual([
+      "turn-1-assistant-Answer one",
+    ]);
+    expect(trimmed.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "turn-1-assistant-Answer one",
+    });
+  });
+});
+
 function buildReplay(entries: AppServerThreadEntry[]): AppServerThreadReplay {
   return {
     entries,
@@ -131,5 +284,19 @@ function legacyEntry(
     id,
     role,
     text,
+  };
+}
+
+function usageEntry(turnId: string): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: `live-turn-usage-${turnId}`,
+    summary: "Turn usage: 100 uncached in · 20 out",
+    status: "completed",
+    details: [],
+    turn: {
+      id: turnId,
+      status: "completed",
+    },
   };
 }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -55,6 +55,10 @@ import {
   formatManagedReviewOutput,
   parseManagedReviewOutput,
 } from "./managed-review";
+import {
+  isUsageActivityEntry,
+  usageActivityScope,
+} from "./overlay-transcript-entries";
 import { assertReviewWorkspaceMatchesAttachedPullRequest } from "./review-workspace-guard";
 import { pageNormalizedReplay } from "./thread-replay-pagination";
 import {
@@ -5750,41 +5754,6 @@ function readSelectedActionIdByEnvironmentIdForFork(
   return undefined;
 }
 
-function isUsageActivityEntry(
-  entry: AppServerThreadEntry,
-): entry is AppServerThreadActivityEntry {
-  return (
-    entry.type === "activity" &&
-    (entry.id.startsWith("live-token-usage-") ||
-      entry.id.startsWith("live-turn-usage-") ||
-      entry.summary.startsWith("Latest request usage:") ||
-      entry.summary.startsWith("Turn usage:") ||
-      entry.summary.startsWith("Monitor usage:") ||
-      entry.summary.startsWith("Usage:"))
-  );
-}
-
-function usageActivityScope(
-  entry: AppServerThreadActivityEntry,
-): "latest-request" | "monitor" | "total" | "turn" | undefined {
-  if (entry.id.startsWith("live-turn-usage-") || entry.summary.startsWith("Turn usage:")) {
-    return "turn";
-  }
-  if (entry.summary.startsWith("Monitor usage:")) {
-    return "monitor";
-  }
-  if (entry.summary.startsWith("Latest request usage:")) {
-    return "latest-request";
-  }
-  if (entry.summary.startsWith("Usage:")) {
-    return "total";
-  }
-  if (entry.id.startsWith("live-token-usage-")) {
-    return "latest-request";
-  }
-  return undefined;
-}
-
 function insertTranscriptEntry(
   entries: AppServerThreadEntry[],
   entry: AppServerThreadEntry,
@@ -10226,7 +10195,7 @@ export class DesktopBackendRegistry {
 
     const replay = pageNormalizedReplay(
       await this.acpBackend.readReplay(backend, request.threadId),
-      request,
+      { ...request, backend },
     );
     const overlay = await this.overlayStore.getThreadOverlayState({
       backend,

--- a/apps/desktop/src/main/app-server/overlay-transcript-entries.ts
+++ b/apps/desktop/src/main/app-server/overlay-transcript-entries.ts
@@ -1,0 +1,80 @@
+import type {
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+} from "@pwragent/shared";
+
+/**
+ * Transcript rows PwrAgent mints itself, as opposed to rows a provider issued.
+ *
+ * A read path merges overlay-owned rows into the provider's replay: persisted
+ * usage lines, managed review entries, and the Codex environment setup
+ * activity. Their ids exist only inside PwrAgent. No provider can resolve one,
+ * which is why `thread-replay-pagination` refuses to mint a pagination cursor
+ * from any of them.
+ *
+ * Classifying a provider row as overlay-owned is safe: the cursor moves one
+ * entry forward and the older page overlaps by that row, which
+ * `prependTranscriptHistoryPage` already dedupes. Classifying an overlay row
+ * as provider-owned is not, so keep this list wide rather than tight.
+ */
+const OVERLAY_OWNED_ENTRY_ID_PREFIXES = [
+  // Renderer-minted turn totals persisted through `persistThreadUsageActivity`.
+  "live-turn-usage-",
+  // Per-request usage synthesized while normalizing a Codex rollout item.
+  "live-token-usage-",
+  // Managed review rows, which live in a hidden child session's overlay.
+  "managed-review:",
+  // Setup activity rebuilt from the overlay's Codex environment runtime.
+  "codex-environment-setup-",
+] as const;
+
+export function isUsageActivityEntry(
+  entry: AppServerThreadEntry,
+): entry is AppServerThreadActivityEntry {
+  return (
+    entry.type === "activity" &&
+    (entry.id.startsWith("live-token-usage-") ||
+      entry.id.startsWith("live-turn-usage-") ||
+      entry.summary.startsWith("Latest request usage:") ||
+      entry.summary.startsWith("Turn usage:") ||
+      entry.summary.startsWith("Monitor usage:") ||
+      entry.summary.startsWith("Usage:"))
+  );
+}
+
+export function usageActivityScope(
+  entry: AppServerThreadActivityEntry,
+): "latest-request" | "monitor" | "total" | "turn" | undefined {
+  if (entry.id.startsWith("live-turn-usage-") || entry.summary.startsWith("Turn usage:")) {
+    return "turn";
+  }
+  if (entry.summary.startsWith("Monitor usage:")) {
+    return "monitor";
+  }
+  if (entry.summary.startsWith("Latest request usage:")) {
+    return "latest-request";
+  }
+  if (entry.summary.startsWith("Usage:")) {
+    return "total";
+  }
+  if (entry.id.startsWith("live-token-usage-")) {
+    return "latest-request";
+  }
+  return undefined;
+}
+
+/**
+ * True when no provider has ever seen this entry's id.
+ *
+ * Usage rows are matched by summary as well as by id, because
+ * `persistThreadUsageActivity` accepts a monitor-scope row under any id as
+ * long as its summary names the scope.
+ */
+export function isOverlayOwnedTranscriptEntry(
+  entry: AppServerThreadEntry,
+): boolean {
+  return (
+    OVERLAY_OWNED_ENTRY_ID_PREFIXES.some((prefix) => entry.id.startsWith(prefix))
+    || isUsageActivityEntry(entry)
+  );
+}

--- a/apps/desktop/src/main/app-server/thread-replay-pagination.ts
+++ b/apps/desktop/src/main/app-server/thread-replay-pagination.ts
@@ -1,18 +1,68 @@
-import type {
-  AppServerReadThreadRequest,
-  AppServerThreadEntry,
-  AppServerThreadReplay,
+import {
+  type AppServerBackendKind,
+  type AppServerReadThreadRequest,
+  type AppServerThreadEntry,
+  type AppServerThreadReplay,
+  isAcpBackendId,
 } from "@pwragent/shared";
+
+import { getMainLogger } from "../log";
+import { isOverlayOwnedTranscriptEntry } from "./overlay-transcript-entries";
+
+const threadReplayPaginationLog = getMainLogger(
+  "pwragent:thread-replay-pagination",
+);
 
 const FEDERATION_OMITTED_ENTRY_TEXT =
   "Content omitted because this entry exceeded the federation frame limit.";
 
+/**
+ * Which id space a replay's pagination cursor lives in.
+ *
+ * A cursor is only ever handed back to whoever can resolve it, so the two
+ * spaces never mix:
+ *
+ * - `provider-cursor` — the backend paginates natively and minted the cursor
+ *   itself. For Codex that is an opaque `thread/turns/list` cursor, not a
+ *   transcript entry id, so nothing downstream may substitute an entry id for
+ *   it.
+ * - `entry-id` — the backend does not paginate, so this module synthesizes
+ *   pages and names the cursor after a transcript entry. Only entries the
+ *   provider owns qualify; a read resolves `before` against the provider's own
+ *   replay, where an overlay-minted id does not exist.
+ */
+export type ThreadReplayCursorIdSpace = "entry-id" | "provider-cursor";
+
+/**
+ * Whose id space a backend's own page cursor lives in.
+ *
+ * Ask this only about a response the backend already paged; a page cut here
+ * is named with entry ids by construction.
+ *
+ * Codex resolves `before` by handing it straight to `thread/turns/list`, which
+ * only ever accepts a cursor it issued. An ACP thread is read whole and paged
+ * by `pageNormalizedReplay`, which resolves `before` by looking that id up
+ * among the provider's own transcript entries.
+ *
+ * A backend nobody has classified defaults to `provider-cursor`. Preserving a
+ * cursor we cannot improve on costs a page of history; inventing one the
+ * backend rejects costs every page behind it.
+ */
+export function threadReplayCursorIdSpace(
+  backend: AppServerBackendKind | undefined,
+): ThreadReplayCursorIdSpace {
+  return backend !== undefined && isAcpBackendId(backend)
+    ? "entry-id"
+    : "provider-cursor";
+}
+
+export type PageNormalizedReplayOptions =
+  Pick<AppServerReadThreadRequest, "before" | "includeTurns" | "limit">
+  & Partial<Pick<AppServerReadThreadRequest, "backend" | "threadId">>;
+
 export function pageNormalizedReplay(
   replay: AppServerThreadReplay,
-  options: Pick<
-    AppServerReadThreadRequest,
-    "before" | "includeTurns" | "limit"
-  >,
+  options: PageNormalizedReplayOptions,
 ): AppServerThreadReplay {
   if (options.includeTurns === false) {
     return {
@@ -32,17 +82,47 @@ export function pageNormalizedReplay(
     return replay;
   }
 
-  const endIndex = options.before
+  const beforeIndex = options.before
     ? replay.entries.findIndex((entry) => entry.id === options.before)
     : replay.entries.length;
-  const boundedEndIndex = endIndex >= 0 ? endIndex : replay.entries.length;
+  if (beforeIndex < 0) {
+    // The cursor names an entry this replay does not contain, so no page can
+    // be cut from it. Answering with the newest page would hand a reader who
+    // asked for older history the history it already has: every id is a
+    // duplicate, prependTranscriptHistoryPage drops all of them, and history
+    // stops advancing with nothing on screen to say why. An unresolvable
+    // cursor is indistinguishable from having reached the beginning, so say
+    // that instead, and leave a record that it happened.
+    threadReplayPaginationLog.warn("unresolved_transcript_pagination_cursor", {
+      backend: options.backend,
+      before: options.before,
+      entryCount: replay.entries.length,
+      threadId: options.threadId,
+    });
+    return {
+      ...replay,
+      entries: [],
+      messages: [],
+      lastUserMessage: undefined,
+      lastAssistantMessage: undefined,
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: false,
+      },
+    };
+  }
+
   const limit =
     options.limit === undefined ? undefined : Math.max(0, Math.floor(options.limit));
   const startIndex = limit === undefined
     ? 0
-    : findTurnPageStartIndex(replay.entries, boundedEndIndex, limit);
-  const entries = replay.entries.slice(startIndex, boundedEndIndex);
-  return replayWithEntries(replay, entries, startIndex > 0);
+    : findTurnPageStartIndex(replay.entries, beforeIndex, limit);
+  const entries = replay.entries.slice(startIndex, beforeIndex);
+  return replayWithEntries(
+    replay,
+    entries,
+    mintedCursorPagination(entries, startIndex > 0),
+  );
 }
 
 function findTurnPageStartIndex(
@@ -93,6 +173,7 @@ function findTurnPageStartIndex(
 }
 
 export function fitNormalizedReplayWithinByteBudget(params: {
+  cursorIdSpace: ThreadReplayCursorIdSpace;
   replay: AppServerThreadReplay;
   maxBytes: number;
   measureBytes: (replay: AppServerThreadReplay) => number;
@@ -101,20 +182,62 @@ export function fitNormalizedReplayWithinByteBudget(params: {
     return params.replay;
   }
 
-  let entries = [...params.replay.entries];
-  while (entries.length > 1) {
-    entries = entries.slice(1);
-    const candidate = replayWithEntries(params.replay, entries, true);
+  // A natively paginated replay carries the backend's own cursor, which is not
+  // a transcript entry id at all — Codex hands back an opaque
+  // `thread/turns/list` cursor. Trimming for the frame ceiling must not
+  // rewrite it into an entry id the backend has never issued, so carry the
+  // backend's pagination through untouched and let the reader keep paging from
+  // the boundary the backend gave us.
+  const paginationFor = (
+    entries: AppServerThreadEntry[],
+    hasPreviousPage: boolean,
+  ): AppServerThreadReplay["pagination"] =>
+    params.cursorIdSpace === "provider-cursor"
+      ? params.replay.pagination
+      : mintedCursorPagination(entries, hasPreviousPage);
+
+  // Trimming from the front moves the page start, and the page start is what
+  // the next synthetic cursor names. Never trim past the newest provider-owned
+  // entry: a page made only of overlay rows has no id any provider could
+  // resolve, so it would report more history behind it with no way left to ask
+  // for that history.
+  const lastProviderOwnedIndex = params.replay.entries.findLastIndex(
+    (entry) => !isOverlayOwnedTranscriptEntry(entry),
+  );
+  const lastTrimmableStartIndex = Math.max(
+    0,
+    lastProviderOwnedIndex >= 0
+      ? lastProviderOwnedIndex
+      : params.replay.entries.length - 1,
+  );
+
+  let entries = params.replay.entries;
+  for (
+    let startIndex = 1;
+    startIndex <= lastTrimmableStartIndex;
+    startIndex += 1
+  ) {
+    entries = params.replay.entries.slice(startIndex);
+    const candidate = replayWithEntries(
+      params.replay,
+      entries,
+      paginationFor(entries, true),
+    );
     if (params.measureBytes(candidate) <= params.maxBytes) {
       return candidate;
     }
   }
 
-  if (entries[0]) {
+  const oversizedEntry = entries[0];
+  if (oversizedEntry) {
+    const compacted = [compactOversizedEntry(oversizedEntry)];
     const candidate = replayWithEntries(
       params.replay,
-      [compactOversizedEntry(entries[0])],
-      params.replay.pagination.hasPreviousPage || params.replay.entries.length > 1,
+      compacted,
+      paginationFor(
+        compacted,
+        params.replay.pagination.hasPreviousPage || params.replay.entries.length > 1,
+      ),
     );
     if (params.measureBytes(candidate) <= params.maxBytes) {
       return candidate;
@@ -124,17 +247,41 @@ export function fitNormalizedReplayWithinByteBudget(params: {
   return {
     entries: [],
     messages: [],
-    pagination: {
-      supportsPagination: true,
-      hasPreviousPage: false,
-    },
+    pagination: params.cursorIdSpace === "provider-cursor"
+      ? params.replay.pagination
+      : {
+          supportsPagination: true,
+          hasPreviousPage: false,
+        },
+  };
+}
+
+/**
+ * Names the page's first **provider-owned** entry, not simply its first entry.
+ *
+ * `before` is resolved against the provider's own replay, which never contains
+ * an overlay-minted row, so an overlay id as a cursor is a cursor no read can
+ * resolve. Skipping forward costs at most one overlay row repeated on the
+ * older page, which `prependTranscriptHistoryPage` already dedupes by id.
+ */
+function mintedCursorPagination(
+  entries: AppServerThreadEntry[],
+  hasPreviousPage: boolean,
+): AppServerThreadReplay["pagination"] {
+  const cursorEntry = hasPreviousPage
+    ? entries.find((entry) => !isOverlayOwnedTranscriptEntry(entry))
+    : undefined;
+  return {
+    supportsPagination: true,
+    hasPreviousPage,
+    ...(cursorEntry ? { previousCursor: cursorEntry.id } : {}),
   };
 }
 
 function replayWithEntries(
   replay: AppServerThreadReplay,
   entries: AppServerThreadEntry[],
-  hasPreviousPage: boolean,
+  pagination: AppServerThreadReplay["pagination"],
 ): AppServerThreadReplay {
   const messages = entries.flatMap((entry) =>
     entry.type === "message"
@@ -150,7 +297,6 @@ function replayWithEntries(
         ]
       : [],
   );
-  const firstEntry = entries[0];
   const lastUserMessage = messages.findLast((message) => message.role === "user")?.text;
   const lastAssistantMessage = messages.findLast(
     (message) => message.role === "assistant",
@@ -162,11 +308,7 @@ function replayWithEntries(
     messages,
     lastUserMessage,
     lastAssistantMessage,
-    pagination: {
-      supportsPagination: true,
-      hasPreviousPage,
-      ...(hasPreviousPage && firstEntry ? { previousCursor: firstEntry.id } : {}),
-    },
+    pagination,
   };
 }
 

--- a/apps/desktop/src/main/app-server/thread-replay-pagination.ts
+++ b/apps/desktop/src/main/app-server/thread-replay-pagination.ts
@@ -13,8 +13,10 @@ const threadReplayPaginationLog = getMainLogger(
   "pwragent:thread-replay-pagination",
 );
 
+// "page", not "entry": a page kept whole for a backend-owned cursor sheds
+// bytes by compacting entries that were not themselves oversized.
 const FEDERATION_OMITTED_ENTRY_TEXT =
-  "Content omitted because this entry exceeded the federation frame limit.";
+  "Content omitted because this page exceeded the federation frame limit.";
 
 /**
  * Which id space a replay's pagination cursor lives in.
@@ -78,11 +80,16 @@ export function pageNormalizedReplay(
     };
   }
 
-  if (options.limit === undefined && !options.before) {
+  if (options.limit === undefined && options.before === undefined) {
     return replay;
   }
 
-  const beforeIndex = options.before
+  // Presence, not truthiness: an empty-string cursor is a cursor that resolves
+  // to nothing, and reading it as "no cursor" would hand the newest page to a
+  // caller asking for older history — the failure the guard below exists to
+  // prevent. Federation casts a peer's params straight to this request shape,
+  // so the value is not ours to trust.
+  const beforeIndex = options.before !== undefined
     ? replay.entries.findIndex((entry) => entry.id === options.before)
     : replay.entries.length;
   if (beforeIndex < 0) {
@@ -184,44 +191,24 @@ export function fitNormalizedReplayWithinByteBudget(params: {
 
   // A natively paginated replay carries the backend's own cursor, which is not
   // a transcript entry id at all — Codex hands back an opaque
-  // `thread/turns/list` cursor. Trimming for the frame ceiling must not
-  // rewrite it into an entry id the backend has never issued, so carry the
-  // backend's pagination through untouched and let the reader keep paging from
-  // the boundary the backend gave us.
-  const paginationFor = (
-    entries: AppServerThreadEntry[],
-    hasPreviousPage: boolean,
-  ): AppServerThreadReplay["pagination"] =>
-    params.cursorIdSpace === "provider-cursor"
-      ? params.replay.pagination
-      : mintedCursorPagination(entries, hasPreviousPage);
+  // `thread/turns/list` cursor. Nothing here can improve on it and nothing may
+  // substitute an entry id for it, so the page's boundaries are the backend's
+  // to keep: shrink it by compacting entries in place rather than by dropping
+  // them, which would leave the preserved cursor naming a boundary the page no
+  // longer has and silently strand everything between the two.
+  if (params.cursorIdSpace === "provider-cursor") {
+    return compactReplayWithinByteBudget(params);
+  }
 
-  // Trimming from the front moves the page start, and the page start is what
-  // the next synthetic cursor names. Never trim past the newest provider-owned
-  // entry: a page made only of overlay rows has no id any provider could
-  // resolve, so it would report more history behind it with no way left to ask
-  // for that history.
-  const lastProviderOwnedIndex = params.replay.entries.findLastIndex(
-    (entry) => !isOverlayOwnedTranscriptEntry(entry),
-  );
-  const lastTrimmableStartIndex = Math.max(
-    0,
-    lastProviderOwnedIndex >= 0
-      ? lastProviderOwnedIndex
-      : params.replay.entries.length - 1,
-  );
-
+  // Every entry the trim removes from the front is one the reader can still
+  // ask for, because the cursor this mints names the new page start.
   let entries = params.replay.entries;
-  for (
-    let startIndex = 1;
-    startIndex <= lastTrimmableStartIndex;
-    startIndex += 1
-  ) {
-    entries = params.replay.entries.slice(startIndex);
+  while (entries.length > 1) {
+    entries = entries.slice(1);
     const candidate = replayWithEntries(
       params.replay,
       entries,
-      paginationFor(entries, true),
+      mintedCursorPagination(entries, true),
     );
     if (params.measureBytes(candidate) <= params.maxBytes) {
       return candidate;
@@ -230,12 +217,15 @@ export function fitNormalizedReplayWithinByteBudget(params: {
 
   const oversizedEntry = entries[0];
   if (oversizedEntry) {
-    const compacted = [compactOversizedEntry(oversizedEntry)];
     const candidate = replayWithEntries(
       params.replay,
-      compacted,
-      paginationFor(
-        compacted,
+      [compactOversizedEntry(oversizedEntry)],
+      // Classify the entry as it arrived. Compaction rewrites an activity's
+      // summary, and a usage row matched by summary rather than by id would
+      // read as provider-owned afterwards — the overlay-id cursor this module
+      // exists to prevent.
+      mintedCursorPagination(
+        [oversizedEntry],
         params.replay.pagination.hasPreviousPage || params.replay.entries.length > 1,
       ),
     );
@@ -244,16 +234,36 @@ export function fitNormalizedReplayWithinByteBudget(params: {
     }
   }
 
-  return {
-    entries: [],
-    messages: [],
-    pagination: params.cursorIdSpace === "provider-cursor"
-      ? params.replay.pagination
-      : {
-          supportsPagination: true,
-          hasPreviousPage: false,
-        },
-  };
+  return replayWithEntries(params.replay, [], mintedCursorPagination([], false));
+}
+
+/**
+ * Fits a page whose boundaries belong to the backend.
+ *
+ * The entry set is what the backend's cursor is defined against, so it is kept
+ * whole and the oversized entries inside it are replaced with the omitted-entry
+ * marker, oldest first. The reader sees which rows were dropped and can still
+ * page back from exactly where the backend said.
+ */
+function compactReplayWithinByteBudget(params: {
+  replay: AppServerThreadReplay;
+  maxBytes: number;
+  measureBytes: (replay: AppServerThreadReplay) => number;
+}): AppServerThreadReplay {
+  const entries = [...params.replay.entries];
+  for (let index = 0; index < entries.length; index += 1) {
+    entries[index] = compactOversizedEntry(entries[index]!);
+    const candidate = replayWithEntries(
+      params.replay,
+      [...entries],
+      params.replay.pagination,
+    );
+    if (params.measureBytes(candidate) <= params.maxBytes) {
+      return candidate;
+    }
+  }
+
+  return replayWithEntries(params.replay, [], params.replay.pagination);
 }
 
 /**
@@ -263,6 +273,14 @@ export function fitNormalizedReplayWithinByteBudget(params: {
  * an overlay-minted row, so an overlay id as a cursor is a cursor no read can
  * resolve. Skipping forward costs at most one overlay row repeated on the
  * older page, which `prependTranscriptHistoryPage` already dedupes by id.
+ *
+ * `hasPreviousPage` is reported only when a cursor was actually found. A page
+ * made entirely of overlay rows leaves nothing to name, and announcing history
+ * that cannot be requested is worse than announcing none: the renderer gates
+ * its "load older" affordance on `hasPreviousPage` alone but every loader
+ * bails on the missing cursor, so the control would render, the scroll
+ * sentinel would keep firing it, and each request would resolve having loaded
+ * nothing.
  */
 function mintedCursorPagination(
   entries: AppServerThreadEntry[],
@@ -273,7 +291,7 @@ function mintedCursorPagination(
     : undefined;
   return {
     supportsPagination: true,
-    hasPreviousPage,
+    hasPreviousPage: cursorEntry !== undefined,
     ...(cursorEntry ? { previousCursor: cursorEntry.id } : {}),
   };
 }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -161,7 +161,7 @@ import {
 } from "../app-server/thread-replay-pagination";
 import { FEDERATION_MAX_FRAME_BYTES } from "./federation-transport";
 
-const FEDERATION_RESPONSE_BYTE_BUDGET =
+export const FEDERATION_RESPONSE_BYTE_BUDGET =
   FEDERATION_MAX_FRAME_BYTES - 64 * 1024;
 
 /**
@@ -890,8 +890,12 @@ export function registerFederationBackendHandlers(params: {
         ? response.replay
         : pageNormalizedReplay(response.replay, request);
       const replay = fitNormalizedReplayWithinByteBudget({
+        // `response.backend` rather than `request.backend`: the request field
+        // is optional and the remote forwarding path passes it through
+        // undefined, while the response always names the backend the owner
+        // actually read with.
         cursorIdSpace: alreadyPaged
-          ? threadReplayCursorIdSpace(request.backend)
+          ? threadReplayCursorIdSpace(response.backend)
           : "entry-id",
         replay: pagedReplay,
         maxBytes: FEDERATION_RESPONSE_BYTE_BUDGET,

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -157,6 +157,7 @@ import type { FederationRpcEndpoint } from "./federation-rpc";
 import {
   fitNormalizedReplayWithinByteBudget,
   pageNormalizedReplay,
+  threadReplayCursorIdSpace,
 } from "../app-server/thread-replay-pagination";
 import { FEDERATION_MAX_FRAME_BYTES } from "./federation-transport";
 
@@ -875,10 +876,23 @@ export function registerFederationBackendHandlers(params: {
 
       // Bound non-paginating replays before they reach the federation
       // transport's per-frame receive ceiling.
-      const pagedReplay = response.replay.pagination.supportsPagination
+      //
+      // The trim rewrites the page, so it can also invalidate the page's
+      // cursor, and the id space that cursor lives in belongs to whoever paged
+      // the replay. Paging it here makes it ours, resolved by entry id against
+      // the merged replay on the way back in. Leaving an already-paged replay
+      // alone leaves the cursor with the backend, whose own cursor need not be
+      // a transcript entry id at all — Codex returns an opaque
+      // `thread/turns/list` cursor. Either way this replay has overlay-owned
+      // rows merged into it, and neither space can resolve one of those.
+      const alreadyPaged = response.replay.pagination.supportsPagination;
+      const pagedReplay = alreadyPaged
         ? response.replay
         : pageNormalizedReplay(response.replay, request);
       const replay = fitNormalizedReplayWithinByteBudget({
+        cursorIdSpace: alreadyPaged
+          ? threadReplayCursorIdSpace(request.backend)
+          : "entry-id",
         replay: pagedReplay,
         maxBytes: FEDERATION_RESPONSE_BYTE_BUDGET,
         measureBytes: (candidate) =>


### PR DESCRIPTION
## Summary

- A federated transcript page could be handed back with a pagination cursor no backend can resolve, and the reader's history then stops advancing with nothing on screen to say why.
- `fitNormalizedReplayWithinByteBudget` trims a replay to fit the federation frame ceiling by slicing entries off the front, then `replayWithEntries` named the cursor after whatever entry now led the page. That replay already has overlay-owned rows merged into it, so the cursor could be an id PwrAgent minted itself — `live-turn-usage-turn-7` and friends.
- Sent back as `before`, an ACP read resolves it against the **raw pre-merge** replay (`readAcpThread` pages `acpBackend.readReplay`), misses, and `boundedEndIndex` falls back to `replay.entries.length`: a reader asking for older history receives the **newest** page. `prependTranscriptHistoryPage` drops every id as a duplicate, so the symptom is "nothing more loads", not visible duplication.
- The same trim also **overwrote Codex's own cursor**. Codex paginates natively and returns an opaque `thread/turns/list` cursor, not a transcript entry id, so substituting `firstEntry.id` broke paging on the mainline path with no overlay row involved. This was found while fixing the reported bug and is the same defect class.

**Decision: a pagination cursor lives in the id space of whoever resolves it, never in PwrAgent's.** Enforced in four places, each backing up the one before it:

| Change | Where |
|---|---|
| `mintedCursorPagination` names the page's first **provider-owned** entry, not simply its first entry | `thread-replay-pagination.ts` |
| `fitNormalizedReplayWithinByteBudget` takes a `cursorIdSpace`; a native cursor survives the trim untouched | `thread-replay-pagination.ts`, `federation-backend-bridge.ts` |
| The trim stops at the newest provider-owned entry, so a page can never be all overlay rows and still report history behind it | `thread-replay-pagination.ts` |
| An unresolvable `before` reports the beginning of the thread and logs it, instead of silently serving the newest page | `thread-replay-pagination.ts` |

Skipping forward to a provider-owned entry repeats at most one overlay row on the older page, which the renderer already dedupes by id — the lossless direction. The bridge passes `entry-id` when it did the paging itself and defers to the backend's own cursor otherwise (`threadReplayCursorIdSpace`), so the two never mix.

`isUsageActivityEntry` and `usageActivityScope` move out of `backend-registry.ts` into a new `overlay-transcript-entries.ts` alongside the overlay id prefixes (`live-turn-usage-`, `live-token-usage-`, `managed-review:`, `codex-environment-setup-`), so what the read path merges in and what the pagination path refuses as a cursor read from **one list**. Summary matching is part of that list because `persistThreadUsageActivity` accepts a monitor-scope row under any id.

This predates #1911. The newest page already carried overlay rows, so the first "load older" could already mint a bad cursor. #1911 widens the exposure by merging usage into every page; that branch is unchanged by this PR and rebases cleanly on top — its `mergeTurnAnchoredUsageActivities` calls the two moved helpers, which are now imported at the top of `backend-registry.ts`.

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint:eslint` — 0 errors (43 pre-existing warnings, none in touched files).
- `pnpm lint:boundaries` — no violations, 1622 modules cruised.
- `pnpm test` — 642 files, 9370 passed, 6 skipped, 0 failures.
- **All four new tests were verified to fail against the pre-fix behavior.** The federated one reproduces the report exactly: `previousCursor: "live-turn-usage-turn-1"`.

New coverage:

- `thread-replay-pagination.test.ts` — cursor skips overlay rows leading a page; unresolvable `before` returns an empty page with `hasPreviousPage: false`; backend cursor-ownership classification; the trim minting a provider cursor when an overlay row leads; the trim preserving a natively paginated backend's cursor; the trim's provider-entry floor.
- `federation-backend-bridge.test.ts` — the end-to-end case the fix is for: a federated `before` read whose page leads with an overlay-owned row. The mock mirrors `readAcpThread` (pages the provider's own replay with the real `pageNormalizedReplay`, then merges the usage row), and the entries are sized so the trim lands with the overlay row leading. The second read returns older history rather than the newest page.

## Notes

- **Two limitations remain, both pre-existing and both improvements on today.** On the Codex path the entries the trim drops stay unreachable, because the preserved cursor points before the whole page — but the pages behind it now load, where the dead cursor previously stopped everything. And `analyzeThreadToolHistory` will report `complete: true` if it ever meets an unresolvable cursor; only reachable if an ACP session reloads with different entry ids, and the new `unresolved_transcript_pagination_cursor` warning names it.
- Test entry sizes in the bridge test are tuned against the real 16 MiB budget and account for a message's text being measured three times over — in `entries`, in `messages`, and again as `lastUserMessage`/`lastAssistantMessage`. That is called out in a comment so a future edit does not silently stop exercising the trim.
- The renderer's own copies of the usage predicates (`useThreadSessionState.ts`, `transcript-render-items.ts`) are deliberately untouched: the renderer boundary forbids importing from main, and they play no part in cursor minting.
- `threadReplayCursorIdSpace` defaults an unclassified backend to `provider-cursor`. Preserving a cursor we cannot improve on costs one page of history; inventing one the backend rejects costs every page behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
