### PR TITLE
fix(messaging): remove config reload from reply routing

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -206,6 +206,9 @@ describe("MessagingController", () => {
     // Everything the admission read did not spend is attributed elsewhere, so
     // the stages sum to the end-to-end number rather than overlapping it.
     const detail = startingTurn?.[1] as Record<string, number>;
+    expect(Object.keys(detail).indexOf("handledToRoutedMs")).toBeLessThan(
+      Object.keys(detail).indexOf("handledTextParsingMs"),
+    );
     const stageTotal =
       detail.receivedToHandledMs
       + detail.handledToRoutedMs

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -279,6 +279,124 @@ describe("MessagingController", () => {
     );
   });
 
+  it("does not let delayed inbound metadata restore a concurrently revoked binding", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    const [binding] = await harness.store.findActiveBindingsForThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    if (!binding) {
+      throw new Error("Expected a bound thread");
+    }
+    const topicChannel: MessagingInboundTextEvent["channel"] = {
+      channel: "telegram",
+      conversation: {
+        id: "topic-1",
+        kind: "topic",
+        parentId: "chat-1",
+      },
+    };
+    const topicBinding = await harness.store.upsertBinding({
+      ...binding,
+      channel: topicChannel,
+      updatedAt: 900,
+    });
+    const managedTopicRead = createDeferred<undefined>();
+    const managedTopicReadStarted = createDeferred<void>();
+    vi.spyOn(harness.store, "findManagedTopicByConversation")
+      .mockImplementationOnce(async () => {
+        managedTopicReadStarted.resolve();
+        return await managedTopicRead.promise;
+      });
+
+    const metadataRefresh = harness.controller.handleInboundChannelMetadata({
+      eventId: "metadata-race",
+      observedAt: 1_000,
+      channel: {
+        ...topicChannel,
+        conversation: {
+          ...topicChannel.conversation,
+          title: "Fresh topic title",
+        },
+      },
+    });
+    await managedTopicReadStarted.promise;
+    await harness.store.revokeBinding({
+      bindingId: topicBinding.id,
+      revokedAt: 1_001,
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(topicChannel),
+    ).resolves.toBeUndefined();
+
+    managedTopicRead.resolve(undefined);
+    await metadataRefresh;
+    await expect(
+      harness.store.findActiveBindingForChannel(topicChannel),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not let delayed topic observation overwrite newer managed-topic state", async () => {
+    const metadataFinished = createDeferred<void>();
+    const debug = vi.fn((message: string) => {
+      if (message === "messaging off-path inbound metadata timing") {
+        metadataFinished.resolve();
+      }
+    });
+    const harness = await createHarness({ logger: { debug } });
+    const bindingRead = createDeferred<undefined>();
+    const bindingReadStarted = createDeferred<void>();
+    vi.spyOn(harness.store, "findActiveBindingForChannel")
+      .mockImplementationOnce(async () => {
+        bindingReadStarted.resolve();
+        return await bindingRead.promise;
+      });
+    const channel: MessagingChannelRef = {
+      channel: "telegram",
+      conversation: {
+        id: "topic-1",
+        kind: "topic",
+        parentId: "chat-1",
+        title: "Observed topic",
+      },
+    };
+
+    const handled = harness.controller.handleInboundEvent(buildTextEvent(
+      "observe topic",
+      { channel },
+    ));
+    await bindingReadStarted.promise;
+    await harness.store.upsertManagedTopic({
+      id: "topic:telegram:chat-1:topic-1",
+      authorizedActorIds: ["user-1"],
+      channel: "telegram",
+      closedAt: 1_001,
+      conversation: channel.conversation,
+      createdAt: 1_000,
+      lastObservedAt: 1_000,
+      lifecycle: "closed",
+      source: "owned",
+      supergroupId: "chat-1",
+      title: "Owned topic",
+      topicId: "topic-1",
+      updatedAt: 1_001,
+    });
+
+    bindingRead.resolve(undefined);
+    await handled;
+    await metadataFinished.promise;
+    await expect(
+      harness.store.getManagedTopic("topic:telegram:chat-1:topic-1"),
+    ).resolves.toMatchObject({
+      closedAt: 1_001,
+      lifecycle: "closed",
+      source: "owned",
+      title: "Owned topic",
+      updatedAt: 1_001,
+    });
+  });
+
   it("merges eventual provider channel metadata without replaying inbound", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -101,6 +101,17 @@ async function createStore(): Promise<MessagingStore> {
   return new MessagingStore(path.join(tempDir, "messaging-state.json"));
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
 afterEach(async () => {
   vi.useRealTimers();
   await Promise.all(
@@ -206,6 +217,63 @@ describe("MessagingController", () => {
       + detail.originToPolicyMs
       + detail.policyToStartTurnIssueMs;
     expect(stageTotal).toBe(detail.pwragentReceivedToStartTurnIssueMs);
+  });
+
+  it("does not await optional inbound metadata before routing a reply", async () => {
+    const debug = vi.fn();
+    const harness = await createHarness({ logger: { debug } });
+    await bindThread(harness);
+    const findBinding = harness.store.findActiveBindingForChannel.bind(
+      harness.store,
+    );
+    const metadataRead = createDeferred<
+      Awaited<ReturnType<typeof findBinding>>
+    >();
+    const metadataStarted = createDeferred<void>();
+    const pendingSessionRead = vi.spyOn(
+      harness.store,
+      "findActiveBrowseSessionForChannel",
+    );
+    let bindingReadCount = 0;
+    vi.spyOn(harness.store, "findActiveBindingForChannel")
+      .mockImplementation(async (channel) => {
+        bindingReadCount += 1;
+        if (bindingReadCount === 1) {
+          metadataStarted.resolve();
+          return await metadataRead.promise;
+        }
+        return await findBinding(channel);
+      });
+
+    const handled = harness.controller.handleInboundEvent(
+      buildTextEvent("route before metadata"),
+    );
+    expect(pendingSessionRead).toHaveBeenCalledTimes(1);
+    await metadataStarted.promise;
+
+    metadataRead.resolve(
+      await findBinding(buildTextEvent("metadata").channel),
+    );
+    await handled;
+    expect(harness.startTurn).toHaveBeenCalledTimes(1);
+    for (let index = 0; index < 10; index += 1) {
+      await Promise.resolve();
+    }
+    expect(debug).toHaveBeenCalledWith(
+      "messaging off-path inbound metadata timing",
+      expect.objectContaining({
+        eventId: "event-text",
+        platform: "telegram",
+      }),
+    );
+    expect(debug).toHaveBeenCalledWith(
+      "messaging admission append timing",
+      expect.objectContaining({
+        eventId: "event-text",
+        finalAdmissionAppendAwaitMs: expect.any(Number),
+        platform: "telegram",
+      }),
+    );
   });
 
   it("merges eventual provider channel metadata without replaying inbound", async () => {
@@ -2223,6 +2291,7 @@ describe("MessagingController", () => {
   });
 
   it("routes an accepted every-message topic to its default Agent without binding it", async () => {
+    const info = vi.fn();
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {
       ...navigation.threads[0]!,
@@ -2235,6 +2304,7 @@ describe("MessagingController", () => {
       },
     };
     const harness = await createHarness({
+      logger: { info },
       navigation,
       responseModeForConversation: () => "every_message",
     });
@@ -2274,6 +2344,26 @@ describe("MessagingController", () => {
     );
     expect(harness.delivered).not.toContainEqual(
       expect.objectContaining({ title: "PwrAgent commands" }),
+    );
+    expect(harness.listBackends).not.toHaveBeenCalled();
+    const startingTurn = info.mock.calls.find(
+      (call) => call[0] === "messaging starting turn",
+    );
+    expect(startingTurn?.[1]).toMatchObject({
+      handledBindingLookupMs: 0,
+      handledDefaultAgentAssignmentsMs: 0,
+      handledDefaultAgentRevocationsMs: 0,
+      handledDefaultAgentTargetValidationMs: 0,
+      handledPendingIntentReadMs: 0,
+      handledPendingNewThreadReadMs: 0,
+      handledPrivateContinuationExpirationMs: 0,
+      handledRequirePermissionMs: 0,
+      handledResponseModeMs: 0,
+      handledSharedMessagePolicyMs: 0,
+      handledTextParsingMs: 0,
+    });
+    expect(startingTurn?.[1]).not.toHaveProperty(
+      "handledDefaultAgentBackendValidationMs",
     );
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -30,6 +30,7 @@ import type {
   MessagingAutomationInboundHandler,
   MessagingAutomationInboundMatcher,
 } from "../messaging/messaging-runtime";
+import type { DesktopMessagingConfig } from "../messaging/messaging-config";
 
 const messagingLog = {
   debug: vi.fn(),
@@ -869,6 +870,157 @@ describe("DesktopMessagingRuntime", () => {
         input: [{ type: "text", text: "continue without a mention" }],
       }),
     );
+  });
+
+  it("routes an accepted shared reply without reloading runtime settings", async () => {
+    await prepareRuntimeStore();
+    const adapter = createAdapter("telegram");
+    const bridge = createBackendBridge();
+    const config: DesktopMessagingConfig = {
+      inputDebounceMs: 0,
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        responseMode: "mention_only",
+      },
+    };
+    const deferredReload = createDeferred<DesktopMessagingConfig>();
+    const loadConfig = vi.fn()
+      .mockResolvedValueOnce(config)
+      .mockImplementation(async () => await deferredReload.promise);
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      config: loadConfig,
+    }));
+    await runtime.start();
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    await getDesktopMessagingStore().upsertBinding({
+      id: "binding:telegram:channel::chat-1:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "channel",
+        },
+      },
+      createdAt: 1_000,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1_000,
+    });
+
+    const handled = adapter.listener?.({
+      ...buildTextEvent("continue in the channel"),
+      botMention: true,
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "channel",
+        },
+      },
+    });
+    await flushMicrotasks();
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+
+    deferredReload.resolve(config);
+    await handled;
+    expect(bridge.startTurn).toHaveBeenCalledTimes(1);
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "messaging starting turn",
+      expect.objectContaining({
+        handledBindingLookupMs: expect.any(Number),
+        handledPendingIntentReadMs: expect.any(Number),
+        handledPendingNewThreadReadMs: expect.any(Number),
+        handledPrivateContinuationExpirationMs: expect.any(Number),
+        handledRemoteScopeMs: expect.any(Number),
+        handledRequirePermissionMs: expect.any(Number),
+        handledResponseModeMs: expect.any(Number),
+        handledSharedMessagePolicyMs: expect.any(Number),
+        handledTextParsingMs: expect.any(Number),
+        inboundEventId: "event-text",
+      }),
+    );
+  });
+
+  it("hot-replaces the response-mode snapshot without restarting the adapter", async () => {
+    await prepareRuntimeStore();
+    const updateAuthorization = vi.fn(async () => undefined);
+    const adapter = createAdapter("telegram", { updateAuthorization });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      config: {
+        inputDebounceMs: 0,
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+          responseMode: "every_message",
+        },
+      },
+    }));
+    await runtime.start();
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    await getDesktopMessagingStore().upsertBinding({
+      id: "binding:telegram:channel::chat-1:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "channel",
+        },
+      },
+      createdAt: 1_000,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1_000,
+    });
+
+    await runtime.applyConfig({
+      inputDebounceMs: 0,
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        responseMode: "mention_only",
+      },
+    });
+    await adapter.listener?.({
+      ...buildTextEvent("ambient after hot apply"),
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "channel",
+        },
+      },
+    });
+
+    expect(updateAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ responseMode: "mention_only" }),
+    );
+    expect(adapter.start).toHaveBeenCalledTimes(1);
+    expect(adapter.stop).not.toHaveBeenCalled();
+    expect(bridge.startTurn).not.toHaveBeenCalled();
   });
 
   it("dispatches ambient replies in a native thread inside a 1:1 DM", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -52,6 +52,7 @@ function trackRuntime(runtime: DesktopMessagingRuntime): DesktopMessagingRuntime
 }
 
 beforeEach(() => {
+  messagingLog.debug.mockReset();
   messagingLog.error.mockReset();
   messagingLog.info.mockReset();
   messagingLog.warn.mockReset();
@@ -877,7 +878,7 @@ describe("DesktopMessagingRuntime", () => {
     const adapter = createAdapter("telegram");
     const bridge = createBackendBridge();
     const config: DesktopMessagingConfig = {
-      inputDebounceMs: 0,
+      inputDebounceMs: 60_000,
       telegram: {
         channel: "telegram",
         botToken: "telegram-token",
@@ -886,9 +887,13 @@ describe("DesktopMessagingRuntime", () => {
       },
     };
     const deferredReload = createDeferred<DesktopMessagingConfig>();
+    const reloadStarted = createDeferred<void>();
     const loadConfig = vi.fn()
       .mockResolvedValueOnce(config)
-      .mockImplementation(async () => await deferredReload.promise);
+      .mockImplementation(async () => {
+        reloadStarted.resolve();
+        return await deferredReload.promise;
+      });
     const { DesktopMessagingRuntime: Runtime } = await import(
       "../messaging/messaging-runtime"
     );
@@ -929,26 +934,22 @@ describe("DesktopMessagingRuntime", () => {
         },
       },
     });
-    await flushMicrotasks();
-
-    expect(loadConfig).toHaveBeenCalledTimes(1);
-
+    const outcome = await Promise.race([
+      handled?.then(() => "handled" as const),
+      reloadStarted.promise.then(() => "config-reload" as const),
+    ]);
     deferredReload.resolve(config);
     await handled;
-    expect(bridge.startTurn).toHaveBeenCalledTimes(1);
-    expect(messagingLog.info).toHaveBeenCalledWith(
-      "messaging starting turn",
+
+    expect(outcome).toBe("handled");
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+    expect(messagingLog.debug).toHaveBeenCalledWith(
+      "messaging admission append timing",
       expect.objectContaining({
-        handledBindingLookupMs: expect.any(Number),
-        handledPendingIntentReadMs: expect.any(Number),
-        handledPendingNewThreadReadMs: expect.any(Number),
-        handledPrivateContinuationExpirationMs: expect.any(Number),
-        handledRemoteScopeMs: expect.any(Number),
-        handledRequirePermissionMs: expect.any(Number),
-        handledResponseModeMs: expect.any(Number),
-        handledSharedMessagePolicyMs: expect.any(Number),
-        handledTextParsingMs: expect.any(Number),
-        inboundEventId: "event-text",
+        eventId: "event-text",
+        finalAdmissionAppendAwaitMs: expect.any(Number),
+        platform: "telegram",
       }),
     );
   });

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -327,6 +327,26 @@ describe("SqliteMessagingStore", () => {
     });
   });
 
+  it("atomically rejects stale binding metadata after revocation", async () => {
+    const store = await createStore();
+    await store.upsertBinding(buildBinding());
+    await store.revokeBinding({
+      bindingId: "binding-1",
+      revokedAt: 1_001,
+    });
+
+    await expect(store.mergeBindingChannelMetadata({
+      bindingId: "binding-1",
+      channel: buildBinding().channel,
+      observedAt: 1_000,
+      title: "Stale title",
+    })).resolves.toBeUndefined();
+    await expect(store.getBinding("binding-1")).resolves.toMatchObject({
+      revokedAt: 1_001,
+      updatedAt: 1_001,
+    });
+  });
+
   it("finds a legacy channel-shaped binding from its normalized thread surface", async () => {
     const store = await createStore();
     await store.upsertBinding(buildBinding({
@@ -1114,6 +1134,32 @@ describe("SqliteMessagingStore", () => {
         "proposal-1": expect.objectContaining({
           status: "pending",
         }),
+      },
+    });
+  });
+
+  it("atomically preserves newer managed-topic state over an old observation", async () => {
+    const store = await createStore();
+    await store.upsertManagedTopic(buildManagedTopic({
+      closedAt: 1_001,
+      lifecycle: "closed",
+      updatedAt: 1_001,
+    }));
+
+    await expect(store.mergeManagedTopicObservation(buildManagedTopic({
+      lastObservedAt: 1_000,
+      lifecycle: "open",
+      source: "observed",
+      title: "Stale observed title",
+      updatedAt: 1_000,
+    }))).resolves.toMatchObject({
+      changed: true,
+      topic: {
+        closedAt: 1_001,
+        lifecycle: "closed",
+        source: "owned",
+        title: "PwrAgent",
+        updatedAt: 1_001,
       },
     });
   });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1238,7 +1238,11 @@ export class MessagingController {
     update: MessagingInboundChannelMetadataUpdate,
   ): Promise<void> {
     try {
-      await this.refreshBindingChannelMetadata(update.channel, update.routingState);
+      await this.refreshBindingChannelMetadata(
+        update.channel,
+        update.routingState,
+        update.observedAt,
+      );
     } catch (error) {
       this.logger.debug?.("messaging inbound metadata enrichment failed", {
         eventId: update.eventId,
@@ -2266,18 +2270,22 @@ export class MessagingController {
   private async refreshBindingFromInbound(
     event: MessagingInboundEvent,
   ): Promise<void> {
-    await this.refreshBindingChannelMetadata(event.channel, event.routingState);
+    await this.refreshBindingChannelMetadata(
+      event.channel,
+      event.routingState,
+      event.receivedAt,
+    );
   }
 
   private async refreshBindingChannelMetadata(
     channel: MessagingChannelRef,
     routingStateUpdate?: MessagingAdapterState,
+    observedAt = this.now(),
   ): Promise<void> {
     const binding = await this.options.store.findActiveBindingForChannel(
       channel,
     );
     if (!binding) return;
-    const stored = binding.channel.conversation;
     const incoming = channel.conversation;
     // Incoming wins when present. Adapters fetch fresher metadata
     // than we stored at bind time:
@@ -2290,10 +2298,12 @@ export class MessagingController {
     //     messages.
     // When `incoming` doesn't carry a field (e.g. a regular Telegram
     // topic message that doesn't ship the topic name and the cache
-    // missed), we fall back to `stored` so we never lose data we
-    // already have.
+    // missed), the store merge keeps the current value so we never
+    // lose data we already have. The read/compare/write is one store
+    // transaction: this off-path task cannot restore a binding that
+    // routing revoked or overwrite a newer preference update.
     //
-    // Loop safety: the `if (!changed)` guard below means an inbound
+    // Loop safety: the store's `changed` guard means an inbound
     // whose values match what's stored produces no write and no
     // broadcast — so the gateway echo of our own `editForumTopic`
     // call (which carries the same name we just wrote in
@@ -2307,27 +2317,16 @@ export class MessagingController {
           })
         : undefined;
     const managedConversation = managedTopic?.conversation;
-    const merged = {
-      ...stored,
-      title: incoming.title ?? stored.title ?? managedConversation?.title,
-      parentTitle:
-        incoming.parentTitle ?? stored.parentTitle ?? managedConversation?.parentTitle,
-      ancestorTitle:
-        incoming.ancestorTitle ?? stored.ancestorTitle ?? managedConversation?.ancestorTitle,
-    };
-    const routingState = routingStateUpdate ?? binding.routingState;
-    const changed =
-      merged.title !== stored.title
-      || merged.parentTitle !== stored.parentTitle
-      || merged.ancestorTitle !== stored.ancestorTitle
-      || !messagingAdapterStateEqual(routingState, binding.routingState);
-    if (!changed) return;
-    await this.options.store.upsertBinding({
-      ...binding,
-      channel: { ...binding.channel, conversation: merged },
-      routingState,
-      updatedAt: this.now(),
+    const merged = await this.options.store.mergeBindingChannelMetadata({
+      ancestorTitle: incoming.ancestorTitle ?? managedConversation?.ancestorTitle,
+      bindingId: binding.id,
+      channel,
+      observedAt,
+      parentTitle: incoming.parentTitle ?? managedConversation?.parentTitle,
+      routingState: routingStateUpdate,
+      title: incoming.title ?? managedConversation?.title,
     });
+    if (!merged?.changed) return;
     // The chip now has fresher breadcrumbs in the store; nudge the
     // renderer to refetch so the tooltip / label reflect them.
     this.notifyBindingChanged("refresh-from-inbound");
@@ -11215,9 +11214,19 @@ export class MessagingController {
     ) {
       return;
     }
-    await this.upsertManagedTopicFromChannel(event, {
-      source: "observed",
+    const observedAt = event.receivedAt;
+    await this.options.store.mergeManagedTopicObservation({
+      ...managedTopicRecordFromConversation({
+        actorIds: this.monitorAuthorizedActorIds(event),
+        channel: event.channel.channel,
+        conversation: event.channel.conversation,
+        now: observedAt,
+        routingState: event.routingState,
+        source: "observed",
+      }),
+      lastObservedAt: observedAt,
       lifecycle: "open",
+      updatedAt: observedAt,
     });
   }
 
@@ -22349,13 +22358,6 @@ function readAcpRuntimeOptionSource(
   return source === "mode" || source === "configOption" || source === "model"
     ? source
     : undefined;
-}
-
-function messagingAdapterStateEqual(
-  left: MessagingAdapterState | undefined,
-  right: MessagingAdapterState | undefined,
-): boolean {
-  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }
 
 function messageOriginForInboundEvent(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -305,7 +305,8 @@ const DEFAULT_INPUT_DEBOUNCE_MS = 500;
 // Upper bound on retained admission stage marks. A turn that is queued behind a
 // busy thread, or that fails before `startTurn`, never reaches the log that
 // consumes its marks, so the ceiling cannot depend on the happy path. Oldest
-// entry is evicted first; each holds at most eight numbers.
+// entry is evicted first; each holds one fixed, bounded set of stage/subspan
+// numbers.
 const ADMISSION_STAGE_MARK_LIMIT = 256;
 
 /**
@@ -332,6 +333,28 @@ type MessagingAdmissionStage =
   | "occupancyResolved"
   | "originBuilt"
   | "policyResolved";
+
+type MessagingHandledToRoutedSubspan =
+  | "handledAutomationInboundMs"
+  | "handledBindingLookupMs"
+  | "handledDefaultAgentAssignmentsMs"
+  | "handledDefaultAgentBackendValidationMs"
+  | "handledDefaultAgentRevocationsMs"
+  | "handledDefaultAgentTargetValidationMs"
+  | "handledPendingIntentReadMs"
+  | "handledPendingNewThreadReadMs"
+  | "handledPrivateContinuationExpirationMs"
+  | "handledRemoteScopeMs"
+  | "handledRequirePermissionMs"
+  | "handledResponseModeMs"
+  | "handledSharedMessagePolicyMs"
+  | "handledTextParsingMs"
+  | "finalAdmissionAppendAwaitMs";
+
+type MessagingAdmissionTimingRecord = {
+  marks: Partial<Record<MessagingAdmissionStage, number>>;
+  subspans: Partial<Record<MessagingHandledToRoutedSubspan, number>>;
+};
 // Upper bound on retained automation start/final delivery-dedup keys. Each entry
 // embeds the full rendered message text and is only consulted while a run's
 // terminal events are in flight; oldest-first eviction reclaims keys for runs
@@ -958,7 +981,7 @@ export class MessagingController {
   private readonly now: () => number;
   private readonly admissionStageMarks = new Map<
     string,
-    Partial<Record<MessagingAdmissionStage, number>>
+    MessagingAdmissionTimingRecord
   >();
   private readonly pendingIntentTtlMs: number;
   private readonly interactionMapper: MessagingInteractionMapper;
@@ -1155,24 +1178,15 @@ export class MessagingController {
     // of it.
     this.markAdmissionStage(event, "handled");
 
-    // Self-heal: every inbound event carries the freshest ancestry data
-    // the adapter knows (parentTitle = supergroup/server, ancestorTitle
-    // = guild for Discord threads). Merge any new fields into the
-    // stored binding so the renderer's binding chip can show full
-    // breadcrumbs without waiting for an explicit refresh.
-    //
-    // Best-effort: a sqlite hiccup here must not abort the inbound kind
-    // dispatch below — the binding refresh is observability/UX, not the
-    // source of truth for routing. Log and continue.
-    try {
-      await this.refreshBindingFromInbound(event);
-      await this.observeManagedTopicFromInbound(event);
-    } catch (error) {
-      this.logger.debug?.("messaging inbound metadata refresh failed", {
-        eventId: event.id,
-        platform: event.channel.channel,
-        error: error instanceof Error ? error.message : String(error),
-      });
+    // Breadcrumb self-healing and managed-topic observation are optional UX
+    // bookkeeping for turn input. Start them from this lifecycle boundary, but
+    // never charge their SQLite reads/writes to accepted reply routing. Control
+    // events retain ordering because commands such as `/monitor topics` can
+    // intentionally promote an observed topic to owned state.
+    if (event.kind === "text" || event.kind === "media") {
+      void this.refreshInboundMetadata(event);
+    } else {
+      await this.refreshInboundMetadata(event);
     }
 
     if (event.kind === "command") {
@@ -1198,10 +1212,16 @@ export class MessagingController {
 
     if (
       (event.kind === "text" || event.kind === "media") &&
-      this.options.automationInboundHandler &&
-      (await this.options.automationInboundHandler(event))
+      this.options.automationInboundHandler
     ) {
-      return;
+      const automationMatched = await this.measureHandledToRoutedSubspan(
+        event,
+        "handledAutomationInboundMs",
+        async () => await this.options.automationInboundHandler?.(event) ?? false,
+      );
+      if (automationMatched) {
+        return;
+      }
     }
 
     if (event.kind === "media") {
@@ -2202,6 +2222,35 @@ export class MessagingController {
         });
         await this.renderAutomaticBindingStatus(binding);
       }
+    }
+  }
+
+  private async refreshInboundMetadata(event: MessagingInboundEvent): Promise<void> {
+    const startedAt = this.now();
+    let refreshBindingFromInboundMs = 0;
+    let observeManagedTopicFromInboundMs = 0;
+    try {
+      const refreshStartedAt = this.now();
+      await this.refreshBindingFromInbound(event);
+      refreshBindingFromInboundMs = this.now() - refreshStartedAt;
+
+      const observeStartedAt = this.now();
+      await this.observeManagedTopicFromInbound(event);
+      observeManagedTopicFromInboundMs = this.now() - observeStartedAt;
+    } catch (error) {
+      this.logger.debug?.("messaging inbound metadata refresh failed", {
+        eventId: event.id,
+        platform: event.channel.channel,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.logger.debug?.("messaging off-path inbound metadata timing", {
+        eventId: event.id,
+        platform: event.channel.channel,
+        refreshBindingFromInboundMs,
+        observeManagedTopicFromInboundMs,
+        totalMs: this.now() - startedAt,
+      });
     }
   }
 
@@ -3264,7 +3313,11 @@ export class MessagingController {
   }
 
   private async handleText(event: MessagingInboundTextEvent): Promise<void> {
-    const command = parseTextCommand(event.text);
+    const command = this.measureHandledToRoutedSyncSubspan(
+      event,
+      "handledTextParsingMs",
+      () => parseTextCommand(event.text),
+    );
     if (command) {
       await this.handleCommand({
         ...event,
@@ -3276,9 +3329,11 @@ export class MessagingController {
       return;
     }
 
-    const mentionCommand = event.botMention
-      ? parseMentionCommand(event.text)
-      : undefined;
+    const mentionCommand = this.measureHandledToRoutedSyncSubspan(
+      event,
+      "handledTextParsingMs",
+      () => event.botMention ? parseMentionCommand(event.text) : undefined,
+    );
     if (mentionCommand) {
       await this.handleCommand({
         ...event,
@@ -3290,12 +3345,23 @@ export class MessagingController {
       return;
     }
 
-    const pendingNewThread = await this.findPendingNewThreadSession(event);
-    const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
-      actorId: event.actor.platformUserId,
-      channel: event.channel,
-      now: this.now(),
-    });
+    const [pendingNewThread, pendingIntent] = await Promise.all([
+      this.measureHandledToRoutedSubspan(
+        event,
+        "handledPendingNewThreadReadMs",
+        async () => await this.findPendingNewThreadSession(event),
+      ),
+      this.measureHandledToRoutedSubspan(
+        event,
+        "handledPendingIntentReadMs",
+        async () =>
+          await this.options.store.findActivePendingIntentForChannel({
+            actorId: event.actor.platformUserId,
+            channel: event.channel,
+            now: this.now(),
+          }),
+      ),
+    ]);
     if (pendingIntent) {
       if (isSkillsSearchIntent(pendingIntent.intent)) {
         const mapped = await this.interactionMapper.mapText({
@@ -3389,10 +3455,22 @@ export class MessagingController {
       return;
     }
 
-    let binding = await this.options.store.findActiveBindingForChannel(event.channel);
-    binding = await this.revokeExpiredPrivateReplyContinuation(binding);
+    let binding = await this.measureHandledToRoutedSubspan(
+      event,
+      "handledBindingLookupMs",
+      async () => await this.options.store.findActiveBindingForChannel(event.channel),
+    );
+    binding = await this.measureHandledToRoutedSubspan(
+      event,
+      "handledPrivateContinuationExpirationMs",
+      async () => await this.revokeExpiredPrivateReplyContinuation(binding),
+    );
     if (!binding) {
-      if (!await this.shouldHandleAmbientSharedMessage(event)) {
+      if (!await this.measureHandledToRoutedSubspan(
+        event,
+        "handledSharedMessagePolicyMs",
+        async () => await this.shouldHandleAmbientSharedMessage(event),
+      )) {
         return;
       }
       if (await this.bootstrapDefaultAgentForAcceptedMessage(event)) {
@@ -3402,7 +3480,11 @@ export class MessagingController {
       return;
     }
 
-    if (!await this.shouldHandleAmbientSharedMessage(event, binding)) {
+    if (!await this.measureHandledToRoutedSubspan(
+      event,
+      "handledSharedMessagePolicyMs",
+      async () => await this.shouldHandleAmbientSharedMessage(event, binding),
+    )) {
       return;
     }
 
@@ -3418,16 +3500,31 @@ export class MessagingController {
     // RBAC floor: sending a turn to the agent needs `message.reply`. Silent
     // drop (no reply) so an under-permissioned sender can't be spammed with
     // rejections in a shared channel.
-    if (!(await this.requirePermission(event, "message.reply", "message:reply", { notify: false }))) {
+    if (!(await this.measureHandledToRoutedSubspan(
+      event,
+      "handledRequirePermissionMs",
+      async () =>
+        await this.requirePermission(
+          event,
+          "message.reply",
+          "message:reply",
+          { notify: false },
+        ),
+    ))) {
       return;
     }
     // A turn into a remote-bound thread runs on the peer's machine.
     if (
-      !(await this.requireRemoteScopeForBinding(
+      !(await this.measureHandledToRoutedSubspan(
         event,
-        binding,
-        "message:reply:remote-instance",
-        { notify: false },
+        "handledRemoteScopeMs",
+        async () =>
+          await this.requireRemoteScopeForBinding(
+            event,
+            binding,
+            "message:reply:remote-instance",
+            { notify: false },
+          ),
       ))
     ) {
       return;
@@ -3440,18 +3537,28 @@ export class MessagingController {
     event: MessagingInboundTextEvent | MessagingInboundMediaEvent,
   ): Promise<boolean> {
     const assignments =
-      await this.options.store.findActiveDefaultAgentAssignmentsForChannel(
-        event.channel,
+      await this.measureHandledToRoutedSubspan(
+        event,
+        "handledDefaultAgentAssignmentsMs",
+        async () =>
+          await this.options.store.findActiveDefaultAgentAssignmentsForChannel(
+            event.channel,
+          ),
       );
     if (assignments.length === 0) {
       return false;
     }
     if (
-      !(await this.requirePermission(
+      !(await this.measureHandledToRoutedSubspan(
         event,
-        "message.reply",
-        event.kind === "media" ? "media:reply" : "message:reply",
-        { notify: false },
+        "handledRequirePermissionMs",
+        async () =>
+          await this.requirePermission(
+            event,
+            "message.reply",
+            event.kind === "media" ? "media:reply" : "message:reply",
+            { notify: false },
+          ),
       ))
     ) {
       return true;
@@ -3462,7 +3569,8 @@ export class MessagingController {
           assignment: MessagingDefaultAgentAssignmentRecord;
         }
       | undefined;
-    const backendSummaries = await this.loadDefaultAgentBackendSummaries();
+    let backendSummaries: BackendSummary[] | undefined;
+    let backendSummariesLoaded = false;
     // Revocations are buffered, not applied as they are decided. Every
     // iteration reads backend state that can fail, and a failure part-way
     // through used to leave the channel half-revoked: the assignments already
@@ -3474,7 +3582,12 @@ export class MessagingController {
       let targetIsAgentThread: boolean;
       try {
         targetIsAgentThread =
-          await this.defaultAgentTargetIsAgentThread(assignment.target);
+          await this.measureHandledToRoutedSubspan(
+            event,
+            "handledDefaultAgentTargetValidationMs",
+            async () =>
+              await this.defaultAgentTargetIsAgentThread(assignment.target),
+          );
       } catch (error) {
         await this.deliverDefaultAgentBootstrapError(
           event,
@@ -3482,6 +3595,17 @@ export class MessagingController {
           error instanceof Error ? error.message : String(error),
         );
         return true;
+      }
+      if (
+        isAcpBackendId(assignment.target.backend)
+        && !backendSummariesLoaded
+      ) {
+        backendSummaries = await this.measureHandledToRoutedSubspan(
+          event,
+          "handledDefaultAgentBackendValidationMs",
+          async () => await this.loadDefaultAgentBackendSummaries(),
+        );
+        backendSummariesLoaded = true;
       }
       const backendSupport = defaultAgentBackendSupport(
         assignment.target.backend,
@@ -3505,13 +3629,19 @@ export class MessagingController {
       }
       revocations.push(assignment);
     }
-    for (const assignment of revocations) {
-      await this.options.store.revokeDefaultAgentAssignment({
-        assignmentId: assignment.id,
-        revokedAt: this.now(),
-      });
-      this.notifyBindingChanged("default-agent-cleared");
-    }
+    await this.measureHandledToRoutedSubspan(
+      event,
+      "handledDefaultAgentRevocationsMs",
+      async () => {
+        for (const assignment of revocations) {
+          await this.options.store.revokeDefaultAgentAssignment({
+            assignmentId: assignment.id,
+            revokedAt: this.now(),
+          });
+          this.notifyBindingChanged("default-agent-cleared");
+        }
+      },
+    );
     if (!selected) {
       return false;
     }
@@ -3593,7 +3723,11 @@ export class MessagingController {
   }
 
   private async handleMedia(event: MessagingInboundMediaEvent): Promise<void> {
-    const command = event.text ? parseTextCommand(event.text) : undefined;
+    const command = this.measureHandledToRoutedSyncSubspan(
+      event,
+      "handledTextParsingMs",
+      () => event.text ? parseTextCommand(event.text) : undefined,
+    );
     if (command) {
       await this.handleCommand({
         ...event,
@@ -3604,9 +3738,13 @@ export class MessagingController {
       });
       return;
     }
-    const mentionCommand = event.botMention && event.text
-      ? parseMentionCommand(event.text)
-      : undefined;
+    const mentionCommand = this.measureHandledToRoutedSyncSubspan(
+      event,
+      "handledTextParsingMs",
+      () => event.botMention && event.text
+        ? parseMentionCommand(event.text)
+        : undefined,
+    );
     if (mentionCommand) {
       await this.handleCommand({
         ...event,
@@ -3618,16 +3756,32 @@ export class MessagingController {
       return;
     }
 
-    const pendingNewThread = await this.findPendingNewThreadSession(event);
+    const pendingNewThread = await this.measureHandledToRoutedSubspan(
+      event,
+      "handledPendingNewThreadReadMs",
+      async () => await this.findPendingNewThreadSession(event),
+    );
     if (pendingNewThread) {
       await this.appendPendingNewThreadPrompt(pendingNewThread, event);
       return;
     }
 
-    let binding = await this.options.store.findActiveBindingForChannel(event.channel);
-    binding = await this.revokeExpiredPrivateReplyContinuation(binding);
+    let binding = await this.measureHandledToRoutedSubspan(
+      event,
+      "handledBindingLookupMs",
+      async () => await this.options.store.findActiveBindingForChannel(event.channel),
+    );
+    binding = await this.measureHandledToRoutedSubspan(
+      event,
+      "handledPrivateContinuationExpirationMs",
+      async () => await this.revokeExpiredPrivateReplyContinuation(binding),
+    );
     if (!binding) {
-      if (!await this.shouldHandleAmbientSharedMessage(event)) {
+      if (!await this.measureHandledToRoutedSubspan(
+        event,
+        "handledSharedMessagePolicyMs",
+        async () => await this.shouldHandleAmbientSharedMessage(event),
+      )) {
         return;
       }
       if (await this.bootstrapDefaultAgentForAcceptedMessage(event)) {
@@ -3656,19 +3810,38 @@ export class MessagingController {
       return;
     }
 
-    if (!await this.shouldHandleAmbientSharedMessage(event, binding)) {
+    if (!await this.measureHandledToRoutedSubspan(
+      event,
+      "handledSharedMessagePolicyMs",
+      async () => await this.shouldHandleAmbientSharedMessage(event, binding),
+    )) {
       return;
     }
 
-    if (!(await this.requirePermission(event, "message.reply", "media:reply", { notify: false }))) {
+    if (!(await this.measureHandledToRoutedSubspan(
+      event,
+      "handledRequirePermissionMs",
+      async () =>
+        await this.requirePermission(
+          event,
+          "message.reply",
+          "media:reply",
+          { notify: false },
+        ),
+    ))) {
       return;
     }
     if (
-      !(await this.requireRemoteScopeForBinding(
+      !(await this.measureHandledToRoutedSubspan(
         event,
-        binding,
-        "media:reply:remote-instance",
-        { notify: false },
+        "handledRemoteScopeMs",
+        async () =>
+          await this.requireRemoteScopeForBinding(
+            event,
+            binding,
+            "media:reply:remote-instance",
+            { notify: false },
+          ),
       ))
     ) {
       return;
@@ -3694,7 +3867,11 @@ export class MessagingController {
     }
     const responseMode = resolveMessagingResponseMode(
       binding,
-      await this.responseModeForConversation(event.channel),
+      await this.measureHandledToRoutedSubspan(
+        event,
+        "handledResponseModeMs",
+        async () => await this.responseModeForConversation(event.channel),
+      ),
     );
     return responseMode === "every_message" || event.botMention === true;
   }
@@ -3748,7 +3925,87 @@ export class MessagingController {
     event: MessagingTurnInputEvent;
   }): Promise<void> {
     this.markAdmissionStage(params.event, "routed");
-    await this.turnAdmission.append(params);
+    const startedAt = this.now();
+    try {
+      await this.turnAdmission.append(params);
+    } finally {
+      const finalAdmissionAppendAwaitMs = this.now() - startedAt;
+      this.recordHandledToRoutedSubspan(
+        params.event,
+        "finalAdmissionAppendAwaitMs",
+        finalAdmissionAppendAwaitMs,
+        false,
+      );
+      this.logger.debug?.("messaging admission append timing", {
+        eventId: params.event.id,
+        platform: params.event.channel.channel,
+        finalAdmissionAppendAwaitMs,
+      });
+    }
+  }
+
+  private async measureHandledToRoutedSubspan<T>(
+    event: MessagingInboundEvent,
+    subspan: MessagingHandledToRoutedSubspan,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const startedAt = this.now();
+    try {
+      return await operation();
+    } finally {
+      this.recordHandledToRoutedSubspan(
+        event,
+        subspan,
+        this.now() - startedAt,
+      );
+    }
+  }
+
+  private measureHandledToRoutedSyncSubspan<T>(
+    event: MessagingInboundEvent,
+    subspan: MessagingHandledToRoutedSubspan,
+    operation: () => T,
+  ): T {
+    const startedAt = this.now();
+    try {
+      return operation();
+    } finally {
+      this.recordHandledToRoutedSubspan(
+        event,
+        subspan,
+        this.now() - startedAt,
+      );
+    }
+  }
+
+  private recordHandledToRoutedSubspan(
+    event: MessagingInboundEvent,
+    subspan: MessagingHandledToRoutedSubspan,
+    durationMs: number,
+    create = true,
+  ): void {
+    const timing = create
+      ? this.admissionTimingForEvent(event)
+      : this.admissionStageMarks.get(event.id);
+    if (!timing) return;
+    timing.subspans[subspan] =
+      (timing.subspans[subspan] ?? 0) + durationMs;
+  }
+
+  private admissionTimingForEvent(
+    event: MessagingInboundEvent,
+  ): MessagingAdmissionTimingRecord {
+    let timing = this.admissionStageMarks.get(event.id);
+    if (!timing) {
+      timing = { marks: {}, subspans: {} };
+      rememberBoundedMap(
+        this.admissionStageMarks,
+        event.id,
+        timing,
+        ADMISSION_STAGE_MARK_LIMIT,
+      );
+    }
+    return timing;
   }
 
   /**
@@ -3763,17 +4020,8 @@ export class MessagingController {
     stage: MessagingAdmissionStage,
   ): void {
     if (!event) return;
-    let marks = this.admissionStageMarks.get(event.id);
-    if (!marks) {
-      marks = {};
-      rememberBoundedMap(
-        this.admissionStageMarks,
-        event.id,
-        marks,
-        ADMISSION_STAGE_MARK_LIMIT,
-      );
-    }
-    marks[stage] ??= this.now();
+    const timing = this.admissionTimingForEvent(event);
+    timing.marks[stage] ??= this.now();
   }
 
   /**
@@ -3793,9 +4041,10 @@ export class MessagingController {
     startTurnIssuedAt: number,
   ): Record<string, number> {
     if (!event) return {};
-    const marks = this.admissionStageMarks.get(event.id);
-    if (!marks) return {};
+    const admissionTiming = this.admissionStageMarks.get(event.id);
+    if (!admissionTiming) return {};
     this.admissionStageMarks.delete(event.id);
+    const marks = admissionTiming.marks;
     const spans: Array<[string, number | undefined, number | undefined]> = [
       ["receivedToHandledMs", event.receivedAt, marks.handled],
       ["handledToRoutedMs", marks.handled, marks.routed],
@@ -3822,7 +4071,9 @@ export class MessagingController {
       ["originToPolicyMs", marks.originBuilt, marks.policyResolved],
       ["policyToStartTurnIssueMs", marks.policyResolved, startTurnIssuedAt],
     ];
-    const timing: Record<string, number> = {};
+    const timing: Record<string, number> = {
+      ...admissionTiming.subspans,
+    };
     for (const [name, from, to] of spans) {
       if (from !== undefined && to !== undefined) {
         timing[name] = to - from;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4071,14 +4071,13 @@ export class MessagingController {
       ["originToPolicyMs", marks.originBuilt, marks.policyResolved],
       ["policyToStartTurnIssueMs", marks.policyResolved, startTurnIssuedAt],
     ];
-    const timing: Record<string, number> = {
-      ...admissionTiming.subspans,
-    };
+    const timing: Record<string, number> = {};
     for (const [name, from, to] of spans) {
       if (from !== undefined && to !== undefined) {
         timing[name] = to - from;
       }
     }
+    Object.assign(timing, admissionTiming.subspans);
     return timing;
   }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3464,6 +3464,7 @@ export class MessagingController {
       "handledPrivateContinuationExpirationMs",
       async () => await this.revokeExpiredPrivateReplyContinuation(binding),
     );
+    binding = bindingWithInboundRoutingState(binding, event.routingState);
     if (!binding) {
       if (!await this.measureHandledToRoutedSubspan(
         event,
@@ -3775,6 +3776,7 @@ export class MessagingController {
       "handledPrivateContinuationExpirationMs",
       async () => await this.revokeExpiredPrivateReplyContinuation(binding),
     );
+    binding = bindingWithInboundRoutingState(binding, event.routingState);
     if (!binding) {
       if (!await this.measureHandledToRoutedSubspan(
         event,
@@ -22358,6 +22360,18 @@ function readAcpRuntimeOptionSource(
   return source === "mode" || source === "configOption" || source === "model"
     ? source
     : undefined;
+}
+
+function bindingWithInboundRoutingState(
+  binding: MessagingBindingRecord | undefined,
+  routingState: MessagingAdapterState | undefined,
+): MessagingBindingRecord | undefined {
+  // Metadata persistence is intentionally off-path, but this event's delivery
+  // state is already authoritative for replies and typing activity on the same
+  // route. Use it immediately without waiting for the merge-safe store update.
+  return binding && routingState
+    ? { ...binding, routingState }
+    : binding;
 }
 
 function messageOriginForInboundEvent(

--- a/apps/desktop/src/main/messaging/core/messaging-store-merge.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store-merge.ts
@@ -1,0 +1,125 @@
+import type {
+  MessagingAdapterState,
+  MessagingBindingRecord,
+  MessagingChannelRef,
+  MessagingManagedTopicRecord,
+} from "@pwragent/messaging-interface";
+
+export type MessagingBindingChannelMetadataUpdate = {
+  ancestorTitle?: string;
+  bindingId: string;
+  channel: MessagingChannelRef;
+  observedAt: number;
+  parentTitle?: string;
+  routingState?: MessagingAdapterState;
+  title?: string;
+};
+
+export type MessagingBindingChannelMetadataMerge = {
+  binding: MessagingBindingRecord;
+  changed: boolean;
+};
+
+export function mergeMessagingBindingChannelMetadata(
+  current: MessagingBindingRecord | undefined,
+  update: MessagingBindingChannelMetadataUpdate,
+): MessagingBindingChannelMetadataMerge | undefined {
+  if (
+    !current
+    || current.revokedAt
+    || current.id !== update.bindingId
+    || messagingConversationKey(current.channel)
+      !== messagingConversationKey(update.channel)
+  ) {
+    return undefined;
+  }
+  if (current.updatedAt > update.observedAt) {
+    return { binding: current, changed: false };
+  }
+  const stored = current.channel.conversation;
+  const conversation = {
+    ...stored,
+    title: update.title ?? stored.title,
+    parentTitle: update.parentTitle ?? stored.parentTitle,
+    ancestorTitle: update.ancestorTitle ?? stored.ancestorTitle,
+  };
+  const routingState = update.routingState ?? current.routingState;
+  const changed =
+    conversation.title !== stored.title
+    || conversation.parentTitle !== stored.parentTitle
+    || conversation.ancestorTitle !== stored.ancestorTitle
+    || !messagingAdapterStateEqual(routingState, current.routingState);
+  if (!changed) {
+    return { binding: current, changed: false };
+  }
+  return {
+    binding: {
+      ...current,
+      channel: { ...current.channel, conversation },
+      routingState,
+      updatedAt: Math.max(current.updatedAt, update.observedAt),
+    },
+    changed: true,
+  };
+}
+
+export type MessagingManagedTopicObservationMerge = {
+  changed: boolean;
+  topic: MessagingManagedTopicRecord;
+};
+
+export function mergeMessagingManagedTopicObservation(
+  current: MessagingManagedTopicRecord | undefined,
+  observation: MessagingManagedTopicRecord,
+): MessagingManagedTopicObservationMerge {
+  if (!current) {
+    return { changed: true, topic: observation };
+  }
+  const lastObservedAt = Math.max(
+    current.lastObservedAt ?? 0,
+    observation.lastObservedAt ?? observation.updatedAt,
+  );
+  if (current.updatedAt >= observation.updatedAt) {
+    if (lastObservedAt === current.lastObservedAt) {
+      return { changed: false, topic: current };
+    }
+    return {
+      changed: true,
+      topic: { ...current, lastObservedAt },
+    };
+  }
+  return {
+    changed: true,
+    topic: {
+      ...observation,
+      ...current,
+      authorizedActorIds: current.authorizedActorIds.length
+        ? current.authorizedActorIds
+        : observation.authorizedActorIds,
+      lastObservedAt,
+      lifecycle: observation.lifecycle,
+      recommendation: observation.recommendation ?? current.recommendation,
+      routingState: observation.routingState ?? current.routingState,
+      source: current.source === "owned" || current.source === "linked"
+        ? current.source
+        : observation.source,
+      updatedAt: observation.updatedAt,
+    },
+  };
+}
+
+function messagingAdapterStateEqual(
+  left: MessagingAdapterState | undefined,
+  right: MessagingAdapterState | undefined,
+): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function messagingConversationKey(channel: MessagingChannelRef): string {
+  return [
+    channel.channel,
+    channel.conversation.kind,
+    channel.conversation.parentId ?? "",
+    channel.conversation.id,
+  ].join(":");
+}

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -31,6 +31,13 @@ import {
   buildDefaultAgentScopeLookup,
   buildMessagingDefaultAgentScopeKey,
 } from "./messaging-default-agent.js";
+import {
+  mergeMessagingBindingChannelMetadata,
+  mergeMessagingManagedTopicObservation,
+  type MessagingBindingChannelMetadataUpdate,
+  type MessagingBindingChannelMetadataMerge,
+  type MessagingManagedTopicObservationMerge,
+} from "./messaging-store-merge.js";
 
 const SECRET_KEY_PATTERN = /token|secret|password|authorization|api[_-]?key/i;
 
@@ -57,6 +64,27 @@ export class MessagingStore {
 
       data.bindings[sanitized.id] = sanitized;
       return structuredClone(sanitized);
+    });
+  }
+
+  async mergeBindingChannelMetadata(
+    update: MessagingBindingChannelMetadataUpdate,
+  ): Promise<MessagingBindingChannelMetadataMerge | undefined> {
+    return await this.withData((data) => {
+      const merged = mergeMessagingBindingChannelMetadata(
+        data.bindings[update.bindingId],
+        update,
+      );
+      if (!merged) {
+        return undefined;
+      }
+      if (merged.changed) {
+        data.bindings[update.bindingId] = sanitizeBinding(merged.binding);
+      }
+      return {
+        binding: structuredClone(merged.binding),
+        changed: merged.changed,
+      };
     });
   }
 
@@ -371,6 +399,25 @@ export class MessagingStore {
     return await this.withData((data) => {
       data.topics[sanitized.id] = sanitized;
       return structuredClone(sanitized);
+    });
+  }
+
+  async mergeManagedTopicObservation(
+    observation: MessagingManagedTopicRecord,
+  ): Promise<MessagingManagedTopicObservationMerge> {
+    const sanitized = sanitizeManagedTopic(observation);
+    return await this.withData((data) => {
+      const merged = mergeMessagingManagedTopicObservation(
+        data.topics[sanitized.id],
+        sanitized,
+      );
+      if (merged.changed) {
+        data.topics[sanitized.id] = sanitizeManagedTopic(merged.topic);
+      }
+      return {
+        changed: merged.changed,
+        topic: structuredClone(merged.topic),
+      };
     });
   }
 

--- a/apps/desktop/src/main/messaging/messaging-response-mode.ts
+++ b/apps/desktop/src/main/messaging/messaging-response-mode.ts
@@ -5,6 +5,72 @@ import type {
 } from "@pwragent/messaging-interface";
 import type { DesktopMessagingConfig } from "./messaging-config";
 
+type MessagingResponseModeEntry = {
+  id: string;
+  responseMode: MessagingResponseMode;
+};
+
+export type MessagingResponseModeSnapshot = {
+  resolve(params: {
+    bindingResponseMode?: MessagingResponseMode;
+    channelRef: MessagingChannelRef;
+  }): MessagingResponseMode;
+};
+
+/**
+ * Capture only the live response-routing policy needed by an inbound message.
+ *
+ * The full desktop messaging config carries credentials and is loaded from the
+ * Settings service. Admission must not reload that config: `readSettings()`
+ * also discovers agent runtimes, Git/GitHub commands, and desktop apps. The
+ * runtime owns this narrow snapshot and replaces it when it hot-applies a
+ * response-mode configuration change.
+ */
+export function createMessagingResponseModeSnapshot(params: {
+  channel: MessagingChannelKind;
+  config: DesktopMessagingConfig;
+}): MessagingResponseModeSnapshot {
+  const policy = responseModePolicy(params);
+  return {
+    resolve: ({ bindingResponseMode, channelRef }) => {
+      if (bindingResponseMode) {
+        return bindingResponseMode;
+      }
+
+      const conversation = channelRef.conversation;
+      switch (policy.channel) {
+        case "discord": {
+          const conversationMode = responseModeForIds(
+            policy.conversationModes,
+            [conversation.id, conversation.parentConversationId],
+          );
+          const guildMode = responseModeForIds(
+            policy.workspaceModes,
+            [conversation.workspaceId ?? conversation.parentId],
+          );
+          return conversationMode ?? guildMode ?? policy.defaultMode;
+        }
+        case "slack":
+          return responseModeForIds(
+            policy.conversationModes,
+            [
+              conversation.id,
+              conversation.parentConversationId,
+              conversation.parentId,
+            ],
+          ) ?? policy.defaultMode;
+        case "telegram":
+          return responseModeForIds(
+            policy.conversationModes,
+            [conversation.id, conversation.parentId],
+          ) ?? policy.defaultMode;
+        default:
+          return "every_message";
+      }
+    },
+  };
+}
+
 /**
  * Resolve shared-conversation response behavior from most specific to least:
  * bound PwrAgent thread, exact Discord native thread/channel, containing
@@ -16,47 +82,72 @@ export function resolveMessagingResponseModeForChannel(params: {
   channelRef: MessagingChannelRef;
   config: DesktopMessagingConfig;
 }): MessagingResponseMode {
-  if (params.bindingResponseMode) {
-    return params.bindingResponseMode;
-  }
+  return createMessagingResponseModeSnapshot(params).resolve({
+    bindingResponseMode: params.bindingResponseMode,
+    channelRef: params.channelRef,
+  });
+}
 
-  const conversation = params.channelRef.conversation;
+function responseModePolicy(params: {
+  channel: MessagingChannelKind;
+  config: DesktopMessagingConfig;
+}): {
+  channel: MessagingChannelKind;
+  conversationModes: MessagingResponseModeEntry[];
+  defaultMode: MessagingResponseMode;
+  workspaceModes: MessagingResponseModeEntry[];
+} {
   switch (params.channel) {
-    case "discord": {
-      const conversationMode = responseModeForIds(
-        params.config.discord?.responseModeOverrides,
-        [conversation.id, conversation.parentConversationId],
-      );
-      const guildMode = responseModeForIds(
-        params.config.discord?.authorizedGuildIds,
-        [conversation.workspaceId ?? conversation.parentId],
-      );
-      return conversationMode
-        ?? guildMode
-        ?? params.config.discord?.responseMode
-        ?? "every_message";
-    }
-    case "slack": {
-      const specificMode = responseModeForIds(
-        params.config.slack?.authorizedConversationIds,
-        [
-          conversation.id,
-          conversation.parentConversationId,
-          conversation.parentId,
-        ],
-      );
-      return specificMode ?? params.config.slack?.responseMode ?? "mention_only";
-    }
-    case "telegram": {
-      const specificMode = responseModeForIds(
-        params.config.telegram?.authorizedSupergroupIds,
-        [conversation.id, conversation.parentId],
-      );
-      return specificMode ?? params.config.telegram?.responseMode ?? "every_message";
-    }
+    case "discord":
+      return {
+        channel: params.channel,
+        conversationModes: responseModeEntries(
+          params.config.discord?.responseModeOverrides,
+        ),
+        defaultMode: params.config.discord?.responseMode ?? "every_message",
+        workspaceModes: responseModeEntries(
+          params.config.discord?.authorizedGuildIds,
+        ),
+      };
+    case "slack":
+      return {
+        channel: params.channel,
+        conversationModes: responseModeEntries(
+          params.config.slack?.authorizedConversationIds,
+        ),
+        defaultMode: params.config.slack?.responseMode ?? "mention_only",
+        workspaceModes: [],
+      };
+    case "telegram":
+      return {
+        channel: params.channel,
+        conversationModes: responseModeEntries(
+          params.config.telegram?.authorizedSupergroupIds,
+        ),
+        defaultMode: params.config.telegram?.responseMode ?? "every_message",
+        workspaceModes: [],
+      };
     default:
-      return "every_message";
+      return {
+        channel: params.channel,
+        conversationModes: [],
+        defaultMode: "every_message",
+        workspaceModes: [],
+      };
   }
+}
+
+function responseModeEntries(
+  entries: readonly {
+    id: string;
+    responseMode?: MessagingResponseMode;
+  }[] | undefined,
+): MessagingResponseModeEntry[] {
+  return entries?.flatMap((entry) =>
+    entry.responseMode
+      ? [{ id: entry.id, responseMode: entry.responseMode }]
+      : [],
+  ) ?? [];
 }
 
 function responseModeForIds(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -79,7 +79,10 @@ import {
   type DesktopMessagingConfigChannel,
   type DesktopMessagingChannelConfigUpdate,
 } from "./messaging-config";
-import { resolveMessagingResponseModeForChannel } from "./messaging-response-mode";
+import {
+  createMessagingResponseModeSnapshot,
+  resolveMessagingResponseModeForChannel,
+} from "./messaging-response-mode";
 import { DesktopMessagingBackendBridge } from "./desktop-backend-bridge";
 import { resolvePwragentRoot } from "../profile";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
@@ -217,6 +220,7 @@ type RunningMessagingAdapter = {
   unsubscribeRateLimit?: () => void;
   unsubscribeReconnect?: () => void;
   unsubscribeRuntimeError?: () => void;
+  updateResponseModeSnapshot(config: DesktopMessagingConfig): void;
 };
 
 type RunningMessagingAuthorization = {
@@ -1341,6 +1345,10 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       actorIds: authorizedActorIds,
       actorIdSet: new Set(authorizedActorIds),
     };
+    let responseModeSnapshot = createMessagingResponseModeSnapshot({
+      channel: adapter.channel,
+      config,
+    });
     const deliveryBudget = new MessagingDeliveryBudget();
     if (adapter.clientRateLimitStrategy === "sdk-managed") {
       messagingLog.warn(`${adapter.channel}: SDK-managed rate-limit retries are enabled`, {
@@ -1369,12 +1377,8 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       ),
       showStreamingOption: async () =>
         (await this.loadConfig()).showStreamingOption ?? false,
-      responseModeForConversation: async (channel) =>
-        resolveMessagingResponseModeForChannel({
-          channel: adapter.channel,
-          channelRef: channel,
-          config: await this.loadConfig(),
-        }),
+      responseModeForConversation: (channel) =>
+        responseModeSnapshot.resolve({ channelRef: channel }),
       toolUpdateDefaultMode: async (targetKind) => {
         const config = await this.loadConfig();
         return targetKind === "agent_thread"
@@ -1602,6 +1606,12 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       unsubscribeRateLimit,
       unsubscribeReconnect,
       unsubscribeRuntimeError,
+      updateResponseModeSnapshot: (nextConfig) => {
+        responseModeSnapshot = createMessagingResponseModeSnapshot({
+          channel: adapter.channel,
+          config: nextConfig,
+        });
+      },
     });
     this.syncRunningAdapterLists();
     this.setPlatformHealth(adapter.channel, "enabled", {
@@ -1741,6 +1751,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
 
     running.config = next.config;
     running.fingerprint = next.fingerprint;
+    running.updateResponseModeSnapshot(next.config);
     this.recordDiagnosticActivity({
       platform: adapter.channel,
       summary: `Hot-applied messaging config: ${adapter.channel}`,

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -32,6 +32,13 @@ import {
   buildDefaultAgentScopeLookup,
   buildMessagingDefaultAgentScopeKey,
 } from "../messaging/core/messaging-default-agent.js";
+import {
+  mergeMessagingBindingChannelMetadata,
+  mergeMessagingManagedTopicObservation,
+  type MessagingBindingChannelMetadataMerge,
+  type MessagingBindingChannelMetadataUpdate,
+  type MessagingManagedTopicObservationMerge,
+} from "../messaging/core/messaging-store-merge.js";
 
 const SECRET_KEY_PATTERN = /token|secret|password|authorization|api[_-]?key/i;
 
@@ -63,6 +70,57 @@ export class SqliteMessagingStore {
       await this.upsertObservedSurface(sanitized.channel, sanitized.updatedAt);
     }
     return structuredClone(sanitized);
+  }
+
+  async mergeBindingChannelMetadata(
+    update: MessagingBindingChannelMetadataUpdate,
+  ): Promise<MessagingBindingChannelMetadataMerge | undefined> {
+    const merge = this.stateDb.raw.transaction(() => {
+      const row = this.stateDb.raw
+        .prepare("SELECT payload FROM bindings WHERE binding_id = ?")
+        .get(update.bindingId) as { payload: string } | undefined;
+      const merged = mergeMessagingBindingChannelMetadata(
+        row
+          ? JSON.parse(row.payload) as MessagingBindingRecord
+          : undefined,
+        update,
+      );
+      if (!merged || !merged.changed) {
+        return merged;
+      }
+      const sanitized = sanitizeBinding(merged.binding);
+      const channel = sanitized.channel;
+      this.stateDb.raw
+        .prepare(
+          `INSERT OR REPLACE INTO bindings(binding_id, channel_kind, channel_id, thread_id, status, created_at, updated_at, revoked_at, payload)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          sanitized.id,
+          channel.channel,
+          buildChannelId(channel),
+          sanitized.threadId,
+          sanitized.revokedAt ? "revoked" : "active",
+          sanitized.createdAt,
+          sanitized.updatedAt,
+          sanitized.revokedAt ?? null,
+          JSON.stringify(sanitized),
+        );
+      return { binding: sanitized, changed: true };
+    });
+    const merged = merge();
+    if (merged?.changed && !merged.binding.revokedAt) {
+      await this.upsertObservedSurface(
+        merged.binding.channel,
+        merged.binding.updatedAt,
+      );
+    }
+    return merged
+      ? {
+          binding: structuredClone(merged.binding),
+          changed: merged.changed,
+        }
+      : undefined;
   }
 
   async getBinding(id: string): Promise<MessagingBindingRecord | undefined> {
@@ -546,6 +604,50 @@ export class SqliteMessagingStore {
         JSON.stringify(sanitized),
       );
     return structuredClone(sanitized);
+  }
+
+  async mergeManagedTopicObservation(
+    observation: MessagingManagedTopicRecord,
+  ): Promise<MessagingManagedTopicObservationMerge> {
+    const sanitizedObservation = sanitizeManagedTopic(observation);
+    const merge = this.stateDb.raw.transaction(() => {
+      const row = this.stateDb.raw
+        .prepare(
+          "SELECT payload FROM messaging_managed_topics WHERE topic_record_id = ?",
+        )
+        .get(sanitizedObservation.id) as { payload: string } | undefined;
+      const merged = mergeMessagingManagedTopicObservation(
+        row
+          ? JSON.parse(row.payload) as MessagingManagedTopicRecord
+          : undefined,
+        sanitizedObservation,
+      );
+      if (!merged.changed) {
+        return merged;
+      }
+      const sanitized = sanitizeManagedTopic(merged.topic);
+      this.stateDb.raw
+        .prepare(
+          `INSERT OR REPLACE INTO messaging_managed_topics(topic_record_id, channel_kind, supergroup_id, topic_id, status, created_at, updated_at, payload)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          sanitized.id,
+          sanitized.channel,
+          sanitized.supergroupId,
+          sanitized.topicId,
+          sanitized.lifecycle,
+          sanitized.createdAt,
+          sanitized.updatedAt,
+          JSON.stringify(sanitized),
+        );
+      return { changed: true, topic: sanitized };
+    });
+    const merged = merge();
+    return {
+      changed: merged.changed,
+      topic: structuredClone(merged.topic),
+    };
   }
 
   async getManagedTopic(
@@ -1402,6 +1504,7 @@ function sanitizeJsonValue(value: MessagingJsonValue): MessagingJsonValue {
 export type MessagingStoreLike = Pick<
   SqliteMessagingStore,
   | "upsertBinding"
+  | "mergeBindingChannelMetadata"
   | "getBinding"
   | "upsertDefaultAgentAssignment"
   | "getDefaultAgentAssignment"
@@ -1422,6 +1525,7 @@ export type MessagingStoreLike = Pick<
   | "findActiveMonitorSubscriptionsForChannelKind"
   | "revokeMonitorSubscription"
   | "upsertManagedTopic"
+  | "mergeManagedTopicObservation"
   | "getManagedTopic"
   | "findManagedTopicsForSupergroup"
   | "findManagedTopicByConversation"


### PR DESCRIPTION
## Summary

- I remove the full desktop Settings reload from accepted shared-message response-mode routing. Each running adapter now owns a narrow live response-mode policy snapshot, and hot authorization updates replace that snapshot without restarting the adapter.
- I move binding breadcrumb self-healing and managed-topic observation off the accepted text/media admission path while preserving ordered handling for control events such as `/monitor topics`.
- I make those off-path mutations race-safe: binding metadata is merged into the current active record inside one store transaction, while older topic observations preserve newer ownership and lifecycle state.
- I use the current inbound event's routing state immediately for typing and reply delivery while its merge-safe persistence remains off-path.
- I add structured handled-to-routed subspan timings keyed by inbound event ID, with no message bodies, secrets, or actor identifiers. I also remove the unconditional backend-fleet capability listing for Codex Default Agents; ACP Default Agents retain the capability validation they require.
- I add deterministic deferred-promise coverage proving that neither a full runtime config reload nor optional metadata work can block accepted reply routing.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/messaging-response-mode.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts` (522 passed).
- I ran `pnpm typecheck` and `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:eslint` (0 errors; 43 existing warnings elsewhere), `pnpm lint:boundaries`, and `pnpm lint:codex-storage`.
- I ran `git diff --check`.
- After #1916 squash-merged, I rebased onto merge commit `b881707bb` and verified all five rewritten commits are signed. The current signed head is `bbbdc796d`.
- I verified the live Discord path after the fix: Default-Agent event `1544355014619828385` measured `handledToRoutedMs=6`, and bound event `1544355128230936808` measured `handledToRoutedMs=2`.

## Notes

- This began as a stacked follow-up based exactly on #1916 at `63ac4db828da9a32659e064aec1af96f4f59321d`. After #1916 squash-merged and GitHub retargeted this PR, I rebased the follow-up commits onto its `main` merge commit so the PR remains separable.
- Before this change, live Discord evidence reported `handledToRoutedMs=3887` for Default-Agent event `1544334536358367283` and `handledToRoutedMs=3333` for bound event `1544334775521902624`. After the change, those paths measured 6 ms and 2 ms respectively: reductions of 3,881 ms (99.85%) and 3,331 ms (99.94%). The deferred regression also proved that a second config-loader call left `startTurn` unreached.
- The complete new Default-Agent admission stages were: provider receipt 31 ms, received-to-handled 4 ms, handled-to-routed 6 ms, routed-to-bundle-ready 502 ms, bundle-ready-to-input-prepared 3,959 ms, input-prepared-to-admission-state 0 ms, admission-state-to-occupancy 0 ms, occupancy-to-origin 1 ms, origin-to-policy 0 ms, and policy-to-start-turn 0 ms.
- The complete new bound admission stages were: provider receipt 144 ms, received-to-handled 1 ms, handled-to-routed 2 ms, routed-to-bundle-ready 529 ms, bundle-ready-to-input-prepared 4,264 ms, input-prepared-to-admission-state 1 ms, admission-state-to-occupancy 0 ms, occupancy-to-origin 0 ms, origin-to-policy 4,226 ms, and policy-to-start-turn 0 ms. Input preparation and Full Access policy are intentionally owned by the two sibling follow-ups.
- The removed awaits are: accepted text/media `refreshBindingFromInbound()`, `observeManagedTopicFromInbound()`, the per-message `loadConfig()` inside `responseModeForConversation`, and Codex Default-Agent `listBackends()`. Pending-session/intent reads now run concurrently.
- The retained awaits are: automation matching/dispatch, pending-session and pending-intent reads, binding lookup, expired private-continuation revocation, in-memory response-mode resolution, targeted Default-Agent thread validation, ACP-only backend capability validation, RBAC, remote-scope authorization, and the final admission append.
- The review-fix regression deterministically pauses metadata after its read, applies a newer revocation or managed-topic command state, and proves the delayed operation cannot restore or overwrite that state. The SQLite path performs the current-record read and conditional write in one transaction. It adds no new write frequency: changed binding metadata retains the existing binding/observed-surface commit count, managed-topic observation retains one commit, and stale binding metadata now performs no write.
- The start-turn log now carries `handledAutomationInboundMs`, `handledTextParsingMs`, `handledPendingNewThreadReadMs`, `handledPendingIntentReadMs`, `handledBindingLookupMs`, `handledPrivateContinuationExpirationMs`, `handledSharedMessagePolicyMs`, `handledResponseModeMs`, `handledDefaultAgentAssignmentsMs`, `handledDefaultAgentBackendValidationMs` when applicable, `handledDefaultAgentTargetValidationMs`, `handledDefaultAgentRevocationsMs`, `handledRequirePermissionMs`, `handledRemoteScopeMs`, and `finalAdmissionAppendAwaitMs`. Separate debug timing records cover the two off-path metadata operations and the append boundary, all keyed by event ID.
- I intentionally did not change `fullAccessControls`, `canUseFullAccessThread()`, origin policy, input preparation, PDF handling, TTLs, retries, or timeouts. The Full Access sibling may touch the adjacent runtime callback wiring; this PR's cached primitive is deliberately response-mode-only to avoid shared cache ownership or stale Full Access policy.
