### PR TITLE
perf(messaging): cache Full Access resume policy

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -397,6 +397,64 @@ describe("MessagingController", () => {
     });
   });
 
+  it("attributes Full Access policy latency to bounded policy subspans", async () => {
+    let clock = 1_000;
+    const info = vi.fn();
+    const navigation = buildNavigationSnapshot();
+    navigation.threads = [{
+      ...navigation.threads[0]!,
+      executionMode: "full-access",
+    }];
+    const harness = await createHarness({
+      navigation,
+      logger: { info },
+      now: () => clock,
+      fullAccessControls: async () => {
+        clock += 1_937;
+        return {
+          allowEscalation: true,
+          allowThreadResume: true,
+          warningPolicy: "dismissable",
+        };
+      },
+    });
+    await bindThread(harness);
+    info.mockClear();
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("measure Full Access policy"),
+      receivedAt: clock,
+    });
+
+    const policy = info.mock.calls.find(
+      (call) => call[0] === "messaging Full Access resume policy evaluated",
+    );
+    expect(policy?.[1]).toMatchObject({
+      inboundEventId: "event-text",
+      allowed: true,
+      controlsSource: "dynamic",
+      targetThreadLookupMs: 0,
+      executionModeResolutionMs: 0,
+      turnSettingsResolutionMs: 0,
+      fullAccessControlsLoadMs: 1_937,
+      fullAccessControlsLoadAwaitCount: 1,
+      settingsConfigReadMs: 1_937,
+      settingsConfigReadAwaitCount: 1,
+      authorizedUserPolicyCheckMs: 0,
+      authorizedUserPolicyCheckAwaitCount: 0,
+      allowedPathAuditPersistenceMs: 0,
+      allowedPathAuditPersistenceAwaitCount: 0,
+      fullAccessPolicyTotalMs: 1_937,
+    });
+    const startingTurn = info.mock.calls.find(
+      (call) => call[0] === "messaging starting turn",
+    );
+    expect(startingTurn?.[1]).toMatchObject({
+      inboundEventId: "event-text",
+      originToPolicyMs: 1_937,
+    });
+  });
+
   it("merges eventual provider channel metadata without replaying inbound", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -23,9 +23,11 @@ import type {
 import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
 import type { MessagingBackendBridge } from "../messaging/core/messaging-adapter";
 import type { MessagingControllerDeliveryBudgetEvent } from "../messaging/core/messaging-controller";
+import type { DesktopMessagingConfig } from "../messaging/messaging-config";
 import type {
   DesktopMessagingAdapter,
   DesktopMessagingAdapterFactory,
+  DesktopMessagingConfigLoader,
   DesktopMessagingRuntime,
   MessagingAutomationInboundHandler,
   MessagingAutomationInboundMatcher,
@@ -125,6 +127,105 @@ describe("DesktopMessagingRuntime", () => {
     await expect(adapter.listener?.(invalidEvent)).rejects.toThrow(
       "omitted a finite first-boundary receivedAt",
     );
+  });
+
+  it("does not reload config to authorize an allowed Full Access bound reply", async () => {
+    const config = buildFullAccessRuntimeConfig(true);
+    let configLoadsAtStartTurn = -1;
+    const loadConfig = vi.fn()
+      .mockResolvedValueOnce(config)
+      // PDF policy remains outside this span and still resolves dynamically.
+      .mockResolvedValueOnce(config)
+      .mockResolvedValue(config);
+    const { runtime, adapter, bridge } = await createFullAccessRuntimeHarness(
+      loadConfig,
+    );
+    vi.mocked(bridge.startTurn).mockImplementation(async (request) => {
+      configLoadsAtStartTurn = loadConfig.mock.calls.length;
+      return {
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: "turn-1",
+      };
+    });
+
+    await runtime.start();
+    await adapter.listener!(buildTextEvent("continue"));
+
+    expect(bridge.startTurn).toHaveBeenCalledTimes(1);
+    expect(configLoadsAtStartTurn).toBe(2);
+    const policy = messagingLog.info.mock.calls.find(
+      (call) => call[0] === "messaging Full Access resume policy evaluated",
+    );
+    expect(policy?.[1]).toMatchObject({
+      inboundEventId: "event-text",
+      allowed: true,
+      controlsSource: "runtime-snapshot",
+      policyRevision: 1,
+      fullAccessControlsLoadAwaitCount: 0,
+      settingsConfigReadMs: 0,
+      settingsConfigReadAwaitCount: 0,
+      authorizedUserPolicyCheckAwaitCount: 0,
+      allowedPathAuditPersistenceAwaitCount: 0,
+    });
+  });
+
+  it("denies a Full Access bound reply from the applied runtime policy", async () => {
+    const { runtime, adapter, bridge } = await createFullAccessRuntimeHarness(
+      buildFullAccessRuntimeConfig(false),
+    );
+
+    await runtime.start();
+    await adapter.listener!(buildTextEvent("continue"));
+
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+    expect(adapter.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access blocked",
+      body: expect.stringContaining("cannot be resumed"),
+    });
+  });
+
+  it("applies a hot Full Access resume policy change without restarting adapters", async () => {
+    const { runtime, adapter, bridge } = await createFullAccessRuntimeHarness(
+      buildFullAccessRuntimeConfig(true),
+    );
+    await runtime.start();
+
+    await runtime.applyConfig(buildFullAccessRuntimeConfig(false));
+    await adapter.listener!(buildTextEvent("continue"));
+
+    expect(adapter.start).toHaveBeenCalledTimes(1);
+    expect(adapter.stop).not.toHaveBeenCalled();
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+    expect(adapter.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access blocked",
+    });
+  });
+
+  it("fails closed after a lifecycle config read fails", async () => {
+    const config = buildFullAccessRuntimeConfig(true);
+    const loadConfig = vi.fn()
+      .mockResolvedValueOnce(config)
+      .mockRejectedValueOnce(new Error("settings unavailable"))
+      // Keep the separately owned PDF setting read out of this policy test.
+      .mockResolvedValue(config);
+    const { runtime, adapter, bridge } = await createFullAccessRuntimeHarness(
+      loadConfig,
+    );
+    await runtime.start();
+
+    await expect(runtime.applyLatestConfig()).rejects.toThrow(
+      "settings unavailable",
+    );
+    await adapter.listener!(buildTextEvent("continue"));
+
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+    expect(adapter.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access blocked",
+    });
   });
 
   it("subscribes only to federated bindings on running adapters", async () => {
@@ -3844,6 +3945,71 @@ function buildRejectedSlackEvent(
     receivedAt: 1234,
     reason: "unauthorized-actor",
   };
+}
+
+function buildFullAccessRuntimeConfig(
+  allowThreadResume: boolean,
+): DesktopMessagingConfig {
+  return {
+    inputDebounceMs: 0,
+    fullAccessControls: {
+      allowEscalation: true,
+      allowThreadResume,
+      warningPolicy: "dismissable",
+      authorizedUsers: {
+        telegram: [{ id: "user-1", displayName: "" }],
+      },
+    },
+    telegram: {
+      channel: "telegram",
+      botToken: "telegram-token",
+      authorizedActorIds: [{ id: "user-1", displayName: "" }],
+    },
+  };
+}
+
+async function createFullAccessRuntimeHarness(
+  config: DesktopMessagingConfig | DesktopMessagingConfigLoader,
+): Promise<{
+  adapter: ReturnType<typeof createAdapter>;
+  bridge: ReturnType<typeof createBackendBridge>;
+  runtime: DesktopMessagingRuntime;
+}> {
+  await prepareRuntimeStore();
+  const adapter = createAdapter("telegram");
+  const bridge = createBackendBridge();
+  const navigation = buildNavigationSnapshot();
+  vi.mocked(bridge.getNavigationSnapshot).mockResolvedValue({
+    ...navigation,
+    threads: [{
+      ...navigation.threads[0]!,
+      executionMode: "full-access",
+    }],
+  });
+  const { DesktopMessagingRuntime: Runtime } = await import(
+    "../messaging/messaging-runtime"
+  );
+  const runtime = trackRuntime(new Runtime({
+    adapterFactory: () => [adapter],
+    backendBridge: bridge,
+    config,
+  }));
+  const { getDesktopMessagingStore } = await import(
+    "../messaging/desktop-messaging-store"
+  );
+  await getDesktopMessagingStore().upsertBinding({
+    id: "binding:full-access",
+    channel: {
+      channel: "telegram",
+      conversation: { id: "chat-1", kind: "dm" },
+    },
+    backend: "codex",
+    threadId: "thread-1",
+    authorizedActorIds: ["user-1"],
+    createdAt: 1_000,
+    updatedAt: 1_000,
+  });
+  return { adapter, bridge, runtime };
 }
 
 async function createRuntimeHarness(options: {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -35,7 +35,6 @@ import type {
   MessagingAutomationInboundHandler,
   MessagingAutomationInboundMatcher,
 } from "../messaging/messaging-runtime";
-import type { DesktopMessagingConfig } from "../messaging/messaging-config";
 
 const messagingLog = {
   debug: vi.fn(),

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -23,7 +23,10 @@ import type {
 import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
 import type { MessagingBackendBridge } from "../messaging/core/messaging-adapter";
 import type { MessagingControllerDeliveryBudgetEvent } from "../messaging/core/messaging-controller";
-import type { DesktopMessagingConfig } from "../messaging/messaging-config";
+import type {
+  DesktopMessagingConfig,
+  DesktopMessagingFullAccessControls,
+} from "../messaging/messaging-config";
 import type {
   DesktopMessagingAdapter,
   DesktopMessagingAdapterFactory,
@@ -226,6 +229,50 @@ describe("DesktopMessagingRuntime", () => {
       kind: "error",
       title: "Full Access blocked",
     });
+  });
+
+  it("refreshes the cached contact after warning dismissal persists", async () => {
+    const persisted = createDeferred<void>();
+    const persistDismissal = vi.fn(async () => await persisted.promise);
+    const config = buildFullAccessRuntimeConfig(true);
+    config.fullAccessControls!.dismissWarning = persistDismissal;
+    config.fullAccessControls!.canDismissWarning = () => true;
+    const { runtime } = await createFullAccessRuntimeHarness(config);
+    await runtime.start();
+    const controller = (
+      runtime as unknown as {
+        controllers: Array<{
+          options: {
+            fullAccessControls: () =>
+              | DesktopMessagingFullAccessControls
+              | Promise<DesktopMessagingFullAccessControls>;
+          };
+        }>;
+      }
+    ).controllers[0]!;
+
+    const before = await controller.options.fullAccessControls();
+    expect(before.authorizedUsers.telegram?.[0]?.fullAccessWarningDismissed)
+      .not.toBe(true);
+    const dismissal = before.dismissWarning!({
+      actorId: "user-1",
+      channel: "telegram",
+    });
+    await flushMicrotasks();
+    const whilePersisting = await controller.options.fullAccessControls();
+    expect(
+      whilePersisting.authorizedUsers.telegram?.[0]?.fullAccessWarningDismissed,
+    ).not.toBe(true);
+    persisted.resolve();
+    await dismissal;
+    const after = await controller.options.fullAccessControls();
+
+    expect(persistDismissal).toHaveBeenCalledWith({
+      actorId: "user-1",
+      channel: "telegram",
+    });
+    expect(after.authorizedUsers.telegram?.[0]?.fullAccessWarningDismissed)
+      .toBe(true);
   });
 
   it("subscribes only to federated bindings on running adapters", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -15,12 +15,16 @@ import { StateDb } from "../state/state-db";
 import type { DesktopMessagingConfig } from "../messaging/messaging-config";
 import type { DesktopMessagingRuntime } from "../messaging/messaging-runtime";
 
+type RuntimeStub = DesktopMessagingRuntime & {
+  failClosedFullAccessPolicy: ReturnType<typeof vi.fn>;
+};
+
 let stateDb: StateDb;
 let store: AppRuntimeInstanceStore;
 let tempDir: string;
 let liveProcessIds: Set<number>;
 
-function createRuntime(options: { failApply?: boolean } = {}): DesktopMessagingRuntime {
+function createRuntime(options: { failApply?: boolean } = {}): RuntimeStub {
   let enabled = false;
   return {
     applyConfig: vi.fn(async () => {
@@ -28,10 +32,11 @@ function createRuntime(options: { failApply?: boolean } = {}): DesktopMessagingR
       enabled = true;
     }),
     isEnabled: vi.fn(() => enabled),
+    failClosedFullAccessPolicy: vi.fn(),
     stop: vi.fn(async () => {
       enabled = false;
     }),
-  } as unknown as DesktopMessagingRuntime;
+  } as unknown as RuntimeStub;
 }
 
 function createCoordinator(
@@ -101,6 +106,28 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
       disabledReason: "explicit_override",
     });
     expect(store.getMessagingLease()).toBeUndefined();
+  });
+
+  it("fails Full Access policy closed when the latest config read fails", async () => {
+    const runtime = createRuntime();
+    const coordinator = createCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+    const loadConfig = vi.fn(async (): Promise<DesktopMessagingConfig> => {
+      throw new Error("settings unavailable");
+    });
+
+    await expect(
+      coordinator.applyLatestConfig(runtime, loadConfig),
+    ).rejects.toThrow("settings unavailable");
+
+    expect(runtime.failClosedFullAccessPolicy).toHaveBeenCalledTimes(1);
+    expect(runtime.applyConfig).not.toHaveBeenCalled();
   });
 
   it("uses the launch root env var for lease owner identity", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -517,11 +517,10 @@ type ExecutionModeResolution = {
   source: "thread" | "binding-preferences" | "permissions-mode" | "unset";
 };
 
-function resolveExecutionModeForBinding(
+function resolveExecutionModeForThread(
   binding: MessagingBindingRecord,
-  navigation?: NavigationSnapshot,
+  thread: NavigationThreadSummary | undefined,
 ): ExecutionModeResolution {
-  const thread = findThreadForBinding(navigation, binding);
   if (thread?.executionMode) {
     return { mode: thread.executionMode, source: "thread" };
   }
@@ -535,6 +534,16 @@ function resolveExecutionModeForBinding(
     return { mode: "default", source: "permissions-mode" };
   }
   return { mode: undefined, source: "unset" };
+}
+
+function resolveExecutionModeForBinding(
+  binding: MessagingBindingRecord,
+  navigation?: NavigationSnapshot,
+): ExecutionModeResolution {
+  return resolveExecutionModeForThread(
+    binding,
+    findThreadForBinding(navigation, binding),
+  );
 }
 
 function executionModeForBinding(
@@ -555,8 +564,26 @@ function turnSettingsForBinding(
   serviceTier?: string;
 } {
   const thread = findThreadForBinding(navigation, binding);
+  return turnSettingsForThread(
+    binding,
+    thread,
+    resolveExecutionModeForThread(binding, thread),
+  );
+}
+
+function turnSettingsForThread(
+  binding: MessagingBindingRecord,
+  thread: NavigationThreadSummary | undefined,
+  executionResolution: ExecutionModeResolution,
+): {
+  executionMode?: ThreadExecutionMode;
+  fastMode?: boolean;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+} {
   return {
-    executionMode: executionModeForBinding(binding, navigation),
+    executionMode: executionResolution.mode,
     fastMode: thread?.fastMode ?? binding.preferences?.fastMode,
     model: thread?.model ?? binding.preferences?.model,
     reasoningEffort: thread?.reasoningEffort ?? binding.preferences?.reasoningEffort,
@@ -721,6 +748,23 @@ type MessagingFullAccessControlsResolverFn = () =>
 type MessagingFullAccessControlsResolver =
   | MessagingFullAccessControls
   | MessagingFullAccessControlsResolverFn;
+
+function normalizeMessagingFullAccessControls(
+  resolved: MessagingFullAccessControls | undefined,
+): MessagingFullAccessControls {
+  return {
+    allowEscalation: resolved?.allowEscalation ?? true,
+    allowThreadResume: resolved?.allowThreadResume ?? true,
+    warningPolicy: resolved?.warningPolicy ?? "dismissable",
+    authorizedUsers: resolved?.authorizedUsers ?? {},
+    dismissWarning: resolved?.dismissWarning,
+    canDismissWarning: resolved?.canDismissWarning,
+  };
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return typeof (value as PromiseLike<T>)?.then === "function";
+}
 
 type FullAccessEscalationContext =
   | {
@@ -896,6 +940,8 @@ export type MessagingControllerOptions = {
   ) => Promise<MessagingResponseMode> | MessagingResponseMode;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
   fullAccessControls?: MessagingFullAccessControlsResolver;
+  fullAccessControlsSource?: "dynamic" | "runtime-snapshot";
+  fullAccessPolicyRevision?: () => number;
   deliveryBudget?: MessagingDeliveryBudget;
   sleepUntil?: (retryAt: number, now: () => number) => Promise<void>;
   activityLog?: () => MessagingActivityLog;
@@ -4575,23 +4621,89 @@ export class MessagingController {
         );
       }
       this.markAdmissionStage(params.event, "originBuilt");
-      const turnSettings = turnSettingsForBinding(params.binding, navigation);
-      const executionResolution = resolveExecutionModeForBinding(
+      const targetThreadLookupStartedAt = this.now();
+      const targetThread = findThreadForBinding(navigation, params.binding);
+      const targetThreadLookupCompletedAt = this.now();
+      const executionModeResolutionStartedAt = this.now();
+      const executionResolution = resolveExecutionModeForThread(
         params.binding,
-        navigation,
+        targetThread,
       );
+      const executionModeResolutionCompletedAt = this.now();
+      const turnSettingsResolutionStartedAt = this.now();
+      const turnSettings = turnSettingsForThread(
+        params.binding,
+        targetThread,
+        executionResolution,
+      );
+      const turnSettingsResolutionCompletedAt = this.now();
       if (
         turnSettings.executionMode === "full-access" &&
-        !(await this.canUseFullAccessThread(params.binding, navigation))
+        targetThread?.executionMode === "full-access"
       ) {
-        await this.deliverFullAccessPolicyError(
-          params.binding,
-          params.event,
-          "Full Access threads cannot be resumed from messaging with the current settings.",
-        );
-        return "failed";
+        const fullAccessControlsLoadStartedAt = this.now();
+        const controlsResolution = this.resolveFullAccessControls();
+        const fullAccessControlsLoadAwaitCount = isPromiseLike(controlsResolution)
+          ? 1
+          : 0;
+        const controls = isPromiseLike(controlsResolution)
+          ? await controlsResolution
+          : controlsResolution;
+        const fullAccessControlsLoadCompletedAt = this.now();
+        const resumeSettingCheckStartedAt = this.now();
+        const allowed = controls.allowThreadResume;
+        const resumeSettingCheckCompletedAt = this.now();
+        const policyResolvedAt = this.now();
+        const controlsSource = this.options.fullAccessControlsSource
+          ?? (typeof this.options.fullAccessControls === "function"
+            ? "dynamic"
+            : "static");
+        this.markAdmissionStage(params.event, "policyResolved");
+        this.logger.info?.("messaging Full Access resume policy evaluated", {
+          inboundEventId: params.event?.id,
+          channel: params.binding.channel.channel,
+          allowed,
+          controlsSource,
+          policyRevision: this.options.fullAccessPolicyRevision?.(),
+          targetThreadFound: true,
+          targetThreadLookupMs:
+            targetThreadLookupCompletedAt - targetThreadLookupStartedAt,
+          executionModeResolutionMs:
+            executionModeResolutionCompletedAt - executionModeResolutionStartedAt,
+          turnSettingsResolutionMs:
+            turnSettingsResolutionCompletedAt - turnSettingsResolutionStartedAt,
+          fullAccessControlsLoadMs:
+            fullAccessControlsLoadCompletedAt - fullAccessControlsLoadStartedAt,
+          fullAccessControlsLoadAwaitCount,
+          settingsConfigReadMs:
+            controlsSource === "runtime-snapshot"
+              ? 0
+              : fullAccessControlsLoadCompletedAt - fullAccessControlsLoadStartedAt,
+          settingsConfigReadAwaitCount:
+            controlsSource === "runtime-snapshot"
+              ? 0
+              : fullAccessControlsLoadAwaitCount,
+          resumeSettingCheckMs:
+            resumeSettingCheckCompletedAt - resumeSettingCheckStartedAt,
+          authorizedUserPolicyCheckMs: 0,
+          authorizedUserPolicyCheckAwaitCount: 0,
+          allowedPathAuditPersistenceMs: 0,
+          allowedPathAuditPersistenceAwaitCount: 0,
+          fullAccessPolicyTotalMs: policyResolvedAt - targetThreadLookupStartedAt,
+        });
+        // Provider authorization already completed before turn admission.
+        // An allowed Full Access resume performs no audit or persistence.
+        if (!allowed) {
+          await this.deliverFullAccessPolicyError(
+            params.binding,
+            params.event,
+            "Full Access threads cannot be resumed from messaging with the current settings.",
+          );
+          return "failed";
+        }
+      } else {
+        this.markAdmissionStage(params.event, "policyResolved");
       }
-      this.markAdmissionStage(params.event, "policyResolved");
       // Diagnostic for #203-class regressions: a turn that the UI shows
       // as Default Access but routes to the Full Access codex client is
       // a silent security bug — the user thinks they're sandboxed but
@@ -13645,17 +13757,6 @@ export class MessagingController {
     return (await this.resolveFullAccessControls()).allowThreadResume;
   }
 
-  private async canUseFullAccessThread(
-    binding: MessagingBindingRecord,
-    navigation: NavigationSnapshot,
-  ): Promise<boolean> {
-    const thread = findThreadForBinding(navigation, binding);
-    if (thread?.executionMode !== "full-access") {
-      return true;
-    }
-    return await this.canResumeFullAccessThreads();
-  }
-
   private async resolveFullAccessRiskForSession(
     session: MessagingBrowseSessionRecord,
     event: MessagingInboundEvent,
@@ -13687,18 +13788,15 @@ export class MessagingController {
     return warning.shouldWarn ? "warning" : "accepted";
   }
 
-  private async resolveFullAccessControls(): Promise<MessagingFullAccessControls> {
+  private resolveFullAccessControls():
+    | MessagingFullAccessControls
+    | Promise<MessagingFullAccessControls> {
     const controls = this.options.fullAccessControls;
     const resolved =
-      typeof controls === "function" ? await controls() : controls;
-    return {
-      allowEscalation: resolved?.allowEscalation ?? true,
-      allowThreadResume: resolved?.allowThreadResume ?? true,
-      warningPolicy: resolved?.warningPolicy ?? "dismissable",
-      authorizedUsers: resolved?.authorizedUsers ?? {},
-      dismissWarning: resolved?.dismissWarning,
-      canDismissWarning: resolved?.canDismissWarning,
-    };
+      typeof controls === "function" ? controls() : controls;
+    return isPromiseLike(resolved)
+      ? Promise.resolve(resolved).then(normalizeMessagingFullAccessControls)
+      : normalizeMessagingFullAccessControls(resolved);
   }
 
   private async resolveFullAccessWarning(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -796,6 +796,10 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     return this.started;
   }
 
+  failClosedFullAccessPolicy(): void {
+    this.invalidateFullAccessPolicySnapshot();
+  }
+
   /**
    * Subscribe to platform status transitions. Returns an unsubscribe.
    * Listeners receive every `health-changed` and `activity` event;
@@ -2957,9 +2961,51 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   }
 
   private applyFullAccessPolicySnapshot(config: DesktopMessagingConfig): void {
+    const controls = snapshotFullAccessControls(config.fullAccessControls);
+    const persistDismissal = controls.dismissWarning;
+    if (persistDismissal) {
+      controls.dismissWarning = async (params) => {
+        await persistDismissal(params);
+        this.rememberFullAccessWarningDismissal(params);
+      };
+    }
     this.fullAccessPolicySnapshot = {
-      controls: snapshotFullAccessControls(config.fullAccessControls),
+      controls,
       revision: this.fullAccessPolicySnapshot.revision + 1,
+    };
+  }
+
+  private rememberFullAccessWarningDismissal(params: {
+    actorId: string;
+    channel: MessagingChannelKind;
+  }): void {
+    const current = this.fullAccessPolicySnapshot;
+    const contacts = current.controls.authorizedUsers[params.channel];
+    if (!contacts) return;
+    let changed = false;
+    const updatedContacts = contacts.map((contact) => {
+      if (
+        contact.id !== params.actorId
+        || contact.fullAccessWarningDismissed === true
+      ) {
+        return contact;
+      }
+      changed = true;
+      return {
+        ...contact,
+        fullAccessWarningDismissed: true,
+      };
+    });
+    if (!changed) return;
+    this.fullAccessPolicySnapshot = {
+      controls: {
+        ...current.controls,
+        authorizedUsers: {
+          ...current.controls.authorizedUsers,
+          [params.channel]: updatedContacts,
+        },
+      },
+      revision: current.revision + 1,
     };
   }
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -78,6 +78,7 @@ import {
   type DesktopMessagingConfig,
   type DesktopMessagingConfigChannel,
   type DesktopMessagingChannelConfigUpdate,
+  type DesktopMessagingFullAccessControls,
 } from "./messaging-config";
 import {
   createMessagingResponseModeSnapshot,
@@ -227,6 +228,44 @@ type RunningMessagingAuthorization = {
   actorIds: string[];
   actorIdSet: Set<string>;
 };
+
+type FullAccessPolicySnapshot = {
+  controls: DesktopMessagingFullAccessControls;
+  revision: number;
+};
+
+function snapshotFullAccessControls(
+  controls: DesktopMessagingFullAccessControls | undefined,
+): DesktopMessagingFullAccessControls {
+  if (!controls) {
+    return {
+      allowEscalation: false,
+      allowThreadResume: false,
+      warningPolicy: "always",
+      authorizedUsers: {},
+    };
+  }
+  const authorizedUsers: DesktopMessagingFullAccessControls["authorizedUsers"] = {};
+  for (const [channel, contacts] of Object.entries(controls.authorizedUsers ?? {})) {
+    authorizedUsers[channel as MessagingChannelKind] = contacts?.map(
+      (contact) => ({ ...contact }),
+    );
+  }
+  const warningPolicy =
+    controls.warningPolicy === "always"
+    || controls.warningPolicy === "dismissable"
+    || controls.warningPolicy === "never"
+      ? controls.warningPolicy
+      : "always";
+  return {
+    allowEscalation: controls.allowEscalation === true,
+    allowThreadResume: controls.allowThreadResume === true,
+    warningPolicy,
+    authorizedUsers,
+    dismissWarning: controls.dismissWarning,
+    canDismissWarning: controls.canDismissWarning,
+  };
+}
 
 type RejectedInboundRoute = {
   backend: MessagingBindingRecord["backend"];
@@ -408,6 +447,13 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   >();
   private pendingAdapterStopReason?: string;
   private lifecycleQueue: Promise<void> = Promise.resolve();
+  // Replaced as one object on the serialized config lifecycle. Controllers
+  // only read this owned copy; a missing or failed lifecycle read installs the
+  // deny/deny snapshot instead of preserving a previously allowed policy.
+  private fullAccessPolicySnapshot: FullAccessPolicySnapshot = {
+    controls: snapshotFullAccessControls(undefined),
+    revision: 0,
+  };
   /**
    * Listeners notified whenever any controller mutates a binding
    * (create / refresh metadata / sync title / detach / revoke). The
@@ -439,7 +485,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     this.pendingAdapterStopReason = undefined;
     this.pendingAdapterStartCancellationReasons.clear();
     await this.enqueueLifecycle(async () => {
-      const config = await this.loadConfig({ logStartupEligibility: true });
+      const config = await this.loadConfigForLifecycle({
+        logStartupEligibility: true,
+      });
       await this.applyConfigWithFailureStatus(config);
     });
   }
@@ -555,6 +603,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     config: DesktopMessagingConfig,
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
+    this.applyFullAccessPolicySnapshot(config);
     try {
       await this.applyConfigNow(config, options);
       this.clearStartupFailuresForDisabledPlatforms(config);
@@ -736,7 +785,10 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
     await this.enqueueLifecycle(async () => {
-      await this.applyConfigWithFailureStatus(await this.loadConfig(), options);
+      await this.applyConfigWithFailureStatus(
+        await this.loadConfigForLifecycle(),
+        options,
+      );
     });
   }
 
@@ -1385,8 +1437,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           ? config.managerToolUpdateDefaultMode ?? "show_none"
           : config.toolUpdateDefaultMode ?? "show_some";
       },
-      fullAccessControls: async () =>
-        (await this.loadConfig()).fullAccessControls,
+      fullAccessControls: () => this.fullAccessPolicySnapshot.controls,
+      fullAccessControlsSource: "runtime-snapshot",
+      fullAccessPolicyRevision: () => this.fullAccessPolicySnapshot.revision,
       onBindingChanged: () => this.broadcastBindingsChanged(),
       onDeliveryBudgetEvent: (event) => {
         void this.handleDeliveryBudgetEvent(event);
@@ -2890,6 +2943,31 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     return typeof this.options.config === "function"
       ? await this.options.config(options)
       : this.options.config;
+  }
+
+  private async loadConfigForLifecycle(
+    options?: DesktopMessagingConfigLoadOptions,
+  ): Promise<DesktopMessagingConfig> {
+    try {
+      return await this.loadConfig(options);
+    } catch (error) {
+      this.invalidateFullAccessPolicySnapshot();
+      throw error;
+    }
+  }
+
+  private applyFullAccessPolicySnapshot(config: DesktopMessagingConfig): void {
+    this.fullAccessPolicySnapshot = {
+      controls: snapshotFullAccessControls(config.fullAccessControls),
+      revision: this.fullAccessPolicySnapshot.revision + 1,
+    };
+  }
+
+  private invalidateFullAccessPolicySnapshot(): void {
+    this.fullAccessPolicySnapshot = {
+      controls: snapshotFullAccessControls(undefined),
+      revision: this.fullAccessPolicySnapshot.revision + 1,
+    };
   }
 }
 

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -96,7 +96,9 @@ export class RuntimeMessagingLeaseCoordinator {
       };
     }
 
-    const config = await loadConfig({ logStartupEligibility: true });
+    const config = await this.loadConfigFailClosed(runtime, loadConfig, {
+      logStartupEligibility: true,
+    });
     return this.applyResolvedConfig(runtime, config, { allowStart: true });
   }
 
@@ -105,13 +107,26 @@ export class RuntimeMessagingLeaseCoordinator {
     loadConfig: DesktopMessagingConfigLoader,
     options: DesktopMessagingConfigLoadOptions & { allowStart?: boolean } = {},
   ): Promise<RuntimeMessagingLeaseApplyResult> {
-    const config = await loadConfig({
+    const config = await this.loadConfigFailClosed(runtime, loadConfig, {
       logStartupEligibility: options.logStartupEligibility,
       messagingEnabledOverride: options.messagingEnabledOverride,
     });
     return this.applyResolvedConfig(runtime, config, {
       allowStart: options.allowStart ?? true,
     });
+  }
+
+  private async loadConfigFailClosed(
+    runtime: DesktopMessagingRuntime,
+    loadConfig: DesktopMessagingConfigLoader,
+    options: DesktopMessagingConfigLoadOptions,
+  ): Promise<DesktopMessagingConfig> {
+    try {
+      return await loadConfig(options);
+    } catch (error) {
+      runtime.failClosedFullAccessPolicy();
+      throw error;
+    }
   }
 
   async applyResolvedConfig(


### PR DESCRIPTION
## Summary

- I replaced the per-reply Full Access settings/config reload with a lifecycle-owned runtime policy snapshot that is atomically replaced when messaging config changes.
- I made missing controls and failed lifecycle config reads fail closed, while keeping valid hot settings changes effective without restarting running adapters.
- I also fail closed when the lease coordinator's pre-runtime settings load fails, and refresh the cached contact only after warning-dismissal persistence succeeds.
- I added one bounded structured timing event per Full Access bound reply, keyed by inbound event ID and containing no message body, secret, or actor identifier.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts` (71 passed)
- `pnpm test apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts` (10 passed)
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` (423 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- Live bound Full Access Discord reply `1544351909501214822`

## Notes

- This is intentionally stacked on `fix/desktop-thread-info-store` at `63ac4db828da9a32659e064aec1af96f4f59321d` and covers only `originToPolicyMs` for bound Full Access replies.
- Before this change, Discord event `1544334775521902624` measured `originToPolicyMs=1937`; the deterministic regression attributes the same 1,937 ms entirely to `fullAccessControlsLoadMs` for the former dynamic resolver.
- After this change, Discord event `1544351909501214822` measured `originToPolicyMs=0`, `policyToStartTurnIssueMs=2`, and `fullAccessPolicyTotalMs=0`. Target lookup, execution-mode resolution, turn-settings resolution, controls load, settings/config read, resume-setting check, authorized-user policy check, and allowed-path audit/persistence each measured 0 ms. Every policy await count was 0.
- The allowed runtime-snapshot path removes the awaited `loadConfig()` / `settings.readSettings()` policy read. It retains the synchronous target-thread lookup, execution-mode resolution, in-memory `allowThreadResume` check, and the later awaited `startTurn`. Provider authorization remains earlier in admission; the allowed policy span performs no actor-policy await, audit, or persistence.
- The existing PDF/config read before `originBuilt` remains unchanged because `bundleReadyToInputPreparedMs` belongs to the sibling follow-up.
- The same live event measured `handledToRoutedMs=3928` and `bundleReadyToInputPreparedMs=3184`; those spans remain intentionally untouched for the two sibling follow-ups.
- Review follow-up `d51eaa051` covers both cache invalidation seams without restoring a settings read to the Full Access reply path: coordinator load failure installs deny/deny before rethrowing, and a successful per-contact warning dismissal atomically replaces only the current cached contact entry.
