### PR TITLE
fix(messaging): skip PDF setup for plain text

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -13843,6 +13843,124 @@ describe("MessagingController", () => {
     );
   });
 
+  it("does not resolve PDF handling for plain-text turns", async () => {
+    const info = vi.fn();
+    let markPdfPolicyEntered!: () => void;
+    let releasePdfPolicy!: (enabled: boolean) => void;
+    const pdfPolicyEntered = new Promise<void>((resolve) => {
+      markPdfPolicyEntered = resolve;
+    });
+    const pdfPolicyGate = new Promise<boolean>((resolve) => {
+      releasePdfPolicy = resolve;
+    });
+    const pdfAnalysisEnabled = vi.fn(() => {
+      markPdfPolicyEntered();
+      return pdfPolicyGate;
+    });
+    const supportsMessagingPdfTools = vi.fn(async () => true);
+    const harness = await createHarness({
+      logger: { info },
+      pdfAnalysisEnabled,
+      supportsMessagingPdfTools,
+    });
+    await bindThread(harness);
+    info.mockClear();
+
+    const handling = harness.controller.handleInboundEvent(
+      buildTextEvent("This turn has no attachments."),
+    );
+    const firstCompletedOperation = await Promise.race([
+      handling.then(() => "turn" as const),
+      pdfPolicyEntered.then(() => "pdf-policy" as const),
+    ]);
+    releasePdfPolicy(true);
+    await handling;
+
+    expect(firstCompletedOperation).toBe("turn");
+    expect(pdfAnalysisEnabled).not.toHaveBeenCalled();
+    expect(supportsMessagingPdfTools).not.toHaveBeenCalled();
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "This turn has no attachments." }],
+      }),
+    );
+    const startingTurn = info.mock.calls.find(
+      (call) => call[0] === "messaging starting turn",
+    );
+    expect(startingTurn?.[1]).toMatchObject({
+      bundleReadyToInputPreparedMs: 0,
+      inboundEventId: "event-text",
+      inputPrepPrivateResponseMs: 0,
+      inputPrepTextConstructionMs: 0,
+    });
+    expect(startingTurn?.[1]).not.toHaveProperty(
+      "inputPrepPdfAnalysisPolicyMs",
+    );
+    expect(startingTurn?.[1]).not.toHaveProperty(
+      "inputPrepPdfToolSupportProbeMs",
+    );
+  });
+
+  it("logs bounded PDF preparation subspans on the start-turn event", async () => {
+    let clock = 1_000;
+    const info = vi.fn();
+    const pdfData = new TextEncoder().encode("%PDF-1.7\n/timed PDF\n");
+    const harness = await createHarness({
+      downloadAttachment: vi.fn(async ({ attachment }) => {
+        clock += 400;
+        return {
+          data: pdfData,
+          fileName: attachment.name,
+          mimeType: attachment.mimeType,
+          sizeBytes: pdfData.byteLength,
+        };
+      }),
+      logger: { info },
+      now: () => clock,
+      pdfAnalysisEnabled: async () => {
+        clock += 2_300;
+        return true;
+      },
+      supportsMessagingPdfTools: async () => {
+        clock += 300;
+        return true;
+      },
+    });
+    await bindThread(harness);
+    info.mockClear();
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("Inspect this."),
+      attachments: [
+        {
+          id: "pdf-timing",
+          kind: "file",
+          name: "timing.pdf",
+          disposition: "available",
+          mimeType: "application/pdf",
+          sizeBytes: pdfData.byteLength,
+        },
+      ],
+      id: "event-pdf-timing",
+      kind: "media",
+      text: "Inspect this.",
+      disposition: "available",
+    });
+
+    const startingTurn = info.mock.calls.find(
+      (call) => call[0] === "messaging starting turn",
+    );
+    expect(startingTurn?.[1]).toMatchObject({
+      bundleReadyToInputPreparedMs: 3_000,
+      inboundEventId: "event-pdf-timing",
+      inputPrepAttachmentProcessingMs: 400,
+      inputPrepPdfAnalysisPolicyMs: 2_300,
+      inputPrepPdfHandlingResolutionMs: 2_600,
+      inputPrepPdfToolSupportProbeMs: 300,
+      inputPrepPrivateResponseMs: 0,
+    });
+  });
+
   it("routes inbound PDFs into bound thread turns as rendered page images", async () => {
     const pdfData = new TextEncoder().encode("%PDF-1.7\n/image data\n");
     vi.mocked(renderPdfPages).mockResolvedValueOnce([

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -351,9 +351,21 @@ type MessagingHandledToRoutedSubspan =
   | "handledTextParsingMs"
   | "finalAdmissionAppendAwaitMs";
 
+type MessagingInputPreparationSpan =
+  | "inputPrepPendingSkillBindingReloadMs"
+  | "inputPrepPdfHandlingResolutionMs"
+  | "inputPrepPdfAnalysisPolicyMs"
+  | "inputPrepPdfToolSupportProbeMs"
+  | "inputPrepPrivateResponseMs"
+  | "inputPrepTextConstructionMs"
+  | "inputPrepAttachmentProcessingMs";
+
 type MessagingAdmissionTimingRecord = {
   marks: Partial<Record<MessagingAdmissionStage, number>>;
-  subspans: Partial<Record<MessagingHandledToRoutedSubspan, number>>;
+  subspans: Partial<Record<
+    MessagingHandledToRoutedSubspan | MessagingInputPreparationSpan,
+    number
+  >>;
 };
 // Upper bound on retained automation start/final delivery-dedup keys. Each entry
 // embeds the full rendered message text and is only consulted while a run's
@@ -4026,6 +4038,24 @@ export class MessagingController {
   }
 
   /**
+   * Add one bounded subspan to the existing start-turn admission log.
+   *
+   * A bundle can contain several text or media events, so repeated spans add
+   * together. The record is keyed by the provider event id and never includes
+   * message content, attachment names, or actor identifiers.
+   */
+  private addInputPreparationTiming(
+    event: MessagingInboundEvent | undefined,
+    span: MessagingInputPreparationSpan,
+    startedAt: number,
+  ): void {
+    if (!event) return;
+    const timing = this.admissionTimingForEvent(event);
+    timing.subspans[span] =
+      (timing.subspans[span] ?? 0) + (this.now() - startedAt);
+  }
+
+  /**
    * Consume this message's marks as span durations for the start-turn log.
    *
    * A span is emitted only when both of its ends were reached, so a path that
@@ -4093,9 +4123,21 @@ export class MessagingController {
     for (const event of bundle.events.slice(1)) {
       this.admissionStageMarks.delete(event.id);
     }
-    const currentBinding = bundle.binding.pendingSkillSelection
-      ? await this.options.store.getBinding(bundle.binding.id) ?? bundle.binding
-      : bundle.binding;
+    let currentBinding = bundle.binding;
+    if (bundle.binding.pendingSkillSelection) {
+      const pendingSkillBindingReloadStartedAt = this.now();
+      try {
+        currentBinding =
+          await this.options.store.getBinding(bundle.binding.id)
+          ?? bundle.binding;
+      } finally {
+        this.addInputPreparationTiming(
+          bundle.events[0],
+          "inputPrepPendingSkillBindingReloadMs",
+          pendingSkillBindingReloadStartedAt,
+        );
+      }
+    }
     const prepared = await this.prepareTurnInput(bundle.events, currentBinding, bundle.events[0]);
     if (!prepared) {
       return;
@@ -4359,7 +4401,12 @@ export class MessagingController {
     const pdfAttachments: PendingPdfAttachment[] = [];
     const previewParts: string[] = [];
     const rejections: MessagingAttachmentRejection[] = [];
-    const pdfHandling = await this.resolveMessagingPdfHandling(binding);
+    let pdfHandling:
+      | "model_directed"
+      | "render_initial_pages"
+      | "pass_through"
+      | undefined;
+    const privateResponseStartedAt = this.now();
     const privateReplyContinuation = binding?.privateReplyContinuation;
     if (
       privateReplyContinuation
@@ -4385,17 +4432,41 @@ export class MessagingController {
         text: PRIVATE_RESPONSE_FALLBACK_INSTRUCTION,
       });
     }
+    this.addInputPreparationTiming(
+      event,
+      "inputPrepPrivateResponseMs",
+      privateResponseStartedAt,
+    );
 
     for (const turnEvent of events) {
       if (turnEvent.kind === "text") {
+        const textConstructionStartedAt = this.now();
         const previewText = turnEvent.text.trim();
         if (previewText) {
           input.push({ type: "text", text: turnEvent.text });
           previewParts.push(previewText);
         }
+        this.addInputPreparationTiming(
+          event,
+          "inputPrepTextConstructionMs",
+          textConstructionStartedAt,
+        );
         continue;
       }
 
+      if (turnEvent.attachments.length > 0 && pdfHandling === undefined) {
+        const pdfHandlingStartedAt = this.now();
+        try {
+          pdfHandling = await this.resolveMessagingPdfHandling(binding, event);
+        } finally {
+          this.addInputPreparationTiming(
+            event,
+            "inputPrepPdfHandlingResolutionMs",
+            pdfHandlingStartedAt,
+          );
+        }
+      }
+      const attachmentProcessingStartedAt = this.now();
       const processed = await processMessagingAttachments({
         adapter: this.options.adapter,
         attachments: turnEvent.attachments,
@@ -4406,6 +4477,11 @@ export class MessagingController {
         pdfHandling,
         text: turnEvent.text,
       });
+      this.addInputPreparationTiming(
+        event,
+        "inputPrepAttachmentProcessingMs",
+        attachmentProcessingStartedAt,
+      );
 
       input.push(...processed.input);
       pdfAttachments.push(...processed.pdfAttachments);
@@ -4450,11 +4526,19 @@ export class MessagingController {
       );
     }
 
+    const previewConstructionStartedAt = this.now();
+    const preview = buildQueuedInputPreview(previewParts);
+    this.addInputPreparationTiming(
+      event,
+      "inputPrepTextConstructionMs",
+      previewConstructionStartedAt,
+    );
+
     return {
       input,
       pdfAttachments,
       privateResponseRequested,
-      preview: buildQueuedInputPreview(previewParts),
+      preview,
     };
   }
 
@@ -4497,8 +4581,9 @@ export class MessagingController {
 
   private async resolveMessagingPdfHandling(
     binding: MessagingBindingRecord | undefined,
+    event?: MessagingInboundEvent,
   ): Promise<"model_directed" | "render_initial_pages" | "pass_through"> {
-    if (!(await this.resolvePdfAnalysisEnabled())) {
+    if (!(await this.resolvePdfAnalysisEnabled(event))) {
       return "pass_through";
     }
     if (
@@ -4507,6 +4592,7 @@ export class MessagingController {
     ) {
       return "render_initial_pages";
     }
+    const pdfToolSupportStartedAt = this.now();
     try {
       return await this.options.backend.supportsMessagingPdfTools({
         backend: binding.backend,
@@ -4521,15 +4607,32 @@ export class MessagingController {
         threadId: binding.threadId,
       });
       return "render_initial_pages";
+    } finally {
+      this.addInputPreparationTiming(
+        event,
+        "inputPrepPdfToolSupportProbeMs",
+        pdfToolSupportStartedAt,
+      );
     }
   }
 
-  private async resolvePdfAnalysisEnabled(): Promise<boolean> {
+  private async resolvePdfAnalysisEnabled(
+    event?: MessagingInboundEvent,
+  ): Promise<boolean> {
+    const pdfAnalysisPolicyStartedAt = this.now();
     const configured = this.options.pdfAnalysisEnabled;
-    if (typeof configured === "function") {
-      return (await configured()) !== false;
+    try {
+      if (typeof configured === "function") {
+        return (await configured()) !== false;
+      }
+      return configured !== false;
+    } finally {
+      this.addInputPreparationTiming(
+        event,
+        "inputPrepPdfAnalysisPolicyMs",
+        pdfAnalysisPolicyStartedAt,
+      );
     }
-    return configured !== false;
   }
 
   private async startPreparedInput(params: {


### PR DESCRIPTION
## Summary

- I moved PDF handling resolution behind the first admitted media event that actually has attachments. Plain-text bundles no longer load PDF policy or probe backend PDF-tool support.
- I added bounded input-preparation subspans to the existing `messaging starting turn` structured log. They share its `inboundEventId` and do not add message bodies, attachment names, secrets, or actor identifiers.
- I preserved the current media/PDF path: PDF policy and tool support are still resolved once per attachment-bearing bundle before attachment download, classification, and PDF preparation.

## Verification

- I added a deterministic deferred-promise regression test. Before the fix, the unresolved PDF-policy callback won the race and blocked the plain-text turn; after the fix, the turn completes first without calling either PDF callback.
- The plain-text regression records `bundleReadyToInputPreparedMs=0` under a deterministic clock. A media timing test records the injected spans exactly: 2,300 ms PDF policy + 300 ms tool support = 2,600 ms PDF handling, followed by 400 ms attachment processing.
- I verified the running dev profile end to end with Discord. Default-route event `1544350736802910269` recorded `bundleReadyToInputPreparedMs=0`; bound-thread event `1544350884803125360` also recorded `bundleReadyToInputPreparedMs=0`.
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` (424 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; pre-existing warnings only)
- `pnpm lint:boundaries` (0 violations)

## Notes

- This PR was originally stacked directly on `fix/desktop-thread-info-store` at `63ac4db828da9a32659e064aec1af96f4f59321d`. After #1916 squash-merged, I replayed only this follow-up's signed commit onto `origin/main` at `b881707bbd0c772c0ff564474efa09ceb3cfa10d`; the PR now targets `main` and remains limited to `bundleReadyToInputPreparedMs`.
- Live PR #1916 evidence before this change was 3,226 ms for default-route Discord event `1544334536358367283` and 2,376 ms for bound-thread event `1544334775521902624`. The equivalent after-fix events measured 0 ms for both routes.
- Plain text removes two awaited operations from this span: `pdfAnalysisEnabled()` (the runtime `loadConfig()` path) and `supportsMessagingPdfTools()`. The conditional pending-skill `store.getBinding()` remains, as does the `prepareTurnInput()` await itself; ordinary text construction inside it has no I/O. Admission-state reads remain after `inputPrepared` and outside this span.
- Media retains PDF policy resolution, the conditional Codex PDF-tool probe, and attachment processing. The live log now reports `inputPrepPendingSkillBindingReloadMs`, `inputPrepPdfHandlingResolutionMs`, `inputPrepPdfAnalysisPolicyMs`, `inputPrepPdfToolSupportProbeMs`, `inputPrepPrivateResponseMs`, `inputPrepTextConstructionMs`, and `inputPrepAttachmentProcessingMs` when those subspans run.
- Live verification passed. The remaining large spans in the two after-fix records were outside this PR's assigned span: `handledToRoutedMs` was 2,752/4,949 ms, and the bound event's `originToPolicyMs` was 1,966 ms.
